### PR TITLE
Always pass name prop down on FormField

### DIFF
--- a/.changeset/form-field-name.md
+++ b/.changeset/form-field-name.md
@@ -1,0 +1,5 @@
+---
+"ariakit": minor
+---
+
+The `name` prop is now always passed down when using `FormField` with custom components. ([#1646](https://github.com/ariakit/ariakit/pull/1646))

--- a/packages/ariakit/src/form/form-field.ts
+++ b/packages/ariakit/src/form/form-field.ts
@@ -5,7 +5,6 @@ import {
   useEvent,
   useForkRef,
   useId,
-  useTagName,
 } from "ariakit-utils/hooks";
 import { cx } from "ariakit-utils/misc";
 import { createMemoComponent, useStore } from "ariakit-utils/store";
@@ -32,16 +31,6 @@ function getNamedElement(ref: RefObject<HTMLInputElement>, name: string) {
     }
   }
   return element;
-}
-
-function acceptsNameAttribute(tagName?: string) {
-  return (
-    tagName === "input" ||
-    tagName === "button" ||
-    tagName === "textarea" ||
-    tagName === "fieldset" ||
-    tagName === "select"
-  );
 }
 
 function findItem(
@@ -141,8 +130,6 @@ export const useFormField = createHook<FormFieldOptions>(
       state?.setFieldTouched(name, true);
     });
 
-    const tagName = useTagName(ref, props.as || "input");
-
     const label = useItem(state, name, "label");
     const error = useItem(state, name, "error");
     const description = useItem(state, name, "description");
@@ -160,13 +147,11 @@ export const useFormField = createHook<FormFieldOptions>(
       "aria-invalid": invalid,
       ...props,
       "aria-describedby": describedBy || undefined,
-      // @ts-expect-error
-      name: acceptsNameAttribute(tagName) ? name : undefined,
       ref: useForkRef(ref, props.ref),
       onBlur,
     };
 
-    props = useCollectionItem({ state, ...props, getItem });
+    props = useCollectionItem({ state, ...props, name, getItem });
 
     return props;
   }


### PR DESCRIPTION
Custom components used with `FormField` won't include the `name` prop on the first render (and on the server) even when the underlying element accepts it. This PR removes the initial check, so the `name` prop is always passed down. The consumer is responsible for stripping this prop if necessary.