### PR TITLE
Fix Performance job failing when checking out PR branch

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -313,6 +313,7 @@ jobs:
       # --- Current (PR branch) ---
       - name: Checkout PR branch
         run: |
+          git reset --hard
           git clean -fd
           git checkout -f ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -313,8 +313,8 @@ jobs:
       # --- Current (PR branch) ---
       - name: Checkout PR branch
         run: |
-          git checkout HEAD -- pnpm-lock.yaml
-          git checkout -f ${{ github.event.pull_request.head.sha }}
+          git reset --hard HEAD
+          git checkout ${{ github.event.pull_request.head.sha }}
 
       - name: Set up PR environment
         uses: ./.github/workflows/setup

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -313,8 +313,7 @@ jobs:
       # --- Current (PR branch) ---
       - name: Checkout PR branch
         run: |
-          git reset --hard
-          git clean -fd
+          git checkout HEAD -- pnpm-lock.yaml
           git checkout -f ${{ github.event.pull_request.head.sha }}
 
       - name: Set up PR environment

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -312,7 +312,9 @@ jobs:
 
       # --- Current (PR branch) ---
       - name: Checkout PR branch
-        run: git checkout -f ${{ github.event.pull_request.head.sha }}
+        run: |
+          git clean -fd
+          git checkout -f ${{ github.event.pull_request.head.sha }}
 
       - name: Set up PR environment
         uses: ./.github/workflows/setup

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -312,7 +312,7 @@ jobs:
 
       # --- Current (PR branch) ---
       - name: Checkout PR branch
-        run: git checkout ${{ github.event.pull_request.head.sha }}
+        run: git checkout -f ${{ github.event.pull_request.head.sha }}
 
       - name: Set up PR environment
         uses: ./.github/workflows/setup


### PR DESCRIPTION
## Summary

Fixes the Performance CI job failing on the "Checkout PR branch" step with error: `Your local changes to the following files would be overwritten by checkout: pnpm-lock.yaml`

The issue occurs because the base branch setup modifies `pnpm-lock.yaml` when running `pnpm install`. Previous attempts using selective file checkout were insufficient.

## Solution

Use `git reset --hard HEAD` to comprehensively discard all local modifications before checking out the PR branch. This is more robust than selective checkouts and handles any type of local changes.

## Test plan

- [ ] Performance job should now successfully complete on PRs without failing on the "Checkout PR branch" step
- [ ] Performance comparison should work correctly
- [ ] No other workflow steps should be affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)