### PR TITLE
Move layer push variable setup into push utilities

### DIFF
--- a/.changeset/300-tailwind-layer-push-perf.md
+++ b/.changeset/300-tailwind-layer-push-perf.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/tailwind": patch
+---
+
+Improved style-recalc performance of `ak-layer`, restoring fast utility toggling.

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -1179,6 +1179,10 @@ function getBaseDeclarations(sourceColor: string | VarProperty) {
   ];
 }
 
+// When push is inactive, blends to `lod`; when push is active, blends to the
+// push direction (`lipdtl*2 - 1`). The blend is declared inside `ak-layer` so
+// it survives the `!` modifier; `ak-layer-push-*` only sets the inputs
+// (`lipv`, `lipdtl`) that the `lcb` expression substitutes at use time.
 function getLayerIdleContrastBiasDirection() {
   const pushEnabled = fn.binary(vars.layerIdlePushValue);
   const pushDirection = fn.sub(
@@ -1198,12 +1202,6 @@ const layerMathDeclarations = [
   // contrast-scale math at each call site.
   set(vars.contrastT, fn.mul(globalContrastT, disabledVars.contrastScale)),
   set(vars.contrastPushScale, fn.add(1, fn.mul(vars.contrastT, 3.334))),
-  set(vars.layerIdlePushValue, getPushValue(inputs.layerIdlePushL)),
-  set(vars.layerPushDirectionToLight, vars.offsetDirectionToLight),
-  set(
-    vars.layerIdlePushDirectionToLight,
-    fn.binary(fn.mul(vars.layerIdlePushValue, vars.lightnessOffsetDirection)),
-  ),
   set(
     vars.layerContrastBias,
     fn.mul(
@@ -1326,18 +1324,8 @@ utility(
   getBaseDeclarations(vars.layer),
   layerMathDeclarations,
   layerColorDeclarations,
-  at.variant(
-    light,
-    set(vars.layerIdlePushDirectionToLight, 0),
-    set(vars.layerPushDirectionToLight, 0),
-    set(vars.edgePushDirection, -1),
-  ),
-  at.variant(
-    dark,
-    set(vars.layerIdlePushDirectionToLight, 1),
-    set(vars.layerPushDirectionToLight, 1),
-    set(vars.edgePushDirection, 1),
-  ),
+  at.variant(light, set(vars.edgePushDirection, -1)),
+  at.variant(dark, set(vars.edgePushDirection, 1)),
   layerContext(({ provide, inherit }) => [
     set(provide(vars.layerParentContext), vars.layer),
     set(provide(vars.layerEdgeContext), vars.edge),
@@ -1469,6 +1457,11 @@ utility(
 utility(
   "layer-push-*",
   getRawPercentDeclarations(inputs.layerIdlePushL),
+  set(vars.layerIdlePushValue, getPushValue(inputs.layerIdlePushL)),
+  set(
+    vars.layerIdlePushDirectionToLight,
+    fn.binary(fn.mul(vars.layerIdlePushValue, vars.lightnessOffsetDirection)),
+  ),
   set(vars.layerIdlePushOffsetL, getLayerIdleOffsetL()),
   set(
     vars.layerIdlePushBaseL,
@@ -1488,6 +1481,8 @@ utility(
     ),
   ),
   set(vars.layerIdlePushColor, getLayerIdlePushColor()),
+  at.variant(light, set(vars.layerIdlePushDirectionToLight, 0)),
+  at.variant(dark, set(vars.layerIdlePushDirectionToLight, 1)),
 );
 
 utility(
@@ -1625,6 +1620,7 @@ utility(
   "state-push-*",
   getRawPercentDeclarations(inputs.layerPushL),
   set(vars.layerPushValue, getPushValue(inputs.layerPushL)),
+  set(vars.layerPushDirectionToLight, vars.offsetDirectionToLight),
   set(
     vars.layerPushBaseL,
     getLayerL(fn.mul(vars.layerPushValue, vars.lightnessOffsetDirection)),
@@ -1637,6 +1633,8 @@ utility(
       vars.layerPushDirectionToLight,
     ),
   ),
+  at.variant(light, set(vars.layerPushDirectionToLight, 0)),
+  at.variant(dark, set(vars.layerPushDirectionToLight, 1)),
 );
 
 utility(

--- a/packages/ariakit-tailwind/src/output.css
+++ b/packages/ariakit-tailwind/src/output.css
@@ -125,9 +125,6 @@
   --_ak-ltl: lch(from var(--ak-layer) round(down, var(--_ak-ltlv), 3.125) 0 0);
   --_ak-ct: calc((max(0, var(--contrast, 0)) / 100) * var(--_ak-contrast-scale));
   --_ak-cps: calc(1 + (var(--_ak-ct) * 3.334));
-  --_ak-lipv: calc(var(--_ak-layer-idle-push-lightness) * var(--_ak-cps));
-  --_ak-lpdtl: var(--_ak-odtl);
-  --_ak-lipdtl: clamp(0, ((var(--_ak-lipv) * var(--_ak-lod)) * 1000000), 1);
   --_ak-lcb: calc((var(--_ak-ct) * -1) * 0.3334 * ((var(--_ak-lod) * (1 - clamp(0, (var(--_ak-lipv) * 1000000), 1))) + (((var(--_ak-lipdtl) * 2) - 1) * clamp(0, (var(--_ak-lipv) * 1000000), 1))));
   --_ak-fla: max(0.2, (var(--_ak-flab) - (var(--_ak-ct) * 0.35)));
   --_ak-flb: min(0.9, (var(--_ak-flbb) + (var(--_ak-ct) * 0.175)));
@@ -145,13 +142,9 @@
   --_ak-lo: oklch(from var(--_ak-lb) var(--_ak-layer-lightness-offset-resolved, calc(l + var(--_ak-layer-lightness-offset) + (clamp(0, (var(--_ak-layer-lightness-offset) * 1000000), 1) * var(--_ak-llfb)))) c h);
   --_ak-lp: oklch(from var(--_ak-lo) var(--_ak-lpl) c h);
   @variant ak-light {
-    --_ak-lipdtl: 0;
-    --_ak-lpdtl: 0;
     --_ak-epd: -1;
   }
   @variant ak-dark {
-    --_ak-lipdtl: 1;
-    --_ak-lpdtl: 1;
     --_ak-epd: 1;
   }
   @container (style(--_context-0: even)) or (not style(--_context-0)) {
@@ -255,10 +248,18 @@
 @utility ak-layer-push-* {
   --_ak-layer-idle-push-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-layer-idle-push-lightness: --value([*]);
+  --_ak-lipv: calc(var(--_ak-layer-idle-push-lightness) * var(--_ak-cps));
+  --_ak-lipdtl: clamp(0, ((var(--_ak-lipv) * var(--_ak-lod)) * 1000000), 1);
   --_ak-lipol: var(--_ak-layer-idle-lightness-offset-resolved, clamp(var(--_ak-layer-lightness-min), (l + var(--_ak-layer-idle-lightness-offset) + (clamp(0, (var(--_ak-layer-idle-lightness-offset) * 1000000), 1) * var(--_ak-llfb))), var(--_ak-layer-lightness-max)));
   --_ak-lipbl: clamp(var(--_ak-layer-lightness-min), (l + (var(--_ak-layer-idle-lightness-offset) + (var(--_ak-lipv) * var(--_ak-lod))) + (clamp(0, ((var(--_ak-layer-idle-lightness-offset) + (var(--_ak-lipv) * var(--_ak-lod))) * 1000000), 1) * var(--_ak-llfb))), var(--_ak-layer-lightness-max));
   --_ak-lipl: clamp(0, (var(--_ak-lipbl) + ((clamp(0, (min((var(--_ak-lipbl) - var(--_ak-fla)), (var(--_ak-flb) - var(--_ak-lipbl))) * 1000000), 1) * clamp(0, (var(--_ak-lipv) * 1000000), 1)) * ((var(--_ak-fla) + (var(--_ak-lipdtl) * var(--_ak-bw))) - var(--_ak-lipbl)))), 1);
   --_ak-lipc: oklch(from var(--_ak-lim) calc(var(--_ak-lipol) + (clamp(0, (var(--_ak-lipv) * 1000000), 1) * (var(--_ak-lipl) - var(--_ak-lipol)))) c h);
+  @variant ak-light {
+    --_ak-lipdtl: 0;
+  }
+  @variant ak-dark {
+    --_ak-lipdtl: 1;
+  }
 }
 
 @utility ak-layer-contrast {
@@ -409,8 +410,15 @@
   --_ak-layer-push-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-layer-push-lightness: --value([*]);
   --_ak-lpv: calc(var(--_ak-layer-push-lightness) * var(--_ak-cps));
+  --_ak-lpdtl: var(--_ak-odtl);
   --_ak-lpbl: calc(l + (var(--_ak-lpv) * var(--_ak-lod)) + (clamp(0, ((var(--_ak-lpv) * var(--_ak-lod)) * 1000000), 1) * var(--_ak-llfb)));
   --_ak-lpl: clamp(0, (var(--_ak-lpbl) + ((clamp(0, (min((var(--_ak-lpbl) - var(--_ak-fla)), (var(--_ak-flb) - var(--_ak-lpbl))) * 1000000), 1) * clamp(0, (var(--_ak-lpv) * 1000000), 1)) * ((var(--_ak-fla) + (var(--_ak-lpdtl) * var(--_ak-bw))) - var(--_ak-lpbl)))), 1);
+  @variant ak-light {
+    --_ak-lpdtl: 0;
+  }
+  @variant ak-dark {
+    --_ak-lpdtl: 1;
+  }
 }
 
 @utility ak-state-saturate-* {


### PR DESCRIPTION
## Motivation

PR #5947 ("Fix layer push lightness bounds") moved several push-related declarations into the base `ak-layer` utility — `--_ak-lipv`, `--_ak-lpdtl`, `--_ak-lipdtl`, plus light/dark variant overrides for both push direction variables. Because every layer in the document carries `ak-layer`, every layer paid that work, even when no push utility was applied. Toggling utility classes amplified the cost: in the `ariakit-tailwind` perf harness, the toggle test regressed (~+38% style recalc) and page load slowed too.

## Solution

The push direction variables and their variant overrides only meaningfully affect the layer color when push is active. Move them into the utilities that introduce push:

- `--_ak-lipv`, `--_ak-lipdtl` (and `@variant ak-light/ak-dark` overrides) → `ak-layer-push-*`.
- `--_ak-lpdtl` (and `@variant ak-light/ak-dark` overrides) → `ak-state-push-*`.

The contrast-bias blend `--_ak-lcb` stays declared inside `ak-layer`. Tailwind's `!` important modifier (`ak-layer!`) raises that declaration's specificity, so a push-utility override of `--_ak-lcb` could not reliably win the cascade. Keeping `--_ak-lcb` on `ak-layer` and feeding it via the input variables that the push utilities set works because CSS variable substitution happens at use time — the importance of the `--_ak-lcb` declaration does not affect how `var(--_ak-lipv)` and `var(--_ak-lipdtl)` resolve from whatever the push utilities set on the same element.

When no push utility is applied, `--_ak-lipv` and `--_ak-lipdtl` fall back to their `@property` initial value `0`, and the blend collapses to `-ct * 0.3334 * lod` — the same form as before PR #5947.

## Tradeoff

`ak-layer-push-*` and `ak-state-push-*` bodies grow slightly because they now host the moved declarations and variants. That weight is paid only on elements that opt into push, which is far fewer than the universe of `ak-layer` instantiations.

## Verification

- All 4 ariakit-tailwind sandbox snapshot tests pass (light, dark, light-high-contrast, dark-high-contrast).
- Both WCAG color-contrast tests pass.
- Perf harness against `codex/layer-lightness-final-bounds` baseline: `toggle layer and text classes` total -28% (3679ms → 2635ms, style recalc -29%), `page load` total -4% (3486ms → 3334ms, style recalc -4%).

## Test plan

- [ ] Sandbox snapshot tests pass on CI.
- [ ] Color contrast tests pass on CI.
- [ ] No regressions on the perf harness on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)