### PR TITLE
Allow DialogOptions.backdrop accepting LegacyRef

### DIFF
--- a/packages/ariakit/src/dialog/dialog.tsx
+++ b/packages/ariakit/src/dialog/dialog.tsx
@@ -566,7 +566,10 @@ export type DialogOptions<T extends As = "div"> = FocusableOptions<T> &
      * <Dialog backdrop={StyledBackdrop} />
      * ```
      */
-    backdrop?: boolean | ElementType<ComponentPropsWithRef<"div">>;
+    backdrop?:
+      | boolean
+      | ElementType<ComponentPropsWithRef<"div">>
+      | ElementType<JSX.IntrinsicElements["div"]>;
     /**
      * Props that will be passed to the backdrop element if `backdrop` is
      * `true`.


### PR DESCRIPTION
Fixes #1698.

Also, `DialogOptions.backdrop` works with `ref` _if and only if_ the ref is `HTMLDivElement`; this might be confusing if someone tries to make an `img` backdrop, for example. Further clarification within code annotations might be needed.