### PR TITLE
Update react-router

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -20,7 +20,7 @@
     "motion": "12.38.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-router": "7.14.2",
+    "react-router": "7.15.0",
     "react-shadow": "20.6.0",
     "react-toastify": "11.1.0",
     "textarea-caret": "3.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,8 +225,8 @@ importers:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
       react-router:
-        specifier: 7.14.2
-        version: 7.14.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 7.15.0
+        version: 7.15.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-shadow:
         specifier: 20.6.0
         version: 20.6.0(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -8697,8 +8697,8 @@ packages:
       '@types/react':
         optional: true
 
-  react-router@7.14.2:
-    resolution: {integrity: sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==}
+  react-router@7.15.0:
+    resolution: {integrity: sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -15102,7 +15102,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@24.12.3)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.10(@types/node@24.12.3)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.0)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@24.12.3)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.10(@types/node@24.12.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -19454,7 +19454,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  react-router@7.14.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router@7.15.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       cookie: 1.1.1
       react: 18.3.1


### PR DESCRIPTION
## Motivation

Keep the examples workspace on the latest React Router release covered by Renovate automerge rules.

## Solution

Updated `react-router` in `examples/package.json` from `7.14.2` to `7.15.0` and regenerated `pnpm-lock.yaml`. No code changes were needed.

## Dependencies

| Package | From | To | Links |
| --- | --- | --- | --- |
| `react-router` | `7.14.2` | `7.15.0` | [changelog](https://reactrouter.com/changelog#v7150) · [compare](https://github.com/remix-run/react-router/compare/react-router@7.14.2...react-router@7.15.0) · [npm](https://www.npmjs.com/package/react-router/v/7.15.0) |

React Router 7.15.0 stabilizes several previously unstable APIs and includes route matching performance improvements for Framework/Data Mode. The examples use browser routing APIs such as `MemoryRouter`, `Routes`, `Route`, `Link`, `useHref`, and `useLocation`; no migrated unstable APIs were found in this workspace.