### PR TITLE
Exclude tailwindcss v3 from pnpm trust policy check

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,8 @@ publicHoistPattern:
 
 saveExact: true
 trustPolicy: no-downgrade
+trustPolicyExclude:
+  - tailwindcss@3.4.18
 
 overrides:
   "@wordpress/components>@ariakit/react": "workspace:*"


### PR DESCRIPTION
tailwindcss@3.4.18 triggers ERR_PNPM_TRUST_DOWNGRADE because v4.x
releases published around the same time have provenance attestation
while v3.4.18 does not. This is a known non-issue confirmed by the
Tailwind maintainers (tailwindlabs/tailwindcss#19423).

Adding trustPolicyExclude for the pinned v3 version unblocks lockfile
generation (and the renovate PR #5664) without weakening trust checks
for any other package.

https://claude.ai/code/session_01TyVEWq4uDyf2kPD2Gp9yEE