### PR TITLE
Await lazy-loaded popover in `popover-lazy` test

### DIFF
--- a/examples/popover-lazy/test.ts
+++ b/examples/popover-lazy/test.ts
@@ -1,10 +1,10 @@
-import { click, press, q } from "@ariakit/test";
+import { click, press, q, waitFor } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 test("show/hide when clicking on disclosure", async () => {
   expect(q.dialog()).not.toBeInTheDocument();
   await click(q.button("Accept invite"));
-  expect(q.dialog()).toBeVisible();
+  await waitFor(() => expect(q.dialog()).toBeVisible());
   expect(q.button("Accept")).toHaveFocus();
   await click(q.button("Accept invite"));
   expect(q.dialog()).not.toBeInTheDocument();
@@ -14,7 +14,7 @@ test("show/hide when clicking on disclosure", async () => {
 test("show/hide when pressing enter on disclosure", async () => {
   await press.Tab();
   await press.Enter();
-  expect(q.dialog()).toBeVisible();
+  await waitFor(() => expect(q.dialog()).toBeVisible());
   expect(q.button("Accept")).toHaveFocus();
   await press.ShiftTab();
   await press.Enter();
@@ -24,7 +24,7 @@ test("show/hide when pressing enter on disclosure", async () => {
 test("show/hide when pressing space on disclosure", async () => {
   await press.Tab();
   await press.Space();
-  expect(q.dialog()).toBeVisible();
+  await waitFor(() => expect(q.dialog()).toBeVisible());
   expect(q.button("Accept")).toHaveFocus();
   await press.ShiftTab();
   await press.Space();
@@ -33,15 +33,15 @@ test("show/hide when pressing space on disclosure", async () => {
 
 test("hide when pressing escape on disclosure", async () => {
   await click(q.button("Accept invite"));
+  await waitFor(() => expect(q.dialog()).toBeVisible());
   await press.ShiftTab();
-  expect(q.dialog()).toBeVisible();
   await press.Escape();
   expect(q.dialog()).not.toBeInTheDocument();
 });
 
 test("hide when pressing escape on popover", async () => {
   await click(q.button("Accept invite"));
-  expect(q.dialog()).toBeVisible();
+  await waitFor(() => expect(q.dialog()).toBeVisible());
   await press.Escape();
   expect(q.dialog()).not.toBeInTheDocument();
   expect(q.button("Accept invite")).toHaveFocus();


### PR DESCRIPTION
## Motivation

The `popover-lazy` example test was flaky because it asserted `q.dialog()` visibility synchronously right after a click/keypress. Since the example uses `React.lazy()` + `useTransition()` to load the Popover component, the dialog may not be in the DOM yet when the assertion runs.

## Solution

Wrap each `expect(q.dialog()).toBeVisible()` assertion (after opening the popover) with `waitFor()` from `@ariakit/test` so the test retries until the lazy-loaded component renders.