### PR TITLE
Fix regression when scrolling composite items

### DIFF
--- a/examples/combobox-multiple/test-browser.ts
+++ b/examples/combobox-multiple/test-browser.ts
@@ -28,3 +28,11 @@ test("scroll offscreen item into view after selecting it", async ({ page }) => {
   await expect(q.option("Pineapple")).toHaveAttribute("data-active-item", "");
   await expect(q.option("Pineapple")).toHaveAttribute("aria-selected", "true");
 });
+
+test("scroll after hovering over an item", async ({ page }) => {
+  const q = query(page);
+  await q.combobox().click();
+  await q.option("Apple").hover();
+  await page.mouse.wheel(0, 200);
+  await expect(q.option("Apple")).not.toBeInViewport();
+});

--- a/examples/menu-maximum-update-depth/index.tsx
+++ b/examples/menu-maximum-update-depth/index.tsx
@@ -1,0 +1,19 @@
+import "./style.css";
+import * as Ariakit from "@ariakit/react";
+
+function Menu() {
+  return (
+    <Ariakit.MenuProvider>
+      <Ariakit.MenuButton className="button">Menu</Ariakit.MenuButton>
+      <Ariakit.Menu className="menu">
+        <Ariakit.MenuItem className="menu-item">A</Ariakit.MenuItem>
+        <Ariakit.MenuItem className="menu-item">B</Ariakit.MenuItem>
+        <Ariakit.MenuItem className="menu-item">C</Ariakit.MenuItem>
+      </Ariakit.Menu>
+    </Ariakit.MenuProvider>
+  );
+}
+
+export default function Example() {
+  return Array.from({ length: 60 }, (_, index) => <Menu key={index} />);
+}

--- a/examples/menu-maximum-update-depth/style.css
+++ b/examples/menu-maximum-update-depth/style.css
@@ -1,0 +1,1 @@
+@import url("../menu/style.css");

--- a/packages/ariakit-core/src/collection/collection-store.ts
+++ b/packages/ariakit-core/src/collection/collection-store.ts
@@ -100,8 +100,7 @@ export function createCollectionStore<
 
   const collection = createStore(initialState, props.store);
 
-  const sortItems = () => {
-    const { renderedItems } = privateStore.getState();
+  const sortItems = (renderedItems: T[]) => {
     const sortedItems = sortBasedOnDOMPosition(renderedItems);
     privateStore.setState("renderedItems", sortedItems);
     collection.setState("renderedItems", sortedItems);
@@ -119,7 +118,7 @@ export function createCollectionStore<
         // because the following lines can cause this function to be called
         // again.
         if (state.renderedItems === renderedItems) return;
-        sortItems();
+        sortItems(state.renderedItems);
       });
 
       if (typeof IntersectionObserver !== "function") {
@@ -134,7 +133,7 @@ export function createCollectionStore<
           return;
         }
         cancelAnimationFrame(raf);
-        raf = requestAnimationFrame(sortItems);
+        raf = requestAnimationFrame(() => sortItems(state.renderedItems));
       };
 
       const root = getCommonParent(state.renderedItems);

--- a/packages/ariakit-core/src/collection/collection-store.ts
+++ b/packages/ariakit-core/src/collection/collection-store.ts
@@ -133,7 +133,6 @@ export function createCollectionStore<
           firstRun = false;
           return;
         }
-        // privateStore.setState("renderedItems", [...state.renderedItems]);
         cancelAnimationFrame(raf);
         raf = requestAnimationFrame(sortItems);
       };

--- a/packages/ariakit-core/src/utils/store.ts
+++ b/packages/ariakit-core/src/utils/store.ts
@@ -78,7 +78,6 @@ export function createStore<S extends State>(
   };
 
   const storeInit: StoreInit = () => {
-    if (!stores.length) return noop;
     // Make sure we only initialize the store once, even when it's passed to
     // other stores. However, the store can't be destroyed until all instances
     // are unmounted. See https://github.com/ariakit/ariakit/issues/3147. See


### PR DESCRIPTION
Fix a regression introduced by #3241 where the `renderedItems` state was being reset on every scroll event.

Closes #3285
Re-opens #3214
