### PR TITLE
Allow missing perf baseline runs

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -349,16 +349,22 @@ jobs:
             local i="$1"
 
             echo "::group::Round $i - baseline"
-            (
-              cd "$BASELINE_DIR"
+            baseline_failed=0
+            if ! (
+              cd "$BASELINE_DIR" || exit 1
               PERF_RESULTS_FILE=baseline-$i.json \
               PERF_ITERATIONS="$PERF_ITERATIONS" \
               PERF_WARMUP="$PERF_WARMUP" \
               xvfb-run -a pnpm -F site run test-perf --pass-with-no-tests
-            )
+            ); then
+              echo "::warning::Baseline perf run failed for round $i; writing an empty baseline."
+              baseline_failed=1
+            fi
             baseline_files=("$BASELINE_DIR"/site/.perf-results/baseline-"$i"*.json)
-            if [ ${#baseline_files[@]} -eq 0 ]; then
-              echo "No baseline perf results for round $i; writing an empty baseline."
+            if [ "$baseline_failed" -eq 1 ] || [ ${#baseline_files[@]} -eq 0 ]; then
+              if [ "$baseline_failed" -eq 0 ]; then
+                echo "::warning::No baseline perf results for round $i; writing an empty baseline."
+              fi
               printf '[]\n' > site/.perf-results/baseline-"$i"-worker0.json
             else
               cp "${baseline_files[@]}" site/.perf-results/

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -349,7 +349,7 @@ jobs:
             local i="$1"
 
             echo "::group::Round $i - baseline"
-            baseline_failed=0
+            local baseline_failed=0
             if ! (
               cd "$BASELINE_DIR" || exit 1
               PERF_RESULTS_FILE=baseline-$i.json \
@@ -360,7 +360,7 @@ jobs:
               echo "::warning::Baseline perf run failed for round $i; writing an empty baseline."
               baseline_failed=1
             fi
-            baseline_files=("$BASELINE_DIR"/site/.perf-results/baseline-"$i"*.json)
+            local baseline_files=("$BASELINE_DIR"/site/.perf-results/baseline-"$i"*.json)
             if [ "$baseline_failed" -eq 1 ] || [ ${#baseline_files[@]} -eq 0 ]; then
               if [ "$baseline_failed" -eq 0 ]; then
                 echo "::warning::No baseline perf results for round $i; writing an empty baseline."
@@ -376,7 +376,7 @@ jobs:
             PERF_ITERATIONS="$PERF_ITERATIONS" \
             PERF_WARMUP="$PERF_WARMUP" \
             xvfb-run -a pnpm -F site run test-perf --pass-with-no-tests
-            current_files=(site/.perf-results/current-"$i"*.json)
+            local current_files=(site/.perf-results/current-"$i"*.json)
             if [ ${#current_files[@]} -eq 0 ]; then
               echo "Missing current perf results for round $i" >&2
               exit 1


### PR DESCRIPTION
## Motivation

The Performance job on #5890 failed while running the baseline worktree, before the workflow could reach its existing empty-baseline fallback. The failure was a baseline-side preview/test infrastructure timeout, not a current-branch performance failure, so increasing the Playwright timeout would only make the flaky path slower and still leave the workflow blocked when the baseline command exits nonzero.

## Solution

Wrap only the baseline perf command so a nonzero exit records a GitHub Actions warning and continues into the fallback path. If the baseline command fails, the workflow now writes an empty baseline result instead of copying any partial baseline files. The current-branch perf run remains strict and still fails the job when current results are missing.

The baseline worktree `cd` is also guarded explicitly so setup failures cannot accidentally run baseline-prefixed tests from the current checkout.

Validation:

- `git diff --check`
- `pnpm exec oxfmt --check .github/workflows/app.yml`