### PR TITLE
Fix clipping math in visual helper

### DIFF
--- a/site/src/test-utils/visual.ts
+++ b/site/src/test-utils/visual.ts
@@ -143,11 +143,15 @@ function getCombinedClip(a: Rect, b: Rect) {
 }
 
 function applyClipMargin(rect: Rect, margin = DEFAULT_CLIP_MARGIN) {
+  const right = Math.ceil(rect.x + rect.width + margin);
+  const bottom = Math.ceil(rect.y + rect.height + margin);
+  const x = Math.max(0, Math.floor(rect.x - margin));
+  const y = Math.max(0, Math.floor(rect.y - margin));
   return {
-    x: rect.x - margin,
-    y: rect.y - margin,
-    width: rect.width + margin * 2,
-    height: rect.height + margin * 2,
+    x,
+    y,
+    width: right - x,
+    height: bottom - y,
   };
 }
 
@@ -167,8 +171,12 @@ function getRectsClip(rects: Rect[], margin = DEFAULT_CLIP_MARGIN) {
   return applyClipMargin({ x, y, width, height }, margin);
 }
 
+async function getPageScrollPosition(page: Page) {
+  return page.evaluate(() => ({ x: window.scrollX, y: window.scrollY }));
+}
+
 async function getBodyClip(page: Page, margin = DEFAULT_CLIP_MARGIN) {
-  const rects = await page.evaluate(() => {
+  const { rects, scrollX, scrollY } = await page.evaluate(() => {
     const viewportWidth = document.documentElement.clientWidth;
     const rects: Rect[] = [];
     const walk = (el: Element, padded = true) => {
@@ -202,9 +210,23 @@ async function getBodyClip(page: Page, margin = DEFAULT_CLIP_MARGIN) {
         walk(child, false);
       }
     }
-    return rects;
+    return {
+      rects: rects.map((rect) => ({
+        x: rect.x,
+        y: rect.y,
+        width: rect.width,
+        height: rect.height,
+      })),
+      scrollX: window.scrollX,
+      scrollY: window.scrollY,
+    };
   });
-  return getRectsClip(rects, margin);
+  const pageRects = rects.map((rect) => ({
+    ...rect,
+    x: rect.x + scrollX,
+    y: rect.y + scrollY,
+  }));
+  return getRectsClip(pageRects, margin);
 }
 
 async function getPlaywrightScreenshotOptions(
@@ -222,7 +244,15 @@ async function getPlaywrightScreenshotOptions(
   const locator = typeof element === "string" ? page.locator(element) : element;
   const rect = await locator.boundingBox();
   invariant(rect, "Element not visible");
-  const clip = applyClipMargin(rect, clipMargin);
+  const scrollPosition = await getPageScrollPosition(page);
+  const clip = applyClipMargin(
+    {
+      ...rect,
+      x: rect.x + scrollPosition.x,
+      y: rect.y + scrollPosition.y,
+    },
+    clipMargin,
+  );
   return { animations: "disabled" as const, clip, fullPage: false };
 }
 


### PR DESCRIPTION
## Summary
- fix visual screenshot clipping to use page-relative coordinates instead of viewport-relative ones
- account for page scroll when building body and element clips
- clamp clip margins so negative origins do not distort the captured region

## Testing
- not run in this environment because the `site` workspace is missing local `node_modules`, so `playwright` is unavailable here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced visual testing infrastructure with improved scroll position handling and element clipping calculations for more accurate screenshot capture in visual regression tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->