### PR TITLE
Improve checkbox examples

### DIFF
--- a/.changeset/checkbox-examples-1.md
+++ b/.changeset/checkbox-examples-1.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+The `Checkbox` component now accepts `string[]` as the `value` prop. This is to conform with the native input prop type. If a string array is passed, it will be stringified, just like in the native input element. ([#2456](https://github.com/ariakit/ariakit/pull/2456))

--- a/.changeset/checkbox-examples-2.md
+++ b/.changeset/checkbox-examples-2.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed the `clickOnEnter` prop on `Checkbox` not working when rendering the component as a native input element. ([#2456](https://github.com/ariakit/ariakit/pull/2456))

--- a/components/checkbox.md
+++ b/components/checkbox.md
@@ -6,13 +6,15 @@
 
 <a href="../examples/checkbox/index.tsx" data-playground>Example</a>
 
-## Installation
+## Examples
 
-```sh
-npm i @ariakit/react
-```
+<div data-cards="examples">
 
-Learn more on the [Getting started](/guide/getting-started) guide.
+- [](/examples/checkbox-as-button)
+- [](/examples/checkbox-custom)
+- [](/examples/checkbox-group)
+
+</div>
 
 ## API
 
@@ -23,3 +25,16 @@ Learn more on the [Getting started](/guide/getting-started) guide.
   &lt;<a href="/apis/checkbox-check">CheckboxCheck</a> /&gt;
 &lt;/Checkbox&gt;
 </pre>
+
+## Related components
+
+<div data-cards="components">
+
+- [](/components/button)
+- [](/components/form)
+- [](/components/menu)
+- [](/components/radio)
+- [](/components/select)
+- [](/components/command)
+
+</div>

--- a/components/group.md
+++ b/components/group.md
@@ -1,0 +1,22 @@
+# Group
+
+<p data-description>
+  Group related elements in a generic container that may have a label. This abstract component is based on the <a href="https://w3c.github.io/aria/#group">WAI-ARIA Group Role</a>.
+</p>
+
+## API
+
+<pre data-api>
+&lt;<a href="/apis/group">Group</a>&gt;
+  &lt;<a href="/apis/group-label">GroupLabel</a> /&gt;
+&lt;/Group&gt;
+</pre>
+
+## Related components
+
+<div data-cards="components">
+
+- [](/components/form)
+- [](/components/composite)
+
+</div>

--- a/examples/checkbox-as-button/readme.md
+++ b/examples/checkbox-as-button/readme.md
@@ -4,7 +4,38 @@
   Rendering a custom <a href="/components/checkbox">Checkbox</a> as a <code>button</code> element in React, while keeping it accessible to screen reader and keyboard users.
 </p>
 
+<aside data-type="note" title="Need to render a native checkbox element?">
+
+This example demonstrates the rendering of a button element. However, if you intend to render the `Checkbox` as a form control or require the preservation of native input element properties for any specific purpose, please refer to the [Custom Checkbox](/examples/checkbox-custom) example.
+
+</aside>
+
 <a href="./index.tsx" data-playground>Example</a>
+
+## Components
+
+<div data-cards="components">
+
+- [](/components/checkbox)
+- [](/components/button)
+
+</div>
+
+## Activating on <kbd>Enter</kbd>
+
+By default, native checkbox elements are activated on <kbd>Space</kbd>, but not on <kbd>Enter</kbd>. The Ariakit `Checkbox` component allows you to control this behavior using the [`clickOnEnter`](/apis/checkbox#clickonenter) and [`clickOnSpace`](/apis/checkbox#clickonspace) props. However, when rendering the `Checkbox` as any non-native input element, the `clickOnEnter` prop will be automatically set to `true`.
+
+## Reading the state
+
+In this example, we're reading the [`value`](/apis/checkbox-store#value) state from the checkbox store to render the button's text. This is done by using the selector form of the [`useState`](/apis/checkbox-store#usestate) hook:
+
+```jsx
+const label = checkbox.useState((state) =>
+  state.value ? "Checked" : "Unchecked"
+);
+```
+
+Learn more about reading the state on the [Component stores](/guide/component-stores#reading-the-state) guide.
 
 ## Styling
 
@@ -13,8 +44,18 @@ When rendering the `Checkbox` component as a non-native `input` element, the `:c
 ```css
 .button[aria-checked="true"] {
   background-color: hsl(204 100% 40%);
-  color: hsl(204, 20%, 100%);
+  color: hsl(204 20% 100%);
 }
 ```
 
 Learn more on the [Styling](/guide/styling) guide.
+
+## Related examples
+
+<div data-cards="examples">
+
+- [](/examples/checkbox-custom)
+- [](/examples/checkbox-group)
+- [](/examples/menu-item-checkbox)
+
+</div>

--- a/examples/checkbox-as-button/site-icon.tsx
+++ b/examples/checkbox-as-button/site-icon.tsx
@@ -2,13 +2,13 @@ export default function Icon() {
   return (
     <svg viewBox="0 0 128 128" width={128} height={128}>
       <foreignObject width={128} height={128}>
-        <div className="flex h-full items-center justify-center p-4">
-          <div className="flex items-center justify-center rounded bg-blue-600 p-2">
+        <div className="flex h-full w-full items-center justify-center p-4">
+          <div className="w-20 gap-2 rounded bg-blue-600 p-2">
             <svg
               fill="none"
               viewBox="0 0 24 24"
               strokeWidth={4}
-              className="h-8 w-8 stroke-white"
+              className="h-6 w-6 stroke-white"
             >
               <path d="M4.5 12.75l6 6 9-13.5" />
             </svg>

--- a/examples/checkbox-as-button/style.css
+++ b/examples/checkbox-as-button/style.css
@@ -5,15 +5,12 @@
     text-blue-900
     bg-blue-200/40
     hover:bg-blue-200/60
-
     dark:text-blue-100
     dark:bg-blue-600/25
     dark:hover:bg-blue-600/40
-
     aria-checked:text-white
     aria-checked:bg-blue-600
     aria-checked:hover:bg-blue-800
-
     dark:aria-checked:text-white
     dark:aria-checked:bg-blue-600
     dark:aria-checked:hover:bg-blue-800

--- a/examples/checkbox-controlled/readme.md
+++ b/examples/checkbox-controlled/readme.md
@@ -1,7 +1,0 @@
-# Controlled Checkbox
-
-<p data-description>
-  Using controlled props, such as <code>checked</code> and <code>onChange</code>, with a native <a href="/components/checkbox">Checkbox</a> component in React.
-</p>
-
-<a href="./index.tsx" data-playground>Example</a>

--- a/examples/checkbox-custom/checkbox.tsx
+++ b/examples/checkbox-custom/checkbox.tsx
@@ -1,0 +1,48 @@
+import { forwardRef, useState } from "react";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import * as Ariakit from "@ariakit/react";
+
+interface CheckboxProps extends ComponentPropsWithoutRef<"input"> {
+  children?: ReactNode;
+}
+
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
+  function Checkbox({ children, ...props }, ref) {
+    const [checked, setChecked] = useState(props.defaultChecked ?? false);
+    const [focusVisible, setFocusVisible] = useState(false);
+    return (
+      <label
+        className="checkbox"
+        data-checked={checked}
+        data-focus-visible={focusVisible || undefined}
+      >
+        <Ariakit.VisuallyHidden>
+          <Ariakit.Checkbox
+            {...props}
+            ref={ref}
+            clickOnEnter
+            onFocusVisible={() => setFocusVisible(true)}
+            onBlur={() => setFocusVisible(false)}
+            onChange={(event) => {
+              setChecked(event.target.checked);
+              props.onChange?.(event);
+            }}
+          />
+        </Ariakit.VisuallyHidden>
+        <div className="check" data-checked={checked}>
+          <svg
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            viewBox="0 0 16 16"
+            height="1em"
+            width="1em"
+          >
+            <polyline points="4,8 7,12 12,4" />
+          </svg>
+        </div>
+        {children}
+      </label>
+    );
+  }
+);

--- a/examples/checkbox-custom/index.tsx
+++ b/examples/checkbox-custom/index.tsx
@@ -1,24 +1,6 @@
-import { useState } from "react";
-import * as Ariakit from "@ariakit/react";
+import { Checkbox } from "./checkbox.jsx";
 import "./style.css";
 
 export default function Example() {
-  const checkbox = Ariakit.useCheckboxStore({ defaultValue: false });
-  const [focusVisible, setFocusVisible] = useState(false);
-  const checked = checkbox.useState("value");
-  return (
-    <label className="label">
-      <Ariakit.VisuallyHidden>
-        <Ariakit.Checkbox
-          store={checkbox}
-          onFocusVisible={() => setFocusVisible(true)}
-          onBlur={() => setFocusVisible(false)}
-        />
-      </Ariakit.VisuallyHidden>
-      <div className="checkbox" data-focus-visible={focusVisible ? "" : null}>
-        <Ariakit.CheckboxCheck checked={checked} />
-      </div>
-      I have read and agree to the terms and conditions
-    </label>
-  );
+  return <Checkbox defaultChecked>Ariakit</Checkbox>;
 }

--- a/examples/checkbox-custom/readme.md
+++ b/examples/checkbox-custom/readme.md
@@ -5,3 +5,22 @@
 </p>
 
 <a href="./index.tsx" data-playground>Example</a>
+
+## Components
+
+<div data-cards="components">
+
+- [](/components/checkbox)
+- [](/components/visually-hidden)
+
+</div>
+
+## Related examples
+
+<div data-cards="examples">
+
+- [](/examples/checkbox-as-button)
+- [](/examples/checkbox-group)
+- [](/examples/menu-item-checkbox)
+
+</div>

--- a/examples/checkbox-custom/site-icon.tsx
+++ b/examples/checkbox-custom/site-icon.tsx
@@ -1,0 +1,23 @@
+export default function Icon() {
+  return (
+    <svg viewBox="0 0 128 128" width={128} height={128}>
+      <foreignObject width={128} height={128}>
+        <div className="flex h-full items-center justify-center p-4">
+          <div className="flex flex-col gap-2 rounded-lg border-[3px] border-blue-600 bg-white p-2 dark:bg-gray-700">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-600 p-2">
+              <svg
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={4}
+                className="h-full w-full stroke-white"
+              >
+                <path d="M4.5 12.75l6 6 9-13.5" />
+              </svg>
+            </div>
+            <div className="h-2 w-14 bg-black/50 dark:bg-white/50" />
+          </div>
+        </div>
+      </foreignObject>
+    </svg>
+  );
+}

--- a/examples/checkbox-custom/style.css
+++ b/examples/checkbox-custom/style.css
@@ -1,19 +1,42 @@
-@import url("../checkbox/style.css");
-
 .checkbox {
   @apply
-    w-5
-    h-5
-    rounded
     flex
-    justify-center
     items-center
-    border
-    text-blue-900
-    bg-blue-200/40
-    border-blue-600
-    dark:text-blue-100
-    dark:bg-blue-600/25
-    dark:border-blue-200/40
+    gap-2
+    p-4
+    pr-6
+    rounded-lg
+    select-none
+    border-2
+    border-black/30
+    dark:border-white/30
+    data-[checked=true]:border-blue-600
+    data-[checked=true]:dark:border-blue-600
+    bg-white
+    dark:bg-gray-700
+    shadow
+    dark:shadow-dark
+    data-[focus-visible]:outline
+    data-[focus-visible]:outline-4
+    data-[focus-visible]:outline-blue-600/25
+  ;
+}
+
+.check {
+  @apply
+    block
+    rounded-full
+    p-0.5
+    text-lg
+    bg-gray-150
+    dark:bg-gray-850
+    [border:inherit]
+    [stroke-dasharray:15]
+    [stroke-dashoffset:15]
+    data-[checked=true]:bg-blue-600
+    data-[checked=true]:dark:bg-blue-600
+    data-[checked=true]:text-white
+    data-[checked=true]:[stroke-dashoffset:0]
+    transition-[stroke-dashoffset]
   ;
 }

--- a/examples/checkbox-custom/test.ts
+++ b/examples/checkbox-custom/test.ts
@@ -1,18 +1,27 @@
 import { click, getByRole, press } from "@ariakit/test";
 
 test("check/uncheck on click", async () => {
-  expect(getByRole("checkbox")).not.toBeChecked();
-  await click(getByRole("checkbox"));
   expect(getByRole("checkbox")).toBeChecked();
   await click(getByRole("checkbox"));
   expect(getByRole("checkbox")).not.toBeChecked();
+  await click(getByRole("checkbox"));
+  expect(getByRole("checkbox")).toBeChecked();
 });
 
 test("check/uncheck on space", async () => {
-  expect(getByRole("checkbox")).not.toBeChecked();
+  expect(getByRole("checkbox")).toBeChecked();
   await press.Tab();
   await press.Space();
-  expect(getByRole("checkbox")).toBeChecked();
-  await press.Space();
   expect(getByRole("checkbox")).not.toBeChecked();
+  await press.Space();
+  expect(getByRole("checkbox")).toBeChecked();
+});
+
+test("check/uncheck on enter", async () => {
+  expect(getByRole("checkbox")).toBeChecked();
+  await press.Tab();
+  await press.Enter();
+  expect(getByRole("checkbox")).not.toBeChecked();
+  await press.Enter();
+  expect(getByRole("checkbox")).toBeChecked();
 });

--- a/examples/checkbox-group/index.tsx
+++ b/examples/checkbox-group/index.tsx
@@ -1,27 +1,20 @@
-import * as Ariakit from "@ariakit/react";
+import { Checkbox, Group, GroupLabel, useCheckboxStore } from "@ariakit/react";
 import "./style.css";
 
 export default function Example() {
-  const checkbox = Ariakit.useCheckboxStore({ defaultValue: [] });
+  const checkbox = useCheckboxStore({ defaultValue: [] });
   return (
-    <Ariakit.Group className="wrapper">
-      <Ariakit.GroupLabel>Your favorite fruits</Ariakit.GroupLabel>
+    <Group className="wrapper">
+      <GroupLabel>Your favorite fruits</GroupLabel>
       <label className="label">
-        <Ariakit.Checkbox store={checkbox} value="apple" className="checkbox" />{" "}
-        Apple
+        <Checkbox store={checkbox} value="apple" className="checkbox" /> Apple
       </label>
       <label className="label">
-        <Ariakit.Checkbox
-          store={checkbox}
-          value="orange"
-          className="checkbox"
-        />{" "}
-        Orange
+        <Checkbox store={checkbox} value="orange" className="checkbox" /> Orange
       </label>
       <label className="label">
-        <Ariakit.Checkbox store={checkbox} value="mango" className="checkbox" />{" "}
-        Mango
+        <Checkbox store={checkbox} value="mango" className="checkbox" /> Mango
       </label>
-    </Ariakit.Group>
+    </Group>
   );
 }

--- a/examples/checkbox-group/readme.md
+++ b/examples/checkbox-group/readme.md
@@ -5,3 +5,22 @@
 </p>
 
 <a href="./index.tsx" data-playground>Example</a>
+
+## Components
+
+<div data-cards="components">
+
+- [](/components/checkbox)
+- [](/components/group)
+
+</div>
+
+## Related examples
+
+<div data-cards="examples">
+
+- [](/examples/checkbox-as-button)
+- [](/examples/checkbox-custom)
+- [](/examples/menu-item-checkbox)
+
+</div>

--- a/examples/checkbox-group/site-icon.tsx
+++ b/examples/checkbox-group/site-icon.tsx
@@ -1,0 +1,31 @@
+function renderLine(checked = false) {
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex items-center justify-center rounded bg-blue-700 p-0.5">
+        <svg
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={4}
+          className="h-3.5 w-3.5 stroke-white dark:stroke-white"
+        >
+          {checked && <path d="M4.5 12.75l6 6 9-13.5" />}
+        </svg>
+      </div>
+      <div className="h-2 w-10 bg-black/50 dark:bg-white/50" />
+    </div>
+  );
+}
+
+export default function Icon() {
+  return (
+    <svg viewBox="0 0 128 128" width={128} height={128}>
+      <foreignObject width={128} height={128}>
+        <div className="flex h-full flex-col items-center justify-center gap-2 p-4">
+          {renderLine(true)}
+          {renderLine()}
+          {renderLine(true)}
+        </div>
+      </foreignObject>
+    </svg>
+  );
+}

--- a/examples/checkbox-store/readme.md
+++ b/examples/checkbox-store/readme.md
@@ -1,7 +1,0 @@
-# useCheckboxStore
-
-<p data-description>
-  Using the <a href="/apis/checkbox-store"><code>useCheckboxStore</code></a> hook to control the state of the <a href="/components/checkbox">Checkbox</a> component.
-</p>
-
-<a href="./index.tsx" data-playground>Example</a>

--- a/examples/checkbox/style.css
+++ b/examples/checkbox/style.css
@@ -9,6 +9,6 @@
 
 .checkbox {
   @apply
-    focus-visible:ariakit-outline
+    data-[focus-visible]:outline-blue-600
   ;
 }

--- a/guide/200-styling/readme.md
+++ b/guide/200-styling/readme.md
@@ -26,6 +26,17 @@ To safely use CSS selectors, utilize the `className` prop or provide your own `d
 
 </aside>
 
+### `[aria-checked]`
+
+The `aria-checked` attribute is applied to the [Checkbox](/components/checkbox) component when the input is checked. It can be either `true` or `false`.
+
+```css
+.checkbox[aria-checked="true"] {
+  background-color: hsl(204 100% 40%);
+  color: hsl(204 20% 100%);
+}
+```
+
 ### `[aria-disabled]`
 
 Not all HTML elements accept the `disabled` attribute. That's why the [Focusable](/components/focusable) component and all components that use it underneath will apply the `aria-disabled` attribute to the rendered element when the `disabled` prop is set to `true`.

--- a/packages/ariakit-react-core/src/command/command.ts
+++ b/packages/ariakit-react-core/src/command/command.ts
@@ -17,14 +17,22 @@ function isNativeClick(event: KeyboardEvent) {
   if (!event.isTrusted) return false;
   // istanbul ignore next: can't test trusted events yet
   const element = event.currentTarget;
-  return (
-    isButton(element) ||
-    element.tagName === "SUMMARY" ||
-    element.tagName === "INPUT" ||
-    element.tagName === "TEXTAREA" ||
-    element.tagName === "A" ||
-    element.tagName === "SELECT"
-  );
+  if (event.key === "Enter") {
+    return (
+      isButton(element) ||
+      element.tagName === "SUMMARY" ||
+      element.tagName === "A"
+    );
+  }
+  if (event.key === " ") {
+    return (
+      isButton(element) ||
+      element.tagName === "SUMMARY" ||
+      element.tagName === "INPUT" ||
+      element.tagName === "SELECT"
+    );
+  }
+  return false;
 }
 
 /**

--- a/website/app/(main)/[category]/[page]/page.tsx
+++ b/website/app/(main)/[category]/[page]/page.tsx
@@ -91,6 +91,7 @@ const style = {
     underline-offset-[0.25em]
     font-medium dark:font-normal
     text-blue-700 dark:text-blue-400
+    [&>code]:text-blue-900 [&>code]:dark:text-blue-300
   `,
   h1: tw`
     text-2xl sm:text-4xl md:text-5xl font-extrabold dark:font-bold
@@ -130,7 +131,7 @@ const style = {
     data-[type="warn"]:before:bg-amber-500
     data-[type="warn"]:before:dark:bg-yellow-600
 
-    data-[type="note"]:bg-blue-50
+    data-[type="note"]:bg-blue-50/70
     data-[type="note"]:dark:bg-blue-900/20
     data-[type="note"]:before:bg-blue-600
   `,
@@ -153,8 +154,8 @@ const style = {
   paragraph: tw`
     dark:text-white/[85%] leading-7 tracking-[-0.016em] dark:tracking-[-0.008em]
 
-    [p&_code]:rounded [p&_code]:p-1 [p&_code]:text-[0.9375em]
-    [p&_code]:bg-black/[6.5%] dark:[p&_code]:bg-white/[6.5%]
+    [p&_code]:rounded [p&_code]:p-[0.25em] [p&_code]:text-[0.9375em]
+    [p&_code]:bg-black/[7.5%] dark:[p&_code]:bg-white/[7.5%]
     [p&_code]:font-monospace
   `,
   strong: tw`
@@ -327,18 +328,9 @@ export default async function Page({ params }: PageProps) {
   const nextPageLink = nextPage && (
     <Link
       href={`/${nextPage.category}/${nextPage.slug}`}
-      className={tw`group flex w-auto items-center
-      gap-3 rounded-lg p-2 pr-4 active:bg-blue-200/70
-      focus-visible:ariakit-outline-input
-      dark:active:!bg-blue-800/25 md:ml-3
-      [@media(any-hover:hover)]:hover:bg-blue-200/40
-      [@media(any-hover:hover)]:dark:hover:bg-blue-600/25`}
+      className="group flex w-auto items-center gap-3 rounded-lg p-2 pr-4 active:bg-blue-200/70 focus-visible:ariakit-outline-input dark:active:!bg-blue-800/25 md:ml-3 [@media(any-hover:hover)]:hover:bg-blue-200/40 [@media(any-hover:hover)]:dark:hover:bg-blue-600/25"
     >
-      <div
-        className={tw`flex h-14 w-14 items-center justify-center overflow-hidden
-        rounded bg-gray-150 group-hover:bg-black/[7.5%]
-        dark:bg-gray-850 dark:group-hover:bg-black/80`}
-      >
+      <div className="flex h-14 w-14 items-center justify-center overflow-hidden rounded bg-gray-150 group-hover:bg-black/[7.5%] dark:bg-gray-850 dark:group-hover:bg-black/80">
         {getPageIcon(nextPage.category, nextPage.slug) || <span />}
       </div>
       <div className="flex flex-1 flex-col gap-0.5 overflow-hidden text-sm">
@@ -423,21 +415,23 @@ export default async function Page({ params }: PageProps) {
                       ))}
                     </div>
                     {isExamples && (
-                      <Link
-                        href={`/examples${isComponentPage ? `#${page}` : ""}`}
-                        className={cx(style.link, "text-center")}
-                      >
-                        View all{isComponentPage ? ` ${pageDetail?.title}` : ""}{" "}
-                        examples
-                      </Link>
+                      <div className="flex justify-center">
+                        <Link
+                          href={`/examples${isComponentPage ? `#${page}` : ""}`}
+                          className={style.link}
+                        >
+                          View all
+                          {isComponentPage ? ` ${pageDetail?.title}` : ""}{" "}
+                          examples
+                        </Link>
+                      </div>
                     )}
                     {isComponents && (
-                      <Link
-                        href="/components"
-                        className={cx(style.link, "text-center")}
-                      >
-                        View all components
-                      </Link>
+                      <div className="flex justify-center">
+                        <Link href="/components" className={style.link}>
+                          View all components
+                        </Link>
+                      </div>
                     )}
                   </>
                 );
@@ -565,6 +559,15 @@ export default async function Page({ params }: PageProps) {
               if (!child.props.href) return paragraph;
               return <>{props.children}</>;
             },
+            kbd: ({ node, ...props }) => (
+              <kbd
+                {...props}
+                className={cx(
+                  "font-monospace rounded-[0.25em] border border-black/[15%] bg-black/[6.5%] p-[0.15em] px-[0.3em] text-[0.9375em] [box-shadow:0_0.15em_0_rgba(0,0,0,0.15)] dark:border-white/[15%] dark:bg-white/10 dark:[box-shadow:0_0.15em_0_rgba(255,255,255,0.15)]",
+                  props.className
+                )}
+              />
+            ),
             strong: ({ node, ...props }) => (
               <strong
                 {...props}

--- a/website/build-pages/config.js
+++ b/website/build-pages/config.js
@@ -31,6 +31,7 @@ const pages = [
         "composite",
         "focus-trap",
         "focusable",
+        "group",
         "portal",
         "role",
         "separator",


### PR DESCRIPTION
This PR improves the current checkbox docs and fixes two related issues:

- The `Checkbox` component now accepts `string[]` as the `value` prop. This is to conform with the native input prop type. If a string array is passed, it will be stringified, just like in the native input element.

- Fixed the `clickOnEnter` prop on `Checkbox` not working when rendering the component as a native input element.