### PR TITLE
Update use-sync-external-store dependency and remove shim workaround

### DIFF
--- a/packages/ariakit-react-core/package.json
+++ b/packages/ariakit-react-core/package.json
@@ -32,10 +32,10 @@
   "dependencies": {
     "@ariakit/core": "workspace:*",
     "@floating-ui/dom": "^1.0.0",
-    "use-sync-external-store": "^1.2.0"
+    "use-sync-external-store": "^1.6.0"
   },
   "devDependencies": {
-    "@types/use-sync-external-store": "0.0.6",
+    "@types/use-sync-external-store": "1.5.0",
     "oxfmt": "0.42.0",
     "oxlint": "1.57.0",
     "oxlint-tsgolint": "0.17.3",

--- a/packages/ariakit-react-core/src/utils/store.tsx
+++ b/packages/ariakit-react-core/src/utils/store.tsx
@@ -12,13 +12,8 @@ import type {
   SetState,
 } from "@ariakit/core/utils/types";
 import * as React from "react";
-// import { useSyncExternalStore } from "use-sync-external-store/shim/index.js";
-// This doesn't work in ESM, because use-sync-external-store only exposes CJS.
-// The following is a workaround until ESM is supported.
-import useSyncExternalStoreExports from "use-sync-external-store/shim/index.js";
+import { useSyncExternalStore } from "use-sync-external-store/shim";
 import { useEvent, useLiveRef, useSafeLayoutEffect } from "./hooks.ts";
-
-const { useSyncExternalStore } = useSyncExternalStoreExports;
 
 export interface UseState<S> {
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,12 +328,12 @@ importers:
         specifier: ^1.0.0
         version: 1.7.6
       use-sync-external-store:
-        specifier: ^1.2.0
+        specifier: ^1.6.0
         version: 1.6.0(react@18.3.1)
     devDependencies:
       '@types/use-sync-external-store':
-        specifier: 0.0.6
-        version: 0.0.6
+        specifier: 1.5.0
+        version: 1.5.0
       oxfmt:
         specifier: 0.42.0
         version: 0.42.0
@@ -937,8 +937,8 @@ importers:
         specifier: 3.0.4
         version: 3.0.4
       '@types/use-sync-external-store':
-        specifier: 0.0.6
-        version: 0.0.6
+        specifier: 1.5.0
+        version: 1.5.0
       '@vitejs/plugin-react':
         specifier: 6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.0)(yaml@2.8.3))
@@ -5660,8 +5660,8 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@types/use-sync-external-store@0.0.6':
-    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
+  '@types/use-sync-external-store@1.5.0':
+    resolution: {integrity: sha512-5dyB8nLC/qogMrlCizZnYWQTA4lnb/v+It+sqNl5YnSRAPMlIqY/X0Xn+gZw8vOL+TgTTr28VEbn3uf8fUtAkw==}
 
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
@@ -16597,7 +16597,7 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@types/use-sync-external-store@0.0.6': {}
+  '@types/use-sync-external-store@1.5.0': {}
 
   '@types/validate-npm-package-name@4.0.2': {}
 

--- a/website/package.json
+++ b/website/package.json
@@ -100,7 +100,7 @@
     "@types/react": "18.3.28",
     "@types/react-dom": "18.3.7",
     "@types/textarea-caret": "3.0.4",
-    "@types/use-sync-external-store": "0.0.6",
+    "@types/use-sync-external-store": "1.5.0",
     "@vitejs/plugin-react": "6.0.1"
   }
 }


### PR DESCRIPTION
## Summary
- bump `use-sync-external-store` in `@ariakit/react-core` from `^1.2.0` to `^1.6.0`
- update `@types/use-sync-external-store` to `1.5.0` in `@ariakit/react-core` and `website`
- replace the default export workaround with a direct `use-sync-external-store/shim` import in `store.tsx`
- refresh `pnpm-lock.yaml` to match the dependency updates

## Testing
- Not run (not requested)