### PR TITLE
Improve Tailwind layer text lightness performance

### DIFF
--- a/.changeset/200-tailwind-layer-text-lightness.md
+++ b/.changeset/200-tailwind-layer-text-lightness.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/tailwind": patch
+---
+
+Improved layer and outline utility performance.

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -1162,7 +1162,7 @@ function getBaseDeclarations(sourceColor: string | VarProperty) {
       fn.lch(sourceColor, {
         l: fn.round(
           "down",
-          getLayerTextLightness(),
+          vars.layerTextLightness,
           LCH_QUANTIZED_LIGHTNESS_INTERVAL,
         ),
         c: 0,

--- a/packages/ariakit-tailwind/src/output.css
+++ b/packages/ariakit-tailwind/src/output.css
@@ -122,7 +122,7 @@
   --_ak-lbd: oklch(from var(--ak-layer) calc(0.5 + (var(--_ak-bdh) * -0.5) + (var(--_ak-bdl) * -0.25) + (var(--_ak-bll) * 0.25) + (var(--_ak-blh) * 0.5)) 0 0);
   --_ak-ls: oklch(from var(--ak-layer) var(--_ak-tfcl) 0 0);
   --_ak-ll: oklch(from var(--ak-layer) round(l, 0.125) 0 0);
-  --_ak-ltl: lch(from var(--ak-layer) round(down, clamp(0, (l + (c * 0.11 * clamp(0, ((20 - l) / 20), 1)) + ((c * 0.18 * clamp(0, ((l - 50) / 50), 1)) * -1)), 100), 3.125) 0 0);
+  --_ak-ltl: lch(from var(--ak-layer) round(down, var(--_ak-ltlv), 3.125) 0 0);
   --_ak-ct: calc((max(0, var(--contrast, 0)) / 100) * var(--_ak-contrast-scale));
   --_ak-cps: calc(1 + (var(--_ak-ct) * 3.334));
   --_ak-lcb: calc((var(--_ak-ct) * -1) * 0.3334 * var(--_ak-lod));
@@ -853,7 +853,7 @@
 
 @utility ak-outline {
   --_ak-ll: oklch(from var(--ak-layer) round(l, 0.125) 0 0);
-  --_ak-ltl: lch(from var(--ak-layer) round(down, clamp(0, (l + (c * 0.11 * clamp(0, ((20 - l) / 20), 1)) + ((c * 0.18 * clamp(0, ((l - 50) / 50), 1)) * -1)), 100), 3.125) 0 0);
+  --_ak-ltl: lch(from var(--ak-layer) round(down, var(--_ak-ltlv), 3.125) 0 0);
   outline-color: var(--ak-outline, canvastext);
   @container style(--_ak-ll) {
     --ak-outline: oklch(from oklch(from var(--_ak-outline-color, var(--ak-layer)) var(--_ak-outline-lightness, calc(l + var(--_ak-outline-relative-lightness))) var(--_ak-outline-chroma, calc(c + var(--_ak-outline-relative-chroma))) var(--_ak-outline-hue, calc(h + var(--_ak-outline-relative-hue)))) clamp(var(--_ak-outline-lightness-min), (l + (var(--_ak-opd) * max(0, (((var(--_ak-opl) + ((max(0.5, var(--_ak-outline-push-lightness)) + (var(--_ak-ct) * 0.3334)) * var(--_ak-opd))) - l) * var(--_ak-opd))))), var(--_ak-outline-lightness-max)) clamp(var(--_ak-outline-chroma-min), c, var(--_ak-outline-chroma-max, var(--chroma-p3-max, 0.368))) h);


### PR DESCRIPTION
**Motivation**

`@ariakit/tailwind` already registers the layer text lightness calculation as a private `@property`, but `ak-layer` and `ak-outline` still inlined the full color-channel expression when deriving `--_ak-ltl`. That repeats CSS color math on page load, where the Tailwind performance suite spends most of its time in style recalculation.

**Solution**

Reuse the existing `vars.layerTextLightness` property in `getBaseDeclarations` so the generated `ak-layer` and `ak-outline` utilities reference `var(--_ak-ltlv)` instead of duplicating the expression. The generated CSS keeps the original math in the `@property --_ak-ltlv` initial value, so computed-style snapshots stay unchanged.

Perf comparison from a fresh baseline/current run:

- Page load total: `3308.7ms -> 3204.7ms` (`-3%`, `-104.1ms`)
- Page load style recalc: `3233.2ms -> 3140.3ms` (`-92.9ms`)
- Toggle total: `1705.5ms -> 1781.7ms` (`+4%`, below the warning threshold)

Validation:

- `pnpm -F @ariakit/tailwind build`
- `SITE_PORT=4322 pnpm -F site test-perf ariakit-tailwind`
- `SITE_PORT=4322 pnpm -F site test-chrome ariakit-tailwind --grep-invert wcag`
- `SITE_PORT=4322 pnpm -F site test-chrome ariakit-tailwind -g wcag`
- `pnpm lint-fix`
- `pnpm tsc`
- `git diff --check`