### PR TITLE
Exclude sandbox previews from visual test screenshots

### DIFF
--- a/site/src/pages/previews.ts
+++ b/site/src/pages/previews.ts
@@ -4,7 +4,7 @@ import { getCollection } from "astro:content";
 export const GET: APIRoute = async () => {
   const entries = await getCollection("previews");
   const paths = entries
-    .filter((entry) => !entry.filePath?.includes("/sandbox/"))
+    .filter((entry) => !/(^|\/)sandbox\//.test(entry.filePath ?? ""))
     .flatMap((entry) =>
       entry.data.frameworks.map(
         (framework) => `/${framework}/previews/${entry.id}`,


### PR DESCRIPTION
## Summary
- Filter out sandbox entries from the `/previews` API endpoint so visual tests only screenshot example previews, not sandboxes
- Sandbox preview pages remain accessible; only the endpoint consumed by the visual test is affected

## Test plan
- [ ] Verify visual test no longer takes screenshots of sandbox previews (e.g., `counter`, `5518`)
- [ ] Verify sandbox preview pages still load correctly at their URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)