### PR TITLE
Fix optional props being listed as required props in docs

### DIFF
--- a/website/build-pages/reference-utils.js
+++ b/website/build-pages/reference-utils.js
@@ -207,11 +207,12 @@ function getProps(node) {
     if (isPrivate(decl)) continue;
     const description = getDescription(decl);
     if (!description) continue;
+    const type = getType(decl);
     props.push({
       name: prop.getEscapedName(),
-      type: getType(decl),
+      type,
       description,
-      optional: prop.isOptional(),
+      optional: prop.isOptional() || type.endsWith(" | undefined"),
       defaultValue: getDefaultValue(decl),
       deprecated: getDeprecated(decl),
       examples: getExamples(decl),


### PR DESCRIPTION
This was affecting `SelectValue`.

See https://ariakit.org/reference/select-value#fallback