### PR TITLE
Add `preserveTabOrderAnchor` prop to `Portal`

### DIFF
--- a/.changeset/3059-preserve-tab-order-anchor-1.md
+++ b/.changeset/3059-preserve-tab-order-anchor-1.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Added new [`preserveTabOrderAnchor`](https://ariakit.org/reference/portal#preservetaborderanchor) prop to [`Portal`](https://ariakit.org/reference/portal) and related components.

--- a/.changeset/3059-preserve-tab-order-anchor-2.md
+++ b/.changeset/3059-preserve-tab-order-anchor-2.md
@@ -1,0 +1,8 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+[`Popover`](https://ariakit.org/reference/popover) and related components now automatically set the new [`preserveTabOrderAnchor`](https://ariakit.org/reference/portal#preservetaborderanchor) prop as the disclosure element.
+
+This ensures that, when the [`portal`](https://ariakit.org/reference/popover#portal) prop is enabled, the tab order will be preserved from the disclosure to the content element even when the [`Popover`](https://ariakit.org/reference/popover) component is rendered in a different location in the React tree.

--- a/packages/ariakit-react-core/src/combobox/combobox-popover.tsx
+++ b/packages/ariakit-react-core/src/combobox/combobox-popover.tsx
@@ -66,6 +66,7 @@ export const useComboboxPopover = createHook<ComboboxPopoverOptions>(
       autoFocusOnShow: false,
       autoFocusOnHide: false,
       finalFocus: baseElement,
+      preserveTabOrderAnchor: null,
       ...props,
       // Combobox popovers can't be modal because the focus may be (and is by
       // default) outside of it on the combobox input element.

--- a/packages/ariakit-react-core/src/popover/popover.tsx
+++ b/packages/ariakit-react-core/src/popover/popover.tsx
@@ -241,6 +241,7 @@ export const usePopover = createHook<PopoverOptions>(
 
     const arrowElement = store.useState("arrowElement");
     const anchorElement = store.useState("anchorElement");
+    const disclosureElement = store.useState("disclosureElement");
     const popoverElement = store.useState("popoverElement");
     const contentElement = store.useState("contentElement");
     const placement = store.useState("placement");
@@ -435,6 +436,7 @@ export const usePopover = createHook<PopoverOptions>(
       store,
       modal,
       preserveTabOrder,
+      preserveTabOrderAnchor: disclosureElement || anchorElement,
       portal,
       autoFocusOnShow: positioned && autoFocusOnShow,
       ...props,


### PR DESCRIPTION
This PR adds a new `preserveTabOrderAnchor` prop to `Portal` and related components. The `Popover` component also automatically sets it as its disclosure element.

This ensures that, when the `portal` prop is enabled, the tab order will be preserved from the disclosure to the content element even when the `Popover` component is rendered in a different location in the React tree when the' portal' prop is enabled.