### PR TITLE
Fix tooltip position

### DIFF
--- a/.changeset/tooltip-position.md
+++ b/.changeset/tooltip-position.md
@@ -1,0 +1,5 @@
+---
+"ariakit": patch
+---
+
+Fixed `Tooltip` position. ([#1622](https://github.com/ariakit/ariakit/pull/1622))

--- a/packages/ariakit/src/tooltip/tooltip.tsx
+++ b/packages/ariakit/src/tooltip/tooltip.tsx
@@ -75,15 +75,16 @@ export const useTooltip = createHook<TooltipOptions>(
         <div
           role="presentation"
           {...wrapperProps}
-          // Avoid the wrapper from taking space when used within a flexbox
-          // container with the gap property.
-          style={{ position: "fixed", ...wrapperProps?.style }}
+          style={{
+            position: state.fixed ? "fixed" : "absolute",
+            ...wrapperProps?.style,
+          }}
           ref={popoverRef}
         >
           {element}
         </div>
       ),
-      [popoverRef, wrapperProps]
+      [state.fixed, popoverRef, wrapperProps]
     );
 
     props = useWrapElement(


### PR DESCRIPTION
On #1592, we removed the popover position style from the `usePopoverState` hook and added it to the `Popover` component, but forgot to add it to the Tooltip as well.