### PR TITLE
Disable react and next updates outside nextjs workspace

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -121,6 +121,7 @@
         "@types/react",
         "@types/react-dom"
       ],
+      "matchUpdateTypes": ["major"],
       "enabled": false
     },
     {
@@ -131,6 +132,7 @@
         "@types/react",
         "@types/react-dom"
       ],
+      "matchUpdateTypes": ["major"],
       "matchFileNames": ["nextjs/**"],
       "enabled": true
     }

--- a/renovate.json
+++ b/renovate.json
@@ -112,6 +112,27 @@
       "automerge": true,
       "automergeType": "pr",
       "platformAutomerge": true
+    },
+    {
+      "matchPackageNames": [
+        "next",
+        "react",
+        "react-dom",
+        "@types/react",
+        "@types/react-dom"
+      ],
+      "enabled": false
+    },
+    {
+      "matchPackageNames": [
+        "next",
+        "react",
+        "react-dom",
+        "@types/react",
+        "@types/react-dom"
+      ],
+      "matchFileNames": ["nextjs/**"],
+      "enabled": true
     }
   ]
 }


### PR DESCRIPTION
## Motivation

The root, site, examples, and Ariakit library workspaces intentionally keep `react`/`react-dom` at v18 and `next` at v14 to match the frozen `website` workspace. Only the `nextjs` workspace uses React 19 and Next.js 16. Without explicit Renovate rules, dependency update PRs would incorrectly try to bump these packages across all workspaces, leading to unintended major upgrades.

## Solution

Add two new package rules at the end of the `packageRules` array in `renovate.json`:

- A rule that globally disables updates for `next`, `react`, `react-dom`, `@types/react`, and `@types/react-dom`.
- A second rule that re-enables updates for those same packages when the file path matches `nextjs/**`.

Because Renovate applies later rules with higher precedence, placing the re-enabling rule after the disabling rule ensures the `nextjs` workspace continues to receive updates while all other workspaces are left untouched.