### PR TITLE
Add a 3-day minimum release age to npm, pnpm, and Renovate

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
 save-exact = true
-min-release-age = 7
+min-release-age = 3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ packages:
   - website
   - site
 
-minimumReleaseAge: 10080
+minimumReleaseAge: 4320
 
 publicHoistPattern:
   - "*react*"

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": ["config:recommended"],
-  "minimumReleaseAge": "7 days",
+  "minimumReleaseAge": "3 days",
   "semanticCommits": "disabled",
   "packageRules": [
     {


### PR DESCRIPTION
## Summary
- add \\`min-release-age = 3\\` to \\`.npmrc\\`
- add \\`minimumReleaseAge: 4320\\` to \\`pnpm-workspace.yaml\\`
- add \\`\"minimumReleaseAge\": \"3 days\"\\` to \\`renovate.json\\`
- align dependency updates across local package manager and Renovate config

## Testing
- Not run (not requested)