### PR TITLE
Fix Select not opening when unmountOnHide is true

### DIFF
--- a/.changeset/3151-select-default-open-controlled.md
+++ b/.changeset/3151-select-default-open-controlled.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/core": patch
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed unmounted [`SelectPopover`](https://ariakit.org/reference/select-popover) not re-opening when its [`open`](https://ariakit.org/reference/select-provider#open) state is initially set to `true`.

--- a/examples/select-default-open-controlled/index.tsx
+++ b/examples/select-default-open-controlled/index.tsx
@@ -1,0 +1,32 @@
+import "./style.css";
+import { useState } from "react";
+import * as Ariakit from "@ariakit/react";
+
+export default function Example() {
+  const [open, setOpen] = useState(true);
+  return (
+    <div className="wrapper">
+      <Ariakit.SelectProvider
+        open={open}
+        setOpen={setOpen}
+        defaultValue="Apple"
+      >
+        <Ariakit.SelectLabel className="label">
+          Favorite fruit
+        </Ariakit.SelectLabel>
+        <Ariakit.Select className="button" />
+        <Ariakit.SelectPopover
+          gutter={4}
+          sameWidth
+          unmountOnHide
+          className="popover"
+        >
+          <Ariakit.SelectItem className="select-item" value="Apple" />
+          <Ariakit.SelectItem className="select-item" value="Banana" />
+          <Ariakit.SelectItem className="select-item" value="Grape" />
+          <Ariakit.SelectItem className="select-item" value="Orange" />
+        </Ariakit.SelectPopover>
+      </Ariakit.SelectProvider>
+    </div>
+  );
+}

--- a/examples/select-default-open-controlled/style.css
+++ b/examples/select-default-open-controlled/style.css
@@ -1,0 +1,1 @@
+@import url("../select/style.css");

--- a/examples/select-default-open-controlled/test.ts
+++ b/examples/select-default-open-controlled/test.ts
@@ -1,0 +1,9 @@
+import { click, q } from "@ariakit/test";
+
+test("popover can be toggled", async () => {
+  expect(q.listbox()).toBeVisible();
+  await click(q.combobox());
+  expect(q.listbox()).not.toBeInTheDocument();
+  await click(q.combobox());
+  expect(q.listbox()).toBeVisible();
+});

--- a/packages/ariakit-core/src/utils/store.ts
+++ b/packages/ariakit-core/src/utils/store.ts
@@ -62,7 +62,6 @@ export function createStore<S extends State>(
   let state = initialState;
   let prevStateBatch = state;
   let lastUpdate = Symbol();
-  let initialized = false;
   const updatedKeys = new Set<keyof S>();
 
   const setups = new Set<() => void | (() => void)>();
@@ -77,9 +76,7 @@ export function createStore<S extends State>(
   };
 
   const storeInit: StoreInit = () => {
-    if (initialized) return noop;
     if (!stores.length) return noop;
-    initialized = true;
 
     const desyncs = getKeys(state).map((key) =>
       chain(
@@ -105,9 +102,7 @@ export function createStore<S extends State>(
 
     const cleanups = stores.map(init);
 
-    return chain(...desyncs, ...teardowns, ...cleanups, () => {
-      initialized = false;
-    });
+    return chain(...desyncs, ...teardowns, ...cleanups);
   };
 
   const sub = (

--- a/packages/ariakit-test/src/react.tsx
+++ b/packages/ariakit-test/src/react.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from "react";
 import { StrictMode } from "react";
 import * as ReactTestingLibrary from "@testing-library/react";
-import { nextFrame, wrapAsync } from "./__utils.js";
+import { flushMicrotasks, nextFrame, wrapAsync } from "./__utils.js";
 
 export * from "./index.js";
 
@@ -20,7 +20,9 @@ export async function render(ui: ReactElement, options?: RenderOptions) {
 
   return wrapAsync(async () => {
     const { unmount } = ReactTestingLibrary.render(ui, { ...options, wrapper });
+    await flushMicrotasks();
     await nextFrame();
+    await flushMicrotasks();
     return unmount;
   });
 }


### PR DESCRIPTION
Closes #3147

When the select popover was mounted by default, the external/context store was only initialized as part of the internal store, not the host/provider component. As a result, if the popover were unmounted, it would be destroyed, leaving the external/context store uninitiated.

This PR modifies the store logic to enable a store to be initialized again before it's destroyed.