### PR TITLE
Rename types to have unique names matching their pattern

### DIFF
--- a/.changeset/unique-type-names.md
+++ b/.changeset/unique-type-names.md
@@ -1,0 +1,5 @@
+---
+"ariakit": patch
+---
+
+**TypeScript**: Renamed types to have unique names matching their pattern. ([#2153](https://github.com/ariakit/ariakit/pull/2153))

--- a/packages/ariakit/src/checkbox/checkbox-state.ts
+++ b/packages/ariakit/src/checkbox/checkbox-state.ts
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { useControlledState } from "ariakit-react-utils/hooks";
 import { SetState } from "ariakit-utils/types";
 
-type Value = boolean | string | number | Array<string | number>;
+type CheckboxStateValue = boolean | string | number | Array<string | number>;
 
 /**
  * Provides state for the `Checkbox` component.
@@ -13,9 +13,9 @@ type Value = boolean | string | number | Array<string | number>;
  * <Checkbox state={checkbox} />
  * ```
  */
-export function useCheckboxState<T extends Value = Value>(
-  props: CheckboxStateProps<T> = {}
-): CheckboxState<T> {
+export function useCheckboxState<
+  T extends CheckboxStateValue = CheckboxStateValue
+>(props: CheckboxStateProps<T> = {}): CheckboxState<T> {
   const [value, setValue] = useControlledState(
     props.defaultValue ?? (false as T),
     props.value,
@@ -25,7 +25,7 @@ export function useCheckboxState<T extends Value = Value>(
   return state;
 }
 
-export type CheckboxState<T extends Value = Value> = {
+export type CheckboxState<T extends CheckboxStateValue = CheckboxStateValue> = {
   /**
    * The checked state of the checkbox.
    */
@@ -39,9 +39,9 @@ export type CheckboxState<T extends Value = Value> = {
   setValue: SetState<T>;
 };
 
-export type CheckboxStateProps<T extends Value = Value> = Partial<
-  Pick<CheckboxState<T>, "value">
-> & {
+export type CheckboxStateProps<
+  T extends CheckboxStateValue = CheckboxStateValue
+> = Partial<Pick<CheckboxState<T>, "value">> & {
   /**
    * The default value of the checkbox.
    * @default false

--- a/packages/ariakit/src/collection/__utils.ts
+++ b/packages/ariakit/src/collection/__utils.ts
@@ -1,7 +1,7 @@
 import { RefObject, createContext } from "react";
 import { CollectionState } from "./collection-state";
 
-export type Item = {
+export type CollectionStateItem = {
   ref: RefObject<HTMLElement>;
 };
 

--- a/packages/ariakit/src/collection/collection-item.ts
+++ b/packages/ariakit/src/collection/collection-item.ts
@@ -7,7 +7,7 @@ import {
   createHook,
 } from "ariakit-react-utils/system";
 import { As, Options, Props } from "ariakit-react-utils/types";
-import { CollectionItemContext, Item } from "./__utils";
+import { CollectionItemContext, CollectionStateItem } from "./__utils";
 import { CollectionState } from "./collection-state";
 
 function identity<T>(value: T) {
@@ -95,7 +95,7 @@ export type CollectionItemOptions<T extends As = "div"> = Options<T> & {
    * <CollectionItem state={state} getItem={getItem} />
    * ```
    */
-  getItem?: (props: Item) => Item;
+  getItem?: (props: CollectionStateItem) => CollectionStateItem;
 };
 
 export type CollectionItemProps<T extends As = "div"> = Props<

--- a/packages/ariakit/src/collection/collection-state.ts
+++ b/packages/ariakit/src/collection/collection-state.ts
@@ -3,7 +3,7 @@ import { useControlledState } from "ariakit-react-utils/hooks";
 import { addItemToArray } from "ariakit-utils/array";
 import { getDocument } from "ariakit-utils/dom";
 import { BivariantCallback, SetState } from "ariakit-utils/types";
-import { Item } from "./__utils";
+import { CollectionStateItem } from "./__utils";
 
 function isElementPreceding(a: Element, b: Element) {
   return Boolean(
@@ -11,7 +11,7 @@ function isElementPreceding(a: Element, b: Element) {
   );
 }
 
-function findDOMIndex(items: Item[], item: Item) {
+function findDOMIndex(items: CollectionStateItem[], item: CollectionStateItem) {
   const itemElement = item.ref.current;
   if (!itemElement) return -1;
   let length = items.length;
@@ -29,7 +29,7 @@ function findDOMIndex(items: Item[], item: Item) {
   return 0;
 }
 
-function sortBasedOnDOMPosition<T extends Item>(items: T[]) {
+function sortBasedOnDOMPosition<T extends CollectionStateItem>(items: T[]) {
   const pairs = items.map((item, index) => [index, item] as const);
   let isOrderDifferent = false;
   pairs.sort(([indexA, a], [indexB, b]) => {
@@ -56,7 +56,7 @@ function sortBasedOnDOMPosition<T extends Item>(items: T[]) {
   return items;
 }
 
-function setItemsBasedOnDOMPosition<T extends Item>(
+function setItemsBasedOnDOMPosition<T extends CollectionStateItem>(
   items: T[],
   setItems: (items: T[]) => any
 ) {
@@ -66,7 +66,7 @@ function setItemsBasedOnDOMPosition<T extends Item>(
   }
 }
 
-function getCommonParent(items: Item[]) {
+function getCommonParent(items: CollectionStateItem[]) {
   const firstItem = items[0];
   const lastItem = items[items.length - 1];
   let parentElement = firstItem?.ref.current?.parentElement;
@@ -80,10 +80,9 @@ function getCommonParent(items: Item[]) {
   return getDocument(parentElement).body;
 }
 
-function useTimeoutObserver<T extends Item = Item>(
-  items: T[],
-  setItems: (items: T[]) => any
-) {
+function useTimeoutObserver<
+  T extends CollectionStateItem = CollectionStateItem
+>(items: T[], setItems: (items: T[]) => any) {
   useEffect(() => {
     const callback = () => setItemsBasedOnDOMPosition(items, setItems);
     const timeout = setTimeout(callback);
@@ -91,10 +90,9 @@ function useTimeoutObserver<T extends Item = Item>(
   });
 }
 
-function useSortBasedOnDOMPosition<T extends Item = Item>(
-  items: T[],
-  setItems: (items: T[]) => any
-) {
+function useSortBasedOnDOMPosition<
+  T extends CollectionStateItem = CollectionStateItem
+>(items: T[], setItems: (items: T[]) => any) {
   // istanbul ignore else: JSDOM doesn't support IntersectionObverser
   // See https://github.com/jsdom/jsdom/issues/2032
   if (typeof IntersectionObserver !== "function") {
@@ -134,9 +132,9 @@ function useSortBasedOnDOMPosition<T extends Item = Item>(
  * </Collection>
  * ```
  */
-export function useCollectionState<T extends Item = Item>(
-  props: CollectionStateProps<T> = {}
-): CollectionState<T> {
+export function useCollectionState<
+  T extends CollectionStateItem = CollectionStateItem
+>(props: CollectionStateProps<T> = {}): CollectionState<T> {
   const [items, setItems] = useControlledState([], props.items, props.setItems);
 
   useSortBasedOnDOMPosition(items, setItems);
@@ -168,7 +166,9 @@ export function useCollectionState<T extends Item = Item>(
   return state;
 }
 
-export type CollectionState<T extends Item = Item> = {
+export type CollectionState<
+  T extends CollectionStateItem = CollectionStateItem
+> = {
   /**
    * Lists all the items with their `ref`s. This state is automatically updated
    * when an item is registered or unregistered with the `registerItem`
@@ -206,9 +206,9 @@ export type CollectionState<T extends Item = Item> = {
   registerItem: BivariantCallback<(item: T) => () => void>;
 };
 
-export type CollectionStateProps<T extends Item = Item> = Partial<
-  Pick<CollectionState<T>, "items">
-> & {
+export type CollectionStateProps<
+  T extends CollectionStateItem = CollectionStateItem
+> = Partial<Pick<CollectionState<T>, "items">> & {
   /**
    * Function that will be called when setting the collection `items` state.
    * @example

--- a/packages/ariakit/src/combobox/combobox-state.ts
+++ b/packages/ariakit/src/combobox/combobox-state.ts
@@ -22,7 +22,7 @@ import {
 
 const isSafariOnMobile = isSafari() && isTouchDevice();
 
-type Item = CompositeState["items"][number] & {
+type ComboboxStateItem = CompositeState["items"][number] & {
   value?: string;
 };
 
@@ -88,7 +88,7 @@ export function useComboboxState({
     props.list,
     props.setList
   );
-  const composite = useCompositeState<Item>({
+  const composite = useCompositeState<ComboboxStateItem>({
     ...props,
     defaultActiveId,
     orientation,
@@ -161,7 +161,7 @@ export function useComboboxState({
   return useStorePublisher(state);
 }
 
-export type ComboboxState = CompositeState<Item> &
+export type ComboboxState = CompositeState<ComboboxStateItem> &
   PopoverState & {
     /**
      * The input value.
@@ -208,7 +208,7 @@ export type ComboboxState = CompositeState<Item> &
     matches: string[];
   };
 
-export type ComboboxStateProps = CompositeStateProps<Item> &
+export type ComboboxStateProps = CompositeStateProps<ComboboxStateItem> &
   PopoverStateProps &
   Partial<Pick<ComboboxState, "value" | "list" | "limit">> & {
     /**

--- a/packages/ariakit/src/composite/__utils.ts
+++ b/packages/ariakit/src/composite/__utils.ts
@@ -5,7 +5,7 @@ import { CompositeState } from "./composite-state";
 
 const NULL_ITEM = { id: null, ref: { current: null } };
 
-function getMaxRowLength(array: Item[][]) {
+function getMaxRowLength(array: CompositeStateItem[][]) {
   let maxLength = 0;
   for (const { length } of array) {
     if (length > maxLength) {
@@ -18,7 +18,10 @@ function getMaxRowLength(array: Item[][]) {
 /**
  * Returns only enabled items.
  */
-export function getEnabledItems(items: Item[], excludeId?: string) {
+export function getEnabledItems(
+  items: CompositeStateItem[],
+  excludeId?: string
+) {
   return items.filter((item) => {
     if (excludeId) {
       return !item.disabled && item.id !== excludeId;
@@ -30,7 +33,10 @@ export function getEnabledItems(items: Item[], excludeId?: string) {
 /**
  * Finds the first enabled item.
  */
-export function findFirstEnabledItem(items: Item[], excludeId?: string) {
+export function findFirstEnabledItem(
+  items: CompositeStateItem[],
+  excludeId?: string
+) {
   return items.find((item) => {
     if (excludeId) {
       return !item.disabled && item.id !== excludeId;
@@ -44,7 +50,7 @@ export function findFirstEnabledItem(items: Item[], excludeId?: string) {
  * length.
  */
 export function normalizeRows(
-  rows: Item[][],
+  rows: CompositeStateItem[][],
   activeId?: string | null,
   focusShift?: boolean
 ) {
@@ -78,7 +84,10 @@ function createEmptyItem(rowId?: string) {
 /**
  * Finds the first enabled item by its id.
  */
-export function findEnabledItemById(items: Item[], id?: string | null) {
+export function findEnabledItemById(
+  items: CompositeStateItem[],
+  id?: string | null
+) {
   if (!id) return;
   return items.find((item) => item.id === id && !item.disabled);
 }
@@ -88,7 +97,7 @@ export function findEnabledItemById(items: Item[], id?: string | null) {
  * precedence.
  */
 export function getActiveId(
-  items: Item[],
+  items: CompositeStateItem[],
   activeId?: string | null,
   passedId?: string | null
 ) {
@@ -104,7 +113,7 @@ export function getActiveId(
 /**
  * Gets all items with the passed rowId.
  */
-export function getItemsInRow(items: Item[], rowId?: string) {
+export function getItemsInRow(items: CompositeStateItem[], rowId?: string) {
   return items.filter((item) => item.rowId === rowId);
 }
 
@@ -120,8 +129,8 @@ export function getOppositeOrientation(orientation: Orientation) {
 /**
  * Creates a two-dimensional array with items grouped by their rowId's.
  */
-export function groupItemsByRows(items: Item[]) {
-  const rows: Item[][] = [];
+export function groupItemsByRows(items: CompositeStateItem[]) {
+  const rows: CompositeStateItem[][] = [];
   for (const item of items) {
     const row = rows.find((currentRow) => currentRow[0]?.rowId === item.rowId);
     if (row) {
@@ -143,7 +152,7 @@ export function groupItemsByRows(items: Item[]) {
  * composite container has focus.
  */
 export function flipItems(
-  items: Item[],
+  items: CompositeStateItem[],
   activeId: string,
   shouldInsertNullItem = false
 ) {
@@ -161,10 +170,10 @@ export function flipItems(
  * the first item in the second row, which is what you would expect when moving
  * up/down.
  */
-export function verticalizeItems(items: Item[]) {
+export function verticalizeItems(items: CompositeStateItem[]) {
   const rows = groupItemsByRows(items);
   const maxLength = getMaxRowLength(rows);
-  const verticalized: Item[] = [];
+  const verticalized: CompositeStateItem[] = [];
   for (let i = 0; i < maxLength; i += 1) {
     for (const row of rows) {
       const item = row[i];
@@ -240,7 +249,7 @@ export function silentlyFocused(element: FocusSilentlyElement) {
  * Determines whether the element is a composite item.
  */
 export function isItem(
-  items: Item[],
+  items: CompositeStateItem[],
   element?: Element | null,
   exclude?: Element
 ) {
@@ -262,7 +271,7 @@ export const CompositeItemContext = createContext<ItemContext>(undefined);
 
 export type Orientation = "horizontal" | "vertical" | "both";
 
-export type Item = {
+export type CompositeStateItem = {
   id: string | null;
   ref: RefObject<HTMLElement>;
   rowId?: string;

--- a/packages/ariakit/src/composite/composite-item.tsx
+++ b/packages/ariakit/src/composite/composite-item.tsx
@@ -32,7 +32,7 @@ import {
   CompositeContext,
   CompositeItemContext,
   CompositeRowContext,
-  Item,
+  CompositeStateItem,
   findEnabledItemById,
   focusSilently,
   getContextId,
@@ -116,14 +116,17 @@ function findNextPageItemId(
   return id;
 }
 
-function useItem(items?: Item[], id?: string) {
+function useItem(items?: CompositeStateItem[], id?: string) {
   return useMemo(() => {
     if (!id) return;
     return items?.find((item) => item.id === id);
   }, [items, id]);
 }
 
-function targetIsAnotherItem(event: SyntheticEvent, items: Item[]) {
+function targetIsAnotherItem(
+  event: SyntheticEvent,
+  items: CompositeStateItem[]
+) {
   if (isSelfTarget(event)) return false;
   const target = event.target as HTMLElement;
   return isItem(items, target, event.currentTarget);

--- a/packages/ariakit/src/composite/composite-state.ts
+++ b/packages/ariakit/src/composite/composite-state.ts
@@ -13,7 +13,7 @@ import {
   useCollectionState,
 } from "../collection/collection-state";
 import {
-  Item,
+  CompositeStateItem,
   Orientation,
   findFirstEnabledItem,
   flipItems,
@@ -38,7 +38,9 @@ import {
  * </Composite>
  * ```
  */
-export function useCompositeState<T extends Item = Item>({
+export function useCompositeState<
+  T extends CompositeStateItem = CompositeStateItem
+>({
   orientation = "both",
   rtl = false,
   virtualFocus = false,
@@ -64,7 +66,7 @@ export function useCompositeState<T extends Item = Item>({
     props.includesBaseElement ?? initialActiveId === null;
   const activeIdRef = useLiveRef(activeId);
 
-  const move = useCallback((id?: Item["id"]) => {
+  const move = useCallback((id?: CompositeStateItem["id"]) => {
     // move() does nothing
     if (id === undefined) return;
     setMoves((prevMoves) => prevMoves + 1);
@@ -83,7 +85,7 @@ export function useCompositeState<T extends Item = Item>({
 
   const getNextId = useCallback(
     (
-      items: Item[],
+      items: CompositeStateItem[],
       orientation: Orientation,
       hasNullItem: boolean,
       skip?: number
@@ -297,231 +299,233 @@ export function useCompositeState<T extends Item = Item>({
   return useStorePublisher(state);
 }
 
-export type CompositeState<T extends Item = Item> = CollectionState<T> & {
-  /**
-   * The ref to the `Composite` element.
-   */
-  baseRef: RefObject<HTMLElement>;
-  /**
-   * If enabled, the composite element will act as an
-   * [aria-activedescendant](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_focus_activedescendant)
-   * container instead of [roving
-   * tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex).
-   * DOM focus will remain on the composite while its items receive virtual
-   * focus.
-   * @default false
-   */
-  virtualFocus: boolean;
-  /**
-   * Defines the orientation of the composite widget. If the composite has a
-   * single row or column (one-dimensional), the `orientation` value determines
-   * which arrow keys can be used to move focus:
-   *   - `both`: all arrow keys work.
-   *   - `horizontal`: only left and right arrow keys work.
-   *   - `vertical`: only up and down arrow keys work.
-   *
-   * It doesn't have any effect on two-dimensional composites.
-   * @default "both"
-   */
-  orientation: Orientation;
-  /**
-   * Determines how the `next` and `previous` functions will behave. If `rtl` is
-   * set to `true`, they will be inverted. This only affects the composite
-   * widget behavior. You still need to set `dir="rtl"` on HTML/CSS.
-   * @default false
-   */
-  rtl: boolean;
-  /**
-   * On one-dimensional composites:
-   *   - `true` loops from the last item to the first item and vice-versa.
-   *   - `horizontal` loops only if `orientation` is `horizontal` or not set.
-   *   - `vertical` loops only if `orientation` is `vertical` or not set.
-   *   - If `activeId` is initially set to `null`, the composite element will be
-   *     focused in between the last and first items.
-   *
-   * On two-dimensional composites:
-   *   - `true` loops from the last row/column item to the first item in the
-   *     same row/column and vice-versa. If it's the last item in the last row,
-   *     it moves to the first item in the first row and vice-versa.
-   *   - `horizontal` loops only from the last row item to the first item in the
-   *     same row.
-   *   - `vertical` loops only from the last column item to the first item in
-   *     the column row.
-   *   - If `activeId` is initially set to `null`, vertical loop will have no
-   *     effect as moving down from the last row or up from the first row will
-   *     focus the composite element.
-   *   - If `focusWrap` matches the value of `focusLoop`, it'll wrap between the
-   *     last item in the last row or column and the first item in the first row
-   *     or column and vice-versa.
-   * @default false
-   */
-  focusLoop: boolean | Orientation;
-  /**
-   * **Has effect only on two-dimensional composites**. If enabled, moving to
-   * the next item from the last one in a row or column will focus the first
-   * item in the next row or column and vice-versa.
-   *   - `true` wraps between rows and columns.
-   *   - `horizontal` wraps only between rows.
-   *   - `vertical` wraps only between columns.
-   *   - If `focusLoop` matches the value of `focusWrap`, it'll wrap between the
-   *     last item in the last row or column and the first item in the first row
-   *     or column and vice-versa.
-   * @default false
-   */
-  focusWrap: boolean | Orientation;
-  /**
-   * **Has effect only on two-dimensional composites**. If enabled, moving up
-   * or down when there's no next item or the next item is disabled will shift
-   * to the item right before it.
-   * @default false
-   */
-  focusShift: boolean;
-  /**
-   * The number of times the `move` function has been called.
-   * @default 0
-   * @example
-   * const composite = useCompositeState();
-   * composite.moves; // 0
-   * composite.move(null);
-   * // On the next render
-   * composite.moves; // 1
-   */
-  moves: number;
-  /**
-   * Sets the `moves` state.
-   */
-  setMoves: SetState<CompositeState["moves"]>;
-  /**
-   * Indicates whether the `Composite` element should be included in the focus
-   * order.
-   * @default false
-   */
-  includesBaseElement: boolean;
-  /**
-   * The current focused item `id`.
-   *   - `undefined` will automatically focus the first enabled composite item.
-   *   - `null` will focus the base composite element and users will be able to
-   *     navigate out of it using arrow keys.
-   *   - If `activeId` is initially set to `null`, the base composite element
-   *     itself will have focus and users will be able to navigate to it using
-   *     arrow keys.
-   */
-  activeId?: Item["id"];
-  /**
-   * Sets the `activeId` state without moving focus.
-   */
-  setActiveId: SetState<CompositeState["activeId"]>;
-  /**
-   * Moves focus to a given item id.
-   * @example
-   * const composite = useCompositeState();
-   * const onClick = () => {
-   *   composite.move("item-2"); // focus item 2
-   * };
-   */
-  move: (id?: Item["id"]) => void;
-  /**
-   * Returns the id of the next item.
-   * @example
-   * const composite = useCompositeState();
-   * const onClick = () => {
-   *   composite.move(composite.next()); // focus next item
-   * };
-   */
-  next: (skip?: number) => Item["id"] | undefined;
-  /**
-   * Returns the id of the previous item.
-   * @example
-   * const composite = useCompositeState();
-   * const onClick = () => {
-   *   composite.move(composite.previous()); // focus previous item
-   * };
-   */
-  previous: (skip?: number) => Item["id"] | undefined;
-  /**
-   * Returns the id of the item above.
-   * @example
-   * const composite = useCompositeState();
-   * const onClick = () => {
-   *   composite.move(composite.up()); // focus the item above
-   * };
-   */
-  up: (skip?: number) => Item["id"] | undefined;
-  /**
-   * Returns the id of the item below.
-   * @example
-   * const composite = useCompositeState();
-   * const onClick = () => {
-   *   composite.move(composite.down()); // focus the item below
-   * };
-   */
-  down: (skip?: number) => Item["id"] | undefined;
-  /**
-   * Returns the id of the first item.
-   * @example
-   * const composite = useCompositeState();
-   * const onClick = () => {
-   *   composite.move(composite.first()); // focus the first item
-   * };
-   */
-  first: () => Item["id"] | undefined;
-  /**
-   * Returns the id of the last item.
-   * @example
-   * const composite = useCompositeState();
-   * const onClick = () => {
-   *   composite.move(composite.last()); // focus the last item
-   * };
-   */
-  last: () => Item["id"] | undefined;
-};
+export type CompositeState<T extends CompositeStateItem = CompositeStateItem> =
+  CollectionState<T> & {
+    /**
+     * The ref to the `Composite` element.
+     */
+    baseRef: RefObject<HTMLElement>;
+    /**
+     * If enabled, the composite element will act as an
+     * [aria-activedescendant](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_focus_activedescendant)
+     * container instead of [roving
+     * tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex).
+     * DOM focus will remain on the composite while its items receive virtual
+     * focus.
+     * @default false
+     */
+    virtualFocus: boolean;
+    /**
+     * Defines the orientation of the composite widget. If the composite has a
+     * single row or column (one-dimensional), the `orientation` value determines
+     * which arrow keys can be used to move focus:
+     *   - `both`: all arrow keys work.
+     *   - `horizontal`: only left and right arrow keys work.
+     *   - `vertical`: only up and down arrow keys work.
+     *
+     * It doesn't have any effect on two-dimensional composites.
+     * @default "both"
+     */
+    orientation: Orientation;
+    /**
+     * Determines how the `next` and `previous` functions will behave. If `rtl` is
+     * set to `true`, they will be inverted. This only affects the composite
+     * widget behavior. You still need to set `dir="rtl"` on HTML/CSS.
+     * @default false
+     */
+    rtl: boolean;
+    /**
+     * On one-dimensional composites:
+     *   - `true` loops from the last item to the first item and vice-versa.
+     *   - `horizontal` loops only if `orientation` is `horizontal` or not set.
+     *   - `vertical` loops only if `orientation` is `vertical` or not set.
+     *   - If `activeId` is initially set to `null`, the composite element will be
+     *     focused in between the last and first items.
+     *
+     * On two-dimensional composites:
+     *   - `true` loops from the last row/column item to the first item in the
+     *     same row/column and vice-versa. If it's the last item in the last row,
+     *     it moves to the first item in the first row and vice-versa.
+     *   - `horizontal` loops only from the last row item to the first item in the
+     *     same row.
+     *   - `vertical` loops only from the last column item to the first item in
+     *     the column row.
+     *   - If `activeId` is initially set to `null`, vertical loop will have no
+     *     effect as moving down from the last row or up from the first row will
+     *     focus the composite element.
+     *   - If `focusWrap` matches the value of `focusLoop`, it'll wrap between the
+     *     last item in the last row or column and the first item in the first row
+     *     or column and vice-versa.
+     * @default false
+     */
+    focusLoop: boolean | Orientation;
+    /**
+     * **Has effect only on two-dimensional composites**. If enabled, moving to
+     * the next item from the last one in a row or column will focus the first
+     * item in the next row or column and vice-versa.
+     *   - `true` wraps between rows and columns.
+     *   - `horizontal` wraps only between rows.
+     *   - `vertical` wraps only between columns.
+     *   - If `focusLoop` matches the value of `focusWrap`, it'll wrap between the
+     *     last item in the last row or column and the first item in the first row
+     *     or column and vice-versa.
+     * @default false
+     */
+    focusWrap: boolean | Orientation;
+    /**
+     * **Has effect only on two-dimensional composites**. If enabled, moving up
+     * or down when there's no next item or the next item is disabled will shift
+     * to the item right before it.
+     * @default false
+     */
+    focusShift: boolean;
+    /**
+     * The number of times the `move` function has been called.
+     * @default 0
+     * @example
+     * const composite = useCompositeState();
+     * composite.moves; // 0
+     * composite.move(null);
+     * // On the next render
+     * composite.moves; // 1
+     */
+    moves: number;
+    /**
+     * Sets the `moves` state.
+     */
+    setMoves: SetState<CompositeState["moves"]>;
+    /**
+     * Indicates whether the `Composite` element should be included in the focus
+     * order.
+     * @default false
+     */
+    includesBaseElement: boolean;
+    /**
+     * The current focused item `id`.
+     *   - `undefined` will automatically focus the first enabled composite item.
+     *   - `null` will focus the base composite element and users will be able to
+     *     navigate out of it using arrow keys.
+     *   - If `activeId` is initially set to `null`, the base composite element
+     *     itself will have focus and users will be able to navigate to it using
+     *     arrow keys.
+     */
+    activeId?: CompositeStateItem["id"];
+    /**
+     * Sets the `activeId` state without moving focus.
+     */
+    setActiveId: SetState<CompositeState["activeId"]>;
+    /**
+     * Moves focus to a given item id.
+     * @example
+     * const composite = useCompositeState();
+     * const onClick = () => {
+     *   composite.move("item-2"); // focus item 2
+     * };
+     */
+    move: (id?: CompositeStateItem["id"]) => void;
+    /**
+     * Returns the id of the next item.
+     * @example
+     * const composite = useCompositeState();
+     * const onClick = () => {
+     *   composite.move(composite.next()); // focus next item
+     * };
+     */
+    next: (skip?: number) => CompositeStateItem["id"] | undefined;
+    /**
+     * Returns the id of the previous item.
+     * @example
+     * const composite = useCompositeState();
+     * const onClick = () => {
+     *   composite.move(composite.previous()); // focus previous item
+     * };
+     */
+    previous: (skip?: number) => CompositeStateItem["id"] | undefined;
+    /**
+     * Returns the id of the item above.
+     * @example
+     * const composite = useCompositeState();
+     * const onClick = () => {
+     *   composite.move(composite.up()); // focus the item above
+     * };
+     */
+    up: (skip?: number) => CompositeStateItem["id"] | undefined;
+    /**
+     * Returns the id of the item below.
+     * @example
+     * const composite = useCompositeState();
+     * const onClick = () => {
+     *   composite.move(composite.down()); // focus the item below
+     * };
+     */
+    down: (skip?: number) => CompositeStateItem["id"] | undefined;
+    /**
+     * Returns the id of the first item.
+     * @example
+     * const composite = useCompositeState();
+     * const onClick = () => {
+     *   composite.move(composite.first()); // focus the first item
+     * };
+     */
+    first: () => CompositeStateItem["id"] | undefined;
+    /**
+     * Returns the id of the last item.
+     * @example
+     * const composite = useCompositeState();
+     * const onClick = () => {
+     *   composite.move(composite.last()); // focus the last item
+     * };
+     */
+    last: () => CompositeStateItem["id"] | undefined;
+  };
 
-export type CompositeStateProps<T extends Item = Item> =
-  CollectionStateProps<T> &
-    Partial<
-      Pick<
-        CompositeState<T>,
-        | "virtualFocus"
-        | "orientation"
-        | "rtl"
-        | "focusLoop"
-        | "focusWrap"
-        | "focusShift"
-        | "moves"
-        | "includesBaseElement"
-        | "activeId"
-      >
-    > & {
-      /**
-       * The composite item id that should be focused when the composite is
-       * initialized.
-       * @example
-       * ```jsx
-       * const composite = useCompositeState({ defaultActiveId: "item-2" });
-       * <Composite state={composite}>
-       *   <CompositeItem>Item 1</CompositeItem>
-       *   <CompositeItem id="item-2">Item 2</CompositeItem>
-       *   <CompositeItem>Item 3</CompositeItem>
-       * </Composite>
-       * ```
-       */
-      defaultActiveId?: CompositeState<T>["activeId"];
-      /**
-       * Function that will be called when setting the composite `moves` state.
-       * @example
-       * const [moves, setMoves] = useState(0);
-       * useCompositeState({ moves, setMoves });
-       */
-      setMoves?: (moves: CompositeState<T>["moves"]) => void;
-      /**
-       * Function that will be called when setting the composite `activeId`.
-       * @example
-       * function MyComposite({ activeId, onActiveIdChange }) {
-       *   const composite = useCompositeState({
-       *     activeId,
-       *     setActiveId: onActiveIdChange,
-       *   });
-       * }
-       */
-      setActiveId?: (activeId: CompositeState<T>["activeId"]) => void;
-    };
+export type CompositeStateProps<
+  T extends CompositeStateItem = CompositeStateItem
+> = CollectionStateProps<T> &
+  Partial<
+    Pick<
+      CompositeState<T>,
+      | "virtualFocus"
+      | "orientation"
+      | "rtl"
+      | "focusLoop"
+      | "focusWrap"
+      | "focusShift"
+      | "moves"
+      | "includesBaseElement"
+      | "activeId"
+    >
+  > & {
+    /**
+     * The composite item id that should be focused when the composite is
+     * initialized.
+     * @example
+     * ```jsx
+     * const composite = useCompositeState({ defaultActiveId: "item-2" });
+     * <Composite state={composite}>
+     *   <CompositeItem>Item 1</CompositeItem>
+     *   <CompositeItem id="item-2">Item 2</CompositeItem>
+     *   <CompositeItem>Item 3</CompositeItem>
+     * </Composite>
+     * ```
+     */
+    defaultActiveId?: CompositeState<T>["activeId"];
+    /**
+     * Function that will be called when setting the composite `moves` state.
+     * @example
+     * const [moves, setMoves] = useState(0);
+     * useCompositeState({ moves, setMoves });
+     */
+    setMoves?: (moves: CompositeState<T>["moves"]) => void;
+    /**
+     * Function that will be called when setting the composite `activeId`.
+     * @example
+     * function MyComposite({ activeId, onActiveIdChange }) {
+     *   const composite = useCompositeState({
+     *     activeId,
+     *     setActiveId: onActiveIdChange,
+     *   });
+     * }
+     */
+    setActiveId?: (activeId: CompositeState<T>["activeId"]) => void;
+  };

--- a/packages/ariakit/src/composite/composite-typeahead.ts
+++ b/packages/ariakit/src/composite/composite-typeahead.ts
@@ -10,7 +10,7 @@ import { As, Options, Props } from "ariakit-react-utils/types";
 import { isTextField } from "ariakit-utils/dom";
 import { isSelfTarget } from "ariakit-utils/events";
 import { normalizeString } from "ariakit-utils/misc";
-import { CompositeContext, Item, flipItems } from "./__utils";
+import { CompositeContext, CompositeStateItem, flipItems } from "./__utils";
 import { CompositeState } from "./composite-state";
 
 let chars = "";
@@ -35,7 +35,7 @@ function isValidTypeaheadEvent(event: KeyboardEvent) {
   );
 }
 
-function isSelfTargetOrItem(event: KeyboardEvent, items: Item[]) {
+function isSelfTargetOrItem(event: KeyboardEvent, items: CompositeStateItem[]) {
   if (isSelfTarget(event)) return true;
   const target = event.target as HTMLElement | null;
   if (!target) return false;
@@ -43,18 +43,18 @@ function isSelfTargetOrItem(event: KeyboardEvent, items: Item[]) {
   return isItem;
 }
 
-function getEnabledItems(items: Item[]) {
+function getEnabledItems(items: CompositeStateItem[]) {
   return items.filter((item) => !item.disabled);
 }
 
-function itemTextStartsWith(item: Item, text: string) {
+function itemTextStartsWith(item: CompositeStateItem, text: string) {
   const itemText = item.ref.current?.textContent;
   if (!itemText) return false;
   return normalizeString(itemText).toLowerCase().startsWith(text.toLowerCase());
 }
 
 function getSameInitialItems(
-  items: Item[],
+  items: CompositeStateItem[],
   char: string,
   activeId?: string | null
 ) {

--- a/packages/ariakit/src/composite/composite.ts
+++ b/packages/ariakit/src/composite/composite.ts
@@ -37,7 +37,7 @@ import { BooleanOrCallback } from "ariakit-utils/types";
 import { FocusableOptions, useFocusable } from "../focusable/focusable";
 import {
   CompositeContext,
-  Item,
+  CompositeStateItem,
   findEnabledItemById,
   findFirstEnabledItem,
   groupItemsByRows,
@@ -46,7 +46,7 @@ import {
 } from "./__utils";
 import { CompositeState } from "./composite-state";
 
-function isGrid(items: Item[]) {
+function isGrid(items: CompositeStateItem[]) {
   return items.some((item) => !!item.rowId);
 }
 
@@ -92,7 +92,7 @@ function canProxyKeyboardEvent(
 
 function useKeyboardEventProxy(
   state: CompositeState,
-  activeItem?: Item,
+  activeItem?: CompositeStateItem,
   onKeyboardEvent?: KeyboardEventHandler,
   previousElementRef?: RefObject<HTMLElement | null>
 ) {
@@ -122,13 +122,13 @@ function useKeyboardEventProxy(
   });
 }
 
-function findFirstEnabledItemInTheLastRow(items: Item[]) {
+function findFirstEnabledItemInTheLastRow(items: CompositeStateItem[]) {
   return findFirstEnabledItem(
     flatten2DArray(reverseArray(groupItemsByRows(items)))
   );
 }
 
-function useScheduleFocus(activeItem?: Item) {
+function useScheduleFocus(activeItem?: CompositeStateItem) {
   const [scheduled, setScheduled] = useState(false);
   const schedule = useCallback(() => setScheduled(true), []);
   useEffect(() => {

--- a/packages/ariakit/src/form/form-state.ts
+++ b/packages/ariakit/src/form/form-state.ts
@@ -29,7 +29,7 @@ import {
 type ErrorMessage = string | undefined | null;
 type Callback = () => void | Promise<void>;
 
-type Item = CollectionState["items"][number] & {
+type FormStateItem = CollectionState["items"][number] & {
   type: "field" | "label" | "description" | "error" | "button";
   name: string;
   id?: string;
@@ -288,7 +288,7 @@ export function useFormState<V extends AnyObject = AnyObject>(
 }
 
 export type FormState<V extends AnyObject = AnyObject> =
-  CollectionState<Item> & {
+  CollectionState<FormStateItem> & {
     /**
      * Form values.
      */
@@ -505,7 +505,7 @@ export type FormState<V extends AnyObject = AnyObject> =
   };
 
 export type FormStateProps<V extends AnyObject = AnyObject> =
-  CollectionStateProps<Item> &
+  CollectionStateProps<FormStateItem> &
     Partial<Pick<FormState<V>, "values" | "errors" | "touched">> & {
       /**
        * The default values of the form.

--- a/packages/ariakit/src/select/__utils.ts
+++ b/packages/ariakit/src/select/__utils.ts
@@ -3,7 +3,7 @@ import { createStoreContext } from "ariakit-react-utils/store";
 import { CompositeState } from "../composite/composite-state";
 import { SelectState } from "./select-state";
 
-export type Item = CompositeState["items"][number] & {
+export type SelectStateItem = CompositeState["items"][number] & {
   value?: string;
 };
 
@@ -11,16 +11,22 @@ export const SelectItemCheckedContext = createContext(false);
 
 export const SelectContext = createStoreContext<SelectState>();
 
-export function findFirstEnabledItemWithValue(items: Item[]) {
+export function findFirstEnabledItemWithValue(items: SelectStateItem[]) {
   return items.find((item) => item.value != null && !item.disabled);
 }
 
-export function findEnabledItemWithValueById(items: Item[], id: string) {
+export function findEnabledItemWithValueById(
+  items: SelectStateItem[],
+  id: string
+) {
   return items.find(
     (item) => item.value != null && item.id === id && !item.disabled
   );
 }
 
-export function findEnabledItemByValue(items: Item[], value: string) {
+export function findEnabledItemByValue(
+  items: SelectStateItem[],
+  value: string
+) {
   return items.find((item) => item.value === value && !item.disabled);
 }

--- a/packages/ariakit/src/select/select-popover.ts
+++ b/packages/ariakit/src/select/select-popover.ts
@@ -7,7 +7,7 @@ import {
 import { As, Props } from "ariakit-react-utils/types";
 import { toArray } from "ariakit-utils/array";
 import { PopoverOptions, usePopover } from "../popover/popover";
-import { Item, findEnabledItemByValue } from "./__utils";
+import { SelectStateItem, findEnabledItemByValue } from "./__utils";
 import { SelectListOptions, useSelectList } from "./select-list";
 
 /**
@@ -28,7 +28,7 @@ export const useSelectPopover = createHook<SelectPopoverOptions>(
   ({ state, ...props }) => {
     const values = toArray(state.value);
     const value = values[values.length - 1] ?? "";
-    const [item, setItem] = useState<Item | null>(null);
+    const [item, setItem] = useState<SelectStateItem | null>(null);
 
     // Sets the initial focus ref.
     useEffect(() => {

--- a/packages/ariakit/src/select/select-state.ts
+++ b/packages/ariakit/src/select/select-state.ts
@@ -18,14 +18,15 @@ import {
   usePopoverState,
 } from "../popover/popover-state";
 import {
-  Item,
+  SelectStateItem,
   findEnabledItemByValue,
   findEnabledItemWithValueById,
   findFirstEnabledItemWithValue,
 } from "./__utils";
 
-type Value = string | string[];
-type MutableValue<T extends Value = Value> = T extends string ? string : T;
+type SelectStateValue = string | string[];
+type MutableValue<T extends SelectStateValue = SelectStateValue> =
+  T extends string ? string : T;
 
 /**
  * Provides state for the `Select` components.
@@ -39,7 +40,7 @@ type MutableValue<T extends Value = Value> = T extends string ? string : T;
  * </SelectPopover>
  * ```
  */
-export function useSelectState<T extends Value = Value>({
+export function useSelectState<T extends SelectStateValue = SelectStateValue>({
   virtualFocus = true,
   orientation = "vertical",
   placement = "bottom-start",
@@ -55,7 +56,7 @@ export function useSelectState<T extends Value = Value>({
     props.value,
     props.setValue
   );
-  const composite = useCompositeState<Item>({
+  const composite = useCompositeState<SelectStateItem>({
     ...props,
     virtualFocus,
     orientation,
@@ -123,37 +124,38 @@ export function useSelectState<T extends Value = Value>({
   return useStorePublisher(state);
 }
 
-export type SelectState<T extends Value = Value> = CompositeState<Item> &
-  PopoverState & {
-    /**
-     * The select value.
-     */
-    value: MutableValue<T>;
-    /**
-     * Sets the `value` state.
-     * @example
-     * const select = useSelectState();
-     * select.setValue("new value");
-     */
-    setValue: SetState<SelectState<T>["value"]>;
-    /**
-     * Whether the select value should be set when the active item changes by
-     * moving (which usually happens when moving to an item using the keyboard).
-     * @default false
-     */
-    setValueOnMove: boolean;
-    /**
-     * The select button element's ref.
-     */
-    selectRef: RefObject<HTMLElement>;
-    /**
-     * The select label element's ref.
-     */
-    labelRef: RefObject<HTMLElement>;
-  };
+export type SelectState<T extends SelectStateValue = SelectStateValue> =
+  CompositeState<SelectStateItem> &
+    PopoverState & {
+      /**
+       * The select value.
+       */
+      value: MutableValue<T>;
+      /**
+       * Sets the `value` state.
+       * @example
+       * const select = useSelectState();
+       * select.setValue("new value");
+       */
+      setValue: SetState<SelectState<T>["value"]>;
+      /**
+       * Whether the select value should be set when the active item changes by
+       * moving (which usually happens when moving to an item using the keyboard).
+       * @default false
+       */
+      setValueOnMove: boolean;
+      /**
+       * The select button element's ref.
+       */
+      selectRef: RefObject<HTMLElement>;
+      /**
+       * The select label element's ref.
+       */
+      labelRef: RefObject<HTMLElement>;
+    };
 
-export type SelectStateProps<T extends Value = Value> =
-  CompositeStateProps<Item> &
+export type SelectStateProps<T extends SelectStateValue = SelectStateValue> =
+  CompositeStateProps<SelectStateItem> &
     PopoverStateProps &
     Partial<Pick<SelectState<T>, "value" | "setValueOnMove">> & {
       /**

--- a/packages/ariakit/src/select/select.tsx
+++ b/packages/ariakit/src/select/select.tsx
@@ -34,7 +34,11 @@ import {
   usePopoverDisclosure,
 } from "../popover/popover-disclosure";
 import { VisuallyHidden } from "../visually-hidden";
-import { Item, SelectContext, findFirstEnabledItemWithValue } from "./__utils";
+import {
+  SelectContext,
+  SelectStateItem,
+  findFirstEnabledItemWithValue,
+} from "./__utils";
 import { SelectArrow } from "./select-arrow";
 import { SelectState } from "./select-state";
 
@@ -46,7 +50,7 @@ function getSelectedValues(select: HTMLSelectElement) {
 
 // When moving through the items when the select list is closed, we don't want
 // to move to items without value, so we filter them out here.
-function nextWithValue(items: Item[], next: SelectState["next"]) {
+function nextWithValue(items: SelectStateItem[], next: SelectState["next"]) {
   return () => {
     const nextId = next();
     if (!nextId) return;

--- a/packages/ariakit/src/tab/tab-state.ts
+++ b/packages/ariakit/src/tab/tab-state.ts
@@ -12,7 +12,7 @@ import {
   useCompositeState,
 } from "../composite/composite-state";
 
-type Item = CompositeState["items"][number] & {
+type TabStateItem = CompositeState["items"][number] & {
   dimmed?: boolean;
 };
 
@@ -21,11 +21,11 @@ type Panel = CollectionState["items"][number] & {
   tabId?: string | null;
 };
 
-function findEnabledTabById(items: Item[], id?: string | null) {
+function findEnabledTabById(items: TabStateItem[], id?: string | null) {
   return items.find((item) => item.id === id && !item.disabled && !item.dimmed);
 }
 
-function findFirstEnabledTab(items: Item[]) {
+function findFirstEnabledTab(items: TabStateItem[]) {
   return items.find((item) => !item.disabled && !item.dimmed);
 }
 
@@ -129,7 +129,7 @@ export function useTabState({
   return useStorePublisher(state);
 }
 
-export type TabState = CompositeState<Item> & {
+export type TabState = CompositeState<TabStateItem> & {
   /**
    * The id of the tab whose panel is currently visible.
    */
@@ -154,7 +154,7 @@ export type TabState = CompositeState<Item> & {
   selectOnMove?: boolean;
 };
 
-export type TabStateProps = CompositeStateProps<Item> &
+export type TabStateProps = CompositeStateProps<TabStateItem> &
   Partial<Pick<TabState, "selectedId" | "selectOnMove">> & {
     /**
      * The id of the tab whose panel should be initially visible.


### PR DESCRIPTION
Due to whitespace changes from reformatting, this diff is better viewed with [?w=1](https://github.com/ariakit/ariakit/pull/2153/files?w=1).

* Update types referenced in #2092 to have unique names, in order to support a .d.ts bundler that requires this uniqueness
* Update references to use the new names, done using IntelliJ's Refactor -> Rename
* Reformat files as required

Closes #2092.

Thank you again for being open to this PR!