### PR TITLE
Add getAnchorRect prop to usePopoverState

### DIFF
--- a/.changeset/popover-state-get-anchor-rect.md
+++ b/.changeset/popover-state-get-anchor-rect.md
@@ -1,0 +1,20 @@
+---
+"ariakit": major
+---
+
+Replaced `defaultAnchorRect`, `anchorRect` and `setAnchorRect` props on `usePopoverState` by a single `getAnchorRect` prop. ([#1252](https://github.com/ariakit/ariakit/pull/1252))
+
+Before:
+
+```js
+const popover = usePopoverState();
+
+// inside an effect or event handler
+popover.setAnchorRect({ x: 10, y: 10 });
+```
+
+After:
+
+```js
+const popover = usePopoverState({ getAnchorRect: () => ({ x: 10, y: 10 }) });
+```

--- a/packages/ariakit/src/menu/__examples__/menu-context-menu/index.tsx
+++ b/packages/ariakit/src/menu/__examples__/menu-context-menu/index.tsx
@@ -1,14 +1,16 @@
+import { useState } from "react";
 import { Menu, MenuItem, MenuSeparator, useMenuState } from "ariakit/menu";
 import "./style.css";
 
 export default function Example() {
-  const menu = useMenuState();
+  const [anchorRect, setAnchorRect] = useState({ x: 0, y: 0 });
+  const menu = useMenuState({ getAnchorRect: () => anchorRect });
   return (
     <div
       className="wrapper"
       onContextMenu={(event) => {
         event.preventDefault();
-        menu.setAnchorRect({ x: event.clientX, y: event.clientY });
+        setAnchorRect({ x: event.clientX, y: event.clientY });
         menu.show();
       }}
     >

--- a/packages/ariakit/src/popover/popover-disclosure.tsx
+++ b/packages/ariakit/src/popover/popover-disclosure.tsx
@@ -33,10 +33,9 @@ export const usePopoverDisclosure = createHook<PopoverDisclosureOptions>(
     const onClick = useCallback(
       (event: MouseEvent<HTMLButtonElement>) => {
         state.anchorRef.current = event.currentTarget;
-        state.setAnchorRect(null);
         onClickProp(event);
       },
-      [state.anchorRef, state.setAnchorRect, onClickProp]
+      [state.anchorRef, onClickProp]
     );
 
     props = useWrapElement(


### PR DESCRIPTION
This PR adds a `getAnchorRect` prop to the `usePopoverState` hook and replaces the existing `defaultAnchorRect`/`anchorRect`/`setAnchorRect` props that don't work in certain situations. For example, due to how React updates work, there's always a delay between `setAnchorRect` and the actual update on the UI.