### PR TITLE
Fix combobox-min-length example

### DIFF
--- a/.changeset/combobox-min-length.md
+++ b/.changeset/combobox-min-length.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed `Combobox` controlled derived state. ([#2705](https://github.com/ariakit/ariakit/pull/2705))

--- a/examples/combobox-min-length/index.tsx
+++ b/examples/combobox-min-length/index.tsx
@@ -1,6 +1,6 @@
+import "./style.css";
 import { useState } from "react";
 import * as Ariakit from "@ariakit/react";
-import "./style.css";
 
 export default function Example() {
   const [open, setOpen] = useState(false);

--- a/examples/combobox-min-length/test.ts
+++ b/examples/combobox-min-length/test.ts
@@ -17,6 +17,12 @@ test("popover is not shown on arrow down key when combobox is pristine", async (
   expect(getPopover()).not.toBeVisible();
 });
 
+test("show popover after typing", async () => {
+  await press.Tab();
+  await type("a");
+  expect(getPopover()).toBeVisible();
+});
+
 test("popover is shown on click when combobox is dirty", async () => {
   await press.Tab();
   await type("a");

--- a/packages/ariakit-react-core/src/combobox/combobox.ts
+++ b/packages/ariakit-react-core/src/combobox/combobox.ts
@@ -328,9 +328,6 @@ export const useCombobox = createHook<ComboboxOptions>(
           setCanInline(textInserted && caretAtEnd);
         }
       }
-      if (showOnChangeProp(event)) {
-        store.show();
-      }
       if (setValueOnChangeProp(event)) {
         const isSameValue = value === store.getState().value;
         store.setValue(value);
@@ -345,6 +342,9 @@ export const useCombobox = createHook<ComboboxOptions>(
           // here so the inline completion effect will be fired.
           forceValueUpdate();
         }
+      }
+      if (showOnChangeProp(event)) {
+        store.show();
       }
       if (!autoSelect || !canAutoSelectRef.current) {
         // If autoSelect is not set or it's not an insertion of text, focus on


### PR DESCRIPTION
The `combobox-min-length` example using the derived state technique (setting a controlled state on render) did not work properly after introducing synchronous updates on the store in #2671. This pull request resolves the issue by moving the `showOnChange` behavior below the value update.