### PR TITLE
Support dynamic role attribute on MenuButton

### DIFF
--- a/.changeset/menu-button-role.md
+++ b/.changeset/menu-button-role.md
@@ -1,0 +1,5 @@
+---
+"ariakit": minor
+---
+
+The `role` attribute on `MenuButton`, when inside another menu, is now based on the popover role instead of being always `menuitem`. ([#1728](https://github.com/ariakit/ariakit/pull/1728))

--- a/.changeset/utils-get-popup-item-role.md
+++ b/.changeset/utils-get-popup-item-role.md
@@ -1,0 +1,5 @@
+---
+"ariakit-utils": patch
+---
+
+Added `getPopupItemRole` function. ([#1728](https://github.com/ariakit/ariakit/pull/1728))

--- a/packages/ariakit-utils/src/__tests__/dom-test.ts
+++ b/packages/ariakit-utils/src/__tests__/dom-test.ts
@@ -5,6 +5,7 @@ import {
   contains,
   getActiveElement,
   getDocument,
+  getPopupItemRole,
   getPopupRole,
   getScrollingElement,
   getTextboxSelection,
@@ -280,6 +281,31 @@ test("getPopupRole", () => {
   expect(getPopupRole(div6, true)).toBe(true);
   expect(getPopupRole(div7)).toBe(undefined);
   expect(getPopupRole(div7, "dialog")).toBe("dialog");
+});
+
+test("getPopupItemRole", () => {
+  document.body.innerHTML = `
+    <div id="testNode2" role="menu" />
+    <div id="testNode3" role="listbox" />
+    <div id="testNode4" role="tree" />
+    <div id="testNode5" role="grid" />
+    <div id="testNode6" role="unsupported" />
+    <div id="testNode7" />
+  `;
+  const div2 = getById("testNode2");
+  const div3 = getById("testNode3");
+  const div4 = getById("testNode4");
+  const div5 = getById("testNode5");
+  const div6 = getById("testNode6");
+  const div7 = getById("testNode7");
+
+  expect(getPopupItemRole(div2)).toBe("menuitem");
+  expect(getPopupItemRole(div3)).toBe("option");
+  expect(getPopupItemRole(div4)).toBe("treeitem");
+  expect(getPopupItemRole(div5)).toBe("gridcell");
+  expect(getPopupItemRole(div6)).toBe(undefined);
+  expect(getPopupItemRole(div6, "menuitem")).toBe("menuitem");
+  expect(getPopupItemRole(div7, "menuitem")).toBe("menuitem");
 });
 
 test("getTextboxSelection", () => {

--- a/packages/ariakit-utils/src/dom.ts
+++ b/packages/ariakit-utils/src/dom.ts
@@ -1,4 +1,4 @@
-import { AriaAttributes } from "react";
+import { AriaAttributes, AriaRole } from "react";
 
 /**
  * It's `true` if it is running in a browser environment or `false` if it is not
@@ -196,6 +196,7 @@ export function getPopupRole(
   element?: Element | null,
   fallback?: AriaAttributes["aria-haspopup"]
 ) {
+  const allowedPopupRoles = ["dialog", "menu", "listbox", "tree", "grid"];
   const role = element?.getAttribute("role");
   if (role && allowedPopupRoles.indexOf(role) !== -1) {
     return role as "dialog" | "menu" | "listbox" | "tree" | "grid";
@@ -203,7 +204,24 @@ export function getPopupRole(
   return fallback;
 }
 
-const allowedPopupRoles = ["dialog", "menu", "listbox", "tree", "grid"];
+/**
+ * Returns the item role attribute based on the popup's role.
+ */
+export function getPopupItemRole(
+  element?: Element | null,
+  fallback?: AriaRole
+) {
+  const itemRoleByPopupRole = {
+    menu: "menuitem",
+    listbox: "option",
+    tree: "treeitem",
+    grid: "gridcell",
+  };
+  const popupRole = getPopupRole(element);
+  if (!popupRole) return fallback;
+  const key = popupRole as keyof typeof itemRoleByPopupRole;
+  return itemRoleByPopupRole[key] ?? fallback;
+}
 
 /**
  * Returns the start and end offsets of the selection in the element.

--- a/packages/ariakit/src/combobox/combobox-item.tsx
+++ b/packages/ariakit/src/combobox/combobox-item.tsx
@@ -1,5 +1,5 @@
 import { KeyboardEvent, MouseEvent, useCallback } from "react";
-import { getPopupRole, isTextField } from "ariakit-utils/dom";
+import { getPopupItemRole, isTextField } from "ariakit-utils/dom";
 import { hasFocus } from "ariakit-utils/focus";
 import { useBooleanEvent, useEvent, useWrapElement } from "ariakit-utils/hooks";
 import { queueMicrotask } from "ariakit-utils/misc";
@@ -16,18 +16,6 @@ import {
 } from "../composite/composite-item";
 import { ComboboxContext, ComboboxItemValueContext } from "./__utils";
 import { ComboboxState } from "./combobox-state";
-
-const itemRoleByPopupRole = {
-  listbox: "option",
-  tree: "treeitem",
-  grid: "gridcell",
-};
-
-function getItemRole(contentElement?: HTMLElement | null) {
-  const popupRole = getPopupRole(contentElement);
-  if (!popupRole) return;
-  return itemRoleByPopupRole[popupRole as keyof typeof itemRoleByPopupRole];
-}
 
 /**
  * A component hook that returns props that can be passed to `Role` or any other
@@ -127,7 +115,7 @@ export const useComboboxItem = createHook<ComboboxItemOptions>(
     );
 
     props = {
-      role: getItemRole(state?.contentElement),
+      role: getPopupItemRole(state?.contentElement),
       children: value,
       ...props,
       onClick,

--- a/packages/ariakit/src/menu/menu-button.ts
+++ b/packages/ariakit/src/menu/menu-button.ts
@@ -5,7 +5,7 @@ import {
   useEffect,
   useRef,
 } from "react";
-import { getPopupRole } from "ariakit-utils/dom";
+import { getPopupItemRole, getPopupRole } from "ariakit-utils/dom";
 import { useEvent, useForkRef, useId } from "ariakit-utils/hooks";
 import { useStore } from "ariakit-utils/store";
 import {
@@ -59,7 +59,11 @@ function getInitialFocus(event: KeyboardEvent, dir: BasePlacement) {
 export const useMenuButton = createHook<MenuButtonOptions>(
   ({ state, focusable, accessibleWhenDisabled, showOnHover, ...props }) => {
     const ref = useRef<HTMLElement>(null);
-    const parentMenu = useStore(MenuContext, ["items", "move"]);
+    const parentMenu = useStore(MenuContext, [
+      "items",
+      "move",
+      "contentElement",
+    ]);
     const parentMenuBar = useStore(MenuBarContext, ["items", "move"]);
     const hasParentMenu = !!parentMenu;
     const parentIsMenuBar = !!parentMenuBar && !hasParentMenu;
@@ -148,9 +152,17 @@ export const useMenuButton = createHook<MenuButtonOptions>(
     // We'll use this id to render the aria-labelledby attribute on the menu.
     const id = useId(props.id);
 
+    // When the menu button is rendered inside another menu, we set the role
+    // attribute here so it doesn't get overridden by the button component with
+    // role="button".
+    const role =
+      hasParentMenu || parentIsMenuBar
+        ? getPopupItemRole(parentMenu?.contentElement, "menuitem")
+        : undefined;
+
     props = {
       id,
-      role: hasParentMenu || parentIsMenuBar ? "menuitem" : undefined,
+      role,
       "aria-haspopup": getPopupRole(state.contentElement, "menu"),
       ...props,
       ref: useForkRef(ref, props.ref),

--- a/packages/ariakit/src/menu/menu-item.ts
+++ b/packages/ariakit/src/menu/menu-item.ts
@@ -43,8 +43,11 @@ export const useMenuItem = createHook<MenuItemOptions>(
     // Use MenuBar state as a fallback.
     const menuBarState = useStore(state || MenuBarContext, ["items"]);
     state =
-      useStore(state || (MenuContext as any), ["move", "hideAll"]) ||
-      menuBarState;
+      useStore(state || (MenuContext as any), [
+        "move",
+        "hideAll",
+        "contentElement",
+      ]) || menuBarState;
 
     const onClickProp = props.onClick;
     const hideOnClickProp = useBooleanEvent(hideOnClick);

--- a/packages/ariakit/src/menu/menu-item.ts
+++ b/packages/ariakit/src/menu/menu-item.ts
@@ -1,4 +1,5 @@
 import { MouseEvent } from "react";
+import { getPopupItemRole } from "ariakit-utils/dom";
 import { useBooleanEvent, useEvent } from "ariakit-utils/hooks";
 import { createMemoComponent, useStore } from "ariakit-utils/store";
 import { createElement, createHook } from "ariakit-utils/system";
@@ -61,8 +62,13 @@ export const useMenuItem = createHook<MenuItemOptions>(
       hideMenu();
     });
 
+    const role = getPopupItemRole(
+      state && "contentElement" in state ? state.contentElement : null,
+      "menuitem"
+    );
+
     props = {
-      role: "menuitem",
+      role,
       ...props,
       onClick,
     };

--- a/packages/ariakit/src/select/select-item.tsx
+++ b/packages/ariakit/src/select/select-item.tsx
@@ -1,5 +1,5 @@
 import { MouseEvent, useCallback } from "react";
-import { getPopupRole } from "ariakit-utils/dom";
+import { getPopupItemRole } from "ariakit-utils/dom";
 import { useBooleanEvent, useEvent, useWrapElement } from "ariakit-utils/hooks";
 import { createMemoComponent, useStore } from "ariakit-utils/store";
 import { createElement, createHook } from "ariakit-utils/system";
@@ -16,12 +16,6 @@ import {
 import { SelectContext, SelectItemCheckedContext } from "./__utils";
 import { SelectState } from "./select-state";
 
-const itemRoleByPopupRole = {
-  listbox: "option",
-  tree: "treeitem",
-  grid: "gridcell",
-};
-
 function isSelected(stateValue?: string | string[], itemValue?: string) {
   if (stateValue == null) return false;
   if (itemValue == null) return false;
@@ -29,12 +23,6 @@ function isSelected(stateValue?: string | string[], itemValue?: string) {
     return stateValue.includes(itemValue);
   }
   return stateValue === itemValue;
-}
-
-function getItemRole(contentElement?: HTMLElement | null) {
-  const popupRole = getPopupRole(contentElement);
-  if (!popupRole) return;
-  return itemRoleByPopupRole[popupRole as keyof typeof itemRoleByPopupRole];
 }
 
 /**
@@ -118,7 +106,7 @@ export const useSelectItem = createHook<SelectItemOptions>(
     );
 
     props = {
-      role: getItemRole(state?.contentElement),
+      role: getPopupItemRole(state?.contentElement),
       "aria-selected": selected,
       children: value,
       ...props,


### PR DESCRIPTION
Currently, the `role` attribute on `MenuButton` is hard-coded as `menuitem` whenever rendered inside another menu.

This may be problematic when we combine nested `Menu` components with other composite containers, like `SelectPopover`, `SelectList`, `ComboboxPopover`, `ComboboxList`, etc.

This PR updates the `MenuButton` component to determine its role attribute based on the composite content element's role. This is similar to what other composite items do.