### PR TITLE
Fix Dialog body scroll on iOS

### DIFF
--- a/.changeset/dialog-prevent-body-scroll-ios.md
+++ b/.changeset/dialog-prevent-body-scroll-ios.md
@@ -1,0 +1,5 @@
+---
+"ariakit": patch
+---
+
+Fixed `Dialog` not correctly preventing body scroll on iOS. ([#1271](https://github.com/ariakit/ariakit/pull/1271))

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,4 +1,3 @@
-// @ts-check
 const jestDOMMatchers = require("@testing-library/jest-dom/matchers");
 const { toHaveNoViolations: axeMatchers } = require("jest-axe");
 const failOnConsole = require("jest-fail-on-console");

--- a/packages/ariakit/src/dialog/__utils/use-prevent-body-scroll.ts
+++ b/packages/ariakit/src/dialog/__utils/use-prevent-body-scroll.ts
@@ -1,23 +1,52 @@
+// Based on https://github.com/floating-ui/floating-ui/blob/01aeb53ad7e4d105469b7fdc5057c067b6767a8b/packages/react-dom-interactions/src/FloatingOverlay.tsx
 import { useSafeLayoutEffect } from "ariakit-utils/hooks";
+
+function assignStyle(
+  element: HTMLElement | null | undefined,
+  style: Partial<CSSStyleDeclaration>
+) {
+  if (!element) return () => {};
+  const previousStyle = element.style.cssText;
+  Object.assign(element.style, style);
+  return () => {
+    element.style.cssText = previousStyle;
+  };
+}
 
 export function usePreventBodyScroll(enabled?: boolean) {
   useSafeLayoutEffect(() => {
     if (!enabled) return;
-    const { documentElement } = document;
+    const { documentElement, body } = document;
     const scrollbarWidth = window.innerWidth - documentElement.clientWidth;
-    const previousOverflow = documentElement.style.overflow;
-    const previousPaddingRight = documentElement.style.paddingRight;
+    const scrollX = window.pageXOffset;
+    const scrollY = window.pageYOffset;
+
+    // RTL <body> scrollbar
+    const documentLeft = documentElement.getBoundingClientRect().left;
+    const scrollbarX = Math.round(documentLeft) + documentElement.scrollLeft;
+    const paddingProp = scrollbarX ? "paddingLeft" : "paddingRight";
+
+    const restoreStyle = assignStyle(body, {
+      position: "fixed",
+      overflow: "hidden",
+      top: `-${scrollY}px`,
+      left: `-${scrollX}px`,
+      right: "0",
+      [paddingProp]: `${scrollbarWidth}px`,
+    });
+
     const previousScrollbarWidth =
       documentElement.style.getPropertyValue("--scrollbar-width");
-    documentElement.style.overflow = "hidden";
-    documentElement.style.paddingRight = `${scrollbarWidth}px`;
+
     documentElement.style.setProperty(
       "--scrollbar-width",
       `${scrollbarWidth}px`
     );
+
     return () => {
-      documentElement.style.overflow = previousOverflow;
-      documentElement.style.paddingRight = previousPaddingRight;
+      restoreStyle();
+      window.scrollTo(scrollX, scrollY);
+
       if (previousScrollbarWidth) {
         documentElement.style.setProperty(
           "--scrollbar-width",

--- a/packages/ariakit/src/dialog/__utils/use-prevent-body-scroll.ts
+++ b/packages/ariakit/src/dialog/__utils/use-prevent-body-scroll.ts
@@ -45,8 +45,10 @@ export function usePreventBodyScroll(enabled?: boolean) {
 
     return () => {
       restoreStyle();
-      window.scrollTo(scrollX, scrollY);
-
+      // istanbul ignore next: JSDOM doesn't implement window.scrollTo
+      if (process.env.NODE_ENV !== "test") {
+        window.scrollTo(scrollX, scrollY);
+      }
       if (previousScrollbarWidth) {
         documentElement.style.setProperty(
           "--scrollbar-width",


### PR DESCRIPTION
This PR improves the "prevent body scroll" logic on `Dialog`.

Closes #1085