### PR TITLE
fix(solid): prevent infinite loop when syncing value in useStoreProp

### DIFF
--- a/packages/ariakit-solid-core/src/utils/store.tsx
+++ b/packages/ariakit-solid-core/src/utils/store.tsx
@@ -180,9 +180,13 @@ export function useStoreProps<
   // If the value prop is provided, we'll always reset the store state to it.
   Solid.createEffect(() => {
     const $store = access(store);
-    const $value = value();
+    const $value = Solid.untrack(value);
     const $key = access(key);
     if ($value === undefined) return;
+
+    const current = $store.getState()[$key];
+    if (current === $value) return;
+
     $store.setState($key, $value);
     return batch($store, [$key], () => {
       if ($value === undefined) return;


### PR DESCRIPTION

**- Problem**

When a value signal  is passed, an infinite loop can occur due to how Solid tracks reactivity. This happens specifically in the useStoreProps hook:

```
Solid.createEffect(() => {
  const $value = value(); // This is tracked
  $store.setState($key, $value);
});
```
If `value()` triggers a state change, Solid will re-run the effect, causing a loop:
`setState → value → setValue → setState → ...`


**- Fix**

To prevent the loop:

We wrap the `value()` access in `Solid.untrack()` to avoid reactive tracking of its dependencies.

We also limit the `getState()` to prevent redundant updates when the state hasn't changed.

```
Solid.createEffect(() => {
  const $value = Solid.untrack(value); // Prevent re-tracking
  const current = $store.getState()[$key];
  if (current === $value) return;
  $store.setState($key, $value);
});
```
This allows the store to receive prop values once when needed, but not re-trigger unnecessarily.

