### PR TITLE
Fix combobox completion string when using inline autoSelect

### DIFF
--- a/.changeset/wet-jobs-relate-2.md
+++ b/.changeset/wet-jobs-relate-2.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed `Combobox` with `autoSelect` and `autoComplete` set to `both` or `inline` where the completion string would lose its selected state. ([#2308](https://github.com/ariakit/ariakit/pull/2308))

--- a/.changeset/wet-jobs-relate-3.md
+++ b/.changeset/wet-jobs-relate-3.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed `Combobox` not processing composition text (like chinese characters or accents). ([#2308](https://github.com/ariakit/ariakit/pull/2308))

--- a/.changeset/wet-jobs-relate.md
+++ b/.changeset/wet-jobs-relate.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/test": patch
+---
+
+Added support for composition text on `type`. ([#2308](https://github.com/ariakit/ariakit/pull/2308))

--- a/examples/combobox-cancel/test.ts
+++ b/examples/combobox-cancel/test.ts
@@ -1,4 +1,4 @@
-import { click, getByRole, press, type } from "@ariakit/test";
+import { click, fireEvent, getByRole, press, sleep, type } from "@ariakit/test";
 
 const getCombobox = () => getByRole("combobox");
 const getPopover = () => getByRole("listbox", { hidden: true });
@@ -70,4 +70,15 @@ test("https://github.com/ariakit/ariakit/issues/1652", async () => {
   await type("a");
   await click(getCancelButton());
   expect(getOption("Apple")).not.toHaveFocus();
+});
+
+test("composition text", async () => {
+  fireEvent.compositionStart(getCombobox());
+  await type("'", getCombobox(), { isComposing: true });
+  expect(getOption("Apple")).not.toHaveFocus();
+  await type("á", getCombobox(), { isComposing: true });
+  fireEvent.compositionEnd(getCombobox());
+  await sleep();
+  expect(getCombobox()).toHaveValue("á");
+  expect(getOption("Apple")).toHaveFocus();
 });

--- a/examples/combobox-group/test-browser.ts
+++ b/examples/combobox-group/test-browser.ts
@@ -1,0 +1,30 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+const getCombobox = (page: Page) => page.getByRole("combobox");
+
+function getSelectionValue(page: Page) {
+  return getCombobox(page).evaluate((element) => {
+    const input = element as HTMLInputElement;
+    const { selectionStart, selectionEnd } = input;
+    const selectionValue = input.value.slice(selectionStart!, selectionEnd!);
+    return selectionValue;
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/previews/combobox-group", { waitUntil: "networkidle" });
+});
+
+test("maintain completion string while typing", async ({ page }) => {
+  await getCombobox(page).click();
+  await page.keyboard.type("av");
+  await expect(getCombobox(page)).toHaveValue("avocado");
+  expect(await getSelectionValue(page)).toBe("ocado");
+  await page.keyboard.type("o");
+  await expect(getCombobox(page)).toHaveValue("avocado");
+  expect(await getSelectionValue(page)).toBe("cado");
+  await page.keyboard.type("ca");
+  await expect(getCombobox(page)).toHaveValue("avocado");
+  expect(await getSelectionValue(page)).toBe("do");
+});

--- a/examples/combobox-group/test.ts
+++ b/examples/combobox-group/test.ts
@@ -1,4 +1,12 @@
-import { click, getByRole, hover, press, type } from "@ariakit/test";
+import {
+  click,
+  fireEvent,
+  getByRole,
+  hover,
+  press,
+  sleep,
+  type,
+} from "@ariakit/test";
 
 const getCombobox = () => getByRole("combobox");
 const getOption = (name: string) => getByRole("option", { name });
@@ -99,4 +107,17 @@ test("autocomplete on focus on hover", async () => {
   expect(getCombobox()).toHaveValue("gelato");
   await hover(getOption("Pudding"));
   expect(getCombobox()).toHaveValue("g");
+});
+
+test("composition text", async () => {
+  // TODO: Add composition util to @ariakit/test
+  fireEvent.compositionStart(getCombobox());
+  await type("'", getCombobox(), { isComposing: true });
+  expect(() => getOption("Apple")).toThrow();
+  await type("á", getCombobox(), { isComposing: true });
+  fireEvent.compositionEnd(getCombobox());
+  await sleep();
+  expect(getCombobox()).toHaveValue("ápple");
+  expect(getSelectionValue(getCombobox())).toBe("pple");
+  expect(getOption("Apple")).toHaveFocus();
 });

--- a/packages/ariakit-react-core/src/combobox/combobox.ts
+++ b/packages/ariakit-react-core/src/combobox/combobox.ts
@@ -348,7 +348,8 @@ export const useCombobox = createHook<ComboboxOptions>(
       onBlurProp?.(event);
       if (event.defaultPrevented) return;
       // TODO: See if it's necessary and refactor this valueChanged logic.
-      // valueChangedRef.current = false;
+      // This is necessary for cancel button to work properly.
+      valueChangedRef.current = false;
     });
 
     // This is necessary so other components like ComboboxCancel can reference


### PR DESCRIPTION
This PR fixes a bug where the completion string would be lost when the user keeps typing the same value. Please take a look at the test-browser file for more details.

This also closes #2203. Unfortunately, neither JSDOM nor Playwright supports IME. I had to simulate it with composition events, so the tests aren't 100% accurate.