### PR TITLE
fix: useCheckboxState alongside having a value="" attribute

### DIFF
--- a/packages/ariakit/src/checkbox/__examples__/checkbox-state-with-value/index.tsx
+++ b/packages/ariakit/src/checkbox/__examples__/checkbox-state-with-value/index.tsx
@@ -1,0 +1,15 @@
+import { Checkbox, useCheckboxState } from "ariakit/checkbox";
+
+import "./style.css";
+
+export default function Example() {
+  const checkbox = useCheckboxState();
+  return (
+    <div>
+      <label className="label">
+        <Checkbox state={checkbox} value="accept" className="checkbox" /> I have
+        read and agree to the terms and conditions
+      </label>
+    </div>
+  );
+}

--- a/packages/ariakit/src/checkbox/__examples__/checkbox-state-with-value/readme.md
+++ b/packages/ariakit/src/checkbox/__examples__/checkbox-state-with-value/readme.md
@@ -1,0 +1,7 @@
+# useCheckboxState and value attribute
+
+<p data-description>
+  Using the <a href="/api-reference/checkbox-state"><code>useCheckboxState</code></a> hook to control the state of the <a href="/components/checkbox">Checkbox</a> component, while also setting an explicit value attribute on the checkbox.
+</p>
+
+<a href="./index.tsx" data-playground>Example</a>

--- a/packages/ariakit/src/checkbox/__examples__/checkbox-state-with-value/style.css
+++ b/packages/ariakit/src/checkbox/__examples__/checkbox-state-with-value/style.css
@@ -1,0 +1,1 @@
+@import url("../checkbox/style.css");

--- a/packages/ariakit/src/checkbox/__examples__/checkbox-state-with-value/test.tsx
+++ b/packages/ariakit/src/checkbox/__examples__/checkbox-state-with-value/test.tsx
@@ -1,0 +1,35 @@
+import { click, getByLabelText, getByRole, press, render } from "ariakit-test";
+import { axe } from "jest-axe";
+import Example from ".";
+
+test("a11y", async () => {
+  render(<Example />);
+  expect(await axe(getByRole("checkbox"))).toHaveNoViolations();
+});
+
+test("check checkbox on click", async () => {
+  render(<Example />);
+  expect(getByRole("checkbox")).not.toBeChecked();
+  await click(
+    getByLabelText("I have read and agree to the terms and conditions")
+  );
+  expect(getByRole("checkbox")).toBeChecked();
+});
+
+test("tab", async () => {
+  render(<Example />);
+  expect(getByRole("checkbox")).not.toHaveFocus();
+  await press.Tab();
+  expect(getByRole("checkbox")).toHaveFocus();
+});
+
+test("space", async () => {
+  render(<Example />);
+  await press.Tab();
+  expect(getByRole("checkbox")).toHaveFocus();
+  expect(getByRole("checkbox")).not.toBeChecked();
+  await press.Space();
+  expect(getByRole("checkbox")).toBeChecked();
+  await press.Space();
+  expect(getByRole("checkbox")).not.toBeChecked();
+});

--- a/packages/ariakit/src/checkbox/checkbox.tsx
+++ b/packages/ariakit/src/checkbox/checkbox.tsx
@@ -101,7 +101,8 @@ export const useCheckbox = createHook<CheckboxOptions>(
 
       state?.setValue((prevValue) => {
         if (!value) return elementChecked;
-        if (!Array.isArray(prevValue)) return value;
+        if (!Array.isArray(prevValue))
+          return prevValue === value ? false : value;
         if (elementChecked) return [...prevValue, value];
         return prevValue.filter((v) => v !== value);
       });

--- a/packages/ariakit/src/checkbox/checkbox.tsx
+++ b/packages/ariakit/src/checkbox/checkbox.tsx
@@ -60,10 +60,16 @@ function isNativeCheckbox(tagName?: string, type?: string) {
  * ```
  */
 export const useCheckbox = createHook<CheckboxOptions>(
-  ({ state, value, checked: checkedProp, defaultChecked, ...props }) => {
+  ({
+    state,
+    value: attributeValue,
+    checked: checkedProp,
+    defaultChecked,
+    ...props
+  }) => {
     const [checked, setChecked] = useControlledState(
       defaultChecked ?? false,
-      checkedProp ?? getStateChecked(state?.value, value)
+      checkedProp ?? getStateChecked(state?.value, attributeValue)
     );
 
     const ref = useRef<HTMLInputElement>(null);
@@ -100,11 +106,11 @@ export const useCheckbox = createHook<CheckboxOptions>(
       setChecked(elementChecked);
 
       state?.setValue((prevValue) => {
-        if (!value) return elementChecked;
+        if (!attributeValue) return elementChecked;
         if (!Array.isArray(prevValue))
-          return prevValue === value ? false : value;
-        if (elementChecked) return [...prevValue, value];
-        return prevValue.filter((v) => v !== value);
+          return prevValue === attributeValue ? false : attributeValue;
+        if (elementChecked) return [...prevValue, attributeValue];
+        return prevValue.filter((v) => v !== attributeValue);
       });
     });
 
@@ -142,7 +148,7 @@ export const useCheckbox = createHook<CheckboxOptions>(
     props = useCommand({ clickOnEnter: !nativeCheckbox, ...props });
 
     return {
-      value: nativeCheckbox ? value : undefined,
+      value: nativeCheckbox ? attributeValue : undefined,
       checked: isChecked,
       ...props,
     };


### PR DESCRIPTION
Fixes https://github.com/ariakit/ariakit/issues/2164

We found that the problem was that, when the `defaultValue` is not initialized as an empty array, AND you also specify a `value="whatever"` attribute, the handler to change the state was not working properly. It should check if the current checkbox's value is the one already selected, and return `false` instead of returning the value. That is what makes it actually switch back to unchecked.

We also added a test, and tried to follow the existing conventions, but let us know if there's something to improve on this regard.

Co-authored alongside @pauloslund as part of our team hackathon to contribute back to open source on projects on which we rely to build our products at Doist.