### PR TITLE
Update @clerk/astro to 3.0.15

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -435,8 +435,8 @@ importers:
         specifier: 6.0.1
         version: 6.0.1(@testing-library/jest-dom@6.9.1)(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(solid-js@1.9.12)(terser@5.46.0)(yaml@2.8.3)
       '@clerk/astro':
-        specifier: 3.0.13
-        version: 3.0.13(astro@5.18.1(@types/node@24.12.2)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.2)(yaml@2.8.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 3.0.15
+        version: 3.0.15(astro@5.18.1(@types/node@24.12.2)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.2)(yaml@2.8.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@fontsource-variable/inter':
         specifier: 5.2.8
         version: 5.2.8
@@ -1936,8 +1936,8 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@clerk/astro@3.0.13':
-    resolution: {integrity: sha512-UvgU5qLovbl/YZwP3MG4XxIRg1RvTjrPYtbhjll7tfn34WB+FAJfK0g6kL85vf+8xs5XHWJRCd+vHOsgKimAvA==}
+  '@clerk/astro@3.0.15':
+    resolution: {integrity: sha512-Q7pMAWoux3rIwsAt9d8jkkVecZIj/+hYpMrKtoWb1em3D5dtNgSpbspFusqNKEJkyu8DlBA1pZGV2NSAMet/Vg==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       astro: ^4.15.0 || ^5.0.0 || ^6.0.0
@@ -1946,8 +1946,8 @@ packages:
     resolution: {integrity: sha512-zmd0jPyb1iALlmyzyRbgujQXrGqw8sf+VpFjm5GkndpBeq5+9+oH7QgMaFEmWi9oxvTd2sZ+EN+QT4+OXPUnGA==}
     engines: {node: '>=14'}
 
-  '@clerk/backend@3.2.9':
-    resolution: {integrity: sha512-59h6F9wo4RrulOUh9u3Dm35VHA6k86OwU8qL4giaAMKpWcsKS+zAI7GFgVAvEMDWXam8DyTKy4/npOFT2dWlAg==}
+  '@clerk/backend@3.2.11':
+    resolution: {integrity: sha512-EPgFP3c4TpsZGMILW0pD0qkM4mCF0eSFMAVB3c6YyM4bCoEg/pTTgBCkNJtt7T/fo0hlMq6qfOoZA8adWTUaaA==}
     engines: {node: '>=20.9.0'}
 
   '@clerk/clerk-react@4.32.5':
@@ -1977,8 +1977,8 @@ packages:
       react:
         optional: true
 
-  '@clerk/shared@4.7.0':
-    resolution: {integrity: sha512-pm2dpxHS2teY87jmpatprG2uBAuuXuHHWvuezL3a5pRoUiIWXgWlLvwRZRgKXwDeIkIT9UCAIQBkcjueSEzqHA==}
+  '@clerk/shared@4.8.1':
+    resolution: {integrity: sha512-4grzU4Zj/0zaDA30cqCgvcS9x7JjhwFixMoDAOHSIN76OOqarzEf69U27MAunW9a7UYbKO5bNFJZDL4oNsnbzA==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
@@ -12922,10 +12922,10 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@clerk/astro@3.0.13(astro@5.18.1(@types/node@24.12.2)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.2)(yaml@2.8.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@clerk/astro@3.0.15(astro@5.18.1(@types/node@24.12.2)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.2)(yaml@2.8.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@clerk/backend': 3.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@clerk/shared': 4.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@clerk/backend': 3.2.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@clerk/shared': 4.8.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       astro: 5.18.1(@types/node@24.12.2)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.2)(yaml@2.8.3)
       nanoid: 5.1.6
       nanostores: 1.0.1
@@ -12947,9 +12947,9 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  '@clerk/backend@3.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@clerk/backend@3.2.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@clerk/shared': 4.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@clerk/shared': 4.8.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       standardwebhooks: 1.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -12997,7 +12997,7 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
 
-  '@clerk/shared@4.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@clerk/shared@4.8.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@tanstack/query-core': 5.90.16
       dequal: 2.0.3

--- a/site/package.json
+++ b/site/package.json
@@ -59,7 +59,7 @@
     "@astrojs/mdx": "5.0.3",
     "@astrojs/react": "5.0.3",
     "@astrojs/solid-js": "6.0.1",
-    "@clerk/astro": "3.0.13",
+    "@clerk/astro": "3.0.15",
     "@fontsource-variable/inter": "5.2.8",
     "@react-aria/utils": "3.33.1",
     "@shikijs/langs": "4.0.2",


### PR DESCRIPTION
## Motivation

Keep `@clerk/astro` current with the latest patch releases so the site picks up upstream bug fixes and dependency updates.

## Solution

Bump `@clerk/astro` from `3.0.13` to `3.0.15` in `site/package.json` and regenerate `pnpm-lock.yaml`. No code changes were required because the only meaningful fix in this range — URL normalization in `createPathMatcher` — applies to an API the site does not use.

## Dependencies

| Package        | From   | To     | Links                                                                                                                                                                                                            |
| -------------- | ------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `@clerk/astro` | 3.0.13 | 3.0.15 | [changelog](https://github.com/clerk/javascript/blob/main/packages/astro/CHANGELOG.md) - [releases](https://github.com/clerk/javascript/releases?q=%40clerk%2Fastro) - [repo](https://github.com/clerk/javascript) |

### `@clerk/astro` 3.0.13 → 3.0.15

#### 3.0.15

- Normalize URL paths in `createPathMatcher` to prevent route protection bypass ([#8311](https://github.com/clerk/javascript/pull/8311)). The site does not use `createPathMatcher` directly, so this fix has no impact on our usage but is still a useful upstream hardening.
- Updated dependencies: `@clerk/shared@4.8.1`, `@clerk/backend@3.2.11`.

#### 3.0.14

- Updated dependencies only: `@clerk/shared@4.8.0`, `@clerk/backend@3.2.10`.

[Full changelog](https://github.com/clerk/javascript/blob/main/packages/astro/CHANGELOG.md)