### PR TITLE
Add Next.js artifact to Performance CI job

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -212,7 +212,7 @@ jobs:
 
   perf:
     name: Performance
-    needs: [build]
+    needs: [build, build-nextjs]
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
@@ -276,9 +276,24 @@ jobs:
           github-token: ${{ github.token }}
           run-id: ${{ steps.find-base-artifact.outputs.run-id }}
 
+      - name: Download base Next.js artifact
+        id: base-nextjs-artifact
+        if: steps.find-base-artifact.outcome == 'success'
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: nextjs-dist
+          path: nextjs/.open-next
+          github-token: ${{ github.token }}
+          run-id: ${{ steps.find-base-artifact.outputs.run-id }}
+
       - name: Build base app
         if: steps.base-artifact.outcome != 'success'
         run: pnpm -F site run build-lite
+
+      - name: Build base Next.js app
+        if: steps.base-nextjs-artifact.outcome != 'success'
+        run: pnpm -F nextjs run build-worker
 
       - name: Run baseline perf tests
         # Baseline failures are expected when perf tests are new.
@@ -299,13 +314,19 @@ jobs:
         uses: ./.github/workflows/setup
 
       - name: Clean base app artifacts
-        run: rm -rf site/dist
+        run: rm -rf site/dist nextjs/.open-next
 
       - name: Download app artifact
         uses: actions/download-artifact@v8
         with:
           name: app-dist
           path: site/dist
+
+      - name: Download Next.js artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: nextjs-dist
+          path: nextjs/.open-next
 
       - name: Restore baseline results
         run: |

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -287,12 +287,16 @@ jobs:
           github-token: ${{ github.token }}
           run-id: ${{ steps.find-base-artifact.outputs.run-id }}
 
+      - name: Clean partial base artifacts
+        if: steps.base-artifact.outcome != 'success' || steps.base-nextjs-artifact.outcome != 'success'
+        run: rm -rf site/dist nextjs/.open-next
+
       - name: Build base app
-        if: steps.base-artifact.outcome != 'success'
+        if: steps.base-artifact.outcome != 'success' || steps.base-nextjs-artifact.outcome != 'success'
         run: pnpm -F site run build-lite
 
       - name: Build base Next.js app
-        if: steps.base-nextjs-artifact.outcome != 'success'
+        if: steps.base-artifact.outcome != 'success' || steps.base-nextjs-artifact.outcome != 'success'
         run: pnpm -F nextjs run build-worker
 
       - name: Run baseline perf tests

--- a/site/src/test-utils/perf.ts
+++ b/site/src/test-utils/perf.ts
@@ -3,8 +3,8 @@ import path from "node:path";
 import type { CDPSession, Page, TestInfo } from "@playwright/test";
 
 const RESULTS_DIR = path.join(process.cwd(), ".perf-results");
-const DEFAULT_ITERATIONS = 20;
-const DEFAULT_WARMUP = 2;
+const DEFAULT_ITERATIONS = 10;
+const DEFAULT_WARMUP = 1;
 
 // CDP metric names (values are in seconds).
 const SCRIPT_DURATION = "ScriptDuration";

--- a/site/src/test-utils/perf.ts
+++ b/site/src/test-utils/perf.ts
@@ -3,8 +3,8 @@ import path from "node:path";
 import type { CDPSession, Page, TestInfo } from "@playwright/test";
 
 const RESULTS_DIR = path.join(process.cwd(), ".perf-results");
-const DEFAULT_ITERATIONS = 5;
-const DEFAULT_WARMUP = 1;
+const DEFAULT_ITERATIONS = 20;
+const DEFAULT_WARMUP = 2;
 
 // CDP metric names (values are in seconds).
 const SCRIPT_DURATION = "ScriptDuration";


### PR DESCRIPTION
## Motivation

The Performance CI job fails on PRs because the Playwright web server starts both the site preview and the Next.js preview (`opennextjs-cloudflare preview`), but the job only downloads the `app-dist` artifact — not the `nextjs-dist` artifact. This causes the error:

```
ERROR Could not find compiled Open Next config, did you run the build command?
```

This was not caught earlier because the Performance job only runs on `pull_request` events, never on `main` pushes, and it was recently added in #5746.

## Solution

- Add `build-nextjs` to the `needs` array so the job waits for the Next.js build.
- Download the `nextjs-dist` artifact for both the baseline (from a prior successful run, with a build fallback) and the current PR branch.
- Clean `nextjs/.open-next` alongside `site/dist` when switching from baseline to current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)