### PR TITLE
Update vitest config to include React plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "@types/textarea-caret": "3.0.3",
         "@types/use-sync-external-store": "0.0.6",
         "@vercel/analytics": "1.5.0",
+        "@vitejs/plugin-react": "4.3.4",
         "@vitest/browser": "3.1.1",
         "@vitest/coverage-c8": "0.33.0",
         "@wordpress/components": "29.7.0",

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "@types/textarea-caret": "3.0.3",
     "@types/use-sync-external-store": "0.0.6",
     "@vercel/analytics": "1.5.0",
+    "@vitejs/plugin-react": "4.3.4",
     "@vitest/browser": "3.1.1",
     "@vitest/coverage-c8": "0.33.0",
     "@wordpress/components": "29.7.0",

--- a/site/src/examples/separator/test.ts
+++ b/site/src/examples/separator/test.ts
@@ -4,7 +4,7 @@ test("render horizontal separator", () => {
   expect(q.separator()).toMatchInlineSnapshot(`
     <hr
       aria-orientation="horizontal"
-      class="separator"
+      class="ak-layer-current"
       role="separator"
     />
   `);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,4 @@
+import reactPlugin from "@vitejs/plugin-react";
 import { version } from "react";
 import solidPlugin from "vite-plugin-solid";
 import { type Plugin, configDefaults, defineConfig } from "vitest/config";
@@ -28,6 +29,9 @@ if (!ALLOWED_TEST_LOADERS.includes(LOADER))
   throw new Error(`Invalid loader: ${LOADER}`);
 
 const PLUGINS_BY_LOADER: Record<string, Array<Plugin> | undefined> = {
+  // @ts-expect-error I believe this error will go away when we regenerate
+  // package-lock.json
+  react: [reactPlugin()],
   solid: [solidPlugin()],
 };
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -69,7 +69,7 @@ async function tryImport(path: string) {
 
 async function loadReact(dir: string) {
   const { component, failedImport } = await tryImport(
-    `./examples/${dir}/index.react.tsx`,
+    `./${dir}/index.react.tsx`,
   );
   if (failedImport) return false;
   const element = createElement(ReactSuspense, {
@@ -83,7 +83,7 @@ async function loadReact(dir: string) {
 
 async function loadSolid(dir: string) {
   const { component, failedImport } = await tryImport(
-    `./examples/${dir}/index.solid.tsx`,
+    `./${dir}/index.solid.tsx`,
   );
   if (failedImport) return false;
   const div = document.createElement("div");
@@ -137,7 +137,7 @@ function parseTest(filename?: string) {
   if (!filename) return false;
   const match = filename.match(
     // @ts-expect-error Test runner is not limited by ES2017 target.
-    /examples\/(?<dir>.*)\/test\.((?<loader>react|solid)\.)?ts$/,
+    /(?<dir>.*)\/test\.((?<loader>react|solid)\.)?ts$/,
   );
   if (!match?.groups) return false;
   const { dir, loader } = match.groups;


### PR DESCRIPTION
I updated the vitest configuration to include the React plugin, which is necessary when the tsconfig doesn't explicitly use React as the JSX import source.

I also updated the test import paths to allow the use of folders other than just `/examples`.