### PR TITLE
Sliding Menu Example: Prevent being able to swipe multiple pages

### DIFF
--- a/packages/ariakit/src/menu/__examples__/menu-slide/style.css
+++ b/packages/ariakit/src/menu/__examples__/menu-slide/style.css
@@ -14,6 +14,7 @@
     shadow-lg
     dark:shadow-lg-dark
     [scroll-snap-type:x_mandatory]
+    [scroll-snap-stop:always]
     [scrollbar-width:none]
     border-canvas-4
     bg-canvas-4


### PR DESCRIPTION
Add `scroll-snap-stop: always` to prevent swiping to go back multiple pages, because I was surprised at the current behavior while using it, but just a suggestion!

With this change, you can only go back one page at a time when swiping fast. You can still drag it all the way though (with no flick).

Before (first fast flick, then slow drag):


https://user-images.githubusercontent.com/15364860/194398697-d2f4c170-6f2c-4e23-8a5c-8a72e75fd91e.mov

After (first fast flick, then slow drag):

https://user-images.githubusercontent.com/15364860/194398770-008d841b-36f3-4c0e-824f-4d09d4a5af12.mov
