### PR TITLE
Fix Tab store reference updates

### DIFF
--- a/.changeset/3234-tab-store-update.md
+++ b/.changeset/3234-tab-store-update.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed [`useTabStore`](https://ariakit.org/reference/use-tab-store) return value not updating its own reference.

--- a/packages/ariakit-react-core/src/tab/tab-store.ts
+++ b/packages/ariakit-react-core/src/tab/tab-store.ts
@@ -6,6 +6,7 @@ import type {
   CompositeStoreState,
 } from "../composite/composite-store.js";
 import { useCompositeStoreProps } from "../composite/composite-store.js";
+import { useUpdateEffect } from "../utils/hooks.js";
 import type { Store } from "../utils/store.js";
 import { useStore, useStoreProps } from "../utils/store.js";
 
@@ -17,8 +18,11 @@ export function useTabStoreProps<T extends Core.TabStore>(
   store = useCompositeStoreProps(store, update, props);
   useStoreProps(store, props, "selectedId", "setSelectedId");
   useStoreProps(store, props, "selectOnMove");
-  const [panels] = useStore(() => store.panels, {});
-  return useMemo(() => ({ ...store, panels }), []);
+
+  const [panels, updatePanels] = useStore(() => store.panels, {});
+  useUpdateEffect(updatePanels, [store, updatePanels]);
+
+  return useMemo(() => ({ ...store, panels }), [store, panels]);
 }
 
 /**


### PR DESCRIPTION
This PR fixes the tab store so it now updates the `store` object reference properly. For example, when a new `store` prop is passed to the tab store.