### PR TITLE
Scope ariakit-bot commits to generator outputs

### DIFF
--- a/.github/workflows/build-styles.yml
+++ b/.github/workflows/build-styles.yml
@@ -34,10 +34,12 @@ jobs:
 
       - name: Detect changes
         id: patch
-        # `commit-or-pr` already stages and writes the diff. This step only
-        # detects whether the generator changed anything so no-op runs stay green.
+        # Scope the diff check to the generator's output. Other tree changes
+        # from earlier steps (e.g., `pnpm install` rewriting `pnpm-lock.yaml`
+        # to re-add pnpm's self-managed `packageManagerDependencies` section)
+        # must not trigger a style commit.
         run: |
-          git add -A
+          git add -- site/src/styles/styles.json
           if git diff --cached --quiet --exit-code; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -56,4 +58,5 @@ jobs:
           message: Update styles
           head-branch: ${{ github.head_ref || github.ref_name }}
           new-branch: chore/update-styles
+          paths: site/src/styles/styles.json
           token: ${{ secrets.ARIAKIT_BOT_PAT }}

--- a/.github/workflows/build-styles.yml
+++ b/.github/workflows/build-styles.yml
@@ -39,7 +39,7 @@ jobs:
         # to re-add pnpm's self-managed `packageManagerDependencies` section)
         # must not trigger a style commit.
         run: |
-          git add -- site/src/styles/styles.json
+          git add -A -- site/src/styles/styles.json
           if git diff --cached --quiet --exit-code; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/commit-or-pr/action.yml
+++ b/.github/workflows/commit-or-pr/action.yml
@@ -22,6 +22,14 @@ inputs:
     description: Directory where the repository is checked out
     required: false
     default: "."
+  paths:
+    description: >
+      Newline-separated pathspecs to stage and commit. When empty, all working
+      tree changes are included. Set this to the generator's output paths so
+      unrelated tree changes (e.g., a `pnpm install` rewriting `pnpm-lock.yaml`)
+      are not captured by the commit.
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -40,6 +48,7 @@ runs:
         # Push workflows should not write directly to `main`; they publish
         # generated changes through a dedicated maintenance PR instead.
         path: ${{ inputs.working-directory }}
+        add-paths: ${{ inputs.paths }}
         commit-message: ${{ inputs.message }}
         title: ${{ inputs.message }}
         base: ${{ inputs.head-branch }}
@@ -55,9 +64,15 @@ runs:
       if: inputs.event == 'pull_request'
       env:
         MESSAGE: ${{ inputs.message }}
+        PATHS: ${{ inputs.paths }}
       run: |
         cd "${{ inputs.working-directory }}"
-        git add -A
+        if [ -n "$PATHS" ]; then
+          mapfile -t path_args < <(printf '%s\n' "$PATHS" | sed '/^[[:space:]]*$/d')
+          git add -- "${path_args[@]}"
+        else
+          git add -A
+        fi
         if git diff --cached --quiet --exit-code; then
           echo "No files to commit."
           echo "did_commit=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/commit-or-pr/action.yml
+++ b/.github/workflows/commit-or-pr/action.yml
@@ -68,8 +68,13 @@ runs:
       run: |
         cd "${{ inputs.working-directory }}"
         if [ -n "$PATHS" ]; then
-          mapfile -t path_args < <(printf '%s\n' "$PATHS" | sed '/^[[:space:]]*$/d')
-          git add -- "${path_args[@]}"
+          # macOS runners ship bash 3.2, which lacks `mapfile`. Fall back to a
+          # read loop that's portable across the bash versions GitHub hosts.
+          path_args=()
+          while IFS= read -r path; do
+            [ -n "${path//[[:space:]]/}" ] && path_args+=("$path")
+          done < <(printf '%s\n' "$PATHS")
+          git add -A -- "${path_args[@]}"
         else
           git add -A
         fi

--- a/.github/workflows/og-images.yml
+++ b/.github/workflows/og-images.yml
@@ -63,10 +63,13 @@ jobs:
 
       - name: Detect changes
         id: patch
-        # `commit-or-pr` handles the actual write path. This only decides
-        # whether the generator produced any file changes worth publishing.
+        # Scope the diff check to the generator's output directory. Other tree
+        # changes from earlier steps (e.g., `pnpm install` rewriting
+        # `pnpm-lock.yaml` to re-add pnpm's self-managed
+        # `packageManagerDependencies` section) must not trigger an OG image
+        # commit.
         run: |
-          git add -A
+          git add -- site/public/og-image
           if git diff --cached --quiet --exit-code; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -85,4 +88,5 @@ jobs:
           message: Update OG images
           head-branch: ${{ github.head_ref || github.ref_name }}
           new-branch: chore/update-og-images
+          paths: site/public/og-image
           token: ${{ secrets.ARIAKIT_BOT_PAT }}

--- a/.github/workflows/og-images.yml
+++ b/.github/workflows/og-images.yml
@@ -69,7 +69,7 @@ jobs:
         # `packageManagerDependencies` section) must not trigger an OG image
         # commit.
         run: |
-          git add -- site/public/og-image
+          git add -A -- site/public/og-image
           if git diff --cached --quiet --exit-code; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
             exit 0


### PR DESCRIPTION
## Summary

Narrows `git add` scope in the `build-styles` and `og-images` write-back steps so only the generator's actual output can trigger a bot commit. Adds a `paths` input to the reusable `commit-or-pr` composite action that threads through to both the in-place `git add -A --` and the `peter-evans/create-pull-request` `add-paths` input. The in-place stage step uses a portable read loop so it works on the bash 3.2 shipped on macOS runners.

The churn that surfaced this — pnpm v10 rewriting `pnpm-lock.yaml` mid-job to re-add the self-managed `packageManagerDependencies` section — is tracked upstream in [pnpm/pnpm#11284](https://github.com/pnpm/pnpm/pull/11284). This PR guards CI regardless of when that fix ships.

## Test plan

- [ ] `build-styles` workflow runs on this PR without producing an "Update styles" bot commit from a lockfile-only change.
- [ ] `og-images` workflow runs on this PR (macOS runner) without producing an "Update OG images" bot commit from a lockfile-only change.
- [ ] Generator output deletions still trigger `has_changes=true`.