### PR TITLE
chore: Add `checkbox-group` example

### DIFF
--- a/packages/ariakit/src/checkbox/__examples__/checkbox-group/index.tsx
+++ b/packages/ariakit/src/checkbox/__examples__/checkbox-group/index.tsx
@@ -1,0 +1,22 @@
+import { Checkbox, useCheckboxState } from "ariakit/checkbox";
+import "./style.css";
+
+export default function Example() {
+  const checkbox = useCheckboxState({
+    defaultValue: [],
+  });
+
+  return (
+    <div>
+      <label className="label">
+        <Checkbox className="checkbox" state={checkbox} value="apple" /> Apple
+      </label>
+      <label className="label">
+        <Checkbox className="checkbox" state={checkbox} value="orange" /> Orange
+      </label>
+      <label className="label">
+        <Checkbox className="checkbox" state={checkbox} value="mango" /> Mango
+      </label>
+    </div>
+  );
+}

--- a/packages/ariakit/src/checkbox/__examples__/checkbox-group/index.tsx
+++ b/packages/ariakit/src/checkbox/__examples__/checkbox-group/index.tsx
@@ -1,13 +1,12 @@
 import { Checkbox, useCheckboxState } from "ariakit/checkbox";
+import { Group, GroupLabel } from "ariakit/group";
 import "./style.css";
 
 export default function Example() {
-  const checkbox = useCheckboxState({
-    defaultValue: [],
-  });
-
+  const checkbox = useCheckboxState({ defaultValue: [] });
   return (
-    <div>
+    <Group className="group">
+      <GroupLabel className="group-label">Your favorite fruits</GroupLabel>
       <label className="label">
         <Checkbox className="checkbox" state={checkbox} value="apple" /> Apple
       </label>
@@ -17,6 +16,6 @@ export default function Example() {
       <label className="label">
         <Checkbox className="checkbox" state={checkbox} value="mango" /> Mango
       </label>
-    </div>
+    </Group>
   );
 }

--- a/packages/ariakit/src/checkbox/__examples__/checkbox-group/style.css
+++ b/packages/ariakit/src/checkbox/__examples__/checkbox-group/style.css
@@ -1,0 +1,7 @@
+.label {
+  @apply flex flex-row items-center gap-2;
+}
+
+.checkbox {
+  @apply ariakit-focus-visible:ariakit-outline;
+}

--- a/packages/ariakit/src/checkbox/__examples__/checkbox-group/style.css
+++ b/packages/ariakit/src/checkbox/__examples__/checkbox-group/style.css
@@ -1,7 +1,1 @@
-.label {
-  @apply flex flex-row items-center gap-2;
-}
-
-.checkbox {
-  @apply ariakit-focus-visible:ariakit-outline;
-}
+@import url("../checkbox/style.css");

--- a/packages/ariakit/src/checkbox/__examples__/checkbox-group/test.tsx
+++ b/packages/ariakit/src/checkbox/__examples__/checkbox-group/test.tsx
@@ -1,0 +1,85 @@
+import { click, getByLabelText, press, render } from "ariakit-test-utils";
+import Example from ".";
+
+test("render checkbox", async () => {
+  const { container } = render(<Example />);
+  expect(container).toMatchInlineSnapshot(`
+    <div>
+      <div>
+        <label
+          class="label"
+        >
+          <input
+            aria-checked="false"
+            class="checkbox"
+            data-command=""
+            type="checkbox"
+            value="apple"
+          />
+           Apple
+        </label>
+        <label
+          class="label"
+        >
+          <input
+            aria-checked="false"
+            class="checkbox"
+            data-command=""
+            type="checkbox"
+            value="orange"
+          />
+           Orange
+        </label>
+        <label
+          class="label"
+        >
+          <input
+            aria-checked="false"
+            class="checkbox"
+            data-command=""
+            type="checkbox"
+            value="mango"
+          />
+           Mango
+        </label>
+      </div>
+    </div>
+  `);
+});
+
+test("check checkbox on click", async () => {
+  render(<Example />);
+  expect(getByLabelText("Apple")).not.toBeChecked();
+  await click(getByLabelText("Apple"));
+  expect(getByLabelText("Apple")).toBeChecked();
+
+  expect(getByLabelText("Orange")).not.toBeChecked();
+  await click(getByLabelText("Orange"));
+  expect(getByLabelText("Orange")).toBeChecked();
+
+  expect(getByLabelText("Mango")).not.toBeChecked();
+  await click(getByLabelText("Mango"));
+  expect(getByLabelText("Mango")).toBeChecked();
+});
+
+test("tab", async () => {
+  render(<Example />);
+  expect(getByLabelText("Apple")).not.toHaveFocus();
+  await press.Tab();
+  expect(getByLabelText("Apple")).toHaveFocus();
+  await press.Tab();
+  expect(getByLabelText("Orange")).toHaveFocus();
+  await press.Tab();
+  expect(getByLabelText("Mango")).toHaveFocus();
+});
+
+test("space", async () => {
+  render(<Example />);
+  await press.Tab();
+  expect(getByLabelText("Apple")).toHaveFocus();
+  expect(getByLabelText("Apple")).not.toBeChecked();
+  await press.Space();
+  expect(getByLabelText("Apple")).toBeChecked();
+  await press.Space();
+  expect(getByLabelText("Apple")).not.toBeChecked();
+});


### PR DESCRIPTION
Adds a "Checkbox group" example https://github.com/reakit/reakit/issues/939.


**Screenshots**
<img width="1030" alt="Screen Shot 2021-12-20 at 8 27 52 AM" src="https://user-images.githubusercontent.com/5148596/146774254-018cb900-4b5c-47c0-b1a4-b9158c549dd5.png">
