### PR TITLE
fix: Fix `PopoverArrow` placement on Safari

### DIFF
--- a/packages/ariakit/src/popover/popover-arrow.tsx
+++ b/packages/ariakit/src/popover/popover-arrow.tsx
@@ -12,14 +12,15 @@ import { POPOVER_ARROW_PATH } from "./__popover-arrow-path";
 import { PopoverContext } from "./__utils";
 import { PopoverState } from "./popover-state";
 
-const rotateMap = {
-  top: "rotate(180 0 0)",
-  right: "rotate(-90 0 0)",
-  bottom: "rotate(0 0 0)",
-  left: "rotate(90 0 0)",
-};
-
 const defaultSize = 30;
+const halfDefaultSize = defaultSize / 2;
+
+const rotateMap = {
+  top: `rotate(180 ${halfDefaultSize} ${halfDefaultSize})`,
+  right: `rotate(-90 ${halfDefaultSize} ${halfDefaultSize})`,
+  bottom: `rotate(0 ${halfDefaultSize} ${halfDefaultSize})`,
+  left: `rotate(90 ${halfDefaultSize} ${halfDefaultSize})`,
+};
 
 function useComputedStyle(element?: Element | null) {
   const [style, setStyle] = useState<CSSStyleDeclaration>();
@@ -60,9 +61,11 @@ export const usePopoverArrow = createHook<PopoverArrowOptions>(
 
     const children = useMemo(
       () => (
-        <svg display="block" transform={transform} viewBox="0 0 30 30">
-          <path fill="none" d={POPOVER_ARROW_PATH} />
-          <path stroke="none" d={POPOVER_ARROW_PATH} />
+        <svg display="block" viewBox="0 0 30 30">
+          <g transform={transform}>
+            <path fill="none" d={POPOVER_ARROW_PATH} />
+            <path stroke="none" d={POPOVER_ARROW_PATH} />
+          </g>
         </svg>
       ),
       [transform]


### PR DESCRIPTION
This PR closes #1040. 

The way to test:
- Boot in Safari, Chrome & Firefox 
- Open the Popover
- Reduce the height of the window to force the pop over to appear above the button

Screenshots of that testing:

Safari:
<img width="777" alt="image" src="https://user-images.githubusercontent.com/13336976/154821040-14e625fb-3285-42e9-8678-d05c1920a00f.png">
<img width="476" alt="image" src="https://user-images.githubusercontent.com/13336976/154821042-cc66a2bd-ff21-4d9e-82ac-41668eb098bc.png">

Chrome: 
<img width="441" alt="image" src="https://user-images.githubusercontent.com/13336976/154821079-b5dd3aca-32f7-44f1-b39d-610983deb09f.png">
<img width="410" alt="image" src="https://user-images.githubusercontent.com/13336976/154821077-3bb09bfc-3b34-40ae-9b8b-145fe87a580c.png">

Firefox:
<img width="415" alt="image" src="https://user-images.githubusercontent.com/13336976/154821107-aca1cc5b-8385-4413-8c0e-16dcf246421f.png">
<img width="366" alt="image" src="https://user-images.githubusercontent.com/13336976/154821104-8e0cee57-4ae0-49ee-b200-24203a86167c.png">
