### PR TITLE
Fix Select focus on Firefox/macOS

### DIFF
--- a/.changeset/select-focus-firefox.md
+++ b/.changeset/select-focus-firefox.md
@@ -1,0 +1,5 @@
+---
+"ariakit": patch
+---
+
+Fixed `SelectPopover` not receiving focus when clicking on `Select` on Firefox/macOS. ([#1585](https://github.com/ariakit/ariakit/pull/1585))


### PR DESCRIPTION
This PR fixes a bug where the select popover wasn't receiving focus when the select button got clicked on Firefox on macOS.

Since Firefox 88, buttons receive focus on mouse down. The fact that we were forcing focus on the select button in a requestAnimationFrame callback was conflicting with the popover initial focus that happened right after the first time the select button received focus.