### PR TITLE
Add overview changeset for pending React fixes

### DIFF
--- a/.changeset/200-overview.md
+++ b/.changeset/200-overview.md
@@ -1,0 +1,8 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Overview
+
+This version focuses on bug fixes across [`Dialog`](https://ariakit.com/reference/dialog), [`Portal`](https://ariakit.com/reference/portal), [`Radio`](https://ariakit.com/reference/radio), [`Combobox`](https://ariakit.com/reference/combobox), and [`MenuButton`](https://ariakit.com/reference/menu-button), along with improvements to how portals behave inside fullscreen elements, how dialogs handle events in popup windows, and how [`Radio`](https://ariakit.com/reference/radio) groups automatically generate unique `name` attributes.


### PR DESCRIPTION
## Motivation

Multiple multi-paragraph changesets for `@ariakit/react-core` and `@ariakit/react` are pending release, covering fixes across [`Dialog`](https://ariakit.com/reference/dialog), [`Portal`](https://ariakit.com/reference/portal), [`Radio`](https://ariakit.com/reference/radio), [`Combobox`](https://ariakit.com/reference/combobox), and [`MenuButton`](https://ariakit.com/reference/menu-button). Per our changeset guidelines, when a package accumulates two or more multi-paragraph entries, an overview changeset is required so the final changelog starts with a concise summary of what's included.

## Solution

Added `.changeset/200-overview.md` summarizing the pending user-facing changes for `@ariakit/react-core` and `@ariakit/react`. The `@ariakit/core` and `@ariakit/test` packages only have single-paragraph entries, so they don't need overviews.

## Testing

- Not applicable (changeset-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)