### PR TITLE
Do not scroll composite item into view on hover

### DIFF
--- a/.changeset/composite-hover-scroll-into-view.md
+++ b/.changeset/composite-hover-scroll-into-view.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Updated composite item components with the `focusOnHover` prop set to `true` so that they don't scroll into view when hovered. ([#2590](https://github.com/ariakit/ariakit/pull/2590))

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -301,9 +301,9 @@ jobs:
     name: Test macOS
     needs: website
     runs-on: macos-latest
-    concurrency:
-      group: test-macos-${{ github.head_ref || github.run_id }}
-      cancel-in-progress: true
+    # concurrency:
+    #   group: test-macos-${{ github.head_ref || github.run_id }}
+    #   cancel-in-progress: true
 
     steps:
       - name: Checkout repository

--- a/examples/combobox-group/test-browser.ts
+++ b/examples/combobox-group/test-browser.ts
@@ -2,6 +2,7 @@ import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 
 const getCombobox = (page: Page) => page.getByRole("combobox");
+const getPopover = (page: Page) => page.getByRole("listbox");
 
 function getSelectionValue(page: Page) {
   return getCombobox(page).evaluate((element) => {
@@ -27,4 +28,13 @@ test("maintain completion string while typing", async ({ page }) => {
   await page.keyboard.type("ca");
   await expect(getCombobox(page)).toHaveValue("avocado");
   expect(await getSelectionValue(page)).toBe("do");
+});
+
+test("do not scroll when hovering over an item", async ({ page }) => {
+  await getCombobox(page).click();
+  await getPopover(page).click({ position: { x: 2, y: 2 } });
+  await getPopover(page).evaluate((el) => (el.scrollTop = 100));
+  expect(await getPopover(page).evaluate((el) => el.scrollTop)).toBe(100);
+  await getPopover(page).hover({ position: { x: 40, y: 10 } });
+  expect(await getPopover(page).evaluate((el) => el.scrollTop)).toBe(100);
 });

--- a/packages/ariakit-react-core/src/composite/composite.tsx
+++ b/packages/ariakit-react-core/src/composite/composite.tsx
@@ -133,7 +133,7 @@ function useScheduleFocus(store: CompositeStore) {
     if (!scheduled) return;
     if (!activeElement) return;
     setScheduled(false);
-    focusIntoView(activeElement);
+    activeElement.focus({ preventScroll: true });
   }, [activeItem, scheduled]);
   return schedule;
 }
@@ -164,15 +164,14 @@ export const useComposite = createHook<CompositeOptions>(
     const moves = store.useState("moves");
 
     // Focus on the active item element.
-    useSafeLayoutEffect(() => {
+    useEffect(() => {
+      if (!moves) return;
       if (!composite) return;
       if (!focusOnMove) return;
-      if (!moves) return;
       const { activeId } = store.getState();
       const itemElement = getEnabledItem(store, activeId)?.element;
       if (!itemElement) return;
-      // TODO: Revisit and explain this.
-      scheduleFocus();
+      focusIntoView(itemElement);
     }, [moves, composite, focusOnMove]);
 
     // If composite.move(null) has been called, the composite container (this


### PR DESCRIPTION
This PR updates the `Composite` component so composite items aren't scrolled into view when they get focused on hover.