### PR TITLE
Update fs-extra

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "cross-env": "10.1.0",
     "cross-spawn": "7.0.6",
     "esbuild-plugin-solid": "0.6.0",
-    "fs-extra": "11.3.4",
+    "fs-extra": "11.3.5",
     "glob": "13.0.6",
     "husky": "9.1.7",
     "jsdom": "29.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,8 +96,8 @@ importers:
         specifier: 0.6.0
         version: 0.6.0(esbuild@0.27.4)(solid-js@1.9.12)
       fs-extra:
-        specifier: 11.3.4
-        version: 11.3.4
+        specifier: 11.3.5
+        version: 11.3.5
       glob:
         specifier: 13.0.6
         version: 13.0.6
@@ -6641,6 +6641,10 @@ packages:
 
   fs-extra@11.3.4:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
+    engines: {node: '>=14.14'}
+
+  fs-extra@11.3.5:
+    resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
     engines: {node: '>=14.14'}
 
   fs-extra@7.0.1:
@@ -16940,6 +16944,12 @@ snapshots:
   fresh@2.0.0: {}
 
   fs-extra@11.3.4:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.0
+      universalify: 2.0.1
+
+  fs-extra@11.3.5:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0


### PR DESCRIPTION
## Motivation

Keep the root development dependency `fs-extra` current with the latest patch release.

## Solution

Updated the root `fs-extra` devDependency from `11.3.4` to `11.3.5` and regenerated `pnpm-lock.yaml`. The `website` workspace remains unchanged because Renovate disables updates for `website/package.json`.

## Dependencies

| Package | From | To | Links |
| --- | --- | --- | --- |
| `fs-extra` | 11.3.4 | 11.3.5 | [changelog](https://github.com/jprichardson/node-fs-extra/blob/master/CHANGELOG.md) · [compare](https://github.com/jprichardson/node-fs-extra/compare/11.3.4...11.3.5) · [repo](https://github.com/jprichardson/node-fs-extra) |

`fs-extra` 11.3.5 is a patch release with fixes for `ensureLink*`/`ensureSymlink*` identical file detection on Windows, timestamp preservation error handling, and a potential file descriptor leak in synchronous timestamp preservation code. No Ariakit code changes were needed.