### PR TITLE
Fix scroll jump on Combobox when pressing modifier keys

### DIFF
--- a/.changeset/composite-proxy-event-modifier-keys.md
+++ b/.changeset/composite-proxy-event-modifier-keys.md
@@ -1,0 +1,5 @@
+---
+"ariakit": patch
+---
+
+Fixed scroll jump on `Combobox` when pressing modifier keys. ([#1826](https://github.com/ariakit/ariakit/pull/1826))

--- a/packages/ariakit/src/composite/composite.ts
+++ b/packages/ariakit/src/composite/composite.ts
@@ -53,11 +53,21 @@ function isPrintableKey(event: ReactKeyboardEvent): boolean {
   return event.key.length === 1 && !event.ctrlKey && !event.metaKey;
 }
 
+function isModifierKey(event: ReactKeyboardEvent) {
+  return (
+    event.key === "Shift" ||
+    event.key === "Control" ||
+    event.key === "Alt" ||
+    event.key === "Meta"
+  );
+}
+
 function canProxyKeyboardEvent(
   event: ReactKeyboardEvent,
   state: CompositeState
 ) {
   if (!isSelfTarget(event)) return false;
+  if (isModifierKey(event)) return false;
   const target = event.target as Element;
   if (!target) return true;
   if (isTextField(target)) {


### PR DESCRIPTION
This PR fixes a bug where a scroll jump happens in this scenario:

1. `ComboboxItem` has `focusOnHover` prop set to `true`.
2. Hover over an item.
3. Move the scroll position without moving the mouse.
4. Press any modifier key.