### PR TITLE
Return composed store props on component stores

### DIFF
--- a/.changeset/0-2776-has-combobox.md
+++ b/.changeset/0-2776-has-combobox.md
@@ -1,6 +1,0 @@
----
-"@ariakit/react-core": minor
-"@ariakit/react": minor
----
-
-[`#2776`](https://github.com/ariakit/ariakit/pull/2776) **BREAKING**: This should affect very few people. The `combobox` state on `useSelectStore` has been removed. You can still pass `combobox` as a prop to `useSelectStore`, but you won't be able to access `selectStore.useState("combobox")` anymore.

--- a/.changeset/0-2783-has-combobox.md
+++ b/.changeset/0-2783-has-combobox.md
@@ -1,0 +1,24 @@
+---
+"@ariakit/react-core": minor
+"@ariakit/react": minor
+---
+
+[`#2783`](https://github.com/ariakit/ariakit/pull/2783) **BREAKING** *(This should affect very few people)*: The `combobox` state on `useSelectStore` has been replaced by the `combobox` property on the store object.
+
+**Before:**
+
+```js
+const combobox = useComboboxStore();
+const select = useSelectStore({ combobox });
+const hasCombobox = select.useState("combobox");
+```
+
+**After:**
+
+```js
+const combobox = useComboboxStore();
+const select = useSelectStore({ combobox });
+const hasCombobox = Boolean(select.combobox);
+```
+
+In the example above, `select.combobox` is literally the same as the `combobox` store. It will be defined if the `combobox` store is passed to `useSelectStore`.

--- a/.changeset/0-2783-menu-select-on-combobox-store.md
+++ b/.changeset/0-2783-menu-select-on-combobox-store.md
@@ -1,4 +1,5 @@
 ---
+"@ariakit/core": minor
 "@ariakit/react-core": minor
 "@ariakit/react": minor
 ---

--- a/.changeset/0-2783-menu-select-on-combobox-store.md
+++ b/.changeset/0-2783-menu-select-on-combobox-store.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": minor
+"@ariakit/react": minor
+---
+
+[`#2783`](https://github.com/ariakit/ariakit/pull/2783) **BREAKING** *(This should affect very few people)*: The `select` and `menu` props on `useComboboxStore` have been removed. If you need to compose `Combobox` with `Select` or `Menu`, use the `combobox` prop on `useSelectStore` or `useMenuStore` instead.

--- a/.changeset/2783-sync-stores.md
+++ b/.changeset/2783-sync-stores.md
@@ -3,4 +3,4 @@
 "@ariakit/react": patch
 ---
 
-[`#2783``](https://github.com/ariakit/ariakit/pull/2783) Component store objects now contain properties for the composed stores passed to them as props. For instance, `useSelectStore({ combobox })` will return a `combobox` property if the `combobox` prop is specified.
+[`#2783`](https://github.com/ariakit/ariakit/pull/2783) Component store objects now contain properties for the composed stores passed to them as props. For instance, `useSelectStore({ combobox })` will return a `combobox` property if the `combobox` prop is specified.

--- a/.changeset/2783-sync-stores.md
+++ b/.changeset/2783-sync-stores.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+[`#2783``](https://github.com/ariakit/ariakit/pull/2783) Component store objects now contain properties for the composed stores passed to them as props. For instance, `useSelectStore({ combobox })` will return a `combobox` property if the `combobox` prop is specified.

--- a/.changeset/2783-sync-stores.md
+++ b/.changeset/2783-sync-stores.md
@@ -1,4 +1,5 @@
 ---
+"@ariakit/core": patch
 "@ariakit/react-core": patch
 "@ariakit/react": patch
 ---

--- a/packages/ariakit-core/src/combobox/combobox-store.ts
+++ b/packages/ariakit-core/src/combobox/combobox-store.ts
@@ -172,6 +172,8 @@ export function createComboboxStore({
     ...popover,
     ...composite,
     ...combobox,
+    menu,
+    select,
     setValue: (value) => combobox.setState("value", value),
   };
 }
@@ -215,7 +217,8 @@ export interface ComboboxStoreState
 
 export interface ComboboxStoreFunctions
   extends CompositeStoreFunctions<Item>,
-    PopoverStoreFunctions {
+    PopoverStoreFunctions,
+    Pick<ComboboxStoreProps, "menu" | "select"> {
   /**
    * Sets the `value` state.
    *

--- a/packages/ariakit-core/src/menu/menu-store.ts
+++ b/packages/ariakit-core/src/menu/menu-store.ts
@@ -104,6 +104,7 @@ export function createMenuStore({
     ...composite,
     ...hovercard,
     ...menu,
+    combobox,
     setInitialFocus: (value) => menu.setState("initialFocus", value),
     setValues: (values) => menu.setState("values", values),
     setValue: (name, value) => {
@@ -150,7 +151,8 @@ export interface MenuStoreState<T extends Values = Values>
 }
 
 export interface MenuStoreFunctions<T extends Values = Values>
-  extends CompositeStoreFunctions,
+  extends Pick<MenuStoreOptions, "combobox">,
+    CompositeStoreFunctions,
     HovercardStoreFunctions {
   /**
    * Sets the `initialFocus` state.

--- a/packages/ariakit-core/src/select/select-store.ts
+++ b/packages/ariakit-core/src/select/select-store.ts
@@ -103,7 +103,6 @@ export function createSelectStore({
   const initialState: SelectStoreState = {
     ...composite.getState(),
     ...popover.getState(),
-    hasCombobox: defaultValue(syncState.hasCombobox, !!combobox),
     value: defaultValue(
       props.value,
       syncState.value,
@@ -172,6 +171,7 @@ export function createSelectStore({
     ...composite,
     ...popover,
     ...select,
+    combobox,
     setValue: (value) => select.setState("value", value),
     setSelectElement: (element) => select.setState("selectElement", element),
     setLabelElement: (element) => select.setState("labelElement", element),
@@ -195,10 +195,6 @@ export interface SelectStoreState<T extends Value = Value>
   orientation: CompositeStoreState<Item>["orientation"];
   /** @default "bottom-start" */
   placement: PopoverStoreState["placement"];
-  /**
-   * Whether the select store has received a combobox prop.
-   */
-  hasCombobox: boolean;
   /**
    * The select value.
    *
@@ -224,7 +220,8 @@ export interface SelectStoreState<T extends Value = Value>
 }
 
 export interface SelectStoreFunctions<T extends Value = Value>
-  extends CompositeStoreFunctions<Item>,
+  extends Pick<SelectStoreOptions<T>, "combobox">,
+    CompositeStoreFunctions<Item>,
     PopoverStoreFunctions {
   /**
    * Sets the `value` state.

--- a/packages/ariakit-react-core/src/combobox/combobox-store.ts
+++ b/packages/ariakit-react-core/src/combobox/combobox-store.ts
@@ -5,15 +5,12 @@ import type {
   CompositeStoreState,
 } from "../composite/composite-store.js";
 import { useCompositeStoreProps } from "../composite/composite-store.js";
-import type { MenuStore } from "../menu/menu-store.js";
 import type {
   PopoverStoreFunctions,
   PopoverStoreOptions,
   PopoverStoreState,
 } from "../popover/popover-store.js";
 import { usePopoverStoreProps } from "../popover/popover-store.js";
-import type { SelectStore } from "../select/select-store.js";
-import { useUpdateEffect } from "../utils/hooks.js";
 import type { Store } from "../utils/store.js";
 import { useStore, useStoreProps } from "../utils/store.js";
 
@@ -22,12 +19,11 @@ export function useComboboxStoreProps<T extends Core.ComboboxStore>(
   update: () => void,
   props: ComboboxStoreProps,
 ) {
-  useUpdateEffect(update, [props.menu, props.select]);
   store = usePopoverStoreProps(store, update, props);
   store = useCompositeStoreProps(store, update, props);
   useStoreProps(store, props, "value", "setValue");
   useStoreProps(store, props, "resetValueOnHide");
-  return Object.assign(store, { menu: props.menu, select: props.select });
+  return store;
 }
 
 /**
@@ -59,13 +55,12 @@ export interface ComboboxStoreState
     PopoverStoreState {}
 
 export interface ComboboxStoreFunctions
-  extends Pick<ComboboxStoreOptions, "menu" | "select">,
-    Omit<Core.ComboboxStoreFunctions, "menu" | "select">,
+  extends Core.ComboboxStoreFunctions,
     CompositeStoreFunctions<ComboboxStoreItem>,
     PopoverStoreFunctions {}
 
 export interface ComboboxStoreOptions
-  extends Omit<Core.ComboboxStoreOptions, "menu" | "select">,
+  extends Core.ComboboxStoreOptions,
     CompositeStoreOptions<ComboboxStoreItem>,
     PopoverStoreOptions {
   /**
@@ -77,14 +72,6 @@ export interface ComboboxStoreOptions
    * }
    */
   setValue?: (value: ComboboxStoreState["value"]) => void;
-  /**
-   * TODO: Comment
-   */
-  menu?: MenuStore;
-  /**
-   * TODO: Comment
-   */
-  select?: SelectStore;
 }
 
 export type ComboboxStoreProps = ComboboxStoreOptions & Core.ComboboxStoreProps;

--- a/packages/ariakit-react-core/src/combobox/combobox-store.ts
+++ b/packages/ariakit-react-core/src/combobox/combobox-store.ts
@@ -5,12 +5,14 @@ import type {
   CompositeStoreState,
 } from "../composite/composite-store.js";
 import { useCompositeStoreProps } from "../composite/composite-store.js";
+import type { MenuStore } from "../menu/menu-store.js";
 import type {
   PopoverStoreFunctions,
   PopoverStoreOptions,
   PopoverStoreState,
 } from "../popover/popover-store.js";
 import { usePopoverStoreProps } from "../popover/popover-store.js";
+import type { SelectStore } from "../select/select-store.js";
 import { useUpdateEffect } from "../utils/hooks.js";
 import type { Store } from "../utils/store.js";
 import { useStore, useStoreProps } from "../utils/store.js";
@@ -25,7 +27,7 @@ export function useComboboxStoreProps<T extends Core.ComboboxStore>(
   store = useCompositeStoreProps(store, update, props);
   useStoreProps(store, props, "value", "setValue");
   useStoreProps(store, props, "resetValueOnHide");
-  return store;
+  return Object.assign(store, { menu: props.menu, select: props.select });
 }
 
 /**
@@ -57,12 +59,13 @@ export interface ComboboxStoreState
     PopoverStoreState {}
 
 export interface ComboboxStoreFunctions
-  extends Core.ComboboxStoreFunctions,
+  extends Pick<ComboboxStoreOptions, "menu" | "select">,
+    Omit<Core.ComboboxStoreFunctions, "menu" | "select">,
     CompositeStoreFunctions<ComboboxStoreItem>,
     PopoverStoreFunctions {}
 
 export interface ComboboxStoreOptions
-  extends Core.ComboboxStoreOptions,
+  extends Omit<Core.ComboboxStoreOptions, "menu" | "select">,
     CompositeStoreOptions<ComboboxStoreItem>,
     PopoverStoreOptions {
   /**
@@ -74,6 +77,14 @@ export interface ComboboxStoreOptions
    * }
    */
   setValue?: (value: ComboboxStoreState["value"]) => void;
+  /**
+   * TODO: Comment
+   */
+  menu?: MenuStore;
+  /**
+   * TODO: Comment
+   */
+  select?: SelectStore;
 }
 
 export type ComboboxStoreProps = ComboboxStoreOptions & Core.ComboboxStoreProps;

--- a/packages/ariakit-react-core/src/menu/menu-store.ts
+++ b/packages/ariakit-react-core/src/menu/menu-store.ts
@@ -4,6 +4,7 @@ import type {
   BivariantCallback,
   PickRequired,
 } from "@ariakit/core/utils/types";
+import type { ComboboxStore } from "../combobox/combobox-store.js";
 import type {
   CompositeStoreFunctions,
   CompositeStoreOptions,
@@ -50,11 +51,9 @@ export function useMenuStoreOptions<T extends Values = Values>(
   };
 }
 
-export function useMenuStoreProps<T extends Omit<MenuStore, "hideAll">>(
-  store: T,
-  update: () => void,
-  props: MenuStoreProps,
-) {
+export function useMenuStoreProps<
+  T extends Omit<MenuStore, "combobox" | "hideAll">,
+>(store: T, update: () => void, props: MenuStoreProps) {
   const parent = useContext(MenuContext);
 
   useUpdateEffect(update, [props.combobox]);
@@ -67,12 +66,13 @@ export function useMenuStoreProps<T extends Omit<MenuStore, "hideAll">>(
   return useMemo(
     () => ({
       ...store,
+      combobox: props.combobox,
       hideAll: () => {
         store.hide();
         parent?.hideAll();
       },
     }),
-    [store],
+    [store, props.combobox],
   );
 }
 
@@ -112,7 +112,8 @@ export interface MenuStoreState<T extends Values = Values>
     HovercardStoreState {}
 
 export interface MenuStoreFunctions<T extends Values = Values>
-  extends Core.MenuStoreFunctions<T>,
+  extends Pick<MenuStoreOptions, "combobox">,
+    Omit<Core.MenuStoreFunctions<T>, "combobox">,
     CompositeStoreFunctions,
     HovercardStoreFunctions {
   /**
@@ -133,6 +134,10 @@ export interface MenuStoreOptions<T extends Values = Values>
    * const menu = useMenuStore({ values, setValues });
    */
   setValues?: BivariantCallback<(values: MenuStoreState<T>["values"]) => void>;
+  /**
+   * TODO: Comment
+   */
+  combobox?: ComboboxStore;
 }
 
 export type MenuStoreProps<T extends Values = Values> = MenuStoreOptions<T> &

--- a/packages/ariakit-react-core/src/menu/menu-store.ts
+++ b/packages/ariakit-react-core/src/menu/menu-store.ts
@@ -135,7 +135,12 @@ export interface MenuStoreOptions<T extends Values = Values>
    */
   setValues?: BivariantCallback<(values: MenuStoreState<T>["values"]) => void>;
   /**
-   * TODO: Comment
+   * A reference to a combobox store. This is used when combining the combobox
+   * with a menu (e.g., dropdown menu with a search input). The stores will
+   * share the same state.
+   *
+   * Live examples:
+   * - [Menu with Combobox](https://ariakit.org/examples/menu-combobox)
    */
   combobox?: ComboboxStore;
 }

--- a/packages/ariakit-react-core/src/select/select-list.tsx
+++ b/packages/ariakit-react-core/src/select/select-list.tsx
@@ -97,7 +97,7 @@ export const useSelectList = createHook<SelectListOptions>(
     );
 
     const labelId = store.useState((state) => state.labelElement?.id);
-    const hasCombobox = store.useState("hasCombobox");
+    const hasCombobox = !!store.combobox;
     composite = composite ?? !hasCombobox;
 
     if (composite) {

--- a/packages/ariakit-react-core/src/select/select-store.ts
+++ b/packages/ariakit-react-core/src/select/select-store.ts
@@ -3,6 +3,7 @@ import type {
   BivariantCallback,
   PickRequired,
 } from "@ariakit/core/utils/types";
+import type { ComboboxStore } from "../combobox/combobox-store.js";
 import type {
   CompositeStoreFunctions,
   CompositeStoreOptions,
@@ -22,7 +23,7 @@ import { useStore, useStoreProps } from "../utils/store.js";
 type Item = Core.SelectStoreItem;
 type Value = Core.SelectStoreValue;
 
-export function useSelectStoreProps<T extends SelectStore>(
+export function useSelectStoreProps<T extends Omit<SelectStore, "combobox">>(
   store: T,
   update: () => void,
   props: SelectStoreProps,
@@ -31,7 +32,7 @@ export function useSelectStoreProps<T extends SelectStore>(
   store = useCompositeStoreProps(store, update, props);
   store = usePopoverStoreProps(store, update, props);
   useStoreProps(store, props, "value", "setValue");
-  return store;
+  return Object.assign(store, { combobox: props.combobox });
 }
 
 /**
@@ -68,7 +69,8 @@ export interface SelectStoreState<T extends Value = Value>
     PopoverStoreState {}
 
 export interface SelectStoreFunctions<T extends Value = Value>
-  extends Core.SelectStoreFunctions<T>,
+  extends Pick<SelectStoreOptions<T>, "combobox">,
+    Omit<Core.SelectStoreFunctions<T>, "combobox">,
     CompositeStoreFunctions<Item>,
     PopoverStoreFunctions {}
 
@@ -85,6 +87,10 @@ export interface SelectStoreOptions<T extends Value = Value>
    * }
    */
   setValue?: BivariantCallback<(value: SelectStoreState<T>["value"]) => void>;
+  /**
+   * TODO: Comment
+   */
+  combobox?: ComboboxStore;
 }
 
 export type SelectStoreProps<T extends Value = Value> = SelectStoreOptions<T> &

--- a/packages/ariakit-react-core/src/select/select-store.ts
+++ b/packages/ariakit-react-core/src/select/select-store.ts
@@ -88,7 +88,13 @@ export interface SelectStoreOptions<T extends Value = Value>
    */
   setValue?: BivariantCallback<(value: SelectStoreState<T>["value"]) => void>;
   /**
-   * TODO: Comment
+   * A reference to a combobox store. This is used when combining the combobox
+   * with a select (e.g., select with a search input). The stores will share the
+   * same state.
+   *
+   * Live examples:
+   * - [Multi-selectable
+   *   Combobox](https://ariakit.org/examples/combobox-multiple)
    */
   combobox?: ComboboxStore;
 }


### PR DESCRIPTION
This PR modifies the component stores that sync with other stores, such as `useMenuStore` and `useSelectStore`, which accept a `combobox` prop. Now, they return the provided store as a property of the store object.

For instance:

```js
const combobox = useComboboxStore();
const select = useSelectStore({ combobox });

console.log(combobox === select.combobox); // true
```

This modification enables us to verify in a Select component if it's being combined with a combobox. We previously relied on a `combobox` state for this, but it proved to be an inadequate general solution.

Furthermore, I've discontinued support for the `menu` and `select` props on `useComboboxStore`. These weren't in use anywhere, and they're more effectively supported as the `combobox` prop on `useSelectStore` and `useMenuStore`. This was merely a redundancy.