### PR TITLE
Update actions/github-script to v9

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -247,7 +247,7 @@ jobs:
       - name: Find base app artifact
         id: find-base-artifact
         continue-on-error: true
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const runs = await github.rest.actions.listWorkflowRuns({
@@ -348,7 +348,7 @@ jobs:
 
       - name: Post or update PR comment
         if: always()
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.ARIAKIT_BOT_PAT }}
           script: |

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set commit status (pending)
         # Preview statuses are created eagerly so the commit shows a stable
         # target URL even when deployment finishes later in the job.
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           SERVER_URL: ${{ github.server_url }}
           REPO: ${{ github.repository }}
@@ -151,7 +151,7 @@ jobs:
         # "Preview (branch)" keeps the old success signal: PRs only go green
         # when both version uploads succeeded, and main only goes green when
         # both deploy steps succeeded.
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           SERVER_URL: ${{ github.server_url }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Compute affected packages
         id: compute-affected-packages
         if: steps.changeset-status.outputs.has-changesets == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('node:fs');

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -81,7 +81,7 @@ jobs:
         if: steps.gate.outputs.is_latest == 'true' && vars.USE_VIZZLY != 'true' && inputs.test-result == 'failure'
         # Only update committed screenshots when every browser shard that
         # uploads screenshots has produced its artifact for this run.
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const perPage = 100;


### PR DESCRIPTION
## Motivation

Keep GitHub Actions dependencies up to date. `actions/github-script` v9 is the latest major version, bringing `@actions/github` v9, `@octokit/core` v7, and a new injected `getOctokit` factory function.

## Solution

Update all 6 occurrences of `actions/github-script@v8` to `actions/github-script@v9` across 4 workflow files: `app.yml`, `deploy-preview.yml`, `release-preview.yml`, and `visual.yml`.

None of the v9 breaking changes affect this repository — the scripts do not use `require('@actions/github')` or redeclare `getOctokit` with `const`/`let`.

## Dependencies

- [`actions/github-script` v8.0.0 -> v9.0.0](https://github.com/actions/github-script/releases/tag/v9.0.0)
  - New `getOctokit` factory function injected into the script context for multi-token workflows
  - `ACTIONS_ORCHESTRATION_ID` automatically appended to user-agent for request tracing
  - **Breaking**: `require('@actions/github')` no longer works (ESM-only); use injected context instead
  - **Breaking**: `const`/`let` redeclaration of `getOctokit` causes `SyntaxError`; use injected parameter directly