### PR TITLE
Upgrade lucide-react from 0.577.0 to 1.6.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -505,8 +505,8 @@ importers:
         specifier: 4.17.23
         version: 4.17.23
       lucide-react:
-        specifier: 0.577.0
-        version: 0.577.0(react@18.3.1)
+        specifier: 1.6.0
+        version: 1.6.0(react@18.3.1)
       match-sorter:
         specifier: 8.2.0
         version: 8.2.0
@@ -8034,8 +8034,8 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-react@0.577.0:
-    resolution: {integrity: sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==}
+  lucide-react@1.6.0:
+    resolution: {integrity: sha512-YxLKVCOF5ZDI1AhKQE5IBYMY9y/Nr4NT15+7QEWpsTSVCdn4vmZhww+6BP76jWYjQx8rSz1Z+gGme1f+UycWEw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -19361,7 +19361,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@0.577.0(react@18.3.1):
+  lucide-react@1.6.0(react@18.3.1):
     dependencies:
       react: 18.3.1
 

--- a/site/package.json
+++ b/site/package.json
@@ -77,7 +77,7 @@
     "import-meta-resolve": "4.2.0",
     "kleur": "4.1.5",
     "lodash-es": "4.17.23",
-    "lucide-react": "0.577.0",
+    "lucide-react": "1.6.0",
     "match-sorter": "8.2.0",
     "motion": "12.38.0",
     "parse-numeric-range": "1.3.0",


### PR DESCRIPTION
## Changes

Upgrades the `lucide-react` icon library to the latest version.

- Updates `lucide-react` dependency from `0.577.0` to `1.6.0` in `site/package.json`
- Updates lock file (`pnpm-lock.yaml`) to reflect the new version and its resolved hash

## Notes

This is a major version bump. Please review the [lucide-react changelog](https://github.com/lucide-icons/lucide/releases) for any breaking changes or icon updates.