### PR TITLE
Fix dialog focus restoration when closed quickly after opening

### DIFF
--- a/.changeset/fix-dialog-focus-restoration-quick-close.md
+++ b/.changeset/fix-dialog-focus-restoration-quick-close.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Dialog`](https://ariakit.com/reference/dialog) not restoring focus to the disclosure element when the dialog was closed quickly after opening (e.g., within the same browser task), because the internal `hasOpened` guard was set in a deferred effect that hadn't run yet.

--- a/packages/ariakit-react-core/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-core/src/dialog/dialog.tsx
@@ -389,11 +389,15 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
   const mayAutoFocusOnHide = !!autoFocusOnHide;
   const autoFocusOnHideProp = useBooleanEvent(autoFocusOnHide);
 
-  // Sets a `hasOpened` flag on an effect so we only auto focus on hide if the
-  // dialog was open before.
+  // Sets a `hasOpened` flag so we only auto focus on hide if the dialog was
+  // open before. This must be a layout effect (not a regular effect) so the
+  // flag is set synchronously during the same commit that renders the dialog.
+  // Otherwise, if the dialog opens and closes before a regular effect runs
+  // (e.g., when the close happens in the same browser task as the open), the
+  // flag would still be false and focusOnHide would not restore focus.
   const [hasOpened, setHasOpened] = useState(false);
 
-  useEffect(() => {
+  useSafeLayoutEffect(() => {
     if (!open) return;
     setHasOpened(true);
     return () => setHasOpened(false);


### PR DESCRIPTION
## Summary

- Fix a race condition where `focusOnHide` would not restore focus when a dialog was opened and closed before React's `useEffect` had a chance to run
- The `hasOpened` guard flag was set in `useEffect` (after paint) but checked in `useSafeLayoutEffect` (before paint), so rapid open/close cycles left `hasOpened` as `false`
- Switch `hasOpened` to `useSafeLayoutEffect` so the flag is set synchronously during the same React commit that renders the dialog open

## Test plan

- [x] Existing flaky test `menu-dialog-close "non-interactive"` now passes consistently (100/100 runs)
- [x] All 3 `menu-dialog-close` browser tests pass
- [x] Other dialog browser tests unaffected
- [x] 770/770 vitest unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)