### PR TITLE
Add setMounted setter function to disclosure store

### DIFF
--- a/.changeset/2802-disclosure-store-set-mounted.md
+++ b/.changeset/2802-disclosure-store-set-mounted.md
@@ -1,0 +1,18 @@
+---
+"@ariakit/core": patch
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+
+---
+
+Added `setMounted` prop to `useDisclosureStore` and derived component stores. This callback prop can be used to react to changes in the `mounted` state. For example:
+
+```js
+useDialogStore({
+  setMounted(mounted) {
+    if (!mounted) {
+      props.onUnmount?.();
+    }
+  },
+});
+```

--- a/.changeset/2802-disclosure-store-set-mounted.md
+++ b/.changeset/2802-disclosure-store-set-mounted.md
@@ -1,7 +1,6 @@
 ---
 "@ariakit/react-core": patch
 "@ariakit/react": patch
-
 ---
 
 Added `setMounted` prop to `useDisclosureStore` and derived component stores. This callback prop can be used to react to changes in the `mounted` state. For example:

--- a/.changeset/2802-disclosure-store-set-mounted.md
+++ b/.changeset/2802-disclosure-store-set-mounted.md
@@ -1,5 +1,4 @@
 ---
-"@ariakit/core": patch
 "@ariakit/react-core": patch
 "@ariakit/react": patch
 

--- a/examples/menu-dialog-animated/dialog.tsx
+++ b/examples/menu-dialog-animated/dialog.tsx
@@ -23,16 +23,12 @@ export const Dialog = React.forwardRef<HTMLDivElement, DialogProps>(
           onClose?.();
         }
       },
+      setMounted(mounted) {
+        if (!mounted) {
+          onUnmount?.();
+        }
+      },
     });
-
-    const mounted = dialog.useState("mounted");
-
-    React.useLayoutEffect(() => {
-      if (!mounted) {
-        onUnmount?.();
-      }
-    }, [mounted]);
-
     return (
       <Ariakit.Dialog
         store={dialog}

--- a/examples/menu-dialog-animated/menu.tsx
+++ b/examples/menu-dialog-animated/menu.tsx
@@ -36,15 +36,12 @@ export const Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
       setValues,
       open,
       setOpen,
+      setMounted(mounted) {
+        if (!mounted) {
+          onUnmount?.();
+        }
+      },
     });
-    const mounted = menu.useState("mounted");
-
-    React.useLayoutEffect(() => {
-      if (!mounted) {
-        onUnmount?.();
-      }
-    }, [mounted]);
-
     return (
       <>
         <Ariakit.MenuButton

--- a/packages/ariakit-core/src/utils/store.ts
+++ b/packages/ariakit-core/src/utils/store.ts
@@ -378,7 +378,7 @@ export type StoreProps<S extends State = State> = { store?: Store<Partial<S>> };
  * Extracts the state type from a store type.
  * @template T Store type.
  */
-export type StoreState<T> = T extends { getState(): infer S } ? S : never;
+export type StoreState<T> = T extends Store<infer S> ? S : never;
 
 /**
  * Store.

--- a/packages/ariakit-react-core/src/disclosure/disclosure-store.ts
+++ b/packages/ariakit-react-core/src/disclosure/disclosure-store.ts
@@ -12,6 +12,7 @@ export function useDisclosureStoreProps<T extends Core.DisclosureStore>(
 ) {
   useUpdateEffect(update, [props.store, props.disclosure, ...deps]);
   useStoreProps(store, props, "open", "setOpen");
+  useStoreProps(store, props, "mounted", "setMounted");
   useStoreProps(store, props, "animated");
   return store;
 }
@@ -46,6 +47,14 @@ export interface DisclosureStoreOptions extends Core.DisclosureStoreOptions {
    * const disclosure = useDisclosureStore({ open, setOpen });
    */
   setOpen?: (open: DisclosureStoreState["open"]) => void;
+  /**
+   * A callback that gets called when the `mounted` state changes.
+   * @param mounted The new mounted value.
+   * @example
+   * const [mounted, setMounted] = useState(false);
+   * const disclosure = useDisclosureStore({ setMounted });
+   */
+  setMounted?: (mounted: DisclosureStoreState["mounted"]) => void;
 }
 
 export type DisclosureStoreProps = DisclosureStoreOptions &

--- a/packages/ariakit-react-core/src/utils/store.tsx
+++ b/packages/ariakit-react-core/src/utils/store.tsx
@@ -137,13 +137,12 @@ export function useStoreState(
  */
 export function useStoreProps<
   S extends State,
-  T extends CoreStore<S>,
-  P extends S,
-  K extends keyof S & keyof P,
+  P extends Partial<S>,
+  K extends keyof S,
   SK extends keyof PickByValue<P, SetState<P[K]>>,
->(store: T, props: P, key: K, setKey?: SK) {
+>(store: CoreStore<S>, props: P, key: K, setKey?: SK) {
   const value = hasOwnProperty(props, key) ? props[key] : undefined;
-  const setValue = setKey ? (props[setKey] as SetState<S[K]>) : undefined;
+  const setValue = setKey ? props[setKey] : undefined;
   const propsRef = useLiveRef({ value, setValue });
   const canSyncValue = React.useRef(true);
 


### PR DESCRIPTION
This PR adds a `setMounted` prop to `useDisclosureStore` and derived component stores. This callback prop can be used to react to changes in the `mounted` state. For example:

```js
useDialogStore({
  setMounted(mounted) {
    if (!mounted) {
      props.onUnmount?.();
    }
  },
});
```