### PR TITLE
Make sure buttons are focused before pointerup on Safari

### DIFF
--- a/.changeset/3288-safari-focus-fix.md
+++ b/.changeset/3288-safari-focus-fix.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Adjusted the focus behavior in Safari to occur prior to the `pointerup` event instead of `mouseup`.

--- a/packages/ariakit-react-core/src/focusable/focusable.ts
+++ b/packages/ariakit-react-core/src/focusable/focusable.ts
@@ -281,10 +281,10 @@ export const useFocusable = createHook<FocusableOptions>(
       element.addEventListener("focusin", onFocus, options);
       // We can't focus right away after on mouse down, otherwise it would
       // prevent drag events from happening. So we queue the focus to the next
-      // animation frame, but always before the next mouseup event. The mouseup
-      // event might happen before the next animation frame on touch devices or
-      // by tapping on a MacBook's trackpad, for example.
-      queueBeforeEvent(element, "mouseup", () => {
+      // animation frame, but always before the next pointerup event. The
+      // pointerup event might happen before the next animation frame on touch
+      // devices or by tapping on a MacBook's trackpad, for example.
+      queueBeforeEvent(element, "pointerup", () => {
         element.removeEventListener("focusin", onFocus, true);
         if (receivedFocus) return;
         focusIfNeeded(element);


### PR DESCRIPTION
`pointerup` is dispatched before `mouseup`, so using the former is safer.