### PR TITLE
Fix Math.random() being called when id prop is provided

### DIFF
--- a/.changeset/fix-composite-store-random-id.md
+++ b/.changeset/fix-composite-store-random-id.md
@@ -1,5 +1,6 @@
 ---
 "@ariakit/core": patch
+"@ariakit/react-core": patch
 "@ariakit/react": patch
 ---
 

--- a/.changeset/fix-composite-store-random-id.md
+++ b/.changeset/fix-composite-store-random-id.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/core": patch
+"@ariakit/react": patch
+---
+
+Fixed `Math.random()` being called unconditionally when creating composite stores ([`useTabStore`](https://ariakit.com/reference/use-tab-store), [`useComboboxStore`](https://ariakit.com/reference/use-combobox-store), [`useSelectStore`](https://ariakit.com/reference/use-select-store), etc.), even when an explicit `id` prop was provided. This was causing Next.js build errors with `cacheComponents` enabled.

--- a/nextjs/app/tab-5147/page.tsx
+++ b/nextjs/app/tab-5147/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import * as Ariakit from "@ariakit/react";
-import { Suspense } from "react";
 
-function TabContent() {
+export default function TabPage() {
   const tab = Ariakit.useTabStore({ id: "my-tabs" });
 
   return (
@@ -15,15 +14,5 @@ function TabContent() {
       <Ariakit.TabPanel>Panel 1</Ariakit.TabPanel>
       <Ariakit.TabPanel>Panel 2</Ariakit.TabPanel>
     </Ariakit.TabProvider>
-  );
-}
-
-// Workaround: Wrap in Suspense to avoid Math.random() detection during prerendering
-// TODO: Remove after https://github.com/ariakit/ariakit/issues/5147 is fixed
-export default function TabPage() {
-  return (
-    <Suspense fallback={<div>Loading...</div>}>
-      <TabContent />
-    </Suspense>
   );
 }

--- a/nextjs/app/tab-5147/page.tsx
+++ b/nextjs/app/tab-5147/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import * as Ariakit from "@ariakit/react";
+import { Suspense } from "react";
 
-export default function TabPage() {
+function TabContent() {
   const tab = Ariakit.useTabStore({ id: "my-tabs" });
 
   return (
@@ -14,5 +15,15 @@ export default function TabPage() {
       <Ariakit.TabPanel>Panel 1</Ariakit.TabPanel>
       <Ariakit.TabPanel>Panel 2</Ariakit.TabPanel>
     </Ariakit.TabProvider>
+  );
+}
+
+// Workaround: Wrap in Suspense to avoid Math.random() detection during prerendering
+// TODO: Remove after https://github.com/ariakit/ariakit/issues/5147 is fixed
+export default function TabPage() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <TabContent />
+    </Suspense>
   );
 }

--- a/nextjs/app/tab-5147/page.tsx
+++ b/nextjs/app/tab-5147/page.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import * as Ariakit from "@ariakit/react";
+
+export default function TabPage() {
+  const tab = Ariakit.useTabStore({ id: "my-tabs" });
+
+  return (
+    <Ariakit.TabProvider store={tab}>
+      <Ariakit.TabList aria-label="Settings">
+        <Ariakit.Tab>Tab 1</Ariakit.Tab>
+        <Ariakit.Tab>Tab 2</Ariakit.Tab>
+      </Ariakit.TabList>
+      <Ariakit.TabPanel>Panel 1</Ariakit.TabPanel>
+      <Ariakit.TabPanel>Panel 2</Ariakit.TabPanel>
+    </Ariakit.TabProvider>
+  );
+}

--- a/nextjs/next.config.ts
+++ b/nextjs/next.config.ts
@@ -7,7 +7,7 @@ const config: NextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
-  // cacheComponents: true,
+  cacheComponents: true,
 
   // Allow cross-origin iframe embedding from the Astro site
   async headers() {

--- a/packages/ariakit-core/src/composite/composite-store.ts
+++ b/packages/ariakit-core/src/composite/composite-store.ts
@@ -161,11 +161,9 @@ export function createCompositeStore<
 
   const initialState: CompositeStoreState<T> = {
     ...collection.getState(),
-    id: defaultValue(
-      props.id,
-      syncState?.id,
+    id:
+      defaultValue(props.id, syncState?.id) ??
       `id-${Math.random().toString(36).slice(2, 8)}`,
-    ),
     activeId,
     baseElement: defaultValue(syncState?.baseElement, null),
     includesBaseElement: defaultValue(


### PR DESCRIPTION
## Summary

Fixes #5147

**Problem:** In `composite-store.ts`, the `id` default uses `defaultValue(props.id, syncState?.id, \`id-${Math.random()...}\`)`. JavaScript eagerly evaluates all arguments, so `Math.random()` runs unconditionally — even when `props.id` is already provided. This breaks Next.js builds with `cacheComponents` enabled because `Math.random()` is non-deterministic.

**Solution:** Use nullish coalescing for lazy evaluation:
```ts
id: defaultValue(props.id, syncState?.id) ?? `id-${Math.random()...}`
```

## Workaround

Wrap components using composite stores in a `Suspense` boundary:

```tsx
import { Suspense } from "react";

// TODO: Remove after ariakit update
export default function Page() {
  return (
    <Suspense fallback={<div>Loading...</div>}>
      <TabContent />
    </Suspense>
  );
}
```

## Test plan

- [x] Next.js build fails with `cacheComponents: true` before the fix
- [x] Next.js build passes after the fix