### PR TITLE
Improve animation logic

### DIFF
--- a/.changeset/disclosure-animated.md
+++ b/.changeset/disclosure-animated.md
@@ -1,0 +1,5 @@
+---
+"ariakit": minor
+---
+
+The logic behind animations on `Disclosure` and derived components (`Dialog`, `Menu`, `Popover`, etc.) has been refactored and is more reliable. ([#1699](https://github.com/ariakit/ariakit/pull/1699))

--- a/packages/ariakit/src/dialog/dialog.tsx
+++ b/packages/ariakit/src/dialog/dialog.tsx
@@ -28,7 +28,6 @@ import {
   useLiveRef,
   usePortalRef,
   useSafeLayoutEffect,
-  useUpdateEffect,
   useWrapElement,
 } from "ariakit-utils/hooks";
 import { chain } from "ariakit-utils/misc";
@@ -200,16 +199,6 @@ export const useDialog = createHook<DialogOptions>(
         };
       }, [state.mounted, state.disclosureRef]);
     }
-
-    // When the dialog is animated, changing the DOM strcuture may cause the
-    // onTransitionEnd/onAnimationEnd event to be skipped. Changing the
-    // backdrop, modal, and portal props will change the DOM structure, so we
-    // need to stop the animation here to prevent the animating state from being
-    // stale.
-    useUpdateEffect(() => {
-      if (!state.animated) return;
-      state.stopAnimation();
-    }, [backdrop, modal, portal, state.animated, state.stopAnimation]);
 
     // Renders a hidden dismiss button at the top of the modal dialog element.
     // So that screen reader users aren't trapped in the dialog when there's no

--- a/packages/ariakit/src/disclosure/disclosure-state.ts
+++ b/packages/ariakit/src/disclosure/disclosure-state.ts
@@ -1,7 +1,6 @@
 import {
   MutableRefObject,
   useCallback,
-  useEffect,
   useMemo,
   useRef,
   useState,
@@ -38,19 +37,6 @@ export function useDisclosureState({
   if (animated && !animating && prevOpen !== open) {
     setAnimating(true);
   }
-
-  useEffect(() => {
-    if (typeof animated === "number" && animating) {
-      const timeout = setTimeout(() => setAnimating(false), animated);
-      return () => clearTimeout(timeout);
-    }
-    // TODO: warn when 8 seconds have been passed
-    return;
-    // We're also listening to the open state here although it's not used in
-    // the effect. This is so we can clear previous timeouts and avoid hiding
-    // the content when the disclosure button gets clicked several times in
-    // sequence.
-  }, [animated, animating, open]);
 
   const show = useCallback(() => setOpen(true), [setOpen]);
   const hide = useCallback(() => setOpen(false), [setOpen]);

--- a/packages/ariakit/src/select/__examples__/select-animated/test-browser.ts
+++ b/packages/ariakit/src/select/__examples__/select-animated/test-browser.ts
@@ -61,7 +61,7 @@ test("show/hide", async ({ page }) => {
 test("https://github.com/ariakit/ariakit/issues/1684", async ({ page }) => {
   await page.goto("/examples/select-animated");
   await getButton(page).focus();
-  page.keyboard.press("Enter");
-  await page.keyboard.press("Shift+Tab");
+  await page.keyboard.press("Enter");
+  await page.mouse.click(1, 1);
   await expect(getPopover(page)).not.toBeVisible();
 });

--- a/packages/ariakit/src/select/__examples__/select-animated/test-browser.ts
+++ b/packages/ariakit/src/select/__examples__/select-animated/test-browser.ts
@@ -61,7 +61,11 @@ test("show/hide", async ({ page }) => {
 test("https://github.com/ariakit/ariakit/issues/1684", async ({ page }) => {
   await page.goto("/examples/select-animated");
   await getButton(page).focus();
-  await page.keyboard.press("Enter");
-  await page.keyboard.press("Shift+Tab");
+  await page.keyboard.down("Shift");
+  await page.keyboard.down("Enter");
+  await page.keyboard.down("Tab");
+  await page.keyboard.up("Enter");
+  await page.keyboard.up("Tab");
+  await page.keyboard.up("Shift");
   await expect(getPopover(page)).not.toBeVisible();
 });

--- a/packages/ariakit/src/select/__examples__/select-animated/test-browser.ts
+++ b/packages/ariakit/src/select/__examples__/select-animated/test-browser.ts
@@ -57,3 +57,11 @@ test("show/hide", async ({ page }) => {
   await expectSelectedOption(page, "Banana");
   await expectActiveOption(page, "Banana");
 });
+
+test("https://github.com/ariakit/ariakit/issues/1684", async ({ page }) => {
+  await page.goto("/examples/select-animated");
+  await getButton(page).focus();
+  await page.keyboard.press("Enter");
+  await page.keyboard.press("Shift+Tab");
+  await expect(getPopover(page)).not.toBeVisible();
+});

--- a/packages/ariakit/src/select/__examples__/select-animated/test-browser.ts
+++ b/packages/ariakit/src/select/__examples__/select-animated/test-browser.ts
@@ -61,11 +61,7 @@ test("show/hide", async ({ page }) => {
 test("https://github.com/ariakit/ariakit/issues/1684", async ({ page }) => {
   await page.goto("/examples/select-animated");
   await getButton(page).focus();
-  await page.keyboard.down("Shift");
-  await page.keyboard.down("Enter");
-  await page.keyboard.down("Tab");
-  await page.keyboard.up("Enter");
-  await page.keyboard.up("Tab");
-  await page.keyboard.up("Shift");
+  page.keyboard.press("Enter");
+  await page.keyboard.press("Shift+Tab");
   await expect(getPopover(page)).not.toBeVisible();
 });


### PR DESCRIPTION
This PR updates the logic behind disclosure animations in the library.

Instead of relying on the `transitionend`/`animationend` events, which may not fire under certain circumstances, we'll detect the animation/transition delay and duration values by parsing the computed styles and automatically schedule the `stopAnimation()` call.

Closes #1684