### PR TITLE
Update stripe to v22

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -531,8 +531,8 @@ importers:
         specifier: 1.9.12
         version: 1.9.12
       stripe:
-        specifier: 21.0.1
-        version: 21.0.1(@types/node@24.12.2)
+        specifier: 22.0.0
+        version: 22.0.0(@types/node@24.12.2)
       tailwindcss:
         specifier: 4.2.2
         version: 4.2.2
@@ -9865,8 +9865,8 @@ packages:
     resolution: {integrity: sha512-aT2BU9KkizY9SATf14WhhYVv2uOapBWX0OFWF4xvcj1mPaNotlSc2CsxpS4DS46ZueSppmCF5BX1sNYBtwBvfw==}
     engines: {node: '>=12.*'}
 
-  stripe@21.0.1:
-    resolution: {integrity: sha512-ocv0j7dWttswDWV2XL/kb6+yiLpDXNXL3RQAOB5OB2kr49z0cEatdQc12+zP/j5nrXk6rAsT4N3y/NUvBbK7Pw==}
+  stripe@22.0.0:
+    resolution: {integrity: sha512-q1UgXXpSfZCmkyzZEh3vFEWT7+ajuaFGqaP9Tsi2NMtwlkigIWNr+KBIUQqtNeNEsreDKgdn+BP5HRW9JDj22Q==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -22072,7 +22072,7 @@ snapshots:
       '@types/node': 25.5.2
       qs: 6.15.0
 
-  stripe@21.0.1(@types/node@24.12.2):
+  stripe@22.0.0(@types/node@24.12.2):
     optionalDependencies:
       '@types/node': 24.12.2
 

--- a/site/package.json
+++ b/site/package.json
@@ -92,7 +92,7 @@
     "rehype-parse": "9.0.1",
     "shiki": "4.0.2",
     "solid-js": "1.9.12",
-    "stripe": "21.0.1",
+    "stripe": "22.0.0",
     "tailwindcss": "4.2.2",
     "ts-morph": "27.0.2",
     "typescript": "6.0.2",

--- a/site/src/lib/stripe.ts
+++ b/site/src/lib/stripe.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: UNLICENSED
  */
 import type { APIContext } from "astro";
-import { Stripe } from "stripe";
+import Stripe from "stripe";
 import { findInOrder } from "./array.ts";
 import type { User } from "./auth.ts";
 import {
@@ -325,7 +325,7 @@ export async function createCheckout({
     price.taxBehavior === stripePrice.tax_behavior &&
     compareCurrency(price.currency, stripePrice.currency);
 
-  const lineItem: Stripe.Checkout.SessionCreateParams.LineItem = isSamePrice
+  const lineItem = isSamePrice
     ? { price: price.id, quantity: 1 }
     : {
         quantity: 1,


### PR DESCRIPTION
## Motivation
Keep the `stripe` dependency up to date with the latest major release.

## Solution
Update `stripe` from v21.0.1 to v22.0.0 in the site workspace.