### PR TITLE
Fix Renovate kernel-out-of-memory by limiting Node.js memory

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,9 @@
   "extends": ["config:recommended"],
   "minimumReleaseAge": "3 days",
   "semanticCommits": "disabled",
+  "toolSettings": {
+    "nodeMaxMemory": 1024
+  },
   "packageRules": [
     {
       "matchFileNames": ["website/package.json"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "minimumReleaseAge": "3 days",
   "semanticCommits": "disabled",


### PR DESCRIPTION
## Summary
- Add `toolSettings.nodeMaxMemory: 1024` to `renovate.json` to cap Node.js memory at 1 GB during Renovate runs
- Prevents pnpm from exceeding the container memory limit and triggering the kernel OOM killer
- See https://github.com/renovatebot/renovate/discussions/41996

## Test plan
- [ ] Verify Renovate runs complete without OOM errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)