### PR TITLE
Set data-focus-visible synchronously

### DIFF
--- a/.changeset/4093-composite-item-active-item-focus-visible.md
+++ b/.changeset/4093-composite-item-active-item-focus-visible.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Removed delay when applying the [`data-focus-visible`](https://ariakit.org/guide/styling#data-focus-visible) attribute.

--- a/examples/composite/test.ts
+++ b/examples/composite/test.ts
@@ -1,5 +1,24 @@
 import { press, q } from "@ariakit/test";
 
+function setActEnvironment(value: boolean) {
+  const scope = globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean };
+  const previousValue = scope.IS_REACT_ACT_ENVIRONMENT;
+  scope.IS_REACT_ACT_ENVIRONMENT = value;
+  const restoreActEnvironment = () => {
+    scope.IS_REACT_ACT_ENVIRONMENT = previousValue;
+  };
+  return restoreActEnvironment;
+}
+
+async function wrapAsync<T>(fn: () => Promise<T>) {
+  const restoreActEnvironment = setActEnvironment(false);
+  try {
+    return await fn();
+  } finally {
+    restoreActEnvironment();
+  }
+}
+
 test("navigate through items with keyboard", async () => {
   expect(q.button("🍎 Apple")).not.toHaveFocus();
   expect(q.button("🍎 Apple")).toHaveAttribute("data-active-item");
@@ -32,4 +51,30 @@ test("navigate through items with keyboard", async () => {
   await press.ArrowDown(); // should not loop
   expect(q.button("🍊 Orange")).toHaveFocus();
   expect(q.button("🍊 Orange")).toHaveAttribute("data-active-item");
+});
+
+test("https://github.com/ariakit/ariakit/issues/4083", async () => {
+  expect.assertions(6);
+
+  await press.Tab();
+
+  expect(q.button("🍎 Apple")).toHaveAttribute("data-focus-visible", "true");
+  expect(q.button("🍎 Apple")).toHaveAttribute("data-active-item", "true");
+
+  await wrapAsync(async () => {
+    document.activeElement?.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        cancelable: true,
+        bubbles: true,
+        key: "ArrowDown",
+      }),
+    );
+    await new Promise(requestAnimationFrame);
+
+    expect(q.button("🍎 Apple")).not.toHaveAttribute("data-focus-visible");
+    expect(q.button("🍎 Apple")).not.toHaveAttribute("data-active-item");
+
+    expect(q.button("🍇 Grape")).toHaveAttribute("data-active-item", "true");
+    expect(q.button("🍇 Grape")).toHaveAttribute("data-focus-visible", "true");
+  });
 });

--- a/packages/ariakit-react-core/src/focusable/focusable.tsx
+++ b/packages/ariakit-react-core/src/focusable/focusable.tsx
@@ -27,6 +27,7 @@ import type {
   SyntheticEvent,
 } from "react";
 import { useContext, useEffect, useMemo, useRef, useState } from "react";
+import { flushSync } from "react-dom";
 import { useEvent, useMergeRefs, useTagName } from "../utils/hooks.ts";
 import { createElement, createHook, forwardRef } from "../utils/system.tsx";
 import type { Options, Props } from "../utils/types.ts";
@@ -358,7 +359,12 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
       if (event.ctrlKey) return;
       if (!isSelfTarget(event)) return;
       const element = event.currentTarget;
-      const applyFocusVisible = () => handleFocusVisible(event, element);
+      const applyFocusVisible = () => {
+        // Need to flush sync to make sure data-focus-visible is applied
+        // visually at the same time as other data attributes like
+        // data-active-item. See https://github.com/ariakit/ariakit/issues/4083
+        flushSync(() => handleFocusVisible(event, element));
+      };
       queueBeforeEvent(element, "focusout", applyFocusVisible);
     });
 
@@ -373,7 +379,10 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
         return;
       }
       const element = event.currentTarget;
-      const applyFocusVisible = () => handleFocusVisible(event, element);
+      const applyFocusVisible = () => {
+        // See https://github.com/ariakit/ariakit/issues/4083
+        flushSync(() => handleFocusVisible(event, element));
+      };
       if (isKeyboardModality || isAlwaysFocusVisible(event.target)) {
         queueBeforeEvent(event.target, "focusout", applyFocusVisible);
       } else {

--- a/packages/ariakit-react-core/src/focusable/focusable.tsx
+++ b/packages/ariakit-react-core/src/focusable/focusable.tsx
@@ -27,7 +27,6 @@ import type {
   SyntheticEvent,
 } from "react";
 import { useContext, useEffect, useMemo, useRef, useState } from "react";
-import { flushSync } from "react-dom";
 import { useEvent, useMergeRefs, useTagName } from "../utils/hooks.ts";
 import { createElement, createHook, forwardRef } from "../utils/system.tsx";
 import type { Options, Props } from "../utils/types.ts";
@@ -344,6 +343,10 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
       if (!hasFocus(element)) return;
       onFocusVisible?.(event);
       if (event.defaultPrevented) return;
+      // Make sure data-focus-visible is applied visually at the same time as
+      // other data attributes like data-active-item. See
+      // https://github.com/ariakit/ariakit/issues/4083
+      element.dataset.focusVisible = "true";
       setFocusVisible(true);
     };
 
@@ -359,12 +362,7 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
       if (event.ctrlKey) return;
       if (!isSelfTarget(event)) return;
       const element = event.currentTarget;
-      const applyFocusVisible = () => {
-        // Need to flush sync to make sure data-focus-visible is applied
-        // visually at the same time as other data attributes like
-        // data-active-item. See https://github.com/ariakit/ariakit/issues/4083
-        flushSync(() => handleFocusVisible(event, element));
-      };
+      const applyFocusVisible = () => handleFocusVisible(event, element);
       queueBeforeEvent(element, "focusout", applyFocusVisible);
     });
 
@@ -379,10 +377,7 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
         return;
       }
       const element = event.currentTarget;
-      const applyFocusVisible = () => {
-        // See https://github.com/ariakit/ariakit/issues/4083
-        flushSync(() => handleFocusVisible(event, element));
-      };
+      const applyFocusVisible = () => handleFocusVisible(event, element);
       if (isKeyboardModality || isAlwaysFocusVisible(event.target)) {
         queueBeforeEvent(event.target, "focusout", applyFocusVisible);
       } else {


### PR DESCRIPTION
Closes #4083

This PR sets the `data-focus-visible` attribute without relying on React to update the `focusVisible` state internally. This ensures `data-focus-visible` and other attributes like `data-active-item` are updated simultaneously (visually).

I tried `ReactDOM.flushSync`, but aside from potentially hurting performance, there were a few React warnings about calling this in lifecycle methods. We could ignore these warnings, but setting the data attribute imperatively seems to be a safer option.