### PR TITLE
chore: Add `separator` example

### DIFF
--- a/packages/ariakit/src/separator/__examples__/separator/index.tsx
+++ b/packages/ariakit/src/separator/__examples__/separator/index.tsx
@@ -1,0 +1,6 @@
+import { Separator } from "ariakit/separator";
+import "./styles.css";
+
+export default function Example() {
+  return <Separator orientation="horizontal" className="separator" />;
+}

--- a/packages/ariakit/src/separator/__examples__/separator/styles.css
+++ b/packages/ariakit/src/separator/__examples__/separator/styles.css
@@ -2,4 +2,5 @@
   @apply
     w-full
     border-canvas-5
-    dark:border-canvas-5-dark; }
+    dark:border-canvas-5-dark;
+}

--- a/packages/ariakit/src/separator/__examples__/separator/styles.css
+++ b/packages/ariakit/src/separator/__examples__/separator/styles.css
@@ -1,0 +1,5 @@
+.separator {
+  @apply
+    w-full
+    border-canvas-5
+    dark:border-canvas-5-dark; }

--- a/packages/ariakit/src/separator/__examples__/separator/test.tsx
+++ b/packages/ariakit/src/separator/__examples__/separator/test.tsx
@@ -1,0 +1,15 @@
+import { render } from "ariakit-test";
+import Example from ".";
+
+test("render horizontal separator", () => {
+  const { container } = render(<Example />);
+  expect(container).toMatchInlineSnapshot(`
+    <div>
+      <hr
+        aria-orientation="horizontal"
+        class="separator"
+        role="separator"
+      />
+    </div>
+  `);
+});

--- a/packages/ariakit/src/separator/readme.md
+++ b/packages/ariakit/src/separator/readme.md
@@ -1,0 +1,3 @@
+# Separator
+
+<a href="./__examples__/separator/index.tsx" data-playground>example</a>

--- a/packages/website/pages/index.tsx
+++ b/packages/website/pages/index.tsx
@@ -55,6 +55,7 @@ const links: Array<{ href: string; label: string }> = [
   { href: "/examples/select-group", label: "Select group" },
   { href: "/examples/select-item-custom", label: "Select item custom" },
   { href: "/examples/select-multiple", label: "Select multiple" },
+  { href: "/examples/separator", label: "Separator" },
   { href: "/examples/tab", label: "Tab" },
   { href: "/examples/tab-react-router", label: "Tab react-router" },
   { href: "/examples/toolbar", label: "Toolbar" },


### PR DESCRIPTION
Adds the `separator` example for #939

Hey, first time here really liked this project and I plan to be an active contributor. If there is anything I missed or could improve let me know.