### PR TITLE
Add negated Ariakit Tailwind layer variants

### DIFF
--- a/.changeset/300-tailwind-not-layer-variants.md
+++ b/.changeset/300-tailwind-not-layer-variants.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/tailwind": patch
+---
+
+Added explicit `not-ak-*` layer appearance variants.

--- a/packages/ariakit-tailwind/readme.md
+++ b/packages/ariakit-tailwind/readme.md
@@ -522,6 +522,9 @@ These variants are scoped to an `ak-layer` container and match based on the laye
 | `ak-light-low`  | A light mid-tier.                    |
 | `ak-light-high` | The lightest tier.                   |
 
+Each layer appearance variant also has a `not-*` counterpart, such as
+`not-ak-dark`, `not-ak-light`, and `not-ak-dark-high`.
+
 ```html
 <div class="ak-layer ak-layer-canvas">
   <div class="ak-dark:ak-layer-darken-6 ak-light:ak-layer-lighten-6">
@@ -531,10 +534,14 @@ These variants are scoped to an `ak-layer` container and match based on the laye
   <div class="ak-dark-high:ak-edge-20 ak-light-high:ak-edge-10">
     Stronger edges on the darkest surfaces.
   </div>
+
+  <div class="not-ak-dark:ak-layer-lighten-6">
+    Applies inside this layer when the current layer is not dark.
+  </div>
 </div>
 ```
 
-> `ak-dark` / `ak-light` and their band variants require a parent `ak-layer`. They're implemented as `@container` style queries, so they silently fail to match outside a layer rather than falling back to a default.
+> `ak-dark` / `ak-light` and their band variants require a parent `ak-layer`. They're implemented as `@container` style queries, so they silently fail to match outside a layer rather than falling back to a default. Negated variants match whenever the queried layer value is absent or different, so wrap them in an `ak-layer` when relying on layer appearance.
 
 ### Accessibility
 

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -776,15 +776,39 @@ const dark = createVariant(
   at.container(fn.style(vars.layerScheme, "oklch(1 0 0)"), set("@slot")),
 );
 
+const notDark = createVariant(
+  "not-ak-dark",
+  at.container(
+    `not ${fn.style(vars.layerScheme, "oklch(1 0 0)")}`,
+    set("@slot"),
+  ),
+);
+
 const light = createVariant(
   "ak-light",
   at.container(fn.style(vars.layerScheme, "oklch(0 0 0)"), set("@slot")),
+);
+
+const notLight = createVariant(
+  "not-ak-light",
+  at.container(
+    `not ${fn.style(vars.layerScheme, "oklch(0 0 0)")}`,
+    set("@slot"),
+  ),
 );
 
 const darkHigh = createVariant(
   "ak-dark-high",
   at.container(
     fn.style(vars.layerBand, fn.oklch({ l: BAND_LEVEL_DARK_HIGH })),
+    set("@slot"),
+  ),
+);
+
+const notDarkHigh = createVariant(
+  "not-ak-dark-high",
+  at.container(
+    `not ${fn.style(vars.layerBand, fn.oklch({ l: BAND_LEVEL_DARK_HIGH }))}`,
     set("@slot"),
   ),
 );
@@ -797,6 +821,14 @@ const darkLow = createVariant(
   ),
 );
 
+const notDarkLow = createVariant(
+  "not-ak-dark-low",
+  at.container(
+    `not ${fn.style(vars.layerBand, fn.oklch({ l: BAND_LEVEL_DARK_LOW }))}`,
+    set("@slot"),
+  ),
+);
+
 const lightLow = createVariant(
   "ak-light-low",
   at.container(
@@ -805,10 +837,26 @@ const lightLow = createVariant(
   ),
 );
 
+const notLightLow = createVariant(
+  "not-ak-light-low",
+  at.container(
+    `not ${fn.style(vars.layerBand, fn.oklch({ l: BAND_LEVEL_LIGHT_LOW }))}`,
+    set("@slot"),
+  ),
+);
+
 const lightHigh = createVariant(
   "ak-light-high",
   at.container(
     fn.style(vars.layerBand, fn.oklch({ l: BAND_LEVEL_LIGHT_HIGH })),
+    set("@slot"),
+  ),
+);
+
+const notLightHigh = createVariant(
+  "not-ak-light-high",
+  at.container(
+    `not ${fn.style(vars.layerBand, fn.oklch({ l: BAND_LEVEL_LIGHT_HIGH }))}`,
     set("@slot"),
   ),
 );
@@ -2367,11 +2415,17 @@ export const input = [
   root,
   disabled,
   dark,
+  notDark,
   light,
+  notLight,
   darkHigh,
+  notDarkHigh,
   darkLow,
+  notDarkLow,
   lightLow,
+  notLightLow,
   lightHigh,
+  notLightHigh,
   ...utilities,
   ...Object.values(vars),
   ...Object.values(inputs),

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -778,10 +778,7 @@ const dark = createVariant(
 
 const notDark = createVariant(
   "not-ak-dark",
-  at.container(
-    `not ${fn.style(vars.layerScheme, "oklch(1 0 0)")}`,
-    set("@slot"),
-  ),
+  at.container.not(fn.style(vars.layerScheme, "oklch(1 0 0)"), set("@slot")),
 );
 
 const light = createVariant(
@@ -791,10 +788,7 @@ const light = createVariant(
 
 const notLight = createVariant(
   "not-ak-light",
-  at.container(
-    `not ${fn.style(vars.layerScheme, "oklch(0 0 0)")}`,
-    set("@slot"),
-  ),
+  at.container.not(fn.style(vars.layerScheme, "oklch(0 0 0)"), set("@slot")),
 );
 
 const darkHigh = createVariant(
@@ -807,8 +801,8 @@ const darkHigh = createVariant(
 
 const notDarkHigh = createVariant(
   "not-ak-dark-high",
-  at.container(
-    `not ${fn.style(vars.layerBand, fn.oklch({ l: BAND_LEVEL_DARK_HIGH }))}`,
+  at.container.not(
+    fn.style(vars.layerBand, fn.oklch({ l: BAND_LEVEL_DARK_HIGH })),
     set("@slot"),
   ),
 );
@@ -823,8 +817,8 @@ const darkLow = createVariant(
 
 const notDarkLow = createVariant(
   "not-ak-dark-low",
-  at.container(
-    `not ${fn.style(vars.layerBand, fn.oklch({ l: BAND_LEVEL_DARK_LOW }))}`,
+  at.container.not(
+    fn.style(vars.layerBand, fn.oklch({ l: BAND_LEVEL_DARK_LOW })),
     set("@slot"),
   ),
 );
@@ -839,8 +833,8 @@ const lightLow = createVariant(
 
 const notLightLow = createVariant(
   "not-ak-light-low",
-  at.container(
-    `not ${fn.style(vars.layerBand, fn.oklch({ l: BAND_LEVEL_LIGHT_LOW }))}`,
+  at.container.not(
+    fn.style(vars.layerBand, fn.oklch({ l: BAND_LEVEL_LIGHT_LOW })),
     set("@slot"),
   ),
 );
@@ -855,8 +849,8 @@ const lightHigh = createVariant(
 
 const notLightHigh = createVariant(
   "not-ak-light-high",
-  at.container(
-    `not ${fn.style(vars.layerBand, fn.oklch({ l: BAND_LEVEL_LIGHT_HIGH }))}`,
+  at.container.not(
+    fn.style(vars.layerBand, fn.oklch({ l: BAND_LEVEL_LIGHT_HIGH })),
     set("@slot"),
   ),
 );

--- a/packages/ariakit-tailwind/src/lib.ts
+++ b/packages/ariakit-tailwind/src/lib.ts
@@ -445,9 +445,14 @@ function variant(
   return atRule(AtRuleName.Variant, name, ...children);
 }
 
-function container(query: string, ...children: AtRuleChild[]): AtRule {
+function containerFn(query: string, ...children: AtRuleChild[]): AtRule {
   return atRule(AtRuleName.Container, query, ...children);
 }
+
+const container = Object.assign(containerFn, {
+  not: (query: string, ...children: AtRuleChild[]): AtRule =>
+    containerFn(`not ${query}`, ...children),
+});
 
 function supportsFn(query: string, ...children: AtRuleChild[]): AtRule {
   return atRule(AtRuleName.Supports, query, ...children);

--- a/packages/ariakit-tailwind/src/output.css
+++ b/packages/ariakit-tailwind/src/output.css
@@ -81,8 +81,20 @@
   }
 }
 
+@custom-variant not-ak-dark {
+  @container not style(--_ak-ls: oklch(1 0 0)) {
+    @slot;
+  }
+}
+
 @custom-variant ak-light {
   @container style(--_ak-ls: oklch(0 0 0)) {
+    @slot;
+  }
+}
+
+@custom-variant not-ak-light {
+  @container not style(--_ak-ls: oklch(0 0 0)) {
     @slot;
   }
 }
@@ -93,8 +105,20 @@
   }
 }
 
+@custom-variant not-ak-dark-high {
+  @container not style(--_ak-lbd: oklch(0 0 0)) {
+    @slot;
+  }
+}
+
 @custom-variant ak-dark-low {
   @container style(--_ak-lbd: oklch(0.25 0 0)) {
+    @slot;
+  }
+}
+
+@custom-variant not-ak-dark-low {
+  @container not style(--_ak-lbd: oklch(0.25 0 0)) {
     @slot;
   }
 }
@@ -105,8 +129,20 @@
   }
 }
 
+@custom-variant not-ak-light-low {
+  @container not style(--_ak-lbd: oklch(0.75 0 0)) {
+    @slot;
+  }
+}
+
 @custom-variant ak-light-high {
   @container style(--_ak-lbd: oklch(1 0 0)) {
+    @slot;
+  }
+}
+
+@custom-variant not-ak-light-high {
+  @container not style(--_ak-lbd: oklch(1 0 0)) {
     @slot;
   }
 }


### PR DESCRIPTION
## Motivation

Tailwind v4 currently generates invalid CSS when its automatic `not-*` variant is applied to custom variants backed by container style queries. This affects the `@ariakit/tailwind` layer appearance variants such as `ak-dark`, where `not-ak-dark:*` can be emitted as `@container style(...) not` instead of a valid negated style query.

## Solution

Add explicit `not-ak-*` custom variants for the layer appearance variants so consumers get valid `@container not style(...)` output without relying on Tailwind's automatic negation for these style queries.

This includes `not-ak-dark`, `not-ak-light`, `not-ak-dark-high`, `not-ak-dark-low`, `not-ak-light-low`, and `not-ak-light-high`, regenerates the published Tailwind input CSS, documents the negated variants, and adds a patch changeset.

## Verification

- `pnpm -F @ariakit/tailwind build`
- `pnpm lint-fix`
- Tailwind v4.3.0 smoke compile for all six `not-ak-*` layer variants
- `pnpm tsc`
- `pnpm test`
