### PR TITLE
Use frozen lockfile for pnpm install on CI

### DIFF
--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -16,4 +16,4 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: pnpm install
+      run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Motivation

CI was running `pnpm install` without `--frozen-lockfile`, so a mismatch between `pnpm-lock.yaml` and `package.json` would silently update the lockfile in the CI environment instead of failing. We want CI to fail fast in that case so missing lockfile updates are caught in review rather than masked.

## Solution

Added `--frozen-lockfile` to the `pnpm install` command in the shared `setup` composite action. All workflows rely on this action, so the flag applies to the entire CI pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency installation configuration to enforce consistency in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->