### PR TITLE
Fix Menu/Combobox initial focus

### DIFF
--- a/.changeset/menu-combobox-initial-focus.md
+++ b/.changeset/menu-combobox-initial-focus.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed `Menu` initial focus when used in combination with `Combobox`. ([#2582](https://github.com/ariakit/ariakit/pull/2582))

--- a/examples/menu-combobox/index.tsx
+++ b/examples/menu-combobox/index.tsx
@@ -1,8 +1,8 @@
+import "./style.css";
 import { useDeferredValue, useMemo } from "react";
 import * as Ariakit from "@ariakit/react";
 import { matchSorter } from "match-sorter";
 import list from "./list.js";
-import "./style.css";
 
 export default function Example() {
   const combobox = Ariakit.useComboboxStore({ resetValueOnHide: true });

--- a/examples/menu-combobox/test.ts
+++ b/examples/menu-combobox/test.ts
@@ -111,6 +111,9 @@ test("move through items with keyboard", async () => {
   expect(getOption("Search")).toHaveFocus();
   await press.ArrowDown();
   expect(getOption("Verse")).toHaveFocus();
+  await press.Escape();
+  await press.ArrowDown();
+  expect(getOption("Paragraph")).toHaveFocus();
 });
 
 test("move through items with mouse and keyboard", async () => {

--- a/guide/400-component-stores/readme.md
+++ b/guide/400-component-stores/readme.md
@@ -104,7 +104,7 @@ function MyCombobox() {
 
 Alternatively, you can pass a string to `store.useState()` to read the value of a specific state property. The component will only re-render when the requested value changes.
 
-```js ""open""
+```js ""value"" ""open""
 const value = combobox.useState("value");
 const isOpen = combobox.useState("open");
 ```

--- a/packages/ariakit-core/src/collection/collection-store.ts
+++ b/packages/ariakit-core/src/collection/collection-store.ts
@@ -107,9 +107,8 @@ export function createCollectionStore<T extends Item = Item>(
         const root = getCommonParent(state.renderedItems);
         const observer = new IntersectionObserver(callback, { root });
         state.renderedItems.forEach((item) => {
-          if (item.element) {
-            observer.observe(item.element);
-          }
+          if (!item.element) return;
+          observer.observe(item.element);
         });
         return () => {
           cancelAnimationFrame(raf);

--- a/packages/ariakit-react-core/src/menu/menu.ts
+++ b/packages/ariakit-react-core/src/menu/menu.ts
@@ -79,7 +79,7 @@ export const useMenu = createHook<MenuOptions>(
     const autoFocusOnShowState = store.useState("autoFocusOnShow");
     const initialFocus = store.useState("initialFocus");
     const baseElement = store.useState("baseElement");
-    const items = store.useState("items");
+    const items = store.useState("renderedItems");
 
     // Sets the initial focus ref.
     useEffect(() => {


### PR DESCRIPTION
When the rendered items changed, pressing <kbd>ArrowDown</kbd> on a menu button, after closing the menu, wouldn't focus on the first menu item.