### PR TITLE
Fix Tab with default selected id on React 17

### DIFF
--- a/.changeset/tab-default-id-react17.md
+++ b/.changeset/tab-default-id-react17.md
@@ -1,0 +1,5 @@
+---
+"ariakit": patch
+---
+
+Fixed `Tab` with `defaultSelectedId` on React 17. ([#1724](https://github.com/ariakit/ariakit/pull/1724))

--- a/packages/ariakit/src/tab/__examples__/tab/index.tsx
+++ b/packages/ariakit/src/tab/__examples__/tab/index.tsx
@@ -7,20 +7,20 @@ export default function Example() {
   return (
     <div className="wrapper">
       <TabList state={tab} className="tab-list" aria-label="Groceries">
+        <Tab className="tab">Fruits</Tab>
         <Tab className="tab" id={defaultSelectedId}>
-          Fruits
+          Vegetables
         </Tab>
-        <Tab className="tab">Vegetables</Tab>
         <Tab className="tab">Meat</Tab>
       </TabList>
-      <TabPanel state={tab} tabId={defaultSelectedId}>
+      <TabPanel state={tab}>
         <ul>
           <li>🍎 Apple</li>
           <li>🍇 Grape</li>
           <li>🍊 Orange</li>
         </ul>
       </TabPanel>
-      <TabPanel state={tab}>
+      <TabPanel state={tab} tabId={defaultSelectedId}>
         <ul>
           <li>🥕 Carrot</li>
           <li>🧅 Onion</li>

--- a/packages/ariakit/src/tab/__examples__/tab/test.tsx
+++ b/packages/ariakit/src/tab/__examples__/tab/test.tsx
@@ -17,17 +17,13 @@ test("a11y", async () => {
 
 test("default selected tab", () => {
   render(<Example />);
-  expect(getTab("Fruits")).toHaveAttribute("aria-selected", "true");
-  expect(getPanel("Fruits")).toBeVisible();
+  expect(getTab("Vegetables")).toHaveAttribute("aria-selected", "true");
+  expect(getPanel("Vegetables")).toBeVisible();
 });
 
 test("select with keyboard", async () => {
   render(<Example />);
   await press.Tab();
-  await press.ArrowRight();
-  expect(getTab("Vegetables")).toHaveAttribute("aria-selected", "true");
-  expect(getTab("Vegetables")).toHaveFocus();
-  expect(getPanel("Vegetables")).toBeVisible();
   await press.ArrowRight();
   expect(getTab("Meat")).toHaveAttribute("aria-selected", "true");
   expect(getTab("Meat")).toHaveFocus();
@@ -44,16 +40,16 @@ test("select with keyboard", async () => {
 
 test("select with mouse", async () => {
   render(<Example />);
-  await click(getTab("Vegetables"));
-  expect(getTab("Vegetables")).toHaveAttribute("aria-selected", "true");
-  expect(getTab("Vegetables")).toHaveFocus();
-  expect(getPanel("Vegetables")).toBeVisible();
+  await click(getTab("Meat"));
+  expect(getTab("Meat")).toHaveAttribute("aria-selected", "true");
+  expect(getTab("Meat")).toHaveFocus();
+  expect(getPanel("Meat")).toBeVisible();
 });
 
 test("do not select with focus (e.g., screen reader focus)", async () => {
   render(<Example />);
-  await focus(getTab("Vegetables"));
-  expect(getTab("Fruits")).toHaveAttribute("aria-selected", "true");
-  expect(getTab("Vegetables")).toHaveFocus();
-  expect(getPanel("Fruits")).toBeVisible();
+  await focus(getTab("Fruits"));
+  expect(getTab("Vegetables")).toHaveAttribute("aria-selected", "true");
+  expect(getTab("Fruits")).toHaveFocus();
+  expect(getPanel("Vegetables")).toBeVisible();
 });

--- a/packages/ariakit/src/tab/tab-panel.ts
+++ b/packages/ariakit/src/tab/tab-panel.ts
@@ -78,12 +78,7 @@ export const useTabPanel = createHook<TabPanelOptions>(
 
     props = useFocusable({ focusable: !hasTabbableChildren, ...props });
     props = useDisclosureContent({ state: disclosure, ...props });
-    props = useCollectionItem({
-      state: state.panels,
-      ...props,
-      getItem,
-      shouldRegisterItem: !!id ? props.shouldRegisterItem : false,
-    });
+    props = useCollectionItem({ state: state.panels, ...props, getItem });
 
     return props;
   }

--- a/packages/ariakit/src/tab/tab.ts
+++ b/packages/ariakit/src/tab/tab.ts
@@ -38,7 +38,11 @@ export const useTab = createHook<TabOptions>(
     getItem: getItemProp,
     ...props
   }) => {
-    const id = useId(props.id);
+    // Keep a reference to the default id so we can wait before all tabs have
+    // been assigned an id before registering them in the state. See
+    // https://github.com/ariakit/ariakit/issues/1721
+    const defaultId = useId();
+    const id = props.id || defaultId;
 
     state = useStore(state || TabContext, [
       useCallback((s: TabState) => id && s.selectedId === id, [id]),
@@ -83,6 +87,7 @@ export const useTab = createHook<TabOptions>(
       ...props,
       accessibleWhenDisabled,
       getItem,
+      shouldRegisterItem: !!defaultId ? props.shouldRegisterItem : false,
     });
 
     return props;


### PR DESCRIPTION
We have a `useId` hook to generate IDs for our components automatically. In React 17, this function needs a second render.

When the user passes a static `id` prop to the `Tab` component, this tab is registered to the state in the first render — before the other tabs relying on the `useId` hook. This means that `TabPanel` components without an explicit `tabId` prop, when scanning the tab items to find its match, will only see that single tab that was registered first and assume that's the matching tab.

To fix this, we're waiting `useId` to be fulfilled on all Tabs before registering them, even those that get an `id` prop. This way, they're all registered at the same time.

Closes #1721