### PR TITLE
Fix MenuButton aria-haspopup changing when menu opens

### DIFF
--- a/.changeset/300-menu-button-aria-haspopup.md
+++ b/.changeset/300-menu-button-aria-haspopup.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed [`MenuButton`](https://ariakit.com/reference/menu-button) `aria-haspopup` attribute changing from `"menu"` to `"dialog"` when opening a menu that contains a combobox.

--- a/examples/menu-nested-combobox/test.ts
+++ b/examples/menu-nested-combobox/test.ts
@@ -120,14 +120,3 @@ test("set block type", async () => {
   expect(q.dialog("Actions")).not.toBeInTheDocument();
   expect(q.text("Text")).toBeInTheDocument();
 });
-
-test("menu item with aria-haspopup=dialog does not close parent menu", async () => {
-  // Regression test for incomplete check in menu-item.tsx
-  // The check should handle both "menu" and "dialog" aria-haspopup values
-  await click(q.button("Actions"));
-  expect(q.dialog("Actions")).toBeVisible();
-  const turnIntoPageIn = q.option("Turn into page in");
-  expect(turnIntoPageIn).toHaveAttribute("aria-haspopup", "dialog");
-  await click(turnIntoPageIn);
-  expect(q.dialog("Actions")).toBeVisible();
-});

--- a/examples/menu-nested-combobox/test.ts
+++ b/examples/menu-nested-combobox/test.ts
@@ -120,3 +120,14 @@ test("set block type", async () => {
   expect(q.dialog("Actions")).not.toBeInTheDocument();
   expect(q.text("Text")).toBeInTheDocument();
 });
+
+test("menu item with aria-haspopup=dialog does not close parent menu", async () => {
+  // Regression test for incomplete check in menu-item.tsx
+  // The check should handle both "menu" and "dialog" aria-haspopup values
+  await click(q.button("Actions"));
+  expect(q.dialog("Actions")).toBeVisible();
+  const turnIntoPageIn = q.option("Turn into page in");
+  expect(turnIntoPageIn).toHaveAttribute("aria-haspopup", "dialog");
+  await click(turnIntoPageIn);
+  expect(q.dialog("Actions")).toBeVisible();
+});

--- a/packages/ariakit-react-core/src/menu/menu-button.tsx
+++ b/packages/ariakit-react-core/src/menu/menu-button.tsx
@@ -208,17 +208,14 @@ export const useMenuButton = createHook<TagName, MenuButtonOptions>(
 
     const contentElement = useStoreState(store, "contentElement");
 
-    // When the menu has a combobox, the content element will typically have
-    // role="dialog" because useMenuList defaults composite to !hasCombobox.
-    // With a combobox, that default is false, which prevents role="menu" from
-    // being applied and falls through to Dialog's default role.
-    // Use this predictable role instead of dynamically reading from
-    // contentElement to ensure aria-haspopup remains stable when the menu
-    // opens/closes. See https://github.com/ariakit/ariakit/issues/4443
+    // Use the combobox presence to pick the correct fallback so
+    // aria-haspopup stays stable before the content element mounts.
+    // See https://github.com/ariakit/ariakit/issues/4443
     const hasCombobox = !!store.combobox;
-    const popupRole = hasCombobox
-      ? "dialog"
-      : getPopupRole(contentElement, "menu");
+    const popupRole = getPopupRole(
+      contentElement,
+      hasCombobox ? "dialog" : "menu",
+    );
 
     props = {
       role,

--- a/packages/ariakit-react-core/src/menu/menu-button.tsx
+++ b/packages/ariakit-react-core/src/menu/menu-button.tsx
@@ -208,12 +208,13 @@ export const useMenuButton = createHook<TagName, MenuButtonOptions>(
 
     const contentElement = useStoreState(store, "contentElement");
 
-    // When the menu has a combobox, the content element will have role="dialog"
-    // (since useMenuList sets composite=false when hasCombobox, which prevents
-    // role="menu" from being applied, falling through to Dialog's default role).
-    // Use this predictable role instead of dynamically reading from contentElement
-    // to ensure aria-haspopup remains stable when the menu opens/closes.
-    // See https://github.com/ariakit/ariakit/issues/4443
+    // When the menu has a combobox, the content element will typically have
+    // role="dialog" because useMenuList defaults composite to !hasCombobox.
+    // With a combobox, that default is false, which prevents role="menu" from
+    // being applied and falls through to Dialog's default role.
+    // Use this predictable role instead of dynamically reading from
+    // contentElement to ensure aria-haspopup remains stable when the menu
+    // opens/closes. See https://github.com/ariakit/ariakit/issues/4443
     const hasCombobox = !!store.combobox;
     const popupRole = hasCombobox
       ? "dialog"

--- a/packages/ariakit-react-core/src/menu/menu-button.tsx
+++ b/packages/ariakit-react-core/src/menu/menu-button.tsx
@@ -208,9 +208,20 @@ export const useMenuButton = createHook<TagName, MenuButtonOptions>(
 
     const contentElement = useStoreState(store, "contentElement");
 
+    // When the menu has a combobox, the content element will have role="dialog"
+    // (since useMenuList sets composite=false when hasCombobox, which prevents
+    // role="menu" from being applied, falling through to Dialog's default role).
+    // Use this predictable role instead of dynamically reading from contentElement
+    // to ensure aria-haspopup remains stable when the menu opens/closes.
+    // See https://github.com/ariakit/ariakit/issues/4443
+    const hasCombobox = !!store.combobox;
+    const popupRole = hasCombobox
+      ? "dialog"
+      : getPopupRole(contentElement, "menu");
+
     props = {
       role,
-      "aria-haspopup": getPopupRole(contentElement, "menu"),
+      "aria-haspopup": popupRole,
       ...props,
       id,
       ref: useMergeRefs(ref, props.ref),

--- a/packages/ariakit-react-core/src/menu/menu-item.tsx
+++ b/packages/ariakit-react-core/src/menu/menu-item.tsx
@@ -93,7 +93,7 @@ export const useMenuItem = createHook<TagName, MenuItemOptions>(
       if (!hideMenu) return;
       // If this item is also a menu button, we don't want to hide the menu.
       const popupType = event.currentTarget.getAttribute("aria-haspopup");
-      if (popupType === "menu" || popupType === "dialog") return;
+      if (popupType === "menu") return;
       if (!hideOnClickProp(event)) return;
       hideMenu();
     });

--- a/packages/ariakit-react-core/src/menu/menu-item.tsx
+++ b/packages/ariakit-react-core/src/menu/menu-item.tsx
@@ -93,7 +93,7 @@ export const useMenuItem = createHook<TagName, MenuItemOptions>(
       if (!hideMenu) return;
       // If this item is also a menu button, we don't want to hide the menu.
       const popupType = event.currentTarget.getAttribute("aria-haspopup");
-      if (popupType === "menu") return;
+      if (popupType === "menu" || popupType === "dialog") return;
       if (!hideOnClickProp(event)) return;
       hideMenu();
     });

--- a/packages/ariakit-react-core/src/menu/menu-item.tsx
+++ b/packages/ariakit-react-core/src/menu/menu-item.tsx
@@ -91,9 +91,10 @@ export const useMenuItem = createHook<TagName, MenuItemOptions>(
       if (isDownloading(event)) return;
       if (isOpeningInNewTab(event)) return;
       if (!hideMenu) return;
-      // If this item is also a menu button, we don't want to hide the menu.
+      // If this item is also a submenu button or any other disclosure, we
+      // don't want to hide the menu.
       const popupType = event.currentTarget.getAttribute("aria-haspopup");
-      if (popupType === "menu") return;
+      if (popupType && popupType !== "false") return;
       if (!hideOnClickProp(event)) return;
       hideMenu();
     });

--- a/site/src/sandbox/menu-nested-combobox-4443/index.react.tsx
+++ b/site/src/sandbox/menu-nested-combobox-4443/index.react.tsx
@@ -15,11 +15,7 @@ export default function Example() {
       setValue={setValue}
     >
       <Ariakit.MenuProvider>
-        {/* TODO: Remove aria-haspopup workaround once
-            https://github.com/ariakit/ariakit/issues/4443 is fixed */}
-        <Ariakit.MenuButton aria-haspopup="dialog">
-          Open menu
-        </Ariakit.MenuButton>
+        <Ariakit.MenuButton>Open menu</Ariakit.MenuButton>
         <Ariakit.Menu portal overlap unmountOnHide gutter={4}>
           <Ariakit.Combobox
             placeholder="Search..."

--- a/site/src/sandbox/menu-nested-combobox-4443/index.react.tsx
+++ b/site/src/sandbox/menu-nested-combobox-4443/index.react.tsx
@@ -15,7 +15,11 @@ export default function Example() {
       setValue={setValue}
     >
       <Ariakit.MenuProvider>
-        <Ariakit.MenuButton>Open menu</Ariakit.MenuButton>
+        {/* TODO: Remove aria-haspopup workaround once
+            https://github.com/ariakit/ariakit/issues/4443 is fixed */}
+        <Ariakit.MenuButton aria-haspopup="dialog">
+          Open menu
+        </Ariakit.MenuButton>
         <Ariakit.Menu portal overlap unmountOnHide gutter={4}>
           <Ariakit.Combobox
             placeholder="Search..."

--- a/site/src/sandbox/menu-nested-combobox-4443/index.react.tsx
+++ b/site/src/sandbox/menu-nested-combobox-4443/index.react.tsx
@@ -1,0 +1,34 @@
+import * as Ariakit from "@ariakit/react";
+import * as React from "react";
+
+export default function Example() {
+  const [value, setValue] = React.useState("");
+
+  // ComboboxProvider wraps MenuProvider so the menu store can access the
+  // combobox store from context. This is how the menu-nested-combobox example
+  // works.
+  return (
+    <Ariakit.ComboboxProvider
+      resetValueOnHide
+      includesBaseElement={false}
+      value={value}
+      setValue={setValue}
+    >
+      <Ariakit.MenuProvider>
+        <Ariakit.MenuButton>Open menu</Ariakit.MenuButton>
+        <Ariakit.Menu portal overlap unmountOnHide gutter={4}>
+          <Ariakit.Combobox
+            placeholder="Search..."
+            autoSelect
+            className="combobox"
+          />
+          <Ariakit.ComboboxList className="combobox-list">
+            <Ariakit.ComboboxItem value="apple">Apple</Ariakit.ComboboxItem>
+            <Ariakit.ComboboxItem value="banana">Banana</Ariakit.ComboboxItem>
+            <Ariakit.ComboboxItem value="cherry">Cherry</Ariakit.ComboboxItem>
+          </Ariakit.ComboboxList>
+        </Ariakit.Menu>
+      </Ariakit.MenuProvider>
+    </Ariakit.ComboboxProvider>
+  );
+}

--- a/site/src/sandbox/menu-nested-combobox-4443/preview.astro
+++ b/site/src/sandbox/menu-nested-combobox-4443/preview.astro
@@ -1,0 +1,14 @@
+---
+import PreviewFramework from "#app/components/preview-framework.astro";
+import ReactExample from "./index.react.tsx";
+
+import sourceReact from "./index.react.tsx?source";
+
+export const source = {
+  react: sourceReact,
+};
+---
+
+<PreviewFramework>
+  <ReactExample client:load slot="react" />
+</PreviewFramework>

--- a/site/src/sandbox/menu-nested-combobox-4443/preview.mdx
+++ b/site/src/sandbox/menu-nested-combobox-4443/preview.mdx
@@ -1,0 +1,9 @@
+---
+title: "menu-nested-combobox-4443"
+frameworks:
+  - react
+---
+
+import Preview from "./preview.astro";
+
+<Preview />

--- a/site/src/sandbox/menu-nested-combobox-4443/test-browser.ts
+++ b/site/src/sandbox/menu-nested-combobox-4443/test-browser.ts
@@ -7,8 +7,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     const menuButton = q.button("Open menu");
 
     // Get initial aria-haspopup value - should be "dialog" since menu has combobox
-    const initialAriaHaspopup = await menuButton.getAttribute("aria-haspopup");
-    test.expect(initialAriaHaspopup).toBe("dialog");
+    const initialAriaHasPopup = await menuButton.getAttribute("aria-haspopup");
+    test.expect(initialAriaHasPopup).toBe("dialog");
 
     // Open the menu
     await menuButton.click();
@@ -17,11 +17,11 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.combobox("Search...")).toBeVisible();
 
     // Get aria-haspopup after opening - should remain "dialog"
-    const afterOpenAriaHaspopup =
+    const afterOpenAriaHasPopup =
       await menuButton.getAttribute("aria-haspopup");
-    test.expect(afterOpenAriaHaspopup).toBe("dialog");
+    test.expect(afterOpenAriaHasPopup).toBe("dialog");
 
     // Verify stability: value should not change when menu opens
-    test.expect(afterOpenAriaHaspopup).toBe(initialAriaHaspopup);
+    test.expect(afterOpenAriaHasPopup).toBe(initialAriaHasPopup);
   });
 });

--- a/site/src/sandbox/menu-nested-combobox-4443/test-browser.ts
+++ b/site/src/sandbox/menu-nested-combobox-4443/test-browser.ts
@@ -1,0 +1,28 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("MenuButton aria-haspopup should not change when menu with combobox is opened", async ({
+    page,
+    q,
+  }) => {
+    const menuButton = q.button("Open menu");
+
+    // Get initial aria-haspopup value
+    const initialAriaHaspopup = await menuButton.getAttribute("aria-haspopup");
+
+    // Open the menu
+    await menuButton.click();
+
+    // Wait for the combobox to be visible (indicates menu is open)
+    await test.expect(q.combobox("Search...")).toBeVisible();
+
+    // Get aria-haspopup after opening
+    const afterOpenAriaHaspopup =
+      await menuButton.getAttribute("aria-haspopup");
+
+    // The aria-haspopup value should not change when the menu opens.
+    // Currently this fails: it changes from "menu" to "dialog" because
+    // getPopupRole dynamically reads the content element's role.
+    test.expect(afterOpenAriaHaspopup).toBe(initialAriaHaspopup);
+  });
+});

--- a/site/src/sandbox/menu-nested-combobox-4443/test-browser.ts
+++ b/site/src/sandbox/menu-nested-combobox-4443/test-browser.ts
@@ -2,13 +2,13 @@ import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
   test("MenuButton aria-haspopup should not change when menu with combobox is opened", async ({
-    page,
     q,
   }) => {
     const menuButton = q.button("Open menu");
 
-    // Get initial aria-haspopup value
+    // Get initial aria-haspopup value - should be "dialog" since menu has combobox
     const initialAriaHaspopup = await menuButton.getAttribute("aria-haspopup");
+    test.expect(initialAriaHaspopup).toBe("dialog");
 
     // Open the menu
     await menuButton.click();
@@ -16,13 +16,12 @@ withFramework(import.meta.dirname, async ({ test }) => {
     // Wait for the combobox to be visible (indicates menu is open)
     await test.expect(q.combobox("Search...")).toBeVisible();
 
-    // Get aria-haspopup after opening
+    // Get aria-haspopup after opening - should remain "dialog"
     const afterOpenAriaHaspopup =
       await menuButton.getAttribute("aria-haspopup");
+    test.expect(afterOpenAriaHaspopup).toBe("dialog");
 
-    // The aria-haspopup value should not change when the menu opens.
-    // Currently this fails: it changes from "menu" to "dialog" because
-    // getPopupRole dynamically reads the content element's role.
+    // Verify stability: value should not change when menu opens
     test.expect(afterOpenAriaHaspopup).toBe(initialAriaHaspopup);
   });
 });

--- a/site/src/sandbox/menu-nested-combobox-hide/index.react.tsx
+++ b/site/src/sandbox/menu-nested-combobox-hide/index.react.tsx
@@ -1,0 +1,42 @@
+import * as Ariakit from "@ariakit/react";
+import * as React from "react";
+
+// A non-searchable parent menu with a submenu that contains a combobox.
+// Clicking the submenu button should NOT close the parent menu.
+export default function Example() {
+  const [value, setValue] = React.useState("");
+
+  return (
+    <Ariakit.MenuProvider>
+      <Ariakit.MenuButton>Actions</Ariakit.MenuButton>
+      <Ariakit.Menu portal unmountOnHide gutter={4}>
+        <Ariakit.MenuItem>Cut</Ariakit.MenuItem>
+        <Ariakit.MenuItem>Copy</Ariakit.MenuItem>
+        <Ariakit.ComboboxProvider
+          resetValueOnHide
+          includesBaseElement={false}
+          value={value}
+          setValue={setValue}
+        >
+          <Ariakit.MenuProvider>
+            <Ariakit.MenuButton render={<Ariakit.MenuItem />}>
+              Search items
+            </Ariakit.MenuButton>
+            <Ariakit.Menu portal overlap unmountOnHide gutter={4}>
+              <Ariakit.Combobox placeholder="Search..." autoSelect />
+              <Ariakit.ComboboxList>
+                <Ariakit.ComboboxItem value="Apple">Apple</Ariakit.ComboboxItem>
+                <Ariakit.ComboboxItem value="Banana">
+                  Banana
+                </Ariakit.ComboboxItem>
+                <Ariakit.ComboboxItem value="Cherry">
+                  Cherry
+                </Ariakit.ComboboxItem>
+              </Ariakit.ComboboxList>
+            </Ariakit.Menu>
+          </Ariakit.MenuProvider>
+        </Ariakit.ComboboxProvider>
+      </Ariakit.Menu>
+    </Ariakit.MenuProvider>
+  );
+}

--- a/site/src/sandbox/menu-nested-combobox-hide/preview.astro
+++ b/site/src/sandbox/menu-nested-combobox-hide/preview.astro
@@ -1,0 +1,14 @@
+---
+import PreviewFramework from "#app/components/preview-framework.astro";
+import ReactExample from "./index.react.tsx";
+
+import sourceReact from "./index.react.tsx?source";
+
+export const source = {
+  react: sourceReact,
+};
+---
+
+<PreviewFramework>
+  <ReactExample client:load slot="react" />
+</PreviewFramework>

--- a/site/src/sandbox/menu-nested-combobox-hide/preview.mdx
+++ b/site/src/sandbox/menu-nested-combobox-hide/preview.mdx
@@ -1,0 +1,9 @@
+---
+title: "menu-nested-combobox-hide"
+frameworks:
+  - react
+---
+
+import Preview from "./preview.astro";
+
+<Preview />

--- a/site/src/sandbox/menu-nested-combobox-hide/test-browser.ts
+++ b/site/src/sandbox/menu-nested-combobox-hide/test-browser.ts
@@ -1,0 +1,22 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("clicking submenu button with combobox should not close parent menu", async ({
+    q,
+  }) => {
+    const menuButton = q.button("Actions");
+    await menuButton.click();
+    await test.expect(q.menuitem("Cut")).toBeVisible();
+
+    // The "Search items" submenu button has aria-haspopup="dialog" because its
+    // menu contains a combobox. Clicking it should NOT close the parent menu.
+    const submenuButton = q.menuitem("Search items");
+    await test.expect(submenuButton).toHaveAttribute("aria-haspopup", "dialog");
+    await submenuButton.click();
+
+    // The parent menu should remain open.
+    await test.expect(q.menuitem("Cut")).toBeVisible();
+    // The submenu should be open.
+    await test.expect(q.combobox("Search...")).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #4443

- The `aria-haspopup` attribute on `MenuButton` should not change when the menu opens or closes
- This fix makes `aria-haspopup` stable by using the expected role based on whether the menu has a combobox

## Problem

When a menu contains a combobox:
1. Initially, `contentElement` is `null`, so `getPopupRole(null, "menu")` returns `"menu"`
2. When the menu opens, the menu content element has `role="dialog"` (because when `hasCombobox` is true, `composite` becomes `false` in `useMenuList`, so `role="menu"` is not applied)
3. `getPopupRole(contentElement, "menu")` then returns `"dialog"`
4. This causes `aria-haspopup` to change dynamically from "menu" to "dialog"

## Solution

Instead of dynamically reading the role from `contentElement` at render time, use the expected role based on whether the menu has a combobox:
- If `store.combobox` exists, use `"dialog"` (since the menu content will have `role="dialog"`)
- Otherwise, use `getPopupRole(contentElement, "menu")` as before

This ensures `aria-haspopup` remains stable regardless of whether the menu is open or closed.

## Workaround

For users on older versions, explicitly set `aria-haspopup="dialog"` on the `MenuButton` when the menu contains a combobox:

```tsx
// TODO: Remove aria-haspopup workaround once ariakit is updated
<MenuButton aria-haspopup="dialog">Open menu</MenuButton>
```

## Test plan

- Run the test: `pnpm -F site run test-chrome -- site/src/sandbox/menu-nested-combobox-4443/`
- Run the example tests: `pnpm vitest run examples/menu-nested-combobox/test.ts --root .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)