### PR TITLE
Fix PopoverArrow styling flash

### DIFF
--- a/.changeset/popover-arrow-flash.md
+++ b/.changeset/popover-arrow-flash.md
@@ -1,0 +1,5 @@
+---
+"ariakit": patch
+---
+
+Fixed `PopoverArrow` styling flash when `Popover` is flipped. ([#1593](https://github.com/ariakit/ariakit/pull/1593))

--- a/packages/ariakit/src/popover/popover-state.ts
+++ b/packages/ariakit/src/popover/popover-state.ts
@@ -16,6 +16,7 @@ import {
   useSafeLayoutEffect,
 } from "ariakit-utils/hooks";
 import { SetState } from "ariakit-utils/types";
+import { flushSync } from "react-dom";
 import {
   DialogState,
   DialogStateProps,
@@ -234,7 +235,14 @@ export function usePopoverState({
           middleware,
         });
 
-        setCurrentPlacement(pos.placement);
+        // Update the current placement state synchronously to avoid styling
+        // flashes. For example, without this, a popover that has initially
+        // placement set to "bottom", but gets flipped to "top" will have a
+        // frame where the popover arrow is not properly rotated (PopoverArrow
+        // uses the currentPlacement state).
+        flushSync(() => {
+          setCurrentPlacement(pos.placement);
+        });
 
         const x = Math.round(pos.x);
         const y = Math.round(pos.y);


### PR DESCRIPTION
Update the current placement state synchronously to avoid styling flashes. For example, without this, a popover that has initially placement set to "bottom", but gets flipped to "top" will have a frame where the popover arrow is not properly rotated (PopoverArrow uses the currentPlacement state).