### PR TITLE
Retry transient OG image failures

### DIFF
--- a/app/src/pages/og-image/_generate-images.ts
+++ b/app/src/pages/og-image/_generate-images.ts
@@ -136,16 +136,25 @@ async function waitForImageReady(page: Page, item: OGImageItem) {
 }
 
 async function screenshotImage(page: Page, item: OGImageItem, url: string) {
+  let lastError: unknown;
   for (let attempt = 1; attempt <= MAX_SCREENSHOT_ATTEMPTS; attempt += 1) {
-    await page.goto(url, { waitUntil: "load" });
-    await waitForImageReady(page, item);
-    const buffer = await page.screenshot({ type: "png", timeout: 60_000 });
-    if (!isBlankImage(buffer)) {
-      return buffer;
+    try {
+      await page.goto(url, { waitUntil: "load" });
+      await waitForImageReady(page, item);
+      const buffer = await page.screenshot({ type: "png", timeout: 60_000 });
+      if (!isBlankImage(buffer)) {
+        return buffer;
+      }
+      lastError = undefined;
+    } catch (error) {
+      lastError = error;
     }
     if (attempt < MAX_SCREENSHOT_ATTEMPTS) {
       await page.waitForTimeout(500 * attempt);
     }
+  }
+  if (lastError) {
+    throw lastError;
   }
   throw new Error(`Blank OG image after ${MAX_SCREENSHOT_ATTEMPTS} attempts`);
 }


### PR DESCRIPTION
## Motivation

The OG image generator already retries blank screenshots, but transient failures while navigating, waiting for readiness, or capturing the screenshot can still fail the run immediately before the retry loop has a chance to recover.

## Solution

Wrap each screenshot attempt in the existing retry loop so transient Playwright errors are retried with the same backoff used for blank captures. If every attempt fails with an error, rethrow the last error; if attempts complete but only produce blank images, keep the existing blank-image exhaustion error.

The pre-commit reviewers explicitly checked whether this was an actual issue on `main` rather than a mistaken carry-over from #5984. Both confirmed that current `main` only retries blank screenshots and does not retry thrown navigation/readiness/screenshot failures.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- Pre-commit review gate with native reviewer and Cursor reviewer
