### PR TITLE
Fix Hovercard when using multiple anchors

### DIFF
--- a/.changeset/3037-hovercard-anchor.md
+++ b/.changeset/3037-hovercard-anchor.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed [Hovercard](https://ariakit.org/components/hovercard) when used with multiple [`HovercardAnchor`](https://ariakit.org/reference/hovercard-anchor) elements.


### PR DESCRIPTION
When multiple `HovercardAnchor` elements are used for the same `Hovercard`, a bug occurred in the popover's position because the `anchorElement` was reset each time the popover was mounted. This PR resolves the problem by not depending on the `mounted` state, but instead setting the `disclosureElement` state in a microtask following the display of the popover.