### PR TITLE
Open SelectPopover on click instead of mousedown

### DIFF
--- a/.changeset/3716-select-toggle-on-click.md
+++ b/.changeset/3716-select-toggle-on-click.md
@@ -1,0 +1,10 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Opening `SelectPopover` on click
+
+To ensure uniformity across all dropdown buttons in the library, the [`SelectPopover`](https://ariakit.org/reference/select-popover) now opens when you click on the [`Select`](https://ariakit.org/reference/select) component, instead of on mouse/touch/pointer down.
+
+This change also resolves a problem where the `:active` state wouldn't be triggered on the select button due to a focus change on mousedown.

--- a/packages/ariakit-react-core/src/form/form-label.tsx
+++ b/packages/ariakit-react-core/src/form/form-label.tsx
@@ -95,6 +95,10 @@ export const useFormLabel = createHook<TagName, FormLabelOptions>(
       queueMicrotask(() => {
         const focusableElement = getFirstTabbableIn(fieldElement, true, true);
         focusableElement?.focus();
+        const role = focusableElement?.getAttribute("role");
+        // If the field is a combobox, we don't want to click on it, as it'll
+        // open the listbox.
+        if (role === "combobox") return;
         focusableElement?.click();
       });
     });

--- a/packages/ariakit-react-core/src/select/select-label.tsx
+++ b/packages/ariakit-react-core/src/select/select-label.tsx
@@ -53,7 +53,6 @@ export const useSelectLabel = createHook<TagName, SelectLabelOptions>(
       queueMicrotask(() => {
         const select = store?.getState().selectElement;
         select?.focus();
-        select?.click();
       });
     });
 

--- a/packages/ariakit-react-core/src/select/select.tsx
+++ b/packages/ariakit-react-core/src/select/select.tsx
@@ -75,8 +75,8 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
   required,
   showOnKeyDown = true,
   moveOnKeyDown = true,
-  toggleOnClick = false,
-  toggleOnPress = !toggleOnClick,
+  toggleOnPress = true,
+  toggleOnClick = toggleOnPress,
   ...props
 }) {
   const context = useSelectProviderContext();
@@ -88,12 +88,9 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
       "Select must receive a `store` prop or be wrapped in a SelectProvider component.",
   );
 
-  toggleOnPress = toggleOnClick ? false : toggleOnPress;
-
   const onKeyDownProp = props.onKeyDown;
   const showOnKeyDownProp = useBooleanEvent(showOnKeyDown);
   const moveOnKeyDownProp = useBooleanEvent(moveOnKeyDown);
-  const toggleOnPressProp = useBooleanEvent(toggleOnPress);
   const placement = store.useState("placement");
   const dir = placement.split("-")[0] as BasePlacement;
   const value = store.useState("value");
@@ -104,13 +101,6 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
     if (event.defaultPrevented) return;
     if (!store) return;
     const { orientation, items, activeId } = store.getState();
-    // toggleOnPress
-    if (event.key === " " || event.key === "Enter") {
-      if (toggleOnPressProp(event)) {
-        event.preventDefault();
-        store.toggle();
-      }
-    }
     // moveOnKeyDown
     const isVertical = orientation !== "horizontal";
     const isHorizontal = orientation !== "vertical";
@@ -147,21 +137,6 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
       // popover is shown.
       queueBeforeEvent(event.currentTarget, "keyup", store.show);
     }
-  });
-
-  const onMouseDownProp = props.onMouseDown;
-
-  const onMouseDown = useEvent((event: MouseEvent<HTMLType>) => {
-    onMouseDownProp?.(event);
-    if (event.defaultPrevented) return;
-    if (event.button) return;
-    if (event.ctrlKey) return;
-    if (!toggleOnPressProp(event)) return;
-    const element = event.currentTarget;
-    queueBeforeEvent(element, "focusin", () => {
-      store?.setDisclosureElement(element);
-      store?.toggle();
-    });
   });
 
   props = useWrapElement(
@@ -297,7 +272,6 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
     ...props,
     ref: useMergeRefs(store.setSelectElement, props.ref),
     onKeyDown,
-    onMouseDown,
   };
 
   props = usePopoverDisclosure({ store, toggleOnClick, ...props });
@@ -369,28 +343,14 @@ export interface SelectOptions<T extends ElementType = TagName>
    */
   moveOnKeyDown?: BooleanOrCallback<KeyboardEvent<HTMLElement>>;
   /**
-   * Determines if
-   * [`toggle`](https://ariakit.org/reference/use-select-store#toggle) should be
-   * invoked on click. By default, the
-   * [`SelectList`](https://ariakit.org/reference/select-list) or
-   * [`SelectPopover`](https://ariakit.org/reference/select-popover) components
-   * are displayed on press (on mouse/key down).
-   *
-   * **Note**: When set to `true`, this prop supersedes the
-   * [`toggleOnPress`](https://ariakit.org/reference/select#toggleonpress) prop.
-   * @default false
-   */
-  toggleOnClick?: BooleanOrCallback<MouseEvent<HTMLElement>>;
-  /**
-   * Determines whether pressing Space, Enter, or a mouse down event will
+   * Determines whether pressing Space, Enter, or a click event will
    * [`toggle`](https://ariakit.org/reference/use-select-store#toggle) the
    * [`SelectList`](https://ariakit.org/reference/select-list) or
    * [`SelectPopover`](https://ariakit.org/reference/select-popover) components.
-   *
-   * **Note**: This prop is disregarded if
-   * [`toggleOnClick`](https://ariakit.org/reference/select#toggleonclick) is
-   * set to `true`.
    * @default true
+   * @deprecated Use
+   * [`toggleOnClick`](https://ariakit.org/reference/select#toggleonclick)
+   * instead.
    */
   toggleOnPress?: BooleanOrCallback<
     MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>

--- a/website/components/header-version-select.tsx
+++ b/website/components/header-version-select.tsx
@@ -102,7 +102,6 @@ export function HeaderVersionSelect({ versions }: Props) {
         Version
       </SelectLabel>
       <Select
-        toggleOnClick
         store={select}
         className="mr-2 hidden h-8 px-3 text-xs font-semibold text-black/80 md:flex md:gap-1.5 dark:text-white/80"
         render={<Command />}

--- a/website/components/playground-edit.tsx
+++ b/website/components/playground-edit.tsx
@@ -307,12 +307,7 @@ export const PlaygroundEditButton = forwardRef<
           title={`Using ${buildToolLabel}`}
           aria-label="Build tool"
           className="size-auto bg-black/[7%] p-0 hover:bg-black/[12%] dark:bg-white/5 dark:hover:bg-white/10"
-          render={
-            <Select
-              toggleOnClick
-              render={<Command flat variant="secondary" />}
-            />
-          }
+          render={<Select render={<Command flat variant="secondary" />} />}
         >
           <BuiltToolIcon className="size-5" />
           <span className="sr-only">{buildToolLabel}</span>

--- a/website/components/playground-toolbar.tsx
+++ b/website/components/playground-toolbar.tsx
@@ -77,7 +77,6 @@ export function PlaygroundToolbar({
           render={
             <Select
               aria-label="Select language"
-              toggleOnClick
               render={<TooltipButton title="Select language" />}
             />
           }


### PR DESCRIPTION
To ensure uniformity across all dropdown buttons in the library, the [`SelectPopover`](https://ariakit.org/reference/select-popover) now opens when you click on the [`Select`](https://ariakit.org/reference/select) component, instead of on mouse/touch/pointer down.

This change also resolves a problem where the `:active` state wouldn't be triggered on the select button due to a focus change on mousedown.