### PR TITLE
Accept null value on composed store props

### DIFF
--- a/.changeset/2796-store-null.md
+++ b/.changeset/2796-store-null.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/core": patch
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+[`#2796`](https://github.com/ariakit/ariakit/pull/2796) Composed store props such as `useSelectStore({ combobox })` now accept `null` as a value.

--- a/packages/ariakit-core/src/disclosure/disclosure-store.ts
+++ b/packages/ariakit-core/src/disclosure/disclosure-store.ts
@@ -198,7 +198,7 @@ export interface DisclosureStoreOptions
    * `disclosureElement` won't be synced. For that, use the `store` prop
    * instead.
    */
-  disclosure?: DisclosureStore;
+  disclosure?: DisclosureStore | null;
 }
 
 export type DisclosureStoreProps = DisclosureStoreOptions &

--- a/packages/ariakit-core/src/menu/menu-store.ts
+++ b/packages/ariakit-core/src/menu/menu-store.ts
@@ -224,16 +224,16 @@ export interface MenuStoreOptions<T extends Values = Values>
    * with a menu (e.g., dropdown menu with a search input). The stores will
    * share the same state.
    */
-  combobox?: ComboboxStore;
+  combobox?: ComboboxStore | null;
   /**
    * A reference to a parent menu store. This should be used on nested menus.
    */
-  parent?: MenuStore;
+  parent?: MenuStore | null;
   /**
    * A reference to a menu bar store. This should be used when rendering menus
    * inside a menu bar.
    */
-  menubar?: MenuBarStore;
+  menubar?: MenuBarStore | null;
   /**
    * The default values for the `values` state.
    * @default {}

--- a/packages/ariakit-core/src/popover/popover-store.ts
+++ b/packages/ariakit-core/src/popover/popover-store.ts
@@ -131,7 +131,7 @@ export interface PopoverStoreOptions
    * A reference to another popover store that's controlling another popover to
    * keep them in sync.
    */
-  popover?: PopoverStore;
+  popover?: PopoverStore | null;
 }
 
 export type PopoverStoreProps = PopoverStoreOptions &

--- a/packages/ariakit-core/src/select/select-store.ts
+++ b/packages/ariakit-core/src/select/select-store.ts
@@ -267,7 +267,7 @@ export interface SelectStoreOptions<T extends Value = Value>
    * - [Multi-selectable
    *   Combobox](https://ariakit.org/examples/combobox-multiple)
    */
-  combobox?: ComboboxStore;
+  combobox?: ComboboxStore | null;
   /**
    * The default value. If not set, the first non-disabled item will be used.
    *

--- a/packages/ariakit-core/src/utils/store.ts
+++ b/packages/ariakit-core/src/utils/store.ts
@@ -202,7 +202,7 @@ export function createStore<S extends State>(
 }
 
 export function setup<T extends Store>(
-  store?: T,
+  store?: T | null,
   ...args: Parameters<StoreSetup>
 ): T extends Store ? ReturnType<StoreSetup> : void;
 
@@ -215,7 +215,7 @@ export function setup(store?: Store, ...args: Parameters<StoreSetup>) {
 }
 
 export function init<T extends Store>(
-  store?: T,
+  store?: T | null,
   ...args: Parameters<StoreInit>
 ): T extends Store ? ReturnType<StoreInit> : void;
 
@@ -228,7 +228,7 @@ export function init(store?: Store, ...args: Parameters<StoreInit>) {
 }
 
 export function subscribe<T extends Store, K extends keyof StoreState<T>>(
-  store?: T,
+  store?: T | null,
   ...args: Parameters<StoreSubscribe<StoreState<T>, K>>
 ): T extends Store ? ReturnType<StoreSubscribe<StoreState<T>, K>> : void;
 
@@ -241,7 +241,7 @@ export function subscribe(store?: Store, ...args: Parameters<StoreSubscribe>) {
 }
 
 export function sync<T extends Store, K extends keyof StoreState<T>>(
-  store?: T,
+  store?: T | null,
   ...args: Parameters<StoreSync<StoreState<T>, K>>
 ): T extends Store ? ReturnType<StoreSync<StoreState<T>, K>> : void;
 
@@ -255,7 +255,7 @@ export function sync(store?: Store, ...args: Parameters<StoreSync>) {
 }
 
 export function batch<T extends Store, K extends keyof StoreState<T>>(
-  store?: T,
+  store?: T | null,
   ...args: Parameters<StoreBatch<StoreState<T>, K>>
 ): T extends Store ? ReturnType<StoreBatch<StoreState<T>, K>> : void;
 
@@ -272,7 +272,7 @@ export function omit<
   T extends Store,
   K extends ReadonlyArray<keyof StoreState<T>>,
 >(
-  store?: T,
+  store?: T | null,
   ...args: Parameters<StoreOmit<StoreState<T>, K>>
 ): T extends Store ? ReturnType<StoreOmit<StoreState<T>, K>> : void;
 
@@ -289,7 +289,7 @@ export function pick<
   T extends Store,
   K extends ReadonlyArray<keyof StoreState<T>>,
 >(
-  store?: T,
+  store?: T | null,
   ...args: Parameters<StorePick<StoreState<T>, K>>
 ): T extends Store ? ReturnType<StorePick<StoreState<T>, K>> : void;
 


### PR DESCRIPTION
Allowing `null` as a value for composed store properties makes it easier for users to override a default value inferred from context. For instance, if the tree is rendered as `Menu` > `Dialog` > `Menu`, the last `Menu` could mistakenly recognize the first one as its parent. In such a situation, the user can pass `parent: null` to `useMenuStore` or `MenuProvider` to turn off the default value.