### PR TITLE
Fix flushSync warning

### DIFF
--- a/.changeset/flush-sync-raf.md
+++ b/.changeset/flush-sync-raf.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed `ReactDOM.flushSync` warning on low-end devices. ([#2677](https://github.com/ariakit/ariakit/pull/2677))

--- a/examples/combobox-links/index.tsx
+++ b/examples/combobox-links/index.tsx
@@ -1,8 +1,8 @@
+import "./style.css";
 import { useDeferredValue, useMemo } from "react";
 import * as Ariakit from "@ariakit/react";
 import { matchSorter } from "match-sorter";
 import { NewWindow } from "./icons.jsx";
-import "./style.css";
 
 const links = [
   {

--- a/packages/ariakit-react-core/src/utils/store.tsx
+++ b/packages/ariakit-react-core/src/utils/store.tsx
@@ -130,7 +130,7 @@ export function useStoreProps<
     // flushSync throws a warning if called from inside a lifecycle method.
     // Since the store.sync callback can be called immediately, we'll make it
     // use the flushSync function only in subsequent calls.
-    queueMicrotask(() => {
+    requestAnimationFrame(() => {
       canFlushSync = true;
     });
     return store.sync(


### PR DESCRIPTION
Even after #2672, there were still situations where the `ReactDOM.flushSync` warning was triggered.