### PR TITLE
Add ComboboxValue component to @ariakit/react

### DIFF
--- a/.changeset/4039-combobox-value.md
+++ b/.changeset/4039-combobox-value.md
@@ -1,0 +1,16 @@
+---
+"@ariakit/react": patch
+---
+
+New `ComboboxValue` component
+
+A [`ComboboxValue`](https://ariakit.org/reference/combobox-value) component is now available. This _value_ component displays the current value of the combobox input without rendering any DOM elements or taking any HTML props. You can optionally pass a function as a child returning any React node based on the current value:
+
+```jsx
+<ComboboxProvider>
+  <Combobox />
+  <ComboboxValue>
+    {(value) => `Current value: ${value}`}
+  </ComboboxValue>
+</ComboboxProvider>
+```

--- a/components/combobox.md
+++ b/components/combobox.md
@@ -41,6 +41,7 @@ useComboboxContext()
   <Combobox />
   <ComboboxCancel />
   <ComboboxDisclosure />
+  <ComboboxValue />
   <ComboboxList />
   <ComboboxPopover>
     <ComboboxGroup>

--- a/examples/combobox-tabs-old/combobox.tsx
+++ b/examples/combobox-tabs-old/combobox.tsx
@@ -68,8 +68,6 @@ export interface ComboboxProps extends Ariakit.ComboboxProps {}
 
 export const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
   function Combobox(props, ref) {
-    const combobox = Ariakit.useComboboxContext()!;
-    const hasValue = combobox.useState((state) => state.value !== "");
     return (
       <div className="combobox-wrapper">
         <Ariakit.Combobox
@@ -90,9 +88,13 @@ export const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
           }}
         />
         <div className="combobox-buttons">
-          {hasValue && (
-            <Ariakit.ComboboxCancel className="button secondary combobox-cancel" />
-          )}
+          <Ariakit.ComboboxValue>
+            {(value) =>
+              value !== "" && (
+                <Ariakit.ComboboxCancel className="button secondary combobox-cancel" />
+              )
+            }
+          </Ariakit.ComboboxValue>
           <Ariakit.ComboboxDisclosure className="button flat combobox-disclosure" />
         </div>
       </div>

--- a/packages/ariakit-react/src/combobox.ts
+++ b/packages/ariakit-react/src/combobox.ts
@@ -14,6 +14,7 @@ export { ComboboxList } from "@ariakit/react-core/combobox/combobox-list";
 export { ComboboxPopover } from "@ariakit/react-core/combobox/combobox-popover";
 export { ComboboxRow } from "@ariakit/react-core/combobox/combobox-row";
 export { ComboboxSeparator } from "@ariakit/react-core/combobox/combobox-separator";
+export { ComboboxValue } from "@ariakit/react-core/combobox/combobox-value";
 
 export type {
   ComboboxStore,
@@ -87,3 +88,5 @@ export type {
   ComboboxSeparatorOptions,
   ComboboxSeparatorProps,
 } from "@ariakit/react-core/combobox/combobox-separator";
+
+export type { ComboboxValueProps } from "@ariakit/react-core/combobox/combobox-value";


### PR DESCRIPTION
A [`ComboboxValue`](https://ariakit.org/reference/combobox-value) component is now available. This _value_ component displays the current value of the combobox input without rendering any DOM elements or taking any HTML props. You can optionally pass a function as a child returning any React node based on the current value:

```jsx
<ComboboxProvider>
  <Combobox />
  <ComboboxValue>
    {(value) => `Current value: ${value}`}
  </ComboboxValue>
</ComboboxProvider>
```