### PR TITLE
Stop shipping src folder with the npm packages

### DIFF
--- a/.changeset/npmignore-src-folder.md
+++ b/.changeset/npmignore-src-folder.md
@@ -1,0 +1,8 @@
+---
+"ariakit": patch
+"ariakit-playground": patch
+"ariakit-test-utils": patch
+"ariakit-utils": patch
+---
+
+Stopped shipping the `src` folder with the npm package to reduce the size of the package. ([#1272](https://github.com/ariakit/ariakit/pull/1272))

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,10 @@
 {
-  "packages": ["packages/ariakit*"],
+  "packages": [
+    "packages/ariakit-utils",
+    "packages/ariakit",
+    "packages/ariakit-test-utils",
+    "packages/ariakit-playground"
+  ],
   "buildCommand": "build",
   "sandboxes": ["m4n32vjkoj"]
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,10 +1,5 @@
 {
-  "packages": [
-    "packages/ariakit-utils",
-    "packages/ariakit",
-    "packages/ariakit-test-utils",
-    "packages/ariakit-playground"
-  ],
+  "packages": ["packages/ariakit*"],
   "buildCommand": "build",
   "sandboxes": ["m4n32vjkoj"],
   "node": "16"

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,10 +1,11 @@
 {
-  "publishDirectory": {
-    "ariakit-utils": "packages/ariakit-utils",
-    "ariakit": "packages/ariakit",
-    "ariakit-test-utils": "packages/ariakit-test-utils",
-    "ariakit-playground": "packages/ariakit-playground"
-  },
+  "packages": [
+    "packages/ariakit-utils",
+    "packages/ariakit",
+    "packages/ariakit-test-utils",
+    "packages/ariakit-playground"
+  ],
   "buildCommand": "build",
-  "sandboxes": ["m4n32vjkoj"]
+  "sandboxes": ["m4n32vjkoj"],
+  "node": "16"
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,10 +1,10 @@
 {
-  "packages": [
-    "packages/ariakit-utils",
-    "packages/ariakit",
-    "packages/ariakit-test-utils",
-    "packages/ariakit-playground"
-  ],
+  "publishDirectory": {
+    "ariakit-utils": "packages/ariakit-utils",
+    "ariakit": "packages/ariakit",
+    "ariakit-test-utils": "packages/ariakit-test-utils",
+    "ariakit-playground": "packages/ariakit-playground"
+  },
   "buildCommand": "build",
   "sandboxes": ["m4n32vjkoj"]
 }

--- a/packages/ariakit-playground/.npmignore
+++ b/packages/ariakit-playground/.npmignore
@@ -1,4 +1,6 @@
 coverage
+src
+tsconfig.json
 *.log
 *.config.js
 *.lock

--- a/packages/ariakit-test-utils/.gitignore
+++ b/packages/ariakit-test-utils/.gitignore
@@ -8,6 +8,7 @@
 /fire-event
 /focus
 /hover
+/mock-get-client-rects
 /press
 /render
 /screen

--- a/packages/ariakit-test-utils/.npmignore
+++ b/packages/ariakit-test-utils/.npmignore
@@ -1,4 +1,6 @@
 coverage
+src
+tsconfig.json
 *.log
 *.config.js
 *.lock

--- a/packages/ariakit-utils/.npmignore
+++ b/packages/ariakit-utils/.npmignore
@@ -1,4 +1,6 @@
 coverage
+src
+tsconfig.json
 *.log
 *.config.js
 *.lock

--- a/packages/ariakit/.npmignore
+++ b/packages/ariakit/.npmignore
@@ -1,4 +1,6 @@
 coverage
+src
+tsconfig.json
 *.log
 *.config.js
 *.lock


### PR DESCRIPTION
This is so we can reduce the downloadable size of the packages, which will get even more prominent as we add more examples and tests.