### PR TITLE
Fix composite typeahead when the item text starts with a space

### DIFF
--- a/.changeset/composite-typeahead-trim.md
+++ b/.changeset/composite-typeahead-trim.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed typeahead behavior when the composite item element's text content starts with an empty space. ([#2475](https://github.com/ariakit/ariakit/pull/2475))

--- a/components/menu.md
+++ b/components/menu.md
@@ -10,8 +10,8 @@
 
 <div data-cards="examples">
 
-- [](/examples/menu-framer-motion/)
-- [](/examples/menu-item-checkbox/)
+- [](/examples/menu-framer-motion)
+- [](/examples/menu-item-checkbox)
 
 </div>
 
@@ -73,11 +73,11 @@ On the other hand, [`MenuButton`](/apis/menu-button) can't hold a value, only a 
 
 <div data-cards="components">
 
-- [](/components/button/)
-- [](/components/checkbox/)
-- [](/components/popover/)
-- [](/components/radio/)
-- [](/components/select/)
-- [](/components/composite/)
+- [](/components/button)
+- [](/components/checkbox)
+- [](/components/popover)
+- [](/components/radio)
+- [](/components/select)
+- [](/components/composite)
 
 </div>

--- a/components/menu.md
+++ b/components/menu.md
@@ -6,13 +6,14 @@
 
 <a href="../examples/menu/index.tsx" data-playground>Example</a>
 
-## Installation
+## Examples
 
-```sh
-npm i @ariakit/react
-```
+<div data-cards="examples">
 
-Learn more on the [Getting started](/guide/getting-started) guide.
+- [](/examples/menu-framer-motion/)
+- [](/examples/menu-item-checkbox/)
+
+</div>
 
 ## API
 
@@ -64,6 +65,19 @@ Because they behave similarly, it may not be obvious when to use `Menu` and when
 - Use `Select` when the purpose is to select a value from a list of options. For example, a dropdown to select a country from a list of countries.
 - Use `Menu` when the purpose is to access a set of commands, actions, or links. For example, a dropdown to access a set of commands to edit a document.
 
-There are also some differences in how both components behave. Similarly to the native `<select>` element, the [`Select`](/apis/select) button's text will reflect the selected item. The button may also have a label in addition to the value. When the [`SelectPopover`](/apis/select-popover) opens, the selected item will be focused and brought into view.
+There are also some differences in how both components behave. Similarly to the native `<select>` element, the [`Select`](/apis/select) button's text will reflect the selected item. The button should also have a label in addition to the value. When the [`SelectPopover`](/apis/select-popover) opens, the selected item will be focused and brought into view.
 
 On the other hand, [`MenuButton`](/apis/menu-button) can't hold a value, only a label, which won't reflect the active item. It's usually a static call to action.
+
+## Related components
+
+<div data-cards="components">
+
+- [](/components/button/)
+- [](/components/checkbox/)
+- [](/components/popover/)
+- [](/components/radio/)
+- [](/components/select/)
+- [](/components/composite/)
+
+</div>

--- a/examples/menu-item-checkbox/index.tsx
+++ b/examples/menu-item-checkbox/index.tsx
@@ -1,62 +1,30 @@
-import * as Ariakit from "@ariakit/react";
 import "./style.css";
+import { useState } from "react";
+import { Menu, MenuItemCheckbox } from "./menu.jsx";
 
 export default function Example() {
-  const menu = Ariakit.useMenuStore({
-    defaultValues: { watching: ["issues"] },
-  });
-  const buttonLabel = menu.useState((state) =>
-    !!state.values.watching.length ? "Unwatch" : "Watch"
-  );
+  const [values, setValues] = useState({ watching: ["issues"] });
   return (
-    <>
-      <Ariakit.MenuButton store={menu} className="button">
-        {buttonLabel}
-        <Ariakit.MenuButtonArrow />
-      </Ariakit.MenuButton>
-      <Ariakit.Menu store={menu} className="menu">
-        <Ariakit.MenuArrow className="menu-arrow" />
-        <Ariakit.MenuItemCheckbox
-          name="watching"
-          value="issues"
-          className="menu-item"
-        >
-          <Ariakit.MenuItemCheck />
-          Issues
-        </Ariakit.MenuItemCheckbox>
-        <Ariakit.MenuItemCheckbox
-          name="watching"
-          value="pull-requests"
-          className="menu-item"
-        >
-          <Ariakit.MenuItemCheck />
-          Pull requests
-        </Ariakit.MenuItemCheckbox>
-        <Ariakit.MenuItemCheckbox
-          name="watching"
-          value="releases"
-          className="menu-item"
-        >
-          <Ariakit.MenuItemCheck />
-          Releases
-        </Ariakit.MenuItemCheckbox>
-        <Ariakit.MenuItemCheckbox
-          name="watching"
-          value="discussions"
-          className="menu-item"
-        >
-          <Ariakit.MenuItemCheck />
-          Discussions
-        </Ariakit.MenuItemCheckbox>
-        <Ariakit.MenuItemCheckbox
-          name="watching"
-          value="security-alerts"
-          className="menu-item"
-        >
-          <Ariakit.MenuItemCheck />
-          Security alerts
-        </Ariakit.MenuItemCheckbox>
-      </Ariakit.Menu>
-    </>
+    <Menu
+      label={values.watching.length ? "Unwatch" : "Watch"}
+      values={values}
+      onValuesChange={(v: typeof values) => setValues(v)}
+    >
+      <MenuItemCheckbox name="watching" value="issues">
+        Issues
+      </MenuItemCheckbox>
+      <MenuItemCheckbox name="watching" value="pull-requests">
+        Pull requests
+      </MenuItemCheckbox>
+      <MenuItemCheckbox name="watching" value="releases">
+        Releases
+      </MenuItemCheckbox>
+      <MenuItemCheckbox name="watching" value="discussions">
+        Discussions
+      </MenuItemCheckbox>
+      <MenuItemCheckbox name="watching" value="security-alerts">
+        Security alerts
+      </MenuItemCheckbox>
+    </Menu>
   );
 }

--- a/examples/menu-item-checkbox/menu.tsx
+++ b/examples/menu-item-checkbox/menu.tsx
@@ -1,0 +1,49 @@
+import { forwardRef } from "react";
+import type { ReactNode } from "react";
+import * as Ariakit from "@ariakit/react";
+
+interface MenuProps extends Omit<Ariakit.MenuButtonProps, "store"> {
+  label: ReactNode;
+  children?: ReactNode;
+  defaultValues?: Ariakit.MenuStoreProps["defaultValues"];
+  values?: Ariakit.MenuStoreProps["values"];
+  onValuesChange?: Ariakit.MenuStoreProps["setValues"];
+}
+
+export const Menu = forwardRef<HTMLButtonElement, MenuProps>(function Menu(
+  { label, defaultValues, values, onValuesChange, ...props },
+  ref
+) {
+  const menu = Ariakit.useMenuStore({
+    defaultValues,
+    values,
+    setValues: onValuesChange,
+  });
+  return (
+    <>
+      <Ariakit.MenuButton ref={ref} className="button" {...props} store={menu}>
+        {label}
+        <Ariakit.MenuButtonArrow />
+      </Ariakit.MenuButton>
+      <Ariakit.Menu store={menu} className="menu">
+        <Ariakit.MenuArrow />
+        {props.children}
+      </Ariakit.Menu>
+    </>
+  );
+});
+
+interface MenuItemCheckboxProps extends Ariakit.MenuItemCheckboxProps {
+  children: ReactNode;
+}
+
+export const MenuItemCheckbox = forwardRef<
+  HTMLDivElement,
+  MenuItemCheckboxProps
+>(function MenuItemCheckbox(props, ref) {
+  return (
+    <Ariakit.MenuItemCheckbox ref={ref} className="menu-item" {...props}>
+      <Ariakit.MenuItemCheck /> {props.children}
+    </Ariakit.MenuItemCheckbox>
+  );
+});

--- a/examples/menu-item-checkbox/readme.md
+++ b/examples/menu-item-checkbox/readme.md
@@ -1,7 +1,35 @@
 # MenuItemCheckbox
 
 <p data-description>
-  Rendering <a href="/components/menu">Menu</a> using <a href="/apis/menu-item-checkbox"><code>MenuItemCheckbox</code></a> as children and the <a href="/apis/menu-store#values"><code>values</code></a> prop from <a href="/apis/menu-store"><code>useMenuStore</code></a> to control the checked items.
+  Rendering a dropdown <a href="/components/menu">Menu</a> using the <a href="/apis/menu-item-checkbox"><code>MenuItemCheckbox</code></a> component with the <a href="/apis/menu-store#values"><code>values</code></a> and <a href="/apis/menu-store#setvalues"><code>setValues</code></a> props from <a href="/apis/menu-store"><code>useMenuStore</code></a> to control the checked items.
 </p>
 
 <a href="./index.tsx" data-playground>Example</a>
+
+## Components
+
+<div data-cards="components">
+
+- [](/components/menu)
+
+</div>
+
+## Controlling the state with props
+
+In this example, we created a higher-level abstraction of the `Menu` component that accepts the `values` and `onValuesChange` props to control the state of the menu store. These props are then passed to the [`useMenuStore`](/apis/menu-store) hook:
+
+```js
+function Menu({ values, onValuesChange }) {
+  const menu = useMenuStore({ values, setValues: onValuesChange });
+}
+```
+
+You can leverage this technique to create your own custom menu components tailored to your specific requirements. Learn more about controlling the state on the [Component stores](/guide/component-stores#providing-state-to-the-store) guide.
+
+## Related examples
+
+<div data-cards="examples">
+
+- [](/examples/menu-framer-motion/)
+
+</div>

--- a/examples/menu-item-checkbox/readme.md
+++ b/examples/menu-item-checkbox/readme.md
@@ -30,6 +30,6 @@ You can leverage this technique to create your own custom menu components tailor
 
 <div data-cards="examples">
 
-- [](/examples/menu-framer-motion/)
+- [](/examples/menu-framer-motion)
 
 </div>

--- a/examples/menu-item-checkbox/site-icon.tsx
+++ b/examples/menu-item-checkbox/site-icon.tsx
@@ -1,0 +1,43 @@
+export default function Icon() {
+  return (
+    <svg viewBox="0 0 128 128" width={128} height={128}>
+      <foreignObject width={128} height={128}>
+        <div className="pl-8 pt-4">
+          <div className="flex flex-col items-center justify-center">
+            <div className="flex flex-col gap-2">
+              <div className="ml-6 h-5 w-12 rounded bg-blue-600" />
+              <div className="flex w-32 flex-col gap-2 rounded-md border border-black/20 bg-white p-3 px-1 shadow dark:border-white/10 dark:bg-white/10 dark:shadow-dark">
+                <div className="flex items-center gap-2">
+                  <svg
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    strokeWidth={4}
+                    className="h-4 w-4 stroke-white/50 dark:stroke-white/50"
+                  >
+                    <path d="M4.5 12.75l6 6 9-13.5" />
+                  </svg>
+                  <div className="h-2 w-14 bg-black/50 dark:bg-white/50" />
+                </div>
+                <div className="flex items-center gap-2">
+                  <svg
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    strokeWidth={4}
+                    className="h-4 w-4 stroke-blue-600 dark:stroke-blue-500"
+                  >
+                    <path d="M4.5 12.75l6 6 9-13.5" />
+                  </svg>
+                  <div className="h-2 w-10 bg-blue-600 dark:bg-blue-500" />
+                </div>
+                <div className="flex items-center gap-2">
+                  <div className="h-4 w-4" />
+                  <div className="h-2 w-12 bg-black/50 dark:bg-white/50" />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </foreignObject>
+    </svg>
+  );
+}

--- a/examples/menu-item-checkbox/test.ts
+++ b/examples/menu-item-checkbox/test.ts
@@ -1,4 +1,4 @@
-import { click, getByRole, press } from "@ariakit/test";
+import { click, getByRole, press, type } from "@ariakit/test";
 
 const getMenuButton = (name: string) => getByRole("button", { name });
 const getMenuItem = (name: string) => getByRole("menuitemcheckbox", { name });
@@ -53,4 +53,10 @@ test("check/uncheck menu item on space", async () => {
     "aria-checked",
     "false"
   );
+});
+
+test("typeahead", async () => {
+  await click(getMenuButton("Unwatch"));
+  await type("d");
+  expect(getMenuItem("Discussions")).toHaveFocus();
 });

--- a/packages/ariakit-react-core/src/composite/composite-typeahead.ts
+++ b/packages/ariakit-react-core/src/composite/composite-typeahead.ts
@@ -46,7 +46,10 @@ function getEnabledItems(items: CompositeStoreItem[]) {
 function itemTextStartsWith(item: CompositeStoreItem, text: string) {
   const itemText = item.element?.textContent || item.children;
   if (!itemText) return false;
-  return normalizeString(itemText).toLowerCase().startsWith(text.toLowerCase());
+  return normalizeString(itemText)
+    .trim()
+    .toLowerCase()
+    .startsWith(text.toLowerCase());
 }
 
 function getSameInitialItems(

--- a/website/components/page-item.tsx
+++ b/website/components/page-item.tsx
@@ -16,7 +16,7 @@ const style = {
   `,
   thumbnail: tw`
     flex items-center justify-center flex-none
-    rounded
+    rounded overflow-hidden
     bg-gray-150 dark:bg-gray-850
     group-hover:bg-black/[7.5%] dark:group-hover:bg-black/80
     group-active:bg-black/[7.5%] dark:group-active:bg-black/80


### PR DESCRIPTION
Trim the composite item element's text before comparing it with the pressed key.