### PR TITLE
Stabilize OG image writebacks

### DIFF
--- a/.github/workflows/commit-or-pr/action.yml
+++ b/.github/workflows/commit-or-pr/action.yml
@@ -11,6 +11,13 @@ inputs:
   head-branch:
     description: Branch name when committing to existing PR
     required: true
+  expected-head-sha:
+    description: >
+      Expected current SHA for the head branch when committing to an existing
+      PR. When set, the action refuses to rebase generated changes onto a
+      different branch tip.
+    required: false
+    default: ""
   new-branch:
     description: Branch name when creating a new PR
     required: true
@@ -110,6 +117,7 @@ runs:
       env:
         GITHUB_REPOSITORY: ${{ github.repository }}
         HEAD_REF: ${{ inputs.head-branch }}
+        EXPECTED_HEAD_SHA: ${{ inputs.expected-head-sha }}
         GH_TOKEN: ${{ inputs.token != '' && inputs.token || steps.app-token.outputs.token != '' && steps.app-token.outputs.token || github.token }}
       # Rebase onto the latest branch tip so generated-file commits do not
       # fail just because another commit landed while the workflow was running.
@@ -143,7 +151,14 @@ runs:
         git remote set-url origin "https://github.com/$GITHUB_REPOSITORY.git"
         git remote set-url --push origin "https://github.com/$GITHUB_REPOSITORY.git"
         gh auth setup-git
-        git fetch origin "$HEAD_REF"
+        git fetch --no-tags origin "$HEAD_REF"
+        if [ -n "$EXPECTED_HEAD_SHA" ]; then
+          remote_sha="$(git rev-parse FETCH_HEAD)"
+          if [ "$remote_sha" != "$EXPECTED_HEAD_SHA" ]; then
+            echo "Branch advanced from $EXPECTED_HEAD_SHA to $remote_sha; refusing write-back." >&2
+            exit 1
+          fi
+        fi
         if ! git rebase "origin/$HEAD_REF"; then
           # `|| true` so a non-zero `--abort` (e.g., no in-progress rebase)
           # doesn't swallow the explicit diagnostic under `set -e`.

--- a/.github/workflows/og-images.yml
+++ b/.github/workflows/og-images.yml
@@ -95,6 +95,7 @@ jobs:
             exit 0
           fi
           echo "is_current=true" >> "$GITHUB_OUTPUT"
+          echo "local_sha=$local_sha" >> "$GITHUB_OUTPUT"
 
       - name: Commit or create PR
         if: >
@@ -110,6 +111,7 @@ jobs:
           event: ${{ github.event_name }}
           message: Update OG images
           head-branch: ${{ github.head_ref || github.ref_name }}
+          expected-head-sha: ${{ steps.branch.outputs.local_sha }}
           new-branch: chore/update-og-images
           paths: app/public/og-image
           app-client-id: ${{ vars.ARIAKIT_CI_APP_CLIENT_ID }}

--- a/.github/workflows/og-images.yml
+++ b/.github/workflows/og-images.yml
@@ -77,10 +77,30 @@ jobs:
           fi
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
 
-      - name: Commit or create PR
+      - name: Verify branch tip
+        id: branch
         if: >
           steps.patch.outputs.has_changes == 'true' &&
           env.WRITEBACK_ALLOWED == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          branch="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
+          git fetch --no-tags origin "$branch"
+          local_sha="$(git rev-parse HEAD)"
+          remote_sha="$(git rev-parse FETCH_HEAD)"
+          if [ "$local_sha" != "$remote_sha" ]; then
+            echo "Branch advanced from $local_sha to $remote_sha; skipping write-back."
+            echo "is_current=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "is_current=true" >> "$GITHUB_OUTPUT"
+
+      - name: Commit or create PR
+        if: >
+          steps.patch.outputs.has_changes == 'true' &&
+          env.WRITEBACK_ALLOWED == 'true' &&
+          steps.branch.outputs.is_current == 'true'
         uses: ./.github/workflows/commit-or-pr
         with:
           # This write-back step intentionally assumes PRs come from branches

--- a/app/src/pages/og-image/_generate-images.ts
+++ b/app/src/pages/og-image/_generate-images.ts
@@ -28,15 +28,35 @@ const MAX_SCREENSHOT_ATTEMPTS = 3;
 
 function isBlankImage(buffer: Buffer) {
   const image = PNG.sync.read(buffer);
-  const [red, green, blue, alpha] = image.data;
+  const pixels = image.data;
+  const red = pixels[0];
+  const green = pixels[1];
+  const blue = pixels[2];
+  const alpha = pixels[3];
+  if (red == null || green == null || blue == null || alpha == null) {
+    return false;
+  }
   let matchingPixels = 0;
   const totalPixels = image.width * image.height;
-  for (let i = 0; i < image.data.length; i += 4) {
+  if (!totalPixels) return false;
+  for (let i = 0; i < pixels.length; i += 4) {
+    const currentRed = pixels[i];
+    const currentGreen = pixels[i + 1];
+    const currentBlue = pixels[i + 2];
+    const currentAlpha = pixels[i + 3];
     if (
-      Math.abs(image.data[i]! - red!) <= 1 &&
-      Math.abs(image.data[i + 1]! - green!) <= 1 &&
-      Math.abs(image.data[i + 2]! - blue!) <= 1 &&
-      Math.abs(image.data[i + 3]! - alpha!) <= 1
+      currentRed == null ||
+      currentGreen == null ||
+      currentBlue == null ||
+      currentAlpha == null
+    ) {
+      continue;
+    }
+    if (
+      Math.abs(currentRed - red) <= 1 &&
+      Math.abs(currentGreen - green) <= 1 &&
+      Math.abs(currentBlue - blue) <= 1 &&
+      Math.abs(currentAlpha - alpha) <= 1
     ) {
       matchingPixels += 1;
     }
@@ -47,7 +67,7 @@ function isBlankImage(buffer: Buffer) {
 function getExpectedText(item: OGImageItem) {
   if (item.title) return item.title;
   if (item.framework) return getFramework(item.framework).label;
-  return "Ariakit";
+  return undefined;
 }
 
 function isWithinTolerance(newBuffer: Buffer, existingPath: string) {
@@ -99,10 +119,10 @@ async function waitForImageReady(page: Page, item: OGImageItem) {
   await page.waitForLoadState("load");
   const expectedText = getExpectedText(item);
   if (expectedText) {
-    await page.waitForFunction((text) => {
-      if (document.title.includes(text)) return true;
-      return document.body.textContent?.includes(text) ?? false;
-    }, expectedText);
+    await page.waitForFunction(
+      (text) => document.body.textContent?.includes(text) ?? false,
+      expectedText,
+    );
   }
   await page.evaluate(async () => {
     await document.fonts.ready;

--- a/app/src/pages/og-image/_generate-images.ts
+++ b/app/src/pages/og-image/_generate-images.ts
@@ -13,15 +13,42 @@ import pixelmatch from "pixelmatch";
 import type { Page } from "playwright";
 import { chromium } from "playwright";
 import { PNG } from "pngjs";
+import { getFramework } from "#app/lib/frameworks.ts";
 import type { OGImageItem } from "./api.ts";
 
-const BASE_URL = "http://localhost:4321";
+const BASE_URL = process.env.OG_IMAGE_BASE_URL ?? "http://localhost:4321";
 const PUBLIC_DIR = path.resolve(process.cwd(), "public");
 
 // Maximum fraction of pixels allowed to differ before the image is
 // considered changed. This avoids committing images that only differ
 // due to sub-pixel rendering or anti-aliasing across runs.
 const MAX_DIFF_PIXEL_RATIO = 0.001;
+const MAX_BLANK_PIXEL_RATIO = 0.995;
+const MAX_SCREENSHOT_ATTEMPTS = 3;
+
+function isBlankImage(buffer: Buffer) {
+  const image = PNG.sync.read(buffer);
+  const [red, green, blue, alpha] = image.data;
+  let matchingPixels = 0;
+  const totalPixels = image.width * image.height;
+  for (let i = 0; i < image.data.length; i += 4) {
+    if (
+      Math.abs(image.data[i]! - red!) <= 1 &&
+      Math.abs(image.data[i + 1]! - green!) <= 1 &&
+      Math.abs(image.data[i + 2]! - blue!) <= 1 &&
+      Math.abs(image.data[i + 3]! - alpha!) <= 1
+    ) {
+      matchingPixels += 1;
+    }
+  }
+  return matchingPixels / totalPixels >= MAX_BLANK_PIXEL_RATIO;
+}
+
+function getExpectedText(item: OGImageItem) {
+  if (item.title) return item.title;
+  if (item.framework) return getFramework(item.framework).label;
+  return "Ariakit";
+}
 
 function isWithinTolerance(newBuffer: Buffer, existingPath: string) {
   if (!fs.existsSync(existingPath)) return false;
@@ -68,8 +95,15 @@ async function getItemsToGenerate() {
   }
 }
 
-async function waitForImageReady(page: Page) {
+async function waitForImageReady(page: Page, item: OGImageItem) {
   await page.waitForLoadState("load");
+  const expectedText = getExpectedText(item);
+  if (expectedText) {
+    await page.waitForFunction((text) => {
+      if (document.title.includes(text)) return true;
+      return document.body.textContent?.includes(text) ?? false;
+    }, expectedText);
+  }
   await page.evaluate(async () => {
     await document.fonts.ready;
     await new Promise((resolve) => {
@@ -80,14 +114,25 @@ async function waitForImageReady(page: Page) {
   });
 }
 
+async function screenshotImage(page: Page, item: OGImageItem, url: string) {
+  for (let attempt = 1; attempt <= MAX_SCREENSHOT_ATTEMPTS; attempt += 1) {
+    await page.goto(url, { waitUntil: "load" });
+    await waitForImageReady(page, item);
+    const buffer = await page.screenshot({ type: "png", timeout: 60_000 });
+    if (!isBlankImage(buffer)) return buffer;
+    if (attempt < MAX_SCREENSHOT_ATTEMPTS) {
+      await page.waitForTimeout(500 * attempt);
+    }
+  }
+  throw new Error(`Blank OG image after ${MAX_SCREENSHOT_ATTEMPTS} attempts`);
+}
+
 async function generateImage(page: Page, item: OGImageItem) {
   const url = `${BASE_URL}/og-image${item.path}`;
 
   try {
-    await page.goto(url, { waitUntil: "commit" });
-    await waitForImageReady(page);
     const imagePath = path.join(PUBLIC_DIR, item.imagePath);
-    const buffer = await page.screenshot({ type: "png", timeout: 60_000 });
+    const buffer = await screenshotImage(page, item, url);
     const relativePath = path.relative(PUBLIC_DIR, imagePath);
 
     if (isWithinTolerance(buffer, imagePath)) {

--- a/app/src/pages/og-image/_generate-images.ts
+++ b/app/src/pages/og-image/_generate-images.ts
@@ -33,9 +33,10 @@ function isBlankImage(buffer: Buffer) {
   const green = pixels[1];
   const blue = pixels[2];
   const alpha = pixels[3];
-  if (red == null || green == null || blue == null || alpha == null) {
-    return false;
-  }
+  if (red == null) return false;
+  if (green == null) return false;
+  if (blue == null) return false;
+  if (alpha == null) return false;
   let matchingPixels = 0;
   const totalPixels = image.width * image.height;
   if (!totalPixels) return false;
@@ -44,14 +45,10 @@ function isBlankImage(buffer: Buffer) {
     const currentGreen = pixels[i + 1];
     const currentBlue = pixels[i + 2];
     const currentAlpha = pixels[i + 3];
-    if (
-      currentRed == null ||
-      currentGreen == null ||
-      currentBlue == null ||
-      currentAlpha == null
-    ) {
-      continue;
-    }
+    if (currentRed == null) continue;
+    if (currentGreen == null) continue;
+    if (currentBlue == null) continue;
+    if (currentAlpha == null) continue;
     if (
       Math.abs(currentRed - red) <= 1 &&
       Math.abs(currentGreen - green) <= 1 &&
@@ -65,8 +62,12 @@ function isBlankImage(buffer: Buffer) {
 }
 
 function getExpectedText(item: OGImageItem) {
-  if (item.title) return item.title;
-  if (item.framework) return getFramework(item.framework).label;
+  if (item.title) {
+    return item.title;
+  }
+  if (item.framework) {
+    return getFramework(item.framework).label;
+  }
   return undefined;
 }
 
@@ -139,7 +140,9 @@ async function screenshotImage(page: Page, item: OGImageItem, url: string) {
     await page.goto(url, { waitUntil: "load" });
     await waitForImageReady(page, item);
     const buffer = await page.screenshot({ type: "png", timeout: 60_000 });
-    if (!isBlankImage(buffer)) return buffer;
+    if (!isBlankImage(buffer)) {
+      return buffer;
+    }
     if (attempt < MAX_SCREENSHOT_ATTEMPTS) {
       await page.waitForTimeout(500 * attempt);
     }


### PR DESCRIPTION
## Motivation

The OG image workflow can write generated assets back to a branch after that branch has already advanced. That risks committing generated images from a stale checkout. The generator also takes a single screenshot after the initial navigation commit, which can capture blank or not-yet-rendered pages when the local app is still settling.

## Solution

Add a branch-tip verification step before the write-back action runs. When generated images change, the workflow fetches the current branch tip and compares it with the checkout `HEAD`; if the branch already advanced, the job skips the write-back before invoking the shared action. The workflow also passes that verified SHA into `commit-or-pr`, where the action re-fetches the branch and refuses to rebase generated output if the branch advanced after the outer verification step.

Make the OG image generator wait for expected page body text before capturing when an item has a title or framework label, support `OG_IMAGE_BASE_URL` for alternate local ports, retry blank screenshots, and reject screenshots that still look blank after the retry budget. The homepage has no item-specific body text, so it relies on the blank-screenshot retry guard instead of a generic document-title match.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/og-images.yml"); YAML.load_file(".github/workflows/commit-or-pr/action.yml"); puts "ok"'`
- `git diff --cached --check`
- `OG_IMAGE_BASE_URL=http://127.0.0.1:4322 pnpm -F app run og-image-generate`
- Pre-commit review gate with native reviewer and Cursor re-review
