### PR TITLE
Fix focus-visible behavior on composite items

### DIFF
--- a/.changeset/composite-hover-focus-visible.md
+++ b/.changeset/composite-hover-focus-visible.md
@@ -1,0 +1,5 @@
+---
+"ariakit": patch
+---
+
+Fixed `data-focus-visible` behavior when using the `focusOnHover` prop on composite items. ([#1433](https://github.com/ariakit/ariakit/pull/1433))

--- a/.changeset/test-hover-microtask.md
+++ b/.changeset/test-hover-microtask.md
@@ -1,0 +1,5 @@
+---
+"ariakit-test": patch
+---
+
+Fixed `hover` not waiting for queued microtasks. ([#1433](https://github.com/ariakit/ariakit/pull/1433))

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,9 @@ module.exports = {
   testTimeout: process.env.CI ? 10000 : 5000,
   testEnvironment: "jsdom",
   reporters: ["default", "github-actions"],
+  snapshotFormat: {
+    printBasicPrototype: false,
+  },
   projects: [
     "<rootDir>/packages/*/jest.config.js",
     "<rootDir>/blog/jest.config.js",

--- a/packages/ariakit-test/src/__tests__/blur-test.tsx
+++ b/packages/ariakit-test/src/__tests__/blur-test.tsx
@@ -22,7 +22,7 @@ test("blur", async () => {
   expect(document.body).toHaveFocus();
 
   expect(stack).toMatchInlineSnapshot(`
-    Array [
+    [
       "blur button",
       "focusout button",
     ]

--- a/packages/ariakit-test/src/hover.ts
+++ b/packages/ariakit-test/src/hover.ts
@@ -1,3 +1,4 @@
+import { queuedMicrotasks } from "./__utils";
 import { fireEvent } from "./fire-event";
 import { sleep } from "./sleep";
 
@@ -59,4 +60,6 @@ export async function hover(element: Element, options?: MouseEventInit) {
   }
 
   document.lastHovered = element;
+
+  await queuedMicrotasks();
 }

--- a/packages/ariakit/src/composite/__examples__/composite-hover-virtual-focus-events/index.tsx
+++ b/packages/ariakit/src/composite/__examples__/composite-hover-virtual-focus-events/index.tsx
@@ -1,0 +1,39 @@
+import { SyntheticEvent } from "react";
+import {
+  Composite,
+  CompositeHover,
+  CompositeItem,
+  useCompositeState,
+} from "ariakit/composite";
+import "./style.css";
+
+export default function Example() {
+  const composite = useCompositeState({ virtualFocus: true });
+
+  const onEvent = (event: SyntheticEvent) => {
+    const target = event.target as HTMLElement;
+    console.log([event.type, event.currentTarget.id, target.id].join(" | "));
+  };
+
+  const props = {
+    onMouseEnter: onEvent,
+    onFocus: onEvent,
+    onBlur: onEvent,
+    onKeyDown: onEvent,
+    onKeyUp: onEvent,
+  };
+
+  return (
+    <Composite state={composite} id="toolbar" role="toolbar" {...props}>
+      <CompositeHover as={CompositeItem} id="item-1" {...props}>
+        item-1
+      </CompositeHover>
+      <CompositeHover as={CompositeItem} id="item-2" {...props}>
+        item-2
+      </CompositeHover>
+      <CompositeHover as={CompositeItem} id="item-3" {...props}>
+        item-3
+      </CompositeHover>
+    </Composite>
+  );
+}

--- a/packages/ariakit/src/composite/__examples__/composite-hover-virtual-focus-events/style.css
+++ b/packages/ariakit/src/composite/__examples__/composite-hover-virtual-focus-events/style.css
@@ -1,0 +1,7 @@
+[role="toolbar"] {
+  @apply flex p-2 gap-2 focus-visible:ariakit-outline;
+}
+
+button {
+  @apply p-2 focus-visible:ariakit-outline;
+}

--- a/packages/ariakit/src/composite/__examples__/composite-hover-virtual-focus-events/test.tsx
+++ b/packages/ariakit/src/composite/__examples__/composite-hover-virtual-focus-events/test.tsx
@@ -1,0 +1,95 @@
+import { getByRole, hover, press, render } from "ariakit-test";
+import Example from ".";
+
+const getToolbar = () => getByRole("toolbar");
+const getButton = (name: string) => getByRole("button", { name });
+
+function expectCalls(mock: jest.SpyInstance) {
+  const calls = mock.mock.calls.flat();
+  mock.mockClear();
+  return expect(calls);
+}
+
+test("events", async () => {
+  render(<Example />);
+
+  const log = jest.spyOn(console, "log").mockImplementation(() => {});
+
+  await hover(getButton("item-3"));
+
+  expectCalls(log).toMatchInlineSnapshot(`
+    [
+      "mouseenter | toolbar | item-3",
+      "mouseenter | item-3 | item-3",
+      "focus | toolbar | toolbar",
+      "focus | item-3 | item-3",
+      "focus | toolbar | item-3",
+    ]
+  `);
+
+  expect(getToolbar()).toHaveAttribute("data-focus-visible");
+  expect(getButton("item-3")).toHaveAttribute("data-focus-visible");
+  expect(getButton("item-3")).toHaveAttribute("data-active-item");
+
+  await press.ArrowLeft();
+
+  expectCalls(log).toMatchInlineSnapshot(`
+    [
+      "keydown | item-3 | item-3",
+      "keydown | toolbar | item-3",
+      "blur | item-3 | item-3",
+      "blur | toolbar | item-3",
+      "focus | item-2 | item-2",
+      "focus | toolbar | item-2",
+      "keyup | item-2 | item-2",
+      "keyup | toolbar | item-2",
+    ]
+  `);
+
+  expect(getToolbar()).toHaveAttribute("data-focus-visible");
+  expect(getButton("item-3")).not.toHaveAttribute("data-focus-visible");
+  expect(getButton("item-3")).not.toHaveAttribute("data-active-item");
+  expect(getButton("item-2")).toHaveAttribute("data-focus-visible");
+  expect(getButton("item-2")).toHaveAttribute("data-active-item");
+
+  await hover(getButton("item-1"));
+
+  expectCalls(log).toMatchInlineSnapshot(`
+    [
+      "blur | item-2 | item-2",
+      "blur | toolbar | item-2",
+      "mouseenter | item-1 | item-1",
+    ]
+  `);
+
+  expect(getToolbar()).toHaveAttribute("data-focus-visible");
+  expect(getButton("item-2")).not.toHaveAttribute("data-focus-visible");
+  expect(getButton("item-2")).not.toHaveAttribute("data-active-item");
+  expect(getButton("item-1")).not.toHaveAttribute("data-focus-visible");
+  expect(getButton("item-1")).toHaveAttribute("data-active-item");
+
+  await press.ArrowRight();
+
+  expectCalls(log).toMatchInlineSnapshot(`
+    [
+      "focus | item-1 | item-1",
+      "focus | toolbar | item-1",
+      "keydown | item-1 | item-1",
+      "keydown | toolbar | item-1",
+      "blur | item-1 | item-1",
+      "blur | toolbar | item-1",
+      "focus | item-2 | item-2",
+      "focus | toolbar | item-2",
+      "keyup | item-2 | item-2",
+      "keyup | toolbar | item-2",
+    ]
+  `);
+
+  expect(getToolbar()).toHaveAttribute("data-focus-visible");
+  expect(getButton("item-1")).not.toHaveAttribute("data-focus-visible");
+  expect(getButton("item-1")).not.toHaveAttribute("data-active-item");
+  expect(getButton("item-2")).toHaveAttribute("data-focus-visible");
+  expect(getButton("item-2")).toHaveAttribute("data-active-item");
+
+  log.mockReset();
+});


### PR DESCRIPTION
This PR fixes the `data-focus-visible` attribute that was being erroneously added to composite items with `CompositeHover` and `virtualFocus: true`.

See tests and example for more details.