### PR TITLE
Fix composition text commands clashing with Composite's `moveOnKeyPress`

### DIFF
--- a/.changeset/4539-react-composite-move-on-key-press-composing-text.md
+++ b/.changeset/4539-react-composite-move-on-key-press-composing-text.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed [`moveOnKeyPress`](https://ariakit.org/reference/composite#moveonkeypress) being triggered with composition text commands.

--- a/packages/ariakit-react-core/src/composite/composite.tsx
+++ b/packages/ariakit-react-core/src/composite/composite.tsx
@@ -368,6 +368,8 @@ export const useComposite = createHook<TagName, CompositeOptions>(
 
     const onKeyDown = useEvent((event: ReactKeyboardEvent<HTMLType>) => {
       onKeyDownProp?.(event);
+      // https://github.com/ariakit/ariakit/issues/4388
+      if (event.nativeEvent.isComposing) return;
       if (event.defaultPrevented) return;
       if (!store) return;
       if (!isSelfTarget(event)) return;


### PR DESCRIPTION
Fixes #4388

Unfortunately, Playwright doesn't currently support IME or composition text, which prevents us from testing it properly. See https://github.com/microsoft/playwright/issues/5777