### PR TITLE
Add overview changeset for React reliability fixes

### DIFF
--- a/.changeset/200-overview.md
+++ b/.changeset/200-overview.md
@@ -1,0 +1,8 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Overview
+
+This release improves React combobox and form reliability, including preserved combobox input and popover scroll position during result updates, more predictable focus behavior after filtering selects on iOS Safari, proper isolation of [`FormRadio`](https://ariakit.org/reference/form-radio) groups inside nested composite widgets, safer handling of explicitly undefined [`id`](https://ariakit.org/reference/select-item#id) props, and better generic typing for [`CheckboxProvider`](https://ariakit.org/reference/checkbox-provider) wrappers.


### PR DESCRIPTION
## Summary
- add an `Overview` changeset for `@ariakit/react-core` and `@ariakit/react`
- summarize the current React reliability fixes covered by the existing changesets

## Testing
- not run (changeset-only change)