### PR TITLE
Fix TagRemove id override when id prop is undefined

### DIFF
--- a/packages/ariakit-react-core/src/tag/tag-remove.tsx
+++ b/packages/ariakit-react-core/src/tag/tag-remove.tsx
@@ -89,7 +89,6 @@ export const useTagRemove = createHook<TagName, TagRemoveOptions>(
     const touchDevice = useTouchDevice() && withinTag;
 
     props = {
-      id,
       children,
       role: touchDevice ? "button" : undefined,
       "aria-hidden": !touchDevice,
@@ -99,6 +98,7 @@ export const useTagRemove = createHook<TagName, TagRemoveOptions>(
           ? "Press Delete or Backspace to remove"
           : undefined,
       ...props,
+      id,
       onClick,
       render: withinTag ? <Role.span render={props.render} /> : props.render,
     };


### PR DESCRIPTION
## Problem

Follow-up to #5611. The review [noted](https://github.com/ariakit/ariakit/pull/5611#discussion_r2106233068) that `TagRemove` was missed in the original sweep. It has the same `{ id, ...props }` pattern where passing `id={undefined}` causes the generated id to be cleared by the props spread. This breaks the `aria-describedby` reference from the parent `Tag` component, which publishes the generated id through `TagRemoveIdContext`.

## Solution

Apply the same fix: move `id` after `...props` in the props spread object.


🤖 Generated with [Claude Code](https://claude.com/claude-code)