### PR TITLE
Fix infinite loop on MenuButton

### DIFF
--- a/.changeset/2812-disclosure-infinite-loop.md
+++ b/.changeset/2812-disclosure-infinite-loop.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed an infinite loop issue when using [`MenuButton`](https://ariakit.org/reference/menu-buton) with a [`store`](https://ariakit.org/reference/menu-button#store) that is synchronized with another store.

--- a/packages/ariakit-react-core/src/disclosure/disclosure-store.ts
+++ b/packages/ariakit-react-core/src/disclosure/disclosure-store.ts
@@ -1,4 +1,3 @@
-import type { DependencyList } from "react";
 import * as Core from "@ariakit/core/disclosure/disclosure-store";
 import { useUpdateEffect } from "../utils/hooks.js";
 import type { Store } from "../utils/store.js";
@@ -8,9 +7,8 @@ export function useDisclosureStoreProps<T extends Core.DisclosureStore>(
   store: T,
   update: () => void,
   props: DisclosureStoreProps,
-  deps: DependencyList = [],
 ) {
-  useUpdateEffect(update, [props.store, props.disclosure, ...deps]);
+  useUpdateEffect(update, [props.store, props.disclosure]);
   useStoreProps(store, props, "open", "setOpen");
   useStoreProps(store, props, "mounted", "setMounted");
   useStoreProps(store, props, "animated");

--- a/packages/ariakit-react-core/src/menu/menu-button.tsx
+++ b/packages/ariakit-react-core/src/menu/menu-button.tsx
@@ -74,7 +74,8 @@ export const useMenuButton = createHook<MenuButtonOptions>(
       // Makes sure that the menu button is assigned as the menu disclosure
       // element. This is needed to support screen reader focusing on sibling
       // menu items.
-      return sync(store, ["disclosureElement"], () => {
+      return sync(store, ["disclosureElement"], (state) => {
+        if (!state.disclosureElement) return;
         store?.setState("disclosureElement", ref.current);
       });
     }, [store]);


### PR DESCRIPTION
This PR fixes an infinite loop when using `MenuButton` with two synchronized stores like so:

```jsx
const store = useMenuStore();
const menu = useMenuStore({ store });
<MenuButton store={menu} />
```

There will be a follow-up PR with a test case.