### PR TITLE
Update Stripe

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -534,8 +534,8 @@ importers:
         specifier: 1.9.12
         version: 1.9.12
       stripe:
-        specifier: 22.1.0
-        version: 22.1.0(@types/node@24.12.3)
+        specifier: 22.1.1
+        version: 22.1.1(@types/node@24.12.3)
       tailwindcss:
         specifier: 4.2.4
         version: 4.2.4
@@ -9289,8 +9289,8 @@ packages:
     resolution: {integrity: sha512-aT2BU9KkizY9SATf14WhhYVv2uOapBWX0OFWF4xvcj1mPaNotlSc2CsxpS4DS46ZueSppmCF5BX1sNYBtwBvfw==}
     engines: {node: '>=12.*'}
 
-  stripe@22.1.0:
-    resolution: {integrity: sha512-w/xHyJGxXWnLPbNHG13sz/fae0MrFGC80Oz7YbICQymbfpqfEcsoG+6yG+9BWb81PWc4rrkeSO4wmTcmefmbLw==}
+  stripe@22.1.1:
+    resolution: {integrity: sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -20307,7 +20307,7 @@ snapshots:
       '@types/node': 24.12.2
       qs: 6.15.0
 
-  stripe@22.1.0(@types/node@24.12.3):
+  stripe@22.1.1(@types/node@24.12.3):
     optionalDependencies:
       '@types/node': 24.12.3
 

--- a/site/package.json
+++ b/site/package.json
@@ -94,7 +94,7 @@
     "rehype-parse": "9.0.1",
     "shiki": "4.0.2",
     "solid-js": "1.9.12",
-    "stripe": "22.1.0",
+    "stripe": "22.1.1",
     "tailwindcss": "4.2.4",
     "ts-morph": "28.0.0",
     "typescript": "6.0.3",


### PR DESCRIPTION
## Motivation

Keep the `site` workspace Stripe SDK current with the latest patch release.

## Solution

Updated `stripe` from 22.1.0 to 22.1.1 and regenerated the pnpm lockfile. No code changes were needed.

## Dependencies

| Package | From | To | Links |
| --- | --- | --- | --- |
| `stripe` | 22.1.0 | 22.1.1 | [release](https://github.com/stripe/stripe-node/releases/tag/v22.1.1) · [repo](https://github.com/stripe/stripe-node) |

Verification: `pnpm lint` passed with existing underscore warnings and clean formatting.