### PR TITLE
Improve support for links on composite components with virtual focus

### DIFF
--- a/.changeset/composite-item-new-tab-background.md
+++ b/.changeset/composite-item-new-tab-background.md
@@ -1,0 +1,5 @@
+---
+"ariakit": minor
+---
+
+Activating `CompositeItem` elements rendered as links with <kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Enter</kbd> now correctly opens the new tab in the background instead of bringing it to front. ([#1771](https://github.com/ariakit/ariakit/pull/1771))

--- a/.changeset/composite-link-download.md
+++ b/.changeset/composite-link-download.md
@@ -2,4 +2,4 @@
 "ariakit": minor
 ---
 
-Added support for clicking on `CompositeItem` components rendered as links with <kbd>Alt</kbd>+<kbd>Enter</kbd> to start a download. ([#1771](https://github.com/ariakit/ariakit/pull/1771))
+Added support for clicking on `CompositeItem` elements rendered as links with <kbd>Alt</kbd>+<kbd>Enter</kbd> to start a download. ([#1771](https://github.com/ariakit/ariakit/pull/1771))

--- a/.changeset/composite-link-download.md
+++ b/.changeset/composite-link-download.md
@@ -1,0 +1,5 @@
+---
+"ariakit": minor
+---
+
+Added support for clicking on `CompositeItem` components rendered as links with <kbd>Alt</kbd>+<kbd>Enter</kbd> to start a download. ([#1771](https://github.com/ariakit/ariakit/pull/1771))

--- a/.changeset/utils-is-downloading.md
+++ b/.changeset/utils-is-downloading.md
@@ -1,0 +1,5 @@
+---
+"ariakit-utils": patch
+---
+
+Added `isDownloading` function. ([#1771](https://github.com/ariakit/ariakit/pull/1771))

--- a/packages/ariakit-utils/src/events.ts
+++ b/packages/ariakit-utils/src/events.ts
@@ -24,19 +24,37 @@ export function isSelfTarget(event: SyntheticEvent | Event): boolean {
  * Checks whether the user event is triggering a page navigation in a new tab.
  */
 export function isOpeningInNewTab(event: MouseEvent | ReactMouseEvent) {
-  const target = event.target as
+  const element = event.currentTarget as
     | HTMLAnchorElement
     | HTMLButtonElement
     | HTMLInputElement
     | null;
-  if (!target) return null;
+  if (!element) return false;
   const isAppleDevice = isApple();
   if (isAppleDevice && !event.metaKey) return false;
   if (!isAppleDevice && !event.ctrlKey) return false;
-  const tagName = target.tagName.toLowerCase();
+  const tagName = element.tagName.toLowerCase();
   if (tagName === "a") return true;
-  if (tagName === "button" && target.type === "submit") return true;
-  if (tagName === "input" && target.type === "submit") return true;
+  if (tagName === "button" && element.type === "submit") return true;
+  if (tagName === "input" && element.type === "submit") return true;
+  return false;
+}
+
+/**
+ * Checks whether the user event is triggering a download.
+ */
+export function isDownloading(event: MouseEvent | ReactMouseEvent) {
+  const element = event.currentTarget as
+    | HTMLAnchorElement
+    | HTMLButtonElement
+    | HTMLInputElement
+    | null;
+  if (!element) return false;
+  const tagName = element.tagName.toLowerCase();
+  if (!event.altKey) return false;
+  if (tagName === "a") return true;
+  if (tagName === "button" && element.type === "submit") return true;
+  if (tagName === "input" && element.type === "submit") return true;
   return false;
 }
 

--- a/packages/ariakit/src/combobox/__examples__/combobox-links/icons.tsx
+++ b/packages/ariakit/src/combobox/__examples__/combobox-links/icons.tsx
@@ -1,0 +1,20 @@
+import { SVGAttributes } from "react";
+
+export function NewWindow(props: SVGAttributes<SVGSVGElement>) {
+  return (
+    <svg
+      aria-label="Opens in New Tab"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={2}
+      stroke="currentColor"
+      {...props}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+      />
+    </svg>
+  );
+}

--- a/packages/ariakit/src/combobox/__examples__/combobox-links/index.tsx
+++ b/packages/ariakit/src/combobox/__examples__/combobox-links/index.tsx
@@ -5,27 +5,55 @@ import {
   useComboboxState,
 } from "ariakit/combobox";
 import "./style.css";
+import { NewWindow } from "./icons";
 
 const links = [
-  { href: "https://ariakit.org", value: "Ariakit.org" },
-  { href: "https://twitter.com/ariakitjs", value: "Twitter", target: "_blank" },
+  {
+    href: "https://twitter.com/ariakitjs",
+    children: "Twitter",
+    target: "_blank",
+  },
   {
     href: "https://www.facebook.com/ariakitjs",
-    value: "Facebook",
+    children: "Facebook",
     target: "_blank",
   },
   {
     href: "https://www.instagram.com/ariakitjs",
-    value: "Instagram",
+    children: "Instagram",
     target: "_blank",
   },
+  { href: "https://ariakit.org", children: "Ariakit.org" },
 ];
+
+const list = links.map((link) => link.children);
 
 export default function Example() {
   const combobox = useComboboxState({
-    gutter: 8,
+    list,
+    gutter: 4,
     sameWidth: true,
   });
+
+  const renderItem = (value: string, i: number) => {
+    const link = links.find((link) => link.children === value);
+    return (
+      <ComboboxItem
+        key={value + i}
+        as="a"
+        focusOnHover
+        hideOnClick
+        className="combobox-item"
+        {...link}
+      >
+        {value}
+        {link?.target === "_blank" && (
+          <NewWindow className="combobox-item-icon" />
+        )}
+      </ComboboxItem>
+    );
+  };
+
   return (
     <div>
       <label className="label">
@@ -34,19 +62,18 @@ export default function Example() {
           state={combobox}
           placeholder="e.g., Twitter"
           className="combobox"
+          autoSelect
         />
       </label>
-      <ComboboxPopover state={combobox} className="popover">
-        {links.map((link) => (
-          <ComboboxItem
-            as="a"
-            key={link.href}
-            focusOnHover
-            className="combobox-item"
-            {...link}
-          />
-        ))}
-      </ComboboxPopover>
+      {combobox.mounted && (
+        <ComboboxPopover state={combobox} className="popover">
+          {combobox.matches.length ? (
+            combobox.matches.map(renderItem)
+          ) : (
+            <div className="no-results">No results found</div>
+          )}
+        </ComboboxPopover>
+      )}
     </div>
   );
 }

--- a/packages/ariakit/src/combobox/__examples__/combobox-links/style.css
+++ b/packages/ariakit/src/combobox/__examples__/combobox-links/style.css
@@ -1,5 +1,13 @@
 @import "../combobox/style.css";
 
 .combobox-item {
-  @apply cursor-pointer;
+  @apply cursor-pointer justify-between;
+}
+
+.combobox-item-icon {
+  @apply w-4 h-4;
+}
+
+.no-results {
+  @apply gap-2 p-2;
 }

--- a/packages/ariakit/src/combobox/__examples__/combobox-links/test-browser.ts
+++ b/packages/ariakit/src/combobox/__examples__/combobox-links/test-browser.ts
@@ -60,7 +60,7 @@ test("click on link with cmd/ctrl + enter", async ({
   await page.goto("/examples/combobox-links");
   await getCombobox(page).click();
   const modifier = await getClickModifier(page);
-  await page.keyboard.press("ArrowDown");
+  await page.keyboard.press("ArrowUp");
   // Safari doesn't support Cmd+Enter to open a link in a new tab
   // programmatically.
   if (browserName === "webkit") {
@@ -83,9 +83,9 @@ test("click on target blank link", async ({ page, context }) => {
   await expect(getCombobox(page)).toHaveValue("");
   const [newPage] = await Promise.all([
     context.waitForEvent("page"),
-    getOption(page, "Twitter").click(),
+    getOption(page, "Twitter Opens in New Tab").click(),
   ]);
   await expect(getPopover(page)).not.toBeVisible();
-  await expect(getCombobox(page)).toHaveValue("Twitter");
+  await expect(getCombobox(page)).toHaveValue("");
   await expect(newPage).toHaveURL(/https:\/\/twitter.com\/ariakitjs/);
 });

--- a/packages/ariakit/src/combobox/__examples__/combobox/style.css
+++ b/packages/ariakit/src/combobox/__examples__/combobox/style.css
@@ -29,6 +29,7 @@
     z-50
     overscroll-contain
     overflow-auto
+    outline-none
     rounded-lg
     border
     border-solid

--- a/packages/ariakit/src/combobox/combobox-item.tsx
+++ b/packages/ariakit/src/combobox/combobox-item.tsx
@@ -1,6 +1,6 @@
 import { KeyboardEvent, MouseEvent, useCallback } from "react";
 import { getPopupItemRole, isTextField } from "ariakit-utils/dom";
-import { isOpeningInNewTab } from "ariakit-utils/events";
+import { isDownloading, isOpeningInNewTab } from "ariakit-utils/events";
 import { hasFocus } from "ariakit-utils/focus";
 import { useBooleanEvent, useEvent, useWrapElement } from "ariakit-utils/hooks";
 import { queueMicrotask } from "ariakit-utils/misc";
@@ -67,6 +67,7 @@ export const useComboboxItem = createHook<ComboboxItemOptions>(
     const onClick = useEvent((event: MouseEvent<HTMLDivElement>) => {
       onClickProp?.(event);
       if (event.defaultPrevented) return;
+      if (isDownloading(event)) return;
       if (isOpeningInNewTab(event)) return;
       if (value != null && setValueOnClickProp(event)) {
         state?.setValue(value);

--- a/packages/ariakit/src/composite/composite-state.ts
+++ b/packages/ariakit/src/composite/composite-state.ts
@@ -304,9 +304,9 @@ export type CompositeState<T extends Item = Item> = CollectionState<T> & {
   baseRef: RefObject<HTMLElement>;
   /**
    * If enabled, the composite element will act as an
-   * [aria-activedescendant](https://www.w3.org/TR/wai-aria-practices-1.1/#kbd_focus_activedescendant)
+   * [aria-activedescendant](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_focus_activedescendant)
    * container instead of [roving
-   * tabindex](https://www.w3.org/TR/wai-aria-practices/#kbd_roving_tabindex).
+   * tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex).
    * DOM focus will remain on the composite while its items receive virtual
    * focus.
    * @default false

--- a/packages/ariakit/src/menu/menu-item.ts
+++ b/packages/ariakit/src/menu/menu-item.ts
@@ -1,6 +1,6 @@
 import { MouseEvent } from "react";
 import { getPopupItemRole } from "ariakit-utils/dom";
-import { isOpeningInNewTab } from "ariakit-utils/events";
+import { isDownloading, isOpeningInNewTab } from "ariakit-utils/events";
 import { useBooleanEvent, useEvent } from "ariakit-utils/hooks";
 import { createMemoComponent, useStore } from "ariakit-utils/store";
 import { createElement, createHook } from "ariakit-utils/system";
@@ -58,6 +58,7 @@ export const useMenuItem = createHook<MenuItemOptions>(
     const onClick = useEvent((event: MouseEvent<HTMLDivElement>) => {
       onClickProp?.(event);
       if (event.defaultPrevented) return;
+      if (isDownloading(event)) return;
       if (isOpeningInNewTab(event)) return;
       if (!hideMenu) return;
       // If this item is also a menu button, we don't want to hide the menu.

--- a/packages/ariakit/src/select/select-item.tsx
+++ b/packages/ariakit/src/select/select-item.tsx
@@ -1,6 +1,6 @@
 import { MouseEvent, useCallback } from "react";
 import { getPopupItemRole } from "ariakit-utils/dom";
-import { isOpeningInNewTab } from "ariakit-utils/events";
+import { isDownloading, isOpeningInNewTab } from "ariakit-utils/events";
 import { useBooleanEvent, useEvent, useWrapElement } from "ariakit-utils/hooks";
 import { createMemoComponent, useStore } from "ariakit-utils/store";
 import { createElement, createHook } from "ariakit-utils/system";
@@ -80,6 +80,7 @@ export const useSelectItem = createHook<SelectItemOptions>(
     const onClick = useEvent((event: MouseEvent<HTMLDivElement>) => {
       onClickProp?.(event);
       if (event.defaultPrevented) return;
+      if (isDownloading(event)) return;
       if (isOpeningInNewTab(event)) return;
       if (setValueOnClickProp(event) && value != null) {
         state?.setValue((prevValue) => {


### PR DESCRIPTION
See changesets for more context.

When the composite item received the <kbd>Enter</kbd> key down event, we were dispatching the click event asynchronously. Because of that, when activating links with <kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Enter</kbd>, some browsers wouldn't open the new tab in the background. Instead, the new tab would be brought to the front.

To fix that, this PR dispatches the click event in a microtask that will be executed at the end of the current event loop.