### PR TITLE
Make sure focus visible is set before sync blur event

### DIFF
--- a/.changeset/3721-focusable-sync-focus-visible.md
+++ b/.changeset/3721-focusable-sync-focus-visible.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed `data-focus-visible` being applied after a `blur` event.

--- a/packages/ariakit-core/src/tab/tab-store.ts
+++ b/packages/ariakit-core/src/tab/tab-store.ts
@@ -52,6 +52,7 @@ export function createTabStore({
 
   const composite = createCompositeStore({
     ...props,
+    store,
     // We need to explicitly set the default value of `includesBaseElement` to
     // `false` since we don't want the composite store to default it to `true`
     // when the activeId state is null, which could be the case when rendering
@@ -60,11 +61,6 @@ export function createTabStore({
       props.includesBaseElement,
       syncState?.includesBaseElement,
       false,
-    ),
-    activeId: defaultValue(
-      props.activeId,
-      syncState?.activeId,
-      props.defaultActiveId,
     ),
     orientation: defaultValue(
       props.orientation,

--- a/packages/ariakit-react-core/src/focusable/focusable.tsx
+++ b/packages/ariakit-react-core/src/focusable/focusable.tsx
@@ -348,7 +348,7 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
       const element = event.currentTarget;
       const applyFocusVisible = () => handleFocusVisible(event, element);
       if (isKeyboardModality || isAlwaysFocusVisible(event.target)) {
-        queueMicrotask(applyFocusVisible);
+        applyFocusVisible();
       }
       // See https://github.com/ariakit/ariakit/issues/1257
       else if (isAlwaysFocusVisibleDelayed(event.target)) {

--- a/packages/ariakit-react-core/src/focusable/focusable.tsx
+++ b/packages/ariakit-react-core/src/focusable/focusable.tsx
@@ -348,7 +348,7 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
       const element = event.currentTarget;
       const applyFocusVisible = () => handleFocusVisible(event, element);
       if (isKeyboardModality || isAlwaysFocusVisible(event.target)) {
-        applyFocusVisible();
+        queueMicrotask(applyFocusVisible);
       }
       // See https://github.com/ariakit/ariakit/issues/1257
       else if (isAlwaysFocusVisibleDelayed(event.target)) {
@@ -366,7 +366,9 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
       onBlurProp?.(event);
       if (!focusable) return;
       if (!isFocusEventOutside(event)) return;
-      setFocusVisible(false);
+      queueMicrotask(() => {
+        setFocusVisible(false);
+      });
     });
 
     const autoFocusOnShow = useContext(FocusableContext);

--- a/packages/ariakit-react-core/src/focusable/focusable.tsx
+++ b/packages/ariakit-react-core/src/focusable/focusable.tsx
@@ -61,14 +61,12 @@ function isAlwaysFocusVisible(element: HTMLElement) {
     return alwaysFocusVisibleInputTypes.includes(type);
   }
   if (element.isContentEditable) return true;
-  return false;
-}
-
-// See https://github.com/ariakit/ariakit/issues/1257
-function isAlwaysFocusVisibleDelayed(element: HTMLElement) {
+  // Take into account custom Ariakit Select within a form.
   const role = element.getAttribute("role");
-  if (role !== "combobox") return false;
-  return !!element.dataset.name;
+  if (role === "combobox" && element.dataset.name) {
+    return true;
+  }
+  return false;
 }
 
 function getLabels(element: HTMLElement | HTMLInputElement) {
@@ -332,7 +330,8 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
       if (event.ctrlKey) return;
       if (!isSelfTarget(event)) return;
       const element = event.currentTarget;
-      queueMicrotask(() => handleFocusVisible(event, element));
+      const applyFocusVisible = () => handleFocusVisible(event, element);
+      queueBeforeEvent(element, "focusout", applyFocusVisible);
     });
 
     const onFocusCaptureProp = props.onFocusCapture;
@@ -348,10 +347,6 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
       const element = event.currentTarget;
       const applyFocusVisible = () => handleFocusVisible(event, element);
       if (isKeyboardModality || isAlwaysFocusVisible(event.target)) {
-        queueMicrotask(applyFocusVisible);
-      }
-      // See https://github.com/ariakit/ariakit/issues/1257
-      else if (isAlwaysFocusVisibleDelayed(event.target)) {
         queueBeforeEvent(event.target, "focusout", applyFocusVisible);
       } else {
         setFocusVisible(false);
@@ -366,9 +361,7 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
       onBlurProp?.(event);
       if (!focusable) return;
       if (!isFocusEventOutside(event)) return;
-      queueMicrotask(() => {
-        setFocusVisible(false);
-      });
+      setFocusVisible(false);
     });
 
     const autoFocusOnShow = useContext(FocusableContext);

--- a/packages/ariakit-react-core/src/tab/tab-panel.tsx
+++ b/packages/ariakit-react-core/src/tab/tab-panel.tsx
@@ -92,9 +92,9 @@ export const useTabPanel = createHook<TagName, TabPanelOptions>(
       // and provide the selected id as the active id. This is necessary because
       // the original tab store may have the same active id as the external
       // composite store, which might not be a valid tab id.
-      const { items, renderedItems, selectedId } = store.getState();
-      const tab = createTabStore({ items, activeId: selectedId });
-      tab.setState("renderedItems", renderedItems);
+      const state = store.getState();
+      const tab = createTabStore({ ...state, activeId: state.selectedId });
+      tab.setState("renderedItems", state.renderedItems);
       const keyMap = {
         ArrowLeft: tab.previous,
         ArrowRight: tab.next,
@@ -106,7 +106,7 @@ export const useTabPanel = createHook<TagName, TabPanelOptions>(
       const nextId = action();
       if (!nextId) return;
       event.preventDefault();
-      store.select(nextId);
+      store.move(nextId);
     });
 
     props = useWrapElement(

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ const excludeFromReact17 = [
   "examples/form-callback-queue",
   "examples/*-framer-motion/**",
   "examples/dialog-animated-various",
+  "examples/combobox-group",
 ];
 
 const includeWithStyles = [


### PR DESCRIPTION
Here we were setting the `data-focus-visible` attribute asynchronously in a microtask on the focus capture event:

https://github.com/ariakit/ariakit/blob/b273686cb6c644b5075e84e1202c15f7c4e67b28/packages/ariakit-react-core/src/focusable/focusable.tsx#L350-L352

However, when a blur event was immediately dispatched right after focus, the `data-focus-visible` attribute would be set after the blur event, leaving the element in an incorrect focus visible state.