### PR TITLE
Fix mousedown on MenuButton hiding Menu

### DIFF
--- a/.changeset/4093-safari-menu-button-hide-mousedown.md
+++ b/.changeset/4093-safari-menu-button-hide-mousedown.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed mouse down on [`MenuButton`](https://ariakit.org/reference/menu-button) hiding the menu on Safari.

--- a/examples/dialog-menu/test-browser.ts
+++ b/examples/dialog-menu/test-browser.ts
@@ -1,53 +1,52 @@
-import type { Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
+import type { Page } from "@ariakit/test/playwright";
+import { expect, query } from "@ariakit/test/playwright";
+import { test } from "../test-utils.ts";
 
-const getButton = (page: Page, name: string) =>
-  page.getByRole("button", { name });
-
-const getDialog = (page: Page) =>
-  page.getByRole("dialog", { includeHidden: true, name: "Homemade Cake" });
-
-const getBackdrop = async (page: Page) => {
-  const id = await getDialog(page).getAttribute("id");
+const backdrop = async (page: Page) => {
+  const q = query(page);
+  const id = await q.dialog().getAttribute("id");
   return page.locator(`[data-backdrop="${id}"]`);
 };
 
-const getMenu = (page: Page) => page.getByRole("menu", { name: "Share" });
-
-const getMenuItem = (page: Page, name: string) =>
-  page.getByRole("menuitem", { name });
-
-test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/dialog-menu", { waitUntil: "networkidle" });
+test("open/close menu by clicking on menu button", async ({ page }) => {
+  const q = query(page);
+  await q.button("View recipe").click();
+  await q.button("Share").click();
+  await expect(q.menu()).toBeVisible();
+  await q.button("Share").click();
+  await expect(q.menu()).not.toBeVisible();
 });
 
 test("dragging the cursor to outside the dialog", async ({ page }) => {
-  await getButton(page, "View recipe").click();
-  await expect(getDialog(page)).toBeVisible();
-  await getDialog(page).dragTo(await getBackdrop(page), {
+  const q = query(page);
+  await q.button("View recipe").click();
+  await expect(q.dialog()).toBeVisible();
+  await q.dialog().dragTo(await backdrop(page), {
     targetPosition: { x: 0, y: 0 },
   });
-  await expect(getDialog(page)).toBeVisible();
+  await expect(q.dialog()).toBeVisible();
 });
 
 test("dragging the cursor to outside the menu", async ({ page }) => {
-  await getButton(page, "View recipe").click();
-  await getButton(page, "Share").click();
-  await expect(getDialog(page)).toBeVisible();
-  await expect(getMenu(page)).toBeVisible();
-  await getMenuItem(page, "Facebook").dragTo(getDialog(page));
-  await expect(getDialog(page)).toBeVisible();
-  await expect(getMenu(page)).toBeVisible();
+  const q = query(page);
+  await q.button("View recipe").click();
+  await q.button("Share").click();
+  await expect(q.dialog()).toBeVisible();
+  await expect(q.menu()).toBeVisible();
+  await q.menuitem("Facebook").dragTo(q.dialog());
+  await expect(q.dialog()).toBeVisible();
+  await expect(q.menu()).toBeVisible();
 });
 
 test("dragging the cursor to outside both", async ({ page }) => {
-  await getButton(page, "View recipe").click();
-  await getButton(page, "Share").click();
-  await expect(getDialog(page)).toBeVisible();
-  await expect(getMenu(page)).toBeVisible();
-  await getMenuItem(page, "Facebook").dragTo(await getBackdrop(page), {
+  const q = query(page);
+  await q.button("View recipe").click();
+  await q.button("Share").click();
+  await expect(q.dialog()).toBeVisible();
+  await expect(q.menu()).toBeVisible();
+  await q.menuitem("Facebook").dragTo(await backdrop(page), {
     targetPosition: { x: 0, y: 0 },
   });
-  await expect(getDialog(page)).toBeVisible();
-  await expect(getMenu(page)).toBeVisible();
+  await expect(q.dialog()).toBeVisible();
+  await expect(q.menu()).toBeVisible();
 });


### PR DESCRIPTION
This PR addresses a long-standing issue where `mousedown` on `MenuButton` hides the menu when it's inside a focusable ancestor (like a dialog) on Safari.

This occurs because Safari focuses on the nearest focusable ancestor when a button is clicked, instead of focusing on the button itself like other browsers. Ariakit normalizes this behavior in a non-intrusive way by restoring focus to the button, but it doesn't prevent the focusable ancestor from receiving focus (as it would also prevent other side effects like drag events, selection, etc.).

The problem is that allowing the focusable ancestor to receive focus also triggers the `hideOnInteractOutside` feature on dialogs. This PR adds a flag to the focused ancestor that's checked in the hiding logic.