### PR TITLE
Revert explicit Tailwind not variants

### DIFF
--- a/.changeset/300-tailwind-not-layer-variants.md
+++ b/.changeset/300-tailwind-not-layer-variants.md
@@ -1,5 +1,0 @@
----
-"@ariakit/tailwind": patch
----
-
-Added explicit `not-ak-*` layer appearance variants.

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -776,32 +776,14 @@ const dark = createVariant(
   at.container(fn.style(vars.layerScheme, "oklch(1 0 0)"), set("@slot")),
 );
 
-const notDark = createVariant(
-  "not-ak-dark",
-  at.container.not(fn.style(vars.layerScheme, "oklch(1 0 0)"), set("@slot")),
-);
-
 const light = createVariant(
   "ak-light",
   at.container(fn.style(vars.layerScheme, "oklch(0 0 0)"), set("@slot")),
 );
 
-const notLight = createVariant(
-  "not-ak-light",
-  at.container.not(fn.style(vars.layerScheme, "oklch(0 0 0)"), set("@slot")),
-);
-
 const darkHigh = createVariant(
   "ak-dark-high",
   at.container(
-    fn.style(vars.layerBand, fn.oklch({ l: BAND_LEVEL_DARK_HIGH })),
-    set("@slot"),
-  ),
-);
-
-const notDarkHigh = createVariant(
-  "not-ak-dark-high",
-  at.container.not(
     fn.style(vars.layerBand, fn.oklch({ l: BAND_LEVEL_DARK_HIGH })),
     set("@slot"),
   ),
@@ -815,14 +797,6 @@ const darkLow = createVariant(
   ),
 );
 
-const notDarkLow = createVariant(
-  "not-ak-dark-low",
-  at.container.not(
-    fn.style(vars.layerBand, fn.oklch({ l: BAND_LEVEL_DARK_LOW })),
-    set("@slot"),
-  ),
-);
-
 const lightLow = createVariant(
   "ak-light-low",
   at.container(
@@ -831,25 +805,9 @@ const lightLow = createVariant(
   ),
 );
 
-const notLightLow = createVariant(
-  "not-ak-light-low",
-  at.container.not(
-    fn.style(vars.layerBand, fn.oklch({ l: BAND_LEVEL_LIGHT_LOW })),
-    set("@slot"),
-  ),
-);
-
 const lightHigh = createVariant(
   "ak-light-high",
   at.container(
-    fn.style(vars.layerBand, fn.oklch({ l: BAND_LEVEL_LIGHT_HIGH })),
-    set("@slot"),
-  ),
-);
-
-const notLightHigh = createVariant(
-  "not-ak-light-high",
-  at.container.not(
     fn.style(vars.layerBand, fn.oklch({ l: BAND_LEVEL_LIGHT_HIGH })),
     set("@slot"),
   ),
@@ -2409,17 +2367,11 @@ export const input = [
   root,
   disabled,
   dark,
-  notDark,
   light,
-  notLight,
   darkHigh,
-  notDarkHigh,
   darkLow,
-  notDarkLow,
   lightLow,
-  notLightLow,
   lightHigh,
-  notLightHigh,
   ...utilities,
   ...Object.values(vars),
   ...Object.values(inputs),

--- a/packages/ariakit-tailwind/src/output.css
+++ b/packages/ariakit-tailwind/src/output.css
@@ -81,20 +81,8 @@
   }
 }
 
-@custom-variant not-ak-dark {
-  @container not style(--_ak-ls: oklch(1 0 0)) {
-    @slot;
-  }
-}
-
 @custom-variant ak-light {
   @container style(--_ak-ls: oklch(0 0 0)) {
-    @slot;
-  }
-}
-
-@custom-variant not-ak-light {
-  @container not style(--_ak-ls: oklch(0 0 0)) {
     @slot;
   }
 }
@@ -105,20 +93,8 @@
   }
 }
 
-@custom-variant not-ak-dark-high {
-  @container not style(--_ak-lbd: oklch(0 0 0)) {
-    @slot;
-  }
-}
-
 @custom-variant ak-dark-low {
   @container style(--_ak-lbd: oklch(0.25 0 0)) {
-    @slot;
-  }
-}
-
-@custom-variant not-ak-dark-low {
-  @container not style(--_ak-lbd: oklch(0.25 0 0)) {
     @slot;
   }
 }
@@ -129,20 +105,8 @@
   }
 }
 
-@custom-variant not-ak-light-low {
-  @container not style(--_ak-lbd: oklch(0.75 0 0)) {
-    @slot;
-  }
-}
-
 @custom-variant ak-light-high {
   @container style(--_ak-lbd: oklch(1 0 0)) {
-    @slot;
-  }
-}
-
-@custom-variant not-ak-light-high {
-  @container not style(--_ak-lbd: oklch(1 0 0)) {
     @slot;
   }
 }


### PR DESCRIPTION
## Motivation

Ariakit added explicit `not-ak-*` Tailwind layer appearance variants in #5967 to work around Tailwind generating invalid CSS for automatic negation of custom variants backed by container style queries.

That Tailwind bug has been fixed upstream and will be available in future Tailwind versions, so Ariakit no longer needs to ship duplicate explicit layer negation variants.

## Solution

Remove the explicit `not-ak-*` layer appearance variants from `@ariakit/tailwind` and regenerate the Tailwind input CSS.

This also removes the unreleased changeset entry that announced those explicit variants. The `at.container.not` helper and README documentation stay in place because Tailwind supports `not-*` variant syntax for the existing `ak-*` custom variants.

## Verification

- `pnpm -F @ariakit/tailwind build`
- `pnpm lint-fix`
- Pre-commit review gate

Tests were not added or run, per request.
