### PR TITLE
Fix solid checkbox dynamic store

### DIFF
--- a/packages/ariakit-solid-core/src/utils/store.tsx
+++ b/packages/ariakit-solid-core/src/utils/store.tsx
@@ -208,6 +208,16 @@ export function useStore<T extends CoreStore, P>(
 ) {
   const [store, setStore] = Solid.createSignal(createStore(props));
 
+  Solid.createEffect(() => {
+    const dynamicStore = access((props as { store?: MaybeAccessor<T> }).store);
+    const currentStore = store();
+
+    if (dynamicStore && dynamicStore !== currentStore) {
+      setStore(() => dynamicStore);
+      return;
+    }
+  });
+
   Solid.createEffect(() => Solid.onCleanup(init(store())));
 
   const useState = ((keyOrSelector: any) =>

--- a/packages/ariakit-solid-core/src/utils/store.tsx
+++ b/packages/ariakit-solid-core/src/utils/store.tsx
@@ -180,9 +180,13 @@ export function useStoreProps<
   // If the value prop is provided, we'll always reset the store state to it.
   Solid.createEffect(() => {
     const $store = access(store);
-    const $value = value();
+    const $value = Solid.untrack(value);
     const $key = access(key);
     if ($value === undefined) return;
+
+    const current = $store.getState()[$key];
+    if (current === $value) return;
+
     $store.setState($key, $value);
     return batch($store, [$key], () => {
       if ($value === undefined) return;


### PR DESCRIPTION
**- Problem**

When a component receives a dynamic store prop, Solid reactivity doesn't automatically respond to changes in the accessor. This causes stale state in components like Checkbox, where checked remains stuck even after the store changes. The underlying issue is that `useStoreState` subscribes to the initial store, but doesn't track the updates to the store


**- Expected behaviour**

When the store prop changes, the component should react to the new store, updating internal values like checked and aria-checked as needed.


**- Fix**

Introduced a utility to wrap `useStoreState` in a `createMemo,` which ensures that any change to the dynamic store accessor causes the value to be re-evaluated. This guarantees the component stays in sync with the current store.
Also added an effect inside `useStore` to detect changes in the store prop and update the internal signal accordingly.