### PR TITLE
Fix Dialog not restoring focus on rapid open/close

### DIFF
--- a/.changeset/300-dialog-focus-on-hide-race.md
+++ b/.changeset/300-dialog-focus-on-hide-race.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Dialog`](https://ariakit.com/reference/dialog) not restoring focus to the disclosure element when the dialog was opened and closed quickly in succession.

--- a/packages/ariakit-react-core/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-core/src/dialog/dialog.tsx
@@ -393,7 +393,7 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
   // dialog was open before.
   const [hasOpened, setHasOpened] = useState(false);
 
-  useEffect(() => {
+  useSafeLayoutEffect(() => {
     if (!open) return;
     setHasOpened(true);
     return () => setHasOpened(false);


### PR DESCRIPTION
## Motivation

When a `Dialog` is opened and closed in quick succession (e.g., opened programmatically and then immediately closed with Escape), focus is not restored to the disclosure element. Instead, focus falls to `<body>`.

## Solution

The `hasOpened` flag — which gates whether `focusOnHide` runs — was managed in a `useEffect` (asynchronous, runs after paint). But `focusOnHide` itself is invoked from a `useSafeLayoutEffect` (synchronous, runs during commit). When the dialog closed before the `useEffect` from the open had a chance to run, `hasOpened` was still `false`, causing `focusOnHide` to bail out.

Changing the `hasOpened` effect from `useEffect` to `useSafeLayoutEffect` ensures it runs in the same commit phase as the open state change, so it's always `true` by the time `focusOnHide` checks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)