### PR TITLE
Fix commit-or-pr leaving conflict markers on merge-ref checkout

### DIFF
--- a/.github/workflows/build-styles.yml
+++ b/.github/workflows/build-styles.yml
@@ -19,6 +19,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          # Check out the PR branch tip (not the merge ref) so `commit-or-pr`
+          # can fetch and rebase onto `origin/$HEAD_REF` cleanly. Otherwise
+          # the merge ref includes commits from `main` that are absent from
+          # the PR branch, which causes rebase conflicts.
+          ref: ${{ github.head_ref || github.ref_name }}
           persist-credentials: false
 
       - name: Set up environment

--- a/.github/workflows/commit-or-pr/action.yml
+++ b/.github/workflows/commit-or-pr/action.yml
@@ -74,16 +74,18 @@ runs:
         GH_TOKEN: ${{ inputs.token != '' && inputs.token || github.token }}
       # Rebase onto the latest branch tip so generated-file commits do not
       # fail just because another commit landed while the workflow was running.
+      # Abort the rebase on conflicts instead of swallowing the error; otherwise
+      # the working tree is left with conflict markers that break later steps
+      # (e.g., composite action YAML parsing on post-job cleanup).
       run: |
         cd "${{ inputs.working-directory }}"
-        set +e
+        set -e
         printf "%s" "$GH_TOKEN" | gh auth login --with-token
         gh auth setup-git
         git fetch origin "$HEAD_REF"
-        git rebase "origin/$HEAD_REF" || true
-        git push origin HEAD:"${HEAD_REF}"
-        status=$?
-        if [ $status -ne 0 ]; then
-          echo "Failed to push to PR head."
+        if ! git rebase "origin/$HEAD_REF"; then
+          git rebase --abort
+          echo "Failed to rebase onto origin/$HEAD_REF."
           exit 1
         fi
+        git push origin HEAD:"${HEAD_REF}"

--- a/.github/workflows/commit-or-pr/action.yml
+++ b/.github/workflows/commit-or-pr/action.yml
@@ -84,8 +84,10 @@ runs:
         gh auth setup-git
         git fetch origin "$HEAD_REF"
         if ! git rebase "origin/$HEAD_REF"; then
-          git rebase --abort
-          echo "Failed to rebase onto origin/$HEAD_REF."
+          # `|| true` so a non-zero `--abort` (e.g., no in-progress rebase)
+          # doesn't swallow the explicit diagnostic under `set -e`.
+          git rebase --abort || true
+          echo "Failed to rebase onto origin/$HEAD_REF." >&2
           exit 1
         fi
         git push origin HEAD:"${HEAD_REF}"

--- a/.github/workflows/og-images.yml
+++ b/.github/workflows/og-images.yml
@@ -20,6 +20,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          # Check out the PR branch tip (not the merge ref) so `commit-or-pr`
+          # can fetch and rebase onto `origin/$HEAD_REF` cleanly. Otherwise
+          # the merge ref includes commits from `main` that are absent from
+          # the PR branch, which causes rebase conflicts.
+          ref: ${{ github.head_ref || github.ref_name }}
           persist-credentials: false
 
       - name: Set up environment


### PR DESCRIPTION
## Motivation

Generated-file workflows (`build-styles`, `og-images`) have been failing on PR #5473 with:

```
.github/workflows/setup/action.yml: (Line: 9, Col: 11, Idx: 129): While scanning a simple key, could not find expected ':'.
```

The parse error looks like `setup/action.yml` is malformed, but the file on disk is fine. The corruption is introduced at runtime by `commit-or-pr` and only becomes visible when a later step (or post-job cleanup) re-reads an `action.yml` that now contains `<<<<<<<` / `=======` / `>>>>>>>` markers.

## Solution

On `pull_request` events, `actions/checkout` defaults to the PR merge ref, which contains commits from `main` that are not on the PR branch. After generating files, `commit-or-pr` ran:

```bash
git fetch origin "$HEAD_REF"
git rebase "origin/$HEAD_REF" || true
git push origin HEAD:"${HEAD_REF}"
```

The rebase tried to reapply the merge commit (carrying `main`'s diverged changes) onto the PR tip, which conflicts whenever `main` has moved. `|| true` swallowed the failure, the push reported "Everything up-to-date", and the working tree was left with unresolved conflict markers across composite `action.yml` files, causing the YAML parser to blow up later.

- Check out the PR branch tip directly in `build-styles.yml` and `og-images.yml` via `ref: ${{ github.head_ref || github.ref_name }}`, so `commit-or-pr` rebases the branch onto its own remote tip (a clean fast-forward in the common case). This mirrors what `visual.yml` already does via a secondary checkout into `pr/`.
- Harden `commit-or-pr/action.yml` to abort the rebase and fail loudly on conflicts instead of silently leaving the working tree broken, so any future regression shows up as the real rebase failure rather than a downstream YAML parse error.