### PR TITLE
Fix `Dialog` not returning focus when rendered with `React.lazy`

### DIFF
--- a/.changeset/short-ties-switch.md
+++ b/.changeset/short-ties-switch.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed `Dialog` not returning focus when closed when rendered with `React.lazy`. ([#2290](https://github.com/ariakit/ariakit/pull/2290))

--- a/examples/menu-dialog-animated/dialog.tsx
+++ b/examples/menu-dialog-animated/dialog.tsx
@@ -10,6 +10,7 @@ export type DialogProps = React.HTMLAttributes<HTMLDivElement> & {
   onUnmount?: () => void;
   initialFocus?: Ariakit.DialogProps["initialFocus"];
   finalFocus?: Ariakit.DialogProps["finalFocus"];
+  autoFocusOnHide?: Ariakit.DialogProps["autoFocusOnHide"];
 };
 
 export const Dialog = React.forwardRef<HTMLDivElement, DialogProps>(
@@ -18,7 +19,7 @@ export const Dialog = React.forwardRef<HTMLDivElement, DialogProps>(
       animated,
       open,
       setOpen: (open) => {
-        if (dialog.getState().open !== open && !open) {
+        if (!open) {
           onClose?.();
         }
       },

--- a/examples/menu-dialog-animated/index.tsx
+++ b/examples/menu-dialog-animated/index.tsx
@@ -107,6 +107,7 @@ export default function Example() {
           createDialogInitialFocusRef.current = null;
         }}
         initialFocus={createDialogInitialFocusRef}
+        autoFocusOnHide={!infoDialog.open && !manageDialog.open}
         onUnmount={() => {
           form.reset();
           createDialog.unmount();


### PR DESCRIPTION
When rendering `Dialog` with `React.lazy`, returning focus when the dialog is closed isn't working. This PR fixes that.