### PR TITLE
Pass hidden prop to DialogBackdrop

### DIFF
--- a/.changeset/dialog-backdrop-hidden.md
+++ b/.changeset/dialog-backdrop-hidden.md
@@ -1,0 +1,17 @@
+---
+"ariakit": minor
+---
+
+The `hidden` prop passed to `Dialog` is now inherited by the internal `DialogBackdrop` component. ([#1387](https://github.com/ariakit/ariakit/pull/1387))
+
+Before, if we wanted to pass `hidden={false}` to both the dialog and the backdrop components, we would have to do this (still works):
+
+```jsx
+<Dialog hidden={false} backdropProps={{ hidden: false }} />
+```
+
+Now, the `backdropProps` is not necessary anymore:
+
+```jsx
+<Dialog hidden={false} />
+```

--- a/packages/ariakit/src/dialog/__utils/dialog-backdrop.tsx
+++ b/packages/ariakit/src/dialog/__utils/dialog-backdrop.tsx
@@ -19,6 +19,7 @@ type DialogBackdropProps = Pick<
   | "backdropProps"
   | "hideOnInteractOutside"
   | "hideOnEscape"
+  | "hidden"
 > & {
   children?: ReactNode;
 };
@@ -29,6 +30,7 @@ export function DialogBackdrop({
   backdropProps,
   hideOnInteractOutside = true,
   hideOnEscape = true,
+  hidden,
   children,
 }: DialogBackdropProps) {
   const ref = useRef<HTMLDivElement>(null);
@@ -86,6 +88,7 @@ export function DialogBackdrop({
     id: undefined,
     role: "presentation",
     tabIndex: -1,
+    hidden,
     ...backdropProps,
     ref: useForkRef(backdropProps?.ref, ref),
     onClick,

--- a/packages/ariakit/src/dialog/dialog.tsx
+++ b/packages/ariakit/src/dialog/dialog.tsx
@@ -416,6 +416,8 @@ export const useDialog = createHook<DialogOptions>(
       [state.visible, modal, visibleModals]
     );
 
+    const hiddenProp = props.hidden;
+
     // Wraps the dialog with a backdrop element if the backdrop prop is truthy.
     props = useWrapElement(
       props,
@@ -428,6 +430,7 @@ export const useDialog = createHook<DialogOptions>(
               backdropProps={backdropProps}
               hideOnInteractOutside={hideOnInteractOutside}
               hideOnEscape={hideOnEscape}
+              hidden={hiddenProp}
             >
               {element}
             </DialogBackdrop>
@@ -435,7 +438,14 @@ export const useDialog = createHook<DialogOptions>(
         }
         return element;
       },
-      [state, backdrop, backdropProps, hideOnInteractOutside, hideOnEscape]
+      [
+        state,
+        backdrop,
+        backdropProps,
+        hideOnInteractOutside,
+        hideOnEscape,
+        hiddenProp,
+      ]
     );
 
     const [headingId, setHeadingId] = useState<string>();


### PR DESCRIPTION
When explicitly rendering `<Dialog hidden={false} />`, we don't style the dialog with `display: none`. But the backdrop element currently doesn't inherit this behavior. We have to do this:

```jsx
<Dialog hidden={false} backdropProps={{ hidden: false }} />
```

This PR changes it so Dialog automatically passes its hidden prop to the backdrop element.