### PR TITLE
Fix Hovercard transit area

### DIFF
--- a/.changeset/hovercard-polygon.md
+++ b/.changeset/hovercard-polygon.md
@@ -1,0 +1,5 @@
+---
+"ariakit": patch
+---
+
+Fixed `Hovercard` prematurely hiding when moving mouse to it when the card is positioned diagonally to the anchor. ([#1742](https://github.com/ariakit/ariakit/pull/1742))

--- a/packages/ariakit/src/hovercard/__examples__/hovercard/test-browser.ts
+++ b/packages/ariakit/src/hovercard/__examples__/hovercard/test-browser.ts
@@ -4,7 +4,7 @@ const getAnchor = (page: Page) => page.locator("role=link[name='@ariakitjs']");
 const getHovercard = (page: Page) =>
   page.locator("role=dialog[name='Ariakit']");
 
-test("show/hide hovercard", async ({ page }) => {
+test("show/hide hovercard after scrolling", async ({ page }) => {
   await page.goto("/examples/hovercard");
   await getAnchor(page).hover();
   await expect(getHovercard(page)).toBeVisible();

--- a/packages/ariakit/src/hovercard/__utils/polygon.ts
+++ b/packages/ariakit/src/hovercard/__utils/polygon.ts
@@ -1,5 +1,3 @@
-import { HovercardState } from "../hovercard-state";
-
 export type Point = [number, number];
 export type Polygon = Point[];
 
@@ -23,45 +21,38 @@ export function isPointInPolygon(point: Point, polygon: Polygon) {
   return isInside;
 }
 
-export function getElementPolygon(
-  element: Element,
-  placement: HovercardState["placement"]
-): Polygon {
-  const { top, right, bottom, left } = element.getBoundingClientRect();
-  const [basePlacement] = placement.split("-");
-  switch (basePlacement) {
-    case "top": {
-      return [
-        [left, bottom],
-        [left, top],
-        [right, top],
-        [right, bottom],
-      ];
+function getEnterPointPlacement(enterPoint: Point, rect: DOMRect) {
+  const { top, right, bottom, left } = rect;
+  const [x, y] = enterPoint;
+  const placementX = x < left ? "left" : x > right ? "right" : null;
+  const placementY = y < top ? "top" : y > bottom ? "bottom" : null;
+  return [placementX, placementY] as const;
+}
+
+export function getElementPolygon(element: Element, enterPoint: Point) {
+  const rect = element.getBoundingClientRect();
+  const { top, right, bottom, left } = rect;
+  const [x, y] = getEnterPointPlacement(enterPoint, rect);
+  const polygon = [enterPoint];
+  if (x) {
+    if (y !== "top") {
+      polygon.push([x === "left" ? left : right, top]);
     }
-    case "right": {
-      return [
-        [left, top],
-        [right, top],
-        [right, bottom],
-        [left, bottom],
-      ];
+    polygon.push([x === "left" ? right : left, top]);
+    polygon.push([x === "left" ? right : left, bottom]);
+    if (y !== "bottom") {
+      polygon.push([x === "left" ? left : right, bottom]);
     }
-    case "bottom": {
-      return [
-        [left, top],
-        [left, bottom],
-        [right, bottom],
-        [right, top],
-      ];
-    }
-    case "left":
-    default: {
-      return [
-        [right, top],
-        [left, top],
-        [left, bottom],
-        [right, bottom],
-      ];
-    }
+  } else if (y === "top") {
+    polygon.push([left, top]);
+    polygon.push([left, bottom]);
+    polygon.push([right, bottom]);
+    polygon.push([right, top]);
+  } else {
+    polygon.push([left, bottom]);
+    polygon.push([left, top]);
+    polygon.push([right, top]);
+    polygon.push([right, bottom]);
   }
+  return polygon;
 }

--- a/packages/ariakit/src/hovercard/hovercard.tsx
+++ b/packages/ariakit/src/hovercard/hovercard.tsx
@@ -212,9 +212,7 @@ export const useHovercard = createHook<HovercardOptions>(
         // element.
         if (enterPoint) {
           const currentPoint = getEventPoint(event);
-          const placement = state.currentPlacement;
-          const elementPolygon = getElementPolygon(element, placement);
-          const polygon = [enterPoint, ...elementPolygon];
+          const polygon = getElementPolygon(element, enterPoint);
           // If the current's event mouse position is inside the transit
           // polygon, this means that the mouse is moving toward the hover card,
           // so we disable this event. This is necessary because the mousemove
@@ -243,7 +241,6 @@ export const useHovercard = createHook<HovercardOptions>(
       mayDisablePointerEvents,
       state.anchorRef,
       nestedHovercards,
-      state.currentPlacement,
       disablePointerEventsProp,
       hideOnHoverOutsideProp,
       state.hide,
@@ -262,9 +259,7 @@ export const useHovercard = createHook<HovercardOptions>(
         if (!element) return;
         const enterPoint = enterPointRef.current;
         if (!enterPoint) return;
-        const placement = state.currentPlacement;
-        const elementPolygon = getElementPolygon(element, placement);
-        const polygon = [enterPoint, ...elementPolygon];
+        const polygon = getElementPolygon(element, enterPoint);
         if (isPointInPolygon(getEventPoint(event), polygon)) {
           if (!disablePointerEventsProp(event)) return;
           event.preventDefault();
@@ -282,7 +277,6 @@ export const useHovercard = createHook<HovercardOptions>(
       domReady,
       state.mounted,
       mayDisablePointerEvents,
-      state.currentPlacement,
       disablePointerEventsProp,
     ]);
 


### PR DESCRIPTION
When the Hovercard component was positioned diagonally to the anchor, it was prematurely hiding when moving the mouse onto it. This was because we only considered one position (`top`, `right`, `bottom`, `left`) when calculating the transit area polygon.

This PR considers both `x` and `y` coordinates when creating the polygon.