### PR TITLE
Expose useStoreState as a public API

### DIFF
--- a/.changeset/0-4048-use-store-state.md
+++ b/.changeset/0-4048-use-store-state.md
@@ -1,0 +1,26 @@
+---
+"@ariakit/react": patch
+---
+
+New `useStoreState` hook
+
+The [`useStoreState`](https://ariakit.org/reference/use-store-state) hook is now part of the public API. Previously used internally by dynamic `useState` hooks from Ariakit store objects, it is now available in the `@ariakit/react` package to ensure compatibility with the new React Compiler.
+
+The following snippets are equivalent:
+
+```js
+const combobox = useComboboxStore();
+const value = combobox.useState("value");
+```
+
+```js
+const combobox = useComboboxStore();
+const value = useStoreState(combobox, "value");
+```
+
+Besides working better with the new React Compiler, [`useStoreState`](https://ariakit.org/reference/use-store-state) is more flexible than `store.useState` as it accepts a store that is `null` or `undefined`, in which case the returned value will be `undefined`. This is useful when you're reading a store from a context that may not always be available:
+
+```js
+const combobox = useComboboxContext();
+const value = useStoreState(combobox, "value");
+```

--- a/packages/ariakit-react-core/src/utils/store.tsx
+++ b/packages/ariakit-react-core/src/utils/store.tsx
@@ -52,6 +52,40 @@ type StateKey<T = CoreStore> = keyof StoreState<T>;
 
 const noopSubscribe = () => () => {};
 
+/**
+ * Receives an Ariakit store object (which can be `null` or `undefined`) and
+ * returns the current state. If a key is provided as the second argument, it
+ * returns the value of that key. If a selector function is provided, the state
+ * is passed to it, and its return value is used.
+ *
+ * The component using this hook will re-render when the returned value changes.
+ * @example
+ * Accessing the whole combobox state:
+ * ```js
+ * const combobox = Ariakit.useComboboxStore();
+ * const state = Ariakit.useStoreState(combobox);
+ * ```
+ * @example
+ * Accessing a specific value from the combobox state:
+ * ```js
+ * const combobox = Ariakit.useComboboxStore();
+ * const value = Ariakit.useStoreState(combobox, "value");
+ * ```
+ * @example
+ * Accessing a value using a selector function:
+ * ```js
+ * const combobox = Ariakit.useComboboxStore();
+ * const value = Ariakit.useStoreState(combobox, (state) => state.value);
+ * ```
+ * @example
+ * Accessing the state of a store that may be `null` or `undefined` (for
+ * example, using a context):
+ * ```js
+ * const combobox = Ariakit.useComboboxContext();
+ * const value = Ariakit.useStoreState(combobox, "value");
+ * ```
+ */
+
 export function useStoreState<T extends CoreStore>(store: T): StoreState<T>;
 
 export function useStoreState<T extends CoreStore>(

--- a/packages/ariakit-react/package.json
+++ b/packages/ariakit-react/package.json
@@ -42,6 +42,7 @@
     "./tooltip": "./src/tooltip.ts",
     "./toolbar": "./src/toolbar.ts",
     "./tab": "./src/tab.ts",
+    "./store": "./src/store.ts",
     "./separator": "./src/separator.ts",
     "./select": "./src/select.ts",
     "./role": "./src/role.ts",

--- a/packages/ariakit-react/src/index.ts
+++ b/packages/ariakit-react/src/index.ts
@@ -20,6 +20,7 @@ export * from "./radio.ts";
 export * from "./role.ts";
 export * from "./select.ts";
 export * from "./separator.ts";
+export * from "./store.ts";
 export * from "./tab.ts";
 export * from "./toolbar.ts";
 export * from "./tooltip.ts";

--- a/packages/ariakit-react/src/store.ts
+++ b/packages/ariakit-react/src/store.ts
@@ -1,0 +1,1 @@
+export { useStoreState } from "@ariakit/react-core/utils/store";

--- a/website/build-pages/reference-utils.js
+++ b/website/build-pages/reference-utils.js
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 import invariant from "tiny-invariant";
 import { FunctionLikeDeclaration, Node, Project, ts } from "ts-morph";
+import { getPageName } from "./get-page-name.js";
 
 const project = new Project({
   tsConfigFilePath: join(process.cwd(), "../tsconfig.json"),
@@ -254,7 +255,11 @@ function getReference(filename, node, props, returnedProps) {
     ? node.getVariableStatementOrThrow()
     : node;
 
-  props = props || getFunction(node)?.getParameters()?.at(0);
+  const hasProps = getPageName(filename) !== "store";
+  if (hasProps) {
+    props = props || getFunction(node)?.getParameters()?.at(0);
+  }
+
   returnedProps =
     returnedProps ||
     (name.endsWith("Store")


### PR DESCRIPTION

The [`useStoreState`](https://ariakit.org/reference/use-store-state) hook is now part of the public API. Previously used internally by dynamic `useState` hooks from Ariakit store objects, it is now available in the `@ariakit/react` package to ensure compatibility with the new React Compiler.

The following snippets are equivalent:

```js
const combobox = useComboboxStore();
const value = combobox.useState("value");
```

```js
const combobox = useComboboxStore();
const value = useStoreState(combobox, "value");
```

Besides working better with the new React Compiler, [`useStoreState`](https://ariakit.org/reference/use-store-state) is more flexible than `store.useState` as it accepts a store that is `null` or `undefined`, in which case the returned value will be `undefined`. This is useful when you're reading a store from a context that may not always be available:

```js
const combobox = useComboboxContext();
const value = useStoreState(combobox, "value");
```