### PR TITLE
feat: Improve `Hovercard` API and behavior

### DIFF
--- a/packages/ariakit/src/hovercard/__examples__/hovercard-disclosure/index.tsx
+++ b/packages/ariakit/src/hovercard/__examples__/hovercard-disclosure/index.tsx
@@ -1,15 +1,18 @@
 import {
   Hovercard,
   HovercardAnchor,
+  HovercardDisclosure,
   HovercardHeading,
   useHovercardState,
 } from "ariakit/hovercard";
+import { VisuallyHidden } from "ariakit/visually-hidden";
+import { HiChevronDown } from "react-icons/hi";
 import "./style.css";
 
 export default function Example() {
   const hovercard = useHovercardState({ gutter: 16 });
-  return (
-    <div className="wrapper">
+  const element = (
+    <span className="hovercard-wrapper">
       <HovercardAnchor
         state={hovercard}
         href="https://twitter.com/ariakitjs"
@@ -17,7 +20,11 @@ export default function Example() {
       >
         @ariakitjs
       </HovercardAnchor>
-      <Hovercard state={hovercard} className="hovercard">
+      <HovercardDisclosure state={hovercard} className="disclosure">
+        <VisuallyHidden>More details about @ariakitjs</VisuallyHidden>
+        <HiChevronDown size={20} />
+      </HovercardDisclosure>
+      <Hovercard portal state={hovercard} className="hovercard">
         <img
           src="https://pbs.twimg.com/profile_images/1116178840467005440/cwXwfYjW_400x400.png"
           alt="Ariakit"
@@ -29,6 +36,9 @@ export default function Example() {
           Follow
         </a>
       </Hovercard>
-    </div>
+    </span>
+  );
+  return (
+    <p>Focus on {element} using the keyboard to see the disclosure button.</p>
   );
 }

--- a/packages/ariakit/src/hovercard/__examples__/hovercard-disclosure/style.css
+++ b/packages/ariakit/src/hovercard/__examples__/hovercard-disclosure/style.css
@@ -1,0 +1,5 @@
+@import url("../hovercard/style.css");
+
+.hovercard-wrapper {
+  @apply inline-flex gap-1 items-center;
+}

--- a/packages/ariakit/src/hovercard/__examples__/hovercard-disclosure/test.tsx
+++ b/packages/ariakit/src/hovercard/__examples__/hovercard-disclosure/test.tsx
@@ -18,6 +18,12 @@ const getFollowLink = () => getByRole("link", { name: "Follow" });
 const waitForHovercardToShow = (timeout = 600) =>
   waitFor(expect(getHovercard()).toBeVisible, { timeout });
 
+const expectDisclosureToBeHidden = () =>
+  expect(getDisclosure()).toHaveStyle({ height: "1px" });
+
+const expectDisclosureToBeVisible = () =>
+  expect(getDisclosure()).not.toHaveStyle({ height: "1px" });
+
 test("show hovercard on hover after timeout", async () => {
   render(<Example />);
   expect(getHovercard()).not.toBeVisible();
@@ -28,14 +34,16 @@ test("show hovercard on hover after timeout", async () => {
 
 test("do not show disclosure when focusing on anchor with mouse", async () => {
   render(<Example />);
+  await click(document.body);
   await focus(getAnchor());
-  expect(getDisclosure()).toHaveStyle({ height: "1px" });
+  expectDisclosureToBeHidden();
 });
 
 test("show disclosure when focusing on anchor with keyboard", async () => {
   render(<Example />);
+  expectDisclosureToBeHidden();
   await press.Tab();
-  expect(getDisclosure()).not.toHaveStyle({ height: "1px" });
+  expectDisclosureToBeVisible();
 });
 
 test("tab to disclosure", async () => {
@@ -103,10 +111,15 @@ test("hide hovercard on blur", async () => {
       <div tabIndex={0} />
     </>
   );
+  expectDisclosureToBeHidden();
   await press.Tab();
-  waitFor(expect(getHovercard()).toBeVisible);
+  expectDisclosureToBeVisible();
   await press.Tab();
-  waitFor(expect(getHovercard()).toBeVisible);
+  expectDisclosureToBeVisible();
   await press.Tab();
-  expect(getHovercard()).not.toBeVisible();
+  expectDisclosureToBeHidden();
+  await press.ShiftTab();
+  expectDisclosureToBeVisible();
+  await press.ShiftTab();
+  expectDisclosureToBeVisible();
 });

--- a/packages/ariakit/src/hovercard/__examples__/hovercard-disclosure/test.tsx
+++ b/packages/ariakit/src/hovercard/__examples__/hovercard-disclosure/test.tsx
@@ -95,3 +95,18 @@ test("hide hovercard on escape", async () => {
   expect(getHovercard()).not.toBeVisible();
   expect(getAnchor()).toHaveFocus();
 });
+
+test("hide hovercard on blur", async () => {
+  render(
+    <>
+      <Example />
+      <div tabIndex={0} />
+    </>
+  );
+  await press.Tab();
+  waitFor(expect(getHovercard()).toBeVisible);
+  await press.Tab();
+  waitFor(expect(getHovercard()).toBeVisible);
+  await press.Tab();
+  expect(getHovercard()).not.toBeVisible();
+});

--- a/packages/ariakit/src/hovercard/__examples__/hovercard-disclosure/test.tsx
+++ b/packages/ariakit/src/hovercard/__examples__/hovercard-disclosure/test.tsx
@@ -1,0 +1,97 @@
+import {
+  click,
+  focus,
+  getByRole,
+  hover,
+  press,
+  render,
+  waitFor,
+} from "ariakit-test-utils";
+import Example from ".";
+
+const getAnchor = () => getByRole("link", { name: "@ariakitjs" });
+const getHovercard = () => getByRole("dialog", { hidden: true });
+const getDisclosure = () =>
+  getByRole("button", { name: "More details about @ariakitjs" });
+const getFollowLink = () => getByRole("link", { name: "Follow" });
+
+const waitForHovercardToShow = (timeout = 600) =>
+  waitFor(expect(getHovercard()).toBeVisible, { timeout });
+
+test("show hovercard on hover after timeout", async () => {
+  render(<Example />);
+  expect(getHovercard()).not.toBeVisible();
+  await hover(getAnchor());
+  expect(getHovercard()).not.toBeVisible();
+  await waitForHovercardToShow();
+});
+
+test("do not show disclosure when focusing on anchor with mouse", async () => {
+  render(<Example />);
+  await focus(getAnchor());
+  expect(getDisclosure()).toHaveStyle({ height: "1px" });
+});
+
+test("show disclosure when focusing on anchor with keyboard", async () => {
+  render(<Example />);
+  await press.Tab();
+  expect(getDisclosure()).not.toHaveStyle({ height: "1px" });
+});
+
+test("tab to disclosure", async () => {
+  render(<Example />);
+  await press.ShiftTab();
+  expect(getDisclosure()).toHaveFocus();
+  expect(getDisclosure()).not.toHaveStyle({ height: "1px" });
+});
+
+test("show/hide hovercard on disclosure click", async () => {
+  render(<Example />);
+  await press.Tab();
+  expect(getHovercard()).not.toBeVisible();
+  await click(getDisclosure());
+  expect(getHovercard()).toBeVisible();
+  expect(getFollowLink()).toHaveFocus();
+  await click(getDisclosure());
+  expect(getHovercard()).not.toBeVisible();
+  expect(getDisclosure()).toHaveFocus();
+});
+
+test("show/hide hovercard on disclosure enter", async () => {
+  render(<Example />);
+  await press.Tab();
+  await press.Tab();
+  expect(getHovercard()).not.toBeVisible();
+  await press.Enter();
+  expect(getHovercard()).toBeVisible();
+  expect(getFollowLink()).toHaveFocus();
+  await press.ShiftTab();
+  await press.Enter();
+  expect(getHovercard()).not.toBeVisible();
+  expect(getDisclosure()).toHaveFocus();
+});
+
+test("show/hide hovercard on disclosure space", async () => {
+  render(<Example />);
+  await press.Tab();
+  await press.Tab();
+  expect(getHovercard()).not.toBeVisible();
+  await press.Space();
+  expect(getHovercard()).toBeVisible();
+  expect(getFollowLink()).toHaveFocus();
+  await press.ShiftTab();
+  await press.Space();
+  expect(getHovercard()).not.toBeVisible();
+  expect(getDisclosure()).toHaveFocus();
+});
+
+test("hide hovercard on escape", async () => {
+  render(<Example />);
+  await press.Tab();
+  await press.Tab();
+  await press.Enter();
+  expect(getHovercard()).toBeVisible();
+  await press.Escape();
+  expect(getHovercard()).not.toBeVisible();
+  expect(getAnchor()).toHaveFocus();
+});

--- a/packages/ariakit/src/hovercard/__examples__/hovercard/test.tsx
+++ b/packages/ariakit/src/hovercard/__examples__/hovercard/test.tsx
@@ -2,6 +2,7 @@ import {
   click,
   getByRole,
   hover,
+  press,
   render,
   sleep,
   waitFor,
@@ -9,13 +10,13 @@ import {
 import { axe } from "jest-axe";
 import Example from ".";
 
-const getAnchor = () => getByRole("link", { name: "@A11YProject" });
+const getAnchor = () => getByRole("link", { name: "@ariakitjs" });
 const getHovercard = () => getByRole("dialog", { hidden: true });
 
-const waitForHovercardToShow = (timeout = 1000) =>
+const waitForHovercardToShow = (timeout = 600) =>
   waitFor(expect(getHovercard()).toBeVisible, { timeout });
 
-const waitForHovercardToHide = (timeout = 1000) =>
+const waitForHovercardToHide = (timeout = 600) =>
   waitFor(expect(getHovercard()).not.toBeVisible, { timeout });
 
 test("a11y", async () => {
@@ -46,7 +47,7 @@ test("keep hovercard visible when it has focus", async () => {
   await waitForHovercardToShow();
   await click(getHovercard());
   await hover(baseElement);
-  await sleep(1000);
+  await sleep(600);
   await expect(getHovercard()).toBeVisible();
 });
 
@@ -61,6 +62,26 @@ test("keep hovercard visible when hovering out and in quickly", async () => {
   await hover(baseElement);
   await sleep(400);
   await hover(getHovercard());
-  await sleep(1000);
+  await sleep(600);
   await expect(getHovercard()).toBeVisible();
+});
+
+test("hide unfocused hovercard on escape", async () => {
+  render(<Example />);
+  await hover(getAnchor());
+  await waitForHovercardToShow();
+  await sleep();
+  await press.Escape();
+  expect(getHovercard()).not.toBeVisible();
+  expect(getAnchor()).not.toHaveFocus();
+});
+
+test("hide focused hovercard on escape", async () => {
+  render(<Example />);
+  await hover(getAnchor());
+  await waitForHovercardToShow();
+  await click(getHovercard());
+  await press.Escape();
+  expect(getHovercard()).not.toBeVisible();
+  expect(getAnchor()).toHaveFocus();
 });

--- a/packages/ariakit/src/hovercard/__utils/debug-polygon.ts
+++ b/packages/ariakit/src/hovercard/__utils/debug-polygon.ts
@@ -1,4 +1,4 @@
-import { Polygon } from "./__utils";
+import { Polygon } from "./polygon";
 
 function getPolygon() {
   const id = "debug-polygon";

--- a/packages/ariakit/src/hovercard/__utils/polygon.ts
+++ b/packages/ariakit/src/hovercard/__utils/polygon.ts
@@ -1,4 +1,4 @@
-import { HovercardState } from "./hovercard-state";
+import { HovercardState } from "../hovercard-state";
 
 export type Point = [number, number];
 export type Polygon = Point[];

--- a/packages/ariakit/src/hovercard/hovercard-anchor.ts
+++ b/packages/ariakit/src/hovercard/hovercard-anchor.ts
@@ -1,18 +1,21 @@
 import {
   MouseEvent as ReactMouseEvent,
-  SyntheticEvent,
   useCallback,
   useEffect,
   useRef,
 } from "react";
 import { addGlobalEventListener } from "ariakit-utils/events";
-import { useEventCallback, useForkRef } from "ariakit-utils/hooks";
+import {
+  useBooleanEventCallback,
+  useEventCallback,
+  useForkRef,
+} from "ariakit-utils/hooks";
 import {
   createComponent,
   createElement,
   createHook,
 } from "ariakit-utils/system";
-import { As, Props } from "ariakit-utils/types";
+import { As, BooleanOrCallback, Props } from "ariakit-utils/types";
 import { FocusableOptions, useFocusable } from "../focusable";
 import { HovercardState } from "./hovercard-state";
 
@@ -30,7 +33,12 @@ import { HovercardState } from "./hovercard-state";
  * ```
  */
 export const useHovercardAnchor = createHook<HovercardAnchorOptions>(
-  ({ state, showOnMouseMove = true, ...props }) => {
+  ({ state, showOnHover = true, ...props }) => {
+    const disabled =
+      props.disabled ||
+      props["aria-disabled"] === true ||
+      props["aria-disabled"] === "true";
+
     const showTimeoutRef = useRef(0);
 
     // Clear the show timeout if the anchor is unmounted
@@ -52,41 +60,29 @@ export const useHovercardAnchor = createHook<HovercardAnchorOptions>(
     }, [state.anchorRef]);
 
     const onMouseMoveProp = useEventCallback(props.onMouseMove);
+    const showOnHoverProp = useBooleanEventCallback(showOnHover);
 
     const onMouseMove = useCallback(
       (event: ReactMouseEvent<HTMLAnchorElement>) => {
         state.anchorRef.current = event.currentTarget;
         onMouseMoveProp(event);
+        if (disabled) return;
         if (event.defaultPrevented) return;
-        if (!showOnMouseMove) return;
-        if (!showTimeoutRef.current) {
-          showTimeoutRef.current = window.setTimeout(() => {
-            showTimeoutRef.current = 0;
-            state.show();
-          }, state.showTimeout);
-        }
+        if (showTimeoutRef.current) return;
+        if (!showOnHoverProp(event)) return;
+        showTimeoutRef.current = window.setTimeout(() => {
+          showTimeoutRef.current = 0;
+          state.show();
+        }, state.showTimeout);
       },
       [
         state.anchorRef,
         onMouseMoveProp,
-        showOnMouseMove,
+        disabled,
+        showOnHoverProp,
         state.show,
         state.showTimeout,
       ]
-    );
-
-    const onFocusVisibleProp = useEventCallback(props.onFocusVisible);
-
-    // When the anchor receives keyboard focus, the hovercard disclosure
-    // element should be visible so keyboard users can use it to access the
-    // hovercard contents.
-    const onFocusVisible = useCallback(
-      (event: SyntheticEvent<HTMLAnchorElement>) => {
-        onFocusVisibleProp(event);
-        if (event.defaultPrevented) return;
-        state.setDisclosureVisible(true);
-      },
-      [onFocusVisibleProp, state.setDisclosureVisible]
     );
 
     props = {
@@ -95,7 +91,7 @@ export const useHovercardAnchor = createHook<HovercardAnchorOptions>(
       onMouseMove,
     };
 
-    props = useFocusable({ ...props, onFocusVisible });
+    props = useFocusable(props);
 
     return props;
   }
@@ -128,7 +124,7 @@ export type HovercardAnchorOptions<T extends As = "a"> = FocusableOptions<T> & {
    * Whether to show the hovercard on mouse move.
    * @default true
    */
-  showOnMouseMove?: boolean;
+  showOnHover?: BooleanOrCallback<ReactMouseEvent<HTMLElement>>;
 };
 
 export type HovercardAnchorProps<T extends As = "a"> = Props<

--- a/packages/ariakit/src/hovercard/hovercard-disclosure.tsx
+++ b/packages/ariakit/src/hovercard/hovercard-disclosure.tsx
@@ -70,14 +70,12 @@ export const useHovercardDisclosure = createHook<HovercardDisclosureOptions>(
     useEffect(() => {
       const anchor = state.anchorRef.current;
       if (!anchor) return;
-      const onFocus = () => {
-        requestAnimationFrame(() => {
-          if (!anchor.hasAttribute("data-focus-visible")) return;
-          setVisible(true);
-        });
-      };
-      anchor.addEventListener("focus", onFocus);
-      return () => anchor.removeEventListener("focus", onFocus);
+      const observer = new MutationObserver(() => {
+        if (!anchor.hasAttribute("data-focus-visible")) return;
+        setVisible(true);
+      });
+      observer.observe(anchor, { attributeFilter: ["data-focus-visible"] });
+      return () => observer.disconnect();
     }, [state.anchorRef]);
 
     const onClickProp = useEventCallback(props.onClick);

--- a/packages/ariakit/src/hovercard/hovercard-disclosure.tsx
+++ b/packages/ariakit/src/hovercard/hovercard-disclosure.tsx
@@ -1,4 +1,10 @@
-import { MouseEvent, useCallback, useEffect } from "react";
+import {
+  MouseEvent,
+  FocusEvent as ReactFocusEvent,
+  useCallback,
+  useEffect,
+  useState,
+} from "react";
 import { contains } from "ariakit-utils/dom";
 import { addGlobalEventListener } from "ariakit-utils/events";
 import { useEventCallback, useForkRef } from "ariakit-utils/hooks";
@@ -12,6 +18,7 @@ import {
   DialogDisclosureOptions,
   useDialogDisclosure,
 } from "../dialog/dialog-disclosure";
+import { useVisuallyHidden } from "../visually-hidden";
 import { HovercardState } from "./hovercard-state";
 
 /**
@@ -32,31 +39,48 @@ import { HovercardState } from "./hovercard-state";
  */
 export const useHovercardDisclosure = createHook<HovercardDisclosureOptions>(
   ({ state, ...props }) => {
-    const onClickProp = useEventCallback(props.onClick);
+    const [visible, setVisible] = useState(false);
 
     // Listens to blur events on the whole document and hides the hovercard
-    // disclosure if whether the hovercard or the disclosure loses focus. We
-    // don't need to listen to blur events on the anchor element because we are
-    // already showing the disclosure when the anchor element is focused.
+    // disclosure if either the hovercard, the anchor or the disclosure button
+    // itself loses focus.
     useEffect(() => {
-      if (!state.disclosureVisible) return;
+      if (!visible) return;
       const onBlur = (event: FocusEvent) => {
-        const nextActiveElement = event.relatedTarget as Node | null;
+        const nextActiveElement = event.relatedTarget as Element | null;
         if (nextActiveElement) {
+          const anchor = state.anchorRef.current;
           const popover = state.popoverRef.current;
           const disclosure = state.disclosureRef.current;
+          if (anchor && contains(anchor, nextActiveElement)) return;
           if (popover && contains(popover, nextActiveElement)) return;
           if (disclosure && contains(disclosure, nextActiveElement)) return;
+          // When the portal prop is set to true on the Hovercard component,
+          // it's going to render focus trap elements outside of the portal.
+          // These elements may transfer focus to the disclosure button, so we
+          // also ignore them here.
+          if (nextActiveElement.hasAttribute("data-focus-trap")) return;
         }
-        state.setDisclosureVisible(false);
+        setVisible(false);
       };
       return addGlobalEventListener("focusout", onBlur, true);
-    }, [
-      state.disclosureVisible,
-      state.popoverRef,
-      state.disclosureRef,
-      state.setDisclosureVisible,
-    ]);
+    }, [visible, state.anchorRef, state.popoverRef, state.disclosureRef]);
+
+    // Shows the hovercard disclosure when the anchor receives keyboard focus.
+    useEffect(() => {
+      const anchor = state.anchorRef.current;
+      if (!anchor) return;
+      const onFocus = () => {
+        requestAnimationFrame(() => {
+          if (!anchor.hasAttribute("data-focus-visible")) return;
+          setVisible(true);
+        });
+      };
+      anchor.addEventListener("focus", onFocus);
+      return () => anchor.removeEventListener("focus", onFocus);
+    }, [state.anchorRef]);
+
+    const onClickProp = useEventCallback(props.onClick);
 
     // By default, hovercards don't receive focus when they are shown. When the
     // disclosure element is clicked, though, we want it to behave like a
@@ -70,26 +94,53 @@ export const useHovercardDisclosure = createHook<HovercardDisclosureOptions>(
       [onClickProp, state.setAutoFocusOnShow]
     );
 
+    const onFocusProp = useEventCallback(props.onFocus);
+
+    // Since the disclosure button is only visually hidden, it may receive focus
+    // when the user tabs to it. So we make sure it's visible when that happens.
+    const onFocus = useCallback(
+      (event: ReactFocusEvent<HTMLButtonElement>) => {
+        onFocusProp(event);
+        if (event.defaultPrevented) return;
+        setVisible(true);
+      },
+      [onFocusProp]
+    );
+
+    const { style } = useVisuallyHidden();
+
+    if (!visible) {
+      props = {
+        ...props,
+        style: {
+          ...style,
+          ...props.style,
+        },
+      };
+    }
+
     const children = (
       <svg
-        aria-label="More information"
+        display="block"
+        fill="none"
         stroke="currentColor"
-        fill="currentColor"
-        strokeWidth="0"
-        viewBox="0 0 24 24"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.5pt"
+        viewBox="0 0 16 16"
         height="1em"
         width="1em"
       >
-        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"></path>
+        <polyline points="4,6 8,10 12,6" />
       </svg>
     );
 
     props = {
-      hidden: !state.disclosureVisible,
       children,
       ...props,
       ref: useForkRef(state.disclosureRef, props.ref),
       onClick,
+      onFocus,
     };
 
     props = useDialogDisclosure({ state, ...props });

--- a/packages/ariakit/src/hovercard/hovercard-state.ts
+++ b/packages/ariakit/src/hovercard/hovercard-state.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { SetState } from "ariakit-utils/types";
 import {
   PopoverState,
@@ -23,22 +23,16 @@ export function useHovercardState({
   ...props
 }: HovercardStateProps = {}): HovercardState {
   const [autoFocusOnShow, setAutoFocusOnShow] = useState(false);
-  const [disclosureVisible, setDisclosureVisible] = useState(false);
-  const disclosureRef = useRef<HTMLElement | null>(null);
-
   const popover = usePopoverState({ placement, ...props });
 
   const state = useMemo(
     () => ({
       ...popover,
-      disclosureRef,
       timeout,
       showTimeout,
       hideTimeout,
       autoFocusOnShow,
       setAutoFocusOnShow,
-      disclosureVisible,
-      setDisclosureVisible,
     }),
     [
       popover,
@@ -47,8 +41,6 @@ export function useHovercardState({
       hideTimeout,
       autoFocusOnShow,
       setAutoFocusOnShow,
-      disclosureVisible,
-      setDisclosureVisible,
     ]
   );
 
@@ -82,15 +74,6 @@ export type HovercardState = PopoverState & {
    * Sets `autoFocusOnShow`.
    */
   setAutoFocusOnShow: SetState<HovercardState["autoFocusOnShow"]>;
-  /**
-   * Whether the popover disclosure is visible.
-   * @default false
-   */
-  disclosureVisible: boolean;
-  /**
-   * Sets `disclosureVisible`.
-   */
-  setDisclosureVisible: SetState<HovercardState["disclosureVisible"]>;
 };
 
 export type HovercardStateProps = PopoverStateProps &

--- a/packages/ariakit/src/menu/menu-button.ts
+++ b/packages/ariakit/src/menu/menu-button.ts
@@ -171,7 +171,7 @@ export const useMenuButton = createHook<MenuButtonOptions>(
 
     props = useHovercardAnchor({
       state,
-      showOnMouseMove: hasParentMenu,
+      showOnHover: hasParentMenu,
       focusable,
       accessibleWhenDisabled,
       ...props,

--- a/packages/ariakit/src/menu/menu.ts
+++ b/packages/ariakit/src/menu/menu.ts
@@ -71,7 +71,7 @@ export const useMenu = createHook<MenuOptions>(
     props = useHovercard({
       state,
       autoFocusOnShow: false,
-      hideOnMouseLeave: hasParentMenu,
+      hideOnHoverOutside: hasParentMenu,
       ...props,
       portalRef,
       // If it's a sub menu, it should behave like a modal dialog, nor display a


### PR DESCRIPTION
This PR introduces a series of improvements on the `Hovercard` components:

- `showOnMouseMove` has been replaced by `showOnHover`.
- `HovercardDisclosure` now controls its own visibility by adding DOM event handlers to the other hovercard elements.
- `hideOnMouseLeave` has been replaced by `hideOnHoverOutside`.
- There's a new `disablePointerEventsOnApproach` prop on `Hovercard` that controls whether pointer/mouse events should be disabled when the mouse is moving towards the hovercard.
- Support for nested hovercards (required for nested submenus).