### PR TITLE
Support autoFocusOnShow prop as a function on Dialog

### DIFF
--- a/.changeset/dialog-auto-focus-on-show.md
+++ b/.changeset/dialog-auto-focus-on-show.md
@@ -1,0 +1,5 @@
+---
+"ariakit": minor
+---
+
+The `autoFocusOnShow` and `autoFocusOnHide` props on `Dialog` now support a function value. ([#1599](https://github.com/ariakit/ariakit/pull/1599))

--- a/.changeset/dialog-scroll-into-view.md
+++ b/.changeset/dialog-scroll-into-view.md
@@ -1,0 +1,5 @@
+---
+"ariakit": patch
+---
+
+Fixed smooth scrolling when auto focusing `Dialog` elements on Firefox. ([#1599](https://github.com/ariakit/ariakit/pull/1599))

--- a/.changeset/utils-ensure-focus.md
+++ b/.changeset/utils-ensure-focus.md
@@ -1,0 +1,5 @@
+---
+"ariakit-utils": minor
+---
+
+Removed `ensureFocus` function. ([#1599](https://github.com/ariakit/ariakit/pull/1599))

--- a/.changeset/utils-focus-into-view.md
+++ b/.changeset/utils-focus-into-view.md
@@ -1,0 +1,5 @@
+---
+"ariakit-utils": patch
+---
+
+Added `focusIntoView` function. ([#1599](https://github.com/ariakit/ariakit/pull/1599))

--- a/packages/ariakit-utils/src/__tests__/focus-test.ts
+++ b/packages/ariakit-utils/src/__tests__/focus-test.ts
@@ -1,9 +1,7 @@
 import "ariakit-test/mock-get-client-rects";
-import { sleep } from "ariakit-test";
 import {
   disableFocus,
   disableFocusIn,
-  ensureFocus,
   focusIfNeeded,
   getAllFocusable,
   getAllFocusableIn,
@@ -626,37 +624,4 @@ test("restoreFocusIn", () => {
   expect(div.getAttribute("tabindex")).toBe("2");
 
   document.body.innerHTML = initialInnerHTML;
-});
-
-test("ensureFocus", async () => {
-  const initialInnerHTML = document.body.innerHTML;
-  document.body.innerHTML = `
-    <input id="testInput" />
-  `;
-  const input = getById("testInput");
-  const rafSpy = jest
-    .spyOn(window, "requestAnimationFrame")
-    .mockImplementation((cb) => {
-      setTimeout(() => cb(0));
-      return 0;
-    });
-
-  expect(document.activeElement === input).toBe(false);
-  ensureFocus(input);
-  expect(document.activeElement === input).toBe(true);
-  input.blur();
-  // isActive -> false
-  const focusSpy = jest.spyOn(input, "focus");
-
-  expect(document.activeElement === input).toBe(false);
-  ensureFocus(input, { isActive: () => false });
-  expect(document.activeElement === input).toBe(true);
-
-  expect(focusSpy).toHaveBeenCalledTimes(1);
-  await sleep();
-  expect(focusSpy).toHaveBeenCalledTimes(2);
-
-  document.body.innerHTML = initialInnerHTML;
-  rafSpy.mockRestore();
-  focusSpy.mockRestore();
 });

--- a/packages/ariakit-utils/src/focus.ts
+++ b/packages/ariakit-utils/src/focus.ts
@@ -350,41 +350,16 @@ export function restoreFocusIn(container: HTMLElement) {
 }
 
 /**
- * Ensures `element` will receive focus if it's not already.
- * @example
- * ensureFocus(document.activeElement); // does nothing
- *
- * const element = document.querySelector("input");
- *
- * ensureFocus(element); // focuses element
- * ensureFocus(element, { preventScroll: true }); // focuses element preventing scroll jump
- *
- * function isActive(el) {
- *   return el.dataset.active === "true";
- * }
- *
- * ensureFocus(document.querySelector("[data-active='true']"), { isActive }); // does nothing
- *
- * @returns {number} `requestAnimationFrame` call ID so it can be passed to `cancelAnimationFrame` if needed.
+ * Focus on element and scroll into view.
  */
-export function ensureFocus(
+export function focusIntoView(
   element: HTMLElement,
-  { preventScroll, isActive = hasFocus }: EnsureFocusOptions = {}
+  options?: ScrollIntoViewOptions
 ) {
-  // TODO: Try to use queueMicrotask before requestAnimationFrame and dispatch
-  // focus events if the element is not focusable?
-  if (isActive(element)) return -1;
-
-  element.focus({ preventScroll });
-
-  if (isActive(element)) return -1;
-
-  return requestAnimationFrame(() => {
-    if (isActive(element)) return;
-    element.focus({ preventScroll });
-  });
+  if (!("scrollIntoView" in element)) {
+    element.focus();
+  } else {
+    element.focus({ preventScroll: true });
+    element.scrollIntoView({ block: "nearest", inline: "nearest", ...options });
+  }
 }
-
-type EnsureFocusOptions = FocusOptions & {
-  isActive?: typeof hasFocus;
-};

--- a/packages/ariakit/src/composite/composite.ts
+++ b/packages/ariakit/src/composite/composite.ts
@@ -15,6 +15,7 @@ import {
   fireKeyboardEvent,
   isSelfTarget,
 } from "ariakit-utils/events";
+import { focusIntoView } from "ariakit-utils/focus";
 import {
   useEvent,
   useForkRef,
@@ -100,12 +101,7 @@ function useScheduleFocus(activeItem?: Item) {
     const activeElement = activeItem?.ref.current;
     if (scheduled && activeElement) {
       setScheduled(false);
-      if (!activeElement.scrollIntoView) {
-        activeElement.focus();
-      } else {
-        activeElement.focus({ preventScroll: true });
-        activeElement.scrollIntoView({ block: "nearest", inline: "nearest" });
-      }
+      focusIntoView(activeElement);
     }
   }, [activeItem, scheduled]);
   return schedule;

--- a/packages/ariakit/src/menu/menu.ts
+++ b/packages/ariakit/src/menu/menu.ts
@@ -104,17 +104,21 @@ export const useMenu = createHook<MenuOptions>(
       state.baseRef,
     ]);
 
+    const mayAutoFocusOnShow = !!autoFocusOnShow;
+    // When the `autoFocusOnShow` prop is set to `true` (default), we'll only
+    // move focus to the menu when there's an initialFocusRef set or the menu is
+    // modal. Otherwise, users would have to manually call
+    // state.setAutoFocusOnShow(true) every time they want to open the menu.
+    // This differs from the usual dialog behavior that would automatically
+    // focus on the dialog container when no initialFocusRef is set.
+    const canAutoFocusOnShow =
+      !!initialFocusRef || !!props.initialFocusRef || !!props.modal;
+
     props = useHovercard({
       state,
       initialFocusRef,
-      // When the `autoFocusOnShow` prop is set to `true` (default), we'll only
-      // move focus to the menu when there's an initialFocusRef set or the menu
-      // is modal. Otherwise, users would have to manually call
-      // state.setAutoFocusOnShow(true) every time they want to open the menu.
-      // This differs from the usual dialog behavior that would automatically
-      // focus on the dialog container when no initialFocusRef is set.
-      autoFocusOnShow: autoFocusOnShow
-        ? !!initialFocusRef || !!props.initialFocusRef || !!props.modal
+      autoFocusOnShow: mayAutoFocusOnShow
+        ? canAutoFocusOnShow && autoFocusOnShow
         : state.autoFocusOnShow || !!props.modal,
       ...props,
       hideOnHoverOutside: (event) => {

--- a/packages/ariakit/src/popover/popover.tsx
+++ b/packages/ariakit/src/popover/popover.tsx
@@ -110,7 +110,7 @@ export const usePopover = createHook<PopoverOptions>(
       modal,
       preserveTabOrder,
       portal,
-      autoFocusOnShow: autoFocusOnShow && canAutoFocusOnShow,
+      autoFocusOnShow: canAutoFocusOnShow && autoFocusOnShow,
       ...props,
       portalRef,
     });


### PR DESCRIPTION
This PR fixes an issue on Firefox where auto focusing on dialog show/hide wouldn't work with [`scroll-behavior: smooth`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior).

`autoFocusOnShow` and `autoFocusOnHide` can now be functions so that the new behavior can be overwritten.