### PR TITLE
Fix auto focus when re-opening menu quickly

### DIFF
--- a/.changeset/menu-button-autofocus.md
+++ b/.changeset/menu-button-autofocus.md
@@ -1,0 +1,5 @@
+---
+"ariakit": patch
+---
+
+Fixed `Menu` not receiving focus when it was re-opened by clicking twice on its `MenuButton`. ([#1629](https://github.com/ariakit/ariakit/pull/1629))

--- a/packages/ariakit/src/menu/menu-button.ts
+++ b/packages/ariakit/src/menu/menu-button.ts
@@ -122,7 +122,7 @@ export const useMenuButton = createHook<MenuButtonOptions>(
       const isKeyboardClick = !event.detail;
       // When the menu button is clicked, if the menu is hidden or if it's a
       // keyboard click (enter or space),
-      if (!state.mounted || isKeyboardClick) {
+      if (!state.open || isKeyboardClick) {
         // we'll only automatically focus on the menu if it's not a submenu
         // button, or if it's a keyboard click.
         if (!hasParentMenu || isKeyboardClick) {


### PR DESCRIPTION
When a menu is open and has a leave animation, clicking twice on the menu button before the animation completes wouldn't move the focus to the menu popup.