### PR TITLE
Update diff to 9.0.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -571,8 +571,8 @@ importers:
         specifier: 4.1.0
         version: 4.1.0
       diff:
-        specifier: 8.0.4
-        version: 8.0.4
+        specifier: 9.0.0
+        version: 9.0.0
       hast-util-to-text:
         specifier: 4.0.2
         version: 4.0.2
@@ -6847,6 +6847,10 @@ packages:
 
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
+
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
 
   dir-glob@3.0.1:
@@ -18024,6 +18028,8 @@ snapshots:
   diff@5.2.2: {}
 
   diff@8.0.4: {}
+
+  diff@9.0.0: {}
 
   dir-glob@3.0.1:
     dependencies:

--- a/site/package.json
+++ b/site/package.json
@@ -73,7 +73,7 @@
     "canvas-confetti": "1.9.4",
     "clsx": "2.1.1",
     "date-fns": "4.1.0",
-    "diff": "8.0.4",
+    "diff": "9.0.0",
     "hast-util-to-text": "4.0.2",
     "html-entities": "2.6.0",
     "import-meta-resolve": "4.2.0",


### PR DESCRIPTION
## Motivation

Keep dependencies current with upstream. `diff` 9.0.0 is a major release that drops ES5 support and reworks patch parsing/formatting APIs.

## Solution

Bump `diff` from `8.0.4` to `9.0.0` in `site`. The site only imports `diffLines` and `diffWordsWithSpace` from `diff` (in `site/src/components/code-block-content.astro`). The v9 breaking changes are limited to `parsePatch`/`formatPatch`/`reversePatch`, the `StructuredPatch` shape, and Git-style patch handling — none of which are used here, so no call-site migration is necessary.

## Dependencies

| Package | From | To | Type | Repo |
| --- | --- | --- | --- | --- |
| `diff` | `8.0.4` | `9.0.0` | major | [kpdecker/jsdiff](https://github.com/kpdecker/jsdiff) |

### `diff` 9.0.0

Source: [`release-notes.md`](https://github.com/kpdecker/jsdiff/blob/master/release-notes.md#900). Entries most relevant to the site codebase:

- **ES5 support dropped.** `parsePatch` now relies on `TextDecoder` and `Uint8Array`, and the library is now compiled with the `es6` target. Modern Node and browser runtimes (what the site targets) are unaffected.
- **No changes to `diffLines` or `diffWordsWithSpace`** — the only two functions the site consumes — so no call-site updates are needed.
- Remaining breaking changes affect patch-handling APIs we do not use: C-style quoted filename headers in `parsePatch`/`formatPatch`; `formatPatch` no longer emits `undefined`/trailing-tab headers and no longer mutates input; Git-style patches (extended headers, hunkless patches, rename/creation info) are now parsed/formatted/reversed; unpaired file headers in `parsePatch` now throw; `parsePatch` is more tolerant of trailing garbage; `oldFileName`/`newFileName` on `StructuredPatch` are now typed `string | undefined`.