### PR TITLE
Add Tailwind inherit utilities

### DIFF
--- a/.changeset/200-tailwind-inherit-utilities.md
+++ b/.changeset/200-tailwind-inherit-utilities.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/tailwind": patch
+---
+
+Added `ak-edge-inherit` and `ak-frame-bordering-inherit` utilities.

--- a/packages/ariakit-tailwind/readme.md
+++ b/packages/ariakit-tailwind/readme.md
@@ -326,6 +326,7 @@ Controls the opacity of text inside a layer — useful for secondary text, capti
 | `ak-edge-<chroma>`      | Sets chroma from a named preset.                                                                                                                              |
 | `ak-edge-<hue>`         | Sets hue from a named preset.                                                                                                                                 |
 | `ak-edge-raw`           | Applies the color exactly as specified — shorthand for `ak-edge-100` + `ak-edge-push-0`.                                                                      |
+| `ak-edge-inherit`       | Uses the parent layer edge as the current edge color while preserving the parent edge alpha and lightness.                                                    |
 
 ### Adjustments
 
@@ -484,6 +485,7 @@ All three utilities accept no argument (defaults to `1px`), named widths (`0`, `
 | `ak-frame-border` / `ak-frame-border-<width>`       | Applies a border whose width is factored into nested-frame radius calculations.                                                                                            |
 | `ak-frame-ring` / `ak-frame-ring-<width>`           | Applies a ring with the same treatment. Rings draw outside the border-box without shifting layout.                                                                         |
 | `ak-frame-bordering` / `ak-frame-bordering-<width>` | Adaptive edge: chooses border or ring based on parent layer appearance and whether the layer is lightening or darkening, keeping surfaces visually separated across modes. |
+| `ak-frame-bordering-inherit`                        | Inherits the parent border or ring width, then chooses whether this element should render that width as a border or a ring.                                                |
 
 ### Cover and flow
 

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -1564,7 +1564,7 @@ utility("edge-raw", set(inputs.edgeA, 1), set(inputs.edgePushL, 0));
 
 utility(
   "edge-inherit",
-  layerContext(({ inherit }) => {
+  layerContext.read(({ inherit }) => {
     const parentEdge = inherit(vars.layerEdgeContext, vars.layer);
     return [
       set(inputs.edgeColor, parentEdge),
@@ -2272,7 +2272,7 @@ utility(
 
 utility(
   "frame-bordering-inherit",
-  frameContext(({ inherit }) => [
+  frameContext.read(({ inherit }) => [
     set(
       inputs.frameBordering,
       fn.max(

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -14,6 +14,7 @@ import {
 const l = "l";
 const c = "c";
 const h = "h";
+const alpha = "alpha";
 
 const CHROMA_MAX_SRGB = 0.32;
 const CHROMA_MAX_P3 = 0.368;
@@ -580,6 +581,7 @@ const layerColorVars = {
   layerPush: _ak.prop.canvas("lp"),
   layer: ak.prop.canvas("layer", { inherits: true }),
   layerParentContext: _ak.var("lpc"),
+  layerEdgeContext: _ak.var("lec"),
   layerParent: ak.var("layer-parent", "canvas"),
   edge: ak.prop.black("edge"),
   text: ak.prop.black("text", { inherits: true }),
@@ -1271,6 +1273,7 @@ utility(
   at.variant(dark, set(vars.edgePushDirection, 1)),
   layerContext(({ provide, inherit }) => [
     set(provide(vars.layerParentContext), vars.layer),
+    set(provide(vars.layerEdgeContext), vars.edge),
     set(vars.layerParent, inherit(vars.layerParentContext)),
   ]),
 );
@@ -1558,6 +1561,19 @@ utility("edge-color-*", set(inputs.edgeColor, fn.value(color, "[*]")));
 utility("edge-alpha-*", getRawPercentDeclarations(inputs.edgeA));
 
 utility("edge-raw", set(inputs.edgeA, 1), set(inputs.edgePushL, 0));
+
+utility(
+  "edge-inherit",
+  layerContext(({ inherit }) => {
+    const parentEdge = inherit(vars.layerEdgeContext, vars.layer);
+    return [
+      set(inputs.edgeColor, parentEdge),
+      set(inputs.edgePushL, fn.neg(vars.edgeContrastValue)),
+      set(inputs.edgeL, fn.sub(l, edgeDirectionalShift)),
+      set(inputs.edgeA, fn.sub(alpha, vars.edgeContrastValue)),
+    ];
+  }),
+);
 
 const edgeLighten = utility(
   "edge-lighten-*",
@@ -2252,6 +2268,20 @@ utility(
   "frame-bordering",
   set(inputs.frameBordering, "1px"),
   getFrameBorderingDarkLight(),
+);
+
+utility(
+  "frame-bordering-inherit",
+  frameContext(({ inherit }) => [
+    set(
+      inputs.frameBordering,
+      fn.max(
+        inherit(vars.frameParentBorderContext, "0px"),
+        inherit(vars.frameParentRingContext, "0px"),
+      ),
+    ),
+    ...getFrameBorderingDarkLight(),
+  ]),
 );
 
 utility(

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -1569,7 +1569,6 @@ utility(
     return [
       set(inputs.edgeColor, parentEdge),
       set(inputs.edgePushL, fn.neg(vars.edgeContrastValue)),
-      set(inputs.edgeL, fn.sub(l, edgeDirectionalShift)),
       set(inputs.edgeA, fn.sub(alpha, vars.edgeContrastValue)),
     ];
   }),

--- a/packages/ariakit-tailwind/src/lib.ts
+++ b/packages/ariakit-tailwind/src/lib.ts
@@ -246,13 +246,29 @@ export interface WithContextParams {
   inherit: typeof fn.var;
 }
 
+interface WithContextReadParams {
+  inherit: typeof fn.var;
+}
+
+type GetContextChildren = (
+  params: WithContextParams,
+) => Array<AtRuleChild | undefined>;
+type GetContextReadChildren = (
+  params: WithContextReadParams,
+) => Array<AtRuleChild | undefined>;
+
+interface Context {
+  (getContextChildren: GetContextChildren): AtRuleChild[];
+  read: (getContextChildren: GetContextReadChildren) => AtRuleChild[];
+}
+
 let contextCounter = 0;
 
 /**
  * Emulates an `inherit()` function by routing parent values through alternating
  * context vars selected by style container queries.
  */
-export function createContext(reset?: boolean) {
+export function createContext(reset?: boolean): Context {
   const id = `--_context-${contextCounter++}`;
 
   const getNextParity = (parity: ContextParity): ContextParity => {
@@ -267,24 +283,9 @@ export function createContext(reset?: boolean) {
     return createVar(`${getIdent(property)}-${parity}`);
   };
 
-  const context = (
-    getContextChildren: (
-      params: WithContextParams,
-    ) => Array<AtRuleChild | undefined>,
+  const withParityContainers = (
+    getChildren: (parity?: ContextParity) => AtRuleChild[],
   ) => {
-    const getChildren = (parity: ContextParity = "even"): AtRuleChild[] => {
-      const nextParity = getNextParity(parity);
-      const contextChildren = getContextChildren({
-        opposite: (property) =>
-          getParityVar(property, parity === "even" ? "odd" : "even"),
-        provide: (property) => getParityVar(property, nextParity),
-        inherit: (property, ...fallbacks) => {
-          const inheritedVar = getParityVar(property, parity);
-          return fn.var(inheritedVar, ...fallbacks);
-        },
-      }).filter((child) => child != null);
-      return [set(id, nextParity), ...contextChildren];
-    };
     if (reset) {
       return getChildren();
     }
@@ -295,7 +296,47 @@ export function createContext(reset?: boolean) {
     ];
   };
 
-  return context;
+  const getContextChildrenForParity = (
+    getContextChildren: GetContextChildren,
+    parity: ContextParity = "even",
+  ) => {
+    const nextParity = getNextParity(parity);
+    const contextChildren = getContextChildren({
+      opposite: (property) =>
+        getParityVar(property, parity === "even" ? "odd" : "even"),
+      provide: (property) => getParityVar(property, nextParity),
+      inherit: (property, ...fallbacks) => {
+        const inheritedVar = getParityVar(property, parity);
+        return fn.var(inheritedVar, ...fallbacks);
+      },
+    }).filter((child) => child != null);
+    return [set(id, nextParity), ...contextChildren];
+  };
+
+  const getContextReadChildrenForParity = (
+    getContextChildren: GetContextReadChildren,
+    parity: ContextParity = "even",
+  ) => {
+    return getContextChildren({
+      inherit: (property, ...fallbacks) => {
+        const inheritedVar = getParityVar(property, parity);
+        return fn.var(inheritedVar, ...fallbacks);
+      },
+    }).filter((child) => child != null);
+  };
+
+  return Object.assign(
+    (getContextChildren: GetContextChildren) =>
+      withParityContainers((parity) =>
+        getContextChildrenForParity(getContextChildren, parity),
+      ),
+    {
+      read: (getContextChildren: GetContextReadChildren) =>
+        withParityContainers((parity) =>
+          getContextReadChildrenForParity(getContextChildren, parity),
+        ),
+    },
+  );
 }
 
 export interface Namespace

--- a/packages/ariakit-tailwind/src/output.css
+++ b/packages/ariakit-tailwind/src/output.css
@@ -422,14 +422,12 @@
 
 @utility ak-edge-inherit {
   @container (style(--_context-0: even)) or (not style(--_context-0)) {
-    --_context-0: odd;
     --_ak-edge-color: var(--_ak-lec-even, var(--ak-layer));
     --_ak-edge-push-lightness: calc(var(--_ak-ecv) * -1);
     --_ak-edge-lightness: calc(l - ((var(--_ak-edge-push-lightness) + var(--_ak-ecv)) * var(--_ak-epd, -1)));
     --_ak-edge-alpha: calc(alpha - var(--_ak-ecv));
   }
   @container style(--_context-0: odd) {
-    --_context-0: even;
     --_ak-edge-color: var(--_ak-lec-odd, var(--ak-layer));
     --_ak-edge-push-lightness: calc(var(--_ak-ecv) * -1);
     --_ak-edge-lightness: calc(l - ((var(--_ak-edge-push-lightness) + var(--_ak-ecv)) * var(--_ak-epd, -1)));
@@ -1155,7 +1153,6 @@
 
 @utility ak-frame-bordering-inherit {
   @container (style(--_context-1: even)) or (not style(--_context-1)) {
-    --_context-1: odd;
     --_ak-frame-bordering: max(var(--_ak-fpbc-even, 0px), var(--_ak-fpgc-even, 0px));
     --_ak-fbd: clamp(0, ((var(--_ak-layer-idle-relative-lightness) * -1) * 1000000), 1);
     @variant ak-dark {
@@ -1170,7 +1167,6 @@
     }
   }
   @container style(--_context-1: odd) {
-    --_context-1: even;
     --_ak-frame-bordering: max(var(--_ak-fpbc-odd, 0px), var(--_ak-fpgc-odd, 0px));
     --_ak-fbd: clamp(0, ((var(--_ak-layer-idle-relative-lightness) * -1) * 1000000), 1);
     @variant ak-dark {

--- a/packages/ariakit-tailwind/src/output.css
+++ b/packages/ariakit-tailwind/src/output.css
@@ -150,11 +150,13 @@
   @container (style(--_context-0: even)) or (not style(--_context-0)) {
     --_context-0: odd;
     --_ak-lpc-odd: var(--ak-layer);
+    --_ak-lec-odd: var(--ak-edge);
     --ak-layer-parent: var(--_ak-lpc-even);
   }
   @container style(--_context-0: odd) {
     --_context-0: even;
     --_ak-lpc-even: var(--ak-layer);
+    --_ak-lec-even: var(--ak-edge);
     --ak-layer-parent: var(--_ak-lpc-odd);
   }
 }
@@ -416,6 +418,23 @@
 @utility ak-edge-raw {
   --_ak-edge-alpha: 1;
   --_ak-edge-push-lightness: 0;
+}
+
+@utility ak-edge-inherit {
+  @container (style(--_context-0: even)) or (not style(--_context-0)) {
+    --_context-0: odd;
+    --_ak-edge-color: var(--_ak-lec-even, var(--ak-layer));
+    --_ak-edge-push-lightness: calc(var(--_ak-ecv) * -1);
+    --_ak-edge-lightness: calc(l - ((var(--_ak-edge-push-lightness) + var(--_ak-ecv)) * var(--_ak-epd, -1)));
+    --_ak-edge-alpha: calc(alpha - var(--_ak-ecv));
+  }
+  @container style(--_context-0: odd) {
+    --_context-0: even;
+    --_ak-edge-color: var(--_ak-lec-odd, var(--ak-layer));
+    --_ak-edge-push-lightness: calc(var(--_ak-ecv) * -1);
+    --_ak-edge-lightness: calc(l - ((var(--_ak-edge-push-lightness) + var(--_ak-ecv)) * var(--_ak-epd, -1)));
+    --_ak-edge-alpha: calc(alpha - var(--_ak-ecv));
+  }
 }
 
 @utility ak-edge-lighten-* {
@@ -1131,6 +1150,39 @@
     --_ak-frame-border: calc(var(--_ak-fbd) * var(--_ak-frame-bordering));
     border-width: calc(var(--_ak-fbd) * var(--_ak-frame-bordering));
     --_ak-frame-ring: calc((1 - var(--_ak-fbd)) * var(--_ak-frame-bordering));
+  }
+}
+
+@utility ak-frame-bordering-inherit {
+  @container (style(--_context-1: even)) or (not style(--_context-1)) {
+    --_context-1: odd;
+    --_ak-frame-bordering: max(var(--_ak-fpbc-even, 0px), var(--_ak-fpgc-even, 0px));
+    --_ak-fbd: clamp(0, ((var(--_ak-layer-idle-relative-lightness) * -1) * 1000000), 1);
+    @variant ak-dark {
+      --_ak-frame-border: calc((1 - var(--_ak-fbd)) * var(--_ak-frame-bordering));
+      border-width: calc((1 - var(--_ak-fbd)) * var(--_ak-frame-bordering));
+      --_ak-frame-ring: calc(var(--_ak-fbd) * var(--_ak-frame-bordering));
+    }
+    @variant ak-light {
+      --_ak-frame-border: calc(var(--_ak-fbd) * var(--_ak-frame-bordering));
+      border-width: calc(var(--_ak-fbd) * var(--_ak-frame-bordering));
+      --_ak-frame-ring: calc((1 - var(--_ak-fbd)) * var(--_ak-frame-bordering));
+    }
+  }
+  @container style(--_context-1: odd) {
+    --_context-1: even;
+    --_ak-frame-bordering: max(var(--_ak-fpbc-odd, 0px), var(--_ak-fpgc-odd, 0px));
+    --_ak-fbd: clamp(0, ((var(--_ak-layer-idle-relative-lightness) * -1) * 1000000), 1);
+    @variant ak-dark {
+      --_ak-frame-border: calc((1 - var(--_ak-fbd)) * var(--_ak-frame-bordering));
+      border-width: calc((1 - var(--_ak-fbd)) * var(--_ak-frame-bordering));
+      --_ak-frame-ring: calc(var(--_ak-fbd) * var(--_ak-frame-bordering));
+    }
+    @variant ak-light {
+      --_ak-frame-border: calc(var(--_ak-fbd) * var(--_ak-frame-bordering));
+      border-width: calc(var(--_ak-fbd) * var(--_ak-frame-bordering));
+      --_ak-frame-ring: calc((1 - var(--_ak-fbd)) * var(--_ak-frame-bordering));
+    }
   }
 }
 

--- a/packages/ariakit-tailwind/src/output.css
+++ b/packages/ariakit-tailwind/src/output.css
@@ -424,13 +424,11 @@
   @container (style(--_context-0: even)) or (not style(--_context-0)) {
     --_ak-edge-color: var(--_ak-lec-even, var(--ak-layer));
     --_ak-edge-push-lightness: calc(var(--_ak-ecv) * -1);
-    --_ak-edge-lightness: calc(l - ((var(--_ak-edge-push-lightness) + var(--_ak-ecv)) * var(--_ak-epd, -1)));
     --_ak-edge-alpha: calc(alpha - var(--_ak-ecv));
   }
   @container style(--_context-0: odd) {
     --_ak-edge-color: var(--_ak-lec-odd, var(--ak-layer));
     --_ak-edge-push-lightness: calc(var(--_ak-ecv) * -1);
-    --_ak-edge-lightness: calc(l - ((var(--_ak-edge-push-lightness) + var(--_ak-ecv)) * var(--_ak-epd, -1)));
     --_ak-edge-alpha: calc(alpha - var(--_ak-ecv));
   }
 }

--- a/site/src/sandbox/ariakit-tailwind/__snapshots__/dark
+++ b/site/src/sandbox/ariakit-tailwind/__snapshots__/dark
@@ -25,6 +25,7 @@
         "class": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
         "children": {
           "20": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
+          "push": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
           "host": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
         }
       },

--- a/site/src/sandbox/ariakit-tailwind/__snapshots__/dark
+++ b/site/src/sandbox/ariakit-tailwind/__snapshots__/dark
@@ -21,6 +21,19 @@
       "raw calc": "bg-[oklch(0.4268_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(84.1828_3.43_266.444)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
       "raw l/c": "bg-[oklch(0.5096_0.18_264.28)] text-[oklch(1_0_0)] *:text-[lch(97.3245_20_284.288)] rounded-[15px] border-[1px] border-[oklch(1_0.18_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.18_264.28_/_0.1)_0px_0px_0px_0px]",
       "raw ink/edge": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0_/_0.4969)] *:text-[lch(57.033_2.32_268.203)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.35)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.35)_0px_0px_0px_0px]",
+      "edge inherit": {
+        "class": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
+        "children": {
+          "20": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.4)_0px_0px_0px_0px]"
+        }
+      },
+      "bordering inherit": {
+        "class": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
+        "children": {
+          "20": "bg-[oklch(0.3634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
+          "20 (2)": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_4px]"
+        }
+      },
       "raw mix": "bg-[oklch(0.4472_0.0957_28.4513)] text-[oklch(1_0_0)] *:text-[lch(88.4225_35.24_33.406)] rounded-[15px] border-[1px] border-[oklch(1_0.0957_28.4513_/_0.1)] p-[4px] shadow-[oklch(1_0.0957_28.4513_/_0.1)_0px_0px_0px_0px]",
       "explicit longhands": {
         "class": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",

--- a/site/src/sandbox/ariakit-tailwind/__snapshots__/dark
+++ b/site/src/sandbox/ariakit-tailwind/__snapshots__/dark
@@ -24,14 +24,16 @@
       "edge inherit": {
         "class": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
         "children": {
-          "20": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.4)_0px_0px_0px_0px]"
+          "20": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
+          "host": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
         }
       },
       "bordering inherit": {
         "class": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
         "children": {
           "20": "bg-[oklch(0.3634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-          "20 (2)": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_4px]"
+          "20 (2)": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_4px]",
+          "host": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_4px]"
         }
       },
       "raw mix": "bg-[oklch(0.4472_0.0957_28.4513)] text-[oklch(1_0_0)] *:text-[lch(88.4225_35.24_33.406)] rounded-[15px] border-[1px] border-[oklch(1_0.0957_28.4513_/_0.1)] p-[4px] shadow-[oklch(1_0.0957_28.4513_/_0.1)_0px_0px_0px_0px]",

--- a/site/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
+++ b/site/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
@@ -25,6 +25,7 @@
         "class": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
         "children": {
           "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
+          "push": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
           "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
         }
       },

--- a/site/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
+++ b/site/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
@@ -24,14 +24,16 @@
       "edge inherit": {
         "class": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
         "children": {
-          "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.7334)_0px_0px_0px_0px]"
+          "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
+          "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
         }
       },
       "bordering inherit": {
         "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
         "children": {
           "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-          "20 (2)": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_4px]"
+          "20 (2)": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_4px]",
+          "host": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_4px]"
         }
       },
       "raw mix": "bg-[oklch(0.0566_0.0957_28.4513)] text-[oklch(1_0_0)] *:text-[lch(100_4.61_4.122)] rounded-[15px] border-[1px] border-[oklch(1_0.0957_28.4513_/_0.4334)] p-[4px] shadow-[oklch(1_0.0957_28.4513_/_0.4334)_0px_0px_0px_0px]",

--- a/site/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
+++ b/site/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
@@ -21,6 +21,19 @@
       "raw calc": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(100_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
       "raw l/c": "bg-[oklch(0.2_0.18_264.28)] text-[oklch(1_0_0)] *:text-[lch(100_79.92_306.787)] rounded-[15px] border-[1px] border-[oklch(1_0.18_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.18_264.28_/_0.4334)_0px_0px_0px_0px]",
       "raw ink/edge": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(100_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.6834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.6834)_0px_0px_0px_0px]",
+      "edge inherit": {
+        "class": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
+        "children": {
+          "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.7334)_0px_0px_0px_0px]"
+        }
+      },
+      "bordering inherit": {
+        "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
+        "children": {
+          "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
+          "20 (2)": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_4px]"
+        }
+      },
       "raw mix": "bg-[oklch(0.0566_0.0957_28.4513)] text-[oklch(1_0_0)] *:text-[lch(100_4.61_4.122)] rounded-[15px] border-[1px] border-[oklch(1_0.0957_28.4513_/_0.4334)] p-[4px] shadow-[oklch(1_0.0957_28.4513_/_0.4334)_0px_0px_0px_0px]",
       "explicit longhands": {
         "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",

--- a/site/src/sandbox/ariakit-tailwind/__snapshots__/light
+++ b/site/src/sandbox/ariakit-tailwind/__snapshots__/light
@@ -25,6 +25,7 @@
         "class": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
         "children": {
           "20": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
+          "push": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.2_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(0.2_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
           "host": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
         }
       },

--- a/site/src/sandbox/ariakit-tailwind/__snapshots__/light
+++ b/site/src/sandbox/ariakit-tailwind/__snapshots__/light
@@ -21,6 +21,19 @@
       "raw calc": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(55.2119_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
       "raw l/c": "bg-[oklch(0.5096_0.18_197.14)] text-[oklch(1_0_0)] *:text-[lch(100_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.18_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.18_197.14_/_0.1)_0px_0px_0px_0px]",
       "raw ink/edge": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0_/_0.5418)] *:text-[lch(43.4424_0.38_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.35)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.35)_0px_0px_0px_0px]",
+      "edge inherit": {
+        "class": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
+        "children": {
+          "20": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.4)_0px_0px_0px_0px]"
+        }
+      },
+      "bordering inherit": {
+        "class": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[15px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_4px]",
+        "children": {
+          "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_4px]",
+          "20 (2)": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+        }
+      },
       "raw mix": "bg-[oklch(0.7377_0.0971_30.0505)] text-[oklch(0_0_0)] *:text-[lch(18.2327_35.22_34.184)] rounded-[15px] border-[1px] border-[oklch(0_0.0971_30.0505_/_0.1)] p-[4px] shadow-[oklch(0_0.0971_30.0505_/_0.1)_0px_0px_0px_0px]",
       "explicit longhands": {
         "class": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",

--- a/site/src/sandbox/ariakit-tailwind/__snapshots__/light
+++ b/site/src/sandbox/ariakit-tailwind/__snapshots__/light
@@ -24,14 +24,16 @@
       "edge inherit": {
         "class": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
         "children": {
-          "20": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.4)_0px_0px_0px_0px]"
+          "20": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
+          "host": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
         }
       },
       "bordering inherit": {
         "class": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[15px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_4px]",
         "children": {
           "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_4px]",
-          "20 (2)": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+          "20 (2)": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
+          "host": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
         }
       },
       "raw mix": "bg-[oklch(0.7377_0.0971_30.0505)] text-[oklch(0_0_0)] *:text-[lch(18.2327_35.22_34.184)] rounded-[15px] border-[1px] border-[oklch(0_0.0971_30.0505_/_0.1)] p-[4px] shadow-[oklch(0_0.0971_30.0505_/_0.1)_0px_0px_0px_0px]",

--- a/site/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
+++ b/site/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
@@ -25,6 +25,7 @@
         "class": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
         "children": {
           "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
+          "push": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.5334_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(0.5334_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
           "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
         }
       },

--- a/site/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
+++ b/site/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
@@ -24,14 +24,16 @@
       "edge inherit": {
         "class": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
         "children": {
-          "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.7334)_0px_0px_0px_0px]"
+          "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
+          "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
         }
       },
       "bordering inherit": {
         "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[15px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_4px]",
         "children": {
           "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_4px]",
-          "20 (2)": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+          "20 (2)": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
+          "host": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
         }
       },
       "raw mix": "bg-[oklch(1_0.0971_30.0505)] text-[oklch(0_0_0)] *:text-[lch(0_34.87_33.938)] rounded-[15px] border-[1px] border-[oklch(0_0.0971_30.0505_/_0.4334)] p-[4px] shadow-[oklch(0_0.0971_30.0505_/_0.4334)_0px_0px_0px_0px]",

--- a/site/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
+++ b/site/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
@@ -21,6 +21,19 @@
       "raw calc": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(100_0.35_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
       "raw l/c": "bg-[oklch(0.2_0.18_197.14)] text-[oklch(1_0_0)] *:text-[lch(100_37.79_209.46)] rounded-[15px] border-[1px] border-[oklch(0_0.18_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.18_197.14_/_0.4334)_0px_0px_0px_0px]",
       "raw ink/edge": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_0.38_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.6834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.6834)_0px_0px_0px_0px]",
+      "edge inherit": {
+        "class": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
+        "children": {
+          "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.7334)_0px_0px_0px_0px]"
+        }
+      },
+      "bordering inherit": {
+        "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[15px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_4px]",
+        "children": {
+          "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_4px]",
+          "20 (2)": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+        }
+      },
       "raw mix": "bg-[oklch(1_0.0971_30.0505)] text-[oklch(0_0_0)] *:text-[lch(0_34.87_33.938)] rounded-[15px] border-[1px] border-[oklch(0_0.0971_30.0505_/_0.4334)] p-[4px] shadow-[oklch(0_0.0971_30.0505_/_0.4334)_0px_0px_0px_0px]",
       "explicit longhands": {
         "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",

--- a/site/src/sandbox/ariakit-tailwind/index.react.tsx
+++ b/site/src/sandbox/ariakit-tailwind/index.react.tsx
@@ -354,6 +354,10 @@ export default function Example() {
             className="ak-layer ak-layer-blue-600 ak-edge-red-600 ak-edge-40 ak-frame ak-frame-p-1 ak-frame-border flex-col"
           >
             <Layer className="ak-layer ak-layer-20 ak-edge-inherit ak-frame ak-frame-p-1 ak-frame-border" />
+            <Layer
+              label="push"
+              className="ak-layer ak-layer-20 ak-edge-inherit ak-edge-push-20 ak-frame ak-frame-p-1 ak-frame-border"
+            />
             <div className="ak-edge-inherit">
               <Layer
                 label="host"

--- a/site/src/sandbox/ariakit-tailwind/index.react.tsx
+++ b/site/src/sandbox/ariakit-tailwind/index.react.tsx
@@ -349,6 +349,19 @@ export default function Example() {
             label="raw ink/edge"
             className="ak-ink-[0.45] ak-edge-alpha-[0.35] *:ak-text"
           />
+          <Layer
+            label="edge inherit"
+            className="ak-layer ak-layer-blue-600 ak-edge-red-600 ak-edge-40 ak-frame ak-frame-p-1 ak-frame-border flex-col"
+          >
+            <Layer className="ak-layer ak-layer-20 ak-edge-inherit ak-frame ak-frame-p-1 ak-frame-border" />
+          </Layer>
+          <Layer
+            label="bordering inherit"
+            className="ak-layer ak-frame ak-frame-p-1 ak-frame-bordering-4 flex-col"
+          >
+            <Layer className="ak-layer ak-layer-lighten-20 ak-frame ak-frame-p-1 ak-frame-bordering-inherit" />
+            <Layer className="ak-layer ak-layer-darken-20 ak-frame ak-frame-p-1 ak-frame-bordering-inherit" />
+          </Layer>
           <Cell
             label="raw mix"
             className="ak-layer-mix ak-layer-mix-color-[oklch(0.6_0.15_30)] ak-layer-mix-amount-[35%] *:ak-text"

--- a/site/src/sandbox/ariakit-tailwind/index.react.tsx
+++ b/site/src/sandbox/ariakit-tailwind/index.react.tsx
@@ -354,6 +354,12 @@ export default function Example() {
             className="ak-layer ak-layer-blue-600 ak-edge-red-600 ak-edge-40 ak-frame ak-frame-p-1 ak-frame-border flex-col"
           >
             <Layer className="ak-layer ak-layer-20 ak-edge-inherit ak-frame ak-frame-p-1 ak-frame-border" />
+            <div className="ak-edge-inherit">
+              <Layer
+                label="host"
+                className="ak-layer ak-layer-20 ak-frame ak-frame-p-1 ak-frame-border"
+              />
+            </div>
           </Layer>
           <Layer
             label="bordering inherit"
@@ -361,6 +367,12 @@ export default function Example() {
           >
             <Layer className="ak-layer ak-layer-lighten-20 ak-frame ak-frame-p-1 ak-frame-bordering-inherit" />
             <Layer className="ak-layer ak-layer-darken-20 ak-frame ak-frame-p-1 ak-frame-bordering-inherit" />
+            <div className="ak-frame-bordering-inherit">
+              <Layer
+                label="host"
+                className="ak-layer ak-layer-darken-20 ak-frame ak-frame-p-1 ak-frame-bordering-inherit"
+              />
+            </div>
           </Layer>
           <Cell
             label="raw mix"


### PR DESCRIPTION
## Motivation

Nested Tailwind layers sometimes need to reuse the parent edge treatment without inheriting every local edge decision. Using the parent `--ak-edge` directly would skip the edge pipeline, which means the child could not reliably preserve the parent edge channels while still applying local edge modifiers.

Similarly, frame bordering needs a way to reuse the parent border/ring width while still letting each element decide whether that width should render as a border or a ring based on its own layer context.

## Solution

Adds two static `@ariakit/tailwind` utilities:

- `ak-edge-inherit` reads the parent layer edge from layer context and feeds it back through the edge pipeline. It cancels the local default edge contrast adjustments for the inherited alpha and lightness channels without setting an absolute edge lightness, so child utilities such as `ak-edge-push-*` can still compose with the inherited edge.
- `ak-frame-bordering-inherit` reads the parent frame border/ring width from frame context, then runs the existing local `ak-frame-bordering` border-versus-ring decision for the current element.

The implementation also adds a read-only context lookup mode so these inherit utilities can read parent context without advancing `--_context-*` parity. This preserves descendant layer/frame context when the utilities are applied to plain wrapper elements between a provider and a nested layer/frame.

The PR also updates the generated Tailwind output, README docs, the ariakit-tailwind sandbox, computed-style snapshots, and adds a changeset. The sandbox includes an `ak-edge-inherit ak-edge-push-20` case to verify inherited edge push composition.

## Validation

- `pnpm -F @ariakit/tailwind build`
- `SITE_PORT=4322 pnpm -F site test-chrome ariakit-tailwind --grep-invert wcag`
- `SITE_PORT=4322 pnpm -F site test-chrome ariakit-tailwind -g wcag`
- `pnpm tsc`
- `pnpm lint-fix` (completed with existing underscore-name warnings, no errors)
- `git diff --check`
- Pre-commit internal review and re-review completed with no findings