### PR TITLE
Added Open in Gitpod

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -46,6 +46,8 @@ If you are already part of the organization on GitHub, clone the repository dire
 ```bash
 git clone https://github.com/ariakit/ariakit.git
 ```
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/ariakit/ariakit)
+
 
 <div align="right">
     <a href="#basic-tutorial">&uarr; back to top</a></b>

--- a/contributing.md
+++ b/contributing.md
@@ -46,8 +46,8 @@ If you are already part of the organization on GitHub, clone the repository dire
 ```bash
 git clone https://github.com/ariakit/ariakit.git
 ```
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/ariakit/ariakit)
 
+Alternatively, you can [open the project in Gitpod](https://gitpod.io/#https://github.com/ariakit/ariakit) and skip to [Creating a component](#creating-a-component).
 
 <div align="right">
     <a href="#basic-tutorial">&uarr; back to top</a></b>

--- a/packages/ariakit/readme.md
+++ b/packages/ariakit/readme.md
@@ -34,8 +34,6 @@
 
 <br>
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/ariakit/ariakit)
-
 ---
 
 <p align="center">

--- a/packages/ariakit/readme.md
+++ b/packages/ariakit/readme.md
@@ -34,6 +34,8 @@
 
 <br>
 
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/ariakit/ariakit)
+
 ---
 
 <p align="center">


### PR DESCRIPTION
Open in Gitpod added in the README.md

Gitpod is a remote development environment. It allows the user to contribute/ browse the contents of the github repository in the browser.
[Link](https://gitpod.io/)

Adding this OS feature in the README.md would allow the contributors to open the codebase directly into their browser.

(P.S : Not sponsored by Gitpod. Just want to add this functionality in order to improve user experiences)