### PR TITLE
Fix controlled component store rendering with stale state

### DIFF
--- a/.changeset/2737-chilly-rivers-argue.md
+++ b/.changeset/2737-chilly-rivers-argue.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+[`#2737`](https://github.com/ariakit/ariakit/pull/2737) Fixed controlled component stores rendering with a stale state.

--- a/examples/select-listbox/index.tsx
+++ b/examples/select-listbox/index.tsx
@@ -1,5 +1,4 @@
 import "./style.css";
-import React from "react";
 import * as Ariakit from "@ariakit/react";
 
 // TODO: This is a temporary example. Replace this with a Listbox component.

--- a/examples/select-listbox/index.tsx
+++ b/examples/select-listbox/index.tsx
@@ -1,0 +1,33 @@
+import "./style.css";
+import React from "react";
+import * as Ariakit from "@ariakit/react";
+
+// TODO: This is a temporary example. Replace this with a Listbox component.
+export default function Example() {
+  const select = Ariakit.useSelectStore({ open: true });
+  return (
+    <Ariakit.SelectList store={select} className="popover">
+      <Ariakit.SelectItem
+        className="select-item"
+        focusOnHover={false}
+        value="Apple"
+      />
+      <Ariakit.SelectItem
+        className="select-item"
+        focusOnHover={false}
+        value="Banana"
+      />
+      <Ariakit.SelectItem
+        className="select-item"
+        focusOnHover={false}
+        value="Grape"
+        disabled
+      />
+      <Ariakit.SelectItem
+        className="select-item"
+        focusOnHover={false}
+        value="Orange"
+      />
+    </Ariakit.SelectList>
+  );
+}

--- a/examples/select-listbox/style.css
+++ b/examples/select-listbox/style.css
@@ -1,0 +1,1 @@
+@import url("../select/style.css");

--- a/examples/select-listbox/test.ts
+++ b/examples/select-listbox/test.ts
@@ -1,0 +1,47 @@
+import { findByRole, press } from "@ariakit/test";
+
+const getListbox = () => findByRole("listbox");
+const getItem = (name: string) => findByRole("option", { name });
+
+test("tab to listbox", async () => {
+  expect(await getListbox()).not.toHaveFocus();
+  await press.Tab();
+  expect(await getListbox()).toHaveFocus();
+  expect(await getItem("Apple")).not.toHaveFocus();
+});
+
+test("move through items with arrow keys", async () => {
+  await press.Tab();
+  await press.ArrowDown();
+  expect(await getListbox()).toHaveFocus();
+  expect(await getItem("Apple")).toHaveFocus();
+  expect(await getItem("Apple")).toHaveAttribute("data-active-item", "");
+  expect(await getItem("Apple")).toHaveAttribute("data-focus-visible", "");
+  expect(await getItem("Apple")).toHaveAttribute("aria-selected", "true");
+  await press.ArrowDown();
+  expect(await getListbox()).toHaveFocus();
+  expect(await getItem("Banana")).toHaveFocus();
+  expect(await getItem("Banana")).toHaveAttribute("data-active-item", "");
+  expect(await getItem("Banana")).toHaveAttribute("data-focus-visible", "");
+  expect(await getItem("Banana")).toHaveAttribute("aria-selected", "false");
+});
+
+test("select item with keyboard", async () => {
+  await press.Tab();
+  await press.ArrowDown();
+  await press.ArrowDown();
+  await press.ArrowDown();
+  await press.Enter();
+  expect(await getListbox()).toHaveFocus();
+  expect(await getItem("Orange")).toHaveFocus();
+  expect(await getItem("Orange")).toHaveAttribute("data-active-item", "");
+  expect(await getItem("Orange")).toHaveAttribute("data-focus-visible", "");
+  expect(await getItem("Orange")).toHaveAttribute("aria-selected", "true");
+  await press.Home();
+  await press.Space();
+  expect(await getListbox()).toHaveFocus();
+  expect(await getItem("Apple")).toHaveFocus();
+  expect(await getItem("Apple")).toHaveAttribute("data-active-item", "");
+  expect(await getItem("Apple")).toHaveAttribute("data-focus-visible", "");
+  expect(await getItem("Apple")).toHaveAttribute("aria-selected", "true");
+});


### PR DESCRIPTION
This PR addresses a bug that occasionally results in components rendering with an incorrect or outdated state when controlled values are passed as props to component stores. In other words, the rendered state differs from the one supplied by the user via the store hook props.