### PR TITLE
chore: Add `toolbar` example 

### DIFF
--- a/packages/ariakit/src/toolbar/__examples__/toolbar-with-menu/index.tsx
+++ b/packages/ariakit/src/toolbar/__examples__/toolbar-with-menu/index.tsx
@@ -1,0 +1,70 @@
+import { forwardRef } from "react";
+import { Button } from "ariakit/button";
+import { Menu, MenuButton, MenuItem, useMenuState } from "ariakit/menu";
+import {
+  Toolbar,
+  ToolbarItem,
+  ToolbarSeparator,
+  useToolbarState,
+} from "ariakit/toolbar";
+import { BiChevronDown } from "react-icons/bi";
+import {
+  ImBold,
+  ImItalic,
+  ImParagraphCenter,
+  ImParagraphLeft,
+  ImParagraphRight,
+  ImUnderline,
+} from "react-icons/im";
+import "./style.css";
+
+const MoreItems = forwardRef((props, ref) => {
+  const menu = useMenuState({ orientation: "horizontal" });
+  return (
+    <>
+      {/* @ts-ignore */}
+      <MenuButton state={menu} ref={ref} {...props} />
+      <Menu state={menu} aria-label="Alignment" className="menu">
+        <MenuItem>
+          <ImParagraphLeft />
+          Left
+        </MenuItem>
+        <MenuItem>
+          <ImParagraphCenter />
+          Center
+        </MenuItem>
+        <MenuItem>
+          <ImParagraphRight />
+          Right
+        </MenuItem>
+      </Menu>
+    </>
+  );
+});
+
+export default function Example() {
+  const toolbar = useToolbarState();
+
+  return (
+    <Toolbar state={toolbar} className="toolbar">
+      <ToolbarItem as={Button} className="button">
+        <ImBold />
+        Bold
+      </ToolbarItem>
+      <ToolbarItem as={Button} className="button">
+        <ImItalic />
+        Italic
+      </ToolbarItem>
+      <ToolbarItem as={Button} className="button">
+        <ImUnderline />
+        Underline
+      </ToolbarItem>
+      <ToolbarSeparator className="toolbar-separator" />
+      {/* @ts-ignore */}
+      <ToolbarItem as={MoreItems} className="button" aria-label="Alignment">
+        Alignment
+        <BiChevronDown />
+      </ToolbarItem>
+    </Toolbar>
+  );
+}

--- a/packages/ariakit/src/toolbar/__examples__/toolbar-with-menu/style.css
+++ b/packages/ariakit/src/toolbar/__examples__/toolbar-with-menu/style.css
@@ -1,0 +1,21 @@
+@import url("../toolbar/style.css");
+
+.menu {
+  @apply flex top-2;
+}
+
+.menu [role="menuitem"] {
+  @apply
+    flex
+    flex-col
+    justify-center
+    items-center
+    w-14
+    h-14
+    border
+    border-alpha-1
+    text-sm
+    bg-canvas-4
+    text-canvas-2
+  ;
+}

--- a/packages/ariakit/src/toolbar/__examples__/toolbar/index.tsx
+++ b/packages/ariakit/src/toolbar/__examples__/toolbar/index.tsx
@@ -1,0 +1,30 @@
+import { Button } from "ariakit/button";
+import {
+  Toolbar,
+  ToolbarItem,
+  ToolbarSeparator,
+  useToolbarState,
+} from "ariakit/toolbar";
+import "./style.css";
+
+export default function Example() {
+  const toolbar = useToolbarState();
+
+  return (
+    <Toolbar state={toolbar} className="toolbar">
+      <ToolbarItem as={Button} className="button">
+        File
+      </ToolbarItem>
+      <ToolbarItem as={Button} className="button">
+        Edit
+      </ToolbarItem>
+      <ToolbarSeparator className="toolbar-separator" />
+      <ToolbarItem as={Button} className="button">
+        Formats
+      </ToolbarItem>
+      <ToolbarItem as={Button} className="button">
+        Help
+      </ToolbarItem>
+    </Toolbar>
+  );
+}

--- a/packages/ariakit/src/toolbar/__examples__/toolbar/index.tsx
+++ b/packages/ariakit/src/toolbar/__examples__/toolbar/index.tsx
@@ -5,6 +5,14 @@ import {
   ToolbarSeparator,
   useToolbarState,
 } from "ariakit/toolbar";
+import {
+  ImBold,
+  ImItalic,
+  ImParagraphCenter,
+  ImParagraphLeft,
+  ImParagraphRight,
+  ImUnderline,
+} from "react-icons/im";
 import "./style.css";
 
 export default function Example() {
@@ -13,17 +21,29 @@ export default function Example() {
   return (
     <Toolbar state={toolbar} className="toolbar">
       <ToolbarItem as={Button} className="button">
-        File
+        <ImBold />
+        Bold
       </ToolbarItem>
       <ToolbarItem as={Button} className="button">
-        Edit
+        <ImItalic />
+        Italic
+      </ToolbarItem>
+      <ToolbarItem as={Button} className="button">
+        <ImUnderline />
+        Underline
       </ToolbarItem>
       <ToolbarSeparator className="toolbar-separator" />
       <ToolbarItem as={Button} className="button">
-        Formats
+        <ImParagraphLeft />
+        Align Left
       </ToolbarItem>
       <ToolbarItem as={Button} className="button">
-        Help
+        <ImParagraphCenter />
+        Align Center
+      </ToolbarItem>
+      <ToolbarItem as={Button} className="button">
+        <ImParagraphRight />
+        Align Right
       </ToolbarItem>
     </Toolbar>
   );

--- a/packages/ariakit/src/toolbar/__examples__/toolbar/style.css
+++ b/packages/ariakit/src/toolbar/__examples__/toolbar/style.css
@@ -1,0 +1,13 @@
+@import url("../../../button/__examples__/button/style.css");
+
+.toolbar {
+  @apply flex border p-1 rounded border-alpha-1 flex-row w-fit items-center;
+}
+
+.button {
+  @apply rounded-none;
+}
+
+.toolbar-separator {
+  @apply hidden sm:block mx-6 lg:mx-4 w-px h-7 bg-canvas-1-border text-canvas-2-dark;
+}

--- a/packages/ariakit/src/toolbar/__examples__/toolbar/style.css
+++ b/packages/ariakit/src/toolbar/__examples__/toolbar/style.css
@@ -32,5 +32,5 @@
 }
 
 .toolbar-separator {
-  @apply hidden sm:block lg:mx-4 w-px h-7 bg-canvas-1-border text-canvas-2-dark;
+  @apply lg:mx-4 w-px h-7 bg-canvas-1-border text-canvas-2-dark;
 }

--- a/packages/ariakit/src/toolbar/__examples__/toolbar/style.css
+++ b/packages/ariakit/src/toolbar/__examples__/toolbar/style.css
@@ -1,13 +1,36 @@
 @import url("../../../button/__examples__/button/style.css");
 
 .toolbar {
-  @apply flex border p-1 rounded border-alpha-1 flex-row w-fit items-center;
+  @apply
+    flex
+    gap-1
+    border
+    p-1
+    rounded
+    border-alpha-1
+    flex-row
+    w-fit
+    items-center
+    bg-canvas-4
+    dark:bg-canvas-4-dark
+  ;
 }
 
 .button {
-  @apply rounded-none;
+  @apply
+    bg-canvas-4
+    text-canvas-2
+    hover:bg-canvas-4-hover
+    dark:hover:bg-canvas-4-dark-hover
+    dark:bg-canvas-4-dark
+    text-sm
+  ;
+}
+
+.button svg {
+  @apply sm:block hidden;
 }
 
 .toolbar-separator {
-  @apply hidden sm:block mx-6 lg:mx-4 w-px h-7 bg-canvas-1-border text-canvas-2-dark;
+  @apply hidden sm:block lg:mx-4 w-px h-7 bg-canvas-1-border text-canvas-2-dark;
 }


### PR DESCRIPTION
Adds a "toolbar" example https://github.com/reakit/reakit/issues/939.

## Toolbar
<img width="888" alt="Screen Shot 2021-12-28 at 23 47 44" src="https://user-images.githubusercontent.com/1995213/147625339-2f723fba-d285-4e83-b5a4-a04a4e0d0fea.png">


## Toolbar with menu
<img width="861" alt="Screen Shot 2021-12-29 at 00 40 48" src="https://user-images.githubusercontent.com/1995213/147625299-103e67eb-b8d8-47f2-8048-fc3912196099.png">
e-2f496bddc296.png">

