### PR TITLE
Exclude .claude directory from test runners

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
   reportSlowTests: null,
   reporter: CI ? [["github"], ["dot"]] : [["list"]],
   retries: 1,
-  testIgnore: ["site/**"],
+  testIgnore: ["site/**", ".claude/**"],
   webServer: {
     command: "pnpm start",
     reuseExistingServer: !CI,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { dirname, join } from "node:path";
 import reactPlugin from "@vitejs/plugin-react";
 import solidPlugin from "vite-plugin-solid";
 import type { Plugin } from "vitest/config";
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 import { sourcePlugin } from "./site/src/lib/source-plugin.ts";
 
 // In a pnpm monorepo, each workspace package may resolve its own copy of
@@ -56,6 +56,7 @@ export default defineConfig({
     testTimeout: 10_000,
     environment: "jsdom",
     setupFiles: ["vitest.setup.ts"],
+    exclude: [...configDefaults.exclude, ".claude/**"],
     include: ["**/*test.{ts,tsx}", `**/*test.${LOADER}.{ts,tsx}`],
     css: {
       include: includeWithStyles,


### PR DESCRIPTION
## Motivation

The `.claude` directory (used by Claude Code for worktrees and configuration) can contain test files that match the glob patterns in vitest and Playwright configs, causing them to be picked up unintentionally during test runs.

## Solution

Added `.claude/**` to the exclusion patterns in both test runner configs:

- **vitest.config.ts**: Added `exclude: [...configDefaults.exclude, ".claude/**"]` to extend the built-in defaults (which include `node_modules`, `dist`, etc.) rather than replacing them.
- **playwright.config.ts**: Added `".claude/**"` to the existing `testIgnore` array.

The `site/playwright.config.ts` already scopes tests to `site/src` via `testDir`, so no change was needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)