### PR TITLE
Remove minimum release age configuration

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,8 +15,6 @@ allowBuilds:
   sharp: true
   workerd: true
 
-minimumReleaseAge: 4320
-
 overrides:
   "@wordpress/components>@ariakit/react": "workspace:*"
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "minimumReleaseAge": "3 days",
   "semanticCommits": "disabled",
   "packageRules": [
     {


### PR DESCRIPTION
## Motivation

pnpm and Renovate should no longer delay dependency releases through minimum release age settings.

## Solution

Remove the `minimumReleaseAge` configuration from `pnpm-workspace.yaml` and `renovate.json` while leaving the rest of each configuration unchanged.

There is no `.npmrc` or `.pnpmrc` in this worktree, and a hidden-file scan found no remaining release-age configuration keys.