### PR TITLE
Keep selected tab accessible when disabled

### DIFF
--- a/.changeset/4018-tab-selected-accessible-when-disabled.md
+++ b/.changeset/4018-tab-selected-accessible-when-disabled.md
@@ -1,0 +1,8 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Accessing selected tabs when disabled
+
+A [Tab](https://ariakit.org/components/tab) component that is both selected and disabled will now remain accessible to keyboard focus even if the [`accessibleWhenDisabled`](https://ariakit.org/reference/tab#accessiblewhendisabled) prop is set to `false`. This ensures users can navigate to other tabs using the keyboard.

--- a/examples/combobox-tabs/style.css
+++ b/examples/combobox-tabs/style.css
@@ -67,6 +67,7 @@
     bg-inherit
     text-sm
     bottom-0
+    mt-auto
     gap-4
     p-2
     border-t

--- a/examples/combobox-tabs/test-browser.ts
+++ b/examples/combobox-tabs/test-browser.ts
@@ -1,0 +1,34 @@
+import { query } from "@ariakit/test/playwright";
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/previews/combobox-tabs", { waitUntil: "networkidle" });
+});
+
+test("https://github.com/ariakit/ariakit/issues/3941", async ({ page }) => {
+  const q = query(page);
+
+  await q.combobox().click();
+  await expect(q.dialog()).toBeVisible();
+
+  await page.keyboard.press("ArrowDown");
+  await page.keyboard.press("ArrowLeft");
+  await expect(q.tab("Guide 6")).toHaveAttribute("data-active-item");
+  await expect(q.tab("Guide 6")).toHaveAttribute("data-focus-visible");
+  await expect(q.tab("Guide 6")).toHaveAttribute("aria-selected", "true");
+
+  await page.keyboard.type("ann");
+  await page.keyboard.press("Backspace");
+  await expect(q.tab("Guide 0")).toHaveAttribute("data-active-item");
+  await expect(q.tab("Guide 0")).toHaveAttribute("data-focus-visible");
+  await expect(q.tab("Guide 0")).toHaveAttribute("aria-selected", "true");
+
+  await page.keyboard.press("ArrowRight");
+  await expect(q.tab("Components 1")).toHaveAttribute("data-active-item");
+  await expect(q.tab("Components 1")).toHaveAttribute("data-focus-visible");
+  await expect(q.tab("Components 1")).toHaveAttribute("aria-selected", "true");
+
+  await expect(q.tab("Guide 0")).toHaveAttribute("aria-selected", "false");
+  await expect(q.tab("Guide 0")).not.toHaveAttribute("data-focus-visible");
+  await expect(q.tab("Guide 0")).not.toHaveAttribute("data-active-item");
+});

--- a/packages/ariakit-react-core/src/focusable/focusable.tsx
+++ b/packages/ariakit-react-core/src/focusable/focusable.tsx
@@ -224,9 +224,9 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
     const trulyDisabled = !!disabled && !accessibleWhenDisabled;
     const [focusVisible, setFocusVisible] = useState(false);
 
-    // When the focusable element is disabled, it doesn't trigger a blur event so
-    // we can't set focusVisible to false there. Instead, we have to do it here by
-    // checking the element's disabled attribute.
+    // When the focusable element is disabled, it doesn't trigger a blur event
+    // so we can't set focusVisible to false there. Instead, we have to do it
+    // here by checking the element's disabled attribute.
     useEffect(() => {
       if (!focusable) return;
       if (trulyDisabled && focusVisible) {
@@ -311,12 +311,12 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
       if (!focusable) return;
       const element = event.currentTarget;
       if (!element) return;
-      if (!hasFocus(element)) return;
-      onFocusVisible?.(event);
-      if (event.defaultPrevented) return;
       // Some extensions like 1password dispatches some keydown events on
       // autofill and immediately moves focus to the next field. That's why we
       // need to check if the current element is still focused.
+      if (!hasFocus(element)) return;
+      onFocusVisible?.(event);
+      if (event.defaultPrevented) return;
       setFocusVisible(true);
     };
 


### PR DESCRIPTION
Closes #3941

Updated the tab code to make sure the selected tab remains accessible to keyboard focus even when the `accessibleWhenDisabled` prop is set to `false`.