### PR TITLE
Improve CompositeTypeahead runtime performance

### DIFF
--- a/.changeset/composite-typeahead-use-store.md
+++ b/.changeset/composite-typeahead-use-store.md
@@ -1,0 +1,5 @@
+---
+"ariakit": minor
+---
+
+Improved `CompositeTypeahead` runtime performance. ([#1792](https://github.com/ariakit/ariakit/pull/1792))

--- a/packages/ariakit/src/composite/composite-typeahead.ts
+++ b/packages/ariakit/src/composite/composite-typeahead.ts
@@ -1,8 +1,9 @@
-import { KeyboardEvent, useContext, useRef } from "react";
+import { KeyboardEvent, useRef } from "react";
 import { isTextField } from "ariakit-utils/dom";
 import { isSelfTarget } from "ariakit-utils/events";
 import { useEvent } from "ariakit-utils/hooks";
 import { normalizeString } from "ariakit-utils/misc";
+import { useStore } from "ariakit-utils/store";
 import {
   createComponent,
   createElement,
@@ -90,8 +91,7 @@ function getSameInitialItems(
  */
 export const useCompositeTypeahead = createHook<CompositeTypeaheadOptions>(
   ({ state, typeahead = true, ...props }) => {
-    const context = useContext(CompositeContext);
-    state = state || context;
+    state = useStore(state || CompositeContext, ["items", "activeId", "move"]);
     const onKeyDownCaptureProp = props.onKeyDownCapture;
     const cleanupTimeoutRef = useRef(0);
 


### PR DESCRIPTION
Instead of using `useContext` directly, this PR updates the `CompositeTypeahead` component to `useStore` so it doesn't try to use the dynamic composite context (that may trigger unnecessary and sometimes expensive re-renders) when the `state` prop has been provided.