### PR TITLE
Add a `render` prop to the system

### DIFF
--- a/.changeset/two-pans-nail.md
+++ b/.changeset/two-pans-nail.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Added a `render` prop to all components as a more flexible alternative to `children` as a function. ([#2411](https://github.com/ariakit/ariakit/pull/2411))

--- a/examples/select-combobox-focus-within/select-combobox.tsx
+++ b/examples/select-combobox-focus-within/select-combobox.tsx
@@ -110,19 +110,14 @@ type SelectComboboxItemProps = React.HTMLAttributes<HTMLDivElement> & {
 export const SelectComboboxItem = React.forwardRef<
   HTMLDivElement,
   SelectComboboxItemProps
->(({ value, children, ...props }, ref) => {
+>(({ value, ...props }, ref) => {
   return (
     <Ariakit.ComboboxItem
       ref={ref}
       focusOnHover
       className="select-item"
+      render={(props) => <Ariakit.SelectItem {...props} value={value} />}
       {...props}
-    >
-      {(props) => (
-        <Ariakit.SelectItem {...props} value={value}>
-          {children}
-        </Ariakit.SelectItem>
-      )}
-    </Ariakit.ComboboxItem>
+    />
   );
 });

--- a/examples/select-combobox/index.tsx
+++ b/examples/select-combobox/index.tsx
@@ -42,9 +42,10 @@ export default function Example() {
               key={value}
               focusOnHover
               className="select-item"
-            >
-              {(props) => <Ariakit.SelectItem {...props} value={value} />}
-            </Ariakit.ComboboxItem>
+              render={(props) => (
+                <Ariakit.SelectItem {...props} value={value} />
+              )}
+            />
           ))}
         </Ariakit.ComboboxList>
       </Ariakit.SelectPopover>

--- a/examples/select-combobox/index.tsx
+++ b/examples/select-combobox/index.tsx
@@ -42,9 +42,7 @@ export default function Example() {
               key={value}
               focusOnHover
               className="select-item"
-              render={(props) => (
-                <Ariakit.SelectItem {...props} value={value} />
-              )}
+              render={(p) => <Ariakit.SelectItem {...p} value={value} />}
             />
           ))}
         </Ariakit.ComboboxList>

--- a/packages/ariakit-react-core/src/combobox/combobox-item-value.tsx
+++ b/packages/ariakit-react-core/src/combobox/combobox-item-value.tsx
@@ -1,4 +1,5 @@
 import { useContext, useMemo } from "react";
+import type { ReactElement } from "react";
 import { invariant, normalizeString } from "@ariakit/core/utils/misc";
 import { createComponent, createElement, createHook } from "../utils/system.js";
 import type { As, Options, Props } from "../utils/types.js";
@@ -15,7 +16,7 @@ function normalizeValue(value: string) {
 function splitValue(itemValue: string, userValue: string) {
   userValue = normalizeValue(userValue);
   let index = normalizeValue(itemValue).indexOf(userValue);
-  const parts: JSX.Element[] = [];
+  const parts: ReactElement[] = [];
   while (index !== -1) {
     if (index !== 0) {
       parts.push(

--- a/packages/ariakit-react-core/src/dialog/dialog-backdrop.tsx
+++ b/packages/ariakit-react-core/src/dialog/dialog-backdrop.tsx
@@ -80,7 +80,9 @@ export function DialogBackdrop({
   if (!backdrop) return null;
 
   if (isValidElement(backdrop)) {
-    return <Role {...props}>{(props) => cloneElement(backdrop, props)}</Role>;
+    return (
+      <Role {...props} render={(props) => cloneElement(backdrop, props)} />
+    );
   }
 
   const Component = typeof backdrop !== "boolean" ? backdrop || "div" : "div";

--- a/packages/ariakit-react-core/src/utils/system.tsx
+++ b/packages/ariakit-react-core/src/utils/system.tsx
@@ -86,6 +86,7 @@ export function createElement(Type: ElementType, props: HTMLProps<Options>) {
   if (As && typeof As !== "string") {
     element = <As {...rest} render={render} />;
   } else if (render) {
+    // @ts-expect-error
     element = render(rest) as ReactElement;
   } else if (isRenderProp(props.children)) {
     const { children, ...otherProps } = rest;

--- a/packages/ariakit-react-core/src/utils/system.tsx
+++ b/packages/ariakit-react-core/src/utils/system.tsx
@@ -81,10 +81,12 @@ export function createMemoComponent<O extends Options>(
  * }
  */
 export function createElement(Type: ElementType, props: HTMLProps<Options>) {
-  const { as: As, wrapElement, ...rest } = props;
+  const { as: As, wrapElement, render, ...rest } = props;
   let element: ReactElement;
   if (As && typeof As !== "string") {
-    element = <As {...rest} />;
+    element = <As {...rest} render={render} />;
+  } else if (render) {
+    element = render(rest) as ReactElement;
   } else if (isRenderProp(props.children)) {
     const { children, ...otherProps } = rest;
     element = props.children(otherProps) as ReactElement;

--- a/packages/ariakit-react-core/src/utils/types.ts
+++ b/packages/ariakit-react-core/src/utils/types.ts
@@ -52,6 +52,7 @@ export type Options<T extends As = any> = { as?: T };
 export type HTMLProps<O extends Options> = {
   wrapElement?: WrapElement;
   children?: Children;
+  render?: RenderProp;
   [index: `data-${string}`]: unknown;
 } & Omit<ComponentPropsWithRef<NonNullable<O["as"]>>, keyof O | "children">;
 
@@ -70,15 +71,11 @@ export type Props<O extends Options> = O & HTMLProps<O>;
  * @example
  * type ButtonComponent = Component<Options<"button">>;
  */
-export type Component<O extends Options> = {
-  <T extends As>(
-    props: Omit<O, "as"> &
-      Omit<HTMLProps<Options<T>>, keyof O> &
-      Required<Options<T>>
-  ): JSX.Element | null;
-  (props: Props<O>): JSX.Element | null;
+export interface Component<O extends Options> {
+  <T extends As>(props: Props<{ as: T } & Omit<O, "as">>): ReactElement | null;
+  (props: Props<O>): ReactElement | null;
   displayName?: string;
-};
+}
 
 /**
  * A component hook that supports the `as` prop and the `children` prop as a
@@ -87,9 +84,9 @@ export type Component<O extends Options> = {
  * @example
  * type ButtonHook = Hook<Options<"button">>;
  */
-export type Hook<O extends Options> = {
+export interface Hook<O extends Options> {
   <T extends As = NonNullable<O["as"]>>(
-    props?: Omit<O, "as"> & Omit<HTMLProps<Options<T>>, keyof O> & Options<T>
+    props?: Props<Options<T> & Omit<O, "as">>
   ): HTMLProps<Options<T>>;
   displayName?: string;
-};
+}

--- a/packages/ariakit-react-core/src/utils/types.ts
+++ b/packages/ariakit-react-core/src/utils/types.ts
@@ -1,12 +1,4 @@
-import type {
-  ComponentPropsWithRef,
-  ElementType,
-  HTMLAttributes,
-  ReactElement,
-  ReactNode,
-  RefAttributes,
-} from "react";
-import type { AnyObject } from "@ariakit/core/utils/types";
+import type * as React from "react";
 
 /**
  * Render prop type.
@@ -14,26 +6,28 @@ import type { AnyObject } from "@ariakit/core/utils/types";
  * @example
  * const children: RenderProp = (props) => <div {...props} />;
  */
-export type RenderProp<P = AnyObject> = (props: P) => ReactNode;
+export type RenderProp<
+  P = React.HTMLAttributes<any> & React.RefAttributes<any>
+> = (props: P) => React.ReactNode;
 
 /**
  * The `as` prop.
  * @template P Props
  */
-export type As<P = any> = ElementType<P>;
+export type As<P = any> = React.ElementType<P>;
 
 /**
  * The `wrapElement` prop.
  */
-export type WrapElement = (element: ReactElement) => ReactElement;
+export type WrapElement = (element: React.ReactElement) => React.ReactElement;
 
 /**
  * The `children` prop that supports a function.
  * @template T Element type.
  */
 export type Children<T = any> =
-  | ReactNode
-  | RenderProp<HTMLAttributes<T> & RefAttributes<T>>;
+  | React.ReactNode
+  | RenderProp<React.HTMLAttributes<T> & React.RefAttributes<T>>;
 
 /**
  * Props with the `as` prop.
@@ -54,7 +48,10 @@ export type HTMLProps<O extends Options> = {
   children?: Children;
   render?: RenderProp;
   [index: `data-${string}`]: unknown;
-} & Omit<ComponentPropsWithRef<NonNullable<O["as"]>>, keyof O | "children">;
+} & Omit<
+  React.ComponentPropsWithRef<NonNullable<O["as"]>>,
+  keyof O | "children"
+>;
 
 /**
  * Options & HTMLProps
@@ -72,8 +69,10 @@ export type Props<O extends Options> = O & HTMLProps<O>;
  * type ButtonComponent = Component<Options<"button">>;
  */
 export interface Component<O extends Options> {
-  <T extends As>(props: Props<{ as: T } & Omit<O, "as">>): ReactElement | null;
-  (props: Props<O>): ReactElement | null;
+  <T extends As>(
+    props: Props<{ as: T } & Omit<O, "as">>
+  ): React.ReactElement | null;
+  (props: Props<O>): React.ReactElement | null;
   displayName?: string;
 }
 

--- a/website/components/editor.tsx
+++ b/website/components/editor.tsx
@@ -213,11 +213,14 @@ export function Editor({ files, theme, codeBlocks }: EditorProps) {
       </div>
       {!editorReady &&
         Object.entries(files).map(([file]) => (
-          <TabPanel key={file} store={tab} tabId={getId(file)}>
-            {(props) => (
+          <TabPanel
+            key={file}
+            store={tab}
+            tabId={getId(file)}
+            render={(props) => (
               <div {...props}>{!props.hidden && codeBlocks[file]}</div>
             )}
-          </TabPanel>
+          />
         ))}
       <div ref={domRef} className={editorReady ? "h-72" : "hidden"} />
     </div>

--- a/website/components/header-menu.tsx
+++ b/website/components/header-menu.tsx
@@ -388,12 +388,12 @@ export const HeaderMenu = forwardRef<HTMLButtonElement, HeaderMenuProps>(
     const selectChildren = select.useState((state) => label ?? state.value);
 
     const button = selectable ? (
-      <Select store={select} {...props} ref={ref}>
-        {(props) => renderButton({ ...props, children: selectChildren })}
+      <Select store={select} {...props} ref={ref} render={renderButton}>
+        {selectChildren}
       </Select>
     ) : (
-      <MenuButton store={menu} {...props} ref={ref}>
-        {(props) => renderButton({ ...props, children: label })}
+      <MenuButton store={menu} {...props} ref={ref} render={renderButton}>
+        {label}
       </MenuButton>
     );
 
@@ -411,18 +411,16 @@ export const HeaderMenu = forwardRef<HTMLButtonElement, HeaderMenuProps>(
             fixed
             fitViewport
             gutter={4}
-          >
-            {(props) => (
+            render={(props) => (
               <MenuList
                 {...props}
                 store={menu}
                 typeahead={false}
                 composite={false}
-              >
-                {renderPopover}
-              </MenuList>
+                render={renderPopover}
+              />
             )}
-          </SelectPopover>
+          />
         )}
       </SelectContext.Provider>
     ) : (
@@ -444,9 +442,8 @@ export const HeaderMenu = forwardRef<HTMLButtonElement, HeaderMenuProps>(
               if (!anchor) return null;
               return anchor.getBoundingClientRect();
             }}
-          >
-            {renderPopover}
-          </Menu>
+            render={renderPopover}
+          />
         )}
       </SelectContext.Provider>
     );

--- a/website/components/header-nav.tsx
+++ b/website/components/header-nav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { MouseEvent, ReactNode } from "react";
+import type { MouseEvent, ReactElement, ReactNode } from "react";
 import {
   createContext,
   memo,
@@ -124,7 +124,7 @@ function highlightValue(
 ) {
   if (!itemValue) return itemValue;
   userValues = userValues.filter(Boolean);
-  const parts: JSX.Element[] = [];
+  const parts: ReactElement[] = [];
 
   const wrap = (value: string, autocomplete = false) => (
     <span

--- a/website/components/header-version-select.tsx
+++ b/website/components/header-version-select.tsx
@@ -19,6 +19,7 @@ import { NewWindow } from "icons/new-window.js";
 import { React } from "icons/react.js";
 import { Vue } from "icons/vue.js";
 import Link from "next/link.js";
+import { usePathname } from "next/navigation.js";
 import { tw } from "utils/tw.js";
 import { Popup } from "./popup.js";
 
@@ -107,19 +108,21 @@ interface Props {
 
 export function HeaderVersionSelect({ versions }: Props) {
   const select = useSelectStore({ defaultValue: getValueFromPkg(pkg) });
+  const pathname = usePathname();
 
   const renderItem = (value: string, tag: string) => {
     const { version } = getPkgFromValue(value);
 
     return (
-      <SelectItem key={value} value={value} className={style.item}>
-        {(props) => (
-          <Link href="" {...props}>
-            <SelectItemCheck />
-            <span className="flex-1 pr-4">{getDisplayValue(version)}</span>
-            <span className={style.itemBadge}>{tag}</span>
-          </Link>
-        )}
+      <SelectItem
+        key={value}
+        value={value}
+        className={style.item}
+        render={(props) => <Link href={pathname} {...props} />}
+      >
+        <SelectItemCheck />
+        <span className="flex-1 pr-4">{getDisplayValue(version)}</span>
+        <span className={style.itemBadge}>{tag}</span>
       </SelectItem>
     );
   };

--- a/website/components/playground-browser.tsx
+++ b/website/components/playground-browser.tsx
@@ -113,13 +113,15 @@ export function PlaygroundBrowser({ previewLink }: PlaygroundBrowserProps) {
             className={style.input}
           />
         </form>
-        <TooltipButton title="Open in new tab" className={style.button}>
-          {(props) => (
-            <Link {...props} href={url || previewLink} target="_blank">
-              <span className="sr-only">Open in new tab</span>
-              <NewWindow />
-            </Link>
+        <TooltipButton
+          title="Open in new tab"
+          className={style.button}
+          render={(props) => (
+            <Link {...props} href={url || previewLink} target="_blank" />
           )}
+        >
+          <span className="sr-only">Open in new tab</span>
+          <NewWindow />
         </TooltipButton>
       </div>
       <iframe

--- a/website/components/playground-toolbar.tsx
+++ b/website/components/playground-toolbar.tsx
@@ -119,21 +119,22 @@ export function PlaygroundToolbar({
 
   return (
     <Toolbar store={toolbar} className={style.toolbar}>
-      <ToolbarItem className={style.toolbarItem}>
-        {(props) => (
+      <ToolbarItem
+        className={style.toolbarItem}
+        render={(props) => (
           <Select
             as={TooltipButton}
             store={select}
             title="Select language"
             {...props}
-          >
-            <span className="sr-only">Select language</span>
-            {isJS ? (
-              <JavaScript className="h-5 w-5" />
-            ) : (
-              <TypeScript className="h-5 w-5" />
-            )}
-          </Select>
+          />
+        )}
+      >
+        <span className="sr-only">Select language</span>
+        {isJS ? (
+          <JavaScript className="h-5 w-5" />
+        ) : (
+          <TypeScript className="h-5 w-5" />
         )}
       </ToolbarItem>
 
@@ -153,18 +154,19 @@ export function PlaygroundToolbar({
         </SelectItem>
       </SelectPopover>
 
-      <ToolbarItem className={style.toolbarItem}>
-        {(props) => (
+      <ToolbarItem
+        className={style.toolbarItem}
+        render={(props) => (
           <MenuButton
             as={TooltipButton}
             store={menu}
             title="Open example in a new tab"
             {...props}
-          >
-            <span className="sr-only">Open example in a new tab</span>
-            <NewWindow strokeWidth={1.5} className="h-5 w-5" />
-          </MenuButton>
+          />
         )}
+      >
+        <span className="sr-only">Open example in a new tab</span>
+        <NewWindow strokeWidth={1.5} className="h-5 w-5" />
       </ToolbarItem>
 
       <Menu as={Popup} store={menu} portal shift={-6} size="responsive">

--- a/website/components/popup.tsx
+++ b/website/components/popup.tsx
@@ -1,11 +1,11 @@
-import type { HTMLAttributes } from "react";
+import type { HTMLAttributes, ReactElement } from "react";
 import { forwardRef } from "react";
 import { cx } from "@ariakit/core/utils/misc";
 import { tw } from "utils/tw.js";
 
 interface PopupProps extends HTMLAttributes<HTMLDivElement> {
   size?: "small" | "medium" | "responsive";
-  renderScoller?: (props: HTMLAttributes<HTMLDivElement>) => JSX.Element;
+  renderScoller?: (props: HTMLAttributes<HTMLDivElement>) => ReactElement;
 }
 
 export const Popup = forwardRef<HTMLDivElement, PopupProps>(


### PR DESCRIPTION
This PR adds a `render` prop to all components as an alternative to the `children` prop as a function.

The difference is that the `render` prop will also receive the `children` passed to the original component, which makes the code much cleaner.

Using `children`:

```jsx
<Ariakit.ComboboxItem
  ref={ref}
  focusOnHover
  className="select-item"
  {...props}
>
  {(props) => (
    <Ariakit.SelectItem {...props} value={value}>
      {props.children}
    </Ariakit.SelectItem>
  )}
</Ariakit.ComboboxItem>
```

Using `render`:

```jsx
<Ariakit.ComboboxItem
  ref={ref}
  focusOnHover
  className="select-item"
  {...props}
  render={(props) => <Ariakit.SelectItem {...props} value={value} />}
/>
```