### PR TITLE
Output `rerender` from `@ariakit/test`'s render.

### DIFF
--- a/.changeset/ninety-comics-worry.md
+++ b/.changeset/ninety-comics-worry.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/test": minor
+---
+
+The `render` method now returns a promise of `{ unmount, rerender }` instead of just the `unmount` function.

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -67,6 +67,6 @@ beforeEach(async ({ task }) => {
     // biome-ignore lint/correctness/noChildrenProp:
     children: createElement(comp),
   });
-  const unmount = await render(element, { strictMode: true });
+  const { unmount } = await render(element, { strictMode: true });
   return unmount;
 });


### PR DESCRIPTION
(rework of #3978 after accidental git mess)

---

This PR changes the output of the `render` function of `@ariakit/test` to return `rerender`. Previously, it returned the `unmount` function directly, and now it returns an object with the shape `{ unmount, rerender }`.

Context: https://github.com/ariakit/ariakit/issues/3939#issuecomment-2258293118