### PR TITLE
Update react-toastify to 11.1.0

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -22,7 +22,7 @@
     "react-dom": "18.3.1",
     "react-router": "7.14.1",
     "react-shadow": "20.6.0",
-    "react-toastify": "11.0.5",
+    "react-toastify": "11.1.0",
     "textarea-caret": "3.1.0",
     "tiny-invariant": "1.3.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,8 +233,8 @@ importers:
         specifier: 20.6.0
         version: 20.6.0(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-toastify:
-        specifier: 11.0.5
-        version: 11.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 11.1.0
+        version: 11.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       textarea-caret:
         specifier: 3.1.0
         version: 3.1.0
@@ -8725,8 +8725,8 @@ packages:
       '@types/react':
         optional: true
 
-  react-toastify@11.0.5:
-    resolution: {integrity: sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==}
+  react-toastify@11.1.0:
+    resolution: {integrity: sha512-e9h23x3phN0wbFeB6yovmWp7lobzV4CaCH0LO8nVP6H7Y+3GbcLpIzMm9dJhcp1RXbpyfvjgpfXqO80QAmn7sg==}
     peerDependencies:
       react: ^18 || ^19
       react-dom: ^18 || ^19
@@ -19496,7 +19496,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  react-toastify@11.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-toastify@11.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       clsx: 2.1.1
       react: 18.3.1


### PR DESCRIPTION
## Motivation

Keep the `dialog-react-toastify` example on the latest `react-toastify` 11.x release.

## Solution

- update `react-toastify` in the `examples` workspace from `11.0.5` to `11.1.0`
- regenerate the lockfile entries for the new package version only

## Dependencies

| Package | From | To | Links |
| --- | --- | --- | --- |
| `react-toastify` | 11.0.5 | 11.1.0 | [releases](https://github.com/fkhadra/react-toastify/releases/tag/v11.1.0) · [repo](https://github.com/fkhadra/react-toastify) · [docs](https://fkhadra.github.io/react-toastify/introduction) |

### `react-toastify` 11.0.5 → 11.1.0

The example integration in this repo still uses the same `ToastContainer` and `toast(...)` calls, so no code changes were needed for the bump.

Relevant upstream changes for this example path:

- adds CSP nonce support on `ToastContainer`
- fixes toast removal event ordering and guards against double `onClose`
- fixes touch/drag and stacked-toast behavior
- adds `aria-valuenow` / `aria-valuemin` / `aria-valuemax` to the progress bar

[Full release notes](https://github.com/fkhadra/react-toastify/releases/tag/v11.1.0)

## Testing

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm test`
- `pnpm build`
- `pnpm test-chrome examples/dialog-react-toastify/test-chrome-firefox.ts` (fails the same way on this branch and on clean `origin/main` before finding the `Say Hello` button)
