### PR TITLE
feat: Add FormReset Button

### DIFF
--- a/packages/ariakit/src/form/form-reset.ts
+++ b/packages/ariakit/src/form/form-reset.ts
@@ -1,0 +1,81 @@
+import { MouseEvent, useCallback } from "react";
+import { useEventCallback } from "ariakit-utils/hooks";
+import { useStore } from "ariakit-utils/store";
+import {
+  createComponent,
+  createElement,
+  createHook,
+} from "ariakit-utils/system";
+import { As, Props } from "ariakit-utils/types";
+import { ButtonOptions, useButton } from "../button";
+import { FormContext } from "./__utils";
+import { FormState } from "./form-state";
+
+/**
+ * A component hook that returns props that can be passed to `Role` or any other
+ * Ariakit component to render a reset buttom in a form.
+ * @see https://ariakit.org/components/form
+ * @example
+ * ```jsx
+ * const state = useFormState();
+ * const props = useFormReset({ state });
+ * <Form state={state}>
+ *   <Role {...props}>Reset</Role>
+ * </Form>
+ * ```
+ */
+export const useFormReset = createHook<FormResetOptions>(
+  ({ state, ...props }) => {
+    state = useStore(state || FormContext, [`submitting`]);
+
+    const onClickProp = useEventCallback(props.onClick);
+
+    const onClick = useCallback(
+      (event: MouseEvent<HTMLButtonElement>) => {
+        onClickProp(event);
+        if (event.defaultPrevented) return;
+        state?.reset();
+      },
+      [onClickProp, state?.reset]
+    );
+
+    props = {
+      type: "reset",
+      disabled: state?.submitting,
+      ...props,
+    };
+
+    return useButton({
+      ...props,
+      onClick,
+    });
+  }
+);
+
+/**
+ * A component that renders a reset buttom in a form.
+ * @see https://ariakit.org/components/form
+ * @example
+ * ```jsx
+ * const form = useFormState();
+ * <Form state={form}>
+ *   <FormReset>Reset</FormReset>
+ * </Form>
+ * ```
+ */
+export const FormReset = createComponent<FormResetOptions>((props) => {
+  const htmlProps = useFormReset(props);
+  return createElement(`button`, htmlProps);
+});
+
+export type FormResetOptions<T extends As = "button"> = ButtonOptions<T> & {
+  /**
+   * Object returned by the `useFormState` hook. If not provided, the parent
+   * `Form` component's context will be used.
+   */
+  state?: FormState;
+};
+
+export type FormResetProps<T extends As = "button"> = Props<
+  FormResetOptions<T>
+>;

--- a/packages/ariakit/src/form/index.ts
+++ b/packages/ariakit/src/form/index.ts
@@ -10,6 +10,7 @@ export * from "./form-push";
 export * from "./form-radio-group";
 export * from "./form-radio";
 export * from "./form-remove";
+export * from "./form-reset";
 export * from "./form-state";
 export * from "./form-submit";
 export * from "./form";


### PR DESCRIPTION
Looked at the existing implementations of FormSubmit and FormRemove and threw this together. Ergonomically it's nice to have a pre-wired Reset/Cancel button that hooks into the Form context just like the Submit button does.

To implement this in userland, you would need to either try to import the correct internal FormContext, which is potentially buggy/unsafe, or you would need to explicitly pass in the form state object.

If there's anything you think that is missing, please let me know and I'll follow up with a fix!