### PR TITLE
Fix Menu autoFocusOnShow false behavior

### DIFF
--- a/.changeset/300-menu-auto-focus-on-show.md
+++ b/.changeset/300-menu-auto-focus-on-show.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Menu`](https://ariakit.com/reference/menu) to respect `autoFocusOnShow={false}` when opened with a mouse while preserving keyboard focus behavior.

--- a/.changeset/300-menu-auto-focus-on-show.md
+++ b/.changeset/300-menu-auto-focus-on-show.md
@@ -3,4 +3,4 @@
 "@ariakit/react": patch
 ---
 
-Fixed [`Menu`](https://ariakit.com/reference/menu) to respect `autoFocusOnShow={false}` when opened with a mouse while preserving keyboard focus behavior.
+Fixed [`Menu`](https://ariakit.com/reference/menu) to respect `autoFocusOnShow={false}` and `autoFocusOnShow={() => false}` when opened with a mouse while preserving keyboard focus behavior.

--- a/packages/ariakit-react-core/src/menu/menu.tsx
+++ b/packages/ariakit-react-core/src/menu/menu.tsx
@@ -1,3 +1,4 @@
+import { getActiveElement } from "@ariakit/core/utils/dom";
 import { fireEvent } from "@ariakit/core/utils/events";
 import { hasFocusWithin } from "@ariakit/core/utils/focus";
 import { invariant, isFalsyBooleanCallback } from "@ariakit/core/utils/misc";
@@ -131,17 +132,26 @@ export const useMenu = createHook<TagName, MenuOptions>(function useMenu({
   // focus on the dialog container when no initialFocusRef is set.
   const canAutoFocusOnShow = !!initialFocusRef || !!props.initialFocus || modal;
   const autoFocusOnShowProp = useEvent((element: HTMLElement | null) => {
-    if (autoFocusOnShow === false || typeof autoFocusOnShow === "function") {
+    if (autoFocusOnShow === false) {
       if (autoFocusOnShowState && initialFocus !== "container") {
         return canAutoFocusOnShow;
       }
-      if (autoFocusOnShow === false) return false;
+      return false;
+    }
+    if (typeof autoFocusOnShow === "function") {
+      if (autoFocusOnShowState && initialFocus !== "container") {
+        if (!canAutoFocusOnShow) return false;
+        const activeElement = getActiveElement(element, true);
+        const autoFocus = autoFocusOnShow(element);
+        if (autoFocus) return autoFocus;
+        if (activeElement !== getActiveElement(element, true)) return false;
+        return true;
+      }
+      if (!canAutoFocusOnShow) return false;
+      return autoFocusOnShow(element);
     }
     if (mayAutoFocusOnShow) {
       if (!canAutoFocusOnShow) return false;
-      if (typeof autoFocusOnShow === "function") {
-        return autoFocusOnShow(element);
-      }
       return autoFocusOnShow;
     }
     return autoFocusOnShowState || modal;

--- a/packages/ariakit-react-core/src/menu/menu.tsx
+++ b/packages/ariakit-react-core/src/menu/menu.tsx
@@ -132,7 +132,9 @@ export const useMenu = createHook<TagName, MenuOptions>(function useMenu({
   const canAutoFocusOnShow = !!initialFocusRef || !!props.initialFocus || modal;
   const autoFocusOnShowProp = useEvent((element: HTMLElement | null) => {
     if (autoFocusOnShow === false || typeof autoFocusOnShow === "function") {
-      if (autoFocusOnShowState && initialFocus !== "container") return true;
+      if (autoFocusOnShowState && initialFocus !== "container") {
+        return canAutoFocusOnShow;
+      }
       if (autoFocusOnShow === false) return false;
     }
     if (mayAutoFocusOnShow) {

--- a/packages/ariakit-react-core/src/menu/menu.tsx
+++ b/packages/ariakit-react-core/src/menu/menu.tsx
@@ -6,7 +6,7 @@ import { createRef, useEffect, useMemo, useRef, useState } from "react";
 import { createDialogComponent } from "../dialog/dialog.tsx";
 import type { HovercardOptions } from "../hovercard/hovercard.tsx";
 import { useHovercard } from "../hovercard/hovercard.tsx";
-import { useMergeRefs } from "../utils/hooks.ts";
+import { useEvent, useMergeRefs } from "../utils/hooks.ts";
 import { useStoreState } from "../utils/store.tsx";
 import { createElement, createHook, forwardRef } from "../utils/system.tsx";
 import type { Props } from "../utils/types.ts";
@@ -130,12 +130,20 @@ export const useMenu = createHook<TagName, MenuOptions>(function useMenu({
   // This differs from the usual dialog behavior that would automatically
   // focus on the dialog container when no initialFocusRef is set.
   const canAutoFocusOnShow = !!initialFocusRef || !!props.initialFocus || modal;
-  const autoFocusOnShowProp =
-    autoFocusOnShow === false
-      ? autoFocusOnShowState && initialFocus !== "container"
-      : mayAutoFocusOnShow
-        ? canAutoFocusOnShow && autoFocusOnShow
-        : autoFocusOnShowState || modal;
+  const autoFocusOnShowProp = useEvent((element: HTMLElement | null) => {
+    if (autoFocusOnShow === false || typeof autoFocusOnShow === "function") {
+      if (autoFocusOnShowState && initialFocus !== "container") return true;
+      if (autoFocusOnShow === false) return false;
+    }
+    if (mayAutoFocusOnShow) {
+      if (!canAutoFocusOnShow) return false;
+      if (typeof autoFocusOnShow === "function") {
+        return autoFocusOnShow(element);
+      }
+      return autoFocusOnShow;
+    }
+    return autoFocusOnShowState || modal;
+  });
 
   const contentElement = useStoreState(
     store.combobox || store,

--- a/packages/ariakit-react-core/src/menu/menu.tsx
+++ b/packages/ariakit-react-core/src/menu/menu.tsx
@@ -130,6 +130,12 @@ export const useMenu = createHook<TagName, MenuOptions>(function useMenu({
   // This differs from the usual dialog behavior that would automatically
   // focus on the dialog container when no initialFocusRef is set.
   const canAutoFocusOnShow = !!initialFocusRef || !!props.initialFocus || modal;
+  const autoFocusOnShowProp =
+    autoFocusOnShow === false
+      ? autoFocusOnShowState && initialFocus !== "container"
+      : mayAutoFocusOnShow
+        ? canAutoFocusOnShow && autoFocusOnShow
+        : autoFocusOnShowState || modal;
 
   const contentElement = useStoreState(
     store.combobox || store,
@@ -169,9 +175,7 @@ export const useMenu = createHook<TagName, MenuOptions>(function useMenu({
     store,
     alwaysVisible,
     initialFocus: initialFocusRef,
-    autoFocusOnShow: mayAutoFocusOnShow
-      ? canAutoFocusOnShow && autoFocusOnShow
-      : autoFocusOnShowState || modal,
+    autoFocusOnShow: autoFocusOnShowProp,
     ...props,
     hideOnEscape(event) {
       if (isFalsyBooleanCallback(hideOnEscape, event)) return false;

--- a/site/src/sandbox/menu-5899/index.react.tsx
+++ b/site/src/sandbox/menu-5899/index.react.tsx
@@ -1,0 +1,16 @@
+import * as Ariakit from "@ariakit/react";
+
+export default function Example() {
+  return (
+    <Ariakit.MenuProvider>
+      <Ariakit.MenuButton>Actions</Ariakit.MenuButton>
+      <Ariakit.Menu autoFocusOnShow={false} gutter={8}>
+        <Ariakit.MenuItem>Edit</Ariakit.MenuItem>
+        <Ariakit.MenuItem>Share</Ariakit.MenuItem>
+        <Ariakit.MenuItem disabled>Delete</Ariakit.MenuItem>
+        <Ariakit.MenuSeparator />
+        <Ariakit.MenuItem>Report</Ariakit.MenuItem>
+      </Ariakit.Menu>
+    </Ariakit.MenuProvider>
+  );
+}

--- a/site/src/sandbox/menu-5899/index.react.tsx
+++ b/site/src/sandbox/menu-5899/index.react.tsx
@@ -1,15 +1,10 @@
 import * as Ariakit from "@ariakit/react";
 
 export default function Example() {
-  const menu = Ariakit.useMenuStore();
-
   return (
-    <Ariakit.MenuProvider store={menu}>
+    <Ariakit.MenuProvider>
       <Ariakit.MenuButton>Actions</Ariakit.MenuButton>
-      <Ariakit.Menu
-        autoFocusOnShow={() => menu.getState().initialFocus !== "container"}
-        gutter={8}
-      >
+      <Ariakit.Menu autoFocusOnShow={false} gutter={8}>
         <Ariakit.MenuItem>Edit</Ariakit.MenuItem>
         <Ariakit.MenuItem>Share</Ariakit.MenuItem>
         <Ariakit.MenuItem disabled>Delete</Ariakit.MenuItem>

--- a/site/src/sandbox/menu-5899/index.react.tsx
+++ b/site/src/sandbox/menu-5899/index.react.tsx
@@ -1,10 +1,18 @@
 import * as Ariakit from "@ariakit/react";
 
-export default function Example() {
+function CallbackTrueMenu() {
+  const menu = Ariakit.useMenuStore();
+
   return (
-    <Ariakit.MenuProvider>
-      <Ariakit.MenuButton>Actions</Ariakit.MenuButton>
-      <Ariakit.Menu autoFocusOnShow={false} gutter={8}>
+    <Ariakit.MenuProvider store={menu}>
+      <Ariakit.Button onClick={() => menu.toggle()}>
+        Toggle Callback True
+      </Ariakit.Button>
+      <Ariakit.Menu
+        autoFocusOnShow={() => true}
+        gutter={8}
+        aria-label="Callback True"
+      >
         <Ariakit.MenuItem>Edit</Ariakit.MenuItem>
         <Ariakit.MenuItem>Share</Ariakit.MenuItem>
         <Ariakit.MenuItem disabled>Delete</Ariakit.MenuItem>
@@ -12,5 +20,33 @@ export default function Example() {
         <Ariakit.MenuItem>Report</Ariakit.MenuItem>
       </Ariakit.Menu>
     </Ariakit.MenuProvider>
+  );
+}
+
+export default function Example() {
+  return (
+    <>
+      <Ariakit.MenuProvider>
+        <Ariakit.MenuButton>Boolean</Ariakit.MenuButton>
+        <Ariakit.Menu autoFocusOnShow={false} gutter={8}>
+          <Ariakit.MenuItem>Edit</Ariakit.MenuItem>
+          <Ariakit.MenuItem>Share</Ariakit.MenuItem>
+          <Ariakit.MenuItem disabled>Delete</Ariakit.MenuItem>
+          <Ariakit.MenuSeparator />
+          <Ariakit.MenuItem>Report</Ariakit.MenuItem>
+        </Ariakit.Menu>
+      </Ariakit.MenuProvider>
+      <Ariakit.MenuProvider>
+        <Ariakit.MenuButton>Callback</Ariakit.MenuButton>
+        <Ariakit.Menu autoFocusOnShow={() => false} gutter={8}>
+          <Ariakit.MenuItem>Edit</Ariakit.MenuItem>
+          <Ariakit.MenuItem>Share</Ariakit.MenuItem>
+          <Ariakit.MenuItem disabled>Delete</Ariakit.MenuItem>
+          <Ariakit.MenuSeparator />
+          <Ariakit.MenuItem>Report</Ariakit.MenuItem>
+        </Ariakit.Menu>
+      </Ariakit.MenuProvider>
+      <CallbackTrueMenu />
+    </>
   );
 }

--- a/site/src/sandbox/menu-5899/index.react.tsx
+++ b/site/src/sandbox/menu-5899/index.react.tsx
@@ -23,6 +23,25 @@ function CallbackTrueMenu() {
   );
 }
 
+function CallbackSideEffectMenu() {
+  return (
+    <Ariakit.MenuProvider>
+      <Ariakit.MenuButton>Callback Side Effect</Ariakit.MenuButton>
+      <Ariakit.Menu
+        autoFocusOnShow={(element) => {
+          element?.setAttribute("data-callback-side-effect", "true");
+          element?.focus({ preventScroll: true });
+          return false;
+        }}
+        gutter={8}
+      >
+        <Ariakit.MenuItem>Side Effect Edit</Ariakit.MenuItem>
+        <Ariakit.MenuItem>Side Effect Share</Ariakit.MenuItem>
+      </Ariakit.Menu>
+    </Ariakit.MenuProvider>
+  );
+}
+
 export default function Example() {
   return (
     <>
@@ -47,6 +66,7 @@ export default function Example() {
         </Ariakit.Menu>
       </Ariakit.MenuProvider>
       <CallbackTrueMenu />
+      <CallbackSideEffectMenu />
     </>
   );
 }

--- a/site/src/sandbox/menu-5899/index.react.tsx
+++ b/site/src/sandbox/menu-5899/index.react.tsx
@@ -1,10 +1,15 @@
 import * as Ariakit from "@ariakit/react";
 
 export default function Example() {
+  const menu = Ariakit.useMenuStore();
+
   return (
-    <Ariakit.MenuProvider>
+    <Ariakit.MenuProvider store={menu}>
       <Ariakit.MenuButton>Actions</Ariakit.MenuButton>
-      <Ariakit.Menu autoFocusOnShow={false} gutter={8}>
+      <Ariakit.Menu
+        autoFocusOnShow={() => menu.getState().initialFocus !== "container"}
+        gutter={8}
+      >
         <Ariakit.MenuItem>Edit</Ariakit.MenuItem>
         <Ariakit.MenuItem>Share</Ariakit.MenuItem>
         <Ariakit.MenuItem disabled>Delete</Ariakit.MenuItem>

--- a/site/src/sandbox/menu-5899/preview.astro
+++ b/site/src/sandbox/menu-5899/preview.astro
@@ -1,0 +1,14 @@
+---
+import PreviewFramework from "#app/components/preview-framework.astro";
+import ReactExample from "./index.react.tsx";
+
+import sourceReact from "./index.react.tsx?source";
+
+export const source = {
+  react: sourceReact,
+};
+---
+
+<PreviewFramework>
+  <ReactExample client:load slot="react" />
+</PreviewFramework>

--- a/site/src/sandbox/menu-5899/preview.mdx
+++ b/site/src/sandbox/menu-5899/preview.mdx
@@ -1,0 +1,9 @@
+---
+title: "menu-5899"
+frameworks:
+  - react
+---
+
+import Preview from "./preview.astro";
+
+<Preview />

--- a/site/src/sandbox/menu-5899/test-browser.ts
+++ b/site/src/sandbox/menu-5899/test-browser.ts
@@ -19,4 +19,30 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.menu()).not.toBeVisible();
     await test.expect(menuButton).toBeFocused();
   });
+
+  test("focuses menu items on arrow key show when autoFocusOnShow is false", async ({
+    page,
+    q,
+  }) => {
+    const menuButton = q.button("Actions");
+
+    await menuButton.focus();
+    await page.keyboard.press("ArrowDown");
+    await test.expect(q.menuitem("Edit")).toBeFocused();
+
+    await page.keyboard.press("Escape");
+    await test.expect(q.menu()).not.toBeVisible();
+    await test.expect(menuButton).toBeFocused();
+  });
+
+  test("focuses menu items on keyboard click when autoFocusOnShow is false", async ({
+    page,
+    q,
+  }) => {
+    const menuButton = q.button("Actions");
+
+    await menuButton.focus();
+    await page.keyboard.press("Enter");
+    await test.expect(q.menuitem("Edit")).toBeFocused();
+  });
 });

--- a/site/src/sandbox/menu-5899/test-browser.ts
+++ b/site/src/sandbox/menu-5899/test-browser.ts
@@ -12,11 +12,11 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.menu()).toBeVisible();
     await test.expect(menuButton).toBeFocused();
 
+    await page.keyboard.press("ArrowDown");
+    await test.expect(q.menuitem("Edit")).toBeFocused();
+
     await page.keyboard.press("Escape");
     await test.expect(q.menu()).not.toBeVisible();
     await test.expect(menuButton).toBeFocused();
-
-    await page.keyboard.press("ArrowDown");
-    await test.expect(q.menuitem("Edit")).toBeFocused();
   });
 });

--- a/site/src/sandbox/menu-5899/test-browser.ts
+++ b/site/src/sandbox/menu-5899/test-browser.ts
@@ -1,48 +1,77 @@
 import { withFramework } from "#app/test-utils/preview.ts";
 
+const menuButtons = ["Boolean", "Callback"] as const;
+
 withFramework(import.meta.dirname, async ({ test }) => {
-  test("preserves menu button focus when autoFocusOnShow is false", async ({
+  test("preserves menu button focus when autoFocusOnShow is false or returns false", async ({
     page,
     q,
   }) => {
-    const menuButton = q.button("Actions");
+    for (const menuButtonName of menuButtons) {
+      const menuButton = q.button(menuButtonName);
 
-    await menuButton.click();
+      await menuButton.click();
 
-    await test.expect(q.menu()).toBeVisible();
-    await test.expect(menuButton).toBeFocused();
+      await test.expect(q.menu(menuButtonName)).toBeVisible();
+      await test.expect(menuButton).toBeFocused();
 
-    await page.keyboard.press("ArrowDown");
-    await test.expect(q.menuitem("Edit")).toBeFocused();
+      await page.keyboard.press("ArrowDown");
+      await test.expect(q.menuitem("Edit")).toBeFocused();
 
-    await page.keyboard.press("Escape");
-    await test.expect(q.menu()).not.toBeVisible();
-    await test.expect(menuButton).toBeFocused();
+      await page.keyboard.press("Escape");
+      await test.expect(q.menu(menuButtonName)).not.toBeVisible();
+      await test.expect(menuButton).toBeFocused();
+    }
   });
 
-  test("focuses menu items on arrow key show when autoFocusOnShow is false", async ({
+  test("focuses menu items on arrow key show when autoFocusOnShow is false or returns false", async ({
     page,
     q,
   }) => {
-    const menuButton = q.button("Actions");
+    for (const menuButtonName of menuButtons) {
+      const menuButton = q.button(menuButtonName);
 
-    await menuButton.focus();
-    await page.keyboard.press("ArrowDown");
-    await test.expect(q.menuitem("Edit")).toBeFocused();
+      await menuButton.focus();
+      await page.keyboard.press("ArrowDown");
+      await test.expect(q.menuitem("Edit")).toBeFocused();
 
-    await page.keyboard.press("Escape");
-    await test.expect(q.menu()).not.toBeVisible();
-    await test.expect(menuButton).toBeFocused();
+      await page.keyboard.press("Escape");
+      await test.expect(q.menu(menuButtonName)).not.toBeVisible();
+      await test.expect(menuButton).toBeFocused();
+    }
   });
 
-  test("focuses menu items on keyboard click when autoFocusOnShow is false", async ({
+  test("focuses menu items on keyboard click when autoFocusOnShow is false or returns false", async ({
     page,
     q,
   }) => {
-    const menuButton = q.button("Actions");
+    for (const menuButtonName of menuButtons) {
+      const menuButton = q.button(menuButtonName);
 
-    await menuButton.focus();
-    await page.keyboard.press("Enter");
-    await test.expect(q.menuitem("Edit")).toBeFocused();
+      await menuButton.focus();
+      await page.keyboard.press("Enter");
+      await test.expect(q.menuitem("Edit")).toBeFocused();
+
+      await page.keyboard.press("Escape");
+      await test.expect(q.menu(menuButtonName)).not.toBeVisible();
+      await test.expect(menuButton).toBeFocused();
+    }
+  });
+
+  test("preserves menu-specific auto focus guard for callback true", async ({
+    q,
+  }) => {
+    const toggleButton = q.button("Toggle Callback True");
+    const menu = q.menu("Callback True");
+
+    await toggleButton.click();
+
+    await test.expect(menu).toBeVisible();
+    await test.expect(toggleButton).toBeFocused();
+
+    await toggleButton.click();
+
+    await test.expect(menu).not.toBeVisible();
+    await test.expect(toggleButton).toBeFocused();
   });
 });

--- a/site/src/sandbox/menu-5899/test-browser.ts
+++ b/site/src/sandbox/menu-5899/test-browser.ts
@@ -1,0 +1,22 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("preserves menu button focus when autoFocusOnShow is false", async ({
+    page,
+    q,
+  }) => {
+    const menuButton = q.button("Actions");
+
+    await menuButton.click();
+
+    await test.expect(q.menu()).toBeVisible();
+    await test.expect(menuButton).toBeFocused();
+
+    await page.keyboard.press("Escape");
+    await test.expect(q.menu()).not.toBeVisible();
+    await test.expect(menuButton).toBeFocused();
+
+    await page.keyboard.press("ArrowDown");
+    await test.expect(q.menuitem("Edit")).toBeFocused();
+  });
+});

--- a/site/src/sandbox/menu-5899/test-browser.ts
+++ b/site/src/sandbox/menu-5899/test-browser.ts
@@ -121,4 +121,20 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(menu).not.toBeVisible();
     await test.expect(toggleButton).toBeFocused();
   });
+
+  test("preserves callback side effects on keyboard show", async ({
+    page,
+    q,
+  }) => {
+    const menuButton = q.button("Callback Side Effect");
+    const menuItem = q.menuitem("Side Effect Edit");
+
+    await menuButton.focus();
+    await page.keyboard.press("ArrowDown");
+
+    await test.expect(menuItem).toBeFocused();
+    await test
+      .expect(menuItem)
+      .toHaveAttribute("data-callback-side-effect", "true");
+  });
 });

--- a/site/src/sandbox/menu-5899/test-browser.ts
+++ b/site/src/sandbox/menu-5899/test-browser.ts
@@ -41,6 +41,53 @@ withFramework(import.meta.dirname, async ({ test }) => {
     }
   });
 
+  test("does not focus the menu container before keyboard item focus", async ({
+    page,
+    q,
+  }) => {
+    await page.evaluate(() => {
+      document.addEventListener(
+        "focusin",
+        (event) => {
+          const element = event.target as HTMLElement;
+          const role = element.getAttribute("role") || element.tagName;
+          const focusLog = JSON.parse(
+            sessionStorage.getItem("menu-5899-focus-log") || "[]",
+          ) as string[];
+          focusLog.push(role);
+          sessionStorage.setItem(
+            "menu-5899-focus-log",
+            JSON.stringify(focusLog),
+          );
+        },
+        { capture: true },
+      );
+    });
+
+    for (const menuButtonName of menuButtons) {
+      const menuButton = q.button(menuButtonName);
+
+      await page.evaluate(() => {
+        sessionStorage.setItem("menu-5899-focus-log", "[]");
+      });
+      await menuButton.focus();
+      await page.keyboard.press("ArrowDown");
+      await test.expect(q.menuitem("Edit")).toBeFocused();
+
+      const focusLog = await page.evaluate(() => {
+        return JSON.parse(
+          sessionStorage.getItem("menu-5899-focus-log") || "[]",
+        ) as string[];
+      });
+      test.expect(focusLog).toContain("menuitem");
+      test.expect(focusLog).not.toContain("menu");
+
+      await page.keyboard.press("Escape");
+      await test.expect(q.menu(menuButtonName)).not.toBeVisible();
+      await test.expect(menuButton).toBeFocused();
+    }
+  });
+
   test("focuses menu items on keyboard click when autoFocusOnShow is false or returns false", async ({
     page,
     q,


### PR DESCRIPTION
## Motivation

`Menu` ignores an explicit `autoFocusOnShow={false}` when it is opened by clicking `MenuButton`. The menu still receives focus because the store `autoFocusOnShow` state set by the button wins over the prop.

The CodeSandbox repro uses `autoFocusOnShow={() => false}`. That callback form should also be able to suppress the mouse/container focus path without preventing keyboard entry into menu items.

Fixes #5899.

## Solution

Add a `menu-5899` sandbox with browser coverage for both `autoFocusOnShow={false}` and `autoFocusOnShow={() => false}`. The tests verify mouse activation keeps focus on the `MenuButton`, ArrowDown activation focuses the first item without focusing the menu container first, Enter activation focuses the first item, Escape returns focus to the button, callback-true guard behavior is preserved, and callback side effects are still honored on keyboard show.

Update `useMenu` so explicit false values suppress the click/container focus path while still allowing store-driven keyboard focus when `MenuButton` records an item-oriented `initialFocus` value. Callback props are still invoked on keyboard show; if the callback moves focus itself and returns `false`, Ariakit preserves that side effect instead of applying its own default focus.

## Workaround

Until this fix is released, consumers can use a controlled menu store and gate `autoFocusOnShow` on the store's `initialFocus` value. `MenuButton` sets `initialFocus` to `"container"` for mouse clicks and to item-oriented values such as `"first"` for keyboard activation, so this keeps click focus on the trigger while preserving keyboard entry into the menu.

```tsx
const menu = Ariakit.useMenuStore();

<Ariakit.MenuProvider store={menu}>
  <Ariakit.MenuButton>Actions</Ariakit.MenuButton>
  <Ariakit.Menu
    // TODO: Remove once https://github.com/ariakit/ariakit/issues/5899 is fixed.
    autoFocusOnShow={() => menu.getState().initialFocus !== "container"}
  >
    {/* ... */}
  </Ariakit.Menu>
</Ariakit.MenuProvider>
```