### PR TITLE
[Select] Fix: prevent native select value from submitting when Select is disabled

### DIFF
--- a/.changeset/4506-native-select-disabled-field-fix.md
+++ b/.changeset/4506-native-select-disabled-field-fix.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed [Select](https://ariakit.org/components/select) not passing down the [`disabled`](https://ariakit.org/reference/select#disabled) prop to the native select element.

--- a/examples/select-form-disabled/index.react.tsx
+++ b/examples/select-form-disabled/index.react.tsx
@@ -1,0 +1,36 @@
+import * as Ariakit from "@ariakit/react";
+import "./style.css";
+
+export default function Example() {
+  return (
+    <form
+      className="wrapper"
+      onSubmit={(event) => {
+        event.preventDefault();
+        const data = new FormData(event.currentTarget);
+        window.alert(data.get("select"));
+      }}
+    >
+      <div className="field">
+        <Ariakit.SelectProvider defaultValue="Apple">
+          <Ariakit.SelectLabel>Favorite fruit</Ariakit.SelectLabel>
+          <Ariakit.Select className="button" name="select" disabled />
+          <Ariakit.SelectPopover
+            gutter={4}
+            sameWidth
+            unmountOnHide
+            className="popover"
+          >
+            <Ariakit.SelectItem className="select-item" value="Apple" />
+            <Ariakit.SelectItem className="select-item" value="Banana" />
+            <Ariakit.SelectItem className="select-item" value="Grape" />
+            <Ariakit.SelectItem className="select-item" value="Orange" />
+          </Ariakit.SelectPopover>
+        </Ariakit.SelectProvider>
+      </div>
+      <Ariakit.Button type="submit" className="button primary">
+        Submit
+      </Ariakit.Button>
+    </form>
+  );
+}

--- a/examples/select-form-disabled/style.css
+++ b/examples/select-form-disabled/style.css
@@ -1,0 +1,1 @@
+@import url("../form-select/style.css");

--- a/examples/select-form-disabled/test.ts
+++ b/examples/select-form-disabled/test.ts
@@ -1,0 +1,38 @@
+import { click, press, q } from "@ariakit/test";
+
+const spyOnAlert = () => vi.spyOn(window, "alert").mockImplementation(() => {});
+
+let alert = spyOnAlert();
+
+beforeEach(() => {
+  alert = spyOnAlert();
+  return () => alert.mockClear();
+});
+
+test("disabled select is visually and semantically disabled", () => {
+  const button = q.combobox();
+  expect(button).toBeDisabled();
+  expect(button).toHaveAttribute("aria-disabled", "true");
+  expect(button).toHaveStyle("pointer-events: none");
+});
+
+test("disabled select cannot be opened with click", async () => {
+  await click(q.combobox());
+  expect(q.listbox()).not.toBeInTheDocument();
+});
+
+test("disabled select cannot be opened with keyboard", async () => {
+  await press.Tab();
+  await press.ShiftTab();
+
+  expect(q.button("Submit")).toHaveFocus();
+
+  await press.ArrowDown();
+  expect(q.listbox()).not.toBeInTheDocument();
+});
+
+test("disabled select does not submit value", async () => {
+  await press.Tab();
+  await press.Enter();
+  expect(alert).toHaveBeenCalledWith(null);
+});

--- a/packages/ariakit-react-core/src/select/select.tsx
+++ b/packages/ariakit-react-core/src/select/select.tsx
@@ -77,7 +77,6 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
   moveOnKeyDown = true,
   toggleOnPress = true,
   toggleOnClick = toggleOnPress,
-  disabled,
   ...props
 }) {
   const context = useSelectProviderContext();
@@ -203,7 +202,7 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
             name={name}
             form={form}
             required={required}
-            disabled={disabled}
+            disabled={props.disabled}
             value={value}
             multiple={multiSelectable}
             // Even though this element is visually hidden and is not

--- a/packages/ariakit-react-core/src/select/select.tsx
+++ b/packages/ariakit-react-core/src/select/select.tsx
@@ -77,6 +77,7 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
   moveOnKeyDown = true,
   toggleOnPress = true,
   toggleOnClick = toggleOnPress,
+  disabled,
   ...props
 }) {
   const context = useSelectProviderContext();
@@ -202,6 +203,7 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
             name={name}
             form={form}
             required={required}
+            disabled={disabled}
             value={value}
             multiple={multiSelectable}
             // Even though this element is visually hidden and is not

--- a/packages/ariakit-react-core/src/select/select.tsx
+++ b/packages/ariakit-react-core/src/select/select.tsx
@@ -250,6 +250,7 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
       value,
       multiSelectable,
       values,
+      props.disabled,
     ],
   );
 


### PR DESCRIPTION
Fixes: #4310

**Problem:**

When the `Select` component was rendered with the `disabled` prop, the hidden native `<select>` element used for form submission was still enabled. As a result, the form would submit a value for the disabled field, which is inconsistent with native HTML form behavior.

**Fix:**

This PR ensures that the native <select> element receives the disabled attribute, preventing its value from being included in the form submission when it is disabled.

A working example and tests have also been added to demonstrate and verify the fix.
Tests cover disabled behavior, keyboard interaction, and correct form submission logic.





