### PR TITLE
Use MenuHeading's id on Menu's aria-labelledby prop

### DIFF
--- a/.changeset/menu-heading-aria-labelledby.md
+++ b/.changeset/menu-heading-aria-labelledby.md
@@ -1,0 +1,5 @@
+---
+"ariakit": patch
+---
+
+Fixed `aria-labelledby` attribute on `Menu` not pointing to the correct element when using `MenuHeading`. ([#1737](https://github.com/ariakit/ariakit/pull/1737))

--- a/packages/ariakit/src/menu/__examples__/menu-dialog-animated/test-chrome.ts
+++ b/packages/ariakit/src/menu/__examples__/menu-dialog-animated/test-chrome.ts
@@ -4,7 +4,7 @@ const getMenuButton = (locator: Page | Locator, count: number | string = "") =>
   locator.locator(`role=button[name^='Add to list ${count}']`);
 
 const getMenu = (locator: Page | Locator) =>
-  locator.locator(`role=menu[name^='Add to list']`);
+  locator.locator(`role=menu[name='Lists']`);
 
 const getMenuItem = (
   locator: Page | Locator,

--- a/packages/ariakit/src/menu/menu.ts
+++ b/packages/ariakit/src/menu/menu.ts
@@ -68,10 +68,18 @@ export const useMenu = createHook<MenuOptions>(
       onKeyDown,
     };
 
-    props = useMenuList({
-      state,
-      ...props,
-    });
+    // The aria-labelledby prop on MenuList defaults to the MenuButton's id. On
+    // Dialog/Popover/Hovercard/Menu, we need to consider MenuHeading as well
+    // and it should take precedence. That's why we need to destructure this
+    // prop here and check if aria-labelledby is set later.
+    const { "aria-labelledby": ariaLabelledBy, ...menuListProps } = useMenuList(
+      {
+        state,
+        ...props,
+      }
+    );
+
+    props = menuListProps;
 
     const [initialFocusRef, setInitialFocusRef] =
       useState<RefObject<HTMLElement>>();
@@ -145,6 +153,11 @@ export const useMenu = createHook<MenuOptions>(
       // be closed.
       hideOnEscape: hasParentMenu ? false : hideOnEscape,
     });
+
+    props = {
+      "aria-labelledby": ariaLabelledBy,
+      ...props,
+    };
 
     return props;
   }


### PR DESCRIPTION
This PR fixes the `aria-labelledby` prop on `Menu` when using `MenuHeading`. Instead of using the heading id, it still referenced the menu button element. Now `MenuHeading` correctly takes precedence.