### PR TITLE
Update dependency @opennextjs/cloudflare to v1.19.1

### DIFF
--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -24,7 +24,7 @@
     "react-dom": "19.2.4"
   },
   "devDependencies": {
-    "@opennextjs/cloudflare": "1.19.0",
+    "@opennextjs/cloudflare": "1.19.1",
     "@tailwindcss/postcss": "4.2.2",
     "@types/node": "24.12.2",
     "@types/react": "19.2.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,8 +276,8 @@ importers:
         version: 19.2.4(react@19.2.4)
     devDependencies:
       '@opennextjs/cloudflare':
-        specifier: 1.19.0
-        version: 1.19.0(encoding@0.1.13)(next@16.2.3(@babel/core@7.29.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(wrangler@4.81.1)
+        specifier: 1.19.1
+        version: 1.19.1(encoding@0.1.13)(next@16.2.3(@babel/core@7.29.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(wrangler@4.81.1)
       '@tailwindcss/postcss':
         specifier: 4.2.2
         version: 4.2.2
@@ -3527,8 +3527,8 @@ packages:
     peerDependencies:
       next: '>=15.5.15 || >=16.2.3'
 
-  '@opennextjs/cloudflare@1.19.0':
-    resolution: {integrity: sha512-w7GeQlMmEFtaeo54mf7yV4K21EcMQOcdQj/CV1GTIijQd/ziIF5wErZqdsnw+BtgekkALY1zMQS6SWIhNcSBeQ==}
+  '@opennextjs/cloudflare@1.19.1':
+    resolution: {integrity: sha512-qW6ivDkwDzomX4uBTwIHiSFMvsXjZ2GuVf/GITxGByr8sA3eyx3IMfFjWyaqBHVqcqtJaCiFo8IPxpLHv0jWbg==}
     hasBin: true
     peerDependencies:
       next: '>=15.5.15 || >=16.2.3'
@@ -14118,7 +14118,7 @@ snapshots:
       - aws-crt
       - supports-color
 
-  '@opennextjs/cloudflare@1.19.0(encoding@0.1.13)(next@16.2.3(@babel/core@7.29.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(wrangler@4.81.1)':
+  '@opennextjs/cloudflare@1.19.1(encoding@0.1.13)(next@16.2.3(@babel/core@7.29.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(wrangler@4.81.1)':
     dependencies:
       '@ast-grep/napi': 0.40.5
       '@dotenvx/dotenvx': 1.31.0


### PR DESCRIPTION
## Motivation

Keep `@opennextjs/cloudflare` up to date in the `nextjs` workspace, which uses it for Cloudflare Workers builds (`opennextjs-cloudflare build`/`preview`) and dev-mode initialization (`initOpenNextCloudflareForDev`).

## Solution

Bump `@opennextjs/cloudflare` from `1.19.0` to `1.19.1`.

## Dependencies

| Package | From | To |
| --- | --- | --- |
| `@opennextjs/cloudflare` | `1.19.0` | `1.19.1` |

### `@opennextjs/cloudflare` v1.19.1

[Release notes](https://github.com/opennextjs/opennextjs-cloudflare/releases/tag/%40opennextjs%2Fcloudflare%401.19.1)

- fix(tag-cache): forward `isStale()` in `withFilter` ([#1189](https://github.com/opennextjs/opennextjs-cloudflare/pull/1189))