### PR TITLE
Fix Performance job failing when checking out PR branch

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -312,7 +312,7 @@ jobs:
 
       # --- Current (PR branch) ---
       - name: Checkout PR branch
-        run: git checkout ${{ github.event.pull_request.head.sha }}
+        run: git checkout -f ${{ github.event.pull_request.head.sha }}
 
       - name: Set up PR environment
         uses: ./.github/workflows/setup


### PR DESCRIPTION
## Summary
The Checkout PR branch step in the Performance job needs the `-f` flag to discard uncommitted changes that may exist after switching between branches. This mirrors the fix applied to the Checkout base branch step.

The root cause is that `pnpm install` on the base branch can modify `pnpm-lock.yaml` in place, causing the subsequent `git checkout` to refuse to switch with "Your local changes to the following files would be overwritten by checkout". Using the `-f` flag forces the checkout and discards these temporary changes.

## Testing
This fix allows the Performance job to complete successfully even when the PR modifies lockfiles or causes working-tree changes during environment setup.