### PR TITLE
Avoid duplicate work when combining two composite components

### DIFF
--- a/.changeset/composite-focus-item.md
+++ b/.changeset/composite-focus-item.md
@@ -1,0 +1,5 @@
+---
+"ariakit": patch
+---
+
+Fixed double focus on `CompositeItem` when combining multiple `Composite` components. ([#1689](https://github.com/ariakit/ariakit/pull/1689))

--- a/packages/ariakit/src/composite/composite.ts
+++ b/packages/ariakit/src/composite/composite.ts
@@ -134,6 +134,7 @@ export const useComposite = createHook<CompositeOptions>(
 
     // Focus on the active item element.
     useSafeLayoutEffect(() => {
+      if (!composite) return;
       if (!focusOnMove) return;
       if (!state.moves) return;
       const itemElement = activeItemRef.current?.ref.current;
@@ -142,7 +143,7 @@ export const useComposite = createHook<CompositeOptions>(
       // event on each item to be triggered before the state changes can
       // propagate to them.
       scheduleFocus();
-    }, [focusOnMove, state.moves]);
+    }, [composite, focusOnMove, state.moves]);
 
     // When virtualFocus is enabled, calling composite.move(null) will not fire
     // a blur event on the active item. So we need to do it manually.


### PR DESCRIPTION
When two or more composite components are used together, but only one has `composite={true}` (default), we only need to focus on the items once.