### PR TITLE
Prepend length to dynamic deps for hooks

### DIFF
--- a/packages/ariakit-react-core/src/utils/hooks.ts
+++ b/packages/ariakit-react-core/src/utils/hooks.ts
@@ -156,7 +156,7 @@ export function useMergeRefs(...refs: Array<Ref<any> | undefined>) {
         setRef(ref, value);
       }
     };
-  }, refs);
+  }, [refs.length, ...refs]);
 }
 
 /**
@@ -269,12 +269,15 @@ export function useAttribute(
 export function useUpdateEffect(effect: EffectCallback, deps?: DependencyList) {
   const mounted = useRef(false);
 
-  useEffect(() => {
-    if (mounted.current) {
-      return effect();
-    }
-    mounted.current = true;
-  }, deps);
+  useEffect(
+    () => {
+      if (mounted.current) {
+        return effect();
+      }
+      mounted.current = true;
+    },
+    deps && [deps.length, ...deps],
+  );
 
   useEffect(
     () => () => {
@@ -293,12 +296,15 @@ export function useUpdateLayoutEffect(
 ) {
   const mounted = useRef(false);
 
-  useSafeLayoutEffect(() => {
-    if (mounted.current) {
-      return effect();
-    }
-    mounted.current = true;
-  }, deps);
+  useSafeLayoutEffect(
+    () => {
+      if (mounted.current) {
+        return effect();
+      }
+      mounted.current = true;
+    },
+    deps && [deps.length, ...deps],
+  );
 
   useSafeLayoutEffect(
     () => () => {


### PR DESCRIPTION
React only checks up to the length of the previously passed deps. When deps are dynamic, we need to pass the length as the first element, so that appended deps will trigger the hook.

I did not hit this bug in practice in Ariakit, but I've hit it in separate projects, so I noticed it while reading the Ariakit source code.

Here is the loop that counts up to `prevDeps.length`:

https://github.com/facebook/react/blob/9ff42a8798863c995523e284142b47e3cdfaee80/packages/react-reconciler/src/ReactFiberHooks.js#L524