### PR TITLE
chore: Add jest-fail-on-console lib

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,11 +1,14 @@
 // @ts-check
 const jestDOMMatchers = require("@testing-library/jest-dom/matchers");
 const { toHaveNoViolations: axeMatchers } = require("jest-axe");
+const failOnConsole = require("jest-fail-on-console");
 const {
   matcherHint,
   printReceived,
   printExpected,
 } = require("jest-matcher-utils");
+
+failOnConsole();
 
 /**
  * Consider [aria-activedescendant="${id}"] #${id} as the focused element.

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "husky": "7.0.4",
         "jest": "27.5.1",
         "jest-axe": "6.0.0",
+        "jest-fail-on-console": "2.2.3",
         "jest-matcher-utils": "27.5.1",
         "lerna": "4.0.0",
         "lint-staged": "12.3.7",
@@ -10587,6 +10588,15 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-fail-on-console": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/jest-fail-on-console/-/jest-fail-on-console-2.2.3.tgz",
+      "integrity": "sha512-fwSslH/Stq1NqN/z7PMYzUuHZxqimPCJOjj3D3RovpYCPXj/2WRiradhpVUm+tsSw4zW4MB9iJcXz6ggmw2nEg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0"
       }
     },
     "node_modules/jest-get-type": {
@@ -25971,6 +25981,15 @@
         "@types/node": "*",
         "jest-mock": "^27.5.1",
         "jest-util": "^27.5.1"
+      }
+    },
+    "jest-fail-on-console": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/jest-fail-on-console/-/jest-fail-on-console-2.2.3.tgz",
+      "integrity": "sha512-fwSslH/Stq1NqN/z7PMYzUuHZxqimPCJOjj3D3RovpYCPXj/2WRiradhpVUm+tsSw4zW4MB9iJcXz6ggmw2nEg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0"
       }
     },
     "jest-get-type": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "husky": "7.0.4",
     "jest": "27.5.1",
     "jest-axe": "6.0.0",
+    "jest-fail-on-console": "2.2.3",
     "jest-matcher-utils": "27.5.1",
     "lerna": "4.0.0",
     "lint-staged": "12.3.7",


### PR DESCRIPTION
This change adds [`jest-fail-on-console`](https://github.com/ValentinH/jest-fail-on-console), a lib to prevent unexpected error logs.

`jest-fail-on-console` is particularly useful since jest doesn't automatically fail when an error log happens, and especially for large codebases, this can end up being a problem as it gets easier to introduce overloaded tests outputs.