### PR TITLE
Add default formatter for jsonc files in VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,5 +32,8 @@
     "https://json.schemastore.org/github-action.json": [
       ".github/workflows/*/action.y*ml"
     ]
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
   }
 }


### PR DESCRIPTION
## Summary
- Add `[jsonc]` language-specific setting to `.vscode/settings.json` to use `oxc.oxc-vscode` as the default formatter for JSONC files

## Test plan
- [x] Verify `.vscode/settings.json` is valid JSON after the change
- [x] Open a `.jsonc` file in VS Code and confirm the formatter is set to oxc

🤖 Generated with [Claude Code](https://claude.com/claude-code)