### PR TITLE
Add implicit store to Toolbar

### DIFF
--- a/.changeset/2803-toolbar-standalone.md
+++ b/.changeset/2803-toolbar-standalone.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+The `Toolbar` component can now render without needing an explicit `store` prop or a `ToolbarProvider` component wrap. `Toolbar` now also supports certain store props such as `focusLoop`, `orientation`, `rtl`, and `virtualFocus`.
+

--- a/examples/toolbar-provider-select/index.tsx
+++ b/examples/toolbar-provider-select/index.tsx
@@ -2,7 +2,6 @@ import "./style.css";
 import { useState } from "react";
 import * as Ariakit from "@ariakit/react";
 import { SelectProvider } from "@ariakit/react-core/select/select-provider";
-import { ToolbarProvider } from "@ariakit/react-core/toolbar/toolbar-provider";
 import * as icons from "./icons.js";
 
 const options = [
@@ -15,39 +14,37 @@ export default function Example() {
   const [value, setValue] = useState("Align Left");
   const selectedIcon = options.find((option) => option.value === value)?.icon;
   return (
-    <ToolbarProvider>
-      <Ariakit.Toolbar className="toolbar">
-        <Ariakit.ToolbarItem className="button secondary">
-          {icons.bold} Bold
-        </Ariakit.ToolbarItem>
-        <Ariakit.ToolbarItem className="button secondary">
-          {icons.italic} Italic
-        </Ariakit.ToolbarItem>
-        <Ariakit.ToolbarItem className="button secondary">
-          {icons.underline} Underline
-        </Ariakit.ToolbarItem>
-        <Ariakit.ToolbarSeparator className="separator" />
-        <SelectProvider value={value} setValue={setValue}>
-          <Ariakit.Select
-            aria-label="Text alignment"
-            className="button secondary"
-            render={<Ariakit.ToolbarItem />}
-          >
-            {selectedIcon} {value} <Ariakit.SelectArrow />
-          </Ariakit.Select>
-          <Ariakit.SelectPopover gutter={4} className="popover">
-            {options.map((option) => (
-              <Ariakit.SelectItem
-                key={option.value}
-                value={option.value}
-                className="select-item"
-              >
-                {option.icon} {option.value}
-              </Ariakit.SelectItem>
-            ))}
-          </Ariakit.SelectPopover>
-        </SelectProvider>
-      </Ariakit.Toolbar>
-    </ToolbarProvider>
+    <Ariakit.Toolbar className="toolbar">
+      <Ariakit.ToolbarItem className="button secondary">
+        {icons.bold} Bold
+      </Ariakit.ToolbarItem>
+      <Ariakit.ToolbarItem className="button secondary">
+        {icons.italic} Italic
+      </Ariakit.ToolbarItem>
+      <Ariakit.ToolbarItem className="button secondary">
+        {icons.underline} Underline
+      </Ariakit.ToolbarItem>
+      <Ariakit.ToolbarSeparator className="separator" />
+      <SelectProvider value={value} setValue={setValue}>
+        <Ariakit.Select
+          aria-label="Text alignment"
+          className="button secondary"
+          render={<Ariakit.ToolbarItem />}
+        >
+          {selectedIcon} {value} <Ariakit.SelectArrow />
+        </Ariakit.Select>
+        <Ariakit.SelectPopover gutter={4} className="popover">
+          {options.map((option) => (
+            <Ariakit.SelectItem
+              key={option.value}
+              value={option.value}
+              className="select-item"
+            >
+              {option.icon} {option.value}
+            </Ariakit.SelectItem>
+          ))}
+        </Ariakit.SelectPopover>
+      </SelectProvider>
+    </Ariakit.Toolbar>
   );
 }

--- a/examples/toolbar-provider/index.tsx
+++ b/examples/toolbar-provider/index.tsx
@@ -1,34 +1,31 @@
 import "./style.css";
 import * as Ariakit from "@ariakit/react";
-import { ToolbarProvider } from "@ariakit/react-core/toolbar/toolbar-provider";
 import { bold, italic, redo, underline, undo } from "./icons.jsx";
 
 export default function Example() {
   return (
-    <ToolbarProvider>
-      <Ariakit.Toolbar className="toolbar">
-        <Ariakit.ToolbarItem className="button secondary">
-          {undo}
-          Undo
-        </Ariakit.ToolbarItem>
-        <Ariakit.ToolbarItem className="button secondary" disabled>
-          {redo}
-          Redo
-        </Ariakit.ToolbarItem>
-        <Ariakit.ToolbarSeparator className="separator" />
-        <Ariakit.ToolbarItem className="button secondary">
-          {bold}
-          Bold
-        </Ariakit.ToolbarItem>
-        <Ariakit.ToolbarItem className="button secondary">
-          {italic}
-          Italic
-        </Ariakit.ToolbarItem>
-        <Ariakit.ToolbarItem className="button secondary">
-          {underline}
-          Underline
-        </Ariakit.ToolbarItem>
-      </Ariakit.Toolbar>
-    </ToolbarProvider>
+    <Ariakit.Toolbar className="toolbar">
+      <Ariakit.ToolbarItem className="button secondary">
+        {undo}
+        Undo
+      </Ariakit.ToolbarItem>
+      <Ariakit.ToolbarItem className="button secondary" disabled>
+        {redo}
+        Redo
+      </Ariakit.ToolbarItem>
+      <Ariakit.ToolbarSeparator className="separator" />
+      <Ariakit.ToolbarItem className="button secondary">
+        {bold}
+        Bold
+      </Ariakit.ToolbarItem>
+      <Ariakit.ToolbarItem className="button secondary">
+        {italic}
+        Italic
+      </Ariakit.ToolbarItem>
+      <Ariakit.ToolbarItem className="button secondary">
+        {underline}
+        Underline
+      </Ariakit.ToolbarItem>
+    </Ariakit.Toolbar>
   );
 }

--- a/packages/ariakit-react-core/src/toolbar/toolbar.tsx
+++ b/packages/ariakit-react-core/src/toolbar/toolbar.tsx
@@ -25,22 +25,22 @@ import type { ToolbarStore, ToolbarStoreProps } from "./toolbar-store.js";
  */
 export const useToolbar = createHook<ToolbarOptions>(
   ({
-    store: _store,
-    focusLoop,
+    store: storeProp,
     orientation: orientationProp,
-    rtl,
     virtualFocus,
+    focusLoop,
+    rtl,
     ...props
   }) => {
     const context = useToolbarProviderContext();
-    _store = _store || context;
+    storeProp = storeProp || context;
 
     const store = useToolbarStore({
-      store: _store,
-      focusLoop,
+      store: storeProp,
       orientation: orientationProp,
-      rtl,
       virtualFocus,
+      focusLoop,
+      rtl,
     });
 
     const orientation = store.useState((state) =>

--- a/packages/ariakit-react-core/src/toolbar/toolbar.tsx
+++ b/packages/ariakit-react-core/src/toolbar/toolbar.tsx
@@ -1,4 +1,3 @@
-import { invariant } from "@ariakit/core/utils/misc";
 import type { CompositeOptions } from "../composite/composite.js";
 import { useComposite } from "../composite/composite.js";
 import { useWrapElement } from "../utils/hooks.js";
@@ -6,9 +5,10 @@ import { createComponent, createElement, createHook } from "../utils/system.js";
 import type { As, Props } from "../utils/types.js";
 import {
   ToolbarScopedContextProvider,
-  useToolbarContext,
+  useToolbarProviderContext,
 } from "./toolbar-context.js";
-import type { ToolbarStore } from "./toolbar-store.js";
+import { useToolbarStore } from "./toolbar-store.js";
+import type { ToolbarStore, ToolbarStoreProps } from "./toolbar-store.js";
 
 /**
  * Returns props to create a `Toolbar` component.
@@ -23,40 +23,51 @@ import type { ToolbarStore } from "./toolbar-store.js";
  * </Role>
  * ```
  */
-export const useToolbar = createHook<ToolbarOptions>(({ store, ...props }) => {
-  const context = useToolbarContext();
-  store = store || context;
+export const useToolbar = createHook<ToolbarOptions>(
+  ({
+    store: _store,
+    focusLoop,
+    orientation: orientationProp,
+    rtl,
+    virtualFocus,
+    ...props
+  }) => {
+    const context = useToolbarProviderContext();
+    _store = _store || context;
 
-  invariant(
-    store,
-    process.env.NODE_ENV !== "production" &&
-      "Toolbar must receive a `store` prop or be wrapped in a ToolbarProvider component.",
-  );
+    const store = useToolbarStore({
+      store: _store,
+      focusLoop,
+      orientation: orientationProp,
+      rtl,
+      virtualFocus,
+    });
 
-  const orientation = store.useState((state) =>
-    state.orientation === "both" ? undefined : state.orientation,
-  );
+    const orientation = store.useState((state) =>
+      state.orientation === "both" ? undefined : state.orientation,
+    );
 
-  props = useWrapElement(
-    props,
-    (element) => (
-      <ToolbarScopedContextProvider value={store}>
-        {element}
-      </ToolbarScopedContextProvider>
-    ),
-    [store],
-  );
+    props = useWrapElement(
+      props,
+      (element) => (
+        <ToolbarScopedContextProvider value={store}>
+          {element}
+        </ToolbarScopedContextProvider>
+      ),
+      [store],
+    );
 
-  props = {
-    role: "toolbar",
-    "aria-orientation": orientation,
-    ...props,
-  };
+    props = {
+      role: "toolbar",
+      "aria-orientation": orientation,
+      ...props,
+    };
 
-  props = useComposite({ store, ...props });
+    props = useComposite({ store, ...props });
 
-  return props;
-});
+    return props;
+  },
+);
 
 /**
  * Renders a toolbar element that groups interactive elements together.
@@ -80,7 +91,11 @@ if (process.env.NODE_ENV !== "production") {
 }
 
 export interface ToolbarOptions<T extends As = "div">
-  extends CompositeOptions<T> {
+  extends CompositeOptions<T>,
+    Pick<
+      ToolbarStoreProps,
+      "focusLoop" | "orientation" | "rtl" | "virtualFocus"
+    > {
   /**
    * Object returned by the `useToolbarStore` hook.
    */


### PR DESCRIPTION
With this PR, the `Toolbar` component can now render without needing an explicit `store` prop or a `ToolbarProvider` component wrap. This also adds some store props to `Toolbar`: `focusLoop`, `orientation`, `rtl`, `virtualFocus`.

Related to #2658 