### PR TITLE
Fix nested Next.js preview IDs

### DIFF
--- a/app/src/lib/nextjs-test.ts
+++ b/app/src/lib/nextjs-test.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2025-present Ariakit FZ-LLC. All Rights Reserved.
+ *
+ * This software is proprietary. See the license.md file in the root of this
+ * package for licensing terms.
+ *
+ * SPDX-License-Identifier: UNLICENSED
+ */
+
+import { expect, test } from "vitest";
+import { getNextjsPreviewId } from "./nextjs.ts";
+
+test("getNextjsPreviewId handles root preview ids", () => {
+  expect(getNextjsPreviewId("/react/previews/tab-nextjs/")).toBe("tab-nextjs");
+  expect(getNextjsPreviewId("/react/previews/menu-nextjs-app-router")).toBe(
+    "menu-nextjs-app-router",
+  );
+});
+
+test("getNextjsPreviewId handles nested preview ids", () => {
+  expect(getNextjsPreviewId("/react/previews/sandbox/counter-nextjs/")).toBe(
+    "counter-nextjs",
+  );
+  expect(getNextjsPreviewId("/react/previews/sandbox/counter-nextjs")).toBe(
+    "counter-nextjs",
+  );
+});
+
+test("getNextjsPreviewId ignores non-Next.js preview ids", () => {
+  expect(getNextjsPreviewId("/react/previews/disclosure/")).toBeNull();
+  expect(getNextjsPreviewId("/react/previews/disclosure/nested/")).toBeNull();
+  expect(getNextjsPreviewId("/react/previews/nextjs/nested/")).toBeNull();
+});

--- a/app/src/lib/nextjs.ts
+++ b/app/src/lib/nextjs.ts
@@ -22,11 +22,13 @@ const NEXTJS_DEFAULT_PORT = "3000";
 /**
  * Regex pattern to match Next.js preview URLs.
  * Matches: /{framework}/previews/{example}/ where example contains "nextjs"
+ * and nested preview IDs such as /{framework}/previews/sandbox/{example}/
  * Examples:
  * - /react/previews/tab-nextjs/
  * - /react/previews/menu-nextjs-app-router/
  */
-const NEXTJS_PREVIEW_PATTERN = /^\/\w+\/previews\/([^/]*nextjs[^/]*)\/?$/i;
+const NEXTJS_PREVIEW_PATTERN =
+  /^\/\w+\/previews\/(?:.*\/)?([^/]*nextjs[^/]*)\/?$/i;
 
 // Next.js App Router convention files that should be auto-included in the
 // source plugin


### PR DESCRIPTION
## Motivation

Nested Next.js preview routes are handled by the SSR redirect path, but the preview ID matcher only recognizes root preview IDs. This means a URL such as `/react/previews/sandbox/counter-nextjs/` is not identified as a Next.js preview and cannot be redirected to the Next.js app.

## Solution

Update `getNextjsPreviewId` to capture the final Next.js preview segment after optional nested path segments, and add focused Vitest coverage for root, nested, no-trailing-slash, and non-Next.js preview paths.
