### PR TITLE
Update @clerk/astro to 3.0.17

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -435,8 +435,8 @@ importers:
         specifier: 6.0.1
         version: 6.0.1(@testing-library/jest-dom@6.9.1)(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(solid-js@1.9.12)(terser@5.46.0)(yaml@2.8.3)
       '@clerk/astro':
-        specifier: 3.0.16
-        version: 3.0.16(astro@5.18.1(@types/node@24.12.2)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.3)(yaml@2.8.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 3.0.17
+        version: 3.0.17(astro@5.18.1(@types/node@24.12.2)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.3)(yaml@2.8.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@fontsource-variable/inter':
         specifier: 5.2.8
         version: 5.2.8
@@ -1936,8 +1936,8 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@clerk/astro@3.0.16':
-    resolution: {integrity: sha512-L4OVK+boPLCNAOkqTe02wg/8p3HxzcUEQ3P6RIoEkchpwx1eQEpyjJNx4BfyH3MeMqYYadti+b51lER83HulNA==}
+  '@clerk/astro@3.0.17':
+    resolution: {integrity: sha512-StdZpbG1D7YpmI/0xvykF4JpGkF+4/ZFSUjWBpTYi9yxFk7DhBO0qCs5zh0gDNVLSFx+yVAztW41e+uhBHgTVg==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       astro: ^4.15.0 || ^5.0.0 || ^6.0.0
@@ -1946,8 +1946,8 @@ packages:
     resolution: {integrity: sha512-zmd0jPyb1iALlmyzyRbgujQXrGqw8sf+VpFjm5GkndpBeq5+9+oH7QgMaFEmWi9oxvTd2sZ+EN+QT4+OXPUnGA==}
     engines: {node: '>=14'}
 
-  '@clerk/backend@3.2.12':
-    resolution: {integrity: sha512-pTuD3+3IvLrjx9XMYdbqpttTltrWc7npxkOIDzhtID5/+IOomxZAzsnxU1G1hvOeBoR1Jl68ZgKQw66aZ+DRFQ==}
+  '@clerk/backend@3.2.13':
+    resolution: {integrity: sha512-E4ir94gs9Cxh+v20SGVLXblb0coVUd2La5o1Lmz7olNOBimMEsZ7T6MpGFNJveEH1sQ+HhSf1a1uLm9pMiK/tg==}
     engines: {node: '>=20.9.0'}
 
   '@clerk/clerk-react@4.32.5':
@@ -12330,9 +12330,9 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@clerk/astro@3.0.16(astro@5.18.1(@types/node@24.12.2)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.3)(yaml@2.8.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@clerk/astro@3.0.17(astro@5.18.1(@types/node@24.12.2)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.3)(yaml@2.8.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@clerk/backend': 3.2.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@clerk/backend': 3.2.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@clerk/shared': 4.8.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       astro: 5.18.1(@types/node@24.12.2)(aws4fetch@1.0.20)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.46.0)(typescript@6.0.3)(yaml@2.8.3)
       nanoid: 5.1.6
@@ -12355,7 +12355,7 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  '@clerk/backend@3.2.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@clerk/backend@3.2.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@clerk/shared': 4.8.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       standardwebhooks: 1.0.0

--- a/site/package.json
+++ b/site/package.json
@@ -59,7 +59,7 @@
     "@astrojs/mdx": "5.0.3",
     "@astrojs/react": "5.0.3",
     "@astrojs/solid-js": "6.0.1",
-    "@clerk/astro": "3.0.16",
+    "@clerk/astro": "3.0.17",
     "@fontsource-variable/inter": "5.2.8",
     "@react-aria/utils": "3.34.0",
     "@shikijs/langs": "4.0.2",


### PR DESCRIPTION
## Motivation

Keep the `site` workspace on the latest allowed non-major Clerk update in the Renovate `clerk` group.

## Solution

Update `@clerk/astro` from `3.0.16` to `3.0.17` in the `site` workspace and regenerate `pnpm-lock.yaml`.

No code changes beyond the version bump and lockfile refresh were needed.

Verification run locally:

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm build-site-lite`
- `pnpm -F site test` (did not pass locally; the failures were reproduced on `origin/main` with a targeted subset, including `site/src/sandbox/counter-nextjs/test-browser.ts`, so they do not appear to be introduced by this dependency bump)

## Dependencies

- `@clerk/astro`
  - Repository: [clerk/javascript](https://github.com/clerk/javascript)
  - Homepage: [clerk.com](https://clerk.com/)
  - Changelog: [GitHub releases](https://github.com/clerk/javascript/releases)
  - Release notes: [3.0.16](https://github.com/clerk/javascript/releases/tag/%40clerk/astro%403.0.16), [3.0.17](https://github.com/clerk/javascript/releases/tag/%40clerk/astro%403.0.17)
- Relevant release notes for `3.0.16 -> 3.0.17`
  - `@clerk/astro@3.0.17`: updates transitive `@clerk/backend` from `3.2.12` to `3.2.13`.
  - `@clerk/backend@3.2.13`: adds path traversal protections in `joinPaths`. Release notes: [@clerk/backend@3.2.13](https://github.com/clerk/javascript/releases/tag/%40clerk/backend%403.2.13)
