### PR TITLE
[Doc]: fix contribution guide link on solid

### DIFF
--- a/packages/ariakit-solid/readme.md
+++ b/packages/ariakit-solid/readme.md
@@ -98,4 +98,4 @@ Browser testing provided by
 
 ## Contributing
 
-Follow the instructions on the [contributing guide](https://github.com/ariakit/ariakit/blob/main/contributing.md).
+Follow the instructions on the [contributing guide](https://github.com/ariakit/ariakit/blob/solid/next/packages/ariakit-solid/contributing.md).


### PR DESCRIPTION
As I started looking into porting new components to Solid, I noticed that the contribution guide link points to the main guide instead of the Solid-specific one 🙂