### PR TITLE
Fix perf workflow artifact selection

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -246,28 +246,32 @@ jobs:
 
       - name: Find base app artifact
         id: find-base-artifact
-        continue-on-error: true
         uses: actions/github-script@v9
         with:
           script: |
+            const baseSha = '${{ github.event.pull_request.base.sha }}';
             const runs = await github.rest.actions.listWorkflowRuns({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'app.yml',
               branch: '${{ github.event.pull_request.base.ref }}',
+              head_sha: baseSha,
               status: 'success',
               per_page: 1,
             });
             const run = runs.data.workflow_runs[0];
             if (!run) {
-              core.setFailed('No successful run found');
+              core.notice(
+                `No successful app.yml run found for base SHA ${baseSha}. ` +
+                  'Building base artifacts in this job.',
+              );
               return;
             }
-            core.setOutput('run-id', run.id);
+            core.setOutput('run-id', String(run.id));
 
       - name: Download base app artifact
         id: base-artifact
-        if: steps.find-base-artifact.outcome == 'success'
+        if: steps.find-base-artifact.outputs.run-id != ''
         continue-on-error: true
         uses: actions/download-artifact@v8
         with:
@@ -278,7 +282,7 @@ jobs:
 
       - name: Download base Next.js artifact
         id: base-nextjs-artifact
-        if: steps.find-base-artifact.outcome == 'success'
+        if: steps.find-base-artifact.outputs.run-id != ''
         continue-on-error: true
         uses: actions/download-artifact@v8
         with:
@@ -310,9 +314,9 @@ jobs:
           mkdir -p /tmp/perf-baseline
           cp site/.perf-results/baseline*.json /tmp/perf-baseline/ 2>/dev/null || true
 
-      # --- Current (PR branch) ---
-      - name: Checkout PR branch
-        run: git checkout -f ${{ github.event.pull_request.head.sha }}
+      # --- Current (merge commit) ---
+      - name: Checkout merge commit
+        run: git checkout -f ${{ github.sha }}
 
       - name: Set up PR environment
         uses: ./.github/workflows/setup

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -246,6 +246,7 @@ jobs:
 
       - name: Find base app artifact
         id: find-base-artifact
+        continue-on-error: true
         uses: actions/github-script@v9
         with:
           script: |


### PR DESCRIPTION
## Motivation

The performance workflow can compare mismatched trees on pull requests. The baseline side may download artifacts from the latest successful `main` run even when that run was for an older commit than the PR base SHA, and the current side checks out the raw PR head while the build artifacts come from GitHub's PR merge commit.

This made the perf comment on #5860 report misleading Tailwind regressions because the baseline source, baseline artifacts, current source, and current artifacts were not all from comparable commits.

## Solution

Require downloaded baseline artifacts to come from a successful `app.yml` run whose `head_sha` matches `github.event.pull_request.base.sha`. If no exact run is available yet, the perf job now builds the base artifacts locally instead of reusing stale artifacts.

The current side now checks out `github.sha`, matching the PR merge commit used by the build jobs that produce the current artifacts.

Validation:

- `git diff --check`
- YAML parse with Ruby
- `pnpm exec prettier --check .github/workflows/app.yml`
- Embedded `github-script` syntax check with Node
- Live GitHub API query confirmed `head_sha` filtering returns the expected base run for #5860