### PR TITLE
Improve Combobox autoSelect and inline autocomplete behavior

### DIFF
--- a/.changeset/combobox-auto-select.md
+++ b/.changeset/combobox-auto-select.md
@@ -1,0 +1,7 @@
+---
+"ariakit": minor
+---
+
+Improved `Combobox` with `autoSelect` behavior. ([#1821](https://github.com/ariakit/ariakit/pull/1821))
+
+Before, when `autoSelect` was enabled, the first item would be selected only on text insertion. That is, deleting or pasting text was ignored. Now, the first item is selected on any change to the input value, including programmatic changes.

--- a/.changeset/composite-item-move-on-key-press copy.md
+++ b/.changeset/composite-item-move-on-key-press copy.md
@@ -1,0 +1,5 @@
+---
+"ariakit": minor
+---
+
+Added `moveOnKeyPress` prop to `CompositeItem`. ([#1821](https://github.com/ariakit/ariakit/pull/1821))

--- a/.changeset/composite-move-on-key-press.md
+++ b/.changeset/composite-move-on-key-press.md
@@ -1,0 +1,5 @@
+---
+"ariakit": minor
+---
+
+Added `moveOnKeyPress` prop to `Composite`. ([#1821](https://github.com/ariakit/ariakit/pull/1821))

--- a/packages/ariakit/src/combobox/__examples__/combobox-group/index.tsx
+++ b/packages/ariakit/src/combobox/__examples__/combobox-group/index.tsx
@@ -45,11 +45,11 @@ export default function Example() {
                 <ComboboxGroupLabel className="group-label">
                   {type}
                 </ComboboxGroupLabel>
-                {items.map((item) => (
+                {items.map((item, i) => (
                   <ComboboxItem
-                    focusOnHover
-                    key={item.name}
+                    key={item.name + i}
                     value={item.name}
+                    focusOnHover
                     className="combobox-item"
                   />
                 ))}

--- a/packages/ariakit/src/combobox/__examples__/combobox-group/test.tsx
+++ b/packages/ariakit/src/combobox/__examples__/combobox-group/test.tsx
@@ -54,6 +54,26 @@ test("auto select with inline autocomplete on arrow down", async () => {
   expect(getCombobox()).toHaveValue("Apple");
 });
 
+test("auto select with inline autocomplete on typing + arrow down", async () => {
+  render(<Example />);
+  await press.Tab();
+  await type("av");
+  expect(getCombobox()).toHaveValue("avocado");
+  expect(getSelectionValue(getCombobox())).toBe("ocado");
+  await type("\b");
+  expect(getCombobox()).toHaveValue("av");
+  expect(getOption("Avocado")).toHaveFocus();
+  expect(getSelectionValue(getCombobox())).toBe("");
+  await type("\b");
+  expect(getCombobox()).toHaveValue("a");
+  expect(getOption("Apple")).toHaveFocus();
+  expect(getSelectionValue(getCombobox())).toBe("");
+  await press.ArrowDown();
+  expect(getCombobox()).toHaveValue("Avocado");
+  expect(getOption("Avocado")).toHaveFocus();
+  expect(getSelectionValue(getCombobox())).toBe("");
+});
+
 test("blur input after autocomplete", async () => {
   render(<Example />);
   await press.Tab();

--- a/packages/ariakit/src/combobox/__examples__/combobox-textarea/test.tsx
+++ b/packages/ariakit/src/combobox/__examples__/combobox-textarea/test.tsx
@@ -56,7 +56,6 @@ test("typing on the textarea", async () => {
   await expect(getPopover()).not.toBeInTheDocument();
   await type("\b");
   await expect(getPopover()).toBeVisible();
-  await press.ArrowUp();
   await press.Enter();
-  expect(getTextarea()).toHaveValue("Hi @tcodes0 @matheus1lva\n\n#1018 t");
+  expect(getTextarea()).toHaveValue("Hi @tcodes0 @matheus1lva\n\n#1253 t");
 });

--- a/packages/ariakit/src/combobox/combobox-item.tsx
+++ b/packages/ariakit/src/combobox/combobox-item.tsx
@@ -37,6 +37,7 @@ export const useComboboxItem = createHook<ComboboxItemOptions>(
     setValueOnClick = true,
     shouldRegisterItem = true,
     focusOnHover = false,
+    moveOnKeyPress = true,
     getItem: getItemProp,
     ...props
   }) => {
@@ -125,6 +126,8 @@ export const useComboboxItem = createHook<ComboboxItemOptions>(
       onKeyDown,
     };
 
+    const moveOnKeyPressProp = useBooleanEvent(moveOnKeyPress);
+
     props = useCompositeItem({
       state,
       ...props,
@@ -132,6 +135,15 @@ export const useComboboxItem = createHook<ComboboxItemOptions>(
       // We only register the item on the state when the popover is open so we
       // don't try to move focus to hidden items when pressing arrow keys.
       shouldRegisterItem: state?.mounted && shouldRegisterItem,
+      // Dispatch a custom event on the combobox input when moving to an item
+      // with the keyboard so the Combobox component can enable inline
+      // autocompletion.
+      moveOnKeyPress: (event) => {
+        if (!moveOnKeyPressProp(event)) return false;
+        const moveEvent = new Event("combobox-item-move");
+        state?.baseRef.current?.dispatchEvent(moveEvent);
+        return true;
+      },
     });
 
     props = useCompositeHover({ state, focusOnHover, ...props });

--- a/packages/ariakit/src/composite/composite-item.tsx
+++ b/packages/ariakit/src/composite/composite-item.tsx
@@ -171,6 +171,7 @@ export const useCompositeItem = createHook<CompositeItemOptions>(
     state,
     rowId: rowIdProp,
     preventScrollOnKeyDown = false,
+    moveOnKeyPress = true,
     getItem: getItemProp,
     ...props
   }) => {
@@ -271,6 +272,7 @@ export const useCompositeItem = createHook<CompositeItemOptions>(
 
     const onKeyDownProp = props.onKeyDown;
     const preventScrollOnKeyDownProp = useBooleanEvent(preventScrollOnKeyDown);
+    const moveOnKeyPressProp = useBooleanEvent(moveOnKeyPress);
     const item = useItem(state?.items, id);
     const isGrid = !!item?.rowId;
 
@@ -317,6 +319,7 @@ export const useCompositeItem = createHook<CompositeItemOptions>(
       if (action) {
         const nextId = action();
         if (preventScrollOnKeyDownProp(event) || nextId !== undefined) {
+          if (!moveOnKeyPressProp(event)) return;
           event.preventDefault();
           state?.move(nextId);
         }
@@ -429,6 +432,11 @@ export type CompositeItemOptions<T extends As = "button"> = CommandOptions<T> &
      * @default false
      */
     preventScrollOnKeyDown?: BooleanOrCallback<KeyboardEvent<HTMLElement>>;
+    /**
+     * Whether pressing arrow keys should move the focus to a different item.
+     * @default true
+     */
+    moveOnKeyPress?: BooleanOrCallback<KeyboardEvent<HTMLElement>>;
   };
 
 export type CompositeItemProps<T extends As = "button"> = Props<

--- a/packages/ariakit/src/composite/composite.ts
+++ b/packages/ariakit/src/composite/composite.ts
@@ -19,6 +19,7 @@ import {
 } from "ariakit-utils/events";
 import { focusIntoView, hasFocus } from "ariakit-utils/focus";
 import {
+  useBooleanEvent,
   useEvent,
   useForkRef,
   useLiveRef,
@@ -31,7 +32,7 @@ import {
   createElement,
   createHook,
 } from "ariakit-utils/system";
-import { As, Props } from "ariakit-utils/types";
+import { As, BooleanOrCallback, Props } from "ariakit-utils/types";
 import { FocusableOptions, useFocusable } from "../focusable/focusable";
 import {
   CompositeContext,
@@ -144,7 +145,13 @@ function useScheduleFocus(activeItem?: Item) {
  * ```
  */
 export const useComposite = createHook<CompositeOptions>(
-  ({ state, composite = true, focusOnMove = composite, ...props }) => {
+  ({
+    state,
+    composite = true,
+    focusOnMove = composite,
+    moveOnKeyPress = true,
+    ...props
+  }) => {
     const ref = useRef<HTMLDivElement>(null);
     const virtualFocus = composite && state.virtualFocus;
     const activeItem = useMemo(
@@ -345,6 +352,7 @@ export const useComposite = createHook<CompositeOptions>(
     });
 
     const onKeyDownProp = props.onKeyDown;
+    const moveOnKeyPressProp = useBooleanEvent(moveOnKeyPress);
 
     const onKeyDown = useEvent((event: ReactKeyboardEvent<HTMLDivElement>) => {
       onKeyDownProp?.(event);
@@ -376,6 +384,7 @@ export const useComposite = createHook<CompositeOptions>(
       if (action) {
         const id = action();
         if (id !== undefined) {
+          if (!moveOnKeyPressProp(event)) return;
           event.preventDefault();
           state.move(id);
         }
@@ -461,6 +470,12 @@ export type CompositeOptions<T extends As = "div"> = FocusableOptions<T> & {
    * @default true
    */
   focusOnMove?: boolean;
+  /**
+   * Whether the composite widget should move focus to an item when pressing
+   * arrow keys.
+   * @default true
+   */
+  moveOnKeyPress?: BooleanOrCallback<ReactKeyboardEvent<HTMLElement>>;
 };
 
 export type CompositeProps<T extends As = "div"> = Props<CompositeOptions<T>>;

--- a/packages/ariakit/src/menu/__examples__/menu-combobox/test.tsx
+++ b/packages/ariakit/src/menu/__examples__/menu-combobox/test.tsx
@@ -99,13 +99,10 @@ test("backspace on combobox", async () => {
   expect(getOption("Group")).toHaveFocus();
   await type("\b");
   expect(getCombobox()).toHaveValue("g");
-  expect(getOption("Gallery")).not.toHaveFocus();
-  expect(getOption("Group")).not.toHaveFocus();
+  expect(getOption("Gallery")).toHaveFocus();
   await type("\b");
   expect(getCombobox()).toHaveValue("");
-  expect(getOption("Paragraph")).not.toHaveFocus();
-  expect(getOption("Gallery")).not.toHaveFocus();
-  expect(getOption("Group")).not.toHaveFocus();
+  expect(getOption("Paragraph")).toHaveFocus();
 });
 
 test("move through items with keyboard", async () => {


### PR DESCRIPTION
Closes #1475

This PR improves the behavior of `Combobox` with the `autoSelect` prop set to `true`.

Before, when `autoSelect` was enabled, the first item would be selected only on text insertion. That is, deleting or pasting text was ignored. This was so the `inline` autocomplete (automatically updating and highlighting the input value while typing) would work properly. In other words, we didn't want to trigger the inline auto-completion when deleting text from the combobox input. After some feedback and research, this behavior seemed counter-intuitive.

This PR decouples `autoSelect` from the `autoComplete="inline"` (or `autoComplete="both"`) behavior. While the latter keeps working only on text insertion (or when the user deliberately moves the focus to an item using the keyboard), the first item is now selected for any input value change, including programmatic changes.