### PR TITLE
Add verbose flag to TypeScript check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         uses: ./.github/workflows/setup
 
       - name: Type check
-        run: pnpm run tsc
+        run: pnpm run tsc -v
 
   build:
     name: Build packages


### PR DESCRIPTION
## Summary
- Adds the `-v` (verbose) flag to the `tsc` command in the CI type check step, providing more detailed output during TypeScript compilation checks.

## Test plan
- [ ] Verify the CI workflow runs successfully with the updated `tsc -v` command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)