### PR TITLE
Add displayName to components in development

### DIFF
--- a/.changeset/display-name.md
+++ b/.changeset/display-name.md
@@ -1,0 +1,5 @@
+---
+"ariakit": minor
+---
+
+Added `displayName` to components in development. ([#1791](https://github.com/ariakit/ariakit/pull/1791))

--- a/contributing.md
+++ b/contributing.md
@@ -148,6 +148,10 @@ export const MyComponent = createComponent<MyComponentOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  MyComponent.displayName = "MyComponent";
+}
+
 export type MyComponentOptions<T extends As = "div"> = Options<T> & {
   /**
    * Description for custom prop.

--- a/packages/ariakit/src/button/button.ts
+++ b/packages/ariakit/src/button/button.ts
@@ -58,6 +58,10 @@ export const Button = createComponent<ButtonOptions>((props) => {
   return createElement("button", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  Button.displayName = "Button";
+}
+
 export type ButtonOptions<T extends As = "button"> = CommandOptions<T>;
 
 export type ButtonProps<T extends As = "button"> = Props<ButtonOptions<T>>;

--- a/packages/ariakit/src/checkbox/checkbox-check.tsx
+++ b/packages/ariakit/src/checkbox/checkbox-check.tsx
@@ -79,6 +79,10 @@ export const CheckboxCheck = createComponent<CheckboxCheckOptions>((props) => {
   return createElement("span", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  CheckboxCheck.displayName = "CheckboxCheck";
+}
+
 export type CheckboxCheckOptions<T extends As = "span"> = Options<T> & {
   /**
    * Object returned by the `useCheckboxState` hook. If not provided, the parent

--- a/packages/ariakit/src/checkbox/checkbox.tsx
+++ b/packages/ariakit/src/checkbox/checkbox.tsx
@@ -163,6 +163,10 @@ export const Checkbox = createComponent<CheckboxOptions>((props) => {
   return createElement("input", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  Checkbox.displayName = "Checkbox";
+}
+
 export type CheckboxOptions<T extends As = "input"> = CommandOptions<T> & {
   /**
    * Object returned by the `useCheckboxState` hook. If not provided, the

--- a/packages/ariakit/src/collection/collection-item.ts
+++ b/packages/ariakit/src/collection/collection-item.ts
@@ -69,6 +69,10 @@ export const CollectionItem = createComponent<CollectionItemOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  CollectionItem.displayName = "CollectionItem";
+}
+
 export type CollectionItemOptions<T extends As = "div"> = Options<T> & {
   /**
    * Object returned by the `useCollectionState` hook. If not provided, the

--- a/packages/ariakit/src/collection/collection.tsx
+++ b/packages/ariakit/src/collection/collection.tsx
@@ -60,6 +60,10 @@ export const Collection = createComponent<CollectionOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  Collection.displayName = "Collection";
+}
+
 export type CollectionOptions<T extends As = "div"> = Options<T> & {
   /**
    * Object returned by the `useCollectionState` hook.

--- a/packages/ariakit/src/combobox/combobox-cancel.tsx
+++ b/packages/ariakit/src/combobox/combobox-cancel.tsx
@@ -95,6 +95,10 @@ export const ComboboxCancel = createComponent<ComboboxCancelOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  ComboboxCancel.displayName = "ComboboxCancel";
+}
+
 export type ComboboxCancelOptions<T extends As = "button"> =
   ButtonOptions<T> & {
     /**

--- a/packages/ariakit/src/combobox/combobox-disclosure.tsx
+++ b/packages/ariakit/src/combobox/combobox-disclosure.tsx
@@ -110,6 +110,10 @@ export const ComboboxDisclosure = createComponent<ComboboxDisclosureOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  ComboboxDisclosure.displayName = "ComboboxDisclosure";
+}
+
 export type ComboboxDisclosureOptions<T extends As = "button"> = Omit<
   DialogDisclosureOptions<T>,
   "state"

--- a/packages/ariakit/src/combobox/combobox-group-label.ts
+++ b/packages/ariakit/src/combobox/combobox-group-label.ts
@@ -55,6 +55,10 @@ export const ComboboxGroupLabel = createComponent<ComboboxGroupLabelOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  ComboboxGroupLabel.displayName = "ComboboxGroupLabel";
+}
+
 export type ComboboxGroupLabelOptions<T extends As = "div"> = Omit<
   CompositeGroupLabelOptions<T>,
   "state"

--- a/packages/ariakit/src/combobox/combobox-group.ts
+++ b/packages/ariakit/src/combobox/combobox-group.ts
@@ -54,6 +54,10 @@ export const ComboboxGroup = createComponent<ComboboxGroupOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  ComboboxGroup.displayName = "ComboboxGroup";
+}
+
 export type ComboboxGroupOptions<T extends As = "div"> = Omit<
   CompositeGroupOptions<T>,
   "state"

--- a/packages/ariakit/src/combobox/combobox-item-value.tsx
+++ b/packages/ariakit/src/combobox/combobox-item-value.tsx
@@ -120,6 +120,10 @@ export const ComboboxItemValue = createComponent<ComboboxItemValueOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  ComboboxItemValue.displayName = "ComboboxItemValue";
+}
+
 export type ComboboxItemValueOptions<T extends As = "span"> = Options<T> & {
   /**
    * Object returned by the `useComboboxState` hook. If not provided, the parent

--- a/packages/ariakit/src/combobox/combobox-item.tsx
+++ b/packages/ariakit/src/combobox/combobox-item.tsx
@@ -166,6 +166,10 @@ export const ComboboxItem = createMemoComponent<ComboboxItemOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  ComboboxItem.displayName = "ComboboxItem";
+}
+
 export type ComboboxItemOptions<T extends As = "div"> = Omit<
   CompositeItemOptions<T>,
   "state"

--- a/packages/ariakit/src/combobox/combobox-list.ts
+++ b/packages/ariakit/src/combobox/combobox-list.ts
@@ -82,6 +82,10 @@ export const ComboboxList = createComponent<ComboboxListOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  ComboboxList.displayName = "ComboboxList";
+}
+
 export type ComboboxListOptions<T extends As = "div"> = Options<T> & {
   /**
    * Object returned by the `useComboboxState` hook.

--- a/packages/ariakit/src/combobox/combobox-popover.ts
+++ b/packages/ariakit/src/combobox/combobox-popover.ts
@@ -94,6 +94,10 @@ export const ComboboxPopover = createComponent<ComboboxPopoverOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  ComboboxPopover.displayName = "ComboboxPopover";
+}
+
 export type ComboboxPopoverOptions<T extends As = "div"> =
   ComboboxListOptions<T> & Omit<PopoverOptions<T>, "state" | "modal">;
 

--- a/packages/ariakit/src/combobox/combobox-row.ts
+++ b/packages/ariakit/src/combobox/combobox-row.ts
@@ -68,6 +68,10 @@ export const ComboboxRow = createComponent<ComboboxRowOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  ComboboxRow.displayName = "ComboboxRow";
+}
+
 export type ComboboxRowOptions<T extends As = "div"> = Omit<
   CompositeRowOptions<T>,
   "state"

--- a/packages/ariakit/src/combobox/combobox-separator.ts
+++ b/packages/ariakit/src/combobox/combobox-separator.ts
@@ -55,6 +55,10 @@ export const ComboboxSeparator = createComponent<ComboboxSeparatorOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  ComboboxSeparator.displayName = "ComboboxSeparator";
+}
+
 export type ComboboxSeparatorOptions<T extends As = "hr"> = Omit<
   CompositeSeparatorOptions<T>,
   "state"

--- a/packages/ariakit/src/combobox/combobox.ts
+++ b/packages/ariakit/src/combobox/combobox.ts
@@ -345,6 +345,10 @@ export const Combobox = createComponent<ComboboxOptions>((props) => {
   return createElement("input", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  Combobox.displayName = "Combobox";
+}
+
 export type ComboboxOptions<T extends As = "input"> = Omit<
   CompositeOptions<T>,
   "state"

--- a/packages/ariakit/src/command/command.ts
+++ b/packages/ariakit/src/command/command.ts
@@ -163,6 +163,10 @@ export const Command = createComponent<CommandOptions>((props) => {
   return createElement("button", props);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  Command.displayName = "Command";
+}
+
 export type CommandOptions<T extends As = "button"> = FocusableOptions<T> & {
   /**
    * If true, pressing the enter key will trigger a click on the button.

--- a/packages/ariakit/src/composite/composite-container.ts
+++ b/packages/ariakit/src/composite/composite-container.ts
@@ -239,6 +239,10 @@ export const CompositeContainer =
     return createElement("div", htmlProps);
   });
 
+if (process.env.NODE_ENV !== "production") {
+  CompositeContainer.displayName = "CompositeContainer";
+}
+
 export type CompositeContainerOptions<T extends As = "div"> = Options<T> & {
   /**
    * Object returned by the `useCompositeState` hook. If not provided, the

--- a/packages/ariakit/src/composite/composite-group-label.ts
+++ b/packages/ariakit/src/composite/composite-group-label.ts
@@ -51,6 +51,10 @@ export const CompositeGroupLabel = createComponent<CompositeGroupLabelOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  CompositeGroupLabel.displayName = "CompositeGroupLabel";
+}
+
 export type CompositeGroupLabelOptions<T extends As = "div"> =
   GroupLabelOptions<T> & {
     /**

--- a/packages/ariakit/src/composite/composite-group.tsx
+++ b/packages/ariakit/src/composite/composite-group.tsx
@@ -53,6 +53,10 @@ export const CompositeGroup = createComponent<CompositeGroupOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  CompositeGroup.displayName = "CompositeGroup";
+}
+
 export type CompositeGroupOptions<T extends As = "div"> = GroupOptions<T> & {
   /**
    * Object returned by the `useCompositeState` hook. If not provided, the

--- a/packages/ariakit/src/composite/composite-hover.ts
+++ b/packages/ariakit/src/composite/composite-hover.ts
@@ -117,6 +117,10 @@ export const CompositeHover = createMemoComponent<CompositeHoverOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  CompositeHover.displayName = "CompositeHover";
+}
+
 export type CompositeHoverOptions<T extends As = "div"> = Options<T> & {
   /**
    * Object returned by the `useCompositeState` hook. If not provided, the

--- a/packages/ariakit/src/composite/composite-input.ts
+++ b/packages/ariakit/src/composite/composite-input.ts
@@ -101,6 +101,10 @@ export const CompositeInput = createComponent<CompositeInputOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  CompositeInput.displayName = "CompositeInput";
+}
+
 export type CompositeInputOptions<T extends As = "input"> = Options<T> & {
   /**
    * Object returned by the `useCompositeState` hook. If not provided, the

--- a/packages/ariakit/src/composite/composite-item.tsx
+++ b/packages/ariakit/src/composite/composite-item.tsx
@@ -406,6 +406,10 @@ export const CompositeItem = createMemoComponent<CompositeItemOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  CompositeItem.displayName = "CompositeItem";
+}
+
 export type CompositeItemOptions<T extends As = "button"> = CommandOptions<T> &
   Omit<CollectionItemOptions<T>, "state"> & {
     /**

--- a/packages/ariakit/src/composite/composite-overflow-disclosure.ts
+++ b/packages/ariakit/src/composite/composite-overflow-disclosure.ts
@@ -92,6 +92,10 @@ export const CompositeOverflowDisclosure =
     return createElement("button", htmlProps);
   });
 
+if (process.env.NODE_ENV !== "production") {
+  CompositeOverflowDisclosure.displayName = "CompositeOverflowDisclosure";
+}
+
 export type CompositeOverflowDisclosureOptions<T extends As = "button"> = Omit<
   PopoverDisclosureOptions<T>,
   "state"

--- a/packages/ariakit/src/composite/composite-overflow.ts
+++ b/packages/ariakit/src/composite/composite-overflow.ts
@@ -109,6 +109,10 @@ export const CompositeOverflow = createComponent<CompositeOverflowOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  CompositeOverflow.displayName = "CompositeOverflow";
+}
+
 export type CompositeOverflowOptions<T extends As = "div"> = Omit<
   PopoverOptions<T>,
   "state"

--- a/packages/ariakit/src/composite/composite-row.tsx
+++ b/packages/ariakit/src/composite/composite-row.tsx
@@ -87,6 +87,10 @@ export const CompositeRow = createComponent<CompositeRowOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  CompositeRow.displayName = "CompositeRow";
+}
+
 export type CompositeRowOptions<T extends As = "div"> = Options<T> & {
   /**
    * Object returned by the `useCompositeState` hook. If not provided, the

--- a/packages/ariakit/src/composite/composite-separator.ts
+++ b/packages/ariakit/src/composite/composite-separator.ts
@@ -57,6 +57,10 @@ export const CompositeSeparator = createComponent<CompositeSeparatorOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  CompositeSeparator.displayName = "CompositeSeparator";
+}
+
 export type CompositeSeparatorOptions<T extends As = "hr"> =
   SeparatorOptions<T> & {
     /**

--- a/packages/ariakit/src/composite/composite-typeahead.ts
+++ b/packages/ariakit/src/composite/composite-typeahead.ts
@@ -160,6 +160,10 @@ export const CompositeTypeahead = createComponent<CompositeTypeaheadOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  CompositeTypeahead.displayName = "CompositeTypeahead";
+}
+
 export type CompositeTypeaheadOptions<T extends As = "div"> = Options<T> & {
   /**
    * Object returned by the `useCompositeState` hook. If not provided, the

--- a/packages/ariakit/src/composite/composite.ts
+++ b/packages/ariakit/src/composite/composite.ts
@@ -423,6 +423,10 @@ export const Composite = createComponent<CompositeOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  Composite.displayName = "Composite";
+}
+
 export type CompositeOptions<T extends As = "div"> = FocusableOptions<T> & {
   /**
    * Object returned by the `useCompositeState` hook.

--- a/packages/ariakit/src/dialog/dialog-description.ts
+++ b/packages/ariakit/src/dialog/dialog-description.ts
@@ -61,6 +61,10 @@ export const DialogDescription = createComponent<DialogDescriptionOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  DialogDescription.displayName = "DialogDescription";
+}
+
 export type DialogDescriptionOptions<T extends As = "p"> = Options<T> & {
   /**
    * Object returned by the `useDialogState` hook. If not provided, the parent

--- a/packages/ariakit/src/dialog/dialog-disclosure.ts
+++ b/packages/ariakit/src/dialog/dialog-disclosure.ts
@@ -43,6 +43,10 @@ export const DialogDisclosure = createComponent<DialogDisclosureOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  DialogDisclosure.displayName = "DialogDisclosure";
+}
+
 export type DialogDisclosureOptions<T extends As = "button"> = Omit<
   DisclosureOptions<T>,
   "state"

--- a/packages/ariakit/src/dialog/dialog-dismiss.tsx
+++ b/packages/ariakit/src/dialog/dialog-dismiss.tsx
@@ -86,6 +86,10 @@ export const DialogDismiss = createComponent<DialogDismissOptions>((props) => {
   return createElement("button", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  DialogDismiss.displayName = "DialogDismiss";
+}
+
 export type DialogDismissOptions<T extends As = "button"> = ButtonOptions<T> & {
   /**
    * Object returned by the `useDialogState` hook.

--- a/packages/ariakit/src/dialog/dialog-heading.ts
+++ b/packages/ariakit/src/dialog/dialog-heading.ts
@@ -62,6 +62,10 @@ export const DialogHeading = createComponent<DialogHeadingOptions>((props) => {
   return createElement("h1", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  DialogHeading.displayName = "DialogHeading";
+}
+
 export type DialogHeadingOptions<T extends As = "h1"> = HeadingOptions<T> & {
   /**
    * Object returned by the `useDialogState` hook. If not provided, the parent

--- a/packages/ariakit/src/dialog/dialog.tsx
+++ b/packages/ariakit/src/dialog/dialog.tsx
@@ -522,6 +522,10 @@ export const Dialog = createComponent<DialogOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  Dialog.displayName = "Dialog";
+}
+
 export type DialogOptions<T extends As = "div"> = FocusableOptions<T> &
   PortalOptions<T> &
   Omit<DisclosureContentOptions<T>, "state"> & {

--- a/packages/ariakit/src/disclosure/disclosure-content.ts
+++ b/packages/ariakit/src/disclosure/disclosure-content.ts
@@ -149,6 +149,10 @@ export const DisclosureContent = createComponent<DisclosureContentOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  DisclosureContent.displayName = "DisclosureContent";
+}
+
 export type DisclosureContentOptions<T extends As = "div"> = Options<T> & {
   /**
    * Object returned by the `useDisclosureState` hook.

--- a/packages/ariakit/src/disclosure/disclosure.ts
+++ b/packages/ariakit/src/disclosure/disclosure.ts
@@ -97,6 +97,10 @@ export const Disclosure = createComponent<DisclosureOptions>((props) => {
   return createElement("button", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  Disclosure.displayName = "Disclosure";
+}
+
 export type DisclosureOptions<T extends As = "button"> = ButtonOptions<T> & {
   /**
    * Object returned by the `useDisclosureState` hook.

--- a/packages/ariakit/src/focus-trap/focus-trap-region.tsx
+++ b/packages/ariakit/src/focus-trap/focus-trap-region.tsx
@@ -89,6 +89,10 @@ export const FocusTrapRegion = createComponent<FocusTrapRegionOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  FocusTrapRegion.displayName = "FocusTrapRegion";
+}
+
 export type FocusTrapRegionOptions<T extends As = "div"> = Options<T> & {
   /**
    * If true, it will trap the focus in the region.

--- a/packages/ariakit/src/focus-trap/focus-trap.ts
+++ b/packages/ariakit/src/focus-trap/focus-trap.ts
@@ -49,6 +49,10 @@ export const FocusTrap = createComponent<FocusTrapOptions>((props) => {
   return createElement("span", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  FocusTrap.displayName = "FocusTrap";
+}
+
 export type FocusTrapOptions<T extends As = "span"> = VisuallyHiddenOptions<T>;
 
 export type FocusTrapProps<T extends As = "span"> = Props<FocusTrapOptions<T>>;

--- a/packages/ariakit/src/focusable/focusable.ts
+++ b/packages/ariakit/src/focusable/focusable.ts
@@ -433,6 +433,10 @@ export const Focusable = createComponent<FocusableOptions>((props) => {
   return createElement("div", props);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  Focusable.displayName = "Focusable";
+}
+
 export type FocusableOptions<T extends As = "div"> = Options<T> & {
   /**
    * Determines whether the focusable element is disabled. If the focusable

--- a/packages/ariakit/src/form/form-checkbox.ts
+++ b/packages/ariakit/src/form/form-checkbox.ts
@@ -86,6 +86,10 @@ export const FormCheckbox = createMemoComponent<FormCheckboxOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  FormCheckbox.displayName = "FormCheckbox";
+}
+
 export type FormCheckboxOptions<T extends As = "input"> = FormFieldOptions<T> &
   Omit<CheckboxOptions<T>, "state">;
 

--- a/packages/ariakit/src/form/form-description.ts
+++ b/packages/ariakit/src/form/form-description.ts
@@ -78,6 +78,10 @@ export const FormDescription = createMemoComponent<FormDescriptionOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  FormDescription.displayName = "FormDescription";
+}
+
 export type FormDescriptionOptions<T extends As = "div"> = Omit<
   CollectionItemOptions<T>,
   "state"

--- a/packages/ariakit/src/form/form-error.ts
+++ b/packages/ariakit/src/form/form-error.ts
@@ -100,6 +100,10 @@ export const FormError = createMemoComponent<FormErrorOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  FormError.displayName = "FormError";
+}
+
 export type FormErrorOptions<T extends As = "div"> = Omit<
   CollectionItemOptions<T>,
   "state"

--- a/packages/ariakit/src/form/form-field.ts
+++ b/packages/ariakit/src/form/form-field.ts
@@ -190,6 +190,10 @@ export const FormField = createMemoComponent<FormFieldOptions>((props) => {
   return createElement("input", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  FormField.displayName = "FormField";
+}
+
 export type FormFieldOptions<T extends As = "input"> = Omit<
   CollectionItemOptions<T>,
   "state"

--- a/packages/ariakit/src/form/form-group-label.ts
+++ b/packages/ariakit/src/form/form-group-label.ts
@@ -58,6 +58,10 @@ export const FormGroupLabel = createComponent<FormGroupLabelOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  FormGroupLabel.displayName = "FormGroupLabel";
+}
+
 export type FormGroupLabelOptions<T extends As = "div"> =
   GroupLabelOptions<T> & {
     /**

--- a/packages/ariakit/src/form/form-group.ts
+++ b/packages/ariakit/src/form/form-group.ts
@@ -56,6 +56,10 @@ export const FormGroup = createComponent<FormGroupOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  FormGroup.displayName = "FormGroup";
+}
+
 export type FormGroupOptions<T extends As = "div"> = GroupOptions<T> & {
   /**
    * Object returned by the `useFormState` hook. If not provided, the parent

--- a/packages/ariakit/src/form/form-input.ts
+++ b/packages/ariakit/src/form/form-input.ts
@@ -74,6 +74,10 @@ export const FormInput = createMemoComponent<FormInputOptions>((props) => {
   return createElement("input", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  FormInput.displayName = "FormInput";
+}
+
 export type FormInputOptions<T extends As = "input"> = FocusableOptions<T> &
   FormFieldOptions<T>;
 

--- a/packages/ariakit/src/form/form-label.ts
+++ b/packages/ariakit/src/form/form-label.ts
@@ -131,6 +131,10 @@ export const FormLabel = createMemoComponent<FormLabelOptions>((props) => {
   return createElement("label", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  FormLabel.displayName = "FormLabel";
+}
+
 export type FormLabelOptions<T extends As = "label"> = Omit<
   CollectionItemOptions<T>,
   "state"

--- a/packages/ariakit/src/form/form-push.ts
+++ b/packages/ariakit/src/form/form-push.ts
@@ -140,6 +140,10 @@ export const FormPush = createComponent<FormPushOptions>((props) => {
   return createElement("button", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  FormPush.displayName = "FormPush";
+}
+
 export type FormPushOptions<T extends As = "button"> = ButtonOptions<T> &
   Omit<CollectionItemOptions<T>, "state"> & {
     /**

--- a/packages/ariakit/src/form/form-radio-group.ts
+++ b/packages/ariakit/src/form/form-radio-group.ts
@@ -55,6 +55,10 @@ export const FormRadioGroup = createComponent<FormRadioGroupOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  FormRadioGroup.displayName = "FormRadioGroup";
+}
+
 export type FormRadioGroupOptions<T extends As = "div"> = FormGroupOptions<T>;
 
 export type FormRadioGroupProps<T extends As = "div"> = Props<

--- a/packages/ariakit/src/form/form-radio.ts
+++ b/packages/ariakit/src/form/form-radio.ts
@@ -86,6 +86,10 @@ export const FormRadio = createMemoComponent<FormRadioOptions>((props) => {
   return createElement("input", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  FormRadio.displayName = "FormRadio";
+}
+
 export type FormRadioOptions<T extends As = "input"> = FormFieldOptions<T> &
   Omit<RadioOptions<T>, "state">;
 

--- a/packages/ariakit/src/form/form-remove.ts
+++ b/packages/ariakit/src/form/form-remove.ts
@@ -123,6 +123,10 @@ export const FormRemove = createComponent<FormRemoveOptions>((props) => {
   return createElement("button", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  FormRemove.displayName = "FormRemove";
+}
+
 export type FormRemoveOptions<T extends As = "button"> = ButtonOptions<T> & {
   /**
    * Object returned by the `useFormState` hook. If not provided, the parent

--- a/packages/ariakit/src/form/form-reset.ts
+++ b/packages/ariakit/src/form/form-reset.ts
@@ -51,8 +51,12 @@ export const useFormReset = createHook<FormResetOptions>(
  */
 export const FormReset = createComponent<FormResetOptions>((props) => {
   const htmlProps = useFormReset(props);
-  return createElement(`button`, htmlProps);
+  return createElement("button", htmlProps);
 });
+
+if (process.env.NODE_ENV !== "production") {
+  FormReset.displayName = "FormReset";
+}
 
 export type FormResetOptions<T extends As = "button"> = ButtonOptions<T> & {
   /**

--- a/packages/ariakit/src/form/form-submit.ts
+++ b/packages/ariakit/src/form/form-submit.ts
@@ -54,6 +54,10 @@ export const FormSubmit = createComponent<FormSubmitOptions>((props) => {
   return createElement("button", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  FormSubmit.displayName = "FormSubmit";
+}
+
 export type FormSubmitOptions<T extends As = "button"> = ButtonOptions<T> & {
   /**
    * Object returned by the `useFormState` hook. If not provided, the parent

--- a/packages/ariakit/src/form/form.ts
+++ b/packages/ariakit/src/form/form.ts
@@ -152,6 +152,10 @@ export const Form = createComponent<FormOptions>((props) => {
   return createElement("form", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  Form.displayName = "Form";
+}
+
 export type FormOptions<T extends As = "form"> = Options<T> & {
   /**
    * Object returned by the `useFormState` hook.

--- a/packages/ariakit/src/group/group-label.ts
+++ b/packages/ariakit/src/group/group-label.ts
@@ -55,6 +55,10 @@ export const GroupLabel = createComponent<GroupLabelOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  GroupLabel.displayName = "GroupLabel";
+}
+
 export type GroupLabelOptions<T extends As = "div"> = Options<T>;
 
 export type GroupLabelProps<T extends As = "div"> = Props<GroupLabelOptions<T>>;

--- a/packages/ariakit/src/group/group.tsx
+++ b/packages/ariakit/src/group/group.tsx
@@ -53,6 +53,10 @@ export const Group = createComponent<GroupOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  Group.displayName = "Group";
+}
+
 export type GroupOptions<T extends As = "div"> = Options<T>;
 
 export type GroupProps<T extends As = "div"> = Props<GroupOptions<T>>;

--- a/packages/ariakit/src/heading/heading.ts
+++ b/packages/ariakit/src/heading/heading.ts
@@ -63,6 +63,10 @@ export const Heading = createComponent<HeadingOptions>((props) => {
   return createElement("h1", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  Heading.displayName = "Heading";
+}
+
 export type HeadingOptions<T extends As = HeadingElements> = Options<T>;
 
 export type HeadingProps<T extends As = HeadingElements> = Props<

--- a/packages/ariakit/src/hovercard/hovercard-anchor.ts
+++ b/packages/ariakit/src/hovercard/hovercard-anchor.ts
@@ -105,6 +105,10 @@ export const HovercardAnchor = createComponent<HovercardAnchorOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  HovercardAnchor.displayName = "HovercardAnchor";
+}
+
 export type HovercardAnchorOptions<T extends As = "a"> = FocusableOptions<T> & {
   /**
    * Object returned by the `useHovercardState` hook.

--- a/packages/ariakit/src/hovercard/hovercard-arrow.ts
+++ b/packages/ariakit/src/hovercard/hovercard-arrow.ts
@@ -46,6 +46,10 @@ export const HovercardArrow = createComponent<HovercardArrowOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  HovercardArrow.displayName = "HovercardArrow";
+}
+
 export type HovercardArrowOptions<T extends As = "div"> = Omit<
   PopoverArrowOptions<T>,
   "state"

--- a/packages/ariakit/src/hovercard/hovercard-description.ts
+++ b/packages/ariakit/src/hovercard/hovercard-description.ts
@@ -49,6 +49,10 @@ export const HovercardDescription =
     return createElement("p", htmlProps);
   });
 
+if (process.env.NODE_ENV !== "production") {
+  HovercardDescription.displayName = "HovercardDescription";
+}
+
 export type HovercardDescriptionOptions<T extends As = "p"> = Omit<
   PopoverDescriptionOptions<T>,
   "state"

--- a/packages/ariakit/src/hovercard/hovercard-disclosure.tsx
+++ b/packages/ariakit/src/hovercard/hovercard-disclosure.tsx
@@ -161,6 +161,10 @@ export const HovercardDisclosure = createComponent<HovercardDisclosureOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  HovercardDisclosure.displayName = "HovercardDisclosure";
+}
+
 export type HovercardDisclosureOptions<T extends As = "button"> = Omit<
   DialogDisclosureOptions<T>,
   "state"

--- a/packages/ariakit/src/hovercard/hovercard-dismiss.ts
+++ b/packages/ariakit/src/hovercard/hovercard-dismiss.ts
@@ -48,6 +48,10 @@ export const HovercardDismiss = createComponent<HovercardDismissOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  HovercardDismiss.displayName = "HovercardDismiss";
+}
+
 export type HovercardDismissOptions<T extends As = "button"> = Omit<
   PopoverDismissOptions<T>,
   "state"

--- a/packages/ariakit/src/hovercard/hovercard-heading.ts
+++ b/packages/ariakit/src/hovercard/hovercard-heading.ts
@@ -50,6 +50,10 @@ export const HovercardHeading = createComponent<HovercardHeadingOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  HovercardHeading.displayName = "HovercardHeading";
+}
+
 export type HovercardHeadingOptions<T extends As = "h1"> = Omit<
   PopoverHeadingOptions<T>,
   "state"

--- a/packages/ariakit/src/hovercard/hovercard.tsx
+++ b/packages/ariakit/src/hovercard/hovercard.tsx
@@ -362,6 +362,10 @@ export const Hovercard = createComponent<HovercardOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  Hovercard.displayName = "Hovercard";
+}
+
 export type HovercardOptions<T extends As = "div"> = Omit<
   PopoverOptions<T>,
   "state"

--- a/packages/ariakit/src/menu/menu-arrow.ts
+++ b/packages/ariakit/src/menu/menu-arrow.ts
@@ -42,6 +42,10 @@ export const MenuArrow = createComponent<MenuArrowOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  MenuArrow.displayName = "MenuArrow";
+}
+
 export type MenuArrowOptions<T extends As = "div"> = Omit<
   PopoverArrowOptions<T>,
   "state"

--- a/packages/ariakit/src/menu/menu-bar.ts
+++ b/packages/ariakit/src/menu/menu-bar.ts
@@ -86,6 +86,10 @@ export const MenuBar = createComponent<MenuBarOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  MenuBar.displayName = "MenuBar";
+}
+
 export type MenuBarOptions<T extends As = "div"> = Omit<
   CompositeOptions<T>,
   "state"

--- a/packages/ariakit/src/menu/menu-button-arrow.ts
+++ b/packages/ariakit/src/menu/menu-button-arrow.ts
@@ -60,6 +60,10 @@ export const MenuButtonArrow = createComponent<MenuButtonArrowOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  MenuButtonArrow.displayName = "MenuButtonArrow";
+}
+
 export type MenuButtonArrowOptions<T extends As = "span"> = Omit<
   PopoverDisclosureArrowOptions<T>,
   "state"

--- a/packages/ariakit/src/menu/menu-button.ts
+++ b/packages/ariakit/src/menu/menu-button.ts
@@ -223,6 +223,10 @@ export const MenuButton = createComponent<MenuButtonOptions>((props) => {
   return createElement("button", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  MenuButton.displayName = "MenuButton";
+}
+
 export type MenuButtonOptions<T extends As = "button" | "div"> = Omit<
   HovercardAnchorOptions<T>,
   "state"

--- a/packages/ariakit/src/menu/menu-description.ts
+++ b/packages/ariakit/src/menu/menu-description.ts
@@ -50,6 +50,10 @@ export const MenuDescription = createComponent<MenuDescriptionOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  MenuDescription.displayName = "MenuDescription";
+}
+
 export type MenuDescriptionOptions<T extends As = "p"> = Omit<
   HovercardDescriptionOptions<T>,
   "state"

--- a/packages/ariakit/src/menu/menu-dismiss.ts
+++ b/packages/ariakit/src/menu/menu-dismiss.ts
@@ -44,6 +44,10 @@ export const MenuDismiss = createComponent<MenuDismissOptions>((props) => {
   return createElement("button", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  MenuDismiss.displayName = "MenuDismiss";
+}
+
 export type MenuDismissOptions<T extends As = "button"> = Omit<
   HovercardDismissOptions<T>,
   "state"

--- a/packages/ariakit/src/menu/menu-group-label.ts
+++ b/packages/ariakit/src/menu/menu-group-label.ts
@@ -53,6 +53,10 @@ export const MenuGroupLabel = createComponent<MenuGroupLabelOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  MenuGroupLabel.displayName = "MenuGroupLabel";
+}
+
 export type MenuGroupLabelOptions<T extends As = "div"> = Omit<
   CompositeGroupLabelOptions<T>,
   "state"

--- a/packages/ariakit/src/menu/menu-group.ts
+++ b/packages/ariakit/src/menu/menu-group.ts
@@ -54,6 +54,10 @@ export const MenuGroup = createComponent<MenuGroupOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  MenuGroup.displayName = "MenuGroup";
+}
+
 export type MenuGroupOptions<T extends As = "div"> = Omit<
   CompositeGroupOptions<T>,
   "state"

--- a/packages/ariakit/src/menu/menu-heading.ts
+++ b/packages/ariakit/src/menu/menu-heading.ts
@@ -46,6 +46,10 @@ export const MenuHeading = createComponent<MenuHeadingOptions>((props) => {
   return createElement("h1", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  MenuHeading.displayName = "MenuHeading";
+}
+
 export type MenuHeadingOptions<T extends As = "h1"> = Omit<
   HovercardHeadingOptions<T>,
   "state"

--- a/packages/ariakit/src/menu/menu-item-check.ts
+++ b/packages/ariakit/src/menu/menu-item-check.ts
@@ -62,6 +62,10 @@ export const MenuItemCheck = createComponent<MenuItemCheckOptions>((props) => {
   return createElement("span", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  MenuItemCheck.displayName = "MenuItemCheck";
+}
+
 export type MenuItemCheckOptions<T extends As = "span"> = Omit<
   CheckboxCheckOptions<T>,
   "state"

--- a/packages/ariakit/src/menu/menu-item-checkbox.ts
+++ b/packages/ariakit/src/menu/menu-item-checkbox.ts
@@ -85,6 +85,10 @@ export const MenuItemCheckbox = createMemoComponent<MenuItemCheckboxOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  MenuItemCheckbox.displayName = "MenuItemCheckbox";
+}
+
 export type MenuItemCheckboxOptions<T extends As = "div"> = Omit<
   MenuItemOptions<T>,
   "state" | "hideOnClick"

--- a/packages/ariakit/src/menu/menu-item-radio.tsx
+++ b/packages/ariakit/src/menu/menu-item-radio.tsx
@@ -97,6 +97,10 @@ export const MenuItemRadio = createMemoComponent<MenuItemRadioOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  MenuItemRadio.displayName = "MenuItemRadio";
+}
+
 export type MenuItemRadioOptions<T extends As = "div"> = Omit<
   MenuItemOptions<T>,
   "hideOnClick"

--- a/packages/ariakit/src/menu/menu-item.ts
+++ b/packages/ariakit/src/menu/menu-item.ts
@@ -132,6 +132,10 @@ export const MenuItem = createMemoComponent<MenuItemOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  MenuItem.displayName = "MenuItem";
+}
+
 export type MenuItemOptions<T extends As = "div"> = Omit<
   CompositeItemOptions<T>,
   "state" | "preventScrollOnKeyDown"

--- a/packages/ariakit/src/menu/menu-list.ts
+++ b/packages/ariakit/src/menu/menu-list.ts
@@ -170,6 +170,10 @@ export const MenuList = createComponent<MenuListOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  MenuList.displayName = "MenuList";
+}
+
 export type MenuListOptions<T extends As = "div"> = Omit<
   CompositeOptions<T>,
   "state"

--- a/packages/ariakit/src/menu/menu-separator.ts
+++ b/packages/ariakit/src/menu/menu-separator.ts
@@ -52,6 +52,10 @@ export const MenuSeparator = createComponent<MenuSeparatorOptions>((props) => {
   return createElement("hr", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  MenuSeparator.displayName = "MenuSeparator";
+}
+
 export type MenuSeparatorOptions<T extends As = "hr"> = Omit<
   CompositeSeparatorOptions<T>,
   "state"

--- a/packages/ariakit/src/menu/menu.ts
+++ b/packages/ariakit/src/menu/menu.ts
@@ -181,6 +181,10 @@ export const Menu = createComponent<MenuOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  Menu.displayName = "Menu";
+}
+
 export type MenuOptions<T extends As = "div"> = MenuListOptions<T> &
   Omit<HovercardOptions<T>, "state">;
 

--- a/packages/ariakit/src/popover/popover-anchor.ts
+++ b/packages/ariakit/src/popover/popover-anchor.ts
@@ -46,6 +46,10 @@ export const PopoverAnchor = createComponent<PopoverAnchorOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  PopoverAnchor.displayName = "PopoverAnchor";
+}
+
 export type PopoverAnchorOptions<T extends As = "div"> = Options<T> & {
   /**
    * Object returned by the `usePopoverState` hook.

--- a/packages/ariakit/src/popover/popover-arrow.tsx
+++ b/packages/ariakit/src/popover/popover-arrow.tsx
@@ -112,6 +112,10 @@ export const PopoverArrow = createComponent<PopoverArrowOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  PopoverArrow.displayName = "PopoverArrow";
+}
+
 export type PopoverArrowOptions<T extends As = "div"> = Options<T> & {
   /**
    * Object returned by the `usePopoverState` hook. If not provided, the parent

--- a/packages/ariakit/src/popover/popover-description.ts
+++ b/packages/ariakit/src/popover/popover-description.ts
@@ -50,6 +50,10 @@ export const PopoverDescription = createComponent<PopoverDescriptionOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  PopoverDescription.displayName = "PopoverDescription";
+}
+
 export type PopoverDescriptionOptions<T extends As = "p"> = Omit<
   DialogDescriptionOptions<T>,
   "state"

--- a/packages/ariakit/src/popover/popover-disclosure-arrow.tsx
+++ b/packages/ariakit/src/popover/popover-disclosure-arrow.tsx
@@ -96,6 +96,10 @@ export const PopoverDisclosureArrow =
     return createElement("span", htmlProps);
   });
 
+if (process.env.NODE_ENV !== "production") {
+  PopoverDisclosureArrow.displayName = "PopoverDisclosureArrow";
+}
+
 export type PopoverDisclosureArrowOptions<T extends As = "span"> =
   Options<T> & {
     /**

--- a/packages/ariakit/src/popover/popover-disclosure.tsx
+++ b/packages/ariakit/src/popover/popover-disclosure.tsx
@@ -75,6 +75,10 @@ export const PopoverDisclosure = createComponent<PopoverDisclosureOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  PopoverDisclosure.displayName = "PopoverDisclosure";
+}
+
 export type PopoverDisclosureOptions<T extends As = "button"> = Omit<
   DialogDisclosureOptions<T>,
   "state"

--- a/packages/ariakit/src/popover/popover-dismiss.ts
+++ b/packages/ariakit/src/popover/popover-dismiss.ts
@@ -46,6 +46,10 @@ export const PopoverDismiss = createComponent<PopoverDismissOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  PopoverDismiss.displayName = "PopoverDismiss";
+}
+
 export type PopoverDismissOptions<T extends As = "button"> = Omit<
   DialogDismissOptions<T>,
   "state"

--- a/packages/ariakit/src/popover/popover-heading.ts
+++ b/packages/ariakit/src/popover/popover-heading.ts
@@ -48,6 +48,10 @@ export const PopoverHeading = createComponent<PopoverHeadingOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  PopoverHeading.displayName = "PopoverHeading";
+}
+
 export type PopoverHeadingOptions<T extends As = "h1"> = Omit<
   DialogHeadingOptions<T>,
   "state"

--- a/packages/ariakit/src/popover/popover.tsx
+++ b/packages/ariakit/src/popover/popover.tsx
@@ -136,6 +136,10 @@ export const Popover = createComponent<PopoverOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  Popover.displayName = "Popover";
+}
+
 export type PopoverOptions<T extends As = "div"> = Omit<
   DialogOptions<T>,
   "state"

--- a/packages/ariakit/src/portal/portal.tsx
+++ b/packages/ariakit/src/portal/portal.tsx
@@ -269,6 +269,10 @@ export const Portal = createComponent<PortalOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  Portal.displayName = "Portal";
+}
+
 export type PortalOptions<T extends As = "div"> = Options<T> & {
   /**
    * When enabled, `preserveTabOrder` will keep the DOM element's tab order the

--- a/packages/ariakit/src/radio/radio-group.ts
+++ b/packages/ariakit/src/radio/radio-group.ts
@@ -55,6 +55,10 @@ export const RadioGroup = createComponent<RadioGroupOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  RadioGroup.displayName = "RadioGroup";
+}
+
 export type RadioGroupOptions<T extends As = "div"> = Omit<
   CompositeOptions<T>,
   "state"

--- a/packages/ariakit/src/radio/radio.ts
+++ b/packages/ariakit/src/radio/radio.ts
@@ -152,6 +152,10 @@ export const Radio = createMemoComponent<RadioOptions>((props) => {
   return createElement("input", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  Radio.displayName = "Radio";
+}
+
 export type RadioOptions<T extends As = "input"> = Omit<
   CompositeItemOptions<T>,
   "state"

--- a/packages/ariakit/src/role/role.ts
+++ b/packages/ariakit/src/role/role.ts
@@ -35,6 +35,10 @@ export const Role = createComponent<RoleOptions>((props) => {
   return createElement("div", props);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  Role.displayName = "Role";
+}
+
 export type RoleOptions<T extends As = "div"> = Options<T>;
 
 export type RoleProps<T extends As = "div"> = Props<RoleOptions<T>>;

--- a/packages/ariakit/src/select/select-arrow.ts
+++ b/packages/ariakit/src/select/select-arrow.ts
@@ -58,6 +58,10 @@ export const SelectArrow = createComponent<SelectArrowOptions>((props) => {
   return createElement("span", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  SelectArrow.displayName = "SelectArrow";
+}
+
 export type SelectArrowOptions<T extends As = "span"> = Omit<
   PopoverDisclosureArrowOptions<T>,
   "state"

--- a/packages/ariakit/src/select/select-group-label.ts
+++ b/packages/ariakit/src/select/select-group-label.ts
@@ -60,6 +60,10 @@ export const SelectGroupLabel = createComponent<SelectGroupLabelOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  SelectGroupLabel.displayName = "SelectGroupLabel";
+}
+
 export type SelectGroupLabelOptions<T extends As = "div"> = Omit<
   CompositeGroupLabelOptions<T>,
   "state"

--- a/packages/ariakit/src/select/select-group.ts
+++ b/packages/ariakit/src/select/select-group.ts
@@ -54,6 +54,10 @@ export const SelectGroup = createComponent<SelectGroupOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  SelectGroup.displayName = "SelectGroup";
+}
+
 export type SelectGroupOptions<T extends As = "div"> = Omit<
   CompositeGroupOptions<T>,
   "state"

--- a/packages/ariakit/src/select/select-item-check.ts
+++ b/packages/ariakit/src/select/select-item-check.ts
@@ -61,6 +61,10 @@ export const SelectItemCheck = createComponent<SelectItemCheckOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  SelectItemCheck.displayName = "SelectItemCheck";
+}
+
 export type SelectItemCheckOptions<T extends As = "span"> = Omit<
   CheckboxCheckOptions<T>,
   "state" | "checked"

--- a/packages/ariakit/src/select/select-item.tsx
+++ b/packages/ariakit/src/select/select-item.tsx
@@ -164,6 +164,10 @@ export const SelectItem = createMemoComponent<SelectItemOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  SelectItem.displayName = "SelectItem";
+}
+
 export type SelectItemOptions<T extends As = "div"> = Omit<
   CompositeItemOptions<T>,
   "state" | "preventScrollOnKeyDown"

--- a/packages/ariakit/src/select/select-label.ts
+++ b/packages/ariakit/src/select/select-label.ts
@@ -77,6 +77,10 @@ export const SelectLabel = createMemoComponent<SelectLabelOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  SelectLabel.displayName = "SelectLabel";
+}
+
 export type SelectLabelOptions<T extends As = "div"> = Options<T> & {
   /**
    * Object returned by the `useSelectState` hook. If not provided, the parent

--- a/packages/ariakit/src/select/select-list.ts
+++ b/packages/ariakit/src/select/select-list.ts
@@ -134,6 +134,10 @@ export const SelectList = createComponent<SelectListOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  SelectList.displayName = "SelectList";
+}
+
 export type SelectListOptions<T extends As = "div"> = Omit<
   CompositeOptions<T>,
   "state"

--- a/packages/ariakit/src/select/select-popover.ts
+++ b/packages/ariakit/src/select/select-popover.ts
@@ -78,6 +78,10 @@ export const SelectPopover = createComponent<SelectPopoverOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  SelectPopover.displayName = "SelectPopover";
+}
+
 export type SelectPopoverOptions<T extends As = "div"> = SelectListOptions<T> &
   Omit<PopoverOptions<T>, "state">;
 

--- a/packages/ariakit/src/select/select-row.ts
+++ b/packages/ariakit/src/select/select-row.ts
@@ -65,6 +65,10 @@ export const SelectRow = createComponent<SelectRowOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  SelectRow.displayName = "SelectRow";
+}
+
 export type SelectRowOptions<T extends As = "div"> = Omit<
   CompositeRowOptions<T>,
   "state"

--- a/packages/ariakit/src/select/select-separator.ts
+++ b/packages/ariakit/src/select/select-separator.ts
@@ -55,6 +55,10 @@ export const SelectSeparator = createComponent<SelectSeparatorOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  SelectSeparator.displayName = "SelectSeparator";
+}
+
 export type SelectSeparatorOptions<T extends As = "hr"> = Omit<
   CompositeSeparatorOptions<T>,
   "state"

--- a/packages/ariakit/src/select/select.tsx
+++ b/packages/ariakit/src/select/select.tsx
@@ -284,6 +284,10 @@ export const Select = createComponent<SelectOptions>((props) => {
   return createElement("button", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  Select.displayName = "Select";
+}
+
 export type SelectOptions<T extends As = "button"> = Omit<
   PopoverDisclosureOptions<T>,
   "state" | "toggleOnClick"

--- a/packages/ariakit/src/separator/separator.ts
+++ b/packages/ariakit/src/separator/separator.ts
@@ -39,6 +39,10 @@ export const Separator = createComponent<SeparatorOptions>((props) => {
   return createElement("hr", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  Separator.displayName = "Separator";
+}
+
 export type SeparatorOptions<T extends As = "hr"> = Options<T> & {
   /**
    * The orientation of the separator.

--- a/packages/ariakit/src/tab/tab-list.ts
+++ b/packages/ariakit/src/tab/tab-list.ts
@@ -60,6 +60,10 @@ export const TabList = createComponent<TabListOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  TabList.displayName = "TabList";
+}
+
 export type TabListOptions<T extends As = "div"> = Omit<
   CompositeOptions<T>,
   "state"

--- a/packages/ariakit/src/tab/tab-panel.ts
+++ b/packages/ariakit/src/tab/tab-panel.ts
@@ -103,6 +103,10 @@ export const TabPanel = createComponent<TabPanelOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  TabPanel.displayName = "TabPanel";
+}
+
 export type TabPanelOptions<T extends As = "div"> = FocusableOptions<T> &
   Omit<CollectionItemOptions, "state"> &
   Omit<DisclosureContentOptions<T>, "state"> & {

--- a/packages/ariakit/src/tab/tab.ts
+++ b/packages/ariakit/src/tab/tab.ts
@@ -114,6 +114,10 @@ export const Tab = createMemoComponent<TabOptions>((props) => {
   return createElement("button", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  Tab.displayName = "Tab";
+}
+
 export type TabOptions<T extends As = "button"> = Omit<
   CompositeItemOptions<T>,
   "state"

--- a/packages/ariakit/src/toolbar/toolbar-container.ts
+++ b/packages/ariakit/src/toolbar/toolbar-container.ts
@@ -52,6 +52,10 @@ export const ToolbarContainer = createMemoComponent<ToolbarContainerOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  ToolbarContainer.displayName = "ToolbarContainer";
+}
+
 export type ToolbarContainerOptions<T extends As = "div"> = Omit<
   CompositeContainerOptions<T>,
   "state"

--- a/packages/ariakit/src/toolbar/toolbar-input.ts
+++ b/packages/ariakit/src/toolbar/toolbar-input.ts
@@ -46,6 +46,10 @@ export const ToolbarInput = createMemoComponent<ToolbarInputOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  ToolbarInput.displayName = "ToolbarInput";
+}
+
 export type ToolbarInputOptions<T extends As = "input"> = Omit<
   CompositeInputOptions<T>,
   "state"

--- a/packages/ariakit/src/toolbar/toolbar-item.ts
+++ b/packages/ariakit/src/toolbar/toolbar-item.ts
@@ -43,6 +43,10 @@ export const ToolbarItem = createMemoComponent<ToolbarItemOptions>((props) => {
   return createElement("button", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  ToolbarItem.displayName = "ToolbarItem";
+}
+
 export type ToolbarItemOptions<T extends As = "button"> = Omit<
   CompositeItemOptions<T>,
   "state"

--- a/packages/ariakit/src/toolbar/toolbar-separator.ts
+++ b/packages/ariakit/src/toolbar/toolbar-separator.ts
@@ -52,6 +52,10 @@ export const ToolbarSeparator = createComponent<ToolbarSeparatorOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  ToolbarSeparator.displayName = "ToolbarSeparator";
+}
+
 export type ToolbarSeparatorOptions<T extends As = "hr"> = Omit<
   CompositeSeparatorOptions<T>,
   "state"

--- a/packages/ariakit/src/toolbar/toolbar.tsx
+++ b/packages/ariakit/src/toolbar/toolbar.tsx
@@ -65,6 +65,10 @@ export const Toolbar = createComponent<ToolbarOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  Toolbar.displayName = "Toolbar";
+}
+
 export type ToolbarOptions<T extends As = "div"> = Omit<
   CompositeOptions<T>,
   "state"

--- a/packages/ariakit/src/tooltip/tooltip-anchor.ts
+++ b/packages/ariakit/src/tooltip/tooltip-anchor.ts
@@ -106,6 +106,10 @@ export const TooltipAnchor = createComponent<TooltipAnchorOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  TooltipAnchor.displayName = "TooltipAnchor";
+}
+
 export type TooltipAnchorOptions<T extends As = "div"> = Omit<
   PopoverAnchorOptions<T>,
   "state"

--- a/packages/ariakit/src/tooltip/tooltip-arrow.ts
+++ b/packages/ariakit/src/tooltip/tooltip-arrow.ts
@@ -53,6 +53,10 @@ export const TooltipArrow = createComponent<TooltipArrowOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  TooltipArrow.displayName = "TooltipArrow";
+}
+
 export type TooltipArrowOptions<T extends As = "div"> = Omit<
   PopoverArrowOptions<T>,
   "state"

--- a/packages/ariakit/src/tooltip/tooltip.tsx
+++ b/packages/ariakit/src/tooltip/tooltip.tsx
@@ -126,6 +126,10 @@ export const Tooltip = createComponent<TooltipOptions>((props) => {
   return createElement("div", htmlProps);
 });
 
+if (process.env.NODE_ENV !== "production") {
+  Tooltip.displayName = "Tooltip";
+}
+
 export type TooltipOptions<T extends As = "div"> = Omit<
   DisclosureContentOptions<T>,
   "state"

--- a/packages/ariakit/src/visually-hidden/visually-hidden.ts
+++ b/packages/ariakit/src/visually-hidden/visually-hidden.ts
@@ -56,6 +56,10 @@ export const VisuallyHidden = createComponent<VisuallyHiddenOptions>(
   }
 );
 
+if (process.env.NODE_ENV !== "production") {
+  VisuallyHidden.displayName = "VisuallyHidden";
+}
+
 export type VisuallyHiddenOptions<T extends As = "span"> = Options<T>;
 
 export type VisuallyHiddenProps<T extends As = "span"> = Props<


### PR DESCRIPTION
This PR adds `displayName` to components to make debugging easier.