### PR TITLE
Update shadcn to 4.2.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -607,8 +607,8 @@ importers:
         specifier: 6.1.3
         version: 6.1.3
       shadcn:
-        specifier: 4.1.2
-        version: 4.1.2(@types/node@24.12.2)(babel-plugin-macros@3.1.0)(typescript@6.0.2)
+        specifier: 4.2.0
+        version: 4.2.0(@types/node@24.12.2)(babel-plugin-macros@3.1.0)(typescript@6.0.2)
       vitest:
         specifier: 4.1.3
         version: 4.1.3(@types/node@24.12.2)(@vitest/coverage-v8@4.1.3)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@24.12.2)(typescript@6.0.2))(vite@8.0.5(@types/node@24.12.2)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
@@ -9592,8 +9592,8 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  shadcn@4.1.2:
-    resolution: {integrity: sha512-qNQcCavkbYsgBj+X09tF2bTcwRd8abR880bsFkDU2kMqceMCLAm5c+cLg7kWDhfh1H9g08knpQ5ZEf6y/co16g==}
+  shadcn@4.2.0:
+    resolution: {integrity: sha512-ZDuV340itidaUd4Gi1BxQX+Y7Ush6BHp6URZBM2RyxUUBZ6yFtOWIr4nVY+Ro+YRSpo82v7JrsmtcU5xoBCMJQ==}
     hasBin: true
 
   sharp@0.34.5:
@@ -21633,7 +21633,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  shadcn@4.1.2(@types/node@24.12.2)(babel-plugin-macros@3.1.0)(typescript@6.0.2):
+  shadcn@4.2.0(@types/node@24.12.2)(babel-plugin-macros@3.1.0)(typescript@6.0.2):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/parser': 7.29.2

--- a/site/package.json
+++ b/site/package.json
@@ -119,7 +119,7 @@
     "pixelmatch": "7.1.0",
     "pngjs": "7.0.0",
     "rimraf": "6.1.3",
-    "shadcn": "4.1.2",
+    "shadcn": "4.2.0",
     "vitest": "4.1.3",
     "wrangler": "4.80.0"
   }


### PR DESCRIPTION
## Motivation

Keep the `shadcn` dev dependency up to date with the latest minor release.

## Solution

Update `shadcn` from 4.1.2 to 4.2.0 in the `site` workspace.

## Dependencies

| Package | From | To | Changelog |
| --- | --- | --- | --- |
| [shadcn](https://github.com/shadcn-ui/ui) | 4.1.2 | 4.2.0 | [Releases](https://github.com/shadcn-ui/ui/releases) |

### Notable changes

- **4.2.0**: Add `shadcn apply` command ([#10313](https://github.com/shadcn-ui/ui/pull/10313))

### Codebase usage

The `shadcn` package is used as a dev dependency in the `site` workspace. The codebase imports `Registry` and `RegistryItem` types from `shadcn/schema` in `site/src/pages/r/[...registry].ts` to serve the component registry API. The new `apply` command does not affect these type imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)