### PR TITLE
Improve performance on DialogBackdrop

### DIFF
--- a/.changeset/4144-dialog-backdrop-performance-improvment.md
+++ b/.changeset/4144-dialog-backdrop-performance-improvment.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Enhanced performance on [Dialog](https://ariakit.org/components/dialog) backdrops.

--- a/packages/ariakit-react-core/src/dialog/dialog-backdrop.tsx
+++ b/packages/ariakit-react-core/src/dialog/dialog-backdrop.tsx
@@ -1,8 +1,9 @@
-import { isValidElement, useRef } from "react";
+import { isValidElement, useEffect, useRef } from "react";
 import { useDisclosureContent } from "../disclosure/disclosure-content.tsx";
 import { useDisclosureStore } from "../disclosure/disclosure-store.ts";
 import { Role } from "../role/role.tsx";
 import { useSafeLayoutEffect } from "../utils/hooks.ts";
+import { useStoreState } from "../utils/store.tsx";
 import type { DialogStore } from "./dialog-store.ts";
 import type { DialogProps } from "./dialog.tsx";
 import { markAncestor } from "./utils/mark-tree-outside.ts";
@@ -20,9 +21,9 @@ export function DialogBackdrop({
 }: DialogBackdropProps) {
   const ref = useRef<HTMLDivElement>(null);
   const disclosure = useDisclosureStore({ disclosure: store });
-  const contentElement = store.useState("contentElement");
+  const contentElement = useStoreState(store, "contentElement");
 
-  useSafeLayoutEffect(() => {
+  useEffect(() => {
     const backdrop = ref.current;
     const dialog = contentElement;
     if (!backdrop) return;


### PR DESCRIPTION
Related to #4075

Although this doesn't fully address the performance issues mentioned in that post, it's probably better to use `useEffect` here anyway. There may be a frame where the backdrop is not visible or is behind some elements if `z-index` values differ, but in that case, users can set a static `z-index` for both the dialog and the backdrop element.

We should continue measuring to see what else we can do.