### PR TITLE
Fix CompositeItem not triggering onClick action when partially visible

### DIFF
--- a/.changeset/3273-combobox-scroll-interupt-link-event.md
+++ b/.changeset/3273-combobox-scroll-interupt-link-event.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed [`ComboboxItem`](https://ariakit.org/reference/combobox-item) not triggering the `onClick` event when the item is partially visible. 

--- a/examples/combobox-links/test-browser.ts
+++ b/examples/combobox-links/test-browser.ts
@@ -95,3 +95,14 @@ test("click on target blank link", async ({ page, context }) => {
   await expect(getCombobox(page)).toHaveValue("");
   await expect(newPage).toHaveURL(/https:\/\/twitter.com/);
 });
+
+test("https://github.com/ariakit/ariakit/issues/2056", async ({ page }) => {
+  await getCombobox(page).click();
+  await expect(getPopover(page)).toBeVisible();
+  // Hover here is important to reproduce the issue.
+  await getOption(page, "Ariakit.org").hover();
+  // Position the page so that the link is not fully visible.
+  await page.evaluate(() => window.scrollTo({ top: 440 }));
+  await getOption(page, "Ariakit.org").click();
+  await expect(page).toHaveURL(/https:\/\/ariakit.org/);
+});

--- a/packages/ariakit-react-core/src/composite/utils.ts
+++ b/packages/ariakit-react-core/src/composite/utils.ts
@@ -91,7 +91,7 @@ type FocusSilentlyElement = HTMLElement & { [FOCUS_SILENTLY]?: boolean };
  */
 export function focusSilently(element: FocusSilentlyElement) {
   element[FOCUS_SILENTLY] = true;
-  element.focus();
+  element.focus({ preventScroll: true });
 }
 
 /**


### PR DESCRIPTION
Closes #2056 