### PR TITLE
Use raw Tailwind arbitrary values

### DIFF
--- a/packages/ariakit-tailwind/migrating-to-v02.md
+++ b/packages/ariakit-tailwind/migrating-to-v02.md
@@ -6,7 +6,7 @@ This guide covers all breaking changes for users of the `@ariakit/tailwind` plug
 
 1. **Explicit base classes.** Utilities like `ak-layer`, `ak-frame`, `ak-text`, and `ak-outline` must now appear as base classes before their modifiers.
 2. **Slash to hyphen.** Opacity/value syntax changes from `/N` to `-N`. Text opacity moves from `ak-text/80` to `ak-ink-80`.
-3. **Explicit longhands for custom properties.** Overloaded shorthand utilities still need typed arbitrary value hints like `(color:--var)` or `(number:--var)`, but explicit longhands can use custom properties directly, such as `ak-layer-color-(--var)` and `ak-layer-offset-(--var)`. Custom-property values are raw CSS values, so use normalized values like `0.2` instead of scaled utility tokens like `20`.
+3. **Explicit longhands for custom properties.** Overloaded shorthand utilities still need typed arbitrary value hints when a shorthand accepts multiple value kinds, such as `ak-layer-(color:--var)` for colors or `ak-layer-(number:--var)` for lightness offsets. For `ak-edge`, `ak-text`, and `ak-outline`, use explicit longhands for custom properties, such as `ak-edge-alpha-(--alpha)`, `ak-text-push-(--value)`, and `ak-outline-push-(--value)`. Custom-property values are raw CSS values, so use normalized values like `0.2` instead of scaled utility tokens like `20`.
 4. **Unified `--ak-edge`.** The CSS variables `--ak-layer-border`, `--ak-border`, `--ak-ring`, and `--ak-layer-ring` are all replaced by `--ak-edge`.
 
 ---

--- a/packages/ariakit-tailwind/migrating-to-v02.md
+++ b/packages/ariakit-tailwind/migrating-to-v02.md
@@ -6,7 +6,7 @@ This guide covers all breaking changes for users of the `@ariakit/tailwind` plug
 
 1. **Explicit base classes.** Utilities like `ak-layer`, `ak-frame`, `ak-text`, and `ak-outline` must now appear as base classes before their modifiers.
 2. **Slash to hyphen.** Opacity/value syntax changes from `/N` to `-N`. Text opacity moves from `ak-text/80` to `ak-ink-80`.
-3. **Explicit longhands for custom properties.** Overloaded shorthand utilities still need typed arbitrary value hints like `(color:--var)` or `(number:--var)`, but explicit longhands can use custom properties directly, such as `ak-layer-color-(--var)` and `ak-layer-offset-(--var)`.
+3. **Explicit longhands for custom properties.** Overloaded shorthand utilities still need typed arbitrary value hints like `(color:--var)` or `(number:--var)`, but explicit longhands can use custom properties directly, such as `ak-layer-color-(--var)` and `ak-layer-offset-(--var)`. Custom-property values are raw CSS values, so use normalized values like `0.2` instead of scaled utility tokens like `20`.
 4. **Unified `--ak-edge`.** The CSS variables `--ak-layer-border`, `--ak-border`, `--ak-ring`, and `--ak-layer-ring` are all replaced by `--ak-edge`.
 
 ---
@@ -129,6 +129,8 @@ Custom pop values can use the explicit offset longhand.
 + ak-layer ak-layer-offset-(--depth)
 ```
 
+The `--depth` value should be a raw normalized offset such as `0.2`, not `20`.
+
 ### Variant prefixes on modifier classes
 
 When `ak-layer` is already on the element unconditionally, variant-prefixed modifiers work without re-applying `ak-layer`:
@@ -184,6 +186,8 @@ For custom properties on the mix utility itself, pair `ak-layer-mix` with explic
 - ak-layer-mix-(color:--my-mix-color) ak-layer-mix-(number:--amount)
 + ak-layer-mix ak-layer-mix-color-(--my-mix-color) ak-layer-mix-amount-(--amount)
 ```
+
+The `--amount` value should be a raw CSS percentage such as `15%`.
 
 ---
 
@@ -248,7 +252,7 @@ Custom color text can use the explicit color longhand.
 + ak-text ak-text-color-(--my-color)
 ```
 
-For custom push values, use `ak-text-push-(--value)` instead of `ak-text-(number:--value)`.
+For custom push values, use `ak-text-push-(--value)` instead of `ak-text-(number:--value)`. The `--value` custom property should contain a raw normalized value such as `0.25`.
 
 ---
 
@@ -279,7 +283,7 @@ In v0.1, `ak-edge-contrast-<color>` set the edge to a solid color with lightness
 
 `ak-edge-raw` is shorthand for `ak-edge-100 ak-edge-push-0` — use it when you want the color to be applied exactly as specified. For other combinations, `ak-edge-N` controls alpha (`100` = opaque) and `ak-edge-push-N` controls how far the edge lightness is pushed away from the layer (`0` = the color's natural lightness).
 
-For custom alpha values, use `ak-edge-alpha-(--alpha)` instead of `ak-edge-(number:--alpha)`.
+For custom alpha values, use `ak-edge-alpha-(--alpha)` instead of `ak-edge-(number:--alpha)`. The `--alpha` custom property should contain a raw alpha value such as `0.4`.
 
 ### CSS variable renames (color)
 

--- a/packages/ariakit-tailwind/package.json
+++ b/packages/ariakit-tailwind/package.json
@@ -33,8 +33,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "node src/build.ts",
-    "lint": "oxlint . && oxfmt --check ."
+    "build": "node src/build.ts"
   },
   "devDependencies": {
     "csstype": "3.2.3",

--- a/packages/ariakit-tailwind/readme.md
+++ b/packages/ariakit-tailwind/readme.md
@@ -66,6 +66,12 @@ Ariakit Tailwind revolves around a few families of utilities:
 
 All color math uses [OKLCH](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/oklch), so modifiers like `ak-layer-warm-40` or `ak-text-saturate-50` behave predictably across hues. Because every value is computed relatively, changing a single theme token ripples through every layer, text, edge, and frame that depends on it — so users can reskin the whole system without breaking contrast, depth, or shape relationships.
 
+### Value scales
+
+Bare numeric modifiers use Ariakit's documented authoring scales. For example, lightness and alpha values use `0`–`100`, chroma values use `0`–`40`, and mix amounts use `0`–`100`.
+
+Arbitrary values and custom properties are raw CSS values. Use normalized OKLCH channel values like `ak-layer-l-[0.8]`, raw deltas like `ak-layer-[calc(l+0.1)]`, percentages where CSS expects percentages like `ak-layer-mix-amount-[35%]`, and custom properties that already contain those raw values.
+
 ## Theming
 
 Ariakit Tailwind integrates directly with Tailwind's theming system. Every `--color-*`, `--radius-*`, and `--spacing-*` token in your `@theme` block becomes available to the matching Ariakit utilities.
@@ -150,31 +156,31 @@ Use [`ak-edge`](#ak-edge) to fine-tune border, ring, and shadow colors without t
 
 ### Setting the layer color
 
-| Utility                   | Description                                                                                                                                                                                               |
-| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ak-layer`                | Required base class. Sets background, text, border, and shadow colors.                                                                                                                                    |
-| `ak-layer-<color>`        | Sets the layer to a specific color. Accepts any theme color (e.g. `ak-layer-primary`, `ak-layer-blue-500`) or arbitrary value (`ak-layer-[#131418]`).                                                     |
-| `ak-layer-color-<color>`  | Explicit color-only alias. Useful for custom properties without a typed arbitrary value hint (`ak-layer-color-(--surface)`).                                                                              |
-| `ak-layer-<number>`       | Shifts lightness relative to parent layer (`0`–`100`). Nested `ak-layer` alone uses a sensible default step.                                                                                              |
-| `ak-layer-offset-<value>` | Explicit lightness-offset alias for `ak-layer-<number>`. Useful for custom properties without a typed arbitrary value hint (`ak-layer-offset-(--depth)`). Custom properties use the same `0`–`100` scale. |
-| `ak-layer-<chroma>`       | Sets chroma from a named preset, e.g. `ak-layer-vivid`, `ak-layer-muted`. See `--chroma-*` tokens.                                                                                                        |
-| `ak-layer-<hue>`          | Sets hue from a named preset, e.g. `ak-layer-red`, `ak-layer-blue`. See `--hue-*` tokens.                                                                                                                 |
+| Utility                   | Description                                                                                                                                                                                         |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ak-layer`                | Required base class. Sets background, text, border, and shadow colors.                                                                                                                              |
+| `ak-layer-<color>`        | Sets the layer to a specific color. Accepts any theme color (e.g. `ak-layer-primary`, `ak-layer-blue-500`) or arbitrary value (`ak-layer-[#131418]`).                                               |
+| `ak-layer-color-<color>`  | Explicit color-only alias. Useful for custom properties without a typed arbitrary value hint (`ak-layer-color-(--surface)`).                                                                        |
+| `ak-layer-<number>`       | Shifts lightness relative to parent layer (`0`–`100`). Nested `ak-layer` alone uses a sensible default step. Arbitrary values are raw, e.g. `ak-layer-[calc(l+0.1)]`.                               |
+| `ak-layer-offset-<value>` | Explicit lightness-offset alias for `ak-layer-<number>`. Useful for custom properties without a typed arbitrary value hint (`ak-layer-offset-(--depth)`). Arbitrary/custom-property values are raw. |
+| `ak-layer-<chroma>`       | Sets chroma from a named preset, e.g. `ak-layer-vivid`, `ak-layer-muted`. See `--chroma-*` tokens.                                                                                                  |
+| `ak-layer-<hue>`          | Sets hue from a named preset, e.g. `ak-layer-red`, `ak-layer-blue`. See `--hue-*` tokens.                                                                                                           |
 
 ### Lightness adjustments
 
-| Utility                      | Description                                                                                                                                                                  |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ak-layer-lighten-<number>`  | Lightens the layer by `<number>`%. Accepts arbitrary values (`ak-layer-lighten-[0.05]`).                                                                                     |
-| `ak-layer-darken-<number>`   | Darkens the layer by `<number>`%.                                                                                                                                            |
-| `ak-layer-push-<number>`     | Minimum lightness shift (self-relative), jumping the forbidden mid-luminance range where contrast math becomes unreliable.                                                   |
-| `ak-layer-contrast`          | Adapts the layer to contrast against its parent (preset `25`).                                                                                                               |
-| `ak-layer-contrast-<number>` | Custom contrast amount (`0`–`100`, default `25`).                                                                                                                            |
-| `ak-layer-invert`            | Inverts lightness (clamped so the result is never pure black).                                                                                                               |
-| `ak-layer-l-<value>`         | Sets absolute lightness (`0`–`100`). Custom properties use the same scale.                                                                                                   |
-| `ak-layer-max-<value>`       | Caps lightness (`0`–`100`) or caps chroma with a named chroma preset (`ak-layer-max-muted`). Custom properties use the same lightness scale.                                 |
-| `ak-layer-min-<value>`       | Floors lightness or chroma, same form as `max-*`.                                                                                                                            |
-| `ak-layer-max-l-<value>`     | Caps lightness specifically. Useful for custom properties without a typed arbitrary value hint (`ak-layer-max-l-(--max-l)`). Custom properties use the same `0`–`100` scale. |
-| `ak-layer-min-l-<value>`     | Floors lightness specifically. Custom properties use the same `0`–`100` scale.                                                                                               |
+| Utility                      | Description                                                                                                                                                            |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ak-layer-lighten-<number>`  | Lightens the layer by `<number>`%. Arbitrary values are raw (`ak-layer-lighten-[0.05]`).                                                                               |
+| `ak-layer-darken-<number>`   | Darkens the layer by `<number>`%.                                                                                                                                      |
+| `ak-layer-push-<number>`     | Minimum lightness shift (self-relative), jumping the forbidden mid-luminance range where contrast math becomes unreliable.                                             |
+| `ak-layer-contrast`          | Adapts the layer to contrast against its parent (preset `25`).                                                                                                         |
+| `ak-layer-contrast-<number>` | Custom contrast amount (`0`–`100`, default `25`).                                                                                                                      |
+| `ak-layer-invert`            | Inverts lightness (clamped so the result is never pure black).                                                                                                         |
+| `ak-layer-l-<value>`         | Sets absolute lightness (`0`–`100` for bare numbers, raw `0`–`1` for arbitrary/custom-property values).                                                                |
+| `ak-layer-max-<value>`       | Caps lightness (`0`–`100` for bare numbers, raw `0`–`1` for arbitrary/custom-property values) or caps chroma with a named chroma preset (`ak-layer-max-muted`).        |
+| `ak-layer-min-<value>`       | Floors lightness or chroma, same form as `max-*`.                                                                                                                      |
+| `ak-layer-max-l-<value>`     | Caps lightness specifically. Useful for custom properties without a typed arbitrary value hint (`ak-layer-max-l-(--max-l)`). Arbitrary/custom-property values are raw. |
+| `ak-layer-min-l-<value>`     | Floors lightness specifically. Arbitrary/custom-property values are raw.                                                                                               |
 
 ### Hue adjustments
 
@@ -191,22 +197,22 @@ Use [`ak-edge`](#ak-edge) to fine-tune border, ring, and shadow colors without t
 | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `ak-layer-saturate-<number>`   | Increases chroma by `<number>`%.                                                                                                                        |
 | `ak-layer-desaturate-<number>` | Decreases chroma by `<number>`%.                                                                                                                        |
-| `ak-layer-c-<value>`           | Sets absolute chroma (`0`–`40`) or a named preset. Custom properties use the same numeric scale.                                                        |
-| `ak-layer-max-c-<value>`       | Caps chroma (`0`–`40`) or a named preset. Custom properties use the same numeric scale.                                                                 |
+| `ak-layer-c-<value>`           | Sets absolute chroma (`0`–`40` for bare numbers, raw OKLCH chroma for arbitrary/custom-property values) or a named preset.                              |
+| `ak-layer-max-c-<value>`       | Caps chroma (`0`–`40` for bare numbers, raw OKLCH chroma for arbitrary/custom-property values) or a named preset.                                       |
 | `ak-layer-min-c-<value>`       | Floors chroma, same form.                                                                                                                               |
 | `ak-layer-max-c-auto`          | Automatically caps chroma based on layer lightness. Peaks at the mid-luminance threshold and tapers toward extremes so colors stay within the P3 gamut. |
 
 ### Mixing with another color
 
-| Utility                        | Description                                                                                                                                              |
-| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ak-layer-mix`                 | Enables mixing. By default, mixes with the parent layer at `50%` using the `oklab` interpolation method.                                                 |
-| `ak-layer-mix-<color>`         | Enables mixing with a color, e.g. `ak-layer-mix-primary` or `ak-layer-mix-[#000]`.                                                                       |
-| `ak-layer-mix-color-<color>`   | Sets the mix color for `ak-layer-mix`. Useful for custom properties (`ak-layer-mix-color-(--mix-color)`).                                                |
-| `ak-layer-mix-<number>`        | Sets the mix amount (`0`–`100`).                                                                                                                         |
-| `ak-layer-mix-amount-<value>`  | Sets the amount for `ak-layer-mix`. Useful for custom properties (`ak-layer-mix-amount-(--mix-amount)`). Custom properties use the same `0`–`100` scale. |
-| `ak-layer-mix-<method>`        | Sets the interpolation method, e.g. `ak-layer-mix-oklch`, `ak-layer-mix-shorter-hue`, `ak-layer-mix-srgb`. See the `--mix-*` tokens.                     |
-| `ak-layer-mix-method-<method>` | Sets the interpolation method for `ak-layer-mix`. Useful for custom properties (`ak-layer-mix-method-(--mix-method)`).                                   |
+| Utility                        | Description                                                                                                                                                        |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ak-layer-mix`                 | Enables mixing. By default, mixes with the parent layer at `50%` using the `oklab` interpolation method.                                                           |
+| `ak-layer-mix-<color>`         | Enables mixing with a color, e.g. `ak-layer-mix-primary` or `ak-layer-mix-[#000]`.                                                                                 |
+| `ak-layer-mix-color-<color>`   | Sets the mix color for `ak-layer-mix`. Useful for custom properties (`ak-layer-mix-color-(--mix-color)`).                                                          |
+| `ak-layer-mix-<number>`        | Sets the mix amount (`0`–`100`).                                                                                                                                   |
+| `ak-layer-mix-amount-<value>`  | Sets the amount for `ak-layer-mix`. Useful for custom properties (`ak-layer-mix-amount-(--mix-amount)`). Arbitrary/custom-property values are raw CSS percentages. |
+| `ak-layer-mix-<method>`        | Sets the interpolation method, e.g. `ak-layer-mix-oklch`, `ak-layer-mix-shorter-hue`, `ak-layer-mix-srgb`. See the `--mix-*` tokens.                               |
+| `ak-layer-mix-method-<method>` | Sets the interpolation method for `ak-layer-mix`. Useful for custom properties (`ak-layer-mix-method-(--mix-method)`).                                             |
 
 Combine freely — `ak-layer ak-layer-primary ak-layer-mix ak-layer-mix-30 ak-layer-mix-oklch` mixes the primary color 30% into the parent layer using OKLCH.
 
@@ -222,16 +228,16 @@ The explicit `ak-layer-mix-*` longhands configure the mix color, amount, and met
 </button>
 ```
 
-| Utility                        | Description                                                                                                                                                         |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ak-state-<value>`             | Adjusts lightness for interactive state (`0`–`100`), parallel to `ak-layer-<number>`. Custom properties can use `ak-state-(--depth)`.                               |
-| `ak-state-offset-<value>`      | Explicit lightness-offset alias for `ak-state-<value>`. Useful for custom properties (`ak-state-offset-(--depth)`). Custom properties use the same `0`–`100` scale. |
-| `ak-state-lighten-<number>`    | Lightens in state context.                                                                                                                                          |
-| `ak-state-darken-<number>`     | Darkens in state context.                                                                                                                                           |
-| `ak-state-saturate-<number>`   | Increases chroma in state context.                                                                                                                                  |
-| `ak-state-desaturate-<number>` | Decreases chroma in state context.                                                                                                                                  |
-| `ak-state-push-<number>`       | Minimum lightness shift in state context.                                                                                                                           |
-| `ak-state-h-rotate-<number>`   | Rotates hue in state context.                                                                                                                                       |
+| Utility                        | Description                                                                                                                                                            |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ak-state-<value>`             | Adjusts lightness for interactive state (`0`–`100` for bare numbers), parallel to `ak-layer-<number>`. Custom properties can use `ak-state-(--depth)` with raw values. |
+| `ak-state-offset-<value>`      | Explicit lightness-offset alias for `ak-state-<value>`. Useful for custom properties (`ak-state-offset-(--depth)`). Arbitrary/custom-property values are raw.          |
+| `ak-state-lighten-<number>`    | Lightens in state context.                                                                                                                                             |
+| `ak-state-darken-<number>`     | Darkens in state context.                                                                                                                                              |
+| `ak-state-saturate-<number>`   | Increases chroma in state context.                                                                                                                                     |
+| `ak-state-desaturate-<number>` | Decreases chroma in state context.                                                                                                                                     |
+| `ak-state-push-<number>`       | Minimum lightness shift in state context.                                                                                                                              |
+| `ak-state-h-rotate-<number>`   | Rotates hue in state context.                                                                                                                                          |
 
 ## `ak-ink`
 
@@ -263,15 +269,15 @@ Controls the opacity of text inside a layer — useful for secondary text, capti
 
 ### Setting the text color
 
-| Utility                 | Description                                                                                                                                                   |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ak-text`               | Required base class for colored text.                                                                                                                         |
-| `ak-text-<color>`       | Applies a color with automatic contrast, e.g. `ak-text-primary`, `ak-text-[#c33]`.                                                                            |
-| `ak-text-color-<color>` | Explicit color-only alias. Useful for custom properties (`ak-text-color-(--text-color)`).                                                                     |
-| `ak-text-<number>`      | Pushes lightness away from the parent layer beyond the automatic readable floor.                                                                              |
-| `ak-text-push-<value>`  | Explicit lightness-push alias for `ak-text-<number>`. Useful for custom properties (`ak-text-push-(--push)`). Custom properties use the same `0`–`100` scale. |
-| `ak-text-<chroma>`      | Sets chroma from a named preset (`ak-text-vivid`).                                                                                                            |
-| `ak-text-<hue>`         | Sets hue from a named preset (`ak-text-blue`).                                                                                                                |
+| Utility                 | Description                                                                                                                                             |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ak-text`               | Required base class for colored text.                                                                                                                   |
+| `ak-text-<color>`       | Applies a color with automatic contrast, e.g. `ak-text-primary`, `ak-text-[#c33]`.                                                                      |
+| `ak-text-color-<color>` | Explicit color-only alias. Useful for custom properties (`ak-text-color-(--text-color)`).                                                               |
+| `ak-text-<number>`      | Pushes lightness away from the parent layer beyond the automatic readable floor.                                                                        |
+| `ak-text-push-<value>`  | Explicit lightness-push alias for `ak-text-<number>`. Useful for custom properties (`ak-text-push-(--push)`). Arbitrary/custom-property values are raw. |
+| `ak-text-<chroma>`      | Sets chroma from a named preset (`ak-text-vivid`).                                                                                                      |
+| `ak-text-<hue>`         | Sets hue from a named preset (`ak-text-blue`).                                                                                                          |
 
 ### Adjustments
 
@@ -286,18 +292,18 @@ Controls the opacity of text inside a layer — useful for secondary text, capti
 
 ### Channels and bounds
 
-| Utility                     | Description                                                                                 |
-| --------------------------- | ------------------------------------------------------------------------------------------- |
-| `ak-text-l-<value>`         | Absolute lightness (`0`–`100`). Custom properties use the same scale.                       |
-| `ak-text-c-<value>`         | Absolute chroma (`0`–`40`) or a named preset. Custom properties use the same numeric scale. |
-| `ak-text-h-<value>`         | Absolute hue. Accepts named hues or degrees, including custom properties.                   |
-| `ak-text-h-rotate-<number>` | Rotates hue by degrees.                                                                     |
-| `ak-text-max-<value>`       | Caps lightness, or caps chroma when given a named chroma preset.                            |
-| `ak-text-min-<value>`       | Floors lightness or chroma, same form.                                                      |
-| `ak-text-max-l-<value>`     | Caps lightness specifically. Custom properties use the same `0`–`100` scale.                |
-| `ak-text-min-l-<value>`     | Floors lightness specifically. Custom properties use the same `0`–`100` scale.              |
-| `ak-text-max-c-<value>`     | Caps chroma specifically. Custom properties use the same `0`–`40` scale.                    |
-| `ak-text-min-c-<value>`     | Floors chroma specifically. Custom properties use the same `0`–`40` scale.                  |
+| Utility                     | Description                                                                                                           |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `ak-text-l-<value>`         | Absolute lightness (`0`–`100` for bare numbers, raw `0`–`1` for arbitrary/custom-property values).                    |
+| `ak-text-c-<value>`         | Absolute chroma (`0`–`40` for bare numbers, raw OKLCH chroma for arbitrary/custom-property values) or a named preset. |
+| `ak-text-h-<value>`         | Absolute hue. Accepts named hues or degrees, including custom properties.                                             |
+| `ak-text-h-rotate-<number>` | Rotates hue by degrees.                                                                                               |
+| `ak-text-max-<value>`       | Caps lightness, or caps chroma when given a named chroma preset.                                                      |
+| `ak-text-min-<value>`       | Floors lightness or chroma, same form.                                                                                |
+| `ak-text-max-l-<value>`     | Caps lightness specifically. Arbitrary/custom-property values are raw.                                                |
+| `ak-text-min-l-<value>`     | Floors lightness specifically. Arbitrary/custom-property values are raw.                                              |
+| `ak-text-max-c-<value>`     | Caps chroma specifically. Arbitrary/custom-property values are raw.                                                   |
+| `ak-text-min-c-<value>`     | Floors chroma specifically. Arbitrary/custom-property values are raw.                                                 |
 
 ## `ak-edge`
 
@@ -312,15 +318,15 @@ Controls the opacity of text inside a layer — useful for secondary text, capti
 
 ### Setting the edge color
 
-| Utility                 | Description                                                                                                                                            |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `ak-edge-<number>`      | Sets edge alpha (`0`–`100`, default `10`).                                                                                                             |
-| `ak-edge-alpha-<value>` | Explicit alpha alias for `ak-edge-<number>`. Useful for custom properties (`ak-edge-alpha-(--alpha)`). Custom properties use the same `0`–`100` scale. |
-| `ak-edge-<color>`       | Applies a specific edge color.                                                                                                                         |
-| `ak-edge-color-<color>` | Explicit color-only alias. Useful for custom properties (`ak-edge-color-(--edge-color)`).                                                              |
-| `ak-edge-<chroma>`      | Sets chroma from a named preset.                                                                                                                       |
-| `ak-edge-<hue>`         | Sets hue from a named preset.                                                                                                                          |
-| `ak-edge-raw`           | Applies the color exactly as specified — shorthand for `ak-edge-100` + `ak-edge-push-0`.                                                               |
+| Utility                 | Description                                                                                                                                                   |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ak-edge-<number>`      | Sets edge alpha (`0`–`100`, default `10`).                                                                                                                    |
+| `ak-edge-alpha-<value>` | Explicit alpha alias for `ak-edge-<number>`. Useful for custom properties (`ak-edge-alpha-(--alpha)`). Arbitrary/custom-property values are raw alpha values. |
+| `ak-edge-<color>`       | Applies a specific edge color.                                                                                                                                |
+| `ak-edge-color-<color>` | Explicit color-only alias. Useful for custom properties (`ak-edge-color-(--edge-color)`).                                                                     |
+| `ak-edge-<chroma>`      | Sets chroma from a named preset.                                                                                                                              |
+| `ak-edge-<hue>`         | Sets hue from a named preset.                                                                                                                                 |
+| `ak-edge-raw`           | Applies the color exactly as specified — shorthand for `ak-edge-100` + `ak-edge-push-0`.                                                                      |
 
 ### Adjustments
 
@@ -336,18 +342,18 @@ Controls the opacity of text inside a layer — useful for secondary text, capti
 
 ### Channels and bounds
 
-| Utility                     | Description                                                                                 |
-| --------------------------- | ------------------------------------------------------------------------------------------- |
-| `ak-edge-l-<value>`         | Absolute lightness (`0`–`100`). Custom properties use the same scale.                       |
-| `ak-edge-c-<value>`         | Absolute chroma (`0`–`40`) or a named preset. Custom properties use the same numeric scale. |
-| `ak-edge-h-<value>`         | Absolute hue. Accepts named hues or degrees, including custom properties.                   |
-| `ak-edge-h-rotate-<number>` | Rotates hue by degrees.                                                                     |
-| `ak-edge-max-<value>`       | Caps lightness or chroma.                                                                   |
-| `ak-edge-min-<value>`       | Floors lightness or chroma.                                                                 |
-| `ak-edge-max-l-<value>`     | Caps lightness specifically. Custom properties use the same `0`–`100` scale.                |
-| `ak-edge-min-l-<value>`     | Floors lightness specifically. Custom properties use the same `0`–`100` scale.              |
-| `ak-edge-max-c-<value>`     | Caps chroma specifically. Custom properties use the same `0`–`40` scale.                    |
-| `ak-edge-min-c-<value>`     | Floors chroma specifically. Custom properties use the same `0`–`40` scale.                  |
+| Utility                     | Description                                                                                                           |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `ak-edge-l-<value>`         | Absolute lightness (`0`–`100` for bare numbers, raw `0`–`1` for arbitrary/custom-property values).                    |
+| `ak-edge-c-<value>`         | Absolute chroma (`0`–`40` for bare numbers, raw OKLCH chroma for arbitrary/custom-property values) or a named preset. |
+| `ak-edge-h-<value>`         | Absolute hue. Accepts named hues or degrees, including custom properties.                                             |
+| `ak-edge-h-rotate-<number>` | Rotates hue by degrees.                                                                                               |
+| `ak-edge-max-<value>`       | Caps lightness or chroma.                                                                                             |
+| `ak-edge-min-<value>`       | Floors lightness or chroma.                                                                                           |
+| `ak-edge-max-l-<value>`     | Caps lightness specifically. Arbitrary/custom-property values are raw.                                                |
+| `ak-edge-min-l-<value>`     | Floors lightness specifically. Arbitrary/custom-property values are raw.                                              |
+| `ak-edge-max-c-<value>`     | Caps chroma specifically. Arbitrary/custom-property values are raw.                                                   |
+| `ak-edge-min-c-<value>`     | Floors chroma specifically. Arbitrary/custom-property values are raw.                                                 |
 
 ## `ak-outline`
 
@@ -363,15 +369,15 @@ Controls the opacity of text inside a layer — useful for secondary text, capti
 
 ### Setting the outline color
 
-| Utility                    | Description                                                                                                                                                         |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ak-outline`               | Required base class.                                                                                                                                                |
-| `ak-outline-<color>`       | Applies a specific outline color.                                                                                                                                   |
-| `ak-outline-color-<color>` | Explicit color-only alias. Useful for custom properties (`ak-outline-color-(--outline-color)`).                                                                     |
-| `ak-outline-<number>`      | Pushes outline lightness away from the parent layer (`0`–`100`).                                                                                                    |
-| `ak-outline-push-<value>`  | Explicit lightness-push alias for `ak-outline-<number>`. Useful for custom properties (`ak-outline-push-(--push)`). Custom properties use the same `0`–`100` scale. |
-| `ak-outline-<chroma>`      | Sets chroma from a named preset.                                                                                                                                    |
-| `ak-outline-<hue>`         | Sets hue from a named preset.                                                                                                                                       |
+| Utility                    | Description                                                                                                                                                   |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ak-outline`               | Required base class.                                                                                                                                          |
+| `ak-outline-<color>`       | Applies a specific outline color.                                                                                                                             |
+| `ak-outline-color-<color>` | Explicit color-only alias. Useful for custom properties (`ak-outline-color-(--outline-color)`).                                                               |
+| `ak-outline-<number>`      | Pushes outline lightness away from the parent layer (`0`–`100`).                                                                                              |
+| `ak-outline-push-<value>`  | Explicit lightness-push alias for `ak-outline-<number>`. Useful for custom properties (`ak-outline-push-(--push)`). Arbitrary/custom-property values are raw. |
+| `ak-outline-<chroma>`      | Sets chroma from a named preset.                                                                                                                              |
+| `ak-outline-<hue>`         | Sets hue from a named preset.                                                                                                                                 |
 
 ### Adjustments
 
@@ -386,18 +392,18 @@ Controls the opacity of text inside a layer — useful for secondary text, capti
 
 ### Channels and bounds
 
-| Utility                        | Description                                                                                 |
-| ------------------------------ | ------------------------------------------------------------------------------------------- |
-| `ak-outline-l-<value>`         | Absolute lightness (`0`–`100`). Custom properties use the same scale.                       |
-| `ak-outline-c-<value>`         | Absolute chroma (`0`–`40`) or a named preset. Custom properties use the same numeric scale. |
-| `ak-outline-h-<value>`         | Absolute hue. Accepts named hues or degrees, including custom properties.                   |
-| `ak-outline-h-rotate-<number>` | Rotates hue by degrees.                                                                     |
-| `ak-outline-max-<value>`       | Caps lightness or chroma.                                                                   |
-| `ak-outline-min-<value>`       | Floors lightness or chroma.                                                                 |
-| `ak-outline-max-l-<value>`     | Caps lightness specifically. Custom properties use the same `0`–`100` scale.                |
-| `ak-outline-min-l-<value>`     | Floors lightness specifically. Custom properties use the same `0`–`100` scale.              |
-| `ak-outline-max-c-<value>`     | Caps chroma specifically. Custom properties use the same `0`–`40` scale.                    |
-| `ak-outline-min-c-<value>`     | Floors chroma specifically. Custom properties use the same `0`–`40` scale.                  |
+| Utility                        | Description                                                                                                           |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| `ak-outline-l-<value>`         | Absolute lightness (`0`–`100` for bare numbers, raw `0`–`1` for arbitrary/custom-property values).                    |
+| `ak-outline-c-<value>`         | Absolute chroma (`0`–`40` for bare numbers, raw OKLCH chroma for arbitrary/custom-property values) or a named preset. |
+| `ak-outline-h-<value>`         | Absolute hue. Accepts named hues or degrees, including custom properties.                                             |
+| `ak-outline-h-rotate-<number>` | Rotates hue by degrees.                                                                                               |
+| `ak-outline-max-<value>`       | Caps lightness or chroma.                                                                                             |
+| `ak-outline-min-<value>`       | Floors lightness or chroma.                                                                                           |
+| `ak-outline-max-l-<value>`     | Caps lightness specifically. Arbitrary/custom-property values are raw.                                                |
+| `ak-outline-min-l-<value>`     | Floors lightness specifically. Arbitrary/custom-property values are raw.                                              |
+| `ak-outline-max-c-<value>`     | Caps chroma specifically. Arbitrary/custom-property values are raw.                                                   |
+| `ak-outline-min-c-<value>`     | Floors chroma specifically. Arbitrary/custom-property values are raw.                                                 |
 
 ## `ak-frame`
 

--- a/packages/ariakit-tailwind/readme.md
+++ b/packages/ariakit-tailwind/readme.md
@@ -70,7 +70,7 @@ All color math uses [OKLCH](https://developer.mozilla.org/en-US/docs/Web/CSS/col
 
 Bare numeric modifiers use Ariakit's documented authoring scales. For example, lightness and alpha values use `0`–`100`, chroma values use `0`–`40`, and mix amounts use `0`–`100`.
 
-Arbitrary values and custom properties are raw CSS values. Use normalized OKLCH channel values like `ak-layer-l-[0.8]`, raw deltas like `ak-layer-[calc(l+0.1)]`, percentages where CSS expects percentages like `ak-layer-mix-amount-[35%]`, and custom properties that already contain those raw values.
+Arbitrary values and custom properties are raw CSS values. That means percent-style modifiers use normalized `0`–`1` values in arbitrary/custom-property form, even when their bare numeric forms use Ariakit's `0`–`100` or `0`–`40` authoring scales. Use normalized OKLCH channel values like `ak-layer-l-[0.8]`, normalized percent-style values like `ak-layer-warm-[0.4]` or `ak-text-saturate-[0.25]`, raw deltas like `ak-layer-[calc(l+0.1)]`, percentages where CSS expects percentages like `ak-layer-mix-amount-[35%]`, and custom properties that already contain those raw values.
 
 ## Theming
 
@@ -171,7 +171,7 @@ Use [`ak-edge`](#ak-edge) to fine-tune border, ring, and shadow colors without t
 | Utility                      | Description                                                                                                                                                            |
 | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `ak-layer-lighten-<number>`  | Lightens the layer by `<number>`%. Arbitrary values are raw (`ak-layer-lighten-[0.05]`).                                                                               |
-| `ak-layer-darken-<number>`   | Darkens the layer by `<number>`%.                                                                                                                                      |
+| `ak-layer-darken-<number>`   | Darkens the layer by `<number>`%. Arbitrary values are raw (`ak-layer-darken-[0.05]`).                                                                                 |
 | `ak-layer-push-<number>`     | Minimum lightness shift (self-relative), jumping the forbidden mid-luminance range where contrast math becomes unreliable.                                             |
 | `ak-layer-contrast`          | Adapts the layer to contrast against its parent (preset `25`).                                                                                                         |
 | `ak-layer-contrast-<number>` | Custom contrast amount (`0`–`100`, default `25`).                                                                                                                      |

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -189,13 +189,6 @@ function getBarePercentTokenValue(options?: NumbersOptions) {
 }
 
 /**
- * Parses an arbitrary utility value without scaling it.
- */
-function getRawArbitraryValue(pattern = "[*]") {
-  return fn.value(pattern);
-}
-
-/**
  * Returns declarations for utilities whose bare numeric tokens use a percent
  * scale while arbitrary values are raw.
  */
@@ -206,7 +199,7 @@ function getRawPercentDeclarations(
 ) {
   return [
     set(target, getBarePercentTokenValue(options)),
-    set(target, getRawArbitraryValue(arbitraryPattern)),
+    set(target, fn.value(arbitraryPattern ?? "[*]")),
   ];
 }
 
@@ -1284,7 +1277,7 @@ utility(
 
 function getLayerOffsetDeclarations(arbitraryPattern = "[*]") {
   const bareValue = getBarePercentTokenValue();
-  const arbitraryValue = getRawArbitraryValue(arbitraryPattern);
+  const arbitraryValue = fn.value(arbitraryPattern ?? "[*]");
   return [
     set(
       inputs.layerIdleLOffsetDelta,
@@ -1342,7 +1335,7 @@ utility(
   set(inputs.layerMixAmount, fn.toPercent(getBareNumericTokenValue())),
   set(inputs.layerMixColor, fn.value(color, "[color]")),
   set(inputs.layerMixMethod, fn.value(mix)),
-  set(inputs.layerMixAmount, getRawArbitraryValue("[percentage]")),
+  set(inputs.layerMixAmount, fn.value("[percentage]")),
   getLayerMixDeclaration(),
 );
 
@@ -1351,7 +1344,7 @@ utility("layer-mix-color-*", set(inputs.layerMixColor, fn.value(color, "[*]")));
 utility(
   "layer-mix-amount-*",
   set(inputs.layerMixAmount, fn.toPercent(getBareNumericTokenValue())),
-  set(inputs.layerMixAmount, getRawArbitraryValue()),
+  set(inputs.layerMixAmount, fn.value("[*]")),
 );
 
 utility("layer-mix-method-*", set(inputs.layerMixMethod, fn.value(mix, "[*]")));
@@ -1368,7 +1361,7 @@ utility("state-lighten-*", getRawPercentDeclarations(inputs.layerRelativeL));
 utility(
   "state-darken-*",
   set(inputs.layerRelativeL, fn.neg(getBarePercentTokenValue())),
-  set(inputs.layerRelativeL, fn.neg(getRawArbitraryValue())),
+  set(inputs.layerRelativeL, fn.neg(fn.value("[*]"))),
 );
 
 /**
@@ -1384,13 +1377,13 @@ function getHueToward(current: Value, target: Value, amount: Value) {
 utility(
   "layer-cool-*",
   set(inputs.layerH, getHueToward(h, vars.hueCool, getBarePercentTokenValue())),
-  set(inputs.layerH, getHueToward(h, vars.hueCool, getRawArbitraryValue())),
+  set(inputs.layerH, getHueToward(h, vars.hueCool, fn.value("[*]"))),
 );
 
 utility(
   "layer-warm-*",
   set(inputs.layerH, getHueToward(h, vars.hueWarm, getBarePercentTokenValue())),
-  set(inputs.layerH, getHueToward(h, vars.hueWarm, getRawArbitraryValue())),
+  set(inputs.layerH, getHueToward(h, vars.hueWarm, fn.value("[*]"))),
 );
 
 utility(
@@ -1496,7 +1489,7 @@ utility(
 
 function getStateOffsetDeclarations() {
   const bareValue = getBarePercentTokenValue();
-  const arbitraryValue = getRawArbitraryValue();
+  const arbitraryValue = fn.value("[*]");
   return [
     set(
       inputs.layerLOffsetDelta,
@@ -1549,7 +1542,7 @@ utility(
     inputs.layerRelativeC,
     fn.neg(getBarePercentTokenValue(CHROMA_TOKEN_OPTIONS)),
   ),
-  set(inputs.layerRelativeC, fn.neg(getRawArbitraryValue())),
+  set(inputs.layerRelativeC, fn.neg(fn.value("[*]"))),
 );
 
 utility(
@@ -1575,13 +1568,13 @@ utility("edge-darken-*", getNegatedDeclarations(edgeLighten));
 utility(
   "edge-cool-*",
   set(inputs.edgeH, getHueToward(h, vars.hueCool, getBarePercentTokenValue())),
-  set(inputs.edgeH, getHueToward(h, vars.hueCool, getRawArbitraryValue())),
+  set(inputs.edgeH, getHueToward(h, vars.hueCool, fn.value("[*]"))),
 );
 
 utility(
   "edge-warm-*",
   set(inputs.edgeH, getHueToward(h, vars.hueWarm, getBarePercentTokenValue())),
-  set(inputs.edgeH, getHueToward(h, vars.hueWarm, getRawArbitraryValue())),
+  set(inputs.edgeH, getHueToward(h, vars.hueWarm, fn.value("[*]"))),
 );
 
 utility("edge-push-*", getRawPercentDeclarations(inputs.edgePushL));
@@ -1744,13 +1737,13 @@ utility("text-darken-*", getNegatedDeclarations(textLighten));
 utility(
   "text-cool-*",
   set(inputs.textH, getHueToward(h, vars.hueCool, getBarePercentTokenValue())),
-  set(inputs.textH, getHueToward(h, vars.hueCool, getRawArbitraryValue())),
+  set(inputs.textH, getHueToward(h, vars.hueCool, fn.value("[*]"))),
 );
 
 utility(
   "text-warm-*",
   set(inputs.textH, getHueToward(h, vars.hueWarm, getBarePercentTokenValue())),
-  set(inputs.textH, getHueToward(h, vars.hueWarm, getRawArbitraryValue())),
+  set(inputs.textH, getHueToward(h, vars.hueWarm, fn.value("[*]"))),
 );
 
 const textSaturate = utility(
@@ -1881,7 +1874,7 @@ utility(
     inputs.outlineH,
     getHueToward(h, vars.hueCool, getBarePercentTokenValue()),
   ),
-  set(inputs.outlineH, getHueToward(h, vars.hueCool, getRawArbitraryValue())),
+  set(inputs.outlineH, getHueToward(h, vars.hueCool, fn.value("[*]"))),
 );
 
 utility(
@@ -1890,7 +1883,7 @@ utility(
     inputs.outlineH,
     getHueToward(h, vars.hueWarm, getBarePercentTokenValue()),
   ),
-  set(inputs.outlineH, getHueToward(h, vars.hueWarm, getRawArbitraryValue())),
+  set(inputs.outlineH, getHueToward(h, vars.hueWarm, fn.value("[*]"))),
 );
 
 const outlineSaturate = utility(

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -175,10 +175,39 @@ function getNumericTokenValue(pattern: string, options?: NumbersOptions) {
 }
 
 /**
- * Parses a numeric utility token and converts it to a 0..1 percentage.
+ * Parses a non-arbitrary numeric utility token such as `10` or `45`.
  */
-function getPercentTokenValue(pattern: string, options?: NumbersOptions) {
-  return fn.div(getNumericTokenValue(pattern, options), 100);
+function getBareNumericTokenValue(options?: NumbersOptions) {
+  return fn.value("number", getNumberTokens(options));
+}
+
+/**
+ * Parses a non-arbitrary numeric utility token as a 0..1 percentage.
+ */
+function getBarePercentTokenValue(options?: NumbersOptions) {
+  return fn.div(getBareNumericTokenValue(options), 100);
+}
+
+/**
+ * Parses an arbitrary utility value without scaling it.
+ */
+function getRawArbitraryValue(pattern = "[*]") {
+  return fn.value(pattern);
+}
+
+/**
+ * Returns declarations for utilities whose bare numeric tokens use a percent
+ * scale while arbitrary values are raw.
+ */
+function getRawPercentDeclarations(
+  target: VarProperty,
+  options?: NumbersOptions,
+  arbitraryPattern?: string,
+) {
+  return [
+    set(target, getBarePercentTokenValue(options)),
+    set(target, getRawArbitraryValue(arbitraryPattern)),
+  ];
 }
 
 /**
@@ -815,10 +844,10 @@ function getLightnessOffset(value: Value) {
  * Keeps a declaration tied to utility tokens while using a factored scratch
  * variable for the expensive expression.
  */
-function withUtilityTokenGate(value: Value, pattern: string) {
+function withUtilityTokenGate(value: Value, tokenValue: Value) {
   // Use raw calc here because fn.mul(0, ...) simplifies to 0, dropping the
   // --value() dependency that gates this declaration to matching utility tokens.
-  return fn.add(value, fn.calc`0 * ${getPercentTokenValue(pattern)}`);
+  return fn.add(value, fn.calc`0 * ${tokenValue}`);
 }
 
 /**
@@ -1253,17 +1282,30 @@ utility(
   ]),
 );
 
-function getLayerOffsetDeclarations(pattern: string) {
+function getLayerOffsetDeclarations(arbitraryPattern = "[*]") {
+  const bareValue = getBarePercentTokenValue();
+  const arbitraryValue = getRawArbitraryValue(arbitraryPattern);
   return [
     set(
       inputs.layerIdleLOffsetDelta,
-      fn.mul(getPercentTokenValue(pattern), vars.lightnessOffsetDirection),
+      fn.mul(bareValue, vars.lightnessOffsetDirection),
     ),
     set(
       inputs.layerIdleLOffset,
       withUtilityTokenGate(
         getLightnessOffset(inputs.layerIdleLOffsetDelta),
-        pattern,
+        bareValue,
+      ),
+    ),
+    set(
+      inputs.layerIdleLOffsetDelta,
+      fn.mul(arbitraryValue, vars.lightnessOffsetDirection),
+    ),
+    set(
+      inputs.layerIdleLOffset,
+      withUtilityTokenGate(
+        getLightnessOffset(inputs.layerIdleLOffsetDelta),
+        arbitraryValue,
       ),
     ),
   ];
@@ -1277,7 +1319,7 @@ utility(
   getLayerOffsetDeclarations("[number]"),
 );
 
-utility("layer-offset-*", getLayerOffsetDeclarations("[*]"));
+utility("layer-offset-*", getLayerOffsetDeclarations());
 
 utility("layer-color-*", set(inputs.layerColor, fn.value(color, "[*]")));
 
@@ -1297,9 +1339,10 @@ utility("layer-mix", getLayerMixDeclaration());
 
 utility(
   "layer-mix-*",
-  set(inputs.layerMixAmount, fn.toPercent(getNumericTokenValue("[number]"))),
+  set(inputs.layerMixAmount, fn.toPercent(getBareNumericTokenValue())),
   set(inputs.layerMixColor, fn.value(color, "[color]")),
   set(inputs.layerMixMethod, fn.value(mix)),
+  set(inputs.layerMixAmount, getRawArbitraryValue("[percentage]")),
   getLayerMixDeclaration(),
 );
 
@@ -1307,26 +1350,25 @@ utility("layer-mix-color-*", set(inputs.layerMixColor, fn.value(color, "[*]")));
 
 utility(
   "layer-mix-amount-*",
-  set(inputs.layerMixAmount, fn.toPercent(getNumericTokenValue("[*]"))),
+  set(inputs.layerMixAmount, fn.toPercent(getBareNumericTokenValue())),
+  set(inputs.layerMixAmount, getRawArbitraryValue()),
 );
 
 utility("layer-mix-method-*", set(inputs.layerMixMethod, fn.value(mix, "[*]")));
 
 const layerLighten = utility(
   "layer-lighten-*",
-  set(inputs.layerIdleRelativeL, getPercentTokenValue("[*]")),
+  getRawPercentDeclarations(inputs.layerIdleRelativeL),
 );
 
 utility("layer-darken-*", getNegatedDeclarations(layerLighten));
 
-utility(
-  "state-lighten-*",
-  set(inputs.layerRelativeL, getPercentTokenValue("[*]")),
-);
+utility("state-lighten-*", getRawPercentDeclarations(inputs.layerRelativeL));
 
 utility(
   "state-darken-*",
-  set(inputs.layerRelativeL, fn.neg(getPercentTokenValue("[*]"))),
+  set(inputs.layerRelativeL, fn.neg(getBarePercentTokenValue())),
+  set(inputs.layerRelativeL, fn.neg(getRawArbitraryValue())),
 );
 
 /**
@@ -1335,29 +1377,25 @@ utility(
 function getHueToward(current: Value, target: Value, amount: Value) {
   // Normalize to [-180, 180] so interpolation follows the shortest arc.
   const delta = fn.sub(fn.mod(fn.add(fn.sub(target, current), 540), 360), 180);
-  const percent = fn.clamp01(fn.div(amount, 100));
+  const percent = fn.clamp01(amount);
   return fn.add(current, fn.mul(delta, percent));
 }
 
 utility(
   "layer-cool-*",
-  set(
-    inputs.layerH,
-    getHueToward(h, vars.hueCool, getNumericTokenValue("[*]")),
-  ),
+  set(inputs.layerH, getHueToward(h, vars.hueCool, getBarePercentTokenValue())),
+  set(inputs.layerH, getHueToward(h, vars.hueCool, getRawArbitraryValue())),
 );
 
 utility(
   "layer-warm-*",
-  set(
-    inputs.layerH,
-    getHueToward(h, vars.hueWarm, getNumericTokenValue("[*]")),
-  ),
+  set(inputs.layerH, getHueToward(h, vars.hueWarm, getBarePercentTokenValue())),
+  set(inputs.layerH, getHueToward(h, vars.hueWarm, getRawArbitraryValue())),
 );
 
 utility(
   "layer-push-*",
-  set(inputs.layerIdlePushL, getPercentTokenValue("[*]")),
+  getRawPercentDeclarations(inputs.layerIdlePushL),
   set(vars.layerIdlePushValue, getPushValue(inputs.layerIdlePushL)),
   set(
     vars.layerIdlePushBaseL,
@@ -1380,35 +1418,35 @@ utility(
 
 utility(
   "layer-contrast-*",
-  set(inputs.layerIdleContrastL, getPercentTokenValue("[*]")),
+  getRawPercentDeclarations(inputs.layerIdleContrastL),
 );
 
 utility(
   "layer-max-*",
   set(inputs.layerCMax, fn.value(chroma)),
-  set(inputs.layerLMax, getPercentTokenValue("[*]")),
+  getRawPercentDeclarations(inputs.layerLMax),
 );
 
 utility(
   "layer-min-*",
   set(inputs.layerCMin, fn.value(chroma)),
-  set(inputs.layerLMin, getPercentTokenValue("[*]")),
+  getRawPercentDeclarations(inputs.layerLMin),
 );
 
-utility("layer-max-l-*", set(inputs.layerLMax, getPercentTokenValue("[*]")));
+utility("layer-max-l-*", getRawPercentDeclarations(inputs.layerLMax));
 
-utility("layer-min-l-*", set(inputs.layerLMin, getPercentTokenValue("[*]")));
+utility("layer-min-l-*", getRawPercentDeclarations(inputs.layerLMin));
 
 utility(
   "layer-max-c-*",
   set(inputs.layerCMax, fn.value(chroma)),
-  set(inputs.layerCMax, getPercentTokenValue("[*]", CHROMA_TOKEN_OPTIONS)),
+  getRawPercentDeclarations(inputs.layerCMax, CHROMA_TOKEN_OPTIONS),
 );
 
 utility(
   "layer-min-c-*",
   set(inputs.layerCMin, fn.value(chroma)),
-  set(inputs.layerCMin, getPercentTokenValue("[*]", CHROMA_TOKEN_OPTIONS)),
+  getRawPercentDeclarations(inputs.layerCMin, CHROMA_TOKEN_OPTIONS),
 );
 
 utility(
@@ -1419,10 +1457,7 @@ utility(
 
 const layerSaturate = utility(
   "layer-saturate-*",
-  set(
-    inputs.layerIdleRelativeC,
-    getPercentTokenValue("[*]", CHROMA_TOKEN_OPTIONS),
-  ),
+  getRawPercentDeclarations(inputs.layerIdleRelativeC, CHROMA_TOKEN_OPTIONS),
 );
 utility("layer-desaturate-*", getNegatedDeclarations(layerSaturate));
 
@@ -1439,12 +1474,12 @@ utility(
   set(inputs.layerRelativeH, getNumericTokenValue("[*]", HUE_TOKEN_OPTIONS)),
 );
 
-utility("layer-l-*", set(inputs.layerL, getPercentTokenValue("[*]")));
+utility("layer-l-*", getRawPercentDeclarations(inputs.layerL));
 
 utility(
   "layer-c-*",
   set(inputs.layerC, fn.value(chroma)),
-  set(inputs.layerC, getPercentTokenValue("[*]", CHROMA_TOKEN_OPTIONS)),
+  getRawPercentDeclarations(inputs.layerC, CHROMA_TOKEN_OPTIONS),
 );
 
 utility(
@@ -1459,29 +1494,42 @@ utility(
   set(inputs.layerL, fn.invert(l)),
 );
 
-function getStateOffsetDeclarations(pattern: string) {
+function getStateOffsetDeclarations() {
+  const bareValue = getBarePercentTokenValue();
+  const arbitraryValue = getRawArbitraryValue();
   return [
     set(
       inputs.layerLOffsetDelta,
-      fn.mul(getPercentTokenValue(pattern), vars.lightnessOffsetDirection),
+      fn.mul(bareValue, vars.lightnessOffsetDirection),
     ),
     set(
       inputs.layerLOffset,
       withUtilityTokenGate(
         getLightnessOffset(inputs.layerLOffsetDelta),
-        pattern,
+        bareValue,
+      ),
+    ),
+    set(
+      inputs.layerLOffsetDelta,
+      fn.mul(arbitraryValue, vars.lightnessOffsetDirection),
+    ),
+    set(
+      inputs.layerLOffset,
+      withUtilityTokenGate(
+        getLightnessOffset(inputs.layerLOffsetDelta),
+        arbitraryValue,
       ),
     ),
   ];
 }
 
-utility("state-*", getStateOffsetDeclarations("[*]"));
+utility("state-*", getStateOffsetDeclarations());
 
-utility("state-offset-*", getStateOffsetDeclarations("[*]"));
+utility("state-offset-*", getStateOffsetDeclarations());
 
 utility(
   "state-push-*",
-  set(inputs.layerPushL, getPercentTokenValue("[*]")),
+  getRawPercentDeclarations(inputs.layerPushL),
   set(vars.layerPushValue, getPushValue(inputs.layerPushL)),
   set(
     vars.layerPushBaseL,
@@ -1492,15 +1540,16 @@ utility(
 
 utility(
   "state-saturate-*",
-  set(inputs.layerRelativeC, getPercentTokenValue("[*]", CHROMA_TOKEN_OPTIONS)),
+  getRawPercentDeclarations(inputs.layerRelativeC, CHROMA_TOKEN_OPTIONS),
 );
 
 utility(
   "state-desaturate-*",
   set(
     inputs.layerRelativeC,
-    fn.neg(getPercentTokenValue("[*]", CHROMA_TOKEN_OPTIONS)),
+    fn.neg(getBarePercentTokenValue(CHROMA_TOKEN_OPTIONS)),
   ),
+  set(inputs.layerRelativeC, fn.neg(getRawArbitraryValue())),
 );
 
 utility(
@@ -1508,36 +1557,38 @@ utility(
   set(inputs.edgeC, fn.value(chroma)),
   set(inputs.edgeH, fn.value(hue)),
   set(inputs.edgeColor, fn.value(color, "[color]")),
-  set(inputs.edgeA, getPercentTokenValue("[number]")),
+  set(inputs.edgeA, getBarePercentTokenValue()),
 );
 
 utility("edge-color-*", set(inputs.edgeColor, fn.value(color, "[*]")));
 
-utility("edge-alpha-*", set(inputs.edgeA, getPercentTokenValue("[*]")));
+utility("edge-alpha-*", getRawPercentDeclarations(inputs.edgeA));
 
 utility("edge-raw", set(inputs.edgeA, 1), set(inputs.edgePushL, 0));
 
 const edgeLighten = utility(
   "edge-lighten-*",
-  set(inputs.edgeRelativeL, getPercentTokenValue("[*]")),
+  getRawPercentDeclarations(inputs.edgeRelativeL),
 );
 utility("edge-darken-*", getNegatedDeclarations(edgeLighten));
 
 utility(
   "edge-cool-*",
-  set(inputs.edgeH, getHueToward(h, vars.hueCool, getNumericTokenValue("[*]"))),
+  set(inputs.edgeH, getHueToward(h, vars.hueCool, getBarePercentTokenValue())),
+  set(inputs.edgeH, getHueToward(h, vars.hueCool, getRawArbitraryValue())),
 );
 
 utility(
   "edge-warm-*",
-  set(inputs.edgeH, getHueToward(h, vars.hueWarm, getNumericTokenValue("[*]"))),
+  set(inputs.edgeH, getHueToward(h, vars.hueWarm, getBarePercentTokenValue())),
+  set(inputs.edgeH, getHueToward(h, vars.hueWarm, getRawArbitraryValue())),
 );
 
-utility("edge-push-*", set(inputs.edgePushL, getPercentTokenValue("[*]")));
+utility("edge-push-*", getRawPercentDeclarations(inputs.edgePushL));
 
 const edgeSaturate = utility(
   "edge-saturate-*",
-  set(inputs.edgeRelativeC, getPercentTokenValue("[*]", CHROMA_TOKEN_OPTIONS)),
+  getRawPercentDeclarations(inputs.edgeRelativeC, CHROMA_TOKEN_OPTIONS),
 );
 utility("edge-desaturate-*", getNegatedDeclarations(edgeSaturate));
 
@@ -1546,12 +1597,12 @@ utility(
   set(inputs.edgeRelativeH, getNumericTokenValue("[*]", HUE_TOKEN_OPTIONS)),
 );
 
-utility("edge-l-*", set(inputs.edgeL, getPercentTokenValue("[*]")));
+utility("edge-l-*", getRawPercentDeclarations(inputs.edgeL));
 
 utility(
   "edge-c-*",
   set(inputs.edgeC, fn.value(chroma)),
-  set(inputs.edgeC, getPercentTokenValue("[*]", CHROMA_TOKEN_OPTIONS)),
+  getRawPercentDeclarations(inputs.edgeC, CHROMA_TOKEN_OPTIONS),
 );
 
 utility(
@@ -1563,29 +1614,29 @@ utility(
 utility(
   "edge-max-*",
   set(inputs.edgeCMax, fn.value(chroma)),
-  set(inputs.edgeLMax, getPercentTokenValue("[*]")),
+  getRawPercentDeclarations(inputs.edgeLMax),
 );
 
 utility(
   "edge-min-*",
   set(inputs.edgeCMin, fn.value(chroma)),
-  set(inputs.edgeLMin, getPercentTokenValue("[*]")),
+  getRawPercentDeclarations(inputs.edgeLMin),
 );
 
-utility("edge-max-l-*", set(inputs.edgeLMax, getPercentTokenValue("[*]")));
+utility("edge-max-l-*", getRawPercentDeclarations(inputs.edgeLMax));
 
-utility("edge-min-l-*", set(inputs.edgeLMin, getPercentTokenValue("[*]")));
+utility("edge-min-l-*", getRawPercentDeclarations(inputs.edgeLMin));
 
 utility(
   "edge-max-c-*",
   set(inputs.edgeCMax, fn.value(chroma)),
-  set(inputs.edgeCMax, getPercentTokenValue("[*]", CHROMA_TOKEN_OPTIONS)),
+  getRawPercentDeclarations(inputs.edgeCMax, CHROMA_TOKEN_OPTIONS),
 );
 
 utility(
   "edge-min-c-*",
   set(inputs.edgeCMin, fn.value(chroma)),
-  set(inputs.edgeCMin, getPercentTokenValue("[*]", CHROMA_TOKEN_OPTIONS)),
+  getRawPercentDeclarations(inputs.edgeCMin, CHROMA_TOKEN_OPTIONS),
 );
 
 const textBaseColor = fn.var(inputs.textColor, vars.layer);
@@ -1670,39 +1721,41 @@ utility(
   set(inputs.textC, fn.value(chroma)),
   set(inputs.textH, fn.value(hue)),
   set(inputs.textColor, fn.value(color, "[color]")),
-  set(inputs.textPushL, getPercentTokenValue("[number]")),
+  set(inputs.textPushL, getBarePercentTokenValue()),
 );
 
 utility("text-color-*", set(inputs.textColor, fn.value(color, "[*]")));
 
-utility("text-push-*", set(inputs.textPushL, getPercentTokenValue("[*]")));
+utility("text-push-*", getRawPercentDeclarations(inputs.textPushL));
 
 utility(
   "ink-*",
-  set(inputs.textA, getPercentTokenValue("[*]")),
+  getRawPercentDeclarations(inputs.textA),
   set(vars.text, inkText),
   set.color(vars.text),
 );
 
 const textLighten = utility(
   "text-lighten-*",
-  set(inputs.textRelativeL, getPercentTokenValue("[*]")),
+  getRawPercentDeclarations(inputs.textRelativeL),
 );
 utility("text-darken-*", getNegatedDeclarations(textLighten));
 
 utility(
   "text-cool-*",
-  set(inputs.textH, getHueToward(h, vars.hueCool, getNumericTokenValue("[*]"))),
+  set(inputs.textH, getHueToward(h, vars.hueCool, getBarePercentTokenValue())),
+  set(inputs.textH, getHueToward(h, vars.hueCool, getRawArbitraryValue())),
 );
 
 utility(
   "text-warm-*",
-  set(inputs.textH, getHueToward(h, vars.hueWarm, getNumericTokenValue("[*]"))),
+  set(inputs.textH, getHueToward(h, vars.hueWarm, getBarePercentTokenValue())),
+  set(inputs.textH, getHueToward(h, vars.hueWarm, getRawArbitraryValue())),
 );
 
 const textSaturate = utility(
   "text-saturate-*",
-  set(inputs.textRelativeC, getPercentTokenValue("[*]", CHROMA_TOKEN_OPTIONS)),
+  getRawPercentDeclarations(inputs.textRelativeC, CHROMA_TOKEN_OPTIONS),
 );
 utility("text-desaturate-*", getNegatedDeclarations(textSaturate));
 
@@ -1711,12 +1764,12 @@ utility(
   set(inputs.textRelativeH, getNumericTokenValue("[*]", HUE_TOKEN_OPTIONS)),
 );
 
-utility("text-l-*", set(inputs.textL, getPercentTokenValue("[*]")));
+utility("text-l-*", getRawPercentDeclarations(inputs.textL));
 
 utility(
   "text-c-*",
   set(inputs.textC, fn.value(chroma)),
-  set(inputs.textC, getPercentTokenValue("[*]", CHROMA_TOKEN_OPTIONS)),
+  getRawPercentDeclarations(inputs.textC, CHROMA_TOKEN_OPTIONS),
 );
 
 utility(
@@ -1728,29 +1781,29 @@ utility(
 utility(
   "text-max-*",
   set(inputs.textCMax, fn.value(chroma)),
-  set(inputs.textLMax, getPercentTokenValue("[*]")),
+  getRawPercentDeclarations(inputs.textLMax),
 );
 
 utility(
   "text-min-*",
   set(inputs.textCMin, fn.value(chroma)),
-  set(inputs.textLMin, getPercentTokenValue("[*]")),
+  getRawPercentDeclarations(inputs.textLMin),
 );
 
-utility("text-max-l-*", set(inputs.textLMax, getPercentTokenValue("[*]")));
+utility("text-max-l-*", getRawPercentDeclarations(inputs.textLMax));
 
-utility("text-min-l-*", set(inputs.textLMin, getPercentTokenValue("[*]")));
+utility("text-min-l-*", getRawPercentDeclarations(inputs.textLMin));
 
 utility(
   "text-max-c-*",
   set(inputs.textCMax, fn.value(chroma)),
-  set(inputs.textCMax, getPercentTokenValue("[*]", CHROMA_TOKEN_OPTIONS)),
+  getRawPercentDeclarations(inputs.textCMax, CHROMA_TOKEN_OPTIONS),
 );
 
 utility(
   "text-min-c-*",
   set(inputs.textCMin, fn.value(chroma)),
-  set(inputs.textCMin, getPercentTokenValue("[*]", CHROMA_TOKEN_OPTIONS)),
+  getRawPercentDeclarations(inputs.textCMin, CHROMA_TOKEN_OPTIONS),
 );
 
 const outlineBaseColor = fn.var(inputs.outlineColor, vars.layer);
@@ -1809,19 +1862,16 @@ utility(
   set(inputs.outlineC, fn.value(chroma)),
   set(inputs.outlineH, fn.value(hue)),
   set(inputs.outlineColor, fn.value(color, "[color]")),
-  set(inputs.outlinePushL, getPercentTokenValue("[number]")),
+  set(inputs.outlinePushL, getBarePercentTokenValue()),
 );
 
 utility("outline-color-*", set(inputs.outlineColor, fn.value(color, "[*]")));
 
-utility(
-  "outline-push-*",
-  set(inputs.outlinePushL, getPercentTokenValue("[*]")),
-);
+utility("outline-push-*", getRawPercentDeclarations(inputs.outlinePushL));
 
 const outlineLighten = utility(
   "outline-lighten-*",
-  set(inputs.outlineRelativeL, getPercentTokenValue("[*]")),
+  getRawPercentDeclarations(inputs.outlineRelativeL),
 );
 utility("outline-darken-*", getNegatedDeclarations(outlineLighten));
 
@@ -1829,24 +1879,23 @@ utility(
   "outline-cool-*",
   set(
     inputs.outlineH,
-    getHueToward(h, vars.hueCool, getNumericTokenValue("[*]")),
+    getHueToward(h, vars.hueCool, getBarePercentTokenValue()),
   ),
+  set(inputs.outlineH, getHueToward(h, vars.hueCool, getRawArbitraryValue())),
 );
 
 utility(
   "outline-warm-*",
   set(
     inputs.outlineH,
-    getHueToward(h, vars.hueWarm, getNumericTokenValue("[*]")),
+    getHueToward(h, vars.hueWarm, getBarePercentTokenValue()),
   ),
+  set(inputs.outlineH, getHueToward(h, vars.hueWarm, getRawArbitraryValue())),
 );
 
 const outlineSaturate = utility(
   "outline-saturate-*",
-  set(
-    inputs.outlineRelativeC,
-    getPercentTokenValue("[*]", CHROMA_TOKEN_OPTIONS),
-  ),
+  getRawPercentDeclarations(inputs.outlineRelativeC, CHROMA_TOKEN_OPTIONS),
 );
 utility("outline-desaturate-*", getNegatedDeclarations(outlineSaturate));
 
@@ -1855,12 +1904,12 @@ utility(
   set(inputs.outlineRelativeH, getNumericTokenValue("[*]", HUE_TOKEN_OPTIONS)),
 );
 
-utility("outline-l-*", set(inputs.outlineL, getPercentTokenValue("[*]")));
+utility("outline-l-*", getRawPercentDeclarations(inputs.outlineL));
 
 utility(
   "outline-c-*",
   set(inputs.outlineC, fn.value(chroma)),
-  set(inputs.outlineC, getPercentTokenValue("[*]", CHROMA_TOKEN_OPTIONS)),
+  getRawPercentDeclarations(inputs.outlineC, CHROMA_TOKEN_OPTIONS),
 );
 
 utility(
@@ -1872,35 +1921,29 @@ utility(
 utility(
   "outline-max-*",
   set(inputs.outlineCMax, fn.value(chroma)),
-  set(inputs.outlineLMax, getPercentTokenValue("[*]")),
+  getRawPercentDeclarations(inputs.outlineLMax),
 );
 
 utility(
   "outline-min-*",
   set(inputs.outlineCMin, fn.value(chroma)),
-  set(inputs.outlineLMin, getPercentTokenValue("[*]")),
+  getRawPercentDeclarations(inputs.outlineLMin),
 );
 
-utility(
-  "outline-max-l-*",
-  set(inputs.outlineLMax, getPercentTokenValue("[*]")),
-);
+utility("outline-max-l-*", getRawPercentDeclarations(inputs.outlineLMax));
 
-utility(
-  "outline-min-l-*",
-  set(inputs.outlineLMin, getPercentTokenValue("[*]")),
-);
+utility("outline-min-l-*", getRawPercentDeclarations(inputs.outlineLMin));
 
 utility(
   "outline-max-c-*",
   set(inputs.outlineCMax, fn.value(chroma)),
-  set(inputs.outlineCMax, getPercentTokenValue("[*]", CHROMA_TOKEN_OPTIONS)),
+  getRawPercentDeclarations(inputs.outlineCMax, CHROMA_TOKEN_OPTIONS),
 );
 
 utility(
   "outline-min-c-*",
   set(inputs.outlineCMin, fn.value(chroma)),
-  set(inputs.outlineCMin, getPercentTokenValue("[*]", CHROMA_TOKEN_OPTIONS)),
+  getRawPercentDeclarations(inputs.outlineCMin, CHROMA_TOKEN_OPTIONS),
 );
 
 function getFrameBorderWidthDeclarations(target: VarProperty) {

--- a/packages/ariakit-tailwind/src/output.css
+++ b/packages/ariakit-tailwind/src/output.css
@@ -163,13 +163,17 @@
   --_ak-layer-chroma: --value(--chroma-*);
   --_ak-layer-hue: --value(--hue-*);
   --_ak-layer-color: --value(--color-*, [color]);
-  --_ak-layer-idle-lightness-offset-delta: calc((--value(number, [number], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * var(--_ak-lod));
-  --_ak-layer-idle-lightness-offset: calc((var(--_ak-layer-idle-lightness-offset-delta) + (clamp(0, (min(((l + var(--_ak-layer-idle-lightness-offset-delta)) - var(--_ak-fla)), (var(--_ak-flb) - (l + var(--_ak-layer-idle-lightness-offset-delta)))) * 1000000), 1) * (((var(--_ak-eb) - l) + (clamp(0, ((((l - clamp(0, (l + (var(--_ak-layer-idle-lightness-offset-delta) * -1)), 1)) * var(--_ak-lod)) - ((var(--_ak-eb) - l) * var(--_ak-lod))) * 1000000), 1) * ((var(--_ak-layer-idle-lightness-offset-delta) * -1) - (var(--_ak-eb) - l)))) - var(--_ak-layer-idle-lightness-offset-delta)))) + (0 * (--value(number, [number], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100)));
+  --_ak-layer-idle-lightness-offset-delta: calc((--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * var(--_ak-lod));
+  --_ak-layer-idle-lightness-offset: calc((var(--_ak-layer-idle-lightness-offset-delta) + (clamp(0, (min(((l + var(--_ak-layer-idle-lightness-offset-delta)) - var(--_ak-fla)), (var(--_ak-flb) - (l + var(--_ak-layer-idle-lightness-offset-delta)))) * 1000000), 1) * (((var(--_ak-eb) - l) + (clamp(0, ((((l - clamp(0, (l + (var(--_ak-layer-idle-lightness-offset-delta) * -1)), 1)) * var(--_ak-lod)) - ((var(--_ak-eb) - l) * var(--_ak-lod))) * 1000000), 1) * ((var(--_ak-layer-idle-lightness-offset-delta) * -1) - (var(--_ak-eb) - l)))) - var(--_ak-layer-idle-lightness-offset-delta)))) + (0 * (--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100)));
+  --_ak-layer-idle-lightness-offset-delta: calc(--value([number]) * var(--_ak-lod));
+  --_ak-layer-idle-lightness-offset: calc((var(--_ak-layer-idle-lightness-offset-delta) + (clamp(0, (min(((l + var(--_ak-layer-idle-lightness-offset-delta)) - var(--_ak-fla)), (var(--_ak-flb) - (l + var(--_ak-layer-idle-lightness-offset-delta)))) * 1000000), 1) * (((var(--_ak-eb) - l) + (clamp(0, ((((l - clamp(0, (l + (var(--_ak-layer-idle-lightness-offset-delta) * -1)), 1)) * var(--_ak-lod)) - ((var(--_ak-eb) - l) * var(--_ak-lod))) * 1000000), 1) * ((var(--_ak-layer-idle-lightness-offset-delta) * -1) - (var(--_ak-eb) - l)))) - var(--_ak-layer-idle-lightness-offset-delta)))) + (0 * --value([number])));
 }
 
 @utility ak-layer-offset-* {
-  --_ak-layer-idle-lightness-offset-delta: calc((--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * var(--_ak-lod));
-  --_ak-layer-idle-lightness-offset: calc((var(--_ak-layer-idle-lightness-offset-delta) + (clamp(0, (min(((l + var(--_ak-layer-idle-lightness-offset-delta)) - var(--_ak-fla)), (var(--_ak-flb) - (l + var(--_ak-layer-idle-lightness-offset-delta)))) * 1000000), 1) * (((var(--_ak-eb) - l) + (clamp(0, ((((l - clamp(0, (l + (var(--_ak-layer-idle-lightness-offset-delta) * -1)), 1)) * var(--_ak-lod)) - ((var(--_ak-eb) - l) * var(--_ak-lod))) * 1000000), 1) * ((var(--_ak-layer-idle-lightness-offset-delta) * -1) - (var(--_ak-eb) - l)))) - var(--_ak-layer-idle-lightness-offset-delta)))) + (0 * (--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100)));
+  --_ak-layer-idle-lightness-offset-delta: calc((--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * var(--_ak-lod));
+  --_ak-layer-idle-lightness-offset: calc((var(--_ak-layer-idle-lightness-offset-delta) + (clamp(0, (min(((l + var(--_ak-layer-idle-lightness-offset-delta)) - var(--_ak-fla)), (var(--_ak-flb) - (l + var(--_ak-layer-idle-lightness-offset-delta)))) * 1000000), 1) * (((var(--_ak-eb) - l) + (clamp(0, ((((l - clamp(0, (l + (var(--_ak-layer-idle-lightness-offset-delta) * -1)), 1)) * var(--_ak-lod)) - ((var(--_ak-eb) - l) * var(--_ak-lod))) * 1000000), 1) * ((var(--_ak-layer-idle-lightness-offset-delta) * -1) - (var(--_ak-eb) - l)))) - var(--_ak-layer-idle-lightness-offset-delta)))) + (0 * (--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100)));
+  --_ak-layer-idle-lightness-offset-delta: calc(--value([*]) * var(--_ak-lod));
+  --_ak-layer-idle-lightness-offset: calc((var(--_ak-layer-idle-lightness-offset-delta) + (clamp(0, (min(((l + var(--_ak-layer-idle-lightness-offset-delta)) - var(--_ak-fla)), (var(--_ak-flb) - (l + var(--_ak-layer-idle-lightness-offset-delta)))) * 1000000), 1) * (((var(--_ak-eb) - l) + (clamp(0, ((((l - clamp(0, (l + (var(--_ak-layer-idle-lightness-offset-delta) * -1)), 1)) * var(--_ak-lod)) - ((var(--_ak-eb) - l) * var(--_ak-lod))) * 1000000), 1) * ((var(--_ak-layer-idle-lightness-offset-delta) * -1) - (var(--_ak-eb) - l)))) - var(--_ak-layer-idle-lightness-offset-delta)))) + (0 * --value([*])));
 }
 
 @utility ak-layer-color-* {
@@ -181,9 +185,10 @@
 }
 
 @utility ak-layer-mix-* {
-  --_ak-layer-mix-amount: calc(--value(number, [number], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") * 1%);
+  --_ak-layer-mix-amount: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") * 1%);
   --_ak-layer-mix-color: --value(--color-*, [color]);
   --_ak-layer-mix-method: --value(--mix-*);
+  --_ak-layer-mix-amount: --value([percentage]);
   --_ak-layer-mix: color-mix(in var(--_ak-layer-mix-method, oklab), var(--_ak-layer-mix-color, var(--ak-layer-parent, canvas)), var(--_ak-lib) var(--_ak-layer-mix-amount, 50%));
 }
 
@@ -192,7 +197,8 @@
 }
 
 @utility ak-layer-mix-amount-* {
-  --_ak-layer-mix-amount: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") * 1%);
+  --_ak-layer-mix-amount: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") * 1%);
+  --_ak-layer-mix-amount: --value([*]);
 }
 
 @utility ak-layer-mix-method-* {
@@ -200,31 +206,38 @@
 }
 
 @utility ak-layer-lighten-* {
-  --_ak-layer-idle-relative-lightness: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-layer-idle-relative-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-layer-idle-relative-lightness: --value([*]);
 }
 
 @utility ak-layer-darken-* {
-  --_ak-layer-idle-relative-lightness: calc((--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * -1);
+  --_ak-layer-idle-relative-lightness: calc((--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * -1);
+  --_ak-layer-idle-relative-lightness: calc(--value([*]) * -1);
 }
 
 @utility ak-state-lighten-* {
-  --_ak-layer-relative-lightness: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-layer-relative-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-layer-relative-lightness: --value([*]);
 }
 
 @utility ak-state-darken-* {
-  --_ak-layer-relative-lightness: calc((--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * -1);
+  --_ak-layer-relative-lightness: calc((--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * -1);
+  --_ak-layer-relative-lightness: calc(--value([*]) * -1);
 }
 
 @utility ak-layer-cool-* {
-  --_ak-layer-hue: calc(h + ((mod(((var(--hue-cool, 220) - h) + 540), 360) - 180) * clamp(0, (--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100), 1)));
+  --_ak-layer-hue: calc(h + ((mod(((var(--hue-cool, 220) - h) + 540), 360) - 180) * clamp(0, (--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100), 1)));
+  --_ak-layer-hue: calc(h + ((mod(((var(--hue-cool, 220) - h) + 540), 360) - 180) * clamp(0, --value([*]), 1)));
 }
 
 @utility ak-layer-warm-* {
-  --_ak-layer-hue: calc(h + ((mod(((var(--hue-warm, 90) - h) + 540), 360) - 180) * clamp(0, (--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100), 1)));
+  --_ak-layer-hue: calc(h + ((mod(((var(--hue-warm, 90) - h) + 540), 360) - 180) * clamp(0, (--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100), 1)));
+  --_ak-layer-hue: calc(h + ((mod(((var(--hue-warm, 90) - h) + 540), 360) - 180) * clamp(0, --value([*]), 1)));
 }
 
 @utility ak-layer-push-* {
-  --_ak-layer-idle-push-lightness: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-layer-idle-push-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-layer-idle-push-lightness: --value([*]);
   --_ak-lipv: calc(var(--_ak-layer-idle-push-lightness) * var(--_ak-cps));
   --_ak-lipbl: calc(l + (var(--_ak-lipv) * var(--_ak-lod)) + (clamp(0, ((var(--_ak-lipv) * var(--_ak-lod)) * 1000000), 1) * var(--_ak-llfb)));
   --_ak-lipl: clamp(0, (var(--_ak-lipbl) + (var(--_ak-lod) * var(--_ak-bw) * max(((clamp(0, ((var(--_ak-fla) - l) * 1000000), 1) * clamp(0, ((var(--_ak-lipbl) - var(--_ak-fla)) * 1000000), 1)) + (clamp(0, ((l - var(--_ak-flb)) * 1000000), 1) * clamp(0, ((var(--_ak-flb) - var(--_ak-lipbl)) * 1000000), 1))), (clamp(0, (min((var(--_ak-lipbl) - var(--_ak-fla)), (var(--_ak-flb) - var(--_ak-lipbl))) * 1000000), 1) * clamp(0, (var(--_ak-lipv) * 1000000), 1))))), 1);
@@ -271,35 +284,42 @@
 }
 
 @utility ak-layer-contrast-* {
-  --_ak-layer-idle-contrast-lightness: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-layer-idle-contrast-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-layer-idle-contrast-lightness: --value([*]);
 }
 
 @utility ak-layer-max-* {
   --_ak-layer-chroma-max: --value(--chroma-*);
-  --_ak-layer-lightness-max: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-layer-lightness-max: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-layer-lightness-max: --value([*]);
 }
 
 @utility ak-layer-min-* {
   --_ak-layer-chroma-min: --value(--chroma-*);
-  --_ak-layer-lightness-min: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-layer-lightness-min: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-layer-lightness-min: --value([*]);
 }
 
 @utility ak-layer-max-l-* {
-  --_ak-layer-lightness-max: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-layer-lightness-max: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-layer-lightness-max: --value([*]);
 }
 
 @utility ak-layer-min-l-* {
-  --_ak-layer-lightness-min: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-layer-lightness-min: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-layer-lightness-min: --value([*]);
 }
 
 @utility ak-layer-max-c-* {
   --_ak-layer-chroma-max: --value(--chroma-*);
-  --_ak-layer-chroma-max: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-layer-chroma-max: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-layer-chroma-max: --value([*]);
 }
 
 @utility ak-layer-min-c-* {
   --_ak-layer-chroma-min: --value(--chroma-*);
-  --_ak-layer-chroma-min: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-layer-chroma-min: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-layer-chroma-min: --value([*]);
 }
 
 @utility ak-layer-max-c-auto {
@@ -307,11 +327,13 @@
 }
 
 @utility ak-layer-saturate-* {
-  --_ak-layer-idle-relative-chroma: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-layer-idle-relative-chroma: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-layer-idle-relative-chroma: --value([*]);
 }
 
 @utility ak-layer-desaturate-* {
-  --_ak-layer-idle-relative-chroma: calc((--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100) * -1);
+  --_ak-layer-idle-relative-chroma: calc((--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100) * -1);
+  --_ak-layer-idle-relative-chroma: calc(--value([*]) * -1);
 }
 
 @utility ak-layer-h-rotate-* {
@@ -323,12 +345,14 @@
 }
 
 @utility ak-layer-l-* {
-  --_ak-layer-lightness: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-layer-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-layer-lightness: --value([*]);
 }
 
 @utility ak-layer-c-* {
   --_ak-layer-chroma: --value(--chroma-*);
-  --_ak-layer-chroma: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-layer-chroma: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-layer-chroma: --value([*]);
 }
 
 @utility ak-layer-h-* {
@@ -342,35 +366,42 @@
 }
 
 @utility ak-state-* {
-  --_ak-layer-lightness-offset-delta: calc((--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * var(--_ak-lod));
-  --_ak-layer-lightness-offset: calc((var(--_ak-layer-lightness-offset-delta) + (clamp(0, (min(((l + var(--_ak-layer-lightness-offset-delta)) - var(--_ak-fla)), (var(--_ak-flb) - (l + var(--_ak-layer-lightness-offset-delta)))) * 1000000), 1) * (((var(--_ak-eb) - l) + (clamp(0, ((((l - clamp(0, (l + (var(--_ak-layer-lightness-offset-delta) * -1)), 1)) * var(--_ak-lod)) - ((var(--_ak-eb) - l) * var(--_ak-lod))) * 1000000), 1) * ((var(--_ak-layer-lightness-offset-delta) * -1) - (var(--_ak-eb) - l)))) - var(--_ak-layer-lightness-offset-delta)))) + (0 * (--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100)));
+  --_ak-layer-lightness-offset-delta: calc((--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * var(--_ak-lod));
+  --_ak-layer-lightness-offset: calc((var(--_ak-layer-lightness-offset-delta) + (clamp(0, (min(((l + var(--_ak-layer-lightness-offset-delta)) - var(--_ak-fla)), (var(--_ak-flb) - (l + var(--_ak-layer-lightness-offset-delta)))) * 1000000), 1) * (((var(--_ak-eb) - l) + (clamp(0, ((((l - clamp(0, (l + (var(--_ak-layer-lightness-offset-delta) * -1)), 1)) * var(--_ak-lod)) - ((var(--_ak-eb) - l) * var(--_ak-lod))) * 1000000), 1) * ((var(--_ak-layer-lightness-offset-delta) * -1) - (var(--_ak-eb) - l)))) - var(--_ak-layer-lightness-offset-delta)))) + (0 * (--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100)));
+  --_ak-layer-lightness-offset-delta: calc(--value([*]) * var(--_ak-lod));
+  --_ak-layer-lightness-offset: calc((var(--_ak-layer-lightness-offset-delta) + (clamp(0, (min(((l + var(--_ak-layer-lightness-offset-delta)) - var(--_ak-fla)), (var(--_ak-flb) - (l + var(--_ak-layer-lightness-offset-delta)))) * 1000000), 1) * (((var(--_ak-eb) - l) + (clamp(0, ((((l - clamp(0, (l + (var(--_ak-layer-lightness-offset-delta) * -1)), 1)) * var(--_ak-lod)) - ((var(--_ak-eb) - l) * var(--_ak-lod))) * 1000000), 1) * ((var(--_ak-layer-lightness-offset-delta) * -1) - (var(--_ak-eb) - l)))) - var(--_ak-layer-lightness-offset-delta)))) + (0 * --value([*])));
 }
 
 @utility ak-state-offset-* {
-  --_ak-layer-lightness-offset-delta: calc((--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * var(--_ak-lod));
-  --_ak-layer-lightness-offset: calc((var(--_ak-layer-lightness-offset-delta) + (clamp(0, (min(((l + var(--_ak-layer-lightness-offset-delta)) - var(--_ak-fla)), (var(--_ak-flb) - (l + var(--_ak-layer-lightness-offset-delta)))) * 1000000), 1) * (((var(--_ak-eb) - l) + (clamp(0, ((((l - clamp(0, (l + (var(--_ak-layer-lightness-offset-delta) * -1)), 1)) * var(--_ak-lod)) - ((var(--_ak-eb) - l) * var(--_ak-lod))) * 1000000), 1) * ((var(--_ak-layer-lightness-offset-delta) * -1) - (var(--_ak-eb) - l)))) - var(--_ak-layer-lightness-offset-delta)))) + (0 * (--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100)));
+  --_ak-layer-lightness-offset-delta: calc((--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * var(--_ak-lod));
+  --_ak-layer-lightness-offset: calc((var(--_ak-layer-lightness-offset-delta) + (clamp(0, (min(((l + var(--_ak-layer-lightness-offset-delta)) - var(--_ak-fla)), (var(--_ak-flb) - (l + var(--_ak-layer-lightness-offset-delta)))) * 1000000), 1) * (((var(--_ak-eb) - l) + (clamp(0, ((((l - clamp(0, (l + (var(--_ak-layer-lightness-offset-delta) * -1)), 1)) * var(--_ak-lod)) - ((var(--_ak-eb) - l) * var(--_ak-lod))) * 1000000), 1) * ((var(--_ak-layer-lightness-offset-delta) * -1) - (var(--_ak-eb) - l)))) - var(--_ak-layer-lightness-offset-delta)))) + (0 * (--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100)));
+  --_ak-layer-lightness-offset-delta: calc(--value([*]) * var(--_ak-lod));
+  --_ak-layer-lightness-offset: calc((var(--_ak-layer-lightness-offset-delta) + (clamp(0, (min(((l + var(--_ak-layer-lightness-offset-delta)) - var(--_ak-fla)), (var(--_ak-flb) - (l + var(--_ak-layer-lightness-offset-delta)))) * 1000000), 1) * (((var(--_ak-eb) - l) + (clamp(0, ((((l - clamp(0, (l + (var(--_ak-layer-lightness-offset-delta) * -1)), 1)) * var(--_ak-lod)) - ((var(--_ak-eb) - l) * var(--_ak-lod))) * 1000000), 1) * ((var(--_ak-layer-lightness-offset-delta) * -1) - (var(--_ak-eb) - l)))) - var(--_ak-layer-lightness-offset-delta)))) + (0 * --value([*])));
 }
 
 @utility ak-state-push-* {
-  --_ak-layer-push-lightness: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-layer-push-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-layer-push-lightness: --value([*]);
   --_ak-lpv: calc(var(--_ak-layer-push-lightness) * var(--_ak-cps));
   --_ak-lpbl: calc(l + (var(--_ak-lpv) * var(--_ak-lod)) + (clamp(0, ((var(--_ak-lpv) * var(--_ak-lod)) * 1000000), 1) * var(--_ak-llfb)));
   --_ak-lpl: clamp(0, (var(--_ak-lpbl) + (var(--_ak-lod) * var(--_ak-bw) * max(((clamp(0, ((var(--_ak-fla) - l) * 1000000), 1) * clamp(0, ((var(--_ak-lpbl) - var(--_ak-fla)) * 1000000), 1)) + (clamp(0, ((l - var(--_ak-flb)) * 1000000), 1) * clamp(0, ((var(--_ak-flb) - var(--_ak-lpbl)) * 1000000), 1))), (clamp(0, (min((var(--_ak-lpbl) - var(--_ak-fla)), (var(--_ak-flb) - var(--_ak-lpbl))) * 1000000), 1) * clamp(0, (var(--_ak-lpv) * 1000000), 1))))), 1);
 }
 
 @utility ak-state-saturate-* {
-  --_ak-layer-relative-chroma: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-layer-relative-chroma: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-layer-relative-chroma: --value([*]);
 }
 
 @utility ak-state-desaturate-* {
-  --_ak-layer-relative-chroma: calc((--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100) * -1);
+  --_ak-layer-relative-chroma: calc((--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100) * -1);
+  --_ak-layer-relative-chroma: calc(--value([*]) * -1);
 }
 
 @utility ak-edge-* {
   --_ak-edge-chroma: --value(--chroma-*);
   --_ak-edge-h: --value(--hue-*);
   --_ak-edge-color: --value(--color-*, [color]);
-  --_ak-edge-alpha: calc(--value(number, [number], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-edge-alpha: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
 }
 
 @utility ak-edge-color-* {
@@ -378,7 +409,8 @@
 }
 
 @utility ak-edge-alpha-* {
-  --_ak-edge-alpha: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-edge-alpha: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-edge-alpha: --value([*]);
 }
 
 @utility ak-edge-raw {
@@ -387,31 +419,38 @@
 }
 
 @utility ak-edge-lighten-* {
-  --_ak-edge-relative-lightness: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-edge-relative-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-edge-relative-lightness: --value([*]);
 }
 
 @utility ak-edge-darken-* {
-  --_ak-edge-relative-lightness: calc((--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * -1);
+  --_ak-edge-relative-lightness: calc((--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * -1);
+  --_ak-edge-relative-lightness: calc(--value([*]) * -1);
 }
 
 @utility ak-edge-cool-* {
-  --_ak-edge-h: calc(h + ((mod(((var(--hue-cool, 220) - h) + 540), 360) - 180) * clamp(0, (--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100), 1)));
+  --_ak-edge-h: calc(h + ((mod(((var(--hue-cool, 220) - h) + 540), 360) - 180) * clamp(0, (--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100), 1)));
+  --_ak-edge-h: calc(h + ((mod(((var(--hue-cool, 220) - h) + 540), 360) - 180) * clamp(0, --value([*]), 1)));
 }
 
 @utility ak-edge-warm-* {
-  --_ak-edge-h: calc(h + ((mod(((var(--hue-warm, 90) - h) + 540), 360) - 180) * clamp(0, (--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100), 1)));
+  --_ak-edge-h: calc(h + ((mod(((var(--hue-warm, 90) - h) + 540), 360) - 180) * clamp(0, (--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100), 1)));
+  --_ak-edge-h: calc(h + ((mod(((var(--hue-warm, 90) - h) + 540), 360) - 180) * clamp(0, --value([*]), 1)));
 }
 
 @utility ak-edge-push-* {
-  --_ak-edge-push-lightness: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-edge-push-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-edge-push-lightness: --value([*]);
 }
 
 @utility ak-edge-saturate-* {
-  --_ak-edge-relative-chroma: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-edge-relative-chroma: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-edge-relative-chroma: --value([*]);
 }
 
 @utility ak-edge-desaturate-* {
-  --_ak-edge-relative-chroma: calc((--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100) * -1);
+  --_ak-edge-relative-chroma: calc((--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100) * -1);
+  --_ak-edge-relative-chroma: calc(--value([*]) * -1);
 }
 
 @utility ak-edge-h-rotate-* {
@@ -419,12 +458,14 @@
 }
 
 @utility ak-edge-l-* {
-  --_ak-edge-lightness: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-edge-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-edge-lightness: --value([*]);
 }
 
 @utility ak-edge-c-* {
   --_ak-edge-chroma: --value(--chroma-*);
-  --_ak-edge-chroma: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-edge-chroma: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-edge-chroma: --value([*]);
 }
 
 @utility ak-edge-h-* {
@@ -434,30 +475,36 @@
 
 @utility ak-edge-max-* {
   --_ak-edge-chroma-max: --value(--chroma-*);
-  --_ak-edge-lightness-max: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-edge-lightness-max: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-edge-lightness-max: --value([*]);
 }
 
 @utility ak-edge-min-* {
   --_ak-edge-chroma-min: --value(--chroma-*);
-  --_ak-edge-lightness-min: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-edge-lightness-min: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-edge-lightness-min: --value([*]);
 }
 
 @utility ak-edge-max-l-* {
-  --_ak-edge-lightness-max: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-edge-lightness-max: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-edge-lightness-max: --value([*]);
 }
 
 @utility ak-edge-min-l-* {
-  --_ak-edge-lightness-min: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-edge-lightness-min: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-edge-lightness-min: --value([*]);
 }
 
 @utility ak-edge-max-c-* {
   --_ak-edge-chroma-max: --value(--chroma-*);
-  --_ak-edge-chroma-max: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-edge-chroma-max: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-edge-chroma-max: --value([*]);
 }
 
 @utility ak-edge-min-c-* {
   --_ak-edge-chroma-min: --value(--chroma-*);
-  --_ak-edge-chroma-min: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-edge-chroma-min: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-edge-chroma-min: --value([*]);
 }
 
 @utility ak-text {
@@ -670,7 +717,7 @@
   --_ak-text-chroma: --value(--chroma-*);
   --_ak-text-hue: --value(--hue-*);
   --_ak-text-color: --value(--color-*, [color]);
-  --_ak-text-push-lightness: calc(--value(number, [number], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-text-push-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
 }
 
 @utility ak-text-color-* {
@@ -678,37 +725,45 @@
 }
 
 @utility ak-text-push-* {
-  --_ak-text-push-lightness: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-text-push-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-text-push-lightness: --value([*]);
 }
 
 @utility ak-ink-* {
-  --_ak-text-alpha: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-text-alpha: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-text-alpha: --value([*]);
   --ak-text: oklch(from var(--ak-layer) var(--_ak-tfcl) 0 0 / max((((((var(--_ak-lil) * var(--_ak-tmal)) + (var(--_ak-dal) * (var(--_ak-tmad) + var(--_ak-tmab)))) + (c * 0.135)) * var(--_ak-text-contrast-scale)) + (var(--_ak-ct) * 0.6668)), var(--_ak-text-alpha)));
   color: var(--ak-text);
 }
 
 @utility ak-text-lighten-* {
-  --_ak-text-relative-lightness: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-text-relative-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-text-relative-lightness: --value([*]);
 }
 
 @utility ak-text-darken-* {
-  --_ak-text-relative-lightness: calc((--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * -1);
+  --_ak-text-relative-lightness: calc((--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * -1);
+  --_ak-text-relative-lightness: calc(--value([*]) * -1);
 }
 
 @utility ak-text-cool-* {
-  --_ak-text-hue: calc(h + ((mod(((var(--hue-cool, 220) - h) + 540), 360) - 180) * clamp(0, (--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100), 1)));
+  --_ak-text-hue: calc(h + ((mod(((var(--hue-cool, 220) - h) + 540), 360) - 180) * clamp(0, (--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100), 1)));
+  --_ak-text-hue: calc(h + ((mod(((var(--hue-cool, 220) - h) + 540), 360) - 180) * clamp(0, --value([*]), 1)));
 }
 
 @utility ak-text-warm-* {
-  --_ak-text-hue: calc(h + ((mod(((var(--hue-warm, 90) - h) + 540), 360) - 180) * clamp(0, (--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100), 1)));
+  --_ak-text-hue: calc(h + ((mod(((var(--hue-warm, 90) - h) + 540), 360) - 180) * clamp(0, (--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100), 1)));
+  --_ak-text-hue: calc(h + ((mod(((var(--hue-warm, 90) - h) + 540), 360) - 180) * clamp(0, --value([*]), 1)));
 }
 
 @utility ak-text-saturate-* {
-  --_ak-text-relative-chroma: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-text-relative-chroma: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-text-relative-chroma: --value([*]);
 }
 
 @utility ak-text-desaturate-* {
-  --_ak-text-relative-chroma: calc((--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100) * -1);
+  --_ak-text-relative-chroma: calc((--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100) * -1);
+  --_ak-text-relative-chroma: calc(--value([*]) * -1);
 }
 
 @utility ak-text-h-rotate-* {
@@ -716,12 +771,14 @@
 }
 
 @utility ak-text-l-* {
-  --_ak-text-lightness: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-text-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-text-lightness: --value([*]);
 }
 
 @utility ak-text-c-* {
   --_ak-text-chroma: --value(--chroma-*);
-  --_ak-text-chroma: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-text-chroma: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-text-chroma: --value([*]);
 }
 
 @utility ak-text-h-* {
@@ -731,30 +788,36 @@
 
 @utility ak-text-max-* {
   --_ak-text-chroma-max: --value(--chroma-*);
-  --_ak-text-lightness-max: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-text-lightness-max: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-text-lightness-max: --value([*]);
 }
 
 @utility ak-text-min-* {
   --_ak-text-chroma-min: --value(--chroma-*);
-  --_ak-text-lightness-min: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-text-lightness-min: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-text-lightness-min: --value([*]);
 }
 
 @utility ak-text-max-l-* {
-  --_ak-text-lightness-max: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-text-lightness-max: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-text-lightness-max: --value([*]);
 }
 
 @utility ak-text-min-l-* {
-  --_ak-text-lightness-min: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-text-lightness-min: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-text-lightness-min: --value([*]);
 }
 
 @utility ak-text-max-c-* {
   --_ak-text-chroma-max: --value(--chroma-*);
-  --_ak-text-chroma-max: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-text-chroma-max: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-text-chroma-max: --value([*]);
 }
 
 @utility ak-text-min-c-* {
   --_ak-text-chroma-min: --value(--chroma-*);
-  --_ak-text-chroma-min: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-text-chroma-min: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-text-chroma-min: --value([*]);
 }
 
 @utility ak-outline {
@@ -806,7 +869,7 @@
   --_ak-outline-chroma: --value(--chroma-*);
   --_ak-outline-hue: --value(--hue-*);
   --_ak-outline-color: --value(--color-*, [color]);
-  --_ak-outline-push-lightness: calc(--value(number, [number], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-outline-push-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
 }
 
 @utility ak-outline-color-* {
@@ -814,31 +877,38 @@
 }
 
 @utility ak-outline-push-* {
-  --_ak-outline-push-lightness: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-outline-push-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-outline-push-lightness: --value([*]);
 }
 
 @utility ak-outline-lighten-* {
-  --_ak-outline-relative-lightness: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-outline-relative-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-outline-relative-lightness: --value([*]);
 }
 
 @utility ak-outline-darken-* {
-  --_ak-outline-relative-lightness: calc((--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * -1);
+  --_ak-outline-relative-lightness: calc((--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * -1);
+  --_ak-outline-relative-lightness: calc(--value([*]) * -1);
 }
 
 @utility ak-outline-cool-* {
-  --_ak-outline-hue: calc(h + ((mod(((var(--hue-cool, 220) - h) + 540), 360) - 180) * clamp(0, (--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100), 1)));
+  --_ak-outline-hue: calc(h + ((mod(((var(--hue-cool, 220) - h) + 540), 360) - 180) * clamp(0, (--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100), 1)));
+  --_ak-outline-hue: calc(h + ((mod(((var(--hue-cool, 220) - h) + 540), 360) - 180) * clamp(0, --value([*]), 1)));
 }
 
 @utility ak-outline-warm-* {
-  --_ak-outline-hue: calc(h + ((mod(((var(--hue-warm, 90) - h) + 540), 360) - 180) * clamp(0, (--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100), 1)));
+  --_ak-outline-hue: calc(h + ((mod(((var(--hue-warm, 90) - h) + 540), 360) - 180) * clamp(0, (--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100), 1)));
+  --_ak-outline-hue: calc(h + ((mod(((var(--hue-warm, 90) - h) + 540), 360) - 180) * clamp(0, --value([*]), 1)));
 }
 
 @utility ak-outline-saturate-* {
-  --_ak-outline-relative-chroma: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-outline-relative-chroma: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-outline-relative-chroma: --value([*]);
 }
 
 @utility ak-outline-desaturate-* {
-  --_ak-outline-relative-chroma: calc((--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100) * -1);
+  --_ak-outline-relative-chroma: calc((--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100) * -1);
+  --_ak-outline-relative-chroma: calc(--value([*]) * -1);
 }
 
 @utility ak-outline-h-rotate-* {
@@ -846,12 +916,14 @@
 }
 
 @utility ak-outline-l-* {
-  --_ak-outline-lightness: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-outline-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-outline-lightness: --value([*]);
 }
 
 @utility ak-outline-c-* {
   --_ak-outline-chroma: --value(--chroma-*);
-  --_ak-outline-chroma: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-outline-chroma: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-outline-chroma: --value([*]);
 }
 
 @utility ak-outline-h-* {
@@ -861,30 +933,36 @@
 
 @utility ak-outline-max-* {
   --_ak-outline-chroma-max: --value(--chroma-*);
-  --_ak-outline-lightness-max: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-outline-lightness-max: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-outline-lightness-max: --value([*]);
 }
 
 @utility ak-outline-min-* {
   --_ak-outline-chroma-min: --value(--chroma-*);
-  --_ak-outline-lightness-min: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-outline-lightness-min: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-outline-lightness-min: --value([*]);
 }
 
 @utility ak-outline-max-l-* {
-  --_ak-outline-lightness-max: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-outline-lightness-max: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-outline-lightness-max: --value([*]);
 }
 
 @utility ak-outline-min-l-* {
-  --_ak-outline-lightness-min: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-outline-lightness-min: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-outline-lightness-min: --value([*]);
 }
 
 @utility ak-outline-max-c-* {
   --_ak-outline-chroma-max: --value(--chroma-*);
-  --_ak-outline-chroma-max: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-outline-chroma-max: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-outline-chroma-max: --value([*]);
 }
 
 @utility ak-outline-min-c-* {
   --_ak-outline-chroma-min: --value(--chroma-*);
-  --_ak-outline-chroma-min: calc(--value(number, [*], "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-outline-chroma-min: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
+  --_ak-outline-chroma-min: --value([*]);
 }
 
 @utility ak-frame {

--- a/site/src/sandbox/ariakit-tailwind/__snapshots__/dark
+++ b/site/src/sandbox/ariakit-tailwind/__snapshots__/dark
@@ -18,6 +18,10 @@
       "#CB8CC6": "bg-[oklch(0.1919_0.0082_274.531)] text-[oklch(1_0_0)] *:text-[lch(66.1436_37.44_327.358)] rounded-[15px] border-[1px] border-[oklch(1_0.0082_274.531_/_0.1)] p-[4px] shadow-[oklch(1_0.0082_274.531_/_0.1)_0px_0px_0px_0px]",
       "#CE9178": "bg-[oklch(0.1919_0.0082_274.531)] text-[oklch(1_0_0)] *:text-[lch(65.8798_31.52_46.871)] rounded-[15px] border-[1px] border-[oklch(1_0.0082_274.531_/_0.1)] p-[4px] shadow-[oklch(1_0.0082_274.531_/_0.1)_0px_0px_0px_0px]",
       "#165DFC": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(57.033_80_288.704)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
+      "raw calc": "bg-[oklch(0.4268_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(84.1828_3.43_266.444)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
+      "raw l/c": "bg-[oklch(0.5096_0.18_264.28)] text-[oklch(1_0_0)] *:text-[lch(97.3245_20_284.288)] rounded-[15px] border-[1px] border-[oklch(1_0.18_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.18_264.28_/_0.1)_0px_0px_0px_0px]",
+      "raw ink/edge": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0_/_0.4969)] *:text-[lch(57.033_2.32_268.203)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.35)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.35)_0px_0px_0px_0px]",
+      "raw mix": "bg-[oklch(0.4472_0.0957_28.4513)] text-[oklch(1_0_0)] *:text-[lch(88.4225_35.24_33.406)] rounded-[15px] border-[1px] border-[oklch(1_0.0957_28.4513_/_0.1)] p-[4px] shadow-[oklch(1_0.0957_28.4513_/_0.1)_0px_0px_0px_0px]",
       "explicit longhands": {
         "class": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
         "children": {
@@ -44,7 +48,7 @@
           "layer contrast": "bg-[oklch(0.9_0.08_260)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.08_260_/_0.1)] p-[4px] shadow-[oklch(1_0.08_260_/_0.1)_0px_0px_0px_0px]"
         }
       },
-      "ak-layer-l-[6.24999497075] ak-text-<number>": {
+      "ak-layer-l-[0.0624999497075] ak-text-<number>": {
         "class": "bg-[oklch(0.0625_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
         "children": {
           "0": "bg-[oklch(0.0625_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(55.2119_0.38_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",

--- a/site/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
+++ b/site/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
@@ -18,6 +18,10 @@
       "#CB8CC6": "bg-[oklch(0_0.0082_274.531)] text-[oklch(1_0_0)] *:text-[lch(100_37.44_327.358)] rounded-[15px] border-[1px] border-[oklch(1_0.0082_274.531_/_0.4334)] p-[4px] shadow-[oklch(1_0.0082_274.531_/_0.4334)_0px_0px_0px_0px]",
       "#CE9178": "bg-[oklch(0_0.0082_274.531)] text-[oklch(1_0_0)] *:text-[lch(100_31.52_46.871)] rounded-[15px] border-[1px] border-[oklch(1_0.0082_274.531_/_0.4334)] p-[4px] shadow-[oklch(1_0.0082_274.531_/_0.4334)_0px_0px_0px_0px]",
       "#165DFC": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(100_80_288.704)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
+      "raw calc": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(100_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
+      "raw l/c": "bg-[oklch(0.2_0.18_264.28)] text-[oklch(1_0_0)] *:text-[lch(100_79.92_306.787)] rounded-[15px] border-[1px] border-[oklch(1_0.18_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.18_264.28_/_0.4334)_0px_0px_0px_0px]",
+      "raw ink/edge": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(100_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.6834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.6834)_0px_0px_0px_0px]",
+      "raw mix": "bg-[oklch(0.0566_0.0957_28.4513)] text-[oklch(1_0_0)] *:text-[lch(100_4.61_4.122)] rounded-[15px] border-[1px] border-[oklch(1_0.0957_28.4513_/_0.4334)] p-[4px] shadow-[oklch(1_0.0957_28.4513_/_0.4334)_0px_0px_0px_0px]",
       "explicit longhands": {
         "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
         "children": {
@@ -44,7 +48,7 @@
           "layer contrast": "bg-[oklch(1_0.08_260)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.08_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.08_260_/_0.4334)_0px_0px_0px_0px]"
         }
       },
-      "ak-layer-l-[6.24999497075] ak-text-<number>": {
+      "ak-layer-l-[0.0624999497075] ak-text-<number>": {
         "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
         "children": {
           "0": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(100_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",

--- a/site/src/sandbox/ariakit-tailwind/__snapshots__/light
+++ b/site/src/sandbox/ariakit-tailwind/__snapshots__/light
@@ -18,6 +18,10 @@
       "#CB8CC6": "bg-[oklch(0.1919_0.0082_274.531)] text-[oklch(1_0_0)] *:text-[lch(66.1436_37.44_327.358)] rounded-[15px] border-[1px] border-[oklch(0_0.0082_274.531_/_0.1)] p-[4px] shadow-[oklch(0_0.0082_274.531_/_0.1)_0px_0px_0px_0px]",
       "#CE9178": "bg-[oklch(0.1919_0.0082_274.531)] text-[oklch(1_0_0)] *:text-[lch(65.8798_31.52_46.871)] rounded-[15px] border-[1px] border-[oklch(0_0.0082_274.531_/_0.1)] p-[4px] shadow-[oklch(0_0.0082_274.531_/_0.1)_0px_0px_0px_0px]",
       "#165DFC": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(43.4424_80_288.704)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
+      "raw calc": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(55.2119_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
+      "raw l/c": "bg-[oklch(0.5096_0.18_197.14)] text-[oklch(1_0_0)] *:text-[lch(100_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.18_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.18_197.14_/_0.1)_0px_0px_0px_0px]",
+      "raw ink/edge": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0_/_0.5418)] *:text-[lch(43.4424_0.38_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.35)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.35)_0px_0px_0px_0px]",
+      "raw mix": "bg-[oklch(0.7377_0.0971_30.0505)] text-[oklch(0_0_0)] *:text-[lch(18.2327_35.22_34.184)] rounded-[15px] border-[1px] border-[oklch(0_0.0971_30.0505_/_0.1)] p-[4px] shadow-[oklch(0_0.0971_30.0505_/_0.1)_0px_0px_0px_0px]",
       "explicit longhands": {
         "class": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
         "children": {
@@ -44,7 +48,7 @@
           "layer contrast": "bg-[oklch(0.8_0.08_260)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.08_260_/_0.1)] p-[4px] shadow-[oklch(0_0.08_260_/_0.1)_0px_0px_0px_0px]"
         }
       },
-      "ak-layer-l-[6.24999497075] ak-text-<number>": {
+      "ak-layer-l-[0.0624999497075] ak-text-<number>": {
         "class": "bg-[oklch(0.0625_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
         "children": {
           "0": "bg-[oklch(0.0625_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(55.2119_0.03_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",

--- a/site/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
+++ b/site/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
@@ -18,6 +18,10 @@
       "#CB8CC6": "bg-[oklch(0_0.0082_274.531)] text-[oklch(1_0_0)] *:text-[lch(100_37.44_327.358)] rounded-[15px] border-[1px] border-[oklch(0_0.0082_274.531_/_0.4334)] p-[4px] shadow-[oklch(0_0.0082_274.531_/_0.4334)_0px_0px_0px_0px]",
       "#CE9178": "bg-[oklch(0_0.0082_274.531)] text-[oklch(1_0_0)] *:text-[lch(100_31.52_46.871)] rounded-[15px] border-[1px] border-[oklch(0_0.0082_274.531_/_0.4334)] p-[4px] shadow-[oklch(0_0.0082_274.531_/_0.4334)_0px_0px_0px_0px]",
       "#165DFC": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_80_288.704)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
+      "raw calc": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(100_0.35_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
+      "raw l/c": "bg-[oklch(0.2_0.18_197.14)] text-[oklch(1_0_0)] *:text-[lch(100_37.79_209.46)] rounded-[15px] border-[1px] border-[oklch(0_0.18_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.18_197.14_/_0.4334)_0px_0px_0px_0px]",
+      "raw ink/edge": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_0.38_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.6834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.6834)_0px_0px_0px_0px]",
+      "raw mix": "bg-[oklch(1_0.0971_30.0505)] text-[oklch(0_0_0)] *:text-[lch(0_34.87_33.938)] rounded-[15px] border-[1px] border-[oklch(0_0.0971_30.0505_/_0.4334)] p-[4px] shadow-[oklch(0_0.0971_30.0505_/_0.4334)_0px_0px_0px_0px]",
       "explicit longhands": {
         "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
         "children": {
@@ -44,7 +48,7 @@
           "layer contrast": "bg-[oklch(0.1332_0.08_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.08_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.08_260_/_0.4334)_0px_0px_0px_0px]"
         }
       },
-      "ak-layer-l-[6.24999497075] ak-text-<number>": {
+      "ak-layer-l-[0.0624999497075] ak-text-<number>": {
         "class": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
         "children": {
           "0": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(100_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",

--- a/site/src/sandbox/ariakit-tailwind/index.react.tsx
+++ b/site/src/sandbox/ariakit-tailwind/index.react.tsx
@@ -340,6 +340,19 @@ export default function Example() {
             className="ak-layer-[#131418] *:ak-text *:ak-text-[#CE9178]"
           />
           <Cell label="#165DFC" className="*:ak-text *:ak-text-[#165DFC]" />
+          <Cell label="raw calc" className="ak-layer-[calc(l+0.1)] *:ak-text" />
+          <Cell
+            label="raw l/c"
+            className="ak-layer-l-[0.62] ak-layer-c-[0.18] *:ak-text"
+          />
+          <Cell
+            label="raw ink/edge"
+            className="ak-ink-[0.45] ak-edge-alpha-[0.35] *:ak-text"
+          />
+          <Cell
+            label="raw mix"
+            className="ak-layer-mix ak-layer-mix-color-[oklch(0.6_0.15_30)] ak-layer-mix-amount-[35%] *:ak-text"
+          />
           <Layer
             label="explicit longhands"
             className="ak-layer ak-frame ak-frame-p-1 ak-frame-border flex-col"
@@ -347,19 +360,19 @@ export default function Example() {
             <Layer className="flex-wrap items-start">
               <Cell
                 label="layer"
-                className="[--demo-color:oklch(0.55_0.12_260)] [--demo-max-l:80] [--demo-offset:20] ak-layer-color-(--demo-color) ak-layer-offset-(--demo-offset) ak-layer-max-l-(--demo-max-l) *:ak-text"
+                className="[--demo-color:oklch(0.55_0.12_260)] [--demo-max-l:0.8] [--demo-offset:0.2] ak-layer-color-(--demo-color) ak-layer-offset-(--demo-offset) ak-layer-max-l-(--demo-max-l) *:ak-text"
               />
               <Cell
                 label="state"
-                className="[--demo-offset:25] ak-state-(--demo-offset)"
+                className="[--demo-offset:0.25] ak-state-(--demo-offset)"
               />
               <Cell
                 label="mix"
-                className="ak-layer-mix [--demo-color:oklch(0.6_0.15_30)] [--demo-mix:35] [--demo-method:oklch] ak-layer-mix-color-(--demo-color) ak-layer-mix-amount-(--demo-mix) ak-layer-mix-method-(--demo-method) *:ak-text"
+                className="ak-layer-mix [--demo-color:oklch(0.6_0.15_30)] [--demo-mix:35%] [--demo-method:oklch] ak-layer-mix-color-(--demo-color) ak-layer-mix-amount-(--demo-mix) ak-layer-mix-method-(--demo-method) *:ak-text"
               />
               <Cell
                 label="edge/text/outline"
-                className="[--demo-alpha:35] [--demo-color:oklch(0.58_0.18_145)] [--demo-push:25] ak-edge-color-(--demo-color) ak-edge-alpha-(--demo-alpha) ak-outline ak-outline-color-(--demo-color) ak-outline-push-(--demo-push) outline-2 *:ak-text *:ak-text-color-(--demo-color) *:ak-text-push-(--demo-push)"
+                className="[--demo-alpha:0.35] [--demo-color:oklch(0.58_0.18_145)] [--demo-push:0.25] ak-edge-color-(--demo-color) ak-edge-alpha-(--demo-alpha) ak-outline ak-outline-color-(--demo-color) ak-outline-push-(--demo-push) outline-2 *:ak-text *:ak-text-color-(--demo-color) *:ak-text-push-(--demo-push)"
               />
             </Layer>
           </Layer>
@@ -419,8 +432,8 @@ export default function Example() {
             </Layer>
           </Layer>
           <Layer
-            label="ak-layer-l-[6.24999497075] ak-text-<number>"
-            className="ak-layer ak-layer-l-[6.24999497075] ak-frame ak-frame-p-1 ak-frame-border flex-col"
+            label="ak-layer-l-[0.0624999497075] ak-text-<number>"
+            className="ak-layer ak-layer-l-[0.0624999497075] ak-frame ak-frame-p-1 ak-frame-border flex-col"
           >
             <Layer className="flex-wrap items-start">
               <Cell className="*:ak-text *:ak-text-0" />


### PR DESCRIPTION
## Motivation

`@ariakit/tailwind` supports arbitrary utility values, but numeric arbitrary values were being scaled like bare tokens. That made raw Tailwind-style values awkward for relative color math, requiring expressions such as `ak-layer-[calc(1*100+10)]` instead of direct CSS-channel math like `ak-layer-[calc(l+0.1)]`.

The v0.2 docs and sandbox should describe the final behavior before this package version ships, without adding migration noise for behavior that has not been published.

## Solution

Bare numeric modifiers still use Ariakit's documented authoring scales, such as `0`–`100` for lightness/alpha and `0`–`40` for chroma. Arbitrary values and custom-property arbitrary forms now pass through as raw CSS values, so consumers can write normalized OKLCH channels, raw deltas, and CSS percentages directly.

This updates the generated Tailwind output, README value-scale docs, existing v0.2 migration examples that mention custom arbitrary values, sandbox one-offs, and computed-style snapshots. It also removes the package-local `lint` script from `@ariakit/tailwind` because linting should run from the repository root.

## Validation

- `pnpm -F @ariakit/tailwind build`
- `pnpm build-site-lite`
- `pnpm lint`
- `SITE_PORT=4322 NEXTJS_PORT=3001 pnpm -F site test-chrome ariakit-tailwind -g wcag`
- `SITE_PORT=4322 NEXTJS_PORT=3001 pnpm -F site test-chrome ariakit-tailwind --grep-invert wcag -u`
- `SITE_PORT=4322 NEXTJS_PORT=3001 pnpm -F site test-chrome ariakit-tailwind --grep-invert wcag`