### PR TITLE
Prevent SelectCombobox to scroll jump on opening when using the keyboard

### DIFF
--- a/.changeset/3264-select-combobox-jump-scroll.md
+++ b/.changeset/3264-select-combobox-jump-scroll.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Select`](https://ariakit.org/reference/select) with [`Combobox`](https://ariakit.org/reference/combobox) scroll jumping when opening using keyboard navigation.
+

--- a/examples/select-combobox/test-browser.ts
+++ b/examples/select-combobox/test-browser.ts
@@ -1,6 +1,9 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 
+const getPopover = (page: Page) =>
+  page.getByRole("dialog", { name: "Favorite fruit" });
+
 const getButton = (page: Page) =>
   page.getByRole("combobox", { name: "Favorite fruit" });
 
@@ -34,3 +37,15 @@ test("auto select first option", async ({ page }) => {
   await page.keyboard.press("Backspace");
   await expectSelected(page, "Apple");
 });
+
+for (const { key } of [{ key: "ArrowUp" }, { key: "ArrowDown" }]) {
+  test(`not scroll jump using the ${key} key to open the combobox`, async ({
+    page,
+  }) => {
+    await getButton(page).focus();
+    await page.evaluate(() => window.scrollTo({ top: 100 }));
+    await page.keyboard.press(key);
+    await expect(getPopover(page)).toBeVisible();
+    expect(await page.evaluate(() => window.scrollY)).toBe(100);
+  });
+}

--- a/packages/ariakit-react-core/src/combobox/combobox.ts
+++ b/packages/ariakit-react-core/src/combobox/combobox.ts
@@ -286,11 +286,11 @@ export const useCombobox = createHook<ComboboxOptions>(
       if ((!autoSelect || !canAutoSelect) && !resetValueOnSelect) return;
       const { baseElement, contentElement, activeId } = store.getState();
       if (baseElement && !hasFocus(baseElement)) return;
-      // The data-placing attribue is an internal state added by the Popover
+      // The data-placing attribute is an internal state added by the Popover
       // component. We can observe it to know when the popover is done placing
       // itself. This is to prevent the focus from moving to the first item
       // while the popover is still calculating its position, which could cause
-      // a srcoll jump. See combobox-group test-browser file.
+      // a scroll jump. See combobox-group test-browser file.
       if (contentElement?.hasAttribute("data-placing")) {
         const observer = new MutationObserver(forceValueUpdate);
         observer.observe(contentElement, { attributeFilter: ["data-placing"] });

--- a/packages/ariakit-react-core/src/select/select.tsx
+++ b/packages/ariakit-react-core/src/select/select.tsx
@@ -136,8 +136,11 @@ export const useSelect = createHook<SelectOptions>(
       const canShow = canShowKeyMap[event.key as keyof typeof canShowKeyMap];
       if (canShow && showOnKeyDownProp(event)) {
         event.preventDefault();
-        store.show();
         store.move(activeId);
+        // Schedule the show event to run after the key event has finished
+        // bubbling. This is necessary to avoid the page to scroll when the
+        // popover is shown.
+        queueBeforeEvent(event.currentTarget, "keyup", store.show);
       }
     });
 


### PR DESCRIPTION
I believe that this solution may not address the underlying issue. However, I am still submitting this PR so that we can have a temporary fix for now.

Another option we have is to call `store.move(activeId);` using a `flushSync` method, but this approach [may negatively impact performance as noted by React team](https://react.dev/reference/react-dom/flushSync).

Closes https://github.com/ariakit/ariakit/issues/1811