### PR TITLE
Add Ariakit Tailwind explicit longhands

### DIFF
--- a/packages/ariakit-tailwind/migrating-to-v02.md
+++ b/packages/ariakit-tailwind/migrating-to-v02.md
@@ -120,25 +120,13 @@ The overloaded `ak-layer-*` shorthand also still accepts typed custom properties
 <div class="ak-layer ak-layer-(color:--my-color)"></div>
 ```
 
-### `ak-layer-(number:--var)` → `ak-layer ak-layer-offset-(--var)`
+### `ak-layer-pop-(--var)` → `ak-layer ak-layer-offset-(--var)`
 
-Custom lightness offsets can use the explicit offset longhand. The custom property keeps the same `0`–`100` scale as `ak-layer-<number>`.
+Custom pop values can use the explicit offset longhand.
 
 ```diff
-- ak-layer-(number:--depth)
+- ak-layer-pop-(--depth)
 + ak-layer ak-layer-offset-(--depth)
-```
-
-### Lightness bounds custom properties
-
-Use explicit `-l-` longhands for lightness min/max custom properties. Custom properties keep the same `0`–`100` scale as numeric lightness utilities.
-
-```diff
-- ak-layer-max-(number:--max-lightness)
-+ ak-layer-max-l-(--max-lightness)
-
-- ak-layer-min-(number:--min-lightness)
-+ ak-layer-min-l-(--min-lightness)
 ```
 
 ### Variant prefixes on modifier classes
@@ -273,11 +261,11 @@ For custom push values, use `ak-text-push-(--value)` instead of `ak-text-(number
 + ak-edge-15
 ```
 
-### `ak-edge-(--color)/N` → `ak-edge-color-(--color) ak-edge-alpha-N`
+### `ak-edge-(--color)/N` → `ak-edge-color-(--color) ak-edge-N`
 
 ```diff
 - ak-edge-(--my-color)/10
-+ ak-edge-color-(--my-color) ak-edge-alpha-10
++ ak-edge-color-(--my-color) ak-edge-10
 ```
 
 ### `ak-edge-contrast-primary` → `ak-edge-primary ak-edge-raw`
@@ -289,7 +277,7 @@ In v0.1, `ak-edge-contrast-<color>` set the edge to a solid color with lightness
 + ak-edge-primary ak-edge-raw
 ```
 
-`ak-edge-raw` is shorthand for `ak-edge-100 ak-edge-push-0` — use it when you want the color to be applied exactly as specified. For other combinations, `ak-edge-N` or `ak-edge-alpha-N` controls alpha (`100` = opaque) and `ak-edge-push-N` controls how far the edge lightness is pushed away from the layer (`0` = the color's natural lightness).
+`ak-edge-raw` is shorthand for `ak-edge-100 ak-edge-push-0` — use it when you want the color to be applied exactly as specified. For other combinations, `ak-edge-N` controls alpha (`100` = opaque) and `ak-edge-push-N` controls how far the edge lightness is pushed away from the layer (`0` = the color's natural lightness).
 
 For custom alpha values, use `ak-edge-alpha-(--alpha)` instead of `ak-edge-(number:--alpha)`.
 
@@ -416,21 +404,6 @@ When overriding a compound utility's frame token (e.g., `ak-button` + `ak-frame-
 ```diff
 - ak-outline-primary
 + ak-outline ak-outline-primary
-```
-
-### Outline custom properties
-
-Use explicit longhands for custom outline color, push, and lightness bounds. Numeric custom properties keep the same `0`–`100` scale as the shorthand utilities.
-
-```diff
-- ak-outline-(color:--outline-color)
-+ ak-outline-color-(--outline-color)
-
-- ak-outline-(number:--outline-push)
-+ ak-outline-push-(--outline-push)
-
-- ak-outline-max-(number:--outline-max-lightness)
-+ ak-outline-max-l-(--outline-max-lightness)
 ```
 
 ---

--- a/packages/ariakit-tailwind/migrating-to-v02.md
+++ b/packages/ariakit-tailwind/migrating-to-v02.md
@@ -6,7 +6,7 @@ This guide covers all breaking changes for users of the `@ariakit/tailwind` plug
 
 1. **Explicit base classes.** Utilities like `ak-layer`, `ak-frame`, `ak-text`, and `ak-outline` must now appear as base classes before their modifiers.
 2. **Slash to hyphen.** Opacity/value syntax changes from `/N` to `-N`. Text opacity moves from `ak-text/80` to `ak-ink-80`.
-3. **`color:` prefix for custom properties.** Custom CSS variable colors now use `(color:--var)` instead of `(--var)`.
+3. **Explicit longhands for custom properties.** Overloaded shorthand utilities still need typed arbitrary value hints like `(color:--var)` or `(number:--var)`, but explicit longhands can use custom properties directly, such as `ak-layer-color-(--var)` and `ak-layer-offset-(--var)`.
 4. **Unified `--ak-edge`.** The CSS variables `--ak-layer-border`, `--ak-border`, `--ak-ring`, and `--ak-layer-ring` are all replaced by `--ak-edge`.
 
 ---
@@ -105,13 +105,40 @@ In v0.1, `ak-layer-contrast-<color>` adjusted the color's lightness to contrast 
 + ak-layer ak-layer-canvas
 ```
 
-### `ak-layer-(--var)` → `ak-layer ak-layer-(color:--var)`
+### `ak-layer-(--var)` → `ak-layer ak-layer-color-(--var)`
 
-Custom color layers now use the `color:` prefix.
+Custom color layers can use the explicit color longhand.
 
 ```diff
 - ak-layer-(--my-color)
-+ ak-layer ak-layer-(color:--my-color)
++ ak-layer ak-layer-color-(--my-color)
+```
+
+The overloaded `ak-layer-*` shorthand also still accepts typed custom properties:
+
+```html
+<div class="ak-layer ak-layer-(color:--my-color)"></div>
+```
+
+### `ak-layer-(number:--var)` → `ak-layer ak-layer-offset-(--var)`
+
+Custom lightness offsets can use the explicit offset longhand. The custom property keeps the same `0`–`100` scale as `ak-layer-<number>`.
+
+```diff
+- ak-layer-(number:--depth)
++ ak-layer ak-layer-offset-(--depth)
+```
+
+### Lightness bounds custom properties
+
+Use explicit `-l-` longhands for lightness min/max custom properties. Custom properties keep the same `0`–`100` scale as numeric lightness utilities.
+
+```diff
+- ak-layer-max-(number:--max-lightness)
++ ak-layer-max-l-(--max-lightness)
+
+- ak-layer-min-(number:--min-lightness)
++ ak-layer-min-l-(--min-lightness)
 ```
 
 ### Variant prefixes on modifier classes
@@ -146,13 +173,13 @@ When `ak-layer` is NOT already on the element and should only appear conditional
 
 ## Layer mix
 
-### `ak-layer-mix-(--color)/N` → `ak-layer ak-layer-(color:--color) ak-layer-mix-N`
+### `ak-layer-mix-(--color)/N` → `ak-layer ak-layer-color-(--color) ak-layer-mix-N`
 
 The color is now set via `ak-layer-<color>`, and `ak-layer-mix-N` controls how much of that color is mixed into the parent. The number stays the same.
 
 ```diff
 - ak-layer-mix-(--my-color)/15
-+ ak-layer ak-layer-(color:--my-color) ak-layer-mix-15
++ ak-layer ak-layer-color-(--my-color) ak-layer-mix-15
 
 - ak-layer-mix-primary/20
 + ak-layer ak-layer-primary ak-layer-mix-20
@@ -161,7 +188,14 @@ The color is now set via `ak-layer-<color>`, and `ak-layer-mix-N` controls how m
 + ak-layer ak-layer-red-500 ak-layer-mix-30
 ```
 
-Note: `ak-layer-mix-<color>` (with a color directly on the mix utility) is a **new** v0.2 feature for mixing another color into the current layer — it is not the migration path for the old `/N` syntax.
+Note: `ak-layer-mix-<color>` and `ak-layer-mix-color-<color>` set the mix color directly on the mix utility. They are **new** v0.2 features for mixing another color into the current layer, not the migration path for the old `/N` syntax.
+
+For custom properties on the mix utility itself, use explicit longhands:
+
+```diff
+- ak-layer-mix-(color:--my-mix-color) ak-layer-mix-(number:--amount)
++ ak-layer-mix-color-(--my-mix-color) ak-layer-mix-amount-(--amount)
+```
 
 ---
 
@@ -214,17 +248,19 @@ If you need to increase contrast beyond the default, add `ak-text-N` alongside t
 + ak-text ak-text-primary
 
 - ak-text-(--color)/70
-+ ak-text ak-text-(color:--color)
++ ak-text ak-text-color-(--color)
 ```
 
-### `ak-text-(--var)` → `ak-text ak-text-(color:--var)`
+### `ak-text-(--var)` → `ak-text ak-text-color-(--var)`
 
-Custom color text now uses the `color:` prefix.
+Custom color text can use the explicit color longhand.
 
 ```diff
 - ak-text-(--my-color)
-+ ak-text ak-text-(color:--my-color)
++ ak-text ak-text-color-(--my-color)
 ```
+
+For custom push values, use `ak-text-push-(--value)` instead of `ak-text-(number:--value)`.
 
 ---
 
@@ -237,11 +273,11 @@ Custom color text now uses the `color:` prefix.
 + ak-edge-15
 ```
 
-### `ak-edge-(--color)/N` → `ak-edge-(color:--color) ak-edge-N`
+### `ak-edge-(--color)/N` → `ak-edge-color-(--color) ak-edge-alpha-N`
 
 ```diff
 - ak-edge-(--my-color)/10
-+ ak-edge-(color:--my-color) ak-edge-10
++ ak-edge-color-(--my-color) ak-edge-alpha-10
 ```
 
 ### `ak-edge-contrast-primary` → `ak-edge-primary ak-edge-raw`
@@ -253,7 +289,9 @@ In v0.1, `ak-edge-contrast-<color>` set the edge to a solid color with lightness
 + ak-edge-primary ak-edge-raw
 ```
 
-`ak-edge-raw` is shorthand for `ak-edge-100 ak-edge-push-0` — use it when you want the color to be applied exactly as specified. For other combinations, `ak-edge-N` controls alpha (`100` = opaque) and `ak-edge-push-N` controls how far the edge lightness is pushed away from the layer (`0` = the color's natural lightness).
+`ak-edge-raw` is shorthand for `ak-edge-100 ak-edge-push-0` — use it when you want the color to be applied exactly as specified. For other combinations, `ak-edge-N` or `ak-edge-alpha-N` controls alpha (`100` = opaque) and `ak-edge-push-N` controls how far the edge lightness is pushed away from the layer (`0` = the color's natural lightness).
+
+For custom alpha values, use `ak-edge-alpha-(--alpha)` instead of `ak-edge-(number:--alpha)`.
 
 ### CSS variable renames (color)
 
@@ -378,6 +416,21 @@ When overriding a compound utility's frame token (e.g., `ak-button` + `ak-frame-
 ```diff
 - ak-outline-primary
 + ak-outline ak-outline-primary
+```
+
+### Outline custom properties
+
+Use explicit longhands for custom outline color, push, and lightness bounds. Numeric custom properties keep the same `0`–`100` scale as the shorthand utilities.
+
+```diff
+- ak-outline-(color:--outline-color)
++ ak-outline-color-(--outline-color)
+
+- ak-outline-(number:--outline-push)
++ ak-outline-push-(--outline-push)
+
+- ak-outline-max-(number:--outline-max-lightness)
++ ak-outline-max-l-(--outline-max-lightness)
 ```
 
 ---

--- a/packages/ariakit-tailwind/readme.md
+++ b/packages/ariakit-tailwind/readme.md
@@ -150,27 +150,31 @@ Use [`ak-edge`](#ak-edge) to fine-tune border, ring, and shadow colors without t
 
 ### Setting the layer color
 
-| Utility             | Description                                                                                                                                           |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ak-layer`          | Required base class. Sets background, text, border, and shadow colors.                                                                                |
-| `ak-layer-<color>`  | Sets the layer to a specific color. Accepts any theme color (e.g. `ak-layer-primary`, `ak-layer-blue-500`) or arbitrary value (`ak-layer-[#131418]`). |
-| `ak-layer-<number>` | Shifts lightness relative to parent layer (`0`–`100`). Nested `ak-layer` alone uses a sensible default step.                                          |
-| `ak-layer-<chroma>` | Sets chroma from a named preset, e.g. `ak-layer-vivid`, `ak-layer-muted`. See `--chroma-*` tokens.                                                    |
-| `ak-layer-<hue>`    | Sets hue from a named preset, e.g. `ak-layer-red`, `ak-layer-blue`. See `--hue-*` tokens.                                                             |
+| Utility                   | Description                                                                                                                                                                                               |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ak-layer`                | Required base class. Sets background, text, border, and shadow colors.                                                                                                                                    |
+| `ak-layer-<color>`        | Sets the layer to a specific color. Accepts any theme color (e.g. `ak-layer-primary`, `ak-layer-blue-500`) or arbitrary value (`ak-layer-[#131418]`).                                                     |
+| `ak-layer-color-<color>`  | Explicit color-only alias. Useful for custom properties without a typed arbitrary value hint (`ak-layer-color-(--surface)`).                                                                              |
+| `ak-layer-<number>`       | Shifts lightness relative to parent layer (`0`–`100`). Nested `ak-layer` alone uses a sensible default step.                                                                                              |
+| `ak-layer-offset-<value>` | Explicit lightness-offset alias for `ak-layer-<number>`. Useful for custom properties without a typed arbitrary value hint (`ak-layer-offset-(--depth)`). Custom properties use the same `0`–`100` scale. |
+| `ak-layer-<chroma>`       | Sets chroma from a named preset, e.g. `ak-layer-vivid`, `ak-layer-muted`. See `--chroma-*` tokens.                                                                                                        |
+| `ak-layer-<hue>`          | Sets hue from a named preset, e.g. `ak-layer-red`, `ak-layer-blue`. See `--hue-*` tokens.                                                                                                                 |
 
 ### Lightness adjustments
 
-| Utility                      | Description                                                                                                                                 |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ak-layer-lighten-<number>`  | Lightens the layer by `<number>`%. Accepts arbitrary values (`ak-layer-lighten-[0.05]`).                                                    |
-| `ak-layer-darken-<number>`   | Darkens the layer by `<number>`%.                                                                                                           |
-| `ak-layer-push-<number>`     | Minimum lightness shift (self-relative), jumping the forbidden mid-luminance range where contrast math becomes unreliable.                  |
-| `ak-layer-contrast`          | Adapts the layer to contrast against its parent (preset `25`).                                                                              |
-| `ak-layer-contrast-<number>` | Custom contrast amount (`0`–`100`, default `25`).                                                                                           |
-| `ak-layer-invert`            | Inverts lightness (clamped so the result is never pure black).                                                                              |
-| `ak-layer-l-<value>`         | Sets absolute lightness. Accepts a percentage (`ak-layer-l-80`), a raw value (`ak-layer-l-[0.8]`), or any valid OKLCH-lightness expression. |
-| `ak-layer-max-<value>`       | Caps lightness at `<value>` (percentage, `[value]`) or caps chroma with a named chroma preset (`ak-layer-max-muted`).                       |
-| `ak-layer-min-<value>`       | Floors lightness or chroma, same form as `max-*`.                                                                                           |
+| Utility                      | Description                                                                                                                                                                  |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ak-layer-lighten-<number>`  | Lightens the layer by `<number>`%. Accepts arbitrary values (`ak-layer-lighten-[0.05]`).                                                                                     |
+| `ak-layer-darken-<number>`   | Darkens the layer by `<number>`%.                                                                                                                                            |
+| `ak-layer-push-<number>`     | Minimum lightness shift (self-relative), jumping the forbidden mid-luminance range where contrast math becomes unreliable.                                                   |
+| `ak-layer-contrast`          | Adapts the layer to contrast against its parent (preset `25`).                                                                                                               |
+| `ak-layer-contrast-<number>` | Custom contrast amount (`0`–`100`, default `25`).                                                                                                                            |
+| `ak-layer-invert`            | Inverts lightness (clamped so the result is never pure black).                                                                                                               |
+| `ak-layer-l-<value>`         | Sets absolute lightness. Accepts a percentage (`ak-layer-l-80`), a raw value (`ak-layer-l-[0.8]`), or any valid OKLCH-lightness expression.                                  |
+| `ak-layer-max-<value>`       | Caps lightness at `<value>` (percentage, `[value]`) or caps chroma with a named chroma preset (`ak-layer-max-muted`).                                                        |
+| `ak-layer-min-<value>`       | Floors lightness or chroma, same form as `max-*`.                                                                                                                            |
+| `ak-layer-max-l-<value>`     | Caps lightness specifically. Useful for custom properties without a typed arbitrary value hint (`ak-layer-max-l-(--max-l)`). Custom properties use the same `0`–`100` scale. |
+| `ak-layer-min-l-<value>`     | Floors lightness specifically. Custom properties use the same `0`–`100` scale.                                                                                               |
 
 ### Hue adjustments
 
@@ -194,12 +198,15 @@ Use [`ak-edge`](#ak-edge) to fine-tune border, ring, and shadow colors without t
 
 ### Mixing with another color
 
-| Utility                 | Description                                                                                                                          |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `ak-layer-mix`          | Enables mixing. By default, mixes with the parent layer at `50%` using the `oklab` interpolation method.                             |
-| `ak-layer-mix-<color>`  | Sets the color to mix with, e.g. `ak-layer-mix-primary` or `ak-layer-mix-[#000]`.                                                    |
-| `ak-layer-mix-<number>` | Sets the mix amount (`0`–`100`).                                                                                                     |
-| `ak-layer-mix-<method>` | Sets the interpolation method, e.g. `ak-layer-mix-oklch`, `ak-layer-mix-shorter-hue`, `ak-layer-mix-srgb`. See the `--mix-*` tokens. |
+| Utility                        | Description                                                                                                                                                             |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ak-layer-mix`                 | Enables mixing. By default, mixes with the parent layer at `50%` using the `oklab` interpolation method.                                                                |
+| `ak-layer-mix-<color>`         | Sets the color to mix with, e.g. `ak-layer-mix-primary` or `ak-layer-mix-[#000]`.                                                                                       |
+| `ak-layer-mix-color-<color>`   | Explicit color-only alias. Useful for custom properties (`ak-layer-mix-color-(--mix-color)`).                                                                           |
+| `ak-layer-mix-<number>`        | Sets the mix amount (`0`–`100`).                                                                                                                                        |
+| `ak-layer-mix-amount-<value>`  | Explicit amount alias for `ak-layer-mix-<number>`. Useful for custom properties (`ak-layer-mix-amount-(--mix-amount)`). Custom properties use the same `0`–`100` scale. |
+| `ak-layer-mix-<method>`        | Sets the interpolation method, e.g. `ak-layer-mix-oklch`, `ak-layer-mix-shorter-hue`, `ak-layer-mix-srgb`. See the `--mix-*` tokens.                                    |
+| `ak-layer-mix-method-<method>` | Explicit interpolation-method alias. Useful for custom properties (`ak-layer-mix-method-(--mix-method)`).                                                               |
 
 Combine freely — `ak-layer ak-layer-primary ak-layer-mix ak-layer-mix-30 ak-layer-mix-oklch` mixes the primary color 30% into the parent layer using OKLCH.
 
@@ -213,15 +220,16 @@ Combine freely — `ak-layer ak-layer-primary ak-layer-mix ak-layer-mix-30 ak-la
 </button>
 ```
 
-| Utility                        | Description                                                                           |
-| ------------------------------ | ------------------------------------------------------------------------------------- |
-| `ak-state-<number>`            | Adjusts lightness for interactive state (`0`–`100`), parallel to `ak-layer-<number>`. |
-| `ak-state-lighten-<number>`    | Lightens in state context.                                                            |
-| `ak-state-darken-<number>`     | Darkens in state context.                                                             |
-| `ak-state-saturate-<number>`   | Increases chroma in state context.                                                    |
-| `ak-state-desaturate-<number>` | Decreases chroma in state context.                                                    |
-| `ak-state-push-<number>`       | Minimum lightness shift in state context.                                             |
-| `ak-state-h-rotate-<number>`   | Rotates hue in state context.                                                         |
+| Utility                        | Description                                                                                                                                                          |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ak-state-<number>`            | Adjusts lightness for interactive state (`0`–`100`), parallel to `ak-layer-<number>`.                                                                                |
+| `ak-state-offset-<value>`      | Explicit lightness-offset alias for `ak-state-<number>`. Useful for custom properties (`ak-state-offset-(--depth)`). Custom properties use the same `0`–`100` scale. |
+| `ak-state-lighten-<number>`    | Lightens in state context.                                                                                                                                           |
+| `ak-state-darken-<number>`     | Darkens in state context.                                                                                                                                            |
+| `ak-state-saturate-<number>`   | Increases chroma in state context.                                                                                                                                   |
+| `ak-state-desaturate-<number>` | Decreases chroma in state context.                                                                                                                                   |
+| `ak-state-push-<number>`       | Minimum lightness shift in state context.                                                                                                                            |
+| `ak-state-h-rotate-<number>`   | Rotates hue in state context.                                                                                                                                        |
 
 ## `ak-ink`
 
@@ -253,13 +261,15 @@ Controls the opacity of text inside a layer — useful for secondary text, capti
 
 ### Setting the text color
 
-| Utility            | Description                                                                        |
-| ------------------ | ---------------------------------------------------------------------------------- |
-| `ak-text`          | Required base class for colored text.                                              |
-| `ak-text-<color>`  | Applies a color with automatic contrast, e.g. `ak-text-primary`, `ak-text-[#c33]`. |
-| `ak-text-<number>` | Pushes lightness away from the parent layer beyond the automatic readable floor.   |
-| `ak-text-<chroma>` | Sets chroma from a named preset (`ak-text-vivid`).                                 |
-| `ak-text-<hue>`    | Sets hue from a named preset (`ak-text-blue`).                                     |
+| Utility                 | Description                                                                                                                                                   |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ak-text`               | Required base class for colored text.                                                                                                                         |
+| `ak-text-<color>`       | Applies a color with automatic contrast, e.g. `ak-text-primary`, `ak-text-[#c33]`.                                                                            |
+| `ak-text-color-<color>` | Explicit color-only alias. Useful for custom properties (`ak-text-color-(--text-color)`).                                                                     |
+| `ak-text-<number>`      | Pushes lightness away from the parent layer beyond the automatic readable floor.                                                                              |
+| `ak-text-push-<value>`  | Explicit lightness-push alias for `ak-text-<number>`. Useful for custom properties (`ak-text-push-(--push)`). Custom properties use the same `0`–`100` scale. |
+| `ak-text-<chroma>`      | Sets chroma from a named preset (`ak-text-vivid`).                                                                                                            |
+| `ak-text-<hue>`         | Sets hue from a named preset (`ak-text-blue`).                                                                                                                |
 
 ### Adjustments
 
@@ -274,16 +284,18 @@ Controls the opacity of text inside a layer — useful for secondary text, capti
 
 ### Channels and bounds
 
-| Utility                     | Description                                                         |
-| --------------------------- | ------------------------------------------------------------------- |
-| `ak-text-l-<value>`         | Absolute lightness (percentage, `[value]`, or raw OKLCH lightness). |
-| `ak-text-c-<value>`         | Absolute chroma (percentage, named preset, or `[value]`).           |
-| `ak-text-h-<value>`         | Absolute hue (named, degrees, or `[value]`).                        |
-| `ak-text-h-rotate-<number>` | Rotates hue by degrees.                                             |
-| `ak-text-max-<value>`       | Caps lightness, or caps chroma when given a named chroma preset.    |
-| `ak-text-min-<value>`       | Floors lightness or chroma, same form.                              |
-| `ak-text-max-c-<value>`     | Caps chroma specifically.                                           |
-| `ak-text-min-c-<value>`     | Floors chroma specifically.                                         |
+| Utility                     | Description                                                                    |
+| --------------------------- | ------------------------------------------------------------------------------ |
+| `ak-text-l-<value>`         | Absolute lightness (percentage, `[value]`, or raw OKLCH lightness).            |
+| `ak-text-c-<value>`         | Absolute chroma (percentage, named preset, or `[value]`).                      |
+| `ak-text-h-<value>`         | Absolute hue (named, degrees, or `[value]`).                                   |
+| `ak-text-h-rotate-<number>` | Rotates hue by degrees.                                                        |
+| `ak-text-max-<value>`       | Caps lightness, or caps chroma when given a named chroma preset.               |
+| `ak-text-min-<value>`       | Floors lightness or chroma, same form.                                         |
+| `ak-text-max-l-<value>`     | Caps lightness specifically. Custom properties use the same `0`–`100` scale.   |
+| `ak-text-min-l-<value>`     | Floors lightness specifically. Custom properties use the same `0`–`100` scale. |
+| `ak-text-max-c-<value>`     | Caps chroma specifically.                                                      |
+| `ak-text-min-c-<value>`     | Floors chroma specifically.                                                    |
 
 ## `ak-edge`
 
@@ -298,13 +310,15 @@ Controls the opacity of text inside a layer — useful for secondary text, capti
 
 ### Setting the edge color
 
-| Utility            | Description                                                                              |
-| ------------------ | ---------------------------------------------------------------------------------------- |
-| `ak-edge-<number>` | Sets edge alpha (`0`–`100`, default `10`).                                               |
-| `ak-edge-<color>`  | Applies a specific edge color.                                                           |
-| `ak-edge-<chroma>` | Sets chroma from a named preset.                                                         |
-| `ak-edge-<hue>`    | Sets hue from a named preset.                                                            |
-| `ak-edge-raw`      | Applies the color exactly as specified — shorthand for `ak-edge-100` + `ak-edge-push-0`. |
+| Utility                 | Description                                                                                                                                            |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ak-edge-<number>`      | Sets edge alpha (`0`–`100`, default `10`).                                                                                                             |
+| `ak-edge-alpha-<value>` | Explicit alpha alias for `ak-edge-<number>`. Useful for custom properties (`ak-edge-alpha-(--alpha)`). Custom properties use the same `0`–`100` scale. |
+| `ak-edge-<color>`       | Applies a specific edge color.                                                                                                                         |
+| `ak-edge-color-<color>` | Explicit color-only alias. Useful for custom properties (`ak-edge-color-(--edge-color)`).                                                              |
+| `ak-edge-<chroma>`      | Sets chroma from a named preset.                                                                                                                       |
+| `ak-edge-<hue>`         | Sets hue from a named preset.                                                                                                                          |
+| `ak-edge-raw`           | Applies the color exactly as specified — shorthand for `ak-edge-100` + `ak-edge-push-0`.                                                               |
 
 ### Adjustments
 
@@ -320,20 +334,22 @@ Controls the opacity of text inside a layer — useful for secondary text, capti
 
 ### Channels and bounds
 
-| Utility                     | Description                 |
-| --------------------------- | --------------------------- |
-| `ak-edge-l-<value>`         | Absolute lightness.         |
-| `ak-edge-c-<value>`         | Absolute chroma.            |
-| `ak-edge-h-<value>`         | Absolute hue.               |
-| `ak-edge-h-rotate-<number>` | Rotates hue by degrees.     |
-| `ak-edge-max-<value>`       | Caps lightness or chroma.   |
-| `ak-edge-min-<value>`       | Floors lightness or chroma. |
-| `ak-edge-max-c-<value>`     | Caps chroma specifically.   |
-| `ak-edge-min-c-<value>`     | Floors chroma specifically. |
+| Utility                     | Description                                                                    |
+| --------------------------- | ------------------------------------------------------------------------------ |
+| `ak-edge-l-<value>`         | Absolute lightness.                                                            |
+| `ak-edge-c-<value>`         | Absolute chroma.                                                               |
+| `ak-edge-h-<value>`         | Absolute hue.                                                                  |
+| `ak-edge-h-rotate-<number>` | Rotates hue by degrees.                                                        |
+| `ak-edge-max-<value>`       | Caps lightness or chroma.                                                      |
+| `ak-edge-min-<value>`       | Floors lightness or chroma.                                                    |
+| `ak-edge-max-l-<value>`     | Caps lightness specifically. Custom properties use the same `0`–`100` scale.   |
+| `ak-edge-min-l-<value>`     | Floors lightness specifically. Custom properties use the same `0`–`100` scale. |
+| `ak-edge-max-c-<value>`     | Caps chroma specifically.                                                      |
+| `ak-edge-min-c-<value>`     | Floors chroma specifically.                                                    |
 
 ## `ak-outline`
 
-`ak-outline` sets an `outline-color` that adapts to the parent layer's contrast. Pair it with Tailwind's `outline-<width>` and `outline-offset-*` utilities for focus styles.
+`ak-outline` sets an `outline-color` that pushes away from the parent layer's lightness. Pair it with Tailwind's `outline-<width>` and `outline-offset-*` utilities for focus styles.
 
 ```html
 <button
@@ -345,13 +361,15 @@ Controls the opacity of text inside a layer — useful for secondary text, capti
 
 ### Setting the outline color
 
-| Utility               | Description                             |
-| --------------------- | --------------------------------------- |
-| `ak-outline`          | Required base class.                    |
-| `ak-outline-<color>`  | Applies a specific outline color.       |
-| `ak-outline-<number>` | Adjusts contrast lightness (`0`–`100`). |
-| `ak-outline-<chroma>` | Sets chroma from a named preset.        |
-| `ak-outline-<hue>`    | Sets hue from a named preset.           |
+| Utility                    | Description                                                                                                                                                         |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ak-outline`               | Required base class.                                                                                                                                                |
+| `ak-outline-<color>`       | Applies a specific outline color.                                                                                                                                   |
+| `ak-outline-color-<color>` | Explicit color-only alias. Useful for custom properties (`ak-outline-color-(--outline-color)`).                                                                     |
+| `ak-outline-<number>`      | Pushes outline lightness away from the parent layer (`0`–`100`).                                                                                                    |
+| `ak-outline-push-<value>`  | Explicit lightness-push alias for `ak-outline-<number>`. Useful for custom properties (`ak-outline-push-(--push)`). Custom properties use the same `0`–`100` scale. |
+| `ak-outline-<chroma>`      | Sets chroma from a named preset.                                                                                                                                    |
+| `ak-outline-<hue>`         | Sets hue from a named preset.                                                                                                                                       |
 
 ### Adjustments
 
@@ -366,16 +384,18 @@ Controls the opacity of text inside a layer — useful for secondary text, capti
 
 ### Channels and bounds
 
-| Utility                        | Description                 |
-| ------------------------------ | --------------------------- |
-| `ak-outline-l-<value>`         | Absolute lightness.         |
-| `ak-outline-c-<value>`         | Absolute chroma.            |
-| `ak-outline-h-<value>`         | Absolute hue.               |
-| `ak-outline-h-rotate-<number>` | Rotates hue by degrees.     |
-| `ak-outline-max-<value>`       | Caps lightness or chroma.   |
-| `ak-outline-min-<value>`       | Floors lightness or chroma. |
-| `ak-outline-max-c-<value>`     | Caps chroma specifically.   |
-| `ak-outline-min-c-<value>`     | Floors chroma specifically. |
+| Utility                        | Description                                                                    |
+| ------------------------------ | ------------------------------------------------------------------------------ |
+| `ak-outline-l-<value>`         | Absolute lightness.                                                            |
+| `ak-outline-c-<value>`         | Absolute chroma.                                                               |
+| `ak-outline-h-<value>`         | Absolute hue.                                                                  |
+| `ak-outline-h-rotate-<number>` | Rotates hue by degrees.                                                        |
+| `ak-outline-max-<value>`       | Caps lightness or chroma.                                                      |
+| `ak-outline-min-<value>`       | Floors lightness or chroma.                                                    |
+| `ak-outline-max-l-<value>`     | Caps lightness specifically. Custom properties use the same `0`–`100` scale.   |
+| `ak-outline-min-l-<value>`     | Floors lightness specifically. Custom properties use the same `0`–`100` scale. |
+| `ak-outline-max-c-<value>`     | Caps chroma specifically.                                                      |
+| `ak-outline-min-c-<value>`     | Floors chroma specifically.                                                    |
 
 ## `ak-frame`
 

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -67,7 +67,7 @@ const LCH_LAYER_LIGHT_CHROMA_DAMPING_START_L = 50;
 const LCH_LAYER_LIGHT_CHROMA_DAMPING_RANGE = 50;
 const LCH_LAYER_DARK_CHROMA_BOOST = 0.11;
 const LCH_LAYER_DARK_CHROMA_BOOST_MAX_L = 20;
-const OUTLINE_MIN_CONTRAST = 0.5;
+const OUTLINE_MIN_PUSH = 0.5;
 const INK_DARK_MID_ALPHA_BOOST_START_L = 0.25;
 const INK_DARK_MID_ALPHA_BOOST = 0.08;
 const TEXT_CONTRAST_CYAN_CHROMA_START = 0.29;
@@ -179,6 +179,24 @@ function getNumericTokenValue(pattern: string, options?: NumbersOptions) {
  */
 function getPercentTokenValue(pattern: string, options?: NumbersOptions) {
   return fn.div(getNumericTokenValue(pattern, options), 100);
+}
+
+/**
+ * Parses a wildcard numeric utility token and converts it to a 0..1 percentage.
+ */
+function getWildcardPercentTokenValue(options?: NumbersOptions) {
+  return getPercentTokenValue("[*]", options);
+}
+
+/**
+ * Parses a wildcard color utility token.
+ */
+function getWildcardColorTokenValue() {
+  return fn.value(color, "[*]");
+}
+
+function getLightnessDeclarations(target: VarProperty) {
+  return set(target, getWildcardPercentTokenValue());
 }
 
 /**
@@ -309,12 +327,12 @@ function getSafeLightness(
 }
 
 /**
- * Computes an automatic lightness delta that avoids forbidden lightness. If the
- * next lightness enters the forbidden interval, we either flip direction or
- * clamp to the entry boundary, whichever yields more lightness distance from
- * the original layer color.
+ * Computes a lightness offset that avoids forbidden lightness. If the next
+ * lightness enters the forbidden interval, we either flip direction or clamp
+ * to the entry boundary, whichever yields more lightness distance from the
+ * original layer color.
  */
-function getAutoLightnessDelta(
+function getResolvedLightnessOffset(
   normalDelta: Value,
   direction: Value,
   lowerBoundary: Value,
@@ -481,7 +499,9 @@ const constantMathVars = {
   layerLFloorBoost: _ak.prop("llfb", {
     initial: fn.relu(fn.sub(LAYER_L_FLOOR, l)),
   }),
-  autoLDirection: _ak.prop("ald", { initial: fn.sub(fn.double(DARK_L), 1) }),
+  lightnessOffsetDirection: _ak.prop("lod", {
+    initial: fn.sub(fn.double(DARK_L), 1),
+  }),
   darkL: _ak.prop("dal", { initial: DARK_L }),
   lightL: _ak.prop("lil", { initial: LIGHT_L }),
   bandDarkHigh: _ak.prop("bdh", { initial: bandDarkHigh }),
@@ -518,7 +538,7 @@ const layerMathVars = {
   forbiddenLa: _ak.var("fla"),
   forbiddenLb: _ak.var("flb"),
   safeL: _ak.var("sl"),
-  autoDirectionToLight: _ak.var("adtl"),
+  offsetDirectionToLight: _ak.var("odtl"),
   forbiddenBandWidth: _ak.var("bw"),
   forbiddenEntryBoundary: _ak.var("eb"),
   layerIdlePushValue: _ak.prop.zero("lipv"),
@@ -545,14 +565,14 @@ const themeTokenVars = {
 const layerColorVars = {
   layerIdleBase: _ak.prop.canvas("lib"),
   layerIdleMixed: _ak.prop.canvas("lim"),
-  layerIdleAuto: _ak.prop.canvas("lia"),
+  layerIdleOffset: _ak.prop.canvas("lio"),
   layerIdle: _ak.prop.canvas("li"),
   layerL: _ak.prop.canvas("ll", { inherits: true }),
   layerTextL: _ak.prop.canvas("ltl", { inherits: true }),
   layerScheme: _ak.prop.black("ls", { inherits: true }),
   layerBand: _ak.prop.black("lbd", { inherits: true }),
   layerBase: _ak.prop.canvas("lb"),
-  layerAuto: _ak.prop.canvas("la"),
+  layerOffset: _ak.prop.canvas("lo"),
   layerPush: _ak.prop.canvas("lp"),
   layer: ak.prop.canvas("layer", { inherits: true }),
   layerParentContext: _ak.var("lpc"),
@@ -568,7 +588,7 @@ const layerContrastMathVars = {
 };
 
 const outlineMathVars = {
-  outlineContrastDirection: _ak.prop.number("ocd", { initial: 1 }),
+  outlinePushDirection: _ak.prop.number("opd", { initial: 1 }),
   outlineParentL: _ak.prop.zero("opl"),
 };
 
@@ -625,10 +645,10 @@ const inputs = {
   layerIdleRelativeL: _ak.prop("layer-idle-relative-lightness", { initial: 0 }),
   layerIdleRelativeC: _ak.prop("layer-idle-relative-chroma", { initial: 0 }),
   layerIdleRelativeH: _ak.prop("layer-idle-relative-hue", { initial: 0 }),
-  layerIdleAutoLDelta: _ak.prop("layer-idle-auto-lightness-delta", {
+  layerIdleLOffsetDelta: _ak.prop("layer-idle-lightness-offset-delta", {
     initial: 0,
   }),
-  layerIdleAutoL: _ak.prop("layer-idle-auto-lightness", { initial: 0 }),
+  layerIdleLOffset: _ak.prop("layer-idle-lightness-offset", { initial: 0 }),
   layerIdlePushL: _ak.prop("layer-idle-push-lightness", { initial: 0 }),
   layerIdleContrastL: _ak.prop("layer-idle-contrast-lightness", { initial: 0 }),
   layerL: _ak.prop("layer-lightness"),
@@ -641,8 +661,8 @@ const inputs = {
   layerRelativeL: _ak.prop("layer-relative-lightness", { initial: 0 }),
   layerRelativeC: _ak.prop("layer-relative-chroma", { initial: 0 }),
   layerRelativeH: _ak.prop("layer-relative-hue", { initial: 0 }),
-  layerAutoLDelta: _ak.prop("layer-auto-lightness-delta", { initial: 0 }),
-  layerAutoL: _ak.prop("layer-auto-lightness", { initial: 0 }),
+  layerLOffsetDelta: _ak.prop("layer-lightness-offset-delta", { initial: 0 }),
+  layerLOffset: _ak.prop("layer-lightness-offset", { initial: 0 }),
   layerPushL: _ak.prop("layer-push-lightness", { initial: 0 }),
   layerMix: _ak.prop("layer-mix"),
   layerMixMethod: _ak.prop("layer-mix-method", "oklab"),
@@ -674,7 +694,7 @@ const inputs = {
   textCMin: _ak.prop("text-chroma-min", { initial: 0 }),
   textCMax: _ak.prop("text-chroma-max", vars.chromaP3Max),
   textH: _ak.prop("text-hue"),
-  outlineContrastL: _ak.prop("outline-contrast-lightness", { initial: 0 }),
+  outlinePushL: _ak.prop("outline-push-lightness", { initial: 0 }),
   outlineColor: _ak.prop("outline-color"),
   outlineRelativeL: _ak.prop("outline-relative-lightness", { initial: 0 }),
   outlineRelativeC: _ak.prop("outline-relative-chroma", { initial: 0 }),
@@ -797,12 +817,12 @@ function getPushValue(value: Value) {
 }
 
 /**
- * Computes auto lightness from an already direction-adjusted delta.
+ * Computes lightness offset from an already direction-adjusted delta.
  */
-function getAutoLDelta(value: Value) {
-  return getAutoLightnessDelta(
+function getLightnessOffset(value: Value) {
+  return getResolvedLightnessOffset(
     value,
-    vars.autoLDirection,
+    vars.lightnessOffsetDirection,
     vars.forbiddenLa,
     vars.forbiddenLb,
     vars.forbiddenEntryBoundary,
@@ -810,10 +830,10 @@ function getAutoLDelta(value: Value) {
 }
 
 /**
- * Keeps a declaration tied to numeric utility tokens while using a factored
- * scratch variable for the expensive expression.
+ * Keeps a declaration tied to utility tokens while using a factored scratch
+ * variable for the expensive expression.
  */
-function withNumericTokenGate(value: Value, pattern: string) {
+function withUtilityTokenGate(value: Value, pattern: string) {
   return fn.calc`${value} + (0 * ${getPercentTokenValue(pattern)})`;
 }
 
@@ -823,7 +843,7 @@ function withNumericTokenGate(value: Value, pattern: string) {
  * to the opposite boundary and preserve their remaining progress there.
  */
 function getPushL(pushValue: Value, baseLightness: Value) {
-  const direction = vars.autoLDirection;
+  const direction = vars.lightnessOffsetDirection;
   const lowerBoundary = vars.forbiddenLa;
   const upperBoundary = vars.forbiddenLb;
   const bandWidth = vars.forbiddenBandWidth;
@@ -840,7 +860,7 @@ function getPushL(pushValue: Value, baseLightness: Value) {
     fn.binary(fn.sub(upperBoundary, baseLightness)),
   );
   // These are mutually exclusive (l cannot be both below fla and above flb),
-  // and each can only fire when the auto-direction aligns with the crossing
+  // and each can only fire when the offset direction aligns with the crossing
   // direction, so the direction weights that were here before are redundant
   // and have been removed.
   const crossed = fn.add(crossedFromDarkSide, crossedFromLightSide);
@@ -1027,11 +1047,11 @@ const forbiddenLb = fn.min(
 const layerBaseColor = fn.var(inputs.layerColor, vars.layerParent);
 const layerIdleBase = fn.oklch(layerBaseColor, idleLayerChannels);
 const layerIdleMixed = fn.var(inputs.layerMix, vars.layerIdleBase);
-const layerIdleAuto = fn.oklch(vars.layerIdleMixed, {
+const layerIdleOffset = fn.oklch(vars.layerIdleMixed, {
   l: fn.add(
     fn.clamp(
       inputs.layerLMin,
-      getLayerL(inputs.layerIdleAutoL),
+      getLayerL(inputs.layerIdleLOffset),
       inputs.layerLMax,
     ),
     vars.layerContrastBias,
@@ -1062,7 +1082,7 @@ function getContrastL(selfRelativeL: Value, contrastValue: Value) {
   );
 }
 
-const layerIdle = fn.oklch(vars.layerIdleAuto, {
+const layerIdle = fn.oklch(vars.layerIdleOffset, {
   l: getContrastL(vars.layerIdlePushL, vars.layerIdleContrastValue),
 });
 
@@ -1070,11 +1090,11 @@ const layerState = fn.oklch(fn.oklch(vars.layerIdle, stateLayerChannels), {
   l: vars.safeL,
 });
 
-const layerAuto = fn.oklch(vars.layerBase, {
-  l: getLayerL(inputs.layerAutoL),
+const layerOffset = fn.oklch(vars.layerBase, {
+  l: getLayerL(inputs.layerLOffset),
 });
 
-const layerPush = fn.oklch(vars.layerAuto, {
+const layerPush = fn.oklch(vars.layerOffset, {
   l: vars.layerPushL,
 });
 
@@ -1121,18 +1141,22 @@ const layerMathDeclarations = [
   set(vars.contrastPushScale, fn.add(1, fn.mul(vars.contrastT, 3.334))),
   set(
     vars.layerContrastBias,
-    fn.mul(fn.neg(vars.contrastT), CONTRAST_SCALE, vars.autoLDirection),
+    fn.mul(
+      fn.neg(vars.contrastT),
+      CONTRAST_SCALE,
+      vars.lightnessOffsetDirection,
+    ),
   ),
   set(vars.forbiddenLa, forbiddenLa),
   set(vars.forbiddenLb, forbiddenLb),
-  set(vars.autoDirectionToLight, fn.clamp01(vars.autoLDirection)),
+  set(vars.offsetDirectionToLight, fn.clamp01(vars.lightnessOffsetDirection)),
   set(vars.forbiddenBandWidth, fn.sub(vars.forbiddenLb, vars.forbiddenLa)),
   set(
     vars.forbiddenEntryBoundary,
     fn.add(
       vars.forbiddenLb,
       fn.mul(
-        vars.autoDirectionToLight,
+        vars.offsetDirectionToLight,
         fn.sub(vars.forbiddenLa, vars.forbiddenLb),
       ),
     ),
@@ -1142,14 +1166,14 @@ const layerMathDeclarations = [
   set(vars.edgeContrastValue, fn.mul(vars.contrastT, CONTRAST_SCALE)),
 ];
 
-// Build the layered color stages from idle -> base -> auto -> final.
+// Build the layered color stages from idle -> base -> offset -> final.
 const layerColorDeclarations = [
   set(vars.layerIdleBase, layerIdleBase),
   set(vars.layerIdleMixed, layerIdleMixed),
-  set(vars.layerIdleAuto, layerIdleAuto),
+  set(vars.layerIdleOffset, layerIdleOffset),
   set(vars.layerIdle, layerIdle),
   set(vars.layerBase, layerState),
-  set(vars.layerAuto, layerAuto),
+  set(vars.layerOffset, layerOffset),
   set(vars.layerPush, layerPush),
 ];
 
@@ -1223,6 +1247,50 @@ const inkText = fn.oklch(vars.layer, {
 
 const layerContext = createContext();
 
+function getLayerMixDeclaration() {
+  return set(
+    inputs.layerMix,
+    fn.colorMix(
+      inputs.layerMixMethod,
+      inputs.layerMixColor,
+      vars.layerIdleBase,
+      inputs.layerMixAmount,
+    ),
+  );
+}
+
+function getLayerOffsetDeclarations(pattern: string) {
+  return [
+    set(
+      inputs.layerIdleLOffsetDelta,
+      fn.mul(getPercentTokenValue(pattern), vars.lightnessOffsetDirection),
+    ),
+    set(
+      inputs.layerIdleLOffset,
+      withUtilityTokenGate(
+        getLightnessOffset(inputs.layerIdleLOffsetDelta),
+        pattern,
+      ),
+    ),
+  ];
+}
+
+function getStateOffsetDeclarations(pattern: string) {
+  return [
+    set(
+      inputs.layerLOffsetDelta,
+      fn.mul(getPercentTokenValue(pattern), vars.lightnessOffsetDirection),
+    ),
+    set(
+      inputs.layerLOffset,
+      withUtilityTokenGate(
+        getLightnessOffset(inputs.layerLOffsetDelta),
+        pattern,
+      ),
+    ),
+  ];
+}
+
 utility(
   "layer",
   set.color(vars.text),
@@ -1250,55 +1318,43 @@ utility(
   set(inputs.layerC, fn.value(chroma)),
   set(inputs.layerH, fn.value(hue)),
   set(inputs.layerColor, fn.value(color, "[color]")),
-  set(
-    inputs.layerIdleAutoLDelta,
-    fn.mul(getPercentTokenValue("[number]"), vars.autoLDirection),
-  ),
-  set(
-    inputs.layerIdleAutoL,
-    withNumericTokenGate(getAutoLDelta(inputs.layerIdleAutoLDelta), "[number]"),
-  ),
+  getLayerOffsetDeclarations("[number]"),
 );
 
-utility(
-  "layer-mix",
-  set(
-    inputs.layerMix,
-    fn.colorMix(
-      inputs.layerMixMethod,
-      inputs.layerMixColor,
-      vars.layerIdleBase,
-      inputs.layerMixAmount,
-    ),
-  ),
-);
+utility("layer-mix", getLayerMixDeclaration());
 
 utility(
   "layer-mix-*",
   set(inputs.layerMixAmount, fn.toPercent(getNumericTokenValue("[number]"))),
   set(inputs.layerMixColor, fn.value(color, "[color]")),
   set(inputs.layerMixMethod, fn.value(mix)),
-  set(
-    inputs.layerMix,
-    fn.colorMix(
-      inputs.layerMixMethod,
-      inputs.layerMixColor,
-      vars.layerIdleBase,
-      inputs.layerMixAmount,
-    ),
-  ),
+  getLayerMixDeclaration(),
+);
+
+utility("state-*", getStateOffsetDeclarations("[*]"));
+
+utility("layer-offset-*", getLayerOffsetDeclarations("[*]"));
+
+utility("state-offset-*", getStateOffsetDeclarations("[*]"));
+
+utility("layer-color-*", set(inputs.layerColor, getWildcardColorTokenValue()));
+
+utility(
+  "layer-mix-color-*",
+  set(inputs.layerMixColor, getWildcardColorTokenValue()),
+  getLayerMixDeclaration(),
 );
 
 utility(
-  "state-*",
-  set(
-    inputs.layerAutoLDelta,
-    fn.mul(getPercentTokenValue("[*]"), vars.autoLDirection),
-  ),
-  set(
-    inputs.layerAutoL,
-    withNumericTokenGate(getAutoLDelta(inputs.layerAutoLDelta), "[*]"),
-  ),
+  "layer-mix-amount-*",
+  set(inputs.layerMixAmount, fn.toPercent(getNumericTokenValue("[*]"))),
+  getLayerMixDeclaration(),
+);
+
+utility(
+  "layer-mix-method-*",
+  set(inputs.layerMixMethod, fn.value(mix, "[*]")),
+  getLayerMixDeclaration(),
 );
 
 const layerLighten = utility(
@@ -1350,7 +1406,7 @@ utility(
   set(vars.layerIdlePushValue, getPushValue(inputs.layerIdlePushL)),
   set(
     vars.layerIdlePushBaseL,
-    getLayerL(fn.mul(vars.layerIdlePushValue, vars.autoLDirection)),
+    getLayerL(fn.mul(vars.layerIdlePushValue, vars.lightnessOffsetDirection)),
   ),
   set(
     vars.layerIdlePushL,
@@ -1364,7 +1420,7 @@ utility(
   set(vars.layerPushValue, getPushValue(inputs.layerPushL)),
   set(
     vars.layerPushBaseL,
-    getLayerL(fn.mul(vars.layerPushValue, vars.autoLDirection)),
+    getLayerL(fn.mul(vars.layerPushValue, vars.lightnessOffsetDirection)),
   ),
   set(vars.layerPushL, getPushL(vars.layerPushValue, vars.layerPushBaseL)),
 );
@@ -1396,6 +1452,10 @@ utility(
   set(inputs.layerLMin, fn.value("[*]")),
   set(inputs.layerLMin, getPercentTokenValue("[number]")),
 );
+
+utility("layer-max-l-*", getLightnessDeclarations(inputs.layerLMax));
+
+utility("layer-min-l-*", getLightnessDeclarations(inputs.layerLMin));
 
 utility(
   "layer-max-c-*",
@@ -1485,6 +1545,10 @@ utility(
   set(inputs.edgeA, getPercentTokenValue("[number]")),
 );
 
+utility("edge-color-*", set(inputs.edgeColor, getWildcardColorTokenValue()));
+
+utility("edge-alpha-*", set(inputs.edgeA, getWildcardPercentTokenValue()));
+
 utility("edge-raw", set(inputs.edgeA, 1), set(inputs.edgePushL, 0));
 
 const edgeLighten = utility(
@@ -1548,6 +1612,10 @@ utility(
   set(inputs.edgeLMin, fn.value("[*]")),
   set(inputs.edgeLMin, getPercentTokenValue("[number]")),
 );
+
+utility("edge-max-l-*", getLightnessDeclarations(inputs.edgeLMax));
+
+utility("edge-min-l-*", getLightnessDeclarations(inputs.edgeLMin));
 
 utility(
   "edge-max-c-*",
@@ -1648,6 +1716,10 @@ utility(
   set(inputs.textPushL, getPercentTokenValue("[number]")),
 );
 
+utility("text-color-*", set(inputs.textColor, getWildcardColorTokenValue()));
+
+utility("text-push-*", set(inputs.textPushL, getWildcardPercentTokenValue()));
+
 utility(
   "ink-*",
   set(inputs.textA, getPercentTokenValue("[number]")),
@@ -1715,6 +1787,10 @@ utility(
   set(inputs.textLMin, getPercentTokenValue("[number]")),
 );
 
+utility("text-max-l-*", getLightnessDeclarations(inputs.textLMax));
+
+utility("text-min-l-*", getLightnessDeclarations(inputs.textLMin));
+
 utility(
   "text-max-c-*",
   set(inputs.textCMax, fn.value("[*]")),
@@ -1750,18 +1826,18 @@ const outlineColorAdjusted = fn.oklch(outlineBaseColor, {
   h: outlineAdjustedHue,
 });
 
-const outlineContrastShift = fn.mul(
+const outlinePushShift = fn.mul(
   fn.add(
-    fn.max(OUTLINE_MIN_CONTRAST, inputs.outlineContrastL),
+    fn.max(OUTLINE_MIN_PUSH, inputs.outlinePushL),
     fn.mul(vars.contrastT, CONTRAST_SCALE),
   ),
-  vars.outlineContrastDirection,
+  vars.outlinePushDirection,
 );
-const outlineComputedL = fn.add(vars.outlineParentL, outlineContrastShift);
+const outlineComputedL = fn.add(vars.outlineParentL, outlinePushShift);
 const outlineDirectedLightness = getDirectionalLightness(
   l,
   outlineComputedL,
-  vars.outlineContrastDirection,
+  vars.outlinePushDirection,
 );
 
 const outlineDirectional = fn.oklch(outlineColorAdjusted, {
@@ -1775,7 +1851,7 @@ utility(
   set.outlineColor(vars.outline),
   at.container(fn.style(vars.layerL), set(vars.outline, outlineDirectional)),
   mapLayerLightnessSteps((parentL, isDark) => [
-    set(vars.outlineContrastDirection, isDark ? 1 : -1),
+    set(vars.outlinePushDirection, isDark ? 1 : -1),
     set(vars.outlineParentL, parentL),
   ]),
 );
@@ -1785,7 +1861,17 @@ utility(
   set(inputs.outlineC, fn.value(chroma)),
   set(inputs.outlineH, fn.value(hue)),
   set(inputs.outlineColor, fn.value(color, "[color]")),
-  set(inputs.outlineContrastL, getPercentTokenValue("[number]")),
+  set(inputs.outlinePushL, getPercentTokenValue("[number]")),
+);
+
+utility(
+  "outline-color-*",
+  set(inputs.outlineColor, getWildcardColorTokenValue()),
+);
+
+utility(
+  "outline-push-*",
+  set(inputs.outlinePushL, getWildcardPercentTokenValue()),
 );
 
 const outlineLighten = utility(
@@ -1856,6 +1942,10 @@ utility(
   set(inputs.outlineLMin, fn.value("[*]")),
   set(inputs.outlineLMin, getPercentTokenValue("[number]")),
 );
+
+utility("outline-max-l-*", getLightnessDeclarations(inputs.outlineLMax));
+
+utility("outline-min-l-*", getLightnessDeclarations(inputs.outlineLMin));
 
 utility(
   "outline-max-c-*",

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -834,6 +834,8 @@ function getLightnessOffset(value: Value) {
  * variable for the expensive expression.
  */
 function withUtilityTokenGate(value: Value, pattern: string) {
+  // Use raw calc here because fn.mul(0, ...) simplifies to 0, dropping the
+  // --value() dependency that gates this declaration to matching utility tokens.
   return fn.add(value, fn.calc`0 * ${getPercentTokenValue(pattern)}`);
 }
 

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -196,7 +196,7 @@ function getWildcardColorTokenValue() {
 }
 
 function getLightnessDeclarations(target: VarProperty) {
-  return set(target, getWildcardPercentTokenValue());
+  return [set(target, getWildcardPercentTokenValue())];
 }
 
 /**
@@ -834,7 +834,7 @@ function getLightnessOffset(value: Value) {
  * variable for the expensive expression.
  */
 function withUtilityTokenGate(value: Value, pattern: string) {
-  return fn.calc`${value} + (0 * ${getPercentTokenValue(pattern)})`;
+  return fn.add(value, fn.calc`0 * ${getPercentTokenValue(pattern)}`);
 }
 
 /**

--- a/packages/ariakit-tailwind/src/output.css
+++ b/packages/ariakit-tailwind/src/output.css
@@ -125,22 +125,22 @@
   --_ak-ltl: lch(from var(--ak-layer) round(down, clamp(0, (l + (c * 0.11 * clamp(0, ((20 - l) / 20), 1)) + ((c * 0.18 * clamp(0, ((l - 50) / 50), 1)) * -1)), 100), 3.125) 0 0);
   --_ak-ct: calc((max(0, var(--contrast, 0)) / 100) * var(--_ak-contrast-scale));
   --_ak-cps: calc(1 + (var(--_ak-ct) * 3.334));
-  --_ak-lcb: calc((var(--_ak-ct) * -1) * 0.3334 * var(--_ak-ald));
+  --_ak-lcb: calc((var(--_ak-ct) * -1) * 0.3334 * var(--_ak-lod));
   --_ak-fla: max(0.2, (var(--_ak-flab) - (var(--_ak-ct) * 0.35)));
   --_ak-flb: min(0.9, (var(--_ak-flbb) + (var(--_ak-ct) * 0.175)));
-  --_ak-adtl: clamp(0, var(--_ak-ald), 1);
+  --_ak-odtl: clamp(0, var(--_ak-lod), 1);
   --_ak-bw: calc(var(--_ak-flb) - var(--_ak-fla));
-  --_ak-eb: calc(var(--_ak-flb) + (var(--_ak-adtl) * (var(--_ak-fla) - var(--_ak-flb))));
+  --_ak-eb: calc(var(--_ak-flb) + (var(--_ak-odtl) * (var(--_ak-fla) - var(--_ak-flb))));
   --_ak-sl: calc(l + (clamp(0, (min((l - var(--_ak-fla)), (var(--_ak-flb) - l)) * 1000000), 1) * ((var(--_ak-fla) + (clamp(0, ((l - ((var(--_ak-fla) + var(--_ak-flb)) / 2)) * 1000000), 1) * (var(--_ak-flb) - var(--_ak-fla)))) - l)));
   --_ak-licv: calc(var(--_ak-layer-idle-contrast-lightness) * var(--_ak-cps));
   --_ak-ecv: calc(var(--_ak-ct) * 0.3334);
   --_ak-lib: oklch(from var(--_ak-layer-color, var(--ak-layer-parent, canvas)) var(--_ak-layer-lightness, calc(l + var(--_ak-layer-idle-relative-lightness) + (clamp(0, (var(--_ak-layer-idle-relative-lightness) * 1000000), 1) * var(--_ak-llfb)))) var(--_ak-layer-chroma, calc(c + var(--_ak-layer-idle-relative-chroma))) var(--_ak-layer-hue, calc(h + var(--_ak-layer-idle-relative-hue))));
   --_ak-lim: var(--_ak-layer-mix, var(--_ak-lib));
-  --_ak-lia: oklch(from var(--_ak-lim) calc(clamp(var(--_ak-layer-lightness-min), (l + var(--_ak-layer-idle-auto-lightness) + (clamp(0, (var(--_ak-layer-idle-auto-lightness) * 1000000), 1) * var(--_ak-llfb))), var(--_ak-layer-lightness-max)) + var(--_ak-lcb)) c h);
-  --_ak-li: oklch(from var(--_ak-lia) calc(((l + (var(--_ak-lcd) * max(0, ((clamp(0, (var(--_ak-lcpl) + (var(--_ak-licv) * var(--_ak-lcd))), 1) - l) * var(--_ak-lcd))))) * (var(--_ak-lcd) * var(--_ak-lcd))) + (var(--_ak-lipl) * (1 - (var(--_ak-lcd) * var(--_ak-lcd))))) c h);
+  --_ak-lio: oklch(from var(--_ak-lim) calc(clamp(var(--_ak-layer-lightness-min), (l + var(--_ak-layer-idle-lightness-offset) + (clamp(0, (var(--_ak-layer-idle-lightness-offset) * 1000000), 1) * var(--_ak-llfb))), var(--_ak-layer-lightness-max)) + var(--_ak-lcb)) c h);
+  --_ak-li: oklch(from var(--_ak-lio) calc(((l + (var(--_ak-lcd) * max(0, ((clamp(0, (var(--_ak-lcpl) + (var(--_ak-licv) * var(--_ak-lcd))), 1) - l) * var(--_ak-lcd))))) * (var(--_ak-lcd) * var(--_ak-lcd))) + (var(--_ak-lipl) * (1 - (var(--_ak-lcd) * var(--_ak-lcd))))) c h);
   --_ak-lb: oklch(from oklch(from var(--_ak-li) calc(l + var(--_ak-layer-relative-lightness) + (clamp(0, (var(--_ak-layer-relative-lightness) * 1000000), 1) * var(--_ak-llfb))) calc(c + var(--_ak-layer-relative-chroma)) calc(h + var(--_ak-layer-relative-hue))) var(--_ak-sl) c h);
-  --_ak-la: oklch(from var(--_ak-lb) calc(l + var(--_ak-layer-auto-lightness) + (clamp(0, (var(--_ak-layer-auto-lightness) * 1000000), 1) * var(--_ak-llfb))) c h);
-  --_ak-lp: oklch(from var(--_ak-la) var(--_ak-lpl) c h);
+  --_ak-lo: oklch(from var(--_ak-lb) calc(l + var(--_ak-layer-lightness-offset) + (clamp(0, (var(--_ak-layer-lightness-offset) * 1000000), 1) * var(--_ak-llfb))) c h);
+  --_ak-lp: oklch(from var(--_ak-lo) var(--_ak-lpl) c h);
   @variant ak-light {
     --_ak-epd: -1;
   }
@@ -163,8 +163,8 @@
   --_ak-layer-chroma: --value(--chroma-*);
   --_ak-layer-hue: --value(--hue-*);
   --_ak-layer-color: --value(--color-*, [color]);
-  --_ak-layer-idle-auto-lightness-delta: calc((--value(number, [number], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * var(--_ak-ald));
-  --_ak-layer-idle-auto-lightness: calc((var(--_ak-layer-idle-auto-lightness-delta) + (clamp(0, (min(((l + var(--_ak-layer-idle-auto-lightness-delta)) - var(--_ak-fla)), (var(--_ak-flb) - (l + var(--_ak-layer-idle-auto-lightness-delta)))) * 1000000), 1) * (((var(--_ak-eb) - l) + (clamp(0, ((((l - clamp(0, (l + (var(--_ak-layer-idle-auto-lightness-delta) * -1)), 1)) * var(--_ak-ald)) - ((var(--_ak-eb) - l) * var(--_ak-ald))) * 1000000), 1) * ((var(--_ak-layer-idle-auto-lightness-delta) * -1) - (var(--_ak-eb) - l)))) - var(--_ak-layer-idle-auto-lightness-delta)))) + (0 * (--value(number, [number], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100)));
+  --_ak-layer-idle-lightness-offset-delta: calc((--value(number, [number], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * var(--_ak-lod));
+  --_ak-layer-idle-lightness-offset: calc((var(--_ak-layer-idle-lightness-offset-delta) + (clamp(0, (min(((l + var(--_ak-layer-idle-lightness-offset-delta)) - var(--_ak-fla)), (var(--_ak-flb) - (l + var(--_ak-layer-idle-lightness-offset-delta)))) * 1000000), 1) * (((var(--_ak-eb) - l) + (clamp(0, ((((l - clamp(0, (l + (var(--_ak-layer-idle-lightness-offset-delta) * -1)), 1)) * var(--_ak-lod)) - ((var(--_ak-eb) - l) * var(--_ak-lod))) * 1000000), 1) * ((var(--_ak-layer-idle-lightness-offset-delta) * -1) - (var(--_ak-eb) - l)))) - var(--_ak-layer-idle-lightness-offset-delta)))) + (0 * (--value(number, [number], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100)));
 }
 
 @utility ak-layer-mix {
@@ -179,8 +179,37 @@
 }
 
 @utility ak-state-* {
-  --_ak-layer-auto-lightness-delta: calc((--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * var(--_ak-ald));
-  --_ak-layer-auto-lightness: calc((var(--_ak-layer-auto-lightness-delta) + (clamp(0, (min(((l + var(--_ak-layer-auto-lightness-delta)) - var(--_ak-fla)), (var(--_ak-flb) - (l + var(--_ak-layer-auto-lightness-delta)))) * 1000000), 1) * (((var(--_ak-eb) - l) + (clamp(0, ((((l - clamp(0, (l + (var(--_ak-layer-auto-lightness-delta) * -1)), 1)) * var(--_ak-ald)) - ((var(--_ak-eb) - l) * var(--_ak-ald))) * 1000000), 1) * ((var(--_ak-layer-auto-lightness-delta) * -1) - (var(--_ak-eb) - l)))) - var(--_ak-layer-auto-lightness-delta)))) + (0 * (--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100)));
+  --_ak-layer-lightness-offset-delta: calc((--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * var(--_ak-lod));
+  --_ak-layer-lightness-offset: calc((var(--_ak-layer-lightness-offset-delta) + (clamp(0, (min(((l + var(--_ak-layer-lightness-offset-delta)) - var(--_ak-fla)), (var(--_ak-flb) - (l + var(--_ak-layer-lightness-offset-delta)))) * 1000000), 1) * (((var(--_ak-eb) - l) + (clamp(0, ((((l - clamp(0, (l + (var(--_ak-layer-lightness-offset-delta) * -1)), 1)) * var(--_ak-lod)) - ((var(--_ak-eb) - l) * var(--_ak-lod))) * 1000000), 1) * ((var(--_ak-layer-lightness-offset-delta) * -1) - (var(--_ak-eb) - l)))) - var(--_ak-layer-lightness-offset-delta)))) + (0 * (--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100)));
+}
+
+@utility ak-layer-offset-* {
+  --_ak-layer-idle-lightness-offset-delta: calc((--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * var(--_ak-lod));
+  --_ak-layer-idle-lightness-offset: calc((var(--_ak-layer-idle-lightness-offset-delta) + (clamp(0, (min(((l + var(--_ak-layer-idle-lightness-offset-delta)) - var(--_ak-fla)), (var(--_ak-flb) - (l + var(--_ak-layer-idle-lightness-offset-delta)))) * 1000000), 1) * (((var(--_ak-eb) - l) + (clamp(0, ((((l - clamp(0, (l + (var(--_ak-layer-idle-lightness-offset-delta) * -1)), 1)) * var(--_ak-lod)) - ((var(--_ak-eb) - l) * var(--_ak-lod))) * 1000000), 1) * ((var(--_ak-layer-idle-lightness-offset-delta) * -1) - (var(--_ak-eb) - l)))) - var(--_ak-layer-idle-lightness-offset-delta)))) + (0 * (--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100)));
+}
+
+@utility ak-state-offset-* {
+  --_ak-layer-lightness-offset-delta: calc((--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * var(--_ak-lod));
+  --_ak-layer-lightness-offset: calc((var(--_ak-layer-lightness-offset-delta) + (clamp(0, (min(((l + var(--_ak-layer-lightness-offset-delta)) - var(--_ak-fla)), (var(--_ak-flb) - (l + var(--_ak-layer-lightness-offset-delta)))) * 1000000), 1) * (((var(--_ak-eb) - l) + (clamp(0, ((((l - clamp(0, (l + (var(--_ak-layer-lightness-offset-delta) * -1)), 1)) * var(--_ak-lod)) - ((var(--_ak-eb) - l) * var(--_ak-lod))) * 1000000), 1) * ((var(--_ak-layer-lightness-offset-delta) * -1) - (var(--_ak-eb) - l)))) - var(--_ak-layer-lightness-offset-delta)))) + (0 * (--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100)));
+}
+
+@utility ak-layer-color-* {
+  --_ak-layer-color: --value(--color-*, [*]);
+}
+
+@utility ak-layer-mix-color-* {
+  --_ak-layer-mix-color: --value(--color-*, [*]);
+  --_ak-layer-mix: color-mix(in var(--_ak-layer-mix-method, oklab), var(--_ak-layer-mix-color, var(--ak-layer-parent, canvas)), var(--_ak-lib) var(--_ak-layer-mix-amount, 50%));
+}
+
+@utility ak-layer-mix-amount-* {
+  --_ak-layer-mix-amount: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") * 1%);
+  --_ak-layer-mix: color-mix(in var(--_ak-layer-mix-method, oklab), var(--_ak-layer-mix-color, var(--ak-layer-parent, canvas)), var(--_ak-lib) var(--_ak-layer-mix-amount, 50%));
+}
+
+@utility ak-layer-mix-method-* {
+  --_ak-layer-mix-method: --value(--mix-*, [*]);
+  --_ak-layer-mix: color-mix(in var(--_ak-layer-mix-method, oklab), var(--_ak-layer-mix-color, var(--ak-layer-parent, canvas)), var(--_ak-lib) var(--_ak-layer-mix-amount, 50%));
 }
 
 @utility ak-layer-lighten-* {
@@ -210,15 +239,15 @@
 @utility ak-layer-push-* {
   --_ak-layer-idle-push-lightness: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-lipv: calc(var(--_ak-layer-idle-push-lightness) * var(--_ak-cps));
-  --_ak-lipbl: calc(l + (var(--_ak-lipv) * var(--_ak-ald)) + (clamp(0, ((var(--_ak-lipv) * var(--_ak-ald)) * 1000000), 1) * var(--_ak-llfb)));
-  --_ak-lipl: clamp(0, (var(--_ak-lipbl) + (var(--_ak-ald) * var(--_ak-bw) * max(((clamp(0, ((var(--_ak-fla) - l) * 1000000), 1) * clamp(0, ((var(--_ak-lipbl) - var(--_ak-fla)) * 1000000), 1)) + (clamp(0, ((l - var(--_ak-flb)) * 1000000), 1) * clamp(0, ((var(--_ak-flb) - var(--_ak-lipbl)) * 1000000), 1))), (clamp(0, (min((var(--_ak-lipbl) - var(--_ak-fla)), (var(--_ak-flb) - var(--_ak-lipbl))) * 1000000), 1) * clamp(0, (var(--_ak-lipv) * 1000000), 1))))), 1);
+  --_ak-lipbl: calc(l + (var(--_ak-lipv) * var(--_ak-lod)) + (clamp(0, ((var(--_ak-lipv) * var(--_ak-lod)) * 1000000), 1) * var(--_ak-llfb)));
+  --_ak-lipl: clamp(0, (var(--_ak-lipbl) + (var(--_ak-lod) * var(--_ak-bw) * max(((clamp(0, ((var(--_ak-fla) - l) * 1000000), 1) * clamp(0, ((var(--_ak-lipbl) - var(--_ak-fla)) * 1000000), 1)) + (clamp(0, ((l - var(--_ak-flb)) * 1000000), 1) * clamp(0, ((var(--_ak-flb) - var(--_ak-lipbl)) * 1000000), 1))), (clamp(0, (min((var(--_ak-lipbl) - var(--_ak-fla)), (var(--_ak-flb) - var(--_ak-lipbl))) * 1000000), 1) * clamp(0, (var(--_ak-lipv) * 1000000), 1))))), 1);
 }
 
 @utility ak-state-push-* {
   --_ak-layer-push-lightness: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-lpv: calc(var(--_ak-layer-push-lightness) * var(--_ak-cps));
-  --_ak-lpbl: calc(l + (var(--_ak-lpv) * var(--_ak-ald)) + (clamp(0, ((var(--_ak-lpv) * var(--_ak-ald)) * 1000000), 1) * var(--_ak-llfb)));
-  --_ak-lpl: clamp(0, (var(--_ak-lpbl) + (var(--_ak-ald) * var(--_ak-bw) * max(((clamp(0, ((var(--_ak-fla) - l) * 1000000), 1) * clamp(0, ((var(--_ak-lpbl) - var(--_ak-fla)) * 1000000), 1)) + (clamp(0, ((l - var(--_ak-flb)) * 1000000), 1) * clamp(0, ((var(--_ak-flb) - var(--_ak-lpbl)) * 1000000), 1))), (clamp(0, (min((var(--_ak-lpbl) - var(--_ak-fla)), (var(--_ak-flb) - var(--_ak-lpbl))) * 1000000), 1) * clamp(0, (var(--_ak-lpv) * 1000000), 1))))), 1);
+  --_ak-lpbl: calc(l + (var(--_ak-lpv) * var(--_ak-lod)) + (clamp(0, ((var(--_ak-lpv) * var(--_ak-lod)) * 1000000), 1) * var(--_ak-llfb)));
+  --_ak-lpl: clamp(0, (var(--_ak-lpbl) + (var(--_ak-lod) * var(--_ak-bw) * max(((clamp(0, ((var(--_ak-fla) - l) * 1000000), 1) * clamp(0, ((var(--_ak-lpbl) - var(--_ak-fla)) * 1000000), 1)) + (clamp(0, ((l - var(--_ak-flb)) * 1000000), 1) * clamp(0, ((var(--_ak-flb) - var(--_ak-lpbl)) * 1000000), 1))), (clamp(0, (min((var(--_ak-lpbl) - var(--_ak-fla)), (var(--_ak-flb) - var(--_ak-lpbl))) * 1000000), 1) * clamp(0, (var(--_ak-lpv) * 1000000), 1))))), 1);
 }
 
 @utility ak-layer-contrast {
@@ -275,6 +304,14 @@
   --_ak-layer-chroma-min: --value(--chroma-*);
   --_ak-layer-lightness-min: --value([*]);
   --_ak-layer-lightness-min: calc(--value(number, [number], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+}
+
+@utility ak-layer-max-l-* {
+  --_ak-layer-lightness-max: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+}
+
+@utility ak-layer-min-l-* {
+  --_ak-layer-lightness-min: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
 }
 
 @utility ak-layer-max-c-* {
@@ -345,6 +382,14 @@
   --_ak-edge-alpha: calc(--value(number, [number], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
 }
 
+@utility ak-edge-color-* {
+  --_ak-edge-color: --value(--color-*, [*]);
+}
+
+@utility ak-edge-alpha-* {
+  --_ak-edge-alpha: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+}
+
 @utility ak-edge-raw {
   --_ak-edge-alpha: 1;
   --_ak-edge-push-lightness: 0;
@@ -408,6 +453,14 @@
   --_ak-edge-chroma-min: --value(--chroma-*);
   --_ak-edge-lightness-min: --value([*]);
   --_ak-edge-lightness-min: calc(--value(number, [number], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+}
+
+@utility ak-edge-max-l-* {
+  --_ak-edge-lightness-max: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+}
+
+@utility ak-edge-min-l-* {
+  --_ak-edge-lightness-min: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
 }
 
 @utility ak-edge-max-c-* {
@@ -635,6 +688,14 @@
   --_ak-text-push-lightness: calc(--value(number, [number], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
 }
 
+@utility ak-text-color-* {
+  --_ak-text-color: --value(--color-*, [*]);
+}
+
+@utility ak-text-push-* {
+  --_ak-text-push-lightness: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+}
+
 @utility ak-ink-* {
   --_ak-text-alpha: calc(--value(number, [number], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --ak-text: oklch(from var(--ak-layer) var(--_ak-tfcl) 0 0 / max((((((var(--_ak-lil) * var(--_ak-tmal)) + (var(--_ak-dal) * (var(--_ak-tmad) + var(--_ak-tmab)))) + (c * 0.135)) * var(--_ak-text-contrast-scale)) + (var(--_ak-ct) * 0.6668)), var(--_ak-text-alpha)));
@@ -697,6 +758,14 @@
   --_ak-text-lightness-min: calc(--value(number, [number], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
 }
 
+@utility ak-text-max-l-* {
+  --_ak-text-lightness-max: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+}
+
+@utility ak-text-min-l-* {
+  --_ak-text-lightness-min: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+}
+
 @utility ak-text-max-c-* {
   --_ak-text-chroma-max: --value([*]);
   --_ak-text-chroma-max: --value(--chroma-*);
@@ -714,42 +783,42 @@
   --_ak-ltl: lch(from var(--ak-layer) round(down, clamp(0, (l + (c * 0.11 * clamp(0, ((20 - l) / 20), 1)) + ((c * 0.18 * clamp(0, ((l - 50) / 50), 1)) * -1)), 100), 3.125) 0 0);
   outline-color: var(--ak-outline, canvastext);
   @container style(--_ak-ll) {
-    --ak-outline: oklch(from oklch(from var(--_ak-outline-color, var(--ak-layer)) var(--_ak-outline-lightness, calc(l + var(--_ak-outline-relative-lightness))) var(--_ak-outline-chroma, calc(c + var(--_ak-outline-relative-chroma))) var(--_ak-outline-hue, calc(h + var(--_ak-outline-relative-hue)))) clamp(var(--_ak-outline-lightness-min), (l + (var(--_ak-ocd) * max(0, (((var(--_ak-opl) + ((max(0.5, var(--_ak-outline-contrast-lightness)) + (var(--_ak-ct) * 0.3334)) * var(--_ak-ocd))) - l) * var(--_ak-ocd))))), var(--_ak-outline-lightness-max)) clamp(var(--_ak-outline-chroma-min), c, var(--_ak-outline-chroma-max, var(--chroma-p3-max, 0.368))) h);
+    --ak-outline: oklch(from oklch(from var(--_ak-outline-color, var(--ak-layer)) var(--_ak-outline-lightness, calc(l + var(--_ak-outline-relative-lightness))) var(--_ak-outline-chroma, calc(c + var(--_ak-outline-relative-chroma))) var(--_ak-outline-hue, calc(h + var(--_ak-outline-relative-hue)))) clamp(var(--_ak-outline-lightness-min), (l + (var(--_ak-opd) * max(0, (((var(--_ak-opl) + ((max(0.5, var(--_ak-outline-push-lightness)) + (var(--_ak-ct) * 0.3334)) * var(--_ak-opd))) - l) * var(--_ak-opd))))), var(--_ak-outline-lightness-max)) clamp(var(--_ak-outline-chroma-min), c, var(--_ak-outline-chroma-max, var(--chroma-p3-max, 0.368))) h);
   }
   @container style(--_ak-ll: oklch(0 0 0)) {
-    --_ak-ocd: 1;
+    --_ak-opd: 1;
     --_ak-opl: 0;
   }
   @container style(--_ak-ll: oklch(0.125 0 0)) {
-    --_ak-ocd: 1;
+    --_ak-opd: 1;
     --_ak-opl: 0.125;
   }
   @container style(--_ak-ll: oklch(0.25 0 0)) {
-    --_ak-ocd: 1;
+    --_ak-opd: 1;
     --_ak-opl: 0.25;
   }
   @container style(--_ak-ll: oklch(0.375 0 0)) {
-    --_ak-ocd: 1;
+    --_ak-opd: 1;
     --_ak-opl: 0.375;
   }
   @container style(--_ak-ll: oklch(0.5 0 0)) {
-    --_ak-ocd: 1;
+    --_ak-opd: 1;
     --_ak-opl: 0.5;
   }
   @container style(--_ak-ll: oklch(0.625 0 0)) {
-    --_ak-ocd: 1;
+    --_ak-opd: 1;
     --_ak-opl: 0.625;
   }
   @container style(--_ak-ll: oklch(0.75 0 0)) {
-    --_ak-ocd: -1;
+    --_ak-opd: -1;
     --_ak-opl: 0.75;
   }
   @container style(--_ak-ll: oklch(0.875 0 0)) {
-    --_ak-ocd: -1;
+    --_ak-opd: -1;
     --_ak-opl: 0.875;
   }
   @container style(--_ak-ll: oklch(1 0 0)) {
-    --_ak-ocd: -1;
+    --_ak-opd: -1;
     --_ak-opl: 1;
   }
 }
@@ -758,7 +827,15 @@
   --_ak-outline-chroma: --value(--chroma-*);
   --_ak-outline-hue: --value(--hue-*);
   --_ak-outline-color: --value(--color-*, [color]);
-  --_ak-outline-contrast-lightness: calc(--value(number, [number], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-outline-push-lightness: calc(--value(number, [number], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+}
+
+@utility ak-outline-color-* {
+  --_ak-outline-color: --value(--color-*, [*]);
+}
+
+@utility ak-outline-push-* {
+  --_ak-outline-push-lightness: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
 }
 
 @utility ak-outline-lighten-* {
@@ -815,6 +892,14 @@
   --_ak-outline-chroma-min: --value(--chroma-*);
   --_ak-outline-lightness-min: --value([*]);
   --_ak-outline-lightness-min: calc(--value(number, [number], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+}
+
+@utility ak-outline-max-l-* {
+  --_ak-outline-lightness-max: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+}
+
+@utility ak-outline-min-l-* {
+  --_ak-outline-lightness-min: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
 }
 
 @utility ak-outline-max-c-* {
@@ -1068,7 +1153,7 @@
   initial-value: max(0, (0.13 - l));
 }
 
-@property --_ak-ald {
+@property --_ak-lod {
   syntax: "*";
   inherits: false;
   initial-value: calc((clamp(0, ((0.645 - l) * 1000000), 1) * 2) - 1);
@@ -1206,7 +1291,7 @@
   initial-value: canvas;
 }
 
-@property --_ak-lia {
+@property --_ak-lio {
   syntax: "<color>";
   inherits: false;
   initial-value: canvas;
@@ -1248,7 +1333,7 @@
   initial-value: canvas;
 }
 
-@property --_ak-la {
+@property --_ak-lo {
   syntax: "<color>";
   inherits: false;
   initial-value: canvas;
@@ -1290,7 +1375,7 @@
   initial-value: 0;
 }
 
-@property --_ak-ocd {
+@property --_ak-opd {
   syntax: "<number>";
   inherits: false;
   initial-value: 1;
@@ -1379,13 +1464,13 @@
   initial-value: 0;
 }
 
-@property --_ak-layer-idle-auto-lightness-delta {
+@property --_ak-layer-idle-lightness-offset-delta {
   syntax: "*";
   inherits: false;
   initial-value: 0;
 }
 
-@property --_ak-layer-idle-auto-lightness {
+@property --_ak-layer-idle-lightness-offset {
   syntax: "*";
   inherits: false;
   initial-value: 0;
@@ -1459,13 +1544,13 @@
   initial-value: 0;
 }
 
-@property --_ak-layer-auto-lightness-delta {
+@property --_ak-layer-lightness-offset-delta {
   syntax: "*";
   inherits: false;
   initial-value: 0;
 }
 
-@property --_ak-layer-auto-lightness {
+@property --_ak-layer-lightness-offset {
   syntax: "*";
   inherits: false;
   initial-value: 0;
@@ -1643,7 +1728,7 @@
   inherits: false;
 }
 
-@property --_ak-outline-contrast-lightness {
+@property --_ak-outline-push-lightness {
   syntax: "*";
   inherits: false;
   initial-value: 0;

--- a/site/src/components/box-patterns.react.tsx
+++ b/site/src/components/box-patterns.react.tsx
@@ -12,11 +12,11 @@ import { Icon } from "#app/icons/icon.react.tsx";
 export function BoxPatternsRight() {
   const top = (
     <div className="absolute bottom-full flex flex-col gap-2 inset-e-0 mb-4 w-full h-40 mask-t-from-50% mask-t-to-95% ak-layer ak-layer-6 ak-frame-border ak-frame ak-frame-2xl/2 [--hole:var(--ak-layer-parent)]">
-      <div className="ak-layer ak-layer-(color:--hole) ak-frame ak-frame-p-2 ring flex-1 flex flex-col">
+      <div className="ak-layer ak-layer-color-(--hole) ak-frame ak-frame-p-2 ring flex-1 flex flex-col">
         <div className="flex-1" />
         <div className="ak-layer ak-layer-6 ak-frame ak-frame-p-1 h-8 w-2/3" />
       </div>
-      <div className="ak-layer ak-dark:ak-layer-(color:--hole) ak-frame ak-frame-p-1 ring flex">
+      <div className="ak-layer ak-dark:ak-layer-color-(--hole) ak-frame ak-frame-p-1 ring flex">
         <div className="size-8 ak-frame ak-frame-p-1 ak-layer ak-layer-6 ms-auto" />
       </div>
     </div>

--- a/site/src/components/code-block-content.astro
+++ b/site/src/components/code-block-content.astro
@@ -836,7 +836,7 @@ function getFragmentPieces(
                           return pieces.map((piece) => (
                             <span
                               style={`--dark:${dark}; --light:${light}`}
-                              class="ak-text ak-text-(color:--dark) ak-light:ak-text-(color:--light)"
+                              class="ak-text ak-text-color-(--dark) ak-light:ak-text-color-(--light)"
                             >
                               {piece.type === "anchor" ? (
                                 <ReferenceHovercardAnchor
@@ -891,7 +891,7 @@ function getFragmentPieces(
                           <span
                             style={`--dark:${dark}; --light:${light}`}
                             class:list={[
-                              "ak-text ak-text-(color:--dark) ak-light:ak-text-(color:--light) ak-layer ak-layer-(color:--ak-text) ak-layer-mix-10 ak-edge-(color:--ak-text) ak-edge-20",
+                              "ak-text ak-text-color-(--dark) ak-light:ak-text-color-(--light) ak-layer ak-layer-color-(--ak-text) ak-layer-mix-10 ak-edge-color-(--ak-text) ak-edge-20",
                               HIGHLIGHT_CHIP_CLASS,
                             ]}
                           >
@@ -944,7 +944,7 @@ function getFragmentPieces(
                           return pieces.map((piece) => (
                             <span
                               style={`--dark:${dark}; --light:${light}`}
-                              class="ak-text ak-text-(color:--dark) ak-light:ak-text-(color:--light)"
+                              class="ak-text ak-text-color-(--dark) ak-light:ak-text-color-(--light)"
                             >
                               {piece.type === "anchor" ? (
                                 <ReferenceHovercardAnchor
@@ -1000,7 +1000,7 @@ function getFragmentPieces(
                           <span
                             style={`--dark:${dark}; --light:${light}`}
                             class:list={[
-                              "ak-text ak-text-(color:--dark) ak-light:ak-text-(color:--light) ak-layer ak-layer-(color:--ak-text) ak-layer-mix-10 ak-edge-(color:--ak-text) ak-edge-20",
+                              "ak-text ak-text-color-(--dark) ak-light:ak-text-color-(--light) ak-layer ak-layer-color-(--ak-text) ak-layer-mix-10 ak-edge-color-(--ak-text) ak-edge-20",
                               HIGHLIGHT_CHIP_CLASS,
                             ]}
                           >

--- a/site/src/components/code-block.react.tsx
+++ b/site/src/components/code-block.react.tsx
@@ -819,7 +819,7 @@ export function CodeBlockTabs({
                   >
                     <ak.TabList
                       className={clsx(
-                        "ak-tab-list ak-layer ak-layer-(color:--ak-layer-parent) ak-layer-darken-0 rounded-b-none!",
+                        "ak-tab-list ak-layer ak-layer-color-(--ak-layer-parent) ak-layer-darken-0 rounded-b-none!",
                         hasToolbar && "sm:ak-frame-p-1",
                       )}
                     >

--- a/site/src/components/content-admonition.astro
+++ b/site/src/components/content-admonition.astro
@@ -65,10 +65,10 @@ const titleContent =
   {...props}
 >
   <div class="ak-prose-content ak-prose-text-base/relaxed">
-    <div class:list={["font-medium ak-text ak-text-(color:--color) flex gap-2"]}>
+    <div class:list={["font-medium ak-text ak-text-color-(--color) flex gap-2"]}>
       <Icon
         name={icon}
-        className="ak-text ak-text-(color:--color) size-[1.25em] flex-none h-(--ak-prose-leading)"
+        className="ak-text ak-text-color-(--color) size-[1.25em] flex-none h-(--ak-prose-leading)"
       />
 
       {titleContent}

--- a/site/src/components/reference-label.react.tsx
+++ b/site/src/components/reference-label.react.tsx
@@ -43,7 +43,7 @@ export function getReferenceLabelText(
 export function getReferenceLabelColors(kind: ReferenceLabelProps["kind"]) {
   const kindColors = labelColors[kind];
   const className =
-    "ak-text ak-text-(color:--dark) ak-light:ak-text-(color:--light) ak-text-0";
+    "ak-text ak-text-color-(--dark) ak-light:ak-text-color-(--light) ak-text-0";
   const getStyle = (color: typeof kindColors) => {
     return {
       "--dark": color.dark,

--- a/site/src/examples/disclosure/actions/index.react.tsx
+++ b/site/src/examples/disclosure/actions/index.react.tsx
@@ -104,7 +104,7 @@ function OrderCard({ order }: OrderCardProps) {
             className={clsx("text-sm", className)}
             checkmark="after"
             icon={
-              <span className="ak-text ak-text-(color:--status-color)">
+              <span className="ak-text ak-text-color-(--status-color)">
                 {icon}
               </span>
             }

--- a/site/src/lib/stackblitz-test.ts
+++ b/site/src/lib/stackblitz-test.ts
@@ -251,11 +251,11 @@ test("solid-vite project emits generated utilities", () => {
     @utility ak-badge-* {
       --ak-badge-color: --value(--color, [*]);
       @apply ak-badge_base;
-      @apply ak-layer ak-layer-(color:--ak-badge-color) ak-layer-mix-15 ak-dark:ak-edge-(color:--ak-badge-color) ak-edge-20 ak-light:ak-edge-(color:--ak-badge-color);
+      @apply ak-layer ak-layer-color-(--ak-badge-color) ak-layer-mix-15 ak-dark:ak-edge-color-(--ak-badge-color) ak-edge-20 ak-light:ak-edge-color-(--ak-badge-color);
       &::before,
       &::after,
       :where(& > *) {
-        @apply ak-text ak-text-(color:--ak-badge-color) ak-text-25;
+        @apply ak-text ak-text-color-(--ak-badge-color) ak-text-25;
       }
     }
 

--- a/site/src/lib/styles-test.ts
+++ b/site/src/lib/styles-test.ts
@@ -58,11 +58,11 @@ test("scanAkTokensInFiles finds tokens inside group-/peer- ak variant prefixes",
 
 test("scanAkTokensInFiles preserves colons inside arbitrary values", () => {
   const tokens = scanAkTokens(`
-    <div className="ak-layer-(color:--ak-layer-parent) ak-dark:ak-edge-(color:--ak-edge)"></div>
+    <div className="ak-badge-(color:--status-color) ak-dark:ak-edge-color-(--ak-edge)"></div>
   `);
-  expect(tokens.has("ak-layer-(color:--ak-layer-parent)")).toBe(true);
-  expect(tokens.has("ak-edge-(color:--ak-edge)")).toBe(true);
-  expect(tokens.has("ak-layer-(color")).toBe(false);
+  expect(tokens.has("ak-badge-(color:--status-color)")).toBe(true);
+  expect(tokens.has("ak-edge-color-(--ak-edge)")).toBe(true);
+  expect(tokens.has("ak-badge-(color")).toBe(false);
   expect(tokens.has("ak-edge-(color")).toBe(false);
 });
 
@@ -313,7 +313,7 @@ test("generated style dependencies preserve arbitrary values", () => {
     expect.arrayContaining([
       {
         type: "utility",
-        name: "ak-layer-(color:--ak-tab-bg)",
+        name: "ak-layer-color-(--ak-tab-bg)",
         import: "@ariakit/tailwind",
       },
     ]),

--- a/site/src/lib/styles-test.ts
+++ b/site/src/lib/styles-test.ts
@@ -58,11 +58,11 @@ test("scanAkTokensInFiles finds tokens inside group-/peer- ak variant prefixes",
 
 test("scanAkTokensInFiles preserves colons inside arbitrary values", () => {
   const tokens = scanAkTokens(`
-    <div className="ak-badge-(color:--status-color) ak-dark:ak-edge-color-(--ak-edge)"></div>
+    <div className="ak-layer-(color:--ak-layer-parent) ak-dark:ak-edge-(color:--ak-edge)"></div>
   `);
-  expect(tokens.has("ak-badge-(color:--status-color)")).toBe(true);
-  expect(tokens.has("ak-edge-color-(--ak-edge)")).toBe(true);
-  expect(tokens.has("ak-badge-(color")).toBe(false);
+  expect(tokens.has("ak-layer-(color:--ak-layer-parent)")).toBe(true);
+  expect(tokens.has("ak-edge-(color:--ak-edge)")).toBe(true);
+  expect(tokens.has("ak-layer-(color")).toBe(false);
   expect(tokens.has("ak-edge-(color")).toBe(false);
 });
 

--- a/site/src/sandbox/ariakit-tailwind/__snapshots__/dark
+++ b/site/src/sandbox/ariakit-tailwind/__snapshots__/dark
@@ -18,6 +18,15 @@
       "#CB8CC6": "bg-[oklch(0.1919_0.0082_274.531)] text-[oklch(1_0_0)] *:text-[lch(66.1436_37.44_327.358)] rounded-[15px] border-[1px] border-[oklch(1_0.0082_274.531_/_0.1)] p-[4px] shadow-[oklch(1_0.0082_274.531_/_0.1)_0px_0px_0px_0px]",
       "#CE9178": "bg-[oklch(0.1919_0.0082_274.531)] text-[oklch(1_0_0)] *:text-[lch(65.8798_31.52_46.871)] rounded-[15px] border-[1px] border-[oklch(1_0.0082_274.531_/_0.1)] p-[4px] shadow-[oklch(1_0.0082_274.531_/_0.1)_0px_0px_0px_0px]",
       "#165DFC": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(57.033_80_288.704)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
+      "explicit longhands": {
+        "class": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
+        "children": {
+          "layer": "bg-[oklch(0.75_0.12_260)] text-[oklch(0_0_0)] *:text-[lch(18.2327_40_269.452)] rounded-[10px] border-[1px] border-[oklch(1_0.12_260_/_0.1)] p-[4px] shadow-[oklch(1_0.12_260_/_0.1)_0px_0px_0px_0px]",
+          "state": "bg-[oklch(0.4134_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
+          "mix": "bg-[oklch(0.4472_0.1007_345.998)] text-[oklch(1_0_0)] *:text-[lch(88.4225_33.14_344.573)] rounded-[10px] border-[1px] border-[oklch(1_0.1007_345.998_/_0.1)] p-[4px] shadow-[oklch(1_0.1007_345.998_/_0.1)_0px_0px_0px_0px]",
+          "edge/text/outline": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(82.4685_65.49_140.432)] rounded-[10px] border-[1px] border-[oklch(1_0.18_145_/_0.35)] p-[4px] shadow-[oklch(1_0.18_145_/_0.35)_0px_0px_0px_0px] ring-[2px] ring-[oklch(0.625_0.18_145)]"
+        }
+      },
       "ak-layer! modifier cascade": {
         "class": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
         "children": {

--- a/site/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
+++ b/site/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
@@ -18,6 +18,15 @@
       "#CB8CC6": "bg-[oklch(0_0.0082_274.531)] text-[oklch(1_0_0)] *:text-[lch(100_37.44_327.358)] rounded-[15px] border-[1px] border-[oklch(1_0.0082_274.531_/_0.4334)] p-[4px] shadow-[oklch(1_0.0082_274.531_/_0.4334)_0px_0px_0px_0px]",
       "#CE9178": "bg-[oklch(0_0.0082_274.531)] text-[oklch(1_0_0)] *:text-[lch(100_31.52_46.871)] rounded-[15px] border-[1px] border-[oklch(1_0.0082_274.531_/_0.4334)] p-[4px] shadow-[oklch(1_0.0082_274.531_/_0.4334)_0px_0px_0px_0px]",
       "#165DFC": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(100_80_288.704)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
+      "explicit longhands": {
+        "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
+        "children": {
+          "layer": "bg-[oklch(0.0166_0.12_260)] text-[oklch(1_0_0)] *:text-[lch(100_13.3_296.465)] rounded-[10px] border-[1px] border-[oklch(1_0.12_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.12_260_/_0.4334)_0px_0px_0px_0px]",
+          "state": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
+          "mix": "bg-[oklch(0.0566_0.1007_345.998)] text-[oklch(1_0_0)] *:text-[lch(100_3.81_347.088)] rounded-[10px] border-[1px] border-[oklch(1_0.1007_345.998_/_0.4334)] p-[4px] shadow-[oklch(1_0.1007_345.998_/_0.4334)_0px_0px_0px_0px]",
+          "edge/text/outline": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(100_65.49_140.432)] rounded-[10px] border-[1px] border-[oklch(1_0.18_145_/_0.6834)] p-[4px] shadow-[oklch(1_0.18_145_/_0.6834)_0px_0px_0px_0px] ring-[2px] ring-[oklch(0.8334_0.18_145)]"
+        }
+      },
       "ak-layer! modifier cascade": {
         "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
         "children": {

--- a/site/src/sandbox/ariakit-tailwind/__snapshots__/light
+++ b/site/src/sandbox/ariakit-tailwind/__snapshots__/light
@@ -18,6 +18,15 @@
       "#CB8CC6": "bg-[oklch(0.1919_0.0082_274.531)] text-[oklch(1_0_0)] *:text-[lch(66.1436_37.44_327.358)] rounded-[15px] border-[1px] border-[oklch(0_0.0082_274.531_/_0.1)] p-[4px] shadow-[oklch(0_0.0082_274.531_/_0.1)_0px_0px_0px_0px]",
       "#CE9178": "bg-[oklch(0.1919_0.0082_274.531)] text-[oklch(1_0_0)] *:text-[lch(65.8798_31.52_46.871)] rounded-[15px] border-[1px] border-[oklch(0_0.0082_274.531_/_0.1)] p-[4px] shadow-[oklch(0_0.0082_274.531_/_0.1)_0px_0px_0px_0px]",
       "#165DFC": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(43.4424_80_288.704)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
+      "explicit longhands": {
+        "class": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
+        "children": {
+          "layer": "bg-[oklch(0.75_0.12_260)] text-[oklch(0_0_0)] *:text-[lch(18.2327_40_269.452)] rounded-[10px] border-[1px] border-[oklch(0_0.12_260_/_0.1)] p-[4px] shadow-[oklch(0_0.12_260_/_0.1)_0px_0px_0px_0px]",
+          "state": "bg-[oklch(0.7433_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
+          "mix": "bg-[oklch(0.7377_0.0979_88.499)] text-[oklch(0_0_0)] *:text-[lch(18.2327_40_84.439)] rounded-[10px] border-[1px] border-[oklch(0_0.0979_88.499_/_0.1)] p-[4px] shadow-[oklch(0_0.0979_88.499_/_0.1)_0px_0px_0px_0px]",
+          "edge/text/outline": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(24.21_69.56_138.596)] rounded-[10px] border-[1px] border-[oklch(0_0.18_145_/_0.35)] p-[4px] shadow-[oklch(0_0.18_145_/_0.35)_0px_0px_0px_0px] ring-[2px] ring-[oklch(0.5_0.18_145)]"
+        }
+      },
       "ak-layer! modifier cascade": {
         "class": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
         "children": {

--- a/site/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
+++ b/site/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
@@ -18,6 +18,15 @@
       "#CB8CC6": "bg-[oklch(0_0.0082_274.531)] text-[oklch(1_0_0)] *:text-[lch(100_37.44_327.358)] rounded-[15px] border-[1px] border-[oklch(0_0.0082_274.531_/_0.4334)] p-[4px] shadow-[oklch(0_0.0082_274.531_/_0.4334)_0px_0px_0px_0px]",
       "#CE9178": "bg-[oklch(0_0.0082_274.531)] text-[oklch(1_0_0)] *:text-[lch(100_31.52_46.871)] rounded-[15px] border-[1px] border-[oklch(0_0.0082_274.531_/_0.4334)] p-[4px] shadow-[oklch(0_0.0082_274.531_/_0.4334)_0px_0px_0px_0px]",
       "#165DFC": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_80_288.704)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
+      "explicit longhands": {
+        "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
+        "children": {
+          "layer": "bg-[oklch(0.0166_0.12_260)] text-[oklch(1_0_0)] *:text-[lch(100_13.3_296.465)] rounded-[10px] border-[1px] border-[oklch(0_0.12_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.12_260_/_0.4334)_0px_0px_0px_0px]",
+          "state": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
+          "mix": "bg-[oklch(1_0.0979_88.499)] text-[oklch(0_0_0)] *:text-[lch(0_39.85_85.481)] rounded-[10px] border-[1px] border-[oklch(0_0.0979_88.499_/_0.4334)] p-[4px] shadow-[oklch(0_0.0979_88.499_/_0.4334)_0px_0px_0px_0px]",
+          "edge/text/outline": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_69.56_138.596)] rounded-[10px] border-[1px] border-[oklch(0_0.18_145_/_0.6834)] p-[4px] shadow-[oklch(0_0.18_145_/_0.6834)_0px_0px_0px_0px] ring-[2px] ring-[oklch(0.1666_0.18_145)]"
+        }
+      },
       "ak-layer! modifier cascade": {
         "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
         "children": {

--- a/site/src/sandbox/ariakit-tailwind/index.react.tsx
+++ b/site/src/sandbox/ariakit-tailwind/index.react.tsx
@@ -341,6 +341,29 @@ export default function Example() {
           />
           <Cell label="#165DFC" className="*:ak-text *:ak-text-[#165DFC]" />
           <Layer
+            label="explicit longhands"
+            className="ak-layer ak-frame ak-frame-p-1 ak-frame-border flex-col"
+          >
+            <Layer className="flex-wrap items-start">
+              <Cell
+                label="layer"
+                className="[--demo-color:oklch(0.55_0.12_260)] [--demo-max-l:80] [--demo-offset:20] ak-layer-color-(--demo-color) ak-layer-offset-(--demo-offset) ak-layer-max-l-(--demo-max-l) *:ak-text"
+              />
+              <Cell
+                label="state"
+                className="[--demo-offset:25] ak-state-offset-(--demo-offset)"
+              />
+              <Cell
+                label="mix"
+                className="[--demo-color:oklch(0.6_0.15_30)] [--demo-mix:35] [--demo-method:oklch] ak-layer-mix-color-(--demo-color) ak-layer-mix-amount-(--demo-mix) ak-layer-mix-method-(--demo-method) *:ak-text"
+              />
+              <Cell
+                label="edge/text/outline"
+                className="[--demo-alpha:35] [--demo-color:oklch(0.58_0.18_145)] [--demo-push:25] ak-edge-color-(--demo-color) ak-edge-alpha-(--demo-alpha) ak-outline ak-outline-color-(--demo-color) ak-outline-push-(--demo-push) outline outline-2 *:ak-text *:ak-text-color-(--demo-color) *:ak-text-push-(--demo-push)"
+              />
+            </Layer>
+          </Layer>
+          <Layer
             label="ak-layer! modifier cascade"
             className="ak-layer ak-frame ak-frame-p-1 ak-frame-border flex-col"
           >

--- a/site/src/styles/ak-badge.css
+++ b/site/src/styles/ak-badge.css
@@ -19,12 +19,12 @@
 @utility ak-badge-* {
   --ak-badge-color: --value(--color, [*]);
   @apply ak-badge_base;
-  @apply ak-layer ak-layer-(color:--ak-badge-color) ak-layer-mix-15 ak-dark:ak-edge-(color:--ak-badge-color) ak-edge-20 ak-light:ak-edge-(color:--ak-badge-color);
+  @apply ak-layer ak-layer-color-(--ak-badge-color) ak-layer-mix-15 ak-dark:ak-edge-color-(--ak-badge-color) ak-edge-20 ak-light:ak-edge-color-(--ak-badge-color);
 
   &::before,
   &::after,
   :where(& > *) {
-    @apply ak-text ak-text-(color:--ak-badge-color) ak-text-25;
+    @apply ak-text ak-text-color-(--ak-badge-color) ak-text-25;
   }
 }
 

--- a/site/src/styles/ak-checkbox.css
+++ b/site/src/styles/ak-checkbox.css
@@ -138,12 +138,12 @@
 }
 
 @utility ak-checkbox-card-check_checked {
-  @apply ak-layer ak-layer-(color:--ak-checkbox-card-edge) ak-layer-darken-0 empty:before:ak-icon-check;
+  @apply ak-layer ak-layer-color-(--ak-checkbox-card-edge) ak-layer-darken-0 empty:before:ak-icon-check;
   @apply ring-(--ak-layer) border-0 ring *:block;
 }
 
 @utility ak-checkbox-card-check_disabled {
-  @apply ak-layer ak-layer-(color:--ak-layer-parent) ak-layer-darken-0 ak-ink-0 ak-edge-10;
+  @apply ak-layer ak-layer-color-(--ak-layer-parent) ak-layer-darken-0 ak-ink-0 ak-edge-10;
 }
 
 @utility ak-checkbox-card-check {

--- a/site/src/styles/ak-nav.css
+++ b/site/src/styles/ak-nav.css
@@ -67,7 +67,7 @@
     @apply bg-transparent;
   }
   &::before {
-    @apply -z-1 ak-layer ak-layer-(color:--ak-layer) absolute inset-x-0 rounded-[inherit];
+    @apply -z-1 ak-layer ak-layer-color-(--ak-layer) absolute inset-x-0 rounded-[inherit];
     content: "";
     inset-block: calc(var(--ak-nav-gap) * 0.5);
   }

--- a/site/src/styles/ak-progress.css
+++ b/site/src/styles/ak-progress.css
@@ -57,7 +57,7 @@
   --ak-progress-layer-parent: var(--ak-layer-parent);
   --ak-progress-ring: var(--ak-edge);
   &::after {
-    @apply ak-layer ak-layer-(color:--ak-progress-layer-parent);
+    @apply ak-layer ak-layer-color-(--ak-progress-layer-parent);
     @apply ring-(--ak-progress-ring) inset-(--ak-progress-thickness) absolute rounded-full ring;
     content: "";
   }

--- a/site/src/styles/ak-tab.css
+++ b/site/src/styles/ak-tab.css
@@ -35,7 +35,7 @@
 }
 
 @utility ak-tab-panel {
-  @apply ak-frame-border-(--ak-tab-border-width) ak-layer ak-layer-(color:--ak-tab-bg) ak-frame ak-frame-cover;
+  @apply ak-frame-border-(--ak-tab-border-width) ak-layer ak-layer-color-(--ak-tab-bg) ak-frame ak-frame-cover;
   @apply border-(--ak-tab-border-color)! relative;
 }
 
@@ -95,7 +95,7 @@
 }
 
 @utility ak-tab-folder_selected {
-  @apply ak-layer ak-layer-(color:--ak-tab-bg) ak-ink-100;
+  @apply ak-layer ak-layer-color-(--ak-tab-bg) ak-ink-100;
   @apply z-2 border-(--ak-tab-border-color)! rounded-b-none!;
 
   &:not(:last-child)::after {

--- a/site/src/styles/styles.json
+++ b/site/src/styles/styles.json
@@ -231,14 +231,14 @@
               "value": {}
             },
             {
-              "name": "@apply ak-layer ak-layer-(color:--ak-badge-color) ak-layer-mix-15 ak-dark:ak-edge-(color:--ak-badge-color) ak-edge-20 ak-light:ak-edge-(color:--ak-badge-color)",
+              "name": "@apply ak-layer ak-layer-color-(--ak-badge-color) ak-layer-mix-15 ak-dark:ak-edge-color-(--ak-badge-color) ak-edge-20 ak-light:ak-edge-color-(--ak-badge-color)",
               "value": {}
             },
             {
               "name": "&::before,\n  &::after,\n  :where(& > *)",
               "value": [
                 {
-                  "name": "@apply ak-text ak-text-(color:--ak-badge-color) ak-text-25",
+                  "name": "@apply ak-text ak-text-color-(--ak-badge-color) ak-text-25",
                   "value": {}
                 }
               ]
@@ -257,7 +257,7 @@
             },
             {
               "type": "utility",
-              "name": "ak-layer-(color:--ak-badge-color)",
+              "name": "ak-layer-color-(--ak-badge-color)",
               "import": "@ariakit/tailwind"
             },
             {
@@ -272,7 +272,7 @@
             },
             {
               "type": "utility",
-              "name": "ak-edge-(color:--ak-badge-color)",
+              "name": "ak-edge-color-(--ak-badge-color)",
               "import": "@ariakit/tailwind"
             },
             {
@@ -292,7 +292,7 @@
             },
             {
               "type": "utility",
-              "name": "ak-text-(color:--ak-badge-color)",
+              "name": "ak-text-color-(--ak-badge-color)",
               "import": "@ariakit/tailwind"
             },
             {
@@ -1660,7 +1660,7 @@
           "type": "utility",
           "properties": [
             {
-              "name": "@apply ak-layer ak-layer-(color:--ak-checkbox-card-edge) ak-layer-darken-0 empty:before:ak-icon-check",
+              "name": "@apply ak-layer ak-layer-color-(--ak-checkbox-card-edge) ak-layer-darken-0 empty:before:ak-icon-check",
               "value": {}
             },
             {
@@ -1676,7 +1676,7 @@
             },
             {
               "type": "utility",
-              "name": "ak-layer-(color:--ak-checkbox-card-edge)",
+              "name": "ak-layer-color-(--ak-checkbox-card-edge)",
               "import": "@ariakit/tailwind"
             },
             {
@@ -1696,7 +1696,7 @@
           "type": "utility",
           "properties": [
             {
-              "name": "@apply ak-layer ak-layer-(color:--ak-layer-parent) ak-layer-darken-0 ak-ink-0 ak-edge-10",
+              "name": "@apply ak-layer ak-layer-color-(--ak-layer-parent) ak-layer-darken-0 ak-ink-0 ak-edge-10",
               "value": {}
             }
           ],
@@ -1708,7 +1708,7 @@
             },
             {
               "type": "utility",
-              "name": "ak-layer-(color:--ak-layer-parent)",
+              "name": "ak-layer-color-(--ak-layer-parent)",
               "import": "@ariakit/tailwind"
             },
             {
@@ -2476,7 +2476,7 @@
           "type": "utility",
           "properties": [
             {
-              "name": "@apply ak-frame-border-(--ak-tab-border-width) ak-layer ak-layer-(color:--ak-tab-bg) ak-frame ak-frame-cover",
+              "name": "@apply ak-frame-border-(--ak-tab-border-width) ak-layer ak-layer-color-(--ak-tab-bg) ak-frame ak-frame-cover",
               "value": {}
             },
             {
@@ -2497,7 +2497,7 @@
             },
             {
               "type": "utility",
-              "name": "ak-layer-(color:--ak-tab-bg)",
+              "name": "ak-layer-color-(--ak-tab-bg)",
               "import": "@ariakit/tailwind"
             },
             {
@@ -2759,7 +2759,7 @@
           "type": "utility",
           "properties": [
             {
-              "name": "@apply ak-layer ak-layer-(color:--ak-tab-bg) ak-ink-100",
+              "name": "@apply ak-layer ak-layer-color-(--ak-tab-bg) ak-ink-100",
               "value": {}
             },
             {
@@ -2888,7 +2888,7 @@
             },
             {
               "type": "utility",
-              "name": "ak-layer-(color:--ak-tab-bg)",
+              "name": "ak-layer-color-(--ak-tab-bg)",
               "import": "@ariakit/tailwind"
             },
             {
@@ -4669,7 +4669,7 @@
               "name": "&::before",
               "value": [
                 {
-                  "name": "@apply -z-1 ak-layer ak-layer-(color:--ak-layer) absolute inset-x-0 rounded-[inherit]",
+                  "name": "@apply -z-1 ak-layer ak-layer-color-(--ak-layer) absolute inset-x-0 rounded-[inherit]",
                   "value": {}
                 },
                 {
@@ -4691,7 +4691,7 @@
             },
             {
               "type": "utility",
-              "name": "ak-layer-(color:--ak-layer)",
+              "name": "ak-layer-color-(--ak-layer)",
               "import": "@ariakit/tailwind"
             }
           ]
@@ -6804,7 +6804,7 @@
               "name": "&::after",
               "value": [
                 {
-                  "name": "@apply ak-layer ak-layer-(color:--ak-progress-layer-parent)",
+                  "name": "@apply ak-layer ak-layer-color-(--ak-progress-layer-parent)",
                   "value": {}
                 },
                 {
@@ -6856,7 +6856,7 @@
             },
             {
               "type": "utility",
-              "name": "ak-layer-(color:--ak-progress-layer-parent)",
+              "name": "ak-layer-color-(--ak-progress-layer-parent)",
               "import": "@ariakit/tailwind"
             }
           ]


### PR DESCRIPTION
## Motivation

`@ariakit/tailwind` has overloaded wildcard utilities where CSS custom properties require typed arbitrary value hints such as `(color:--var)` or `(number:--var)`. That makes variable-based usage noisier than necessary and leaves some naming around automatic layer offsets and outline contrast less precise than the behavior it controls.

## Solution

Add explicit longhand aliases for the overloaded slots so custom properties can use untyped forms like `ak-layer-offset-(--depth)`, `ak-layer-color-(--surface)`, `ak-outline-push-(--push)`, and the `*-max-l-*`/`*-min-l-*` lightness-bound utilities. Existing shorthand utilities remain supported.

The Ariakit Tailwind internals and generated CSS now use `lightness-offset` naming for layer/state offset variables and `outline-push` naming for outline directional lightness controls. The README and migration guide document the new aliases and custom-property scale behavior.

This also updates practical site call sites to use the new explicit color utilities, regenerates `site/src/styles/styles.json`, and adds representative sandbox coverage plus updated snapshots.

Validation:

- `pnpm -F @ariakit/tailwind build`
- `pnpm -F site run build-styles`
- `pnpm exec oxlint --disable-nested-config packages/ariakit-tailwind`
- `pnpm exec oxfmt --check packages/ariakit-tailwind`
- `pnpm exec vitest run site/src/lib/styles-test.ts site/src/lib/stackblitz-test.ts`
- `SITE_PORT=4322 pnpm -F site test-chrome ariakit-tailwind --grep-invert wcag -u`
- `SITE_PORT=4322 pnpm -F site test-chrome ariakit-tailwind --grep-invert wcag`
- `SITE_PORT=4322 pnpm -F site test-chrome ariakit-tailwind -g wcag`
- `git diff --check`

Note: `pnpm -F @ariakit/tailwind lint` is currently blocked before linting by oxlint rejecting `options.typeAware` in the repository config; the direct package oxlint run with `--disable-nested-config` and package format check pass.

No changeset, per request.