### PR TITLE
Prevent private exports in `package.json`

### DIFF
--- a/scripts/build/utils.js
+++ b/scripts/build/utils.js
@@ -56,8 +56,11 @@ export function getPackageJson(rootPath, prod = false) {
     };
   };
 
+  const PRIVATE_REGEXP = /(^_|\/_)/;
+
   const moduleExports = Object.entries(publicFiles).reduce(
     (acc, [name, path]) => {
+      if (PRIVATE_REGEXP.test(name)) return acc;
       if (name === "index") {
         // biome-ignore lint/performance/noAccumulatingSpread: TODO
         return { ".": getExports(path), ...acc };


### PR DESCRIPTION
Ariakit Solid, due to the unique setup that results from the porting approach, requires some "private" utility files in the core package. I've tweaked the build scripts to prevent those from being exported.

I realize it doesn't matter much since core is an internal package, but it also doesn't hurt since it's also technically public.

Any entries that have any path segments that start with `_` (e.g. `_private/something` or `something/_private`) are ignored when updating the `package.json` exports.