### PR TITLE
Improve open performance for long comboboxes by ~30%

### DIFF
--- a/.changeset/sad-pants-shout.md
+++ b/.changeset/sad-pants-shout.md
@@ -1,5 +1,8 @@
 ---
 "@ariakit/react-core": patch
+"@ariakit/react": patch
 ---
 
-Improve mount performance of Focusable
+Improved Combobox performance
+
+Thanks to [@iamakulov](https://github.com/iamakulov), the [Combobox](https://ariakit.org/components/combobox) component now opens ~30% faster by removing unnecessary calls to an internal function that adds global event listeners. See the [pull request](https://github.com/ariakit/ariakit/pull/4860) for more details.

--- a/.changeset/sad-pants-shout.md
+++ b/.changeset/sad-pants-shout.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/react-core": patch
+---
+
+Improve mount performance of Focusable

--- a/packages/ariakit-core/src/utils/events.ts
+++ b/packages/ariakit-core/src/utils/events.ts
@@ -225,8 +225,8 @@ export function addGlobalEventListener(
   // Prevent errors from "sandbox" frames.
   try {
     if (!hasEventListenerBeenAdded(type, listener, options, scope)) {
-      scope.document.addEventListener(type, listener, options);
       markEventListenerAsAdded(type, listener, options, scope);
+      scope.document.addEventListener(type, listener, options);
     }
 
     for (const frame of Array.from(scope.frames)) {

--- a/packages/ariakit-core/src/utils/events.ts
+++ b/packages/ariakit-core/src/utils/events.ts
@@ -249,29 +249,61 @@ export function addGlobalEventListener(
 
 const addedGlobalEventListeners = new WeakMap<
   EventListenerOrEventListenerObject,
-  { type: string, options: boolean | AddEventListenerOptions | undefined, scope: Window }[]
->
-function hasEventListenerBeenAdded(type: string, listener: EventListenerOrEventListenerObject, options: boolean | AddEventListenerOptions | undefined, scope: Window) {
+  {
+    type: string;
+    options: boolean | AddEventListenerOptions | undefined;
+    scope: Window;
+  }[]
+>();
+function hasEventListenerBeenAdded(
+  type: string,
+  listener: EventListenerOrEventListenerObject,
+  options: boolean | AddEventListenerOptions | undefined,
+  scope: Window,
+) {
   const cache = addedGlobalEventListeners.get(listener) || [];
-  const existing = cache.find(item => item.type === type && booleanOrShallowEqual(item.options, options) && item.scope === scope);
+  const existing = cache.find(
+    (item) =>
+      item.type === type &&
+      booleanOrShallowEqual(item.options, options) &&
+      item.scope === scope,
+  );
   return !!existing;
 }
 
-function markEventListenerAsAdded(type: string, listener: EventListenerOrEventListenerObject, options: boolean | AddEventListenerOptions | undefined, scope: Window) {
+function markEventListenerAsAdded(
+  type: string,
+  listener: EventListenerOrEventListenerObject,
+  options: boolean | AddEventListenerOptions | undefined,
+  scope: Window,
+) {
   const cache = addedGlobalEventListeners.get(listener) || [];
   cache.push({ type, options, scope });
   addedGlobalEventListeners.set(listener, cache);
 }
 
-function markEventListenerAsRemoved(type: string, listener: EventListenerOrEventListenerObject, options: boolean | AddEventListenerOptions | undefined, scope: Window) {
+function markEventListenerAsRemoved(
+  type: string,
+  listener: EventListenerOrEventListenerObject,
+  options: boolean | AddEventListenerOptions | undefined,
+  scope: Window,
+) {
   const cache = addedGlobalEventListeners.get(listener) || [];
-  const index = cache.findIndex(item => item.type === type && booleanOrShallowEqual(item.options, options) && item.scope === scope);
+  const index = cache.findIndex(
+    (item) =>
+      item.type === type &&
+      booleanOrShallowEqual(item.options, options) &&
+      item.scope === scope,
+  );
   if (index !== -1) {
     cache.splice(index, 1);
   }
 }
 
-function booleanOrShallowEqual(a: boolean | AddEventListenerOptions | undefined, b: boolean | AddEventListenerOptions | undefined) {
+function booleanOrShallowEqual(
+  a: boolean | AddEventListenerOptions | undefined,
+  b: boolean | AddEventListenerOptions | undefined,
+) {
   if (typeof a === "boolean" || typeof b === "boolean") {
     return a === b;
   }

--- a/packages/ariakit-core/src/utils/events.ts
+++ b/packages/ariakit-core/src/utils/events.ts
@@ -1,5 +1,4 @@
 import { contains } from "./dom.ts";
-import { shallowEqual } from "./misc.ts";
 import { isApple } from "./platform.ts";
 
 /**
@@ -224,11 +223,7 @@ export function addGlobalEventListener(
 
   // Prevent errors from "sandbox" frames.
   try {
-    if (!hasEventListenerBeenAdded(type, listener, options, scope)) {
-      markEventListenerAsAdded(type, listener, options, scope);
-      scope.document.addEventListener(type, listener, options);
-    }
-
+    scope.document.addEventListener(type, listener, options);
     for (const frame of Array.from(scope.frames)) {
       children.push(addGlobalEventListener(type, listener, options, frame));
     }
@@ -236,7 +231,6 @@ export function addGlobalEventListener(
 
   const removeEventListener = () => {
     try {
-      markEventListenerAsRemoved(type, listener, options, scope);
       scope.document.removeEventListener(type, listener, options);
     } catch {}
     for (const remove of children) {
@@ -245,67 +239,4 @@ export function addGlobalEventListener(
   };
 
   return removeEventListener;
-}
-
-const addedGlobalEventListeners = new WeakMap<
-  EventListenerOrEventListenerObject,
-  {
-    type: string;
-    options: boolean | AddEventListenerOptions | undefined;
-    scope: Window;
-  }[]
->();
-function hasEventListenerBeenAdded(
-  type: string,
-  listener: EventListenerOrEventListenerObject,
-  options: boolean | AddEventListenerOptions | undefined,
-  scope: Window,
-) {
-  const cache = addedGlobalEventListeners.get(listener) || [];
-  const existing = cache.find(
-    (item) =>
-      item.type === type &&
-      booleanOrShallowEqual(item.options, options) &&
-      item.scope === scope,
-  );
-  return !!existing;
-}
-
-function markEventListenerAsAdded(
-  type: string,
-  listener: EventListenerOrEventListenerObject,
-  options: boolean | AddEventListenerOptions | undefined,
-  scope: Window,
-) {
-  const cache = addedGlobalEventListeners.get(listener) || [];
-  cache.push({ type, options, scope });
-  addedGlobalEventListeners.set(listener, cache);
-}
-
-function markEventListenerAsRemoved(
-  type: string,
-  listener: EventListenerOrEventListenerObject,
-  options: boolean | AddEventListenerOptions | undefined,
-  scope: Window,
-) {
-  const cache = addedGlobalEventListeners.get(listener) || [];
-  const index = cache.findIndex(
-    (item) =>
-      item.type === type &&
-      booleanOrShallowEqual(item.options, options) &&
-      item.scope === scope,
-  );
-  if (index !== -1) {
-    cache.splice(index, 1);
-  }
-}
-
-function booleanOrShallowEqual(
-  a: boolean | AddEventListenerOptions | undefined,
-  b: boolean | AddEventListenerOptions | undefined,
-) {
-  if (typeof a === "boolean" || typeof b === "boolean") {
-    return a === b;
-  }
-  return shallowEqual(a, b);
 }

--- a/packages/ariakit-react-core/src/focusable/focusable.tsx
+++ b/packages/ariakit-react-core/src/focusable/focusable.tsx
@@ -168,7 +168,7 @@ function useDisableEvent(
 
 let hasInstalledGlobalEventListeners = false;
 
-// isKeyboardModality should be true by defaault.
+// isKeyboardModality should be true by default.
 let isKeyboardModality = true;
 
 function onGlobalMouseDown(event: MouseEvent) {

--- a/packages/ariakit-react-core/src/focusable/focusable.tsx
+++ b/packages/ariakit-react-core/src/focusable/focusable.tsx
@@ -166,6 +166,8 @@ function useDisableEvent(
   });
 }
 
+let hasInstalledGlobalEventListeners = false;
+
 // isKeyboardModality should be true by defaault.
 let isKeyboardModality = true;
 
@@ -210,8 +212,10 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
     // keyboard to navigate the site or not.
     useEffect(() => {
       if (!focusable) return;
+      if (hasInstalledGlobalEventListeners) return;
       addGlobalEventListener("mousedown", onGlobalMouseDown, true);
       addGlobalEventListener("keydown", onGlobalKeyDown, true);
+      hasInstalledGlobalEventListeners = true;
     }, [focusable]);
 
     // Safari and Firefox on Apple devices don't focus on checkboxes or radio

--- a/packages/ariakit-react-core/src/focusable/focusable.tsx
+++ b/packages/ariakit-react-core/src/focusable/focusable.tsx
@@ -166,7 +166,6 @@ function useDisableEvent(
   });
 }
 
-let hasInstalledGlobalEventListeners = false;
 // isKeyboardModality should be true by defaault.
 let isKeyboardModality = true;
 
@@ -211,10 +210,8 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
     // keyboard to navigate the site or not.
     useEffect(() => {
       if (!focusable) return;
-      if (hasInstalledGlobalEventListeners) return;
       addGlobalEventListener("mousedown", onGlobalMouseDown, true);
       addGlobalEventListener("keydown", onGlobalKeyDown, true);
-      hasInstalledGlobalEventListeners = true;
     }, [focusable]);
 
     // Safari and Firefox on Apple devices don't focus on checkboxes or radio

--- a/packages/ariakit-react-core/src/focusable/focusable.tsx
+++ b/packages/ariakit-react-core/src/focusable/focusable.tsx
@@ -166,6 +166,7 @@ function useDisableEvent(
   });
 }
 
+let hasInstalledGlobalEventListeners = false;
 // isKeyboardModality should be true by defaault.
 let isKeyboardModality = true;
 
@@ -210,8 +211,10 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
     // keyboard to navigate the site or not.
     useEffect(() => {
       if (!focusable) return;
+      if (hasInstalledGlobalEventListeners) return;
       addGlobalEventListener("mousedown", onGlobalMouseDown, true);
       addGlobalEventListener("keydown", onGlobalKeyDown, true);
+      hasInstalledGlobalEventListeners = true;
     }, [focusable]);
 
     // Safari and Firefox on Apple devices don't focus on checkboxes or radio

--- a/packages/ariakit-react-core/src/utils/hooks.ts
+++ b/packages/ariakit-react-core/src/utils/hooks.ts
@@ -383,11 +383,14 @@ export function useMetadataProps<T, K extends keyof any>(
   return [parent?.[key], { onLoadedMetadataCapture }] as const;
 }
 
+let hasInstalledGlobalEventListeners = false;
+
 /**
  * Returns a function that checks whether the mouse is moving.
  */
 export function useIsMouseMoving() {
   useEffect(() => {
+    if (hasInstalledGlobalEventListeners) return;
     // We're not returning the event listener cleanup function here because we
     // may lose some events if this component is unmounted, but others are
     // still mounted.
@@ -397,6 +400,7 @@ export function useIsMouseMoving() {
     addGlobalEventListener("mouseup", resetMouseMoving, true);
     addGlobalEventListener("keydown", resetMouseMoving, true);
     addGlobalEventListener("scroll", resetMouseMoving, true);
+    hasInstalledGlobalEventListeners = true;
   }, []);
 
   const isMouseMoving = useEvent(() => mouseMoving);


### PR DESCRIPTION
When profiling why opening a `Combobox` with 100+ items feels laggy (it’s 100 list items, how slow could it be?), I noticed that `Focusable` (which is used by `Combobox` and a bunch of other things) installs global event listeners every time it mounts. With 100 items in a list, it’s 100 focusables – and, therefore, 200 `addGlobalEventListener` calls. This ends up taking ~30% of the total opening time:

<img width="2816" height="1560" alt="Screenshot 2025-07-28 at 15 18 23" src="https://github.com/user-attachments/assets/f7e71487-29d3-4d40-bfa6-44451f38e38d" />

This PR fixes this by introducing a global flag in `focusable.tsx` that prevents calling `addGlobalEventListener` more than once.