### PR TITLE
Fix unmountOnHide on TabPanel

### DIFF
--- a/.changeset/3559-tab-panel-unmount-on-hide.md
+++ b/.changeset/3559-tab-panel-unmount-on-hide.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed [`unmountOnHide`](https://ariakit.org/reference/tab-panel#unmountonhide) prop not working on [`TabPanel`](https://ariakit.org/reference/tab-panel) without [`tabId`](https://ariakit.org/reference/tab-panel#tabid).

--- a/packages/ariakit-react-core/src/tab/tab-panel.tsx
+++ b/packages/ariakit-react-core/src/tab/tab-panel.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { ElementType, KeyboardEvent } from "react";
 import { createTabStore } from "@ariakit/core/tab/tab-store";
 import { getAllTabbableIn } from "@ariakit/core/utils/focus";
@@ -126,27 +126,18 @@ export const useTabPanel = createHook<TagName, TabPanelOptions>(
       (state) => !!tabId && state.selectedId === tabId,
     );
 
+    const disclosure = useDisclosureStore({ open });
+    const mounted = disclosure.useState("mounted");
+
     props = {
       id,
       role: "tabpanel",
       "aria-labelledby": tabId || undefined,
       ...props,
+      children: unmountOnHide && !mounted ? null : props.children,
       ref: useMergeRefs(ref, props.ref),
       onKeyDown,
     };
-
-    const disclosure = useDisclosureStore({ open });
-    const mounted = disclosure.useState("mounted");
-
-    props = useWrapElement(
-      props,
-      (element) => {
-        if (!unmountOnHide) return element;
-        if (!mounted) return <Fragment />;
-        return element;
-      },
-      [unmountOnHide, mounted],
-    );
 
     props = useFocusable({
       // If the tab panel is rendered as part of another composite widget such


### PR DESCRIPTION
When `TabPanel` has no `tabId`, it uses the element position in the DOM to determine the related tab. If we completely unmount the tab panel element, the active tab panel will be always rendered as the first one, and thus connected to the first tab.

This PR updates the logic so only the panel children will be unmounted, not the panel element itself.