### PR TITLE
Add worktree fetch-before-create rule to workflow skill

### DIFF
--- a/.agents/skills/ariakit-workflow/SKILL.md
+++ b/.agents/skills/ariakit-workflow/SKILL.md
@@ -11,6 +11,14 @@ description: Workflow instructions for this repository. Always use when planning
 - If a skill change updates code standards or formatting rules, apply the change across existing files in the repository so the codebase stays in sync with the skills.
 - Add changesets in the `.changeset` folder for user-facing updates such as bug fixes, performance improvements, and new features. Refactors and other changes that do not affect shipped code should not require changesets.
 
+## Worktrees
+
+- Before creating a worktree (via `EnterWorktree` or `git worktree add`), always fetch the base branch from origin first so you start from the latest remote state:
+  ```sh
+  git fetch origin main
+  ```
+  Replace `main` with the actual base branch if it differs. This prevents starting work from a stale local branch.
+
 ## Dependencies
 
 - Every workspace must declare the dependencies it actually uses in its own `package.json`. Do not rely on hoisting from the root.


### PR DESCRIPTION
## Summary
- Adds a **Worktrees** section to the `ariakit-workflow` agent skill instructing agents to always `git fetch origin main` (or the relevant base branch) before creating a worktree
- Prevents agents from starting work on a stale local `main`

## Test plan
- [x] Verify the skill file renders correctly
- [ ] Confirm future agent worktree creation follows the new instruction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Worktrees guidance to Ariakit workflow documentation with detailed instructions and practical examples for maintaining up-to-date branch references when creating worktrees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->