### PR TITLE
Use exact matching by default in Playwright query helper

### DIFF
--- a/.changeset/300-playwright-query-exact-match.md
+++ b/.changeset/300-playwright-query-exact-match.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/test": patch
+---
+
+Changed the [`query`](https://ariakit.com/reference/query) helper to use `exact: true` by default for role and text queries in Playwright tests.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,9 +6,9 @@
   "files.eol": "\n",
   "files.trimTrailingWhitespace": true,
   "files.insertFinalNewline": true,
-  "typescript.preferences.preferTypeOnlyAutoImports": true,
   "js/ts.preferences.preferTypeOnlyAutoImports": true,
-  "tailwindCSS.classFunctions": ["clsx", "twMerge", "twJoin"],
+  "typescript.preferences.preferTypeOnlyAutoImports": true,
+  "tailwindCSS.classFunctions": ["cv", "clsx", "twMerge", "twJoin"],
   "tailwindCSS.experimental.configFile": {
     "site/src/styles/global.css": ["site/**", "nextjs/**"],
     "templates/react/src/style.css": "templates/react/**"

--- a/examples/combobox-group/test-browser.ts
+++ b/examples/combobox-group/test-browser.ts
@@ -99,7 +99,7 @@ test("set value on click outside", async ({ page }) => {
   await page.mouse.down();
   await expect(getCombobox(page)).toHaveValue("Avocado");
   await expect(getPopover(page)).toBeVisible();
-  expect(await page.getByRole("option").all()).toHaveLength(1);
+  await expect(page.getByRole("option")).toHaveCount(1);
   await page.mouse.up();
   await expect(getPopover(page)).not.toBeVisible();
 });

--- a/examples/combobox/test-mobile.ts
+++ b/examples/combobox/test-mobile.ts
@@ -14,7 +14,7 @@ test("show/hide on tap", async ({ page }) => {
 test("hide when tapping on item", async ({ page }) => {
   const q = query(page);
   await q.combobox("Your favorite fruit").tap();
-  await q.option("Apple").tap();
+  await q.option("🍎 Apple").tap();
   await expect(q.listbox()).not.toBeVisible();
   await expect(q.combobox()).toBeFocused();
 });
@@ -24,7 +24,7 @@ test("hide when tapping on item after clicking outside", async ({ page }) => {
   await q.combobox().tap();
   await q.document().click({ position: { x: 10, y: 10 } });
   await q.combobox().tap();
-  await q.option("Apple").tap();
+  await q.option("🍎 Apple").tap();
   await expect(q.listbox()).not.toBeVisible();
   await expect(q.combobox()).toBeFocused();
 });

--- a/packages/ariakit-test/src/playwright.ts
+++ b/packages/ariakit-test/src/playwright.ts
@@ -12,12 +12,14 @@ type RoleQueries = Record<AriaRole, RoleQuery>;
 export function query(locator: Page | Locator | FrameLocator) {
   const roleQueries = roles.reduce((acc, role) => {
     acc[role] = (name, options) =>
-      locator.getByRole(role, { name, ...options });
+      locator.getByRole(role, { name, exact: true, ...options });
     return acc;
   }, {} as RoleQueries);
 
-  const text = (...args: Parameters<Page["getByText"]>) =>
-    locator.getByText(...args);
+  const text = (
+    name: Parameters<Page["getByText"]>[0],
+    options?: Parameters<Page["getByText"]>[1],
+  ) => locator.getByText(name, { exact: true, ...options });
 
   return {
     ...roleQueries,

--- a/site/src/examples/disclosure/actions/test-browser.ts
+++ b/site/src/examples/disclosure/actions/test-browser.ts
@@ -21,7 +21,7 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
 
   test("click select @visual", async ({ q, visual }) => {
     const qq = query(q.button("Lina Park"));
-    await qq.combobox("Order Status").click();
+    await qq.combobox("Order status").click();
     await visual();
   });
 });

--- a/site/src/examples/disclosure/checklist/test-browser.ts
+++ b/site/src/examples/disclosure/checklist/test-browser.ts
@@ -8,7 +8,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
   test("open @visual", async ({ q, visual }) => {
     await q.button(/Set up invoices/).click();
-    await q.link("Add your branding").hover();
+    await q.link(/Add your branding/).hover();
     await visual();
   });
 });

--- a/site/src/examples/disclosure/checklist/test-browser.ts
+++ b/site/src/examples/disclosure/checklist/test-browser.ts
@@ -2,12 +2,12 @@ import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
   test("hover @visual", async ({ q, visual }) => {
-    await q.button("Set up payments").hover();
+    await q.button(/Set up payments/).hover();
     await visual();
   });
 
   test("open @visual", async ({ q, visual }) => {
-    await q.button("Set up invoices").click();
+    await q.button(/Set up invoices/).click();
     await q.link("Add your branding").hover();
     await visual();
   });

--- a/site/src/examples/disclosure/group/test-browser.ts
+++ b/site/src/examples/disclosure/group/test-browser.ts
@@ -8,12 +8,12 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
   test("open @visual", async ({ page, q, visual }) => {
     await q.button(/^What do "lifetime access"/).click();
-    await test.expect(q.text("Lifetime access and")).toBeVisible();
+    await test.expect(q.text(/Lifetime access and/)).toBeVisible();
     // Avoid hover state
     await page.mouse.move(0, 0);
     await visual();
     await q.button(/^How does the Team license/).click();
-    await test.expect(q.text("When you purchase a team")).toBeVisible();
+    await test.expect(q.text(/When you purchase a team/)).toBeVisible();
     // Avoid hover state
     await page.mouse.move(0, 0);
     await visual();
@@ -21,7 +21,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await q.button(/^What do "lifetime access"/).hover();
     await visual();
     // Hover the content
-    await q.text("Lifetime access and").hover();
+    await q.text(/Lifetime access and/).hover();
     await visual();
   });
 });

--- a/website/app/(examples)/previews/select-next-router/test-browser.ts
+++ b/website/app/(examples)/previews/select-next-router/test-browser.ts
@@ -109,7 +109,7 @@ test("select statuses with a mouse", async ({ page }) => {
   );
   await expect(q.combobox("Status")).toHaveText("3 selected");
 
-  await q.option("published").click();
+  await q.option("Published").click();
   await page.waitForURL(hasSearchParam("status", ["draft", "archived"]));
   await expect(q.combobox("Status")).toHaveText("2 selected");
 });


### PR DESCRIPTION
## Motivation

The `query` helper in `@ariakit/test` uses Playwright's `getByRole` and `getByText` under the hood, which default to substring matching. This can lead to tests passing when they match the wrong element (e.g., `q.option("Apple")` matching "🍎 Apple" or "Pineapple"). Exact matching is almost always the intended behavior in tests.

## Solution

Default to `exact: true` in both role queries and text queries returned by the `query` helper. Callers can still opt out with `{ exact: false }` when needed.

## Changes

- Set `exact: true` as the default in `query()` role and text lookups in `packages/ariakit-test/src/playwright.ts`
- Update `examples/combobox/test-mobile.ts` to use the full option text `"🍎 Apple"` (required by exact matching)
- Replace `page.getByRole("option").all()).toHaveLength(1)` with the Playwright-recommended `toHaveCount(1)` assertion in `examples/combobox-group/test-browser.ts`
- Add `"cv"` to `tailwindCSS.classFunctions` and sort entries in `.vscode/settings.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)