### PR TITLE
[Solid] Util improvements

### DIFF
--- a/packages/ariakit-solid-core/src/group/group-label.tsx
+++ b/packages/ariakit-solid-core/src/group/group-label.tsx
@@ -36,16 +36,14 @@ export const useGroupLabel = createHook<TagName, GroupLabelOptions>(
 
     props = mergeProps(
       {
-        get id() {
-          return id();
-        },
+        $id: id,
         "aria-hidden": true,
       },
       props,
     );
 
     // [port]: no need to remove undefined values because `mergeProps` handles it.
-    // TODO: verify that the note above is true.
+    // TODO: verify that the note above is true. It might actually be because Solid just doesn't render undefined props, but if that's the case it could cause issues with further prop chaining.
     return props;
   },
 );

--- a/packages/ariakit-solid-core/src/group/group.tsx
+++ b/packages/ariakit-solid-core/src/group/group.tsx
@@ -31,13 +31,13 @@ export const useGroup = createHook<TagName, GroupOptions>(
       {
         // [port]: Solid type for `role` is more strict, hence the `as const`.
         role: "group" as const,
-        get "aria-labelledby"() {
-          return labelId();
-        },
+        "$aria-labelledby": labelId,
       },
       props,
     );
 
+    // [port]: no need to remove undefined values because `mergeProps` handles it.
+    // TODO: verify that the note above is true. It might actually be because Solid just doesn't render undefined props, but if that's the case it could cause issues with further prop chaining.
     return props;
   },
 );

--- a/packages/ariakit-solid-core/src/separator/separator.tsx
+++ b/packages/ariakit-solid-core/src/separator/separator.tsx
@@ -23,9 +23,7 @@ export const useSeparator = createHook<TagName, SeparatorOptions>(
         {
           // [port]: Solid type for `role` is more strict, hence the `as const`.
           role: "separator" as const,
-          get "aria-orientation"() {
-            return options.orientation;
-          },
+          "$aria-orientation": () => options.orientation,
         },
         props,
       );

--- a/packages/ariakit-solid-core/src/utils/misc.ts
+++ b/packages/ariakit-solid-core/src/utils/misc.ts
@@ -11,6 +11,20 @@ import {
 import type { WrapInstance, WrapInstanceValue } from "./types.ts";
 
 /**
+ * Sets both a function and "object" ref.
+ */
+export function setRef<T>(
+  ref: ((element: T) => void) | RefObject<T> | undefined,
+  value: T,
+) {
+  if (typeof ref === "function") {
+    ref(value);
+  } else if (ref) {
+    ref.current = value;
+  }
+}
+
+/**
  * Creates a stable accessor. Useful when creating derived accessors that
  * depend on a mutable variable that may change later.
  * @example

--- a/packages/ariakit-solid-core/src/utils/misc.ts
+++ b/packages/ariakit-solid-core/src/utils/misc.ts
@@ -168,6 +168,7 @@ export type RefObject<T> = {
  * ```
  */
 export function createRef<T>(): RefObject<T | undefined>;
+export function createRef<T>(initialValue: T | null): RefObject<T | null>;
 export function createRef<T>(initialValue: T): RefObject<T>;
 export function createRef<T>(initialValue?: any): RefObject<T> {
   let value = initialValue;


### PR DESCRIPTION
Parent: #4378

- `setRef`
- support `null` in `createRef`
- support special dollar syntax for expanding getters in `mergeProps`
- misc fixes, cleanups, and comments