### PR TITLE
chore: Add `checkbox-custom` example 

### DIFF
--- a/packages/ariakit/src/checkbox/__examples__/checkbox-custom/index.tsx
+++ b/packages/ariakit/src/checkbox/__examples__/checkbox-custom/index.tsx
@@ -1,0 +1,30 @@
+import { useState } from "react";
+import { Checkbox, CheckboxCheck, useCheckboxState } from "ariakit/checkbox";
+import { VisuallyHidden } from "ariakit/visually-hidden";
+
+import "./style.css";
+
+export default function Example() {
+  const checkbox = useCheckboxState<boolean>();
+  const [focusVisible, setFocusVisible] = useState(false);
+
+  return (
+    <label className="label">
+      <VisuallyHidden>
+        <Checkbox
+          state={checkbox}
+          onFocusVisible={() => setFocusVisible(true)}
+          onBlur={() => setFocusVisible(false)}
+        />
+      </VisuallyHidden>
+      <div
+        className="checkbox"
+        data-focus-visible={focusVisible ? "" : undefined}
+        data-checked={checkbox.value}
+      >
+        <CheckboxCheck checked={checkbox.value} />
+      </div>
+      I have read and agree to the terms and conditions
+    </label>
+  );
+}

--- a/packages/ariakit/src/checkbox/__examples__/checkbox-custom/style.css
+++ b/packages/ariakit/src/checkbox/__examples__/checkbox-custom/style.css
@@ -1,0 +1,18 @@
+@import url("../checkbox/style.css");
+
+.checkbox {
+  @apply
+    w-5
+    h-5
+    rounded
+    flex
+    justify-center
+    items-center
+    border
+    bg-primary-1
+    border-primary-1
+    text-primary-1
+    dark:bg-primary-1-dark
+    dark:border-primary-1-dark
+    dark:text-primary-1-dark;
+}

--- a/packages/ariakit/src/checkbox/__examples__/checkbox-custom/test.tsx
+++ b/packages/ariakit/src/checkbox/__examples__/checkbox-custom/test.tsx
@@ -56,3 +56,11 @@ test("check and uncheck checkbox by with keyboard (space)", async () => {
   await press.Space();
   expect(getByRole("checkbox")).not.toBeChecked();
 });
+
+test("input gets focus on tab and loses it on blur", async () => {
+  render(<Example />);
+  await press.Tab();
+  expect(getByRole("checkbox")).toHaveFocus();
+  getByRole("checkbox").blur();
+  expect(getByRole("checkbox")).not.toHaveFocus();
+});

--- a/packages/ariakit/src/checkbox/__examples__/checkbox-custom/test.tsx
+++ b/packages/ariakit/src/checkbox/__examples__/checkbox-custom/test.tsx
@@ -47,20 +47,21 @@ test("check and uncheck checkbox by clicking", async () => {
   expect(getByRole("checkbox")).not.toBeChecked();
 });
 
-test("check and uncheck checkbox by with keyboard (space)", async () => {
-  render(<Example />);
-  expect(getByRole("checkbox")).not.toBeChecked();
-  await press.Tab();
-  await press.Space();
-  expect(getByRole("checkbox")).toBeChecked();
-  await press.Space();
-  expect(getByRole("checkbox")).not.toBeChecked();
-});
-
 test("input gets focus on tab and loses it on blur", async () => {
   render(<Example />);
   await press.Tab();
   expect(getByRole("checkbox")).toHaveFocus();
   getByRole("checkbox").blur();
   expect(getByRole("checkbox")).not.toHaveFocus();
+});
+
+test("check and uncheck checkbox by with keyboard (space)", async () => {
+  render(<Example />);
+  expect(getByRole("checkbox")).not.toBeChecked();
+  await press.Tab();
+  expect(getByRole("checkbox")).toHaveFocus();
+  await press.Space();
+  expect(getByRole("checkbox")).toBeChecked();
+  await press.Space();
+  expect(getByRole("checkbox")).not.toBeChecked();
 });

--- a/packages/ariakit/src/checkbox/__examples__/checkbox-custom/test.tsx
+++ b/packages/ariakit/src/checkbox/__examples__/checkbox-custom/test.tsx
@@ -1,0 +1,58 @@
+import { click, getByRole, press, render } from "ariakit-test-utils";
+import { axe } from "jest-axe";
+import Example from ".";
+
+test("a11y", async () => {
+  render(<Example />);
+  expect(await axe(getByRole("checkbox"))).toHaveNoViolations();
+});
+
+test("render checkbox as button", async () => {
+  const { container } = render(<Example />);
+  expect(container).toMatchInlineSnapshot(`
+    <div>
+      <label
+        class="label"
+      >
+        <span
+          style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; white-space: nowrap; width: 1px;"
+        >
+          <input
+            aria-checked="false"
+            data-command=""
+            type="checkbox"
+          />
+        </span>
+        <div
+          class="checkbox"
+          data-checked="false"
+        >
+          <span
+            aria-hidden="true"
+            style="width: 1em; height: 1em; pointer-events: none;"
+          />
+        </div>
+        I have read and agree to the terms and conditions
+      </label>
+    </div>
+  `);
+});
+
+test("check and uncheck checkbox by clicking", async () => {
+  render(<Example />);
+  expect(getByRole("checkbox")).not.toBeChecked();
+  await click(getByRole("checkbox"));
+  expect(getByRole("checkbox")).toBeChecked();
+  await click(getByRole("checkbox"));
+  expect(getByRole("checkbox")).not.toBeChecked();
+});
+
+test("check and uncheck checkbox by with keyboard (space)", async () => {
+  render(<Example />);
+  expect(getByRole("checkbox")).not.toBeChecked();
+  await press.Tab();
+  await press.Space();
+  expect(getByRole("checkbox")).toBeChecked();
+  await press.Space();
+  expect(getByRole("checkbox")).not.toBeChecked();
+});

--- a/packages/website/pages/index.tsx
+++ b/packages/website/pages/index.tsx
@@ -33,7 +33,7 @@ export default function Home() {
           <Link href="/examples/checkbox-controlled">Checkbox controlled</Link>
         </li>
         <li>
-          <Link href="/examples/checkbox-controlled">Checkbox custom</Link>
+          <Link href="/examples/checkbox-custom">Checkbox custom</Link>
         </li>
         <li>
           <Link href="/examples/collection">Collection</Link>

--- a/packages/website/pages/index.tsx
+++ b/packages/website/pages/index.tsx
@@ -33,6 +33,9 @@ export default function Home() {
           <Link href="/examples/checkbox-controlled">Checkbox controlled</Link>
         </li>
         <li>
+          <Link href="/examples/checkbox-controlled">Checkbox custom</Link>
+        </li>
+        <li>
           <Link href="/examples/collection">Collection</Link>
         </li>
         <li>


### PR DESCRIPTION
This update adds a custom styled checkbox example for the Checkbox component:

Screenshots
![image](https://user-images.githubusercontent.com/13336976/154604615-971905c3-f914-48e5-9115-e17803940d5b.png)
![image](https://user-images.githubusercontent.com/13336976/154604645-a2f6fbe4-475c-466e-a258-fa56cac967f7.png)
![image](https://user-images.githubusercontent.com/13336976/154604657-61cce2df-3cd0-4c39-ac00-b31e1cbc9f99.png)
![image](https://user-images.githubusercontent.com/13336976/154604665-1a1d0616-ea70-4955-bde5-3103e9007744.png)


How to test?
- `npm run dev`
- Visit http://localhost:3000/examples/checkbox-custom


Does this PR introduce breaking changes?
Nope, just an example