### PR TITLE
Clean up test loader logic.

### DIFF
--- a/packages/ariakit-test/src/__tests__/blur-test.react.tsx
+++ b/packages/ariakit-test/src/__tests__/blur-test.react.tsx
@@ -3,9 +3,7 @@ import { blur } from "../blur.ts";
 import { q, render } from "../react.tsx";
 import { useAllEvents } from "./use-all-events.ts";
 
-test("blur", async ({ skip }) => {
-  if (loader !== "react") skip();
-
+test("blur", async () => {
   const stack: string[] = [];
 
   const Test = () => {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -9,6 +9,7 @@ import {
   render as renderSolid,
 } from "solid-js/web";
 import failOnConsole from "vitest-fail-on-console";
+import type { AllowedTestLoader } from "./vitest.config.ts";
 
 if (!version.startsWith("17")) {
   failOnConsole();
@@ -58,18 +59,6 @@ if (version.startsWith("17")) {
     };
     return { ...mocks, ...actual };
   });
-}
-
-const ALLOWED_TEST_LOADERS = ["react", "solid"] as const;
-type AllowedTestLoader = (typeof ALLOWED_TEST_LOADERS)[number];
-declare global {
-  var loader: AllowedTestLoader;
-}
-const TEST_LOADER = (process.env.ARIAKIT_TEST_LOADER ??
-  "react") as AllowedTestLoader;
-globalThis.loader = TEST_LOADER;
-if (!ALLOWED_TEST_LOADERS.includes(TEST_LOADER)) {
-  throw new Error(`Invalid loader: ${TEST_LOADER}`);
 }
 
 async function tryImport(path: string, fallbackPath?: string) {
@@ -160,12 +149,15 @@ function parseTest(filename?: string) {
   };
 }
 
+const LOADER = (process.env.ARIAKIT_TEST_LOADER ??
+  "react") as AllowedTestLoader;
+
 beforeEach(async ({ task, skip }) => {
   const parseResult = parseTest(task.file?.name);
   if (!parseResult) return;
   const { dir, loader } = parseResult;
-  if (loader !== "all" && loader !== TEST_LOADER) skip();
-  const result = await LOADERS[TEST_LOADER](dir);
+  if (loader !== "all" && loader !== LOADER) skip();
+  const result = await LOADERS[LOADER](dir);
   if (result === false) skip();
   return result;
 });


### PR DESCRIPTION
Following #4400 up, this PR cleans up the test loader logic in a few ways:

- Instead of relying on a global variable, test files can be explicitly made exclusive to a loader by adding a suffix, e.g. `something-test.react.tsx` or `something-test.solid.tsx`. The "blur test" file was updated to reflect this pattern.
- Centralized loader logic and types in config file rather than setup.
- Cleaned up config a bit, leaning into the idea that it will always be run with a "loader" as parameter in a "matrix" type setup. E.g. `PLUGINS_BY_LOADER`.