### PR TITLE
Force checkout of PR branch in Performance job

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -312,7 +312,7 @@ jobs:
 
       # --- Current (PR branch) ---
       - name: Checkout PR branch
-        run: git checkout ${{ github.event.pull_request.head.sha }}
+        run: git checkout -f ${{ github.event.pull_request.head.sha }}
 
       - name: Set up PR environment
         uses: ./.github/workflows/setup


### PR DESCRIPTION
## Motivation

The `Performance` job in `.github/workflows/app.yml` runs baseline perf tests on the PR's base branch, then switches back to the PR branch to run the current perf tests. On PRs that modify `pnpm-lock.yaml` (e.g. the Renovate update in [#5809](https://github.com/ariakit/ariakit/pull/5809)), the `Checkout PR branch` step fails with:

```
error: Your local changes to the following files would be overwritten by checkout:
	pnpm-lock.yaml
Please commit your changes or stash them before you switch branches.
Aborting
```

This happens because `pnpm install` on the base branch can modify `pnpm-lock.yaml` in the working tree, and the subsequent plain `git checkout` refuses to overwrite those local changes.

See the failing run: https://github.com/ariakit/ariakit/actions/runs/24603698617/job/71946526628.

## Solution

Mirror the `Checkout base branch` step, which already uses `git checkout -f`. The intermediate working-tree changes introduced by the base-branch `pnpm install` are throwaway state — we only want the tracked files at the PR head SHA before the next `pnpm install` runs — so forcing the checkout is safe and resolves the failure.