### PR TITLE
Update @clerk/astro to 3.0.12

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -435,8 +435,8 @@ importers:
         specifier: 6.0.1
         version: 6.0.1(@testing-library/jest-dom@6.9.1)(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(solid-js@1.9.12)(terser@5.46.0)(yaml@2.8.3)
       '@clerk/astro':
-        specifier: 3.0.11
-        version: 3.0.11(astro@5.18.1(@types/node@24.12.2)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.2)(yaml@2.8.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 3.0.12
+        version: 3.0.12(astro@5.18.1(@types/node@24.12.2)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.2)(yaml@2.8.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@fontsource-variable/inter':
         specifier: 5.2.8
         version: 5.2.8
@@ -1936,8 +1936,8 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@clerk/astro@3.0.11':
-    resolution: {integrity: sha512-Xf+4kH7nSJeuxo93DW/+H8jzVmPfQnraRrLV2utulpfXytSwxyTJoVu4Zdn0SVZM2ajriV3jrsVjBELNqTg1Kw==}
+  '@clerk/astro@3.0.12':
+    resolution: {integrity: sha512-Vwtek7WiGWuQmsqgPF9klePF9pZoQa7jBgI9+K1YTBcAecuLjXyeFHDqtQwfdHomX9NpJIB06dXyVBWX/q3dKw==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       astro: ^4.15.0 || ^5.0.0 || ^6.0.0
@@ -1946,8 +1946,8 @@ packages:
     resolution: {integrity: sha512-zmd0jPyb1iALlmyzyRbgujQXrGqw8sf+VpFjm5GkndpBeq5+9+oH7QgMaFEmWi9oxvTd2sZ+EN+QT4+OXPUnGA==}
     engines: {node: '>=14'}
 
-  '@clerk/backend@3.2.7':
-    resolution: {integrity: sha512-8IdAKqFpmWhaK0HkyheXv4kP5E3eE1KCCbTokNvVKA3xWh8Jk1CjrYCk+Uq1R/PA3b2h418qbsA21ZCFoSUY7g==}
+  '@clerk/backend@3.2.8':
+    resolution: {integrity: sha512-N9yqCQCdkn/4XpfiVnaoS6wXDeC2yQf85ioHGolOIOCWXOPwMd63fONUfRhwOZSlXGTAsgyUNZu87Ps0tcVYsg==}
     engines: {node: '>=20.9.0'}
 
   '@clerk/clerk-react@4.32.5':
@@ -1977,8 +1977,8 @@ packages:
       react:
         optional: true
 
-  '@clerk/shared@4.5.0':
-    resolution: {integrity: sha512-01xc2Mb6/srZa9kvk9apEFr98Zsoe3XZusTUrSzAQDaX0ltQn5W0r7V1cJiDGHKTYG5vv4ACeNfZ7sZgspKTbA==}
+  '@clerk/shared@4.6.0':
+    resolution: {integrity: sha512-dtbsO/+xK5e+qWuOAY1ekZ8BJxsB0F0LYDpXWjRON7JSoFKSaqqaH5cwBvdjbbWaehb6jz1YUQmWVV8gBOx6Ag==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
@@ -12880,10 +12880,10 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@clerk/astro@3.0.11(astro@5.18.1(@types/node@24.12.2)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.2)(yaml@2.8.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@clerk/astro@3.0.12(astro@5.18.1(@types/node@24.12.2)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.2)(yaml@2.8.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@clerk/backend': 3.2.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@clerk/shared': 4.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@clerk/backend': 3.2.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@clerk/shared': 4.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       astro: 5.18.1(@types/node@24.12.2)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.2)(yaml@2.8.3)
       nanoid: 5.1.6
       nanostores: 1.0.1
@@ -12905,9 +12905,9 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  '@clerk/backend@3.2.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@clerk/backend@3.2.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@clerk/shared': 4.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@clerk/shared': 4.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       standardwebhooks: 1.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -12955,7 +12955,7 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
 
-  '@clerk/shared@4.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@clerk/shared@4.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@tanstack/query-core': 5.90.16
       dequal: 2.0.3

--- a/site/package.json
+++ b/site/package.json
@@ -60,7 +60,7 @@
     "@astrojs/mdx": "5.0.3",
     "@astrojs/react": "5.0.3",
     "@astrojs/solid-js": "6.0.1",
-    "@clerk/astro": "3.0.11",
+    "@clerk/astro": "3.0.12",
     "@fontsource-variable/inter": "5.2.8",
     "@react-aria/utils": "3.33.1",
     "@shikijs/langs": "4.0.2",


### PR DESCRIPTION
## Motivation

Keep the `@clerk/astro` dependency in the `site` workspace up to date with the latest patch release.

## Solution

Update `@clerk/astro` from 3.0.11 to 3.0.12 and regenerate the lockfile.

## Dependencies

| Package | From | To |
|---------|------|----|
| [@clerk/astro](https://github.com/clerk/javascript) | 3.0.11 | [3.0.12](https://github.com/clerk/javascript/releases/tag/%40clerk%2Fastro%403.0.12) |

This is a patch release that updates internal dependencies (`@clerk/shared@4.6.0`, `@clerk/backend@3.2.8`). The underlying changes include:

- Improved ticket and SSO types for Future APIs ([`fdac10e`](https://github.com/clerk/javascript/commit/fdac10e))
- Localized API keys revoke confirmation input ([`4e3cb0a`](https://github.com/clerk/javascript/commit/4e3cb0a))
- Added support for Banned badge ([`aa32bbc`](https://github.com/clerk/javascript/commit/aa32bbc))

None of these changes affect the `@clerk/astro` integration API directly. The site uses `@clerk/astro` for authentication middleware, account/login pages, and admin utilities, all of which remain compatible.