### PR TITLE
Support controlled props on MenuItemCheckbox and MenuItemRadio

### DIFF
--- a/.changeset/2945-menu-item-controlled-1.md
+++ b/.changeset/2945-menu-item-controlled-1.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/core": patch
+---
+
+Added new `disabledFromProps` function to `@ariakit/core/utils/misc`.

--- a/.changeset/2945-menu-item-controlled-2.md
+++ b/.changeset/2945-menu-item-controlled-2.md
@@ -1,0 +1,8 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Added `name` and `value` properties to non-native input elements rendered by [`Checkbox`](https://ariakit.org/reference/checkbox), [`Radio`](https://ariakit.org), [`MenuItemCheckbox`](https://ariakit.org/reference/menu-item-checkbox), and [`MenuItemRadio`](https://ariakit.org/reference/menu-item-radio).
+
+It's now possible to access the `name` and `value` properties from the `event.target` element in the [`onChange`](https://ariakit.org/reference/checkbox#onchange) event handler.

--- a/.changeset/2945-menu-item-controlled-3.md
+++ b/.changeset/2945-menu-item-controlled-3.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed [`CompositeItem`](https://ariakit.org/reference/composite-item) and associated components not receiving the [`disabled`](https://ariakit.org/reference/composite-item#disabled) prop when it's being used by a higher-level component such as [`MenuItemCheckbox`](https://ariakit.org/reference/menu-item-checkbox) or [`MenuItemRadio`](https://ariakit.org/reference/menu-item-radio).

--- a/.changeset/2945-menu-item-controlled-4.md
+++ b/.changeset/2945-menu-item-controlled-4.md
@@ -3,14 +3,4 @@
 "@ariakit/react": patch
 ---
 
-It's now possible to control the menu [`values`](https://ariakit.org/reference/menu-provider#values) state by passing the [`checked`](https://ariakit.org/reference/menu-item-checkbox#checked), [`defaultChecked`](https://ariakit.org/reference/menu-item-checkbox#defaultchecked) and [`onChange`](https://ariakit.org/reference/menu-item-checkbox#onchange) props to [`MenuItemCheckbox`](https://ariakit.org/reference/menu-item-checkbox) and [`MenuItemRadio`](https://ariakit.org/reference/menu-item-radio):
-
-```jsx
-<MenuProvider setValue={console.log}>
-  <Menu>
-    <MenuItemCheckbox name="fruits" value="Apple" />
-    <MenuItemCheckbox name="fruits" value="Banana" defaultChecked />
-    <MenuItemCheckbox name="fruits" value="Orange" />
-  </Menu>
-</MenuProvider>
-```
+It's now possible to control the menu [`values`](https://ariakit.org/reference/menu-provider#values) state by passing the [`checked`](https://ariakit.org/reference/menu-item-checkbox#checked), [`defaultChecked`](https://ariakit.org/reference/menu-item-checkbox#defaultchecked) and [`onChange`](https://ariakit.org/reference/menu-item-checkbox#onchange) props to [`MenuItemCheckbox`](https://ariakit.org/reference/menu-item-checkbox) and [`MenuItemRadio`](https://ariakit.org/reference/menu-item-radio).

--- a/.changeset/2945-menu-item-controlled-4.md
+++ b/.changeset/2945-menu-item-controlled-4.md
@@ -1,0 +1,16 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+It's now possible to control the menu [`values`](https://ariakit.org/reference/menu-provider#values) state by passing the [`checked`](https://ariakit.org/reference/menu-item-checkbox#checked), [`defaultChecked`](https://ariakit.org/reference/menu-item-checkbox#defaultchecked) and [`onChange`](https://ariakit.org/reference/menu-item-checkbox#onchange) props to [`MenuItemCheckbox`](https://ariakit.org/reference/menu-item-checkbox) and [`MenuItemRadio`](https://ariakit.org/reference/menu-item-radio):
+
+```jsx
+<MenuProvider setValue={console.log}>
+  <Menu>
+    <MenuItemCheckbox name="fruits" value="Apple" />
+    <MenuItemCheckbox name="fruits" value="Banana" defaultChecked />
+    <MenuItemCheckbox name="fruits" value="Orange" />
+  </Menu>
+</MenuProvider>
+```

--- a/examples/menu-values-test/index.tsx
+++ b/examples/menu-values-test/index.tsx
@@ -18,11 +18,9 @@ export default function Example() {
 
   const onChange =
     (setValue: typeof setControlledValue) => (event: React.SyntheticEvent) => {
-      const element = event.target as HTMLElement | HTMLInputElement;
-      if (!("value" in element)) return;
+      const element = event.target as HTMLInputElement;
       const { value, checked } = element;
       if (!value) return;
-      // Never check Apple
       if (value === "Apple") return;
       setValue((prev) => {
         if (checked) return value;
@@ -32,10 +30,9 @@ export default function Example() {
 
   const onArrayChange =
     (setValue: typeof setControlledValues) => (event: React.SyntheticEvent) => {
-      const element = event.target as HTMLElement | HTMLInputElement;
-      if (!("value" in element)) return;
+      const element = event.target as HTMLInputElement;
       const { value, checked } = element;
-      // Never check Apple
+      if (!value) return;
       if (value === "Apple") return;
       if (checked) {
         return setValue((prev) => [...prev, value]);

--- a/examples/menu-values-test/index.tsx
+++ b/examples/menu-values-test/index.tsx
@@ -1,0 +1,157 @@
+import "./style.css";
+import { useState } from "react";
+import * as Ariakit from "@ariakit/react";
+
+const fruits = ["Apple", "Banana", "Grape", "Orange"];
+
+export default function Example() {
+  const [controlledValues, setControlledValues] = useState(["Banana"]);
+  const [parentValues, setParentValues] = useState(["Orange"]);
+
+  const [controlledValue, setControlledValue] = useState("Banana");
+  const [parentValue, setParentValue] = useState("Orange");
+
+  const isChecked = (currentValue: string | string[], value: string) => {
+    if (Array.isArray(currentValue)) return currentValue.includes(value);
+    return currentValue === value;
+  };
+
+  const onChange =
+    (setValue: typeof setControlledValue) => (event: React.SyntheticEvent) => {
+      const element = event.target as HTMLElement | HTMLInputElement;
+      if (!("value" in element)) return;
+      const { value, checked } = element;
+      if (!value) return;
+      // Never check Apple
+      if (value === "Apple") return;
+      setValue((prev) => {
+        if (checked) return value;
+        return prev === value ? "" : prev;
+      });
+    };
+
+  const onArrayChange =
+    (setValue: typeof setControlledValues) => (event: React.SyntheticEvent) => {
+      const element = event.target as HTMLElement | HTMLInputElement;
+      if (!("value" in element)) return;
+      const { value, checked } = element;
+      // Never check Apple
+      if (value === "Apple") return;
+      if (checked) {
+        return setValue((prev) => [...prev, value]);
+      }
+      setValue((prev) => prev.filter((v) => v !== value));
+    };
+
+  return (
+    <div className="wrapper">
+      <Ariakit.MenuProvider setValues={console.log}>
+        <Ariakit.MenuButton className="button">
+          Menu
+          <Ariakit.MenuButtonArrow />
+        </Ariakit.MenuButton>
+        <Ariakit.Menu gutter={8} className="menu">
+          {fruits.map((value) => (
+            <Ariakit.MenuItemCheckbox
+              key={value}
+              name="checkboxControlled"
+              value={value}
+              className="menu-item"
+              checked={isChecked(controlledValues, value)}
+              onChange={onArrayChange(setControlledValues)}
+              disabled={value === "Grape"}
+            >
+              <Ariakit.MenuItemCheck />
+              {value} (checkboxControlled)
+            </Ariakit.MenuItemCheckbox>
+          ))}
+
+          <Ariakit.MenuSeparator className="separator" />
+
+          {fruits.map((value) => (
+            <Ariakit.MenuItemCheckbox
+              key={value}
+              name="checkboxUncontrolled"
+              value={value}
+              className="menu-item"
+              defaultChecked={value === "Banana" || value === "Grape"}
+              disabled={value === "Grape"}
+            >
+              <Ariakit.MenuItemCheck />
+              {value} (checkboxUncontrolled)
+            </Ariakit.MenuItemCheckbox>
+          ))}
+
+          <Ariakit.MenuSeparator className="separator" />
+
+          <div onClick={onArrayChange(setParentValues)}>
+            {fruits.map((value) => (
+              <Ariakit.MenuItemCheckbox
+                key={value}
+                name="checkboxParent"
+                value={value}
+                className="menu-item"
+                checked={isChecked(parentValues, value)}
+                disabled={value === "Grape"}
+              >
+                <Ariakit.MenuItemCheck />
+                {value} (checkboxParent)
+              </Ariakit.MenuItemCheckbox>
+            ))}
+          </div>
+
+          <Ariakit.MenuSeparator className="separator" />
+
+          {fruits.map((value) => (
+            <Ariakit.MenuItemRadio
+              key={value}
+              name="radioControlled"
+              value={value}
+              className="menu-item"
+              checked={isChecked(controlledValue, value)}
+              onChange={onChange(setControlledValue)}
+              disabled={value === "Grape"}
+            >
+              <Ariakit.MenuItemCheck />
+              {value} (radioControlled)
+            </Ariakit.MenuItemRadio>
+          ))}
+
+          <Ariakit.MenuSeparator className="separator" />
+
+          {fruits.map((value) => (
+            <Ariakit.MenuItemRadio
+              key={value}
+              name="radioUncontrolled"
+              value={value}
+              className="menu-item"
+              defaultChecked={value === "Banana"}
+              disabled={value === "Grape"}
+            >
+              <Ariakit.MenuItemCheck />
+              {value} (radioUncontrolled)
+            </Ariakit.MenuItemRadio>
+          ))}
+
+          <Ariakit.MenuSeparator className="separator" />
+
+          <div onClick={onChange(setParentValue)}>
+            {fruits.map((value) => (
+              <Ariakit.MenuItemRadio
+                key={value}
+                name="radioParent"
+                value={value}
+                className="menu-item"
+                checked={isChecked(parentValue, value)}
+                disabled={value === "Grape"}
+              >
+                <Ariakit.MenuItemCheck />
+                {value} (radioParent)
+              </Ariakit.MenuItemRadio>
+            ))}
+          </div>
+        </Ariakit.Menu>
+      </Ariakit.MenuProvider>
+    </div>
+  );
+}

--- a/examples/menu-values-test/index.tsx
+++ b/examples/menu-values-test/index.tsx
@@ -42,7 +42,7 @@ export default function Example() {
 
   return (
     <div className="wrapper">
-      <Ariakit.MenuProvider setValues={console.log}>
+      <Ariakit.MenuProvider setValues={(values) => console.log(values)}>
         <Ariakit.MenuButton className="button">
           Menu
           <Ariakit.MenuButtonArrow />

--- a/examples/menu-values-test/style.css
+++ b/examples/menu-values-test/style.css
@@ -1,0 +1,1 @@
+@import url("../menu/style.css");

--- a/examples/menu-values-test/test.ts
+++ b/examples/menu-values-test/test.ts
@@ -1,0 +1,191 @@
+import { click, press, q, type } from "@ariakit/test";
+
+const spyOnLog = () => vi.spyOn(console, "log").mockImplementation(() => {});
+
+let log = spyOnLog();
+
+beforeEach(() => {
+  log = spyOnLog();
+  return () => log.mockClear();
+});
+
+function getVisualState() {
+  const checkboxes = q.menuitemcheckbox.all.includesHidden();
+  const radios = q.menuitemradio.all.includesHidden();
+  return [...checkboxes, ...radios].reduce<Record<string, string | string[]>>(
+    (acc, element: HTMLElement | HTMLInputElement) => {
+      if (!("name" in element)) return acc;
+      if (element.getAttribute("role") === "menuitemradio") {
+        acc[element.name] = element.checked
+          ? element.value
+          : acc[element.name] || "";
+        return acc;
+      }
+      const accValue = acc[element.name];
+      const withoutValue = Array.isArray(accValue)
+        ? accValue.filter((v) => v !== element.value)
+        : [];
+      acc[element.name] = element.checked
+        ? [...withoutValue, element.value]
+        : withoutValue;
+      return acc;
+    },
+    {},
+  );
+}
+
+test("default values", async () => {
+  expect(getVisualState()).toEqual({
+    checkboxControlled: ["Banana"],
+    checkboxParent: ["Orange"],
+    checkboxUncontrolled: ["Banana", "Grape"],
+    radioControlled: "Banana",
+    radioParent: "Orange",
+    radioUncontrolled: "Banana",
+  });
+  expect(log.mock.lastCall?.at(0)).toEqual({
+    checkboxControlled: ["Banana"],
+    checkboxParent: ["Orange"],
+    checkboxUncontrolled: ["Banana", "Grape"],
+    radioControlled: "Banana",
+    radioParent: "Orange",
+    radioUncontrolled: "Banana",
+  });
+});
+
+test("interact with checkboxControlled items", async () => {
+  await click(q.button());
+  await click(q.menuitemcheckbox("Apple (checkboxControlled)"));
+  await click(q.menuitemcheckbox("Banana (checkboxControlled)"));
+  await click(q.menuitemcheckbox.includesHidden("Grape (checkboxControlled)"));
+  await click(q.menuitemcheckbox("Orange (checkboxControlled)"));
+  expect(getVisualState().checkboxControlled).toEqual(["Orange"]);
+  expect(log.mock.lastCall?.at(0).checkboxControlled).toEqual(["Orange"]);
+  log.mockClear();
+  await click(q.menuitemcheckbox("Orange (checkboxControlled)"));
+  expect(getVisualState().checkboxControlled).toEqual([]);
+  expect(log.mock.lastCall?.at(0).checkboxControlled).toEqual([]);
+});
+
+test("interact with checkboxUncontrolled items", async () => {
+  await click(q.button());
+  await click(q.menuitemcheckbox("Apple (checkboxUncontrolled)"));
+  await click(q.menuitemcheckbox("Banana (checkboxUncontrolled)"));
+  await click(
+    q.menuitemcheckbox.includesHidden("Grape (checkboxUncontrolled)"),
+  );
+  await click(q.menuitemcheckbox("Orange (checkboxUncontrolled)"));
+  expect(getVisualState().checkboxUncontrolled).toEqual([
+    "Apple",
+    "Grape",
+    "Orange",
+  ]);
+  expect(log.mock.lastCall?.at(0).checkboxUncontrolled).toEqual([
+    "Grape",
+    "Apple",
+    "Orange",
+  ]);
+  log.mockClear();
+  await click(q.menuitemcheckbox("Orange (checkboxUncontrolled)"));
+  await click(q.menuitemcheckbox("Apple (checkboxUncontrolled)"));
+  expect(getVisualState().checkboxUncontrolled).toEqual(["Grape"]);
+  expect(log.mock.lastCall?.at(0).checkboxUncontrolled).toEqual(["Grape"]);
+});
+
+test("interact with checkboxParent items", async () => {
+  await click(q.button());
+  await click(q.menuitemcheckbox("Apple (checkboxParent)"));
+  await click(q.menuitemcheckbox("Banana (checkboxParent)"));
+  await click(q.menuitemcheckbox.includesHidden("Grape (checkboxParent)"));
+  await click(q.menuitemcheckbox("Orange (checkboxParent)"));
+  expect(getVisualState().checkboxParent).toEqual(["Banana"]);
+  expect(log.mock.lastCall?.at(0).checkboxParent).toEqual(["Banana"]);
+  log.mockClear();
+  await click(q.menuitemcheckbox("Banana (checkboxParent)"));
+  expect(getVisualState().checkboxParent).toEqual([]);
+  expect(log.mock.lastCall?.at(0).checkboxParent).toEqual([]);
+});
+
+test("interact with radioControlled items", async () => {
+  await click(q.button());
+  log.mockClear();
+  await click(q.menuitemradio("Apple (radioControlled)"));
+  expect(getVisualState().radioControlled).toBe("Banana");
+  expect(log.mock.calls).toHaveLength(0);
+  log.mockClear();
+  await click(q.menuitemradio("Banana (radioControlled)"));
+  expect(getVisualState().radioControlled).toBe("Banana");
+  expect(log.mock.calls).toHaveLength(0);
+  log.mockClear();
+  await click(q.menuitemradio.includesHidden("Grape (radioControlled)"));
+  expect(getVisualState().radioControlled).toBe("Banana");
+  expect(log.mock.calls).toHaveLength(0);
+  log.mockClear();
+  await click(q.menuitemradio("Orange (radioControlled)"));
+  expect(getVisualState().radioControlled).toBe("Orange");
+  expect(log.mock.lastCall?.at(0).radioControlled).toBe("Orange");
+  log.mockClear();
+  await click(q.menuitemradio("Banana (radioControlled)"));
+  expect(getVisualState().radioControlled).toBe("Banana");
+  expect(log.mock.lastCall?.at(0).radioControlled).toBe("Banana");
+});
+
+test("interact with radioUncontrolled items", async () => {
+  await click(q.button());
+  log.mockClear();
+  await click(q.menuitemradio("Apple (radioUncontrolled)"));
+  expect(getVisualState().radioUncontrolled).toBe("Apple");
+  expect(log.mock.lastCall?.at(0).radioUncontrolled).toBe("Apple");
+  log.mockClear();
+  await click(q.menuitemradio("Banana (radioUncontrolled)"));
+  expect(getVisualState().radioUncontrolled).toBe("Banana");
+  expect(log.mock.lastCall?.at(0).radioUncontrolled).toBe("Banana");
+  log.mockClear();
+  await click(q.menuitemradio.includesHidden("Grape (radioUncontrolled)"));
+  expect(getVisualState().radioUncontrolled).toBe("Banana");
+  expect(log.mock.calls).toHaveLength(0);
+  log.mockClear();
+  await click(q.menuitemradio("Orange (radioUncontrolled)"));
+  expect(getVisualState().radioUncontrolled).toBe("Orange");
+  expect(log.mock.lastCall?.at(0).radioUncontrolled).toBe("Orange");
+});
+
+test("interact with radioParent items", async () => {
+  await click(q.button());
+  log.mockClear();
+  await click(q.menuitemradio("Apple (radioParent)"));
+  expect(getVisualState().radioParent).toBe("Orange");
+  expect(log.mock.calls).toHaveLength(0);
+  log.mockClear();
+  await click(q.menuitemradio("Orange (radioParent)"));
+  expect(getVisualState().radioParent).toBe("Orange");
+  expect(log.mock.calls).toHaveLength(0);
+  log.mockClear();
+  await click(q.menuitemradio.includesHidden("Grape (radioParent)"));
+  expect(getVisualState().radioParent).toBe("Orange");
+  expect(log.mock.calls).toHaveLength(0);
+  log.mockClear();
+  await click(q.menuitemradio("Banana (radioParent)"));
+  expect(getVisualState().radioParent).toBe("Banana");
+  expect(log.mock.lastCall?.at(0).radioParent).toBe("Banana");
+});
+
+test("navigate with keyboard ignoring disabled items", async () => {
+  await press.Tab();
+  await press.Enter();
+  expect(q.menuitemcheckbox("Apple (checkboxControlled)")).toHaveFocus();
+  await press.ArrowDown();
+  expect(q.menuitemcheckbox("Banana (checkboxControlled)")).toHaveFocus();
+  await press.ArrowDown();
+  expect(q.menuitemcheckbox("Orange (checkboxControlled)")).toHaveFocus();
+  await press.ArrowDown();
+  expect(q.menuitemcheckbox("Apple (checkboxUncontrolled)")).toHaveFocus();
+  await press.ArrowDown();
+  expect(q.menuitemcheckbox("Banana (checkboxUncontrolled)")).toHaveFocus();
+  await press.ArrowDown();
+  expect(q.menuitemcheckbox("Orange (checkboxUncontrolled)")).toHaveFocus();
+  await type("bbbb");
+  expect(q.menuitemradio("Banana (radioControlled)")).toHaveFocus();
+  await press.ArrowDown();
+  expect(q.menuitemradio("Orange (radioControlled)")).toHaveFocus();
+});

--- a/packages/ariakit-core/src/utils/misc.ts
+++ b/packages/ariakit-core/src/utils/misc.ts
@@ -252,6 +252,20 @@ export function isFalsyBooleanCallback<T extends unknown[]>(
 }
 
 /**
+ * Checks whether something is disabled or not based on its props.
+ */
+export function disabledFromProps(props: {
+  disabled?: boolean;
+  "aria-disabled"?: boolean | "true" | "false";
+}) {
+  return (
+    props.disabled ||
+    props["aria-disabled"] === true ||
+    props["aria-disabled"] === "true"
+  );
+}
+
+/**
  * Returns the first value that is not `undefined`.
  */
 export function defaultValue<T extends readonly any[]>(...values: T) {

--- a/packages/ariakit-react-core/src/command/command.ts
+++ b/packages/ariakit-react-core/src/command/command.ts
@@ -6,6 +6,7 @@ import {
   isSelfTarget,
   queueBeforeEvent,
 } from "@ariakit/core/utils/events";
+import { disabledFromProps } from "@ariakit/core/utils/misc";
 import { isFirefox } from "@ariakit/core/utils/platform";
 import type { FocusableOptions } from "../focusable/focusable.js";
 import { useFocusable } from "../focusable/focusable.js";
@@ -63,6 +64,7 @@ export const useCommand = createHook<CommandOptions>(
     const [active, setActive] = useState(false);
     const activeRef = useRef(false);
     const isDuplicate = "data-command" in props;
+    const disabled = disabledFromProps(props);
 
     const onKeyDownProp = props.onKeyDown;
 
@@ -72,7 +74,7 @@ export const useCommand = createHook<CommandOptions>(
 
       if (event.defaultPrevented) return;
       if (isDuplicate) return;
-      if (props.disabled) return;
+      if (disabled) return;
       if (!isSelfTarget(event)) return;
       if (isTextField(element)) return;
       if (element.isContentEditable) return;
@@ -122,7 +124,7 @@ export const useCommand = createHook<CommandOptions>(
 
       if (event.defaultPrevented) return;
       if (isDuplicate) return;
-      if (props.disabled) return;
+      if (disabled) return;
       if (event.metaKey) return;
 
       const isSpace = clickOnSpace && event.key === " ";

--- a/packages/ariakit-react-core/src/composite/composite-item.tsx
+++ b/packages/ariakit-react-core/src/composite/composite-item.tsx
@@ -11,6 +11,7 @@ import {
   isTextField,
 } from "@ariakit/core/utils/dom";
 import { isPortalEvent, isSelfTarget } from "@ariakit/core/utils/events";
+import { disabledFromProps } from "@ariakit/core/utils/misc";
 import type { BooleanOrCallback } from "@ariakit/core/utils/types";
 import type { CollectionItemOptions } from "../collection/collection-item.js";
 import { useCollectionItem } from "../collection/collection-item.js";
@@ -182,7 +183,8 @@ export const useCompositeItem = createHook<CompositeItemOptions>(
       if (row.baseElement !== state.baseElement) return;
       return row.id;
     });
-    const trulyDisabled = props.disabled && !props.accessibleWhenDisabled;
+    const disabled = disabledFromProps(props);
+    const trulyDisabled = disabled && !props.accessibleWhenDisabled;
 
     const getItem = useCallback<NonNullable<CollectionItemOptions["getItem"]>>(
       (item) => {

--- a/packages/ariakit-react-core/src/focusable/focusable.ts
+++ b/packages/ariakit-react-core/src/focusable/focusable.ts
@@ -19,6 +19,7 @@ import {
   hasFocus,
   isFocusable,
 } from "@ariakit/core/utils/focus";
+import { disabledFromProps } from "@ariakit/core/utils/misc";
 import { isSafari } from "@ariakit/core/utils/platform";
 import type { BivariantCallback } from "@ariakit/core/utils/types";
 import { useEvent, useMergeRefs, useTagName } from "../utils/hooks.js";
@@ -210,7 +211,7 @@ export const useFocusable = createHook<FocusableOptions>(
       }, [focusable]);
     }
 
-    const disabled = focusable && props.disabled;
+    const disabled = focusable && disabledFromProps(props);
     const trulyDisabled = !!disabled && !accessibleWhenDisabled;
     const [focusVisible, setFocusVisible] = useState(false);
 

--- a/packages/ariakit-react-core/src/form/form-checkbox.ts
+++ b/packages/ariakit-react-core/src/form/form-checkbox.ts
@@ -89,7 +89,7 @@ if (process.env.NODE_ENV !== "production") {
 
 export interface FormCheckboxOptions<T extends As = "input">
   extends FormFieldOptions<T>,
-    Omit<CheckboxOptions<T>, "store"> {}
+    Omit<CheckboxOptions<T>, "store" | "name"> {}
 
 export type FormCheckboxProps<T extends As = "input"> = Props<
   FormCheckboxOptions<T>

--- a/packages/ariakit-react-core/src/form/form-radio.ts
+++ b/packages/ariakit-react-core/src/form/form-radio.ts
@@ -107,6 +107,6 @@ if (process.env.NODE_ENV !== "production") {
 
 export interface FormRadioOptions<T extends As = "input">
   extends FormFieldOptions<T>,
-    Omit<RadioOptions<T>, "store"> {}
+    Omit<RadioOptions<T>, "store" | "name"> {}
 
 export type FormRadioProps<T extends As = "input"> = Props<FormRadioOptions<T>>;

--- a/packages/ariakit-react-core/src/hovercard/hovercard-anchor.ts
+++ b/packages/ariakit-react-core/src/hovercard/hovercard-anchor.ts
@@ -1,7 +1,7 @@
 import type { MouseEvent as ReactMouseEvent } from "react";
 import { useEffect, useRef } from "react";
 import { addGlobalEventListener } from "@ariakit/core/utils/events";
-import { invariant } from "@ariakit/core/utils/misc";
+import { disabledFromProps, invariant } from "@ariakit/core/utils/misc";
 import type { BooleanOrCallback } from "@ariakit/core/utils/types";
 import type { FocusableOptions } from "../focusable/focusable.js";
 import { useFocusable } from "../focusable/focusable.js";
@@ -39,11 +39,7 @@ export const useHovercardAnchor = createHook<HovercardAnchorOptions>(
     );
 
     const mounted = store.useState("mounted");
-    const disabled =
-      props.disabled ||
-      props["aria-disabled"] === true ||
-      props["aria-disabled"] === "true";
-
+    const disabled = disabledFromProps(props);
     const showTimeoutRef = useRef(0);
 
     // Clear the show timeout if the anchor is unmounted

--- a/packages/ariakit-react-core/src/menu/menu-button.tsx
+++ b/packages/ariakit-react-core/src/menu/menu-button.tsx
@@ -1,7 +1,7 @@
 import type { FocusEvent, KeyboardEvent, MouseEvent } from "react";
 import { useEffect, useRef } from "react";
 import { getPopupItemRole, getPopupRole } from "@ariakit/core/utils/dom";
-import { invariant } from "@ariakit/core/utils/misc";
+import { disabledFromProps, invariant } from "@ariakit/core/utils/misc";
 import { sync } from "@ariakit/core/utils/store";
 import type { CompositeTypeaheadOptions } from "../composite/composite-typeahead.js";
 import { useCompositeTypeahead } from "../composite/composite-typeahead.js";
@@ -65,10 +65,7 @@ export const useMenuButton = createHook<MenuButtonOptions>(
     const parentMenuBar = store.menubar;
     const hasParentMenu = !!parentMenu;
     const parentIsMenuBar = !!parentMenuBar && !hasParentMenu;
-    const disabled =
-      props.disabled ||
-      props["aria-disabled"] === true ||
-      props["aria-disabled"] === "true";
+    const disabled = disabledFromProps(props);
 
     useEffect(() => {
       // Makes sure that the menu button is assigned as the menu disclosure

--- a/packages/ariakit-react-core/src/menu/menu-item-checkbox.ts
+++ b/packages/ariakit-react-core/src/menu/menu-item-checkbox.ts
@@ -172,6 +172,18 @@ export interface MenuItemCheckboxOptions<T extends As = "div">
    */
   name: string;
   /**
+   * The controlled checked state of the element. It will set the menu
+   * [`values`](https://ariakit.org/reference/menu-provider#values) state if
+   * provided.
+   */
+  checked?: boolean;
+  /**
+   * The default checked state of the element. It will set the default value in
+   * the menu [`values`](https://ariakit.org/reference/menu-provider#values)
+   * state if provided.
+   */
+  defaultChecked?: boolean;
+  /**
    * @default false
    */
   hideOnClick?: MenuItemOptions<T>["hideOnClick"];

--- a/packages/ariakit-react-core/src/menu/menu-item-radio.tsx
+++ b/packages/ariakit-react-core/src/menu/menu-item-radio.tsx
@@ -21,7 +21,6 @@ import type { MenuStore } from "./menu-store.js";
 function getValue<T>(prevValue: T, value: T, checked?: boolean) {
   if (checked === undefined) return prevValue;
   if (checked) return value;
-  // if (!checked && prevValue === value) return false;
   return prevValue;
 }
 
@@ -159,6 +158,18 @@ export interface MenuItemRadioOptions<T extends As = "div">
    * [`values`](https://ariakit.org/reference/menu-provider#values) state.
    */
   name: string;
+  /**
+   * The controlled checked state of the element. It will set the menu
+   * [`values`](https://ariakit.org/reference/menu-provider#values) state if
+   * provided.
+   */
+  checked?: boolean;
+  /**
+   * The default checked state of the element. It will set the default value in
+   * the menu [`values`](https://ariakit.org/reference/menu-provider#values)
+   * state if provided.
+   */
+  defaultChecked?: boolean;
   /**
    * @default false
    */

--- a/packages/ariakit-react-core/src/select/select-item.tsx
+++ b/packages/ariakit-react-core/src/select/select-item.tsx
@@ -2,7 +2,7 @@ import type { MouseEvent } from "react";
 import { useCallback } from "react";
 import { getPopupItemRole } from "@ariakit/core/utils/dom";
 import { isDownloading, isOpeningInNewTab } from "@ariakit/core/utils/events";
-import { invariant } from "@ariakit/core/utils/misc";
+import { disabledFromProps, invariant } from "@ariakit/core/utils/misc";
 import type { BooleanOrCallback } from "@ariakit/core/utils/types";
 import type { CompositeHoverOptions } from "../composite/composite-hover.js";
 import { useCompositeHover } from "../composite/composite-hover.js";
@@ -66,7 +66,7 @@ export const useSelectItem = createHook<SelectItemOptions>(
     );
 
     const id = useId(props.id);
-    const disabled = props.disabled;
+    const disabled = disabledFromProps(props);
 
     const getItem = useCallback<NonNullable<CompositeItemOptions["getItem"]>>(
       (item) => {

--- a/packages/ariakit-react-core/src/tab/tab.ts
+++ b/packages/ariakit-react-core/src/tab/tab.ts
@@ -1,6 +1,6 @@
 import type { MouseEvent } from "react";
 import { useCallback } from "react";
-import { invariant } from "@ariakit/core/utils/misc";
+import { disabledFromProps, invariant } from "@ariakit/core/utils/misc";
 import type { CompositeItemOptions } from "../composite/composite-item.js";
 import { useCompositeItem } from "../composite/composite-item.js";
 import { useEvent, useId } from "../utils/hooks.js";
@@ -47,7 +47,7 @@ export const useTab = createHook<TabOptions>(
     // https://github.com/ariakit/ariakit/issues/1721
     const defaultId = useId();
     const id = props.id || defaultId;
-    const dimmed = props.disabled;
+    const dimmed = disabledFromProps(props);
 
     const getItem = useCallback<NonNullable<CompositeItemOptions["getItem"]>>(
       (item) => {


### PR DESCRIPTION
Closes #2913
Closes #2914
Closes #2915
Closes #2916

This PR introduces a new example, `menu-values-test`, illustrating various applications of the `MenuItemCheckbox` and `MenuItemRadio` components:

- Controlled with `checked` and `onChange` props.
- Uncontrolled with the `defaultChecked` prop.
- Controlled with a parent `onClick` handler.
- Disabled.

This PR addresses some bugs and missing features found in those scenarios. For more details, please refer to the linked issues and changeset files.