### PR TITLE
Fix menu store not syncing internal items

### DIFF
--- a/.changeset/4211-menu-store-sync-private-store.md
+++ b/.changeset/4211-menu-store-sync-private-store.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+"@ariakit/core": patch
+---
+
+Fixed the [`item`](https://ariakit.org/reference/use-menu-store#item) method when keeping different menu stores in sync.

--- a/examples/menubar-navigation/menubar.tsx
+++ b/examples/menubar-navigation/menubar.tsx
@@ -32,7 +32,6 @@ export const Menubar = React.forwardRef<HTMLDivElement, MenubarProps>(
         <SetShiftContext.Provider value={setShift}>
           <SetPlacementContext.Provider value={setPlacement}>
             <Ariakit.MenuProvider
-              animated
               placement={placement}
               showTimeout={100}
               hideTimeout={250}

--- a/examples/menubar-navigation/test-browser.ts
+++ b/examples/menubar-navigation/test-browser.ts
@@ -1,5 +1,5 @@
-import type { Locator, Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
+import { type Page, expect, query } from "@ariakit/test/playwright";
+import { test } from "../test-utils.ts";
 
 function pressTab(page: Page, browserName: string, shift = false) {
   const key = shift ? "Shift+Tab" : "Tab";
@@ -7,14 +7,6 @@ function pressTab(page: Page, browserName: string, shift = false) {
     return page.keyboard.press(`Alt+${key}`);
   }
   return page.keyboard.press(key);
-}
-
-function query(locator: Page | Locator) {
-  return {
-    menu: (name: string) => locator.getByRole("menu", { name }),
-    menuitem: (name: string) =>
-      locator.getByRole("menuitem", { name, includeHidden: true }),
-  };
 }
 
 test.beforeEach(async ({ page }) => {
@@ -183,4 +175,20 @@ test("click on menuitem links", async ({ page, browserName }) => {
   await page.keyboard.press("Enter");
   await expect(q.menu("Services")).not.toBeVisible();
   await expect(q.menuitem("Services")).toBeFocused();
+});
+
+test("moving between menu items with arrow keys", async ({ page }) => {
+  const q = query(page);
+
+  await q.menuitem("Blog").click();
+  await expect(q.menu("Blog")).toBeVisible();
+
+  await page.keyboard.press("ArrowDown");
+  await expect(q.menuitem("Tech")).toBeFocused();
+
+  await page.keyboard.press("ArrowDown");
+  await expect(q.menuitem("Business")).toBeFocused();
+
+  await page.keyboard.press("ArrowDown");
+  await expect(q.menuitem("Archives")).toBeFocused();
 });

--- a/examples/menubar-navigation/test-browser.ts
+++ b/examples/menubar-navigation/test-browser.ts
@@ -9,10 +9,6 @@ function pressTab(page: Page, browserName: string, shift = false) {
   return page.keyboard.press(key);
 }
 
-test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/menubar-navigation", { waitUntil: "networkidle" });
-});
-
 test.describe.configure({ retries: 2 });
 
 test("show menus by hovering over items without moving focus", async ({

--- a/packages/ariakit-core/src/utils/store.ts
+++ b/packages/ariakit-core/src/utils/store.ts
@@ -340,7 +340,7 @@ export function mergeStore<S extends State>(
     return Object.assign(state, nextState);
   }, {} as S);
   const store = createStore(initialState, ...stores);
-  return store;
+  return Object.assign({}, ...stores, store);
 }
 
 /**


### PR DESCRIPTION
The `menuStore.item(id)` method isn't working on menu stores synced with other menu stores using the `store` prop.

This issue arises because the `__unstablePrivateStore` property (or any other custom property) wasn't being copied to the new store object when using `mergeStore`. This PR updates `mergeStore` to use `Object.assign`, ensuring the resulting store includes properties from the merged store objects.