### PR TITLE
Use useId from util for backward compatibility

### DIFF
--- a/.changeset/beige-fireants-agree.md
+++ b/.changeset/beige-fireants-agree.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/react-core": patch
+---
+
+used useId from util for backward compatibility

--- a/.changeset/beige-fireants-agree.md
+++ b/.changeset/beige-fireants-agree.md
@@ -1,5 +1,6 @@
 ---
 "@ariakit/react-core": patch
+"@ariakit/react": patch
 ---
 
-used useId from util for backward compatibility
+Restored support for React 17 in [`PopoverArrow`](https://ariakit.org/reference/popover-arrow).

--- a/packages/ariakit-react-core/src/popover/popover-arrow.tsx
+++ b/packages/ariakit-react-core/src/popover/popover-arrow.tsx
@@ -1,8 +1,8 @@
 import { getWindow } from "@ariakit/core/utils/dom";
 import { invariant, removeUndefinedValues } from "@ariakit/core/utils/misc";
 import type { ElementType } from "react";
-import { useId, useMemo, useState } from "react";
-import { useMergeRefs, useSafeLayoutEffect } from "../utils/hooks.ts";
+import { useMemo, useState } from "react";
+import { useId, useMergeRefs, useSafeLayoutEffect } from "../utils/hooks.ts";
 import { useStoreState } from "../utils/store.tsx";
 import {
   createElement,


### PR DESCRIPTION
Fixes #4547 

- [x]  Backward compatibility for popover component as mentioned in the issue #4547 