### PR TITLE
Move resetValueOnSelect option to ComboboxItem

### DIFF
--- a/.changeset/3640-combobox-item-reset-value-on-select-1.md
+++ b/.changeset/3640-combobox-item-reset-value-on-select-1.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Added new [`resetValueOnSelect`](https://ariakit.org/reference/combobox-item#resetvalueonselect) prop to [`ComboboxItem`](https://ariakit.org/reference/combobox-item).

--- a/.changeset/3640-combobox-item-reset-value-on-select-2.md
+++ b/.changeset/3640-combobox-item-reset-value-on-select-2.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/core": patch
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Added new [`resetValue`](https://ariakit.org/reference/use-combobox-store#resetvalue) method to combobox store.

--- a/packages/ariakit-core/src/combobox/combobox-store.ts
+++ b/packages/ariakit-core/src/combobox/combobox-store.ts
@@ -132,13 +132,6 @@ export function createComboboxStore(
     }),
   );
 
-  setup(combobox, () =>
-    sync(combobox, ["resetValueOnSelect", "selectedValue"], (state) => {
-      if (!state.resetValueOnSelect) return;
-      combobox.setState("value", value);
-    }),
-  );
-
   // Resets the state when the combobox popover is hidden.
   setup(combobox, () =>
     batch(combobox, ["mounted"], (state) => {
@@ -174,6 +167,7 @@ export function createComboboxStore(
     ...composite,
     ...combobox,
     setValue: (value) => combobox.setState("value", value),
+    resetValue: () => combobox.setState("value", initialState.value),
     setSelectedValue: (selectedValue) =>
       combobox.setState("selectedValue", selectedValue),
   };
@@ -256,10 +250,10 @@ export interface ComboboxStoreState<
    * or
    * [`defaultSelectedValue`](https://ariakit.org/reference/combobox-provider#defaultselectedvalue)
    * props are arrays.
-   *
-   * Live examples:
-   * - [Multi-selectable
-   *   Combobox](https://ariakit.org/examples/combobox-multiple)
+   * @deprecated Use the
+   * [`resetValueOnSelect`](https://ariakit.org/reference/combobox-item#resetvalueonselect)
+   * prop on [`ComboboxItem`](https://ariakit.org/reference/combobox-item)
+   * instead.
    */
   resetValueOnSelect: boolean;
 }
@@ -280,6 +274,11 @@ export interface ComboboxStoreFunctions<
    * store.setValue((value) => value + "!");
    */
   setValue: SetState<ComboboxStoreState<T>["value"]>;
+  /**
+   * Resets the [`value`](https://ariakit.org/reference/combobox-provider#value)
+   * state to its initial value.
+   */
+  resetValue: () => void;
   /**
    * Sets the
    * [`selectedValue`](https://ariakit.org/reference/combobox-provider#selectedvalue)

--- a/packages/ariakit-react-core/src/combobox/combobox-item.tsx
+++ b/packages/ariakit-react-core/src/combobox/combobox-item.tsx
@@ -63,8 +63,9 @@ export const useComboboxItem = createHook<TagName, ComboboxItemOptions>(
     store,
     value,
     hideOnClick,
-    selectValueOnClick = true,
     setValueOnClick,
+    selectValueOnClick = true,
+    resetValueOnSelect,
     focusOnHover = false,
     moveOnKeyPress = true,
     getItem: getItemProp,
@@ -94,12 +95,21 @@ export const useComboboxItem = createHook<TagName, ComboboxItemOptions>(
       Array.isArray(state.selectedValue),
     );
 
+    const selected = store.useState((state) =>
+      isSelected(state.selectedValue, value),
+    );
+
+    const resetValueOnSelectState = store.useState("resetValueOnSelect");
+
     setValueOnClick = setValueOnClick ?? !multiSelectable;
     hideOnClick = hideOnClick ?? (value != null && !multiSelectable);
 
     const onClickProp = props.onClick;
     const setValueOnClickProp = useBooleanEvent(setValueOnClick);
     const selectValueOnClickProp = useBooleanEvent(selectValueOnClick);
+    const resetValueOnSelectProp = useBooleanEvent(
+      resetValueOnSelect ?? resetValueOnSelectState ?? multiSelectable,
+    );
     const hideOnClickProp = useBooleanEvent(hideOnClick);
 
     const onClick = useEvent((event: MouseEvent<HTMLType>) => {
@@ -109,6 +119,9 @@ export const useComboboxItem = createHook<TagName, ComboboxItemOptions>(
       if (isOpeningInNewTab(event)) return;
       if (value != null) {
         if (selectValueOnClickProp(event)) {
+          if (resetValueOnSelectProp(event)) {
+            store?.resetValue();
+          }
           store?.setSelectedValue((prevValue) => {
             if (!Array.isArray(prevValue)) return value;
             if (prevValue.includes(value)) {
@@ -151,10 +164,6 @@ export const useComboboxItem = createHook<TagName, ComboboxItemOptions>(
         }
       }
     });
-
-    const selected = store.useState((state) =>
-      isSelected(state.selectedValue, value),
-    );
 
     if (multiSelectable && selected != null) {
       props = {
@@ -294,6 +303,20 @@ export interface ComboboxItemOptions<T extends ElementType = TagName>
    */
   hideOnClick?: BooleanOrCallback<MouseEvent<HTMLElement>>;
   /**
+   * Whether to set the combobox
+   * [`value`](https://ariakit.org/reference/combobox-provider#value) state
+   * using this item's
+   * [`value`](https://ariakit.org/reference/combobox-item#value) when the item
+   * is clicked. The default is `true`, unless the combobox is
+   * [multi-selectable](https://ariakit.org/examples/combobox-multiple).
+   *
+   * Live examples:
+   * - [Menu with Combobox](https://ariakit.org/examples/menu-combobox)
+   * - [Submenu with
+   *   Combobox](https://ariakit.org/examples/menu-nested-combobox)
+   */
+  setValueOnClick?: BooleanOrCallback<MouseEvent<HTMLElement>>;
+  /**
    * Whether to set the
    * [`selectedValue`](https://ariakit.org/reference/combobox-provider#selectedvalue)
    * state using this item's
@@ -308,19 +331,15 @@ export interface ComboboxItemOptions<T extends ElementType = TagName>
    */
   selectValueOnClick?: BooleanOrCallback<MouseEvent<HTMLElement>>;
   /**
-   * Whether to set the combobox
-   * [`value`](https://ariakit.org/reference/combobox-provider#value) state
-   * using this item's
-   * [`value`](https://ariakit.org/reference/combobox-item#value) when the item
-   * is clicked. The default is `true`, unless the combobox is
-   * [multi-selectable](https://ariakit.org/examples/combobox-multiple).
-   *
-   * Live examples:
-   * - [Menu with Combobox](https://ariakit.org/examples/menu-combobox)
-   * - [Submenu with
-   *   Combobox](https://ariakit.org/examples/menu-nested-combobox)
+   * Whether to reset the the combobox input value when this item is selected or
+   * unselected by click. This prop is set to `true` by default if
+   * the combobox supports multiple selections. In other words, if the
+   * [`selectedValue`](https://ariakit.org/reference/combobox-provider#selectedvalue)
+   * or
+   * [`defaultSelectedValue`](https://ariakit.org/reference/combobox-provider#defaultselectedvalue)
+   * props are arrays.
    */
-  setValueOnClick?: BooleanOrCallback<MouseEvent<HTMLElement>>;
+  resetValueOnSelect?: BooleanOrCallback<MouseEvent<HTMLElement>>;
   /**
    * @default false
    */


### PR DESCRIPTION
Don't reset the value every time the `selectedValue` state changes. Only do so when the user interacts with the `ComboboxItem` component.