### PR TITLE
Remove aria-selected from focused composite items

### DIFF
--- a/.changeset/4040-composite-item-remove-aria-selected.md
+++ b/.changeset/4040-composite-item-remove-aria-selected.md
@@ -1,0 +1,10 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+`aria-selected` on composite items
+
+Composite items like [`ComboboxItem`](https://ariakit.org/reference/combobox-item) no longer have the `aria-selected` attribute automatically set when focused. This attribute was previously used to address an old bug in Google Chrome, but it's no longer needed. Now, it's only set when the item is actually selected, such as in a select widget or a multi-selectable combobox.
+
+This change shouldn't affect most users since the `aria-selected` attribute is not part of the public API and is not recommended as a [CSS selector](https://ariakit.org/guide/styling#css-selectors) (use [`[data-active-item]`](https://ariakit.org/guide/styling#data-active-item) instead). However, if you have snapshot tests, you may need to update them.

--- a/examples/menu-nested-combobox/test.ts
+++ b/examples/menu-nested-combobox/test.ts
@@ -24,12 +24,15 @@ test("filter actions", async () => {
   await click(q.button("Actions"));
   await type("de");
   expect(q.option("Default checked")).toHaveFocus();
-  expect(q.option("Default checked")).toHaveAttribute("aria-selected", "true");
+  expect(q.option("Default checked")).toHaveAttribute(
+    "data-active-item",
+    "true",
+  );
   await press.ArrowDown();
   expect(q.option("Default background checked")).toHaveFocus();
   await press.ArrowDown();
   expect(q.option("Delete")).toHaveFocus();
-  expect(q.option("Delete")).toHaveAttribute("aria-selected", "true");
+  expect(q.option("Delete")).toHaveAttribute("data-active-item", "true");
   await press.ArrowDown();
   expect(q.option("Code not checked")).toHaveFocus();
 });

--- a/packages/ariakit-react-core/src/composite/composite-item.tsx
+++ b/packages/ariakit-react-core/src/composite/composite-item.tsx
@@ -17,10 +17,9 @@ import type {
   ElementType,
   FocusEvent,
   KeyboardEvent,
-  RefObject,
   SyntheticEvent,
 } from "react";
-import { useCallback, useContext, useMemo, useRef, useState } from "react";
+import { useCallback, useContext, useMemo, useRef } from "react";
 import type { CollectionItemOptions } from "../collection/collection-item.tsx";
 import { useCollectionItem } from "../collection/collection-item.tsx";
 import type { CommandOptions } from "../command/command.tsx";
@@ -30,7 +29,6 @@ import {
   useEvent,
   useId,
   useMergeRefs,
-  useSafeLayoutEffect,
   useWrapElement,
 } from "../utils/hooks.ts";
 import { useStoreState } from "../utils/store.tsx";
@@ -136,34 +134,6 @@ function findNextPageItemId(
 function targetIsAnotherItem(event: SyntheticEvent, store: CompositeStore) {
   if (isSelfTarget(event)) return false;
   return isItem(store, event.target as HTMLElement);
-}
-
-function useRole(ref: RefObject<HTMLElement>, props: CompositeItemProps) {
-  const roleProp = props.role;
-  const [role, setRole] = useState(roleProp);
-
-  useSafeLayoutEffect(() => {
-    const element = ref.current;
-    if (!element) return;
-    setRole(element.getAttribute("role") || roleProp);
-  }, [roleProp]);
-
-  return role;
-}
-
-function requiresAriaSelected(role?: string) {
-  return role === "option" || role === "treeitem";
-}
-
-function supportsAriaSelected(role?: string) {
-  if (role === "option") return true;
-  if (role === "tab") return true;
-  if (role === "treeitem") return true;
-  if (role === "gridcell") return true;
-  if (role === "row") return true;
-  if (role === "columnheader") return true;
-  if (role === "rowheader") return true;
-  return false;
 }
 
 /**
@@ -401,23 +371,6 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
       store,
       (state) => !!state && state.activeId === id,
     );
-    const virtualFocus = useStoreState(store, "virtualFocus");
-    const role = useRole(ref, props);
-    let ariaSelected: boolean | undefined;
-
-    if (isActiveItem) {
-      if (requiresAriaSelected(role)) {
-        // When the active item role _requires_ the aria-selected attribute
-        // (e.g., option, treeitem), we always set it to true.
-        ariaSelected = true;
-      } else if (virtualFocus && supportsAriaSelected(role)) {
-        // Otherwise, it will be set to true when virtualFocus is set to true
-        // (meaning that the focus will be managed using the
-        // aria-activedescendant attribute) and the aria-selected attribute is
-        // _supported_ by the active item role.
-        ariaSelected = true;
-      }
-    }
 
     const ariaSetSize = useStoreState(store, (state) => {
       if (ariaSetSizeProp != null) return ariaSetSizeProp;
@@ -447,7 +400,6 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
 
     props = {
       id,
-      "aria-selected": ariaSelected,
       "data-active-item": isActiveItem || undefined,
       ...props,
       ref: useMergeRefs(ref, props.ref),


### PR DESCRIPTION
Composite items like [`ComboboxItem`](https://ariakit.org/reference/combobox-item) no longer have the `aria-selected` attribute automatically set when focused. This attribute was previously used to address an old bug in Google Chrome, but it's no longer needed. Now, it's only set when the item is actually selected, such as in a select widget or a multi-selectable combobox.

This change shouldn't affect most users since the `aria-selected` attribute is not part of the public API and is not recommended as a [CSS selector](https://ariakit.org/guide/styling#css-selectors) (use [`[data-active-item]`](https://ariakit.org/guide/styling#data-active-item) instead). However, if you have snapshot tests, you may need to update them.