### PR TITLE
Fix hovercard hiding on scroll on Safari

### DIFF
--- a/.changeset/4011-fix-hovercard-hide-on-scroll-safari.md
+++ b/.changeset/4011-fix-hovercard-hide-on-scroll-safari.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed [Hovercard](https://ariakit.org/components/hovercard) unexpectedly hiding when scrolling in Safari.

--- a/packages/ariakit-react-core/src/hovercard/hovercard.tsx
+++ b/packages/ariakit-react-core/src/hovercard/hovercard.tsx
@@ -23,6 +23,7 @@ import { usePopover } from "../popover/popover.tsx";
 import {
   useBooleanEvent,
   useEvent,
+  useIsMouseMoving,
   useLiveRef,
   useMergeRefs,
   usePortalRef,
@@ -150,6 +151,8 @@ export const useHovercard = createHook<TagName, HovercardOptions>(
     const enterPointRef = useRef<Point | null>(null);
     const { portalRef, domReady } = usePortalRef(portal, props.portalRef);
 
+    const isMouseMoving = useIsMouseMoving();
+
     const mayHideOnHoverOutside = !!hideOnHoverOutside;
     const hideOnHoverOutsideProp = useBooleanEvent(hideOnHoverOutside);
     const mayDisablePointerEvents = !!disablePointerEventsOnApproach;
@@ -170,6 +173,7 @@ export const useHovercard = createHook<TagName, HovercardOptions>(
       if (!element) return;
       const onMouseMove = (event: MouseEvent) => {
         if (!store) return;
+        if (!isMouseMoving()) return;
         const { anchorElement, hideTimeout, timeout } = store.getState();
         const enterPoint = enterPointRef.current;
         const [target] = event.composedPath() as Node[];
@@ -221,6 +225,7 @@ export const useHovercard = createHook<TagName, HovercardOptions>(
       );
     }, [
       store,
+      isMouseMoving,
       domReady,
       mounted,
       mayHideOnHoverOutside,


### PR DESCRIPTION
Apparently, recent versions of Safari are triggering a `mousemove` event on scroll without any actual mouse movement, causing our hovercard tests to be flaky. This PR updates the hovercard logic to check for mouse movement before executing the code inside the `mousemove` event handler to hide the hovercard.