### PR TITLE
Fix useEvent hook timing

### DIFF
--- a/.changeset/utils-use-event-timing.md
+++ b/.changeset/utils-use-event-timing.md
@@ -1,0 +1,5 @@
+---
+"ariakit-utils": patch
+---
+
+Fixed `useEvent` hook timing. ([#1481](https://github.com/ariakit/ariakit/pull/1481))

--- a/packages/ariakit-utils/src/__tests__/hooks-test.tsx
+++ b/packages/ariakit-utils/src/__tests__/hooks-test.tsx
@@ -103,19 +103,6 @@ test("useEvent function is stable", () => {
   expect(effectFunction).toBeCalledTimes(1);
 });
 
-test("useEvent errors is used during render", () => {
-  const consoleError = jest.spyOn(console, "error").mockImplementation();
-  const TestComponent = () => {
-    const result = useEvent(jest.fn());
-    result();
-    return null;
-  };
-  expect(() => render(<TestComponent />)).toThrow(
-    "Cannot call an event handler while rendering."
-  );
-  consoleError.mockRestore();
-});
-
 test("useForkRef", () => {
   const ref1 = jest.fn();
   const ref2 = jest.fn();


### PR DESCRIPTION
There are situations where `useLayoutEffect` may not execute before the event callback is called. For example, when calling the event callback in a layout effect in a child component.