### PR TITLE
Potential fix for code scanning alert no. 34: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -26,6 +26,9 @@ jobs:
   finalize:
     name: Finalize
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/ariakit/ariakit/security/code-scanning/34](https://github.com/ariakit/ariakit/security/code-scanning/34)

In general, fix this by adding an explicit `permissions:` block that grants the least privileges needed, either at the workflow root (applies to all jobs) or on the specific job. Here, there is a single `finalize` job, so adding `permissions` under that job is sufficient and minimally invasive.

This job needs to: (1) read workflow jobs and artifacts using `actions/github-script` and `gh api`, which requires `actions: read`, and (2) read commits/contents, which requires `contents: read`. It does not need write access via `GITHUB_TOKEN` because repository modifications are done using `secrets.ARIAKIT_BOT_PAT`. Therefore, the best change is to add:

```yaml
permissions:
  contents: read
  actions: read
```

under `jobs.finalize`, between `runs-on: ubuntu-latest` and `steps:`. No other functionality needs to change, and no additional imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
