### PR TITLE
Update dependency lodash-es to v4.18.1

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -15,7 +15,7 @@
     "@radix-ui/react-select": "2.2.6",
     "@wordpress/components": "32.4.0",
     "clsx": "2.1.1",
-    "lodash-es": "4.17.23",
+    "lodash-es": "4.18.1",
     "match-sorter": "8.2.0",
     "motion": "12.38.0",
     "react": "18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,8 +209,8 @@ importers:
         specifier: 2.1.1
         version: 2.1.1
       lodash-es:
-        specifier: 4.17.23
-        version: 4.17.23
+        specifier: 4.18.1
+        version: 4.18.1
       match-sorter:
         specifier: 8.2.0
         version: 8.2.0
@@ -483,8 +483,8 @@ importers:
         specifier: 4.1.5
         version: 4.1.5
       lodash-es:
-        specifier: 4.17.23
-        version: 4.17.23
+        specifier: 4.18.1
+        version: 4.18.1
       lucide-react:
         specifier: 1.7.0
         version: 1.7.0(react@18.3.1)
@@ -8001,6 +8001,9 @@ packages:
 
   lodash-es@4.17.23:
     resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
+
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
@@ -19418,6 +19421,8 @@ snapshots:
       p-locate: 5.0.0
 
   lodash-es@4.17.23: {}
+
+  lodash-es@4.18.1: {}
 
   lodash.debounce@4.0.8: {}
 

--- a/site/package.json
+++ b/site/package.json
@@ -76,7 +76,7 @@
     "html-entities": "2.6.0",
     "import-meta-resolve": "4.2.0",
     "kleur": "4.1.5",
-    "lodash-es": "4.17.23",
+    "lodash-es": "4.18.1",
     "lucide-react": "1.7.0",
     "match-sorter": "8.2.0",
     "motion": "12.38.0",


### PR DESCRIPTION
## Motivation

Keep the `lodash-es` dependency up to date with the latest release.

## Solution

Update `lodash-es` from `4.17.23` to `4.18.1` in `examples/package.json` and `site/package.json`.