### PR TITLE
Update dependency @types/node to v24.12.2

### DIFF
--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@opennextjs/cloudflare": "1.19.0",
     "@tailwindcss/postcss": "4.2.2",
-    "@types/node": "25.5.2",
+    "@types/node": "24.12.2",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "babel-plugin-react-compiler": "1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,8 +282,8 @@ importers:
         specifier: 4.2.2
         version: 4.2.2
       '@types/node':
-        specifier: 25.5.2
-        version: 25.5.2
+        specifier: 24.12.2
+        version: 24.12.2
       '@types/react':
         specifier: 19.2.14
         version: 19.2.14
@@ -912,8 +912,8 @@ importers:
         specifier: 5.0.2
         version: 5.0.2
       '@types/node':
-        specifier: 24.12.0
-        version: 24.12.0
+        specifier: 24.12.2
+        version: 24.12.2
       '@types/postcss-import':
         specifier: 14.0.3
         version: 14.0.3
@@ -931,7 +931,7 @@ importers:
         version: 1.5.0
       '@vitejs/plugin-react':
         specifier: 6.0.1
-        version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
 packages:
 
@@ -5602,9 +5602,6 @@ packages:
 
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
-
-  '@types/node@24.12.0':
-    resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
 
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
@@ -16439,7 +16436,7 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 25.5.2
+      '@types/node': 24.12.2
 
   '@types/canvas-confetti@1.9.0': {}
 
@@ -16452,14 +16449,14 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 24.12.2
 
   '@types/cookies@0.7.7':
     dependencies:
       '@types/connect': 3.4.38
       '@types/express': 4.17.14
       '@types/keygrip': 1.0.6
-      '@types/node': 25.5.2
+      '@types/node': 24.12.2
 
   '@types/cross-spawn@6.0.6':
     dependencies:
@@ -16489,7 +16486,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.8':
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 24.12.2
       '@types/qs': 6.15.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -16524,7 +16521,7 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 24.12.2
 
   '@types/keygrip@1.0.6': {}
 
@@ -16556,12 +16553,12 @@ snapshots:
 
   '@types/node-fetch@2.6.13':
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 24.12.2
       form-data: 4.0.5
 
   '@types/node-fetch@2.6.2':
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 24.12.2
       form-data: 3.0.4
 
   '@types/node@12.20.55': {}
@@ -16571,10 +16568,6 @@ snapshots:
   '@types/node@18.19.130':
     dependencies:
       undici-types: 5.26.5
-
-  '@types/node@24.12.0':
-    dependencies:
-      undici-types: 7.16.0
 
   '@types/node@24.12.2':
     dependencies:
@@ -16594,7 +16587,7 @@ snapshots:
 
   '@types/pngjs@6.0.5':
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 24.12.2
 
   '@types/postcss-import@14.0.3':
     dependencies:
@@ -16630,12 +16623,12 @@ snapshots:
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 24.12.2
 
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 25.5.2
+      '@types/node': 24.12.2
 
   '@types/statuses@2.0.6': {}
 
@@ -16675,17 +16668,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
-    optionalDependencies:
-      babel-plugin-react-compiler: 1.0.0
-
   '@vitejs/plugin-react@6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.0)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.0)(yaml@2.8.3)
+    optionalDependencies:
+      babel-plugin-react-compiler: 1.0.0
+
+  '@vitejs/plugin-react@6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.7
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3)
     optionalDependencies:
       babel-plugin-react-compiler: 1.0.0
 
@@ -19159,7 +19152,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 24.12.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -21994,7 +21987,7 @@ snapshots:
 
   stripe@17.7.0:
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 24.12.2
       qs: 6.15.0
 
   stripe@22.0.1(@types/node@24.12.2):
@@ -22705,21 +22698,6 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
-      terser: 5.46.0
-      yaml: 2.8.3
-
-  vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.8
-      rolldown: 1.0.0-rc.15
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.12.0
-      esbuild: 0.27.4
-      fsevents: 2.3.3
-      jiti: 2.6.1
       terser: 5.46.0
       yaml: 2.8.3
 

--- a/renovate.json
+++ b/renovate.json
@@ -64,6 +64,10 @@
       "allowedVersions": "/^12\\./"
     },
     {
+      "matchPackageNames": ["@types/node"],
+      "allowedVersions": "/^24\\./"
+    },
+    {
       "matchPackageNames": ["lint-staged", "vite", "/^@vitejs/"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,

--- a/website/package.json
+++ b/website/package.json
@@ -94,7 +94,7 @@
     "@types/lodash": "4.17.24",
     "@types/lodash-es": "4.17.12",
     "@types/marked": "5.0.2",
-    "@types/node": "24.12.0",
+    "@types/node": "24.12.2",
     "@types/postcss-import": "14.0.3",
     "@types/react": "18.3.28",
     "@types/react-dom": "18.3.7",


### PR DESCRIPTION
## Motivation

The project uses Node 24 (pinned in `.nvmrc`), but the `nextjs` workspace had `@types/node` at v25.5.2, which doesn't match the runtime. Type definitions should track the Node major version to avoid exposing APIs that don't exist at runtime.

## Solution

- Downgraded `@types/node` from 25.5.2 to 24.12.2 in `nextjs/package.json`.
- Updated `@types/node` from 24.12.0 to 24.12.2 in `website/package.json` to align all workspaces.
- Added a Renovate `allowedVersions` rule restricting `@types/node` to `/^24\./` so Renovate won't propose a v25 bump in the future.

## Dependencies

| Package | From | To | Links |
| --- | --- | --- | --- |
| `@types/node` | 25.5.2 (nextjs), 24.12.0 (website) | 24.12.2 | [repo](https://github.com/DefinitelyTyped/DefinitelyTyped) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)