### PR TITLE
chore: Add `focus-trap` example

### DIFF
--- a/packages/ariakit/src/focus-trap/__examples__/focus-trap/index.tsx
+++ b/packages/ariakit/src/focus-trap/__examples__/focus-trap/index.tsx
@@ -1,46 +1,37 @@
-import { ReactNode, forwardRef, useRef } from "react";
-import { getFirstTabbableIn, getLastTabbableIn } from "ariakit-utils/focus";
+import { FocusEvent, useRef } from "react";
+import { Checkbox, useCheckboxState } from "ariakit/checkbox";
 import { FocusTrap } from "ariakit/focus-trap";
 import "./style.css";
 
-type ContainerProps = {
-  children: ReactNode;
-  label: string;
-};
-const Container = forwardRef<HTMLDivElement, ContainerProps>(
-  ({ children, label, ...rest }, ref) => (
-    <div className="example-container" ref={ref} {...rest}>
-      <span>{label}</span>
-      <div className="buttons-container">{children}</div>
-    </div>
-  )
-);
-
 export default function Example() {
-  const focusContainerRef = useRef<HTMLDivElement>(null);
+  const focusTrapped = useCheckboxState({ defaultValue: true });
+  const firstRef = useRef<HTMLButtonElement>(null);
+  const lastRef = useRef<HTMLButtonElement>(null);
 
-  const handleOnFocusTrapStart = () => {
-    const node = focusContainerRef.current as HTMLDivElement;
-    getFirstTabbableIn(node).focus();
-  };
-  const handleOnFocusTrapEnd = () => {
-    const node = focusContainerRef.current as HTMLDivElement;
-    getLastTabbableIn(node).focus();
+  const onTrapFocus = (event: FocusEvent) => {
+    if (event.relatedTarget === firstRef.current) {
+      lastRef.current?.focus();
+    } else {
+      firstRef.current?.focus();
+    }
   };
 
   return (
-    <div className="flex gap-2">
-      <FocusTrap className="FocusTrap" onFocus={handleOnFocusTrapStart} />
-      <Container label="Focus trapped" ref={focusContainerRef}>
-        <button className="button">One</button>
-        <button className="button">Two</button>
-        <button className="button">Three</button>
-      </Container>
-      <FocusTrap className="FocusTrap" onFocus={handleOnFocusTrapEnd} />
-      <Container label="Untrapped focus">
-        <button className="button">Four</button>
-        <button className="button">Five</button>
-      </Container>
-    </div>
+    <>
+      {focusTrapped.value && <FocusTrap onFocus={onTrapFocus} />}
+      <div className="wrapper">
+        <label className="label">
+          <Checkbox state={focusTrapped} clickOnEnter className="checkbox" />
+          Trap focus
+        </label>
+        <button className="button" ref={firstRef}>
+          First
+        </button>
+        <button className="button" ref={lastRef}>
+          Last
+        </button>
+      </div>
+      {focusTrapped.value && <FocusTrap onFocus={onTrapFocus} />}
+    </>
   );
 }

--- a/packages/ariakit/src/focus-trap/__examples__/focus-trap/index.tsx
+++ b/packages/ariakit/src/focus-trap/__examples__/focus-trap/index.tsx
@@ -1,0 +1,46 @@
+import { ReactNode, forwardRef, useRef } from "react";
+import { getFirstTabbableIn, getLastTabbableIn } from "ariakit-utils/focus";
+import { FocusTrap } from "ariakit/focus-trap";
+import "./style.css";
+
+type ContainerProps = {
+  children: ReactNode;
+  label: string;
+};
+const Container = forwardRef<HTMLDivElement, ContainerProps>(
+  ({ children, label, ...rest }, ref) => (
+    <div className="example-container" ref={ref} {...rest}>
+      <span>{label}</span>
+      <div className="buttons-container">{children}</div>
+    </div>
+  )
+);
+
+export default function Example() {
+  const focusContainerRef = useRef<HTMLDivElement>(null);
+
+  const handleOnFocusTrapStart = () => {
+    const node = focusContainerRef.current as HTMLDivElement;
+    getFirstTabbableIn(node).focus();
+  };
+  const handleOnFocusTrapEnd = () => {
+    const node = focusContainerRef.current as HTMLDivElement;
+    getLastTabbableIn(node).focus();
+  };
+
+  return (
+    <div className="flex gap-2">
+      <FocusTrap className="FocusTrap" onFocus={handleOnFocusTrapStart} />
+      <Container label="Focus trapped" ref={focusContainerRef}>
+        <button className="button">One</button>
+        <button className="button">Two</button>
+        <button className="button">Three</button>
+      </Container>
+      <FocusTrap className="FocusTrap" onFocus={handleOnFocusTrapEnd} />
+      <Container label="Untrapped focus">
+        <button className="button">Four</button>
+        <button className="button">Five</button>
+      </Container>
+    </div>
+  );
+}

--- a/packages/ariakit/src/focus-trap/__examples__/focus-trap/index.tsx
+++ b/packages/ariakit/src/focus-trap/__examples__/focus-trap/index.tsx
@@ -5,7 +5,7 @@ import "./style.css";
 
 export default function Example() {
   const focusTrapped = useCheckboxState({ defaultValue: true });
-  const firstRef = useRef<HTMLButtonElement>(null);
+  const firstRef = useRef<HTMLInputElement>(null);
   const lastRef = useRef<HTMLButtonElement>(null);
 
   const onTrapFocus = (event: FocusEvent) => {
@@ -21,14 +21,12 @@ export default function Example() {
       {focusTrapped.value && <FocusTrap onFocus={onTrapFocus} />}
       <div className="wrapper">
         <label className="label">
-          <Checkbox state={focusTrapped} clickOnEnter className="checkbox" />
+          <Checkbox state={focusTrapped} ref={firstRef} className="checkbox" />
           Trap focus
         </label>
-        <button className="button" ref={firstRef}>
-          First
-        </button>
+
         <button className="button" ref={lastRef}>
-          Last
+          Button
         </button>
       </div>
       {focusTrapped.value && <FocusTrap onFocus={onTrapFocus} />}

--- a/packages/ariakit/src/focus-trap/__examples__/focus-trap/style.css
+++ b/packages/ariakit/src/focus-trap/__examples__/focus-trap/style.css
@@ -1,9 +1,6 @@
 @import url("../../../button/__examples__/button/style.css");
+@import url("../../../checkbox/__examples__/checkbox/style.css");
 
-.example-container {
-  @apply flex gap-2 flex-col rounded-lg border border-canvas-3 dark:border-canvas-3-dark p-3;
-}
-
-.buttons-container {
-  @apply flex gap-2;
+.wrapper {
+  @apply flex gap-2 flex-col rounded-lg border border-canvas-3 dark:border-canvas-3-dark p-3 w-56;
 }

--- a/packages/ariakit/src/focus-trap/__examples__/focus-trap/style.css
+++ b/packages/ariakit/src/focus-trap/__examples__/focus-trap/style.css
@@ -1,0 +1,9 @@
+@import url("../../../button/__examples__/button/style.css");
+
+.example-container {
+  @apply flex gap-2 flex-col rounded-lg border border-canvas-3 dark:border-canvas-3-dark p-3;
+}
+
+.buttons-container {
+  @apply flex gap-2;
+}

--- a/packages/ariakit/src/focus-trap/__examples__/focus-trap/test.tsx
+++ b/packages/ariakit/src/focus-trap/__examples__/focus-trap/test.tsx
@@ -13,34 +13,47 @@ test("correctly traps focus", async () => {
   // Focus trap is on by default in the Example
   render(
     <div>
+      <div tabIndex={0}>Before</div>
       <Example />
-      <div tabIndex={0}>Outside</div>
+      <div tabIndex={0}>After</div>
     </div>
   );
-  focus(getByRole("checkbox"));
+  await press.Tab();
+  expect(getByText("Before")).toHaveFocus();
+  await press.Tab();
   expect(getByRole("checkbox")).toHaveFocus();
   await press.Tab();
   expect(getByRole("button")).toHaveFocus();
   await press.Tab();
-  expect(getByRole("checkbox")).toHaveFocus();
-  expect(getByText("Outside")).not.toHaveFocus();
+  expect(getByText("After")).not.toHaveFocus();
   await press.Tab();
   expect(getByRole("button")).toHaveFocus();
+  await press.ShiftTab();
+  expect(getByRole("checkbox")).toHaveFocus();
+  await press.ShiftTab();
+  expect(getByText("Before")).not.toHaveFocus();
 });
 
 test("correctly releases focus", async () => {
   // Focus trap is on by default in the Example
   render(
     <div>
+      <div tabIndex={0}>Before</div>
       <Example />
-      <div tabIndex={0}>Outside</div>
+      <div tabIndex={0}>After</div>
     </div>
   );
-  // Disabling focus trap
+  // First, disabling focus trap
   await click(getByLabelText("Trap focus"));
-  await focus(getByRole("button"));
+  expect(getByRole("checkbox")).toHaveFocus();
   await press.Tab();
-  expect(getByRole("checkbox")).not.toHaveFocus();
-  expect(getByRole("button")).not.toHaveFocus();
-  expect(getByText("Outside")).toHaveFocus();
+  expect(getByRole("button")).toHaveFocus();
+  await press.Tab();
+  expect(getByText("After")).toHaveFocus();
+  await press.ShiftTab();
+  expect(getByRole("button")).toHaveFocus();
+  await press.ShiftTab();
+  expect(getByRole("checkbox")).toHaveFocus();
+  await press.ShiftTab();
+  expect(getByText("Before")).toHaveFocus();
 });

--- a/packages/ariakit/src/focus-trap/__examples__/focus-trap/test.tsx
+++ b/packages/ariakit/src/focus-trap/__examples__/focus-trap/test.tsx
@@ -1,6 +1,5 @@
 import {
   click,
-  focus,
   getByLabelText,
   getByRole,
   getByText,

--- a/packages/ariakit/src/focus-trap/__examples__/focus-trap/test.tsx
+++ b/packages/ariakit/src/focus-trap/__examples__/focus-trap/test.tsx
@@ -1,0 +1,46 @@
+import {
+  click,
+  focus,
+  getByLabelText,
+  getByRole,
+  getByText,
+  press,
+  render,
+} from "ariakit-test-utils";
+import Example from ".";
+
+test("correctly traps focus", async () => {
+  // Focus trap is on by default in the Example
+  render(
+    <div>
+      <Example />
+      <div tabIndex={0}>Outside</div>
+    </div>
+  );
+  focus(getByRole("checkbox"));
+  expect(getByRole("checkbox")).toHaveFocus();
+  await press.Tab();
+  expect(getByRole("button")).toHaveFocus();
+  await press.Tab();
+  expect(getByRole("checkbox")).toHaveFocus();
+  expect(getByText("Outside")).not.toHaveFocus();
+  await press.Tab();
+  expect(getByRole("button")).toHaveFocus();
+});
+
+test("correctly releases focus", async () => {
+  // Focus trap is on by default in the Example
+  render(
+    <div>
+      <Example />
+      <div tabIndex={0}>Outside</div>
+    </div>
+  );
+  // Disabling focus trap
+  await click(getByLabelText("Trap focus"));
+  await focus(getByRole("button"));
+  await press.Tab();
+  expect(getByRole("checkbox")).not.toHaveFocus();
+  expect(getByRole("button")).not.toHaveFocus();
+  expect(getByText("Outside")).toHaveFocus();
+});

--- a/packages/website/pages/index.tsx
+++ b/packages/website/pages/index.tsx
@@ -50,6 +50,9 @@ export default function Home() {
           <Link href="/examples/disclosure">Disclosure</Link>
         </li>
         <li>
+          <Link href="/examples/focus-trap">Focus trap</Link>
+        </li>
+        <li>
           <Link href="/examples/form">Form</Link>
         </li>
         <li>


### PR DESCRIPTION
This update adds a basic example for the `FocusTrap` component as part of this effort: https://github.com/reakit/reakit/issues/939

**Screenshots**

<img width="306" alt="FocusTrap example update" src="https://user-images.githubusercontent.com/2322354/152088386-696f4280-95b9-462e-a14e-b6d1c59d6638.png">

**How to test?**

- Run `yarn dev`
- Visit http://localhost:3000/examples/focus-trap.
- Press `Tab`.
- Toggle Focus Trap will trap `Tab` focus.

**Does this PR introduce breaking changes?**

Nope! Only adding an example.