### PR TITLE
Fix Menu autoFocusOnShow open behavior

### DIFF
--- a/.changeset/300-menu-autofocus-on-show.md
+++ b/.changeset/300-menu-autofocus-on-show.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-core": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Menu`](https://ariakit.com/reference/menu) to respect `autoFocusOnShow={false}` and `autoFocusOnShow={() => false}` while still allowing arrow keys to move focus into an already-open menu.

--- a/.changeset/300-menu-autofocus-on-show.md
+++ b/.changeset/300-menu-autofocus-on-show.md
@@ -3,4 +3,4 @@
 "@ariakit/react": patch
 ---
 
-Fixed [`Menu`](https://ariakit.com/reference/menu) to respect `autoFocusOnShow={false}` and `autoFocusOnShow={() => false}` while still allowing arrow keys to move focus into an already-open menu.
+Fixed [`Menu`](https://ariakit.com/reference/menu) to respect the [`autoFocusOnShow`](https://ariakit.com/reference/menu#autofocusonshow) prop when set to `false` or when a callback returns `false`, while still allowing arrow keys to move focus into an already-open menu.

--- a/packages/ariakit-react-core/src/menu/menu-button.tsx
+++ b/packages/ariakit-react-core/src/menu/menu-button.tsx
@@ -140,6 +140,12 @@ export const useMenuButton = createHook<TagName, MenuButtonOptions>(
       const initialFocus = getInitialFocus(event, dir);
       if (initialFocus) {
         event.preventDefault();
+        const { open } = store.getState();
+        if (open) {
+          const id = initialFocus === "last" ? store.last() : store.first();
+          store.move(id);
+          return;
+        }
         showMenu();
         store?.setAutoFocusOnShow(true);
         store?.setInitialFocus(initialFocus);

--- a/packages/ariakit-react-core/src/menu/menu.tsx
+++ b/packages/ariakit-react-core/src/menu/menu.tsx
@@ -122,7 +122,6 @@ export const useMenu = createHook<TagName, MenuOptions>(function useMenu({
     };
   }, [store, modal, autoFocusOnShowState, initialFocus, items, baseElement]);
 
-  const mayAutoFocusOnShow = !!autoFocusOnShow;
   // When the `autoFocusOnShow` prop is set to `true` (default), we'll only
   // move focus to the menu when there's an initialFocusRef set or the menu is
   // modal. Otherwise, users would have to manually call
@@ -130,6 +129,8 @@ export const useMenu = createHook<TagName, MenuOptions>(function useMenu({
   // This differs from the usual dialog behavior that would automatically
   // focus on the dialog container when no initialFocusRef is set.
   const canAutoFocusOnShow = !!initialFocusRef || !!props.initialFocus || modal;
+  const autoFocusOnShowProp =
+    autoFocusOnShow === false ? false : canAutoFocusOnShow && autoFocusOnShow;
 
   const contentElement = useStoreState(
     store.combobox || store,
@@ -169,9 +170,7 @@ export const useMenu = createHook<TagName, MenuOptions>(function useMenu({
     store,
     alwaysVisible,
     initialFocus: initialFocusRef,
-    autoFocusOnShow: mayAutoFocusOnShow
-      ? canAutoFocusOnShow && autoFocusOnShow
-      : autoFocusOnShowState || modal,
+    autoFocusOnShow: autoFocusOnShowProp,
     ...props,
     hideOnEscape(event) {
       if (isFalsyBooleanCallback(hideOnEscape, event)) return false;

--- a/site/src/sandbox/menu-5899/index.react.tsx
+++ b/site/src/sandbox/menu-5899/index.react.tsx
@@ -1,9 +1,4 @@
 import * as Ariakit from "@ariakit/react";
-import type { KeyboardEvent } from "react";
-
-interface MenuExampleProps {
-  name: string;
-}
 
 function MenuItems() {
   return (
@@ -17,45 +12,21 @@ function MenuItems() {
   );
 }
 
-function MenuExample({ name }: MenuExampleProps) {
-  const store = Ariakit.useMenuStore();
-
-  const focusItem = (id: string | null | undefined) => {
-    if (!id) return;
-    requestAnimationFrame(() => store.move(id));
-  };
-
-  const onKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
-    const { open } = store.getState();
-    if (!open) return;
-
-    if (event.key === "ArrowDown") {
-      event.preventDefault();
-      focusItem(store.first());
-      return;
-    }
-
-    if (event.key === "ArrowUp") {
-      event.preventDefault();
-      focusItem(store.last());
-    }
-  };
-
-  return (
-    <Ariakit.MenuProvider store={store}>
-      <Ariakit.MenuButton onKeyDown={onKeyDown}>{name}</Ariakit.MenuButton>
-      <Ariakit.Menu autoFocusOnShow={() => false} gutter={8}>
-        <MenuItems />
-      </Ariakit.Menu>
-    </Ariakit.MenuProvider>
-  );
-}
-
 export default function Example() {
   return (
     <>
-      <MenuExample name="Boolean" />
-      <MenuExample name="Callback" />
+      <Ariakit.MenuProvider>
+        <Ariakit.MenuButton>Boolean</Ariakit.MenuButton>
+        <Ariakit.Menu autoFocusOnShow={false} gutter={8}>
+          <MenuItems />
+        </Ariakit.Menu>
+      </Ariakit.MenuProvider>
+      <Ariakit.MenuProvider>
+        <Ariakit.MenuButton>Callback</Ariakit.MenuButton>
+        <Ariakit.Menu autoFocusOnShow={() => false} gutter={8}>
+          <MenuItems />
+        </Ariakit.Menu>
+      </Ariakit.MenuProvider>
     </>
   );
 }

--- a/site/src/sandbox/menu-5899/index.react.tsx
+++ b/site/src/sandbox/menu-5899/index.react.tsx
@@ -1,4 +1,9 @@
 import * as Ariakit from "@ariakit/react";
+import type { KeyboardEvent } from "react";
+
+interface MenuExampleProps {
+  name: string;
+}
 
 function MenuItems() {
   return (
@@ -12,21 +17,45 @@ function MenuItems() {
   );
 }
 
+function MenuExample({ name }: MenuExampleProps) {
+  const store = Ariakit.useMenuStore();
+
+  const focusItem = (id: string | null | undefined) => {
+    if (!id) return;
+    requestAnimationFrame(() => store.move(id));
+  };
+
+  const onKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    const { open } = store.getState();
+    if (!open) return;
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      focusItem(store.first());
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      focusItem(store.last());
+    }
+  };
+
+  return (
+    <Ariakit.MenuProvider store={store}>
+      <Ariakit.MenuButton onKeyDown={onKeyDown}>{name}</Ariakit.MenuButton>
+      <Ariakit.Menu autoFocusOnShow={() => false} gutter={8}>
+        <MenuItems />
+      </Ariakit.Menu>
+    </Ariakit.MenuProvider>
+  );
+}
+
 export default function Example() {
   return (
     <>
-      <Ariakit.MenuProvider>
-        <Ariakit.MenuButton>Boolean</Ariakit.MenuButton>
-        <Ariakit.Menu autoFocusOnShow={false} gutter={8}>
-          <MenuItems />
-        </Ariakit.Menu>
-      </Ariakit.MenuProvider>
-      <Ariakit.MenuProvider>
-        <Ariakit.MenuButton>Callback</Ariakit.MenuButton>
-        <Ariakit.Menu autoFocusOnShow={() => false} gutter={8}>
-          <MenuItems />
-        </Ariakit.Menu>
-      </Ariakit.MenuProvider>
+      <MenuExample name="Boolean" />
+      <MenuExample name="Callback" />
     </>
   );
 }

--- a/site/src/sandbox/menu-5899/index.react.tsx
+++ b/site/src/sandbox/menu-5899/index.react.tsx
@@ -23,7 +23,13 @@ export default function Example() {
       </Ariakit.MenuProvider>
       <Ariakit.MenuProvider>
         <Ariakit.MenuButton>Callback</Ariakit.MenuButton>
-        <Ariakit.Menu autoFocusOnShow={() => false} gutter={8}>
+        <Ariakit.Menu
+          autoFocusOnShow={(element) => {
+            element?.setAttribute("data-autofocus-on-show-callback", "true");
+            return false;
+          }}
+          gutter={8}
+        >
           <MenuItems />
         </Ariakit.Menu>
       </Ariakit.MenuProvider>

--- a/site/src/sandbox/menu-5899/index.react.tsx
+++ b/site/src/sandbox/menu-5899/index.react.tsx
@@ -1,0 +1,32 @@
+import * as Ariakit from "@ariakit/react";
+
+function MenuItems() {
+  return (
+    <>
+      <Ariakit.MenuItem>Edit</Ariakit.MenuItem>
+      <Ariakit.MenuItem>Share</Ariakit.MenuItem>
+      <Ariakit.MenuItem disabled>Delete</Ariakit.MenuItem>
+      <Ariakit.MenuSeparator />
+      <Ariakit.MenuItem>Report</Ariakit.MenuItem>
+    </>
+  );
+}
+
+export default function Example() {
+  return (
+    <>
+      <Ariakit.MenuProvider>
+        <Ariakit.MenuButton>Boolean</Ariakit.MenuButton>
+        <Ariakit.Menu autoFocusOnShow={false} gutter={8}>
+          <MenuItems />
+        </Ariakit.Menu>
+      </Ariakit.MenuProvider>
+      <Ariakit.MenuProvider>
+        <Ariakit.MenuButton>Callback</Ariakit.MenuButton>
+        <Ariakit.Menu autoFocusOnShow={() => false} gutter={8}>
+          <MenuItems />
+        </Ariakit.Menu>
+      </Ariakit.MenuProvider>
+    </>
+  );
+}

--- a/site/src/sandbox/menu-5899/preview.astro
+++ b/site/src/sandbox/menu-5899/preview.astro
@@ -1,0 +1,14 @@
+---
+import PreviewFramework from "#app/components/preview-framework.astro";
+import ReactExample from "./index.react.tsx";
+
+import sourceReact from "./index.react.tsx?source";
+
+export const source = {
+  react: sourceReact,
+};
+---
+
+<PreviewFramework>
+  <ReactExample client:load slot="react" />
+</PreviewFramework>

--- a/site/src/sandbox/menu-5899/preview.mdx
+++ b/site/src/sandbox/menu-5899/preview.mdx
@@ -1,0 +1,9 @@
+---
+title: Menu auto focus on show
+frameworks:
+  - react
+---
+
+import Preview from "./preview.astro";
+
+<Preview />

--- a/site/src/sandbox/menu-5899/test-browser.ts
+++ b/site/src/sandbox/menu-5899/test-browser.ts
@@ -1,0 +1,58 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+const menuButtons = ["Boolean", "Callback"] as const;
+const openKeys = ["Enter", "Space", "ArrowDown", "ArrowUp"] as const;
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  for (const name of menuButtons) {
+    test(`${name} autoFocusOnShow false does not focus menu on open`, async ({
+      page,
+      q,
+    }) => {
+      const menuButton = q.button(name);
+
+      await menuButton.click();
+      await test.expect(q.menu(name)).toBeVisible();
+      await test.expect(menuButton).toBeFocused();
+
+      await page.keyboard.press("Escape");
+      await test.expect(q.menu(name)).not.toBeVisible();
+
+      for (const key of openKeys) {
+        await menuButton.focus();
+        await page.keyboard.press(key);
+
+        await test.expect(q.menu(name)).toBeVisible();
+        await test.expect(menuButton).toBeFocused();
+
+        await page.keyboard.press("Escape");
+        await test.expect(q.menu(name)).not.toBeVisible();
+      }
+    });
+
+    test(`${name} menu accepts arrow focus after it is open`, async ({
+      page,
+      q,
+    }) => {
+      const menuButton = q.button(name);
+
+      await menuButton.focus();
+      await page.keyboard.press("ArrowDown");
+      await test.expect(q.menu(name)).toBeVisible();
+      await test.expect(menuButton).toBeFocused();
+
+      await page.keyboard.press("ArrowDown");
+      await test.expect(q.menuitem("Edit")).toBeFocused();
+
+      await page.keyboard.press("Escape");
+      await test.expect(q.menu(name)).not.toBeVisible();
+
+      await page.keyboard.press("ArrowUp");
+      await test.expect(q.menu(name)).toBeVisible();
+      await test.expect(menuButton).toBeFocused();
+
+      await page.keyboard.press("ArrowUp");
+      await test.expect(q.menuitem("Report")).toBeFocused();
+    });
+  }
+});

--- a/site/src/sandbox/menu-5899/test-browser.ts
+++ b/site/src/sandbox/menu-5899/test-browser.ts
@@ -45,6 +45,23 @@ withFramework(import.meta.dirname, async ({ test }) => {
       await test.expect(q.menuitem("Edit")).toBeFocused();
     });
 
+    if (name === "Callback") {
+      test(`${name} autoFocusOnShow false calls the callback`, async ({
+        page,
+        q,
+      }) => {
+        const menuButton = q.button(name);
+
+        await menuButton.focus();
+        await page.keyboard.press("ArrowDown");
+
+        await test
+          .expect(q.menuitem("Edit"))
+          .toHaveAttribute("data-autofocus-on-show-callback", "true");
+        await test.expect(menuButton).toBeFocused();
+      });
+    }
+
     test(`${name} menu accepts ArrowUp focus after it is open`, async ({
       page,
       q,

--- a/site/src/sandbox/menu-5899/test-browser.ts
+++ b/site/src/sandbox/menu-5899/test-browser.ts
@@ -6,7 +6,6 @@ const openKeys = ["Enter", "Space", "ArrowDown", "ArrowUp"] as const;
 withFramework(import.meta.dirname, async ({ test }) => {
   for (const name of menuButtons) {
     test(`${name} autoFocusOnShow false does not focus menu on click`, async ({
-      page,
       q,
     }) => {
       const menuButton = q.button(name);

--- a/site/src/sandbox/menu-5899/test-browser.ts
+++ b/site/src/sandbox/menu-5899/test-browser.ts
@@ -5,7 +5,7 @@ const openKeys = ["Enter", "Space", "ArrowDown", "ArrowUp"] as const;
 
 withFramework(import.meta.dirname, async ({ test }) => {
   for (const name of menuButtons) {
-    test(`${name} autoFocusOnShow false does not focus menu on open`, async ({
+    test(`${name} autoFocusOnShow false does not focus menu on click`, async ({
       page,
       q,
     }) => {
@@ -14,23 +14,24 @@ withFramework(import.meta.dirname, async ({ test }) => {
       await menuButton.click();
       await test.expect(q.menu(name)).toBeVisible();
       await test.expect(menuButton).toBeFocused();
+    });
 
-      await page.keyboard.press("Escape");
-      await test.expect(q.menu(name)).not.toBeVisible();
+    for (const key of openKeys) {
+      test(`${name} autoFocusOnShow false does not focus menu on ${key}`, async ({
+        page,
+        q,
+      }) => {
+        const menuButton = q.button(name);
 
-      for (const key of openKeys) {
         await menuButton.focus();
         await page.keyboard.press(key);
 
         await test.expect(q.menu(name)).toBeVisible();
         await test.expect(menuButton).toBeFocused();
+      });
+    }
 
-        await page.keyboard.press("Escape");
-        await test.expect(q.menu(name)).not.toBeVisible();
-      }
-    });
-
-    test(`${name} menu accepts arrow focus after it is open`, async ({
+    test(`${name} menu accepts ArrowDown focus after it is open`, async ({
       page,
       q,
     }) => {
@@ -43,10 +44,15 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
       await page.keyboard.press("ArrowDown");
       await test.expect(q.menuitem("Edit")).toBeFocused();
+    });
 
-      await page.keyboard.press("Escape");
-      await test.expect(q.menu(name)).not.toBeVisible();
+    test(`${name} menu accepts ArrowUp focus after it is open`, async ({
+      page,
+      q,
+    }) => {
+      const menuButton = q.button(name);
 
+      await menuButton.focus();
       await page.keyboard.press("ArrowUp");
       await test.expect(q.menu(name)).toBeVisible();
       await test.expect(menuButton).toBeFocused();


### PR DESCRIPTION
## Motivation

Fixes #5899.

`Menu` should respect `autoFocusOnShow={false}` and `autoFocusOnShow={() => false}` when the menu is opened. The menu should open from click, Enter, Space, ArrowDown, and ArrowUp without moving focus away from the `MenuButton`.

The same menu should still be keyboard-accessible after it is already open: pressing ArrowDown or ArrowUp again from the focused `MenuButton` should move focus into the menu.

## Solution

Added a sandbox regression test in `site/src/sandbox/menu-5899` covering both the direct boolean and callback forms of `autoFocusOnShow={false}`.

`Menu` now treats an explicit `autoFocusOnShow={false}` as a hard opt-out instead of falling back to the store's open-time autofocus state. `MenuButton` also handles ArrowDown and ArrowUp directly when its menu is already open, moving focus to the first or last menu item without relying on open-time autofocus.

## Workaround

Until the fix is available, use the callback form to prevent open-time focus movement. If the menu button should still move focus into an already-open menu on ArrowDown or ArrowUp, intercept those keys only after the menu is open and call `store.move()` yourself.

```tsx
const menu = Ariakit.useMenuStore();

const focusItem = (id: string | null | undefined) => {
  if (!id) return;
  requestAnimationFrame(() => menu.move(id));
};

// TODO: Remove this workaround once https://github.com/ariakit/ariakit/issues/5899 is fixed.
<Ariakit.MenuButton
  onKeyDown={(event) => {
    const { open } = menu.getState();
    if (!open) return;

    if (event.key === "ArrowDown") {
      event.preventDefault();
      focusItem(menu.first());
      return;
    }

    if (event.key === "ArrowUp") {
      event.preventDefault();
      focusItem(menu.last());
    }
  }}
>
  Actions
</Ariakit.MenuButton>
<Ariakit.Menu autoFocusOnShow={() => false}>
  {/* ... */}
</Ariakit.Menu>
```