### PR TITLE
Fix modal dialog disabling focus traps of nested dialogs

### DIFF
--- a/.changeset/4101-dialog-nested-focus-trap-inert.md
+++ b/.changeset/4101-dialog-nested-focus-trap-inert.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed the ability to <kbd>Tab</kbd> out of a nested [Menu](https://ariakit.org/components/menu) within a modal [Dialog](https://ariakit.org/components/dialog).

--- a/examples/dialog-menu/test.ts
+++ b/examples/dialog-menu/test.ts
@@ -62,3 +62,11 @@ test("hide both menu and dialog by clicking outside dialog", async () => {
   expect(q.menu()).not.toBeInTheDocument();
   expect(q.button("View recipe")).toHaveFocus();
 });
+
+test("move back to menu button with Shift+Tab", async () => {
+  await click(q.button("View recipe"));
+  await click(q.button("Share"));
+  expect(q.menu()).toBeVisible();
+  await press.ShiftTab();
+  expect(q.button("Share")).toHaveFocus();
+});

--- a/packages/ariakit-react-core/package.json
+++ b/packages/ariakit-react-core/package.json
@@ -195,6 +195,7 @@
     "./dialog/utils/prepend-hidden-dismiss": "./src/dialog/utils/prepend-hidden-dismiss.ts",
     "./dialog/utils/orchestrate": "./src/dialog/utils/orchestrate.ts",
     "./dialog/utils/mark-tree-outside": "./src/dialog/utils/mark-tree-outside.ts",
+    "./dialog/utils/is-focus-trap": "./src/dialog/utils/is-focus-trap.ts",
     "./dialog/utils/is-backdrop": "./src/dialog/utils/is-backdrop.ts",
     "./dialog/utils/disable-tree": "./src/dialog/utils/disable-tree.ts",
     "./dialog/utils/disable-accessibility-tree-outside": "./src/dialog/utils/disable-accessibility-tree-outside.ts",

--- a/packages/ariakit-react-core/src/dialog/utils/disable-tree.ts
+++ b/packages/ariakit-react-core/src/dialog/utils/disable-tree.ts
@@ -3,6 +3,7 @@ import { getAllTabbableIn } from "@ariakit/core/utils/focus";
 import { chain, noop } from "@ariakit/core/utils/misc";
 import { hideElementFromAccessibilityTree } from "./disable-accessibility-tree-outside.ts";
 import { isBackdrop } from "./is-backdrop.ts";
+import { isFocusTrap } from "./is-focus-trap.ts";
 import {
   assignStyle,
   orchestrate,
@@ -58,6 +59,9 @@ export function disableTreeOutside(id: string, elements: Elements) {
     elements,
     (element) => {
       if (isBackdrop(element, ...ids)) return;
+      // Ignore focus trap elements connected to any of the dialog elements. See
+      // dialog-menu "move back to menu button with Shift+Tab" test.
+      if (isFocusTrap(element, ...ids)) return;
       cleanups.unshift(disableTree(element, elements));
     },
     (element) => {

--- a/packages/ariakit-react-core/src/dialog/utils/is-focus-trap.ts
+++ b/packages/ariakit-react-core/src/dialog/utils/is-focus-trap.ts
@@ -1,0 +1,11 @@
+export function isFocusTrap(
+  element?: Element | null,
+  ...ids: Array<string | null | undefined>
+) {
+  if (!element) return false;
+  const attr = element.getAttribute("data-focus-trap");
+  if (attr == null) return false;
+  if (!ids.length) return true;
+  if (attr === "") return false;
+  return ids.some((id) => attr === id);
+}

--- a/packages/ariakit-react-core/src/menu/menu-button.tsx
+++ b/packages/ariakit-react-core/src/menu/menu-button.tsx
@@ -120,7 +120,8 @@ export const useMenuButton = createHook<TagName, MenuButtonOptions>(
       }
     });
 
-    const dir = store.useState(
+    const dir = useStoreState(
+      store,
       (state) => state.placement.split("-")[0] as BasePlacement,
     );
 

--- a/packages/ariakit-react-core/src/portal/portal.tsx
+++ b/packages/ariakit-react-core/src/portal/portal.tsx
@@ -203,6 +203,7 @@ export const usePortal = createHook<TagName, PortalOptions>(function usePortal({
           {preserveTabOrder && portalNode && (
             <FocusTrap
               ref={innerBeforeRef}
+              data-focus-trap={props.id}
               className="__focus-trap-inner-before"
               onFocus={(event) => {
                 if (isFocusEventOutside(event, portalNode)) {
@@ -217,6 +218,7 @@ export const usePortal = createHook<TagName, PortalOptions>(function usePortal({
           {preserveTabOrder && portalNode && (
             <FocusTrap
               ref={innerAfterRef}
+              data-focus-trap={props.id}
               className="__focus-trap-inner-after"
               onFocus={(event) => {
                 if (isFocusEventOutside(event, portalNode)) {
@@ -239,6 +241,7 @@ export const usePortal = createHook<TagName, PortalOptions>(function usePortal({
           {preserveTabOrder && portalNode && (
             <FocusTrap
               ref={outerBeforeRef}
+              data-focus-trap={props.id}
               className="__focus-trap-outer-before"
               onFocus={(event) => {
                 // If the event is coming from the outer after focus trap, it
@@ -262,6 +265,7 @@ export const usePortal = createHook<TagName, PortalOptions>(function usePortal({
           {preserveTabOrder && portalNode && (
             <FocusTrap
               ref={outerAfterRef}
+              data-focus-trap={props.id}
               className="__focus-trap-outer-after"
               onFocus={(event) => {
                 if (isFocusEventOutside(event, portalNode)) {


### PR DESCRIPTION
When a non-[`modal`](https://ariakit.org/reference/popover#modal) [`portal`](https://ariakit.org/reference/popover#portal) [`preserveTabOrder`](https://ariakit.org/reference/popover#preservetaborder) popover (e.g., `<Menu portal>`) is rendered within a modal dialog, the user cannot <kbd>Tab</kbd> out of the popover once it receives focus. This happens because the modal dialog disables the tree outside it, including the focus trap elements that allow users to <kbd>Tab</kbd> in and out of the nested popover.

This PR addresses the issue by ignoring focus trap elements in the `disableTreeOutside` function.

See test for more details.