### PR TITLE
Fix Tab activeId sync

### DIFF
--- a/.changeset/tab-activeid.md
+++ b/.changeset/tab-activeid.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/core": patch
+"@ariakit/react": patch
+---
+
+Fixed `activeId` state on `Tab` not updating correctly when setting `selectedId` with the Next.js App Router. ([#2443](https://github.com/ariakit/ariakit/pull/2443))

--- a/examples/dialog-nested/confirm-dialog.tsx
+++ b/examples/dialog-nested/confirm-dialog.tsx
@@ -26,7 +26,7 @@ export function ConfirmDialog({
 }: Props) {
   const dialog = Ariakit.useDialogStore({
     open,
-    setOpen: (open) => {
+    setOpen(open) {
       if (!open) {
         onClose?.();
       }

--- a/examples/dialog-react-router/index.tsx
+++ b/examples/dialog-react-router/index.tsx
@@ -13,7 +13,7 @@ function Tweet() {
   const navigate = useNavigate();
   const dialog = Ariakit.useDialogStore({
     open: true,
-    setOpen: (open) => {
+    setOpen(open) {
       if (!open) {
         navigate("/");
       }

--- a/examples/dialog-react-router/readme.md
+++ b/examples/dialog-react-router/readme.md
@@ -6,6 +6,25 @@
 
 <a href="./index.tsx" data-playground>Example</a>
 
+## Related components
+
+<div data-cards="components">
+
+- [](/components/dialog)
+
+</div>
+
+## Related examples
+
+<div data-cards="examples">
+
+- [](/examples/tab-react-router)
+- [](/examples/dialog-next-router)
+- [](/examples/dialog-menu)
+- [](/examples/dialog-nested)
+
+</div>
+
 ## Controlling the Dialog state
 
 To control the open state, you can pass the [`open`](/apis/dialog-store#open) and [`setOpen`](/apis/dialog-store#setopen) props to [`useDialogStore`](/apis/dialog-store). These props allow you to synchronize the dialog state with other state sources, such as the browser history.
@@ -17,7 +36,7 @@ const navigate = useNavigate();
 
 const dialog = Ariakit.useDialogStore({
   open: true,
-  setOpen: (open) => {
+  setOpen(open) {
     if (!open) {
       navigate("/");
     }

--- a/examples/menu-dialog-animated/dialog.tsx
+++ b/examples/menu-dialog-animated/dialog.tsx
@@ -18,7 +18,7 @@ export const Dialog = React.forwardRef<HTMLDivElement, DialogProps>(
     const dialog = Ariakit.useDialogStore({
       animated,
       open,
-      setOpen: (open) => {
+      setOpen(open) {
         if (!open) {
           onClose?.();
         }

--- a/examples/popover-focus-within/popover.tsx
+++ b/examples/popover-focus-within/popover.tsx
@@ -30,8 +30,10 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(
     const popover = Ariakit.usePopoverStore({
       placement,
       open: isOpen,
-      setOpen: (open) => {
-        if (!open && onClose) onClose();
+      setOpen(open) {
+        if (!open) {
+          onClose?.();
+        }
       },
     });
     return (

--- a/examples/popover-lazy/index.tsx
+++ b/examples/popover-lazy/index.tsx
@@ -16,7 +16,7 @@ export default function Example() {
 
   const popover = Ariakit.usePopoverStore({
     open,
-    setOpen: (open) => {
+    setOpen(open) {
       if (open) {
         return startTransition(() => setOpen(open));
       }

--- a/examples/popover-standalone/popover.tsx
+++ b/examples/popover-standalone/popover.tsx
@@ -30,8 +30,10 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(
     const popover = Ariakit.usePopoverStore({
       placement,
       open: isOpen,
-      setOpen: (open) => {
-        if (!open && onClose) onClose();
+      setOpen(open) {
+        if (!open) {
+          onClose?.();
+        }
       },
     });
     return (

--- a/examples/tab-react-router/index.tsx
+++ b/examples/tab-react-router/index.tsx
@@ -4,7 +4,7 @@ import "./style.css";
 
 function GroceriesTabs() {
   return (
-    <Tabs selectOnMove={false}>
+    <Tabs>
       <div className="wrapper">
         <TabList aria-label="Groceries">
           <Tab to="/">Fruits</Tab>

--- a/examples/tab-react-router/tabs.tsx
+++ b/examples/tab-react-router/tabs.tsx
@@ -11,7 +11,13 @@ interface TabsProps extends Ariakit.TabStoreProps {
 
 export function Tabs({ children, ...props }: TabsProps) {
   const { pathname: selectedId } = useLocation();
-  const store = Ariakit.useTabStore({ selectedId, ...props });
+
+  const store = Ariakit.useTabStore({
+    selectOnMove: false,
+    selectedId,
+    ...props,
+  });
+
   return <TabsContext.Provider value={store}>{children}</TabsContext.Provider>;
 }
 
@@ -20,6 +26,7 @@ type TabListProps = Omit<Ariakit.TabListProps, "store">;
 export function TabList(props: TabListProps) {
   const tab = React.useContext(TabsContext);
   if (!tab) throw new Error("TabList must be wrapped in a Tabs component");
+
   return <Ariakit.TabList className="tab-list" {...props} store={tab} />;
 }
 
@@ -27,7 +34,8 @@ type TabProps = LinkProps;
 
 export function Tab(props: TabProps) {
   const id = useHref(props.to);
-  return <Ariakit.Tab className="tab" {...props} as={Link} id={id} />;
+
+  return <Ariakit.Tab as={Link} id={id} className="tab" {...props} />;
 }
 
 type TabPanelProps = Omit<Ariakit.TabPanelProps, "store">;
@@ -35,6 +43,8 @@ type TabPanelProps = Omit<Ariakit.TabPanelProps, "store">;
 export function TabPanel(props: TabPanelProps) {
   const tab = React.useContext(TabsContext);
   if (!tab) throw new Error("TabPanel must be wrapped in a Tabs component");
+
   const tabId = tab.useState("selectedId");
+
   return <Ariakit.TabPanel tabId={tabId} {...props} store={tab} />;
 }

--- a/guide/400-component-stores/readme.md
+++ b/guide/400-component-stores/readme.md
@@ -51,7 +51,7 @@ In addition to state, component stores may also accept state updater functions. 
 ```js {3-5}
 const form = useFormStore({
   defaultValues: { name: "", email: "" },
-  setValues: (values) => {
+  setValues(values) {
     console.log(values);
   },
 });

--- a/packages/ariakit-core/src/tab/tab-store.ts
+++ b/packages/ariakit-core/src/tab/tab-store.ts
@@ -73,7 +73,7 @@ export function createTabStore(props: TabStoreProps = {}): TabStore {
 
   // Keep activeId in sync with selectedId.
   tab.setup(() =>
-    tab.sync(
+    tab.syncBatch(
       (state) => tab.setState("activeId", state.selectedId),
       ["selectedId"]
     )

--- a/packages/ariakit-react-core/src/utils/store.tsx
+++ b/packages/ariakit-react-core/src/utils/store.tsx
@@ -11,12 +11,7 @@ import type {
   SetState,
 } from "@ariakit/core/utils/types";
 import { useSyncExternalStore } from "use-sync-external-store/shim/index.js";
-import {
-  useLazyValue,
-  useLiveRef,
-  useSafeLayoutEffect,
-  useUpdateLayoutEffect,
-} from "./hooks.js";
+import { useLazyValue, useLiveRef, useSafeLayoutEffect } from "./hooks.js";
 
 type UseState<S> = {
   /**
@@ -145,16 +140,9 @@ export function useStoreProps<
   // If the value prop is provided, we'll always reset the store state to it.
   useSafeLayoutEffect(() => {
     return store.sync(() => {
-      const { value } = propsRef.current;
       if (value === undefined) return;
       store.setState(key, value);
     }, [key]);
-  }, [store, key]);
-
-  // When the value prop changes, we set the state value to keep it controlled.
-  useUpdateLayoutEffect(() => {
-    if (value === undefined) return;
-    store.setState(key, value);
   }, [store, key, value]);
 }
 /**

--- a/website/app/(examples)/previews/dialog-next-router/readme.md
+++ b/website/app/(examples)/previews/dialog-next-router/readme.md
@@ -6,6 +6,25 @@
 
 <a href="./page.tsx" data-playground>Example</a>
 
+## Components
+
+<div data-cards="components">
+
+- [](/components/dialog)
+
+</div>
+
+## Related examples
+
+<div data-cards="examples">
+
+- [](/examples/tab-next-router/)
+- [](/examples/dialog-react-router/)
+- [](/examples/dialog-menu/)
+- [](/examples/dialog-nested/)
+
+</div>
+
 ## Controlling the Dialog state
 
 To control the open state, you can pass the [`open`](/apis/dialog-store#open) and [`setOpen`](/apis/dialog-store#setopen) props to [`useDialogStore`](/apis/dialog-store). These props allow you to synchronize the dialog state with other state sources, such as the browser history.

--- a/website/app/(examples)/previews/tab-next-router/readme.md
+++ b/website/app/(examples)/previews/tab-next-router/readme.md
@@ -6,6 +6,23 @@
 
 <a href="./layout.tsx" data-playground>Example</a>
 
+## Related components
+
+<div data-cards="components">
+
+- [](/components/tab)
+
+</div>
+
+## Related examples
+
+<div data-cards="examples">
+
+- [](/examples/dialog-next-router/)
+- [](/examples/tab-react-router/)
+
+</div>
+
 ## Abstracting the Tab components
 
 In this example, we're abstracting the Ariakit [Tab](/components/tab) components into higher-level components with a simpler API integrated with the [Next.js App Router](https://nextjs.org/docs/api-reference/next/router). Check out the `tabs.tsx` file above to see the source code.
@@ -16,13 +33,15 @@ We're using React Context to provide the tab store to the [`TabList`](/apis/tab-
 
 To control the selected tab state, you can pass the [`selectedId`](/apis/tab-store#selectedid) and [`setSelectedId`](/apis/tab-store#setselectedid) props to [`useTabStore`](/apis/tab-store). These props allow you to synchronize the tab state with other state sources, such as the browser history.
 
-```jsx {5,6}
+```jsx {5-8}
 const router = useRouter();
 const pathname = usePathname();
 
 const tab = Ariakit.useTabStore({
   selectedId: pathname,
-  setSelectedId: (id) => router.push(id || "/"),
+  setSelectedId(id) {
+    router.push(id || pathname);
+  },
 });
 ```
 
@@ -33,7 +52,7 @@ You can learn more about controlled state on the [Component stores](/guide/compo
 It's possible to render a single [`TabPanel`](/apis/tab-panel) component and use the [`tabId`](/apis/tab-panel#tabid) prop to point to the selected tab.
 
 ```jsx
-const selectedId = tab.useState("selectedId");
+const tabId = tab.useState("selectedId");
 
-<TabPanel tabId={selectedId}>{props.children}</TabPanel>;
+<TabPanel tabId={tabId}>{props.children}</TabPanel>;
 ```

--- a/website/app/(examples)/previews/tab-next-router/tabs.tsx
+++ b/website/app/(examples)/previews/tab-next-router/tabs.tsx
@@ -12,50 +12,41 @@ interface TabsProps extends Ariakit.TabStoreProps {
 
 export function Tabs({ children, ...props }: TabsProps) {
   const router = useRouter();
-  const pathname = usePathname();
+  const selectedId = usePathname();
 
   const tab = Ariakit.useTabStore({
+    selectedId,
+    setSelectedId: (id) => router.push(id || selectedId),
     ...props,
-    selectOnMove: false,
-    selectedId: pathname,
-    setSelectedId: (id) => router.push(id || "/"),
   });
 
   return <TabContext.Provider value={tab}>{children}</TabContext.Provider>;
 }
 
-type TabListProps = Partial<Ariakit.TabListProps>;
+type TabListProps = Omit<Ariakit.TabListProps, "store">;
 
-export const TabList = React.forwardRef<HTMLDivElement, TabListProps>(
-  (props, ref) => {
-    const tab = React.useContext(TabContext);
-    if (!tab) throw new Error("TabList must be wrapped in a Tabs component");
-    return (
-      <Ariakit.TabList className="tab-list" {...props} ref={ref} store={tab} />
-    );
-  }
-);
+export function TabList(props: TabListProps) {
+  const tab = React.useContext(TabContext);
+  if (!tab) throw new Error("TabList must be wrapped in a Tabs component");
+
+  return <Ariakit.TabList className="tab-list" {...props} store={tab} />;
+}
 
 type TabProps = Ariakit.TabProps<typeof Link>;
 
-export const Tab = React.forwardRef<HTMLAnchorElement, TabProps>(
-  (props, ref) => {
-    const id = props.href.toString();
-    return (
-      <Ariakit.Tab className="tab" {...props} as={Link} id={id} ref={ref} />
-    );
-  }
-);
+export function Tab(props: TabProps) {
+  const id = props.href.toString();
 
-type TabPanelProps = Partial<Ariakit.TabPanelProps>;
+  return <Ariakit.Tab as={Link} id={id} className="tab" {...props} />;
+}
 
-export const TabPanel = React.forwardRef<HTMLDivElement, TabPanelProps>(
-  (props, ref) => {
-    const tab = React.useContext(TabContext);
-    if (!tab) throw new Error("TabPanel must be wrapped in a Tabs component");
-    const selectedId = tab.useState("selectedId");
-    return (
-      <Ariakit.TabPanel {...props} ref={ref} store={tab} tabId={selectedId} />
-    );
-  }
-);
+type TabPanelProps = Omit<Ariakit.TabPanelProps, "store">;
+
+export function TabPanel(props: TabPanelProps) {
+  const tab = React.useContext(TabContext);
+  if (!tab) throw new Error("TabPanel must be wrapped in a Tabs component");
+
+  const tabId = tab.useState("selectedId");
+
+  return <Ariakit.TabPanel tabId={tabId} {...props} store={tab} />;
+}

--- a/website/app/(examples)/previews/tab-next-router/test-browser.ts
+++ b/website/app/(examples)/previews/tab-next-router/test-browser.ts
@@ -41,17 +41,19 @@ test("click on tabs", async ({ page }) => {
 test("select tabs with keyboard", async ({ page }) => {
   await getTab(page, "Hot").press("ArrowRight");
   await expect(getTab(page, "New")).toBeFocused();
-  await expect(getTabPanel(page, "Hot")).toBeVisible();
-  await expect(getTabPanel(page, "New")).not.toBeVisible();
-  await page.keyboard.press("Enter");
+  // Manual tabs
+  // await expect(getTabPanel(page, "Hot")).toBeVisible();
+  // await expect(getTabPanel(page, "New")).not.toBeVisible();
+  // await page.keyboard.press("Enter");
   await expect(getTabPanel(page, "Hot")).not.toBeVisible();
   await expect(getTabPanel(page, "New")).toBeVisible();
   await expect(getTab(page, "New")).toBeFocused();
   await page.keyboard.press("ArrowLeft");
   await expect(getTab(page, "Hot")).toBeFocused();
-  await expect(getTabPanel(page, "Hot")).not.toBeVisible();
-  await expect(getTabPanel(page, "New")).toBeVisible();
-  await page.keyboard.press("Enter");
+  // Manual tabs
+  // await expect(getTabPanel(page, "Hot")).not.toBeVisible();
+  // await expect(getTabPanel(page, "New")).toBeVisible();
+  // await page.keyboard.press("Enter");
   await expect(getTabPanel(page, "Hot")).toBeVisible();
   await expect(getTabPanel(page, "New")).not.toBeVisible();
   await expect(getTab(page, "Hot")).toBeFocused();

--- a/website/components/header-menu.tsx
+++ b/website/components/header-menu.tsx
@@ -239,18 +239,14 @@ export const HeaderMenu = forwardRef<HTMLButtonElement, HeaderMenuProps>(
       includesBaseElement: false,
       focusLoop: false,
       open,
-      setOpen: (open) => {
-        if (onToggle) {
-          onToggle(open);
-        }
-      },
+      setOpen: onToggle,
     });
     const select = useSelectStore({
       combobox,
       value,
-      setValue: (value) => {
-        if (onChange && typeof value === "string") {
-          onChange(value);
+      setValue(value) {
+        if (typeof value === "string") {
+          onChange?.(value);
         }
       },
     });


### PR DESCRIPTION
This PR fixed the [Tab with Next.js App Router](https://ariakit.org/examples/tab-next-router) example when the `selectOnMove` prop is set to `true` (default).

It turns out there was a problem with getting the `activeId` state in sync with `selectedId`.