### PR TITLE
Fix stale validity state on FormField

### DIFF
--- a/.changeset/form-field-validity-state.md
+++ b/.changeset/form-field-validity-state.md
@@ -1,0 +1,5 @@
+---
+"ariakit": patch
+---
+
+Fixed stale validity state on `FormField`. ([#1778](https://github.com/ariakit/ariakit/pull/1778))

--- a/packages/ariakit/src/form/form-field.ts
+++ b/packages/ariakit/src/form/form-field.ts
@@ -101,9 +101,11 @@ export const useFormField = createHook<FormFieldOptions>(
     const ref = useRef<HTMLInputElement>(null);
     const id = useId(props.id);
 
-    state?.useValidate(() => {
+    state?.useValidate(async () => {
       const element = getNamedElement(ref, name);
       if (!element) return;
+      // Flush microtasks to make sure the validity state is up to date
+      await Promise.resolve();
       if ("validity" in element && !element.validity.valid) {
         state?.setError(name, element.validationMessage);
       }

--- a/packages/ariakit/src/form/form-state.ts
+++ b/packages/ariakit/src/form/form-state.ts
@@ -35,6 +35,10 @@ type Item = CollectionState["items"][number] & {
   id?: string;
 };
 
+function nextFrame() {
+  return new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+}
+
 /**
  * Provides state for the `Form` component.
  * @example
@@ -177,7 +181,8 @@ export function useFormState<V = AnyObject>(
     try {
       const callbacks = [...validateCallbacks];
       const results = callbacks.map((callback) => callback());
-      await Promise.all(results);
+      // Wait for the next frame to allow the errors to be set on the state.
+      await Promise.all(results).then(nextFrame);
       return !hasMessages(errorsRef.current);
     } finally {
       setValidating(false);
@@ -193,7 +198,8 @@ export function useFormState<V = AnyObject>(
       if (await validate()) {
         const callbacks = [...submitCallbacks];
         const results = callbacks.map((callback) => callback());
-        await Promise.all(results);
+        // Wait for the next frame to allow the errors to be set on the state.
+        await Promise.all(results).then(nextFrame);
         if (!hasMessages(errorsRef.current)) {
           setSubmitSucceed((value) => value + 1);
           return true;


### PR DESCRIPTION
In some situations, the validity state is out of date when validation happens on `FormField`.

This PR changes the logic so we wait for microtasks to be executed before checking the element's validity state.