### PR TITLE
Throw when passing conflicting props to store

### DIFF
--- a/.changeset/2745-thin-pugs-thank.md
+++ b/.changeset/2745-thin-pugs-thank.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/react-core": minor
+"@ariakit/core": minor
+"@ariakit/react": minor
+---
+
+[`#2745`](https://github.com/ariakit/ariakit/pull/2745) Component stores will now throw an error if they receive another store prop in conjunction with default prop values.

--- a/packages/ariakit-core/src/checkbox/checkbox-store.ts
+++ b/packages/ariakit-core/src/checkbox/checkbox-store.ts
@@ -1,6 +1,6 @@
 import { defaultValue } from "../utils/misc.js";
 import type { Store, StoreOptions, StoreProps } from "../utils/store.js";
-import { createStore } from "../utils/store.js";
+import { createStore, throwOnConflictingProps } from "../utils/store.js";
 import type { PickRequired, SetState, ToPrimitive } from "../utils/types.js";
 
 type Value = boolean | string | number | Array<string | number>;
@@ -17,6 +17,8 @@ export function createCheckboxStore(props?: CheckboxStoreProps): CheckboxStore;
 export function createCheckboxStore(
   props: CheckboxStoreProps = {},
 ): CheckboxStore {
+  throwOnConflictingProps(props, props.store);
+
   const syncState = props.store?.getState();
   const initialState: CheckboxStoreState = {
     value: defaultValue(

--- a/packages/ariakit-core/src/collection/collection-store.ts
+++ b/packages/ariakit-core/src/collection/collection-store.ts
@@ -1,7 +1,12 @@
 import { getDocument } from "../utils/dom.js";
 import { chain, defaultValue } from "../utils/misc.js";
 import type { Store, StoreOptions, StoreProps } from "../utils/store.js";
-import { batch, createStore, setup } from "../utils/store.js";
+import {
+  batch,
+  createStore,
+  setup,
+  throwOnConflictingProps,
+} from "../utils/store.js";
 import type { BivariantCallback } from "../utils/types.js";
 
 type Item = {
@@ -62,6 +67,8 @@ function getCommonParent(items: Item[]) {
 export function createCollectionStore<T extends Item = Item>(
   props: CollectionStoreProps<T> = {},
 ): CollectionStore<T> {
+  throwOnConflictingProps(props, props.store);
+
   const syncState = props.store?.getState();
 
   const items = defaultValue(

--- a/packages/ariakit-core/src/combobox/combobox-store.ts
+++ b/packages/ariakit-core/src/combobox/combobox-store.ts
@@ -23,6 +23,7 @@ import {
   omit,
   setup,
   sync,
+  throwOnConflictingProps,
 } from "../utils/store.js";
 import type { SetState } from "../utils/types.js";
 
@@ -63,6 +64,8 @@ export function createComboboxStore({
       "disclosureElement",
     ]),
   );
+
+  throwOnConflictingProps(props, store);
 
   const syncState = store.getState();
 

--- a/packages/ariakit-core/src/disclosure/disclosure-store.ts
+++ b/packages/ariakit-core/src/disclosure/disclosure-store.ts
@@ -1,6 +1,13 @@
 import { defaultValue } from "../utils/misc.js";
 import type { Store, StoreOptions, StoreProps } from "../utils/store.js";
-import { createStore, mergeStore, omit, setup, sync } from "../utils/store.js";
+import {
+  createStore,
+  mergeStore,
+  omit,
+  setup,
+  sync,
+  throwOnConflictingProps,
+} from "../utils/store.js";
 import type { SetState } from "../utils/types.js";
 
 /**
@@ -13,6 +20,8 @@ export function createDisclosureStore(
     props.store,
     omit(props.disclosure, ["contentElement", "disclosureElement"]),
   );
+
+  throwOnConflictingProps(props, store);
 
   const syncState = store?.getState();
 

--- a/packages/ariakit-core/src/form/form-store.ts
+++ b/packages/ariakit-core/src/form/form-store.ts
@@ -12,7 +12,7 @@ import {
   isObject,
 } from "../utils/misc.js";
 import type { Store, StoreOptions, StoreProps } from "../utils/store.js";
-import { createStore } from "../utils/store.js";
+import { createStore, throwOnConflictingProps } from "../utils/store.js";
 import type {
   AnyObject,
   PickRequired,
@@ -151,6 +151,8 @@ export function createFormStore<T extends Values = Values>(
 export function createFormStore(props: FormStoreProps): FormStore;
 
 export function createFormStore(props: FormStoreProps = {}): FormStore {
+  throwOnConflictingProps(props, props.store);
+
   const syncState = props.store?.getState();
   const collection = createCollectionStore(props);
 

--- a/packages/ariakit-core/src/menu/menu-store.ts
+++ b/packages/ariakit-core/src/menu/menu-store.ts
@@ -13,7 +13,14 @@ import type {
 import { createHovercardStore } from "../hovercard/hovercard-store.js";
 import { applyState, defaultValue } from "../utils/misc.js";
 import type { Store, StoreOptions, StoreProps } from "../utils/store.js";
-import { createStore, mergeStore, omit, setup, sync } from "../utils/store.js";
+import {
+  createStore,
+  mergeStore,
+  omit,
+  setup,
+  sync,
+  throwOnConflictingProps,
+} from "../utils/store.js";
 import type {
   BivariantCallback,
   PickRequired,
@@ -46,6 +53,9 @@ export function createMenuStore({
       "disclosureElement",
     ]),
   );
+
+  throwOnConflictingProps(props, store);
+
   const syncState = store.getState();
 
   const composite = createCompositeStore({

--- a/packages/ariakit-core/src/popover/popover-store.ts
+++ b/packages/ariakit-core/src/popover/popover-store.ts
@@ -6,7 +6,12 @@ import type {
 import { createDialogStore } from "../dialog/dialog-store.js";
 import { defaultValue } from "../utils/misc.js";
 import type { Store, StoreOptions, StoreProps } from "../utils/store.js";
-import { createStore, mergeStore, omit } from "../utils/store.js";
+import {
+  createStore,
+  mergeStore,
+  omit,
+  throwOnConflictingProps,
+} from "../utils/store.js";
 import type { SetState } from "../utils/types.js";
 
 type BasePlacement = "top" | "bottom" | "left" | "right";
@@ -33,6 +38,9 @@ export function createPopoverStore({
       "disclosureElement",
     ]),
   );
+
+  throwOnConflictingProps(props, store);
+
   const syncState = store?.getState();
 
   const dialog = createDialogStore({ ...props, store });

--- a/packages/ariakit-core/src/select/select-store.ts
+++ b/packages/ariakit-core/src/select/select-store.ts
@@ -22,6 +22,7 @@ import {
   omit,
   setup,
   sync,
+  throwOnConflictingProps,
 } from "../utils/store.js";
 import type { PickRequired, SetState } from "../utils/types.js";
 
@@ -56,6 +57,9 @@ export function createSelectStore({
       "disclosureElement",
     ]),
   );
+
+  throwOnConflictingProps(props, store);
+
   const syncState = store.getState();
 
   const composite = createCompositeStore({

--- a/packages/ariakit-core/src/utils/store.ts
+++ b/packages/ariakit-core/src/utils/store.ts
@@ -347,6 +347,8 @@ Instead, pass the default state to the topmost store:
 const store = useSelectStore({ defaultValue: "Apple" });
 <SelectProvider store={store} />
 
+See https://github.com/ariakit/ariakit/pull/2745 for more details.
+
 If there's a particular need for this, please submit a feature request at https://github.com/ariakit/ariakit
 `,
   );

--- a/packages/ariakit-core/src/utils/store.ts
+++ b/packages/ariakit-core/src/utils/store.ts
@@ -318,6 +318,41 @@ export function mergeStore<S extends State>(
 }
 
 /**
+ * Throws when a store prop is passed in conjunction with a default state.
+ */
+export function throwOnConflictingProps(props: AnyObject, store?: Store) {
+  if (process.env.NODE_ENV === "production") return;
+  if (!store) return;
+  const defaultKeys = Object.entries(props)
+    .filter(([key, value]) => key.startsWith("default") && value !== undefined)
+    .map(([key]) => {
+      const stateKey = key.replace("default", "");
+      return `${stateKey[0]?.toLowerCase() || ""}${stateKey.slice(1)}`;
+    });
+  if (!defaultKeys.length) return;
+  const storeState = store.getState();
+  const conflictingProps = defaultKeys.filter((key) =>
+    hasOwnProperty(storeState, key),
+  );
+  if (!conflictingProps.length) return;
+  throw new Error(
+    `Passing a store prop in conjunction with a default state is not supported.
+
+const store = useSelectStore();
+<SelectProvider store={store} defaultValue="Apple" />
+                ^             ^
+
+Instead, pass the default state to the topmost store:
+
+const store = useSelectStore({ defaultValue: "Apple" });
+<SelectProvider store={store} />
+
+If there's a particular need for this, please submit a feature request at https://github.com/ariakit/ariakit
+`,
+  );
+}
+
+/**
  * Store state type.
  */
 export type State = AnyObject;

--- a/packages/ariakit-react-core/src/utils/system.tsx
+++ b/packages/ariakit-react-core/src/utils/system.tsx
@@ -112,7 +112,6 @@ export function createElement(
   if (process.env.NODE_ENV !== "production") {
     React.useEffect(() => {
       if (!As) return;
-      console.log(As);
       console.warn(
         "The `as` prop is deprecated. Use the `render` prop instead.",
         "See https://ariakit.org/guide/composition",


### PR DESCRIPTION
This PR introduces an error that's triggered in the following scenario:

```js
const a = useDialogStore();
const b = useDialogStore({ store: a, defaultOpen: true });
```

Both `a` and `b` ought to be synchronized. By default, the last store in the call stack takes precedence. However, it's still unclear what the value of the `open` state should be in the example above.

`a` has the `open` state set to `false` by default, while `b` has a default open state set to `true`. The default state should only be used when the `open` state is undefined. Since we're passing `a` to `b` and `a` has the `open` state defined, the `defaultOpen` value is disregarded, resulting in both `a` and `b` having the `open` state set to `false`.

This could be confusing, and we might change this behavior in the future. For now, we're throwing an error to prevent users from relying on any specific behavior until we make a decision.

_**If you have a particular use case that prefers one behavior over another, please [submit a feature request](https://github.com/ariakit/ariakit/issues/new?assignees=&labels=feature&projects=&template=feature.yml).**_