### PR TITLE
Stabilize CI performance test comparisons

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -331,21 +331,25 @@ jobs:
         # out runner-level noise (CPU governor, neighbor jobs) that a
         # sequential run would attribute entirely to one side. Baseline
         # failures are tolerated because new perf tests don't exist yet on
-        # the base branch.
+        # the base branch. `xvfb-run -a` picks the next free display number
+        # so back-to-back rounds in this job don't collide on `/tmp/.X99-lock`
+        # if a prior `xvfb-run` invocation hasn't finished tearing down its
+        # default display.
         run: |
+          rm -rf site/.perf-results "$BASELINE_DIR/site/.perf-results"
           mkdir -p site/.perf-results
           for i in $(seq 1 "$PERF_ROUNDS"); do
             echo "::group::Round $i — baseline"
             (cd "$BASELINE_DIR" && \
               PERF_RESULTS_FILE="baseline-$i.json" \
-              xvfb-run pnpm -F site run test-perf --pass-with-no-tests) || true
+              xvfb-run -a pnpm -F site run test-perf --pass-with-no-tests) || true
             cp "$BASELINE_DIR"/site/.perf-results/baseline-"$i"-*.json \
               site/.perf-results/ 2>/dev/null || true
             echo "::endgroup::"
 
             echo "::group::Round $i — current"
             PERF_RESULTS_FILE="current-$i.json" \
-              xvfb-run pnpm -F site run test-perf --pass-with-no-tests
+              xvfb-run -a pnpm -F site run test-perf --pass-with-no-tests
             echo "::endgroup::"
           done
 
@@ -360,6 +364,9 @@ jobs:
           name: perf-results
           path: site/.perf-results
           if-no-files-found: ignore
+          # `.perf-results` starts with a dot, so upload-artifact treats it as
+          # hidden and skips its contents unless this is set.
+          include-hidden-files: true
           retention-days: 7
 
       - name: Post or update PR comment

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -218,6 +218,15 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    env:
+      # Number of interleaved baseline/current rounds. Three rounds keeps the
+      # job under ~10 minutes while letting the agreement check filter out
+      # one-off CI hiccups.
+      PERF_ROUNDS: 3
+      # The baseline worktree shares `.git/config` with the main checkout, so
+      # husky's prepare step would otherwise rewrite `core.hooksPath` to a
+      # relative path under a temporary worktree that is removed at job end.
+      HUSKY: 0
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -232,17 +241,16 @@ jobs:
         with:
           engine: chromium
 
-      # --- Baseline (base branch) ---
-      - name: Checkout base branch
-        run: git checkout -f ${{ github.event.pull_request.base.sha }}
+      - name: Set up baseline worktree
+        run: |
+          BASELINE_DIR="$RUNNER_TEMP/perf-baseline"
+          echo "BASELINE_DIR=$BASELINE_DIR" >> "$GITHUB_ENV"
+          git worktree add --detach "$BASELINE_DIR" \
+            ${{ github.event.pull_request.base.sha }}
 
-      - name: Set up base environment
-        uses: ./.github/workflows/setup
-
-      - name: Install Playwright (base)
-        uses: ./.github/workflows/install-playwright
-        with:
-          engine: chromium
+      - name: Install baseline dependencies
+        working-directory: ${{ env.BASELINE_DIR }}
+        run: pnpm install --frozen-lockfile
 
       - name: Find base app artifact
         id: find-base-artifact
@@ -277,7 +285,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: app-dist
-          path: site/dist
+          path: ${{ env.BASELINE_DIR }}/site/dist
           github-token: ${{ github.token }}
           run-id: ${{ steps.find-base-artifact.outputs.run-id }}
 
@@ -288,42 +296,23 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: nextjs-dist
-          path: nextjs/.open-next
+          path: ${{ env.BASELINE_DIR }}/nextjs/.open-next
           github-token: ${{ github.token }}
           run-id: ${{ steps.find-base-artifact.outputs.run-id }}
 
       - name: Clean partial base artifacts
         if: steps.base-artifact.outcome != 'success' || steps.base-nextjs-artifact.outcome != 'success'
-        run: rm -rf site/dist nextjs/.open-next
+        run: rm -rf "$BASELINE_DIR/site/dist" "$BASELINE_DIR/nextjs/.open-next"
 
       - name: Build base app
         if: steps.base-artifact.outcome != 'success' || steps.base-nextjs-artifact.outcome != 'success'
+        working-directory: ${{ env.BASELINE_DIR }}
         run: pnpm -F site run build-lite
 
       - name: Build base Next.js app
         if: steps.base-artifact.outcome != 'success' || steps.base-nextjs-artifact.outcome != 'success'
+        working-directory: ${{ env.BASELINE_DIR }}
         run: pnpm -F nextjs run build-worker
-
-      - name: Run baseline perf tests
-        # Baseline failures are expected when perf tests are new.
-        run: |
-          PERF_RESULTS_FILE=baseline.json \
-          xvfb-run pnpm -F site run test-perf --pass-with-no-tests || true
-
-      - name: Save baseline results
-        run: |
-          mkdir -p /tmp/perf-baseline
-          cp site/.perf-results/baseline*.json /tmp/perf-baseline/ 2>/dev/null || true
-
-      # --- Current (merge commit) ---
-      - name: Checkout merge commit
-        run: git checkout -f ${{ github.sha }}
-
-      - name: Set up PR environment
-        uses: ./.github/workflows/setup
-
-      - name: Clean base app artifacts
-        run: rm -rf site/dist nextjs/.open-next
 
       - name: Download app artifact
         uses: actions/download-artifact@v8
@@ -337,19 +326,41 @@ jobs:
           name: nextjs-dist
           path: nextjs/.open-next
 
-      - name: Restore baseline results
+      - name: Run interleaved perf tests
+        # Alternating baseline and current within the same job lets us cancel
+        # out runner-level noise (CPU governor, neighbor jobs) that a
+        # sequential run would attribute entirely to one side. Baseline
+        # failures are tolerated because new perf tests don't exist yet on
+        # the base branch.
         run: |
           mkdir -p site/.perf-results
-          cp /tmp/perf-baseline/*.json site/.perf-results/ 2>/dev/null || true
+          for i in $(seq 1 "$PERF_ROUNDS"); do
+            echo "::group::Round $i — baseline"
+            (cd "$BASELINE_DIR" && \
+              PERF_RESULTS_FILE="baseline-$i.json" \
+              xvfb-run pnpm -F site run test-perf --pass-with-no-tests) || true
+            cp "$BASELINE_DIR"/site/.perf-results/baseline-"$i"-*.json \
+              site/.perf-results/ 2>/dev/null || true
+            echo "::endgroup::"
 
-      - name: Run current perf tests
-        run: |
-          PERF_RESULTS_FILE=current.json \
-          xvfb-run pnpm -F site run test-perf --pass-with-no-tests
+            echo "::group::Round $i — current"
+            PERF_RESULTS_FILE="current-$i.json" \
+              xvfb-run pnpm -F site run test-perf --pass-with-no-tests
+            echo "::endgroup::"
+          done
 
       - name: Compare results
         if: always()
         run: pnpm -F site run perf-compare
+
+      - name: Upload performance results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: perf-results
+          path: site/.perf-results
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: Post or update PR comment
         if: always()

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -329,22 +329,30 @@ jobs:
       - name: Run interleaved perf tests
         # Alternating baseline and current within the same job lets us cancel
         # out runner-level noise (CPU governor, neighbor jobs) that a
-        # sequential run would attribute entirely to one side. Baseline
-        # failures are tolerated because new perf tests don't exist yet on
-        # the base branch. `xvfb-run -a` picks the next free display number
-        # so back-to-back rounds in this job don't collide on `/tmp/.X99-lock`
-        # if a prior `xvfb-run` invocation hasn't finished tearing down its
-        # default display.
+        # sequential run would attribute entirely to one side. `xvfb-run -a`
+        # picks the next free display number so back-to-back rounds in this
+        # job don't collide on `/tmp/.X99-lock` if a prior `xvfb-run`
+        # invocation hasn't finished tearing down its default display.
+        # `--pass-with-no-tests` keeps the very-first-perf-test PR working
+        # because the base SHA simply has no perf files for Playwright to
+        # discover; an actual baseline failure (server crash, browser mismatch,
+        # truncated artifact) must still propagate so the PR comment doesn't
+        # publish a misleading comparison built on partial data. `nullglob`
+        # makes the round-N glob deterministic when the round produced no
+        # files instead of expanding to a literal pattern.
         run: |
+          shopt -s nullglob
           rm -rf site/.perf-results "$BASELINE_DIR/site/.perf-results"
           mkdir -p site/.perf-results
           for i in $(seq 1 "$PERF_ROUNDS"); do
             echo "::group::Round $i — baseline"
             (cd "$BASELINE_DIR" && \
               PERF_RESULTS_FILE="baseline-$i.json" \
-              xvfb-run -a pnpm -F site run test-perf --pass-with-no-tests) || true
-            cp "$BASELINE_DIR"/site/.perf-results/baseline-"$i"-*.json \
-              site/.perf-results/ 2>/dev/null || true
+              xvfb-run -a pnpm -F site run test-perf --pass-with-no-tests)
+            baseline_files=("$BASELINE_DIR"/site/.perf-results/baseline-"$i"-*.json)
+            if [ ${#baseline_files[@]} -gt 0 ]; then
+              cp "${baseline_files[@]}" site/.perf-results/
+            fi
             echo "::endgroup::"
 
             echo "::group::Round $i — current"
@@ -354,10 +362,11 @@ jobs:
           done
 
       - name: Compare results
-        if: always()
         run: pnpm -F site run perf-compare
 
       - name: Upload performance results
+        # `always()` so a failed comparison still uploads the raw
+        # `.perf-results` artifacts for debugging the failure.
         if: always()
         uses: actions/upload-artifact@v7
         with:
@@ -370,7 +379,6 @@ jobs:
           retention-days: 7
 
       - name: Post or update PR comment
-        if: always()
         uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.ARIAKIT_BOT_PAT }}

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -252,6 +252,18 @@ jobs:
         working-directory: ${{ env.BASELINE_DIR }}
         run: pnpm install --frozen-lockfile
 
+      - name: Install baseline Playwright browsers
+        working-directory: ${{ env.BASELINE_DIR }}
+        # The earlier `Install Playwright` step (composite) ran in the main
+        # checkout, so `~/.cache/ms-playwright` only has the current PR's
+        # browser revision. A PR that bumps `@playwright/test` would
+        # otherwise leave the baseline worktree with the wrong browser
+        # version and the baseline `test-perf` would fail before producing
+        # artifacts — exactly the dependency-only PR case this perf job is
+        # meant to make trustworthy. Install for the baseline lockfile too;
+        # the global cache then holds both revisions.
+        run: pnpm exec playwright install --with-deps chromium
+
       - name: Find base app artifact
         id: find-base-artifact
         continue-on-error: true

--- a/site/src/test-utils/perf-compare-test.ts
+++ b/site/src/test-utils/perf-compare-test.ts
@@ -1,0 +1,477 @@
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import type { PerfMetrics, PerfResult } from "./perf.ts";
+
+const resultsDir = ".perf-results";
+const scriptPath = path.join(import.meta.dirname, "perf-compare.ts");
+const tempDirs: string[] = [];
+
+interface MetricsInput {
+  scripting?: number;
+  layout?: number;
+  styleRecalc?: number;
+  painting?: number;
+  rendering?: number;
+  inp?: number;
+  total?: number;
+}
+
+function fillMetrics(input: MetricsInput): PerfMetrics {
+  const layout = input.layout ?? 0;
+  const styleRecalc = input.styleRecalc ?? 0;
+  const painting = input.painting ?? 0;
+  const rendering = input.rendering ?? layout + styleRecalc + painting;
+  const scripting = input.scripting ?? 0;
+  const total = input.total ?? scripting + rendering;
+  return {
+    scripting,
+    layout,
+    styleRecalc,
+    painting,
+    rendering,
+    inp: input.inp ?? 0,
+    total,
+  };
+}
+
+function createResult(
+  label: string,
+  metrics: MetricsInput,
+  testFile = "site/src/sandbox/example/perf-chrome.ts",
+): PerfResult {
+  return {
+    testFile,
+    testTitle: `${label} > ${testFile}`,
+    label,
+    metrics: fillMetrics(metrics),
+    raw: [fillMetrics(metrics)],
+  };
+}
+
+function createTempDir() {
+  const dir = realpathSync(mkdtempSync(path.join(tmpdir(), "ariakit-perf-")));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeJson(dir: string, name: string, data: unknown) {
+  const filePath = path.join(dir, resultsDir, name);
+  writeFileSync(filePath, JSON.stringify(data), "utf-8");
+}
+
+function runCompareSingle({
+  baseline,
+  current,
+}: {
+  baseline?: PerfResult[];
+  current?: PerfResult[];
+}) {
+  const dir = createTempDir();
+  const outputDir = path.join(dir, resultsDir);
+  mkdirSync(outputDir, { recursive: true });
+  if (baseline) {
+    writeJson(dir, "baseline-worker0.json", baseline);
+  }
+  if (current) {
+    writeJson(dir, "current-worker0.json", current);
+  }
+  execFileSync(process.execPath, [scriptPath], {
+    cwd: dir,
+    stdio: "pipe",
+  });
+  return readFileSync(path.join(outputDir, "comparison.md"), "utf-8");
+}
+
+function runCompareRounds({
+  baseline,
+  current,
+}: {
+  baseline: PerfResult[][];
+  current: PerfResult[][];
+}) {
+  const dir = createTempDir();
+  const outputDir = path.join(dir, resultsDir);
+  mkdirSync(outputDir, { recursive: true });
+  baseline.forEach((round, index) => {
+    writeJson(dir, `baseline-${index + 1}-worker0.json`, round);
+  });
+  current.forEach((round, index) => {
+    writeJson(dir, `current-${index + 1}-worker0.json`, round);
+  });
+  execFileSync(process.execPath, [scriptPath], {
+    cwd: dir,
+    stdio: "pipe",
+  });
+  return readFileSync(path.join(outputDir, "comparison.md"), "utf-8");
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("perf-compare", () => {
+  test("reports no significant changes when within threshold", () => {
+    const markdown = runCompareSingle({
+      baseline: [
+        createResult("toggle classes", { scripting: 100, total: 100 }),
+      ],
+      current: [createResult("toggle classes", { scripting: 105, total: 105 })],
+    });
+    expect(markdown).toContain("No significant performance changes detected.");
+    expect(markdown).not.toMatch(/% :warning:/);
+  });
+
+  test("flags a regression above the threshold", () => {
+    const markdown = runCompareSingle({
+      baseline: [
+        createResult("toggle classes", { scripting: 100, total: 100 }),
+      ],
+      current: [createResult("toggle classes", { scripting: 130, total: 130 })],
+    });
+    expect(markdown).toContain("+30%");
+    expect(markdown).toContain(":warning:");
+  });
+
+  test("flags an improvement above the threshold", () => {
+    const markdown = runCompareSingle({
+      baseline: [
+        createResult("toggle classes", { scripting: 100, total: 100 }),
+      ],
+      current: [createResult("toggle classes", { scripting: 70, total: 70 })],
+    });
+    expect(markdown).toContain("-30%");
+    expect(markdown).toContain(":rocket:");
+  });
+
+  test("does not flag tiny absolute changes that exceed the threshold", () => {
+    // The painting metric goes from 0.4ms → 0.6ms (50% but only 0.2ms). The
+    // floor blocks the warning so CDP quantization noise doesn't read as a
+    // regression. Total moves only 0.2ms so it stays quiet too.
+    const markdown = runCompareSingle({
+      baseline: [
+        createResult("tiny", {
+          scripting: 1,
+          painting: 0.4,
+          total: 1.4,
+        }),
+      ],
+      current: [
+        createResult("tiny", {
+          scripting: 1,
+          painting: 0.6,
+          total: 1.6,
+        }),
+      ],
+    });
+    expect(markdown).toContain("No significant performance changes detected.");
+    expect(markdown).not.toMatch(/% :warning:/);
+  });
+
+  test("does not flag sub-metric jitter when primary metrics stay flat", () => {
+    // Layout drops by 5ms while painting rises by 5ms; rendering and total
+    // both stay flat. Layout and painting are not primary metrics, so the
+    // jitter must not surface as a warning.
+    const markdown = runCompareSingle({
+      baseline: [
+        createResult("jitter", {
+          scripting: 100,
+          layout: 15,
+          painting: 5,
+          rendering: 20,
+          total: 120,
+        }),
+      ],
+      current: [
+        createResult("jitter", {
+          scripting: 100,
+          layout: 10,
+          painting: 10,
+          rendering: 20,
+          total: 120,
+        }),
+      ],
+    });
+    expect(markdown).toContain("No significant performance changes detected.");
+    expect(markdown).not.toMatch(/% :warning:/);
+  });
+
+  test("flags rendering when its sub-metrics combine into a real shift", () => {
+    const markdown = runCompareSingle({
+      baseline: [
+        createResult("render shift", {
+          scripting: 50,
+          layout: 20,
+          painting: 20,
+          rendering: 40,
+          total: 90,
+        }),
+      ],
+      current: [
+        createResult("render shift", {
+          scripting: 50,
+          layout: 30,
+          painting: 30,
+          rendering: 60,
+          total: 110,
+        }),
+      ],
+    });
+    expect(markdown).toContain(":warning:");
+    expect(markdown).toMatch(/Rendering.*\+50%/s);
+  });
+
+  test("does not flag a regression when rounds disagree on direction", () => {
+    const baselineRounds = [100, 100, 100, 100, 100].map((value) => [
+      createResult("noisy bench", { scripting: value, total: value }),
+    ]);
+    // Five rounds with a slim majority claiming regression and a couple of
+    // rounds going the other way. The median is a regression but rounds do
+    // not agree, so this must not be flagged.
+    const currentRounds = [130, 135, 90, 88, 132].map((value) => [
+      createResult("noisy bench", { scripting: value, total: value }),
+    ]);
+    const markdown = runCompareRounds({
+      baseline: baselineRounds,
+      current: currentRounds,
+    });
+    expect(markdown).toContain("No significant performance changes detected.");
+    expect(markdown).not.toMatch(/% :warning:/);
+    expect(markdown).toContain("Comparison spans 5 interleaved");
+  });
+
+  test("flags a consistent regression across rounds", () => {
+    const baselineRounds = [100, 102, 99, 101, 100].map((value) => [
+      createResult("consistent bench", { scripting: value, total: value }),
+    ]);
+    const currentRounds = [130, 128, 132, 129, 131].map((value) => [
+      createResult("consistent bench", { scripting: value, total: value }),
+    ]);
+    const markdown = runCompareRounds({
+      baseline: baselineRounds,
+      current: currentRounds,
+    });
+    expect(markdown).toContain(":warning:");
+    expect(markdown).toContain("+30%");
+  });
+
+  test("tolerates a single dissenting round when there are 5", () => {
+    const baselineRounds = [100, 100, 100, 100, 100].map((value) => [
+      createResult("robust bench", { scripting: value, total: value }),
+    ]);
+    // 4 of 5 rounds show a regression; 1 round shows a tiny noise gain.
+    const currentRounds = [130, 132, 95, 128, 134].map((value) => [
+      createResult("robust bench", { scripting: value, total: value }),
+    ]);
+    const markdown = runCompareRounds({
+      baseline: baselineRounds,
+      current: currentRounds,
+    });
+    expect(markdown).toContain(":warning:");
+  });
+
+  test("does not flag with two dissenters at five rounds", () => {
+    const baselineRounds = [100, 100, 100, 100, 100].map((value) => [
+      createResult("two-dissent bench", { scripting: value, total: value }),
+    ]);
+    // 3 of 5 regress, 2 disagree — beyond the single-dissenter tolerance.
+    const currentRounds = [130, 132, 128, 95, 92].map((value) => [
+      createResult("two-dissent bench", { scripting: value, total: value }),
+    ]);
+    const markdown = runCompareRounds({
+      baseline: baselineRounds,
+      current: currentRounds,
+    });
+    expect(markdown).toContain("No significant performance changes detected.");
+    expect(markdown).not.toMatch(/% :warning:/);
+  });
+
+  test("requires unanimity with three rounds", () => {
+    const baselineRounds = [100, 100, 100].map((value) => [
+      createResult("small-n bench", { scripting: value, total: value }),
+    ]);
+    // 2 of 3 regress; with only three rounds we require unanimity.
+    const currentRounds = [130, 132, 95].map((value) => [
+      createResult("small-n bench", { scripting: value, total: value }),
+    ]);
+    const markdown = runCompareRounds({
+      baseline: baselineRounds,
+      current: currentRounds,
+    });
+    expect(markdown).toContain("No significant performance changes detected.");
+    expect(markdown).not.toMatch(/% :warning:/);
+  });
+
+  test("flags a unanimous regression with three rounds", () => {
+    const baselineRounds = [100, 100, 100].map((value) => [
+      createResult("three-round bench", { scripting: value, total: value }),
+    ]);
+    const currentRounds = [128, 130, 132].map((value) => [
+      createResult("three-round bench", { scripting: value, total: value }),
+    ]);
+    const markdown = runCompareRounds({
+      baseline: baselineRounds,
+      current: currentRounds,
+    });
+    expect(markdown).toContain(":warning:");
+    expect(markdown).toContain("+30%");
+  });
+
+  test("aggregates from shared rounds when round counts differ", () => {
+    // Baseline has four rounds; current has only two. The unpaired baseline
+    // rounds (3-4) are far slower — if they leaked into the displayed
+    // baseline median the comparison would report an improvement instead of
+    // a regression.
+    const baselineRounds = [
+      [createResult("asymmetric", { scripting: 100, total: 100 })],
+      [createResult("asymmetric", { scripting: 100, total: 100 })],
+      [createResult("asymmetric", { scripting: 200, total: 200 })],
+      [createResult("asymmetric", { scripting: 200, total: 200 })],
+    ];
+    const currentRounds = [
+      [createResult("asymmetric", { scripting: 130, total: 130 })],
+      [createResult("asymmetric", { scripting: 130, total: 130 })],
+    ];
+    const markdown = runCompareRounds({
+      baseline: baselineRounds,
+      current: currentRounds,
+    });
+    expect(markdown).toContain(":warning:");
+    expect(markdown).toContain("+30%");
+  });
+
+  test("reports renamed tests as new and removed", () => {
+    const markdown = runCompareSingle({
+      baseline: [createResult("old name", { scripting: 100, total: 100 })],
+      current: [createResult("new name", { scripting: 100, total: 100 })],
+    });
+    expect(markdown).toContain("### New tests (no baseline)");
+    expect(markdown).toContain("### Removed tests");
+    expect(markdown).toContain("- old name");
+    expect(markdown).toContain("new name");
+  });
+
+  test("reports a metric that goes from zero to non-trivial", () => {
+    const markdown = runCompareSingle({
+      baseline: [createResult("zero-to-nonzero", { scripting: 0, total: 0 })],
+      current: [createResult("zero-to-nonzero", { scripting: 5, total: 5 })],
+    });
+    expect(markdown).toContain(":warning:");
+  });
+
+  test("falls back to empty results for malformed JSON", () => {
+    const dir = createTempDir();
+    const outputDir = path.join(dir, resultsDir);
+    mkdirSync(outputDir, { recursive: true });
+    writeFileSync(path.join(outputDir, "baseline-worker0.json"), "{", "utf-8");
+    writeJson(dir, "current-worker0.json", [
+      createResult("bench", { scripting: 100, total: 100 }),
+    ]);
+    execFileSync(process.execPath, [scriptPath], {
+      cwd: dir,
+      stdio: "pipe",
+    });
+    const markdown = readFileSync(
+      path.join(outputDir, "comparison.md"),
+      "utf-8",
+    );
+    expect(markdown).toContain("No baseline results available for comparison.");
+  });
+
+  test("ignores unrelated round files when discovering numbered rounds", () => {
+    // Even though `current-1-worker0.json` exists for some other prefix
+    // (e.g., another concurrent run) `baseline-worker0.json` is the only
+    // file matching prefix=baseline, so the legacy single-round path kicks in.
+    const dir = createTempDir();
+    const outputDir = path.join(dir, resultsDir);
+    mkdirSync(outputDir, { recursive: true });
+    writeJson(dir, "baseline-worker0.json", [
+      createResult("bench", { scripting: 100, total: 100 }),
+    ]);
+    writeJson(dir, "current-1-worker0.json", [
+      createResult("bench", { scripting: 130, total: 130 }),
+    ]);
+    execFileSync(process.execPath, [scriptPath], {
+      cwd: dir,
+      stdio: "pipe",
+    });
+    const markdown = readFileSync(
+      path.join(outputDir, "comparison.md"),
+      "utf-8",
+    );
+    expect(markdown).toContain(":warning:");
+    expect(markdown).toContain("+30%");
+  });
+
+  test("combines worker shards that report the same test in the same round", () => {
+    // Shouldn't happen today (`workers: 1` is forced for PERF_TEST), but the
+    // file naming scheme allows it. If the comparator silently dropped the
+    // second shard the median would be 200ms (worker0) instead of the median
+    // of [200, 100] = 150ms — exposing the regression as +50% instead of +30%.
+    const dir = createTempDir();
+    const outputDir = path.join(dir, resultsDir);
+    mkdirSync(outputDir, { recursive: true });
+    writeJson(dir, "baseline-1-worker0.json", [
+      createResult("shard", { scripting: 100, total: 100 }),
+    ]);
+    writeJson(dir, "baseline-1-worker1.json", [
+      createResult("shard", { scripting: 100, total: 100 }),
+    ]);
+    writeJson(dir, "current-1-worker0.json", [
+      createResult("shard", { scripting: 200, total: 200 }),
+    ]);
+    writeJson(dir, "current-1-worker1.json", [
+      createResult("shard", { scripting: 100, total: 100 }),
+    ]);
+    execFileSync(process.execPath, [scriptPath], {
+      cwd: dir,
+      stdio: "pipe",
+    });
+    const markdown = readFileSync(
+      path.join(outputDir, "comparison.md"),
+      "utf-8",
+    );
+    expect(markdown).toContain(":warning:");
+    expect(markdown).toContain("+50%");
+    expect(markdown).not.toContain("+100%");
+  });
+
+  test("warns when only one side has profile data for a test", () => {
+    const baselineWithProfile = createResult("profile-mismatch", {
+      scripting: 100,
+      total: 100,
+    });
+    baselineWithProfile.profiles = {
+      script: [
+        {
+          functionName: "expensive",
+          url: "src/example.ts",
+          line: 1,
+          column: 1,
+          selfTime: 50,
+          totalTime: 50,
+          hitCount: 5,
+        },
+      ],
+    };
+    const markdown = runCompareSingle({
+      baseline: [baselineWithProfile],
+      current: [
+        createResult("profile-mismatch", { scripting: 100, total: 100 }),
+      ],
+    });
+    expect(markdown).toContain("Profile data differs between baseline");
+    expect(markdown).toContain("profile-mismatch");
+  });
+});

--- a/site/src/test-utils/perf-compare-test.ts
+++ b/site/src/test-utils/perf-compare-test.ts
@@ -367,6 +367,76 @@ describe("perf-compare", () => {
     expect(markdown).toContain(":warning:");
   });
 
+  test("does not flag tests with no shared rounds", () => {
+    // Baseline ran only round 1, current ran only round 2. No round produced
+    // both sides, so cross-round medians would be the only comparison —
+    // exactly the runner-noise the rounds layout is supposed to filter. The
+    // test must surface as unpaired and never get a flag, even if the
+    // cross-round values look like a regression.
+    const dir = createTempDir();
+    const outputDir = path.join(dir, resultsDir);
+    mkdirSync(outputDir, { recursive: true });
+    writeJson(dir, "baseline-1-worker0.json", [
+      createResult("disjoint", { scripting: 100, total: 100 }),
+    ]);
+    writeJson(dir, "current-2-worker0.json", [
+      createResult("disjoint", { scripting: 130, total: 130 }),
+    ]);
+    execFileSync(process.execPath, [scriptPath], {
+      cwd: dir,
+      stdio: "pipe",
+    });
+    const markdown = readFileSync(
+      path.join(outputDir, "comparison.md"),
+      "utf-8",
+    );
+    expect(markdown).not.toMatch(/% :warning:/);
+    expect(markdown).toContain("Tests without paired rounds");
+    expect(markdown).toMatch(/disjoint.*\| 1 \| 2 \|/);
+    // Headline must reflect the unpaired state instead of falling through to
+    // "No performance results found." — the breakdown below contradicts that.
+    expect(markdown).toContain(
+      "No comparable rounds across baseline and current.",
+    );
+    expect(markdown).not.toContain("No performance results found.");
+  });
+
+  test("notes mixed paired-round counts in the footer", () => {
+    // One test has all three rounds paired; another has only the second
+    // round paired. The footer must call out the mixed counts so readers
+    // don't assume the agreement check spans the same number of rounds for
+    // every row.
+    const dir = createTempDir();
+    const outputDir = path.join(dir, resultsDir);
+    mkdirSync(outputDir, { recursive: true });
+    for (let i = 1; i <= 3; i++) {
+      writeJson(dir, `baseline-${i}-worker0.json`, [
+        createResult("full-rounds", { scripting: 100, total: 100 }),
+      ]);
+      writeJson(dir, `current-${i}-worker0.json`, [
+        createResult("full-rounds", { scripting: 100, total: 100 }),
+      ]);
+    }
+    writeJson(dir, "baseline-2-worker0.json", [
+      createResult("full-rounds", { scripting: 100, total: 100 }),
+      createResult("partial", { scripting: 100, total: 100 }),
+    ]);
+    writeJson(dir, "current-2-worker0.json", [
+      createResult("full-rounds", { scripting: 100, total: 100 }),
+      createResult("partial", { scripting: 100, total: 100 }),
+    ]);
+    execFileSync(process.execPath, [scriptPath], {
+      cwd: dir,
+      stdio: "pipe",
+    });
+    const markdown = readFileSync(
+      path.join(outputDir, "comparison.md"),
+      "utf-8",
+    );
+    expect(markdown).toContain("mix of paired baseline/current round counts");
+    expect(markdown).toMatch(/1.{1,3}3 rounds/);
+  });
+
   test("aggregates from shared rounds when round counts differ", () => {
     // Baseline has four rounds; current has only two. The unpaired baseline
     // rounds (3-4) are far slower — if they leaked into the displayed

--- a/site/src/test-utils/perf-compare-test.ts
+++ b/site/src/test-utils/perf-compare-test.ts
@@ -370,7 +370,11 @@ describe("perf-compare", () => {
     expect(markdown).toContain(":warning:");
   });
 
-  test("falls back to empty results for malformed JSON", () => {
+  test("hard-fails when a results file is malformed JSON", () => {
+    // Silently treating a corrupt artifact as missing input would surface as
+    // "No baseline results available" in the PR comment, hiding the real
+    // problem. The comparator must exit non-zero with the file path so CI
+    // fails loudly.
     const dir = createTempDir();
     const outputDir = path.join(dir, resultsDir);
     mkdirSync(outputDir, { recursive: true });
@@ -378,15 +382,12 @@ describe("perf-compare", () => {
     writeJson(dir, "current-worker0.json", [
       createResult("bench", { scripting: 100, total: 100 }),
     ]);
-    execFileSync(process.execPath, [scriptPath], {
-      cwd: dir,
-      stdio: "pipe",
-    });
-    const markdown = readFileSync(
-      path.join(outputDir, "comparison.md"),
-      "utf-8",
-    );
-    expect(markdown).toContain("No baseline results available for comparison.");
+    expect(() =>
+      execFileSync(process.execPath, [scriptPath], {
+        cwd: dir,
+        stdio: "pipe",
+      }),
+    ).toThrowError(/Failed to parse perf results/);
   });
 
   test("ignores unrelated round files when discovering numbered rounds", () => {

--- a/site/src/test-utils/perf-compare-test.ts
+++ b/site/src/test-utils/perf-compare-test.ts
@@ -367,6 +367,30 @@ describe("perf-compare", () => {
     expect(markdown).toContain(":warning:");
   });
 
+  test("counts zero-baseline rounds toward the agreement denominator", () => {
+    // Baseline `[0, 100]` and current `[0, 130]` median to `50ms → 65ms`
+    // (+30%). Only the second paired round provides agreeing direction; the
+    // first round is `0 → 0` and contributes nothing. With two paired rounds
+    // unanimity is required, so this must not flag — even though one round
+    // alone agrees with the median direction. Filtering the zero-baseline
+    // round out of the agreement check would shrink the denominator to one
+    // and let a single agreeing round pass.
+    const baselineRounds = [
+      [createResult("zero-baseline", { scripting: 0, total: 0 })],
+      [createResult("zero-baseline", { scripting: 100, total: 100 })],
+    ];
+    const currentRounds = [
+      [createResult("zero-baseline", { scripting: 0, total: 0 })],
+      [createResult("zero-baseline", { scripting: 130, total: 130 })],
+    ];
+    const markdown = runCompareRounds({
+      baseline: baselineRounds,
+      current: currentRounds,
+    });
+    expect(markdown).toContain("No significant performance changes detected.");
+    expect(markdown).not.toMatch(/% :warning:/);
+  });
+
   test("does not flag tests with no shared rounds", () => {
     // Baseline ran only round 1, current ran only round 2. No round produced
     // both sides, so cross-round medians would be the only comparison —

--- a/site/src/test-utils/perf-compare-test.ts
+++ b/site/src/test-utils/perf-compare-test.ts
@@ -328,6 +328,45 @@ describe("perf-compare", () => {
     expect(markdown).toContain("+30%");
   });
 
+  test("requires unanimity with two paired rounds", () => {
+    // With two rounds, accepting a single agreeing direction would let any
+    // disagreeing pair flag whatever way the median happens to fall — exactly
+    // the flip-flop the agreement check exists to filter. Bumping to N=2
+    // makes both rounds matter.
+    const baselineRounds = [
+      [createResult("two-round", { scripting: 100, total: 100 })],
+      [createResult("two-round", { scripting: 100, total: 100 })],
+    ];
+    // Round 1 regresses, round 2 improves — median is +15% but rounds
+    // disagree on direction.
+    const currentRounds = [
+      [createResult("two-round", { scripting: 150, total: 150 })],
+      [createResult("two-round", { scripting: 80, total: 80 })],
+    ];
+    const markdown = runCompareRounds({
+      baseline: baselineRounds,
+      current: currentRounds,
+    });
+    expect(markdown).toContain("No significant performance changes detected.");
+    expect(markdown).not.toMatch(/% :warning:/);
+  });
+
+  test("flags a unanimous regression with two paired rounds", () => {
+    const baselineRounds = [
+      [createResult("two-round-pass", { scripting: 100, total: 100 })],
+      [createResult("two-round-pass", { scripting: 100, total: 100 })],
+    ];
+    const currentRounds = [
+      [createResult("two-round-pass", { scripting: 130, total: 130 })],
+      [createResult("two-round-pass", { scripting: 132, total: 132 })],
+    ];
+    const markdown = runCompareRounds({
+      baseline: baselineRounds,
+      current: currentRounds,
+    });
+    expect(markdown).toContain(":warning:");
+  });
+
   test("aggregates from shared rounds when round counts differ", () => {
     // Baseline has four rounds; current has only two. The unpaired baseline
     // rounds (3-4) are far slower — if they leaked into the displayed
@@ -363,9 +402,12 @@ describe("perf-compare", () => {
   });
 
   test("reports a metric that goes from zero to non-trivial", () => {
+    // The from-zero branch needs a current value above MIN_DELTA_MS,
+    // otherwise the same floor that suppresses CDP quantization noise
+    // suppresses this case too.
     const markdown = runCompareSingle({
       baseline: [createResult("zero-to-nonzero", { scripting: 0, total: 0 })],
-      current: [createResult("zero-to-nonzero", { scripting: 5, total: 5 })],
+      current: [createResult("zero-to-nonzero", { scripting: 10, total: 10 })],
     });
     expect(markdown).toContain(":warning:");
   });

--- a/site/src/test-utils/perf-compare.ts
+++ b/site/src/test-utils/perf-compare.ts
@@ -21,9 +21,12 @@ const PROFILE_LIMIT = 10;
 // A metric must move by both this much in percent and at least MIN_DELTA_MS in
 // absolute terms before it is flagged. Without an absolute floor a 1ms metric
 // drifting to 1.2ms reads as a 20% regression even though the underlying
-// timing is well inside CDP's quantization noise.
+// timing is well inside CDP's quantization noise. The 5ms floor is wide enough
+// to cover CDP timer quantization (~1ms) plus the typical run-to-run jitter we
+// see on shared CI runners; values below it tend to be noise rather than
+// signal even on the primary metrics.
 const THRESHOLD_PERCENT = 10;
-const MIN_DELTA_MS = 1;
+const MIN_DELTA_MS = 5;
 
 type MetricKey = keyof PerfMetrics;
 
@@ -307,13 +310,14 @@ function aggregateByKey(rounds: RoundResult[]): Map<string, AggregatedResult> {
   return aggregated;
 }
 
-// Direction-of-change agreement check across rounds. Up to two rounds we fall
-// back to magnitude only — with so few samples a single noise round would
-// otherwise veto every flag, which is the failure mode this exists to avoid.
-// Three or four rounds require unanimity. Five or more rounds tolerate a
-// single dissenter so a one-off CI hiccup cannot block an alert.
+// Direction-of-change agreement check across rounds. With one round the
+// agreement check carries no signal and we fall back to magnitude only. From
+// two rounds up through four rounds we require unanimity — with so few
+// samples even a single dissenting round is enough to suspect noise. Five or
+// more rounds tolerate one dissenter so a single CI hiccup cannot veto a real
+// flag.
 function requiredAgreement(roundsCount: number) {
-  if (roundsCount <= 2) return 1;
+  if (roundsCount <= 1) return 1;
   if (roundsCount <= 4) return roundsCount;
   return roundsCount - 1;
 }

--- a/site/src/test-utils/perf-compare.ts
+++ b/site/src/test-utils/perf-compare.ts
@@ -62,6 +62,21 @@ interface ComparisonRow {
   perRoundPercents: number[];
   agreement: number;
   significant: boolean;
+  // Number of baseline/current round indices that paired up for this row's
+  // test. Tracked per-row instead of globally because different tests can
+  // produce different numbers of paired rounds when one side drops a round.
+  pairedRoundsCount: number;
+}
+
+// Tests where baseline and current never produced the same round index, so
+// no per-round comparison was possible. Listed separately rather than
+// silently compared via cross-round medians, which would reintroduce the
+// runner-noise the rounds layout exists to filter.
+interface UnpairedTest {
+  testFile: string;
+  label: string;
+  baselineRounds: number[];
+  currentRounds: number[];
 }
 
 interface ProfileModeMismatch {
@@ -79,7 +94,7 @@ interface ComparisonSummary {
   profileModeMismatches: ProfileModeMismatch[];
   newTests: AggregatedResult[];
   removedTests: AggregatedResult[];
-  pairedRoundsCount: number;
+  unpairedTests: UnpairedTest[];
 }
 
 interface PersistedComparisonSummary {
@@ -88,7 +103,7 @@ interface PersistedComparisonSummary {
   profileModeMismatches: ProfileModeMismatch[];
   newTests: PerfResult[];
   removedTests: PerfResult[];
-  pairedRoundsCount: number;
+  unpairedTests: UnpairedTest[];
 }
 
 // Metrics that can trigger a warning/rocket flag. Sub-metrics (layout,
@@ -372,7 +387,7 @@ function compare(): ComparisonSummary {
   const profileModeMismatches: ProfileModeMismatch[] = [];
   const newTests: AggregatedResult[] = [];
   const removedTests: AggregatedResult[] = [];
-  const pairedRoundIndices = new Set<number>();
+  const unpairedTests: UnpairedTest[] = [];
 
   for (const [key, cur] of current) {
     const base = baseline.get(key);
@@ -401,27 +416,37 @@ function compare(): ComparisonSummary {
       }
     }
     sharedRounds.sort((a, b) => a - b);
+
+    // No round produced both a baseline and current sample for this test.
+    // Comparing cross-round medians would silently feed runner noise into
+    // the report — exactly the failure mode the rounds layout was added to
+    // filter — so surface these tests as unpaired and skip flagging.
+    if (sharedRounds.length === 0) {
+      unpairedTests.push({
+        testFile: cur.testFile,
+        label: cur.label,
+        baselineRounds: [...base.byRound.keys()].sort((a, b) => a - b),
+        currentRounds: [...cur.byRound.keys()].sort((a, b) => a - b),
+      });
+      continue;
+    }
+
     const sharedBaseline: PerfResult[] = [];
     const sharedCurrent: PerfResult[] = [];
     for (const roundIndex of sharedRounds) {
       const baselineRound = base.byRound.get(roundIndex);
       const currentRound = cur.byRound.get(roundIndex);
       if (!baselineRound || !currentRound) continue;
-      pairedRoundIndices.add(roundIndex);
       sharedBaseline.push(baselineRound);
       sharedCurrent.push(currentRound);
     }
-    // Aggregate displayed baseline/current from shared rounds only. Otherwise
-    // an unpaired round can drag one side's median past the paired rounds and
-    // even flip the sign of the change relative to per-round percents.
-    const baselineMetrics =
-      sharedBaseline.length > 0
-        ? computeMedianMetrics(sharedBaseline)
-        : base.metrics;
-    const currentMetrics =
-      sharedCurrent.length > 0
-        ? computeMedianMetrics(sharedCurrent)
-        : cur.metrics;
+    // Aggregate displayed baseline/current from shared rounds only. An
+    // unpaired round on either side could otherwise drag one side's median
+    // past the paired rounds and even flip the sign of the change relative
+    // to per-round percents.
+    const baselineMetrics = computeMedianMetrics(sharedBaseline);
+    const currentMetrics = computeMedianMetrics(sharedCurrent);
+    const pairedRoundsCount = sharedBaseline.length;
 
     for (const metric of ALL_METRICS) {
       const baseVal = baselineMetrics[metric];
@@ -459,6 +484,7 @@ function compare(): ComparisonSummary {
         perRoundPercents,
         agreement,
         significant,
+        pairedRoundsCount,
       });
     }
   }
@@ -476,7 +502,7 @@ function compare(): ComparisonSummary {
     profileModeMismatches,
     newTests,
     removedTests,
-    pairedRoundsCount: pairedRoundIndices.size,
+    unpairedTests,
   };
 }
 
@@ -640,6 +666,21 @@ function formatDetailedBreakdown(
   return lines;
 }
 
+function formatPairedRoundsNote(counts: Set<number>): string | null {
+  if (counts.size === 0) return null;
+  if (counts.size === 1) {
+    const [count] = counts;
+    // Only worth pointing out the agreement check when there's more than one
+    // round per row — at one round per row the agreement check is auto-
+    // satisfied and the message would mislead.
+    if (count == null || count <= 1) return null;
+    return `Comparison spans ${count} interleaved baseline/current rounds; a change is flagged only when the median exceeds the threshold and the per-round directions agree.`;
+  }
+  const min = Math.min(...counts);
+  const max = Math.max(...counts);
+  return `Compared rows used a mix of paired baseline/current round counts (${min}–${max} rounds). Rows with fewer paired rounds carry weaker agreement signal — see the per-test breakdown for the count behind each row.`;
+}
+
 function formatMarkdown(summary: ComparisonSummary): string {
   const {
     rows,
@@ -648,7 +689,7 @@ function formatMarkdown(summary: ComparisonSummary): string {
     profileModeMismatches,
     newTests,
     removedTests,
-    pairedRoundsCount,
+    unpairedTests,
   } = summary;
   const currentByKey = new Map<string, AggregatedResult>();
   for (const result of currentResults) {
@@ -660,7 +701,12 @@ function formatMarkdown(summary: ComparisonSummary): string {
     rows.some((r) => rowKey(r) === key && r.significant),
   );
 
-  const totalTests = allKeys.length + newTests.length + removedTests.length;
+  const totalTests =
+    allKeys.length +
+    newTests.length +
+    removedTests.length +
+    unpairedTests.length;
+  const pairedRoundsCounts = new Set(rows.map((r) => r.pairedRoundsCount));
 
   const lines: string[] = [];
   lines.push("## Performance");
@@ -670,8 +716,18 @@ function formatMarkdown(summary: ComparisonSummary): string {
     lines.push(...formatSummaryTable(rows, significantKeys));
   } else if (rows.length === 0 && newTests.length > 0) {
     lines.push("No baseline results available for comparison.");
-  } else if (rows.length === 0 && newTests.length === 0) {
+  } else if (
+    rows.length === 0 &&
+    newTests.length === 0 &&
+    unpairedTests.length === 0
+  ) {
     lines.push("No performance results found.");
+  } else if (rows.length === 0 && unpairedTests.length > 0) {
+    // No row was comparable, but the run isn't empty — every test produced
+    // results on each side, just never in the same round. Surface that
+    // directly so the headline doesn't claim "no results found" while the
+    // breakdown lists tests below.
+    lines.push("No comparable rounds across baseline and current.");
   } else {
     lines.push("No significant performance changes detected.");
   }
@@ -714,16 +770,32 @@ function formatMarkdown(summary: ComparisonSummary): string {
     lines.push("");
   }
 
+  if (unpairedTests.length > 0) {
+    lines.push("### Tests without paired rounds");
+    lines.push("");
+    lines.push(
+      "Baseline and current never produced the same round index for these tests, so no change is flagged.",
+    );
+    lines.push("");
+    lines.push("| Test | Baseline rounds | Current rounds |");
+    lines.push("|------|-----------------|----------------|");
+    for (const result of unpairedTests) {
+      lines.push(
+        `| ${escapeTableCell(result.label)} | ${result.baselineRounds.join(", ") || "—"} | ${result.currentRounds.join(", ") || "—"} |`,
+      );
+    }
+    lines.push("");
+  }
+
   lines.push("</details>");
   lines.push("");
   lines.push(
     `:warning: = regression above ${THRESHOLD_PERCENT}% · :rocket: = improvement above ${THRESHOLD_PERCENT}%`,
   );
-  if (pairedRoundsCount > 1) {
+  const footerNote = formatPairedRoundsNote(pairedRoundsCounts);
+  if (footerNote) {
     lines.push("");
-    lines.push(
-      `Comparison spans ${pairedRoundsCount} interleaved baseline/current rounds; a change is flagged only when the median exceeds the threshold and the per-round directions agree.`,
-    );
+    lines.push(footerNote);
   }
 
   return lines.join("\n");
@@ -738,7 +810,7 @@ function toPersistedSummary(
     profileModeMismatches: summary.profileModeMismatches,
     newTests: summary.newTests.map(toPersistedResult),
     removedTests: summary.removedTests.map(toPersistedResult),
-    pairedRoundsCount: summary.pairedRoundsCount,
+    unpairedTests: summary.unpairedTests,
   };
 }
 

--- a/site/src/test-utils/perf-compare.ts
+++ b/site/src/test-utils/perf-compare.ts
@@ -59,7 +59,12 @@ interface ComparisonRow {
   current: number;
   delta: number;
   percent: number;
-  perRoundPercents: number[];
+  // Signed per-round deltas (current - baseline) for every shared round.
+  // Used for the agreement check so every paired round contributes a vote,
+  // including rounds where the baseline measured zero — those rounds still
+  // carry direction information and dropping them shrinks the denominator
+  // `requiredAgreement` sees.
+  perRoundDeltas: number[];
   agreement: number;
   significant: boolean;
   // Number of baseline/current round indices that paired up for this row's
@@ -343,7 +348,7 @@ interface SignificanceParams {
   percent: number;
   baseline: number;
   current: number;
-  perRoundPercents: number[];
+  perRoundDeltas: number[];
 }
 
 interface SignificanceResult {
@@ -352,11 +357,10 @@ interface SignificanceResult {
 }
 
 function computeSignificance(params: SignificanceParams): SignificanceResult {
-  const { metric, delta, percent, baseline, current, perRoundPercents } =
-    params;
+  const { metric, delta, percent, baseline, current, perRoundDeltas } = params;
   const direction = Math.sign(delta);
   let agreement = 0;
-  for (const value of perRoundPercents) {
+  for (const value of perRoundDeltas) {
     if (Math.sign(value) === direction) {
       agreement += 1;
     }
@@ -367,7 +371,7 @@ function computeSignificance(params: SignificanceParams): SignificanceResult {
   const magnitudeOk = Math.abs(percent) > THRESHOLD_PERCENT;
   const absoluteOk = Math.abs(delta) > MIN_DELTA_MS;
   const fromZeroOk = baseline === 0 && Math.abs(current) > MIN_DELTA_MS;
-  const enoughRounds = perRoundPercents.length;
+  const enoughRounds = perRoundDeltas.length;
   const agreementOk =
     enoughRounds === 0 || agreement >= requiredAgreement(enoughRounds);
   const significant =
@@ -453,17 +457,18 @@ function compare(): ComparisonSummary {
       const curVal = currentMetrics[metric];
       const delta = curVal - baseVal;
       const percent = baseVal > 0 ? (delta / baseVal) * 100 : 0;
-      const perRoundPercents: number[] = [];
+      // One signed delta per paired round, including rounds where baseline
+      // measured zero. Filtering zero-baseline rounds out shrinks the array
+      // `requiredAgreement` operates on and lets a 2-round row flag from a
+      // single agreeing round whenever one baseline sample is zero.
+      const perRoundDeltas: number[] = [];
       for (let i = 0; i < sharedBaseline.length; i++) {
         const baselineRoundEntry = sharedBaseline[i];
         const currentRoundEntry = sharedCurrent[i];
         if (!baselineRoundEntry || !currentRoundEntry) continue;
         const baselineRoundValue = baselineRoundEntry.metrics[metric];
         const currentRoundValue = currentRoundEntry.metrics[metric];
-        if (baselineRoundValue <= 0) continue;
-        perRoundPercents.push(
-          ((currentRoundValue - baselineRoundValue) / baselineRoundValue) * 100,
-        );
+        perRoundDeltas.push(currentRoundValue - baselineRoundValue);
       }
       const { agreement, significant } = computeSignificance({
         metric,
@@ -471,7 +476,7 @@ function compare(): ComparisonSummary {
         percent,
         baseline: baseVal,
         current: curVal,
-        perRoundPercents,
+        perRoundDeltas,
       });
       rows.push({
         testFile: cur.testFile,
@@ -481,7 +486,7 @@ function compare(): ComparisonSummary {
         current: curVal,
         delta,
         percent,
-        perRoundPercents,
+        perRoundDeltas,
         agreement,
         significant,
         pairedRoundsCount,

--- a/site/src/test-utils/perf-compare.ts
+++ b/site/src/test-utils/perf-compare.ts
@@ -122,17 +122,31 @@ const RENDERING_SUB_METRICS = new Set<MetricKey>([
 
 function readJsonFile(filePath: string): PerfResult[] {
   if (!existsSync(filePath)) return [];
+  // Hard-fail on parse errors. A truncated or malformed artifact otherwise
+  // surfaces as an empty side and the comparison silently degrades into "no
+  // baseline / new tests", masking the real cause.
+  let raw: string;
   try {
-    const parsed = JSON.parse(readFileSync(filePath, "utf-8"));
-    if (Array.isArray(parsed)) return parsed as PerfResult[];
-    return [];
+    raw = readFileSync(filePath, "utf-8");
   } catch (error) {
-    console.warn(
-      `Warning: failed to parse JSON file at ${filePath}. Falling back to empty results.`,
-      error,
-    );
-    return [];
+    throw new Error(`Failed to read perf results at ${filePath}`, {
+      cause: error,
+    });
   }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Failed to parse perf results at ${filePath}`, {
+      cause: error,
+    });
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      `Perf results at ${filePath} must be a JSON array, got ${typeof parsed}`,
+    );
+  }
+  return parsed as PerfResult[];
 }
 
 // Discover round files like `baseline-1-worker0.json`, `baseline-2-worker0.json`,

--- a/site/src/test-utils/perf-compare.ts
+++ b/site/src/test-utils/perf-compare.ts
@@ -6,12 +6,47 @@ import {
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
-import type { PerfMetrics, PerfResult } from "./perf.ts";
+import {
+  mergeScriptProfiles,
+  mergeSelectorProfiles,
+  type PerfMetrics,
+  type PerfProfiles,
+  type PerfResult,
+  type PerfScriptProfileEntry,
+  type PerfSelectorProfileEntry,
+} from "./perf.ts";
 
 const RESULTS_DIR = path.join(process.cwd(), ".perf-results");
+const PROFILE_LIMIT = 10;
+// A metric must move by both this much in percent and at least MIN_DELTA_MS in
+// absolute terms before it is flagged. Without an absolute floor a 1ms metric
+// drifting to 1.2ms reads as a 20% regression even though the underlying
+// timing is well inside CDP's quantization noise.
 const THRESHOLD_PERCENT = 10;
+const MIN_DELTA_MS = 1;
 
 type MetricKey = keyof PerfMetrics;
+
+interface RoundFile {
+  filePath: string;
+  roundIndex: number;
+}
+
+interface RoundResult {
+  roundIndex: number;
+  result: PerfResult;
+}
+
+interface AggregatedResult {
+  testFile: string;
+  testTitle: string;
+  label: string;
+  // Indexed by roundIndex so we can pair baseline and current entries from the
+  // same round even when one side is missing a round for some test.
+  byRound: Map<number, PerfResult>;
+  metrics: PerfMetrics;
+  profiles?: PerfProfiles;
+}
 
 interface ComparisonRow {
   testFile: string;
@@ -21,24 +56,9 @@ interface ComparisonRow {
   current: number;
   delta: number;
   percent: number;
+  perRoundPercents: number[];
+  agreement: number;
   significant: boolean;
-}
-
-interface ComparisonSummary {
-  rows: ComparisonRow[];
-  hasSignificantChanges: boolean;
-  currentResults: PerfResult[];
-  profileModeMismatches: ProfileModeMismatch[];
-  newTests: PerfResult[];
-  removedTests: PerfResult[];
-}
-
-interface PersistedComparisonSummary {
-  rows: ComparisonRow[];
-  hasSignificantChanges: boolean;
-  profileModeMismatches: ProfileModeMismatch[];
-  newTests: PerfResult[];
-  removedTests: PerfResult[];
 }
 
 interface ProfileModeMismatch {
@@ -49,10 +69,31 @@ interface ProfileModeMismatch {
   current: boolean;
 }
 
-// Primary metrics shown in the summary table.
+interface ComparisonSummary {
+  rows: ComparisonRow[];
+  hasSignificantChanges: boolean;
+  currentResults: AggregatedResult[];
+  profileModeMismatches: ProfileModeMismatch[];
+  newTests: AggregatedResult[];
+  removedTests: AggregatedResult[];
+  pairedRoundsCount: number;
+}
+
+interface PersistedComparisonSummary {
+  rows: ComparisonRow[];
+  hasSignificantChanges: boolean;
+  profileModeMismatches: ProfileModeMismatch[];
+  newTests: PerfResult[];
+  removedTests: PerfResult[];
+  pairedRoundsCount: number;
+}
+
+// Metrics that can trigger a warning/rocket flag. Sub-metrics (layout,
+// styleRecalc, painting) and inp are still shown in the breakdown for
+// debugging but they fluctuate enough at small absolute values that flagging
+// them produces too many false positives.
 const PRIMARY_METRICS: MetricKey[] = ["scripting", "rendering", "total"];
 
-// All metrics shown in the detailed breakdown.
 const ALL_METRICS: MetricKey[] = [
   "scripting",
   "rendering",
@@ -73,26 +114,352 @@ const METRIC_LABELS: Record<MetricKey, string> = {
   total: "Total",
 };
 
-// Rendering sub-metrics are indented in the detailed breakdown.
 const RENDERING_SUB_METRICS = new Set<MetricKey>([
   "layout",
   "styleRecalc",
   "painting",
 ]);
 
-function loadResults(prefix: string): PerfResult[] {
-  if (!existsSync(RESULTS_DIR)) return [];
-  const files = readdirSync(RESULTS_DIR)
-    .filter((f) => f.startsWith(prefix) && f.endsWith(".json"))
-    .sort();
-  const all: PerfResult[] = [];
-  for (const file of files) {
-    const data = JSON.parse(
-      readFileSync(path.join(RESULTS_DIR, file), "utf-8"),
+function readJsonFile(filePath: string): PerfResult[] {
+  if (!existsSync(filePath)) return [];
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, "utf-8"));
+    if (Array.isArray(parsed)) return parsed as PerfResult[];
+    return [];
+  } catch (error) {
+    console.warn(
+      `Warning: failed to parse JSON file at ${filePath}. Falling back to empty results.`,
+      error,
     );
-    all.push(...data);
+    return [];
   }
-  return all;
+}
+
+// Discover round files like `baseline-1-worker0.json`, `baseline-2-worker0.json`,
+// ... and expose each one's round number so per-round comparisons stay aligned
+// across baseline and current even if a round is missing on one side. Falls
+// back to single-round `baseline-worker*.json` (assigned roundIndex 1) so
+// existing single-run setups keep working.
+function discoverRoundFiles(prefix: string): RoundFile[] {
+  if (!existsSync(RESULTS_DIR)) return [];
+  const numbered: RoundFile[] = [];
+  const fallback: RoundFile[] = [];
+  for (const name of readdirSync(RESULTS_DIR)) {
+    if (!name.endsWith(".json")) continue;
+    const numberedMatch = name.match(/^(.+)-(\d+)-worker\d+\.json$/);
+    if (numberedMatch && numberedMatch[1] === prefix) {
+      numbered.push({
+        filePath: path.join(RESULTS_DIR, name),
+        roundIndex: Number(numberedMatch[2] ?? 0),
+      });
+      continue;
+    }
+    const singleMatch = name.match(/^(.+)-worker\d+\.json$/);
+    if (singleMatch && singleMatch[1] === prefix) {
+      fallback.push({
+        filePath: path.join(RESULTS_DIR, name),
+        roundIndex: 1,
+      });
+    }
+  }
+  if (numbered.length > 0) {
+    return numbered.sort((a, b) => a.roundIndex - b.roundIndex);
+  }
+  return fallback;
+}
+
+function loadRounds(prefix: string): RoundResult[] {
+  const discovered = discoverRoundFiles(prefix);
+  const out: RoundResult[] = [];
+  for (const { filePath, roundIndex } of discovered) {
+    for (const result of readJsonFile(filePath)) {
+      out.push({ roundIndex, result });
+    }
+  }
+  return out;
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  const midValue = sorted[mid];
+  if (midValue == null) return 0;
+  if (sorted.length % 2 !== 0) return midValue;
+  const prevValue = sorted[mid - 1];
+  if (prevValue == null) return midValue;
+  return (prevValue + midValue) / 2;
+}
+
+function computeMedianMetrics(results: PerfResult[]): PerfMetrics {
+  return {
+    scripting: median(results.map((r) => r.metrics.scripting)),
+    layout: median(results.map((r) => r.metrics.layout)),
+    styleRecalc: median(results.map((r) => r.metrics.styleRecalc)),
+    painting: median(results.map((r) => r.metrics.painting)),
+    rendering: median(results.map((r) => r.metrics.rendering)),
+    inp: median(results.map((r) => r.metrics.inp)),
+    total: median(results.map((r) => r.metrics.total)),
+  };
+}
+
+function mergeProfiles(results: PerfResult[]): PerfProfiles | undefined {
+  const scriptProfiles: PerfScriptProfileEntry[][] = [];
+  const selectorProfiles: PerfSelectorProfileEntry[][] = [];
+  for (const result of results) {
+    if (result.profiles?.script && result.profiles.script.length > 0) {
+      scriptProfiles.push(result.profiles.script);
+    }
+    if (result.profiles?.selectors && result.profiles.selectors.length > 0) {
+      selectorProfiles.push(result.profiles.selectors);
+    }
+  }
+  const profiles: PerfProfiles = {};
+  if (scriptProfiles.length > 0) {
+    profiles.script = mergeScriptProfiles(scriptProfiles, PROFILE_LIMIT);
+  }
+  if (selectorProfiles.length > 0) {
+    profiles.selectors = mergeSelectorProfiles(selectorProfiles, PROFILE_LIMIT);
+  }
+  if (
+    (profiles.script == null || profiles.script.length === 0) &&
+    (profiles.selectors == null || profiles.selectors.length === 0)
+  ) {
+    return;
+  }
+  return profiles;
+}
+
+function resultKey(testFile: string, label: string): string {
+  return `${testFile}::${label}`;
+}
+
+// Combine the worker shards that contributed to a single round into one
+// representative `PerfResult`. Today Playwright forces `workers: 1` whenever
+// `PERF_TEST=true` so this is single-pass, but the file naming scheme exposes
+// `worker\d+`, and a future config change could land multiple shards in the
+// same round. Without this, `aggregateByKey` would silently drop every shard
+// after the first.
+function combineWorkerShards(shards: PerfResult[]): PerfResult {
+  const first = shards[0];
+  if (!first) {
+    throw new Error("combineWorkerShards: expected at least one shard");
+  }
+  if (shards.length === 1) return first;
+  return {
+    testFile: first.testFile,
+    testTitle: first.testTitle,
+    label: first.label,
+    metrics: computeMedianMetrics(shards),
+    raw: shards.flatMap((s) => s.raw),
+    profiles: mergeProfiles(shards),
+  };
+}
+
+function aggregateByKey(rounds: RoundResult[]): Map<string, AggregatedResult> {
+  const grouped = new Map<string, Map<number, PerfResult[]>>();
+  for (const { roundIndex, result } of rounds) {
+    const key = resultKey(result.testFile, result.label);
+    let inner = grouped.get(key);
+    if (!inner) {
+      inner = new Map();
+      grouped.set(key, inner);
+    }
+    const shards = inner.get(roundIndex);
+    if (shards) {
+      shards.push(result);
+    } else {
+      inner.set(roundIndex, [result]);
+    }
+  }
+  const aggregated = new Map<string, AggregatedResult>();
+  for (const [key, byRound] of grouped) {
+    const collapsed = new Map<number, PerfResult>();
+    for (const [roundIndex, shards] of byRound) {
+      collapsed.set(roundIndex, combineWorkerShards(shards));
+    }
+    const entries = [...collapsed.values()];
+    const first = entries[0];
+    if (!first) continue;
+    aggregated.set(key, {
+      testFile: first.testFile,
+      testTitle: first.testTitle,
+      label: first.label,
+      byRound: collapsed,
+      metrics: computeMedianMetrics(entries),
+      profiles: mergeProfiles(entries),
+    });
+  }
+  return aggregated;
+}
+
+// Direction-of-change agreement check across rounds. Up to two rounds we fall
+// back to magnitude only — with so few samples a single noise round would
+// otherwise veto every flag, which is the failure mode this exists to avoid.
+// Three or four rounds require unanimity. Five or more rounds tolerate a
+// single dissenter so a one-off CI hiccup cannot block an alert.
+function requiredAgreement(roundsCount: number) {
+  if (roundsCount <= 2) return 1;
+  if (roundsCount <= 4) return roundsCount;
+  return roundsCount - 1;
+}
+
+interface SignificanceParams {
+  metric: MetricKey;
+  delta: number;
+  percent: number;
+  baseline: number;
+  current: number;
+  perRoundPercents: number[];
+}
+
+interface SignificanceResult {
+  agreement: number;
+  significant: boolean;
+}
+
+function computeSignificance(params: SignificanceParams): SignificanceResult {
+  const { metric, delta, percent, baseline, current, perRoundPercents } =
+    params;
+  const direction = Math.sign(delta);
+  let agreement = 0;
+  for (const value of perRoundPercents) {
+    if (Math.sign(value) === direction) {
+      agreement += 1;
+    }
+  }
+  if (!PRIMARY_METRICS.includes(metric)) {
+    return { agreement, significant: false };
+  }
+  const magnitudeOk = Math.abs(percent) > THRESHOLD_PERCENT;
+  const absoluteOk = Math.abs(delta) > MIN_DELTA_MS;
+  const fromZeroOk = baseline === 0 && Math.abs(current) > MIN_DELTA_MS;
+  const enoughRounds = perRoundPercents.length;
+  const agreementOk =
+    enoughRounds === 0 || agreement >= requiredAgreement(enoughRounds);
+  const significant =
+    (magnitudeOk && absoluteOk && agreementOk) || (fromZeroOk && agreementOk);
+  return { agreement, significant };
+}
+
+function hasProfile(result: AggregatedResult, profile: "script" | "selectors") {
+  return (result.profiles?.[profile]?.length ?? 0) > 0;
+}
+
+function compare(): ComparisonSummary {
+  const baseline = aggregateByKey(loadRounds("baseline"));
+  const current = aggregateByKey(loadRounds("current"));
+
+  const rows: ComparisonRow[] = [];
+  const profileModeMismatches: ProfileModeMismatch[] = [];
+  const newTests: AggregatedResult[] = [];
+  const removedTests: AggregatedResult[] = [];
+  const pairedRoundIndices = new Set<number>();
+
+  for (const [key, cur] of current) {
+    const base = baseline.get(key);
+    if (!base) {
+      newTests.push(cur);
+      continue;
+    }
+
+    for (const profile of ["script", "selectors"] as const) {
+      const baselineHas = hasProfile(base, profile);
+      const currentHas = hasProfile(cur, profile);
+      if (baselineHas === currentHas) continue;
+      profileModeMismatches.push({
+        testFile: cur.testFile,
+        label: cur.label,
+        profile,
+        baseline: baselineHas,
+        current: currentHas,
+      });
+    }
+
+    const sharedRounds: number[] = [];
+    for (const roundIndex of cur.byRound.keys()) {
+      if (base.byRound.has(roundIndex)) {
+        sharedRounds.push(roundIndex);
+      }
+    }
+    sharedRounds.sort((a, b) => a - b);
+    const sharedBaseline: PerfResult[] = [];
+    const sharedCurrent: PerfResult[] = [];
+    for (const roundIndex of sharedRounds) {
+      const baselineRound = base.byRound.get(roundIndex);
+      const currentRound = cur.byRound.get(roundIndex);
+      if (!baselineRound || !currentRound) continue;
+      pairedRoundIndices.add(roundIndex);
+      sharedBaseline.push(baselineRound);
+      sharedCurrent.push(currentRound);
+    }
+    // Aggregate displayed baseline/current from shared rounds only. Otherwise
+    // an unpaired round can drag one side's median past the paired rounds and
+    // even flip the sign of the change relative to per-round percents.
+    const baselineMetrics =
+      sharedBaseline.length > 0
+        ? computeMedianMetrics(sharedBaseline)
+        : base.metrics;
+    const currentMetrics =
+      sharedCurrent.length > 0
+        ? computeMedianMetrics(sharedCurrent)
+        : cur.metrics;
+
+    for (const metric of ALL_METRICS) {
+      const baseVal = baselineMetrics[metric];
+      const curVal = currentMetrics[metric];
+      const delta = curVal - baseVal;
+      const percent = baseVal > 0 ? (delta / baseVal) * 100 : 0;
+      const perRoundPercents: number[] = [];
+      for (let i = 0; i < sharedBaseline.length; i++) {
+        const baselineRoundEntry = sharedBaseline[i];
+        const currentRoundEntry = sharedCurrent[i];
+        if (!baselineRoundEntry || !currentRoundEntry) continue;
+        const baselineRoundValue = baselineRoundEntry.metrics[metric];
+        const currentRoundValue = currentRoundEntry.metrics[metric];
+        if (baselineRoundValue <= 0) continue;
+        perRoundPercents.push(
+          ((currentRoundValue - baselineRoundValue) / baselineRoundValue) * 100,
+        );
+      }
+      const { agreement, significant } = computeSignificance({
+        metric,
+        delta,
+        percent,
+        baseline: baseVal,
+        current: curVal,
+        perRoundPercents,
+      });
+      rows.push({
+        testFile: cur.testFile,
+        label: cur.label,
+        metric,
+        baseline: baseVal,
+        current: curVal,
+        delta,
+        percent,
+        perRoundPercents,
+        agreement,
+        significant,
+      });
+    }
+  }
+
+  for (const [key, base] of baseline) {
+    if (!current.has(key)) {
+      removedTests.push(base);
+    }
+  }
+
+  return {
+    rows,
+    hasSignificantChanges: rows.some((r) => r.significant),
+    currentResults: [...current.values()],
+    profileModeMismatches,
+    newTests,
+    removedTests,
+    pairedRoundsCount: pairedRoundIndices.size,
+  };
 }
 
 function formatMs(value: number): string {
@@ -119,93 +486,12 @@ function escapeTableCell(value: string): string {
     .trim();
 }
 
-function resultKey(result: PerfResult): string {
-  return `${result.testFile}::${result.label}`;
-}
-
-function hasProfile(result: PerfResult, profile: "script" | "selectors") {
-  return (result.profiles?.[profile]?.length ?? 0) > 0;
-}
-
-function compare(): ComparisonSummary {
-  const baseline = loadResults("baseline");
-  const current = loadResults("current");
-
-  const baselineByKey = new Map<string, PerfResult>();
-  for (const result of baseline) {
-    baselineByKey.set(resultKey(result), result);
-  }
-
-  const currentByKey = new Map<string, PerfResult>();
-  for (const result of current) {
-    currentByKey.set(resultKey(result), result);
-  }
-
-  const rows: ComparisonRow[] = [];
-  const profileModeMismatches: ProfileModeMismatch[] = [];
-  const newTests: PerfResult[] = [];
-  const removedTests: PerfResult[] = [];
-
-  for (const cur of current) {
-    const key = resultKey(cur);
-    const base = baselineByKey.get(key);
-    if (!base) {
-      newTests.push(cur);
-      continue;
-    }
-    for (const profile of ["script", "selectors"] as const) {
-      const baselineHasProfile = hasProfile(base, profile);
-      const currentHasProfile = hasProfile(cur, profile);
-      if (baselineHasProfile === currentHasProfile) continue;
-      profileModeMismatches.push({
-        testFile: cur.testFile,
-        label: cur.label,
-        profile,
-        baseline: baselineHasProfile,
-        current: currentHasProfile,
-      });
-    }
-    for (const metric of ALL_METRICS) {
-      const baseVal = base.metrics[metric];
-      const curVal = cur.metrics[metric];
-      const delta = curVal - baseVal;
-      const percent = baseVal > 0 ? (delta / baseVal) * 100 : 0;
-      // Flag as significant when percentage exceeds threshold, or when a
-      // metric goes from zero to a non-trivial value (> 1ms).
-      const significant =
-        Math.abs(percent) > THRESHOLD_PERCENT ||
-        (baseVal === 0 && Math.abs(curVal) > 1);
-      rows.push({
-        testFile: cur.testFile,
-        label: cur.label,
-        metric,
-        baseline: baseVal,
-        current: curVal,
-        delta,
-        percent,
-        significant,
-      });
-    }
-  }
-
-  for (const base of baseline) {
-    if (!currentByKey.has(resultKey(base))) {
-      removedTests.push(base);
-    }
-  }
-
-  return {
-    rows,
-    hasSignificantChanges: rows.some((r) => r.significant),
-    currentResults: current,
-    profileModeMismatches,
-    newTests,
-    removedTests,
-  };
-}
-
 function rowKey(row: ComparisonRow): string {
-  return `${row.testFile}::${row.label}`;
+  return resultKey(row.testFile, row.label);
+}
+
+function aggregatedKey(result: AggregatedResult): string {
+  return resultKey(result.testFile, result.label);
 }
 
 function formatSummaryTable(rows: ComparisonRow[], keys: string[]): string[] {
@@ -216,14 +502,14 @@ function formatSummaryTable(rows: ComparisonRow[], keys: string[]): string[] {
   for (const key of keys) {
     const testRows = rows.filter((r) => rowKey(r) === key);
     const label = testRows[0]?.label ?? key;
-    const cells: string[] = [label];
+    const cells: string[] = [escapeTableCell(label)];
     for (const metric of PRIMARY_METRICS) {
       const row = testRows.find((r) => r.metric === metric);
       if (!row) {
         cells.push("--");
         continue;
       }
-      let cell = `${formatMs(row.baseline)} \u2192 ${formatMs(row.current)}`;
+      let cell = `${formatMs(row.baseline)} → ${formatMs(row.current)}`;
       cell +=
         row.baseline === 0
           ? " (n/a)"
@@ -238,32 +524,28 @@ function formatSummaryTable(rows: ComparisonRow[], keys: string[]): string[] {
   return lines;
 }
 
-function formatScriptProfile(result: PerfResult): string[] {
+function formatScriptProfile(result: AggregatedResult): string[] {
   const profile = result.profiles?.script;
-  if (!profile) return [];
-  if (profile.length === 0) return [];
+  if (!profile || profile.length === 0) return [];
 
   const lines: string[] = [];
   lines.push("#### Script profile");
   lines.push("");
   lines.push("| Function | Self | Total | Hits | Source |");
   lines.push("|----------|------|-------|------|--------|");
-
   for (const item of profile) {
     const source = `${item.url}:${item.line}:${item.column}`;
     lines.push(
       `| ${escapeTableCell(item.functionName)} | ${formatMs(item.selfTime)} | ${formatMs(item.totalTime)} | ${item.hitCount} | ${escapeTableCell(source)} |`,
     );
   }
-
   lines.push("");
   return lines;
 }
 
-function formatSelectorProfile(result: PerfResult): string[] {
+function formatSelectorProfile(result: AggregatedResult): string[] {
   const profile = result.profiles?.selectors;
-  if (!profile) return [];
-  if (profile.length === 0) return [];
+  if (!profile || profile.length === 0) return [];
 
   const lines: string[] = [];
   lines.push("#### Selector profile");
@@ -274,18 +556,16 @@ function formatSelectorProfile(result: PerfResult): string[] {
   lines.push(
     "|----------|---------|----------|---------|----------------|------------|",
   );
-
   for (const item of profile) {
     lines.push(
       `| ${escapeTableCell(item.selector)} | ${formatMs(item.elapsed)} | ${item.matchAttempts} | ${item.matchCount} | ${formatPercent(item.slowPathNonMatchPercent)} | ${escapeTableCell(item.styleSheetUrl || item.styleSheetId)} |`,
     );
   }
-
   lines.push("");
   return lines;
 }
 
-function formatProfiles(result?: PerfResult): string[] {
+function formatProfiles(result?: AggregatedResult): string[] {
   if (!result) return [];
   return [...formatScriptProfile(result), ...formatSelectorProfile(result)];
 }
@@ -312,7 +592,7 @@ function formatProfileModeWarning(mismatches: ProfileModeMismatch[]): string[] {
 function formatDetailedBreakdown(
   rows: ComparisonRow[],
   keys: string[],
-  currentByKey: Map<string, PerfResult>,
+  currentByKey: Map<string, AggregatedResult>,
 ): string[] {
   const lines: string[] = [];
   for (const key of keys) {
@@ -350,10 +630,11 @@ function formatMarkdown(summary: ComparisonSummary): string {
     profileModeMismatches,
     newTests,
     removedTests,
+    pairedRoundsCount,
   } = summary;
-  const currentByKey = new Map<string, PerfResult>();
+  const currentByKey = new Map<string, AggregatedResult>();
   for (const result of currentResults) {
-    currentByKey.set(resultKey(result), result);
+    currentByKey.set(aggregatedKey(result), result);
   }
 
   const allKeys = [...new Set(rows.map((r) => rowKey(r)))];
@@ -390,14 +671,13 @@ function formatMarkdown(summary: ComparisonSummary): string {
     lines.push("| Test | Scripting | Rendering | Total |");
     lines.push("|------|-----------|-----------|-------|");
     for (const result of newTests) {
-      const cells: string[] = [result.label];
+      const cells: string[] = [escapeTableCell(result.label)];
       for (const metric of PRIMARY_METRICS) {
         cells.push(formatMs(result.metrics[metric]));
       }
       lines.push(`| ${cells.join(" | ")} |`);
     }
     lines.push("");
-
     for (const result of newTests) {
       const profileLines = formatProfiles(result);
       if (profileLines.length === 0) continue;
@@ -418,10 +698,15 @@ function formatMarkdown(summary: ComparisonSummary): string {
 
   lines.push("</details>");
   lines.push("");
-
   lines.push(
     `:warning: = regression above ${THRESHOLD_PERCENT}% · :rocket: = improvement above ${THRESHOLD_PERCENT}%`,
   );
+  if (pairedRoundsCount > 1) {
+    lines.push("");
+    lines.push(
+      `Comparison spans ${pairedRoundsCount} interleaved baseline/current rounds; a change is flagged only when the median exceeds the threshold and the per-round directions agree.`,
+    );
+  }
 
   return lines.join("\n");
 }
@@ -433,12 +718,23 @@ function toPersistedSummary(
     rows: summary.rows,
     hasSignificantChanges: summary.hasSignificantChanges,
     profileModeMismatches: summary.profileModeMismatches,
-    newTests: summary.newTests,
-    removedTests: summary.removedTests,
+    newTests: summary.newTests.map(toPersistedResult),
+    removedTests: summary.removedTests.map(toPersistedResult),
+    pairedRoundsCount: summary.pairedRoundsCount,
   };
 }
 
-// Main
+function toPersistedResult(result: AggregatedResult): PerfResult {
+  return {
+    testFile: result.testFile,
+    testTitle: result.testTitle,
+    label: result.label,
+    metrics: result.metrics,
+    raw: [...result.byRound.values()].flatMap((r) => r.raw),
+    profiles: result.profiles,
+  };
+}
+
 const summary = compare();
 const markdown = formatMarkdown(summary);
 

--- a/site/src/test-utils/perf.ts
+++ b/site/src/test-utils/perf.ts
@@ -7,9 +7,6 @@ const RESULTS_DIR = path.join(process.cwd(), ".perf-results");
 const DEFAULT_ITERATIONS = 10;
 const DEFAULT_WARMUP = 1;
 const DEFAULT_PROFILE_LIMIT = 10;
-// Idle barrier after the rAF×2 settle. Long enough for any deferred microtasks
-// to drain, short enough that it doesn't dominate iteration time.
-const IDLE_TIMEOUT_MS = 200;
 const initializedResultFiles = new Set<string>();
 
 // CDP metric names (values are in seconds).
@@ -189,45 +186,6 @@ function getMetricValue(
   const metric = metrics.find((m) => m.name === name);
   if (!metric) return 0;
   return metric.value;
-}
-
-/**
- * Resets the page to the given URL and waits for the DOM, fonts, and a couple
- * of frames to settle before returning. Replaces `networkidle`, which on
- * larger pages reliably wastes 2-3 seconds waiting on idle connections that
- * don't influence the measured interaction.
- *
- * Trade-off: this only waits on fonts already requested at the time
- * `document.fonts.ready` is awaited and does not gate on lazy-loaded images
- * or post-DCL prefetches. If a perf test interacts with content that pulls in
- * a fresh `@font-face` or a deferred image, the resulting layout cost can
- * leak into the measured interaction. Tests that need that wait should
- * trigger the load explicitly before calling `createPerfMeasure`.
- */
-async function navigateAndSettle(page: Page, url: string) {
-  await page.goto(url, { waitUntil: "domcontentloaded" });
-  await page.evaluate(async (idleTimeout) => {
-    await document.fonts?.ready?.catch(() => {});
-    await new Promise<void>((resolve) => {
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => resolve());
-      });
-    });
-    if (typeof requestIdleCallback === "function") {
-      await new Promise<void>((resolve) => {
-        requestIdleCallback(() => resolve(), { timeout: idleTimeout });
-      });
-    }
-  }, IDLE_TIMEOUT_MS);
-}
-
-/**
- * Runs the Chrome heap GC via CDP so allocations from the previous iteration
- * don't bleed into the next iteration's measurement. This is the same pass
- * DevTools uses; it doesn't require `--js-flags=--expose-gc`.
- */
-async function forceGarbageCollect(cdp: CDPSession) {
-  await cdp.send("HeapProfiler.collectGarbage").catch(() => {});
 }
 
 function median(values: number[]): number {
@@ -622,14 +580,6 @@ async function measureOnce(
     w.__perfObserver = observer;
   });
 
-  // Drain any allocations from a previous iteration so this measurement
-  // starts from a clean heap. Otherwise GC pauses can bleed into either the
-  // baseline or current side at random and inflate variance. The major GC
-  // does not collect the observer (it is rooted on `window.__perfObserver`)
-  // or its captured durations (we just reset `__perfInpEntries` to a fresh
-  // array above), so this call only frees previous-iteration garbage.
-  await forceGarbageCollect(cdp);
-
   let before: MetricsResponse | undefined;
   let selectorTrace: SelectorTraceSession | undefined;
   let scriptProfilerStarted = false;
@@ -803,7 +753,7 @@ export async function createPerfMeasure(
     for (let i = 0; i < warmup + iterations; i++) {
       if (resetPage) {
         // Re-navigate for a clean state on every iteration.
-        await navigateAndSettle(page, url);
+        await page.goto(url, { waitUntil: "networkidle" });
       }
 
       const result = await measureOnce(page, cdp, interaction, {

--- a/site/src/test-utils/perf.ts
+++ b/site/src/test-utils/perf.ts
@@ -7,6 +7,9 @@ const RESULTS_DIR = path.join(process.cwd(), ".perf-results");
 const DEFAULT_ITERATIONS = 10;
 const DEFAULT_WARMUP = 1;
 const DEFAULT_PROFILE_LIMIT = 10;
+// Idle barrier after the rAF×2 settle. Long enough for any deferred microtasks
+// to drain, short enough that it doesn't dominate iteration time.
+const IDLE_TIMEOUT_MS = 200;
 const initializedResultFiles = new Set<string>();
 
 // CDP metric names (values are in seconds).
@@ -186,6 +189,45 @@ function getMetricValue(
   const metric = metrics.find((m) => m.name === name);
   if (!metric) return 0;
   return metric.value;
+}
+
+/**
+ * Resets the page to the given URL and waits for the DOM, fonts, and a couple
+ * of frames to settle before returning. Replaces `networkidle`, which on
+ * larger pages reliably wastes 2-3 seconds waiting on idle connections that
+ * don't influence the measured interaction.
+ *
+ * Trade-off: this only waits on fonts already requested at the time
+ * `document.fonts.ready` is awaited and does not gate on lazy-loaded images
+ * or post-DCL prefetches. If a perf test interacts with content that pulls in
+ * a fresh `@font-face` or a deferred image, the resulting layout cost can
+ * leak into the measured interaction. Tests that need that wait should
+ * trigger the load explicitly before calling `createPerfMeasure`.
+ */
+async function navigateAndSettle(page: Page, url: string) {
+  await page.goto(url, { waitUntil: "domcontentloaded" });
+  await page.evaluate(async (idleTimeout) => {
+    await document.fonts?.ready?.catch(() => {});
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => resolve());
+      });
+    });
+    if (typeof requestIdleCallback === "function") {
+      await new Promise<void>((resolve) => {
+        requestIdleCallback(() => resolve(), { timeout: idleTimeout });
+      });
+    }
+  }, IDLE_TIMEOUT_MS);
+}
+
+/**
+ * Runs the Chrome heap GC via CDP so allocations from the previous iteration
+ * don't bleed into the next iteration's measurement. This is the same pass
+ * DevTools uses; it doesn't require `--js-flags=--expose-gc`.
+ */
+async function forceGarbageCollect(cdp: CDPSession) {
+  await cdp.send("HeapProfiler.collectGarbage").catch(() => {});
 }
 
 function median(values: number[]): number {
@@ -444,7 +486,7 @@ async function startSelectorTrace(
   };
 }
 
-function mergeScriptProfiles(
+export function mergeScriptProfiles(
   profiles: PerfScriptProfileEntry[][],
   limit: number,
 ): PerfScriptProfileEntry[] {
@@ -471,7 +513,7 @@ function mergeScriptProfiles(
     .slice(0, limit);
 }
 
-function mergeSelectorProfiles(
+export function mergeSelectorProfiles(
   profiles: PerfSelectorProfileEntry[][],
   limit: number,
 ): PerfSelectorProfileEntry[] {
@@ -579,6 +621,14 @@ async function measureOnce(
     observer.observe({ type: "event", buffered: false });
     w.__perfObserver = observer;
   });
+
+  // Drain any allocations from a previous iteration so this measurement
+  // starts from a clean heap. Otherwise GC pauses can bleed into either the
+  // baseline or current side at random and inflate variance. The major GC
+  // does not collect the observer (it is rooted on `window.__perfObserver`)
+  // or its captured durations (we just reset `__perfInpEntries` to a fresh
+  // array above), so this call only frees previous-iteration garbage.
+  await forceGarbageCollect(cdp);
 
   let before: MetricsResponse | undefined;
   let selectorTrace: SelectorTraceSession | undefined;
@@ -753,7 +803,7 @@ export async function createPerfMeasure(
     for (let i = 0; i < warmup + iterations; i++) {
       if (resetPage) {
         // Re-navigate for a clean state on every iteration.
-        await page.goto(url, { waitUntil: "networkidle" });
+        await navigateAndSettle(page, url);
       }
 
       const result = await measureOnce(page, cdp, interaction, {


### PR DESCRIPTION
## Motivation

PRs that don't touch runtime code (e.g. dependency-only updates such as #5898) were reporting 1–12% baseline-vs-current swings on the perf job. Two factors drove the noise:

1. Baseline and current measurements ran sequentially in the same job, so any runner-level event during one half — CPU governor changes, neighbor jobs on the host, GC pauses — landed entirely on that side and showed up as a regression or improvement.
2. Sub-metric jitter at small absolute values surfaced as flagged regressions even when the primary timings hadn't actually moved.

## Solution

Two independent changes that each reduce a different source of variance and compound when applied together:

- **Interleave rounds across a parallel worktree.** `PERF_ROUNDS=3` baseline/current rounds run within the same job. The baseline checkout lives in a `git worktree add --detach` directory so we don't have to swap branches between rounds. Runner-level noise now affects both sides roughly evenly. `HUSKY=0` is set in the perf job because the worktree shares `.git/config`, and we don't want husky to rewrite `core.hooksPath` mid-job.
- **Tighter significance gating.** Only `scripting`, `rendering`, and `total` can flag a regression. A flag requires >10% magnitude AND >5 ms absolute delta. Multi-round runs additionally require directional agreement: ≤4 rounds → unanimous, ≥5 → all-but-one. These thresholds live in `perf-compare.ts` constants and are covered by the test file.

CI also uploads each round's per-worker JSON as an artifact so post-mortem inspection is possible without re-running the job.

A `perf.ts` measurement-layer rewrite (force-GC via `HeapProfiler.collectGarbage` + a custom navigation helper that replaced `networkidle` with `domcontentloaded` + `fonts.ready` + 2× rAF + a short `requestIdleCallback`) was attempted in the original commit but had to be reverted in 039e31f4 — touching `perf.ts` in the same PR contaminates the baseline-vs-current comparison since baseline runs the old `perf.ts` and current runs the new one. That class of measurement-layer change has to land separately on `main` first, then get measured in a follow-up.

## Robustness fixes (review feedback)

- `readJsonFile` now hard-fails on read/parse errors and non-array shapes (e56745c4) so a truncated or malformed artifact surfaces as a real error instead of silently degrading the comparison into "no baseline / new tests".
- Tests with zero paired baseline/current rounds surface in a separate "Tests without paired rounds" section (45cc88d5) instead of being flagged from one-sided medians, with a new "No comparable rounds across baseline and current." headline for unpaired-only runs.
- Paired-round count is tracked per row (`pairedRoundsCount` on `ComparisonRow`) and the footer notes mixed counts when row counts differ (45cc88d5), instead of reporting a single global number.
- CI hardening (2ed63375): `xvfb-run -a` to avoid `/tmp/.X99-lock` collisions across rounds in the same job, wipe `site/.perf-results` (current and baseline worktree) before each run so leftover files can't poison `discoverRoundFiles`, and `include-hidden-files: true` on the artifact upload (the path starts with a dot).
- Agreement check tied to all paired rounds (ed31d5f5): switched `perRoundPercents` → `perRoundDeltas` so a 2-round row with one zero-baseline sample no longer collapses the denominator to one and flags from a single agreeing round. New regression test for `[0, 100]` vs `[0, 130]`.
- Workflow fail-fast on baseline collection (852c4662): dropped `|| true` from the baseline `xvfb-run`, replaced the silent `cp` with a `shopt -s nullglob` array-length guard, and removed `if: always()` from `Compare results` and `Post or update PR comment`. `Upload performance results` keeps `if: always()` for debugging artifacts.
- Baseline Playwright install (f97eb0b5): `pnpm exec playwright install --with-deps chromium` from `$BASELINE_DIR` after baseline `pnpm install`, so dependency-bump PRs install the baseline lockfile's browser revision into the shared `~/.cache/ms-playwright`.

## Test plan

- [x] `pnpm tsc` clean
- [x] `pnpm lint` clean
- [x] `pnpm test perf-compare` — 24 cases pass (threshold flagging, absolute-delta floor, sub-metric jitter rejection, agreement variants including unanimity at two rounds and the zero-baseline denominator regression test, asymmetric round counts, malformed-JSON hard failure, unpaired-only headline, mixed paired-round footer, profile-mode mismatch warning, shard combination)
- [ ] CI perf job runs with `PERF_ROUNDS=3` and reports stable comparisons for runtime-neutral PRs
