### PR TITLE
Also exclude semver@6.3.1 from trust policy check

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,7 @@ trustPolicy: no-downgrade
 trustPolicyExclude:
   - tailwindcss@3.4.18
   - tailwind-merge@2.6.1
+  - semver@6.3.1
 
 overrides:
   "@wordpress/components>@ariakit/react": "workspace:*"


### PR DESCRIPTION
Reproduced the shadcn 4.1.1 → 4.1.2 upgrade locally — pnpm install fails with ERR_PNPM_TRUST_DOWNGRADE for semver@6.3.1 (a transitive dependency via @babel/plugin-transform-typescript). Same false positive as tailwindcss and tailwind-merge: older v6.x release lacks provenance attestation that newer versions have.

Verified that pnpm install --lockfile-only succeeds with all three exclusions in place.

https://claude.ai/code/session_01TyVEWq4uDyf2kPD2Gp9yEE