### PR TITLE
Update useStoreProvider to return a more accurate type

### DIFF
--- a/.changeset/utils-use-store-provider-return-type.md
+++ b/.changeset/utils-use-store-provider-return-type.md
@@ -1,0 +1,5 @@
+---
+"ariakit-utils": patch
+---
+
+Adjusted the return type of `useStoreProvider` to be more accurate. ([#1367](https://github.com/ariakit/ariakit/pull/1367))

--- a/packages/ariakit-utils/src/store.tsx
+++ b/packages/ariakit-utils/src/store.tsx
@@ -173,7 +173,7 @@ export function useStoreProvider<P, S>(
 
   const initialContext = getInitialContext(context);
 
-  props = useWrapElement(
+  return useWrapElement(
     props,
     (element) => {
       if (value && initialContext) {
@@ -190,8 +190,6 @@ export function useStoreProvider<P, S>(
     },
     [value, initialContext, state, context]
   );
-
-  return props;
 }
 
 /**


### PR DESCRIPTION
While writing tests for the store utils, I got confused by the return type of `useStoreProvider`. TS was saying that `wrapElement` might be undefined. 
<img width="359" alt="image" src="https://user-images.githubusercontent.com/13336976/168836134-d6a89a3a-6d4d-4ce6-ad4f-ae26699e4d8e.png">
However, when inspecting the way `useWrapElement` works and its types, I was pretty sure there was no way it could be undefined and its types agreed.
<img width="434" alt="image" src="https://user-images.githubusercontent.com/13336976/168836332-bb0f34dd-36c9-4a6d-894a-b4eceef2195a.png">
So after adjusting things a bit I realized it was because the types were being inherited from the `useStoreProvider` argument types. Specifically `{ state, ...props }: P & { state?: S; wrapElement?: WrapElement },`. This was because props was being redefined. I updated the code to simply return `useWrapElement` however, if there was a reason to keep it closer to the previous code, defining a new variable (Ex. `newProps`) would have the same result. 

I didn't update any changeset files because I wasn't sure if this warranted that (these being internal utils and it being more of a TS thing than anything functional)