### PR TITLE
Update TypeScript config to support alternative jsx sources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25131,6 +25131,7 @@
     "packages/tmp-solid-ts-issue-repro": {
       "version": "0.0.1",
       "dependencies": {
+        "@ariakit/core": "0.4.14",
         "solid-js": "^1.8"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -21144,6 +21144,27 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/seroval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.2.0.tgz",
+      "integrity": "sha512-GURoU99ko2UiAgUC3qDCk59Jb3Ss4Po8VIMGkG8j5PFo2Q7y0YSMP8QG9NuL/fJCoTz9V1XZUbpNIMXPOfaGpA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/seroval-plugins": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.2.0.tgz",
+      "integrity": "sha512-hULTbfzSe81jGWLH8TAJjkEvw6JWMqOo9Uq+4V4vg+HNq53hyHldM9ZOfjdzokcFysiTp9aFdV2vJpZFqKeDjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "seroval": "^1.0"
+      }
+    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "license": "ISC"
@@ -21553,6 +21574,17 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/solid-js": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.4.tgz",
+      "integrity": "sha512-ipQl8FJ31bFUoBNScDQTG3BjN6+9Rg+Q+f10bUbnO6EOTTf5NGerJeHc7wyu5I4RMHEl/WwZwUmy/PTRgxxZ8g==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.0",
+        "seroval": "^1.1.0",
+        "seroval-plugins": "^1.1.0"
       }
     },
     "node_modules/sort-keys": {
@@ -22915,6 +22947,10 @@
       "engines": {
         "node": ">=0.6.0"
       }
+    },
+    "node_modules/tmp-solid-ts-issue-repro": {
+      "resolved": "packages/tmp-solid-ts-issue-repro",
+      "link": true
     },
     "node_modules/to-no-case": {
       "version": "1.0.2",
@@ -25090,6 +25126,12 @@
         "react": {
           "optional": true
         }
+      }
+    },
+    "packages/tmp-solid-ts-issue-repro": {
+      "version": "0.0.1",
+      "dependencies": {
+        "solid-js": "^1.8"
       }
     },
     "website": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lint": "biome check .",
     "lint-fix": "biome check --write .",
     "lint-css": "stylelint '**/*.css' --ignore-path .gitignore",
-    "tsc": "conc -r 'tsc --noEmit' 'tsc --noEmit -p website/tsconfig.json'",
+    "tsc": "conc -r 'tsc' 'tsc -p website' 'tsc -p packages/*solid*'",
     "tsc-clean": "tsc --build --clean",
     "build": "lerna exec --scope @ariakit/* -- npm run build",
     "build-website": "npm run build --prefix website",

--- a/packages/tmp-solid-ts-issue-repro/README.md
+++ b/packages/tmp-solid-ts-issue-repro/README.md
@@ -1,0 +1,3 @@
+This is a temporary package meant to reproduce the Solid TS issue.
+
+See: <https://github.com/ariakit/ariakit/pull/4360#issuecomment-2581681491>

--- a/packages/tmp-solid-ts-issue-repro/package.json
+++ b/packages/tmp-solid-ts-issue-repro/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "type": "module",
   "dependencies": {
+    "@ariakit/core": "0.4.14",
     "solid-js": "^1.8"
   }
 }

--- a/packages/tmp-solid-ts-issue-repro/package.json
+++ b/packages/tmp-solid-ts-issue-repro/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "tmp-solid-ts-issue-repro",
+  "version": "0.0.1",
+  "type": "module",
+  "dependencies": {
+    "solid-js": "^1.8"
+  }
+}

--- a/packages/tmp-solid-ts-issue-repro/src/example.tsx
+++ b/packages/tmp-solid-ts-issue-repro/src/example.tsx
@@ -1,7 +1,11 @@
 import { Dynamic } from "solid-js/web";
 
 function App() {
-  return <Dynamic component="a" />;
+  return (
+    <div>
+      <Dynamic component="a" />
+    </div>
+  );
 }
 
 <App />;

--- a/packages/tmp-solid-ts-issue-repro/src/example.tsx
+++ b/packages/tmp-solid-ts-issue-repro/src/example.tsx
@@ -1,4 +1,7 @@
+import { createTooltipStore } from "@ariakit/core/tooltip/tooltip-store";
 import { Dynamic } from "solid-js/web";
+
+createTooltipStore("wrong argument");
 
 function App() {
   return (

--- a/packages/tmp-solid-ts-issue-repro/src/example.tsx
+++ b/packages/tmp-solid-ts-issue-repro/src/example.tsx
@@ -1,0 +1,7 @@
+import { Dynamic } from "solid-js/web";
+
+function App() {
+  return <Dynamic component="a" />;
+}
+
+<App />;

--- a/packages/tmp-solid-ts-issue-repro/src/example.tsx
+++ b/packages/tmp-solid-ts-issue-repro/src/example.tsx
@@ -1,7 +1,7 @@
 import { createTooltipStore } from "@ariakit/core/tooltip/tooltip-store";
 import { Dynamic } from "solid-js/web";
 
-createTooltipStore("wrong argument");
+createTooltipStore();
 
 function App() {
   return (

--- a/packages/tmp-solid-ts-issue-repro/tsconfig.json
+++ b/packages/tmp-solid-ts-issue-repro/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js"
+  },
+  "include": ["src"]
+}

--- a/packages/tmp-solid-ts-issue-repro/tsconfig.json
+++ b/packages/tmp-solid-ts-issue-repro/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "composite": true,
-    "jsx": "preserve",
-    "jsxImportSource": "solid-js"
+    "jsx": "preserve"
   },
   "include": ["src"]
 }

--- a/packages/tmp-solid-ts-issue-repro/tsconfig.json
+++ b/packages/tmp-solid-ts-issue-repro/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "jsx": "preserve",
     "jsxImportSource": "solid-js"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": []
 }

--- a/packages/tmp-solid-ts-issue-repro/tsconfig.json
+++ b/packages/tmp-solid-ts-issue-repro/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "composite": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js"
   },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,5 +33,5 @@
     "**/*.cjs",
     "**/*.mjs"
   ],
-  "exclude": ["node_modules", "website", "packages/*solid*", "coverage"]
+  "exclude": ["node_modules", "coverage", "website", "packages/*solid*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,5 +33,5 @@
     "**/*.cjs",
     "**/*.mjs"
   ],
-  "exclude": ["node_modules", "website", "coverage"]
+  "exclude": ["node_modules", "website", "packages/*solid*", "coverage"]
 }


### PR DESCRIPTION
Closes #4360
Closes #4363

This is my attempt to support alternative JSX sources in the TypeScript config with minimal changes to the repository. I'm trying to avoid project references because they don't support `noEmit` and add extra complexity to the project.

In the future, we can switch to project references if they improve. For now, running `tsc -p` concurrently and excluding certain paths from the root project seems simpler and faster.

cc @paularmstrong @DaniGuardiola 