### PR TITLE
Update dependency react-router to v7.14.0

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -20,7 +20,7 @@
     "motion": "12.38.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-router": "7.13.2",
+    "react-router": "7.14.0",
     "react-shadow": "20.6.0",
     "react-toastify": "11.0.5",
     "textarea-caret": "3.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,8 +224,8 @@ importers:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
       react-router:
-        specifier: 7.13.2
-        version: 7.13.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 7.14.0
+        version: 7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-shadow:
         specifier: 20.6.0
         version: 20.6.0(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9274,8 +9274,8 @@ packages:
       '@types/react':
         optional: true
 
-  react-router@7.13.2:
-    resolution: {integrity: sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA==}
+  react-router@7.14.0:
+    resolution: {integrity: sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -21199,7 +21199,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  react-router@7.13.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       cookie: 1.1.1
       react: 18.3.1


### PR DESCRIPTION
## Motivation
Keep react-router dependency up to date.

## Solution
Update react-router from v7.13.2 to v7.14.0 in the examples workspace.