### PR TITLE
Improve modal behavior on animated dialogs

### DIFF
--- a/.changeset/dialog-modal-animated-1.md
+++ b/.changeset/dialog-modal-animated-1.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed `Focusable` not receiving focus when rendered as a native button on Safari. ([#2534](https://github.com/ariakit/ariakit/pull/2534))

--- a/.changeset/dialog-modal-animated-2.md
+++ b/.changeset/dialog-modal-animated-2.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed `Dialog` with `preventBodyScroll` set to `true` (default) not preventing body scroll on nested animated dialogs. ([#2534](https://github.com/ariakit/ariakit/pull/2534))

--- a/examples/dialog-nested-multiple/dialog.tsx
+++ b/examples/dialog-nested-multiple/dialog.tsx
@@ -5,19 +5,29 @@ export interface DialogProps extends Omit<Ariakit.DialogProps, "store"> {
   open?: boolean;
   onClose?: () => void;
   unmount?: boolean;
+  animated?: boolean;
 }
 
-export function Dialog({ open, onClose, unmount, ...props }: DialogProps) {
+export function Dialog({
+  open,
+  onClose,
+  unmount,
+  animated,
+  ...props
+}: DialogProps) {
   const dialog = Ariakit.useDialogStore({
     open,
     setOpen: (open) => !open && onClose?.(),
+    animated,
   });
   const mounted = dialog.useState((state) => (unmount ? state.mounted : true));
   if (!mounted) return null;
+  const dataAnimated = animated ? "" : undefined;
   return (
     <Ariakit.Dialog
-      backdrop={<div className="backdrop" />}
+      backdrop={<div data-animated={dataAnimated} className="backdrop" />}
       className="dialog"
+      data-animated={dataAnimated}
       {...props}
       store={dialog}
     />

--- a/examples/dialog-nested-multiple/index.tsx
+++ b/examples/dialog-nested-multiple/index.tsx
@@ -21,6 +21,13 @@ export default function Example() {
   const [nestedNoBackdrop, setNestedNoBackdrop] = useState(false);
   const [nestedNoBackdropNested, setNestedNoBackdropNested] = useState(false);
 
+  const [nestedDismiss, setNestedDismiss] = useState(false);
+  const [nestedDismissNested, setNestedDismissNested] = useState(false);
+
+  const [nestedDismissAnimated, setNestedDismissAnimated] = useState(false);
+  const [nestedDismissAnimatedNested, setNestedDismissAnimatedNested] =
+    useState(false);
+
   const [sibling, setSibling] = useState(false);
   const [siblingSibling, setSiblingSibling] = useState(false);
 
@@ -38,6 +45,24 @@ export default function Example() {
   const [siblingNoBackdropSibling, setSiblingNoBackdropSibling] =
     useState(false);
 
+  const [siblingDismiss, setSiblingDismiss] = useState(false);
+  const [siblingDismissSibling, setSiblingDismissSibling] = useState(false);
+
+  const [siblingDismissUnmount, setSiblingDismissUnmount] = useState(false);
+  const [siblingDismissUnmountSibling, setSiblingDismissUnmountSibling] =
+    useState(false);
+
+  const [siblingDismissAnimated, setSiblingDismissAnimated] = useState(false);
+  const [siblingDismissAnimatedSibling, setSiblingDismissAnimatedSibling] =
+    useState(false);
+
+  const [siblingDismissAnimatedUnmount, setSiblingDismissAnimatedUnmount] =
+    useState(false);
+  const [
+    siblingDismissAnimatedUnmountSibling,
+    setSiblingDismissAnimatedUnmountSibling,
+  ] = useState(false);
+
   const siblindId = useId();
   const siblingSiblingId = useId();
   const siblingNoPortalId = useId();
@@ -52,9 +77,14 @@ export default function Example() {
       <Button onClick={() => setOpen(true)}>Open dialog</Button>
 
       <Dialog
+        unmount={
+          !nestedDismiss &&
+          !nestedDismissNested &&
+          !nestedDismissAnimated &&
+          !nestedDismissAnimatedNested
+        }
         open={open}
         onClose={() => setOpen(false)}
-        unmount
         getPersistentElements={() => [
           document.getElementById(siblindId)!,
           document.getElementById(siblingSiblingId)!,
@@ -86,6 +116,20 @@ export default function Example() {
           nested no backdrop
         </Button>
 
+        <DialogDismiss
+          onClick={() => requestAnimationFrame(() => setNestedDismiss(true))}
+        >
+          nested dismiss
+        </DialogDismiss>
+
+        <DialogDismiss
+          onClick={() =>
+            requestAnimationFrame(() => setNestedDismissAnimated(true))
+          }
+        >
+          nested dismiss animated
+        </DialogDismiss>
+
         {/* Sibling buttons */}
         <Button onClick={() => setSibling(true)}>sibling</Button>
 
@@ -102,6 +146,22 @@ export default function Example() {
         <Button onClick={() => setSiblingNoBackdrop(true)}>
           sibling no backdrop
         </Button>
+
+        <DialogDismiss onClick={() => setSiblingDismiss(true)}>
+          sibling dismiss
+        </DialogDismiss>
+
+        <DialogDismiss onClick={() => setSiblingDismissUnmount(true)}>
+          sibling dismiss unmount
+        </DialogDismiss>
+
+        <DialogDismiss onClick={() => setSiblingDismissAnimated(true)}>
+          sibling dismiss animated
+        </DialogDismiss>
+
+        <DialogDismiss onClick={() => setSiblingDismissAnimatedUnmount(true)}>
+          sibling dismiss animated unmount
+        </DialogDismiss>
 
         {/* Nested default */}
         <Dialog open={nested} onClose={() => setNested(false)}>
@@ -203,6 +263,55 @@ export default function Example() {
             onClose={() => setNestedNoPortalPortalNested(false)}
           >
             <DialogHeading>nested no portal portal nested</DialogHeading>
+            <DialogDismiss>Close</DialogDismiss>
+          </Dialog>
+        </Dialog>
+
+        {/* Nested dismiss */}
+        <Dialog open={nestedDismiss} onClose={() => setNestedDismiss(false)}>
+          <DialogHeading>nested dismiss</DialogHeading>
+          <DialogDismiss>Close</DialogDismiss>
+
+          <DialogDismiss
+            onClick={() =>
+              requestAnimationFrame(() => setNestedDismissNested(true))
+            }
+          >
+            nested dismiss nested
+          </DialogDismiss>
+
+          <Dialog
+            open={nestedDismissNested}
+            onClose={() => setNestedDismissNested(false)}
+          >
+            <DialogHeading>nested dismiss nested</DialogHeading>
+            <DialogDismiss>Close</DialogDismiss>
+          </Dialog>
+        </Dialog>
+
+        {/* Nested dismiss animated */}
+        <Dialog
+          animated
+          open={nestedDismissAnimated}
+          onClose={() => setNestedDismissAnimated(false)}
+        >
+          <DialogHeading>nested dismiss animated</DialogHeading>
+          <DialogDismiss>Close</DialogDismiss>
+
+          <DialogDismiss
+            onClick={() =>
+              requestAnimationFrame(() => setNestedDismissAnimatedNested(true))
+            }
+          >
+            nested dismiss animated nested
+          </DialogDismiss>
+
+          <Dialog
+            animated
+            open={nestedDismissAnimatedNested}
+            onClose={() => setNestedDismissAnimatedNested(false)}
+          >
+            <DialogHeading>nested dismiss animated nested</DialogHeading>
             <DialogDismiss>Close</DialogDismiss>
           </Dialog>
         </Dialog>
@@ -343,6 +452,97 @@ export default function Example() {
         backdrop={false}
       >
         <DialogHeading>sibling no backdrop sibling</DialogHeading>
+        <DialogDismiss>Close</DialogDismiss>
+      </Dialog>
+
+      {/* Sibling dismiss */}
+      <Dialog open={siblingDismiss} onClose={() => setSiblingDismiss(false)}>
+        <DialogHeading>sibling dismiss</DialogHeading>
+        <DialogDismiss>Close</DialogDismiss>
+        <DialogDismiss onClick={() => setSiblingDismissSibling(true)}>
+          sibling dismiss sibling
+        </DialogDismiss>
+      </Dialog>
+
+      {/* Sibling dismiss sibling */}
+      <Dialog
+        open={siblingDismissSibling}
+        onClose={() => setSiblingDismissSibling(false)}
+      >
+        <DialogHeading>sibling dismiss sibling</DialogHeading>
+        <DialogDismiss>Close</DialogDismiss>
+      </Dialog>
+
+      {/* Sibling dismiss unmount */}
+      <Dialog
+        unmount
+        open={siblingDismissUnmount}
+        onClose={() => setSiblingDismissUnmount(false)}
+      >
+        <DialogHeading>sibling dismiss unmount</DialogHeading>
+        <DialogDismiss>Close</DialogDismiss>
+        <DialogDismiss onClick={() => setSiblingDismissUnmountSibling(true)}>
+          sibling dismiss unmount sibling
+        </DialogDismiss>
+      </Dialog>
+
+      {/* Sibling dismiss unmount sibling */}
+      <Dialog
+        unmount
+        open={siblingDismissUnmountSibling}
+        onClose={() => setSiblingDismissUnmountSibling(false)}
+      >
+        <DialogHeading>sibling dismiss unmount sibling</DialogHeading>
+        <DialogDismiss>Close</DialogDismiss>
+      </Dialog>
+
+      {/* Sibling dismiss animated */}
+      <Dialog
+        animated
+        open={siblingDismissAnimated}
+        onClose={() => setSiblingDismissAnimated(false)}
+      >
+        <DialogHeading>sibling dismiss animated</DialogHeading>
+        <DialogDismiss>Close</DialogDismiss>
+        <DialogDismiss onClick={() => setSiblingDismissAnimatedSibling(true)}>
+          sibling dismiss animated sibling
+        </DialogDismiss>
+      </Dialog>
+
+      {/* Sibling dismiss animated sibling */}
+      <Dialog
+        animated
+        open={siblingDismissAnimatedSibling}
+        onClose={() => setSiblingDismissAnimatedSibling(false)}
+      >
+        <DialogHeading>sibling dismiss animated sibling</DialogHeading>
+        <DialogDismiss>Close</DialogDismiss>
+      </Dialog>
+
+      {/* Sibling dismiss animated unmount */}
+      <Dialog
+        unmount
+        animated
+        open={siblingDismissAnimatedUnmount}
+        onClose={() => setSiblingDismissAnimatedUnmount(false)}
+      >
+        <DialogHeading>sibling dismiss animated unmount</DialogHeading>
+        <DialogDismiss>Close</DialogDismiss>
+        <DialogDismiss
+          onClick={() => setSiblingDismissAnimatedUnmountSibling(true)}
+        >
+          sibling dismiss animated unmount sibling
+        </DialogDismiss>
+      </Dialog>
+
+      {/* Sibling dismiss animated unmount sibling */}
+      <Dialog
+        unmount
+        animated
+        open={siblingDismissAnimatedUnmountSibling}
+        onClose={() => setSiblingDismissAnimatedUnmountSibling(false)}
+      >
+        <DialogHeading>sibling dismiss animated unmount sibling</DialogHeading>
         <DialogDismiss>Close</DialogDismiss>
       </Dialog>
     </>

--- a/examples/dialog-nested-multiple/style.css
+++ b/examples/dialog-nested-multiple/style.css
@@ -1,1 +1,23 @@
 @import url("../dialog-nested/style.css");
+
+.button {
+  @apply
+    flex-none
+  ;
+}
+
+.dialog {
+  @apply
+    data-[animated]:transition-opacity
+    data-[animated]:opacity-0
+    data-[animated]:data-[enter]:opacity-100
+  ;
+}
+
+.backdrop {
+  @apply
+    data-[animated]:transition-opacity
+    data-[animated]:opacity-0
+    data-[animated]:data-[enter]:opacity-100
+  ;
+}

--- a/examples/dialog-nested-multiple/test-browser.ts
+++ b/examples/dialog-nested-multiple/test-browser.ts
@@ -1,0 +1,183 @@
+import type { Locator, Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+const getButton = (page: Page | Locator, name: string) =>
+  page.getByRole("button", { name, exact: true });
+
+const getAccessibleDialog = (page: Page | Locator, name: string) =>
+  page.getByRole("dialog", { name, exact: true });
+
+const getDialog = (page: Page | Locator, name: string) =>
+  page.getByRole("dialog", { includeHidden: true, name, exact: true });
+
+function expectAccessibleDialog(
+  page: Page | Locator,
+  name: string,
+  toBeVisible: boolean
+) {
+  const dialog = getAccessibleDialog(page, name);
+  if (toBeVisible) {
+    return expect(dialog).toBeVisible();
+  }
+  return expect(dialog).not.toBeVisible({ visible: false });
+}
+
+async function canScrollBody(page: Page) {
+  await page.mouse.move(1, 1);
+  const scrollY = await page.evaluate(() => window.scrollY);
+  await page.mouse.wheel(0, 100);
+  await page.waitForTimeout(100);
+  const scrollY2 = await page.evaluate(() => window.scrollY);
+  return scrollY !== scrollY2;
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/previews/dialog-nested-multiple", {
+    waitUntil: "networkidle",
+  });
+});
+
+for (const { name, type } of [
+  { name: "nested", type: "" },
+  { name: "sibling", type: "" },
+  { name: "nested", type: " unmount" },
+  { name: "sibling", type: " unmount" },
+  { name: "nested", type: " no portal" },
+  { name: "sibling", type: " no portal" },
+  { name: "nested", type: " no portal portal" },
+  { name: "sibling", type: " no portal portal" },
+  { name: "nested", type: " no backdrop" },
+  { name: "sibling", type: " no backdrop" },
+]) {
+  test(`hide ${name}${type} dialog by pressing Escape`, async ({ page }) => {
+    await getButton(page, "Open dialog").click();
+    await getButton(page, `${name}${type}`).click();
+    await getButton(page, `${name}${type} ${name}`).click();
+    await expect(getDialog(page, "Dialog")).toBeVisible();
+    await expect(getDialog(page, `${name}${type}`)).toBeVisible();
+    await expect(getDialog(page, `${name}${type} ${name}`)).toBeVisible();
+    await expectAccessibleDialog(page, "Dialog", false);
+    await expectAccessibleDialog(page, `${name}${type}`, false);
+    await expectAccessibleDialog(page, `${name}${type} ${name}`, true);
+    await expect(canScrollBody(page)).resolves.toBe(false);
+    await page.keyboard.press("Escape");
+    await expect(getDialog(page, `${name}${type} ${name}`)).not.toBeVisible();
+    await expect(getDialog(page, `${name}${type}`)).toBeVisible();
+    await expectAccessibleDialog(page, "Dialog", false);
+    await expectAccessibleDialog(page, `${name}${type}`, true);
+    await expect(canScrollBody(page)).resolves.toBe(false);
+    await page.keyboard.press("Escape");
+    await expect(getDialog(page, `${name}${type}`)).not.toBeVisible();
+    await expect(getDialog(page, "Dialog")).toBeVisible();
+    await expectAccessibleDialog(page, "Dialog", true);
+    await expect(canScrollBody(page)).resolves.toBe(false);
+    await page.keyboard.press("Escape");
+    await expect(getButton(page, "Open dialog")).toBeFocused();
+    await expect(getDialog(page, "Dialog")).not.toBeVisible();
+    await expect(canScrollBody(page)).resolves.toBe(true);
+  });
+}
+
+for (const { name, type } of [
+  { name: "nested", type: "" },
+  { name: "sibling", type: "" },
+  { name: "nested", type: " unmount" },
+  { name: "sibling", type: " unmount" },
+  { name: "nested", type: " no portal" },
+  { name: "sibling", type: " no portal" },
+  { name: "nested", type: " no portal portal" },
+  { name: "sibling", type: " no portal portal" },
+]) {
+  test(`hide ${name}${type} dialog by clicking outside`, async ({ page }) => {
+    await getButton(page, "Open dialog").click();
+    await getButton(page, `${name}${type}`).click();
+    await getButton(page, `${name}${type} ${name}`).click();
+    await expect(getDialog(page, "Dialog")).toBeVisible();
+    await expect(getDialog(page, `${name}${type}`)).toBeVisible();
+    await expect(getDialog(page, `${name}${type} ${name}`)).toBeVisible();
+    await expectAccessibleDialog(page, "Dialog", false);
+    await expectAccessibleDialog(page, `${name}${type}`, false);
+    await expectAccessibleDialog(page, `${name}${type} ${name}`, true);
+    await expect(canScrollBody(page)).resolves.toBe(false);
+    await page.mouse.click(1, 1);
+    await expect(getDialog(page, `${name}${type} ${name}`)).not.toBeVisible();
+    await expect(getDialog(page, `${name}${type}`)).toBeVisible();
+    await expectAccessibleDialog(page, "Dialog", false);
+    await expectAccessibleDialog(page, `${name}${type}`, true);
+    await expect(canScrollBody(page)).resolves.toBe(false);
+    await page.mouse.click(1, 1);
+    await expect(getDialog(page, `${name}${type}`)).not.toBeVisible();
+    await expect(getDialog(page, "Dialog")).toBeVisible();
+    await expectAccessibleDialog(page, "Dialog", true);
+    await expect(canScrollBody(page)).resolves.toBe(false);
+    await page.mouse.click(1, 1);
+    await expect(getButton(page, "Open dialog")).toBeFocused();
+    await expect(getDialog(page, "Dialog")).not.toBeVisible();
+    await expect(canScrollBody(page)).resolves.toBe(true);
+  });
+}
+
+for (const name of ["nested", "sibling"]) {
+  test(`hide all ${name} no backdrop dialogs by clicking outside`, async ({
+    page,
+  }) => {
+    await getButton(page, "Open dialog").click();
+    await getButton(page, `${name} no backdrop`).click();
+    await getButton(page, `${name} no backdrop ${name}`).click();
+    await expect(getDialog(page, "Dialog")).toBeVisible();
+    await expect(getDialog(page, `${name} no backdrop`)).toBeVisible();
+    await expect(getDialog(page, `${name} no backdrop ${name}`)).toBeVisible();
+    await page.mouse.click(1, 1);
+    await expect(getDialog(page, "Dialog")).not.toBeVisible();
+    await expect(getDialog(page, `${name} no backdrop`)).not.toBeVisible();
+    await expect(
+      getDialog(page, `${name} no backdrop ${name}`)
+    ).not.toBeVisible();
+    await expect(getButton(page, "Open dialog")).toBeFocused();
+  });
+}
+
+for (const name of ["nested", "sibling"]) {
+  test(`hide only the topmost ${name} no backdrop dialog by on the parent dialog`, async ({
+    page,
+  }) => {
+    await getButton(page, "Open dialog").click();
+    await getButton(page, `${name} no backdrop`).click();
+    await getButton(page, `${name} no backdrop ${name}`).click();
+    await expect(getDialog(page, "Dialog")).toBeVisible();
+    await expect(getDialog(page, `${name} no backdrop`)).toBeVisible();
+    await expect(getDialog(page, `${name} no backdrop ${name}`)).toBeVisible();
+    await page.mouse.click(500, 220);
+    await expect(getDialog(page, "Dialog")).toBeVisible();
+    await expect(getDialog(page, `${name} no backdrop`)).toBeVisible();
+    await expect(
+      getDialog(page, `${name} no backdrop ${name}`)
+    ).not.toBeVisible();
+    await page.mouse.click(500, 280);
+    await expect(getDialog(page, "Dialog")).toBeVisible();
+    await expect(getDialog(page, `${name} no backdrop`)).not.toBeVisible();
+  });
+}
+
+for (const { name, type } of [
+  { name: "nested", type: " dismiss animated" },
+  { name: "sibling", type: " dismiss animated" },
+  { name: "sibling", type: " dismiss animated unmount" },
+]) {
+  test(`${name}${type}`, async ({ page }) => {
+    await getButton(page, "Open dialog").click();
+    await expect(getDialog(page, "Dialog")).toBeVisible();
+    await getButton(page, `${name}${type}`).click();
+    await expect(getDialog(page, `${name}${type}`)).toBeVisible();
+    await expect(getDialog(page, "Dialog")).not.toBeVisible();
+    await expect(canScrollBody(page)).resolves.toBe(false);
+    await getButton(page, `${name}${type} ${name}`).click();
+    await expect(getDialog(page, `${name}${type} ${name}`)).toBeVisible();
+    await expect(getDialog(page, `${name}${type}`)).not.toBeVisible();
+    await expect(canScrollBody(page)).resolves.toBe(false);
+    await page.keyboard.press("Escape");
+    await expect(getButton(page, "Open dialog")).toBeFocused();
+    await expect(getDialog(page, `${name}${type} ${name}`)).not.toBeVisible();
+    await expect(canScrollBody(page)).resolves.toBe(true);
+  });
+}

--- a/examples/dialog-nested-multiple/test.ts
+++ b/examples/dialog-nested-multiple/test.ts
@@ -235,3 +235,49 @@ test.each(["nested", "sibling"])(
     expectModalStyle(false);
   }
 );
+
+test.each(["nested", "sibling"])(
+  "show %s dismiss dialog and hide with escape",
+  async (name) => {
+    await click(getButton("Open dialog"));
+    await click(getButton(`${name} dismiss`));
+    expect(getButton("Close")).toHaveFocus();
+    expectAccessibleDialog(`${name} dismiss`, true);
+    expectAccessibleDialog("Dialog", false);
+    expectModalStyle(true);
+    await click(getButton(`${name} dismiss ${name}`));
+    expect(getDialog(`${name} dismiss`)).not.toBeVisible();
+    expect(getButton("Close")).toHaveFocus();
+    expectAccessibleDialog(`${name} dismiss`, false);
+    expectAccessibleDialog(`${name} dismiss ${name}`, true);
+    expectModalStyle(true);
+    await press.Escape();
+    expect(getButton("Open dialog")).toHaveFocus();
+    expectAccessibleDialog(`${name} dismiss ${name}`, false);
+    expectModalStyle(false);
+  }
+);
+
+test.each(["sibling"])(
+  "show %s dismiss unmount dialog and hide with escape",
+  async (name) => {
+    await click(getButton("Open dialog"));
+    await click(getButton(`${name} dismiss unmount`));
+    expect(getDialog("Dialog")).not.toBeInTheDocument();
+    expect(getButton("Close")).toHaveFocus();
+    expectAccessibleDialog(`${name} dismiss unmount`, true);
+    expectModalStyle(true);
+    await click(getButton(`${name} dismiss unmount ${name}`));
+    expect(getDialog(`${name} dismiss unmount`)).not.toBeInTheDocument();
+    expect(getButton("Close")).toHaveFocus();
+    expectAccessibleDialog(`${name} dismiss unmount`, false);
+    expectAccessibleDialog(`${name} dismiss unmount ${name}`, true);
+    expectModalStyle(true);
+    await press.Escape();
+    expect(
+      getDialog(`${name} dismiss unmount ${name}`)
+    ).not.toBeInTheDocument();
+    expect(getButton("Open dialog")).toHaveFocus();
+    expectModalStyle(false);
+  }
+);

--- a/packages/ariakit-react-core/package.json
+++ b/packages/ariakit-react-core/package.json
@@ -158,6 +158,7 @@
     "./disclosure/disclosure-store": "./src/disclosure/disclosure-store.ts",
     "./disclosure/disclosure-content": "./src/disclosure/disclosure-content.ts",
     "./dialog/utils/walk-tree-outside": "./src/dialog/utils/walk-tree-outside.ts",
+    "./dialog/utils/use-root-dialog": "./src/dialog/utils/use-root-dialog.ts",
     "./dialog/utils/use-previous-mouse-down-ref": "./src/dialog/utils/use-previous-mouse-down-ref.ts",
     "./dialog/utils/use-prevent-body-scroll": "./src/dialog/utils/use-prevent-body-scroll.ts",
     "./dialog/utils/use-nested-dialogs": "./src/dialog/utils/use-nested-dialogs.tsx",

--- a/packages/ariakit-react-core/src/dialog/dialog-backdrop.tsx
+++ b/packages/ariakit-react-core/src/dialog/dialog-backdrop.tsx
@@ -38,8 +38,6 @@ export function DialogBackdrop({
     if (!id) return;
     const backdrop = ref.current;
     if (!backdrop) return;
-    // TODO: Test clicking outside a nested dialog and outside the parent dialog
-    // (should close only the nested dialog)
     return markAncestor(backdrop, id);
   }, [contentElement]);
 

--- a/packages/ariakit-react-core/src/dialog/dialog-backdrop.tsx
+++ b/packages/ariakit-react-core/src/dialog/dialog-backdrop.tsx
@@ -38,6 +38,8 @@ export function DialogBackdrop({
     if (!id) return;
     const backdrop = ref.current;
     if (!backdrop) return;
+    // TODO: Test clicking outside a nested dialog and outside the parent dialog
+    // (should close only the nested dialog)
     return markAncestor(backdrop, id);
   }, [contentElement]);
 

--- a/packages/ariakit-react-core/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-core/src/dialog/dialog.tsx
@@ -116,10 +116,7 @@ export const useDialog = createHook<DialogOptions>(
     // domReady can be also the portal node element so it's updated when the
     // portal node changes (like in between re-renders), triggering effects
     // again.
-    const { portalRef, portalNode, domReady } = usePortalRef(
-      portal,
-      props.portalRef
-    );
+    const { portalRef, domReady } = usePortalRef(portal, props.portalRef);
     // Sets preserveTabOrder to true only if the dialog is not a modal and is
     // open.
     const preserveTabOrderProp = props.preserveTabOrder;
@@ -214,6 +211,7 @@ export const useDialog = createHook<DialogOptions>(
 
     // Disables/enables the element tree around the modal dialog element.
     useSafeLayoutEffect(() => {
+      if (!domReady) return;
       if (!id) return;
       // When the dialog is animating, we immediately restore the element tree
       // outside. This means the element tree will be enabled when the focus is
@@ -225,9 +223,6 @@ export const useDialog = createHook<DialogOptions>(
       const persistentElements = getPersistentElementsProp() || [];
       const allElements = [
         dialog,
-        // TODO: Comment, necessary for clicking outside a nested dialog and
-        // outside a parent dialog, but closing only the nested dialog.
-        portalNode,
         ...persistentElements,
         ...nestedDialogs.map((dialog) => dialog.getState().contentElement),
       ];
@@ -245,13 +240,12 @@ export const useDialog = createHook<DialogOptions>(
         disableAccessibilityTreeOutside(...allElements)
       );
     }, [
+      domReady,
       id,
       open,
       store,
-      portal,
-      portalNode,
-      nestedDialogs,
       getPersistentElementsProp,
+      nestedDialogs,
       shouldDisableAccessibilityTree,
       modal,
     ]);

--- a/packages/ariakit-react-core/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-core/src/dialog/dialog.tsx
@@ -224,14 +224,11 @@ export const useDialog = createHook<DialogOptions>(
       const dialog = ref.current;
       const persistentElements = getPersistentElementsProp() || [];
       const allElements = [
-        // In addition to the dialog element, we also include the portal node
-        // here so nested dialogs are considered as well.
         dialog,
+        // TODO: Comment, necessary for clicking outside a nested dialog and
+        // outside a parent dialog, but closing only the nested dialog.
         portalNode,
         ...persistentElements,
-        // We still need to include nested dialogs here because they may be
-        // outside the portal node or the parent dialog may not be using a
-        // portal.
         ...nestedDialogs.map((dialog) => dialog.getState().contentElement),
       ];
       if (!shouldDisableAccessibilityTree) {

--- a/packages/ariakit-react-core/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-core/src/dialog/dialog.tsx
@@ -129,7 +129,7 @@ export const useDialog = createHook<DialogOptions>(
     const contentElement = store.useState("contentElement");
     const hidden = isHidden(mounted, props.hidden, props.alwaysVisible);
 
-    usePreventBodyScroll(store, preventBodyScroll && !hidden);
+    usePreventBodyScroll(contentElement, id, preventBodyScroll && !hidden);
     useHideOnInteractOutside(store, hideOnInteractOutside);
 
     const { wrapElement, nestedDialogs } = useNestedDialogs(store);

--- a/packages/ariakit-react-core/src/dialog/utils/disable-accessibility-tree-outside.ts
+++ b/packages/ariakit-react-core/src/dialog/utils/disable-accessibility-tree-outside.ts
@@ -1,3 +1,4 @@
+import { isBackdrop } from "./is-backdrop.js";
 import { setAttribute } from "./orchestrate.js";
 import { walkTreeOutside } from "./walk-tree-outside.js";
 
@@ -9,8 +10,10 @@ export function hideElementFromAccessibilityTree(element: Element) {
 
 export function disableAccessibilityTreeOutside(...elements: Elements) {
   const cleanups: Array<() => void> = [];
+  const ids = elements.map((el) => el?.id);
 
   walkTreeOutside(elements, (element) => {
+    if (isBackdrop(element, ...ids)) return;
     cleanups.unshift(hideElementFromAccessibilityTree(element));
   });
 

--- a/packages/ariakit-react-core/src/dialog/utils/disable-tree-outside.ts
+++ b/packages/ariakit-react-core/src/dialog/utils/disable-tree-outside.ts
@@ -2,6 +2,7 @@ import { contains } from "@ariakit/core/utils/dom";
 import { getAllTabbable } from "@ariakit/core/utils/focus";
 import { chain, noop } from "@ariakit/core/utils/misc";
 import { hideElementFromAccessibilityTree } from "./disable-accessibility-tree-outside.js";
+import { isBackdrop } from "./is-backdrop.js";
 import { assignStyle, setAttribute, setProperty } from "./orchestrate.js";
 import { supportsInert } from "./supports-inert.js";
 import { walkTreeOutside } from "./walk-tree-outside.js";
@@ -27,6 +28,7 @@ function disableElement(element: Element | HTMLElement) {
 
 export function disableTreeOutside(...elements: Elements) {
   const cleanups: Array<() => void> = [];
+  const ids = elements.map((el) => el?.id);
 
   // If the browser doesn't support the inert attribute, we need to manually
   // disable all tabbable elements outside the dialog.
@@ -39,6 +41,7 @@ export function disableTreeOutside(...elements: Elements) {
   }
 
   walkTreeOutside(elements, (element) => {
+    if (isBackdrop(element, ...ids)) return;
     cleanups.unshift(disableElement(element));
   });
 

--- a/packages/ariakit-react-core/src/dialog/utils/is-backdrop.ts
+++ b/packages/ariakit-react-core/src/dialog/utils/is-backdrop.ts
@@ -1,13 +1,12 @@
 export function isBackdrop(
   element?: Element | null,
-  dialog?: HTMLElement | null
+  ...ids: Array<string | null | undefined>
 ) {
   if (!element) return false;
   const backdrop = element.getAttribute("data-backdrop");
   if (backdrop == null) return false;
   if (backdrop === "") return true;
   if (backdrop === "true") return true;
-  const id = dialog?.id;
-  if (!id) return false;
-  return backdrop === id;
+  if (!ids.length) return true;
+  return ids.some((id) => backdrop === id);
 }

--- a/packages/ariakit-react-core/src/dialog/utils/mark-tree-outside.ts
+++ b/packages/ariakit-react-core/src/dialog/utils/mark-tree-outside.ts
@@ -1,4 +1,5 @@
 import { chain } from "@ariakit/core/utils/misc";
+import { isBackdrop } from "./is-backdrop.js";
 import { setProperty } from "./orchestrate.js";
 import { walkTreeOutside } from "./walk-tree-outside.js";
 
@@ -40,7 +41,10 @@ export function markTreeOutside(dialogId: string, ...elements: Elements) {
 
   walkTreeOutside(
     elements,
-    (element) => cleanups.unshift(markElement(element, dialogId)),
+    (element) => {
+      if (isBackdrop(element)) return;
+      cleanups.unshift(markElement(element, dialogId));
+    },
     (ancestor) => cleanups.unshift(markAncestor(ancestor, dialogId))
   );
 

--- a/packages/ariakit-react-core/src/dialog/utils/mark-tree-outside.ts
+++ b/packages/ariakit-react-core/src/dialog/utils/mark-tree-outside.ts
@@ -38,11 +38,12 @@ export function isElementMarked(element: Element, id?: string) {
 
 export function markTreeOutside(dialogId: string, ...elements: Elements) {
   const cleanups: Array<() => void> = [];
+  const ids = elements.map((el) => el?.id);
 
   walkTreeOutside(
     elements,
     (element) => {
-      if (isBackdrop(element)) return;
+      if (isBackdrop(element, ...ids)) return;
       cleanups.unshift(markElement(element, dialogId));
     },
     (ancestor) => cleanups.unshift(markAncestor(ancestor, dialogId))

--- a/packages/ariakit-react-core/src/dialog/utils/use-prevent-body-scroll.ts
+++ b/packages/ariakit-react-core/src/dialog/utils/use-prevent-body-scroll.ts
@@ -1,10 +1,11 @@
 // Based on https://github.com/floating-ui/floating-ui/blob/1201e72e67a80e479122293d46d96c9bbc8f156d/packages/react-dom-interactions/src/FloatingOverlay.tsx
+import { useEffect } from "react";
 import { getDocument, getWindow } from "@ariakit/core/utils/dom";
 import { chain } from "@ariakit/core/utils/misc";
 import { isApple, isMac } from "@ariakit/core/utils/platform";
-import { useSafeLayoutEffect } from "../../utils/hooks.js";
 import type { DialogStore } from "../dialog-store.js";
 import { assignStyle, setCSSProperty } from "./orchestrate.js";
+import { useRootDialog } from "./use-root-dialog.js";
 
 function getPaddingProperty(documentElement: HTMLElement) {
   // RTL <body> scrollbar
@@ -14,8 +15,13 @@ function getPaddingProperty(documentElement: HTMLElement) {
 }
 
 export function usePreventBodyScroll(store: DialogStore, enabled?: boolean) {
-  useSafeLayoutEffect(() => {
-    if (!enabled) return;
+  const isRootDialog = useRootDialog(
+    "data-dialog-prevent-body-scroll",
+    store,
+    enabled
+  );
+  useEffect(() => {
+    if (!isRootDialog()) return;
     const { contentElement } = store.getState();
     const doc = getDocument(contentElement);
     const win = getWindow(contentElement);
@@ -73,5 +79,5 @@ export function usePreventBodyScroll(store: DialogStore, enabled?: boolean) {
       setScrollbarWidthProperty(),
       isIOS ? setIOSStyle() : setStyle()
     );
-  }, [enabled]);
+  }, [isRootDialog]);
 }

--- a/packages/ariakit-react-core/src/dialog/utils/use-prevent-body-scroll.ts
+++ b/packages/ariakit-react-core/src/dialog/utils/use-prevent-body-scroll.ts
@@ -3,7 +3,6 @@ import { useEffect } from "react";
 import { getDocument, getWindow } from "@ariakit/core/utils/dom";
 import { chain } from "@ariakit/core/utils/misc";
 import { isApple, isMac } from "@ariakit/core/utils/platform";
-import type { DialogStore } from "../dialog-store.js";
 import { assignStyle, setCSSProperty } from "./orchestrate.js";
 import { useRootDialog } from "./use-root-dialog.js";
 
@@ -14,15 +13,21 @@ function getPaddingProperty(documentElement: HTMLElement) {
   return scrollbarX ? "paddingLeft" : "paddingRight";
 }
 
-export function usePreventBodyScroll(store: DialogStore, enabled?: boolean) {
-  const isRootDialog = useRootDialog(
-    "data-dialog-prevent-body-scroll",
-    store,
-    enabled
-  );
+export function usePreventBodyScroll(
+  contentElement: HTMLElement | null,
+  contentId?: string,
+  enabled?: boolean
+) {
+  const isRootDialog = useRootDialog({
+    attribute: "data-dialog-prevent-body-scroll",
+    contentElement,
+    contentId,
+    enabled,
+  });
+
   useEffect(() => {
     if (!isRootDialog()) return;
-    const { contentElement } = store.getState();
+    if (!contentElement) return;
     const doc = getDocument(contentElement);
     const win = getWindow(contentElement);
     const { documentElement, body } = doc;
@@ -79,5 +84,5 @@ export function usePreventBodyScroll(store: DialogStore, enabled?: boolean) {
       setScrollbarWidthProperty(),
       isIOS ? setIOSStyle() : setStyle()
     );
-  }, [isRootDialog]);
+  }, [isRootDialog, contentElement]);
 }

--- a/packages/ariakit-react-core/src/dialog/utils/use-root-dialog.ts
+++ b/packages/ariakit-react-core/src/dialog/utils/use-root-dialog.ts
@@ -1,0 +1,41 @@
+import { useCallback, useEffect } from "react";
+import { getDocument } from "@ariakit/core/utils/dom";
+import { flushSync } from "react-dom";
+import { useForceUpdate } from "../../utils/hooks.js";
+import type { DialogStore } from "../dialog-store.js";
+
+export function useRootDialog(
+  attribute: string,
+  store: DialogStore,
+  enabled?: boolean
+) {
+  const [updated, retry] = useForceUpdate();
+
+  const isRootDialog = useCallback(() => {
+    if (!enabled) return false;
+    const dialog = store.getState().contentElement;
+    if (!dialog) return false;
+    const { body } = getDocument(dialog);
+    const id = body.getAttribute(attribute);
+    return !id || id === dialog.id;
+  }, [updated, store, enabled, attribute]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const dialog = store.getState().contentElement;
+    if (!dialog) return;
+    const { body } = getDocument(dialog);
+    if (isRootDialog()) {
+      body.setAttribute(attribute, dialog.id);
+      return () => body.removeAttribute(attribute);
+    }
+    // If the dialog is not the root, there may be another dialog that will be
+    // closed soon, which will remove the root attribute from the body. We
+    // observe this change and retry to see if this dialog is now the root.
+    const observer = new MutationObserver(() => flushSync(retry));
+    observer.observe(body, { attributeFilter: [attribute] });
+    return () => observer.disconnect();
+  }, [updated, enabled, store, isRootDialog, attribute]);
+
+  return isRootDialog;
+}

--- a/packages/ariakit-react-core/src/focusable/focusable.ts
+++ b/packages/ariakit-react-core/src/focusable/focusable.ts
@@ -277,10 +277,7 @@ export const useFocusable = createHook<FocusableOptions>(
         receivedFocus = true;
       };
       const options = { capture: true, once: true };
-      // In addition to that, there may be another element that has received
-      // focus between this mouse down event and the next mouse up event. So we
-      // attach the event listener to the body element.
-      document.body.addEventListener("focusin", onFocus, options);
+      element.addEventListener("focusin", onFocus, options);
       // We can't focus right away after on mouse down, otherwise it would
       // prevent drag events from happening. So we queue the focus to the next
       // animation frame, but always before the next mouseup event. The mouseup


### PR DESCRIPTION
Closes #2528

Instead of allowing any dialog to disable body scroll, this PR makes it so only the root dialog (determined by the internal `useRootDialog` hook) has control over this behavior.