### PR TITLE
Use default import instead of namespace when checking for React v18 APIs

### DIFF
--- a/.changeset/fix-react-17-webpack-error-again.md
+++ b/.changeset/fix-react-17-webpack-error-again.md
@@ -1,0 +1,6 @@
+---
+"ariakit": patch
+"ariakit-utils": patch
+---
+
+Fixed an issue where `ariakit-utils` was importing React v18 APIs via a _namespace_ (and previously named) import (`import * as React from 'react'`). When using React v17, Webpack will raise an error when using either named or namedspace imports.

--- a/packages/ariakit-utils/src/hooks.ts
+++ b/packages/ariakit-utils/src/hooks.ts
@@ -1,4 +1,4 @@
-import {
+import React, {
   ComponentType,
   DependencyList,
   EffectCallback,
@@ -12,7 +12,6 @@ import {
   useRef,
   useState,
 } from "react";
-import * as React from "react";
 import { canUseDOM } from "./dom";
 import { applyState, setRef } from "./misc";
 import { AnyFunction, SetState, WrapElement } from "./types";


### PR DESCRIPTION
I had previously submitted https://github.com/ariakit/ariakit/pull/1542, which I believed worked, but I am still seeing similar errors.

In the application where I was seeing this error, I manually edited `node_modules/ariakit-utils/esm/hooks.js` to make the error go away. This feels like a pretty crude way to verify its working.