### PR TITLE
Fix mergeProps falsy value handling for className and event handlers

### DIFF
--- a/.changeset/300-merge-props-falsy-values.md
+++ b/.changeset/300-merge-props-falsy-values.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/react-core": patch
+---
+
+Fixed [`render`](https://ariakit.com/guide/composition) prop merging when the rendered element passes falsy `className` or event handler values such as `undefined` or `null`.

--- a/.changeset/300-merge-props-falsy-values.md
+++ b/.changeset/300-merge-props-falsy-values.md
@@ -1,5 +1,6 @@
 ---
 "@ariakit/react-core": patch
+"@ariakit/react": patch
 ---
 
 Fixed [`render`](https://ariakit.com/guide/composition) prop merging when the rendered element passes falsy `className` or event handler values such as `undefined` or `null`.

--- a/packages/ariakit-react-core/src/utils/misc.ts
+++ b/packages/ariakit-react-core/src/utils/misc.ts
@@ -58,9 +58,13 @@ export function mergeProps<T extends HTMLAttributes<any>>(
 
     if (key === "className") {
       const prop = "className";
-      props[prop] = base[prop]
-        ? `${base[prop]} ${overrides[prop]}`
-        : overrides[prop];
+      const baseClass = base[prop];
+      const overrideClass = overrides[prop];
+      if (baseClass && overrideClass) {
+        props[prop] = `${baseClass} ${overrideClass}`;
+      } else {
+        props[prop] = overrideClass || baseClass;
+      }
       continue;
     }
 
@@ -74,7 +78,11 @@ export function mergeProps<T extends HTMLAttributes<any>>(
 
     const overrideValue = overrides[key];
 
-    if (typeof overrideValue === "function" && key.startsWith("on")) {
+    if (key.startsWith("on")) {
+      if (typeof overrideValue !== "function") {
+        // Skip nullish event handler overrides to preserve base handlers.
+        continue;
+      }
       const baseValue = base[key];
       if (typeof baseValue === "function") {
         type EventKey = Extract<keyof HTMLAttributes<any>, `on${string}`>;

--- a/packages/ariakit-react-core/src/utils/misc.ts
+++ b/packages/ariakit-react-core/src/utils/misc.ts
@@ -80,7 +80,7 @@ export function mergeProps<T extends HTMLAttributes<any>>(
 
     if (key.startsWith("on")) {
       if (typeof overrideValue !== "function") {
-        // Skip nullish event handler overrides to preserve base handlers.
+        // Skip non-function event handler overrides to preserve base handlers.
         continue;
       }
       const baseValue = base[key];

--- a/site/src/examples/_lib/react-utils/merge-props.ts
+++ b/site/src/examples/_lib/react-utils/merge-props.ts
@@ -15,9 +15,13 @@ export function mergeProps<T extends React.HTMLAttributes<any>>(
 
     if (key === "className") {
       const prop = "className";
-      props[prop] = base[prop]
-        ? `${base[prop]} ${overrides[prop]}`
-        : overrides[prop];
+      const baseClass = base[prop];
+      const overrideClass = overrides[prop];
+      if (baseClass && overrideClass) {
+        props[prop] = `${baseClass} ${overrideClass}`;
+      } else {
+        props[prop] = overrideClass || baseClass;
+      }
       continue;
     }
 
@@ -31,7 +35,10 @@ export function mergeProps<T extends React.HTMLAttributes<any>>(
 
     const overrideValue = overrides[key];
 
-    if (typeof overrideValue === "function" && key.startsWith("on")) {
+    if (key.startsWith("on")) {
+      if (typeof overrideValue !== "function") {
+        continue;
+      }
       const baseValue = base[key];
       if (typeof baseValue === "function") {
         type EventKey = Extract<keyof React.HTMLAttributes<any>, `on${string}`>;

--- a/site/src/sandbox/dialog-disclosure-5224/index.react.tsx
+++ b/site/src/sandbox/dialog-disclosure-5224/index.react.tsx
@@ -6,10 +6,7 @@ export default function Example() {
       <Ariakit.DialogProvider>
         <Ariakit.DialogDisclosure
           render={
-            // TODO: Remove workaround once
-            // https://github.com/ariakit/ariakit/issues/5224 is fixed.
-            // Workaround: omit the onClick prop instead of passing undefined.
-            <Ariakit.Button>Open dialog</Ariakit.Button>
+            <Ariakit.Button onClick={undefined}>Open dialog</Ariakit.Button>
           }
         />
         <Ariakit.Dialog unmountOnHide>
@@ -18,10 +15,7 @@ export default function Example() {
           <Ariakit.DialogDismiss>Close</Ariakit.DialogDismiss>
         </Ariakit.Dialog>
       </Ariakit.DialogProvider>
-      {/* TODO: Remove workaround once
-          https://github.com/ariakit/ariakit/issues/5224 is fixed.
-          Workaround: omit the className prop instead of passing undefined. */}
-      <Ariakit.Button className="base" render={<a />}>
+      <Ariakit.Button className="base" render={<a className={undefined} />}>
         Check className
       </Ariakit.Button>
     </div>

--- a/site/src/sandbox/dialog-disclosure-5224/index.react.tsx
+++ b/site/src/sandbox/dialog-disclosure-5224/index.react.tsx
@@ -6,7 +6,10 @@ export default function Example() {
       <Ariakit.DialogProvider>
         <Ariakit.DialogDisclosure
           render={
-            <Ariakit.Button onClick={undefined}>Open dialog</Ariakit.Button>
+            // TODO: Remove workaround once
+            // https://github.com/ariakit/ariakit/issues/5224 is fixed.
+            // Workaround: omit the onClick prop instead of passing undefined.
+            <Ariakit.Button>Open dialog</Ariakit.Button>
           }
         />
         <Ariakit.Dialog unmountOnHide>
@@ -15,7 +18,10 @@ export default function Example() {
           <Ariakit.DialogDismiss>Close</Ariakit.DialogDismiss>
         </Ariakit.Dialog>
       </Ariakit.DialogProvider>
-      <Ariakit.Button className="base" render={<a className={undefined} />}>
+      {/* TODO: Remove workaround once
+          https://github.com/ariakit/ariakit/issues/5224 is fixed.
+          Workaround: omit the className prop instead of passing undefined. */}
+      <Ariakit.Button className="base" render={<a />}>
         Check className
       </Ariakit.Button>
     </div>

--- a/site/src/sandbox/dialog-disclosure-5224/index.react.tsx
+++ b/site/src/sandbox/dialog-disclosure-5224/index.react.tsx
@@ -1,0 +1,23 @@
+import * as Ariakit from "@ariakit/react";
+
+export default function Example() {
+  return (
+    <div>
+      <Ariakit.DialogProvider>
+        <Ariakit.DialogDisclosure
+          render={
+            <Ariakit.Button onClick={undefined}>Open dialog</Ariakit.Button>
+          }
+        />
+        <Ariakit.Dialog unmountOnHide>
+          <Ariakit.DialogHeading>Success</Ariakit.DialogHeading>
+          <p>Dialog is open</p>
+          <Ariakit.DialogDismiss>Close</Ariakit.DialogDismiss>
+        </Ariakit.Dialog>
+      </Ariakit.DialogProvider>
+      <Ariakit.Button className="base" render={<a className={undefined} />}>
+        Check className
+      </Ariakit.Button>
+    </div>
+  );
+}

--- a/site/src/sandbox/dialog-disclosure-5224/preview.astro
+++ b/site/src/sandbox/dialog-disclosure-5224/preview.astro
@@ -1,0 +1,14 @@
+---
+import PreviewFramework from "#app/components/preview-framework.astro";
+import ReactExample from "./index.react.tsx";
+
+import sourceReact from "./index.react.tsx?source";
+
+export const source = {
+  react: sourceReact,
+};
+---
+
+<PreviewFramework>
+  <ReactExample client:load slot="react" />
+</PreviewFramework>

--- a/site/src/sandbox/dialog-disclosure-5224/preview.mdx
+++ b/site/src/sandbox/dialog-disclosure-5224/preview.mdx
@@ -1,0 +1,9 @@
+---
+title: "dialog-disclosure-5224"
+frameworks:
+  - react
+---
+
+import Preview from "./preview.astro";
+
+<Preview />

--- a/site/src/sandbox/dialog-disclosure-5224/test-browser.ts
+++ b/site/src/sandbox/dialog-disclosure-5224/test-browser.ts
@@ -1,0 +1,24 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("dialog opens when render prop has onClick={undefined}", async ({
+    q,
+  }) => {
+    // When DialogDisclosure uses render={<Button onClick={undefined}>},
+    // mergeProps should preserve the internal onClick handler instead of
+    // overwriting it with undefined.
+    // See https://github.com/ariakit/ariakit/issues/5224
+    await q.button("Open dialog").click();
+    await test.expect(q.dialog()).toBeVisible();
+  });
+
+  test("className does not include falsy values from render prop", async ({
+    q,
+  }) => {
+    // When Button has className="base" and render={<a className={undefined}>},
+    // mergeProps should produce "base" instead of "base undefined".
+    // See https://github.com/ariakit/ariakit/issues/5224
+    const el = q.text("Check className");
+    await test.expect(el).toHaveAttribute("class", "base");
+  });
+});


### PR DESCRIPTION
## Motivation

`mergeProps` incorrectly handles falsy values passed via the `render` prop:

1. Falsy `className` overrides (`null`, `undefined`, `""`) are concatenated as strings, producing invalid class names like `"base undefined"`.
2. Falsy event handler overrides (`null`, `undefined`) silently overwrite base handlers, breaking internal behavior like `DialogDisclosure`'s click handler.

Fixes #5224

## Solution

- For `className`: check that both base and override are truthy before concatenating. When only one is truthy, use that value.
- For event handlers: when an override key starts with `on` but the value is not a function, skip it entirely so the base handler is preserved.
- Applied the same fix to the site's example `mergeProps` utility.

## Workaround

Avoid passing `null` or `undefined` as `className` or event handler values to components via the `render` prop. Omit the key entirely instead:

```tsx
// Instead of:
<DialogDisclosure
  render={
    // TODO: Remove workaround once
    // https://github.com/ariakit/ariakit/issues/5224 is fixed.
    <Button onClick={condition ? handler : undefined}>Open</Button>
  }
/>

// Do:
<DialogDisclosure
  render={
    <Button {...(condition ? { onClick: handler } : {})}>Open</Button>
  }
/>
```

## Test plan

- [x] Failing repro tests for both className and event handler bugs
- [x] Workaround applied in sandbox passes tests
- [x] Library fix passes tests
- [x] All 57 existing browser tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)