### PR TITLE
Fix combobox inline selection

### DIFF
--- a/.changeset/combobox-set-value-on-mouse-down.md
+++ b/.changeset/combobox-set-value-on-mouse-down.md
@@ -1,0 +1,5 @@
+---
+"ariakit": patch
+---
+
+Fixed `Combobox` with `autoComplete="inline"` or `autoComplete="both"` not allowing text selection in some cases. ([#1773](https://github.com/ariakit/ariakit/pull/1773))

--- a/packages/ariakit/src/combobox/__examples__/combobox-inline-autocomplete/test.tsx
+++ b/packages/ariakit/src/combobox/__examples__/combobox-inline-autocomplete/test.tsx
@@ -1,4 +1,4 @@
-import { getByRole, press, render, type } from "ariakit-test";
+import { click, getByRole, press, render, type } from "ariakit-test";
 import { axe } from "jest-axe";
 import Example from ".";
 
@@ -29,5 +29,14 @@ test("autocomplete on arrow up key", async () => {
   await type("w");
   expect(getPopover()).toBeVisible();
   await press.ArrowUp();
+  expect(getCombobox()).toHaveValue("Watermelon");
+});
+
+test("clicking on combobox input makes the inline autocomplete the value", async () => {
+  render(<Example />);
+  await press.Tab();
+  await type("w");
+  await press.ArrowUp();
+  await click(getCombobox());
   expect(getCombobox()).toHaveValue("Watermelon");
 });

--- a/packages/ariakit/src/combobox/__examples__/combobox/test.tsx
+++ b/packages/ariakit/src/combobox/__examples__/combobox/test.tsx
@@ -143,3 +143,14 @@ test("re-open listbox when deleting content", async () => {
   await type("\b");
   expect(getPopover()).toBeVisible();
 });
+
+test("clicking on combobox input removes focus from item", async () => {
+  render(<Example />);
+  await press.Tab();
+  await press.ArrowDown();
+  await press.ArrowDown();
+  await press.ArrowDown();
+  expect(getOption("🍇 Grape")).toHaveFocus();
+  await click(getCombobox());
+  expect(getOption("🍇 Grape")).not.toHaveFocus();
+});

--- a/packages/ariakit/src/combobox/combobox.ts
+++ b/packages/ariakit/src/combobox/combobox.ts
@@ -249,6 +249,7 @@ export const useCombobox = createHook<ComboboxOptions>(
     );
 
     const onMouseDownProp = props.onMouseDown;
+    const setValueOnClickProp = useBooleanEvent(setValueOnClick);
     const showOnMouseDownProp = useBooleanEvent(showOnMouseDown);
 
     const onMouseDown = useEvent((event: MouseEvent<HTMLInputElement>) => {
@@ -256,21 +257,12 @@ export const useCombobox = createHook<ComboboxOptions>(
       if (event.defaultPrevented) return;
       if (event.button) return;
       if (event.ctrlKey) return;
-      if (!showOnMouseDownProp(event)) return;
-      queueBeforeEvent(event.currentTarget, "mouseup", state.show);
-    });
-
-    const onClickProp = props.onClick;
-    const setValueOnClickProp = useBooleanEvent(setValueOnClick);
-
-    // When clicking on the combobox input, we should make sure the current
-    // input value is set on the state and focus is set on the input only.
-    const onClick = useEvent((event: MouseEvent<HTMLInputElement>) => {
-      onClickProp?.(event);
-      if (event.defaultPrevented) return;
       state.setActiveId(null);
       if (setValueOnClickProp(event)) {
         state.setValue(value);
+      }
+      if (showOnMouseDownProp(event)) {
+        queueBeforeEvent(event.currentTarget, "mouseup", state.show);
       }
     });
 
@@ -323,7 +315,6 @@ export const useCombobox = createHook<ComboboxOptions>(
       onChange,
       onCompositionEnd,
       onMouseDown,
-      onClick,
       onKeyDown,
       onBlur,
     };


### PR DESCRIPTION
This PR fixes a bug that wouldn't allow text selection on a `Combobox` with `autoComplete="inline"` or `autoComplete="both"` if the mouse is released outside of the combobox input.

The problem was that the temporary inline value would only be set to the combobox state on click. If the mouse is released outside of the element, the click event is not dispatched so we don't get the value set. This PR changes this behavior, so the logic is performed on mouse down instead.