### PR TITLE
Prevent combobox Enter from submitting form when popover has no items

### DIFF
--- a/.changeset/300-combobox-form-enter.md
+++ b/.changeset/300-combobox-form-enter.md
@@ -3,4 +3,4 @@
 "@ariakit/react": patch
 ---
 
-Fixed [`Combobox`](https://ariakit.com/reference/combobox) pressing Enter submitting a parent form when the popover is open but has no matching items.
+Fixed [`Combobox`](https://ariakit.com/reference/combobox) pressing Enter from submitting a parent form when the popover is open but has no matching items.

--- a/.changeset/300-combobox-form-enter.md
+++ b/.changeset/300-combobox-form-enter.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Combobox`](https://ariakit.com/reference/combobox) pressing Enter submitting a parent form when the popover is open but has no matching items.

--- a/packages/ariakit-react-core/src/combobox/combobox.tsx
+++ b/packages/ariakit-react-core/src/combobox/combobox.tsx
@@ -564,24 +564,24 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
         canAutoSelectRef.current = false;
       }
       if (event.defaultPrevented) return;
+      if (!store) return;
+      const { open } = store.getState();
+      // When the popover is open, prevent Enter (with or without modifiers)
+      // from triggering the default behavior (submitting a parent form). If
+      // there's an active item, the keyboard event proxy on Composite will
+      // dispatch Enter to the item, which handles selection. If there's no
+      // active item (e.g., all items are filtered out, or activeId is stale
+      // after a React transition), Enter should be a no-op rather than
+      // submitting a form.
+      if (open && event.key === "Enter") {
+        event.preventDefault();
+        return;
+      }
       if (event.ctrlKey) return;
       if (event.altKey) return;
       if (event.shiftKey) return;
       if (event.metaKey) return;
-      if (!store) return;
-      const { open } = store.getState();
-      if (open) {
-        // When the popover is open, prevent Enter from triggering the default
-        // behavior (submitting a parent form). If there's an active item, the
-        // keyboard event proxy on Composite will dispatch Enter to the item,
-        // which handles selection. If there's no active item (e.g., all items
-        // are filtered out, or activeId is stale after a React transition),
-        // Enter should be a no-op rather than submitting a form.
-        if (event.key === "Enter") {
-          event.preventDefault();
-        }
-        return;
-      }
+      if (open) return;
       // Up and Down arrow keys should open the combobox popover.
       if (event.key === "ArrowUp" || event.key === "ArrowDown") {
         if (showOnKeyPressProp(event)) {

--- a/packages/ariakit-react-core/src/combobox/combobox.tsx
+++ b/packages/ariakit-react-core/src/combobox/combobox.tsx
@@ -570,7 +570,18 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       if (event.metaKey) return;
       if (!store) return;
       const { open } = store.getState();
-      if (open) return;
+      if (open) {
+        // When the popover is open, prevent Enter from triggering the default
+        // behavior (submitting a parent form). If there's an active item, the
+        // keyboard event proxy on Composite will dispatch Enter to the item,
+        // which handles selection. If there's no active item (e.g., all items
+        // are filtered out, or activeId is stale after a React transition),
+        // Enter should be a no-op rather than submitting a form.
+        if (event.key === "Enter") {
+          event.preventDefault();
+        }
+        return;
+      }
       // Up and Down arrow keys should open the combobox popover.
       if (event.key === "ArrowUp" || event.key === "ArrowDown") {
         if (showOnKeyPressProp(event)) {

--- a/site/src/sandbox/select-combobox-form-3323/index.react.tsx
+++ b/site/src/sandbox/select-combobox-form-3323/index.react.tsx
@@ -1,0 +1,52 @@
+import * as Ariakit from "@ariakit/react";
+import { matchSorter } from "match-sorter";
+import { startTransition, useMemo, useState } from "react";
+
+const list = ["Apple", "Banana", "Cherry", "Grape", "Lemon", "Orange"];
+
+export default function Example() {
+  const [searchValue, setSearchValue] = useState("");
+  const [submitted, setSubmitted] = useState(false);
+
+  const matches = useMemo(() => {
+    return matchSorter(list, searchValue, {
+      baseSort: (a, b) => (a.index < b.index ? -1 : 1),
+    });
+  }, [searchValue]);
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        setSubmitted(true);
+      }}
+    >
+      <Ariakit.ComboboxProvider
+        resetValueOnHide
+        setValue={(value) => {
+          startTransition(() => {
+            setSearchValue(value);
+          });
+        }}
+      >
+        <Ariakit.SelectProvider defaultValue="Apple">
+          <Ariakit.SelectLabel>Favorite fruit</Ariakit.SelectLabel>
+          <Ariakit.Select />
+          <Ariakit.SelectPopover gutter={4} sameWidth>
+            <Ariakit.Combobox autoSelect placeholder="Search..." />
+            <Ariakit.ComboboxList>
+              {matches.map((value) => (
+                <Ariakit.SelectItem
+                  key={value}
+                  value={value}
+                  render={<Ariakit.ComboboxItem />}
+                />
+              ))}
+            </Ariakit.ComboboxList>
+          </Ariakit.SelectPopover>
+        </Ariakit.SelectProvider>
+      </Ariakit.ComboboxProvider>
+      {submitted && <div>Form submitted</div>}
+    </form>
+  );
+}

--- a/site/src/sandbox/select-combobox-form-3323/index.react.tsx
+++ b/site/src/sandbox/select-combobox-form-3323/index.react.tsx
@@ -33,7 +33,17 @@ export default function Example() {
           <Ariakit.SelectLabel>Favorite fruit</Ariakit.SelectLabel>
           <Ariakit.Select />
           <Ariakit.SelectPopover gutter={4} sameWidth>
-            <Ariakit.Combobox autoSelect placeholder="Search..." />
+            <Ariakit.Combobox
+              autoSelect
+              placeholder="Search..."
+              // TODO: Remove this workaround when the fix lands.
+              // https://github.com/ariakit/ariakit/issues/3323
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && !matches.length) {
+                  event.preventDefault();
+                }
+              }}
+            />
             <Ariakit.ComboboxList>
               {matches.map((value) => (
                 <Ariakit.SelectItem

--- a/site/src/sandbox/select-combobox-form-3323/index.react.tsx
+++ b/site/src/sandbox/select-combobox-form-3323/index.react.tsx
@@ -33,17 +33,7 @@ export default function Example() {
           <Ariakit.SelectLabel>Favorite fruit</Ariakit.SelectLabel>
           <Ariakit.Select />
           <Ariakit.SelectPopover gutter={4} sameWidth>
-            <Ariakit.Combobox
-              autoSelect
-              placeholder="Search..."
-              // TODO: Remove this workaround when the fix lands.
-              // https://github.com/ariakit/ariakit/issues/3323
-              onKeyDown={(event) => {
-                if (event.key === "Enter" && !matches.length) {
-                  event.preventDefault();
-                }
-              }}
-            />
+            <Ariakit.Combobox autoSelect placeholder="Search..." />
             <Ariakit.ComboboxList>
               {matches.map((value) => (
                 <Ariakit.SelectItem

--- a/site/src/sandbox/select-combobox-form-3323/preview.astro
+++ b/site/src/sandbox/select-combobox-form-3323/preview.astro
@@ -1,0 +1,14 @@
+---
+import PreviewFramework from "#app/components/preview-framework.astro";
+import ReactExample from "./index.react.tsx";
+
+import sourceReact from "./index.react.tsx?source";
+
+export const source = {
+  react: sourceReact,
+};
+---
+
+<PreviewFramework>
+  <ReactExample client:load slot="react" />
+</PreviewFramework>

--- a/site/src/sandbox/select-combobox-form-3323/preview.mdx
+++ b/site/src/sandbox/select-combobox-form-3323/preview.mdx
@@ -1,0 +1,9 @@
+---
+title: "select-combobox-form-3323"
+frameworks:
+  - react
+---
+
+import Preview from "./preview.astro";
+
+<Preview />

--- a/site/src/sandbox/select-combobox-form-3323/test-browser.ts
+++ b/site/src/sandbox/select-combobox-form-3323/test-browser.ts
@@ -9,7 +9,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await page.keyboard.type("asdasd");
     await test.expect(q.option("Apple")).toBeHidden();
     await page.keyboard.press("Enter");
-    await test.expect(page.getByText("Form submitted")).toBeHidden();
+    await test.expect(q.text("Form submitted")).toBeHidden();
   });
 
   test("pressing Shift+Enter with no matching items does not submit the form", async ({
@@ -20,7 +20,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await page.keyboard.type("asdasd");
     await test.expect(q.option("Apple")).toBeHidden();
     await page.keyboard.press("Shift+Enter");
-    await test.expect(page.getByText("Form submitted")).toBeHidden();
+    await test.expect(q.text("Form submitted")).toBeHidden();
   });
 
   test("pressing Enter with a matching item selects it without submitting the form", async ({
@@ -31,6 +31,6 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.option("Apple")).toBeVisible();
     await page.keyboard.press("Enter");
     await test.expect(q.option("Apple")).toBeHidden();
-    await test.expect(page.getByText("Form submitted")).toBeHidden();
+    await test.expect(q.text("Form submitted")).toBeHidden();
   });
 });

--- a/site/src/sandbox/select-combobox-form-3323/test-browser.ts
+++ b/site/src/sandbox/select-combobox-form-3323/test-browser.ts
@@ -1,0 +1,14 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("pressing Enter with no matching items does not submit the form", async ({
+    page,
+    q,
+  }) => {
+    await q.combobox("Favorite fruit").click();
+    await page.keyboard.type("asdasd");
+    await test.expect(q.option("Apple")).toBeHidden();
+    await page.keyboard.press("Enter");
+    await test.expect(page.getByText("Form submitted")).toBeHidden();
+  });
+});

--- a/site/src/sandbox/select-combobox-form-3323/test-browser.ts
+++ b/site/src/sandbox/select-combobox-form-3323/test-browser.ts
@@ -11,4 +11,15 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await page.keyboard.press("Enter");
     await test.expect(page.getByText("Form submitted")).toBeHidden();
   });
+
+  test("pressing Enter with a matching item selects it without submitting the form", async ({
+    page,
+    q,
+  }) => {
+    await q.combobox("Favorite fruit").click();
+    await test.expect(q.option("Apple")).toBeVisible();
+    await page.keyboard.press("Enter");
+    await test.expect(q.option("Apple")).toBeHidden();
+    await test.expect(page.getByText("Form submitted")).toBeHidden();
+  });
 });

--- a/site/src/sandbox/select-combobox-form-3323/test-browser.ts
+++ b/site/src/sandbox/select-combobox-form-3323/test-browser.ts
@@ -12,6 +12,17 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(page.getByText("Form submitted")).toBeHidden();
   });
 
+  test("pressing Shift+Enter with no matching items does not submit the form", async ({
+    page,
+    q,
+  }) => {
+    await q.combobox("Favorite fruit").click();
+    await page.keyboard.type("asdasd");
+    await test.expect(q.option("Apple")).toBeHidden();
+    await page.keyboard.press("Shift+Enter");
+    await test.expect(page.getByText("Form submitted")).toBeHidden();
+  });
+
   test("pressing Enter with a matching item selects it without submitting the form", async ({
     page,
     q,


### PR DESCRIPTION
Fixes #3323

## Motivation

When a combobox is inside a form and the popover is open with no matching items, pressing Enter triggers form submission. This is because the combobox input is a native `<input>` element inside a `<form>`, and without any active item to intercept the Enter key, the browser's default form submission behavior takes over.

The issue is exacerbated when consumers use `startTransition` for filtering — the store's `activeId` can briefly reference a stale item that has already been removed from the DOM, creating a window where Enter falls through to the browser's default behavior.

## Solution

When the combobox popover is open, always prevent the Enter key's default behavior. If there's an active item, the Composite's keyboard event proxy dispatches the event to that item, which handles selection via its own click handler. If there's no active item (e.g., all items are filtered out or `activeId` is stale), Enter becomes a no-op instead of submitting the form.

## Workaround

When the combobox popover is open but all items are filtered out, pressing Enter on the combobox input falls through to the browser's default behavior, which submits the enclosing form. To prevent this, add an `onKeyDown` handler that calls `preventDefault` when there are no matching items:

```tsx
const [searchValue, setSearchValue] = useState("");

const matches = useMemo(() => matchSorter(list, searchValue), [searchValue]);

<Ariakit.Combobox
  // TODO: Remove when https://github.com/ariakit/ariakit/issues/3323 is fixed
  onKeyDown={(event) => {
    if (event.key === "Enter" && !matches.length) {
      event.preventDefault();
    }
  }}
/>
```