### PR TITLE
Fix onFocusVisible timing

### DIFF
--- a/.changeset/focusable-focus-visible-timing.md
+++ b/.changeset/focusable-focus-visible-timing.md
@@ -1,0 +1,5 @@
+---
+"ariakit": patch
+---
+
+Fixed `onFocusVisible` timing on the `Focusable` component so it waits for any logic in focus/keydown events to be performed before applying the `data-focus-visible` attribute. ([#1774](https://github.com/ariakit/ariakit/pull/1774))

--- a/packages/ariakit/src/focusable/focusable.ts
+++ b/packages/ariakit/src/focusable/focusable.ts
@@ -31,6 +31,7 @@ import {
   createHook,
 } from "ariakit-utils/system";
 import { As, BivariantCallback, Options, Props } from "ariakit-utils/types";
+import { flushSync } from "react-dom";
 
 const isSafariBrowser = isSafari();
 
@@ -312,7 +313,7 @@ export const useFocusable = createHook<FocusableOptions>(
       // autofill and immediately moves focus to the next field. That's why we
       // need to check if the current element is still focused.
       if (!hasFocus(element)) return;
-      setFocusVisible(true);
+      flushSync(() => setFocusVisible(true));
     };
 
     const onKeyDownCaptureProp = props.onKeyDownCapture;

--- a/packages/ariakit/src/focusable/focusable.ts
+++ b/packages/ariakit/src/focusable/focusable.ts
@@ -16,7 +16,7 @@ import {
   isSelfTarget,
   queueBeforeEvent,
 } from "ariakit-utils/events";
-import { focusIfNeeded, isFocusable } from "ariakit-utils/focus";
+import { focusIfNeeded, hasFocus, isFocusable } from "ariakit-utils/focus";
 import {
   useEvent,
   useForkRef,
@@ -296,32 +296,39 @@ export const useFocusable = createHook<FocusableOptions>(
       });
     });
 
-    const onFocusVisibleProp = onFocusVisible;
-
-    const onFocusVisibleEvent = useEvent(
-      (event: SyntheticEvent<HTMLDivElement>) => {
-        onFocusVisibleProp?.(event);
-        if (event.defaultPrevented) return;
-        if (!focusable) return;
-        setFocusVisible(true);
+    const handleFocusVisible = (
+      event: SyntheticEvent<HTMLDivElement>,
+      currentTarget?: HTMLDivElement
+    ) => {
+      if (currentTarget) {
+        event.currentTarget = currentTarget;
       }
-    );
+      onFocusVisible?.(event);
+      if (event.defaultPrevented) return;
+      if (!focusable) return;
+      const element = event.currentTarget;
+      if (!element) return;
+      // Some extensions like 1password dispatches some keydown events on
+      // autofill and immediately moves focus to the next field. That's why we
+      // need to check if the current element is still focused.
+      if (!hasFocus(element)) return;
+      setFocusVisible(true);
+    };
 
     const onKeyDownCaptureProp = props.onKeyDownCapture;
 
     const onKeyDownCapture = useEvent(
       (event: ReactKeyboardEvent<HTMLDivElement>) => {
         onKeyDownCaptureProp?.(event);
+        if (event.defaultPrevented) return;
         if (!focusable) return;
+        if (focusVisible) return;
         if (event.metaKey) return;
         if (event.altKey) return;
         if (event.ctrlKey) return;
         if (!isSelfTarget(event)) return;
-        if (!focusVisible && !event.defaultPrevented) {
-          // Triggers onFocusVisible when the element has initially received
-          // non-keyboard focus, but then a key has been pressed.
-          onFocusVisibleEvent(event);
-        }
+        const element = event.currentTarget;
+        queueMicrotask(() => handleFocusVisible(event, element));
       }
     );
 
@@ -335,14 +342,14 @@ export const useFocusable = createHook<FocusableOptions>(
         setFocusVisible(false);
         return;
       }
+      const element = event.currentTarget;
+      const applyFocusVisible = () => handleFocusVisible(event, element);
       if (isKeyboardModality || isAlwaysFocusVisible(event.target)) {
-        onFocusVisibleEvent(event);
+        queueMicrotask(applyFocusVisible);
       }
       // See https://github.com/ariakit/ariakit/issues/1257
       else if (isAlwaysFocusVisibleDelayed(event.target)) {
-        queueBeforeEvent(event.target, "focusout", () =>
-          onFocusVisibleEvent(event)
-        );
+        queueBeforeEvent(event.target, "focusout", applyFocusVisible);
       } else {
         setFocusVisible(false);
       }

--- a/packages/ariakit/src/focusable/focusable.ts
+++ b/packages/ariakit/src/focusable/focusable.ts
@@ -31,7 +31,6 @@ import {
   createHook,
 } from "ariakit-utils/system";
 import { As, BivariantCallback, Options, Props } from "ariakit-utils/types";
-import { flushSync } from "react-dom";
 
 const isSafariBrowser = isSafari();
 
@@ -313,7 +312,7 @@ export const useFocusable = createHook<FocusableOptions>(
       // autofill and immediately moves focus to the next field. That's why we
       // need to check if the current element is still focused.
       if (!hasFocus(element)) return;
-      flushSync(() => setFocusVisible(true));
+      setFocusVisible(true);
     };
 
     const onKeyDownCaptureProp = props.onKeyDownCapture;


### PR DESCRIPTION
If the focus changed during the key down event on a Focusable element, the blur event would trigger before our `onFocusVisible` function. This means that the `data-focus-visible` attribute would be set *after* the blur event and, therefore, wouldn't be removed.

This is the case with some browser extensions like 1password.

This PR solves this by calling `onFocusVisible` in a microtask and always checking if the element has focus before setting the focusVisible state to true.