### PR TITLE
Add missing gitignore entry (store)

### DIFF
--- a/packages/ariakit-react/.gitignore
+++ b/packages/ariakit-react/.gitignore
@@ -23,6 +23,7 @@
 /role
 /select
 /separator
+/store
 /tab
 /toolbar
 /tooltip


### PR DESCRIPTION
This has been missing from the gitignore for a while. Generated with the "clean" script.