### PR TITLE
Fix auto focus on the native select element

### DIFF
--- a/.changeset/select-autofill-focus.md
+++ b/.changeset/select-autofill-focus.md
@@ -1,0 +1,5 @@
+---
+"ariakit": patch
+---
+
+Fixed `Select` not getting focus when some browser extensions (like 1password) automatically moves focus to the next form element. ([#1777](https://github.com/ariakit/ariakit/pull/1777))

--- a/packages/ariakit/src/select/__examples__/select-autofill/test.tsx
+++ b/packages/ariakit/src/select/__examples__/select-autofill/test.tsx
@@ -1,12 +1,27 @@
-import { fireEvent, getAllByLabelText, getByRole, render } from "ariakit-test";
+import {
+  fireEvent,
+  focus,
+  getAllByLabelText,
+  getByRole,
+  render,
+  sleep,
+} from "ariakit-test";
 import Example from ".";
 
 const getNativeSelect = () => getAllByLabelText("Role")[0]!;
 const getSelect = () => getByRole("combobox", { name: "Role" });
 
-test("select has data-autofill attribute", async () => {
+test("select has data-autofill attribute", () => {
   render(<Example />);
   expect(getSelect()).not.toHaveAttribute("data-autofill");
   fireEvent.change(getNativeSelect(), { target: { value: "Tutor" } });
   expect(getSelect()).toHaveAttribute("data-autofill");
+});
+
+test("focusing on native select moves focus to custom select", async () => {
+  render(<Example />);
+  expect(getSelect()).not.toHaveFocus();
+  focus(getNativeSelect());
+  await sleep();
+  expect(getSelect()).toHaveFocus();
 });

--- a/packages/ariakit/src/select/select.tsx
+++ b/packages/ariakit/src/select/select.tsx
@@ -201,6 +201,11 @@ export const useSelect = createHook<SelectOptions>(
             required={required}
             value={state.value}
             multiple={multiSelectable}
+            // Even though this element is visually hidden and is not tabbable,
+            // it's still focusable. Some autofill extensions like 1password
+            // will move focus to the next form element on autofill. In this
+            // case, we want to move focus to our custom select element.
+            onFocus={() => state.selectRef.current?.focus()}
             onChange={(event: ChangeEvent<HTMLSelectElement>) => {
               nativeSelectChangedRef.current = true;
               setAutofill(true);
@@ -228,6 +233,7 @@ export const useSelect = createHook<SelectOptions>(
         required,
         state.value,
         multiSelectable,
+        state.selectRef,
         state.setValue,
         values,
       ]


### PR DESCRIPTION
Some browser extensions, like 1password, move focus to the next form element when auto-filling fields. We render a visually hidden native select element on the' Select' component. This element is not tabbable, but it's still focusable. To fix the issue, we'll automatically focus on our custom select element when the native element receives focus.