### PR TITLE
Extract meta descriptions without rendering MDX

### DIFF
--- a/app/src/lib/content-test.ts
+++ b/app/src/lib/content-test.ts
@@ -8,15 +8,32 @@
  * SPDX-License-Identifier: UNLICENSED
  */
 
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { expect, test } from "vitest";
 import { descriptionToText } from "./content.ts";
 
-test("descriptionToText extracts text from description markdown", async () => {
-  const body = `
-import ContentLink from "#app/components/content-link.astro";
+function getDescriptionFiles(
+  path = join(import.meta.dirname, "../examples"),
+): string[] {
+  return readdirSync(path, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = join(path, entry.name);
+    if (entry.isDirectory()) {
+      return getDescriptionFiles(entryPath);
+    }
+    if (entry.name === "description.mdx") {
+      return [entryPath];
+    }
+    return [];
+  });
+}
 
-Build **accessible** {getFramework(props.framework).label} components with <ContentLink href="/react">Ariakit</ContentLink>.
-`;
+test("descriptionToText extracts text from description markdown", async () => {
+  const body = [
+    `import ContentLink from "#app/components/content-link.astro";`,
+    "",
+    "Build **accessible** {getFramework(props.framework).label} components with <ContentLink href={`/${props.framework}/components/checkbox/`}>Ariakit</ContentLink>.",
+  ].join("\n");
 
   await expect(descriptionToText(body, "react")).resolves.toBe(
     "Build accessible React components with Ariakit.",
@@ -33,4 +50,13 @@ Second paragraph.
   await expect(descriptionToText(body, "react")).resolves.toBe(
     "First paragraph. Second paragraph.",
   );
+});
+
+test("descriptionToText handles real descriptions", async () => {
+  for (const file of getDescriptionFiles()) {
+    const body = readFileSync(file, "utf8");
+    const text = await descriptionToText(body, "react");
+    expect(text, file).toBeTruthy();
+    expect(text, file).not.toMatch(/[<{}]/);
+  }
 });

--- a/app/src/lib/content-test.ts
+++ b/app/src/lib/content-test.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2025-present Ariakit FZ-LLC. All Rights Reserved.
+ *
+ * This software is proprietary. See the license.md file in the root of this
+ * package for licensing terms.
+ *
+ * SPDX-License-Identifier: UNLICENSED
+ */
+
+import { expect, test } from "vitest";
+import { descriptionToText } from "./content.ts";
+
+test("descriptionToText extracts text from description markdown", async () => {
+  const body = `
+import ContentLink from "#app/components/content-link.astro";
+
+Build **accessible** {getFramework(props.framework).label} components with <ContentLink href="/react">Ariakit</ContentLink>.
+`;
+
+  await expect(descriptionToText(body, "react")).resolves.toBe(
+    "Build accessible React components with Ariakit.",
+  );
+});
+
+test("descriptionToText returns only the first text block", async () => {
+  const body = `
+First paragraph.
+
+Second paragraph.
+`;
+
+  await expect(descriptionToText(body, "react")).resolves.toBe(
+    "First paragraph.",
+  );
+});

--- a/app/src/lib/content-test.ts
+++ b/app/src/lib/content-test.ts
@@ -23,7 +23,7 @@ Build **accessible** {getFramework(props.framework).label} components with <Cont
   );
 });
 
-test("descriptionToText returns only the first text block", async () => {
+test("descriptionToText extracts text from all blocks", async () => {
   const body = `
 First paragraph.
 
@@ -31,6 +31,6 @@ Second paragraph.
 `;
 
   await expect(descriptionToText(body, "react")).resolves.toBe(
-    "First paragraph.",
+    "First paragraph. Second paragraph.",
   );
 });

--- a/app/src/lib/content-test.ts
+++ b/app/src/lib/content-test.ts
@@ -40,7 +40,7 @@ test("descriptionToText extracts text from description markdown", async () => {
   );
 });
 
-test("descriptionToText extracts text from all blocks", async () => {
+test("descriptionToText extracts text from the first block", async () => {
   const body = `
 First paragraph.
 
@@ -48,7 +48,7 @@ Second paragraph.
 `;
 
   await expect(descriptionToText(body, "react")).resolves.toBe(
-    "First paragraph. Second paragraph.",
+    "First paragraph.",
   );
 });
 

--- a/app/src/lib/content.ts
+++ b/app/src/lib/content.ts
@@ -9,15 +9,8 @@
  */
 import { invariant } from "@ariakit/core/utils/misc";
 import type { MarkdownProcessor, RehypePlugin } from "@astrojs/markdown-remark";
-import { createMarkdownProcessor } from "@astrojs/markdown-remark";
-import type { CollectionEntry, RenderResult } from "astro:content";
-import type { Element } from "hast";
-import { toText } from "hast-util-to-text";
-import rehypeParse from "rehype-parse";
-import { unified } from "unified";
-import { createContainer } from "./astro.ts";
-import { isFramework } from "./frameworks.ts";
-import { rehypeAsTagName } from "./rehype.ts";
+import type { CollectionEntry } from "astro:content";
+import { getFramework, isFramework } from "./frameworks.ts";
 import type { Framework } from "./schemas.ts";
 
 interface ContentGroup {
@@ -135,6 +128,10 @@ async function getMarkdownProcessor() {
   if (markdownProcessor) {
     return markdownProcessor;
   }
+  const [{ createMarkdownProcessor }, { rehypeAsTagName }] = await Promise.all([
+    import("@astrojs/markdown-remark"),
+    import("./rehype.ts"),
+  ]);
   markdownProcessor = await createMarkdownProcessor({
     syntaxHighlight: false,
     rehypePlugins: [
@@ -153,92 +150,42 @@ export async function markdownToHtml(markdownString: string) {
   return result.code;
 }
 
-interface Section {
-  parent: string | null;
-  id: string | null;
-  title: string | null;
-  content: string[];
-}
-
-export async function contentToText(
-  component: RenderResult["Content"],
-  props: Record<string, any>,
+export async function descriptionToText(
+  body: string | undefined,
+  framework: Framework,
 ) {
-  const container = await createContainer({
-    renderers: ["mdx", "react"],
-    client: true,
-  });
-  const result = await container.renderToString(component, { props });
-  const sections = parseContentToSections(result);
-  return sections;
-}
-
-export function parseContentToSections(html: string): Section[] {
-  const tree = unified().use(rehypeParse, { fragment: true }).parse(html);
-
-  const sections: Section[] = [
-    { id: null, parent: null, title: null, content: [] },
-  ];
-  const parentHeadings: Element[] = [];
-
-  for (const node of tree.children) {
-    if (node.type !== "element") continue;
-
-    const { tagName } = node;
-    const isHeading = /^h[1-6]$/.test(tagName);
-
-    if (isHeading) {
-      const { id } = node.properties || {};
-      if (typeof id === "string") {
-        const level = parseInt(tagName.charAt(1), 10);
-        while (parentHeadings.length > 0) {
-          const parentHeading = parentHeadings[parentHeadings.length - 1];
-          if (!parentHeading) break;
-          const parentLevel = parseInt(parentHeading.tagName.charAt(1), 10);
-          if (parentLevel >= level) {
-            parentHeadings.pop();
-          } else {
-            break;
-          }
-        }
-        const parentHeading = parentHeadings[parentHeadings.length - 1];
-        const parent = parentHeading?.properties?.id;
-        const newSection: Section = {
-          id,
-          parent: typeof parent === "string" ? parent : null,
-          // @ts-ignore TODO: Remove this comment once we fully migrate the app
-          title: toText(node),
-          content: [],
-        };
-        sections.push(newSection);
-        // @ts-ignore TODO: Remove this comment once we fully migrate the app
-        parentHeadings.push(node);
-        continue;
-      }
-    }
-
-    // @ts-ignore TODO: Remove this comment once we fully migrate the app
-    const content = toText(node).trim();
-    if (content) {
-      const lastSection = sections[sections.length - 1];
-      if (lastSection) {
-        lastSection.content.push(content);
-      }
+  if (!body) return;
+  const frameworkLabel = getFramework(framework).label;
+  let markdown = "";
+  for (const line of body.split("\n")) {
+    if (!line.trimStart().startsWith("import ")) {
+      markdown += `${line}\n`;
     }
   }
-
-  return sections.filter((s) => s.id || s.content.length > 0);
-}
-
-export async function descriptionToText(
-  component: RenderResult["Content"] | undefined,
-  framework: Framework,
-  components: Record<string, any>,
-) {
-  if (!component) return;
-  const sections = await contentToText(component, {
-    framework,
-    components,
-  });
-  return sections[0]?.content[0];
+  markdown = markdown
+    .split("{getFramework(props.framework).label}")
+    .join(frameworkLabel);
+  while (true) {
+    const start = markdown.indexOf("<ContentLink");
+    if (start < 0) break;
+    const openEnd = markdown.indexOf(">", start);
+    if (openEnd < 0) break;
+    const closeStart = markdown.indexOf("</ContentLink>", openEnd);
+    if (closeStart < 0) break;
+    const closeEnd = closeStart + "</ContentLink>".length;
+    markdown =
+      markdown.slice(0, start) +
+      markdown.slice(openEnd + 1, closeStart) +
+      markdown.slice(closeEnd);
+  }
+  const [{ unified }, { default: rehypeParse }, { toText }] = await Promise.all(
+    [import("unified"), import("rehype-parse"), import("hast-util-to-text")],
+  );
+  const html = await markdownToHtml(markdown);
+  const tree = unified().use(rehypeParse, { fragment: true }).parse(html);
+  for (const node of tree.children) {
+    const text = toText(node).replace(/\s+/g, " ").trim();
+    if (text) return text;
+  }
+  return undefined;
 }

--- a/app/src/lib/content.ts
+++ b/app/src/lib/content.ts
@@ -8,9 +8,17 @@
  * SPDX-License-Identifier: UNLICENSED
  */
 import { invariant } from "@ariakit/core/utils/misc";
-import type { MarkdownProcessor, RehypePlugin } from "@astrojs/markdown-remark";
+import {
+  createMarkdownProcessor,
+  type MarkdownProcessor,
+  type RehypePlugin,
+} from "@astrojs/markdown-remark";
 import type { CollectionEntry } from "astro:content";
+import { toText } from "hast-util-to-text";
+import rehypeParse from "rehype-parse";
+import { unified } from "unified";
 import { getFramework, isFramework } from "./frameworks.ts";
+import { rehypeAsTagName } from "./rehype.ts";
 import type { Framework } from "./schemas.ts";
 
 interface ContentGroup {
@@ -128,10 +136,6 @@ async function getMarkdownProcessor() {
   if (markdownProcessor) {
     return markdownProcessor;
   }
-  const [{ createMarkdownProcessor }, { rehypeAsTagName }] = await Promise.all([
-    import("@astrojs/markdown-remark"),
-    import("./rehype.ts"),
-  ]);
   markdownProcessor = await createMarkdownProcessor({
     syntaxHighlight: false,
     rehypePlugins: [
@@ -150,21 +154,7 @@ export async function markdownToHtml(markdownString: string) {
   return result.code;
 }
 
-export async function descriptionToText(
-  body: string | undefined,
-  framework: Framework,
-) {
-  if (!body) return;
-  const frameworkLabel = getFramework(framework).label;
-  let markdown = "";
-  for (const line of body.split("\n")) {
-    if (!line.trimStart().startsWith("import ")) {
-      markdown += `${line}\n`;
-    }
-  }
-  markdown = markdown
-    .split("{getFramework(props.framework).label}")
-    .join(frameworkLabel);
+function unwrapContentLinks(markdown: string) {
   while (true) {
     const start = markdown.indexOf("<ContentLink");
     if (start < 0) break;
@@ -178,14 +168,29 @@ export async function descriptionToText(
       markdown.slice(openEnd + 1, closeStart) +
       markdown.slice(closeEnd);
   }
-  const [{ unified }, { default: rehypeParse }, { toText }] = await Promise.all(
-    [import("unified"), import("rehype-parse"), import("hast-util-to-text")],
-  );
+  return markdown;
+}
+
+function getDescriptionMarkdown(body: string, framework: Framework) {
+  const frameworkLabel = getFramework(framework).label;
+  const lines = body.split("\n").filter((line) => {
+    return !line.trimStart().startsWith("import ");
+  });
+  const markdown = lines
+    .join("\n")
+    .split("{getFramework(props.framework).label}")
+    .join(frameworkLabel);
+  return unwrapContentLinks(markdown);
+}
+
+export async function descriptionToText(
+  body: string | undefined,
+  framework: Framework,
+) {
+  if (!body) return;
+  const markdown = getDescriptionMarkdown(body, framework);
   const html = await markdownToHtml(markdown);
   const tree = unified().use(rehypeParse, { fragment: true }).parse(html);
-  for (const node of tree.children) {
-    const text = toText(node).replace(/\s+/g, " ").trim();
-    if (text) return text;
-  }
-  return undefined;
+  const text = toText(tree).replace(/\s+/g, " ").trim();
+  return text || undefined;
 }

--- a/app/src/lib/content.ts
+++ b/app/src/lib/content.ts
@@ -192,5 +192,9 @@ export async function descriptionToText(
   const html = await markdownToHtml(markdown);
   const tree = unified().use(rehypeParse, { fragment: true }).parse(html);
   const text = toText(tree).replace(/\s+/g, " ").trim();
+  invariant(
+    !/[<{}]/.test(text),
+    `descriptionToText: unsupported MDX in description (got: ${text})`,
+  );
   return text || undefined;
 }

--- a/app/src/lib/content.ts
+++ b/app/src/lib/content.ts
@@ -191,10 +191,14 @@ export async function descriptionToText(
   const markdown = getDescriptionMarkdown(body, framework);
   const html = await markdownToHtml(markdown);
   const tree = unified().use(rehypeParse, { fragment: true }).parse(html);
-  const text = toText(tree).replace(/\s+/g, " ").trim();
-  invariant(
-    !/[<{}]/.test(text),
-    `descriptionToText: unsupported MDX in description (got: ${text})`,
-  );
-  return text || undefined;
+  for (const node of tree.children) {
+    const text = toText(node).replace(/\s+/g, " ").trim();
+    if (!text) continue;
+    invariant(
+      !/[<{}]/.test(text),
+      `descriptionToText: unsupported MDX in description (got: ${text})`,
+    );
+    return text;
+  }
+  return undefined;
 }

--- a/app/src/pages/[...component].astro
+++ b/app/src/pages/[...component].astro
@@ -32,16 +32,10 @@ import TimelineAnchor from "#app/components/timeline-anchor.astro";
 import TimelineAnimate from "#app/components/timeline-animate.astro";
 import { Icon } from "#app/icons/icon.react.tsx";
 import { descriptionToText } from "#app/lib/content.ts";
-import { rehypeAsTagName } from "#app/lib/rehype.ts";
 import { trimRight } from "#app/lib/string.ts";
 import { mapTags } from "#app/lib/tags.ts";
 import { getReferencePath } from "#app/lib/url.ts";
 import Layout from "#app/pages/_layout.astro";
-import {
-  createMarkdownProcessor,
-  type MarkdownProcessor,
-  type RehypePlugin,
-} from "@astrojs/markdown-remark";
 import type { GetStaticPaths } from "astro";
 import { getCollection, render } from "astro:content";
 
@@ -177,29 +171,6 @@ function isCurrentHref(href: string, pathname = Astro.url.pathname) {
   return trimRight(pathname, "/") === trimRight(url.pathname, "/");
 }
 
-let markdownProcessor: MarkdownProcessor | null = null;
-
-async function getMarkdownProcessor() {
-  if (markdownProcessor) {
-    return markdownProcessor;
-  }
-  markdownProcessor = await createMarkdownProcessor({
-    syntaxHighlight: false,
-    rehypePlugins: [
-      [
-        rehypeAsTagName as RehypePlugin,
-        { tags: ["h1", "h2", "h3", "h4", "h5", "h6", "ul", "ol"] },
-      ],
-    ],
-  });
-  return markdownProcessor;
-}
-
-async function parseDescription(description: string) {
-  const processor = await getMarkdownProcessor();
-  const result = await processor.render(description);
-  return result.code;
-}
 ---
 
 <Layout title={title}>

--- a/app/src/pages/[...component].astro
+++ b/app/src/pages/[...component].astro
@@ -32,10 +32,16 @@ import TimelineAnchor from "#app/components/timeline-anchor.astro";
 import TimelineAnimate from "#app/components/timeline-animate.astro";
 import { Icon } from "#app/icons/icon.react.tsx";
 import { descriptionToText } from "#app/lib/content.ts";
+import { rehypeAsTagName } from "#app/lib/rehype.ts";
 import { trimRight } from "#app/lib/string.ts";
 import { mapTags } from "#app/lib/tags.ts";
 import { getReferencePath } from "#app/lib/url.ts";
 import Layout from "#app/pages/_layout.astro";
+import {
+  createMarkdownProcessor,
+  type MarkdownProcessor,
+  type RehypePlugin,
+} from "@astrojs/markdown-remark";
 import type { GetStaticPaths } from "astro";
 import { getCollection, render } from "astro:content";
 
@@ -169,6 +175,30 @@ const apiLinks = referenceMenu.filter(isLinkItem);
 function isCurrentHref(href: string, pathname = Astro.url.pathname) {
   const url = new URL(href, Astro.url.origin);
   return trimRight(pathname, "/") === trimRight(url.pathname, "/");
+}
+
+let markdownProcessor: MarkdownProcessor | null = null;
+
+async function getMarkdownProcessor() {
+  if (markdownProcessor) {
+    return markdownProcessor;
+  }
+  markdownProcessor = await createMarkdownProcessor({
+    syntaxHighlight: false,
+    rehypePlugins: [
+      [
+        rehypeAsTagName as RehypePlugin,
+        { tags: ["h1", "h2", "h3", "h4", "h5", "h6", "ul", "ol"] },
+      ],
+    ],
+  });
+  return markdownProcessor;
+}
+
+async function parseDescription(description: string) {
+  const processor = await getMarkdownProcessor();
+  const result = await processor.render(description);
+  return result.code;
 }
 ---
 

--- a/app/src/pages/[...component].astro
+++ b/app/src/pages/[...component].astro
@@ -32,15 +32,10 @@ import TimelineAnchor from "#app/components/timeline-anchor.astro";
 import TimelineAnimate from "#app/components/timeline-animate.astro";
 import { Icon } from "#app/icons/icon.react.tsx";
 import { descriptionToText } from "#app/lib/content.ts";
-import { rehypeAsTagName } from "#app/lib/rehype.ts";
 import { trimRight } from "#app/lib/string.ts";
 import { mapTags } from "#app/lib/tags.ts";
 import { getReferencePath } from "#app/lib/url.ts";
 import Layout from "#app/pages/_layout.astro";
-import {
-  type RehypePlugin,
-  createMarkdownProcessor,
-} from "@astrojs/markdown-remark";
 import type { GetStaticPaths } from "astro";
 import { getCollection, render } from "astro:content";
 
@@ -117,11 +112,7 @@ headings.unshift(
 
 const tags = mapTags(entry.data.tags, [framework]);
 const title = entry.data.title;
-const descriptionText = await descriptionToText(
-  Description,
-  framework,
-  components,
-);
+const descriptionText = await descriptionToText(description?.body, framework);
 
 // Build href to the full API reference page for the default reference
 const referenceHref = reference && getReferencePath({ reference });
@@ -178,22 +169,6 @@ const apiLinks = referenceMenu.filter(isLinkItem);
 function isCurrentHref(href: string, pathname = Astro.url.pathname) {
   const url = new URL(href, Astro.url.origin);
   return trimRight(pathname, "/") === trimRight(url.pathname, "/");
-}
-
-// TODO: This should be a singleton.
-const processor = await createMarkdownProcessor({
-  syntaxHighlight: false,
-  rehypePlugins: [
-    [
-      rehypeAsTagName as RehypePlugin,
-      { tags: ["h1", "h2", "h3", "h4", "h5", "h6", "ul", "ol"] },
-    ],
-  ],
-});
-
-async function parseDescription(description: string) {
-  const result = await processor.render(description);
-  return result.code;
 }
 ---
 

--- a/app/src/pages/[...example].astro
+++ b/app/src/pages/[...example].astro
@@ -46,11 +46,7 @@ Astro.locals.framework = framework;
 
 const tags = mapTags(entry.data.tags, [framework]);
 const title = entry.data.title;
-const descriptionText = await descriptionToText(
-  Description,
-  framework,
-  components
-);
+const descriptionText = await descriptionToText(description?.body, framework);
 ---
 
 <Layout title={title}>


### PR DESCRIPTION
## Motivation

PR #5984 included a meta-description extraction change that is independent from the Astro migration. The current app renders description MDX through a component/container path just to derive text for the `<meta>` description, which adds an unnecessary MDX/React render step to metadata generation.

## Solution

Read description collection bodies directly for metadata, normalize the small MDX subset used by the current descriptions, then run the existing markdown-to-HTML pipeline and extract the first non-empty top-level text block from the rendered fragment. The source descriptions can still contain Markdown/MDX syntax such as links and inline code; this path converts that authored content into the text value needed by the meta tag. The visible page description still renders through the normal MDX component path.

This PR is synced with the current #5984 implementation for the extracted source files (`app/src/lib/content.ts`, `app/src/pages/[...component].astro`, and `app/src/pages/[...example].astro`) except where the follow-up review confirmed PR-local cleanup should stay: the now-unused component-page markdown processor remains removed, and the meta description extraction preserves the original first-block behavior.

Unsupported MDX in the extracted description now fails loudly if raw markup markers leak into the generated text, and the tests cover the real `description.mdx` corpus.

## Verification

- `pnpm lint-fix` (existing underscore warnings, no errors)
- `pnpm test app/src/lib/content-test.ts`
- `pnpm tsc`
- `pnpm build-app-lite`
- Pre-commit review gate with native and Cursor reviewers, including re-review after the parity update and after the follow-up review fixes
