### PR TITLE
Update wrangler to 4.78.0 and compatibility_date

### DIFF
--- a/nextjs/wrangler.jsonc
+++ b/nextjs/wrangler.jsonc
@@ -3,7 +3,7 @@
   "name": "ariakit-nextjs",
   "main": ".open-next/worker.js",
   "preview_urls": true,
-  "compatibility_date": "2025-11-27",
+  "compatibility_date": "2026-03-27",
   "compatibility_flags": ["nodejs_compat"],
   "placement": {
     "mode": "smart",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "vite-plugin-solid": "2.11.11",
     "vitest": "4.1.1",
     "vitest-fail-on-console": "0.10.1",
-    "wrangler": "4.77.0"
+    "wrangler": "4.78.0"
   },
   "lint-staged": {
     "package.json": "pnpm -r run --if-present clean",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,8 +179,8 @@ importers:
         specifier: 0.10.1
         version: 0.10.1(@vitest/utils@4.1.1)(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.1(@types/node@24.12.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@24.12.0)(typescript@6.0.2))(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)))
       wrangler:
-        specifier: 4.77.0
-        version: 4.77.0(@cloudflare/workers-types@4.20260316.1)
+        specifier: 4.78.0
+        version: 4.78.0(@cloudflare/workers-types@4.20260316.1)
 
   examples:
     dependencies:
@@ -274,7 +274,7 @@ importers:
     devDependencies:
       '@opennextjs/cloudflare':
         specifier: 1.17.3
-        version: 1.17.3(encoding@0.1.13)(next@16.2.1(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(wrangler@4.77.0)
+        version: 1.17.3(encoding@0.1.13)(next@16.2.1(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(wrangler@4.78.0)
       '@tailwindcss/postcss':
         specifier: 4.2.2
         version: 4.2.2
@@ -632,8 +632,8 @@ importers:
         specifier: 4.1.1
         version: 4.1.1(@types/node@24.12.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@24.12.0)(typescript@6.0.2))(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       wrangler:
-        specifier: 4.77.0
-        version: 4.77.0(@cloudflare/workers-types@4.20260316.1)
+        specifier: 4.78.0
+        version: 4.78.0(@cloudflare/workers-types@4.20260316.1)
 
   templates/react:
     dependencies:
@@ -8437,8 +8437,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  miniflare@4.20260317.2:
-    resolution: {integrity: sha512-qNL+yWAFMX6fr0pWU6Lx1vNpPobpnDSF1V8eunIckWvoIQl8y1oBjL2RJFEGY3un+l3f9gwW9dirDPP26usYJQ==}
+  miniflare@4.20260317.3:
+    resolution: {integrity: sha512-tK78D3X4q30/SXqVwMhWrUfH+ffRou9dJLC+jkhNy5zh1I7i7T4JH6xihOvYxdCSBavJ5fQXaaxDJz6orh09BA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -10870,8 +10870,8 @@ packages:
       '@cloudflare/workers-types':
         optional: true
 
-  wrangler@4.77.0:
-    resolution: {integrity: sha512-E2Gm69+K++BFd3QvoWjC290RPQj1vDOUotA++sNHmtKPb7EP6C8Qv+1D5Ii73tfZtyNgakpqHlh8lBBbVWTKAQ==}
+  wrangler@4.78.0:
+    resolution: {integrity: sha512-He/vUhk4ih0D0eFmtNnlbT6Od8j+BEokaSR+oYjbVsH0SWIrIch+eHqfLRSBjBQaOoh6HCNxcafcIkBm2u0Hag==}
     engines: {node: '>=20.3.0'}
     hasBin: true
     peerDependencies:
@@ -14087,7 +14087,7 @@ snapshots:
       - aws-crt
       - supports-color
 
-  '@opennextjs/cloudflare@1.17.3(encoding@0.1.13)(next@16.2.1(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(wrangler@4.77.0)':
+  '@opennextjs/cloudflare@1.17.3(encoding@0.1.13)(next@16.2.1(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(wrangler@4.78.0)':
     dependencies:
       '@ast-grep/napi': 0.40.5
       '@dotenvx/dotenvx': 1.31.0
@@ -14098,7 +14098,7 @@ snapshots:
       glob: 12.0.0
       next: 16.2.1(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-tqdm: 0.8.6
-      wrangler: 4.77.0(@cloudflare/workers-types@4.20260316.1)
+      wrangler: 4.78.0(@cloudflare/workers-types@4.20260316.1)
       yargs: 18.0.0
     transitivePeerDependencies:
       - aws-crt
@@ -20168,7 +20168,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  miniflare@4.20260317.2:
+  miniflare@4.20260317.3:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
@@ -23023,13 +23023,13 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  wrangler@4.77.0(@cloudflare/workers-types@4.20260316.1):
+  wrangler@4.78.0(@cloudflare/workers-types@4.20260316.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@cloudflare/unenv-preset': 2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260317.1)
       blake3-wasm: 2.1.5
       esbuild: 0.27.3
-      miniflare: 4.20260317.2
+      miniflare: 4.20260317.3
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
       workerd: 1.20260317.1

--- a/site/package.json
+++ b/site/package.json
@@ -121,6 +121,6 @@
     "rimraf": "6.1.3",
     "shadcn": "4.1.0",
     "vitest": "4.1.1",
-    "wrangler": "4.77.0"
+    "wrangler": "4.78.0"
   }
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,7 +3,7 @@
   "name": "ariakit",
   "main": "./site/dist/_worker.js/index.js",
   "preview_urls": false,
-  "compatibility_date": "2025-11-27",
+  "compatibility_date": "2026-03-27",
   "compatibility_flags": ["nodejs_compat"],
   "placement": {
     "mode": "smart",


### PR DESCRIPTION
## Summary
- Bump `wrangler` from 4.77.0 to 4.78.0 in root and site `package.json`
- Update `compatibility_date` from `2025-11-27` to `2026-03-27` in root and nextjs `wrangler.jsonc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)