### PR TITLE
Make the iOS scroll restoration instant on Dialog close

### DIFF
--- a/.changeset/3983-fix-ios-smooth-scroll-restoration.md
+++ b/.changeset/3983-fix-ios-smooth-scroll-restoration.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed [Dialog](https://ariakit.org/components/dialog) to prevent smooth scrolling on hide.

--- a/packages/ariakit-react-core/src/dialog/utils/use-prevent-body-scroll.ts
+++ b/packages/ariakit-react-core/src/dialog/utils/use-prevent-body-scroll.ts
@@ -73,7 +73,7 @@ export function usePreventBodyScroll(
         restoreStyle();
         // istanbul ignore next: JSDOM doesn't implement window.scrollTo
         if (process.env.NODE_ENV !== "test") {
-          win.scrollTo(scrollX, scrollY);
+          win.scrollTo({ left: scrollX, top: scrollY, behavior: "instant" });
         }
       };
     };


### PR DESCRIPTION
Tested locally, not sure if i missed an edge case.

fixes: #3980 