### PR TITLE
Group React updates in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -49,6 +49,10 @@
       "matchPackageNames": ["/^@radix-ui/"]
     },
     {
+      "groupName": "react",
+      "matchPackageNames": ["react", "react-dom"]
+    },
+    {
       "groupName": "vite",
       "matchPackageNames": ["vite", "/^@vitejs/"]
     },


### PR DESCRIPTION
## Motivation

Renovate currently treats `react` and `react-dom` as independent dependency updates. These runtime packages should stay in sync because they are released and consumed together.

## Solution

Add a Renovate package group for `react` and `react-dom`, preserving the existing automerge and major-version rules. This deliberately keeps the group scoped to the runtime packages; the existing type-package rules remain unchanged.