### PR TITLE
Fix Menu initial focus

### DIFF
--- a/.changeset/menu-initial-focus.md
+++ b/.changeset/menu-initial-focus.md
@@ -1,0 +1,5 @@
+---
+"ariakit": patch
+---
+
+Fixed `Menu` initial focus. ([#1260](https://github.com/ariakit/ariakit/pull/1260))

--- a/.changeset/menu-initial-focus.md
+++ b/.changeset/menu-initial-focus.md
@@ -2,4 +2,4 @@
 "ariakit": patch
 ---
 
-Fixed `Menu` initial focus. ([#1260](https://github.com/ariakit/ariakit/pull/1260))
+Fixed `Menu` initial focus when all the menu items are re-mounted. ([#1260](https://github.com/ariakit/ariakit/pull/1260))

--- a/packages/ariakit/src/menu/__examples__/menu-bar/test.tsx
+++ b/packages/ariakit/src/menu/__examples__/menu-bar/test.tsx
@@ -85,6 +85,10 @@ test("show/hide on key down", async () => {
   expect(getMenuItem("Edit")).toHaveFocus();
   await press.ArrowUp();
   expect(getMenuItem("Emoji & Symbols")).toHaveFocus();
+  await press.ArrowLeft();
+  await press.ArrowRight();
+  await press.ArrowUp();
+  expect(getMenuItem("Emoji & Symbols")).toHaveFocus();
   await type("f");
   expect(getMenuItem("Find")).toHaveFocus();
   expect(getMenu("Find")).not.toBeInTheDocument();

--- a/packages/ariakit/src/menu/menu.ts
+++ b/packages/ariakit/src/menu/menu.ts
@@ -76,36 +76,37 @@ export const useMenu = createHook<MenuOptions>(
       ...props,
     });
 
-    const hasItems = !!state.items.length;
     const [initialFocusRef, setInitialFocusRef] =
       useState<RefObject<HTMLElement>>();
 
+    // Sets the initial focus ref.
     useEffect(() => {
-      if (!hasItems) return;
-      if (!state.mounted) return;
-      setInitialFocusRef(
-        state.initialFocus === "first"
-          ? getItemRefById(state.items, state.first())
-          : state.initialFocus === "last"
-          ? getItemRefById(state.items, state.last())
-          : state.baseRef
-      );
-      // We're intentionally only listening to hasItems here and not to
-      // state.items, state.first and state.last, because we don't want to set
-      // the initial focus ref again whenever the items change, but only when
-      // the menu and the items have been mounted.
-    }, [hasItems, state.mounted, state.initialFocus, state.baseRef]);
-
-    const autoFocusOnShow =
-      props.autoFocusOnShow != null
-        ? props.autoFocusOnShow
-        : state.autoFocusOnShow || !!props.modal;
+      setInitialFocusRef((prevInitialFocusRef) => {
+        if (!state.autoFocusOnShow) return undefined;
+        if (prevInitialFocusRef) return prevInitialFocusRef;
+        switch (state.initialFocus) {
+          case "first":
+            return getItemRefById(state.items, state.first());
+          case "last":
+            return getItemRefById(state.items, state.last());
+          default:
+            return state.baseRef;
+        }
+      });
+    }, [
+      state.autoFocusOnShow,
+      state.initialFocus,
+      state.items,
+      state.first,
+      state.last,
+      state.baseRef,
+    ]);
 
     props = useHovercard({
       state,
       initialFocusRef,
+      autoFocusOnShow: state.autoFocusOnShow || !!props.modal,
       ...props,
-      autoFocusOnShow,
       hideOnHoverOutside: (event) => {
         if (typeof hideOnHoverOutside === "function") {
           return hideOnHoverOutside(event);


### PR DESCRIPTION
This PR fixes an inconsistency in the initial focus of the Menu component (especially when we unmount and re-mount all the menu items). See `menu-combobox` example.