### PR TITLE
Use listbox as a fallback ref when there is no focusable item to focus

### DIFF
--- a/.changeset/select-empty-initial-focus.md
+++ b/.changeset/select-empty-initial-focus.md
@@ -1,0 +1,5 @@
+---
+"ariakit": patch
+---
+
+Fixed `SelectPopover` not focusing on the base element when there's no selected item. ([#1557](https://github.com/ariakit/ariakit/pull/1557))

--- a/packages/ariakit/src/select/select-popover.ts
+++ b/packages/ariakit/src/select/select-popover.ts
@@ -47,7 +47,7 @@ export const useSelectPopover = createHook<SelectPopoverOptions>(
     props = useSelectList({ state, ...props });
     props = usePopover({
       state,
-      initialFocusRef: item?.ref ?? state.baseRef,
+      initialFocusRef: item?.ref || state.baseRef,
       ...props,
     });
 

--- a/packages/ariakit/src/select/select-popover.ts
+++ b/packages/ariakit/src/select/select-popover.ts
@@ -45,7 +45,11 @@ export const useSelectPopover = createHook<SelectPopoverOptions>(
     }, [state.mounted, state.items, value]);
 
     props = useSelectList({ state, ...props });
-    props = usePopover({ state, initialFocusRef: item?.ref, ...props });
+    props = usePopover({
+      state,
+      initialFocusRef: item?.ref ?? state.baseRef,
+      ...props,
+    });
 
     return props;
   }


### PR DESCRIPTION
This pull request uses the select's base ref as a fallback when there is no focusable item to focus.

Fixes #1553