### PR TITLE
Browser tests: add support for other frameworks

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -505,9 +505,10 @@ Let's create an end-to-end test for our example:
 
 ```ts
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/my-component");
+  await page.goto(preview("my-component"));
 });
 
 test("my component", async ({ page }) => {

--- a/contributing.md
+++ b/contributing.md
@@ -504,12 +504,8 @@ Let's create an end-to-end test for our example:
 `examples/my-component/test-chrome.ts`
 
 ```ts
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("my-component"));
-});
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 test("my component", async ({ page }) => {
   const element = await page.getByText("My component");

--- a/examples/button/test-safari.ts
+++ b/examples/button/test-safari.ts
@@ -1,9 +1,5 @@
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("button"), { waitUntil: "networkidle" });
-});
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 test("button receives focus on click", async ({ page }) => {
   const button = page.getByRole("button", { name: "Button" });

--- a/examples/button/test-safari.ts
+++ b/examples/button/test-safari.ts
@@ -1,10 +1,11 @@
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/button", { waitUntil: "networkidle" });
+  await page.goto(preview("button"), { waitUntil: "networkidle" });
 });
 
-test("buton receives focus on click", async ({ page }) => {
+test("button receives focus on click", async ({ page }) => {
   const button = page.getByRole("button", { name: "Button" });
   await button.click();
   await expect(button).toBeFocused();

--- a/examples/checkbox-as-button/generate-images.ts
+++ b/examples/checkbox-as-button/generate-images.ts
@@ -1,9 +1,9 @@
 import { query } from "@ariakit/test/playwright";
 import { test } from "@playwright/test";
-import { screenshot } from "../test-utils.ts";
+import { preview, screenshot } from "../test-utils.ts";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/checkbox-as-button", { waitUntil: "networkidle" });
+  await page.goto(preview("checkbox-as-button"), { waitUntil: "networkidle" });
 });
 
 test("generate images", async ({ page }) => {

--- a/examples/checkbox-as-button/generate-images.ts
+++ b/examples/checkbox-as-button/generate-images.ts
@@ -1,10 +1,5 @@
 import { query } from "@ariakit/test/playwright";
-import { test } from "@playwright/test";
-import { preview, screenshot } from "../test-utils.ts";
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("checkbox-as-button"), { waitUntil: "networkidle" });
-});
+import { screenshot, test } from "../test-utils.ts";
 
 test("generate images", async ({ page }) => {
   const q = query(page);

--- a/examples/checkbox-custom/generate-images.ts
+++ b/examples/checkbox-custom/generate-images.ts
@@ -1,8 +1,8 @@
 import { test } from "@playwright/test";
-import { screenshot } from "../test-utils.ts";
+import { preview, screenshot } from "../test-utils.ts";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/checkbox-custom", { waitUntil: "networkidle" });
+  await page.goto(preview("checkbox-custom"), { waitUntil: "networkidle" });
 });
 
 test("generate images", async ({ page }) => {

--- a/examples/checkbox-custom/generate-images.ts
+++ b/examples/checkbox-custom/generate-images.ts
@@ -1,9 +1,4 @@
-import { test } from "@playwright/test";
-import { preview, screenshot } from "../test-utils.ts";
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("checkbox-custom"), { waitUntil: "networkidle" });
-});
+import { screenshot, test } from "../test-utils.ts";
 
 test("generate images", async ({ page }) => {
   const label = page.locator("label");

--- a/examples/checkbox-group/generate-images.ts
+++ b/examples/checkbox-group/generate-images.ts
@@ -1,9 +1,9 @@
 import { query } from "@ariakit/test/playwright";
 import { test } from "@playwright/test";
-import { screenshot } from "../test-utils.ts";
+import { preview, screenshot } from "../test-utils.ts";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/checkbox-group", { waitUntil: "networkidle" });
+  await page.goto(preview("checkbox-group"), { waitUntil: "networkidle" });
 });
 
 test("generate images", async ({ page }) => {

--- a/examples/checkbox-group/generate-images.ts
+++ b/examples/checkbox-group/generate-images.ts
@@ -1,10 +1,5 @@
 import { query } from "@ariakit/test/playwright";
-import { test } from "@playwright/test";
-import { preview, screenshot } from "../test-utils.ts";
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("checkbox-group"), { waitUntil: "networkidle" });
-});
+import { screenshot, test } from "../test-utils.ts";
 
 test("generate images", async ({ page }) => {
   const q = query(page);

--- a/examples/combobox-animated/generate-images.ts
+++ b/examples/combobox-animated/generate-images.ts
@@ -1,10 +1,5 @@
 import { query } from "@ariakit/test/playwright";
-import { test } from "@playwright/test";
-import { preview, screenshot } from "../test-utils.ts";
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("combobox-animated"), { waitUntil: "networkidle" });
-});
+import { screenshot, test } from "../test-utils.ts";
 
 test("generate images", async ({ page }) => {
   const q = query(page);

--- a/examples/combobox-animated/generate-images.ts
+++ b/examples/combobox-animated/generate-images.ts
@@ -1,9 +1,9 @@
 import { query } from "@ariakit/test/playwright";
 import { test } from "@playwright/test";
-import { screenshot } from "../test-utils.ts";
+import { preview, screenshot } from "../test-utils.ts";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/combobox-animated", { waitUntil: "networkidle" });
+  await page.goto(preview("combobox-animated"), { waitUntil: "networkidle" });
 });
 
 test("generate images", async ({ page }) => {

--- a/examples/combobox-animated/test-chrome.ts
+++ b/examples/combobox-animated/test-chrome.ts
@@ -1,16 +1,12 @@
 import type { Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 const getCombobox = (page: Page) =>
   page.getByRole("combobox", { name: "Your favorite fruit" });
 const getListbox = (page: Page) => page.getByRole("listbox");
 const getOption = (page: Page, name: string) =>
   page.getByRole("option", { name });
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("combobox-animated"), { waitUntil: "networkidle" });
-});
 
 test("combobox show/hide animation", async ({ page }) => {
   await getCombobox(page).click();

--- a/examples/combobox-animated/test-chrome.ts
+++ b/examples/combobox-animated/test-chrome.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 const getCombobox = (page: Page) =>
   page.getByRole("combobox", { name: "Your favorite fruit" });
@@ -8,7 +9,7 @@ const getOption = (page: Page, name: string) =>
   page.getByRole("option", { name });
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/combobox-animated", { waitUntil: "networkidle" });
+  await page.goto(preview("combobox-animated"), { waitUntil: "networkidle" });
 });
 
 test("combobox show/hide animation", async ({ page }) => {

--- a/examples/combobox-cancel/generate-images.ts
+++ b/examples/combobox-cancel/generate-images.ts
@@ -1,10 +1,5 @@
 import { query } from "@ariakit/test/playwright";
-import { test } from "@playwright/test";
-import { preview, screenshot } from "../test-utils.ts";
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("combobox-cancel"), { waitUntil: "networkidle" });
-});
+import { screenshot, test } from "../test-utils.ts";
 
 test("generate images", async ({ page }) => {
   const q = query(page);

--- a/examples/combobox-cancel/generate-images.ts
+++ b/examples/combobox-cancel/generate-images.ts
@@ -1,9 +1,9 @@
 import { query } from "@ariakit/test/playwright";
 import { test } from "@playwright/test";
-import { screenshot } from "../test-utils.ts";
+import { preview, screenshot } from "../test-utils.ts";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/combobox-cancel", { waitUntil: "networkidle" });
+  await page.goto(preview("combobox-cancel"), { waitUntil: "networkidle" });
 });
 
 test("generate images", async ({ page }) => {

--- a/examples/combobox-disclosure/generate-images.ts
+++ b/examples/combobox-disclosure/generate-images.ts
@@ -1,11 +1,9 @@
 import { query } from "@ariakit/test/playwright";
 import { test } from "@playwright/test";
-import { screenshot } from "../test-utils.ts";
+import { preview, screenshot } from "../test-utils.ts";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/combobox-disclosure", {
-    waitUntil: "networkidle",
-  });
+  await page.goto(preview("combobox-disclosure"), { waitUntil: "networkidle" });
 });
 
 test("generate images", async ({ page }) => {

--- a/examples/combobox-disclosure/generate-images.ts
+++ b/examples/combobox-disclosure/generate-images.ts
@@ -1,10 +1,5 @@
 import { query } from "@ariakit/test/playwright";
-import { test } from "@playwright/test";
-import { preview, screenshot } from "../test-utils.ts";
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("combobox-disclosure"), { waitUntil: "networkidle" });
-});
+import { screenshot, test } from "../test-utils.ts";
 
 test("generate images", async ({ page }) => {
   const q = query(page);

--- a/examples/combobox-filtering-integrated/generate-images.ts
+++ b/examples/combobox-filtering-integrated/generate-images.ts
@@ -1,9 +1,9 @@
 import { query } from "@ariakit/test/playwright";
 import { test } from "@playwright/test";
-import { screenshot } from "../test-utils.ts";
+import { preview, screenshot } from "../test-utils.ts";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/combobox-filtering-integrated", {
+  await page.goto(preview("combobox-filtering-integrated"), {
     waitUntil: "networkidle",
   });
 });

--- a/examples/combobox-filtering-integrated/generate-images.ts
+++ b/examples/combobox-filtering-integrated/generate-images.ts
@@ -1,12 +1,5 @@
 import { query } from "@ariakit/test/playwright";
-import { test } from "@playwright/test";
-import { preview, screenshot } from "../test-utils.ts";
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("combobox-filtering-integrated"), {
-    waitUntil: "networkidle",
-  });
-});
+import { screenshot, test } from "../test-utils.ts";
 
 test("generate images", async ({ page }) => {
   const q = query(page);

--- a/examples/combobox-filtering/generate-images.ts
+++ b/examples/combobox-filtering/generate-images.ts
@@ -1,11 +1,9 @@
 import { query } from "@ariakit/test/playwright";
 import { test } from "@playwright/test";
-import { screenshot } from "../test-utils.ts";
+import { preview, screenshot } from "../test-utils.ts";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/combobox-filtering", {
-    waitUntil: "networkidle",
-  });
+  await page.goto(preview("combobox-filtering"), { waitUntil: "networkidle" });
 });
 
 test("generate images", async ({ page }) => {

--- a/examples/combobox-filtering/generate-images.ts
+++ b/examples/combobox-filtering/generate-images.ts
@@ -1,10 +1,5 @@
 import { query } from "@ariakit/test/playwright";
-import { test } from "@playwright/test";
-import { preview, screenshot } from "../test-utils.ts";
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("combobox-filtering"), { waitUntil: "networkidle" });
-});
+import { screenshot, test } from "../test-utils.ts";
 
 test("generate images", async ({ page }) => {
   const q = query(page);

--- a/examples/combobox-group/generate-images.ts
+++ b/examples/combobox-group/generate-images.ts
@@ -1,11 +1,9 @@
 import { query } from "@ariakit/test/playwright";
 import { test } from "@playwright/test";
-import { screenshot } from "../test-utils.ts";
+import { preview, screenshot } from "../test-utils.ts";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/combobox-group", {
-    waitUntil: "networkidle",
-  });
+  await page.goto(preview("combobox-group"), { waitUntil: "networkidle" });
 });
 
 test("generate images", async ({ page }) => {

--- a/examples/combobox-group/generate-images.ts
+++ b/examples/combobox-group/generate-images.ts
@@ -1,10 +1,5 @@
 import { query } from "@ariakit/test/playwright";
-import { test } from "@playwright/test";
-import { preview, screenshot } from "../test-utils.ts";
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("combobox-group"), { waitUntil: "networkidle" });
-});
+import { screenshot, test } from "../test-utils.ts";
 
 test("generate images", async ({ page }) => {
   const q = query(page);

--- a/examples/combobox-group/test-browser.ts
+++ b/examples/combobox-group/test-browser.ts
@@ -1,6 +1,5 @@
 import type { Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { test } from "../test-utils.ts";
 
 const getCombobox = (page: Page) => page.getByPlaceholder("e.g., Apple");
 const getPopover = (page: Page) => page.getByRole("listbox");
@@ -15,10 +14,6 @@ function getSelectionValue(page: Page) {
     return selectionValue;
   });
 }
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("combobox-group"), { waitUntil: "networkidle" });
-});
 
 test("maintain completion string while typing", async ({ page }) => {
   await getCombobox(page).click();

--- a/examples/combobox-group/test-browser.ts
+++ b/examples/combobox-group/test-browser.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 const getCombobox = (page: Page) => page.getByPlaceholder("e.g., Apple");
 const getPopover = (page: Page) => page.getByRole("listbox");
@@ -16,7 +17,7 @@ function getSelectionValue(page: Page) {
 }
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/combobox-group", { waitUntil: "networkidle" });
+  await page.goto(preview("combobox-group"), { waitUntil: "networkidle" });
 });
 
 test("maintain completion string while typing", async ({ page }) => {

--- a/examples/combobox-group/test-browser.ts
+++ b/examples/combobox-group/test-browser.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test";
+import { type Page, expect } from "@playwright/test";
 import { test } from "../test-utils.ts";
 
 const getCombobox = (page: Page) => page.getByPlaceholder("e.g., Apple");

--- a/examples/combobox-input-email/test-browser.ts
+++ b/examples/combobox-input-email/test-browser.ts
@@ -1,12 +1,6 @@
 import { query } from "@ariakit/test/playwright";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("combobox-input-email"), {
-    waitUntil: "networkidle",
-  });
-});
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 test("combobox should not throw when input type=email", async ({ page }) => {
   const q = query(page);

--- a/examples/combobox-input-email/test-browser.ts
+++ b/examples/combobox-input-email/test-browser.ts
@@ -1,8 +1,9 @@
 import { query } from "@ariakit/test/playwright";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/combobox-input-email", {
+  await page.goto(preview("combobox-input-email"), {
     waitUntil: "networkidle",
   });
 });

--- a/examples/combobox-links/generate-images.ts
+++ b/examples/combobox-links/generate-images.ts
@@ -1,11 +1,9 @@
 import { query } from "@ariakit/test/playwright";
 import { test } from "@playwright/test";
-import { screenshot } from "../test-utils.ts";
+import { preview, screenshot } from "../test-utils.ts";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/combobox-links", {
-    waitUntil: "networkidle",
-  });
+  await page.goto(preview("combobox-links"), { waitUntil: "networkidle" });
 });
 
 test("generate images", async ({ page }) => {

--- a/examples/combobox-links/generate-images.ts
+++ b/examples/combobox-links/generate-images.ts
@@ -1,10 +1,5 @@
 import { query } from "@ariakit/test/playwright";
-import { test } from "@playwright/test";
-import { preview, screenshot } from "../test-utils.ts";
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("combobox-links"), { waitUntil: "networkidle" });
-});
+import { screenshot, test } from "../test-utils.ts";
 
 test("generate images", async ({ page }) => {
   const q = query(page);

--- a/examples/combobox-multiple/generate-images.ts
+++ b/examples/combobox-multiple/generate-images.ts
@@ -1,10 +1,5 @@
 import { query } from "@ariakit/test/playwright";
-import { test } from "@playwright/test";
-import { preview, screenshot } from "../test-utils.ts";
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("combobox-multiple"), { waitUntil: "networkidle" });
-});
+import { screenshot, test } from "../test-utils.ts";
 
 test("generate images", async ({ page }) => {
   await page.setViewportSize({ width: 500, height: 600 });

--- a/examples/combobox-multiple/generate-images.ts
+++ b/examples/combobox-multiple/generate-images.ts
@@ -1,9 +1,9 @@
 import { query } from "@ariakit/test/playwright";
 import { test } from "@playwright/test";
-import { screenshot } from "../test-utils.ts";
+import { preview, screenshot } from "../test-utils.ts";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/combobox-multiple", { waitUntil: "networkidle" });
+  await page.goto(preview("combobox-multiple"), { waitUntil: "networkidle" });
 });
 
 test("generate images", async ({ page }) => {

--- a/examples/combobox-multiple/test-browser.ts
+++ b/examples/combobox-multiple/test-browser.ts
@@ -1,5 +1,6 @@
 import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 function query(locator: Page | Locator) {
   return {
@@ -11,7 +12,7 @@ function query(locator: Page | Locator) {
 }
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/combobox-multiple", { waitUntil: "networkidle" });
+  await page.goto(preview("combobox-multiple"), { waitUntil: "networkidle" });
 });
 
 test("scroll offscreen item into view after selecting it", async ({ page }) => {

--- a/examples/combobox-multiple/test-browser.ts
+++ b/examples/combobox-multiple/test-browser.ts
@@ -1,6 +1,6 @@
 import type { Locator, Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 function query(locator: Page | Locator) {
   return {
@@ -10,10 +10,6 @@ function query(locator: Page | Locator) {
       locator.getByRole("option", { name, exact: true }),
   };
 }
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("combobox-multiple"), { waitUntil: "networkidle" });
-});
 
 test("scroll offscreen item into view after selecting it", async ({ page }) => {
   const q = query(page);

--- a/examples/combobox-radix/generate-images.ts
+++ b/examples/combobox-radix/generate-images.ts
@@ -1,11 +1,9 @@
 import { query } from "@ariakit/test/playwright";
 import { test } from "@playwright/test";
-import { screenshot } from "../test-utils.ts";
+import { preview, screenshot } from "../test-utils.ts";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/combobox-radix", {
-    waitUntil: "networkidle",
-  });
+  await page.goto(preview("combobox-radix"), { waitUntil: "networkidle" });
 });
 
 test("generate images", async ({ page }) => {

--- a/examples/combobox-radix/generate-images.ts
+++ b/examples/combobox-radix/generate-images.ts
@@ -1,10 +1,5 @@
 import { query } from "@ariakit/test/playwright";
-import { test } from "@playwright/test";
-import { preview, screenshot } from "../test-utils.ts";
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("combobox-radix"), { waitUntil: "networkidle" });
-});
+import { screenshot, test } from "../test-utils.ts";
 
 test("generate images", async ({ page }) => {
   const q = query(page);

--- a/examples/combobox-tabs/generate-images.ts
+++ b/examples/combobox-tabs/generate-images.ts
@@ -1,9 +1,9 @@
 import { query } from "@ariakit/test/playwright";
 import { test } from "@playwright/test";
-import { screenshot } from "../test-utils.ts";
+import { preview, screenshot } from "../test-utils.ts";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/combobox-tabs", { waitUntil: "networkidle" });
+  await page.goto(preview("combobox-tabs"), { waitUntil: "networkidle" });
 });
 
 test("generate images", async ({ page }) => {

--- a/examples/combobox-tabs/generate-images.ts
+++ b/examples/combobox-tabs/generate-images.ts
@@ -1,10 +1,5 @@
 import { query } from "@ariakit/test/playwright";
-import { test } from "@playwright/test";
-import { preview, screenshot } from "../test-utils.ts";
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("combobox-tabs"), { waitUntil: "networkidle" });
-});
+import { screenshot, test } from "../test-utils.ts";
 
 test("generate images", async ({ page }) => {
   await page.setViewportSize({ width: 800, height: 600 });

--- a/examples/combobox-tabs/test-browser.ts
+++ b/examples/combobox-tabs/test-browser.ts
@@ -1,8 +1,9 @@
 import { query } from "@ariakit/test/playwright";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/combobox-tabs", { waitUntil: "networkidle" });
+  await page.goto(preview("combobox-tabs"), { waitUntil: "networkidle" });
 });
 
 test("https://github.com/ariakit/ariakit/issues/3941", async ({ page }) => {

--- a/examples/combobox-tabs/test-browser.ts
+++ b/examples/combobox-tabs/test-browser.ts
@@ -1,10 +1,6 @@
 import { query } from "@ariakit/test/playwright";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("combobox-tabs"), { waitUntil: "networkidle" });
-});
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 test("https://github.com/ariakit/ariakit/issues/3941", async ({ page }) => {
   const q = query(page);

--- a/examples/combobox-textarea/generate-images.ts
+++ b/examples/combobox-textarea/generate-images.ts
@@ -1,6 +1,6 @@
 import { query } from "@ariakit/test/playwright";
 import { test } from "@playwright/test";
-import { screenshot } from "../test-utils.ts";
+import { preview, screenshot } from "../test-utils.ts";
 
 test.beforeEach(async ({ page }) => {
   await page.goto(preview("combobox-textarea"), {

--- a/examples/combobox-textarea/generate-images.ts
+++ b/examples/combobox-textarea/generate-images.ts
@@ -3,7 +3,7 @@ import { test } from "@playwright/test";
 import { screenshot } from "../test-utils.ts";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/combobox-textarea", {
+  await page.goto(preview("combobox-textarea"), {
     waitUntil: "networkidle",
   });
 });

--- a/examples/combobox-textarea/generate-images.ts
+++ b/examples/combobox-textarea/generate-images.ts
@@ -1,12 +1,5 @@
 import { query } from "@ariakit/test/playwright";
-import { test } from "@playwright/test";
-import { preview, screenshot } from "../test-utils.ts";
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("combobox-textarea"), {
-    waitUntil: "networkidle",
-  });
-});
+import { screenshot, test } from "../test-utils.ts";
 
 test("generate images", async ({ page }) => {
   const q = query(page);

--- a/examples/combobox-textarea/test-chrome.ts
+++ b/examples/combobox-textarea/test-chrome.ts
@@ -1,7 +1,8 @@
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/combobox-textarea", { waitUntil: "networkidle" });
+  await page.goto(preview("combobox-textarea"), { waitUntil: "networkidle" });
 });
 
 test("popover is positioned correctly", async ({ page }) => {

--- a/examples/combobox-textarea/test-chrome.ts
+++ b/examples/combobox-textarea/test-chrome.ts
@@ -1,9 +1,5 @@
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("combobox-textarea"), { waitUntil: "networkidle" });
-});
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 test("popover is positioned correctly", async ({ page }) => {
   test.info().snapshotSuffix = "";

--- a/examples/combobox/test-mobile.ts
+++ b/examples/combobox/test-mobile.ts
@@ -1,10 +1,6 @@
 import { query } from "@ariakit/test/playwright";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("combobox"), { waitUntil: "networkidle" });
-});
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 test("show/hide on tap", async ({ page }) => {
   const q = query(page);

--- a/examples/combobox/test-mobile.ts
+++ b/examples/combobox/test-mobile.ts
@@ -1,8 +1,9 @@
 import { query } from "@ariakit/test/playwright";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/combobox", { waitUntil: "networkidle" });
+  await page.goto(preview("combobox"), { waitUntil: "networkidle" });
 });
 
 test("show/hide on tap", async ({ page }) => {

--- a/examples/dialog-animated/test-browser.ts
+++ b/examples/dialog-animated/test-browser.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 const getDialog = (page: Page) => page.getByRole("dialog", { name: "Success" });
 const getButton = (page: Page, name: string) =>
@@ -15,7 +16,7 @@ const createTransition = (duration = 100) => {
 };
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/dialog-animated", { waitUntil: "networkidle" });
+  await page.goto(preview("dialog-animated"), { waitUntil: "networkidle" });
 });
 
 test("show/hide", async ({ page }) => {

--- a/examples/dialog-animated/test-browser.ts
+++ b/examples/dialog-animated/test-browser.ts
@@ -1,6 +1,6 @@
 import type { Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 const getDialog = (page: Page) => page.getByRole("dialog", { name: "Success" });
 const getButton = (page: Page, name: string) =>
@@ -14,10 +14,6 @@ const createTransition = (duration = 100) => {
   };
   return isPending;
 };
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("dialog-animated"), { waitUntil: "networkidle" });
-});
 
 test("show/hide", async ({ page }) => {
   await expect(getDialog(page)).not.toBeVisible();

--- a/examples/dialog-backdrop-scrollable/test-chrome.ts
+++ b/examples/dialog-backdrop-scrollable/test-chrome.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 const getDialog = (page: Page) =>
   page.getByRole("dialog", { name: "Homemade Cake" });

--- a/examples/dialog-backdrop-scrollable/test-chrome.ts
+++ b/examples/dialog-backdrop-scrollable/test-chrome.ts
@@ -21,7 +21,7 @@ const waitForBackdropScrollTop = async (page: Page, value: number) => {
 };
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/dialog-backdrop-scrollable", {
+  await page.goto(preview("dialog-backdrop-scrollable"), {
     waitUntil: "networkidle",
   });
 });

--- a/examples/dialog-backdrop-scrollable/test-chrome.ts
+++ b/examples/dialog-backdrop-scrollable/test-chrome.ts
@@ -1,6 +1,6 @@
 import type { Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 const getDialog = (page: Page) =>
   page.getByRole("dialog", { name: "Homemade Cake" });
@@ -20,12 +20,6 @@ const waitForBackdropScrollTop = async (page: Page, value: number) => {
     { backdrop, value },
   );
 };
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("dialog-backdrop-scrollable"), {
-    waitUntil: "networkidle",
-  });
-});
 
 test.use({ headless: false });
 

--- a/examples/dialog-details/test-browser.ts
+++ b/examples/dialog-details/test-browser.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 const getDialog = (page: Page) => page.getByRole("dialog", { name: "Success" });
 const getButton = (page: Page, name: string) =>

--- a/examples/dialog-details/test-browser.ts
+++ b/examples/dialog-details/test-browser.ts
@@ -14,7 +14,7 @@ test("show before JS", async ({ page }) => {
       }
     });
   });
-  await page.goto("/previews/dialog-details");
+  await page.goto(preview("dialog-details"));
   await page.waitForTimeout(250);
   await expect(getDialog(page)).toBeVisible();
   await expect(getButton(page, "OK")).toBeFocused();

--- a/examples/dialog-details/test-browser.ts
+++ b/examples/dialog-details/test-browser.ts
@@ -1,6 +1,6 @@
 import type { Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { expect } from "@playwright/test";
+import { preview, test } from "../test-utils.ts";
 
 const getDialog = (page: Page) => page.getByRole("dialog", { name: "Success" });
 const getButton = (page: Page, name: string) =>

--- a/examples/dialog-menu/test-mobile.ts
+++ b/examples/dialog-menu/test-mobile.ts
@@ -1,7 +1,8 @@
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/dialog-menu", { waitUntil: "networkidle" });
+  await page.goto(preview("dialog-menu"), { waitUntil: "networkidle" });
 });
 
 test("menu closes when tapping dialog", async ({ page }) => {

--- a/examples/dialog-menu/test-mobile.ts
+++ b/examples/dialog-menu/test-mobile.ts
@@ -1,9 +1,5 @@
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("dialog-menu"), { waitUntil: "networkidle" });
-});
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 test("menu closes when tapping dialog", async ({ page }) => {
   await page.getByRole("button", { name: "View recipe" }).tap();

--- a/examples/dialog-nested/test-chrome.ts
+++ b/examples/dialog-nested/test-chrome.ts
@@ -1,5 +1,6 @@
 import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 const getButton = (page: Page | Locator, name: string) =>
   page.getByRole("button", { name });
@@ -8,7 +9,7 @@ const getDialog = (page: Page | Locator, name: string) =>
   page.getByRole("dialog", { name });
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/dialog-nested", { waitUntil: "networkidle" });
+  await page.goto(preview("dialog-nested"), { waitUntil: "networkidle" });
 });
 
 test("remove product", async ({ page }) => {

--- a/examples/dialog-nested/test-chrome.ts
+++ b/examples/dialog-nested/test-chrome.ts
@@ -1,16 +1,12 @@
 import type { Locator, Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 const getButton = (page: Page | Locator, name: string) =>
   page.getByRole("button", { name });
 
 const getDialog = (page: Page | Locator, name: string) =>
   page.getByRole("dialog", { name });
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("dialog-nested"), { waitUntil: "networkidle" });
-});
 
 test("remove product", async ({ page }) => {
   await getButton(page, "View Cart").click();

--- a/examples/dialog-react-toastify/test-chrome-firefox.ts
+++ b/examples/dialog-react-toastify/test-chrome-firefox.ts
@@ -1,6 +1,6 @@
 import type { Locator, Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 const getButton = (page: Page | Locator, name: string) =>
   page.getByRole("button", { name });
@@ -10,12 +10,6 @@ const getDialog = (page: Page | Locator, name: string) =>
 
 const getNotifications = (page: Page | Locator) =>
   page.getByRole("alert").filter({ hasText: "Hello!" });
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("dialog-react-toastify"), {
-    waitUntil: "networkidle",
-  });
-});
 
 test("show notification", async ({ page }) => {
   await expect(getNotifications(page)).toHaveCount(0);

--- a/examples/dialog-react-toastify/test-chrome-firefox.ts
+++ b/examples/dialog-react-toastify/test-chrome-firefox.ts
@@ -11,7 +11,7 @@ const getNotifications = (page: Page | Locator) =>
   page.getByRole("alert").filter({ hasText: "Hello!" });
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/dialog-react-toastify", {
+  await page.goto(preview("dialog-react-toastify"), {
     waitUntil: "networkidle",
   });
 });

--- a/examples/dialog-react-toastify/test-chrome-firefox.ts
+++ b/examples/dialog-react-toastify/test-chrome-firefox.ts
@@ -1,5 +1,6 @@
 import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 const getButton = (page: Page | Locator, name: string) =>
   page.getByRole("button", { name });

--- a/examples/disclosure-animated/test-chrome.ts
+++ b/examples/disclosure-animated/test-chrome.ts
@@ -1,6 +1,7 @@
 import { query } from "@ariakit/test/playwright";
 import { expect, test } from "@playwright/test";
 import type { Page } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 function getWrapper(page: Page) {
   return page.locator(".content-wrapper");

--- a/examples/disclosure-animated/test-chrome.ts
+++ b/examples/disclosure-animated/test-chrome.ts
@@ -7,7 +7,7 @@ function getWrapper(page: Page) {
 }
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/disclosure-animated", {
+  await page.goto(preview("disclosure-animated"), {
     waitUntil: "networkidle",
   });
 });

--- a/examples/disclosure-animated/test-chrome.ts
+++ b/examples/disclosure-animated/test-chrome.ts
@@ -1,17 +1,11 @@
 import { query } from "@ariakit/test/playwright";
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
 import type { Page } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { test } from "../test-utils.ts";
 
 function getWrapper(page: Page) {
   return page.locator(".content-wrapper");
 }
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("disclosure-animated"), {
-    waitUntil: "networkidle",
-  });
-});
 
 test.describe.configure({ retries: 2 });
 

--- a/examples/form-select/test-browser.ts
+++ b/examples/form-select/test-browser.ts
@@ -6,7 +6,7 @@ const getSelect = (page: Page) =>
 const getList = (page: Page) => page.getByRole("listbox");
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/form-select");
+  await page.goto(preview("form-select"));
 });
 
 test("show/hide with click", async ({ page }) => {

--- a/examples/form-select/test-browser.ts
+++ b/examples/form-select/test-browser.ts
@@ -1,14 +1,10 @@
 import type { Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 const getSelect = (page: Page) =>
   page.getByRole("combobox", { name: "Favorite fruit" });
 const getList = (page: Page) => page.getByRole("listbox");
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("form-select"));
-});
 
 test("show/hide with click", async ({ page }) => {
   await getSelect(page).click();

--- a/examples/form-select/test-browser.ts
+++ b/examples/form-select/test-browser.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 const getSelect = (page: Page) =>
   page.getByRole("combobox", { name: "Favorite fruit" });

--- a/examples/hovercard-shadow-dom/test-browser.ts
+++ b/examples/hovercard-shadow-dom/test-browser.ts
@@ -7,7 +7,7 @@ const getHovercard = (page: Page) =>
   page.getByRole("dialog", { name: "Ariakit" });
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/hovercard-shadow-dom", {
+  await page.goto(preview("hovercard-shadow-dom"), {
     waitUntil: "networkidle",
   });
 });

--- a/examples/hovercard-shadow-dom/test-browser.ts
+++ b/examples/hovercard-shadow-dom/test-browser.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 const getAnchor = (page: Page) =>
   page.getByRole("link", { name: "@ariakitjs" });

--- a/examples/hovercard-shadow-dom/test-browser.ts
+++ b/examples/hovercard-shadow-dom/test-browser.ts
@@ -1,17 +1,11 @@
 import type { Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 const getAnchor = (page: Page) =>
   page.getByRole("link", { name: "@ariakitjs" });
 const getHovercard = (page: Page) =>
   page.getByRole("dialog", { name: "Ariakit" });
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("hovercard-shadow-dom"), {
-    waitUntil: "networkidle",
-  });
-});
 
 test("https://github.com/ariakit/ariakit/issues/2983", async ({ page }) => {
   await getAnchor(page).hover();

--- a/examples/menu-combobox-store/test-browser.ts
+++ b/examples/menu-combobox-store/test-browser.ts
@@ -13,7 +13,7 @@ const getOption = (page: Page, name: string) =>
   page.getByRole("option", { name });
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/menu-combobox-store", {
+  await page.goto(preview("menu-combobox-store"), {
     waitUntil: "networkidle",
   });
 });

--- a/examples/menu-combobox-store/test-browser.ts
+++ b/examples/menu-combobox-store/test-browser.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 const getMenuButton = (page: Page) =>
   page.getByRole("button", { name: "Add block" });

--- a/examples/menu-combobox-store/test-browser.ts
+++ b/examples/menu-combobox-store/test-browser.ts
@@ -1,6 +1,6 @@
 import type { Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 const getMenuButton = (page: Page) =>
   page.getByRole("button", { name: "Add block" });
@@ -12,12 +12,6 @@ const getCombobox = (page: Page) =>
 
 const getOption = (page: Page, name: string) =>
   page.getByRole("option", { name });
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("menu-combobox-store"), {
-    waitUntil: "networkidle",
-  });
-});
 
 test("auto select first option", async ({ page }) => {
   await getMenuButton(page).click();

--- a/examples/menu-combobox/test-browser.ts
+++ b/examples/menu-combobox/test-browser.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 const getMenuButton = (page: Page) =>
   page.getByRole("button", { name: "Add block" });
@@ -13,7 +14,7 @@ const getOption = (page: Page, name: string) =>
   page.getByRole("option", { name });
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/menu-combobox", { waitUntil: "networkidle" });
+  await page.goto(preview("menu-combobox"), { waitUntil: "networkidle" });
 });
 
 test("auto select first option", async ({ page }) => {

--- a/examples/menu-combobox/test-browser.ts
+++ b/examples/menu-combobox/test-browser.ts
@@ -1,6 +1,6 @@
 import type { Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 const getMenuButton = (page: Page) =>
   page.getByRole("button", { name: "Add block" });
@@ -12,10 +12,6 @@ const getCombobox = (page: Page) =>
 
 const getOption = (page: Page, name: string) =>
   page.getByRole("option", { name });
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("menu-combobox"), { waitUntil: "networkidle" });
-});
 
 test("auto select first option", async ({ page }) => {
   await getMenuButton(page).click();

--- a/examples/menu-dialog-animated/test-chrome.ts
+++ b/examples/menu-dialog-animated/test-chrome.ts
@@ -1,5 +1,6 @@
 import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 const getMenuButton = (locator: Page | Locator, count: number | string = "") =>
   locator.getByRole("button", {

--- a/examples/menu-dialog-animated/test-chrome.ts
+++ b/examples/menu-dialog-animated/test-chrome.ts
@@ -1,6 +1,6 @@
 import type { Locator, Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 const getMenuButton = (locator: Page | Locator, count: number | string = "") =>
   locator.getByRole("button", {
@@ -33,12 +33,6 @@ const getError = (locator: Page | Locator) => locator.getByText("Please fill");
 const repeat = async (fn: () => unknown, count: number) => {
   await [...new Array(count)].reduce((p) => p.then(fn), Promise.resolve());
 };
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("menu-dialog-animated"), {
-    waitUntil: "networkidle",
-  });
-});
 
 test("interact with menu", async ({ page }) => {
   await getMenuButton(page).click();

--- a/examples/menu-dialog-animated/test-chrome.ts
+++ b/examples/menu-dialog-animated/test-chrome.ts
@@ -34,7 +34,7 @@ const repeat = async (fn: () => unknown, count: number) => {
 };
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/menu-dialog-animated", {
+  await page.goto(preview("menu-dialog-animated"), {
     waitUntil: "networkidle",
   });
 });

--- a/examples/menu-framer-motion/test-chrome.ts
+++ b/examples/menu-framer-motion/test-chrome.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 const getMenuButton = (page: Page) =>
   page.getByRole("button", { name: "Options" });
@@ -7,7 +8,7 @@ const getMenuButton = (page: Page) =>
 const getMenu = (page: Page) => page.getByRole("menu");
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/menu-framer-motion", { waitUntil: "networkidle" });
+  await page.goto(preview("menu-framer-motion"), { waitUntil: "networkidle" });
 });
 
 test("show/hide with click", async ({ page }) => {

--- a/examples/menu-framer-motion/test-chrome.ts
+++ b/examples/menu-framer-motion/test-chrome.ts
@@ -1,15 +1,11 @@
 import type { Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 const getMenuButton = (page: Page) =>
   page.getByRole("button", { name: "Options" });
 
 const getMenu = (page: Page) => page.getByRole("menu");
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("menu-framer-motion"), { waitUntil: "networkidle" });
-});
 
 test("show/hide with click", async ({ page }) => {
   test.info().snapshotSuffix = "";

--- a/examples/menu-nested-combobox/generate-images.ts
+++ b/examples/menu-nested-combobox/generate-images.ts
@@ -3,7 +3,7 @@ import { test } from "@playwright/test";
 import { screenshot } from "../test-utils.ts";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/menu-nested-combobox", {
+  await page.goto(preview("menu-nested-combobox"), {
     waitUntil: "networkidle",
   });
 });

--- a/examples/menu-nested-combobox/generate-images.ts
+++ b/examples/menu-nested-combobox/generate-images.ts
@@ -1,6 +1,6 @@
 import { query } from "@ariakit/test/playwright";
 import { test } from "@playwright/test";
-import { screenshot } from "../test-utils.ts";
+import { preview, screenshot } from "../test-utils.ts";
 
 test.beforeEach(async ({ page }) => {
   await page.goto(preview("menu-nested-combobox"), {

--- a/examples/menu-nested-combobox/generate-images.ts
+++ b/examples/menu-nested-combobox/generate-images.ts
@@ -1,12 +1,5 @@
 import { query } from "@ariakit/test/playwright";
-import { test } from "@playwright/test";
-import { preview, screenshot } from "../test-utils.ts";
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("menu-nested-combobox"), {
-    waitUntil: "networkidle",
-  });
-});
+import { screenshot, test } from "../test-utils.ts";
 
 test("generate images", async ({ page }) => {
   await page.setViewportSize({ width: 800, height: 800 });

--- a/examples/menu-slide/test-chrome-safari.ts
+++ b/examples/menu-slide/test-chrome-safari.ts
@@ -1,5 +1,6 @@
 import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 const getMenuButton = (locator: Page | Locator) =>
   locator.getByRole("button", { name: "Options" });
@@ -17,7 +18,7 @@ const getMenuItem = (
 ) => locator.locator(`role=${role}[name='${name}']`);
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/menu-slide", { waitUntil: "networkidle" });
+  await page.goto(preview("menu-slide"), { waitUntil: "networkidle" });
 });
 
 test("show/hide with click", async ({ page }) => {

--- a/examples/menu-slide/test-chrome-safari.ts
+++ b/examples/menu-slide/test-chrome-safari.ts
@@ -1,6 +1,6 @@
 import type { Locator, Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 const getMenuButton = (locator: Page | Locator) =>
   locator.getByRole("button", { name: "Options" });
@@ -16,10 +16,6 @@ const getMenuItem = (
   name: string,
   role = "menuitem",
 ) => locator.locator(`role=${role}[name='${name}']`);
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("menu-slide"), { waitUntil: "networkidle" });
-});
 
 test("show/hide with click", async ({ page }) => {
   test.info().snapshotSuffix = "";

--- a/examples/menu-slide/test-safari.ts
+++ b/examples/menu-slide/test-safari.ts
@@ -1,6 +1,6 @@
 import type { Locator, Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 const getMenuButton = (locator: Page | Locator) =>
   locator.getByRole("button", { name: "Options" });
@@ -16,10 +16,6 @@ const getMenuItem = (
   name: string,
   role = "menuitem",
 ) => locator.locator(`role=${role}[name='${name}']`);
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("menu-slide"), { waitUntil: "networkidle" });
-});
 
 test("hide with wheel", async ({ page }) => {
   await getMenuButton(page).click();

--- a/examples/menu-slide/test-safari.ts
+++ b/examples/menu-slide/test-safari.ts
@@ -1,5 +1,6 @@
 import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 const getMenuButton = (locator: Page | Locator) =>
   locator.getByRole("button", { name: "Options" });
@@ -17,7 +18,7 @@ const getMenuItem = (
 ) => locator.locator(`role=${role}[name='${name}']`);
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/menu-slide", { waitUntil: "networkidle" });
+  await page.goto(preview("menu-slide"), { waitUntil: "networkidle" });
 });
 
 test("hide with wheel", async ({ page }) => {

--- a/examples/menu-wordpress-modal/test-chrome.ts
+++ b/examples/menu-wordpress-modal/test-chrome.ts
@@ -1,6 +1,6 @@
 import type { Locator, Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 type PopupRole = "dialog" | "menu" | "tooltip";
 
@@ -28,12 +28,6 @@ const getAccessibleTooltip = (page: Page, name?: string) =>
 const getMenu = (page: Page, name?: string) => getPopup(page, "menu", name);
 const getAccessibleMenu = (page: Page, name?: string) =>
   getAccessiblePopup(page, "menu", name);
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("menu-wordpress-modal"), {
-    waitUntil: "networkidle",
-  });
-});
 
 for (const menuitem of [
   "Nested",

--- a/examples/menu-wordpress-modal/test-chrome.ts
+++ b/examples/menu-wordpress-modal/test-chrome.ts
@@ -29,7 +29,7 @@ const getAccessibleMenu = (page: Page, name?: string) =>
   getAccessiblePopup(page, "menu", name);
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/menu-wordpress-modal", {
+  await page.goto(preview("menu-wordpress-modal"), {
     waitUntil: "networkidle",
   });
 });

--- a/examples/menu-wordpress-modal/test-chrome.ts
+++ b/examples/menu-wordpress-modal/test-chrome.ts
@@ -1,5 +1,6 @@
 import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 type PopupRole = "dialog" | "menu" | "tooltip";
 

--- a/examples/menubar/test-browser.ts
+++ b/examples/menubar/test-browser.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import type { Locator, Page } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 function query(locator: Page | Locator) {
   return {
@@ -9,7 +10,7 @@ function query(locator: Page | Locator) {
 }
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/menubar", { waitUntil: "networkidle" });
+  await page.goto(preview("menubar"), { waitUntil: "networkidle" });
 });
 
 test("re-open submenu and shift-tab back to the parent menu", async ({

--- a/examples/menubar/test-browser.ts
+++ b/examples/menubar/test-browser.ts
@@ -1,6 +1,6 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
 import type { Locator, Page } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { test } from "../test-utils.ts";
 
 function query(locator: Page | Locator) {
   return {
@@ -8,10 +8,6 @@ function query(locator: Page | Locator) {
     menuitem: (name: string) => locator.getByRole("menuitem", { name }),
   };
 }
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("menubar"), { waitUntil: "networkidle" });
-});
 
 test("re-open submenu and shift-tab back to the parent menu", async ({
   page,

--- a/examples/popover-flip/test-chrome.ts
+++ b/examples/popover-flip/test-chrome.ts
@@ -1,9 +1,5 @@
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("popover-flip"), { waitUntil: "networkidle" });
-});
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 test("popover flip", async ({ page }) => {
   test.info().snapshotSuffix = "";

--- a/examples/popover-flip/test-chrome.ts
+++ b/examples/popover-flip/test-chrome.ts
@@ -1,7 +1,8 @@
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/popover-flip", { waitUntil: "networkidle" });
+  await page.goto(preview("popover-flip"), { waitUntil: "networkidle" });
 });
 
 test("popover flip", async ({ page }) => {

--- a/examples/popover-responsive/test-chrome.ts
+++ b/examples/popover-responsive/test-chrome.ts
@@ -1,12 +1,13 @@
 import { expect, test } from "@playwright/test";
 import type { Locator, Page } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 const getPopover = (page: Page) => page.getByRole("dialog");
 const getButton = (locator: Page | Locator, name?: string) =>
   locator.getByRole("button", { name, exact: true });
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/popover-responsive", { waitUntil: "networkidle" });
+  await page.goto(preview("popover-responsive"), { waitUntil: "networkidle" });
 });
 
 test("popover responsive", async ({ page }) => {

--- a/examples/popover-responsive/test-chrome.ts
+++ b/examples/popover-responsive/test-chrome.ts
@@ -1,14 +1,10 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
 import type { Locator, Page } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { test } from "../test-utils.ts";
 
 const getPopover = (page: Page) => page.getByRole("dialog");
 const getButton = (locator: Page | Locator, name?: string) =>
   locator.getByRole("button", { name, exact: true });
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("popover-responsive"), { waitUntil: "networkidle" });
-});
 
 test("popover responsive", async ({ page }) => {
   await page.setViewportSize({ width: 768, height: 480 });

--- a/examples/popover-standalone/test-browser.ts
+++ b/examples/popover-standalone/test-browser.ts
@@ -1,5 +1,6 @@
 import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 const getButton = (page: Page | Locator, name: string) =>
   page.getByRole("button", { name });
@@ -7,7 +8,7 @@ const getPopover = (page: Page | Locator) =>
   page.getByRole("dialog", { name: "Team meeting" });
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/popover-standalone", { waitUntil: "networkidle" });
+  await page.goto(preview("popover-standalone"), { waitUntil: "networkidle" });
 });
 
 test("do not scroll when opening the popover", async ({ page }) => {

--- a/examples/popover-standalone/test-browser.ts
+++ b/examples/popover-standalone/test-browser.ts
@@ -1,15 +1,11 @@
 import type { Locator, Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 const getButton = (page: Page | Locator, name: string) =>
   page.getByRole("button", { name });
 const getPopover = (page: Page | Locator) =>
   page.getByRole("dialog", { name: "Team meeting" });
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("popover-standalone"), { waitUntil: "networkidle" });
-});
 
 test("do not scroll when opening the popover", async ({ page }) => {
   await page.setViewportSize({ width: 800, height: 600 });

--- a/examples/select-animated-store/test-browser.ts
+++ b/examples/select-animated-store/test-browser.ts
@@ -1,6 +1,6 @@
 import { query } from "@ariakit/test/playwright";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 const createTransition = (duration = 100) => {
   const then = performance.now();
@@ -10,12 +10,6 @@ const createTransition = (duration = 100) => {
   };
   return isPending;
 };
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("select-animated-store"), {
-    waitUntil: "networkidle",
-  });
-});
 
 test("show/hide", async ({ page }) => {
   const q = query(page);

--- a/examples/select-animated-store/test-browser.ts
+++ b/examples/select-animated-store/test-browser.ts
@@ -11,7 +11,7 @@ const createTransition = (duration = 100) => {
 };
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/select-animated-store", {
+  await page.goto(preview("select-animated-store"), {
     waitUntil: "networkidle",
   });
 });

--- a/examples/select-animated-store/test-browser.ts
+++ b/examples/select-animated-store/test-browser.ts
@@ -1,5 +1,6 @@
 import { query } from "@ariakit/test/playwright";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 const createTransition = (duration = 100) => {
   const then = performance.now();

--- a/examples/select-animated/test-browser.ts
+++ b/examples/select-animated/test-browser.ts
@@ -1,6 +1,6 @@
 import { query } from "@ariakit/test/playwright";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 const createTransition = (duration = 100) => {
   const then = performance.now();
@@ -10,10 +10,6 @@ const createTransition = (duration = 100) => {
   };
   return isPending;
 };
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("select-animated"), { waitUntil: "networkidle" });
-});
 
 test("show/hide", async ({ page }) => {
   const q = query(page);

--- a/examples/select-animated/test-browser.ts
+++ b/examples/select-animated/test-browser.ts
@@ -1,5 +1,6 @@
 import { query } from "@ariakit/test/playwright";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 const createTransition = (duration = 100) => {
   const then = performance.now();
@@ -11,7 +12,7 @@ const createTransition = (duration = 100) => {
 };
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/select-animated", { waitUntil: "networkidle" });
+  await page.goto(preview("select-animated"), { waitUntil: "networkidle" });
 });
 
 test("show/hide", async ({ page }) => {

--- a/examples/select-combobox-store/test-browser.ts
+++ b/examples/select-combobox-store/test-browser.ts
@@ -1,6 +1,6 @@
 import type { Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 const getButton = (page: Page) =>
   page.getByRole("combobox", { name: "Favorite fruit" });
@@ -12,10 +12,6 @@ async function expectSelected(page: Page, name: string) {
   await expect(getOption(page, name)).toBeInViewport();
   await expect(getOption(page, name)).toHaveAttribute("data-active-item");
 }
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("select-combobox-store"));
-});
 
 test("auto select first option", async ({ page }) => {
   await getButton(page).click();

--- a/examples/select-combobox-store/test-browser.ts
+++ b/examples/select-combobox-store/test-browser.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 const getButton = (page: Page) =>
   page.getByRole("combobox", { name: "Favorite fruit" });

--- a/examples/select-combobox-store/test-browser.ts
+++ b/examples/select-combobox-store/test-browser.ts
@@ -13,7 +13,7 @@ async function expectSelected(page: Page, name: string) {
 }
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/select-combobox-store");
+  await page.goto(preview("select-combobox-store"));
 });
 
 test("auto select first option", async ({ page }) => {

--- a/examples/select-combobox-tab/test-browser.ts
+++ b/examples/select-combobox-tab/test-browser.ts
@@ -6,7 +6,7 @@ const SELECT_COMBOBOX_TAB = "Select with Combobox and Tab";
 const TAB = [SELECT_TAB, SELECT_COMBOBOX_TAB];
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/select-combobox-tab");
+  await page.goto(preview("select-combobox-tab"));
 });
 
 for (const label of TAB) {

--- a/examples/select-combobox-tab/test-browser.ts
+++ b/examples/select-combobox-tab/test-browser.ts
@@ -1,14 +1,10 @@
 import { query } from "@ariakit/test/playwright";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 const SELECT_TAB = "Select with Tab";
 const SELECT_COMBOBOX_TAB = "Select with Combobox and Tab";
 const TAB = [SELECT_TAB, SELECT_COMBOBOX_TAB];
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("select-combobox-tab"));
-});
 
 for (const label of TAB) {
   test(`${label} - reset scroll position when switching tabs`, async ({

--- a/examples/select-combobox-tab/test-browser.ts
+++ b/examples/select-combobox-tab/test-browser.ts
@@ -1,5 +1,6 @@
 import { query } from "@ariakit/test/playwright";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 const SELECT_TAB = "Select with Tab";
 const SELECT_COMBOBOX_TAB = "Select with Combobox and Tab";

--- a/examples/select-combobox/test-browser.ts
+++ b/examples/select-combobox/test-browser.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 const getPopover = (page: Page) =>
   page.getByRole("dialog", { name: "Favorite fruit" });

--- a/examples/select-combobox/test-browser.ts
+++ b/examples/select-combobox/test-browser.ts
@@ -1,6 +1,6 @@
 import type { Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 const getPopover = (page: Page) =>
   page.getByRole("dialog", { name: "Favorite fruit" });
@@ -15,10 +15,6 @@ async function expectSelected(page: Page, name: string) {
   await expect(getOption(page, name)).toBeInViewport();
   await expect(getOption(page, name)).toHaveAttribute("data-active-item");
 }
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("select-combobox"));
-});
 
 test("auto select first option", async ({ page }) => {
   await getButton(page).click();

--- a/examples/select-combobox/test-browser.ts
+++ b/examples/select-combobox/test-browser.ts
@@ -16,7 +16,7 @@ async function expectSelected(page: Page, name: string) {
 }
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/select-combobox");
+  await page.goto(preview("select-combobox"));
 });
 
 test("auto select first option", async ({ page }) => {

--- a/examples/select-group/test-browser.ts
+++ b/examples/select-group/test-browser.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 function query(page: Page) {
   return {
@@ -12,7 +13,7 @@ function query(page: Page) {
 test.describe.configure({ retries: 2 });
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/select-group", { waitUntil: "networkidle" });
+  await page.goto(preview("select-group"), { waitUntil: "networkidle" });
 });
 
 test("scroll into view", async ({ page }) => {

--- a/examples/select-group/test-browser.ts
+++ b/examples/select-group/test-browser.ts
@@ -1,6 +1,6 @@
 import type { Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 function query(page: Page) {
   return {
@@ -11,10 +11,6 @@ function query(page: Page) {
 }
 
 test.describe.configure({ retries: 2 });
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("select-group"), { waitUntil: "networkidle" });
-});
 
 test("scroll into view", async ({ page }) => {
   test.info().snapshotSuffix = "";

--- a/examples/tab-panel-animated/test-chrome.ts
+++ b/examples/tab-panel-animated/test-chrome.ts
@@ -1,14 +1,10 @@
 import { query } from "@ariakit/test/playwright";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 const tab1 = "Popular";
 const tab2 = "Recent";
 const tab3 = "Explore";
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("tab-panel-animated"), { waitUntil: "networkidle" });
-});
 
 test.describe.configure({ retries: 2 });
 

--- a/examples/tab-panel-animated/test-chrome.ts
+++ b/examples/tab-panel-animated/test-chrome.ts
@@ -1,12 +1,13 @@
 import { query } from "@ariakit/test/playwright";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 const tab1 = "Popular";
 const tab2 = "Recent";
 const tab3 = "Explore";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/tab-panel-animated", { waitUntil: "networkidle" });
+  await page.goto(preview("tab-panel-animated"), { waitUntil: "networkidle" });
 });
 
 test.describe.configure({ retries: 2 });

--- a/examples/tag/test-chrome.ts
+++ b/examples/tag/test-chrome.ts
@@ -1,6 +1,7 @@
 import { query } from "@ariakit/test/playwright";
 import { expect, test } from "@playwright/test";
 import type { Page } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 async function copy(page: Page, text: string) {
   await page.evaluate((text) => navigator.clipboard.writeText(text), text);
@@ -18,7 +19,7 @@ async function tags(page: Page) {
 }
 
 test.beforeEach(async ({ page, context }) => {
-  await page.goto("/previews/tag", { waitUntil: "networkidle" });
+  await page.goto(preview("tag"), { waitUntil: "networkidle" });
   await context.grantPermissions(["clipboard-read", "clipboard-write"]);
 });
 

--- a/examples/tag/test-chrome.ts
+++ b/examples/tag/test-chrome.ts
@@ -1,7 +1,7 @@
 import { query } from "@ariakit/test/playwright";
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
 import type { Page } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { test } from "../test-utils.ts";
 
 async function copy(page: Page, text: string) {
   await page.evaluate((text) => navigator.clipboard.writeText(text), text);
@@ -18,8 +18,7 @@ async function tags(page: Page) {
   return Promise.all(options.map((el) => el.textContent()));
 }
 
-test.beforeEach(async ({ page, context }) => {
-  await page.goto(preview("tag"), { waitUntil: "networkidle" });
+test.beforeEach(async ({ context }) => {
   await context.grantPermissions(["clipboard-read", "clipboard-write"]);
 });
 

--- a/examples/test-utils.ts
+++ b/examples/test-utils.ts
@@ -8,11 +8,25 @@ import { test as base } from "@playwright/test";
 import type { Locator, Page, PageScreenshotOptions } from "@playwright/test";
 import type { AllowedTestLoader } from "../vitest.config.ts";
 
+const LOADER = (process.env.ARIAKIT_TEST_LOADER ??
+  "react") as AllowedTestLoader;
+
+export function preview(name: string) {
+  switch (LOADER) {
+    case "react":
+      return `/previews/${name}`;
+    case "solid":
+      return `/previews/${name}__solid`;
+    default:
+      throw new Error(`Unknown test loader: ${LOADER}`);
+  }
+}
+
 export const test = base.extend<{ forEachTest: void }>({
   forEachTest: [
     async ({ page }, use, testInfo) => {
       const name = basename(dirname(testInfo.file));
-      await page.goto(`/previews/${name}`, { waitUntil: "networkidle" });
+      await page.goto(preview(name), { waitUntil: "networkidle" });
       await use();
     },
     { auto: true },
@@ -151,19 +165,5 @@ export async function screenshot({
       omitBackground: true,
       style,
     });
-  }
-}
-
-const LOADER = (process.env.ARIAKIT_TEST_LOADER ??
-  "react") as AllowedTestLoader;
-
-export function preview(name: string) {
-  switch (LOADER) {
-    case "react":
-      return `/previews/${name}`;
-    case "solid":
-      return `/previews/${name}__solid`;
-    default:
-      throw new Error(`Unknown test loader: ${LOADER}`);
   }
 }

--- a/examples/test-utils.ts
+++ b/examples/test-utils.ts
@@ -1,4 +1,5 @@
-import { basename, dirname } from "node:path";
+import fs from "node:fs";
+import { basename, dirname, resolve } from "node:path";
 import {
   getTextboxSelection,
   getTextboxValue,
@@ -25,7 +26,14 @@ export function preview(name: string) {
 export const test = base.extend<{ forEachTest: void }>({
   forEachTest: [
     async ({ page }, use, testInfo) => {
-      const name = basename(dirname(testInfo.file));
+      const examplePath = dirname(testInfo.file);
+      const isWebsitePath = examplePath.includes("website/app");
+      const name = basename(examplePath);
+      const exampleExists = isWebsitePath
+        ? LOADER === "react" // for now, assume all website examples are React
+        : fs.existsSync(resolve(examplePath, `index.${LOADER}.tsx`));
+      if (!exampleExists) return testInfo.skip();
+
       await page.goto(preview(name), { waitUntil: "networkidle" });
       await use();
     },

--- a/examples/test-utils.ts
+++ b/examples/test-utils.ts
@@ -6,6 +6,7 @@ import {
 } from "@ariakit/core/utils/dom";
 import { test as base } from "@playwright/test";
 import type { Locator, Page, PageScreenshotOptions } from "@playwright/test";
+import type { AllowedTestLoader } from "../vitest.config.ts";
 
 export const test = base.extend<{ forEachTest: void }>({
   forEachTest: [
@@ -150,5 +151,19 @@ export async function screenshot({
       omitBackground: true,
       style,
     });
+  }
+}
+
+const LOADER = (process.env.ARIAKIT_TEST_LOADER ??
+  "react") as AllowedTestLoader;
+
+export function preview(name: string) {
+  switch (LOADER) {
+    case "react":
+      return `/previews/${name}`;
+    case "solid":
+      return `/previews/${name}__solid`;
+    default:
+      throw new Error(`Unknown test loader: ${LOADER}`);
   }
 }

--- a/examples/toolbar/test-chrome-js-disabled.ts
+++ b/examples/toolbar/test-chrome-js-disabled.ts
@@ -8,7 +8,7 @@ test.use({ javaScriptEnabled: false });
 
 test("make sure elements are tabbable with JS disabled", async ({ page }) => {
   await expect(async () => {
-    await page.goto("/previews/toolbar");
+    await page.goto(preview("toolbar"));
     await expect(getButton(page, "Undo")).toBeInViewport();
   }).toPass();
   await page.keyboard.press("Tab");

--- a/examples/toolbar/test-chrome-js-disabled.ts
+++ b/examples/toolbar/test-chrome-js-disabled.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 const getButton = (page: Page, name: string) =>
   page.getByRole("button", { name });

--- a/examples/toolbar/test-chrome-js-disabled.ts
+++ b/examples/toolbar/test-chrome-js-disabled.ts
@@ -1,6 +1,6 @@
 import type { Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
+import { expect } from "@playwright/test";
+import { preview, test } from "../test-utils.ts";
 
 const getButton = (page: Page, name: string) =>
   page.getByRole("button", { name });

--- a/examples/tooltip-label/test-mobile.ts
+++ b/examples/tooltip-label/test-mobile.ts
@@ -1,7 +1,8 @@
 import { expect, test } from "@playwright/test";
+import { preview } from "../test-utils.ts";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/tooltip-label", { waitUntil: "networkidle" });
+  await page.goto(preview("tooltip-label"), { waitUntil: "networkidle" });
 });
 
 test("tooltip does not appear on mobile click", async ({ page }) => {

--- a/examples/tooltip-label/test-mobile.ts
+++ b/examples/tooltip-label/test-mobile.ts
@@ -1,9 +1,5 @@
-import { expect, test } from "@playwright/test";
-import { preview } from "../test-utils.ts";
-
-test.beforeEach(async ({ page }) => {
-  await page.goto(preview("tooltip-label"), { waitUntil: "networkidle" });
-});
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
 
 test("tooltip does not appear on mobile click", async ({ page }) => {
   await expect(page.getByRole("tooltip", { name: "Bold" })).not.toBeVisible();

--- a/website/app/(examples)/previews/dialog-next-router/test-browser.ts
+++ b/website/app/(examples)/previews/dialog-next-router/test-browser.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { test } from "../../../../../examples/test-utils.ts";
 
 const getDialog = (page: Page) => page.getByRole("dialog", { name: "Login" });
 
@@ -7,10 +8,6 @@ const getLink = (page: Page) => page.getByRole("link", { name: "Login" });
 
 const getInput = (page: Page, name: string) =>
   page.getByRole("textbox", { name });
-
-test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/dialog-next-router", { waitUntil: "networkidle" });
-});
 
 test("show/hide", async ({ page }) => {
   // Open with click

--- a/website/app/(examples)/previews/select-next-router/test-browser.ts
+++ b/website/app/(examples)/previews/select-next-router/test-browser.ts
@@ -1,6 +1,7 @@
 import { query } from "@ariakit/test/playwright";
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
 import type { Page } from "@playwright/test";
+import { test } from "../../../../../examples/test-utils.ts";
 
 async function getNewTabModifier(page: Page) {
   const isMac = await page.evaluate(() => navigator.platform.startsWith("Mac"));
@@ -13,10 +14,6 @@ function hasSearchParam(name: string, value: string | string[]) {
     return values.every((v) => url.searchParams.has(name, v));
   };
 }
-
-test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/select-next-router", { waitUntil: "networkidle" });
-});
 
 test("default language", async ({ page }) => {
   const q = query(page);

--- a/website/app/(examples)/previews/tab-next-router/test-browser.ts
+++ b/website/app/(examples)/previews/tab-next-router/test-browser.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { test } from "../../../../../examples/test-utils.ts";
 
 const getLink = (page: Page, name: string) => page.getByRole("link", { name });
 
@@ -7,10 +8,6 @@ const getTab = (page: Page, name: string) => page.getByRole("tab", { name });
 
 const getTabPanel = (page: Page, name: string) =>
   page.getByRole("tabpanel", { name });
-
-test.beforeEach(async ({ page }) => {
-  await page.goto("/previews/tab-next-router", { waitUntil: "networkidle" });
-});
 
 test("click on links", async ({ page }) => {
   await expect(getTabPanel(page, "Hot")).toBeVisible();


### PR DESCRIPTION
Instead of hardcoding the preview URL, we use a `preview` function that allows routing to the appropriate URL depending on the loader, similar to how we handle unit tests.

Remaining things to figure out / discuss:

- [x] How to skip tests if example doesn't exist for given loader - ideas: filesystem lookup, check for 404
- [x] Do we also route the tests inside of `website/` (instead of `examples`)?

---

Update: I took care of both. Details:

- Tests are skipped by doing a filesystem lookup for an example with the proper loader (e.g. `index.solid.tsx`), similar to how it's done in unit tests.
  - In website examples, it's always assumed that they are React examples for now. When the Astro rewrite is worked on, a clean approach to loaders should probably be considered from the start.
- Website tests are also routed with the test fixture. The only exception is the Ariakit Plus test, since it's very different and does not test an example. The default playwright `test` function is still imported there.
- There are 2 tests where, on top of the fixture, there's manual routing going on for various reasons. The tests are `dialog-details` and `toolbar` (both in `examples/`). While using the fixture does introduce the slight overhead of having to navigate to the example path first, and then navigating again during the test's runtime, it doesn't get in the way of the test itself. So I think it's fine. These use the `preview()` utility directly to route to the loader-appropriate URL.