### PR TITLE
Fix scoping in the Composite context

### DIFF
--- a/.changeset/300-composite-context-scoping.md
+++ b/.changeset/300-composite-context-scoping.md
@@ -9,15 +9,14 @@ Fixed [`CompositeItem`](https://ariakit.com/reference/composite-item) to registe
 
 Before this fix, you had to pass the enclosing composite store explicitly:
 
-```tsx {6}
+```tsx {5}
 const composite = Ariakit.useCompositeStore();
 
 <Ariakit.Composite store={composite}>
   <Ariakit.MenuProvider>
-    <Ariakit.CompositeItem
-      store={composite}
-      render={<Ariakit.MenuButton>Menu</Ariakit.MenuButton>}
-    />
+    <Ariakit.CompositeItem store={composite} render={<Ariakit.MenuButton />}>
+      Menu
+    </Ariakit.CompositeItem>
     <Ariakit.Menu>
       <Ariakit.MenuItem>Edit</Ariakit.MenuItem>
     </Ariakit.Menu>
@@ -32,9 +31,9 @@ const composite = Ariakit.useCompositeStore();
 
 <Ariakit.Composite store={composite}>
   <Ariakit.MenuProvider>
-    <Ariakit.CompositeItem
-      render={<Ariakit.MenuButton>Menu</Ariakit.MenuButton>}
-    />
+    <Ariakit.CompositeItem render={<Ariakit.MenuButton />}>
+      Menu
+    </Ariakit.CompositeItem>
     <Ariakit.Menu>
       <Ariakit.MenuItem>Edit</Ariakit.MenuItem>
     </Ariakit.Menu>

--- a/.changeset/300-composite-context-scoping.md
+++ b/.changeset/300-composite-context-scoping.md
@@ -3,4 +3,41 @@
 "@ariakit/react": patch
 ---
 
-Fixed [`CompositeItem`](https://ariakit.com/reference/composite-item) to register on the enclosing [`Composite`](https://ariakit.com/reference/composite) store — and thus stay reachable with the arrow keys — when rendered as the same element as a component that sets its own composite context, such as a [`MenuButton`](https://ariakit.com/reference/menu-button) inside a [`MenuProvider`](https://ariakit.com/reference/menu-provider).
+Composite items keep their enclosing store
+
+Fixed [`CompositeItem`](https://ariakit.com/reference/composite-item) to register on the enclosing [`Composite`](https://ariakit.com/reference/composite) store when rendered as the same element as a component that sets its own composite context, such as a [`MenuButton`](https://ariakit.com/reference/menu-button) inside a [`MenuProvider`](https://ariakit.com/reference/menu-provider). This keeps the item reachable with the arrow keys in one- and two-dimensional composite widgets.
+
+Before this fix, you had to pass the enclosing composite store explicitly:
+
+```tsx {6}
+const composite = Ariakit.useCompositeStore();
+
+<Ariakit.Composite store={composite}>
+  <Ariakit.MenuProvider>
+    <Ariakit.CompositeItem
+      store={composite}
+      render={<Ariakit.MenuButton>Menu</Ariakit.MenuButton>}
+    />
+    <Ariakit.Menu>
+      <Ariakit.MenuItem>Edit</Ariakit.MenuItem>
+    </Ariakit.Menu>
+  </Ariakit.MenuProvider>
+</Ariakit.Composite>;
+```
+
+Now the [`CompositeItem`](https://ariakit.com/reference/composite-item) can omit the explicit `store` prop and still register on the enclosing composite:
+
+```tsx {5-7}
+const composite = Ariakit.useCompositeStore();
+
+<Ariakit.Composite store={composite}>
+  <Ariakit.MenuProvider>
+    <Ariakit.CompositeItem
+      render={<Ariakit.MenuButton>Menu</Ariakit.MenuButton>}
+    />
+    <Ariakit.Menu>
+      <Ariakit.MenuItem>Edit</Ariakit.MenuItem>
+    </Ariakit.Menu>
+  </Ariakit.MenuProvider>
+</Ariakit.Composite>;
+```

--- a/.changeset/300-composite-context-scoping.md
+++ b/.changeset/300-composite-context-scoping.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`CompositeItem`](https://ariakit.com/reference/composite-item) to register on the enclosing [`Composite`](https://ariakit.com/reference/composite) store — and thus stay reachable with the arrow keys — when rendered as the same element as a component that sets its own composite context, such as a [`MenuButton`](https://ariakit.com/reference/menu-button) inside a [`MenuProvider`](https://ariakit.com/reference/menu-provider).

--- a/.changeset/300-composite-context-scoping.md
+++ b/.changeset/300-composite-context-scoping.md
@@ -7,24 +7,7 @@ Composite items keep their enclosing store
 
 Fixed [`CompositeItem`](https://ariakit.com/reference/composite-item) to register on the enclosing [`Composite`](https://ariakit.com/reference/composite) store when rendered as the same element as a component that sets its own composite context, such as a [`MenuButton`](https://ariakit.com/reference/menu-button) inside a [`MenuProvider`](https://ariakit.com/reference/menu-provider). This keeps the item reachable with the arrow keys in one- and two-dimensional composite widgets.
 
-Before this fix, you had to pass the enclosing composite store explicitly:
-
-```tsx {5}
-const composite = Ariakit.useCompositeStore();
-
-<Ariakit.Composite store={composite}>
-  <Ariakit.MenuProvider>
-    <Ariakit.CompositeItem store={composite} render={<Ariakit.MenuButton />}>
-      Menu
-    </Ariakit.CompositeItem>
-    <Ariakit.Menu>
-      <Ariakit.MenuItem>Edit</Ariakit.MenuItem>
-    </Ariakit.Menu>
-  </Ariakit.MenuProvider>
-</Ariakit.Composite>;
-```
-
-Now the [`CompositeItem`](https://ariakit.com/reference/composite-item) can omit the explicit `store` prop and still register on the enclosing composite:
+The [`CompositeItem`](https://ariakit.com/reference/composite-item) can now omit the explicit `store` prop and still register on the enclosing composite:
 
 ```tsx {5-7}
 const composite = Ariakit.useCompositeStore();

--- a/app/src/sandbox/composite-menu-3768/index.react.tsx
+++ b/app/src/sandbox/composite-menu-3768/index.react.tsx
@@ -1,34 +1,40 @@
 import * as Ariakit from "@ariakit/react";
 
 export default function Example() {
+  // TODO: Workaround for https://github.com/ariakit/ariakit/issues/3768. Once
+  // it's fixed, revert to `CompositeProvider` and drop these `store` props.
+  const composite = Ariakit.useCompositeStore();
   return (
-    <Ariakit.CompositeProvider>
-      <Ariakit.Composite aria-label="Two-dimensional grid with menus">
-        <Ariakit.CompositeRow>
-          <Ariakit.CompositeItem>Button A1</Ariakit.CompositeItem>
-          <Ariakit.MenuProvider>
-            <Ariakit.CompositeItem
-              render={<Ariakit.MenuButton>Menu A2</Ariakit.MenuButton>}
-            />
-            <Ariakit.Menu>
-              <Ariakit.MenuItem>Item A</Ariakit.MenuItem>
-            </Ariakit.Menu>
-          </Ariakit.MenuProvider>
-          <Ariakit.CompositeItem>Button A3</Ariakit.CompositeItem>
-        </Ariakit.CompositeRow>
-        <Ariakit.CompositeRow>
-          <Ariakit.CompositeItem>Button B1</Ariakit.CompositeItem>
-          <Ariakit.MenuProvider>
-            <Ariakit.CompositeItem
-              render={<Ariakit.MenuButton>Menu B2</Ariakit.MenuButton>}
-            />
-            <Ariakit.Menu>
-              <Ariakit.MenuItem>Item B</Ariakit.MenuItem>
-            </Ariakit.Menu>
-          </Ariakit.MenuProvider>
-          <Ariakit.CompositeItem>Button B3</Ariakit.CompositeItem>
-        </Ariakit.CompositeRow>
-      </Ariakit.Composite>
-    </Ariakit.CompositeProvider>
+    <Ariakit.Composite
+      store={composite}
+      aria-label="Two-dimensional grid with menus"
+    >
+      <Ariakit.CompositeRow>
+        <Ariakit.CompositeItem>Button A1</Ariakit.CompositeItem>
+        <Ariakit.MenuProvider>
+          <Ariakit.CompositeItem
+            store={composite}
+            render={<Ariakit.MenuButton>Menu A2</Ariakit.MenuButton>}
+          />
+          <Ariakit.Menu>
+            <Ariakit.MenuItem>Item A</Ariakit.MenuItem>
+          </Ariakit.Menu>
+        </Ariakit.MenuProvider>
+        <Ariakit.CompositeItem>Button A3</Ariakit.CompositeItem>
+      </Ariakit.CompositeRow>
+      <Ariakit.CompositeRow>
+        <Ariakit.CompositeItem>Button B1</Ariakit.CompositeItem>
+        <Ariakit.MenuProvider>
+          <Ariakit.CompositeItem
+            store={composite}
+            render={<Ariakit.MenuButton>Menu B2</Ariakit.MenuButton>}
+          />
+          <Ariakit.Menu>
+            <Ariakit.MenuItem>Item B</Ariakit.MenuItem>
+          </Ariakit.Menu>
+        </Ariakit.MenuProvider>
+        <Ariakit.CompositeItem>Button B3</Ariakit.CompositeItem>
+      </Ariakit.CompositeRow>
+    </Ariakit.Composite>
   );
 }

--- a/app/src/sandbox/composite-menu-3768/index.react.tsx
+++ b/app/src/sandbox/composite-menu-3768/index.react.tsx
@@ -1,40 +1,34 @@
 import * as Ariakit from "@ariakit/react";
 
 export default function Example() {
-  // TODO: Workaround for https://github.com/ariakit/ariakit/issues/3768. Once
-  // it's fixed, revert to `CompositeProvider` and drop these `store` props.
-  const composite = Ariakit.useCompositeStore();
   return (
-    <Ariakit.Composite
-      store={composite}
-      aria-label="Two-dimensional grid with menus"
-    >
-      <Ariakit.CompositeRow>
-        <Ariakit.CompositeItem>Button A1</Ariakit.CompositeItem>
-        <Ariakit.MenuProvider>
-          <Ariakit.CompositeItem
-            store={composite}
-            render={<Ariakit.MenuButton>Menu A2</Ariakit.MenuButton>}
-          />
-          <Ariakit.Menu>
-            <Ariakit.MenuItem>Item A</Ariakit.MenuItem>
-          </Ariakit.Menu>
-        </Ariakit.MenuProvider>
-        <Ariakit.CompositeItem>Button A3</Ariakit.CompositeItem>
-      </Ariakit.CompositeRow>
-      <Ariakit.CompositeRow>
-        <Ariakit.CompositeItem>Button B1</Ariakit.CompositeItem>
-        <Ariakit.MenuProvider>
-          <Ariakit.CompositeItem
-            store={composite}
-            render={<Ariakit.MenuButton>Menu B2</Ariakit.MenuButton>}
-          />
-          <Ariakit.Menu>
-            <Ariakit.MenuItem>Item B</Ariakit.MenuItem>
-          </Ariakit.Menu>
-        </Ariakit.MenuProvider>
-        <Ariakit.CompositeItem>Button B3</Ariakit.CompositeItem>
-      </Ariakit.CompositeRow>
-    </Ariakit.Composite>
+    <Ariakit.CompositeProvider>
+      <Ariakit.Composite aria-label="Two-dimensional grid with menus">
+        <Ariakit.CompositeRow>
+          <Ariakit.CompositeItem>Button A1</Ariakit.CompositeItem>
+          <Ariakit.MenuProvider>
+            <Ariakit.CompositeItem
+              render={<Ariakit.MenuButton>Menu A2</Ariakit.MenuButton>}
+            />
+            <Ariakit.Menu>
+              <Ariakit.MenuItem>Item A</Ariakit.MenuItem>
+            </Ariakit.Menu>
+          </Ariakit.MenuProvider>
+          <Ariakit.CompositeItem>Button A3</Ariakit.CompositeItem>
+        </Ariakit.CompositeRow>
+        <Ariakit.CompositeRow>
+          <Ariakit.CompositeItem>Button B1</Ariakit.CompositeItem>
+          <Ariakit.MenuProvider>
+            <Ariakit.CompositeItem
+              render={<Ariakit.MenuButton>Menu B2</Ariakit.MenuButton>}
+            />
+            <Ariakit.Menu>
+              <Ariakit.MenuItem>Item B</Ariakit.MenuItem>
+            </Ariakit.Menu>
+          </Ariakit.MenuProvider>
+          <Ariakit.CompositeItem>Button B3</Ariakit.CompositeItem>
+        </Ariakit.CompositeRow>
+      </Ariakit.Composite>
+    </Ariakit.CompositeProvider>
   );
 }

--- a/app/src/sandbox/composite-menu-3768/index.react.tsx
+++ b/app/src/sandbox/composite-menu-3768/index.react.tsx
@@ -1,0 +1,34 @@
+import * as Ariakit from "@ariakit/react";
+
+export default function Example() {
+  return (
+    <Ariakit.CompositeProvider>
+      <Ariakit.Composite aria-label="Two-dimensional grid with menus">
+        <Ariakit.CompositeRow>
+          <Ariakit.CompositeItem>Button A1</Ariakit.CompositeItem>
+          <Ariakit.MenuProvider>
+            <Ariakit.CompositeItem
+              render={<Ariakit.MenuButton>Menu A2</Ariakit.MenuButton>}
+            />
+            <Ariakit.Menu>
+              <Ariakit.MenuItem>Item A</Ariakit.MenuItem>
+            </Ariakit.Menu>
+          </Ariakit.MenuProvider>
+          <Ariakit.CompositeItem>Button A3</Ariakit.CompositeItem>
+        </Ariakit.CompositeRow>
+        <Ariakit.CompositeRow>
+          <Ariakit.CompositeItem>Button B1</Ariakit.CompositeItem>
+          <Ariakit.MenuProvider>
+            <Ariakit.CompositeItem
+              render={<Ariakit.MenuButton>Menu B2</Ariakit.MenuButton>}
+            />
+            <Ariakit.Menu>
+              <Ariakit.MenuItem>Item B</Ariakit.MenuItem>
+            </Ariakit.Menu>
+          </Ariakit.MenuProvider>
+          <Ariakit.CompositeItem>Button B3</Ariakit.CompositeItem>
+        </Ariakit.CompositeRow>
+      </Ariakit.Composite>
+    </Ariakit.CompositeProvider>
+  );
+}

--- a/app/src/sandbox/composite-menu-3768/index.react.tsx
+++ b/app/src/sandbox/composite-menu-3768/index.react.tsx
@@ -7,9 +7,9 @@ export default function Example() {
         <Ariakit.CompositeRow>
           <Ariakit.CompositeItem>Button A1</Ariakit.CompositeItem>
           <Ariakit.MenuProvider>
-            <Ariakit.CompositeItem
-              render={<Ariakit.MenuButton>Menu A2</Ariakit.MenuButton>}
-            />
+            <Ariakit.CompositeItem render={<Ariakit.MenuButton />}>
+              Menu A2
+            </Ariakit.CompositeItem>
             <Ariakit.Menu>
               <Ariakit.MenuItem>Item A</Ariakit.MenuItem>
             </Ariakit.Menu>
@@ -19,9 +19,9 @@ export default function Example() {
         <Ariakit.CompositeRow>
           <Ariakit.CompositeItem>Button B1</Ariakit.CompositeItem>
           <Ariakit.MenuProvider>
-            <Ariakit.CompositeItem
-              render={<Ariakit.MenuButton>Menu B2</Ariakit.MenuButton>}
-            />
+            <Ariakit.CompositeItem render={<Ariakit.MenuButton />}>
+              Menu B2
+            </Ariakit.CompositeItem>
             <Ariakit.Menu>
               <Ariakit.MenuItem>Item B</Ariakit.MenuItem>
             </Ariakit.Menu>

--- a/app/src/sandbox/composite-menu-3768/preview.astro
+++ b/app/src/sandbox/composite-menu-3768/preview.astro
@@ -1,0 +1,14 @@
+---
+import PreviewFramework from "#app/components/preview-framework.astro";
+import ReactExample from "./index.react.tsx";
+
+import sourceReact from "./index.react.tsx?source";
+
+export const source = {
+  react: sourceReact,
+};
+---
+
+<PreviewFramework>
+  <ReactExample client:load slot="react" />
+</PreviewFramework>

--- a/app/src/sandbox/composite-menu-3768/preview.mdx
+++ b/app/src/sandbox/composite-menu-3768/preview.mdx
@@ -1,0 +1,9 @@
+---
+title: "composite-menu-3768"
+frameworks:
+  - react
+---
+
+import Preview from "./preview.astro";
+
+<Preview />

--- a/app/src/sandbox/composite-menu-3768/test-browser.ts
+++ b/app/src/sandbox/composite-menu-3768/test-browser.ts
@@ -1,0 +1,25 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("composite items merged with menu buttons are reachable via arrow keys", async ({
+    page,
+    q,
+  }) => {
+    // The menu button in the first row must be reachable with ArrowRight from
+    // its preceding sibling. It's a `CompositeItem` wrapped in a `MenuProvider`,
+    // so before the fix it was registered in the menu's own composite store
+    // instead of the outer composite store, and arrow navigation skipped it.
+    await q.button("Button A1").focus();
+    await test.expect(q.button("Button A1")).toBeFocused();
+    await page.keyboard.press("ArrowRight");
+    await test.expect(q.button("Menu A2")).toBeFocused();
+
+    // Two-dimensional navigation: moving down a row and then right must also
+    // reach the menu button in the second row.
+    await q.button("Button A1").focus();
+    await page.keyboard.press("ArrowDown");
+    await test.expect(q.button("Button B1")).toBeFocused();
+    await page.keyboard.press("ArrowRight");
+    await test.expect(q.button("Menu B2")).toBeFocused();
+  });
+});

--- a/packages/ariakit-react-components/src/composite/composite-container.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-container.tsx
@@ -20,7 +20,7 @@ import {
 } from "@ariakit/utils";
 import type { ElementType, FocusEvent, KeyboardEvent, MouseEvent } from "react";
 import { useEffect, useRef } from "react";
-import { useCompositeContext } from "./composite-context.tsx";
+import { useCompositeScopedContext } from "./composite-context.tsx";
 import type { CompositeStore } from "./composite-store.ts";
 import { selectTextField } from "./utils.ts";
 
@@ -56,7 +56,7 @@ export const useCompositeContainer = createHook<
   TagName,
   CompositeContainerOptions
 >(function useCompositeContainer({ store, ...props }) {
-  const context = useCompositeContext();
+  const context = useCompositeScopedContext();
   store = store || context;
 
   const ref = useRef<HTMLType>(null);

--- a/packages/ariakit-react-components/src/composite/composite-hover.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-hover.tsx
@@ -20,7 +20,7 @@ import {
 import type { BooleanOrCallback } from "@ariakit/utils";
 import type { ElementType, MouseEvent as ReactMouseEvent } from "react";
 import { useCallback } from "react";
-import { useCompositeContext } from "./composite-context.tsx";
+import { useCompositeScopedContext } from "./composite-context.tsx";
 import type { CompositeStore } from "./composite-store.ts";
 
 const TagName = "div" satisfies ElementType;
@@ -75,7 +75,7 @@ export const useCompositeHover = createHook<TagName, CompositeHoverOptions>(
     blurOnHoverEnd = !!focusOnHover,
     ...props
   }) {
-    const context = useCompositeContext();
+    const context = useCompositeScopedContext();
     store = store || context;
 
     invariant(

--- a/packages/ariakit-react-components/src/composite/composite-item-offscreen.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-item-offscreen.tsx
@@ -8,7 +8,7 @@ import { useCollectionItemOffscreen } from "../collection/collection-item-offscr
 import type { ComboboxStoreState } from "../combobox/combobox-store.ts";
 import { Role } from "../role/role.tsx";
 import type { SelectStoreState } from "../select/select-store.ts";
-import { useCompositeContext } from "./composite-context.tsx";
+import { useCompositeScopedContext } from "./composite-context.tsx";
 import * as Base from "./composite-item.tsx";
 import type { CompositeStoreState } from "./composite-store.ts";
 
@@ -20,7 +20,7 @@ export function useCompositeItemOffscreen<
   // oxlint-disable-next-line no-unnecessary-type-parameters
   P extends CompositeItemProps<T>,
 >({ store, offscreenMode = "active", disabled, value, ...props }: P) {
-  const context = useCompositeContext();
+  const context = useCompositeScopedContext();
   store = store || context;
 
   const id = useId(props.id);

--- a/packages/ariakit-react-components/src/composite/composite-item.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-item.tsx
@@ -39,7 +39,7 @@ import { useCommand } from "../command/command.tsx";
 import {
   CompositeItemContext,
   CompositeRowContext,
-  useCompositeContext,
+  useCompositeScopedContext,
 } from "./composite-context.tsx";
 import type { CompositeStore } from "./composite-store.ts";
 import {
@@ -155,7 +155,7 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
     "aria-posinset": ariaPosInSetProp,
     ...props
   }) {
-    const context = useCompositeContext();
+    const context = useCompositeScopedContext();
     store = store || context;
 
     const id = useId(props.id);

--- a/packages/ariakit-react-components/src/composite/composite-renderer.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-renderer.tsx
@@ -16,7 +16,7 @@ import {
   useCollectionRenderer,
 } from "../collection/collection-renderer.tsx";
 import type { CollectionStoreItem } from "../collection/collection-store.ts";
-import { useCompositeContext } from "./composite-context.tsx";
+import { useCompositeScopedContext } from "./composite-context.tsx";
 import type { CompositeStore, CompositeStoreItem } from "./composite-store.ts";
 
 const TagName = "div" satisfies ElementType;
@@ -102,7 +102,7 @@ export function useCompositeRenderer<T extends Item = any>({
   "aria-posinset": ariaPosInSet = 1,
   ...props
 }: CompositeRendererProps<T>) {
-  const context = useCompositeContext();
+  const context = useCompositeScopedContext();
   store = store || (context as typeof store);
 
   const orientation = useStoreState(store, (state) =>

--- a/packages/ariakit-react-components/src/composite/composite-row.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-row.tsx
@@ -12,7 +12,7 @@ import type { ElementType } from "react";
 import { useMemo } from "react";
 import {
   CompositeRowContext,
-  useCompositeContext,
+  useCompositeScopedContext,
 } from "./composite-context.tsx";
 import type { CompositeStore } from "./composite-store.ts";
 
@@ -44,7 +44,7 @@ export const useCompositeRow = createHook<TagName, CompositeRowOptions>(
     "aria-posinset": ariaPosInSet,
     ...props
   }) {
-    const context = useCompositeContext();
+    const context = useCompositeScopedContext();
     store = store || context;
 
     invariant(

--- a/packages/ariakit-react-components/src/composite/composite-separator.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-separator.tsx
@@ -5,7 +5,7 @@ import { invariant } from "@ariakit/utils";
 import type { ElementType } from "react";
 import type { SeparatorOptions } from "../separator/separator.tsx";
 import { useSeparator } from "../separator/separator.tsx";
-import { useCompositeContext } from "./composite-context.tsx";
+import { useCompositeScopedContext } from "./composite-context.tsx";
 import type { CompositeStore } from "./composite-store.ts";
 
 const TagName = "hr" satisfies ElementType;
@@ -29,7 +29,7 @@ export const useCompositeSeparator = createHook<
   TagName,
   CompositeSeparatorOptions
 >(function useCompositeSeparator({ store, ...props }) {
-  const context = useCompositeContext();
+  const context = useCompositeScopedContext();
   store = store || context;
 
   invariant(

--- a/packages/ariakit-react-components/src/composite/composite-typeahead.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-typeahead.tsx
@@ -16,7 +16,7 @@ import {
 } from "@ariakit/utils";
 import type { ElementType, KeyboardEvent } from "react";
 import { useRef } from "react";
-import { useCompositeContext } from "./composite-context.tsx";
+import { useCompositeScopedContext } from "./composite-context.tsx";
 import type { CompositeStore, CompositeStoreItem } from "./composite-store.ts";
 import { flipItems } from "./utils.ts";
 
@@ -112,7 +112,7 @@ export const useCompositeTypeahead = createHook<
   TagName,
   CompositeTypeaheadOptions
 >(function useCompositeTypeahead({ store, typeahead = true, ...props }) {
-  const context = useCompositeContext();
+  const context = useCompositeScopedContext();
   store = store || context;
 
   invariant(

--- a/packages/ariakit-react-components/src/composite/composite.tsx
+++ b/packages/ariakit-react-components/src/composite/composite.tsx
@@ -35,7 +35,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { FocusableOptions } from "../focusable/focusable.tsx";
 import { useFocusable } from "../focusable/focusable.tsx";
 import {
-  CompositeContextProvider,
+  CompositeScopedContextProvider,
   useCompositeProviderContext,
 } from "./composite-context.tsx";
 import type { CompositeStore, CompositeStoreItem } from "./composite-store.ts";
@@ -445,9 +445,9 @@ export const useComposite = createHook<TagName, CompositeOptions>(
     props = useWrapElement(
       props,
       (element) => (
-        <CompositeContextProvider value={store}>
+        <CompositeScopedContextProvider value={store}>
           {element}
-        </CompositeContextProvider>
+        </CompositeScopedContextProvider>
       ),
       [store],
     );


### PR DESCRIPTION
## Motivation

When a `CompositeItem` is rendered as the same element as a component that provides its own composite-based context — most commonly a `MenuButton` wrapped in `MenuProvider`, but the same applies to `Select`, `Combobox`, and other composite-derived widgets — the item registers on that inner store instead of on the enclosing `Composite`. As a result, arrow-key navigation (in both one- and two-dimensional composites) skips the item: it can never be focused with the keyboard inside the composite widget.

This blocks valid patterns such as a toolbar or grid whose cells are menu buttons (the WordPress/Gutenberg two-dimensional navigation use case in #3768).

The affected markup looks like this — the middle item of each row is unreachable with the arrow keys:

```jsx
<Ariakit.CompositeProvider>
  <Ariakit.Composite>
    <Ariakit.CompositeRow>
      <Ariakit.CompositeItem>Button</Ariakit.CompositeItem>
      <Ariakit.MenuProvider>
        <Ariakit.CompositeItem
          render={<Ariakit.MenuButton>Menu</Ariakit.MenuButton>}
        />
        <Ariakit.Menu>…</Ariakit.Menu>
      </Ariakit.MenuProvider>
      <Ariakit.CompositeItem>Button</Ariakit.CompositeItem>
    </Ariakit.CompositeRow>
  </Ariakit.Composite>
</Ariakit.CompositeProvider>
```

## Solution

`Menu` (like `Select`, `Combobox`, etc.) provides its store through the regular composite context, so any `CompositeItem` nested under `MenuProvider`/`MenuButton` reads the menu's store from `useCompositeContext()` and registers there instead of on the enclosing `Composite`.

The fix applies the same context-scoping pattern already used by `Tab`, `MenuItem`, `SelectItem`, and `ComboboxItem`:

- `Composite` now provides its store through the **scoped** composite context (`CompositeScopedContextProvider`) instead of the plain `CompositeContextProvider`. The scoped provider sets both the regular and the scoped contexts, so this is a superset of the previous behavior.
- The composite collection components — `CompositeItem`, `CompositeRow`, `CompositeSeparator`, `CompositeTypeahead`, `CompositeHover`, `CompositeContainer`, `CompositeItemOffscreen`, and `CompositeRenderer` — now resolve their store from `useCompositeScopedContext()` instead of `useCompositeContext()`, so the whole collection consistently binds to the enclosing `Composite`.

A provider like `MenuProvider` only overrides the **regular** composite context for its subtree, not the scoped one. So the scoped context still points at the enclosing `Composite`, and the item registers on the correct store and becomes reachable with the arrow keys. When a `CompositeItem` is legitimately inside a menu's own content (`Menu`/`MenuList`), the scoped composite context is the menu store, so that behavior is unchanged.

## Workaround

Until this is released, pass the composite store explicitly to the affected `CompositeItem` so it registers on the right store. Keep the `CompositeItem` as the outermost component (`CompositeItem render={<MenuButton />}`) so it takes precedence for interactions like the arrow keys:

```jsx
// TODO: Remove once https://github.com/ariakit/ariakit/issues/3768 is released.
const composite = Ariakit.useCompositeStore();

<Ariakit.Composite store={composite}>
  <Ariakit.MenuProvider>
    <Ariakit.CompositeItem
      store={composite}
      render={<Ariakit.MenuButton>Menu</Ariakit.MenuButton>}
    />
    <Ariakit.Menu>…</Ariakit.Menu>
  </Ariakit.MenuProvider>
</Ariakit.Composite>;
```

Fixes #3768
