### PR TITLE
Add performance test suite for site workspace

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -204,6 +204,115 @@ jobs:
       test-result: ${{ needs.test.result }}
     secrets: inherit
 
+  perf:
+    name: Performance
+    needs: [build]
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up environment
+        uses: ./.github/workflows/setup
+
+      - name: Install Playwright
+        uses: ./.github/workflows/install-playwright
+        with:
+          engine: chromium
+
+      # --- Baseline (base branch) ---
+      - name: Checkout base branch
+        run: git checkout ${{ github.event.pull_request.base.sha }}
+
+      - name: Install base dependencies
+        run: pnpm install --frozen-lockfile || pnpm install
+
+      - name: Build base app
+        run: pnpm -F site run build-lite
+
+      - name: Run baseline perf tests
+        # Baseline failures are expected when perf tests are new.
+        run: |
+          PERF_RESULTS_FILE=baseline.json \
+          xvfb-run pnpm -F site run test-perf --pass-with-no-tests || true
+
+      - name: Save baseline results
+        run: |
+          mkdir -p /tmp/perf-baseline
+          cp site/.perf-results/baseline*.json /tmp/perf-baseline/ 2>/dev/null || true
+
+      # --- Current (PR branch) ---
+      - name: Checkout PR branch
+        run: git checkout ${{ github.event.pull_request.head.sha }}
+
+      - name: Install PR dependencies
+        run: pnpm install --frozen-lockfile || pnpm install
+
+      - name: Download app artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: app-dist
+          path: site/dist
+
+      - name: Restore baseline results
+        run: |
+          mkdir -p site/.perf-results
+          cp /tmp/perf-baseline/*.json site/.perf-results/ 2>/dev/null || true
+
+      - name: Run current perf tests
+        run: |
+          PERF_RESULTS_FILE=current.json \
+          xvfb-run pnpm -F site run test-perf --pass-with-no-tests
+
+      - name: Compare results
+        if: always()
+        run: pnpm -F site run perf-compare
+
+      - name: Post or update PR comment
+        if: always()
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.ARIAKIT_BOT_PAT }}
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- perf-results -->';
+            let body;
+            try {
+              body = fs.readFileSync('site/.perf-results/comparison.md', 'utf-8');
+            } catch {
+              body = 'No performance results available.';
+            }
+            body = marker + '\n' + body;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find((c) => c.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
   deploy-preview:
     # Preview deployments and commit statuses intentionally run only under the
     # same-repo PR model adopted by this repository.

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -233,6 +233,11 @@ jobs:
       - name: Set up base environment
         uses: ./.github/workflows/setup
 
+      - name: Install Playwright (base)
+        uses: ./.github/workflows/install-playwright
+        with:
+          engine: chromium
+
       - name: Find base app artifact
         id: find-base-artifact
         continue-on-error: true
@@ -323,7 +328,7 @@ jobs:
             }
             body = marker + '\n' + body;
 
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -230,8 +230,8 @@ jobs:
       - name: Checkout base branch
         run: git checkout ${{ github.event.pull_request.base.sha }}
 
-      - name: Install base dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Set up base environment
+        uses: ./.github/workflows/setup
 
       - name: Build base app
         run: pnpm -F site run build-lite
@@ -251,8 +251,8 @@ jobs:
       - name: Checkout PR branch
         run: git checkout ${{ github.event.pull_request.head.sha }}
 
-      - name: Install PR dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Set up PR environment
+        uses: ./.github/workflows/setup
 
       - name: Download app artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -292,6 +292,9 @@ jobs:
       - name: Set up PR environment
         uses: ./.github/workflows/setup
 
+      - name: Clean base app artifacts
+        run: rm -rf site/dist
+
       - name: Download app artifact
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -233,7 +233,27 @@ jobs:
       - name: Set up base environment
         uses: ./.github/workflows/setup
 
+      - name: Download base app artifact
+        id: base-artifact
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          RUN_ID=$(gh run list \
+            --branch "${{ github.event.pull_request.base.ref }}" \
+            --workflow app.yml \
+            --status success \
+            --limit 1 \
+            --json databaseId \
+            --jq '.[0].databaseId')
+          if [ -n "$RUN_ID" ]; then
+            gh run download "$RUN_ID" --name app-dist --dir site/dist
+          else
+            exit 1
+          fi
+
       - name: Build base app
+        if: steps.base-artifact.outcome != 'success'
         run: pnpm -F site run build-lite
 
       - name: Run baseline perf tests

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -233,24 +233,37 @@ jobs:
       - name: Set up base environment
         uses: ./.github/workflows/setup
 
+      - name: Find base app artifact
+        id: find-base-artifact
+        continue-on-error: true
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'app.yml',
+              branch: '${{ github.event.pull_request.base.ref }}',
+              status: 'success',
+              per_page: 1,
+            });
+            const run = runs.data.workflow_runs[0];
+            if (!run) {
+              core.setFailed('No successful run found');
+              return;
+            }
+            core.setOutput('run-id', run.id);
+
       - name: Download base app artifact
         id: base-artifact
+        if: steps.find-base-artifact.outcome == 'success'
         continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          RUN_ID=$(gh run list \
-            --branch "${{ github.event.pull_request.base.ref }}" \
-            --workflow app.yml \
-            --status success \
-            --limit 1 \
-            --json databaseId \
-            --jq '.[0].databaseId')
-          if [ -n "$RUN_ID" ]; then
-            gh run download "$RUN_ID" --name app-dist --dir site/dist
-          else
-            exit 1
-          fi
+        uses: actions/download-artifact@v8
+        with:
+          name: app-dist
+          path: site/dist
+          github-token: ${{ github.token }}
+          run-id: ${{ steps.find-base-artifact.outputs.run-id }}
 
       - name: Build base app
         if: steps.base-artifact.outcome != 'success'

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -231,7 +231,7 @@ jobs:
         run: git checkout ${{ github.event.pull_request.base.sha }}
 
       - name: Install base dependencies
-        run: pnpm install --frozen-lockfile || pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build base app
         run: pnpm -F site run build-lite
@@ -252,7 +252,7 @@ jobs:
         run: git checkout ${{ github.event.pull_request.head.sha }}
 
       - name: Install PR dependencies
-        run: pnpm install --frozen-lockfile || pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Download app artifact
         uses: actions/download-artifact@v8

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .cache
 dist
 test-results
+.perf-results
 playwright-report
 .playwright
 .playwright-cli

--- a/site/package.json
+++ b/site/package.json
@@ -41,6 +41,9 @@
     "test-visual-safari": "cross-env VISUAL_TEST=true playwright test --project=safari",
     "test-visual-ios": "cross-env VISUAL_TEST=true playwright test --project=ios",
     "test-visual-android": "cross-env VISUAL_TEST=true playwright test --project=android",
+    "test-perf": "playwright test --project=perf",
+    "test-perf-headed": "playwright test --project=perf --headed",
+    "perf-compare": "node src/test-utils/perf-compare.ts",
     "og-image-clean": "rimraf public/og-image",
     "og-image-generate": "node src/pages/og-image/_generate-images.ts",
     "build-styles": "node src/lib/build-styles.ts"

--- a/site/playwright.config.ts
+++ b/site/playwright.config.ts
@@ -70,5 +70,17 @@ export default defineConfig({
       testMatch: testMatchersFor("android", "mobile"),
       use: devices["Pixel 5"],
     },
+    {
+      name: "perf",
+      testMatch: [/\/perf[^/]*-chrome/, /\/perfs\/[^/]*-chrome/],
+      use: {
+        ...devices["Desktop Chrome"],
+        launchOptions: {
+          args: ["--enable-precise-memory-info"],
+        },
+      },
+      retries: 0,
+      timeout: 120_000,
+    },
   ],
 });

--- a/site/src/examples/dialog-framer-motion/perf-chrome.ts
+++ b/site/src/examples/dialog-framer-motion/perf-chrome.ts
@@ -1,9 +1,11 @@
+import { expect } from "@playwright/test";
 import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
   test("open dialog", async ({ q, perf }) => {
     await perf.measure(async () => {
       await q.button("Show modal").click();
+      await expect(q.dialog("Success")).toBeVisible();
     });
   });
 });

--- a/site/src/examples/dialog-framer-motion/perf-chrome.ts
+++ b/site/src/examples/dialog-framer-motion/perf-chrome.ts
@@ -1,0 +1,9 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("open dialog", async ({ q, perf }) => {
+    await perf.measure(async () => {
+      await q.button("Show modal").click();
+    });
+  });
+});

--- a/site/src/test-utils/fixtures.ts
+++ b/site/src/test-utils/fixtures.ts
@@ -1,0 +1,43 @@
+import { query } from "@ariakit/test/playwright";
+import { test as base } from "@playwright/test";
+import {
+  appendResults,
+  createPerfMeasure,
+  type PerfMeasureOptions,
+  type PerfMetrics,
+  type PerfResult,
+} from "./perf.ts";
+import { visual, type ScreenshotOptions } from "./visual.ts";
+
+export const test = base.extend<{
+  visual: (options?: ScreenshotOptions) => Promise<void>;
+  perf: {
+    measure: (
+      interaction: () => Promise<void>,
+      options?: PerfMeasureOptions,
+    ) => Promise<PerfMetrics>;
+  };
+  q: ReturnType<typeof query>;
+}>({
+  visual: async ({ page }, use, testInfo) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await use((options) => visual(page, options, testInfo));
+  },
+
+  // Lazy fixture: no CDP session is opened until measure() is called, so
+  // existing visual tests pay zero overhead.
+  perf: async ({ page }, use, testInfo) => {
+    const results: PerfResult[] = [];
+    await use({
+      measure: (interaction, options) =>
+        createPerfMeasure(page, interaction, results, testInfo, options),
+    });
+    if (results.length > 0) {
+      appendResults(results, testInfo);
+    }
+  },
+
+  q: async ({ page }, use) => {
+    await use(query(page));
+  },
+});

--- a/site/src/test-utils/perf-compare.ts
+++ b/site/src/test-utils/perf-compare.ts
@@ -228,7 +228,7 @@ function formatMarkdown(summary: ComparisonSummary): string {
     rows.some((r) => rowKey(r) === key && r.significant),
   );
 
-  const totalTests = allKeys.length + newTests.length;
+  const totalTests = allKeys.length + newTests.length + removedTests.length;
 
   const lines: string[] = [];
   lines.push("## Performance");

--- a/site/src/test-utils/perf-compare.ts
+++ b/site/src/test-utils/perf-compare.ts
@@ -26,7 +26,7 @@ interface ComparisonRow {
 interface ComparisonSummary {
   rows: ComparisonRow[];
   hasSignificantChanges: boolean;
-  newTests: string[];
+  newTests: PerfResult[];
   removedTests: string[];
 }
 
@@ -88,28 +88,33 @@ function formatDelta(delta: number, percent: number, baseline: number): string {
   return `${sign}${formatMs(delta)} (${sign}${percent.toFixed(0)}%)`;
 }
 
+function resultKey(result: PerfResult): string {
+  return `${result.testFile}::${result.label}`;
+}
+
 function compare(): ComparisonSummary {
   const baseline = loadResults("baseline");
   const current = loadResults("current");
 
-  const baselineByLabel = new Map<string, PerfResult>();
+  const baselineByKey = new Map<string, PerfResult>();
   for (const result of baseline) {
-    baselineByLabel.set(result.label, result);
+    baselineByKey.set(resultKey(result), result);
   }
 
-  const currentByLabel = new Map<string, PerfResult>();
+  const currentByKey = new Map<string, PerfResult>();
   for (const result of current) {
-    currentByLabel.set(result.label, result);
+    currentByKey.set(resultKey(result), result);
   }
 
   const rows: ComparisonRow[] = [];
-  const newTests: string[] = [];
+  const newTests: PerfResult[] = [];
   const removedTests: string[] = [];
 
   for (const cur of current) {
-    const base = baselineByLabel.get(cur.label);
+    const key = resultKey(cur);
+    const base = baselineByKey.get(key);
     if (!base) {
-      newTests.push(cur.label);
+      newTests.push(cur);
       continue;
     }
     for (const metric of ALL_METRICS) {
@@ -130,7 +135,7 @@ function compare(): ComparisonSummary {
   }
 
   for (const base of baseline) {
-    if (!currentByLabel.has(base.label)) {
+    if (!currentByKey.has(resultKey(base))) {
       removedTests.push(base.label);
     }
   }
@@ -158,7 +163,10 @@ function formatSummaryTable(rows: ComparisonRow[], labels: string[]): string[] {
         continue;
       }
       let cell = `${formatMs(row.baseline)} \u2192 ${formatMs(row.current)}`;
-      cell += ` (${row.delta >= 0 ? "+" : ""}${row.percent.toFixed(0)}%)`;
+      cell +=
+        row.baseline === 0
+          ? " (n/a)"
+          : ` (${row.delta >= 0 ? "+" : ""}${row.percent.toFixed(0)}%)`;
       if (row.significant && row.delta > 0) {
         cell += " :warning:";
       }
@@ -223,8 +231,14 @@ function formatMarkdown(summary: ComparisonSummary): string {
   if (newTests.length > 0) {
     lines.push("### New tests (no baseline)");
     lines.push("");
-    for (const label of newTests) {
-      lines.push(`- ${label}`);
+    lines.push("| Test | Scripting | Rendering | Total |");
+    lines.push("|------|-----------|-----------|-------|");
+    for (const result of newTests) {
+      const cells: string[] = [result.label];
+      for (const metric of PRIMARY_METRICS) {
+        cells.push(formatMs(result.metrics[metric]));
+      }
+      lines.push(`| ${cells.join(" | ")} |`);
     }
     lines.push("");
   }

--- a/site/src/test-utils/perf-compare.ts
+++ b/site/src/test-utils/perf-compare.ts
@@ -14,6 +14,7 @@ const THRESHOLD_PERCENT = 10;
 type MetricKey = keyof PerfMetrics;
 
 interface ComparisonRow {
+  testFile: string;
   label: string;
   metric: MetricKey;
   baseline: number;
@@ -122,14 +123,20 @@ function compare(): ComparisonSummary {
       const curVal = cur.metrics[metric];
       const delta = curVal - baseVal;
       const percent = baseVal > 0 ? (delta / baseVal) * 100 : 0;
+      // Flag as significant when percentage exceeds threshold, or when a
+      // metric goes from zero to a non-trivial value (> 1ms).
+      const significant =
+        Math.abs(percent) > THRESHOLD_PERCENT ||
+        (baseVal === 0 && Math.abs(curVal) > 1);
       rows.push({
+        testFile: cur.testFile,
         label: cur.label,
         metric,
         baseline: baseVal,
         current: curVal,
         delta,
         percent,
-        significant: Math.abs(percent) > THRESHOLD_PERCENT,
+        significant,
       });
     }
   }
@@ -148,13 +155,18 @@ function compare(): ComparisonSummary {
   };
 }
 
-function formatSummaryTable(rows: ComparisonRow[], labels: string[]): string[] {
+function rowKey(row: ComparisonRow): string {
+  return `${row.testFile}::${row.label}`;
+}
+
+function formatSummaryTable(rows: ComparisonRow[], keys: string[]): string[] {
   const lines: string[] = [];
   lines.push("| Test | Scripting | Rendering | Total |");
   lines.push("|------|-----------|-----------|-------|");
 
-  for (const label of labels) {
-    const testRows = rows.filter((r) => r.label === label);
+  for (const key of keys) {
+    const testRows = rows.filter((r) => rowKey(r) === key);
+    const label = testRows[0]?.label ?? key;
     const cells: string[] = [label];
     for (const metric of PRIMARY_METRICS) {
       const row = testRows.find((r) => r.metric === metric);
@@ -179,11 +191,12 @@ function formatSummaryTable(rows: ComparisonRow[], labels: string[]): string[] {
 
 function formatDetailedBreakdown(
   rows: ComparisonRow[],
-  labels: string[],
+  keys: string[],
 ): string[] {
   const lines: string[] = [];
-  for (const label of labels) {
-    const testRows = rows.filter((r) => r.label === label);
+  for (const key of keys) {
+    const testRows = rows.filter((r) => rowKey(r) === key);
+    const label = testRows[0]?.label ?? key;
     lines.push(`### ${label}`);
     lines.push("");
     lines.push("| Metric | Baseline | Current | Delta |");
@@ -210,26 +223,30 @@ function formatDetailedBreakdown(
 function formatMarkdown(summary: ComparisonSummary): string {
   const { rows, hasSignificantChanges, newTests, removedTests } = summary;
 
-  const allLabels = [...new Set(rows.map((r) => r.label))];
-  const significantLabels = allLabels.filter((label) =>
-    rows.some((r) => r.label === label && r.significant),
+  const allKeys = [...new Set(rows.map((r) => rowKey(r)))];
+  const significantKeys = allKeys.filter((key) =>
+    rows.some((r) => rowKey(r) === key && r.significant),
   );
+
+  const totalTests = allKeys.length + newTests.length;
 
   const lines: string[] = [];
   lines.push("## Performance");
   lines.push("");
 
   if (hasSignificantChanges) {
-    lines.push(...formatSummaryTable(rows, significantLabels));
+    lines.push(...formatSummaryTable(rows, significantKeys));
+  } else if (rows.length === 0 && newTests.length > 0) {
+    lines.push("No baseline results available for comparison.");
   } else {
     lines.push("No significant performance changes detected.");
   }
 
   lines.push("");
   lines.push(`<details>`);
-  lines.push(`<summary>Full breakdown (${allLabels.length} tests)</summary>`);
+  lines.push(`<summary>Full breakdown (${totalTests} tests)</summary>`);
   lines.push("");
-  lines.push(...formatDetailedBreakdown(rows, allLabels));
+  lines.push(...formatDetailedBreakdown(rows, allKeys));
 
   if (newTests.length > 0) {
     lines.push("### New tests (no baseline)");

--- a/site/src/test-utils/perf-compare.ts
+++ b/site/src/test-utils/perf-compare.ts
@@ -167,8 +167,8 @@ function formatSummaryTable(rows: ComparisonRow[], labels: string[]): string[] {
         row.baseline === 0
           ? " (n/a)"
           : ` (${row.delta >= 0 ? "+" : ""}${row.percent.toFixed(0)}%)`;
-      if (row.significant && row.delta > 0) {
-        cell += " :warning:";
+      if (row.significant) {
+        cell += row.delta > 0 ? " :warning:" : " :rocket:";
       }
       cells.push(cell);
     }
@@ -194,9 +194,12 @@ function formatDetailedBreakdown(
       const prefix = RENDERING_SUB_METRICS.has(metric) ? "- " : "";
       const metricLabel = `${prefix}${METRIC_LABELS[metric]}`;
       const deltaStr = formatDelta(row.delta, row.percent, row.baseline);
-      const warn = row.significant && row.delta > 0 ? " :warning:" : "";
+      let icon = "";
+      if (row.significant) {
+        icon = row.delta > 0 ? " :warning:" : " :rocket:";
+      }
       lines.push(
-        `| ${metricLabel} | ${formatMs(row.baseline)} | ${formatMs(row.current)} | ${deltaStr}${warn} |`,
+        `| ${metricLabel} | ${formatMs(row.baseline)} | ${formatMs(row.current)} | ${deltaStr}${icon} |`,
       );
     }
     lines.push("");
@@ -255,7 +258,9 @@ function formatMarkdown(summary: ComparisonSummary): string {
   lines.push("</details>");
   lines.push("");
 
-  lines.push(`:warning: = regression above ${THRESHOLD_PERCENT}%`);
+  lines.push(
+    `:warning: = regression above ${THRESHOLD_PERCENT}% · :rocket: = improvement above ${THRESHOLD_PERCENT}%`,
+  );
 
   return lines.join("\n");
 }

--- a/site/src/test-utils/perf-compare.ts
+++ b/site/src/test-utils/perf-compare.ts
@@ -28,7 +28,7 @@ interface ComparisonSummary {
   rows: ComparisonRow[];
   hasSignificantChanges: boolean;
   newTests: PerfResult[];
-  removedTests: string[];
+  removedTests: PerfResult[];
 }
 
 // Primary metrics shown in the summary table.
@@ -109,7 +109,7 @@ function compare(): ComparisonSummary {
 
   const rows: ComparisonRow[] = [];
   const newTests: PerfResult[] = [];
-  const removedTests: string[] = [];
+  const removedTests: PerfResult[] = [];
 
   for (const cur of current) {
     const key = resultKey(cur);
@@ -143,7 +143,7 @@ function compare(): ComparisonSummary {
 
   for (const base of baseline) {
     if (!currentByKey.has(resultKey(base))) {
-      removedTests.push(resultKey(base));
+      removedTests.push(base);
     }
   }
 
@@ -268,8 +268,8 @@ function formatMarkdown(summary: ComparisonSummary): string {
   if (removedTests.length > 0) {
     lines.push("### Removed tests");
     lines.push("");
-    for (const label of removedTests) {
-      lines.push(`- ${label}`);
+    for (const result of removedTests) {
+      lines.push(`- ${result.label}`);
     }
     lines.push("");
   }

--- a/site/src/test-utils/perf-compare.ts
+++ b/site/src/test-utils/perf-compare.ts
@@ -143,7 +143,7 @@ function compare(): ComparisonSummary {
 
   for (const base of baseline) {
     if (!currentByKey.has(resultKey(base))) {
-      removedTests.push(base.label);
+      removedTests.push(resultKey(base));
     }
   }
 
@@ -238,6 +238,8 @@ function formatMarkdown(summary: ComparisonSummary): string {
     lines.push(...formatSummaryTable(rows, significantKeys));
   } else if (rows.length === 0 && newTests.length > 0) {
     lines.push("No baseline results available for comparison.");
+  } else if (rows.length === 0 && newTests.length === 0) {
+    lines.push("No performance results found.");
   } else {
     lines.push("No significant performance changes detected.");
   }

--- a/site/src/test-utils/perf-compare.ts
+++ b/site/src/test-utils/perf-compare.ts
@@ -1,0 +1,260 @@
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import type { PerfMetrics, PerfResult } from "./perf.ts";
+
+const RESULTS_DIR = path.join(process.cwd(), ".perf-results");
+const THRESHOLD_PERCENT = 10;
+
+type MetricKey = keyof PerfMetrics;
+
+interface ComparisonRow {
+  label: string;
+  metric: MetricKey;
+  baseline: number;
+  current: number;
+  delta: number;
+  percent: number;
+  significant: boolean;
+}
+
+interface ComparisonSummary {
+  rows: ComparisonRow[];
+  hasSignificantChanges: boolean;
+  newTests: string[];
+  removedTests: string[];
+}
+
+// Primary metrics shown in the summary table.
+const PRIMARY_METRICS: MetricKey[] = ["scripting", "rendering", "total"];
+
+// All metrics shown in the detailed breakdown.
+const ALL_METRICS: MetricKey[] = [
+  "scripting",
+  "rendering",
+  "layout",
+  "styleRecalc",
+  "painting",
+  "inp",
+  "total",
+];
+
+const METRIC_LABELS: Record<MetricKey, string> = {
+  scripting: "Scripting",
+  layout: "Layout",
+  styleRecalc: "Style recalc",
+  painting: "Painting",
+  rendering: "Rendering",
+  inp: "INP",
+  total: "Total",
+};
+
+// Rendering sub-metrics are indented in the detailed breakdown.
+const RENDERING_SUB_METRICS = new Set<MetricKey>([
+  "layout",
+  "styleRecalc",
+  "painting",
+]);
+
+function loadResults(prefix: string): PerfResult[] {
+  if (!existsSync(RESULTS_DIR)) return [];
+  const files = readdirSync(RESULTS_DIR).filter(
+    (f) => f.startsWith(prefix) && f.endsWith(".json"),
+  );
+  const all: PerfResult[] = [];
+  for (const file of files) {
+    const data = JSON.parse(
+      readFileSync(path.join(RESULTS_DIR, file), "utf-8"),
+    );
+    all.push(...data);
+  }
+  return all;
+}
+
+function formatMs(value: number): string {
+  return `${value.toFixed(1)}ms`;
+}
+
+function formatDelta(delta: number, percent: number, baseline: number): string {
+  const sign = delta >= 0 ? "+" : "";
+  if (baseline === 0) {
+    return `${sign}${formatMs(delta)}`;
+  }
+  return `${sign}${formatMs(delta)} (${sign}${percent.toFixed(0)}%)`;
+}
+
+function compare(): ComparisonSummary {
+  const baseline = loadResults("baseline");
+  const current = loadResults("current");
+
+  const baselineByLabel = new Map<string, PerfResult>();
+  for (const result of baseline) {
+    baselineByLabel.set(result.label, result);
+  }
+
+  const currentByLabel = new Map<string, PerfResult>();
+  for (const result of current) {
+    currentByLabel.set(result.label, result);
+  }
+
+  const rows: ComparisonRow[] = [];
+  const newTests: string[] = [];
+  const removedTests: string[] = [];
+
+  for (const cur of current) {
+    const base = baselineByLabel.get(cur.label);
+    if (!base) {
+      newTests.push(cur.label);
+      continue;
+    }
+    for (const metric of ALL_METRICS) {
+      const baseVal = base.metrics[metric];
+      const curVal = cur.metrics[metric];
+      const delta = curVal - baseVal;
+      const percent = baseVal > 0 ? (delta / baseVal) * 100 : 0;
+      rows.push({
+        label: cur.label,
+        metric,
+        baseline: baseVal,
+        current: curVal,
+        delta,
+        percent,
+        significant: Math.abs(percent) > THRESHOLD_PERCENT,
+      });
+    }
+  }
+
+  for (const base of baseline) {
+    if (!currentByLabel.has(base.label)) {
+      removedTests.push(base.label);
+    }
+  }
+
+  return {
+    rows,
+    hasSignificantChanges: rows.some((r) => r.significant),
+    newTests,
+    removedTests,
+  };
+}
+
+function formatSummaryTable(rows: ComparisonRow[], labels: string[]): string[] {
+  const lines: string[] = [];
+  lines.push("| Test | Scripting | Rendering | Total |");
+  lines.push("|------|-----------|-----------|-------|");
+
+  for (const label of labels) {
+    const testRows = rows.filter((r) => r.label === label);
+    const cells: string[] = [label];
+    for (const metric of PRIMARY_METRICS) {
+      const row = testRows.find((r) => r.metric === metric);
+      if (!row) {
+        cells.push("--");
+        continue;
+      }
+      let cell = `${formatMs(row.baseline)} \u2192 ${formatMs(row.current)}`;
+      cell += ` (${row.delta >= 0 ? "+" : ""}${row.percent.toFixed(0)}%)`;
+      if (row.significant && row.delta > 0) {
+        cell += " :warning:";
+      }
+      cells.push(cell);
+    }
+    lines.push(`| ${cells.join(" | ")} |`);
+  }
+  return lines;
+}
+
+function formatDetailedBreakdown(
+  rows: ComparisonRow[],
+  labels: string[],
+): string[] {
+  const lines: string[] = [];
+  for (const label of labels) {
+    const testRows = rows.filter((r) => r.label === label);
+    lines.push(`### ${label}`);
+    lines.push("");
+    lines.push("| Metric | Baseline | Current | Delta |");
+    lines.push("|--------|----------|---------|-------|");
+    for (const metric of ALL_METRICS) {
+      const row = testRows.find((r) => r.metric === metric);
+      if (!row) continue;
+      const prefix = RENDERING_SUB_METRICS.has(metric) ? "- " : "";
+      const metricLabel = `${prefix}${METRIC_LABELS[metric]}`;
+      const deltaStr = formatDelta(row.delta, row.percent, row.baseline);
+      const warn = row.significant && row.delta > 0 ? " :warning:" : "";
+      lines.push(
+        `| ${metricLabel} | ${formatMs(row.baseline)} | ${formatMs(row.current)} | ${deltaStr}${warn} |`,
+      );
+    }
+    lines.push("");
+  }
+  return lines;
+}
+
+function formatMarkdown(summary: ComparisonSummary): string {
+  const { rows, hasSignificantChanges, newTests, removedTests } = summary;
+
+  const allLabels = [...new Set(rows.map((r) => r.label))];
+  const significantLabels = allLabels.filter((label) =>
+    rows.some((r) => r.label === label && r.significant),
+  );
+
+  const lines: string[] = [];
+  lines.push("## Performance");
+  lines.push("");
+
+  if (hasSignificantChanges) {
+    lines.push(...formatSummaryTable(rows, significantLabels));
+  } else {
+    lines.push("No significant performance changes detected.");
+  }
+
+  lines.push("");
+  lines.push(`<details>`);
+  lines.push(`<summary>Full breakdown (${allLabels.length} tests)</summary>`);
+  lines.push("");
+  lines.push(...formatDetailedBreakdown(rows, allLabels));
+
+  if (newTests.length > 0) {
+    lines.push("### New tests (no baseline)");
+    lines.push("");
+    for (const label of newTests) {
+      lines.push(`- ${label}`);
+    }
+    lines.push("");
+  }
+
+  if (removedTests.length > 0) {
+    lines.push("### Removed tests");
+    lines.push("");
+    for (const label of removedTests) {
+      lines.push(`- ${label}`);
+    }
+    lines.push("");
+  }
+
+  lines.push("</details>");
+  lines.push("");
+
+  lines.push(`:warning: = regression above ${THRESHOLD_PERCENT}%`);
+
+  return lines.join("\n");
+}
+
+// Main
+const summary = compare();
+const markdown = formatMarkdown(summary);
+
+mkdirSync(RESULTS_DIR, { recursive: true });
+writeFileSync(
+  path.join(RESULTS_DIR, "comparison.json"),
+  JSON.stringify(summary, null, 2),
+);
+writeFileSync(path.join(RESULTS_DIR, "comparison.md"), markdown);
+
+console.log(markdown);

--- a/site/src/test-utils/perf.ts
+++ b/site/src/test-utils/perf.ts
@@ -49,6 +49,7 @@ function getMetricValue(
 }
 
 function median(values: number[]): number {
+  if (values.length === 0) return 0;
   const sorted = [...values].sort((a, b) => a - b);
   const mid = Math.floor(sorted.length / 2);
   if (sorted.length % 2 !== 0) return sorted[mid]!;
@@ -156,26 +157,36 @@ export async function createPerfMeasure(
     label,
   } = options;
 
+  if (!Number.isInteger(iterations) || iterations <= 0) {
+    throw new Error(`Invalid perf iterations: ${iterations}`);
+  }
+  if (!Number.isInteger(warmup) || warmup < 0) {
+    throw new Error(`Invalid perf warmup: ${warmup}`);
+  }
+
   const cdp = await page.context().newCDPSession(page);
   await cdp.send("Performance.enable");
 
-  const url = page.url();
   const allMetrics: PerfMetrics[] = [];
 
-  for (let i = 0; i < warmup + iterations; i++) {
-    // Re-navigate for a clean state on every iteration.
-    await page.goto(url, { waitUntil: "networkidle" });
+  try {
+    const url = page.url();
 
-    const metrics = await measureOnce(page, cdp, interaction);
+    for (let i = 0; i < warmup + iterations; i++) {
+      // Re-navigate for a clean state on every iteration.
+      await page.goto(url, { waitUntil: "networkidle" });
 
-    // Only keep measured (non-warmup) iterations.
-    if (i >= warmup) {
-      allMetrics.push(metrics);
+      const metrics = await measureOnce(page, cdp, interaction);
+
+      // Only keep measured (non-warmup) iterations.
+      if (i >= warmup) {
+        allMetrics.push(metrics);
+      }
     }
+  } finally {
+    await cdp.send("Performance.disable").catch(() => {});
+    await cdp.detach().catch(() => {});
   }
-
-  await cdp.send("Performance.disable");
-  await cdp.detach();
 
   const medianMetrics = computeMedianMetrics(allMetrics);
 

--- a/site/src/test-utils/perf.ts
+++ b/site/src/test-utils/perf.ts
@@ -196,7 +196,9 @@ export async function createPerfMeasure(
 
   const testTitle = testInfo.titlePath.filter(Boolean).join(" > ");
   const baseLabel = label ?? testTitle;
-  const duplicateCount = results.filter((r) => r.label === baseLabel).length;
+  const duplicateCount = results.filter(
+    (r) => r.label === baseLabel || r.label.startsWith(`${baseLabel} #`),
+  ).length;
   const resolvedLabel =
     duplicateCount === 0 ? baseLabel : `${baseLabel} #${duplicateCount + 1}`;
 

--- a/site/src/test-utils/perf.ts
+++ b/site/src/test-utils/perf.ts
@@ -195,10 +195,15 @@ export async function createPerfMeasure(
   const medianMetrics = computeMedianMetrics(allMetrics);
 
   const testTitle = testInfo.titlePath.filter(Boolean).join(" > ");
+  const baseLabel = label ?? testTitle;
+  const duplicateCount = results.filter((r) => r.label === baseLabel).length;
+  const resolvedLabel =
+    duplicateCount === 0 ? baseLabel : `${baseLabel} #${duplicateCount + 1}`;
+
   results.push({
     testFile: path.relative(process.cwd(), testInfo.file),
     testTitle,
-    label: label ?? testTitle,
+    label: resolvedLabel,
     metrics: medianMetrics,
     raw: allMetrics,
   });

--- a/site/src/test-utils/perf.ts
+++ b/site/src/test-utils/perf.ts
@@ -52,8 +52,12 @@ function median(values: number[]): number {
   if (values.length === 0) return 0;
   const sorted = [...values].sort((a, b) => a - b);
   const mid = Math.floor(sorted.length / 2);
-  if (sorted.length % 2 !== 0) return sorted[mid]!;
-  return (sorted[mid - 1]! + sorted[mid]!) / 2;
+  const midValue = sorted[mid];
+  if (midValue == null) return 0;
+  if (sorted.length % 2 !== 0) return midValue;
+  const prevValue = sorted[mid - 1];
+  if (prevValue == null) return midValue;
+  return (prevValue + midValue) / 2;
 }
 
 function computeMedianMetrics(all: PerfMetrics[]): PerfMetrics {
@@ -88,7 +92,7 @@ async function measureOnce(
         }
       }
     });
-    observer.observe({ type: "event", buffered: true });
+    observer.observe({ type: "event", buffered: false });
     w.__perfObserver = observer;
   });
 

--- a/site/src/test-utils/perf.ts
+++ b/site/src/test-utils/perf.ts
@@ -1,0 +1,211 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import type { CDPSession, Page, TestInfo } from "@playwright/test";
+
+const RESULTS_DIR = path.join(process.cwd(), ".perf-results");
+const DEFAULT_ITERATIONS = 5;
+const DEFAULT_WARMUP = 1;
+
+// CDP metric names (values are in seconds).
+const SCRIPT_DURATION = "ScriptDuration";
+const LAYOUT_DURATION = "LayoutDuration";
+const RECALC_STYLE_DURATION = "RecalcStyleDuration";
+const PAINTING_DURATION = "PaintingDuration";
+
+export interface PerfMetrics {
+  scripting: number;
+  layout: number;
+  styleRecalc: number;
+  painting: number;
+  rendering: number;
+  inp: number;
+  total: number;
+}
+
+export interface PerfMeasureOptions {
+  /** Number of measured iterations (warmup runs are additional). */
+  iterations?: number;
+  /** Number of discarded warm-up runs before measurement begins. */
+  warmup?: number;
+  /** Override the auto-generated label for this measurement. */
+  label?: string;
+}
+
+export interface PerfResult {
+  testFile: string;
+  testTitle: string;
+  label: string;
+  metrics: PerfMetrics;
+  raw: PerfMetrics[];
+}
+
+function getMetricValue(
+  metrics: Array<{ name: string; value: number }>,
+  name: string,
+): number {
+  const metric = metrics.find((m) => m.name === name);
+  if (!metric) return 0;
+  return metric.value;
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 !== 0) return sorted[mid]!;
+  return (sorted[mid - 1]! + sorted[mid]!) / 2;
+}
+
+function computeMedianMetrics(all: PerfMetrics[]): PerfMetrics {
+  return {
+    scripting: median(all.map((m) => m.scripting)),
+    layout: median(all.map((m) => m.layout)),
+    styleRecalc: median(all.map((m) => m.styleRecalc)),
+    painting: median(all.map((m) => m.painting)),
+    rendering: median(all.map((m) => m.rendering)),
+    inp: median(all.map((m) => m.inp)),
+    total: median(all.map((m) => m.total)),
+  };
+}
+
+/**
+ * Runs a single interaction measurement cycle: snapshot CDP metrics before and
+ * after the interaction, collect INP entries, and return the deltas.
+ */
+async function measureOnce(
+  page: Page,
+  cdp: CDPSession,
+  interaction: () => Promise<void>,
+): Promise<PerfMetrics> {
+  // Install INP observer before the interaction.
+  await page.evaluate(() => {
+    const w = window as any;
+    w.__perfInpEntries = [];
+    const observer = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        if ((entry as any).interactionId) {
+          w.__perfInpEntries.push(entry.duration);
+        }
+      }
+    });
+    observer.observe({ type: "event", buffered: true });
+    w.__perfObserver = observer;
+  });
+
+  const before = await cdp.send("Performance.getMetrics");
+
+  await interaction();
+
+  // Let paint and layout settle.
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => resolve());
+        });
+      }),
+  );
+  await page.waitForTimeout(50);
+
+  const after = await cdp.send("Performance.getMetrics");
+
+  // Collect INP entries and disconnect the observer.
+  const inpValues: number[] = await page.evaluate(() => {
+    const w = window as any;
+    if (w.__perfObserver) {
+      w.__perfObserver.disconnect();
+    }
+    return w.__perfInpEntries ?? [];
+  });
+
+  const scriptBefore = getMetricValue(before.metrics, SCRIPT_DURATION);
+  const scriptAfter = getMetricValue(after.metrics, SCRIPT_DURATION);
+  const layoutBefore = getMetricValue(before.metrics, LAYOUT_DURATION);
+  const layoutAfter = getMetricValue(after.metrics, LAYOUT_DURATION);
+  const styleBefore = getMetricValue(before.metrics, RECALC_STYLE_DURATION);
+  const styleAfter = getMetricValue(after.metrics, RECALC_STYLE_DURATION);
+  const paintBefore = getMetricValue(before.metrics, PAINTING_DURATION);
+  const paintAfter = getMetricValue(after.metrics, PAINTING_DURATION);
+
+  // CDP values are in seconds; convert to milliseconds.
+  const scripting = (scriptAfter - scriptBefore) * 1000;
+  const layout = (layoutAfter - layoutBefore) * 1000;
+  const styleRecalc = (styleAfter - styleBefore) * 1000;
+  const painting = (paintAfter - paintBefore) * 1000;
+  const rendering = layout + styleRecalc + painting;
+  const inp = inpValues.length > 0 ? Math.max(...inpValues) : 0;
+  const total = scripting + rendering;
+
+  return { scripting, layout, styleRecalc, painting, rendering, inp, total };
+}
+
+/**
+ * Runs the interaction multiple times, discards warm-up runs, and returns the
+ * median metrics. Each iteration re-navigates to the page URL for a clean
+ * state.
+ */
+export async function createPerfMeasure(
+  page: Page,
+  interaction: () => Promise<void>,
+  results: PerfResult[],
+  testInfo: TestInfo,
+  options: PerfMeasureOptions = {},
+): Promise<PerfMetrics> {
+  const {
+    iterations = DEFAULT_ITERATIONS,
+    warmup = DEFAULT_WARMUP,
+    label,
+  } = options;
+
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send("Performance.enable");
+
+  const url = page.url();
+  const allMetrics: PerfMetrics[] = [];
+
+  for (let i = 0; i < warmup + iterations; i++) {
+    // Re-navigate for a clean state on every iteration.
+    await page.goto(url, { waitUntil: "networkidle" });
+
+    const metrics = await measureOnce(page, cdp, interaction);
+
+    // Only keep measured (non-warmup) iterations.
+    if (i >= warmup) {
+      allMetrics.push(metrics);
+    }
+  }
+
+  await cdp.send("Performance.disable");
+  await cdp.detach();
+
+  const medianMetrics = computeMedianMetrics(allMetrics);
+
+  const testTitle = testInfo.titlePath.filter(Boolean).join(" > ");
+  results.push({
+    testFile: path.relative(process.cwd(), testInfo.file),
+    testTitle,
+    label: label ?? testTitle,
+    metrics: medianMetrics,
+    raw: allMetrics,
+  });
+
+  return medianMetrics;
+}
+
+/**
+ * Appends collected results to a worker-specific JSON file inside the results
+ * directory. Using per-worker files avoids write conflicts when Playwright runs
+ * tests in parallel.
+ */
+export function appendResults(results: PerfResult[], testInfo: TestInfo) {
+  mkdirSync(RESULTS_DIR, { recursive: true });
+  const prefix =
+    process.env.PERF_RESULTS_FILE?.replace(/\.json$/, "") ?? "current";
+  const fileName = `${prefix}-worker${testInfo.workerIndex}.json`;
+  const filePath = path.join(RESULTS_DIR, fileName);
+  let existing: PerfResult[] = [];
+  if (existsSync(filePath)) {
+    existing = JSON.parse(readFileSync(filePath, "utf-8"));
+  }
+  existing.push(...results);
+  writeFileSync(filePath, JSON.stringify(existing, null, 2));
+}

--- a/site/src/test-utils/preview.ts
+++ b/site/src/test-utils/preview.ts
@@ -1,9 +1,8 @@
 import { readdirSync } from "node:fs";
 import { query } from "@ariakit/test/playwright";
-import { test } from "@playwright/test";
 import { frameworks, getIndexFile } from "#app/lib/frameworks.ts";
 import { keys } from "#app/lib/object.ts";
-import { visualTest } from "./visual.ts";
+import { test } from "./fixtures.ts";
 
 function getPreviewId(dirname: string) {
   if (!dirname.includes("site/src")) return null;
@@ -25,7 +24,7 @@ function getPreviewFramworks(dirname: string) {
 
 interface WithFrameworkCallbackParams {
   id: string;
-  test: typeof visualTest;
+  test: typeof test;
   framework: keyof typeof frameworks;
   query: typeof query;
 }
@@ -46,7 +45,7 @@ export function withFramework(
           waitUntil: "networkidle",
         });
       });
-      return callback({ id, framework, query, test: visualTest });
+      return callback({ id, framework, query, test });
     });
   }
 }

--- a/site/src/test-utils/visual.ts
+++ b/site/src/test-utils/visual.ts
@@ -1,7 +1,6 @@
 import { utimesSync } from "node:fs";
 import path from "node:path";
 import { invariant } from "@ariakit/core/utils/misc";
-import { query } from "@ariakit/test/playwright";
 import type { Locator, Page, TestInfo } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import { vizzlyScreenshot } from "@vizzly-testing/cli/client";
@@ -29,7 +28,7 @@ type CSSProperties = Record<string, string | number>;
 type Viewports = Record<string, ViewportSize>;
 type Styles = Record<string, CSSProperties>;
 
-interface ScreenshotOptions {
+export interface ScreenshotOptions {
   /**
    * Viewports to capture.
    */
@@ -438,16 +437,3 @@ export async function visual(
     });
   }
 }
-
-export const visualTest = test.extend<{
-  visual: (options?: ScreenshotOptions) => Promise<void>;
-  q: ReturnType<typeof query>;
-}>({
-  visual: async ({ page }, use, testInfo) => {
-    await page.emulateMedia({ reducedMotion: "reduce" });
-    await use((options) => visual(page, options, testInfo));
-  },
-  q: async ({ page }, use) => {
-    await use(query(page));
-  },
-});

--- a/site/src/tests/previews-browser.ts
+++ b/site/src/tests/previews-browser.ts
@@ -1,4 +1,5 @@
-import { visualTest as test, viewports } from "#app/test-utils/visual.ts";
+import { test } from "#app/test-utils/fixtures.ts";
+import { viewports } from "#app/test-utils/visual.ts";
 
 const TIMEOUT_PER_STEP = 10_000;
 


### PR DESCRIPTION
## Motivation

Ariakit ships both JavaScript (`@ariakit/react`, `@ariakit/solid`) and CSS (`@ariakit/tailwind`) libraries. We need in-browser performance measurements that separately capture scripting time (JS cost) and rendering time (layout + painting cost) so regressions in either library are caught early.

## Solution

Introduce a performance test suite mirroring the existing browser test infrastructure. Tests use `perf-chrome.ts` files (analogous to `test-chrome.ts`), reuse the `withFramework` helper, and measure real browser performance via Chrome DevTools Protocol.

### Test utilities refactoring

- Extract the `visualTest` fixture from `visual.ts` into a new `fixtures.ts` that composes `q`, `visual`, and `perf` into a single `test` object. The `visual.ts` module keeps the `visual()` function and screenshot helpers.
- The `perf` fixture is lazy — no CDP session opens until `perf.measure()` is called, so existing visual tests pay zero overhead.

### Metrics collected

Each `perf.measure()` call runs the interaction 6 times (1 warmup + 5 measured) with a fresh page navigation between each, then takes the **median**:

- **Scripting** — `ScriptDuration` delta (ms)
- **Rendering** — aggregated layout + style recalc + painting
  - **Layout** — `LayoutDuration` delta
  - **Style recalc** — `RecalcStyleDuration` delta
  - **Painting** — `PaintingDuration` delta
- **INP** — via `PerformanceObserver` event timing
- **Total** — scripting + rendering

### CI integration

A new `perf` job in `app.yml` (runs on PRs only):
1. Checks out the base branch, builds, runs perf tests → baseline
2. Checks out the PR branch, uses the pre-built `app-dist` artifact, runs perf tests → current
3. Compares results and posts a compact PR comment via `ariakit-bot` (updates existing comment on re-push)

The comment shows a summary table with only significant changes (>10%) visible, with full breakdowns in a collapsible `<details>` section.

### Files

- `site/src/test-utils/fixtures.ts` — central `test.extend<{ q, visual, perf }>` fixture
- `site/src/test-utils/perf.ts` — CDP measurement, iteration/median, result storage
- `site/src/test-utils/perf-compare.ts` — baseline vs current comparison, Markdown output
- `site/src/examples/dialog-framer-motion/perf-chrome.ts` — sample perf test
- `site/playwright.config.ts` — new `perf` project (Chrome-only, 0 retries, 120s timeout)
- `.github/workflows/app.yml` — new `perf` job

### Writing a perf test

```typescript
import { withFramework } from "#app/test-utils/preview.ts";

withFramework(import.meta.dirname, async ({ test }) => {
  test("open dialog", async ({ q, perf }) => {
    await perf.measure(async () => {
      await q.button("Show modal").click();
    });
  });
});
```

## Test plan

- [x] `pnpm tsc` passes (0 errors)
- [x] `pnpm lint-fix` passes (0 errors)
- [x] `pnpm -F site run test-perf` runs the sample test and writes results to `.perf-results/`
- [x] `pnpm -F site run perf-compare` generates correct Markdown comparison
- [x] Existing browser test (`dialog-framer-motion/test-browser.ts`) still passes
- [x] Perf test not discovered by `--project=chrome` (isolated to `--project=perf`)
- [ ] CI workflow runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)