### PR TITLE
Allow onKeyDown prop on Combobox when pressing printable keys

### DIFF
--- a/.changeset/combobox-on-key-down.md
+++ b/.changeset/combobox-on-key-down.md
@@ -1,0 +1,5 @@
+---
+"ariakit": patch
+---
+
+Fixed `Combobox` not calling the `onKeyDown` prop when pressing printable keys. ([#1739](https://github.com/ariakit/ariakit/pull/1739))

--- a/packages/ariakit/src/combobox/combobox.ts
+++ b/packages/ariakit/src/combobox/combobox.ts
@@ -57,10 +57,6 @@ function isInputEvent(event: Event): event is InputEvent {
   return event.type === "input";
 }
 
-function isPrintableKey(event: ReactKeyboardEvent): boolean {
-  return event.key.length === 1 && !event.ctrlKey && !event.metaKey;
-}
-
 /**
  * A component hook that returns props that can be passed to `Role` or any other
  * Ariakit component to render a combobox input.
@@ -278,34 +274,6 @@ export const useCombobox = createHook<ComboboxOptions>(
       }
     });
 
-    const onKeyDownCaptureProp = props.onKeyDownCapture;
-
-    const onKeyDownCapture = useEvent(
-      (event: ReactKeyboardEvent<HTMLInputElement>) => {
-        onKeyDownCaptureProp?.(event);
-        if (event.defaultPrevented) return;
-        if (isPrintableKey(event)) {
-          // Printable characters shouldn't perform actions on the combobox
-          // items, only on the combobox input.
-          return event.stopPropagation();
-        }
-        const hasRows = state.items.some((item) => !!item.rowId);
-        const focusingInputOnly = state.activeId === null;
-        // Pressing Home or End keys on the combobox should only be allowed when
-        // the widget has rows and the combobox input is not the only element
-        // with focus. That is, the aria-activedescendant has no value.
-        const allowHorizontalNavigationOnItems = hasRows && !focusingInputOnly;
-        const isHomeOrEnd = event.key === "Home" || event.key === "End";
-        // If there are no rows or the combobox input is the only focused
-        // element, then we should stop the event propagation so no action is
-        // performed on the combobox items, but only on the combobox input, like
-        // moving the caret/selection.
-        if (!allowHorizontalNavigationOnItems && isHomeOrEnd) {
-          event.stopPropagation();
-        }
-      }
-    );
-
     const onKeyDownProp = props.onKeyDown;
     const showOnKeyDownProp = useBooleanEvent(showOnKeyDown);
 
@@ -356,7 +324,6 @@ export const useCombobox = createHook<ComboboxOptions>(
       onCompositionEnd,
       onMouseDown,
       onClick,
-      onKeyDownCapture,
       onKeyDown,
       onBlur,
     };

--- a/packages/ariakit/src/composite/composite.ts
+++ b/packages/ariakit/src/composite/composite.ts
@@ -5,11 +5,12 @@ import {
   RefObject,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
 import { flatten2DArray, reverseArray } from "ariakit-utils/array";
-import { getActiveElement } from "ariakit-utils/dom";
+import { getActiveElement, isTextField } from "ariakit-utils/dom";
 import {
   fireBlurEvent,
   fireFocusEvent,
@@ -43,17 +44,42 @@ import {
 } from "./__utils";
 import { CompositeState } from "./composite-state";
 
-function canProxyKeyboardEvent(event: ReactKeyboardEvent) {
+function isGrid(items: Item[]) {
+  return items.some((item) => !!item.rowId);
+}
+
+function isPrintableKey(event: ReactKeyboardEvent): boolean {
+  return event.key.length === 1 && !event.ctrlKey && !event.metaKey;
+}
+
+function canProxyKeyboardEvent(
+  event: ReactKeyboardEvent,
+  state: CompositeState
+) {
   if (!isSelfTarget(event)) return false;
-  // If the propagation of the event has been prevented, we don't want to proxy
-  // this event to the active item element. For example, on a combobox, the Home
-  // and End keys shouldn't propagate to the active item, but move the caret on
-  // the combobox input instead.
-  if (event.isPropagationStopped()) return false;
-  return true;
+  const target = event.target as Element;
+  if (!target) return true;
+  if (isTextField(target)) {
+    // Printable characters shouldn't perform actions on the composite items if
+    // the composite widget is a combobox.
+    if (isPrintableKey(event)) return false;
+    const grid = isGrid(state.items);
+    const focusingInputOnly = state.activeId === null;
+    // Pressing Home or End keys on the text field should only be allowed when
+    // the widget has rows and the input is not the only element with focus.
+    // That is, the aria-activedescendant has no value.
+    const allowHorizontalNavigationOnItems = grid && !focusingInputOnly;
+    const isHomeOrEnd = event.key === "Home" || event.key === "End";
+    // If there are no rows or the input is the only focused element, then we
+    // should stop the event propagation so no action is performed on the
+    // composite items, but only on the input, like moving the caret/selection.
+    if (!allowHorizontalNavigationOnItems && isHomeOrEnd) return false;
+  }
+  return !event.isPropagationStopped();
 }
 
 function useKeyboardEventProxy(
+  state: CompositeState,
   activeItem?: Item,
   onKeyboardEvent?: KeyboardEventHandler,
   previousElementRef?: RefObject<HTMLElement | null>
@@ -61,7 +87,7 @@ function useKeyboardEventProxy(
   return useEvent((event: ReactKeyboardEvent) => {
     onKeyboardEvent?.(event);
     if (event.defaultPrevented) return;
-    if (!canProxyKeyboardEvent(event)) return;
+    if (!canProxyKeyboardEvent(event, state)) return;
     const activeElement = activeItem?.ref.current;
     if (!activeElement) return;
     const { view, ...eventInit } = event;
@@ -121,7 +147,10 @@ export const useComposite = createHook<CompositeOptions>(
   ({ state, composite = true, focusOnMove = composite, ...props }) => {
     const ref = useRef<HTMLDivElement>(null);
     const virtualFocus = composite && state.virtualFocus;
-    const activeItem = findEnabledItemById(state.items, state.activeId);
+    const activeItem = useMemo(
+      () => findEnabledItemById(state.items, state.activeId),
+      [state.items, state.activeId]
+    );
     const activeItemRef = useLiveRef(activeItem);
     const previousElementRef = useRef<HTMLElement | null>(null);
     const isSelfActive = state.activeId === null;
@@ -185,12 +214,14 @@ export const useComposite = createHook<CompositeOptions>(
     }, [virtualFocus, composite, state.activeId]);
 
     const onKeyDownCapture = useKeyboardEventProxy(
+      state,
       activeItem,
       props.onKeyDownCapture,
       previousElementRef
     );
 
     const onKeyUpCapture = useKeyboardEventProxy(
+      state,
       activeItem,
       props.onKeyUpCapture,
       previousElementRef
@@ -322,9 +353,9 @@ export const useComposite = createHook<CompositeOptions>(
       if (activeItemRef.current) return;
       const isVertical = state.orientation !== "horizontal";
       const isHorizontal = state.orientation !== "vertical";
-      const isGrid = !!findFirstEnabledItem(state.items)?.rowId;
+      const grid = isGrid(state.items);
       const up = () => {
-        if (isGrid) {
+        if (grid) {
           const item =
             state.items && findFirstEnabledItemInTheLastRow(state.items);
           return item?.id;
@@ -332,10 +363,10 @@ export const useComposite = createHook<CompositeOptions>(
         return state.last();
       };
       const keyMap = {
-        ArrowUp: (isGrid || isVertical) && up,
-        ArrowRight: (isGrid || isHorizontal) && state.first,
-        ArrowDown: (isGrid || isVertical) && state.first,
-        ArrowLeft: (isGrid || isHorizontal) && state.last,
+        ArrowUp: (grid || isVertical) && up,
+        ArrowRight: (grid || isHorizontal) && state.first,
+        ArrowDown: (grid || isVertical) && state.first,
+        ArrowLeft: (grid || isHorizontal) && state.last,
         Home: state.first,
         End: state.last,
         PageUp: state.first,


### PR DESCRIPTION
We were stopping the propagation of the `onKeyDownCapture` event on the `Combobox` component when pressing printable keys and the Home/End keys. This was so the event wasn't propagated to the combobox items by the `Composite` component. But, as a side effect, we were also preventing the `onKeyDown` event from happening on the combobox itself.

This PR moves this logic to the composite component, so we don't need to stop the propagation on combobox.