### PR TITLE
Fix commit-or-pr gh auth login failing under set -e

### DIFF
--- a/.github/workflows/commit-or-pr/action.yml
+++ b/.github/workflows/commit-or-pr/action.yml
@@ -80,7 +80,9 @@ runs:
       run: |
         cd "${{ inputs.working-directory }}"
         set -e
-        printf "%s" "$GH_TOKEN" | gh auth login --with-token
+        # `gh auth git-credential` reads GH_TOKEN from the environment, so no
+        # explicit `gh auth login` is needed — and calling it under `set -e`
+        # would fail the step because gh exits 1 when GH_TOKEN is already set.
         gh auth setup-git
         git fetch origin "$HEAD_REF"
         if ! git rebase "origin/$HEAD_REF"; then


### PR DESCRIPTION
## Motivation

After #5786 switched the `Push to PR head branch` step in `commit-or-pr` to `set -e`, generated-file write-back jobs on PRs started failing at the auth step. Currently-visible examples on #5790:

- [Build styles](https://github.com/ariakit/ariakit/actions/runs/24533156940/job/71721384782)
- [Generate OG images](https://github.com/ariakit/ariakit/actions/runs/24533156915/job/71721384420)

Both logs show the same failure right after `gh auth setup-git` would have run:

```
The value of the GH_TOKEN environment variable is being used for authentication.
To have GitHub CLI store credentials instead, first clear the value from the environment.
##[error]Process completed with exit code 1.
```

`gh auth login --with-token` refuses to store a token (and exits 1) when `GH_TOKEN` (or the runner's `GITHUB_TOKEN`) is already set. Previously this was hidden because the step used `set +e`; under `set -e` it now aborts the whole push.

## Solution

Drop the `gh auth login --with-token` call. The step already exports the token as `GH_TOKEN`, which is what `gh auth git-credential` reads when git invokes the credential helper configured by `gh auth setup-git`. Storing the same token via login is redundant and, under `set -e`, actively breaks the step.

Verified locally:

- `gh auth setup-git` succeeds with only `GH_TOKEN` set (no prior login) and writes the `credential.helper = !gh auth git-credential` entries for `github.com`.
- `gh auth git-credential get` returns `username=x-access-token` and the `GH_TOKEN` value as the password when invoked with only the env var set.

So the subsequent `git push origin HEAD:$HEAD_REF` picks up the token from the env via the credential helper, which is exactly the behavior the previous `set +e` version relied on.