### PR TITLE
Remove hideOnControl prop from Hovercard

### DIFF
--- a/.changeset/hide-on-control.md
+++ b/.changeset/hide-on-control.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Removed the `hideOnControl` prop from `Hovercard`. ([#2478](https://github.com/ariakit/ariakit/pull/2478))


### PR DESCRIPTION
This PR removes the `hideOnControl` prop from the `Hovercard` and derived components (`Tooltip`, `Menu`, etc.).