### PR TITLE
Improve `PopoverArrow` SVG and add `borderWidth` features

### DIFF
--- a/.changeset/4531-react-popover-arrow-1.md
+++ b/.changeset/4531-react-popover-arrow-1.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Added [`borderWidth`](https://ariakit.org/reference/popover-arrow#borderwidth) prop to [`PopoverArrow`](https://ariakit.org/reference/popover-arrow).

--- a/.changeset/4531-react-popover-arrow-2.md
+++ b/.changeset/4531-react-popover-arrow-2.md
@@ -1,0 +1,14 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Improved `PopoverArrow`
+
+The [`PopoverArrow`](https://ariakit.org/reference/popover-arrow) component now attempts to infer its border width from the popover’s `box-shadow` style when all lengths are `0px` and the spread radius exceeds `0px` (e.g., `box-shadow: 0 0 0 1px black`), which is commonly known as a "ring".
+
+If the border width cannot be inferred, you can use the new [`borderWidth`](https://ariakit.org/reference/popover-arrow#borderwidth) prop to define it. This ensures a consistent size regardless of the arrow's size, which wasn't achievable before when manually setting the CSS `stroke-width` property.
+
+In addition, the arrow’s SVG path has been slightly modified to be more angled in the pointing direction.
+
+**Note**: You can always provide your own SVG using the `children` prop.

--- a/packages/ariakit-react-core/src/popover/popover-arrow-path.ts
+++ b/packages/ariakit-react-core/src/popover/popover-arrow-path.ts
@@ -15,7 +15,7 @@
  *
  * Modifications Copyright 2019 - present by Diego Haz.
  *
- * Extracted the SVG path only.
+ * Extracted the SVG path and made the tip more angled.
  */
 export const POPOVER_ARROW_PATH =
-  "M23,27.8c1.1,1.2,3.4,2.2,5,2.2h2H0h2c1.7,0,3.9-1,5-2.2l6.6-7.2c0.7-0.8,2-0.8,2.7,0L23,27.8L23,27.8z";
+  "M23 27.8C24.1 29 26.4 30 28 30H30H0H2C3.7 30 5.9 29 7 27.8L14 20.6C14.7 19.8 15.3 19.8 16 20.6L23 27.8Z";

--- a/packages/ariakit-react-core/src/popover/popover-arrow.tsx
+++ b/packages/ariakit-react-core/src/popover/popover-arrow.tsx
@@ -1,9 +1,15 @@
 import { getWindow } from "@ariakit/core/utils/dom";
 import { invariant, removeUndefinedValues } from "@ariakit/core/utils/misc";
 import type { ElementType } from "react";
-import { useMemo, useState } from "react";
+import { useId, useMemo, useState } from "react";
 import { useMergeRefs, useSafeLayoutEffect } from "../utils/hooks.ts";
-import { createElement, createHook, forwardRef } from "../utils/system.tsx";
+import { useStoreState } from "../utils/store.tsx";
+import {
+  createElement,
+  createHook,
+  forwardRef,
+  memo,
+} from "../utils/system.tsx";
 import type { Options, Props } from "../utils/types.ts";
 import { POPOVER_ARROW_PATH } from "./popover-arrow-path.ts";
 import { usePopoverContext } from "./popover-context.tsx";
@@ -25,7 +31,7 @@ const rotateMap = {
 
 function useComputedStyle(store: PopoverStore) {
   const [style, setStyle] = useState<CSSStyleDeclaration>();
-  const contentElement = store.useState("contentElement");
+  const contentElement = useStoreState(store, "contentElement");
   useSafeLayoutEffect(() => {
     if (!contentElement) return;
     const win = getWindow(contentElement);
@@ -33,6 +39,13 @@ function useComputedStyle(store: PopoverStore) {
     setStyle(computedStyle);
   }, [contentElement]);
   return style;
+}
+
+function getRingWidth(style?: CSSStyleDeclaration) {
+  if (!style) return;
+  const boxShadow = style.getPropertyValue("box-shadow");
+  const ringWidth = boxShadow.match(/0px 0px 0px ([^0]+px)/)?.[1];
+  return ringWidth;
 }
 
 /**
@@ -49,7 +62,12 @@ function useComputedStyle(store: PopoverStore) {
  * ```
  */
 export const usePopoverArrow = createHook<TagName, PopoverArrowOptions>(
-  function usePopoverArrow({ store, size = defaultSize, ...props }) {
+  function usePopoverArrow({
+    store,
+    size = defaultSize,
+    borderWidth: borderWidthProp,
+    ...props
+  }) {
     const context = usePopoverContext();
     store = store || context;
 
@@ -59,27 +77,49 @@ export const usePopoverArrow = createHook<TagName, PopoverArrowOptions>(
         "PopoverArrow must be wrapped in a Popover component.",
     );
 
-    const dir = store.useState(
+    const dir = useStoreState(
+      store,
       (state) => state.currentPlacement.split("-")[0] as BasePlacement,
     );
 
+    const maskId = useId();
     const style = useComputedStyle(store);
     const fill = style?.getPropertyValue("background-color") || "none";
     const stroke = style?.getPropertyValue(`border-${dir}-color`) || "none";
-    const borderWidth = style?.getPropertyValue(`border-${dir}-width`) || "0px";
-    const strokeWidth = Number.parseInt(borderWidth) * 2 * (defaultSize / size);
+
+    const borderWidth = useMemo(() => {
+      if (borderWidthProp != null) return borderWidthProp;
+      if (!style) return 0;
+      const ringWidth = getRingWidth(style);
+      if (ringWidth) return Number.parseInt(ringWidth);
+      const borderWidth = style.getPropertyValue(`border-${dir}-width`);
+      if (borderWidth) return Number.parseInt(borderWidth);
+      return 0;
+    }, [borderWidthProp, style, dir]);
+
+    const strokeWidth = borderWidth * 2 * (defaultSize / size);
     const transform = rotateMap[dir];
 
     const children = useMemo(
       () => (
         <svg display="block" viewBox="0 0 30 30">
           <g transform={transform}>
-            <path fill="none" d={POPOVER_ARROW_PATH} />
+            <path fill="none" d={POPOVER_ARROW_PATH} mask={`url(#${maskId})`} />
             <path stroke="none" d={POPOVER_ARROW_PATH} />
+            <mask id={maskId} maskUnits="userSpaceOnUse">
+              <rect
+                x="-15"
+                y="0"
+                width="60"
+                height="30"
+                fill="white"
+                stroke="black"
+              />
+            </mask>
           </g>
         </svg>
       ),
-      [transform],
+      [transform, maskId],
     );
 
     props = {
@@ -88,14 +128,13 @@ export const usePopoverArrow = createHook<TagName, PopoverArrowOptions>(
       ...props,
       ref: useMergeRefs(store.setArrowElement, props.ref),
       style: {
-        // server side rendering
         position: "absolute",
         fontSize: size,
         width: "1em",
         height: "1em",
         pointerEvents: "none",
-        fill,
-        stroke,
+        fill: `var(--ak-layer, ${fill})`,
+        stroke: `var(--ak-layer-border, ${stroke})`,
         strokeWidth,
         ...props.style,
       },
@@ -120,12 +159,12 @@ export const usePopoverArrow = createHook<TagName, PopoverArrowOptions>(
  * </PopoverProvider>
  * ```
  */
-export const PopoverArrow = forwardRef(function PopoverArrow(
-  props: PopoverArrowProps,
-) {
-  const htmlProps = usePopoverArrow(props);
-  return createElement(TagName, htmlProps);
-});
+export const PopoverArrow = memo(
+  forwardRef(function PopoverArrow(props: PopoverArrowProps) {
+    const htmlProps = usePopoverArrow(props);
+    return createElement(TagName, htmlProps);
+  }),
+);
 
 export interface PopoverArrowOptions<_T extends ElementType = TagName>
   extends Options {
@@ -146,6 +185,11 @@ export interface PopoverArrowOptions<_T extends ElementType = TagName>
    * @default 30
    */
   size?: number;
+  /**
+   * The arrow's border width. If not specified, Ariakit will infer it from the
+   * popover `contentElement`'s style.
+   */
+  borderWidth?: number;
 }
 
 export type PopoverArrowProps<T extends ElementType = TagName> = Props<


### PR DESCRIPTION
This pull request includes several enhancements and improvements to the `PopoverArrow` component in the `@ariakit/react-core` and `@ariakit/react` packages. The main changes include adding a new prop, improving the component's functionality, and refactoring the code for better maintainability.

Enhancements to `PopoverArrow` component:

* Added a new `borderWidth` prop to the `PopoverArrow` component to allow users to define the border width explicitly.
* Improved the `PopoverArrow` component to infer its border width from the popover’s `box-shadow` style when applicable, ensuring a consistent size regardless of the arrow's size.
* Modified the arrow’s SVG path to be more angled in the pointing direction for better visual accuracy.

Code refactoring and improvements:

* Refactored the `usePopoverArrow` hook to include the new `borderWidth` prop and improve the logic for determining the border width. [[1]](diffhunk://#diff-6995e34e35c8bc2bd92fb9642b82052d29e7f6b4c4778debdb5be8d64a61a1a3L52-R70) [[2]](diffhunk://#diff-6995e34e35c8bc2bd92fb9642b82052d29e7f6b4c4778debdb5be8d64a61a1a3L62-R122) [[3]](diffhunk://#diff-6995e34e35c8bc2bd92fb9642b82052d29e7f6b4c4778debdb5be8d64a61a1a3L91-R137)
* Updated the `PopoverArrow` component to use `memo` for performance optimization and refactored the code to use `useStoreState` instead of `store.useState`. [[1]](diffhunk://#diff-6995e34e35c8bc2bd92fb9642b82052d29e7f6b4c4778debdb5be8d64a61a1a3L4-R12) [[2]](diffhunk://#diff-6995e34e35c8bc2bd92fb9642b82052d29e7f6b4c4778debdb5be8d64a61a1a3L28-R34) [[3]](diffhunk://#diff-6995e34e35c8bc2bd92fb9642b82052d29e7f6b4c4778debdb5be8d64a61a1a3R44-R50) [[4]](diffhunk://#diff-6995e34e35c8bc2bd92fb9642b82052d29e7f6b4c4778debdb5be8d64a61a1a3L123-R167) [[5]](diffhunk://#diff-6995e34e35c8bc2bd92fb9642b82052d29e7f6b4c4778debdb5be8d64a61a1a3R188-R192)