### PR TITLE
Prevent screen readers from announcing pristine fields as invalid

### DIFF
--- a/packages/ariakit/src/form/form-field.ts
+++ b/packages/ariakit/src/form/form-field.ts
@@ -157,7 +157,7 @@ export const useFormField = createHook<FormFieldOptions>(
     props = {
       id,
       "aria-labelledby": label?.id,
-      "aria-invalid": invalid ? true : undefined,
+      "aria-invalid": invalid,
       ...props,
       "aria-describedby": describedBy || undefined,
       // @ts-expect-error


### PR DESCRIPTION
More context: https://twitter.com/diegohaz/status/1527259432979156997