### PR TITLE
fix: Fix modal `Dialog` not opening when triggered by `MenuItem`

### DIFF
--- a/packages/ariakit/src/composite/composite-hover.ts
+++ b/packages/ariakit/src/composite/composite-hover.ts
@@ -71,6 +71,7 @@ export const useCompositeHover = createHook<CompositeHoverOptions>(
       // may lose some events if this component is unmounted, but others are
       // still mounted.
       addGlobalEventListener("mousemove", setMouseMoving, true);
+      addGlobalEventListener("mouseup", resetMouseMoving, true);
       addGlobalEventListener("keydown", resetMouseMoving, true);
       addGlobalEventListener("scroll", resetMouseMoving, true);
     }, []);

--- a/packages/ariakit/src/composite/composite-hover.ts
+++ b/packages/ariakit/src/composite/composite-hover.ts
@@ -71,6 +71,8 @@ export const useCompositeHover = createHook<CompositeHoverOptions>(
       // may lose some events if this component is unmounted, but others are
       // still mounted.
       addGlobalEventListener("mousemove", setMouseMoving, true);
+      // See https://github.com/ariakit/ariakit/issues/1137
+      addGlobalEventListener("mousedown", resetMouseMoving, true);
       addGlobalEventListener("mouseup", resetMouseMoving, true);
       addGlobalEventListener("keydown", resetMouseMoving, true);
       addGlobalEventListener("scroll", resetMouseMoving, true);


### PR DESCRIPTION
Fixes #1137 