### PR TITLE
Fix scrolling issue when closing dialogs by clicking outside

### DIFF
--- a/.changeset/4535-react-dialog-focus-on-hide-prevent-scroll.md
+++ b/.changeset/4535-react-dialog-focus-on-hide-prevent-scroll.md
@@ -1,0 +1,8 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Scrolling behavior when closing dialogs and popovers
+
+When hiding a dialog or popover, the [`finalFocus`](https://ariakit.org/reference/dialog#finalfocus) element will no longer scroll into view. This change prevents scrolling issues when the element lies outside the viewport and mirrors the behavior of native HTML dialog and popover elements.

--- a/examples/menu-combobox/test-browser.ts
+++ b/examples/menu-combobox/test-browser.ts
@@ -19,5 +19,5 @@ test("https://github.com/ariakit/ariakit/issues/4324", async ({ page }) => {
   });
   await page.mouse.click(10, 10);
   await expect(q.dialog("Add block")).not.toBeVisible();
-  expect(q.button("Add block")).not.toBeInViewport();
+  await expect(q.button("Add block")).not.toBeInViewport();
 });

--- a/examples/menu-combobox/test-browser.ts
+++ b/examples/menu-combobox/test-browser.ts
@@ -1,21 +1,23 @@
-import type { Page } from "@playwright/test";
+import { query } from "@ariakit/test/playwright";
 import { expect } from "@playwright/test";
 import { test } from "../test-utils.ts";
 
-const getMenuButton = (page: Page) =>
-  page.getByRole("button", { name: "Add block" });
-
-const getMenu = (page: Page) => page.getByRole("dialog", { name: "Add block" });
-
-const getCombobox = (page: Page) =>
-  page.getByRole("combobox", { name: "Search..." });
-
-const getOption = (page: Page, name: string) =>
-  page.getByRole("option", { name });
-
 test("auto select first option", async ({ page }) => {
-  await getMenuButton(page).click();
-  await expect(getMenu(page)).toBeVisible();
-  await getCombobox(page).type("a");
-  await expect(getOption(page, "Audio")).toHaveAttribute("data-active-item");
+  const q = query(page);
+  await q.button("Add block").click();
+  await expect(q.dialog("Add block")).toBeVisible();
+  await q.combobox("Search...").fill("a");
+  await expect(q.option("Audio")).toHaveAttribute("data-active-item");
+});
+
+test("https://github.com/ariakit/ariakit/issues/4324", async ({ page }) => {
+  const q = query(page);
+  await q.button("Add block").click();
+  await expect(q.dialog("Add block")).toBeVisible();
+  await page.evaluate(() => {
+    window.scrollTo(0, document.body.scrollHeight);
+  });
+  await page.mouse.click(10, 10);
+  await expect(q.dialog("Add block")).not.toBeVisible();
+  expect(q.button("Add block")).not.toBeInViewport();
 });

--- a/packages/ariakit-react-core/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-core/src/dialog/dialog.tsx
@@ -423,7 +423,7 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
       }
       if (!autoFocusOnHideProp(isElementFocusable ? element : null)) return;
       if (!isElementFocusable) return;
-      element?.focus();
+      element?.focus({ preventScroll: true });
     },
     [store, finalFocus, autoFocusOnHideProp],
   );


### PR DESCRIPTION
Fixes #4324

When hiding a dialog or popover, the [`finalFocus`](https://ariakit.org/reference/dialog#finalfocus) element will no longer scroll into view. This change prevents scrolling issues when the element lies outside the viewport and mirrors the behavior of native HTML dialog and popover elements.