### PR TITLE
Update @tanstack/react-query to 5.97.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -459,8 +459,8 @@ importers:
         specifier: 4.2.2
         version: 4.2.2(vite@8.0.7(@types/node@24.12.2)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
       '@tanstack/react-query':
-        specifier: 5.96.2
-        version: 5.96.2(react@18.3.1)
+        specifier: 5.97.0
+        version: 5.97.0(react@18.3.1)
       astro:
         specifier: 5.18.1
         version: 5.18.1(@types/node@24.12.2)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.2)(yaml@2.8.3)
@@ -5408,16 +5408,16 @@ packages:
   '@tanstack/query-core@5.95.2':
     resolution: {integrity: sha512-o4T8vZHZET4Bib3jZ/tCW9/7080urD4c+0/AUaYVpIqOsr7y0reBc1oX3ttNaSW5mYyvZHctiQ/UOP2PfdmFEQ==}
 
-  '@tanstack/query-core@5.96.2':
-    resolution: {integrity: sha512-hzI6cTVh4KNRk8UtoIBS7Lv9g6BnJPXvBKsvYH1aGWvv0347jT3BnSvztOE+kD76XGvZnRC/t6qdW1CaIfwCeA==}
+  '@tanstack/query-core@5.97.0':
+    resolution: {integrity: sha512-QdpLP5VzVMgo4VtaPppRA2W04UFjIqX+bxke/ZJhE5cfd5UPkRzqIAJQt9uXkQJjqE8LBOMbKv7f8HCsZltXlg==}
 
   '@tanstack/react-query@5.95.2':
     resolution: {integrity: sha512-/wGkvLj/st5Ud1Q76KF1uFxScV7WeqN1slQx5280ycwAyYkIPGaRZAEgHxe3bjirSd5Zpwkj6zNcR4cqYni/ZA==}
     peerDependencies:
       react: ^18 || ^19
 
-  '@tanstack/react-query@5.96.2':
-    resolution: {integrity: sha512-sYyzzJT4G0g02azzJ8o55VFFV31XvFpdUpG+unxS0vSaYsJnSPKGoI6WdPwUucJL1wpgGfwfmntNX/Ub1uOViA==}
+  '@tanstack/react-query@5.97.0':
+    resolution: {integrity: sha512-y4So4eGcQoK2WVMAcDNZE9ofB/p5v1OlKvtc1F3uqHwrtifobT7q+ZnXk2mRkc8E84HKYSlAE9z6HXl2V0+ySQ==}
     peerDependencies:
       react: ^18 || ^19
 
@@ -16308,16 +16308,16 @@ snapshots:
 
   '@tanstack/query-core@5.95.2': {}
 
-  '@tanstack/query-core@5.96.2': {}
+  '@tanstack/query-core@5.97.0': {}
 
   '@tanstack/react-query@5.95.2(react@18.3.1)':
     dependencies:
       '@tanstack/query-core': 5.95.2
       react: 18.3.1
 
-  '@tanstack/react-query@5.96.2(react@18.3.1)':
+  '@tanstack/react-query@5.97.0(react@18.3.1)':
     dependencies:
-      '@tanstack/query-core': 5.96.2
+      '@tanstack/query-core': 5.97.0
       react: 18.3.1
 
   '@testing-library/dom@10.4.1':

--- a/site/package.json
+++ b/site/package.json
@@ -68,7 +68,7 @@
     "@stackblitz/sdk": "1.11.0",
     "@stripe/stripe-js": "9.1.0",
     "@tailwindcss/vite": "4.2.2",
-    "@tanstack/react-query": "5.96.2",
+    "@tanstack/react-query": "5.97.0",
     "astro": "5.18.1",
     "astro-remote": "0.3.4",
     "canvas-confetti": "1.9.4",


### PR DESCRIPTION
## Motivation

Keep `@tanstack/react-query` up to date in the `site` workspace.

## Solution

Update `@tanstack/react-query` from `5.96.2` to `5.97.0` in `site/package.json`.

## Dependencies

**@tanstack/react-query** `5.96.2` -> `5.97.0` ([release](https://github.com/TanStack/query/releases/tag/%40tanstack%2Freact-query%405.97.0))

- Updated dependency `@tanstack/query-core` to `5.97.0`, which fixes an explicit `undefined` check for timer IDs so that custom `TimeoutProvider`s returning `0` as a valid timer ID are properly cleared ([#10401](https://github.com/TanStack/query/pull/10401)).