### PR TITLE
Revert "Output `rerender` from `@ariakit/test`'s `render`."

### DIFF
--- a/.changeset/ninety-comics-worry.md
+++ b/.changeset/ninety-comics-worry.md
@@ -1,5 +1,0 @@
----
-"@ariakit/test": minor
----
-
-The `render` method now returns a promise of `{ unmount, rerender }` instead of just the `unmount` function.

--- a/packages/ariakit-test/src/react.tsx
+++ b/packages/ariakit-test/src/react.tsx
@@ -10,18 +10,6 @@ export interface RenderOptions
   strictMode?: boolean;
 }
 
-function wrapRender<T extends (...args: any[]) => any>(
-  renderFn: T,
-): Promise<ReturnType<T>> {
-  return wrapAsync(async () => {
-    const output: ReturnType<T> = renderFn();
-    await flushMicrotasks();
-    await nextFrame();
-    await flushMicrotasks();
-    return output;
-  });
-}
-
 export async function render(ui: ReactNode, options?: RenderOptions) {
   const wrapper = (props: { children: ReactNode }) => {
     const Wrapper = options?.wrapper;
@@ -30,14 +18,11 @@ export async function render(ui: ReactNode, options?: RenderOptions) {
     return <StrictMode>{element}</StrictMode>;
   };
 
-  return wrapRender(() => {
-    const { unmount, rerender } = ReactTestingLibrary.render(ui, {
-      ...options,
-      wrapper,
-    });
-    return {
-      unmount,
-      rerender: (newUi: ReactNode) => wrapRender(() => rerender(newUi)),
-    };
+  return wrapAsync(async () => {
+    const { unmount } = ReactTestingLibrary.render(ui, { ...options, wrapper });
+    await flushMicrotasks();
+    await nextFrame();
+    await flushMicrotasks();
+    return unmount;
   });
 }

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -67,6 +67,6 @@ beforeEach(async ({ task }) => {
     // biome-ignore lint/correctness/noChildrenProp:
     children: createElement(comp),
   });
-  const { unmount } = await render(element, { strictMode: true });
+  const unmount = await render(element, { strictMode: true });
   return unmount;
 });


### PR DESCRIPTION
Reverts ariakit/ariakit#3978