### PR TITLE
Add Renovate minimum release age

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "minimumReleaseAge": "3 days",
   "semanticCommits": "disabled",
   "packageRules": [
     {


### PR DESCRIPTION
**Motivation**

Renovate should wait before proposing dependency updates so newly published releases have a short stabilization window.

**Solution**

Set Renovate's top-level `minimumReleaseAge` option to `3 days` in the root `renovate.json` config. No pnpm settings or lockfiles are changed.

Validated with `renovate-config-validator`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update configuration to enforce a 3-day minimum release age before considering dependency updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ariakit/ariakit/pull/5961)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->