### PR TITLE
Render DialogBackdrop as a sibling of Dialog

### DIFF
--- a/.changeset/__breaking-2.md
+++ b/.changeset/__breaking-2.md
@@ -1,0 +1,21 @@
+---
+"@ariakit/react-core": minor
+"@ariakit/react": minor
+---
+
+**BREAKING**: The backdrop element on the `Dialog` component is now rendered as a sibling rather than as a parent of the dialog. This should make it easier to animate them separately. ([#2407](https://github.com/ariakit/ariakit/pull/2407))
+
+This might be a breaking change if you're relying on their parent/child relationship for styling purposes (for example, to position the dialog in the center of the backdrop). If that's the case,
+you can apply the following styles to the dialog to achieve the same effect:
+
+```css
+.dialog {
+  position: fixed;
+  inset: 1rem;
+  margin: auto;
+  height: fit-content;
+  max-height: calc(100vh - 2 * 1rem);
+}
+```
+
+These styles work even if the dialog is a child of the backdrop, so you can use them regardless of whether you're upgrading to this version or not.

--- a/.changeset/bright-suns-refuse-1.md
+++ b/.changeset/bright-suns-refuse-1.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Deprecated the `backdropProps` prop on the `Dialog` component. Use the `backdrop` prop instead. ([#2407](https://github.com/ariakit/ariakit/pull/2407))

--- a/.changeset/bright-suns-refuse-2.md
+++ b/.changeset/bright-suns-refuse-2.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+The `backdrop` prop on the `Dialog` component now accepts a JSX element as its value. ([#2407](https://github.com/ariakit/ariakit/pull/2407))

--- a/.changeset/bright-suns-refuse-3.md
+++ b/.changeset/bright-suns-refuse-3.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+The `Dialog` component will now wait for being unmounted before restoring the body scroll when the `hidden` prop is set to `false`. This should prevent the body scroll from being restored too early when the dialog is being animated out using third-party libraries like Framer Motion. ([#2407](https://github.com/ariakit/ariakit/pull/2407))

--- a/components/dialog.md
+++ b/components/dialog.md
@@ -39,13 +39,11 @@ You can style all the backdrop elements using the `[data-backdrop]` selector:
 }
 ```
 
-To style the backdrop of a specific dialog, use the [`backdropProps`](/apis/dialog#backdropprops) prop:
+To style the backdrop of a specific dialog, use the [`backdrop`](/apis/dialog#backdrop) prop:
 
 ```jsx
-<Dialog backdropProps={{ className: "my-backdrop" }} />
+<Dialog backdrop={<div className="backdrop" />} />
 ```
-
-Alternatively, you can pass a custom component to the [`backdrop`](/apis/dialog#backdrop) prop.
 
 ### Scrollbar width
 
@@ -56,6 +54,18 @@ Ariakit automatically defines a `--scrollbar-width` CSS variable. You can apply 
 ```css
 .header {
   padding-right: calc(16px + var(--scrollbar-width, 0));
+}
+```
+
+### Z-index
+
+Modal dialogs are rendered at the end of the document using [React Portal](https://react.dev/reference/react-dom/createPortal), which means they will be rendered on top of all other elements by default.
+
+However, if you set the [`portal`](/apis/dialog#portal) prop to `false` or use the `z-index` property on other elements, you might need to adjust the `z-index` of the dialog:
+
+```css
+.dialog {
+  z-index: 100;
 }
 ```
 

--- a/examples/button/style.css
+++ b/examples/button/style.css
@@ -10,6 +10,7 @@
     px-4
     text-base
     select-none
+    touch-none
     no-underline
     whitespace-nowrap
     focus-visible:ariakit-outline

--- a/examples/dialog-animated/index.tsx
+++ b/examples/dialog-animated/index.tsx
@@ -5,10 +5,14 @@ export default function Example() {
   const dialog = Ariakit.useDialogStore({ animated: true });
   return (
     <>
-      <Ariakit.Button onClick={dialog.toggle} className="button">
+      <Ariakit.Button onClick={dialog.show} className="button">
         Show modal
       </Ariakit.Button>
-      <Ariakit.Dialog store={dialog} className="dialog">
+      <Ariakit.Dialog
+        store={dialog}
+        backdrop={<div className="backdrop" />}
+        className="dialog"
+      >
         <Ariakit.DialogHeading className="heading">
           Success
         </Ariakit.DialogHeading>

--- a/examples/dialog-animated/readme.md
+++ b/examples/dialog-animated/readme.md
@@ -1,7 +1,7 @@
 # Animated Dialog
 
 <p data-description>
-  Animating a modal <a href="/components/dialog">Dialog</a> and its backdrop using CSS. The component waits for the transition to finish before completely hiding the dialog or removing it from the React tree.
+  Animating a modal <a href="/components/dialog">Dialog</a> and its <a href="/apis/dialog#backdrop"><code>backdrop</code></a> element using CSS. The component waits for the transition to finish before completely hiding the dialog or removing it from the React tree.
 </p>
 
 <a href="./index.tsx" data-playground>Example</a>

--- a/examples/dialog-animated/readme.md
+++ b/examples/dialog-animated/readme.md
@@ -4,8 +4,6 @@
   Animating a modal <a href="/components/dialog">Dialog</a> and its backdrop using CSS. The component waits for the transition to finish before completely hiding the dialog or removing it from the React tree.
 </p>
 
-The [`animated`](/apis/dialog-store#animated) prop on the [`useDialogStore`](/apis/dialog-store) hook must be set to `true`. Ariakit will assign the `data-enter` and `data-leave` attributes and wait for the transition to finish before hiding or unmounting the dialog.
-
 <a href="./index.tsx" data-playground>Example</a>
 
 ## Styling
@@ -13,17 +11,17 @@ The [`animated`](/apis/dialog-store#animated) prop on the [`useDialogStore`](/ap
 Use the `data-enter` and `data-leave` attributes to animate the dialog and the backdrop elements:
 
 ```css
-[data-backdrop] {
+.backdrop {
   opacity: 0;
   transition: opacity 200ms;
 }
 
-[data-backdrop][data-enter] {
+.backdrop[data-enter] {
   opacity: 1;
 }
 
 .dialog {
-  transform: scale(0.9);
+  transform: scale(0.95);
   transition: transform 200ms;
 }
 
@@ -32,4 +30,4 @@ Use the `data-enter` and `data-leave` attributes to animate the dialog and the b
 }
 ```
 
-Learn more on the [Styling](/guide/styling) guide.
+You can learn more about these `data-*` attributes on the [Styling](/guide/styling) guide.

--- a/examples/dialog-animated/site-icon.tsx
+++ b/examples/dialog-animated/site-icon.tsx
@@ -1,0 +1,18 @@
+export default function Icon() {
+  return (
+    <svg viewBox="0 0 128 128" width={128} height={128}>
+      <foreignObject width={128} height={128}>
+        <div className="flex h-full flex-col items-center justify-center p-5">
+          <div className="w-full rounded-md border border-black/10 bg-gray-100 p-2 shadow-md dark:border-white/5 dark:bg-white/5 dark:shadow-md-dark">
+            <div className="w-full rounded border border-black/10 bg-gray-50 p-2 shadow-md dark:border-white/5 dark:bg-white/5 dark:shadow-md-dark">
+              <div className="flex w-full flex-col gap-2 rounded-sm border border-black/10 bg-white p-2 shadow-md dark:border-white/5 dark:bg-white/5 dark:shadow-md-dark">
+                <div className="h-1 w-8 bg-black/70 dark:bg-white/70" />
+                <div className="h-2 w-6 rounded-sm bg-blue-600 dark:bg-blue-500" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </foreignObject>
+    </svg>
+  );
+}

--- a/examples/dialog-animated/style.css
+++ b/examples/dialog-animated/style.css
@@ -1,14 +1,12 @@
 @import url("../dialog/style.css");
 
-[data-backdrop] {
+.backdrop {
   @apply
     transition-[opacity,backdrop-filter]
-    enter:duration-200
-    leave:duration-500
     [backdrop-filter:blur(0)]
-    enter:[backdrop-filter:blur(4px)]
+    data-[enter]:[backdrop-filter:blur(4px)]
     opacity-0
-    enter:opacity-100
+    data-[enter]:opacity-100
   ;
 }
 
@@ -16,12 +14,9 @@
   @apply
     origin-center
     transition-[opacity,transform]
-    enter:duration-200
-    leave:duration-500
-    enter:delay-200
     opacity-0
-    enter:opacity-100
+    data-[enter]:opacity-100
     [transform:scale(0.95)]
-    enter:[transform:scale(1)]
+    data-[enter]:[transform:scale(1)]
   ;
 }

--- a/examples/dialog-details/index.tsx
+++ b/examples/dialog-details/index.tsx
@@ -1,9 +1,16 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import * as Ariakit from "@ariakit/react";
 import "./style.css";
 
+function useLoaded() {
+  const [loaded, setLoaded] = useState(false);
+  useEffect(() => setLoaded(true), []);
+  return loaded;
+}
+
 export default function Example() {
   const ref = useRef<HTMLDetailsElement>(null);
+  const loaded = useLoaded();
   const dialog = Ariakit.useDialogStore();
   const mounted = dialog.useState("mounted");
 
@@ -22,15 +29,14 @@ export default function Example() {
       </Ariakit.Button>
       <Ariakit.Dialog
         store={dialog}
-        // We're setting the modal prop to true only when the dialog is open and
-        // JavaScript is enabled. This means that the dialog will initially have
-        // a non-modal state with no backdrop element, allowing users to
-        // interact with the content behind. This is necessary because, before
-        // JavaScript finishes loading, we can't automatically move focus to the
-        // dialog.
-        modal={mounted}
-        portal={false}
-        hidden={false}
+        // We're setting the modal prop to true only when JavaScript is enabled.
+        // This means that the dialog will initially have a non-modal state with
+        // no backdrop element, allowing users to interact with the content
+        // behind. This is necessary because, before JavaScript finishes
+        // loading, we can't automatically move focus to the dialog.
+        modal={loaded}
+        backdrop={loaded && <div className="backdrop" />}
+        hidden={loaded ? undefined : false}
         className="dialog"
       >
         <Ariakit.DialogHeading className="heading">

--- a/examples/dialog-details/readme.md
+++ b/examples/dialog-details/readme.md
@@ -4,15 +4,13 @@
   Combining <a href="/components/dialog">Dialog</a> with the native <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details">details element</a> in React so users can interact with it before JavaScript finishes loading.
 </p>
 
-<div class="warning">
+<aside data-type="warn">
 
 **Before you use this example**
 
-This is not the best way to make modal dialogs accessible without JavaScript. Consider using [Dialog with React Router](/examples/dialog-react-router) instead.
+This is not the best way to make modal dialogs accessible without JavaScript. Consider using a Router instead. Check out the [Dialog with React Router](/examples/dialog-react-router) and the [Dialog with Next.js App Router](/examples/dialog-next-router) examples.
 
-</div>
-
-Try it by hard-refreshing this page. Then click on the `Show modal` button below before JavaScript finishes loading.
+</aside>
 
 <a href="./index.tsx" data-playground>Example</a>
 
@@ -33,16 +31,4 @@ By default, browsers apply some default styles to the `details` element. We can 
 }
 ```
 
-### Fixing the layout shift
-
-Since we're changing between non-modal and [`modal`](/apis/dialog#modal) states and, therefore, between non-portal and [`portal`](/apis/dialog#portal) dialogs right after it's shown, there may be a layout shift if the browser has visible scrollbars.
-
-To fix this, we can use the `--scrollbar-width` CSS variable:
-
-```css
-.dialog {
-  margin-left: calc(var(--scrollbar-width, 0) * -0.5);
-}
-```
-
-Learn more on the [Styling](/guide/styling) guide.
+You can learn more about styling Ariakit components on the [Styling](/guide/styling) guide.

--- a/examples/dialog-details/site-icon.tsx
+++ b/examples/dialog-details/site-icon.tsx
@@ -1,0 +1,30 @@
+export default function Icon() {
+  return (
+    <svg viewBox="0 0 128 128" width={128} height={128}>
+      <foreignObject width={128} height={128}>
+        <div className="flex h-full flex-col items-center justify-center p-5">
+          <div className="ml-2 flex h-4 w-12 items-center self-start rounded bg-blue-600 px-1">
+            <svg
+              fill="none"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              viewBox="0 0 16 16"
+              className="h-3 w-3 stroke-white"
+            >
+              <polyline points="4,6 8,10 12,6" />
+            </svg>
+          </div>
+          <div className="-mt-0.5 flex w-full flex-col gap-2 rounded border border-black/20 bg-white p-2 shadow-md dark:border-white/10 dark:bg-gray-650 dark:shadow-md-dark">
+            <div className="h-1 w-10 bg-black/70 dark:bg-white/70" />
+            <div className="flex flex-col gap-1">
+              <div className="h-1 w-full bg-black/40 dark:bg-white/40" />
+              <div className="h-1 w-10 bg-black/40 dark:bg-white/40" />
+            </div>
+            <div className="h-2 w-6 rounded-sm bg-blue-600 dark:bg-blue-500" />
+          </div>
+        </div>
+      </foreignObject>
+    </svg>
+  );
+}

--- a/examples/dialog-details/style.css
+++ b/examples/dialog-details/style.css
@@ -7,13 +7,3 @@
     [&::-webkit-details-marker]:hidden
   ;
 }
-
-.dialog {
-  @apply
-    fixed
-    top-0
-    left-1/2
-    sm:ml-[calc(var(--scrollbar-width,0)*-0.5)]
-    [transform:translateX(-50%)]
-  ;
-}

--- a/examples/dialog-framer-motion/index.tsx
+++ b/examples/dialog-framer-motion/index.tsx
@@ -1,0 +1,45 @@
+import * as Ariakit from "@ariakit/react";
+import { AnimatePresence, motion } from "framer-motion";
+import "./style.css";
+
+export default function Example() {
+  const dialog = Ariakit.useDialogStore();
+  const mounted = dialog.useState("mounted");
+  return (
+    <>
+      <Ariakit.Button onClick={dialog.show} className="button">
+        Show modal
+      </Ariakit.Button>
+      <AnimatePresence>
+        {mounted && (
+          <Ariakit.Dialog
+            className="dialog"
+            store={dialog}
+            hidden={false}
+            as={motion.div}
+            initial={{ opacity: 0, scale: 0.95 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.95 }}
+            backdrop={
+              <motion.div
+                className="backdrop"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+              />
+            }
+          >
+            <Ariakit.DialogHeading className="heading">
+              Success
+            </Ariakit.DialogHeading>
+            <p className="description">
+              Your payment has been successfully processed. We have emailed your
+              receipt.
+            </p>
+            <Ariakit.DialogDismiss className="button">OK</Ariakit.DialogDismiss>
+          </Ariakit.Dialog>
+        )}
+      </AnimatePresence>
+    </>
+  );
+}

--- a/examples/dialog-framer-motion/readme.md
+++ b/examples/dialog-framer-motion/readme.md
@@ -1,0 +1,42 @@
+# Dialog with Framer Motion
+
+<p data-description>
+  Using <a href="https://www.framer.com/motion/">Framer Motion</a> to add initial and exit animations to a modal <a href="/components/dialog">Dialog</a> and its <a href="/apis/dialog#backdrop"><code>backdrop</code></a> element.
+</p>
+
+<a href="./index.tsx" data-playground>Example</a>
+
+## AnimatePresence
+
+We use the [AnimatePresence](https://www.framer.com/motion/animate-presence/) component from Framer Motion to animate the Ariakit [Dialog](/components/dialog) component when it gets mounted and unmounted from the DOM.
+
+```jsx
+<AnimatePresence>
+  {mounted && (
+    <Ariakit.Dialog
+      store={dialog}
+      hidden={false}
+      as={motion.div}
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      exit={{ opacity: 0, scale: 0.95 }}
+      backdrop={
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        />
+      }
+    />
+  )}
+</AnimatePresence>
+```
+
+To dynamically render the dialog component, you can use the [`mounted`](/apis/dialog-store#mounted) state that can be retrieved from the store:
+
+```jsx
+const dialog = Ariakit.useDialogStore();
+const mounted = dialog.useState("mounted");
+```
+
+You can learn more about reading state from the store on the [Component stores](/guide/component-stores#reading-the-state) guide.

--- a/examples/dialog-framer-motion/site-icon.tsx
+++ b/examples/dialog-framer-motion/site-icon.tsx
@@ -1,0 +1,18 @@
+export default function Icon() {
+  return (
+    <svg viewBox="0 0 128 128" width={128} height={128}>
+      <foreignObject width={128} height={128}>
+        <div className="flex h-full flex-col items-center justify-center p-5">
+          <div className="w-full rounded-md border border-black/10 bg-gray-100 p-2 shadow-md dark:border-white/5 dark:bg-white/5 dark:shadow-md-dark">
+            <div className="w-full rounded border border-black/10 bg-gray-50 p-2 shadow-md dark:border-white/5 dark:bg-white/5 dark:shadow-md-dark">
+              <div className="flex w-full flex-col gap-2 rounded-sm border border-black/10 bg-white p-2 shadow-md dark:border-white/5 dark:bg-white/5 dark:shadow-md-dark">
+                <div className="h-1 w-8 bg-black/70 dark:bg-white/70" />
+                <div className="h-2 w-6 rounded-sm bg-green-600 dark:bg-green-500" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </foreignObject>
+    </svg>
+  );
+}

--- a/examples/dialog-framer-motion/style.css
+++ b/examples/dialog-framer-motion/style.css
@@ -1,0 +1,7 @@
+@import url("../dialog/style.css");
+
+.dialog {
+  @apply
+    items-start
+  ;
+}

--- a/examples/dialog-framer-motion/test-chrome.ts
+++ b/examples/dialog-framer-motion/test-chrome.ts
@@ -1,0 +1,21 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+const getButton = (page: Page, name: string) =>
+  page.getByRole("button", { name });
+
+const getDialog = (page: Page) => page.getByRole("dialog");
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/previews/dialog-framer-motion", {
+    waitUntil: "networkidle",
+  });
+});
+
+test("show/hide with click", async ({ page }) => {
+  await expect(getDialog(page)).not.toBeVisible();
+  await getButton(page, "Show modal").click();
+  await expect(getDialog(page)).toBeVisible();
+  await getButton(page, "OK").click();
+  await expect(getDialog(page)).not.toBeVisible();
+});

--- a/examples/dialog-menu/dialog.tsx
+++ b/examples/dialog-menu/dialog.tsx
@@ -12,7 +12,14 @@ export const Dialog = React.forwardRef<HTMLDivElement, DialogProps>(
       open,
       setOpen: (open) => !open && onClose?.(),
     });
-    return <Ariakit.Dialog {...props} store={dialog} ref={ref} />;
+    return (
+      <Ariakit.Dialog
+        {...props}
+        ref={ref}
+        store={dialog}
+        backdrop={<div className="backdrop" />}
+      />
+    );
   }
 );
 

--- a/examples/dialog-menu/test-browser.ts
+++ b/examples/dialog-menu/test-browser.ts
@@ -7,7 +7,10 @@ const getButton = (page: Page, name: string) =>
 const getDialog = (page: Page) =>
   page.getByRole("dialog", { includeHidden: true, name: "Homemade Cake" });
 
-const getBackdrop = async (page: Page) => getDialog(page).locator("xpath=..");
+const getBackdrop = async (page: Page) => {
+  const id = await getDialog(page).getAttribute("id");
+  return page.locator(`[data-backdrop="${id}"]`);
+};
 
 const getMenu = (page: Page) => page.getByRole("menu", { name: "Share" });
 

--- a/examples/dialog-menu/test.ts
+++ b/examples/dialog-menu/test.ts
@@ -7,7 +7,8 @@ const getDialog = () =>
 
 const getDialogBackdrop = () => {
   const dialog = getDialog();
-  const backdrop = dialog?.parentElement;
+  const id = dialog?.id;
+  const backdrop = document.querySelector(`[data-backdrop="${id}"]`);
   expect(backdrop).toBeInTheDocument();
   return backdrop!;
 };

--- a/examples/dialog-nested-mounted/test.ts
+++ b/examples/dialog-nested-mounted/test.ts
@@ -2,7 +2,12 @@ import { click, getByRole, press, queryByRole } from "@ariakit/test";
 
 const getButton = (name: string) => getByRole("button", { name });
 
-const getDialog = () => queryByRole("dialog", { hidden: true, name: "Dialog" });
+const getDialog = () =>
+  queryByRole("dialog", {
+    hidden: true,
+    name: (name, element) =>
+      name === "Dialog" || element.getAttribute("aria-hidden") === "true",
+  });
 
 const getNestedDialog = () =>
   queryByRole("dialog", { hidden: true, name: "Confirm" });

--- a/examples/dialog-nested/confirm-dialog.tsx
+++ b/examples/dialog-nested/confirm-dialog.tsx
@@ -33,7 +33,11 @@ export function ConfirmDialog({
     },
   });
   return (
-    <Ariakit.Dialog store={dialog} className="dialog">
+    <Ariakit.Dialog
+      store={dialog}
+      backdrop={<div className="backdrop" />}
+      className="dialog"
+    >
       {title && (
         <Ariakit.DialogHeading className="heading">
           {title}

--- a/examples/dialog-nested/index.tsx
+++ b/examples/dialog-nested/index.tsx
@@ -19,7 +19,11 @@ export default function Example() {
         View Cart
       </Ariakit.Button>
 
-      <Ariakit.Dialog store={dialog} className="dialog">
+      <Ariakit.Dialog
+        store={dialog}
+        backdrop={<div className="backdrop" />}
+        className="dialog"
+      >
         <div className="header">
           <Ariakit.DialogHeading className="heading">
             Your Shopping Cart

--- a/examples/dialog-nested/test.ts
+++ b/examples/dialog-nested/test.ts
@@ -3,7 +3,12 @@ import { click, getByRole, press, queryByRole } from "@ariakit/test";
 const getCartDisclosure = () => getByRole("button", { name: "View Cart" });
 
 const getCartDialog = () =>
-  queryByRole("dialog", { hidden: true, name: "Your Shopping Cart" });
+  queryByRole("dialog", {
+    hidden: true,
+    name: (name, element) =>
+      name === "Your Shopping Cart" ||
+      element.getAttribute("aria-hidden") === "true",
+  });
 
 const getDismissButton = () => getByRole("button", { name: "Dismiss popup" });
 

--- a/examples/dialog-react-router/index.tsx
+++ b/examples/dialog-react-router/index.tsx
@@ -20,7 +20,11 @@ function Tweet() {
     },
   });
   return (
-    <Ariakit.Dialog store={dialog} className="dialog">
+    <Ariakit.Dialog
+      store={dialog}
+      backdrop={<div className="backdrop" />}
+      className="dialog"
+    >
       <Ariakit.DialogDismiss
         as={Link}
         to="/"

--- a/examples/dialog-react-toastify/index.tsx
+++ b/examples/dialog-react-toastify/index.tsx
@@ -15,6 +15,7 @@ function Example() {
       </Ariakit.Button>
       <Ariakit.Dialog
         store={dialog}
+        backdrop={<div className="backdrop" />}
         getPersistentElements={() => document.querySelectorAll(".Toastify")}
         className="dialog"
       >

--- a/examples/dialog/index.tsx
+++ b/examples/dialog/index.tsx
@@ -5,7 +5,7 @@ export default function Example() {
   const dialog = Ariakit.useDialogStore();
   return (
     <>
-      <Ariakit.Button onClick={dialog.toggle} className="button">
+      <Ariakit.Button onClick={dialog.show} className="button">
         Show modal
       </Ariakit.Button>
       <Ariakit.Dialog store={dialog} className="dialog">

--- a/examples/dialog/style.css
+++ b/examples/dialog/style.css
@@ -1,6 +1,6 @@
 @import url("../button/style.css");
 
-[data-backdrop] {
+.backdrop {
   @apply
     [backdrop-filter:blur(4px)]
     bg-black/10

--- a/guide/200-styling.md
+++ b/guide/200-styling.md
@@ -6,15 +6,27 @@
 
 ## Applying styles
 
-Ariakit components accept all native props, including `className`, `style`, and `ref`. You can use them to apply your styles just like you would with any other React element.
+Ariakit components accept all native props, including `className`, `style`, and `ref`. You can use them to apply your styles just like you would with any other React element using plain CSS, inline CSS, CSS modules, CSS-in-JS, Styled Components, Emotion, Tailwind, etc.
+
+```jsx
+<Dialog
+  ref={dialogRef}
+  style={{ backgroundColor: "white" }}
+  className="dialog bg-white"
+/>
+```
 
 ## CSS selectors
 
-**Important: Do not use any selectors that are not listed below.**
+<aside data-type="danger">
+
+**Do not use any selectors that are not listed below.**
 
 Ariakit renders elements with HTML attributes, such as `role`, that should not be used as CSS selectors as they're not part of the public API and may change in future minor and patch releases.
 
 To safely use CSS selectors, utilize the `className` prop or provide your own `data-*` attributes to the component. Refer to the list below for all the selectors that are safe to use.
+
+</aside>
 
 ### `[aria-disabled]`
 
@@ -76,6 +88,16 @@ The `data-autofill` attribute is applied to the [Select](/components/select) com
 ```css
 .select[data-autofill] {
   background-color: rgb(219 237 255);
+}
+```
+
+### `[data-backdrop]`
+
+The `data-backdrop` attribute can be used to style all [Dialog](/components/dialog) backdrop elements at once.
+
+```css
+[data-backdrop] {
+  background-color: rgba(0, 0, 0, 0.5);
 }
 ```
 

--- a/packages/ariakit-react-core/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-core/src/dialog/dialog.tsx
@@ -131,8 +131,12 @@ export const useDialog = createHook<DialogOptions>(
     const open = store.useState("open");
     const mounted = store.useState("mounted");
     const contentElement = store.useState("contentElement");
+    const hiddenProp = props.hidden;
 
-    usePreventBodyScroll(store, mounted && preventBodyScroll);
+    usePreventBodyScroll(
+      store,
+      (mounted || hiddenProp === false) && preventBodyScroll
+    );
     useHideOnInteractOutside(store, hideOnInteractOutside);
 
     const { wrapElement, nestedDialogs } = useNestedDialogs(store);
@@ -432,8 +436,6 @@ export const useDialog = createHook<DialogOptions>(
       [modal]
     );
 
-    const hiddenProp = props.hidden;
-
     // Wraps the dialog with a backdrop element if the backdrop prop is truthy.
     props = useWrapElement(
       props,
@@ -542,10 +544,22 @@ export interface DialogOptions<T extends As = "div">
   /**
    * Determines whether there will be a backdrop behind the dialog. On modal
    * dialogs, this is `true` by default. Besides a `boolean`, this prop can also
-   * be a React component that will be rendered as the backdrop.
+   * be a React component or JSX element that will be rendered as the backdrop.
+   *
+   * **If a custom component is used, it must accept ref and spread all props to
+   * its underlying DOM element**, the same way a native element would.
+   *
+   * Live examples:
+   * - [Animated Dialog](https://ariakit.org/examples/dialog-animated)
+   * - [Dialog with Framer
+   *   Motion](https://ariakit.org/examples/dialog-framer-motion)
+   * - [Dialog with Menu](https://ariakit.org/examples/dialog-menu)
+   * - [Nested Dialog](https://ariakit.org/examples/dialog-nested)
+   * - [Dialog with Next.js App
+   *   Router](https://ariakit.org/examples/dialog-next-router)
    * @example
    * ```jsx
-   * <Dialog backdrop={StyledBackdrop} />
+   * <Dialog backdrop={<div className="backdrop" />} />
    * ```
    */
   backdrop?:
@@ -554,6 +568,7 @@ export interface DialogOptions<T extends As = "div">
     | ElementType<ComponentPropsWithRef<"div">>;
   /**
    * Props that will be passed to the backdrop element if `backdrop` is `true`.
+   * @deprecated Use the `backdrop` prop instead.
    */
   backdropProps?: ComponentPropsWithRef<"div">;
   /**

--- a/packages/ariakit-react-core/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-core/src/dialog/dialog.tsx
@@ -1,6 +1,7 @@
 import type {
-  ComponentProps,
+  ComponentPropsWithRef,
   ElementType,
+  ReactElement,
   KeyboardEvent as ReactKeyboardEvent,
   RefObject,
   SyntheticEvent,
@@ -25,10 +26,7 @@ import {
 import { chain } from "@ariakit/core/utils/misc";
 import { isSafari } from "@ariakit/core/utils/platform";
 import type { BooleanOrCallback } from "@ariakit/core/utils/types";
-import type {
-  DisclosureContentOptions,
-  DisclosureContentProps,
-} from "../disclosure/disclosure-content.js";
+import type { DisclosureContentOptions } from "../disclosure/disclosure-content.js";
 import { useDisclosureContent } from "../disclosure/disclosure-content.js";
 import { useFocusableContainer } from "../focusable/focusable-container.js";
 import type { FocusableOptions } from "../focusable/focusable.js";
@@ -442,14 +440,17 @@ export const useDialog = createHook<DialogOptions>(
       (element) => {
         if (backdrop) {
           return (
-            <DialogBackdrop
-              store={store}
-              backdrop={backdrop}
-              backdropProps={backdropProps}
-              hidden={hiddenProp}
-            >
+            <>
+              {backdrop && (
+                <DialogBackdrop
+                  store={store}
+                  backdrop={backdrop}
+                  backdropProps={backdropProps}
+                  hidden={hiddenProp}
+                />
+              )}
               {element}
-            </DialogBackdrop>
+            </>
           );
         }
         return element;
@@ -547,11 +548,14 @@ export interface DialogOptions<T extends As = "div">
    * <Dialog backdrop={StyledBackdrop} />
    * ```
    */
-  backdrop?: boolean | ElementType<ComponentProps<"div">>;
+  backdrop?:
+    | boolean
+    | ReactElement<ComponentPropsWithRef<"div">>
+    | ElementType<ComponentPropsWithRef<"div">>;
   /**
    * Props that will be passed to the backdrop element if `backdrop` is `true`.
    */
-  backdropProps?: Omit<DisclosureContentProps, "store">;
+  backdropProps?: ComponentPropsWithRef<"div">;
   /**
    * Determines whether the dialog will be hidden when the user presses the
    * Escape key.

--- a/website/app/(examples)/previews/dialog-next-router/@login/login/page.tsx
+++ b/website/app/(examples)/previews/dialog-next-router/@login/login/page.tsx
@@ -18,6 +18,7 @@ export default function Page() {
       store={dialog}
       // React portal is not rendered on the server, so we disable it.
       portal={false}
+      backdrop={<div className="backdrop" />}
       className="dialog"
       autoFocusOnHide={(element) => {
         if (!element) {

--- a/website/app/(examples)/previews/dialog-next-router/site-icon.tsx
+++ b/website/app/(examples)/previews/dialog-next-router/site-icon.tsx
@@ -12,7 +12,7 @@ export default function Icon() {
             <div className="m-2 flex flex-col gap-2 rounded border border-black/20 bg-white p-2 shadow-md dark:border-white/10 dark:bg-white/10 dark:shadow-md-dark">
               <div className="h-1 w-8 bg-black/70 dark:bg-white/70" />
               <div className="h-3 w-12 rounded-sm border border-black/30 bg-white dark:border-white/20 dark:bg-black" />
-              <div className="h-2 w-6 rounded-sm bg-blue-600 dark:bg-blue-500" />
+              <div className="h-2 w-6 rounded-sm bg-green-600 dark:bg-green-500" />
             </div>
           </div>
         </div>

--- a/website/app/(main)/[category]/[page]/page.tsx
+++ b/website/app/(main)/[category]/[page]/page.tsx
@@ -28,9 +28,9 @@ import { TableOfContents } from "./table-of-contents.js";
 const { pages } = pagesConfig;
 
 const stickyHeading = tw`
-  sticky md:static top-16 z-20 py-4 -my-4 md:my-0 md:py-0 scroll-mt-16
+  sticky md:static top-16 z-20 py-2 -my-2 md:my-0 md:py-0 scroll-mt-16
   flex items-center md:block pr-12 md:pr-0
-  min-h-[72px] md:min-h-0 bg-gray-50 dark:bg-gray-800
+  min-h-[56px] md:min-h-0 bg-gray-50 dark:bg-gray-800
 `;
 
 const style = {
@@ -67,6 +67,25 @@ const style = {
     text-black dark:text-white
     tracking-[-0.035em] dark:tracking-[-0.015em]
     ${stickyHeading}
+  `,
+  aside: tw`
+    flex flex-col gap-4 !max-w-[832px] p-4 pl-5 sm:p-8
+    rounded-lg sm:rounded-xl !rounded-l relative overflow-hidden
+
+    before:absolute before:top-0 before:left-0 before:bottom-0 before:w-1
+
+    data-[type="danger"]:bg-red-100
+    data-[type="danger"]:dark:bg-red-700/20
+    data-[type="danger"]:before:bg-red-600
+
+    data-[type="warn"]:bg-amber-100
+    data-[type="warn"]:dark:bg-amber-800/20
+    data-[type="warn"]:before:bg-amber-500
+    data-[type="warn"]:before:dark:bg-yellow-600
+
+    data-[type="note"]:bg-blue-50
+    data-[type="note"]:dark:bg-blue-900/20
+    data-[type="note"]:before:bg-blue-600
   `,
   paragraph: tw`
     dark:text-white/[85%] leading-7 tracking-[-0.016em] dark:tracking-[-0.008em]
@@ -208,6 +227,10 @@ export default async function Page({ params }: PageProps) {
               );
               if (ordered) return <ol {...props} className={className} />;
               return <ul {...props} className={className} />;
+            },
+            aside: ({ node, ...props }) => {
+              const className = cx(style.aside, props.className);
+              return <aside {...props} className={className} />;
             },
             pre: ({ node, ...props }) => {
               const pre = (

--- a/website/app/(main)/[category]/[page]/table-of-contents.tsx
+++ b/website/app/(main)/[category]/[page]/table-of-contents.tsx
@@ -26,7 +26,7 @@ const padding: Record<number, string> = {
 
 const style = {
   stickyWrapper: tw`
-    sticky top-20 z-30 mt-8 flex h-0 w-full justify-end px-3
+    sticky top-[72px] z-30 mt-8 flex h-0 w-full justify-end px-3
     md:hidden
   `,
   disclosure: tw`


### PR DESCRIPTION
Closes #2085

This PR updates the `Dialog` component to render its backdrop element as a sibling rather than a parent element. This should make it easier to perform animations on both the dialog and the backdrop elements separately.

In addition, we're deprecating the `backdropProps` prop in favor of passing a JSX element to the `backdrop` prop. This should fix type errors when using `backdropProps` to pass props to custom backdrop elements.

