### PR TITLE
Disable CodeRabbit on publish PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,3 +4,6 @@ reviews:
   in_progress_fortune: false
   poem: false
   high_level_summary_in_walkthrough: true
+  auto_review:
+    ignore_title_keywords:
+      - Publish


### PR DESCRIPTION
## Motivation

Changesets release PRs use the generic `Publish` title, so CodeRabbit can spend review cycles on generated version/changelog updates and leave noisy comments on PRs that are meant to be reviewed as release artifacts.

## Solution

Configure CodeRabbit auto-review to skip PRs whose title contains `Publish`. This targets the release PR title without ignoring the `ariakit-bot` user, so bot-authored PRs with other titles can still be reviewed.

## Checks

- `git diff --check HEAD~1..HEAD`
- `ruby -e 'require "yaml"; data = YAML.load_file(".coderabbit.yaml"); abort unless data.dig("reviews", "auto_review", "ignore_title_keywords") == ["Publish"]; puts "coderabbit config ok"'`