### PR TITLE
Freeze postcss updates in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,10 @@
       "enabled": false
     },
     {
+      "matchPackageNames": ["postcss"],
+      "enabled": false
+    },
+    {
       "matchPackageNames": ["tailwindcss"],
       "matchCurrentVersion": "/^3\\./",
       "enabled": false

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
       "enabled": false
     },
     {
+      "matchFileNames": ["package.json"],
       "matchPackageNames": ["postcss"],
       "enabled": false
     },


### PR DESCRIPTION
## Motivation

The root `postcss` dependency is used by root-level tooling (`postcss.config.cjs` with stylelint, tailwindcss v3, autoprefixer). The website workspace also has its own `postcss` dependency at the same version, which it uses to process examples CSS during its Next.js build (`website/build-pages/parse-css-file.js`).

Since the website workspace is frozen in Renovate to avoid breaking the legacy build, the root `postcss` should also be frozen to prevent version divergence between the two.

## Solution

Add a Renovate package rule that disables updates for `postcss`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)