### PR TITLE
Consolidate pnpm config into pnpm-workspace.yaml

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-save-exact = true
-min-release-age = 3
-trust-policy = no-downgrade

--- a/package.json
+++ b/package.json
@@ -124,18 +124,5 @@
       "oxfmt --no-error-on-unmatched-pattern"
     ]
   },
-  "packageManager": "pnpm@10.33.0",
-  "pnpm": {
-    "overrides": {
-      "@wordpress/components>@ariakit/react": "workspace:*"
-    },
-    "patchedDependencies": {
-      "@changesets/apply-release-plan@7.1.0": "patches/@changesets__apply-release-plan@7.1.0.patch"
-    },
-    "allowBuilds": {
-      "esbuild": true,
-      "sharp": true,
-      "workerd": true
-    }
-  }
+  "packageManager": "pnpm@10.33.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,3 +12,17 @@ minimumReleaseAge: 4320
 publicHoistPattern:
   - "*react*"
   - "*testing-library*"
+
+saveExact: true
+trustPolicy: no-downgrade
+
+overrides:
+  "@wordpress/components>@ariakit/react": "workspace:*"
+
+patchedDependencies:
+  "@changesets/apply-release-plan@7.1.0": "patches/@changesets__apply-release-plan@7.1.0.patch"
+
+allowBuilds:
+  esbuild: true
+  sharp: true
+  workerd: true


### PR DESCRIPTION
## Summary
- Replace deprecated `onlyBuiltDependencies` with `allowBuilds`
- Add `trustPolicy: no-downgrade` for supply chain security
- Move all pnpm settings (`overrides`, `patchedDependencies`, `allowBuilds`, `saveExact`, `trustPolicy`) from `package.json` and `.npmrc` into `pnpm-workspace.yaml`
- Remove now-empty `.npmrc`

https://claude.ai/code/session_01MxjmDGws3Lnym3AGtkwuVT