### PR TITLE
Exclude tailwind packages from pnpm trust policy

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,7 @@ saveExact: true
 trustPolicy: no-downgrade
 trustPolicyExclude:
   - tailwindcss@3.4.18
+  - tailwind-merge@2.6.1
 
 overrides:
   "@wordpress/components>@ariakit/react": "workspace:*"


### PR DESCRIPTION
## Summary
- Adds `trustPolicyExclude` for `tailwindcss@3.4.18` and `tailwind-merge@2.6.1` in `pnpm-workspace.yaml`
- Both packages trigger `ERR_PNPM_TRUST_DOWNGRADE` because earlier versions had provenance attestation that these versions lack
- This is a known non-issue ([tailwindlabs/tailwindcss#19423](https://github.com/tailwindlabs/tailwindcss/issues/19423)) — not a real security concern
- Unblocks #5664 and future lockfile regenerations

## Test plan
- [x] `pnpm install --lockfile-only` succeeds without trust downgrade errors

https://claude.ai/code/session_01TyVEWq4uDyf2kPD2Gp9yEE