### PR TITLE
Make `accessibleWhenDisabled` `true` by default again

### DIFF
--- a/.changeset/4056-tab-accessible-when-disabled.md
+++ b/.changeset/4056-tab-accessible-when-disabled.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed a regression introduced in v0.4.8 that set the [`accessibleWhenDisabled`](https://ariakit.org/reference/tab#accessiblewhendisabled) prop to `false` by default on the [`Tab`](https://ariakit.org/reference/tab) component.

--- a/examples/tab-disabled/index.tsx
+++ b/examples/tab-disabled/index.tsx
@@ -1,0 +1,44 @@
+import * as Ariakit from "@ariakit/react";
+import "./style.css";
+
+export default function Example() {
+  const defaultSelectedId = "default-selected-tab";
+  return (
+    <div className="wrapper">
+      <Ariakit.TabProvider defaultSelectedId={defaultSelectedId}>
+        <Ariakit.TabList className="tab-list" aria-label="Groceries">
+          <Ariakit.Tab className="tab">Fruits</Ariakit.Tab>
+          <Ariakit.Tab className="tab" id={defaultSelectedId}>
+            Vegetables
+          </Ariakit.Tab>
+          <Ariakit.Tab className="tab" disabled>
+            Meat
+          </Ariakit.Tab>
+        </Ariakit.TabList>
+        <div className="panels">
+          <Ariakit.TabPanel>
+            <ul>
+              <li>🍎 Apple</li>
+              <li>🍇 Grape</li>
+              <li>🍊 Orange</li>
+            </ul>
+          </Ariakit.TabPanel>
+          <Ariakit.TabPanel tabId={defaultSelectedId}>
+            <ul>
+              <li>🥕 Carrot</li>
+              <li>🧅 Onion</li>
+              <li>🥔 Potato</li>
+            </ul>
+          </Ariakit.TabPanel>
+          <Ariakit.TabPanel>
+            <ul>
+              <li>🥩 Beef</li>
+              <li>🍗 Chicken</li>
+              <li>🥓 Pork</li>
+            </ul>
+          </Ariakit.TabPanel>
+        </div>
+      </Ariakit.TabProvider>
+    </div>
+  );
+}

--- a/examples/tab-disabled/style.css
+++ b/examples/tab-disabled/style.css
@@ -1,0 +1,1 @@
+@import url("../tab/style.css");

--- a/examples/tab-disabled/test.ts
+++ b/examples/tab-disabled/test.ts
@@ -1,0 +1,20 @@
+import { press, q } from "@ariakit/test";
+
+test("navigate through tabs with keyboard", async () => {
+  await press.Tab();
+  expect(q.tab("Vegetables")).toHaveFocus();
+  expect(q.tab("Vegetables")).toHaveAttribute("aria-selected", "true");
+  expect(q.tabpanel("Vegetables")).toBeVisible();
+
+  await press.ArrowRight();
+  expect(q.tab("Meat")).toHaveFocus();
+  expect(q.tab("Meat")).toHaveAttribute("aria-selected", "false");
+  expect(q.tabpanel.includesHidden("Meat")).not.toBeVisible();
+  expect(q.tab("Vegetables")).toHaveAttribute("aria-selected", "true");
+  expect(q.tabpanel("Vegetables")).toBeVisible();
+
+  await press.ArrowRight();
+  expect(q.tab("Fruits")).toHaveFocus();
+  expect(q.tab("Fruits")).toHaveAttribute("aria-selected", "true");
+  expect(q.tabpanel("Fruits")).toBeVisible();
+});

--- a/packages/ariakit-react-core/src/tab/tab.tsx
+++ b/packages/ariakit-react-core/src/tab/tab.tsx
@@ -84,7 +84,8 @@ export const useTab = createHook<TagName, TabOptions>(function useTab({
   const selected = store.useState((state) => !!id && state.selectedId === id);
   const hasActiveItem = store.useState((state) => !!store.item(state.activeId));
   const canRegisterComposedItem = isActive || (selected && !hasActiveItem);
-  const accessibleWhenDisabled = selected || ( props.accessibleWhenDisabled ?? true );
+  const accessibleWhenDisabled =
+    selected || (props.accessibleWhenDisabled ?? true);
 
   // If the tab is rendered within another composite widget with virtual focus,
   // such as combobox, it shouldn't be tabbable even if the tab store uses

--- a/packages/ariakit-react-core/src/tab/tab.tsx
+++ b/packages/ariakit-react-core/src/tab/tab.tsx
@@ -84,7 +84,7 @@ export const useTab = createHook<TagName, TabOptions>(function useTab({
   const selected = store.useState((state) => !!id && state.selectedId === id);
   const hasActiveItem = store.useState((state) => !!store.item(state.activeId));
   const canRegisterComposedItem = isActive || (selected && !hasActiveItem);
-  const accessibleWhenDisabled = selected || props.accessibleWhenDisabled;
+  const accessibleWhenDisabled = selected || ( props.accessibleWhenDisabled ?? true );
 
   // If the tab is rendered within another composite widget with virtual focus,
   // such as combobox, it shouldn't be tabbable even if the tab store uses


### PR DESCRIPTION
This suggests reverting the unintended changes caused by https://github.com/ariakit/ariakit/pull/4018

See https://github.com/WordPress/gutenberg/pull/64637#issuecomment-2298634076