### PR TITLE
[docs] replace SelectSeparator with SelectGroup and border styling

### DIFF
--- a/examples/select-group/index.react.tsx
+++ b/examples/select-group/index.react.tsx
@@ -6,7 +6,6 @@ import {
   SelectLabel,
   SelectPopover,
   SelectProvider,
-  SelectSeparator,
 } from "@ariakit/react";
 import "./style.css";
 

--- a/examples/select-group/index.react.tsx
+++ b/examples/select-group/index.react.tsx
@@ -26,15 +26,13 @@ export default function Example() {
             <SelectItem className="select-item" value="Grape" />
             <SelectItem className="select-item" value="Orange" />
           </SelectGroup>
-          <SelectSeparator className="separator" />
-          <SelectGroup className="group">
+          <SelectGroup className="group group-separator">
             <SelectGroupLabel className="group-label">Dairy</SelectGroupLabel>
             <SelectItem className="select-item" value="Milk" />
             <SelectItem className="select-item" value="Cheese" />
             <SelectItem className="select-item" value="Yogurt" />
           </SelectGroup>
-          <SelectSeparator className="separator" />
-          <SelectGroup className="group">
+          <SelectGroup className="group group-separator">
             <SelectGroupLabel className="group-label">
               Beverages
             </SelectGroupLabel>
@@ -42,8 +40,7 @@ export default function Example() {
             <SelectItem className="select-item" value="Juice" />
             <SelectItem className="select-item" value="Soda" />
           </SelectGroup>
-          <SelectSeparator className="separator" />
-          <SelectGroup className="group">
+          <SelectGroup className="group group-separator">
             <SelectGroupLabel className="group-label">Snacks</SelectGroupLabel>
             <SelectItem className="select-item" value="Chips" />
             <SelectItem className="select-item" value="Nuts" />

--- a/examples/select-group/style.css
+++ b/examples/select-group/style.css
@@ -2,12 +2,9 @@
 @import url("../separator/style.css");
 
 .group-label {
-  @apply
-    text-sm
-    p-2
-    font-medium
-    opacity-60
-    cursor-default
-    [&+*]:scroll-mt-10
-  ;
+  @apply cursor-default p-2 text-sm font-medium opacity-60 [&+*]:scroll-mt-10;
+}
+
+.group-separator {
+  @apply mt-2 border-t border-gray-250 pt-2 dark:border-t-gray-550;
 }


### PR DESCRIPTION
Fixes: #4395


The `SelectSeparator` component is deprecated. Users are now advised to use `SelectGroup` with custom CSS border styling to visually separate groups of items.

