### PR TITLE
Update @clerk/astro to 3.0.13

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -529,8 +529,8 @@ importers:
         specifier: 6.0.1
         version: 6.0.1(@testing-library/jest-dom@6.9.1)(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(solid-js@1.9.12)(terser@5.46.0)(yaml@2.8.3)
       '@clerk/astro':
-        specifier: 3.0.12
-        version: 3.0.12(astro@5.18.1(@types/node@24.12.2)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.2)(yaml@2.8.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 3.0.13
+        version: 3.0.13(astro@5.18.1(@types/node@24.12.2)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.2)(yaml@2.8.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@fontsource-variable/inter':
         specifier: 5.2.8
         version: 5.2.8
@@ -2030,8 +2030,8 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@clerk/astro@3.0.12':
-    resolution: {integrity: sha512-Vwtek7WiGWuQmsqgPF9klePF9pZoQa7jBgI9+K1YTBcAecuLjXyeFHDqtQwfdHomX9NpJIB06dXyVBWX/q3dKw==}
+  '@clerk/astro@3.0.13':
+    resolution: {integrity: sha512-UvgU5qLovbl/YZwP3MG4XxIRg1RvTjrPYtbhjll7tfn34WB+FAJfK0g6kL85vf+8xs5XHWJRCd+vHOsgKimAvA==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       astro: ^4.15.0 || ^5.0.0 || ^6.0.0
@@ -2040,8 +2040,8 @@ packages:
     resolution: {integrity: sha512-zmd0jPyb1iALlmyzyRbgujQXrGqw8sf+VpFjm5GkndpBeq5+9+oH7QgMaFEmWi9oxvTd2sZ+EN+QT4+OXPUnGA==}
     engines: {node: '>=14'}
 
-  '@clerk/backend@3.2.8':
-    resolution: {integrity: sha512-N9yqCQCdkn/4XpfiVnaoS6wXDeC2yQf85ioHGolOIOCWXOPwMd63fONUfRhwOZSlXGTAsgyUNZu87Ps0tcVYsg==}
+  '@clerk/backend@3.2.9':
+    resolution: {integrity: sha512-59h6F9wo4RrulOUh9u3Dm35VHA6k86OwU8qL4giaAMKpWcsKS+zAI7GFgVAvEMDWXam8DyTKy4/npOFT2dWlAg==}
     engines: {node: '>=20.9.0'}
 
   '@clerk/clerk-react@4.32.5':
@@ -2071,8 +2071,8 @@ packages:
       react:
         optional: true
 
-  '@clerk/shared@4.6.0':
-    resolution: {integrity: sha512-dtbsO/+xK5e+qWuOAY1ekZ8BJxsB0F0LYDpXWjRON7JSoFKSaqqaH5cwBvdjbbWaehb6jz1YUQmWVV8gBOx6Ag==}
+  '@clerk/shared@4.7.0':
+    resolution: {integrity: sha512-pm2dpxHS2teY87jmpatprG2uBAuuXuHHWvuezL3a5pRoUiIWXgWlLvwRZRgKXwDeIkIT9UCAIQBkcjueSEzqHA==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
@@ -12997,10 +12997,10 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@clerk/astro@3.0.12(astro@5.18.1(@types/node@24.12.2)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.2)(yaml@2.8.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@clerk/astro@3.0.13(astro@5.18.1(@types/node@24.12.2)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.2)(yaml@2.8.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@clerk/backend': 3.2.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@clerk/shared': 4.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@clerk/backend': 3.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@clerk/shared': 4.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       astro: 5.18.1(@types/node@24.12.2)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.2)(yaml@2.8.3)
       nanoid: 5.1.6
       nanostores: 1.0.1
@@ -13022,9 +13022,9 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  '@clerk/backend@3.2.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@clerk/backend@3.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@clerk/shared': 4.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@clerk/shared': 4.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       standardwebhooks: 1.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -13072,7 +13072,7 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
 
-  '@clerk/shared@4.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@clerk/shared@4.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@tanstack/query-core': 5.90.16
       dequal: 2.0.3

--- a/site/package.json
+++ b/site/package.json
@@ -59,7 +59,7 @@
     "@astrojs/mdx": "5.0.3",
     "@astrojs/react": "5.0.3",
     "@astrojs/solid-js": "6.0.1",
-    "@clerk/astro": "3.0.12",
+    "@clerk/astro": "3.0.13",
     "@fontsource-variable/inter": "5.2.8",
     "@react-aria/utils": "3.33.1",
     "@shikijs/langs": "4.0.2",


### PR DESCRIPTION
## Motivation

Keep the `@clerk/astro` dependency up to date with upstream bug fixes and security improvements.

## Solution

Bump `@clerk/astro` from `3.0.12` to `3.0.13` in the `site` workspace and regenerate the lock file. This patch release bumps the `astro` peer dependency floor to pick up an upstream security fix, simplifies keyless service initialization, and pulls in transitive `@clerk/backend@3.2.9` and `@clerk/shared@4.7.0` updates. No changes were required outside of the version bump and lock file regeneration.

## Dependencies

| Package          | From   | To     | Links                                                                                                                                                                           |
| ---------------- | ------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `@clerk/astro`   | 3.0.12 | 3.0.13 | [release](https://github.com/clerk/javascript/releases/tag/%40clerk%2Fastro%403.0.13) · [repo](https://github.com/clerk/javascript/tree/main/packages/astro)                    |

### `@clerk/astro` 3.0.12 → 3.0.13

- Bump `astro` devDependency floor to `5.18.1` to pick up an upstream security fix. ([#8279](https://github.com/clerk/javascript/pull/8279))
- Simplified keyless service initialization. ([#7844](https://github.com/clerk/javascript/pull/7844))
- Updated transitive dependencies: `@clerk/backend@3.2.9`, `@clerk/shared@4.7.0`.

[Full changelog](https://github.com/clerk/javascript/releases/tag/%40clerk%2Fastro%403.0.13)