### PR TITLE
Fix Popover blurred pixels when trying to fit viewport

### DIFF
--- a/.changeset/popover-size-available.md
+++ b/.changeset/popover-size-available.md
@@ -1,0 +1,5 @@
+---
+"ariakit": patch
+---
+
+Fixed `Popover` blurred pixels when trying to fit viewport. ([#1793](https://github.com/ariakit/ariakit/pull/1793))

--- a/packages/ariakit/src/popover/popover-state.ts
+++ b/packages/ariakit/src/popover/popover-state.ts
@@ -197,6 +197,8 @@ export function usePopoverState({
             padding: overflowPadding,
             apply({ availableWidth, availableHeight, rects }) {
               const referenceWidth = Math.round(rects.reference.width);
+              availableWidth = Math.floor(availableWidth);
+              availableHeight = Math.floor(availableHeight);
               popover.style.setProperty(
                 "--popover-anchor-width",
                 `${referenceWidth}px`


### PR DESCRIPTION
Some displays will show blurred pixels when the Popover tries to fit the viewport with float numbers. This PR fixes this using `Math.floor` on them.