### PR TITLE
Add scroll restoration functionality to TabPanel

### DIFF
--- a/.changeset/0-4169-tab-panel-scroll-restoration.md
+++ b/.changeset/0-4169-tab-panel-scroll-restoration.md
@@ -1,0 +1,27 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Tab panels with scroll restoration
+
+Ariakit now supports scroll restoration for the [`TabPanel`](https://ariakit.org/reference/tab-panel) component. This allows you to control whether and how the scroll position is restored when switching tabs.
+
+To enable scroll restoration, use the new [`scrollRestoration`](https://ariakit.org/reference/tab-panel#scrollrestoration) prop:
+
+```jsx
+// Restores the scroll position of the tab panel element when switching tabs
+<TabPanel scrollRestoration />
+```
+
+By default, the scroll position is restored when switching tabs. You can set it to `"reset"` to return the scroll position to the top of the tab panel when changing tabs. Use the [`scrollElement`](https://ariakit.org/reference/tab-panel#scrollelement) prop to specify a different scrollable element:
+
+```jsx
+// Resets the scroll position of a different scrollable element
+<div className="overflow-auto">
+  <TabPanel
+    scrollRestoration="reset"
+    scrollElement={(panel) => panel.parentElement}
+  />
+</div>
+```

--- a/examples/tab-panel-scroll-restoration-various/index.tsx
+++ b/examples/tab-panel-scroll-restoration-various/index.tsx
@@ -1,0 +1,520 @@
+import "./style.css";
+import * as Ariakit from "@ariakit/react";
+import clsx from "clsx";
+import { forwardRef, useState } from "react";
+
+function Content() {
+  return (
+    <div className="w-[calc(100%+24px)] opacity-50">
+      {Array.from({ length: 256 }).map((_, i) => `${i} `)}
+    </div>
+  );
+}
+
+const Scroller = forwardRef<HTMLDivElement, Ariakit.RoleProps>(
+  function Scroller(props, ref) {
+    return (
+      <Ariakit.Role
+        ref={ref}
+        {...props}
+        className={clsx(
+          props.className,
+          "!overflow-auto overscroll-contain h-48",
+        )}
+      />
+    );
+  },
+);
+
+const Container = forwardRef<HTMLDivElement, Ariakit.RoleProps>(
+  function Container(props, ref) {
+    return (
+      <Ariakit.Role
+        ref={ref}
+        {...props}
+        className={clsx(
+          props.className,
+          "ak-popup ak-tab-border flex flex-col overflow-clip z-10",
+        )}
+      />
+    );
+  },
+);
+
+const TabList = forwardRef<HTMLDivElement, Ariakit.TabListProps>(
+  function TabList(props, ref) {
+    return (
+      <Ariakit.TabList
+        ref={ref}
+        {...props}
+        className={clsx(props.className, "ak-tab-list ak-popup-cover")}
+      />
+    );
+  },
+);
+
+const Tab = forwardRef<HTMLButtonElement, Ariakit.TabProps>(
+  function Tab(props, ref) {
+    return (
+      <Ariakit.Tab
+        ref={ref}
+        {...props}
+        className={clsx(props.className, "ak-tab ak-tab-default ak-clickable")}
+      />
+    );
+  },
+);
+
+const TabPanel = forwardRef<HTMLDivElement, Ariakit.TabPanelProps>(
+  function TabPanel(props, ref) {
+    return (
+      <Ariakit.TabPanel
+        ref={ref}
+        {...props}
+        className={clsx(
+          props.className,
+          "ak-tab-panel ak-popup-cover ak-popup-layer overflow-clip flex-none",
+        )}
+      >
+        {props.children ?? <Content />}
+      </Ariakit.TabPanel>
+    );
+  },
+);
+
+function Default() {
+  return (
+    <Container>
+      <Ariakit.TabProvider>
+        <TabList aria-label="Default">
+          <Tab>Default 1</Tab>
+          <Tab>Default 2</Tab>
+        </TabList>
+        <TabPanel scrollRestoration render={<Scroller />} />
+        <TabPanel scrollRestoration render={<Scroller />} />
+      </Ariakit.TabProvider>
+    </Container>
+  );
+}
+
+function DefaultReset() {
+  return (
+    <Container>
+      <Ariakit.TabProvider>
+        <TabList aria-label="DefaultReset">
+          <Tab>DefaultReset 1</Tab>
+          <Tab>DefaultReset 2</Tab>
+        </TabList>
+        <TabPanel scrollRestoration="reset" render={<Scroller />} />
+        <TabPanel scrollRestoration="reset" render={<Scroller />} />
+      </Ariakit.TabProvider>
+    </Container>
+  );
+}
+
+function DefaultUnmount() {
+  return (
+    <Container>
+      <Ariakit.TabProvider>
+        <TabList aria-label="DefaultUnmount">
+          <Tab>DefaultUnmount 1</Tab>
+          <Tab>DefaultUnmount 2</Tab>
+        </TabList>
+        <TabPanel scrollRestoration unmountOnHide render={<Scroller />} />
+        <TabPanel scrollRestoration unmountOnHide render={<Scroller />} />
+      </Ariakit.TabProvider>
+    </Container>
+  );
+}
+
+function DefaultUnmountReset() {
+  return (
+    <Container>
+      <Ariakit.TabProvider>
+        <TabList aria-label="DefaultUnmountReset">
+          <Tab>DefaultUnmountReset 1</Tab>
+          <Tab>DefaultUnmountReset 2</Tab>
+        </TabList>
+        <TabPanel
+          scrollRestoration="reset"
+          unmountOnHide
+          render={<Scroller />}
+        />
+        <TabPanel
+          scrollRestoration="reset"
+          unmountOnHide
+          render={<Scroller />}
+        />
+      </Ariakit.TabProvider>
+    </Container>
+  );
+}
+
+function DefaultSingle() {
+  const [tabId, setTabId] = useState<string | null | undefined>();
+  return (
+    <Container>
+      <Ariakit.TabProvider selectedId={tabId} setSelectedId={setTabId}>
+        <TabList aria-label="DefaultSingle">
+          <Tab>DefaultSingle 1</Tab>
+          <Tab>DefaultSingle 2</Tab>
+        </TabList>
+        <TabPanel tabId={tabId} scrollRestoration render={<Scroller />} />
+      </Ariakit.TabProvider>
+    </Container>
+  );
+}
+
+function DefaultSingleReset() {
+  const [tabId, setTabId] = useState<string | null | undefined>();
+  return (
+    <Container>
+      <Ariakit.TabProvider selectedId={tabId} setSelectedId={setTabId}>
+        <TabList aria-label="DefaultSingleReset">
+          <Tab>DefaultSingleReset 1</Tab>
+          <Tab>DefaultSingleReset 2</Tab>
+        </TabList>
+        <TabPanel
+          tabId={tabId}
+          scrollRestoration="reset"
+          render={<Scroller />}
+        />
+      </Ariakit.TabProvider>
+    </Container>
+  );
+}
+
+function Child() {
+  return (
+    <Container>
+      <Ariakit.TabProvider>
+        <TabList aria-label="Child">
+          <Tab>Child 1</Tab>
+          <Tab>Child 2</Tab>
+        </TabList>
+        <TabPanel
+          scrollRestoration
+          scrollElement={(panel) => panel.querySelector(".scroller")}
+        >
+          <Scroller className="scroller">
+            <Content />
+          </Scroller>
+        </TabPanel>
+        <TabPanel
+          scrollRestoration
+          scrollElement={(panel) => panel.querySelector(".scroller")}
+        >
+          <Scroller className="scroller">
+            <Content />
+          </Scroller>
+        </TabPanel>
+      </Ariakit.TabProvider>
+    </Container>
+  );
+}
+
+function ChildReset() {
+  return (
+    <Container>
+      <Ariakit.TabProvider>
+        <TabList aria-label="ChildReset">
+          <Tab>ChildReset 1</Tab>
+          <Tab>ChildReset 2</Tab>
+        </TabList>
+        <TabPanel
+          scrollRestoration="reset"
+          scrollElement={(panel) => panel.querySelector(".scroller")}
+        >
+          <Scroller className="scroller">
+            <Content />
+          </Scroller>
+        </TabPanel>
+        <TabPanel
+          scrollRestoration="reset"
+          scrollElement={(panel) => panel.querySelector(".scroller")}
+        >
+          <Scroller className="scroller">
+            <Content />
+          </Scroller>
+        </TabPanel>
+      </Ariakit.TabProvider>
+    </Container>
+  );
+}
+
+function ChildUnmount() {
+  return (
+    <Container>
+      <Ariakit.TabProvider>
+        <TabList aria-label="ChildUnmount">
+          <Tab>ChildUnmount 1</Tab>
+          <Tab>ChildUnmount 2</Tab>
+        </TabList>
+        <TabPanel
+          scrollRestoration
+          unmountOnHide
+          scrollElement={(panel) => panel.querySelector(".scroller")}
+        >
+          <Scroller className="scroller">
+            <Content />
+          </Scroller>
+        </TabPanel>
+        <TabPanel
+          scrollRestoration
+          unmountOnHide
+          scrollElement={(panel) => panel.querySelector(".scroller")}
+        >
+          <Scroller className="scroller">
+            <Content />
+          </Scroller>
+        </TabPanel>
+      </Ariakit.TabProvider>
+    </Container>
+  );
+}
+
+function ChildUnmountReset() {
+  return (
+    <Container>
+      <Ariakit.TabProvider>
+        <TabList aria-label="ChildUnmountReset">
+          <Tab>ChildUnmountReset 1</Tab>
+          <Tab>ChildUnmountReset 2</Tab>
+        </TabList>
+        <TabPanel
+          scrollRestoration="reset"
+          unmountOnHide
+          scrollElement={(panel) => panel.querySelector(".scroller")}
+        >
+          <Scroller className="scroller">
+            <Content />
+          </Scroller>
+        </TabPanel>
+        <TabPanel
+          scrollRestoration="reset"
+          unmountOnHide
+          scrollElement={(panel) => panel.querySelector(".scroller")}
+        >
+          <Scroller className="scroller">
+            <Content />
+          </Scroller>
+        </TabPanel>
+      </Ariakit.TabProvider>
+    </Container>
+  );
+}
+
+function ChildSingle() {
+  const [tabId, setTabId] = useState<string | null | undefined>();
+  return (
+    <Container>
+      <Ariakit.TabProvider selectedId={tabId} setSelectedId={setTabId}>
+        <TabList aria-label="ChildSingle">
+          <Tab>ChildSingle 1</Tab>
+          <Tab>ChildSingle 2</Tab>
+        </TabList>
+        <TabPanel
+          tabId={tabId}
+          scrollRestoration
+          scrollElement={(panel) => panel.querySelector(".scroller")}
+        >
+          <Scroller key={tabId} className="scroller">
+            <Content />
+          </Scroller>
+        </TabPanel>
+      </Ariakit.TabProvider>
+    </Container>
+  );
+}
+
+function ChildSingleReset() {
+  const [tabId, setTabId] = useState<string | null | undefined>();
+  return (
+    <Container>
+      <Ariakit.TabProvider selectedId={tabId} setSelectedId={setTabId}>
+        <TabList aria-label="ChildSingleReset">
+          <Tab>ChildSingleReset 1</Tab>
+          <Tab>ChildSingleReset 2</Tab>
+        </TabList>
+        <TabPanel
+          tabId={tabId}
+          scrollRestoration="reset"
+          scrollElement={(panel) => panel.querySelector(".scroller")}
+        >
+          <Scroller key={tabId} className="scroller">
+            <Content />
+          </Scroller>
+        </TabPanel>
+      </Ariakit.TabProvider>
+    </Container>
+  );
+}
+
+function Parent() {
+  return (
+    <Container className="overflow-y-auto h-56">
+      <Ariakit.TabProvider>
+        <TabList
+          aria-label="Parent"
+          className="sticky top-[--negative-margin] z-10"
+        >
+          <Tab>Parent 1</Tab>
+          <Tab>Parent 2</Tab>
+        </TabList>
+        <TabPanel
+          scrollRestoration
+          scrollElement={(panel) => panel.parentElement}
+        />
+        <TabPanel
+          scrollRestoration
+          scrollElement={(panel) => panel.parentElement}
+        />
+      </Ariakit.TabProvider>
+    </Container>
+  );
+}
+
+function ParentReset() {
+  return (
+    <Container className="overflow-y-auto h-56">
+      <Ariakit.TabProvider>
+        <TabList
+          aria-label="ParentReset"
+          className="sticky top-[--negative-margin] z-10"
+        >
+          <Tab>ParentReset 1</Tab>
+          <Tab>ParentReset 2</Tab>
+        </TabList>
+        <TabPanel
+          scrollRestoration="reset"
+          scrollElement={(panel) => panel.parentElement}
+        />
+        <TabPanel
+          scrollRestoration="reset"
+          scrollElement={(panel) => panel.parentElement}
+        />
+      </Ariakit.TabProvider>
+    </Container>
+  );
+}
+
+function ParentUnmount() {
+  return (
+    <Container className="overflow-y-auto h-56">
+      <Ariakit.TabProvider>
+        <TabList
+          aria-label="ParentUnmount"
+          className="sticky top-[--negative-margin] z-10"
+        >
+          <Tab>ParentUnmount 1</Tab>
+          <Tab>ParentUnmount 2</Tab>
+        </TabList>
+        <TabPanel
+          scrollRestoration
+          unmountOnHide
+          scrollElement={(panel) => panel.parentElement}
+        />
+        <TabPanel
+          scrollRestoration
+          unmountOnHide
+          scrollElement={(panel) => panel.parentElement}
+        />
+      </Ariakit.TabProvider>
+    </Container>
+  );
+}
+
+function ParentUnmountReset() {
+  return (
+    <Container className="overflow-y-auto h-56">
+      <Ariakit.TabProvider>
+        <TabList
+          aria-label="ParentUnmountReset"
+          className="sticky top-[--negative-margin] z-10"
+        >
+          <Tab>ParentUnmountReset 1</Tab>
+          <Tab>ParentUnmountReset 2</Tab>
+        </TabList>
+        <TabPanel
+          scrollRestoration="reset"
+          unmountOnHide
+          scrollElement={(panel) => panel.parentElement}
+        />
+        <TabPanel
+          scrollRestoration="reset"
+          unmountOnHide
+          scrollElement={(panel) => panel.parentElement}
+        />
+      </Ariakit.TabProvider>
+    </Container>
+  );
+}
+
+function ParentSingle() {
+  const [tabId, setTabId] = useState<string | null | undefined>();
+  return (
+    <Container className="overflow-y-auto h-56">
+      <Ariakit.TabProvider selectedId={tabId} setSelectedId={setTabId}>
+        <TabList
+          aria-label="ParentSingle"
+          className="sticky top-[--negative-margin] z-10"
+        >
+          <Tab>ParentSingle 1</Tab>
+          <Tab>ParentSingle 2</Tab>
+        </TabList>
+        <TabPanel
+          tabId={tabId}
+          scrollRestoration
+          scrollElement={(panel) => panel.parentElement}
+        />
+      </Ariakit.TabProvider>
+    </Container>
+  );
+}
+
+function ParentSingleReset() {
+  const [tabId, setTabId] = useState<string | null | undefined>();
+  return (
+    <Container className="overflow-y-auto h-56">
+      <Ariakit.TabProvider selectedId={tabId} setSelectedId={setTabId}>
+        <TabList
+          aria-label="ParentSingleReset"
+          className="sticky top-[--negative-margin] z-10"
+        >
+          <Tab>ParentSingleReset 1</Tab>
+          <Tab>ParentSingleReset 2</Tab>
+        </TabList>
+        <TabPanel
+          tabId={tabId}
+          scrollRestoration="reset"
+          scrollElement={(panel) => panel.parentElement}
+        />
+      </Ariakit.TabProvider>
+    </Container>
+  );
+}
+
+export default function Example() {
+  return (
+    <div className="grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] gap-2 w-[768px] max-w-full">
+      <Default />
+      <DefaultReset />
+      <DefaultUnmount />
+      <DefaultUnmountReset />
+      <DefaultSingle />
+      <DefaultSingleReset />
+      <Child />
+      <ChildReset />
+      <ChildUnmount />
+      <ChildUnmountReset />
+      <ChildSingle />
+      <ChildSingleReset />
+      <Parent />
+      <ParentReset />
+      <ParentUnmount />
+      <ParentUnmountReset />
+      <ParentSingle />
+      <ParentSingleReset />
+    </div>
+  );
+}

--- a/examples/tab-panel-scroll-restoration-various/style.css
+++ b/examples/tab-panel-scroll-restoration-various/style.css
@@ -1,0 +1,1 @@
+@import url("../theme.css");

--- a/examples/tab-panel-scroll-restoration-various/test-chrome-firefox.ts
+++ b/examples/tab-panel-scroll-restoration-various/test-chrome-firefox.ts
@@ -1,0 +1,89 @@
+import {
+  type Locator,
+  type Page,
+  expect,
+  query,
+} from "@ariakit/test/playwright";
+import { test } from "../test-utils.ts";
+
+function getScrollElement(page: Page, name: string) {
+  const q = query(page);
+  if (name.startsWith("Default")) {
+    return q.tabpanel(name);
+  }
+  if (name.startsWith("Child")) {
+    return q.tabpanel(name).locator("div").first();
+  }
+  return q.tabpanel(name).locator("..");
+}
+
+function scroll(locator: Locator, x: number, y: number) {
+  return locator.evaluate(
+    (el, [x, y]) => {
+      el.scrollLeft = x;
+      el.scrollTop = y;
+    },
+    [x, y] as const,
+  );
+}
+
+function getScrollPosition(locator: Locator) {
+  return locator.evaluate((el) => [el.scrollLeft, el.scrollTop]);
+}
+
+for (const scrollElement of ["Default", "Child", "Parent"]) {
+  const scrollX = scrollElement === "Parent" ? 0 : 5;
+  const scrollY = 100;
+
+  for (const restore of ["", "Unmount", "Single"]) {
+    const name = `${scrollElement}${restore}`;
+    const tabs = [`${name} 1`, `${name} 2`];
+
+    for (const tab of tabs) {
+      test(`Restore scroll on ${tab}`, async ({ page }) => {
+        const q = query(page);
+
+        await q.tab(tab).click();
+        await expect(q.tabpanel(tab)).toBeVisible();
+
+        const scroller = getScrollElement(page, tab);
+        await scroll(scroller, scrollX, scrollY);
+
+        const otherTab = tabs.find((t) => t !== tab);
+        await q.tab(otherTab).click();
+        await expect(q.tabpanel(otherTab)).toBeVisible();
+        await expect(q.tabpanel(tab)).not.toBeVisible();
+        await q.tab(tab).click();
+        await expect(q.tabpanel(tab)).toBeVisible();
+
+        expect(await getScrollPosition(scroller)).toEqual([scrollX, scrollY]);
+      });
+    }
+  }
+
+  for (const reset of ["Reset", "UnmountReset", "SingleReset"]) {
+    const name = `${scrollElement}${reset}`;
+    const tabs = [`${name} 1`, `${name} 2`];
+
+    for (const tab of tabs) {
+      test(`Reset scroll on ${tab}`, async ({ page }) => {
+        const q = query(page);
+
+        await q.tab(tab).click();
+        await expect(q.tabpanel(tab)).toBeVisible();
+
+        const scroller = getScrollElement(page, tab);
+        await scroll(scroller, scrollX, scrollY);
+
+        const otherTab = tabs.find((t) => t !== tab);
+        await q.tab(otherTab).click();
+        await expect(q.tabpanel(otherTab)).toBeVisible();
+        await expect(q.tabpanel(tab)).not.toBeVisible();
+        await q.tab(tab).click();
+        await expect(q.tabpanel(tab)).toBeVisible();
+
+        expect(await getScrollPosition(scroller)).toEqual([0, 0]);
+      });
+    }
+  }
+}

--- a/examples/theme.css
+++ b/examples/theme.css
@@ -438,7 +438,8 @@
       margin-block-start: var(--negative-margin);
     }
 
-    &:last-child {
+    &:has(+ &),
+    &:not(:has(~ *:not([hidden]))) {
       margin-block-end: var(--negative-margin);
     }
   }
@@ -524,6 +525,19 @@
   }
 
   /* Tabs */
+  .ak-tab-list {
+    display: flex;
+    flex: none;
+    overflow-x: auto;
+    background-image: linear-gradient(
+      to bottom,
+      var(--popup-background) calc(100% - var(--padding) - 1px),
+      var(--border) calc(100% - var(--padding) - 1px),
+      var(--border) calc(100% - var(--padding)),
+      transparent calc(100% - var(--padding))
+    );
+  }
+
   .ak-tab {
     position: relative;
     display: inline-block;

--- a/packages/ariakit-react-core/src/disclosure/disclosure-content.tsx
+++ b/packages/ariakit-react-core/src/disclosure/disclosure-content.tsx
@@ -217,7 +217,9 @@ export const useDisclosureContent = createHook<
   const hidden = isHidden(mounted, props.hidden, alwaysVisible);
   const styleProp = props.style;
   const style = useMemo(() => {
-    if (hidden) return { ...styleProp, display: "none" };
+    if (hidden) {
+      return { ...styleProp, display: "none" };
+    }
     return styleProp;
   }, [hidden, styleProp]);
 

--- a/packages/ariakit-react-core/src/tab/tab-panel.tsx
+++ b/packages/ariakit-react-core/src/tab/tab-panel.tsx
@@ -72,6 +72,9 @@ export const useTabPanel = createHook<TagName, TabPanelOptions>(
       (state) => !!tabId && state.selectedId === tabId,
     );
 
+    const disclosure = useDisclosureStore({ open });
+    const mounted = useStoreState(disclosure, "mounted");
+
     // Store the scroll position for each tabId. The component may receive
     // different tab ids if it's a single tab panel with dynamic tab id and
     // content.
@@ -95,18 +98,18 @@ export const useTabPanel = createHook<TagName, TabPanelOptions>(
     // Adds scroll restoration behavior to the tab panel.
     useEffect(() => {
       if (!scrollRestoration) return;
-      if (!open) return;
+      if (!mounted) return;
       const element = getScrollElement();
       if (!element) return;
       // If scrollRestoration is set to "reset", scroll to the top of the
       // element and return early.
       if (scrollRestoration === "reset") {
-        element.scrollTo(0, 0);
+        element.scroll(0, 0);
         return;
       }
       if (!tabId) return;
       const position = scrollPositionRef.current.get(tabId);
-      element.scrollTo(position?.x ?? 0, position?.y ?? 0);
+      element.scroll(position?.x ?? 0, position?.y ?? 0);
       // On scroll, save the scroll position for the current tab id.
       const onScroll = () => {
         scrollPositionRef.current.set(tabId, {
@@ -118,7 +121,7 @@ export const useTabPanel = createHook<TagName, TabPanelOptions>(
       return () => {
         element.removeEventListener("scroll", onScroll);
       };
-    }, [scrollRestoration, open, tabId, getScrollElement, store]);
+    }, [scrollRestoration, mounted, tabId, getScrollElement, store]);
 
     const [hasTabbableChildren, setHasTabbableChildren] = useState(false);
 
@@ -170,9 +173,6 @@ export const useTabPanel = createHook<TagName, TabPanelOptions>(
       ),
       [store],
     );
-
-    const disclosure = useDisclosureStore({ open });
-    const mounted = useStoreState(disclosure, "mounted");
 
     props = {
       id,

--- a/packages/ariakit-react-core/src/tab/tab-panel.tsx
+++ b/packages/ariakit-react-core/src/tab/tab-panel.tsx
@@ -1,7 +1,7 @@
 import { getAllTabbableIn } from "@ariakit/core/utils/focus";
 import { invariant } from "@ariakit/core/utils/misc";
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { ElementType, KeyboardEvent } from "react";
+import type { ElementType, KeyboardEvent, RefObject } from "react";
 import type { CollectionItemOptions } from "../collection/collection-item.tsx";
 import { useCollectionItem } from "../collection/collection-item.tsx";
 import type { DisclosureContentOptions } from "../disclosure/disclosure-content.tsx";
@@ -47,6 +47,8 @@ export const useTabPanel = createHook<TagName, TabPanelOptions>(
     unmountOnHide,
     tabId: tabIdProp,
     getItem: getItemProp,
+    scrollRestoration,
+    scrollElement,
     ...props
   }) {
     const context = useTabProviderContext();
@@ -60,6 +62,63 @@ export const useTabPanel = createHook<TagName, TabPanelOptions>(
 
     const ref = useRef<HTMLType>(null);
     const id = useId(props.id);
+
+    const tabId = useStoreState(
+      store.panels,
+      () => tabIdProp || store?.panels.item(id)?.tabId,
+    );
+    const open = useStoreState(
+      store,
+      (state) => !!tabId && state.selectedId === tabId,
+    );
+
+    // Store the scroll position for each tabId. The component may receive
+    // different tab ids if it's a single tab panel with dynamic tab id and
+    // content.
+    const scrollPositionRef = useRef<Map<string, { x: number; y: number }>>(
+      new Map(),
+    );
+
+    const getScrollElement = useEvent(() => {
+      const panelElement = ref.current;
+      if (!panelElement) return null;
+      if (!scrollElement) return panelElement;
+      if (typeof scrollElement === "function") {
+        return scrollElement(panelElement);
+      }
+      if ("current" in scrollElement) {
+        return scrollElement.current;
+      }
+      return scrollElement;
+    });
+
+    // Adds scroll restoration behavior to the tab panel.
+    useEffect(() => {
+      if (!scrollRestoration) return;
+      if (!open) return;
+      const element = getScrollElement();
+      if (!element) return;
+      // If scrollRestoration is set to "reset", scroll to the top of the
+      // element and return early.
+      if (scrollRestoration === "reset") {
+        element.scrollTo(0, 0);
+        return;
+      }
+      if (!tabId) return;
+      const position = scrollPositionRef.current.get(tabId);
+      element.scrollTo(position?.x ?? 0, position?.y ?? 0);
+      // On scroll, save the scroll position for the current tab id.
+      const onScroll = () => {
+        scrollPositionRef.current.set(tabId, {
+          x: element.scrollLeft,
+          y: element.scrollTop,
+        });
+      };
+      element.addEventListener("scroll", onScroll);
+      return () => {
+        element.removeEventListener("scroll", onScroll);
+      };
+    }, [scrollRestoration, open, tabId, getScrollElement, store]);
 
     const [hasTabbableChildren, setHasTabbableChildren] = useState(false);
 
@@ -110,15 +169,6 @@ export const useTabPanel = createHook<TagName, TabPanelOptions>(
         </TabScopedContextProvider>
       ),
       [store],
-    );
-
-    const tabId = useStoreState(
-      store.panels,
-      () => tabIdProp || store?.panels.item(id)?.tabId,
-    );
-    const open = useStoreState(
-      store,
-      (state) => !!tabId && state.selectedId === tabId,
     );
 
     const disclosure = useDisclosureStore({ open });
@@ -207,6 +257,47 @@ export interface TabPanelOptions<T extends ElementType = TagName>
    *   Tabs](https://ariakit.org/examples/select-combobox-tab)
    */
   tabId?: string | null;
+  /**
+   * Manages the scrolling behavior of the tab panel when it is hidden and then
+   * shown again.
+   *
+   * This is especially useful when using a single tab panel for multiple tabs,
+   * where you dynamically change the
+   * [`tabId`](https://ariakit.org/reference/tab-panel#tabid) prop and the
+   * panel's children, which would otherwise retain the current scroll position
+   * when switching tabs.
+   *
+   * When set to `true`, the component will save the scroll position and restore
+   * it when the panel is shown again. When set to `"reset"`, the scroll
+   * position will reset to the top when the panel is displayed again.
+   *
+   * The default scroll element is the tab panel itself. To scroll a different
+   * element, use the
+   * [`scrollElement`](https://ariakit.org/reference/tab-panel#scrollelement)
+   * prop.
+   * @default false
+   */
+  scrollRestoration?: boolean | "reset";
+  /**
+   * When using the
+   * [`scrollRestoration`](https://ariakit.org/reference/tab-panel#scrollrestoration)
+   * prop, the tab panel element serves as the default scroll element. You can
+   * use this prop to designate a different element for scrolling.
+   *
+   * If a function is provided, it will be called with the tab panel element as
+   * an argument. The function should return the element to scroll.
+   * @example
+   * ```jsx
+   * <TabPanel
+   *   scrollRestoration
+   *   scrollElement={(panel) => panel.querySelector(".scrollable")}
+   * />
+   * ```
+   */
+  scrollElement?:
+    | HTMLElement
+    | RefObject<HTMLElement>
+    | ((panel: HTMLElement) => HTMLElement | null);
 }
 
 export type TabPanelProps<T extends ElementType = TagName> = Props<

--- a/website/components/playground-client.tsx
+++ b/website/components/playground-client.tsx
@@ -371,6 +371,8 @@ export function PlaygroundClient({
               ref={tabPanelRef}
               store={tab}
               tabId={selectedId}
+              scrollRestoration
+              scrollElement={(panel) => panel.querySelector("pre")}
               className={twJoin(
                 collapsed
                   ? "[--max-height:256px] [[data-level='1']_&]:md:[--max-height:440px]"


### PR DESCRIPTION
Ariakit now supports scroll restoration for the [`TabPanel`](https://ariakit.org/reference/tab-panel) component. This allows you to control whether and how the scroll position is restored when switching tabs.

To enable scroll restoration, use the new [`scrollRestoration`](https://ariakit.org/reference/tab-panel#scrollrestoration) prop:

```jsx
// Restores the scroll position of the tab panel element when switching tabs
<TabPanel scrollRestoration />
```

By default, the scroll position is restored when switching tabs. You can set it to `"reset"` to return the scroll position to the top of the tab panel when changing tabs. Use the [`scrollElement`](https://ariakit.org/reference/tab-panel#scrollelement) prop to specify a different scrollable element:

```jsx
// Resets the scroll position of a different scrollable element
<div className="overflow-auto">
  <TabPanel
    scrollRestoration="reset"
    scrollElement={(panel) => panel.parentElement}
  />
</div>
```
