### PR TITLE
Fix flushSync warning

### DIFF
--- a/.changeset/cyan-forks-pretend.md
+++ b/.changeset/cyan-forks-pretend.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed `flushSync` warning. ([#2672](https://github.com/ariakit/ariakit/pull/2672))

--- a/examples/menu/index.tsx
+++ b/examples/menu/index.tsx
@@ -1,5 +1,5 @@
-import * as Ariakit from "@ariakit/react";
 import "./style.css";
+import * as Ariakit from "@ariakit/react";
 
 export default function Example() {
   const menu = Ariakit.useMenuStore();


### PR DESCRIPTION
With the #2671 change, React started showing a warning when `flushSync` was called from inside a lifecycle method. Since the `store.sync` callback can be called immediately, this PR changes it so the `flushSync` function is used only in subsequent calls.