### PR TITLE
Optimize the type of DialogOptions.backdrop

### DIFF
--- a/.changeset/dialog-backdrop-type-re.md
+++ b/.changeset/dialog-backdrop-type-re.md
@@ -1,5 +1,0 @@
----
-"ariakit": minor
----
-
-Updated the `backdrop` prop type on `Dialog` again to remove the original type which is a subset of the new type.

--- a/.changeset/dialog-backdrop-type-re.md
+++ b/.changeset/dialog-backdrop-type-re.md
@@ -1,0 +1,5 @@
+---
+"ariakit": minor
+---
+
+Updated the `backdrop` prop type on `Dialog` again to remove the original type which is a subset of the new type.

--- a/.changeset/dialog-backdrop-type.md
+++ b/.changeset/dialog-backdrop-type.md
@@ -2,4 +2,4 @@
 "ariakit": minor
 ---
 
-Updated the `backdrop` prop type on `Dialog` so it accepts elements with a legacy `ref` prop type. ([#1700](https://github.com/ariakit/ariakit/pull/1700))
+Updated the `backdrop` prop type on `Dialog` so it accepts elements with a legacy `ref` prop type. ([#1703](https://github.com/ariakit/ariakit/pull/1703))

--- a/packages/ariakit/src/dialog/dialog.tsx
+++ b/packages/ariakit/src/dialog/dialog.tsx
@@ -1,5 +1,5 @@
 import {
-  ComponentPropsWithRef,
+  ComponentProps,
   ElementType,
   KeyboardEvent as ReactKeyboardEvent,
   RefObject,
@@ -555,10 +555,7 @@ export type DialogOptions<T extends As = "div"> = FocusableOptions<T> &
      * <Dialog backdrop={StyledBackdrop} />
      * ```
      */
-    backdrop?:
-      | boolean
-      | ElementType<ComponentPropsWithRef<"div">>
-      | ElementType<JSX.IntrinsicElements["div"]>;
+    backdrop?: boolean | ElementType<ComponentProps<"div">>;
     /**
      * Props that will be passed to the backdrop element if `backdrop` is
      * `true`.


### PR DESCRIPTION
As mentioned in [this comment](https://github.com/ariakit/ariakit/issues/1698#issuecomment-1203456837), the previous type for DialogOptions.backdrop(`ElementType<ComponentPropsWithRef<"div">>`) is actually a subset of the type added in #1700. Replaced both with `ElementType<ComponentProps<"div">>`.