### PR TITLE
Stabilize performance comparisons

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -220,9 +220,9 @@ jobs:
       pull-requests: write
     env:
       PERF_ROUNDS: 3
-      # Keep each round short enough for CI while still collecting more total
-      # samples than the previous single 10-iteration baseline/current runs.
-      PERF_ITERATIONS: 5
+      # Keep the previous per-run sample depth so detached baselines from
+      # revisions that do not read PERF_ITERATIONS remain comparable.
+      PERF_ITERATIONS: 10
       PERF_WARMUP: 1
     steps:
       - name: Checkout repository
@@ -339,6 +339,7 @@ jobs:
         run: |
           rm -rf site/.perf-results "$BASELINE_DIR/site/.perf-results"
           mkdir -p site/.perf-results
+          shopt -s nullglob
           for i in $(seq 1 "$PERF_ROUNDS"); do
             echo "::group::Round $i - baseline"
             (
@@ -348,7 +349,12 @@ jobs:
               PERF_WARMUP="$PERF_WARMUP" \
               xvfb-run -a pnpm -F site run test-perf --pass-with-no-tests
             )
-            cp "$BASELINE_DIR"/site/.perf-results/baseline-"$i"*.json site/.perf-results/ 2>/dev/null || true
+            baseline_files=("$BASELINE_DIR"/site/.perf-results/baseline-"$i"*.json)
+            if [ ${#baseline_files[@]} -eq 0 ]; then
+              echo "Missing baseline perf results for round $i" >&2
+              exit 1
+            fi
+            cp "${baseline_files[@]}" site/.perf-results/
             echo "::endgroup::"
 
             echo "::group::Round $i - current"
@@ -356,11 +362,15 @@ jobs:
             PERF_ITERATIONS="$PERF_ITERATIONS" \
             PERF_WARMUP="$PERF_WARMUP" \
             xvfb-run -a pnpm -F site run test-perf --pass-with-no-tests
+            current_files=(site/.perf-results/current-"$i"*.json)
+            if [ ${#current_files[@]} -eq 0 ]; then
+              echo "Missing current perf results for round $i" >&2
+              exit 1
+            fi
             echo "::endgroup::"
           done
 
       - name: Compare results
-        if: always()
         run: pnpm -F site run perf-compare
 
       - name: Upload performance results
@@ -374,7 +384,6 @@ jobs:
           retention-days: 7
 
       - name: Post or update PR comment
-        if: always()
         uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.ARIAKIT_BOT_PAT }}

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -216,6 +216,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       pull-requests: write
     env:

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -218,6 +218,12 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    env:
+      PERF_ROUNDS: 3
+      PERF_ITERATIONS: 5
+      PERF_WARMUP: 1
+      # Skip husky's prepare script in the detached baseline worktree.
+      HUSKY: 0
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -232,17 +238,20 @@ jobs:
         with:
           engine: chromium
 
-      # --- Baseline (base branch) ---
-      - name: Checkout base branch
-        run: git checkout -f ${{ github.event.pull_request.base.sha }}
+      - name: Set up baseline worktree
+        run: |
+          BASELINE_DIR="$RUNNER_TEMP/perf-baseline"
+          echo "BASELINE_DIR=$BASELINE_DIR" >> "$GITHUB_ENV"
+          git worktree add --detach "$BASELINE_DIR" \
+            ${{ github.event.pull_request.base.sha }}
 
-      - name: Set up base environment
-        uses: ./.github/workflows/setup
+      - name: Install dependencies (baseline)
+        working-directory: ${{ runner.temp }}/perf-baseline
+        run: pnpm install --frozen-lockfile
 
-      - name: Install Playwright (base)
-        uses: ./.github/workflows/install-playwright
-        with:
-          engine: chromium
+      - name: Install Playwright (baseline)
+        working-directory: ${{ runner.temp }}/perf-baseline
+        run: pnpm exec playwright install --with-deps chromium
 
       - name: Find base app artifact
         id: find-base-artifact
@@ -277,7 +286,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: app-dist
-          path: site/dist
+          path: ${{ runner.temp }}/perf-baseline/site/dist
           github-token: ${{ github.token }}
           run-id: ${{ steps.find-base-artifact.outputs.run-id }}
 
@@ -288,41 +297,25 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: nextjs-dist
-          path: nextjs/.open-next
+          path: ${{ runner.temp }}/perf-baseline/nextjs/.open-next
           github-token: ${{ github.token }}
           run-id: ${{ steps.find-base-artifact.outputs.run-id }}
 
       - name: Clean partial base artifacts
         if: steps.base-artifact.outcome != 'success' || steps.base-nextjs-artifact.outcome != 'success'
-        run: rm -rf site/dist nextjs/.open-next
+        run: rm -rf "$BASELINE_DIR/site/dist" "$BASELINE_DIR/nextjs/.open-next"
 
       - name: Build base app
         if: steps.base-artifact.outcome != 'success' || steps.base-nextjs-artifact.outcome != 'success'
+        working-directory: ${{ runner.temp }}/perf-baseline
         run: pnpm -F site run build-lite
 
       - name: Build base Next.js app
         if: steps.base-artifact.outcome != 'success' || steps.base-nextjs-artifact.outcome != 'success'
+        working-directory: ${{ runner.temp }}/perf-baseline
         run: pnpm -F nextjs run build-worker
 
-      - name: Run baseline perf tests
-        # Baseline failures are expected when perf tests are new.
-        run: |
-          PERF_RESULTS_FILE=baseline.json \
-          xvfb-run pnpm -F site run test-perf --pass-with-no-tests || true
-
-      - name: Save baseline results
-        run: |
-          mkdir -p /tmp/perf-baseline
-          cp site/.perf-results/baseline*.json /tmp/perf-baseline/ 2>/dev/null || true
-
-      # --- Current (merge commit) ---
-      - name: Checkout merge commit
-        run: git checkout -f ${{ github.sha }}
-
-      - name: Set up PR environment
-        uses: ./.github/workflows/setup
-
-      - name: Clean base app artifacts
+      - name: Clean current app artifacts
         run: rm -rf site/dist nextjs/.open-next
 
       - name: Download app artifact
@@ -337,19 +330,43 @@ jobs:
           name: nextjs-dist
           path: nextjs/.open-next
 
-      - name: Restore baseline results
+      - name: Run interleaved perf tests
         run: |
+          rm -rf site/.perf-results "$BASELINE_DIR/site/.perf-results"
           mkdir -p site/.perf-results
-          cp /tmp/perf-baseline/*.json site/.perf-results/ 2>/dev/null || true
+          for i in $(seq 1 "$PERF_ROUNDS"); do
+            echo "::group::Round $i - baseline"
+            (
+              cd "$BASELINE_DIR"
+              PERF_RESULTS_FILE=baseline-$i.json \
+              PERF_ITERATIONS="$PERF_ITERATIONS" \
+              PERF_WARMUP="$PERF_WARMUP" \
+              xvfb-run -a pnpm -F site run test-perf --pass-with-no-tests
+            )
+            cp "$BASELINE_DIR"/site/.perf-results/baseline-"$i"*.json site/.perf-results/ 2>/dev/null || true
+            echo "::endgroup::"
 
-      - name: Run current perf tests
-        run: |
-          PERF_RESULTS_FILE=current.json \
-          xvfb-run pnpm -F site run test-perf --pass-with-no-tests
+            echo "::group::Round $i - current"
+            PERF_RESULTS_FILE=current-$i.json \
+            PERF_ITERATIONS="$PERF_ITERATIONS" \
+            PERF_WARMUP="$PERF_WARMUP" \
+            xvfb-run -a pnpm -F site run test-perf --pass-with-no-tests
+            echo "::endgroup::"
+          done
 
       - name: Compare results
         if: always()
         run: pnpm -F site run perf-compare
+
+      - name: Upload performance results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: perf-results
+          path: site/.perf-results
+          if-no-files-found: ignore
+          include-hidden-files: true
+          retention-days: 7
 
       - name: Post or update PR comment
         if: always()

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -224,9 +224,9 @@ jobs:
       # extra confirmation round before the PR comment is published.
       PERF_INITIAL_ROUNDS: 2
       PERF_CONFIRMATION_ROUNDS: 1
-      # Keep the previous per-run sample depth so detached baselines from
-      # revisions that do not read PERF_ITERATIONS remain comparable.
-      PERF_ITERATIONS: 10
+      # Keep per-round samples modest; paired rounds and confirmation preserve
+      # enough signal for noisy results.
+      PERF_ITERATIONS: 5
       PERF_WARMUP: 1
     steps:
       - name: Checkout repository
@@ -358,10 +358,11 @@ jobs:
             )
             baseline_files=("$BASELINE_DIR"/site/.perf-results/baseline-"$i"*.json)
             if [ ${#baseline_files[@]} -eq 0 ]; then
-              echo "Missing baseline perf results for round $i" >&2
-              exit 1
+              echo "No baseline perf results for round $i; writing an empty baseline."
+              printf '[]\n' > site/.perf-results/baseline-"$i"-worker0.json
+            else
+              cp "${baseline_files[@]}" site/.perf-results/
             fi
-            cp "${baseline_files[@]}" site/.perf-results/
             echo "::endgroup::"
 
             echo "::group::Round $i - current"

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -220,10 +220,10 @@ jobs:
       pull-requests: write
     env:
       PERF_ROUNDS: 3
+      # Keep each round short enough for CI while still collecting more total
+      # samples than the previous single 10-iteration baseline/current runs.
       PERF_ITERATIONS: 5
       PERF_WARMUP: 1
-      # Skip husky's prepare script in the detached baseline worktree.
-      HUSKY: 0
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -247,6 +247,11 @@ jobs:
 
       - name: Install dependencies (baseline)
         working-directory: ${{ runner.temp }}/perf-baseline
+        env:
+          # The baseline worktree shares `.git/config` with the main checkout,
+          # so husky's prepare step would otherwise rewrite `core.hooksPath`
+          # to a relative path under a temporary worktree.
+          HUSKY: 0
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright (baseline)

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -220,7 +220,10 @@ jobs:
       contents: read
       pull-requests: write
     env:
-      PERF_ROUNDS: 3
+      # Clean runs stop after two paired rounds. Significant deltas get one
+      # extra confirmation round before the PR comment is published.
+      PERF_INITIAL_ROUNDS: 2
+      PERF_CONFIRMATION_ROUNDS: 1
       # Keep the previous per-run sample depth so detached baselines from
       # revisions that do not read PERF_ITERATIONS remain comparable.
       PERF_ITERATIONS: 10
@@ -341,7 +344,10 @@ jobs:
           rm -rf site/.perf-results "$BASELINE_DIR/site/.perf-results"
           mkdir -p site/.perf-results
           shopt -s nullglob
-          for i in $(seq 1 "$PERF_ROUNDS"); do
+
+          run_perf_round() {
+            local i="$1"
+
             echo "::group::Round $i - baseline"
             (
               cd "$BASELINE_DIR"
@@ -369,10 +375,41 @@ jobs:
               exit 1
             fi
             echo "::endgroup::"
+          }
+
+          for i in $(seq 1 "$PERF_INITIAL_ROUNDS"); do
+            run_perf_round "$i"
           done
 
-      - name: Compare results
-        run: pnpm -F site run perf-compare
+          echo "::group::Preliminary comparison"
+          pnpm -F site run perf-compare
+          has_significant_changes=$(
+            node --input-type=module <<'NODE'
+          import { readFileSync } from "node:fs";
+
+          const summary = JSON.parse(
+            readFileSync("site/.perf-results/comparison.json", "utf-8"),
+          );
+
+          console.log(summary.hasSignificantChanges ? "true" : "false");
+          NODE
+          )
+          echo "::endgroup::"
+
+          if [ "$has_significant_changes" = "true" ]; then
+            echo "Significant changes detected; running confirmation rounds."
+            start_round=$((PERF_INITIAL_ROUNDS + 1))
+            end_round=$((PERF_INITIAL_ROUNDS + PERF_CONFIRMATION_ROUNDS))
+            for i in $(seq "$start_round" "$end_round"); do
+              run_perf_round "$i"
+            done
+
+            echo "::group::Final comparison"
+            pnpm -F site run perf-compare
+            echo "::endgroup::"
+          else
+            echo "No significant changes detected; skipping confirmation rounds."
+          fi
 
       - name: Upload performance results
         if: always()

--- a/site/src/test-utils/perf-compare-test.ts
+++ b/site/src/test-utils/perf-compare-test.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: UNLICENSED
  */
 
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import {
   mkdirSync,
   mkdtempSync,
@@ -86,6 +86,17 @@ function runCompare(dir: string) {
   return readFileSync(path.join(dir, resultsDir, "comparison.md"), "utf-8");
 }
 
+function runCompareFailure(dir: string) {
+  const result = spawnSync(process.execPath, [scriptPath], {
+    cwd: dir,
+    encoding: "utf-8",
+  });
+  if (result.status === 0) {
+    throw new Error("Expected performance comparison to fail");
+  }
+  return `${result.stderr}${result.stdout}`;
+}
+
 afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
@@ -150,6 +161,35 @@ test("aggregates displayed values from shared rounds", () => {
   expect(markdown).toContain("Aggregated across 2 interleaved rounds");
 });
 
+test("does not overstate mixed paired round counts", () => {
+  const dir = createTempDir();
+  writeJson(dir, "baseline-1-worker0.json", [
+    createResultWithLabel("three rounds", 100),
+    createResultWithLabel("one round", 100),
+  ]);
+  writeJson(dir, "baseline-2-worker0.json", [
+    createResultWithLabel("three rounds", 100),
+  ]);
+  writeJson(dir, "baseline-3-worker0.json", [
+    createResultWithLabel("three rounds", 100),
+  ]);
+  writeJson(dir, "current-1-worker0.json", [
+    createResultWithLabel("three rounds", 120),
+    createResultWithLabel("one round", 120),
+  ]);
+  writeJson(dir, "current-2-worker0.json", [
+    createResultWithLabel("three rounds", 120),
+  ]);
+  writeJson(dir, "current-3-worker0.json", [
+    createResultWithLabel("three rounds", 120),
+  ]);
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).not.toContain("Aggregated across 3 interleaved rounds");
+  expect(markdown).toContain("mixed interleaved round counts");
+});
+
 test("requires both rounds to agree in two-round comparisons", () => {
   const dir = createTempDir();
   [100, 100].forEach((total, index) => {
@@ -164,6 +204,19 @@ test("requires both rounds to agree in two-round comparisons", () => {
   expect(markdown).toContain("No significant performance changes detected.");
   expect(markdown).toContain("100.0ms | 115.0ms | +15.0ms (+15%)");
   expect(markdown).not.toMatch(/% :warning:/);
+});
+
+test("fails on malformed perf result files", () => {
+  const dir = createTempDir();
+  const outputDir = path.join(dir, resultsDir);
+  mkdirSync(outputDir, { recursive: true });
+  writeFileSync(path.join(outputDir, "baseline-worker0.json"), "{", "utf-8");
+  writeJson(dir, "current-worker0.json", [createResult(100)]);
+
+  const stderr = runCompareFailure(dir);
+
+  expect(stderr).toContain("Failed to parse perf results");
+  expect(stderr).toContain("baseline-worker0.json");
 });
 
 test("reports tests with no paired rounds separately", () => {

--- a/site/src/test-utils/perf-compare-test.ts
+++ b/site/src/test-utils/perf-compare-test.ts
@@ -239,6 +239,35 @@ test("requires both rounds to agree in two-round comparisons", () => {
   expect(markdown).not.toMatch(/% :warning:/);
 });
 
+test("flags unanimous two-round regressions", () => {
+  const dir = createTempDir();
+  [100, 100].forEach((total, index) => {
+    writeRound(dir, "baseline", index + 1, total);
+  });
+  [130, 132].forEach((total, index) => {
+    writeRound(dir, "current", index + 1, total);
+  });
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain(":warning:");
+  expect(markdown).toContain("+31%");
+});
+
+test("keeps zero-baseline paired rounds in the agreement count", () => {
+  const dir = createTempDir();
+  writeRound(dir, "baseline", 1, 0);
+  writeRound(dir, "current", 1, 0);
+  writeRound(dir, "baseline", 2, 100);
+  writeRound(dir, "current", 2, 130);
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain("No significant performance changes detected.");
+  expect(markdown).toContain("50.0ms | 65.0ms | +15.0ms (+30%)");
+  expect(markdown).not.toMatch(/% :warning:/);
+});
+
 test("fails on malformed perf result files", () => {
   const dir = createTempDir();
   const outputDir = path.join(dir, resultsDir);
@@ -274,6 +303,9 @@ test("reports tests with no paired rounds separately", () => {
     "No paired performance results available for comparison.",
   );
   expect(markdown).toContain("### Unpaired tests");
+  expect(markdown).toContain(
+    "| sandbox/example/perf-chrome.ts > react > example | 1 | 2 |",
+  );
   expect(markdown).not.toContain("0.0ms | 0.0ms");
 });
 
@@ -302,6 +334,24 @@ test("surfaces unpaired tests outside the details block", () => {
   expect(markdown.indexOf("- unpaired")).toBeLessThan(
     markdown.indexOf("<details>"),
   );
+  expect(markdown).toContain("| unpaired | 1 | 2 |");
+});
+
+test("reports renamed tests as new and removed", () => {
+  const dir = createTempDir();
+  writeJson(dir, "baseline-worker0.json", [
+    createResultWithLabel("old name", 100),
+  ]);
+  writeJson(dir, "current-worker0.json", [
+    createResultWithLabel("new name", 100),
+  ]);
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain("### New tests (no baseline)");
+  expect(markdown).toContain("### Removed tests");
+  expect(markdown).toContain("new name");
+  expect(markdown).toContain("- old name");
 });
 
 test("does not flag percentage-only changes below the absolute floor", () => {
@@ -393,4 +443,21 @@ test("merges profiles across rounds", () => {
 
   expect(markdown).toContain("firstRoundFn");
   expect(markdown).toContain("secondRoundFn");
+});
+
+test("warns when only one side has profile data for a test", () => {
+  const dir = createTempDir();
+  writeJson(dir, "baseline-worker0.json", [
+    createResultWithMetrics("profile-mismatch", createMetrics(100), {
+      script: [createScriptProfileEntry("baselineProfile", 1)],
+    }),
+  ]);
+  writeJson(dir, "current-worker0.json", [
+    createResultWithMetrics("profile-mismatch", createMetrics(100)),
+  ]);
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain("Profile data differs between baseline");
+  expect(markdown).toContain("| profile-mismatch | script | yes | no |");
 });

--- a/site/src/test-utils/perf-compare-test.ts
+++ b/site/src/test-utils/perf-compare-test.ts
@@ -15,6 +15,7 @@ import {
   readFileSync,
   realpathSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -278,6 +279,19 @@ test("fails on malformed perf result files", () => {
   const stderr = runCompareFailure(dir);
 
   expect(stderr).toContain("Failed to parse perf results");
+  expect(stderr).toContain("baseline-worker0.json");
+});
+
+test("fails on missing discovered perf result files", () => {
+  const dir = createTempDir();
+  const outputDir = path.join(dir, resultsDir);
+  mkdirSync(outputDir, { recursive: true });
+  symlinkSync("missing.json", path.join(outputDir, "baseline-worker0.json"));
+  writeJson(dir, "current-worker0.json", [createResult(100)]);
+
+  const stderr = runCompareFailure(dir);
+
+  expect(stderr).toContain("Failed to read perf results");
   expect(stderr).toContain("baseline-worker0.json");
 });
 

--- a/site/src/test-utils/perf-compare-test.ts
+++ b/site/src/test-utils/perf-compare-test.ts
@@ -1,0 +1,155 @@
+/**
+ * @license
+ * Copyright 2025-present Ariakit FZ-LLC. All Rights Reserved.
+ *
+ * This software is proprietary. See the license.md file in the root of this
+ * package for licensing terms.
+ *
+ * SPDX-License-Identifier: UNLICENSED
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, expect, test } from "vitest";
+import type { PerfMetrics, PerfResult } from "./perf.ts";
+
+const resultsDir = ".perf-results";
+const scriptPath = path.join(import.meta.dirname, "perf-compare.ts");
+const tempDirs: string[] = [];
+
+function createTempDir() {
+  const dir = realpathSync(mkdtempSync(path.join(tmpdir(), "ariakit-perf-")));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function createMetrics(total: number): PerfMetrics {
+  return {
+    scripting: total,
+    layout: 0,
+    styleRecalc: 0,
+    painting: 0,
+    rendering: 0,
+    inp: 0,
+    total,
+  };
+}
+
+function createResult(total: number): PerfResult {
+  const metrics = createMetrics(total);
+  return {
+    testFile: "sandbox/example/perf-chrome.ts",
+    testTitle: "sandbox/example/perf-chrome.ts > react > example",
+    label: "sandbox/example/perf-chrome.ts > react > example",
+    metrics,
+    raw: [metrics],
+  };
+}
+
+function writeJson(dir: string, file: string, data: unknown) {
+  const outputDir = path.join(dir, resultsDir);
+  mkdirSync(outputDir, { recursive: true });
+  writeFileSync(path.join(outputDir, file), JSON.stringify(data), "utf-8");
+}
+
+function writeRound(
+  dir: string,
+  prefix: "baseline" | "current",
+  round: number,
+  total: number,
+) {
+  writeJson(dir, `${prefix}-${round}-worker0.json`, [createResult(total)]);
+}
+
+function runCompare(dir: string) {
+  execFileSync(process.execPath, [scriptPath], {
+    cwd: dir,
+    encoding: "utf-8",
+  });
+  return readFileSync(path.join(dir, resultsDir, "comparison.md"), "utf-8");
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("keeps single-run comparison behavior", () => {
+  const dir = createTempDir();
+  writeJson(dir, "baseline-worker0.json", [createResult(100)]);
+  writeJson(dir, "current-worker0.json", [createResult(120)]);
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain("100.0ms → 120.0ms (+20%) :warning:");
+  expect(markdown).not.toContain("Aggregated across");
+});
+
+test("does not flag noisy rounds that disagree on direction", () => {
+  const dir = createTempDir();
+  for (let round = 1; round <= 5; round++) {
+    writeRound(dir, "baseline", round, 100);
+  }
+  [80, 85, 82, 130, 135].forEach((total, index) => {
+    writeRound(dir, "current", index + 1, total);
+  });
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain("No significant performance changes detected.");
+  expect(markdown).not.toMatch(/% :warning:/);
+  expect(markdown).toContain("Aggregated across 5 interleaved rounds");
+});
+
+test("flags a consistent regression across rounds", () => {
+  const dir = createTempDir();
+  for (let round = 1; round <= 3; round++) {
+    writeRound(dir, "baseline", round, 100);
+  }
+  [125, 128, 130].forEach((total, index) => {
+    writeRound(dir, "current", index + 1, total);
+  });
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain(":warning:");
+  expect(markdown).toContain("+28%");
+});
+
+test("aggregates displayed values from shared rounds", () => {
+  const dir = createTempDir();
+  [200, 200, 50, 50].forEach((total, index) => {
+    writeRound(dir, "baseline", index + 1, total);
+  });
+  [160, 160].forEach((total, index) => {
+    writeRound(dir, "current", index + 1, total);
+  });
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain("200.0ms → 160.0ms (-20%) :rocket:");
+  expect(markdown).not.toContain("125.0ms");
+  expect(markdown).toContain("Aggregated across 2 interleaved rounds");
+});
+
+test("does not flag percentage-only changes below the absolute floor", () => {
+  const dir = createTempDir();
+  writeJson(dir, "baseline-worker0.json", [createResult(20)]);
+  writeJson(dir, "current-worker0.json", [createResult(24)]);
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain("No significant performance changes detected.");
+  expect(markdown).toContain("20.0ms | 24.0ms | +4.0ms (+20%)");
+  expect(markdown).not.toMatch(/% :warning:/);
+});

--- a/site/src/test-utils/perf-compare-test.ts
+++ b/site/src/test-utils/perf-compare-test.ts
@@ -20,7 +20,12 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, expect, test } from "vitest";
-import type { PerfMetrics, PerfResult } from "./perf.ts";
+import type {
+  PerfMetrics,
+  PerfProfiles,
+  PerfResult,
+  PerfScriptProfileEntry,
+} from "./perf.ts";
 
 const resultsDir = ".perf-results";
 const scriptPath = path.join(import.meta.dirname, "perf-compare.ts");
@@ -60,6 +65,34 @@ function createResultWithLabel(label: string, total: number): PerfResult {
     ...createResult(total),
     label,
     testTitle: label,
+  };
+}
+
+function createResultWithMetrics(
+  label: string,
+  metrics: PerfMetrics,
+  profiles?: PerfProfiles,
+): PerfResult {
+  return {
+    ...createResultWithLabel(label, metrics.total),
+    metrics,
+    raw: [metrics],
+    profiles,
+  };
+}
+
+function createScriptProfileEntry(
+  functionName: string,
+  selfTime: number,
+): PerfScriptProfileEntry {
+  return {
+    functionName,
+    url: "https://example.com/script.js",
+    line: 1,
+    column: 1,
+    selfTime,
+    totalTime: selfTime,
+    hitCount: 1,
   };
 }
 
@@ -219,6 +252,17 @@ test("fails on malformed perf result files", () => {
   expect(stderr).toContain("baseline-worker0.json");
 });
 
+test("fails on parsed non-array perf result files", () => {
+  const dir = createTempDir();
+  writeJson(dir, "baseline-worker0.json", {});
+  writeJson(dir, "current-worker0.json", [createResult(100)]);
+
+  const stderr = runCompareFailure(dir);
+
+  expect(stderr).toContain("Invalid perf results format");
+  expect(stderr).toContain("baseline-worker0.json");
+});
+
 test("reports tests with no paired rounds separately", () => {
   const dir = createTempDir();
   writeRound(dir, "baseline", 1, 100);
@@ -270,4 +314,83 @@ test("does not flag percentage-only changes below the absolute floor", () => {
   expect(markdown).toContain("No significant performance changes detected.");
   expect(markdown).toContain("20.0ms | 24.0ms | +4.0ms (+20%)");
   expect(markdown).not.toMatch(/% :warning:/);
+});
+
+test("does not flag rendering sub-metric noise", () => {
+  const dir = createTempDir();
+  const baselineMetrics: PerfMetrics = {
+    scripting: 100,
+    layout: 16,
+    styleRecalc: 4,
+    painting: 0,
+    rendering: 20,
+    inp: 0,
+    total: 120,
+  };
+  const currentMetrics: PerfMetrics = {
+    scripting: 100,
+    layout: 11,
+    styleRecalc: 9,
+    painting: 0,
+    rendering: 20,
+    inp: 0,
+    total: 120,
+  };
+  writeJson(dir, "baseline-worker0.json", [
+    createResultWithMetrics("sub-metrics", baselineMetrics),
+  ]);
+  writeJson(dir, "current-worker0.json", [
+    createResultWithMetrics("sub-metrics", currentMetrics),
+  ]);
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain("No significant performance changes detected.");
+  expect(markdown).toContain(
+    "| - Style recalc | 4.0ms | 9.0ms | +5.0ms (+125%) |",
+  );
+  expect(markdown).not.toContain("+5.0ms (+125%) :warning:");
+  expect(markdown).not.toContain("-5.0ms (-31%) :rocket:");
+});
+
+test("aggregates worker shards within the same round", () => {
+  const dir = createTempDir();
+  writeJson(dir, "baseline-1-worker0.json", [createResult(100)]);
+  writeJson(dir, "baseline-1-worker1.json", [createResult(100)]);
+  writeJson(dir, "current-1-worker0.json", [createResult(200)]);
+  writeJson(dir, "current-1-worker1.json", [createResult(100)]);
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain("100.0ms → 150.0ms (+50%) :warning:");
+  expect(markdown).toContain("100.0ms | 150.0ms | +50.0ms (+50%) :warning:");
+});
+
+test("merges profiles across rounds", () => {
+  const dir = createTempDir();
+  writeJson(dir, "baseline-1-worker0.json", [
+    createResultWithMetrics("profiled", createMetrics(100), {
+      script: [createScriptProfileEntry("baselineFirstRound", 1)],
+    }),
+  ]);
+  writeJson(dir, "baseline-2-worker0.json", [
+    createResultWithMetrics("profiled", createMetrics(100), {
+      script: [createScriptProfileEntry("baselineSecondRound", 1)],
+    }),
+  ]);
+  writeJson(dir, "current-1-worker0.json", [
+    createResultWithMetrics("profiled", createMetrics(100), {
+      script: [createScriptProfileEntry("firstRoundFn", 8)],
+    }),
+  ]);
+  writeJson(dir, "current-2-worker0.json", [
+    createResultWithMetrics("profiled", createMetrics(100), {
+      script: [createScriptProfileEntry("secondRoundFn", 7)],
+    }),
+  ]);
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain("firstRoundFn");
+  expect(markdown).toContain("secondRoundFn");
 });

--- a/site/src/test-utils/perf-compare-test.ts
+++ b/site/src/test-utils/perf-compare-test.ts
@@ -55,6 +55,14 @@ function createResult(total: number): PerfResult {
   };
 }
 
+function createResultWithLabel(label: string, total: number): PerfResult {
+  return {
+    ...createResult(total),
+    label,
+    testTitle: label,
+  };
+}
+
 function writeJson(dir: string, file: string, data: unknown) {
   const outputDir = path.join(dir, resultsDir);
   mkdirSync(outputDir, { recursive: true });
@@ -140,6 +148,63 @@ test("aggregates displayed values from shared rounds", () => {
   expect(markdown).toContain("200.0ms → 160.0ms (-20%) :rocket:");
   expect(markdown).not.toContain("125.0ms");
   expect(markdown).toContain("Aggregated across 2 interleaved rounds");
+});
+
+test("requires both rounds to agree in two-round comparisons", () => {
+  const dir = createTempDir();
+  [100, 100].forEach((total, index) => {
+    writeRound(dir, "baseline", index + 1, total);
+  });
+  [80, 150].forEach((total, index) => {
+    writeRound(dir, "current", index + 1, total);
+  });
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain("No significant performance changes detected.");
+  expect(markdown).toContain("100.0ms | 115.0ms | +15.0ms (+15%)");
+  expect(markdown).not.toMatch(/% :warning:/);
+});
+
+test("reports tests with no paired rounds separately", () => {
+  const dir = createTempDir();
+  writeRound(dir, "baseline", 1, 100);
+  writeRound(dir, "current", 2, 120);
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain(
+    "No paired performance results available for comparison.",
+  );
+  expect(markdown).toContain("### Unpaired tests");
+  expect(markdown).not.toContain("0.0ms | 0.0ms");
+});
+
+test("surfaces unpaired tests outside the details block", () => {
+  const dir = createTempDir();
+  writeJson(dir, "baseline-1-worker0.json", [
+    createResultWithLabel("paired", 100),
+    createResultWithLabel("unpaired", 100),
+  ]);
+  writeJson(dir, "current-1-worker0.json", [
+    createResultWithLabel("paired", 100),
+  ]);
+  writeJson(dir, "current-2-worker0.json", [
+    createResultWithLabel("unpaired", 120),
+  ]);
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain("No significant performance changes detected.");
+  expect(markdown).toContain(
+    ":warning: 1 test had no paired baseline/current rounds and was not compared.",
+  );
+  expect(markdown.indexOf(":warning: 1 test")).toBeLessThan(
+    markdown.indexOf("<details>"),
+  );
+  expect(markdown.indexOf("- unpaired")).toBeLessThan(
+    markdown.indexOf("<details>"),
+  );
 });
 
 test("does not flag percentage-only changes below the absolute floor", () => {

--- a/site/src/test-utils/perf-compare.ts
+++ b/site/src/test-utils/perf-compare.ts
@@ -22,6 +22,7 @@ interface ComparisonRow {
   current: number;
   delta: number;
   percent: number;
+  pairedRoundsCount: number;
   perRoundDeltas: number[];
   agreement: number;
   significant: boolean;
@@ -35,7 +36,7 @@ interface ComparisonSummary {
   newTests: AggregatedPerfResult[];
   removedTests: AggregatedPerfResult[];
   unpairedTests: AggregatedPerfResult[];
-  pairedRoundsCount: number;
+  pairedRoundsCount: number | null;
 }
 
 interface PersistedComparisonSummary {
@@ -45,7 +46,7 @@ interface PersistedComparisonSummary {
   newTests: PerfResult[];
   removedTests: PerfResult[];
   unpairedTests: PerfResult[];
-  pairedRoundsCount: number;
+  pairedRoundsCount: number | null;
 }
 
 interface ProfileModeMismatch {
@@ -108,11 +109,9 @@ function readJsonFile(filePath: string): unknown {
   try {
     return JSON.parse(readFileSync(filePath, "utf-8"));
   } catch (error) {
-    console.warn(
-      `Warning: failed to parse JSON file at ${filePath}. Falling back to empty results.`,
-      error,
-    );
-    return [];
+    throw new Error(`Failed to parse perf results at ${filePath}`, {
+      cause: error,
+    });
   }
 }
 
@@ -335,7 +334,6 @@ function compare(): ComparisonSummary {
   const newTests: AggregatedPerfResult[] = [];
   const removedTests: AggregatedPerfResult[] = [];
   const unpairedTests: AggregatedPerfResult[] = [];
-  const pairedRoundIndices = new Set<number>();
 
   for (const [key, cur] of current) {
     const base = baseline.get(key);
@@ -360,10 +358,6 @@ function compare(): ComparisonSummary {
     if (sharedRoundIndices.length === 0) {
       unpairedTests.push(cur);
       continue;
-    }
-
-    for (const roundIndex of sharedRoundIndices) {
-      pairedRoundIndices.add(roundIndex);
     }
 
     for (const metric of ALL_METRICS) {
@@ -399,6 +393,7 @@ function compare(): ComparisonSummary {
         current: curVal,
         delta,
         percent,
+        pairedRoundsCount: sharedRoundIndices.length,
         perRoundDeltas,
         agreement,
         significant,
@@ -412,6 +407,8 @@ function compare(): ComparisonSummary {
     }
   }
 
+  const pairedRoundsCounts = new Set(rows.map((row) => row.pairedRoundsCount));
+
   return {
     rows,
     hasSignificantChanges: rows.some((r) => r.significant),
@@ -420,7 +417,12 @@ function compare(): ComparisonSummary {
     newTests,
     removedTests,
     unpairedTests,
-    pairedRoundsCount: pairedRoundIndices.size,
+    pairedRoundsCount:
+      pairedRoundsCounts.size === 0
+        ? 0
+        : pairedRoundsCounts.size === 1
+          ? (pairedRoundsCounts.values().next().value ?? 0)
+          : null,
   };
 }
 
@@ -681,7 +683,12 @@ function formatMarkdown(summary: ComparisonSummary): string {
   lines.push(
     `:warning: = regression above ${THRESHOLD_PERCENT}% and ${formatMs(MIN_SIGNIFICANT_DELTA_MS)} · :rocket: = improvement above ${THRESHOLD_PERCENT}% and ${formatMs(MIN_SIGNIFICANT_DELTA_MS)}`,
   );
-  if (pairedRoundsCount > 1) {
+  if (pairedRoundsCount == null) {
+    lines.push("");
+    lines.push(
+      "Compared tests used mixed interleaved round counts; a change is flagged only when the median exceeds the threshold and rounds agree on direction.",
+    );
+  } else if (pairedRoundsCount > 1) {
     lines.push("");
     lines.push(
       `Aggregated across ${pairedRoundsCount} interleaved rounds; a change is flagged only when the median exceeds the threshold and rounds agree on direction.`,

--- a/site/src/test-utils/perf-compare.ts
+++ b/site/src/test-utils/perf-compare.ts
@@ -6,12 +6,14 @@ import {
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
-import type {
-  PerfMetrics,
-  PerfProfiles,
-  PerfResult,
-  PerfScriptProfileEntry,
-  PerfSelectorProfileEntry,
+import {
+  mergeScriptProfiles,
+  mergeSelectorProfiles,
+  type PerfMetrics,
+  type PerfProfiles,
+  type PerfResult,
+  type PerfScriptProfileEntry,
+  type PerfSelectorProfileEntry,
 } from "./perf.ts";
 
 const RESULTS_DIR = path.join(process.cwd(), ".perf-results");
@@ -42,7 +44,7 @@ interface ComparisonSummary {
   profileModeMismatches: ProfileModeMismatch[];
   newTests: AggregatedPerfResult[];
   removedTests: AggregatedPerfResult[];
-  unpairedTests: AggregatedPerfResult[];
+  unpairedTests: UnpairedTest[];
   pairedRoundsCount: number | null;
 }
 
@@ -52,7 +54,7 @@ interface PersistedComparisonSummary {
   profileModeMismatches: ProfileModeMismatch[];
   newTests: PerfResult[];
   removedTests: PerfResult[];
-  unpairedTests: PerfResult[];
+  unpairedTests: UnpairedTest[];
   pairedRoundsCount: number | null;
 }
 
@@ -73,6 +75,13 @@ interface AggregatedPerfResult {
   key: string;
   result: PerfResult;
   byRound: Map<number, PerfResult>;
+}
+
+interface UnpairedTest {
+  testFile: string;
+  label: string;
+  baselineRounds: number[];
+  currentRounds: number[];
 }
 
 interface DiscoveredRoundFile {
@@ -202,81 +211,6 @@ function computeMedianMetrics(all: PerfMetrics[]): PerfMetrics {
   };
 }
 
-function scriptProfileKey(entry: PerfScriptProfileEntry) {
-  return [entry.functionName, entry.url, entry.line, entry.column].join("\0");
-}
-
-function selectorProfileKey(entry: PerfSelectorProfileEntry) {
-  return [entry.selector, entry.styleSheetId].join("\0");
-}
-
-function mergeScriptProfiles(
-  profiles: PerfScriptProfileEntry[][],
-): PerfScriptProfileEntry[] {
-  const entries = new Map<string, PerfScriptProfileEntry>();
-  for (const profile of profiles) {
-    for (const entry of profile) {
-      const key = scriptProfileKey(entry);
-      const existing = entries.get(key);
-      if (existing) {
-        existing.selfTime += entry.selfTime;
-        existing.totalTime += entry.totalTime;
-        existing.hitCount += entry.hitCount;
-        continue;
-      }
-      entries.set(key, { ...entry });
-    }
-  }
-  return [...entries.values()]
-    .sort((a, b) => b.selfTime - a.selfTime || b.totalTime - a.totalTime)
-    .slice(0, PROFILE_LIMIT);
-}
-
-interface SelectorProfileAccumulator extends PerfSelectorProfileEntry {
-  weightedSlowPathSum: number;
-}
-
-function mergeSelectorProfiles(
-  profiles: PerfSelectorProfileEntry[][],
-): PerfSelectorProfileEntry[] {
-  const entries = new Map<string, SelectorProfileAccumulator>();
-  for (const profile of profiles) {
-    for (const entry of profile) {
-      const key = selectorProfileKey(entry);
-      const weightedSlowPathSum =
-        entry.matchAttempts * entry.slowPathNonMatchPercent;
-      const existing = entries.get(key);
-      if (existing) {
-        existing.elapsed += entry.elapsed;
-        existing.matchAttempts += entry.matchAttempts;
-        existing.matchCount += entry.matchCount;
-        existing.invalidationCount += entry.invalidationCount;
-        existing.weightedSlowPathSum += weightedSlowPathSum;
-        if (!existing.styleSheetUrl && entry.styleSheetUrl) {
-          existing.styleSheetUrl = entry.styleSheetUrl;
-        }
-        continue;
-      }
-      entries.set(key, {
-        ...entry,
-        weightedSlowPathSum,
-      });
-    }
-  }
-  return [...entries.values()]
-    .map(({ weightedSlowPathSum, ...entry }) => {
-      return {
-        ...entry,
-        slowPathNonMatchPercent:
-          entry.matchAttempts > 0
-            ? weightedSlowPathSum / entry.matchAttempts
-            : 0,
-      };
-    })
-    .sort((a, b) => b.elapsed - a.elapsed)
-    .slice(0, PROFILE_LIMIT);
-}
-
 function mergeProfiles(results: PerfResult[]): PerfProfiles | undefined {
   const scriptProfiles: PerfScriptProfileEntry[][] = [];
   const selectorProfiles: PerfSelectorProfileEntry[][] = [];
@@ -290,10 +224,10 @@ function mergeProfiles(results: PerfResult[]): PerfProfiles | undefined {
   }
   const profiles: PerfProfiles = {};
   if (scriptProfiles.length > 0) {
-    profiles.script = mergeScriptProfiles(scriptProfiles);
+    profiles.script = mergeScriptProfiles(scriptProfiles, PROFILE_LIMIT);
   }
   if (selectorProfiles.length > 0) {
-    profiles.selectors = mergeSelectorProfiles(selectorProfiles);
+    profiles.selectors = mergeSelectorProfiles(selectorProfiles, PROFILE_LIMIT);
   }
   if (!profiles.script && !profiles.selectors) return;
   return profiles;
@@ -460,7 +394,7 @@ function compare(): ComparisonSummary {
   const profileModeMismatches: ProfileModeMismatch[] = [];
   const newTests: AggregatedPerfResult[] = [];
   const removedTests: AggregatedPerfResult[] = [];
-  const unpairedTests: AggregatedPerfResult[] = [];
+  const unpairedTests: UnpairedTest[] = [];
 
   for (const [key, cur] of current) {
     const base = baseline.get(key);
@@ -483,7 +417,12 @@ function compare(): ComparisonSummary {
 
     const sharedRoundIndices = getSharedRoundIndices(base, cur);
     if (sharedRoundIndices.length === 0) {
-      unpairedTests.push(cur);
+      unpairedTests.push({
+        testFile: cur.result.testFile,
+        label: cur.result.label,
+        baselineRounds: [...base.byRound.keys()].sort((a, b) => a - b),
+        currentRounds: [...cur.byRound.keys()].sort((a, b) => a - b),
+      });
       continue;
     }
 
@@ -556,6 +495,11 @@ function compare(): ComparisonSummary {
 
 function rowKey(row: ComparisonRow): string {
   return `${row.testFile}::${row.label}`;
+}
+
+function formatRoundList(rounds: number[]): string {
+  if (rounds.length === 0) return "-";
+  return rounds.join(", ");
 }
 
 function formatSummaryTable(rows: ComparisonRow[], keys: string[]): string[] {
@@ -745,7 +689,7 @@ function formatMarkdown(summary: ComparisonSummary): string {
     lines.push(
       `:warning: ${unpairedTests.length} ${label} had no paired baseline/current rounds and ${verb} not compared.`,
     );
-    for (const { result } of visibleUnpairedTests) {
+    for (const result of visibleUnpairedTests) {
       lines.push(`- ${result.label}`);
     }
     if (hiddenUnpairedTests > 0) {
@@ -790,8 +734,12 @@ function formatMarkdown(summary: ComparisonSummary): string {
       "These tests produced baseline and current results, but no shared round index.",
     );
     lines.push("");
-    for (const { result } of unpairedTests) {
-      lines.push(`- ${result.label}`);
+    lines.push("| Test | Baseline rounds | Current rounds |");
+    lines.push("|------|-----------------|----------------|");
+    for (const result of unpairedTests) {
+      lines.push(
+        `| ${escapeTableCell(result.label)} | ${formatRoundList(result.baselineRounds)} | ${formatRoundList(result.currentRounds)} |`,
+      );
     }
     lines.push("");
   }
@@ -835,7 +783,7 @@ function toPersistedSummary(
     profileModeMismatches: summary.profileModeMismatches,
     newTests: summary.newTests.map((entry) => entry.result),
     removedTests: summary.removedTests.map((entry) => entry.result),
-    unpairedTests: summary.unpairedTests.map((entry) => entry.result),
+    unpairedTests: summary.unpairedTests,
     pairedRoundsCount: summary.pairedRoundsCount,
   };
 }

--- a/site/src/test-utils/perf-compare.ts
+++ b/site/src/test-utils/perf-compare.ts
@@ -34,6 +34,7 @@ interface ComparisonSummary {
   profileModeMismatches: ProfileModeMismatch[];
   newTests: AggregatedPerfResult[];
   removedTests: AggregatedPerfResult[];
+  unpairedTests: AggregatedPerfResult[];
   pairedRoundsCount: number;
 }
 
@@ -43,6 +44,7 @@ interface PersistedComparisonSummary {
   profileModeMismatches: ProfileModeMismatch[];
   newTests: PerfResult[];
   removedTests: PerfResult[];
+  unpairedTests: PerfResult[];
   pairedRoundsCount: number;
 }
 
@@ -250,7 +252,7 @@ function getSharedRoundIndices(
 }
 
 function requiredAgreement(roundsCount: number) {
-  if (roundsCount <= 2) return 1;
+  if (roundsCount <= 1) return 1;
   if (roundsCount <= 4) return roundsCount;
   return roundsCount - 1;
 }
@@ -332,6 +334,7 @@ function compare(): ComparisonSummary {
   const profileModeMismatches: ProfileModeMismatch[] = [];
   const newTests: AggregatedPerfResult[] = [];
   const removedTests: AggregatedPerfResult[] = [];
+  const unpairedTests: AggregatedPerfResult[] = [];
   const pairedRoundIndices = new Set<number>();
 
   for (const [key, cur] of current) {
@@ -354,6 +357,11 @@ function compare(): ComparisonSummary {
     }
 
     const sharedRoundIndices = getSharedRoundIndices(base, cur);
+    if (sharedRoundIndices.length === 0) {
+      unpairedTests.push(cur);
+      continue;
+    }
+
     for (const roundIndex of sharedRoundIndices) {
       pairedRoundIndices.add(roundIndex);
     }
@@ -411,6 +419,7 @@ function compare(): ComparisonSummary {
     profileModeMismatches,
     newTests,
     removedTests,
+    unpairedTests,
     pairedRoundsCount: pairedRoundIndices.size,
   };
 }
@@ -561,6 +570,7 @@ function formatMarkdown(summary: ComparisonSummary): string {
     profileModeMismatches,
     newTests,
     removedTests,
+    unpairedTests,
     pairedRoundsCount,
   } = summary;
   const currentByKey = new Map<string, AggregatedPerfResult>();
@@ -573,7 +583,11 @@ function formatMarkdown(summary: ComparisonSummary): string {
     rows.some((r) => rowKey(r) === key && r.significant),
   );
 
-  const totalTests = allKeys.length + newTests.length + removedTests.length;
+  const totalTests =
+    allKeys.length +
+    newTests.length +
+    removedTests.length +
+    unpairedTests.length;
 
   const lines: string[] = [];
   lines.push("## Performance");
@@ -583,10 +597,30 @@ function formatMarkdown(summary: ComparisonSummary): string {
     lines.push(...formatSummaryTable(rows, significantKeys));
   } else if (rows.length === 0 && newTests.length > 0) {
     lines.push("No baseline results available for comparison.");
+  } else if (rows.length === 0 && unpairedTests.length > 0) {
+    lines.push("No paired performance results available for comparison.");
   } else if (rows.length === 0 && newTests.length === 0) {
     lines.push("No performance results found.");
   } else {
     lines.push("No significant performance changes detected.");
+  }
+
+  if (unpairedTests.length > 0) {
+    const visibleUnpairedTests = unpairedTests.slice(0, 5);
+    const hiddenUnpairedTests =
+      unpairedTests.length - visibleUnpairedTests.length;
+    const label = unpairedTests.length === 1 ? "test" : "tests";
+    const verb = unpairedTests.length === 1 ? "was" : "were";
+    lines.push("");
+    lines.push(
+      `:warning: ${unpairedTests.length} ${label} had no paired baseline/current rounds and ${verb} not compared.`,
+    );
+    for (const { result } of visibleUnpairedTests) {
+      lines.push(`- ${result.label}`);
+    }
+    if (hiddenUnpairedTests > 0) {
+      lines.push(`- ...and ${hiddenUnpairedTests} more.`);
+    }
   }
 
   lines.push("");
@@ -617,6 +651,19 @@ function formatMarkdown(summary: ComparisonSummary): string {
       lines.push("");
       lines.push(...profileLines);
     }
+  }
+
+  if (unpairedTests.length > 0) {
+    lines.push("### Unpaired tests");
+    lines.push("");
+    lines.push(
+      "These tests produced baseline and current results, but no shared round index.",
+    );
+    lines.push("");
+    for (const { result } of unpairedTests) {
+      lines.push(`- ${result.label}`);
+    }
+    lines.push("");
   }
 
   if (removedTests.length > 0) {
@@ -653,6 +700,7 @@ function toPersistedSummary(
     profileModeMismatches: summary.profileModeMismatches,
     newTests: summary.newTests.map((entry) => entry.result),
     removedTests: summary.removedTests.map((entry) => entry.result),
+    unpairedTests: summary.unpairedTests.map((entry) => entry.result),
     pairedRoundsCount: summary.pairedRoundsCount,
   };
 }

--- a/site/src/test-utils/perf-compare.ts
+++ b/site/src/test-utils/perf-compare.ts
@@ -6,9 +6,16 @@ import {
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
-import type { PerfMetrics, PerfResult } from "./perf.ts";
+import type {
+  PerfMetrics,
+  PerfProfiles,
+  PerfResult,
+  PerfScriptProfileEntry,
+  PerfSelectorProfileEntry,
+} from "./perf.ts";
 
 const RESULTS_DIR = path.join(process.cwd(), ".perf-results");
+const PROFILE_LIMIT = 10;
 const THRESHOLD_PERCENT = 10;
 const MIN_SIGNIFICANT_DELTA_MS = 5;
 
@@ -159,7 +166,11 @@ function loadRounds(prefix: string): RoundPerfResult[] {
   const rounds: RoundPerfResult[] = [];
   for (const { filePath, roundIndex } of discoverRoundFiles(prefix)) {
     const data = readJsonFile(filePath);
-    if (!Array.isArray(data)) continue;
+    if (!Array.isArray(data)) {
+      throw new Error(
+        `Invalid perf results format at ${filePath}: expected an array of results.`,
+      );
+    }
     for (const result of data) {
       rounds.push({ roundIndex, result: result as PerfResult });
     }
@@ -191,8 +202,112 @@ function computeMedianMetrics(all: PerfMetrics[]): PerfMetrics {
   };
 }
 
-function getAggregatedProfiles(results: PerfResult[]) {
-  return results.find((result) => result.profiles)?.profiles;
+function scriptProfileKey(entry: PerfScriptProfileEntry) {
+  return [entry.functionName, entry.url, entry.line, entry.column].join("\0");
+}
+
+function selectorProfileKey(entry: PerfSelectorProfileEntry) {
+  return [entry.selector, entry.styleSheetId].join("\0");
+}
+
+function mergeScriptProfiles(
+  profiles: PerfScriptProfileEntry[][],
+): PerfScriptProfileEntry[] {
+  const entries = new Map<string, PerfScriptProfileEntry>();
+  for (const profile of profiles) {
+    for (const entry of profile) {
+      const key = scriptProfileKey(entry);
+      const existing = entries.get(key);
+      if (existing) {
+        existing.selfTime += entry.selfTime;
+        existing.totalTime += entry.totalTime;
+        existing.hitCount += entry.hitCount;
+        continue;
+      }
+      entries.set(key, { ...entry });
+    }
+  }
+  return [...entries.values()]
+    .sort((a, b) => b.selfTime - a.selfTime || b.totalTime - a.totalTime)
+    .slice(0, PROFILE_LIMIT);
+}
+
+interface SelectorProfileAccumulator extends PerfSelectorProfileEntry {
+  weightedSlowPathSum: number;
+}
+
+function mergeSelectorProfiles(
+  profiles: PerfSelectorProfileEntry[][],
+): PerfSelectorProfileEntry[] {
+  const entries = new Map<string, SelectorProfileAccumulator>();
+  for (const profile of profiles) {
+    for (const entry of profile) {
+      const key = selectorProfileKey(entry);
+      const weightedSlowPathSum =
+        entry.matchAttempts * entry.slowPathNonMatchPercent;
+      const existing = entries.get(key);
+      if (existing) {
+        existing.elapsed += entry.elapsed;
+        existing.matchAttempts += entry.matchAttempts;
+        existing.matchCount += entry.matchCount;
+        existing.invalidationCount += entry.invalidationCount;
+        existing.weightedSlowPathSum += weightedSlowPathSum;
+        if (!existing.styleSheetUrl && entry.styleSheetUrl) {
+          existing.styleSheetUrl = entry.styleSheetUrl;
+        }
+        continue;
+      }
+      entries.set(key, {
+        ...entry,
+        weightedSlowPathSum,
+      });
+    }
+  }
+  return [...entries.values()]
+    .map(({ weightedSlowPathSum, ...entry }) => {
+      return {
+        ...entry,
+        slowPathNonMatchPercent:
+          entry.matchAttempts > 0
+            ? weightedSlowPathSum / entry.matchAttempts
+            : 0,
+      };
+    })
+    .sort((a, b) => b.elapsed - a.elapsed)
+    .slice(0, PROFILE_LIMIT);
+}
+
+function mergeProfiles(results: PerfResult[]): PerfProfiles | undefined {
+  const scriptProfiles: PerfScriptProfileEntry[][] = [];
+  const selectorProfiles: PerfSelectorProfileEntry[][] = [];
+  for (const result of results) {
+    if (result.profiles?.script && result.profiles.script.length > 0) {
+      scriptProfiles.push(result.profiles.script);
+    }
+    if (result.profiles?.selectors && result.profiles.selectors.length > 0) {
+      selectorProfiles.push(result.profiles.selectors);
+    }
+  }
+  const profiles: PerfProfiles = {};
+  if (scriptProfiles.length > 0) {
+    profiles.script = mergeScriptProfiles(scriptProfiles);
+  }
+  if (selectorProfiles.length > 0) {
+    profiles.selectors = mergeSelectorProfiles(selectorProfiles);
+  }
+  if (!profiles.script && !profiles.selectors) return;
+  return profiles;
+}
+
+function combineResults(results: PerfResult[]): PerfResult | undefined {
+  const first = results[0];
+  if (!first) return;
+  return {
+    ...first,
+    metrics: computeMedianMetrics(results.map((result) => result.metrics)),
+    raw: results.flatMap((result) => result.raw),
+    profiles: mergeProfiles(results),
+  };
 }
 
 function createAggregatedResult(
@@ -200,24 +315,19 @@ function createAggregatedResult(
   byRound: Map<number, PerfResult>,
 ): AggregatedPerfResult | undefined {
   const results = [...byRound.values()];
-  const first = results[0];
-  if (!first) return;
+  const result = combineResults(results);
+  if (!result) return;
   return {
     key,
     byRound,
-    result: {
-      ...first,
-      metrics: computeMedianMetrics(results.map((result) => result.metrics)),
-      raw: results.flatMap((result) => result.raw),
-      profiles: getAggregatedProfiles(results),
-    },
+    result,
   };
 }
 
 function aggregateByKey(
   roundResults: RoundPerfResult[],
 ): Map<string, AggregatedPerfResult> {
-  const grouped = new Map<string, Map<number, PerfResult>>();
+  const grouped = new Map<string, Map<number, PerfResult[]>>();
   for (const { roundIndex, result } of roundResults) {
     const key = resultKey(result);
     let byRound = grouped.get(key);
@@ -225,11 +335,22 @@ function aggregateByKey(
       byRound = new Map();
       grouped.set(key, byRound);
     }
-    byRound.set(roundIndex, result);
+    const resultsForRound = byRound.get(roundIndex);
+    if (resultsForRound) {
+      resultsForRound.push(result);
+    } else {
+      byRound.set(roundIndex, [result]);
+    }
   }
 
   const aggregated = new Map<string, AggregatedPerfResult>();
-  for (const [key, byRound] of grouped) {
+  for (const [key, groupedByRound] of grouped) {
+    const byRound = new Map<number, PerfResult>();
+    for (const [roundIndex, roundResults] of groupedByRound) {
+      const result = combineResults(roundResults);
+      if (!result) continue;
+      byRound.set(roundIndex, result);
+    }
     const result = createAggregatedResult(key, byRound);
     if (!result) continue;
     aggregated.set(key, result);
@@ -259,11 +380,13 @@ function requiredAgreement(roundsCount: number) {
 function computeSignificance({
   baseline,
   current,
+  metric,
   percent,
   perRoundDeltas,
 }: {
   baseline: number;
   current: number;
+  metric: MetricKey;
   percent: number;
   perRoundDeltas: number[];
 }) {
@@ -286,8 +409,12 @@ function computeSignificance({
     baseline === 0 && Math.abs(current) >= MIN_SIGNIFICANT_DELTA_MS;
   const magnitudeOk = baseline === 0 ? zeroBaselineOk : percentOk && deltaOk;
   const agreementOk = agreement >= requiredAgreement(perRoundDeltas.length);
+  const primaryMetric = PRIMARY_METRICS.includes(metric);
 
-  return { agreement, significant: magnitudeOk && agreementOk };
+  return {
+    agreement,
+    significant: primaryMetric && magnitudeOk && agreementOk,
+  };
 }
 
 function formatMs(value: number): string {
@@ -382,6 +509,7 @@ function compare(): ComparisonSummary {
       const { agreement, significant } = computeSignificance({
         baseline: baseVal,
         current: curVal,
+        metric,
         percent,
         perRoundDeltas,
       });

--- a/site/src/test-utils/perf-compare.ts
+++ b/site/src/test-utils/perf-compare.ts
@@ -121,9 +121,17 @@ const RENDERING_SUB_METRICS = new Set<MetricKey>([
 ]);
 
 function readJsonFile(filePath: string): unknown {
-  if (!existsSync(filePath)) return [];
+  let contents: string;
   try {
-    return JSON.parse(readFileSync(filePath, "utf-8"));
+    contents = readFileSync(filePath, "utf-8");
+  } catch (error) {
+    throw new Error(`Failed to read perf results at ${filePath}`, {
+      cause: error,
+    });
+  }
+
+  try {
+    return JSON.parse(contents);
   } catch (error) {
     throw new Error(`Failed to parse perf results at ${filePath}`, {
       cause: error,

--- a/site/src/test-utils/perf-compare.ts
+++ b/site/src/test-utils/perf-compare.ts
@@ -10,6 +10,7 @@ import type { PerfMetrics, PerfResult } from "./perf.ts";
 
 const RESULTS_DIR = path.join(process.cwd(), ".perf-results");
 const THRESHOLD_PERCENT = 10;
+const MIN_SIGNIFICANT_DELTA_MS = 5;
 
 type MetricKey = keyof PerfMetrics;
 
@@ -21,16 +22,19 @@ interface ComparisonRow {
   current: number;
   delta: number;
   percent: number;
+  perRoundDeltas: number[];
+  agreement: number;
   significant: boolean;
 }
 
 interface ComparisonSummary {
   rows: ComparisonRow[];
   hasSignificantChanges: boolean;
-  currentResults: PerfResult[];
+  currentResults: AggregatedPerfResult[];
   profileModeMismatches: ProfileModeMismatch[];
-  newTests: PerfResult[];
-  removedTests: PerfResult[];
+  newTests: AggregatedPerfResult[];
+  removedTests: AggregatedPerfResult[];
+  pairedRoundsCount: number;
 }
 
 interface PersistedComparisonSummary {
@@ -39,6 +43,7 @@ interface PersistedComparisonSummary {
   profileModeMismatches: ProfileModeMismatch[];
   newTests: PerfResult[];
   removedTests: PerfResult[];
+  pairedRoundsCount: number;
 }
 
 interface ProfileModeMismatch {
@@ -47,6 +52,22 @@ interface ProfileModeMismatch {
   profile: "script" | "selectors";
   baseline: boolean;
   current: boolean;
+}
+
+interface RoundPerfResult {
+  roundIndex: number;
+  result: PerfResult;
+}
+
+interface AggregatedPerfResult {
+  key: string;
+  result: PerfResult;
+  byRound: Map<number, PerfResult>;
+}
+
+interface DiscoveredRoundFile {
+  filePath: string;
+  roundIndex: number;
 }
 
 // Primary metrics shown in the summary table.
@@ -80,19 +101,192 @@ const RENDERING_SUB_METRICS = new Set<MetricKey>([
   "painting",
 ]);
 
-function loadResults(prefix: string): PerfResult[] {
+function readJsonFile(filePath: string): unknown {
+  if (!existsSync(filePath)) return [];
+  try {
+    return JSON.parse(readFileSync(filePath, "utf-8"));
+  } catch (error) {
+    console.warn(
+      `Warning: failed to parse JSON file at ${filePath}. Falling back to empty results.`,
+      error,
+    );
+    return [];
+  }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// Discover round files like `baseline-1-worker0.json` and
+// `current-1-worker0.json`. If no numbered rounds are present, fall back to
+// the previous single-run files such as `baseline-worker0.json`.
+function discoverRoundFiles(prefix: string): DiscoveredRoundFile[] {
   if (!existsSync(RESULTS_DIR)) return [];
   const files = readdirSync(RESULTS_DIR)
-    .filter((f) => f.startsWith(prefix) && f.endsWith(".json"))
+    .filter((file) => file.startsWith(prefix) && file.endsWith(".json"))
     .sort();
-  const all: PerfResult[] = [];
+
+  const numbered: DiscoveredRoundFile[] = [];
+  const roundPattern = new RegExp(
+    `^${escapeRegExp(prefix)}-(\\d+)(?:-.+)?\\.json$`,
+  );
   for (const file of files) {
-    const data = JSON.parse(
-      readFileSync(path.join(RESULTS_DIR, file), "utf-8"),
-    );
-    all.push(...data);
+    const match = file.match(roundPattern);
+    if (!match) continue;
+    const roundIndex = Number(match[1] ?? 0);
+    if (!Number.isInteger(roundIndex) || roundIndex <= 0) continue;
+    numbered.push({
+      filePath: path.join(RESULTS_DIR, file),
+      roundIndex,
+    });
   }
-  return all;
+  if (numbered.length > 0) {
+    return numbered.sort(
+      (a, b) =>
+        a.roundIndex - b.roundIndex || a.filePath.localeCompare(b.filePath),
+    );
+  }
+
+  return files.map((file) => ({
+    filePath: path.join(RESULTS_DIR, file),
+    roundIndex: 1,
+  }));
+}
+
+function loadRounds(prefix: string): RoundPerfResult[] {
+  const rounds: RoundPerfResult[] = [];
+  for (const { filePath, roundIndex } of discoverRoundFiles(prefix)) {
+    const data = readJsonFile(filePath);
+    if (!Array.isArray(data)) continue;
+    for (const result of data) {
+      rounds.push({ roundIndex, result: result as PerfResult });
+    }
+  }
+  return rounds;
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  const midValue = sorted[mid];
+  if (midValue == null) return 0;
+  if (sorted.length % 2 !== 0) return midValue;
+  const prevValue = sorted[mid - 1];
+  if (prevValue == null) return midValue;
+  return (prevValue + midValue) / 2;
+}
+
+function computeMedianMetrics(all: PerfMetrics[]): PerfMetrics {
+  return {
+    scripting: median(all.map((m) => m.scripting)),
+    layout: median(all.map((m) => m.layout)),
+    styleRecalc: median(all.map((m) => m.styleRecalc)),
+    painting: median(all.map((m) => m.painting)),
+    rendering: median(all.map((m) => m.rendering)),
+    inp: median(all.map((m) => m.inp)),
+    total: median(all.map((m) => m.total)),
+  };
+}
+
+function getAggregatedProfiles(results: PerfResult[]) {
+  return results.find((result) => result.profiles)?.profiles;
+}
+
+function createAggregatedResult(
+  key: string,
+  byRound: Map<number, PerfResult>,
+): AggregatedPerfResult | undefined {
+  const results = [...byRound.values()];
+  const first = results[0];
+  if (!first) return;
+  return {
+    key,
+    byRound,
+    result: {
+      ...first,
+      metrics: computeMedianMetrics(results.map((result) => result.metrics)),
+      raw: results.flatMap((result) => result.raw),
+      profiles: getAggregatedProfiles(results),
+    },
+  };
+}
+
+function aggregateByKey(
+  roundResults: RoundPerfResult[],
+): Map<string, AggregatedPerfResult> {
+  const grouped = new Map<string, Map<number, PerfResult>>();
+  for (const { roundIndex, result } of roundResults) {
+    const key = resultKey(result);
+    let byRound = grouped.get(key);
+    if (!byRound) {
+      byRound = new Map();
+      grouped.set(key, byRound);
+    }
+    byRound.set(roundIndex, result);
+  }
+
+  const aggregated = new Map<string, AggregatedPerfResult>();
+  for (const [key, byRound] of grouped) {
+    const result = createAggregatedResult(key, byRound);
+    if (!result) continue;
+    aggregated.set(key, result);
+  }
+  return aggregated;
+}
+
+function getSharedRoundIndices(
+  baseline: AggregatedPerfResult,
+  current: AggregatedPerfResult,
+) {
+  const roundIndices: number[] = [];
+  for (const roundIndex of current.byRound.keys()) {
+    if (baseline.byRound.has(roundIndex)) {
+      roundIndices.push(roundIndex);
+    }
+  }
+  return roundIndices.sort((a, b) => a - b);
+}
+
+function requiredAgreement(roundsCount: number) {
+  if (roundsCount <= 2) return 1;
+  if (roundsCount <= 4) return roundsCount;
+  return roundsCount - 1;
+}
+
+function computeSignificance({
+  baseline,
+  current,
+  percent,
+  perRoundDeltas,
+}: {
+  baseline: number;
+  current: number;
+  percent: number;
+  perRoundDeltas: number[];
+}) {
+  if (perRoundDeltas.length === 0) {
+    return { agreement: 0, significant: false };
+  }
+
+  const delta = current - baseline;
+  const direction = Math.sign(delta);
+  let agreement = 0;
+  for (const roundDelta of perRoundDeltas) {
+    if (Math.sign(roundDelta) === direction) {
+      agreement += 1;
+    }
+  }
+
+  const percentOk = Math.abs(percent) > THRESHOLD_PERCENT;
+  const deltaOk = Math.abs(delta) >= MIN_SIGNIFICANT_DELTA_MS;
+  const zeroBaselineOk =
+    baseline === 0 && Math.abs(current) >= MIN_SIGNIFICANT_DELTA_MS;
+  const magnitudeOk = baseline === 0 ? zeroBaselineOk : percentOk && deltaOk;
+  const agreementOk = agreement >= requiredAgreement(perRoundDeltas.length);
+
+  return { agreement, significant: magnitudeOk && agreementOk };
 }
 
 function formatMs(value: number): string {
@@ -123,32 +317,25 @@ function resultKey(result: PerfResult): string {
   return `${result.testFile}::${result.label}`;
 }
 
-function hasProfile(result: PerfResult, profile: "script" | "selectors") {
-  return (result.profiles?.[profile]?.length ?? 0) > 0;
+function hasProfile(
+  result: AggregatedPerfResult,
+  profile: "script" | "selectors",
+) {
+  return (result.result.profiles?.[profile]?.length ?? 0) > 0;
 }
 
 function compare(): ComparisonSummary {
-  const baseline = loadResults("baseline");
-  const current = loadResults("current");
-
-  const baselineByKey = new Map<string, PerfResult>();
-  for (const result of baseline) {
-    baselineByKey.set(resultKey(result), result);
-  }
-
-  const currentByKey = new Map<string, PerfResult>();
-  for (const result of current) {
-    currentByKey.set(resultKey(result), result);
-  }
+  const baseline = aggregateByKey(loadRounds("baseline"));
+  const current = aggregateByKey(loadRounds("current"));
 
   const rows: ComparisonRow[] = [];
   const profileModeMismatches: ProfileModeMismatch[] = [];
-  const newTests: PerfResult[] = [];
-  const removedTests: PerfResult[] = [];
+  const newTests: AggregatedPerfResult[] = [];
+  const removedTests: AggregatedPerfResult[] = [];
+  const pairedRoundIndices = new Set<number>();
 
-  for (const cur of current) {
-    const key = resultKey(cur);
-    const base = baselineByKey.get(key);
+  for (const [key, cur] of current) {
+    const base = baseline.get(key);
     if (!base) {
       newTests.push(cur);
       continue;
@@ -158,38 +345,61 @@ function compare(): ComparisonSummary {
       const currentHasProfile = hasProfile(cur, profile);
       if (baselineHasProfile === currentHasProfile) continue;
       profileModeMismatches.push({
-        testFile: cur.testFile,
-        label: cur.label,
+        testFile: cur.result.testFile,
+        label: cur.result.label,
         profile,
         baseline: baselineHasProfile,
         current: currentHasProfile,
       });
     }
+
+    const sharedRoundIndices = getSharedRoundIndices(base, cur);
+    for (const roundIndex of sharedRoundIndices) {
+      pairedRoundIndices.add(roundIndex);
+    }
+
     for (const metric of ALL_METRICS) {
-      const baseVal = base.metrics[metric];
-      const curVal = cur.metrics[metric];
+      const baselineValues: number[] = [];
+      const currentValues: number[] = [];
+      const perRoundDeltas: number[] = [];
+      for (const roundIndex of sharedRoundIndices) {
+        const baselineRound = base.byRound.get(roundIndex);
+        const currentRound = cur.byRound.get(roundIndex);
+        if (!baselineRound || !currentRound) continue;
+        const baselineValue = baselineRound.metrics[metric];
+        const currentValue = currentRound.metrics[metric];
+        baselineValues.push(baselineValue);
+        currentValues.push(currentValue);
+        perRoundDeltas.push(currentValue - baselineValue);
+      }
+
+      const baseVal = median(baselineValues);
+      const curVal = median(currentValues);
       const delta = curVal - baseVal;
       const percent = baseVal > 0 ? (delta / baseVal) * 100 : 0;
-      // Flag as significant when percentage exceeds threshold, or when a
-      // metric goes from zero to a non-trivial value (> 1ms).
-      const significant =
-        Math.abs(percent) > THRESHOLD_PERCENT ||
-        (baseVal === 0 && Math.abs(curVal) > 1);
+      const { agreement, significant } = computeSignificance({
+        baseline: baseVal,
+        current: curVal,
+        percent,
+        perRoundDeltas,
+      });
       rows.push({
-        testFile: cur.testFile,
-        label: cur.label,
+        testFile: cur.result.testFile,
+        label: cur.result.label,
         metric,
         baseline: baseVal,
         current: curVal,
         delta,
         percent,
+        perRoundDeltas,
+        agreement,
         significant,
       });
     }
   }
 
-  for (const base of baseline) {
-    if (!currentByKey.has(resultKey(base))) {
+  for (const [key, base] of baseline) {
+    if (!current.has(key)) {
       removedTests.push(base);
     }
   }
@@ -197,10 +407,11 @@ function compare(): ComparisonSummary {
   return {
     rows,
     hasSignificantChanges: rows.some((r) => r.significant),
-    currentResults: current,
+    currentResults: [...current.values()],
     profileModeMismatches,
     newTests,
     removedTests,
+    pairedRoundsCount: pairedRoundIndices.size,
   };
 }
 
@@ -312,7 +523,7 @@ function formatProfileModeWarning(mismatches: ProfileModeMismatch[]): string[] {
 function formatDetailedBreakdown(
   rows: ComparisonRow[],
   keys: string[],
-  currentByKey: Map<string, PerfResult>,
+  currentByKey: Map<string, AggregatedPerfResult>,
 ): string[] {
   const lines: string[] = [];
   for (const key of keys) {
@@ -337,7 +548,7 @@ function formatDetailedBreakdown(
       );
     }
     lines.push("");
-    lines.push(...formatProfiles(currentByKey.get(key)));
+    lines.push(...formatProfiles(currentByKey.get(key)?.result));
   }
   return lines;
 }
@@ -350,10 +561,11 @@ function formatMarkdown(summary: ComparisonSummary): string {
     profileModeMismatches,
     newTests,
     removedTests,
+    pairedRoundsCount,
   } = summary;
-  const currentByKey = new Map<string, PerfResult>();
+  const currentByKey = new Map<string, AggregatedPerfResult>();
   for (const result of currentResults) {
-    currentByKey.set(resultKey(result), result);
+    currentByKey.set(result.key, result);
   }
 
   const allKeys = [...new Set(rows.map((r) => rowKey(r)))];
@@ -389,7 +601,7 @@ function formatMarkdown(summary: ComparisonSummary): string {
     lines.push("");
     lines.push("| Test | Scripting | Rendering | Total |");
     lines.push("|------|-----------|-----------|-------|");
-    for (const result of newTests) {
+    for (const { result } of newTests) {
       const cells: string[] = [result.label];
       for (const metric of PRIMARY_METRICS) {
         cells.push(formatMs(result.metrics[metric]));
@@ -398,7 +610,7 @@ function formatMarkdown(summary: ComparisonSummary): string {
     }
     lines.push("");
 
-    for (const result of newTests) {
+    for (const { result } of newTests) {
       const profileLines = formatProfiles(result);
       if (profileLines.length === 0) continue;
       lines.push(`#### ${result.label}`);
@@ -410,7 +622,7 @@ function formatMarkdown(summary: ComparisonSummary): string {
   if (removedTests.length > 0) {
     lines.push("### Removed tests");
     lines.push("");
-    for (const result of removedTests) {
+    for (const { result } of removedTests) {
       lines.push(`- ${result.label}`);
     }
     lines.push("");
@@ -420,8 +632,14 @@ function formatMarkdown(summary: ComparisonSummary): string {
   lines.push("");
 
   lines.push(
-    `:warning: = regression above ${THRESHOLD_PERCENT}% · :rocket: = improvement above ${THRESHOLD_PERCENT}%`,
+    `:warning: = regression above ${THRESHOLD_PERCENT}% and ${formatMs(MIN_SIGNIFICANT_DELTA_MS)} · :rocket: = improvement above ${THRESHOLD_PERCENT}% and ${formatMs(MIN_SIGNIFICANT_DELTA_MS)}`,
   );
+  if (pairedRoundsCount > 1) {
+    lines.push("");
+    lines.push(
+      `Aggregated across ${pairedRoundsCount} interleaved rounds; a change is flagged only when the median exceeds the threshold and rounds agree on direction.`,
+    );
+  }
 
   return lines.join("\n");
 }
@@ -433,8 +651,9 @@ function toPersistedSummary(
     rows: summary.rows,
     hasSignificantChanges: summary.hasSignificantChanges,
     profileModeMismatches: summary.profileModeMismatches,
-    newTests: summary.newTests,
-    removedTests: summary.removedTests,
+    newTests: summary.newTests.map((entry) => entry.result),
+    removedTests: summary.removedTests.map((entry) => entry.result),
+    pairedRoundsCount: summary.pairedRoundsCount,
   };
 }
 

--- a/site/src/test-utils/perf-test.ts
+++ b/site/src/test-utils/perf-test.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2025-present Ariakit FZ-LLC. All Rights Reserved.
+ *
+ * This software is proprietary. See the license.md file in the root of this
+ * package for licensing terms.
+ *
+ * SPDX-License-Identifier: UNLICENSED
+ */
+
+import { afterEach, expect, test } from "vitest";
+import { getIntegerEnv } from "./perf.ts";
+
+const envName = "PERF_ITERATIONS";
+const originalValue = process.env[envName];
+
+afterEach(() => {
+  if (originalValue == null) {
+    delete process.env[envName];
+    return;
+  }
+  process.env[envName] = originalValue;
+});
+
+test("gets integer env values with range validation", () => {
+  process.env[envName] = "3";
+  expect(getIntegerEnv(envName, 10, { min: 1 })).toBe(3);
+
+  for (const value of ["", "2.5", "0", "-1"]) {
+    process.env[envName] = value;
+    expect(getIntegerEnv(envName, 10, { min: 1 })).toBe(10);
+  }
+
+  process.env[envName] = "0";
+  expect(getIntegerEnv(envName, 1, { min: 0 })).toBe(0);
+});

--- a/site/src/test-utils/perf.ts
+++ b/site/src/test-utils/perf.ts
@@ -214,10 +214,22 @@ function isTruthyEnv(name: string): boolean {
   return process.env[name] === "true" || process.env[name] === "1";
 }
 
-function getIntegerEnv(name: string, fallback: number): number {
+interface IntegerEnvOptions {
+  min?: number;
+}
+
+export function getIntegerEnv(
+  name: string,
+  fallback: number,
+  options: IntegerEnvOptions = {},
+): number {
   const value = process.env[name];
   if (value == null) return fallback;
-  return Number(value);
+  if (value.trim() === "") return fallback;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed)) return fallback;
+  if (options.min != null && parsed < options.min) return fallback;
+  return parsed;
 }
 
 function normalizeProfileUrl(url: string): string {
@@ -707,8 +719,8 @@ export async function createPerfMeasure(
   options: CreatePerfMeasureOptions = {},
 ): Promise<PerfMetrics> {
   const {
-    iterations = getIntegerEnv("PERF_ITERATIONS", 10),
-    warmup = getIntegerEnv("PERF_WARMUP", 1),
+    iterations = getIntegerEnv("PERF_ITERATIONS", 10, { min: 1 }),
+    warmup = getIntegerEnv("PERF_WARMUP", 1, { min: 0 }),
     resetPage = true,
     label,
     profileLimit = DEFAULT_PROFILE_LIMIT,

--- a/site/src/test-utils/perf.ts
+++ b/site/src/test-utils/perf.ts
@@ -460,7 +460,7 @@ async function startSelectorTrace(
   };
 }
 
-function mergeScriptProfiles(
+export function mergeScriptProfiles(
   profiles: PerfScriptProfileEntry[][],
   limit: number,
 ): PerfScriptProfileEntry[] {
@@ -487,7 +487,7 @@ function mergeScriptProfiles(
     .slice(0, limit);
 }
 
-function mergeSelectorProfiles(
+export function mergeSelectorProfiles(
   profiles: PerfSelectorProfileEntry[][],
   limit: number,
 ): PerfSelectorProfileEntry[] {

--- a/site/src/test-utils/perf.ts
+++ b/site/src/test-utils/perf.ts
@@ -4,8 +4,6 @@ import { fileURLToPath } from "node:url";
 import type { CDPSession, Page, TestInfo } from "@playwright/test";
 
 const RESULTS_DIR = path.join(process.cwd(), ".perf-results");
-const DEFAULT_ITERATIONS = 10;
-const DEFAULT_WARMUP = 1;
 const DEFAULT_PROFILE_LIMIT = 10;
 const initializedResultFiles = new Set<string>();
 
@@ -214,6 +212,12 @@ function computeMedianMetrics(all: PerfMetrics[]): PerfMetrics {
 
 function isTruthyEnv(name: string): boolean {
   return process.env[name] === "true" || process.env[name] === "1";
+}
+
+function getIntegerEnv(name: string, fallback: number): number {
+  const value = process.env[name];
+  if (value == null) return fallback;
+  return Number(value);
 }
 
 function normalizeProfileUrl(url: string): string {
@@ -703,8 +707,8 @@ export async function createPerfMeasure(
   options: CreatePerfMeasureOptions = {},
 ): Promise<PerfMetrics> {
   const {
-    iterations = DEFAULT_ITERATIONS,
-    warmup = DEFAULT_WARMUP,
+    iterations = getIntegerEnv("PERF_ITERATIONS", 10),
+    warmup = getIntegerEnv("PERF_WARMUP", 1),
     resetPage = true,
     label,
     profileLimit = DEFAULT_PROFILE_LIMIT,


### PR DESCRIPTION
## Motivation

Performance comments on unrelated PRs can currently show meaningful-looking baseline/current movement even when the PR should not affect the measured code. The comparison uses one baseline run and one current run, does not preserve raw CI output, and can surface a top-level summary row because a small detailed metric crossed the percentage threshold.

## Solution

This makes the performance job run paired baseline/current rounds on the same runner from separate current and baseline worktrees. The comparator now discovers numbered result files, compares only shared rounds, aggregates displayed values from those shared rounds, and requires both the existing percentage threshold and a 5ms absolute delta before a metric can be significant. Multi-round comparisons also require direction agreement across rounds.

The job now uploads `site/.perf-results` so raw per-iteration data and generated comparison files can be inspected after CI. `PERF_ITERATIONS` and `PERF_WARMUP` environment knobs let CI balance total runtime with the outer paired rounds.

## Validation

- `pnpm exec vitest site/src/test-utils/perf-compare-test.ts`
- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm lint`

No changeset: this changes CI/test infrastructure only.