### PR TITLE
Remove Tailwind layer invert utility

### DIFF
--- a/.changeset/300-tailwind-layer-invert.md
+++ b/.changeset/300-tailwind-layer-invert.md
@@ -1,0 +1,21 @@
+---
+"@ariakit/tailwind": patch
+---
+
+Removed `ak-layer-invert`
+
+**BREAKING** if you're using the `ak-layer-invert` utility.
+
+The `ak-layer-invert` utility has been removed. Use the [`ak-layer-l-*`](https://ariakit.com/styles#ak-layer) utility with a raw expression and the [`ak-layer-min-*`](https://ariakit.com/styles#ak-layer) lightness clamp instead.
+
+Before:
+
+```tsx
+<div className="ak-layer ak-layer-invert" />
+```
+
+After:
+
+```tsx
+<div className="ak-layer ak-layer-l-[calc(1-l)] ak-layer-min-25" />
+```

--- a/.changeset/300-tailwind-layer-invert.md
+++ b/.changeset/300-tailwind-layer-invert.md
@@ -6,7 +6,7 @@ Removed `ak-layer-invert`
 
 **BREAKING** if you're using the `ak-layer-invert` utility.
 
-The `ak-layer-invert` utility has been removed. Use the [`ak-layer-l-*`](https://ariakit.com/styles#ak-layer) utility with a raw expression and the [`ak-layer-min-*`](https://ariakit.com/styles#ak-layer) lightness clamp instead.
+The `ak-layer-invert` utility has been removed. Use the `ak-layer-l-*` utility with a raw expression and the `ak-layer-min-*` lightness clamp instead.
 
 Before:
 

--- a/packages/ariakit-tailwind/readme.md
+++ b/packages/ariakit-tailwind/readme.md
@@ -174,7 +174,6 @@ Use [`ak-edge`](#ak-edge) to fine-tune border and ring colors without touching t
 | `ak-layer-push-<number>`     | Minimum lightness shift (self-relative), jumping the forbidden mid-luminance range where contrast math becomes unreliable.                                             |
 | `ak-layer-contrast`          | Adapts the layer to contrast against its parent (preset `25`).                                                                                                         |
 | `ak-layer-contrast-<number>` | Custom contrast amount (`0`–`100`, default `25`).                                                                                                                      |
-| `ak-layer-invert`            | Inverts lightness (clamped so the result is never pure black).                                                                                                         |
 | `ak-layer-l-<value>`         | Sets absolute lightness (`0`–`100` for bare numbers, raw `0`–`1` for arbitrary/custom-property values).                                                                |
 | `ak-layer-max-<value>`       | Caps lightness (`0`–`100` for bare numbers, raw `0`–`1` for arbitrary/custom-property values) or caps chroma with a named chroma preset (`ak-layer-max-muted`).        |
 | `ak-layer-min-<value>`       | Floors lightness or chroma, same form as `max-*`.                                                                                                                      |

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -1528,12 +1528,6 @@ utility(
   set(inputs.layerH, getNumericTokenValue("[*]", HUE_TOKEN_OPTIONS)),
 );
 
-utility(
-  "layer-invert",
-  set(inputs.layerLMin, 0.25),
-  set(inputs.layerL, fn.invert(l)),
-);
-
 function getStateOffsetDeclarations() {
   const bareValue = getBarePercentTokenValue();
   const arbitraryValue = fn.value("[*]");

--- a/packages/ariakit-tailwind/src/output.css
+++ b/packages/ariakit-tailwind/src/output.css
@@ -370,11 +370,6 @@
   --_ak-layer-hue: --value(number, [*], "0", "15", "30", "45", "60", "75", "90", "105", "120", "135", "150", "165", "180", "195", "210", "225", "240", "255", "270", "285", "300", "315", "330", "345", "360");
 }
 
-@utility ak-layer-invert {
-  --_ak-layer-lightness-min: 0.25;
-  --_ak-layer-lightness: calc(1 - l);
-}
-
 @utility ak-state-* {
   --_ak-layer-lightness-offset-delta: calc((--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * var(--_ak-lod));
   --_ak-lobl: calc((l + var(--_ak-layer-lightness-offset-delta) + (clamp(0, (var(--_ak-layer-lightness-offset-delta) * 1000000), 1) * var(--_ak-llfb))) + (0 * (--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100)));

--- a/site/src/sandbox/ariakit-tailwind/index.react.tsx
+++ b/site/src/sandbox/ariakit-tailwind/index.react.tsx
@@ -122,7 +122,7 @@ function Layers() {
       </Layer>
       <Layer
         label="ak-layer-invert"
-        className="ak-layer ak-layer-invert ak-frame ak-frame-full/1 ak-frame-force ak-frame-border ak-edge-min-c-30 ak-edge-raw *:ak-text"
+        className="ak-layer ak-layer-l-[calc(1-l)] ak-layer-min-25 ak-frame ak-frame-full/1 ak-frame-force ak-frame-border ak-edge-min-c-30 ak-edge-raw *:ak-text"
       />
       <Layer
         label="ak-layer-darken-<number>"


### PR DESCRIPTION
## Motivation

`ak-layer-invert` duplicates behavior that can already be expressed with the lower-level layer lightness utilities. Removing it keeps `@ariakit/tailwind` smaller while still giving consumers an explicit migration path.

## Solution

Remove the `layer-invert` utility source and regenerated output CSS, and remove it from the README utility table.

The Ariakit Tailwind sandbox now uses `ak-layer-l-[calc(1-l)] ak-layer-min-25` in the existing `ak-layer-invert` row so the computed-style snapshots verify the replacement stays equivalent without snapshot churn.

The changeset documents the removal as a **BREAKING** patch change and includes the before/after migration.