### PR TITLE
Fix `collectionStore.item()` getting out of sync with current items

### DIFF
--- a/.changeset/4202-collection-store-item-out-of-sync.md
+++ b/.changeset/4202-collection-store-item-out-of-sync.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+"@ariakit/core": patch
+---
+
+Fixed the [`item`](https://ariakit.org/reference/use-collection-store#item) method to prevent it from returning items that have been removed from the collection store.

--- a/packages/ariakit-core/src/collection/collection-store.ts
+++ b/packages/ariakit-core/src/collection/collection-store.ts
@@ -222,7 +222,7 @@ export function createCollectionStore<
       if (!id) return null;
       let item = itemsMap.get(id);
       if (!item) {
-        const { items } = collection.getState();
+        const { items } = privateStore.getState();
         item = items.find((item) => item.id === id);
         if (item) {
           itemsMap.set(id, item);

--- a/packages/ariakit-react-core/src/composite/composite-item.tsx
+++ b/packages/ariakit-react-core/src/composite/composite-item.tsx
@@ -403,7 +403,7 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
       // https://github.com/ariakit/ariakit/issues/4129
       const item = store?.item(state.activeId);
       if (item?.disabled) return true;
-      if (!item?.element?.isConnected) return true;
+      if (!item?.element) return true;
       return state.activeId === id;
     });
 


### PR DESCRIPTION
Currently, calling `store.item(id)` may return an item that has been previously removed from the collection/composite store. This occurs because we were searching for the item in the public store, which may lag behind the private store where items are registered synchronously one by one (this prevents multiple unnecessary updates when rendering several items).

This PR modifies the `item` method logic to use the private store instead of the batched public store.

I also updated the tabbable logic introduced in #4191 to consider only `item?.element` instead of `item?.element?.isConnected`. This is because when `isConnected` changes, it doesn't always trigger the `useStoreState` callback, as the component may not re-render or the state may not update in response to this DOM change.