### PR TITLE
Maintain Combobox value on blur

### DIFF
--- a/.changeset/combobox-auto-select-maintain-value.md
+++ b/.changeset/combobox-auto-select-maintain-value.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed `Combobox` with `autoSelect` and `autoComplete="both"` so the value is maintained when the combobox input loses focus. ([#2595](https://github.com/ariakit/ariakit/pull/2595))

--- a/examples/combobox-group/combobox.tsx
+++ b/examples/combobox-group/combobox.tsx
@@ -1,0 +1,80 @@
+import * as React from "react";
+import * as Ariakit from "@ariakit/react";
+
+export interface ComboboxProps
+  extends Omit<Ariakit.ComboboxProps, "store" | "onChange"> {
+  value?: string;
+  onChange?: (value: string) => void;
+}
+
+export const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
+  function Combobox({ value, onChange, children, ...props }, ref) {
+    const combobox = Ariakit.useComboboxStore({ value, setValue: onChange });
+    return (
+      <>
+        <Ariakit.Combobox
+          ref={ref}
+          store={combobox}
+          className="combobox"
+          {...props}
+        />
+        <Ariakit.ComboboxPopover
+          store={combobox}
+          portal
+          sameWidth
+          gutter={4}
+          className="popover"
+        >
+          {children}
+        </Ariakit.ComboboxPopover>
+      </>
+    );
+  }
+);
+
+export interface ComboboxGroupProps extends Ariakit.ComboboxGroupProps {
+  label?: React.ReactNode;
+  children?: React.ReactNode;
+}
+
+export const ComboboxGroup = React.forwardRef<
+  HTMLDivElement,
+  ComboboxGroupProps
+>(function ComboboxGroup({ label, children, ...props }, ref) {
+  return (
+    <Ariakit.ComboboxGroup ref={ref} className="group" {...props}>
+      {label && (
+        <Ariakit.ComboboxGroupLabel className="group-label">
+          {label}
+        </Ariakit.ComboboxGroupLabel>
+      )}
+      {children}
+    </Ariakit.ComboboxGroup>
+  );
+});
+
+export type ComboboxItemProps = Ariakit.ComboboxItemProps;
+
+export const ComboboxItem = React.forwardRef<HTMLDivElement, ComboboxItemProps>(
+  function ComboboxItem(props, ref) {
+    return (
+      <Ariakit.ComboboxItem
+        ref={ref}
+        focusOnHover
+        className="combobox-item"
+        {...props}
+      />
+    );
+  }
+);
+
+export type ComboboxSeparatorProps = Ariakit.ComboboxSeparatorProps;
+
+export const ComboboxSeparator = React.forwardRef<
+  HTMLHRElement,
+  ComboboxSeparatorProps
+>(function ComboboxSeparator(props, ref) {
+  return (
+    <Ariakit.ComboboxSeparator ref={ref} className="separator" {...props} />
+  );
+});

--- a/examples/combobox-group/index.tsx
+++ b/examples/combobox-group/index.tsx
@@ -1,13 +1,17 @@
+import "./style.css";
 import * as React from "react";
-import * as Ariakit from "@ariakit/react";
 import groupBy from "lodash-es/groupBy.js";
 import { matchSorter } from "match-sorter";
+import {
+  Combobox,
+  ComboboxGroup,
+  ComboboxItem,
+  ComboboxSeparator,
+} from "./combobox.jsx";
 import food from "./food.js";
-import "./style.css";
 
 export default function Example() {
-  const combobox = Ariakit.useComboboxStore();
-  const value = combobox.useState("value");
+  const [value, setValue] = React.useState("");
   const deferredValue = React.useDeferredValue(value);
 
   const matches = React.useMemo(() => {
@@ -19,45 +23,29 @@ export default function Example() {
     <div className="wrapper">
       <label className="label">
         Your favorite food
-        <Ariakit.Combobox
-          store={combobox}
-          placeholder="e.g., Apple"
-          className="combobox"
-          autoComplete="both"
+        <Combobox
+          value={value}
+          onChange={setValue}
           autoSelect
-        />
+          autoComplete="both"
+          placeholder="e.g., Apple"
+        >
+          {matches.length ? (
+            matches.map(([type, items], i) => (
+              <React.Fragment key={type}>
+                <ComboboxGroup label={type}>
+                  {items.map((item) => (
+                    <ComboboxItem key={item.name} value={item.name} />
+                  ))}
+                </ComboboxGroup>
+                {i < matches.length - 1 && <ComboboxSeparator />}
+              </React.Fragment>
+            ))
+          ) : (
+            <div className="no-results">No results found</div>
+          )}
+        </Combobox>
       </label>
-      <Ariakit.ComboboxPopover
-        store={combobox}
-        gutter={4}
-        sameWidth
-        className="popover"
-      >
-        {!!matches.length ? (
-          matches.map(([type, items], i) => (
-            <React.Fragment key={type}>
-              <Ariakit.ComboboxGroup className="group">
-                <Ariakit.ComboboxGroupLabel className="group-label">
-                  {type}
-                </Ariakit.ComboboxGroupLabel>
-                {items.map((item) => (
-                  <Ariakit.ComboboxItem
-                    key={item.name}
-                    value={item.name}
-                    focusOnHover
-                    className="combobox-item"
-                  />
-                ))}
-              </Ariakit.ComboboxGroup>
-              {i < matches.length - 1 && (
-                <Ariakit.ComboboxSeparator className="separator" />
-              )}
-            </React.Fragment>
-          ))
-        ) : (
-          <div className="no-results">No results found</div>
-        )}
-      </Ariakit.ComboboxPopover>
     </div>
   );
 }

--- a/examples/combobox-group/test-browser.ts
+++ b/examples/combobox-group/test-browser.ts
@@ -1,8 +1,10 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 
-const getCombobox = (page: Page) => page.getByRole("combobox");
+const getCombobox = (page: Page) => page.getByPlaceholder("e.g., Apple");
 const getPopover = (page: Page) => page.getByRole("listbox");
+const getOption = (page: Page, name: string) =>
+  page.getByRole("option", { name, exact: true });
 
 function getSelectionValue(page: Page) {
   return getCombobox(page).evaluate((element) => {
@@ -28,13 +30,74 @@ test("maintain completion string while typing", async ({ page }) => {
   await page.keyboard.type("ca");
   await expect(getCombobox(page)).toHaveValue("avocado");
   expect(await getSelectionValue(page)).toBe("do");
+  await page.keyboard.type("o");
+  await expect(getCombobox(page)).toHaveValue("avocao");
+  expect(await getSelectionValue(page)).toBe("");
+  await expect(getOption(page, "Avocado")).toBeVisible();
+  await expect(getOption(page, "Avocado")).toHaveAttribute(
+    "data-active-item",
+    ""
+  );
 });
 
 test("do not scroll when hovering over an item", async ({ page }) => {
   await getCombobox(page).click();
   await getPopover(page).click({ position: { x: 2, y: 2 } });
-  await getPopover(page).evaluate((el) => (el.scrollTop = 100));
+  await getPopover(page).evaluate((el) => el.scrollTo({ top: 100 }));
   expect(await getPopover(page).evaluate((el) => el.scrollTop)).toBe(100);
   await getPopover(page).hover({ position: { x: 40, y: 10 } });
   expect(await getPopover(page).evaluate((el) => el.scrollTop)).toBe(100);
+});
+
+test("set value on tab", async ({ page }) => {
+  await page.evaluate(() => {
+    const div = document.createElement("div");
+    div.tabIndex = 0;
+    document.body.append(div);
+  });
+  await page.keyboard.press("Tab");
+  await expect(getCombobox(page)).toBeFocused();
+  await page.keyboard.type("a");
+  await expect(getPopover(page)).toBeVisible();
+  await expect(getCombobox(page)).toHaveValue("apple");
+  expect(await getSelectionValue(page)).toBe("pple");
+  await page.keyboard.press("Tab");
+  await expect(getCombobox(page)).not.toBeFocused();
+  await expect(getPopover(page)).not.toBeVisible();
+  await expect(getCombobox(page)).toHaveValue("apple");
+});
+
+test("set value on tab after moving to another item", async ({ page }) => {
+  await page.evaluate(() => {
+    const div = document.createElement("div");
+    div.tabIndex = 0;
+    document.body.append(div);
+  });
+  await getCombobox(page).click();
+  await page.keyboard.type("ap");
+  await expect(getCombobox(page)).toHaveValue("apple");
+  expect(await getSelectionValue(page)).toBe("ple");
+  await page.keyboard.press("ArrowDown");
+  await page.keyboard.press("ArrowDown");
+  expect(getCombobox(page)).toHaveValue("Papaya");
+  await page.keyboard.press("Tab");
+  await expect(getCombobox(page)).not.toBeFocused();
+  await expect(getPopover(page)).not.toBeVisible();
+  await expect(getCombobox(page)).toHaveValue("Papaya");
+});
+
+test("set value on click outside", async ({ page }) => {
+  await getCombobox(page).click();
+  await page.keyboard.type("co");
+  await expect(getCombobox(page)).toHaveValue("coconut");
+  expect(await getSelectionValue(page)).toBe("conut");
+  await page.keyboard.press("ArrowDown");
+  await expect(getCombobox(page)).toHaveValue("Avocado");
+  await page.mouse.move(10, 10);
+  await page.mouse.down();
+  await expect(getCombobox(page)).toHaveValue("Avocado");
+  await expect(getPopover(page)).toBeVisible();
+  expect(await page.getByRole("option").all()).toHaveLength(1);
+  await page.mouse.up();
+  await expect(getPopover(page)).not.toBeVisible();
 });


### PR DESCRIPTION
This PR fixes the `Combobox` behavior when using the `autoSelect` and the `autoComplete="both|inline"` props. Pressing <kbd>Tab</kbd> or clicking outside while the inline auto-complete was active wouldn't work as expected.