### PR TITLE
Update stripe to 22.0.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -540,8 +540,8 @@ importers:
         specifier: 1.9.12
         version: 1.9.12
       stripe:
-        specifier: 22.0.0
-        version: 22.0.0(@types/node@24.12.2)
+        specifier: 22.0.1
+        version: 22.0.1(@types/node@24.12.2)
       tailwindcss:
         specifier: 4.2.2
         version: 4.2.2
@@ -9839,8 +9839,8 @@ packages:
     resolution: {integrity: sha512-aT2BU9KkizY9SATf14WhhYVv2uOapBWX0OFWF4xvcj1mPaNotlSc2CsxpS4DS46ZueSppmCF5BX1sNYBtwBvfw==}
     engines: {node: '>=12.*'}
 
-  stripe@22.0.0:
-    resolution: {integrity: sha512-q1UgXXpSfZCmkyzZEh3vFEWT7+ajuaFGqaP9Tsi2NMtwlkigIWNr+KBIUQqtNeNEsreDKgdn+BP5HRW9JDj22Q==}
+  stripe@22.0.1:
+    resolution: {integrity: sha512-Yw764pZ6s8Xu4CtUZdD5uWOkw6gc9xzO9OKylCuj1gMhMDLbyGbDtaPNNSFE4mB6njYSHESYIVbF1iIzUfAl2g==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -21970,7 +21970,7 @@ snapshots:
       '@types/node': 25.5.2
       qs: 6.15.0
 
-  stripe@22.0.0(@types/node@24.12.2):
+  stripe@22.0.1(@types/node@24.12.2):
     optionalDependencies:
       '@types/node': 24.12.2
 

--- a/site/package.json
+++ b/site/package.json
@@ -95,7 +95,7 @@
     "rehype-parse": "9.0.1",
     "shiki": "4.0.2",
     "solid-js": "1.9.12",
-    "stripe": "22.0.0",
+    "stripe": "22.0.1",
     "tailwindcss": "4.2.2",
     "ts-morph": "27.0.2",
     "typescript": "6.0.2",


### PR DESCRIPTION
## Motivation

Keep the `stripe` dependency in the `site` workspace up to date with the latest patch release.

## Solution

Update `stripe` from `22.0.0` to `22.0.1` in `site/package.json` and regenerate the lockfile.

## Dependencies

- **stripe** `22.0.0` → `22.0.1`
  - Source: [stripe/stripe-node](https://github.com/stripe/stripe-node)
  - [Release notes](https://github.com/stripe/stripe-node/releases/tag/v22.0.1)
  - Constructor-based initialization for CJS TypeScript projects
  - Fixed nested service parameter exports in the Stripe namespace
  - Compile-time type safety improvements for constructor config
  - More descriptive error when calling `rawRequest` with absolute URLs
  - Expanded webhook `signature` parameter type to include `string[]` for Express.js compatibility