### PR TITLE
Add optional perf profiling

### DIFF
--- a/site/src/test-utils/perf-compare.ts
+++ b/site/src/test-utils/perf-compare.ts
@@ -27,6 +27,7 @@ interface ComparisonRow {
 interface ComparisonSummary {
   rows: ComparisonRow[];
   hasSignificantChanges: boolean;
+  currentResults: PerfResult[];
   newTests: PerfResult[];
   removedTests: PerfResult[];
 }
@@ -87,6 +88,14 @@ function formatDelta(delta: number, percent: number, baseline: number): string {
     return `${sign}${formatMs(delta)}`;
   }
   return `${sign}${formatMs(delta)} (${sign}${percent.toFixed(0)}%)`;
+}
+
+function formatPercent(value: number): string {
+  return `${value.toFixed(0)}%`;
+}
+
+function escapeTableCell(value: string): string {
+  return value.replace(/\|/g, "\\|").replace(/\s+/g, " ").trim();
 }
 
 function resultKey(result: PerfResult): string {
@@ -150,6 +159,7 @@ function compare(): ComparisonSummary {
   return {
     rows,
     hasSignificantChanges: rows.some((r) => r.significant),
+    currentResults: current,
     newTests,
     removedTests,
   };
@@ -189,9 +199,62 @@ function formatSummaryTable(rows: ComparisonRow[], keys: string[]): string[] {
   return lines;
 }
 
+function formatScriptProfile(result: PerfResult): string[] {
+  const profile = result.profiles?.script;
+  if (!profile) return [];
+  if (profile.length === 0) return [];
+
+  const lines: string[] = [];
+  lines.push("#### Script profile");
+  lines.push("");
+  lines.push("| Function | Self | Total | Hits | Source |");
+  lines.push("|----------|------|-------|------|--------|");
+
+  for (const item of profile) {
+    const source = `${item.url}:${item.line}:${item.column}`;
+    lines.push(
+      `| ${escapeTableCell(item.functionName)} | ${formatMs(item.selfTime)} | ${formatMs(item.totalTime)} | ${item.hitCount} | ${escapeTableCell(source)} |`,
+    );
+  }
+
+  lines.push("");
+  return lines;
+}
+
+function formatSelectorProfile(result: PerfResult): string[] {
+  const profile = result.profiles?.selectors;
+  if (!profile) return [];
+  if (profile.length === 0) return [];
+
+  const lines: string[] = [];
+  lines.push("#### Selector profile");
+  lines.push("");
+  lines.push(
+    "| Selector | Elapsed | Attempts | Matches | Slow non-match | Stylesheet |",
+  );
+  lines.push(
+    "|----------|---------|----------|---------|----------------|------------|",
+  );
+
+  for (const item of profile) {
+    lines.push(
+      `| ${escapeTableCell(item.selector)} | ${formatMs(item.elapsed)} | ${item.matchAttempts} | ${item.matchCount} | ${formatPercent(item.slowPathNonMatchPercent)} | ${escapeTableCell(item.styleSheetUrl || item.styleSheetId)} |`,
+    );
+  }
+
+  lines.push("");
+  return lines;
+}
+
+function formatProfiles(result?: PerfResult): string[] {
+  if (!result) return [];
+  return [...formatScriptProfile(result), ...formatSelectorProfile(result)];
+}
+
 function formatDetailedBreakdown(
   rows: ComparisonRow[],
   keys: string[],
+  currentByKey: Map<string, PerfResult>,
 ): string[] {
   const lines: string[] = [];
   for (const key of keys) {
@@ -216,12 +279,23 @@ function formatDetailedBreakdown(
       );
     }
     lines.push("");
+    lines.push(...formatProfiles(currentByKey.get(key)));
   }
   return lines;
 }
 
 function formatMarkdown(summary: ComparisonSummary): string {
-  const { rows, hasSignificantChanges, newTests, removedTests } = summary;
+  const {
+    rows,
+    hasSignificantChanges,
+    currentResults,
+    newTests,
+    removedTests,
+  } = summary;
+  const currentByKey = new Map<string, PerfResult>();
+  for (const result of currentResults) {
+    currentByKey.set(resultKey(result), result);
+  }
 
   const allKeys = [...new Set(rows.map((r) => rowKey(r)))];
   const significantKeys = allKeys.filter((key) =>
@@ -248,7 +322,7 @@ function formatMarkdown(summary: ComparisonSummary): string {
   lines.push(`<details>`);
   lines.push(`<summary>Full breakdown (${totalTests} tests)</summary>`);
   lines.push("");
-  lines.push(...formatDetailedBreakdown(rows, allKeys));
+  lines.push(...formatDetailedBreakdown(rows, allKeys, currentByKey));
 
   if (newTests.length > 0) {
     lines.push("### New tests (no baseline)");
@@ -263,6 +337,14 @@ function formatMarkdown(summary: ComparisonSummary): string {
       lines.push(`| ${cells.join(" | ")} |`);
     }
     lines.push("");
+
+    for (const result of newTests) {
+      const profileLines = formatProfiles(result);
+      if (profileLines.length === 0) continue;
+      lines.push(`#### ${result.label}`);
+      lines.push("");
+      lines.push(...profileLines);
+    }
   }
 
   if (removedTests.length > 0) {

--- a/site/src/test-utils/perf-compare.ts
+++ b/site/src/test-utils/perf-compare.ts
@@ -28,8 +28,25 @@ interface ComparisonSummary {
   rows: ComparisonRow[];
   hasSignificantChanges: boolean;
   currentResults: PerfResult[];
+  profileModeMismatches: ProfileModeMismatch[];
   newTests: PerfResult[];
   removedTests: PerfResult[];
+}
+
+interface PersistedComparisonSummary {
+  rows: ComparisonRow[];
+  hasSignificantChanges: boolean;
+  profileModeMismatches: ProfileModeMismatch[];
+  newTests: PerfResult[];
+  removedTests: PerfResult[];
+}
+
+interface ProfileModeMismatch {
+  testFile: string;
+  label: string;
+  profile: "script" | "selectors";
+  baseline: boolean;
+  current: boolean;
 }
 
 // Primary metrics shown in the summary table.
@@ -95,11 +112,19 @@ function formatPercent(value: number): string {
 }
 
 function escapeTableCell(value: string): string {
-  return value.replace(/\|/g, "\\|").replace(/\s+/g, " ").trim();
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/\|/g, "\\|")
+    .replace(/[\r\n\t]/g, " ")
+    .trim();
 }
 
 function resultKey(result: PerfResult): string {
   return `${result.testFile}::${result.label}`;
+}
+
+function hasProfile(result: PerfResult, profile: "script" | "selectors") {
+  return (result.profiles?.[profile]?.length ?? 0) > 0;
 }
 
 function compare(): ComparisonSummary {
@@ -117,6 +142,7 @@ function compare(): ComparisonSummary {
   }
 
   const rows: ComparisonRow[] = [];
+  const profileModeMismatches: ProfileModeMismatch[] = [];
   const newTests: PerfResult[] = [];
   const removedTests: PerfResult[] = [];
 
@@ -126,6 +152,18 @@ function compare(): ComparisonSummary {
     if (!base) {
       newTests.push(cur);
       continue;
+    }
+    for (const profile of ["script", "selectors"] as const) {
+      const baselineHasProfile = hasProfile(base, profile);
+      const currentHasProfile = hasProfile(cur, profile);
+      if (baselineHasProfile === currentHasProfile) continue;
+      profileModeMismatches.push({
+        testFile: cur.testFile,
+        label: cur.label,
+        profile,
+        baseline: baselineHasProfile,
+        current: currentHasProfile,
+      });
     }
     for (const metric of ALL_METRICS) {
       const baseVal = base.metrics[metric];
@@ -160,6 +198,7 @@ function compare(): ComparisonSummary {
     rows,
     hasSignificantChanges: rows.some((r) => r.significant),
     currentResults: current,
+    profileModeMismatches,
     newTests,
     removedTests,
   };
@@ -251,6 +290,25 @@ function formatProfiles(result?: PerfResult): string[] {
   return [...formatScriptProfile(result), ...formatSelectorProfile(result)];
 }
 
+function formatProfileModeWarning(mismatches: ProfileModeMismatch[]): string[] {
+  if (mismatches.length === 0) return [];
+
+  const lines: string[] = [];
+  lines.push(
+    ":warning: Profile data differs between baseline and current. Run both sides with the same profiling flags before comparing aggregate metrics.",
+  );
+  lines.push("");
+  lines.push("| Test | Profile | Baseline | Current |");
+  lines.push("|------|---------|----------|---------|");
+  for (const mismatch of mismatches) {
+    lines.push(
+      `| ${escapeTableCell(mismatch.label)} | ${mismatch.profile} | ${mismatch.baseline ? "yes" : "no"} | ${mismatch.current ? "yes" : "no"} |`,
+    );
+  }
+  lines.push("");
+  return lines;
+}
+
 function formatDetailedBreakdown(
   rows: ComparisonRow[],
   keys: string[],
@@ -289,6 +347,7 @@ function formatMarkdown(summary: ComparisonSummary): string {
     rows,
     hasSignificantChanges,
     currentResults,
+    profileModeMismatches,
     newTests,
     removedTests,
   } = summary;
@@ -319,6 +378,7 @@ function formatMarkdown(summary: ComparisonSummary): string {
   }
 
   lines.push("");
+  lines.push(...formatProfileModeWarning(profileModeMismatches));
   lines.push(`<details>`);
   lines.push(`<summary>Full breakdown (${totalTests} tests)</summary>`);
   lines.push("");
@@ -366,6 +426,18 @@ function formatMarkdown(summary: ComparisonSummary): string {
   return lines.join("\n");
 }
 
+function toPersistedSummary(
+  summary: ComparisonSummary,
+): PersistedComparisonSummary {
+  return {
+    rows: summary.rows,
+    hasSignificantChanges: summary.hasSignificantChanges,
+    profileModeMismatches: summary.profileModeMismatches,
+    newTests: summary.newTests,
+    removedTests: summary.removedTests,
+  };
+}
+
 // Main
 const summary = compare();
 const markdown = formatMarkdown(summary);
@@ -373,7 +445,7 @@ const markdown = formatMarkdown(summary);
 mkdirSync(RESULTS_DIR, { recursive: true });
 writeFileSync(
   path.join(RESULTS_DIR, "comparison.json"),
-  JSON.stringify(summary, null, 2),
+  JSON.stringify(toPersistedSummary(summary), null, 2),
 );
 writeFileSync(path.join(RESULTS_DIR, "comparison.md"), markdown);
 

--- a/site/src/test-utils/perf.ts
+++ b/site/src/test-utils/perf.ts
@@ -1,10 +1,13 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { CDPSession, Page, TestInfo } from "@playwright/test";
 
 const RESULTS_DIR = path.join(process.cwd(), ".perf-results");
 const DEFAULT_ITERATIONS = 10;
 const DEFAULT_WARMUP = 1;
+const DEFAULT_PROFILE_LIMIT = 10;
+const SCRIPT_PROFILE_INTERVAL = 100;
 const initializedResultFiles = new Set<string>();
 
 // CDP metric names (values are in seconds).
@@ -12,6 +15,21 @@ const SCRIPT_DURATION = "ScriptDuration";
 const LAYOUT_DURATION = "LayoutDuration";
 const RECALC_STYLE_DURATION = "RecalcStyleDuration";
 const PAINTING_DURATION = "PaintingDuration";
+
+const SELECTOR_TRACE_CATEGORIES = [
+  "-*",
+  "devtools.timeline",
+  "disabled-by-default-devtools.timeline",
+  "disabled-by-default-blink.debug",
+  "disabled-by-default-devtools.timeline.invalidationTracking",
+];
+
+const INTERNAL_SCRIPT_FUNCTIONS = new Set([
+  "(garbage collector)",
+  "(idle)",
+  "(program)",
+  "(root)",
+]);
 
 export interface PerfMetrics {
   scripting: number;
@@ -23,6 +41,32 @@ export interface PerfMetrics {
   total: number;
 }
 
+export interface PerfScriptProfileEntry {
+  functionName: string;
+  url: string;
+  line: number;
+  column: number;
+  selfTime: number;
+  totalTime: number;
+  hitCount: number;
+}
+
+export interface PerfSelectorProfileEntry {
+  selector: string;
+  styleSheetId: string;
+  styleSheetUrl: string;
+  elapsed: number;
+  matchAttempts: number;
+  matchCount: number;
+  slowPathNonMatchPercent: number;
+  invalidationCount: number;
+}
+
+export interface PerfProfiles {
+  script?: PerfScriptProfileEntry[];
+  selectors?: PerfSelectorProfileEntry[];
+}
+
 export interface PerfMeasureOptions {
   /** Number of measured iterations (warmup runs are additional). */
   iterations?: number;
@@ -30,6 +74,12 @@ export interface PerfMeasureOptions {
   warmup?: number;
   /** Override the auto-generated label for this measurement. */
   label?: string;
+  /** Collect the most expensive JS functions during measured iterations. */
+  scriptProfile?: boolean;
+  /** Collect the most expensive CSS selectors during measured iterations. */
+  selectorProfile?: boolean;
+  /** Maximum number of profile entries stored per profile type. */
+  profileLimit?: number;
 }
 
 interface CreatePerfMeasureOptions extends PerfMeasureOptions {
@@ -43,6 +93,84 @@ export interface PerfResult {
   label: string;
   metrics: PerfMetrics;
   raw: PerfMetrics[];
+  profiles?: PerfProfiles;
+}
+
+interface CdpCallFrame {
+  functionName: string;
+  scriptId: string;
+  url: string;
+  lineNumber: number;
+  columnNumber: number;
+}
+
+interface CdpProfileNode {
+  id: number;
+  callFrame: CdpCallFrame;
+  hitCount?: number;
+  children?: number[];
+}
+
+interface CdpProfile {
+  nodes: CdpProfileNode[];
+  samples?: number[];
+  timeDeltas?: number[];
+}
+
+interface ProfilerStopResponse {
+  profile: CdpProfile;
+}
+
+interface CssStyleSheetHeader {
+  styleSheetId: string;
+  sourceURL?: string;
+}
+
+interface CssStyleSheetAddedEvent {
+  header: CssStyleSheetHeader;
+}
+
+interface CdpTraceEvent {
+  name?: string;
+  args?: {
+    selector_stats?: {
+      selector_timings?: CdpSelectorTiming[];
+    };
+  };
+}
+
+interface TracingDataCollectedEvent {
+  value?: CdpTraceEvent[];
+}
+
+interface CdpSelectorTiming {
+  "elapsed (us)": number;
+  fast_reject_count?: number;
+  match_attempts?: number;
+  selector?: string;
+  style_sheet_id?: string;
+  match_count?: number;
+  invalidation_count?: number;
+}
+
+interface SelectorTraceSession {
+  stop: () => Promise<PerfSelectorProfileEntry[]>;
+}
+
+interface MeasureOnceOptions {
+  scriptProfile: boolean;
+  selectorProfile: boolean;
+  profileLimit: number;
+  styleSheetUrls: Map<string, string>;
+}
+
+interface MeasureOnceResult {
+  metrics: PerfMetrics;
+  profiles?: PerfProfiles;
+}
+
+interface MutableSelectorProfileEntry extends PerfSelectorProfileEntry {
+  fastRejectCount: number;
 }
 
 function getMetricValue(
@@ -78,6 +206,330 @@ function computeMedianMetrics(all: PerfMetrics[]): PerfMetrics {
   };
 }
 
+function isTruthyEnv(name: string): boolean {
+  return process.env[name] === "true" || process.env[name] === "1";
+}
+
+function normalizeProfileUrl(url: string): string {
+  try {
+    const parsedUrl = new URL(url);
+    if (parsedUrl.protocol === "file:") {
+      return path.relative(process.cwd(), fileURLToPath(parsedUrl));
+    }
+    return `${parsedUrl.pathname}${parsedUrl.search}`;
+  } catch {
+    return url;
+  }
+}
+
+function shouldIncludeScriptFrame(callFrame: CdpCallFrame): boolean {
+  if (!callFrame.url) return false;
+  if (INTERNAL_SCRIPT_FUNCTIONS.has(callFrame.functionName)) return false;
+  if (callFrame.url.startsWith("node:")) return false;
+  if (callFrame.url.startsWith("chrome:")) return false;
+  if (callFrame.url.startsWith("chrome-extension:")) return false;
+  if (callFrame.url.includes("__playwright_evaluation_script__")) {
+    return false;
+  }
+  return true;
+}
+
+function scriptProfileKey(callFrame: CdpCallFrame): string {
+  return [
+    callFrame.functionName || "(anonymous)",
+    callFrame.url,
+    callFrame.lineNumber,
+    callFrame.columnNumber,
+  ].join("\0");
+}
+
+function getScriptProfileEntry(
+  entries: Map<string, PerfScriptProfileEntry>,
+  callFrame: CdpCallFrame,
+) {
+  const key = scriptProfileKey(callFrame);
+  const existingEntry = entries.get(key);
+  if (existingEntry) {
+    return existingEntry;
+  }
+
+  const entry: PerfScriptProfileEntry = {
+    functionName: callFrame.functionName || "(anonymous)",
+    url: normalizeProfileUrl(callFrame.url),
+    line: callFrame.lineNumber + 1,
+    column: callFrame.columnNumber + 1,
+    selfTime: 0,
+    totalTime: 0,
+    hitCount: 0,
+  };
+  entries.set(key, entry);
+  return entry;
+}
+
+function parseScriptProfile(
+  profile: CdpProfile,
+  limit: number,
+): PerfScriptProfileEntry[] {
+  const nodes = new Map<number, CdpProfileNode>();
+  const parents = new Map<number, number>();
+
+  for (const node of profile.nodes) {
+    nodes.set(node.id, node);
+    for (const childId of node.children ?? []) {
+      parents.set(childId, node.id);
+    }
+  }
+
+  const entries = new Map<string, PerfScriptProfileEntry>();
+  const samples = profile.samples ?? [];
+  const timeDeltas = profile.timeDeltas ?? [];
+
+  for (let sampleIndex = 0; sampleIndex < samples.length; sampleIndex++) {
+    const sampleId = samples[sampleIndex];
+    if (sampleId == null) continue;
+
+    const timeDelta = timeDeltas[sampleIndex] ?? 0;
+    const timeMs = timeDelta / 1000;
+    const sampleNode = nodes.get(sampleId);
+    if (!sampleNode) continue;
+
+    if (shouldIncludeScriptFrame(sampleNode.callFrame)) {
+      const entry = getScriptProfileEntry(entries, sampleNode.callFrame);
+      entry.selfTime += timeMs;
+      entry.hitCount += 1;
+    }
+
+    let currentNode: CdpProfileNode | undefined = sampleNode;
+    while (currentNode) {
+      if (shouldIncludeScriptFrame(currentNode.callFrame)) {
+        const entry = getScriptProfileEntry(entries, currentNode.callFrame);
+        entry.totalTime += timeMs;
+      }
+      const parentId = parents.get(currentNode.id);
+      if (parentId == null) break;
+      currentNode = nodes.get(parentId);
+    }
+  }
+
+  return [...entries.values()]
+    .sort((a, b) => b.selfTime - a.selfTime || b.totalTime - a.totalTime)
+    .slice(0, limit);
+}
+
+function selectorProfileKey(timing: CdpSelectorTiming): string {
+  return `${timing.style_sheet_id ?? ""}\0${timing.selector ?? ""}`;
+}
+
+function getSelectorProfileEntry(
+  entries: Map<string, MutableSelectorProfileEntry>,
+  timing: CdpSelectorTiming,
+  styleSheetUrls: Map<string, string>,
+) {
+  const key = selectorProfileKey(timing);
+  const existingEntry = entries.get(key);
+  if (existingEntry) {
+    return existingEntry;
+  }
+
+  const styleSheetId = timing.style_sheet_id ?? "";
+  const entry: MutableSelectorProfileEntry = {
+    selector: timing.selector ?? "",
+    styleSheetId,
+    styleSheetUrl: normalizeProfileUrl(styleSheetUrls.get(styleSheetId) ?? ""),
+    elapsed: 0,
+    matchAttempts: 0,
+    matchCount: 0,
+    slowPathNonMatchPercent: 0,
+    invalidationCount: 0,
+    fastRejectCount: 0,
+  };
+  entries.set(key, entry);
+  return entry;
+}
+
+function parseSelectorTrace(
+  events: CdpTraceEvent[],
+  styleSheetUrls: Map<string, string>,
+  limit: number,
+): PerfSelectorProfileEntry[] {
+  const entries = new Map<string, MutableSelectorProfileEntry>();
+
+  for (const event of events) {
+    if (event.name !== "SelectorStats") continue;
+
+    const timings = event.args?.selector_stats?.selector_timings ?? [];
+    for (const timing of timings) {
+      if (!timing.selector) continue;
+      if (timing.style_sheet_id === "ua-style-sheet") continue;
+
+      const entry = getSelectorProfileEntry(entries, timing, styleSheetUrls);
+      entry.elapsed += timing["elapsed (us)"] / 1000;
+      entry.matchAttempts += timing.match_attempts ?? 0;
+      entry.matchCount += timing.match_count ?? 0;
+      entry.fastRejectCount += timing.fast_reject_count ?? 0;
+      entry.invalidationCount += timing.invalidation_count ?? 0;
+    }
+  }
+
+  for (const entry of entries.values()) {
+    const slowPathNonMatches = Math.max(
+      0,
+      entry.matchAttempts - entry.matchCount - entry.fastRejectCount,
+    );
+    entry.slowPathNonMatchPercent =
+      entry.matchAttempts > 0
+        ? (slowPathNonMatches / entry.matchAttempts) * 100
+        : 0;
+  }
+
+  return [...entries.values()]
+    .sort((a, b) => b.elapsed - a.elapsed)
+    .slice(0, limit)
+    .map((entry) => ({
+      selector: entry.selector,
+      styleSheetId: entry.styleSheetId,
+      styleSheetUrl: entry.styleSheetUrl,
+      elapsed: entry.elapsed,
+      matchAttempts: entry.matchAttempts,
+      matchCount: entry.matchCount,
+      slowPathNonMatchPercent: entry.slowPathNonMatchPercent,
+      invalidationCount: entry.invalidationCount,
+    }));
+}
+
+async function startSelectorTrace(
+  cdp: CDPSession,
+  styleSheetUrls: Map<string, string>,
+  limit: number,
+): Promise<SelectorTraceSession> {
+  const events: CdpTraceEvent[] = [];
+  let resolveTracingComplete: () => void = () => {};
+  const tracingComplete = new Promise<void>((resolve) => {
+    resolveTracingComplete = resolve;
+  });
+
+  const onDataCollected = (event: TracingDataCollectedEvent) => {
+    events.push(...(event.value ?? []));
+  };
+
+  const onTracingComplete = () => {
+    resolveTracingComplete();
+  };
+
+  cdp.on("Tracing.dataCollected", onDataCollected);
+  cdp.on("Tracing.tracingComplete", onTracingComplete);
+
+  try {
+    await cdp.send("Tracing.start", {
+      categories: SELECTOR_TRACE_CATEGORIES.join(","),
+      transferMode: "ReportEvents",
+    });
+  } catch (error) {
+    cdp.off("Tracing.dataCollected", onDataCollected);
+    cdp.off("Tracing.tracingComplete", onTracingComplete);
+    throw error;
+  }
+
+  return {
+    stop: async () => {
+      try {
+        await cdp.send("Tracing.end");
+        await tracingComplete;
+        return parseSelectorTrace(events, styleSheetUrls, limit);
+      } finally {
+        cdp.off("Tracing.dataCollected", onDataCollected);
+        cdp.off("Tracing.tracingComplete", onTracingComplete);
+      }
+    },
+  };
+}
+
+function mergeScriptProfiles(
+  profiles: PerfScriptProfileEntry[][],
+  limit: number,
+): PerfScriptProfileEntry[] {
+  const entries = new Map<string, PerfScriptProfileEntry>();
+
+  for (const profile of profiles) {
+    for (const item of profile) {
+      const key = [item.functionName, item.url, item.line, item.column].join(
+        "\0",
+      );
+      const existingItem = entries.get(key);
+      if (existingItem) {
+        existingItem.selfTime += item.selfTime;
+        existingItem.totalTime += item.totalTime;
+        existingItem.hitCount += item.hitCount;
+        continue;
+      }
+      entries.set(key, { ...item });
+    }
+  }
+
+  return [...entries.values()]
+    .sort((a, b) => b.selfTime - a.selfTime || b.totalTime - a.totalTime)
+    .slice(0, limit);
+}
+
+function mergeSelectorProfiles(
+  profiles: PerfSelectorProfileEntry[][],
+  limit: number,
+): PerfSelectorProfileEntry[] {
+  const entries = new Map<string, PerfSelectorProfileEntry>();
+
+  for (const profile of profiles) {
+    for (const item of profile) {
+      const key = `${item.styleSheetId}\0${item.selector}`;
+      const existingItem = entries.get(key);
+      if (existingItem) {
+        existingItem.elapsed += item.elapsed;
+        existingItem.matchAttempts += item.matchAttempts;
+        existingItem.matchCount += item.matchCount;
+        existingItem.invalidationCount += item.invalidationCount;
+        continue;
+      }
+      entries.set(key, { ...item });
+    }
+  }
+
+  for (const item of entries.values()) {
+    const originalItems = profiles.flatMap((profile) =>
+      profile.filter(
+        (entry) =>
+          entry.styleSheetId === item.styleSheetId &&
+          entry.selector === item.selector,
+      ),
+    );
+    const weightedSlowPathNonMatches = originalItems.reduce((sum, entry) => {
+      return sum + entry.matchAttempts * entry.slowPathNonMatchPercent;
+    }, 0);
+    item.slowPathNonMatchPercent =
+      item.matchAttempts > 0
+        ? weightedSlowPathNonMatches / item.matchAttempts
+        : 0;
+  }
+
+  return [...entries.values()]
+    .sort((a, b) => b.elapsed - a.elapsed)
+    .slice(0, limit);
+}
+
+function createProfiles(
+  scriptProfiles: PerfScriptProfileEntry[][],
+  selectorProfiles: PerfSelectorProfileEntry[][],
+  limit: number,
+): PerfProfiles | undefined {
+  const profiles: PerfProfiles = {};
+  if (scriptProfiles.length > 0) {
+    profiles.script = mergeScriptProfiles(scriptProfiles, limit);
+  }
+  if (selectorProfiles.length > 0) {
+    profiles.selectors = mergeSelectorProfiles(selectorProfiles, limit);
+  }
+  if (!profiles.script && !profiles.selectors) return;
+  return profiles;
+}
+
 /**
  * Runs a single interaction measurement cycle: snapshot CDP metrics before and
  * after the interaction, collect INP entries, and return the deltas.
@@ -86,7 +538,8 @@ async function measureOnce(
   page: Page,
   cdp: CDPSession,
   interaction: () => Promise<void>,
-): Promise<PerfMetrics> {
+  options: MeasureOnceOptions,
+): Promise<MeasureOnceResult> {
   // Install INP observer before the interaction.
   await page.evaluate(() => {
     const w = window as any;
@@ -103,19 +556,62 @@ async function measureOnce(
   });
 
   const before = await cdp.send("Performance.getMetrics");
+  const selectorTrace = options.selectorProfile
+    ? await startSelectorTrace(
+        cdp,
+        options.styleSheetUrls,
+        options.profileLimit,
+      )
+    : undefined;
 
-  await interaction();
+  if (options.scriptProfile) {
+    await cdp.send("Profiler.start");
+  }
 
-  // Let paint and layout settle.
-  await page.evaluate(
-    () =>
-      new Promise<void>((resolve) => {
-        requestAnimationFrame(() => {
-          requestAnimationFrame(() => resolve());
-        });
-      }),
-  );
-  await page.waitForTimeout(50);
+  let interactionError: unknown;
+
+  try {
+    await interaction();
+
+    // Let paint and layout settle.
+    await page.evaluate(
+      () =>
+        new Promise<void>((resolve) => {
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => resolve());
+          });
+        }),
+    );
+    await page.waitForTimeout(50);
+  } catch (error) {
+    interactionError = error;
+  }
+
+  const profiles: PerfProfiles = {};
+
+  try {
+    if (options.scriptProfile) {
+      const response: ProfilerStopResponse = await cdp.send("Profiler.stop");
+      profiles.script = parseScriptProfile(
+        response.profile,
+        options.profileLimit,
+      );
+    }
+  } finally {
+    if (selectorTrace) {
+      profiles.selectors = await selectorTrace.stop();
+    }
+  }
+
+  if (interactionError) {
+    await page.evaluate(() => {
+      const w = window as any;
+      if (w.__perfObserver) {
+        w.__perfObserver.disconnect();
+      }
+    });
+    throw interactionError;
+  }
 
   const after = await cdp.send("Performance.getMetrics");
 
@@ -146,7 +642,20 @@ async function measureOnce(
   const inp = inpValues.length > 0 ? Math.max(...inpValues) : 0;
   const total = scripting + rendering;
 
-  return { scripting, layout, styleRecalc, painting, rendering, inp, total };
+  const metrics = {
+    scripting,
+    layout,
+    styleRecalc,
+    painting,
+    rendering,
+    inp,
+    total,
+  };
+
+  return {
+    metrics,
+    profiles: profiles.script || profiles.selectors ? profiles : undefined,
+  };
 }
 
 /**
@@ -166,7 +675,14 @@ export async function createPerfMeasure(
     warmup = DEFAULT_WARMUP,
     resetPage = true,
     label,
+    profileLimit = DEFAULT_PROFILE_LIMIT,
   } = options;
+  const scriptProfile =
+    options.scriptProfile ?? isTruthyEnv("PERF_SCRIPT_PROFILE");
+  const selectorProfile =
+    options.selectorProfile ??
+    (isTruthyEnv("PERF_SELECTOR_PROFILE") ||
+      isTruthyEnv("PERF_CSS_SELECTOR_PROFILE"));
 
   if (!Number.isInteger(iterations) || iterations <= 0) {
     throw new Error(`Invalid perf iterations: ${iterations}`);
@@ -174,13 +690,35 @@ export async function createPerfMeasure(
   if (!Number.isInteger(warmup) || warmup < 0) {
     throw new Error(`Invalid perf warmup: ${warmup}`);
   }
+  if (!Number.isInteger(profileLimit) || profileLimit <= 0) {
+    throw new Error(`Invalid perf profile limit: ${profileLimit}`);
+  }
 
   const cdp = await page.context().newCDPSession(page);
   await cdp.send("Performance.enable");
 
   const allMetrics: PerfMetrics[] = [];
+  const scriptProfiles: PerfScriptProfileEntry[][] = [];
+  const selectorProfiles: PerfSelectorProfileEntry[][] = [];
+  const styleSheetUrls = new Map<string, string>();
+  const onStyleSheetAdded = (event: CssStyleSheetAddedEvent) => {
+    const { styleSheetId, sourceURL = "" } = event.header;
+    styleSheetUrls.set(styleSheetId, sourceURL);
+  };
 
   try {
+    if (scriptProfile) {
+      await cdp.send("Profiler.enable");
+      await cdp.send("Profiler.setSamplingInterval", {
+        interval: SCRIPT_PROFILE_INTERVAL,
+      });
+    }
+    if (selectorProfile) {
+      cdp.on("CSS.styleSheetAdded", onStyleSheetAdded);
+      await cdp.send("DOM.enable");
+      await cdp.send("CSS.enable");
+    }
+
     const url = page.url();
 
     for (let i = 0; i < warmup + iterations; i++) {
@@ -189,14 +727,29 @@ export async function createPerfMeasure(
         await page.goto(url, { waitUntil: "networkidle" });
       }
 
-      const metrics = await measureOnce(page, cdp, interaction);
+      const result = await measureOnce(page, cdp, interaction, {
+        scriptProfile,
+        selectorProfile,
+        profileLimit,
+        styleSheetUrls,
+      });
 
       // Only keep measured (non-warmup) iterations.
       if (i >= warmup) {
-        allMetrics.push(metrics);
+        allMetrics.push(result.metrics);
+        if (result.profiles?.script) {
+          scriptProfiles.push(result.profiles.script);
+        }
+        if (result.profiles?.selectors) {
+          selectorProfiles.push(result.profiles.selectors);
+        }
       }
     }
   } finally {
+    cdp.off("CSS.styleSheetAdded", onStyleSheetAdded);
+    await cdp.send("Profiler.disable").catch(() => {});
+    await cdp.send("CSS.disable").catch(() => {});
+    await cdp.send("DOM.disable").catch(() => {});
     await cdp.send("Performance.disable").catch(() => {});
     await cdp.detach().catch(() => {});
   }
@@ -217,6 +770,7 @@ export async function createPerfMeasure(
     label: resolvedLabel,
     metrics: medianMetrics,
     raw: allMetrics,
+    profiles: createProfiles(scriptProfiles, selectorProfiles, profileLimit),
   });
 
   return medianMetrics;

--- a/site/src/test-utils/perf.ts
+++ b/site/src/test-utils/perf.ts
@@ -7,7 +7,6 @@ const RESULTS_DIR = path.join(process.cwd(), ".perf-results");
 const DEFAULT_ITERATIONS = 10;
 const DEFAULT_WARMUP = 1;
 const DEFAULT_PROFILE_LIMIT = 10;
-const SCRIPT_PROFILE_INTERVAL = 100;
 const initializedResultFiles = new Set<string>();
 
 // CDP metric names (values are in seconds).
@@ -74,9 +73,9 @@ export interface PerfMeasureOptions {
   warmup?: number;
   /** Override the auto-generated label for this measurement. */
   label?: string;
-  /** Collect the most expensive JS functions during measured iterations. */
+  /** Collect expensive JS functions. Adds overhead to measured metrics. */
   scriptProfile?: boolean;
-  /** Collect the most expensive CSS selectors during measured iterations. */
+  /** Collect expensive CSS selectors. Adds overhead to measured metrics. */
   selectorProfile?: boolean;
   /** Maximum number of profile entries stored per profile type. */
   profileLimit?: number;
@@ -160,7 +159,6 @@ interface SelectorTraceSession {
 interface MeasureOnceOptions {
   scriptProfile: boolean;
   selectorProfile: boolean;
-  profileLimit: number;
   styleSheetUrls: Map<string, string>;
 }
 
@@ -171,6 +169,14 @@ interface MeasureOnceResult {
 
 interface MutableSelectorProfileEntry extends PerfSelectorProfileEntry {
   fastRejectCount: number;
+}
+
+interface SelectorProfileAccumulator extends PerfSelectorProfileEntry {
+  weightedSlowPathSum: number;
+}
+
+interface MetricsResponse {
+  metrics: Array<{ name: string; value: number }>;
 }
 
 function getMetricValue(
@@ -266,10 +272,7 @@ function getScriptProfileEntry(
   return entry;
 }
 
-function parseScriptProfile(
-  profile: CdpProfile,
-  limit: number,
-): PerfScriptProfileEntry[] {
+function parseScriptProfile(profile: CdpProfile): PerfScriptProfileEntry[] {
   const nodes = new Map<number, CdpProfileNode>();
   const parents = new Map<number, number>();
 
@@ -311,9 +314,9 @@ function parseScriptProfile(
     }
   }
 
-  return [...entries.values()]
-    .sort((a, b) => b.selfTime - a.selfTime || b.totalTime - a.totalTime)
-    .slice(0, limit);
+  return [...entries.values()].sort(
+    (a, b) => b.selfTime - a.selfTime || b.totalTime - a.totalTime,
+  );
 }
 
 function selectorProfileKey(timing: CdpSelectorTiming): string {
@@ -350,7 +353,6 @@ function getSelectorProfileEntry(
 function parseSelectorTrace(
   events: CdpTraceEvent[],
   styleSheetUrls: Map<string, string>,
-  limit: number,
 ): PerfSelectorProfileEntry[] {
   const entries = new Map<string, MutableSelectorProfileEntry>();
 
@@ -384,7 +386,6 @@ function parseSelectorTrace(
 
   return [...entries.values()]
     .sort((a, b) => b.elapsed - a.elapsed)
-    .slice(0, limit)
     .map((entry) => ({
       selector: entry.selector,
       styleSheetId: entry.styleSheetId,
@@ -400,7 +401,6 @@ function parseSelectorTrace(
 async function startSelectorTrace(
   cdp: CDPSession,
   styleSheetUrls: Map<string, string>,
-  limit: number,
 ): Promise<SelectorTraceSession> {
   const events: CdpTraceEvent[] = [];
   let resolveTracingComplete: () => void = () => {};
@@ -435,7 +435,7 @@ async function startSelectorTrace(
       try {
         await cdp.send("Tracing.end");
         await tracingComplete;
-        return parseSelectorTrace(events, styleSheetUrls, limit);
+        return parseSelectorTrace(events, styleSheetUrls);
       } finally {
         cdp.off("Tracing.dataCollected", onDataCollected);
         cdp.off("Tracing.tracingComplete", onTracingComplete);
@@ -475,43 +475,41 @@ function mergeSelectorProfiles(
   profiles: PerfSelectorProfileEntry[][],
   limit: number,
 ): PerfSelectorProfileEntry[] {
-  const entries = new Map<string, PerfSelectorProfileEntry>();
+  const entries = new Map<string, SelectorProfileAccumulator>();
 
   for (const profile of profiles) {
     for (const item of profile) {
       const key = `${item.styleSheetId}\0${item.selector}`;
+      const weightedSlowPathSum =
+        item.matchAttempts * item.slowPathNonMatchPercent;
       const existingItem = entries.get(key);
       if (existingItem) {
         existingItem.elapsed += item.elapsed;
         existingItem.matchAttempts += item.matchAttempts;
         existingItem.matchCount += item.matchCount;
         existingItem.invalidationCount += item.invalidationCount;
+        existingItem.weightedSlowPathSum += weightedSlowPathSum;
         continue;
       }
-      entries.set(key, { ...item });
+      entries.set(key, { ...item, weightedSlowPathSum });
     }
-  }
-
-  for (const item of entries.values()) {
-    const originalItems = profiles.flatMap((profile) =>
-      profile.filter(
-        (entry) =>
-          entry.styleSheetId === item.styleSheetId &&
-          entry.selector === item.selector,
-      ),
-    );
-    const weightedSlowPathNonMatches = originalItems.reduce((sum, entry) => {
-      return sum + entry.matchAttempts * entry.slowPathNonMatchPercent;
-    }, 0);
-    item.slowPathNonMatchPercent =
-      item.matchAttempts > 0
-        ? weightedSlowPathNonMatches / item.matchAttempts
-        : 0;
   }
 
   return [...entries.values()]
     .sort((a, b) => b.elapsed - a.elapsed)
-    .slice(0, limit);
+    .slice(0, limit)
+    .map(({ weightedSlowPathSum, ...item }) => ({
+      ...item,
+      slowPathNonMatchPercent:
+        item.matchAttempts > 0 ? weightedSlowPathSum / item.matchAttempts : 0,
+    }));
+}
+
+function hasProfileEntries(profiles: PerfProfiles): boolean {
+  return (
+    (profiles.script != null && profiles.script.length > 0) ||
+    (profiles.selectors != null && profiles.selectors.length > 0)
+  );
 }
 
 function createProfiles(
@@ -521,13 +519,40 @@ function createProfiles(
 ): PerfProfiles | undefined {
   const profiles: PerfProfiles = {};
   if (scriptProfiles.length > 0) {
-    profiles.script = mergeScriptProfiles(scriptProfiles, limit);
+    const script = mergeScriptProfiles(scriptProfiles, limit);
+    if (script.length > 0) {
+      profiles.script = script;
+    }
   }
   if (selectorProfiles.length > 0) {
-    profiles.selectors = mergeSelectorProfiles(selectorProfiles, limit);
+    const selectors = mergeSelectorProfiles(selectorProfiles, limit);
+    if (selectors.length > 0) {
+      profiles.selectors = selectors;
+    }
   }
-  if (!profiles.script && !profiles.selectors) return;
+  if (!hasProfileEntries(profiles)) return;
   return profiles;
+}
+
+async function disconnectPerfObserver(page: Page) {
+  await page
+    .evaluate(() => {
+      const w = window as any;
+      if (w.__perfObserver) {
+        w.__perfObserver.disconnect();
+      }
+    })
+    .catch(() => {});
+}
+
+async function collectInpValues(page: Page): Promise<number[]> {
+  return page.evaluate(() => {
+    const w = window as any;
+    if (w.__perfObserver) {
+      w.__perfObserver.disconnect();
+    }
+    return w.__perfInpEntries ?? [];
+  });
 }
 
 /**
@@ -555,22 +580,23 @@ async function measureOnce(
     w.__perfObserver = observer;
   });
 
-  const before = await cdp.send("Performance.getMetrics");
-  const selectorTrace = options.selectorProfile
-    ? await startSelectorTrace(
-        cdp,
-        options.styleSheetUrls,
-        options.profileLimit,
-      )
-    : undefined;
-
-  if (options.scriptProfile) {
-    await cdp.send("Profiler.start");
-  }
-
-  let interactionError: unknown;
+  let before: MetricsResponse | undefined;
+  let selectorTrace: SelectorTraceSession | undefined;
+  let scriptProfilerStarted = false;
+  let measureError: unknown;
+  let profilingError: unknown;
+  const profiles: PerfProfiles = {};
 
   try {
+    before = await cdp.send("Performance.getMetrics");
+    if (options.selectorProfile) {
+      selectorTrace = await startSelectorTrace(cdp, options.styleSheetUrls);
+    }
+    if (options.scriptProfile) {
+      await cdp.send("Profiler.start");
+      scriptProfilerStarted = true;
+    }
+
     await interaction();
 
     // Let paint and layout settle.
@@ -584,45 +610,51 @@ async function measureOnce(
     );
     await page.waitForTimeout(50);
   } catch (error) {
-    interactionError = error;
+    measureError = error;
   }
 
-  const profiles: PerfProfiles = {};
+  if (scriptProfilerStarted) {
+    try {
+      const response: ProfilerStopResponse = await cdp.send("Profiler.stop");
+      profiles.script = parseScriptProfile(response.profile);
+    } catch (error) {
+      profilingError = error;
+    }
+  }
+
+  if (selectorTrace) {
+    try {
+      profiles.selectors = await selectorTrace.stop();
+    } catch (error) {
+      profilingError ??= error;
+    }
+  }
+
+  if (measureError) {
+    await disconnectPerfObserver(page);
+    throw measureError;
+  }
+
+  if (profilingError) {
+    await disconnectPerfObserver(page);
+    throw profilingError;
+  }
+
+  if (!before) {
+    await disconnectPerfObserver(page);
+    throw new Error("Missing perf metrics snapshot.");
+  }
+
+  let after: MetricsResponse;
+  let inpValues: number[];
 
   try {
-    if (options.scriptProfile) {
-      const response: ProfilerStopResponse = await cdp.send("Profiler.stop");
-      profiles.script = parseScriptProfile(
-        response.profile,
-        options.profileLimit,
-      );
-    }
-  } finally {
-    if (selectorTrace) {
-      profiles.selectors = await selectorTrace.stop();
-    }
+    after = await cdp.send("Performance.getMetrics");
+    inpValues = await collectInpValues(page);
+  } catch (error) {
+    await disconnectPerfObserver(page);
+    throw error;
   }
-
-  if (interactionError) {
-    await page.evaluate(() => {
-      const w = window as any;
-      if (w.__perfObserver) {
-        w.__perfObserver.disconnect();
-      }
-    });
-    throw interactionError;
-  }
-
-  const after = await cdp.send("Performance.getMetrics");
-
-  // Collect INP entries and disconnect the observer.
-  const inpValues: number[] = await page.evaluate(() => {
-    const w = window as any;
-    if (w.__perfObserver) {
-      w.__perfObserver.disconnect();
-    }
-    return w.__perfInpEntries ?? [];
-  });
 
   const scriptBefore = getMetricValue(before.metrics, SCRIPT_DURATION);
   const scriptAfter = getMetricValue(after.metrics, SCRIPT_DURATION);
@@ -654,7 +686,7 @@ async function measureOnce(
 
   return {
     metrics,
-    profiles: profiles.script || profiles.selectors ? profiles : undefined,
+    profiles: hasProfileEntries(profiles) ? profiles : undefined,
   };
 }
 
@@ -709,9 +741,6 @@ export async function createPerfMeasure(
   try {
     if (scriptProfile) {
       await cdp.send("Profiler.enable");
-      await cdp.send("Profiler.setSamplingInterval", {
-        interval: SCRIPT_PROFILE_INTERVAL,
-      });
     }
     if (selectorProfile) {
       cdp.on("CSS.styleSheetAdded", onStyleSheetAdded);
@@ -730,17 +759,19 @@ export async function createPerfMeasure(
       const result = await measureOnce(page, cdp, interaction, {
         scriptProfile,
         selectorProfile,
-        profileLimit,
         styleSheetUrls,
       });
 
       // Only keep measured (non-warmup) iterations.
       if (i >= warmup) {
         allMetrics.push(result.metrics);
-        if (result.profiles?.script) {
+        if (result.profiles?.script && result.profiles.script.length > 0) {
           scriptProfiles.push(result.profiles.script);
         }
-        if (result.profiles?.selectors) {
+        if (
+          result.profiles?.selectors &&
+          result.profiles.selectors.length > 0
+        ) {
           selectorProfiles.push(result.profiles.selectors);
         }
       }


### PR DESCRIPTION
## Motivation

The current perf harness reports aggregate scripting and rendering timings, but it does not help identify which JavaScript functions or CSS selectors contributed to a slow measured render. That makes regressions harder to investigate after `test-perf` flags a scripting or style recalculation change.

## Solution

Add optional profiling to `site/src/test-utils/perf.ts` without changing the default perf path:

- `scriptProfile` / `PERF_SCRIPT_PROFILE=true` records a CDP CPU profile around each measured interaction and stores the top JavaScript functions by self time.
- `selectorProfile` / `PERF_SELECTOR_PROFILE=true` or `PERF_CSS_SELECTOR_PROFILE=true` records Chrome selector stats tracing and stores the top codebase CSS selectors by elapsed matching time.
- `profileLimit` controls how many entries are retained per profile type.

The collected profiles are stored under each perf result's `profiles` field and `perf-compare` now renders script and selector profile tables in the full breakdown when profile data is present.

## Verification

- `pnpm lint-fix`
- `pnpm exec oxlint site/src/test-utils/perf.ts site/src/test-utils/perf-compare.ts`
- `pnpm -F site exec tsc --noEmit --ignoreConfig --pretty false --target es2018 --module nodenext --moduleResolution nodenext --types node --lib DOM,ESNext --strict --noUncheckedIndexedAccess --allowImportingTsExtensions src/test-utils/perf.ts src/test-utils/perf-compare.ts`
- `pnpm -F site run perf-compare`
- Browser smoke test with both `scriptProfile` and `selectorProfile` enabled against a synthetic page, verifying both JS function and CSS selector entries are captured.