### PR TITLE
Add tooltip-framer-motion example

### DIFF
--- a/.changeset/tooltip-framer-motion-1.md
+++ b/.changeset/tooltip-framer-motion-1.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/core": patch
+"@ariakit/react": patch
+---
+
+Fixed `useHovercardStore` and `useTooltipStore` not updating the state when the `timeout`, `showTimeout` or `hideTimeout` props changed. ([#2421](https://github.com/ariakit/ariakit/pull/2421))

--- a/.changeset/tooltip-framer-motion-2.md
+++ b/.changeset/tooltip-framer-motion-2.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed `useTooltipStore` not updating the state when the `type` or `skipTimeout` props changed. ([#2421](https://github.com/ariakit/ariakit/pull/2421))

--- a/.changeset/tooltip-framer-motion-3.md
+++ b/.changeset/tooltip-framer-motion-3.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed `Dialog` moving focus on show and hide too early. ([#2421](https://github.com/ariakit/ariakit/pull/2421))

--- a/.changeset/tooltip-framer-motion-4.md
+++ b/.changeset/tooltip-framer-motion-4.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed `Hovercard` and `Tooltip` hiding too early when pressing the `Escape` key. ([#2421](https://github.com/ariakit/ariakit/pull/2421))

--- a/.changeset/tooltip-framer-motion-5.md
+++ b/.changeset/tooltip-framer-motion-5.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Removed unnecessary `tabIndex={0}` prop from `TooltipAnchor`. ([#2421](https://github.com/ariakit/ariakit/pull/2421))

--- a/components/dialog.md
+++ b/components/dialog.md
@@ -6,13 +6,18 @@
 
 <a href="../examples/dialog/index.tsx" data-playground>Example</a>
 
-## Installation
+## Examples
 
-```sh
-npm i @ariakit/react
-```
+<div data-cards="examples">
 
-Learn more on the [Getting started](/guide/getting-started) guide.
+- [](/examples/dialog-animated)
+- [](/examples/dialog-framer-motion)
+- [](/examples/dialog-menu)
+- [](/examples/dialog-nested)
+- [](/examples/dialog-react-router)
+- [](/examples/dialog-next-router)
+
+</div>
 
 ## API
 

--- a/components/tooltip.md
+++ b/components/tooltip.md
@@ -6,13 +6,13 @@
 
 <a href="../examples/tooltip/index.tsx" data-playground>Example</a>
 
-## Installation
+## Examples
 
-```sh
-npm i @ariakit/react
-```
+<div data-cards="examples">
 
-Learn more on the [Getting started](/guide/getting-started) guide.
+- [](/examples/tooltip-framer-motion)
+
+</div>
 
 ## API
 
@@ -24,3 +24,20 @@ Learn more on the [Getting started](/guide/getting-started) guide.
   &lt;<a href="/apis/tooltip-arrow">TooltipArrow</a> /&gt;
 &lt;/Tooltip&gt;
 </pre>
+
+## Tooltips are descriptions
+
+By default, tooltips describe the element they are attached to (the anchor element) and are referenced by the [`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) attribute.
+
+You should make sure the anchor element has an accessible name, either by:
+
+- Rendering a visible label or a [VisuallyHidden](/components/visually-hidden) text inside the anchor element.
+- Using the [`aria-label`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) or [`aria-labelledby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) attributes on the anchor element.
+
+Alternatively, if you want to use the tooltip as a label, you must set the [`type`](/apis/tooltip-store#type) prop on the [`useTooltipStore`](/apis/tooltip-store) hook to `label`:
+
+```js
+const tooltip = useTooltipStore({ type: "label" });
+```
+
+This will make the tooltip behave like a label and will use the `aria-labelledby` attribute on the anchor element. Additionally, the tooltip's `role` attribute will be set to `none`.

--- a/examples/dialog-framer-motion/readme.md
+++ b/examples/dialog-framer-motion/readme.md
@@ -4,7 +4,23 @@
   Using <a href="https://www.framer.com/motion/">Framer Motion</a> to add initial and exit animations to a modal <a href="/components/dialog">Dialog</a> and its <a href="/apis/dialog#backdrop"><code>backdrop</code></a> element.
 </p>
 
+<div data-cards="components">
+
+- [](/components/button)
+- [](/components/dialog)
+
+</div>
+
 <a href="./index.tsx" data-playground>Example</a>
+
+## Related examples
+
+<div data-cards="examples">
+
+- [](/examples/menu-framer-motion)
+- [](/examples/tooltip-framer-motion)
+
+</div>
 
 ## AnimatePresence
 

--- a/examples/hovercard/test-browser.ts
+++ b/examples/hovercard/test-browser.ts
@@ -10,6 +10,8 @@ test.beforeEach(async ({ page }) => {
   await page.goto("/previews/hovercard", { waitUntil: "networkidle" });
 });
 
+test.describe.configure({ retries: process.env.CI ? 2 : 1 });
+
 test("https://github.com/ariakit/ariakit/issues/1662", async ({ page }) => {
   await getAnchor(page).hover();
   await expect(getHovercard(page)).toBeVisible();

--- a/examples/menu-framer-motion/readme.md
+++ b/examples/menu-framer-motion/readme.md
@@ -4,7 +4,22 @@
   Abstracting <a href="/components/menu">Menu</a> into a reusable dropdown menu component that uses <a href="https://www.framer.com/motion/">Framer Motion</a> to create smooth initial and exit animations.
 </p>
 
+<div data-cards="components">
+
+- [](/components/menu)
+
+</div>
+
 <a href="./index.tsx" data-playground>Example</a>
+
+## Related examples
+
+<div data-cards="examples">
+
+- [](/examples/dialog-framer-motion)
+- [](/examples/tooltip-framer-motion)
+
+</div>
 
 ## Controlling the Menu state
 

--- a/examples/tooltip-framer-motion/index.tsx
+++ b/examples/tooltip-framer-motion/index.tsx
@@ -1,0 +1,15 @@
+import { TooltipAnchor } from "./tooltip-anchor.jsx";
+import "./style.css";
+
+export default function Example() {
+  const href = "https://ariakit.org/examples/tooltip-framer-motion";
+  return (
+    <TooltipAnchor
+      description={href}
+      className="link"
+      render={(props) => <a href={href} {...props} />}
+    >
+      Tooltip with Framer Motion
+    </TooltipAnchor>
+  );
+}

--- a/examples/tooltip-framer-motion/readme.md
+++ b/examples/tooltip-framer-motion/readme.md
@@ -1,0 +1,32 @@
+# Tooltip with Framer Motion
+
+<p data-description>
+  Abstracting <a href="/components/tooltip">Tooltip</a> into a reusable custom component that uses <a href="https://www.framer.com/motion/">Framer Motion</a> to create smooth initial and exit animations.
+</p>
+
+<div data-cards="components">
+
+- [](/components/tooltip)
+
+</div>
+
+<a href="./index.tsx" data-playground>Example</a>
+
+## Related examples
+
+<div data-cards="examples">
+
+- [](/examples/menu-framer-motion)
+- [](/examples/dialog-framer-motion)
+
+</div>
+
+## Composing with other components
+
+In the custom `TooltipAnchor` component we've created in this example, we're exposing the [`render`](/apis/tooltip-anchor#render) prop to allow the user to render the anchor element however they want.
+
+```jsx
+<TooltipAnchor render={(props) => <a {...props} />} />
+```
+
+You can learn more about this pattern on the [Composition](/guide/composition#render) guide.

--- a/examples/tooltip-framer-motion/site-icon.tsx
+++ b/examples/tooltip-framer-motion/site-icon.tsx
@@ -1,0 +1,25 @@
+export default function Icon() {
+  return (
+    <svg viewBox="0 0 128 128" width={128} height={128}>
+      <foreignObject width={128} height={128}>
+        <div className="flex h-full flex-col items-center justify-center gap-4 p-5">
+          <div className="h-6 w-14 rounded-t bg-black/10 dark:bg-white/10" />
+          <div className="-mt-8 h-6 w-14 rounded-t bg-black/20 dark:bg-white/20" />
+          <div className="-mt-8 flex w-14 flex-col items-center gap-2 rounded bg-gray-450 p-4 pb-0 dark:bg-gray-300">
+            <svg
+              viewBox="0 0 16 16"
+              width={16}
+              height={16}
+              className="-mb-2 flex-none"
+            >
+              <foreignObject width={16} height={16} transform="rotate(45 8 8)">
+                <div className="h-3 w-3 bg-gray-450 dark:bg-gray-300" />
+              </foreignObject>
+            </svg>
+          </div>
+          <div className="h-2 w-6 bg-blue-600 dark:bg-blue-400" />
+        </div>
+      </foreignObject>
+    </svg>
+  );
+}

--- a/examples/tooltip-framer-motion/style.css
+++ b/examples/tooltip-framer-motion/style.css
@@ -1,2 +1,1 @@
-@import url("../button/style.css");
 @import url("../tooltip/style.css");

--- a/examples/tooltip-framer-motion/test.ts
+++ b/examples/tooltip-framer-motion/test.ts
@@ -1,0 +1,51 @@
+import { version } from "react";
+import {
+  click,
+  getByRole,
+  hover,
+  press,
+  queryByRole,
+  waitFor,
+} from "@ariakit/test";
+
+const getAnchor = () => getByRole("link");
+const getTooltip = () => queryByRole("tooltip", { hidden: true });
+
+const hoverOutside = async () => {
+  await hover(document.body);
+  await hover(document.body, { clientX: 10, clientY: 10 });
+  await hover(document.body, { clientX: 20, clientY: 20 });
+};
+
+const is17 = version.startsWith("17");
+
+describe.skipIf(is17)("tooltip-framer-motion", () => {
+  test("show tooltip on hover", async () => {
+    expect(getTooltip()).not.toBeInTheDocument();
+    await hover(getAnchor());
+    await waitFor(() => expect(getTooltip()).toBeVisible());
+    await hoverOutside();
+    expect(getTooltip()).toBeVisible();
+    await waitFor(() => expect(getTooltip()).not.toBeInTheDocument());
+  });
+
+  test("show tooltip on focus", async () => {
+    expect(getTooltip()).not.toBeInTheDocument();
+    await press.Tab();
+    expect(getTooltip()).toBeVisible();
+    await click(document.body);
+    expect(getTooltip()).toBeVisible();
+    await waitFor(() => expect(getTooltip()).not.toBeInTheDocument());
+  });
+
+  test("click on tooltip and press esc", async () => {
+    expect(getTooltip()).not.toBeInTheDocument();
+    await hover(getAnchor());
+    await waitFor(() => expect(getTooltip()).toBeVisible());
+    await click(getTooltip()!);
+    expect(getTooltip()).toBeVisible();
+    await press.Escape();
+    expect(getAnchor()).toHaveFocus();
+    await waitFor(() => expect(getTooltip()).not.toBeInTheDocument());
+  });
+});

--- a/examples/tooltip-framer-motion/tooltip-anchor.tsx
+++ b/examples/tooltip-framer-motion/tooltip-anchor.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+import * as Ariakit from "@ariakit/react";
+import { AnimatePresence, motion } from "framer-motion";
+
+interface Props extends React.HTMLAttributes<HTMLElement> {
+  description: string;
+  render?: Ariakit.TooltipAnchorProps["render"];
+}
+
+export const TooltipAnchor = React.forwardRef<HTMLDivElement, Props>(
+  ({ description, ...props }, ref) => {
+    const tooltip = Ariakit.useTooltipStore({ hideTimeout: 250 });
+    const mounted = tooltip.useState("mounted");
+
+    // We move the tooltip up or down depending on the current placement.
+    const y = tooltip.useState((state) => {
+      const dir = state.currentPlacement.split("-")[0]!;
+      return dir === "top" ? -8 : 8;
+    });
+
+    return (
+      <>
+        <Ariakit.TooltipAnchor store={tooltip} ref={ref} {...props} />
+        <AnimatePresence>
+          {mounted && (
+            <Ariakit.Tooltip
+              store={tooltip}
+              hidden={false}
+              gutter={4}
+              className="tooltip"
+              as={motion.div}
+              initial={{ opacity: 0, y }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y }}
+            >
+              <Ariakit.TooltipArrow />
+              {description}
+            </Ariakit.Tooltip>
+          )}
+        </AnimatePresence>
+      </>
+    );
+  }
+);

--- a/examples/tooltip-label/index.tsx
+++ b/examples/tooltip-label/index.tsx
@@ -19,9 +19,9 @@ export default function Example() {
   return (
     <>
       <Ariakit.TooltipAnchor
-        as={Ariakit.Button}
         store={tooltip}
         className="button"
+        as={Ariakit.Button}
       >
         {icon}
       </Ariakit.TooltipAnchor>

--- a/examples/tooltip-label/style.css
+++ b/examples/tooltip-label/style.css
@@ -1,1 +1,2 @@
+@import url("../button/style.css");
 @import url("../tooltip/style.css");

--- a/examples/tooltip-label/test-mobile.ts
+++ b/examples/tooltip-label/test-mobile.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/tooltip", { waitUntil: "networkidle" });
+  await page.goto("/previews/tooltip-label", { waitUntil: "networkidle" });
 });
 
 test("tooltip does not appear on mobile click", async ({ page }) => {

--- a/examples/tooltip-label/test.ts
+++ b/examples/tooltip-label/test.ts
@@ -1,4 +1,4 @@
-import { getByRole, getByText, hover, waitFor } from "@ariakit/test";
+import { click, getByRole, getByText, hover, waitFor } from "@ariakit/test";
 
 const getButton = () => getByRole("button", { name: "Bold" });
 const getTooltip = () => getByText("Bold");
@@ -13,6 +13,15 @@ test("show tooltip on hover", async () => {
   expect(getTooltip()).not.toBeVisible();
   await hover(getButton());
   await waitFor(() => expect(getTooltip()).toBeVisible());
+  await hoverOutside();
+  expect(getTooltip()).not.toBeVisible();
+});
+
+test("do not hide tooltip on click", async () => {
+  await hover(getButton());
+  await waitFor(() => expect(getTooltip()).toBeVisible());
+  await click(getButton());
+  expect(getTooltip()).toBeVisible();
   await hoverOutside();
   expect(getTooltip()).not.toBeVisible();
 });

--- a/examples/tooltip/index.tsx
+++ b/examples/tooltip/index.tsx
@@ -7,13 +7,14 @@ export default function Example() {
     <>
       <Ariakit.TooltipAnchor
         store={tooltip}
-        as="button"
-        className="button secondary"
+        as="a"
+        href="https://ariakit.org/components/tooltip"
+        className="link"
       >
-        Hover or focus on me
+        Tooltip
       </Ariakit.TooltipAnchor>
       <Ariakit.Tooltip store={tooltip} className="tooltip">
-        Tooltip
+        https://ariakit.org/components/tooltip
       </Ariakit.Tooltip>
     </>
   );

--- a/examples/tooltip/site-icon.tsx
+++ b/examples/tooltip/site-icon.tsx
@@ -1,0 +1,23 @@
+export default function Icon() {
+  return (
+    <svg viewBox="0 0 128 128" width={128} height={128}>
+      <foreignObject width={128} height={128}>
+        <div className="flex h-full flex-col items-center justify-center gap-4 p-5">
+          <div className="flex w-14 flex-col items-center gap-2 rounded bg-gray-450 p-4 pb-0 dark:bg-gray-300">
+            <svg
+              viewBox="0 0 16 16"
+              width={16}
+              height={16}
+              className="-mb-2 flex-none"
+            >
+              <foreignObject width={16} height={16} transform="rotate(45 8 8)">
+                <div className="h-3 w-3 bg-gray-450 dark:bg-gray-300" />
+              </foreignObject>
+            </svg>
+          </div>
+          <div className="h-2 w-6 bg-blue-600 dark:bg-blue-400" />
+        </div>
+      </foreignObject>
+    </svg>
+  );
+}

--- a/examples/tooltip/style.css
+++ b/examples/tooltip/style.css
@@ -1,5 +1,3 @@
-@import url("../button/style.css");
-
 .tooltip {
   @apply
     rounded-md
@@ -16,5 +14,17 @@
     dark:bg-gray-700
     shadow-sm
     dark:shadow-sm-dark
+  ;
+}
+
+.link {
+  @apply
+    font-medium
+    underline
+    decoration-1
+    hover:decoration-[3px]
+    underline-offset-[0.25em]
+    text-blue-700
+    dark:text-blue-400
   ;
 }

--- a/examples/tooltip/test.ts
+++ b/examples/tooltip/test.ts
@@ -1,9 +1,7 @@
 import { click, getByRole, hover, press, waitFor } from "@ariakit/test";
 
+const getAnchor = () => getByRole("link");
 const getTooltip = () => getByRole("tooltip", { hidden: true });
-
-const waitForTooltipToShow = () =>
-  waitFor(() => expect(getTooltip()).toBeVisible());
 
 const hoverOutside = async () => {
   await hover(document.body);
@@ -13,33 +11,24 @@ const hoverOutside = async () => {
 
 test("show tooltip on hover", async () => {
   expect(getTooltip()).not.toBeVisible();
-  await hover(getByRole("button"));
-  await waitForTooltipToShow();
-  await hoverOutside();
-  expect(getTooltip()).not.toBeVisible();
-});
-
-test("do not hide tooltip on click", async () => {
-  await hover(getByRole("button"));
-  await waitForTooltipToShow();
-  await click(getByRole("button"));
-  expect(getTooltip()).toBeVisible();
+  await hover(getAnchor());
+  await waitFor(() => expect(getTooltip()).toBeVisible());
   await hoverOutside();
   expect(getTooltip()).not.toBeVisible();
 });
 
 test("do not wait to show the tooltip if it was just hidden", async () => {
-  await hover(getByRole("button"));
-  await waitForTooltipToShow();
+  await hover(getAnchor());
+  await waitFor(() => expect(getTooltip()).toBeVisible());
   await hoverOutside();
   expect(getTooltip()).not.toBeVisible();
-  await hover(getByRole("button"));
+  await hover(getAnchor());
   expect(getTooltip()).toBeVisible();
 });
 
 test("if tooltip was shown on hover, then the anchor received keyboard focus, do not hide on mouseleave", async () => {
-  await hover(getByRole("button"));
-  await waitForTooltipToShow();
+  await hover(getAnchor());
+  await waitFor(() => expect(getTooltip()).toBeVisible());
   await press.Tab();
   expect(getTooltip()).toBeVisible();
   await hoverOutside();
@@ -48,13 +37,24 @@ test("if tooltip was shown on hover, then the anchor received keyboard focus, do
 
 test("if tooltip was shown on focus visible, do not hide on mouseleave", async () => {
   await press.Tab();
-  await waitForTooltipToShow();
+  await waitFor(() => expect(getTooltip()).toBeVisible());
   await hoverOutside();
   expect(getTooltip()).toBeVisible();
-  await hover(getByRole("button"));
+  await hover(getAnchor());
   expect(getTooltip()).toBeVisible();
   await hoverOutside();
   expect(getTooltip()).toBeVisible();
+});
+
+test("click on tooltip and press esc", async () => {
+  expect(getTooltip()).not.toBeVisible();
+  await hover(getAnchor());
+  await waitFor(() => expect(getTooltip()).toBeVisible());
+  await click(getTooltip()!);
+  expect(getTooltip()).toBeVisible();
+  await press.Escape();
+  expect(getAnchor()).toHaveFocus();
+  await waitFor(() => expect(getTooltip()).not.toBeVisible());
 });
 
 test("show tooltip on focus", async () => {
@@ -76,14 +76,14 @@ test("do not show tooltip immediately if focus was lost", async () => {
   div.tabIndex = 0;
   document.body.append(div);
 
-  await hover(getByRole("button"));
-  await waitForTooltipToShow();
+  await hover(getAnchor());
+  await waitFor(() => expect(getTooltip()).toBeVisible());
   await press.Tab();
   await press.Tab();
   expect(getTooltip()).not.toBeVisible();
-  await hover(getByRole("button"));
+  await hover(getAnchor());
   expect(getTooltip()).not.toBeVisible();
-  await waitForTooltipToShow();
+  await waitFor(() => expect(getTooltip()).toBeVisible());
 
   div.remove();
 });

--- a/packages/ariakit-core/src/hovercard/hovercard-store.ts
+++ b/packages/ariakit-core/src/hovercard/hovercard-store.ts
@@ -17,8 +17,6 @@ export function createHovercardStore(
 ): HovercardStore {
   const syncState = props.store?.getState();
 
-  const timeout = defaultValue(props.timeout, syncState?.timeout, 500);
-
   const popover = createPopoverStore({
     ...props,
     placement: defaultValue(
@@ -28,33 +26,17 @@ export function createHovercardStore(
     ),
   });
 
+  const timeout = defaultValue(props.timeout, syncState?.timeout, 500);
+
   const initialState: HovercardStoreState = {
     ...popover.getState(),
     timeout,
-    showTimeout: defaultValue(
-      props.showTimeout,
-      syncState?.showTimeout,
-      timeout
-    ),
-    hideTimeout: defaultValue(
-      props.hideTimeout,
-      syncState?.hideTimeout,
-      timeout
-    ),
+    showTimeout: defaultValue(props.showTimeout, syncState?.showTimeout),
+    hideTimeout: defaultValue(props.hideTimeout, syncState?.hideTimeout),
     autoFocusOnShow: defaultValue(syncState?.autoFocusOnShow, false),
   };
 
   const hovercard = createStore(initialState, popover, props.store);
-
-  hovercard.setup(() =>
-    hovercard.sync(
-      (state) => {
-        hovercard.setState("showTimeout", (value) => value ?? state.timeout);
-        hovercard.setState("hideTimeout", (value) => value ?? state.timeout);
-      },
-      ["timeout"]
-    )
-  );
 
   return {
     ...popover,
@@ -79,12 +61,12 @@ export interface HovercardStoreState extends PopoverStoreState {
    * The amount of time in milliseconds to wait before **showing** the popover.
    * It defaults to the value passed to `timeout`.
    */
-  showTimeout: number;
+  showTimeout?: number;
   /**
    * The amount of time in milliseconds to wait before **hiding** the popover.
    * It defaults to the value passed to `timeout`.
    */
-  hideTimeout: number;
+  hideTimeout?: number;
   /**
    * Whether the popover or an element inside it should be focused when it is
    * shown.

--- a/packages/ariakit-core/src/menu/menu-store.ts
+++ b/packages/ariakit-core/src/menu/menu-store.ts
@@ -126,18 +126,6 @@ export interface MenuStoreState<T extends Values = Values>
   extends CompositeStoreState,
     HovercardStoreState {
   /**
-   * @default "vertical"
-   */
-  orientation: CompositeStoreState["orientation"];
-  /**
-   * @default "bottom-start"
-   */
-  placement: HovercardStoreState["placement"];
-  /**
-   * @default 0
-   */
-  hideTimeout: HovercardStoreState["hideTimeout"];
-  /**
    * Determines the element that should be focused when the menu is opened.
    */
   initialFocus: "container" | "first" | "last";
@@ -146,6 +134,12 @@ export interface MenuStoreState<T extends Values = Values>
    * `MenuItemRadio` components.
    */
   values: T;
+  /** @default "vertical" */
+  orientation: CompositeStoreState["orientation"];
+  /** @default "bottom-start" */
+  placement: HovercardStoreState["placement"];
+  /** @default 0 */
+  hideTimeout?: HovercardStoreState["hideTimeout"];
 }
 
 export interface MenuStoreFunctions<T extends Values = Values>

--- a/packages/ariakit-core/src/tooltip/tooltip-store.ts
+++ b/packages/ariakit-core/src/tooltip/tooltip-store.ts
@@ -23,18 +23,7 @@ export function createTooltipStore(
       syncState?.placement,
       "top" as const
     ),
-    showTimeout: defaultValue(
-      props.showTimeout,
-      syncState?.showTimeout,
-      props.timeout,
-      500
-    ),
-    hideTimeout: defaultValue(
-      props.hideTimeout,
-      syncState?.hideTimeout,
-      props.timeout,
-      0
-    ),
+    hideTimeout: defaultValue(props.hideTimeout, syncState?.hideTimeout, 0),
   });
 
   const initialState: TooltipStoreState = {
@@ -67,11 +56,7 @@ export interface TooltipStoreState extends HovercardStoreState {
   /** @default "top" */
   placement: HovercardStoreState["placement"];
   /** @default 0 */
-  timeout: HovercardStoreState["timeout"];
-  /** @default 500 */
-  showTimeout: HovercardStoreState["showTimeout"];
-  /** @default 0 */
-  hideTimeout: HovercardStoreState["hideTimeout"];
+  hideTimeout?: HovercardStoreState["hideTimeout"];
 }
 
 export type TooltipStoreFunctions = HovercardStoreFunctions;

--- a/packages/ariakit-react-core/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-core/src/dialog/dialog.tsx
@@ -299,7 +299,7 @@ export const useDialog = createHook<DialogOptions>(
       const isElementFocusable = isFocusable(element);
       if (!autoFocusOnShowProp(isElementFocusable ? element : null)) return;
       setAutoFocusEnabled(true);
-      element.focus();
+      queueMicrotask(() => element.focus());
     }, [
       open,
       mayAutoFocusOnShow,
@@ -376,7 +376,7 @@ export const useDialog = createHook<DialogOptions>(
         }
         if (!autoFocusOnHideProp(isElementFocusable ? element : null)) return;
         if (!isElementFocusable) return;
-        element?.focus();
+        queueMicrotask(() => element?.focus());
       };
       if (!open) {
         // If this effect is running while the open state is false, this means

--- a/packages/ariakit-react-core/src/hovercard/hovercard-anchor.ts
+++ b/packages/ariakit-react-core/src/hovercard/hovercard-anchor.ts
@@ -65,14 +65,14 @@ export const useHovercardAnchor = createHook<HovercardAnchorOptions>(
         if (showTimeoutRef.current) return;
         if (!isMouseMoving()) return;
         if (!showOnHoverProp(event)) return;
-        const { showTimeout } = store.getState();
+        const { showTimeout, timeout } = store.getState();
         showTimeoutRef.current = window.setTimeout(() => {
           showTimeoutRef.current = 0;
           // Let's check again if the mouse is moving. This is to avoid showing
           // the hovercard on mobile clicks or after clicking on the anchor.
           if (!isMouseMoving()) return;
           store.show();
-        }, showTimeout);
+        }, showTimeout ?? timeout);
       }
     );
 

--- a/packages/ariakit-react-core/src/hovercard/hovercard-store.ts
+++ b/packages/ariakit-react-core/src/hovercard/hovercard-store.ts
@@ -9,7 +9,7 @@ import {
   usePopoverStoreProps,
 } from "../popover/popover-store.js";
 import type { Store } from "../utils/store.js";
-import { useStore } from "../utils/store.js";
+import { useStore, useStoreProps } from "../utils/store.js";
 
 export function useHovercardStoreOptions(props: HovercardStoreProps) {
   return usePopoverStoreOptions(props);
@@ -19,7 +19,11 @@ export function useHovercardStoreProps<T extends HovercardStore>(
   store: T,
   props: HovercardStoreProps
 ) {
-  return usePopoverStoreProps(store, props);
+  store = usePopoverStoreProps(store, props);
+  useStoreProps(store, props, "timeout");
+  useStoreProps(store, props, "showTimeout");
+  useStoreProps(store, props, "hideTimeout");
+  return store;
 }
 
 /**

--- a/packages/ariakit-react-core/src/tooltip/tooltip-anchor.ts
+++ b/packages/ariakit-react-core/src/tooltip/tooltip-anchor.ts
@@ -84,7 +84,6 @@ export const useTooltipAnchor = createHook<TooltipAnchorOptions>(
     const contentId = store.useState((state) => state.contentElement?.id);
 
     props = {
-      tabIndex: 0,
       "aria-labelledby": type === "label" ? contentId : undefined,
       "aria-describedby": type === "description" ? contentId : undefined,
       ...props,

--- a/packages/ariakit-react-core/src/tooltip/tooltip-store.ts
+++ b/packages/ariakit-react-core/src/tooltip/tooltip-store.ts
@@ -9,7 +9,7 @@ import {
   useHovercardStoreProps,
 } from "../hovercard/hovercard-store.js";
 import type { Store } from "../utils/store.js";
-import { useStore } from "../utils/store.js";
+import { useStore, useStoreProps } from "../utils/store.js";
 
 export function useTooltipStoreOptions(props: TooltipStoreProps) {
   return useHovercardStoreOptions(props);
@@ -19,7 +19,10 @@ export function useTooltipStoreProps<T extends TooltipStore>(
   store: T,
   props: TooltipStoreProps
 ) {
-  return useHovercardStoreProps(store, props);
+  store = useHovercardStoreProps(store, props);
+  useStoreProps(store, props, "type");
+  useStoreProps(store, props, "skipTimeout");
+  return store;
 }
 
 /**

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   forbidOnly: CI,
   reportSlowTests: null,
   reporter: CI ? [["github"], ["dot"]] : [["list"]],
-  retries: CI ? 1 : 0,
+  retries: 1,
   webServer: {
     command: "npm start",
     reuseExistingServer: !CI,
@@ -41,7 +41,7 @@ export default defineConfig({
     {
       name: "firefox",
       testMatch: [/\/test[^\/]*\-firefox/, /\/test[^\/]*\-browser/],
-      retries: CI ? 2 : 0,
+      retries: CI ? 2 : 1,
       use: devices["Desktop Firefox"],
     },
     {

--- a/website/app/(main)/[category]/[page]/page.tsx
+++ b/website/app/(main)/[category]/[page]/page.tsx
@@ -150,10 +150,12 @@ const style = {
 
 function findCardLinks(children: ReactNode & ReactNode[]): string[] {
   return Children.toArray(children).flatMap((child) =>
-    isValidElement(child) && child.props?.href
-      ? child.props.href
-      : child.props?.children
-      ? findCardLinks(child.props.children)
+    isValidElement(child)
+      ? child.props?.href
+        ? child.props.href
+        : child.props?.children
+        ? findCardLinks(child.props.children)
+        : []
       : []
   );
 }

--- a/website/app/(main)/[category]/[page]/page.tsx
+++ b/website/app/(main)/[category]/[page]/page.tsx
@@ -9,6 +9,7 @@ import { getPageTreeFromContent } from "build-pages/get-page-tree.js";
 import pagesIndex from "build-pages/index.js";
 import type { TableOfContents as TableOfContentsData } from "build-pages/types.js";
 import { CodeBlock } from "components/code-block.js";
+import { PageItem } from "components/page-item.jsx";
 import matter from "gray-matter";
 import { ArrowRight } from "icons/arrow-right.jsx";
 import { Hashtag } from "icons/hashtag.js";
@@ -20,6 +21,7 @@ import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import rehypeSlug from "rehype-slug";
 import { getNextPageMetadata } from "utils/get-next-page-metadata.js";
+import { getPageIcon } from "utils/get-page-icon.jsx";
 import { rehypeCodeMeta } from "utils/rehype-code-meta.js";
 import { rehypeWrapHeadings } from "utils/rehype-wrap-headings.js";
 import { tw } from "utils/tw.js";
@@ -141,7 +143,20 @@ const style = {
     data-[api]:leading-8 data-[api]:tracking-wide
     data-[api]:text-black/60 dark:data-[api]:text-white/60
   `,
+  cards: tw`
+    grid grid-cols-1 gap-4 md:grid-cols-2
+  `,
 };
+
+function findCardLinks(children: ReactNode & ReactNode[]): string[] {
+  return Children.toArray(children).flatMap((child) =>
+    isValidElement(child) && child.props?.href
+      ? child.props.href
+      : child.props?.children
+      ? findCardLinks(child.props.children)
+      : []
+  );
+}
 
 function getPageNames(dir: string | string[]) {
   return getPageEntryFiles(dir).map(getPageName);
@@ -234,6 +249,55 @@ export default async function Page({ params }: PageProps) {
                     {...props}
                     className={cx(style.wrapper, props.className)}
                   />
+                );
+              }
+              if (node.properties?.dataCards != null) {
+                const links = findCardLinks(props.children);
+                const pages = links.flatMap((link) => {
+                  const [, category, slug] = link.split("/");
+                  if (!category || !slug) return [];
+                  const page = pagesIndex[category]?.find(
+                    (item) => item.slug === slug
+                  );
+                  return page || [];
+                });
+                const type = node.properties.dataCards;
+                const isComponents = type === "components";
+                const isExamples = type === "examples";
+                const showViewAll =
+                  isExamples && pages.length === 6 && category === "components";
+                return (
+                  <>
+                    <div
+                      {...props}
+                      className={cx(
+                        style.cards,
+                        props.className,
+                        isExamples && "!max-w-[832px]"
+                      )}
+                    >
+                      {pages.map((page) => (
+                        <PageItem
+                          key={page.slug}
+                          href={`/${page.category}/${page.slug}`}
+                          title={page.title}
+                          description={page.content}
+                          size={isComponents ? "sm" : "md"}
+                          thumbnail={
+                            getPageIcon(page.category, page.slug) || <span />
+                          }
+                        />
+                      ))}
+                    </div>
+                    {showViewAll && (
+                      <Link
+                        href={`/examples#${page}`}
+                        className={cx(style.link, "text-center")}
+                      >
+                        View all {pageDetail?.title} examples
+                      </Link>
+                    )}
+                  </>
                 );
               }
               return <div {...props} />;

--- a/website/app/(main)/[category]/list-page-section.tsx
+++ b/website/app/(main)/[category]/list-page-section.tsx
@@ -2,6 +2,7 @@
 
 import type { PropsWithChildren } from "react";
 import { Heading, HeadingLevel } from "@ariakit/react/heading";
+import { kebabCase } from "lodash";
 import { tw } from "utils/tw.js";
 
 interface Props {
@@ -9,9 +10,11 @@ interface Props {
 }
 
 export function ListPageSection({ title, children }: PropsWithChildren<Props>) {
+  const slug = kebabCase(title);
   return (
     <HeadingLevel>
       <Heading
+        id={slug}
         className={tw`
         mt-6 scroll-mt-24 text-2xl font-semibold tracking-[-0.035em]
         text-black/70 dark:font-medium dark:tracking-[-0.015em]

--- a/website/app/(main)/[category]/page.tsx
+++ b/website/app/(main)/[category]/page.tsx
@@ -1,10 +1,10 @@
 import pagesConfig from "build-pages/config.js";
 import index from "build-pages/index.js";
+import { PageItem } from "components/page-item.jsx";
 import { groupBy } from "lodash";
 import { notFound } from "next/navigation.js";
 import { getNextPageMetadata } from "utils/get-next-page-metadata.js";
 import { getPageIcon } from "utils/get-page-icon.js";
-import { ListPageItem } from "./list-page-item.js";
 import { ListPageSection } from "./list-page-section.js";
 import { ListPage } from "./list-page.js";
 
@@ -50,7 +50,7 @@ export default function Page({ params }: Props) {
       {!!grouplessPages.length && (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
           {grouplessPages.map((page) => (
-            <ListPageItem
+            <PageItem
               key={page.slug}
               href={`/${category}/${page.slug}`}
               title={page.title}
@@ -65,7 +65,7 @@ export default function Page({ params }: Props) {
         <ListPageSection key={group} title={group}>
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
             {pages?.map((page) => (
-              <ListPageItem
+              <PageItem
                 key={page.slug}
                 href={`/${category}/${page.slug}`}
                 title={page.title}

--- a/website/components/page-item.tsx
+++ b/website/components/page-item.tsx
@@ -39,7 +39,7 @@ interface Props extends AnchorHTMLAttributes<HTMLAnchorElement> {
   size?: "sm" | "md" | "lg";
 }
 
-export function ListPageItem({
+export function PageItem({
   title,
   thumbnail,
   description,


### PR DESCRIPTION
This PR adds a new `Tooltip with Framer Motion` example and fixes some minor bugs related to this. Check out the changeset files for more details.