### PR TITLE
Update @stripe/stripe-js to 9.1.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -444,8 +444,8 @@ importers:
         specifier: 1.11.0
         version: 1.11.0
       '@stripe/stripe-js':
-        specifier: 9.0.1
-        version: 9.0.1
+        specifier: 9.1.0
+        version: 9.1.0
       '@tailwindcss/vite':
         specifier: 4.2.2
         version: 4.2.2(vite@8.0.5(@types/node@24.12.2)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
@@ -5255,8 +5255,8 @@ packages:
     resolution: {integrity: sha512-/5zxRol+MU4I7fjZXPxP2M6E1nuHOxAzoc0tOEC/TLnC31Gzc+5EE93mIjoAnu28O1Sqpl7/BkceDHwnGmn75A==}
     engines: {node: '>=12.16'}
 
-  '@stripe/stripe-js@9.0.1':
-    resolution: {integrity: sha512-un0URSosrW7wNr7xZ5iI2mC9mdeXZ3KERoVlA2RdmeLXYxHUPXq0yHzir2n/MtyXXEdSaELtz4WXGS6dzPEeKA==}
+  '@stripe/stripe-js@9.1.0':
+    resolution: {integrity: sha512-v51LoEfZNiNS/5DcarWPCYgn24w4dqwwALR4GTbMW/N0DDzzj4DgYNoixX6PYvpt6uIJMucGUabn/BHhylggIQ==}
     engines: {node: '>=12.16'}
 
   '@swc/counter@0.1.3':
@@ -16170,7 +16170,7 @@ snapshots:
 
   '@stripe/stripe-js@6.1.0': {}
 
-  '@stripe/stripe-js@9.0.1': {}
+  '@stripe/stripe-js@9.1.0': {}
 
   '@swc/counter@0.1.3': {}
 

--- a/site/package.json
+++ b/site/package.json
@@ -63,7 +63,7 @@
     "@shikijs/langs": "4.0.2",
     "@shikijs/themes": "4.0.2",
     "@stackblitz/sdk": "1.11.0",
-    "@stripe/stripe-js": "9.0.1",
+    "@stripe/stripe-js": "9.1.0",
     "@tailwindcss/vite": "4.2.2",
     "@tanstack/react-query": "5.96.2",
     "astro": "5.18.1",


### PR DESCRIPTION
## Motivation

The `@stripe/stripe-js` package in the `site` workspace is outdated at 9.0.1. Version 9.1.0 includes new type definitions for percentage-based amounts and unit amount decimals.

## Solution

Bump `@stripe/stripe-js` from 9.0.1 to 9.1.0 in `site/package.json` and update the lockfile.

## Dependencies

| Package | From | To |
| --- | --- | --- |
| [`@stripe/stripe-js`](https://github.com/stripe/stripe-js) | 9.0.1 | 9.1.0 |

### Changes in @stripe/stripe-js 9.1.0

- Add percentage type support ([#911](https://github.com/stripe/stripe-js/pull/911))
- Add unit amount decimal ([#907](https://github.com/stripe/stripe-js/pull/907))

These are additive type changes that do not affect the site's current usage of `loadStripe` and `initEmbeddedCheckout`.