### PR TITLE
Add experimental element keys to Role

### DIFF
--- a/.changeset/role-elements.md
+++ b/.changeset/role-elements.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/react-core": patch
+---
+
+Added experimental element keys to the `Role` component. ([#2660](https://github.com/ariakit/ariakit/pull/2660))

--- a/packages/ariakit-react-core/src/role/role.ts
+++ b/packages/ariakit-react-core/src/role/role.ts
@@ -1,5 +1,38 @@
 import { createComponent, createElement, createHook } from "../utils/system.js";
-import type { As, Options, Props } from "../utils/types.js";
+import type { As, Component, Options, Props } from "../utils/types.js";
+
+const elements = [
+  "a",
+  "button",
+  "details",
+  "dialog",
+  "div",
+  "form",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "header",
+  "img",
+  "input",
+  "label",
+  "li",
+  "nav",
+  "ol",
+  "p",
+  "section",
+  "select",
+  "span",
+  "textarea",
+  "ul",
+  "svg",
+] as const;
+
+type RoleElements = {
+  [K in (typeof elements)[number]]: Component<RoleOptions<K>>;
+};
 
 /**
  * Returns props to create a `Role` component.
@@ -26,11 +59,21 @@ export const useRole = createHook<RoleOptions>((props) => {
  */
 export const Role = createComponent<RoleOptions>((props) => {
   return createElement("div", props);
-});
+}) as Component<RoleOptions<"div">> & RoleElements;
 
 if (process.env.NODE_ENV !== "production") {
   Role.displayName = "Role";
 }
+
+Object.assign(
+  Role,
+  elements.reduce((acc, element) => {
+    acc[element] = createComponent<RoleOptions<typeof element>>((props) => {
+      return createElement(element, props);
+    });
+    return acc;
+  }, {} as RoleElements),
+);
 
 export type RoleOptions<T extends As = "div"> = Options<T>;
 

--- a/website/app/(main)/[category]/[page]/page.tsx
+++ b/website/app/(main)/[category]/[page]/page.tsx
@@ -5,6 +5,7 @@ import pagesConfig from "build-pages/config.js";
 import { getPageContent } from "build-pages/get-page-content.js";
 import { getPageEntryFiles } from "build-pages/get-page-entry-files.js";
 import { getPageName } from "build-pages/get-page-name.js";
+import { getPageTitle } from "build-pages/get-page-title.js";
 import { getPageTreeFromContent } from "build-pages/get-page-tree.js";
 import pagesIndex from "build-pages/index.js";
 import links from "build-pages/links.js";
@@ -14,6 +15,7 @@ import type {
   TableOfContents as TableOfContentsData,
 } from "build-pages/types.js";
 import { CodeBlock } from "components/code-block.js";
+import { NewsletterForm } from "components/newsletter-form.jsx";
 import { PageItem } from "components/page-item.jsx";
 import { PageVideo } from "components/page-video.jsx";
 import matter from "gray-matter";
@@ -741,6 +743,36 @@ export default async function Page({ params }: PageProps) {
         >
           {contentWithoutMatter}
         </ReactMarkdown>
+        <div className="mt-20 grid w-full max-w-[832px] grid-cols-1 justify-between gap-4 rounded-lg bg-gradient-to-br from-blue-100 to-pink-100 p-4 dark:from-blue-600/30 dark:to-pink-600/10 sm:grid-cols-2 sm:rounded-xl sm:p-8">
+          <div className="flex flex-col gap-3">
+            <h2 className="text-lg font-medium sm:text-2xl">Follow updates</h2>
+            <p className="dark:font-light">
+              Join 1,000+ subscribers and receive monthly updates with the
+              latest improvements on{" "}
+              <strong className="font-semibold">
+                {getPageTitle(category)}
+              </strong>
+              .
+            </p>
+          </div>
+          <NewsletterForm location="page" className="flex flex-col gap-3">
+            <div className="flex gap-3 sm:flex-col sm:gap-4">
+              <input
+                className="h-10 w-full flex-1 rounded border-none bg-white px-4 text-black placeholder-black/60 focus-visible:ariakit-outline-input sm:h-12 sm:flex-none sm:px-5 sm:text-lg"
+                type="email"
+                name="email"
+                required
+                placeholder="Your email address"
+              />
+              <button className="h-10 !cursor-pointer whitespace-nowrap rounded bg-blue-600 px-4 text-white shadow-xl hover:bg-blue-800 focus-visible:ariakit-outline sm:h-12 sm:px-5 sm:text-lg">
+                Subscribe
+              </button>
+            </div>
+            <p className="text-sm opacity-70 sm:text-center">
+              No Spam. Unsubscribe at any time.
+            </p>
+          </NewsletterForm>
+        </div>
       </main>
     </div>
   );

--- a/website/components/header-updates.tsx
+++ b/website/components/header-updates.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import { useId, useMemo, useState } from "react";
 import type { ComponentPropsWithoutRef } from "react";
 import { isDownloading, isOpeningInNewTab } from "@ariakit/core/utils/events";
@@ -12,6 +13,7 @@ import { twJoin, twMerge } from "tailwind-merge";
 import type { UpdateItem } from "updates.js";
 import { useMedia } from "utils/use-media.js";
 import { useUpdates } from "utils/use-updates.js";
+import { NewsletterForm } from "./newsletter-form.jsx";
 import { Popup } from "./popup.jsx";
 import { TooltipButton } from "./tooltip-button.jsx";
 import { UpdateLink } from "./update-link.jsx";
@@ -106,24 +108,25 @@ export function HeaderUpdates({ updates, ...props }: HeaderUpdatesProps) {
             <Ariakit.PopoverDismiss className="relative flex h-10 w-10 flex-none cursor-default items-center justify-center rounded-md border-none hover:bg-black/5 dark:hover:bg-white/5 [&:focus-visible]:ariakit-outline-input [&_svg]:stroke-[1pt]" />
           </div>
           <Ariakit.HeadingLevel>
-            <div className="flex flex-col gap-3 rounded bg-gradient-to-br from-blue-100 to-pink-100 p-4 dark:from-blue-600/30 dark:to-pink-600/30">
-              <Ariakit.Heading className="m-0 font-medium">
-                Newsletter
-              </Ariakit.Heading>
-              <p className="text-[15px] dark:font-light">
-                Join 1,000+ subscribers and receive monthly{" "}
-                <strong className="font-semibold">tips &amp; updates</strong> on
-                new Ariakit content.
-              </p>
-              <form
-                action="https://newsletter.ariakit.org/api/v1/free?email="
-                method="post"
-                target="_blank"
+            <div className="grid gap-3 rounded bg-gradient-to-br from-blue-100 to-pink-100 p-4 dark:from-blue-600/30 dark:to-pink-600/10">
+              <div className="flex flex-col gap-2">
+                <Ariakit.Heading className="font-medium">
+                  Newsletter
+                </Ariakit.Heading>
+                <p className="text-[15px] dark:font-light">
+                  Join 1,000+ subscribers and receive monthly{" "}
+                  <strong className="font-semibold">tips &amp; updates</strong>{" "}
+                  on new Ariakit content.
+                </p>
+              </div>
+              <NewsletterForm
+                location="header-updates"
+                className="flex flex-col gap-2"
               >
                 <div className="flex gap-2">
                   <Ariakit.Focusable
-                    className="h-10 w-full flex-1 scroll-mt-96 rounded border-none bg-white px-4 text-base text-black placeholder-black/60 focus-visible:ariakit-outline-input"
                     autoFocus
+                    className="h-10 w-full scroll-mt-96 rounded border-none bg-white px-4 text-black placeholder-black/60 focus-visible:ariakit-outline-input"
                     render={
                       <input
                         type="email"
@@ -133,11 +136,14 @@ export function HeaderUpdates({ updates, ...props }: HeaderUpdatesProps) {
                       />
                     }
                   />
-                  <button className="flex h-10 !cursor-pointer scroll-mt-96 items-center justify-center gap-2 whitespace-nowrap rounded bg-blue-600 px-4 text-white shadow-xl hover:bg-blue-800 focus-visible:ariakit-outline">
+                  <button className="h-10 !cursor-pointer scroll-mt-96 whitespace-nowrap rounded bg-blue-600 px-4 text-white shadow-xl hover:bg-blue-800 focus-visible:ariakit-outline">
                     Subscribe
                   </button>
                 </div>
-              </form>
+                <p className="text-sm opacity-70">
+                  No Spam. Unsubscribe at any time.
+                </p>
+              </NewsletterForm>
             </div>
           </Ariakit.HeadingLevel>
           {!!unreadItems.length && (

--- a/website/components/newsletter-form.tsx
+++ b/website/components/newsletter-form.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { forwardRef } from "react";
+import { Role } from "@ariakit/react";
+import type { RoleProps } from "@ariakit/react";
+import { track } from "@vercel/analytics";
+
+export interface NewsletterFormProps extends RoleProps<"form"> {
+  location: string;
+}
+
+export const NewsletterForm = forwardRef<HTMLFormElement, NewsletterFormProps>(
+  function NewsletterForm(props, ref) {
+    return (
+      <Role.form
+        ref={ref}
+        action="https://newsletter.ariakit.org/api/v1/free?email="
+        method="post"
+        target="_blank"
+        {...props}
+        onSubmit={(event) => {
+          props.onSubmit?.(event);
+          if (event.defaultPrevented) return;
+          const data = new FormData(event.currentTarget);
+          const email = `${data.get("email")}`;
+          track("newsletter-subscribe", { location: props.location, email });
+        }}
+      />
+    );
+  },
+);


### PR DESCRIPTION
This PR adds a new experimental feature to the `Role` component. It can be rendered like `Role.div`, `Role.a`, `Role.buton`, etc.