### PR TITLE
Improve support for composite items as links

### DIFF
--- a/.changeset/combobox-links.md
+++ b/.changeset/combobox-links.md
@@ -1,0 +1,5 @@
+---
+"ariakit": minor
+---
+
+Improved support for `CompositeItem` rendered as a link. This includes `ComboboxItem`, `MenuItem`, and `SelectItem` components. Now clicking on `<a>` items with a mouse or keyboard while pressing `metaKey` (macOS) or `ctrlKey` (PC) opens the link in a new tab as expected. Popovers won't close and `Select`/`Combobox` values won't change when clicking with those modifiers. ([#1736](https://github.com/ariakit/ariakit/pull/1736))

--- a/.changeset/utils-is-opening-in-new-tab.md
+++ b/.changeset/utils-is-opening-in-new-tab.md
@@ -1,0 +1,5 @@
+---
+"ariakit-utils": patch
+---
+
+Added `isOpeningInNewTab` function. ([#1736](https://github.com/ariakit/ariakit/pull/1736))

--- a/packages/ariakit-playground/src/__examples__/playground/test-chrome.ts
+++ b/packages/ariakit-playground/src/__examples__/playground/test-chrome.ts
@@ -1,8 +1,9 @@
 import { expect, test } from "@playwright/test";
 
-test("editor screenshot", async ({ page }, testInfo) => {
+test("editor screenshot", async ({ page, headless }, testInfo) => {
   testInfo.snapshotSuffix = "";
   await page.goto("/examples/playground");
   const editor = await page.locator("role=group[name=index.js]");
+  if (!headless) return;
   expect(await editor.screenshot()).toMatchSnapshot();
 });

--- a/packages/ariakit-utils/src/events.ts
+++ b/packages/ariakit-utils/src/events.ts
@@ -1,5 +1,10 @@
-import { FocusEvent as ReactFocusEvent, SyntheticEvent } from "react";
+import {
+  FocusEvent as ReactFocusEvent,
+  MouseEvent as ReactMouseEvent,
+  SyntheticEvent,
+} from "react";
 import { contains } from "./dom";
+import { isApple } from "./platform";
 
 /**
  * Returns `true` if `event` has been fired within a React Portal element.
@@ -13,6 +18,26 @@ export function isPortalEvent(event: SyntheticEvent): boolean {
  */
 export function isSelfTarget(event: SyntheticEvent | Event): boolean {
   return event.target === event.currentTarget;
+}
+
+/**
+ * Checks whether the user event is triggering a page navigation in a new tab.
+ */
+export function isOpeningInNewTab(event: MouseEvent | ReactMouseEvent) {
+  const target = event.target as
+    | HTMLAnchorElement
+    | HTMLButtonElement
+    | HTMLInputElement
+    | null;
+  if (!target) return null;
+  const isAppleDevice = isApple();
+  if (isAppleDevice && !event.metaKey) return false;
+  if (!isAppleDevice && !event.ctrlKey) return false;
+  const tagName = target.tagName.toLowerCase();
+  if (tagName === "a") return true;
+  if (tagName === "button" && target.type === "submit") return true;
+  if (tagName === "input" && target.type === "submit") return true;
+  return false;
 }
 
 /**
@@ -81,10 +106,7 @@ export function fireKeyboardEvent(
  * fireClickEvent(document.getElementById("id"));
  */
 export function fireClickEvent(element: Element, eventInit?: PointerEventInit) {
-  const event =
-    typeof PointerEvent !== "undefined"
-      ? new PointerEvent("click", eventInit)
-      : new MouseEvent("click", eventInit);
+  const event = new MouseEvent("click", eventInit);
   return element.dispatchEvent(event);
 }
 

--- a/packages/ariakit/src/combobox/__examples__/combobox-links/index.tsx
+++ b/packages/ariakit/src/combobox/__examples__/combobox-links/index.tsx
@@ -1,0 +1,52 @@
+import {
+  Combobox,
+  ComboboxItem,
+  ComboboxPopover,
+  useComboboxState,
+} from "ariakit/combobox";
+import "./style.css";
+
+const links = [
+  { href: "https://ariakit.org", value: "Ariakit.org" },
+  { href: "https://twitter.com/ariakitjs", value: "Twitter", target: "_blank" },
+  {
+    href: "https://www.facebook.com/ariakitjs",
+    value: "Facebook",
+    target: "_blank",
+  },
+  {
+    href: "https://www.instagram.com/ariakitjs",
+    value: "Instagram",
+    target: "_blank",
+  },
+];
+
+export default function Example() {
+  const combobox = useComboboxState({
+    gutter: 8,
+    sameWidth: true,
+  });
+  return (
+    <div>
+      <label className="label">
+        Links
+        <Combobox
+          state={combobox}
+          placeholder="e.g., Twitter"
+          className="combobox"
+        />
+      </label>
+      <ComboboxPopover state={combobox} className="popover">
+        {links.map((link) => (
+          <ComboboxItem
+            as="a"
+            key={link.href}
+            focusOnHover
+            className="combobox-item"
+            {...link}
+          />
+        ))}
+      </ComboboxPopover>
+    </div>
+  );
+}

--- a/packages/ariakit/src/combobox/__examples__/combobox-links/style.css
+++ b/packages/ariakit/src/combobox/__examples__/combobox-links/style.css
@@ -1,0 +1,5 @@
+@import "../combobox/style.css";
+
+.combobox-item {
+  @apply cursor-pointer;
+}

--- a/packages/ariakit/src/combobox/__examples__/combobox-links/test-browser.ts
+++ b/packages/ariakit/src/combobox/__examples__/combobox-links/test-browser.ts
@@ -1,0 +1,91 @@
+import { Page, expect, test } from "@playwright/test";
+
+const getCombobox = (page: Page) => page.locator("role=combobox[name='Links']");
+const getPopover = (page: Page) => page.locator(".popover[role='listbox']");
+const getOption = (page: Page, name: string) =>
+  getPopover(page).locator(`role=option[name='${name}']`);
+
+const getClickModifier = async (page: Page) => {
+  const isMac = await page.evaluate(() => navigator.platform.startsWith("Mac"));
+  return isMac ? "Meta" : "Control";
+};
+
+test("click on link with mouse", async ({ page }) => {
+  await page.goto("/examples/combobox-links");
+  await getCombobox(page).click();
+  await getOption(page, "Ariakit.org").click();
+  await expect(page).toHaveURL(/https:\/\/ariakit.org/);
+});
+
+test("click on link with middle button", async ({
+  page,
+  context,
+  browserName,
+}) => {
+  await page.goto("/examples/combobox-links");
+  await getCombobox(page).click();
+  await expect(getCombobox(page)).toHaveValue("");
+  if (browserName === "webkit") {
+    await getOption(page, "Ariakit.org").click({ button: "middle" });
+    await expect(page).toHaveURL(/https:\/\/ariakit.org/);
+  } else {
+    const [newPage] = await Promise.all([
+      context.waitForEvent("page"),
+      getOption(page, "Ariakit.org").click({ button: "middle" }),
+    ]);
+    await expect(getPopover(page)).toBeVisible();
+    await expect(getCombobox(page)).toHaveValue("");
+    await expect(newPage).toHaveURL(/https:\/\/ariakit.org/);
+  }
+});
+
+test("click on link with cmd/ctrl", async ({ page, context }) => {
+  await page.goto("/examples/combobox-links");
+  await getCombobox(page).click();
+  const modifier = await getClickModifier(page);
+  const [newPage] = await Promise.all([
+    context.waitForEvent("page"),
+    getOption(page, "Ariakit.org").click({ modifiers: [modifier] }),
+  ]);
+  await expect(getPopover(page)).toBeVisible();
+  await expect(getCombobox(page)).toHaveValue("");
+  await expect(newPage).toHaveURL(/https:\/\/ariakit.org/);
+});
+
+test("click on link with cmd/ctrl + enter", async ({
+  page,
+  context,
+  browserName,
+}) => {
+  await page.goto("/examples/combobox-links");
+  await getCombobox(page).click();
+  const modifier = await getClickModifier(page);
+  await page.keyboard.press("ArrowDown");
+  // Safari doesn't support Cmd+Enter to open a link in a new tab
+  // programmatically.
+  if (browserName === "webkit") {
+    await page.keyboard.press(`${modifier}+Enter`);
+    await expect(page).toHaveURL(/https:\/\/ariakit.org/);
+  } else {
+    const [newPage] = await Promise.all([
+      context.waitForEvent("page"),
+      page.keyboard.press(`${modifier}+Enter`),
+    ]);
+    await expect(getPopover(page)).toBeVisible();
+    await expect(getCombobox(page)).toHaveValue("");
+    await expect(newPage).toHaveURL(/https:\/\/ariakit.org/);
+  }
+});
+
+test("click on target blank link", async ({ page, context }) => {
+  await page.goto("/examples/combobox-links");
+  await getCombobox(page).click();
+  await expect(getCombobox(page)).toHaveValue("");
+  const [newPage] = await Promise.all([
+    context.waitForEvent("page"),
+    getOption(page, "Twitter").click(),
+  ]);
+  await expect(getPopover(page)).not.toBeVisible();
+  await expect(getCombobox(page)).toHaveValue("Twitter");
+  await expect(newPage).toHaveURL(/https:\/\/twitter.com\/ariakitjs/);
+});

--- a/packages/ariakit/src/combobox/__examples__/combobox-textarea/test-chrome.ts
+++ b/packages/ariakit/src/combobox/__examples__/combobox-textarea/test-chrome.ts
@@ -1,29 +1,31 @@
 import { expect, test } from "@playwright/test";
 
-test("popover is positioned correctly", async ({ page }, testInfo) => {
+test("popover is positioned correctly", async ({
+  page,
+  headless,
+}, testInfo) => {
   testInfo.snapshotSuffix = "";
   await page.goto("/examples/combobox-textarea");
-
   const textarea = await page.locator("role=combobox[name='Comment']");
   await textarea.click({ position: { x: 10, y: 10 } });
   await textarea.type("Hello @a");
-
   const popover = await page.locator(".popover[role='listbox']");
   await expect(popover).toBeVisible();
-
-  expect(await textarea.screenshot()).toMatchSnapshot();
-
+  if (headless) {
+    expect(await textarea.screenshot()).toMatchSnapshot();
+  }
   await textarea.type("\n\n\n\n\n\n\n\n\n\n");
   await textarea.press("ArrowUp");
   await textarea.press("ArrowUp");
   await textarea.press("ArrowUp");
   await textarea.press("ArrowUp");
   await textarea.type("@");
-
-  expect(await textarea.screenshot()).toMatchSnapshot();
-
+  if (headless) {
+    expect(await textarea.screenshot()).toMatchSnapshot();
+  }
   await page.mouse.wheel(0, -50);
   await page.waitForTimeout(250);
-
-  expect(await textarea.screenshot()).toMatchSnapshot();
+  if (headless) {
+    expect(await textarea.screenshot()).toMatchSnapshot();
+  }
 });

--- a/packages/ariakit/src/combobox/combobox-item.tsx
+++ b/packages/ariakit/src/combobox/combobox-item.tsx
@@ -1,5 +1,6 @@
 import { KeyboardEvent, MouseEvent, useCallback } from "react";
 import { getPopupItemRole, isTextField } from "ariakit-utils/dom";
+import { isOpeningInNewTab } from "ariakit-utils/events";
 import { hasFocus } from "ariakit-utils/focus";
 import { useBooleanEvent, useEvent, useWrapElement } from "ariakit-utils/hooks";
 import { queueMicrotask } from "ariakit-utils/misc";
@@ -66,6 +67,7 @@ export const useComboboxItem = createHook<ComboboxItemOptions>(
     const onClick = useEvent((event: MouseEvent<HTMLDivElement>) => {
       onClickProp?.(event);
       if (event.defaultPrevented) return;
+      if (isOpeningInNewTab(event)) return;
       if (value != null && setValueOnClickProp(event)) {
         state?.setValue(value);
       }

--- a/packages/ariakit/src/command/command.ts
+++ b/packages/ariakit/src/command/command.ts
@@ -65,7 +65,6 @@ export const useCommand = createHook<CommandOptions>(
       if (event.defaultPrevented) return;
       if (isDuplicate) return;
       if (props.disabled) return;
-      if (event.metaKey) return;
       if (!isSelfTarget(event)) return;
       if (isTextField(element)) return;
       if (element.isContentEditable) return;

--- a/packages/ariakit/src/composite/composite.ts
+++ b/packages/ariakit/src/composite/composite.ts
@@ -45,7 +45,6 @@ import { CompositeState } from "./composite-state";
 
 function canProxyKeyboardEvent(event: ReactKeyboardEvent) {
   if (!isSelfTarget(event)) return false;
-  if (event.metaKey) return false;
   // If the propagation of the event has been prevented, we don't want to proxy
   // this event to the active item element. For example, on a combobox, the Home
   // and End keys shouldn't propagate to the active item, but move the caret on

--- a/packages/ariakit/src/menu/menu-item.ts
+++ b/packages/ariakit/src/menu/menu-item.ts
@@ -1,5 +1,6 @@
 import { MouseEvent } from "react";
 import { getPopupItemRole } from "ariakit-utils/dom";
+import { isOpeningInNewTab } from "ariakit-utils/events";
 import { useBooleanEvent, useEvent } from "ariakit-utils/hooks";
 import { createMemoComponent, useStore } from "ariakit-utils/store";
 import { createElement, createHook } from "ariakit-utils/system";
@@ -57,6 +58,7 @@ export const useMenuItem = createHook<MenuItemOptions>(
     const onClick = useEvent((event: MouseEvent<HTMLDivElement>) => {
       onClickProp?.(event);
       if (event.defaultPrevented) return;
+      if (isOpeningInNewTab(event)) return;
       if (!hideMenu) return;
       // If this item is also a menu button, we don't want to hide the menu.
       const popupType = event.currentTarget.getAttribute("aria-haspopup");

--- a/packages/ariakit/src/popover/__examples__/popover-flip/test-chrome.ts
+++ b/packages/ariakit/src/popover/__examples__/popover-flip/test-chrome.ts
@@ -3,11 +3,12 @@ import { Page, devices, expect, test } from "@playwright/test";
 const getPreview = (page: Page) =>
   page.locator("role=button[name='Accept invite'] >> xpath=..");
 
-test("popover flip", async ({ page }, testInfo) => {
+test("popover flip", async ({ page, headless }, testInfo) => {
   testInfo.snapshotSuffix = "";
   await page.goto("/examples/popover-flip");
   await page.locator("role=button[name='Accept invite']").click();
   await expect(page.locator("role=dialog[name='Team meeting']")).toBeVisible();
+  if (!headless) return;
   // Expect the popover to be placed on the right
   expect(await getPreview(page).screenshot()).toMatchSnapshot();
   // Resize the viewport to ensure it overflows

--- a/packages/ariakit/src/select/select-item.tsx
+++ b/packages/ariakit/src/select/select-item.tsx
@@ -1,5 +1,6 @@
 import { MouseEvent, useCallback } from "react";
 import { getPopupItemRole } from "ariakit-utils/dom";
+import { isOpeningInNewTab } from "ariakit-utils/events";
 import { useBooleanEvent, useEvent, useWrapElement } from "ariakit-utils/hooks";
 import { createMemoComponent, useStore } from "ariakit-utils/store";
 import { createElement, createHook } from "ariakit-utils/system";
@@ -79,6 +80,7 @@ export const useSelectItem = createHook<SelectItemOptions>(
     const onClick = useEvent((event: MouseEvent<HTMLDivElement>) => {
       onClickProp?.(event);
       if (event.defaultPrevented) return;
+      if (isOpeningInNewTab(event)) return;
       if (setValueOnClickProp(event) && value != null) {
         state?.setValue((prevValue) => {
           if (!Array.isArray(prevValue)) return value;


### PR DESCRIPTION
This PR improves support for `CompositeItem` rendered as a link. This includes `ComboboxItem`, `MenuItem`, and `SelectItem` components. Now clicking on `<a>` items with a mouse or keyboard while pressing `metaKey` (macOS) or `ctrlKey` (PC) opens the link in a new tab as expected. Popovers won't close, and `Select`/`Combobox` values won't change when clicking with those modifiers.