### PR TITLE
Allow inline auto-complete only when caret is at the end

### DIFF
--- a/.changeset/combobox-inline-caret-at-end.md
+++ b/.changeset/combobox-inline-caret-at-end.md
@@ -1,0 +1,5 @@
+---
+"ariakit": minor
+---
+
+Updated the behavior of `autoComplete="inline"` and `autoComplete="both"` on `Combobox` so the completion string is only appended and highlighted when the caret is at the end of the input. ([#1823](https://github.com/ariakit/ariakit/pull/1823))

--- a/packages/ariakit/src/combobox/__examples__/combobox-group/test.tsx
+++ b/packages/ariakit/src/combobox/__examples__/combobox-group/test.tsx
@@ -72,6 +72,24 @@ test("auto select with inline autocomplete on typing + arrow down", async () => 
   expect(getCombobox()).toHaveValue("Avocado");
   expect(getOption("Avocado")).toHaveFocus();
   expect(getSelectionValue(getCombobox())).toBe("");
+  for (const _ of "Avocado") {
+    await press.ArrowLeft(null, { shiftKey: true });
+  }
+  await type("p");
+  expect(getCombobox()).toHaveValue("papaya");
+  expect(getOption("Papaya")).toHaveFocus();
+  expect(getSelectionValue(getCombobox())).toBe("apaya");
+  await type("\b");
+  await press.ArrowLeft();
+  await type("a");
+  expect(getCombobox()).toHaveValue("ap");
+  expect(getOption("Apple")).toHaveFocus();
+  expect(getSelectionValue(getCombobox())).toBe("");
+  await press.ArrowRight();
+  await type("p");
+  expect(getCombobox()).toHaveValue("apple");
+  expect(getOption("Apple")).toHaveFocus();
+  expect(getSelectionValue(getCombobox())).toBe("le");
 });
 
 test("blur input after autocomplete", async () => {

--- a/packages/ariakit/src/combobox/combobox.ts
+++ b/packages/ariakit/src/combobox/combobox.ts
@@ -244,16 +244,19 @@ export const useCombobox = createHook<ComboboxOptions>(
     const onChange = useEvent((event: ChangeEvent<HTMLInputElement>) => {
       onChangeProp?.(event);
       if (event.defaultPrevented) return;
+      const { target } = event;
       const nativeEvent = event.nativeEvent;
       valueChangedRef.current = true;
       if (isInputEvent(nativeEvent) && inline) {
-        setCanInline(nativeEvent.inputType === "insertText");
+        const textInserted = nativeEvent.inputType === "insertText";
+        const caretAtEnd = target.selectionStart === target.value.length;
+        setCanInline(textInserted && caretAtEnd);
       }
       if (showOnChangeProp(event)) {
         state.show();
       }
       if (setValueOnChangeProp(event)) {
-        state.setValue(event.target.value);
+        state.setValue(target.value);
       }
       if (inline && autoSelect) {
         // The state.setValue(event.target.value) above may not trigger a state


### PR DESCRIPTION
This PR updates the behavior of the `Combobox` component with `autoComplete="inline"` or `autoComplete="both"` so the completion string is only appended and highlighted when the caret is at the end of the input. This avoids a situation where inserting text at the beginning of an input unexpectedly moves the caret to the end.