### PR TITLE
Wait for stable clips before visual screenshots

### DIFF
--- a/site/src/test-utils/visual.ts
+++ b/site/src/test-utils/visual.ts
@@ -152,11 +152,15 @@ function areRectsEqual(a: Rect, b: Rect) {
 }
 
 function applyClipMargin(rect: Rect, margin = DEFAULT_CLIP_MARGIN) {
+  const newX = Math.max(0, rect.x - margin);
+  const newY = Math.max(0, rect.y - margin);
+  const deltaX = newX - (rect.x - margin);
+  const deltaY = newY - (rect.y - margin);
   return {
-    x: rect.x - margin,
-    y: rect.y - margin,
-    width: rect.width + margin * 2,
-    height: rect.height + margin * 2,
+    x: newX,
+    y: newY,
+    width: Math.max(0, rect.width + margin * 2 - deltaX),
+    height: Math.max(0, rect.height + margin * 2 - deltaY),
   };
 }
 
@@ -243,11 +247,13 @@ async function waitForStableScreenshotClip(
   // Some previews update their layout a few frames after they become visible.
   // Wait until the computed clip stays unchanged for a short window.
   let previousClip = await getScreenshotClip(page, options);
+  let lastClip = previousClip;
   let stableSince = Date.now();
   const deadline = Date.now() + CLIP_STABILITY_TIMEOUT;
   while (Date.now() < deadline) {
     await page.waitForTimeout(CLIP_STABILITY_INTERVAL);
     const clip = await getScreenshotClip(page, options);
+    lastClip = clip;
     if (previousClip && clip && areRectsEqual(previousClip, clip)) {
       if (Date.now() - stableSince >= CLIP_STABILITY_DURATION) {
         return;
@@ -257,6 +263,13 @@ async function waitForStableScreenshotClip(
     stableSince = Date.now();
     previousClip = clip;
   }
+  console.debug("waitForStableScreenshotClip timed out", {
+    clipStabilityTimeout: CLIP_STABILITY_TIMEOUT,
+    clipStabilityDuration: CLIP_STABILITY_DURATION,
+    stableFor: Date.now() - stableSince,
+    previousClip,
+    lastClip,
+  });
 }
 
 async function getPlaywrightScreenshotOptions(


### PR DESCRIPTION
## Summary
- remove the earlier scroll-aware clipping changes from visual.ts
- wait for the computed screenshot clip to stay stable before taking a visual snapshot
- keep the fix in the shared helper instead of adding disclosure-specific test logic

## Verification
- pnpm -F site run test-visual-safari -- src/examples/disclosure/group/test-browser.ts
- repeated the same Safari visual test 5 times locally
- pnpm tsc (fails on existing unrelated Stripe typing errors in site/src/lib/stripe.ts and site/src/pages/api/stripe-webhook.ts)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved visual testing: more reliable screenshot clipping with stability controls, refined clip calculations, and full-page handling to reduce flaky captures.
  * Added a stability check that waits for consistent clip results before taking screenshots, improving repeatability across visual variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->