### PR TITLE
Add `combobox` inline autocomplete example

### DIFF
--- a/packages/ariakit/src/combobox/__examples__/combobox-inline-autocomplete/index.tsx
+++ b/packages/ariakit/src/combobox/__examples__/combobox-inline-autocomplete/index.tsx
@@ -1,0 +1,42 @@
+import {
+  Combobox,
+  ComboboxItem,
+  ComboboxPopover,
+  useComboboxState,
+} from "ariakit/combobox";
+import "./style.css";
+
+export default function Example() {
+  const combobox = useComboboxState({ gutter: 8, sameWidth: true });
+  return (
+    <div>
+      <label className="label">
+        Your favorite fruit
+        <Combobox
+          state={combobox}
+          placeholder="e.g., Apple"
+          className="combobox"
+          autoComplete="inline"
+          autoSelect
+        />
+      </label>
+      <ComboboxPopover state={combobox} className="popover">
+        <ComboboxItem className="combobox-item" value="Apple">
+          🍎 Apple
+        </ComboboxItem>
+        <ComboboxItem className="combobox-item" value="Grape">
+          🍇 Grape
+        </ComboboxItem>
+        <ComboboxItem className="combobox-item" value="Orange">
+          🍊 Orange
+        </ComboboxItem>
+        <ComboboxItem className="combobox-item" value="Strawberry">
+          🍓 Strawberry
+        </ComboboxItem>
+        <ComboboxItem className="combobox-item" value="Watermelon">
+          🍉 Watermelon
+        </ComboboxItem>
+      </ComboboxPopover>
+    </div>
+  );
+}

--- a/packages/ariakit/src/combobox/__examples__/combobox-inline-autocomplete/index.tsx
+++ b/packages/ariakit/src/combobox/__examples__/combobox-inline-autocomplete/index.tsx
@@ -17,7 +17,6 @@ export default function Example() {
           placeholder="e.g., Apple"
           className="combobox"
           autoComplete="inline"
-          autoSelect
         />
       </label>
       <ComboboxPopover state={combobox} className="popover">

--- a/packages/ariakit/src/combobox/__examples__/combobox-inline-autocomplete/style.css
+++ b/packages/ariakit/src/combobox/__examples__/combobox-inline-autocomplete/style.css
@@ -1,0 +1,1 @@
+@import "../combobox/style.css";

--- a/packages/ariakit/src/combobox/__examples__/combobox-inline-autocomplete/test.tsx
+++ b/packages/ariakit/src/combobox/__examples__/combobox-inline-autocomplete/test.tsx
@@ -12,26 +12,22 @@ test("a11y", async () => {
 
 test("autocomplete on arrow down key", async () => {
   render(<Example />);
-  const combobox = getCombobox();
-  const popover = getPopover();
   await press.Tab();
-  expect(popover).not.toBeVisible();
-  expect(combobox).toHaveFocus();
+  expect(getPopover()).not.toBeVisible();
+  expect(getCombobox()).toHaveFocus();
   await type("a");
-  expect(popover).toBeVisible();
+  expect(getPopover()).toBeVisible();
   await press.ArrowDown();
-  expect(combobox).toHaveValue("Apple");
+  expect(getCombobox()).toHaveValue("Apple");
 });
 
 test("autocomplete on arrow up key", async () => {
   render(<Example />);
-  const combobox = getCombobox();
-  const popover = getPopover();
   await press.Tab();
-  expect(popover).not.toBeVisible();
-  expect(combobox).toHaveFocus();
+  expect(getPopover()).not.toBeVisible();
+  expect(getCombobox()).toHaveFocus();
   await type("w");
-  expect(popover).toBeVisible();
+  expect(getPopover()).toBeVisible();
   await press.ArrowUp();
-  expect(combobox).toHaveValue("Watermelon");
+  expect(getCombobox()).toHaveValue("Watermelon");
 });

--- a/packages/ariakit/src/combobox/__examples__/combobox-inline-autocomplete/test.tsx
+++ b/packages/ariakit/src/combobox/__examples__/combobox-inline-autocomplete/test.tsx
@@ -1,0 +1,8 @@
+import { render } from "ariakit-test";
+import { axe } from "jest-axe";
+import Example from ".";
+
+test("a11y", async () => {
+  const { container } = render(<Example />);
+  expect(await axe(container)).toHaveNoViolations();
+});

--- a/packages/ariakit/src/combobox/__examples__/combobox-inline-autocomplete/test.tsx
+++ b/packages/ariakit/src/combobox/__examples__/combobox-inline-autocomplete/test.tsx
@@ -1,8 +1,37 @@
-import { render } from "ariakit-test";
+import { getByRole, press, render, type } from "ariakit-test";
 import { axe } from "jest-axe";
 import Example from ".";
+
+const getCombobox = () => getByRole("combobox");
+const getPopover = () => getByRole("listbox", { hidden: true });
 
 test("a11y", async () => {
   const { container } = render(<Example />);
   expect(await axe(container)).toHaveNoViolations();
+});
+
+test("autocomplete on arrow down key", async () => {
+  render(<Example />);
+  const combobox = getCombobox();
+  const popover = getPopover();
+  await press.Tab();
+  expect(popover).not.toBeVisible();
+  expect(combobox).toHaveFocus();
+  await type("a");
+  expect(popover).toBeVisible();
+  await press.ArrowDown();
+  expect(combobox).toHaveValue("Apple");
+});
+
+test("autocomplete on arrow up key", async () => {
+  render(<Example />);
+  const combobox = getCombobox();
+  const popover = getPopover();
+  await press.Tab();
+  expect(popover).not.toBeVisible();
+  expect(combobox).toHaveFocus();
+  await type("w");
+  expect(popover).toBeVisible();
+  await press.ArrowUp();
+  expect(combobox).toHaveValue("Watermelon");
 });

--- a/packages/website/pages/index.tsx
+++ b/packages/website/pages/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Link from "next/link";
 
 const links: Array<{ href: string; label: string }> = [
@@ -16,6 +15,10 @@ const links: Array<{ href: string; label: string }> = [
   { href: "/examples/combobox-animated", label: "Combobox animated" },
   { href: "/examples/combobox-cancel", label: "Combobox cancel" },
   { href: "/examples/combobox-disclosure", label: "Combobox disclosure" },
+  {
+    href: "/examples/combobox-inline-autocomplete",
+    label: "Combobox inline autocomplete",
+  },
   { href: "/examples/combobox-matches", label: "Combobox matches" },
   { href: "/examples/combobox-multiple", label: "Combobox multiple" },
   { href: "/examples/command", label: "Command" },

--- a/packages/website/pages/index.tsx
+++ b/packages/website/pages/index.tsx
@@ -17,7 +17,7 @@ const links: Array<{ href: string; label: string }> = [
   { href: "/examples/combobox-disclosure", label: "Combobox disclosure" },
   {
     href: "/examples/combobox-inline-autocomplete",
-    label: "Combobox inline autocomplete",
+    label: "Combobox with inline autocomplete",
   },
   { href: "/examples/combobox-matches", label: "Combobox matches" },
   { href: "/examples/combobox-multiple", label: "Combobox multiple" },


### PR DESCRIPTION
Trying to complete: #939 "Combobox with autoComplete set to inline"

I'm not sure if the test cases are enough and if the example is complete enough, let me know!