### PR TITLE
Fix plus price key parsing

### DIFF
--- a/app/src/actions/admin.ts
+++ b/app/src/actions/admin.ts
@@ -202,6 +202,15 @@ async function syncPrices(context: APIContext) {
 
   // Delete prices that are not active
   for (const price of cachedPrices) {
+    const { type } = parsePlusPriceKey(price.key);
+    if (!type) {
+      logger.warn(
+        "Price %s has invalid key. Deleting from cache...",
+        price.key,
+      );
+      await deletePrice(context, price.key);
+      continue;
+    }
     const stripePrice = prices.find((p) => p.id === price.id);
     if (stripePrice?.active) continue;
     logger.warn("Price %s is not active. Deleting from cache...", price.key);

--- a/app/src/lib/price-key-test.ts
+++ b/app/src/lib/price-key-test.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2025-present Ariakit FZ-LLC. All Rights Reserved.
+ *
+ * This software is proprietary. See the license.md file in the root of this
+ * package for licensing terms.
+ *
+ * SPDX-License-Identifier: UNLICENSED
+ */
+
+import { expect, test } from "vitest";
+import { parsePlusPriceKey } from "./price-key.ts";
+
+test("parsePlusPriceKey parses personal and team keys", () => {
+  expect(parsePlusPriceKey("ariakit-plus-usd")).toEqual({
+    type: "personal",
+    currency: "usd",
+    countryCode: undefined,
+  });
+  expect(parsePlusPriceKey("ariakit-plus-team-eur-br")).toEqual({
+    type: "team",
+    currency: "eur",
+    countryCode: "br",
+  });
+});
+
+test("parsePlusPriceKey ignores prefixed keys", () => {
+  expect(parsePlusPriceKey("invalid-ariakit-plus-usd")).toEqual({});
+  expect(parsePlusPriceKey("team-invalid-ariakit-plus-usd")).toEqual({});
+});

--- a/app/src/lib/price-key-test.ts
+++ b/app/src/lib/price-key-test.ts
@@ -17,6 +17,16 @@ test("parsePlusPriceKey parses personal and team keys", () => {
     currency: "usd",
     countryCode: undefined,
   });
+  expect(parsePlusPriceKey("ariakit-plus-usd-br")).toEqual({
+    type: "personal",
+    currency: "usd",
+    countryCode: "br",
+  });
+  expect(parsePlusPriceKey("ariakit-plus-team-eur")).toEqual({
+    type: "team",
+    currency: "eur",
+    countryCode: undefined,
+  });
   expect(parsePlusPriceKey("ariakit-plus-team-eur-br")).toEqual({
     type: "team",
     currency: "eur",

--- a/app/src/lib/price-key.ts
+++ b/app/src/lib/price-key.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2025-present Ariakit FZ-LLC. All Rights Reserved.
+ *
+ * This software is proprietary. See the license.md file in the root of this
+ * package for licensing terms.
+ *
+ * SPDX-License-Identifier: UNLICENSED
+ */
+
+export interface GetPlusPriceKeyParams {
+  type?: "personal" | "team";
+  currency?: string;
+  countryCode?: string;
+}
+
+export function getPlusPriceKey({
+  type = "personal",
+  currency = "USD",
+  countryCode,
+}: GetPlusPriceKeyParams) {
+  const isPersonal = type === "personal";
+  const lowercaseCurrency = currency.toLowerCase();
+  const country = countryCode ? `-${countryCode.toLowerCase()}` : "";
+  return isPersonal
+    ? `ariakit-plus-${lowercaseCurrency}${country}`
+    : `ariakit-plus-${type}-${lowercaseCurrency}${country}`;
+}
+
+export function parsePlusPriceKey(key: string) {
+  const match = key.match(/^ariakit-plus-(team-)?([a-z]+)(?:-([a-z]{2}))?$/);
+  if (!match) return {};
+  const [, teamPrefix, currency, countryCode] = match;
+  if (!currency) return {};
+  return {
+    type: teamPrefix ? ("team" as const) : ("personal" as const),
+    currency,
+    countryCode,
+  };
+}

--- a/app/src/lib/schemas.ts
+++ b/app/src/lib/schemas.ts
@@ -10,7 +10,7 @@
 import { z } from "zod";
 import { frameworks } from "./frameworks.ts";
 import { keys } from "./object.ts";
-import { parsePlusPriceKey } from "./stripe.ts";
+import { parsePlusPriceKey } from "./price-key.ts";
 import { tags } from "./tags.ts";
 
 export const FRAMEWORKS = keys(frameworks);

--- a/app/src/lib/stripe.ts
+++ b/app/src/lib/stripe.ts
@@ -32,8 +32,12 @@ import {
 import { getCountryCode, getCurrency } from "./locale.ts";
 import { createLogger } from "./logger.ts";
 import { objectId } from "./object.ts";
+import { getPlusPriceKey } from "./price-key.ts";
 import type { PlusType, PriceData, PromoData } from "./schemas.ts";
 import { PlusTypeSchema } from "./schemas.ts";
+
+export { getPlusPriceKey, parsePlusPriceKey } from "./price-key.ts";
+export type { GetPlusPriceKeyParams } from "./price-key.ts";
 
 const logger = createLogger("stripe");
 
@@ -187,37 +191,6 @@ export async function createCustomer({
   });
   await setCustomer(context, userId, customer.id);
   return customer;
-}
-
-export interface GetPlusPriceKeyParams {
-  type?: PlusType;
-  currency?: string;
-  countryCode?: string;
-}
-
-export function getPlusPriceKey({
-  type = "personal",
-  currency = "USD",
-  countryCode,
-}: GetPlusPriceKeyParams) {
-  const isPersonal = type === "personal";
-  const lowercaseCurrency = currency.toLowerCase();
-  const country = countryCode ? `-${countryCode.toLowerCase()}` : "";
-  return isPersonal
-    ? `ariakit-plus-${lowercaseCurrency}${country}`
-    : `ariakit-plus-${type}-${lowercaseCurrency}${country}`;
-}
-
-export function parsePlusPriceKey(key: string) {
-  const match = key.match(/ariakit-plus-(?:team-)?([a-z]+)(?:-([a-z]{2}))?$/);
-  if (!match) return {};
-  const [, currency, countryCode] = match;
-  if (!currency) return {};
-  return {
-    type: key.includes("team-") ? ("team" as const) : ("personal" as const),
-    currency,
-    countryCode,
-  };
 }
 
 export interface PlusPrice

--- a/app/src/pages/api/stripe-webhook.ts
+++ b/app/src/pages/api/stripe-webhook.ts
@@ -118,6 +118,7 @@ export const POST: APIRoute = async (context) => {
     const { type } = parsePlusPriceKey(key);
     if (!type) {
       logger.error("Price not a plus price", key);
+      await deletePrice(context, key);
       return ok();
     }
     if (price.deleted || !price.active) {


### PR DESCRIPTION
## Motivation

Plus price keys are parsed with a suffix-matching regular expression on `main`, so strings such as `invalid-ariakit-plus-usd` can be treated as valid Ariakit Plus prices. The parser also infers team prices with `key.includes("team-")`, which means a malformed prefix can affect the parsed type.

This matters because Stripe price lookup keys flow through the webhook and admin sync before being cached in KV, and `PriceKeySchema` relies on the parser to validate stored price keys.

## Solution

Moved the Plus price-key helpers into a standalone `price-key` module, anchored the parser to the full key, and derives the price type from the structured `team-` segment instead of checking the whole string.

The Stripe module still re-exports the helpers so existing imports keep working, while schemas can import the parser without pulling in the Stripe module. Admin sync and price webhooks now also delete cached entries for invalid lookup keys so previously cached malformed keys do not remain visible after the parser is tightened.

## Verification

- `pnpm test app/src/lib/price-key-test.ts`
- `pnpm lint-fix`
- `pnpm tsc`
- `git diff --check`
- Pre-commit review gate with native and Cursor reviewers, including an explicit check that this fixes an actual issue on `main`
