### PR TITLE
Fix Performance job failing when PR modifies lockfile

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -234,7 +234,7 @@ jobs:
 
       # --- Baseline (base branch) ---
       - name: Checkout base branch
-        run: git checkout ${{ github.event.pull_request.base.sha }}
+        run: git checkout -f ${{ github.event.pull_request.base.sha }}
 
       - name: Set up base environment
         uses: ./.github/workflows/setup


### PR DESCRIPTION
## Motivation

The `Performance` job in `.github/workflows/app.yml` fails on any PR that modifies `pnpm-lock.yaml` at the `Checkout base branch` step:

```
Run git checkout 13848a9f4246160217a3de0c8fb9542a685fc10d
error: Your local changes to the following files would be overwritten by checkout:
        pnpm-lock.yaml
Please commit your changes or stash them before you switch branches.
Aborting
```

The preceding `Set up environment` step runs `pnpm install` (without `--frozen-lockfile`), which can modify `pnpm-lock.yaml` in place — for example when the pnpm version that produced the committed lockfile differs from the one installed by `pnpm/action-setup`. That leaves an uncommitted diff in the working tree, and the plain `git checkout <sha>` in `Checkout base branch` refuses to overwrite it.

Failing example: https://github.com/ariakit/ariakit/actions/runs/24533156975/job/71721718556

## Solution

Use `git checkout -f` in the `Checkout base branch` step so any transient lockfile modifications left by the preceding `pnpm install` are discarded before switching to the base SHA. The subsequent `Set up base environment` step re-runs `pnpm install` for the base ref, so losing that transient diff is safe.

The shared `./.github/workflows/setup` action is intentionally left unchanged because other workflows depend on it and switching to `--frozen-lockfile` globally is a larger, separate decision.