### PR TITLE
Fix Portal rendering outside fullscreen element

### DIFF
--- a/.changeset/300-portal-fullscreen.md
+++ b/.changeset/300-portal-fullscreen.md
@@ -1,0 +1,8 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Portal`](https://ariakit.com/reference/portal) not rendering inside fullscreen elements
+
+Portals were always appended to `document.body`, which made them invisible when an ancestor element entered fullscreen mode via the Fullscreen API. Portals are now automatically moved to `document.fullscreenElement` when it's active, and back to `document.body` when fullscreen is exited.

--- a/.changeset/300-portal-fullscreen.md
+++ b/.changeset/300-portal-fullscreen.md
@@ -3,6 +3,6 @@
 "@ariakit/react": patch
 ---
 
-Fixed [`Portal`](https://ariakit.com/reference/portal) not rendering inside fullscreen elements
+Fixed `Portal` not rendering inside fullscreen elements
 
-Portals were always appended to `document.body`, which made them invisible when an ancestor element entered fullscreen mode via the Fullscreen API. Portals are now automatically moved to `document.fullscreenElement` when it's active, and back to `document.body` when fullscreen is exited.
+[`Portal`](https://ariakit.com/reference/portal) was always appended to `document.body`, which made it invisible when an ancestor element entered fullscreen mode via the Fullscreen API. Portals are now automatically moved to `document.fullscreenElement` when it's active, and back to `document.body` when fullscreen is exited.

--- a/packages/ariakit-react-core/src/portal/portal.tsx
+++ b/packages/ariakit-react-core/src/portal/portal.tsx
@@ -140,6 +140,10 @@ export const usePortal = createHook<TagName, PortalOptions>(function usePortal({
         rootElement.appendChild(portalNode);
       }
     };
+    // Sync immediately in case fullscreen was entered before this effect
+    // ran, which can happen if the portal mounts while already in
+    // fullscreen mode.
+    onFullscreenChange();
     doc.addEventListener("fullscreenchange", onFullscreenChange);
     return () => {
       doc.removeEventListener("fullscreenchange", onFullscreenChange);

--- a/packages/ariakit-react-core/src/portal/portal.tsx
+++ b/packages/ariakit-react-core/src/portal/portal.tsx
@@ -24,8 +24,16 @@ const TagName = "div" satisfies ElementType;
 type TagName = typeof TagName;
 type HTMLType = HTMLElementTagNameMap[TagName];
 
+// Returns the best root element for appending portal nodes. When an element
+// is in fullscreen mode, portals must be appended inside the fullscreen
+// element instead of document.body so they remain visible.
 function getRootElement(element?: Element | null) {
-  return getDocument(element).body;
+  const doc = getDocument(element);
+  const { fullscreenElement } = doc;
+  if (fullscreenElement instanceof HTMLElement) {
+    return fullscreenElement;
+  }
+  return doc.body;
 }
 
 function getPortalElement(
@@ -119,6 +127,24 @@ export const usePortal = createHook<TagName, PortalOptions>(function usePortal({
       setRef(portalRef, null);
     };
   }, [portal, portalElement, context, portalRef]);
+
+  // Move the portal node when fullscreen state changes so it stays visible.
+  useEffect(() => {
+    if (!portalNode) return;
+    if (context) return;
+    if (portalElement) return;
+    const doc = getDocument(portalNode);
+    const onFullscreenChange = () => {
+      const rootElement = getRootElement(portalNode);
+      if (portalNode.parentElement !== rootElement) {
+        rootElement.appendChild(portalNode);
+      }
+    };
+    doc.addEventListener("fullscreenchange", onFullscreenChange);
+    return () => {
+      doc.removeEventListener("fullscreenchange", onFullscreenChange);
+    };
+  }, [portalNode, context, portalElement]);
 
   // Create the anchor portal node and attach it to the DOM.
   useSafeLayoutEffect(() => {

--- a/site/src/sandbox/tooltip-865/index.react.tsx
+++ b/site/src/sandbox/tooltip-865/index.react.tsx
@@ -1,8 +1,9 @@
 import * as Ariakit from "@ariakit/react";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 
 export default function Example() {
   const containerRef = useRef<HTMLDivElement>(null);
+  const [showSecond, setShowSecond] = useState(false);
 
   const enterFullscreen = () => {
     void containerRef.current?.requestFullscreen();
@@ -23,12 +24,23 @@ export default function Example() {
       <button type="button" onClick={exitFullscreen}>
         Exit fullscreen
       </button>
+      <button type="button" onClick={() => setShowSecond(true)}>
+        Show second tooltip
+      </button>
       <Ariakit.TooltipProvider>
         <Ariakit.TooltipAnchor render={<button type="button" />}>
           Hover me
         </Ariakit.TooltipAnchor>
         <Ariakit.Tooltip>Tooltip content</Ariakit.Tooltip>
       </Ariakit.TooltipProvider>
+      {showSecond && (
+        <Ariakit.TooltipProvider>
+          <Ariakit.TooltipAnchor render={<button type="button" />}>
+            Second anchor
+          </Ariakit.TooltipAnchor>
+          <Ariakit.Tooltip>Second tooltip</Ariakit.Tooltip>
+        </Ariakit.TooltipProvider>
+      )}
     </div>
   );
 }

--- a/site/src/sandbox/tooltip-865/index.react.tsx
+++ b/site/src/sandbox/tooltip-865/index.react.tsx
@@ -1,0 +1,34 @@
+import * as Ariakit from "@ariakit/react";
+import { useRef } from "react";
+
+export default function Example() {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const enterFullscreen = () => {
+    void containerRef.current?.requestFullscreen();
+  };
+
+  const exitFullscreen = () => {
+    void document.exitFullscreen();
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      style={{ padding: 20, background: "white", color: "black" }}
+    >
+      <button type="button" onClick={enterFullscreen}>
+        Enter fullscreen
+      </button>
+      <button type="button" onClick={exitFullscreen}>
+        Exit fullscreen
+      </button>
+      <Ariakit.TooltipProvider>
+        <Ariakit.TooltipAnchor render={<button type="button" />}>
+          Hover me
+        </Ariakit.TooltipAnchor>
+        <Ariakit.Tooltip>Tooltip content</Ariakit.Tooltip>
+      </Ariakit.TooltipProvider>
+    </div>
+  );
+}

--- a/site/src/sandbox/tooltip-865/index.react.tsx
+++ b/site/src/sandbox/tooltip-865/index.react.tsx
@@ -1,23 +1,8 @@
 import * as Ariakit from "@ariakit/react";
-import { useEffect, useRef, useState } from "react";
+import { useRef } from "react";
 
 export default function Example() {
   const containerRef = useRef<HTMLDivElement>(null);
-  const [portalContainer, setPortalContainer] = useState<HTMLElement | null>(
-    null,
-  );
-
-  useEffect(() => {
-    const onFullscreenChange = () => {
-      // TODO: Remove this workaround once
-      // https://github.com/ariakit/ariakit/issues/865 is fixed.
-      setPortalContainer(document.fullscreenElement as HTMLElement | null);
-    };
-    document.addEventListener("fullscreenchange", onFullscreenChange);
-    return () => {
-      document.removeEventListener("fullscreenchange", onFullscreenChange);
-    };
-  }, []);
 
   const enterFullscreen = () => {
     void containerRef.current?.requestFullscreen();
@@ -28,24 +13,22 @@ export default function Example() {
   };
 
   return (
-    <Ariakit.PortalContext.Provider value={portalContainer}>
-      <div
-        ref={containerRef}
-        style={{ padding: 20, background: "white", color: "black" }}
-      >
-        <button type="button" onClick={enterFullscreen}>
-          Enter fullscreen
-        </button>
-        <button type="button" onClick={exitFullscreen}>
-          Exit fullscreen
-        </button>
-        <Ariakit.TooltipProvider>
-          <Ariakit.TooltipAnchor render={<button type="button" />}>
-            Hover me
-          </Ariakit.TooltipAnchor>
-          <Ariakit.Tooltip>Tooltip content</Ariakit.Tooltip>
-        </Ariakit.TooltipProvider>
-      </div>
-    </Ariakit.PortalContext.Provider>
+    <div
+      ref={containerRef}
+      style={{ padding: 20, background: "white", color: "black" }}
+    >
+      <button type="button" onClick={enterFullscreen}>
+        Enter fullscreen
+      </button>
+      <button type="button" onClick={exitFullscreen}>
+        Exit fullscreen
+      </button>
+      <Ariakit.TooltipProvider>
+        <Ariakit.TooltipAnchor render={<button type="button" />}>
+          Hover me
+        </Ariakit.TooltipAnchor>
+        <Ariakit.Tooltip>Tooltip content</Ariakit.Tooltip>
+      </Ariakit.TooltipProvider>
+    </div>
   );
 }

--- a/site/src/sandbox/tooltip-865/index.react.tsx
+++ b/site/src/sandbox/tooltip-865/index.react.tsx
@@ -1,8 +1,23 @@
 import * as Ariakit from "@ariakit/react";
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export default function Example() {
   const containerRef = useRef<HTMLDivElement>(null);
+  const [portalContainer, setPortalContainer] = useState<HTMLElement | null>(
+    null,
+  );
+
+  useEffect(() => {
+    const onFullscreenChange = () => {
+      // TODO: Remove this workaround once
+      // https://github.com/ariakit/ariakit/issues/865 is fixed.
+      setPortalContainer(document.fullscreenElement as HTMLElement | null);
+    };
+    document.addEventListener("fullscreenchange", onFullscreenChange);
+    return () => {
+      document.removeEventListener("fullscreenchange", onFullscreenChange);
+    };
+  }, []);
 
   const enterFullscreen = () => {
     void containerRef.current?.requestFullscreen();
@@ -13,22 +28,24 @@ export default function Example() {
   };
 
   return (
-    <div
-      ref={containerRef}
-      style={{ padding: 20, background: "white", color: "black" }}
-    >
-      <button type="button" onClick={enterFullscreen}>
-        Enter fullscreen
-      </button>
-      <button type="button" onClick={exitFullscreen}>
-        Exit fullscreen
-      </button>
-      <Ariakit.TooltipProvider>
-        <Ariakit.TooltipAnchor render={<button type="button" />}>
-          Hover me
-        </Ariakit.TooltipAnchor>
-        <Ariakit.Tooltip>Tooltip content</Ariakit.Tooltip>
-      </Ariakit.TooltipProvider>
-    </div>
+    <Ariakit.PortalContext.Provider value={portalContainer}>
+      <div
+        ref={containerRef}
+        style={{ padding: 20, background: "white", color: "black" }}
+      >
+        <button type="button" onClick={enterFullscreen}>
+          Enter fullscreen
+        </button>
+        <button type="button" onClick={exitFullscreen}>
+          Exit fullscreen
+        </button>
+        <Ariakit.TooltipProvider>
+          <Ariakit.TooltipAnchor render={<button type="button" />}>
+            Hover me
+          </Ariakit.TooltipAnchor>
+          <Ariakit.Tooltip>Tooltip content</Ariakit.Tooltip>
+        </Ariakit.TooltipProvider>
+      </div>
+    </Ariakit.PortalContext.Provider>
   );
 }

--- a/site/src/sandbox/tooltip-865/preview.astro
+++ b/site/src/sandbox/tooltip-865/preview.astro
@@ -1,0 +1,14 @@
+---
+import PreviewFramework from "#app/components/preview-framework.astro";
+import ReactExample from "./index.react.tsx";
+
+import sourceReact from "./index.react.tsx?source";
+
+export const source = {
+  react: sourceReact,
+};
+---
+
+<PreviewFramework>
+  <ReactExample client:load slot="react" />
+</PreviewFramework>

--- a/site/src/sandbox/tooltip-865/preview.mdx
+++ b/site/src/sandbox/tooltip-865/preview.mdx
@@ -1,0 +1,9 @@
+---
+title: "tooltip-865"
+frameworks:
+  - react
+---
+
+import Preview from "./preview.astro";
+
+<Preview />

--- a/site/src/sandbox/tooltip-865/test-browser.ts
+++ b/site/src/sandbox/tooltip-865/test-browser.ts
@@ -1,0 +1,19 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("tooltip renders inside fullscreen element", async ({ page, q }) => {
+    await q.button("Enter fullscreen").click();
+    await page.waitForFunction(() => document.fullscreenElement != null);
+    await q.button("Hover me").hover();
+    await test.expect(q.tooltip("Tooltip content")).toBeVisible();
+    // The portal containing the tooltip must be inside the fullscreen
+    // element. Otherwise, the tooltip is invisible to the user.
+    const isInsideFullscreen = await page.evaluate(() => {
+      const fullscreenEl = document.fullscreenElement;
+      const tooltipEl = document.querySelector("[role=tooltip]");
+      if (!fullscreenEl || !tooltipEl) return false;
+      return fullscreenEl.contains(tooltipEl);
+    });
+    test.expect(isInsideFullscreen).toBe(true);
+  });
+});

--- a/site/src/sandbox/tooltip-865/test-browser.ts
+++ b/site/src/sandbox/tooltip-865/test-browser.ts
@@ -16,4 +16,43 @@ withFramework(import.meta.dirname, async ({ test }) => {
     });
     test.expect(isInsideFullscreen).toBe(true);
   });
+
+  test("tooltip moves back to body after exiting fullscreen", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Enter fullscreen").click();
+    await page.waitForFunction(() => document.fullscreenElement != null);
+    await q.button("Hover me").hover();
+    await test.expect(q.tooltip("Tooltip content")).toBeVisible();
+    await q.button("Exit fullscreen").click();
+    await page.waitForFunction(() => document.fullscreenElement == null);
+    await q.button("Hover me").hover();
+    await test.expect(q.tooltip("Tooltip content")).toBeVisible();
+    const isInBody = await page.evaluate(() => {
+      const tooltipEl = document.querySelector("[role=tooltip]");
+      if (!tooltipEl) return false;
+      return tooltipEl.closest("body") === document.body;
+    });
+    test.expect(isInBody).toBe(true);
+  });
+
+  test("tooltip mounted while in fullscreen renders inside it", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Enter fullscreen").click();
+    await page.waitForFunction(() => document.fullscreenElement != null);
+    // Mount the second tooltip while already in fullscreen.
+    await q.button("Show second tooltip").click();
+    await q.button("Second anchor").hover();
+    await test.expect(q.tooltip("Second tooltip")).toBeVisible();
+    const isInsideFullscreen = await page.evaluate(() => {
+      const fullscreenEl = document.fullscreenElement;
+      const tooltipEl = document.querySelectorAll("[role=tooltip]")[1];
+      if (!fullscreenEl || !tooltipEl) return false;
+      return fullscreenEl.contains(tooltipEl);
+    });
+    test.expect(isInsideFullscreen).toBe(true);
+  });
 });

--- a/site/src/sandbox/tooltip-865/test-browser.ts
+++ b/site/src/sandbox/tooltip-865/test-browser.ts
@@ -29,12 +29,15 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await page.waitForFunction(() => document.fullscreenElement == null);
     await q.button("Hover me").hover();
     await test.expect(q.tooltip("Tooltip content")).toBeVisible();
-    const isInBody = await page.evaluate(() => {
+    // The portal node must be a direct child of document.body, not still
+    // inside the former fullscreen container.
+    const portalParentIsBody = await page.evaluate(() => {
       const tooltipEl = document.querySelector("[role=tooltip]");
-      if (!tooltipEl) return false;
-      return tooltipEl.closest("body") === document.body;
+      const portalNode = tooltipEl?.closest("[id^='portal/']");
+      if (!portalNode) return false;
+      return portalNode.parentElement === document.body;
     });
-    test.expect(isInBody).toBe(true);
+    test.expect(portalParentIsBody).toBe(true);
   });
 
   test("tooltip mounted while in fullscreen renders inside it", async ({


### PR DESCRIPTION
## Motivation

When a DOM element enters fullscreen mode via the Fullscreen API (`element.requestFullscreen()`), portaled content (tooltips, popovers, dialogs, etc.) becomes invisible because the portal is appended to `document.body`, which is outside the fullscreen element. Only the fullscreen element and its descendants are visible in fullscreen mode.

Reported in #865.

## Solution

- Modified `getRootElement` in the Portal component to check `document.fullscreenElement` before falling back to `document.body`. When a fullscreen element exists, portals are appended there instead.
- Added a `fullscreenchange` event listener that automatically moves existing portal nodes between the fullscreen element and `document.body` as fullscreen state changes. This handles portals that were already created before fullscreen was entered.
- The listener is only active for portals without a custom `PortalContext` or `portalElement`, since those are explicitly managed by the consumer.

## Workaround

For versions before this fix, the [`PortalContext`](https://ariakit.com/reference/portal-context) provider can override where portals are rendered. By listening to the `fullscreenchange` event and setting the portal container to `document.fullscreenElement`, portals will render inside the fullscreen element when active:

```tsx
import * as Ariakit from "@ariakit/react";
import { useEffect, useState } from "react";

function App() {
  const [portalContainer, setPortalContainer] = useState<HTMLElement | null>(
    null,
  );

  useEffect(() => {
    const onFullscreenChange = () => {
      // TODO: Remove this workaround once
      // https://github.com/ariakit/ariakit/issues/865 is fixed.
      setPortalContainer(document.fullscreenElement as HTMLElement | null);
    };
    document.addEventListener("fullscreenchange", onFullscreenChange);
    return () => {
      document.removeEventListener("fullscreenchange", onFullscreenChange);
    };
  }, []);

  return (
    <Ariakit.PortalContext.Provider value={portalContainer}>
      {/* Your app content */}
    </Ariakit.PortalContext.Provider>
  );
}
```

When `portalContainer` is `null` (not in fullscreen), portals fall back to `document.body` as usual.

Fixes #865