### PR TITLE
Revert Menubar always expanding with focus

### DIFF
--- a/.changeset/3098-menubar-expand-focus.md
+++ b/.changeset/3098-menubar-expand-focus.md
@@ -1,0 +1,8 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Expanding Menubar
+
+The [Menubar](https://ariakit.org/components/menubar) component will now only expand if there's another menu already expanded in the same menubar.

--- a/examples/menubar/test.ts
+++ b/examples/menubar/test.ts
@@ -119,8 +119,8 @@ test("hide on escape", async () => {
   expect(q.menu("File")).not.toBeInTheDocument();
   await press.ArrowRight();
   expect(q.menuitem("Edit")).toHaveFocus();
-  expect(q.menu("Edit")).toBeInTheDocument();
+  expect(q.menu("Edit")).not.toBeInTheDocument();
   await press.Escape();
   await hover(q.menuitem("View"));
-  expect(q.menu("View")).toBeVisible();
+  expect(q.menu("View")).not.toBeInTheDocument();
 });

--- a/packages/ariakit-core/src/menubar/menubar-store.ts
+++ b/packages/ariakit-core/src/menubar/menubar-store.ts
@@ -1,12 +1,12 @@
 import type {
-  CompositeStore,
   CompositeStoreFunctions,
   CompositeStoreOptions,
-  CompositeStoreProps,
   CompositeStoreState,
 } from "../composite/composite-store.js";
 import { createCompositeStore } from "../composite/composite-store.js";
 import { defaultValue } from "../utils/misc.js";
+import { createStore } from "../utils/store.js";
+import type { Store, StoreProps } from "../utils/store.js";
 
 /**
  * Creates a menu bar store.
@@ -16,7 +16,7 @@ export function createMenubarStore(
 ): MenubarStore {
   const syncState = props.store?.getState();
 
-  return createCompositeStore({
+  const composite = createCompositeStore({
     ...props,
     orientation: defaultValue(
       props.orientation,
@@ -25,14 +25,29 @@ export function createMenubarStore(
     ),
     focusLoop: defaultValue(props.focusLoop, syncState?.focusLoop, true),
   });
+
+  const initialState: MenubarStoreState = {
+    ...composite.getState(),
+  };
+
+  const menubar = createStore(initialState, composite, props.store);
+
+  return {
+    ...composite,
+    ...menubar,
+  };
 }
 
-export type MenubarStoreState = CompositeStoreState;
+export interface MenubarStoreState extends CompositeStoreState {}
 
-export type MenubarStoreFunctions = CompositeStoreFunctions;
+export interface MenubarStoreFunctions extends CompositeStoreFunctions {}
 
-export type MenubarStoreOptions = CompositeStoreOptions;
+export interface MenubarStoreOptions extends CompositeStoreOptions {}
 
-export type MenubarStoreProps = CompositeStoreProps;
+export interface MenubarStoreProps
+  extends MenubarStoreOptions,
+    StoreProps<MenubarStoreState> {}
 
-export type MenubarStore = CompositeStore;
+export interface MenubarStore
+  extends MenubarStoreFunctions,
+    Store<MenubarStoreState> {}


### PR DESCRIPTION
This PR reverts a change introduced in v0.3.6. In that version, the `Menubar` component was updated so that hovering or focusing on one of its menu buttons would invariably open the menu popover if another menu button was already in focus.

This behavior proved to be inconsistent. So, I'm now reverting to the previous state where menus only expand if another menu is already expanded.