### PR TITLE
Fix Changesets release plan changelog

### DIFF
--- a/.changeset/get-changelog-entry-test.ts
+++ b/.changeset/get-changelog-entry-test.ts
@@ -7,10 +7,21 @@ test("changesets getChangelogEntry hook", async () => {
   // Create a temporary package to avoid touching real repo packages
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "changesets-test-"));
   const pkgDir = path.join(tempDir, "pkg-a");
+  const dependentPkgDir = path.join(tempDir, "pkg-b");
   await fs.ensureDir(pkgDir);
+  await fs.ensureDir(dependentPkgDir);
   await fs.writeJson(
     path.join(pkgDir, "package.json"),
     { name: "pkg-a", version: "1.0.0" },
+    { spaces: 2 },
+  );
+  await fs.writeJson(
+    path.join(dependentPkgDir, "package.json"),
+    {
+      name: "pkg-b",
+      version: "1.0.0",
+      dependencies: { "pkg-a": "^1.0.0" },
+    },
     { spaces: 2 },
   );
 
@@ -39,6 +50,12 @@ test("changesets getChangelogEntry hook", async () => {
         newVersion: "1.1.0",
         changesets: ["fake-id-1", "fake-id-2", "fake-id-3"],
       },
+      {
+        name: "pkg-b",
+        type: "patch",
+        newVersion: "1.0.1",
+        changesets: [],
+      },
     ],
     preState: undefined,
   } as const;
@@ -49,6 +66,14 @@ test("changesets getChangelogEntry hook", async () => {
       {
         dir: pkgDir,
         packageJson: { name: "pkg-a", version: "1.0.0" },
+      },
+      {
+        dir: dependentPkgDir,
+        packageJson: {
+          name: "pkg-b",
+          version: "1.0.0",
+          dependencies: { "pkg-a": "^1.0.0" },
+        },
       },
     ],
   } as const;
@@ -91,6 +116,18 @@ test("changesets getChangelogEntry hook", async () => {
     ### Other updates
 
     - Chore: update docs
+    "
+  `);
+
+  const dependentChangelogPath = path.join(dependentPkgDir, "CHANGELOG.md");
+  const dependentChangelog = await fs.readFile(dependentChangelogPath, "utf8");
+
+  expect(dependentChangelog).toMatchInlineSnapshot(`
+    "# pkg-b
+
+    ## 1.0.1
+
+    - Updated dependencies: \`pkg-a@1.1.0\`
     "
   `);
 });

--- a/.changeset/get-changelog-entry-test.ts
+++ b/.changeset/get-changelog-entry-test.ts
@@ -6,101 +6,102 @@ import { expect, test } from "vitest";
 test("changesets getChangelogEntry hook", async () => {
   // Create a temporary package to avoid touching real repo packages
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "changesets-test-"));
-  const pkgDir = path.join(tempDir, "pkg-a");
-  const dependentPkgDir = path.join(tempDir, "pkg-b");
-  await fs.ensureDir(pkgDir);
-  await fs.ensureDir(dependentPkgDir);
-  await fs.writeJson(
-    path.join(pkgDir, "package.json"),
-    { name: "pkg-a", version: "1.0.0" },
-    { spaces: 2 },
-  );
-  await fs.writeJson(
-    path.join(dependentPkgDir, "package.json"),
-    {
-      name: "pkg-b",
-      version: "1.0.0",
-      dependencies: { "pkg-a": "^1.0.0" },
-    },
-    { spaces: 2 },
-  );
-
-  const releasePlan = {
-    changesets: [
-      {
-        id: "fake-id-1",
-        summary: "Overview\n\nAdd awesome feature",
-        releases: [{ name: "pkg-a", type: "minor" }],
-      },
-      {
-        id: "fake-id-2",
-        summary: "Testing title\n\nAdd awesome feature\n\n2",
-        releases: [{ name: "pkg-a", type: "minor" }],
-      },
-      {
-        id: "fake-id-3",
-        summary: "Chore: update docs",
-        releases: [{ name: "pkg-a", type: "patch" }],
-      },
-    ],
-    releases: [
-      {
-        name: "pkg-a",
-        type: "minor",
-        newVersion: "1.1.0",
-        changesets: ["fake-id-1", "fake-id-2", "fake-id-3"],
-      },
+  try {
+    const pkgDir = path.join(tempDir, "pkg-a");
+    const dependentPkgDir = path.join(tempDir, "pkg-b");
+    await fs.ensureDir(pkgDir);
+    await fs.ensureDir(dependentPkgDir);
+    await fs.writeJson(
+      path.join(pkgDir, "package.json"),
+      { name: "pkg-a", version: "1.0.0" },
+      { spaces: 2 },
+    );
+    await fs.writeJson(
+      path.join(dependentPkgDir, "package.json"),
       {
         name: "pkg-b",
-        type: "patch",
-        newVersion: "1.0.1",
-        changesets: [],
+        version: "1.0.0",
+        dependencies: { "pkg-a": "^1.0.0" },
       },
-    ],
-    preState: undefined,
-  } as const;
+      { spaces: 2 },
+    );
 
-  const packages = {
-    root: { dir: process.cwd() },
-    packages: [
-      {
-        dir: pkgDir,
-        packageJson: { name: "pkg-a", version: "1.0.0" },
-      },
-      {
-        dir: dependentPkgDir,
-        packageJson: {
-          name: "pkg-b",
-          version: "1.0.0",
-          dependencies: { "pkg-a": "^1.0.0" },
+    const releasePlan = {
+      changesets: [
+        {
+          id: "fake-id-1",
+          summary: "Overview\n\nAdd awesome feature",
+          releases: [{ name: "pkg-a", type: "minor" }],
         },
+        {
+          id: "fake-id-2",
+          summary: "Testing title\n\nAdd awesome feature\n\n2",
+          releases: [{ name: "pkg-a", type: "minor" }],
+        },
+        {
+          id: "fake-id-3",
+          summary: "Chore: update docs",
+          releases: [{ name: "pkg-a", type: "patch" }],
+        },
+      ],
+      releases: [
+        {
+          name: "pkg-a",
+          type: "minor",
+          newVersion: "1.1.0",
+          changesets: ["fake-id-1", "fake-id-2", "fake-id-3"],
+        },
+        {
+          name: "pkg-b",
+          type: "patch",
+          newVersion: "1.0.1",
+          changesets: [],
+        },
+      ],
+      preState: undefined,
+    } as const;
+
+    const packages = {
+      root: { dir: process.cwd() },
+      packages: [
+        {
+          dir: pkgDir,
+          packageJson: { name: "pkg-a", version: "1.0.0" },
+        },
+        {
+          dir: dependentPkgDir,
+          packageJson: {
+            name: "pkg-b",
+            version: "1.0.0",
+            dependencies: { "pkg-a": "^1.0.0" },
+          },
+        },
+      ],
+    } as const;
+
+    const applyReleasePlan = (await import("@changesets/apply-release-plan"))
+      .default as unknown as (...args: any[]) => Promise<string[]>;
+
+    // Minimal config that points to our repo's .changeset/changelog.cjs
+    const config = {
+      changelog: ["./changelog.cjs", {}],
+      updateInternalDependencies: "patch",
+      ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
+        onlyUpdatePeerDependentsWhenOutOfRange: true,
       },
-    ],
-  } as const;
+      bumpVersionsWithWorkspaceProtocolOnly: false,
+      prettier: false,
+      ignore: [],
+      privatePackages: { version: false, tag: false },
+    } as const;
 
-  const applyReleasePlan = (await import("@changesets/apply-release-plan"))
-    .default as unknown as (...args: any[]) => Promise<string[]>;
+    const touched = await applyReleasePlan(releasePlan, packages, config);
+    expect(Array.isArray(touched)).toBe(true);
 
-  // Minimal config that points to our repo's .changeset/changelog.cjs
-  const config = {
-    changelog: ["./changelog.cjs", {}],
-    updateInternalDependencies: "patch",
-    ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
-      onlyUpdatePeerDependentsWhenOutOfRange: true,
-    },
-    bumpVersionsWithWorkspaceProtocolOnly: false,
-    prettier: false,
-    ignore: [],
-    privatePackages: { version: false, tag: false },
-  } as const;
+    const changelogPath = path.join(pkgDir, "CHANGELOG.md");
+    const changelog = await fs.readFile(changelogPath, "utf8");
 
-  const touched = await applyReleasePlan(releasePlan, packages, config);
-  expect(Array.isArray(touched)).toBe(true);
-
-  const changelogPath = path.join(pkgDir, "CHANGELOG.md");
-  const changelog = await fs.readFile(changelogPath, "utf8");
-
-  expect(changelog).toMatchInlineSnapshot(`
+    expect(changelog).toMatchInlineSnapshot(`
     "# pkg-a
 
     ## 1.1.0
@@ -119,10 +120,13 @@ test("changesets getChangelogEntry hook", async () => {
     "
   `);
 
-  const dependentChangelogPath = path.join(dependentPkgDir, "CHANGELOG.md");
-  const dependentChangelog = await fs.readFile(dependentChangelogPath, "utf8");
+    const dependentChangelogPath = path.join(dependentPkgDir, "CHANGELOG.md");
+    const dependentChangelog = await fs.readFile(
+      dependentChangelogPath,
+      "utf8",
+    );
 
-  expect(dependentChangelog).toMatchInlineSnapshot(`
+    expect(dependentChangelog).toMatchInlineSnapshot(`
     "# pkg-b
 
     ## 1.0.1
@@ -130,4 +134,7 @@ test("changesets getChangelogEntry hook", async () => {
     - Updated dependencies: \`pkg-a@1.1.0\`
     "
   `);
+  } finally {
+    await fs.remove(tempDir);
+  }
 });

--- a/patches/@changesets__apply-release-plan@7.1.1.patch
+++ b/patches/@changesets__apply-release-plan@7.1.1.patch
@@ -1,7 +1,7 @@
 diff --git a/dist/changesets-apply-release-plan.cjs.js b/dist/changesets-apply-release-plan.cjs.js
 --- a/dist/changesets-apply-release-plan.cjs.js
 +++ b/dist/changesets-apply-release-plan.cjs.js
-@@ -447,15 +447,61 @@ async function getNewChangelogEntry(releasesWithPackage, changesets, config, cwd
+@@ -447,15 +447,63 @@ async function getNewChangelogEntry(releasesWithPackage, changesets, config, cwd
    } else {
      throw new Error("Could not resolve changelog generation functions");
    }
@@ -37,9 +37,11 @@ diff --git a/dist/changesets-apply-release-plan.cjs.js b/dist/changesets-apply-r
 +          const peerDependencyVersionRange = (_release$packageJson$2 = release.packageJson.peerDependencies) === null || _release$packageJson$2 === void 0 ? void 0 : _release$packageJson$2[rel.name];
 +          const versionRange = dependencyVersionRange || peerDependencyVersionRange;
 +          const usesWorkspaceRange = versionRange === null || versionRange === void 0 ? void 0 : versionRange.startsWith("workspace:");
-+          return versionRange && (usesWorkspaceRange || validRange__default["default"](versionRange) !== null) && shouldUpdateDependencyBasedOnConfig({
++          return versionRange && (usesWorkspaceRange || validRange__default["default"](versionRange) !== null) && shouldUpdateDependencyBasedOnConfig(cwd, {
 +            type: rel.type,
-+            version: rel.newVersion
++            version: rel.newVersion,
++            oldVersion: rel.oldVersion,
++            dir: rel.dir
 +          }, {
 +            depVersionRange: versionRange,
 +            depType: dependencyVersionRange ? "dependencies" : "peerDependencies"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
 
 patchedDependencies:
   '@changesets/apply-release-plan@7.1.1':
-    hash: f29011b4c524844645e36619b9ff9456017c62b0591f411a98e3f4826ea22852
+    hash: 19cb6131207f59da50995e2f93d09dbcaccb346cdc696d59f1aa89e3114f6ac5
     path: patches/@changesets__apply-release-plan@7.1.1.patch
 
 importers:
@@ -42,7 +42,7 @@ importers:
         version: link:packages/ariakit-test
       '@changesets/apply-release-plan':
         specifier: 7.1.1
-        version: 7.1.1(patch_hash=f29011b4c524844645e36619b9ff9456017c62b0591f411a98e3f4826ea22852)
+        version: 7.1.1(patch_hash=19cb6131207f59da50995e2f93d09dbcaccb346cdc696d59f1aa89e3114f6ac5)
       '@changesets/cli':
         specifier: 2.31.0
         version: 2.31.0(@types/node@24.12.2)
@@ -12318,7 +12318,7 @@ snapshots:
     dependencies:
       fontkitten: 1.0.3
 
-  '@changesets/apply-release-plan@7.1.1(patch_hash=f29011b4c524844645e36619b9ff9456017c62b0591f411a98e3f4826ea22852)':
+  '@changesets/apply-release-plan@7.1.1(patch_hash=19cb6131207f59da50995e2f93d09dbcaccb346cdc696d59f1aa89e3114f6ac5)':
     dependencies:
       '@changesets/config': 3.1.4
       '@changesets/get-version-range-type': 0.4.0
@@ -12349,7 +12349,7 @@ snapshots:
 
   '@changesets/cli@2.31.0(@types/node@24.12.2)':
     dependencies:
-      '@changesets/apply-release-plan': 7.1.1(patch_hash=f29011b4c524844645e36619b9ff9456017c62b0591f411a98e3f4826ea22852)
+      '@changesets/apply-release-plan': 7.1.1(patch_hash=19cb6131207f59da50995e2f93d09dbcaccb346cdc696d59f1aa89e3114f6ac5)
       '@changesets/assemble-release-plan': 6.0.10
       '@changesets/changelog-git': 0.2.1
       '@changesets/config': 3.1.4


### PR DESCRIPTION
## Motivation

The release workflow was failing during `pnpm run version` when Changesets generated changelog entries for packages with internal dependency updates. The repo patch for `@changesets/apply-release-plan` called `shouldUpdateDependencyBasedOnConfig` with the wrong argument shape, which left the config parameter undefined and crashed changelog generation.

## Solution

Update the patch to pass the expected `cwd`, release metadata, dependency metadata, and config arguments through to `shouldUpdateDependencyBasedOnConfig`. Add regression coverage for a dependent package changelog entry so the custom `getChangelogEntry` path exercises internal dependency updates.

Validated with:

- `pnpm run version`
- `pnpm vitest run .changeset/get-changelog-entry-test.ts`
- `pnpm lint`