### PR TITLE
Update match-sorter to 8.3.0 in examples workspace

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -16,7 +16,7 @@
     "@wordpress/components": "32.5.0",
     "clsx": "2.1.1",
     "lodash-es": "4.18.1",
-    "match-sorter": "8.2.0",
+    "match-sorter": "8.3.0",
     "motion": "12.38.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,8 +215,8 @@ importers:
         specifier: 4.18.1
         version: 4.18.1
       match-sorter:
-        specifier: 8.2.0
-        version: 8.2.0
+        specifier: 8.3.0
+        version: 8.3.0
       motion:
         specifier: 12.38.0
         version: 12.38.0(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
## Motivation

The previous bump to `match-sorter` 8.3.0 (#5810) only updated the root `package.json`, leaving the `examples` workspace pinned to 8.2.0. This keeps the repository on two versions of the same package and is at odds with the workspace dependency conventions.

## Solution

Bump `match-sorter` from 8.2.0 to 8.3.0 in `examples/package.json` (the `examples` workspace is private, so the version stays as an exact pin) and regenerate `pnpm-lock.yaml`. No example code needed to change because 8.3.0 is purely additive.

## Dependencies

| Package        | From  | To    | Links                                                                                                                                                                                                |
| -------------- | ----- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `match-sorter` | 8.2.0 | 8.3.0 | [release](https://github.com/kentcdodds/match-sorter/releases/tag/v8.3.0) · [releases](https://github.com/kentcdodds/match-sorter/releases) · [repo](https://github.com/kentcdodds/match-sorter) |

### `match-sorter` 8.2.0 → 8.3.0

- **Feat**: add `matchSorterWithRankInfo` to expose rank info in results ([#169](https://github.com/kentcdodds/match-sorter/issues/169)).

This is a purely additive change — every `examples/**` import continues to use the existing `matchSorter` named export, so no code changes are required.

[Full changelog](https://github.com/kentcdodds/match-sorter/releases/tag/v8.3.0)