### PR TITLE
Do not prevent scroll on Dialog auto focus

### DIFF
--- a/.changeset/dialog-auto-focus.md
+++ b/.changeset/dialog-auto-focus.md
@@ -1,0 +1,5 @@
+---
+"ariakit": minor
+---
+
+The `Dialog` component doesn't modify the scroll behavior when auto focusing elements on show/hide anymore. ([#1687](https://github.com/ariakit/ariakit/pull/1687))

--- a/packages/ariakit/src/dialog/dialog.tsx
+++ b/packages/ariakit/src/dialog/dialog.tsx
@@ -18,7 +18,6 @@ import {
 import { addGlobalEventListener, queueBeforeEvent } from "ariakit-utils/events";
 import {
   focusIfNeeded,
-  focusIntoView,
   getFirstTabbableIn,
   isFocusable,
 } from "ariakit-utils/focus";
@@ -306,7 +305,7 @@ export const useDialog = createHook<DialogOptions>(
         if (activeElement && contains(dialog, activeElement)) return;
       }
       if (!autoFocusOnShowProp(element)) return;
-      focusIntoView(element);
+      element.focus();
     }, [
       openStable,
       mayAutoFocusOnShow,
@@ -365,7 +364,7 @@ export const useDialog = createHook<DialogOptions>(
             }
           }
           if (!autoFocusOnHideProp(element)) return;
-          focusIntoView(element);
+          element.focus();
         }
       };
       if (!state.open) {

--- a/packages/ariakit/src/menu/__examples__/menu-slide/menu.tsx
+++ b/packages/ariakit/src/menu/__examples__/menu-slide/menu.tsx
@@ -127,6 +127,13 @@ export const Menu = forwardRef<HTMLDivElement, MenuProps>(
       className: !isSubmenu ? "menu-wrapper" : "",
     };
 
+    const autoFocus = (element: HTMLElement) => {
+      if (!isSubmenu) return true;
+      element.focus({ preventScroll: true });
+      element.scrollIntoView({ block: "nearest", inline: "start" });
+      return false;
+    };
+
     return (
       <>
         {isSubmenu ? (
@@ -152,12 +159,8 @@ export const Menu = forwardRef<HTMLDivElement, MenuProps>(
             portal={isSubmenu}
             portalElement={parent?.getWrapper}
             wrapperProps={wrapperProps}
-            autoFocusOnShow={(element) => {
-              if (!isSubmenu) return true;
-              element.focus({ preventScroll: true });
-              element.scrollIntoView({ block: "nearest", inline: "start" });
-              return false;
-            }}
+            autoFocusOnShow={autoFocus}
+            autoFocusOnHide={autoFocus}
           >
             <MenuContext.Provider value={contextValue}>
               {isSubmenu && (


### PR DESCRIPTION
This PR reverts a change we made on #1599. It turns out that preventing scroll when a dialog shows up has other side effects. For example, the selected option in a Select component will be at the end of the popover viewport when it needs to scroll when opening. This isn't a great UX as the following options won't be immediately visible.