### PR TITLE
Simplify test spy cleanup

### DIFF
--- a/examples/command-enter-disabled/test.ts
+++ b/examples/command-enter-disabled/test.ts
@@ -2,23 +2,19 @@ import { press, q } from "@ariakit/test";
 import { expect, test, vi } from "vitest";
 
 test("enter doesn't trigger the alert", async () => {
-  const alertMock = vi.spyOn(window, "alert").mockImplementation(() => {});
+  using alertMock = vi.spyOn(window, "alert").mockImplementation(() => {});
 
   await press.Tab();
   expect(q.text("Accessible button")).toHaveFocus();
   await press.Enter();
   expect(alertMock).toHaveBeenCalledTimes(0);
-
-  alertMock.mockRestore();
 });
 
 test("space does trigger the alert", async () => {
-  const alertMock = vi.spyOn(window, "alert").mockImplementation(() => {});
+  using alertMock = vi.spyOn(window, "alert").mockImplementation(() => {});
 
   await press.Tab();
   expect(q.text("Accessible button")).toHaveFocus();
   await press.Space();
   expect(alertMock).toHaveBeenCalledTimes(1);
-
-  alertMock.mockRestore();
 });

--- a/examples/command-space-disabled/test.ts
+++ b/examples/command-space-disabled/test.ts
@@ -2,23 +2,19 @@ import { press, q } from "@ariakit/test";
 import { expect, test, vi } from "vitest";
 
 test("enter does trigger the alert", async () => {
-  const alertMock = vi.spyOn(window, "alert").mockImplementation(() => {});
+  using alertMock = vi.spyOn(window, "alert").mockImplementation(() => {});
 
   await press.Tab();
   expect(q.text("Accessible button")).toHaveFocus();
   await press.Enter();
   expect(alertMock).toHaveBeenCalledTimes(1);
-
-  alertMock.mockRestore();
 });
 
 test("space doesn't trigger the alert", async () => {
-  const alertMock = vi.spyOn(window, "alert").mockImplementation(() => {});
+  using alertMock = vi.spyOn(window, "alert").mockImplementation(() => {});
 
   await press.Tab();
   expect(q.text("Accessible button")).toHaveFocus();
   await press.Space();
   expect(alertMock).toHaveBeenCalledTimes(0);
-
-  alertMock.mockRestore();
 });

--- a/examples/command/test.ts
+++ b/examples/command/test.ts
@@ -20,19 +20,17 @@ test("tab", async () => {
 });
 
 test("enter", async () => {
-  const alertMock = vi.spyOn(window, "alert").mockImplementation(() => {});
+  using alertMock = vi.spyOn(window, "alert").mockImplementation(() => {});
   await press.Tab();
   expect(q.button()).toHaveFocus();
   await press.Enter();
   expect(alertMock).toHaveBeenCalledTimes(1);
-  alertMock.mockRestore();
 });
 
 test("space", async () => {
-  const alertMock = vi.spyOn(window, "alert").mockImplementation(() => {});
+  using alertMock = vi.spyOn(window, "alert").mockImplementation(() => {});
   await press.Tab();
   expect(q.button()).toHaveFocus();
   await press.Space();
   expect(alertMock).toHaveBeenCalledTimes(1);
-  alertMock.mockRestore();
 });

--- a/examples/composite-hover-virtual-focus-events/test.ts
+++ b/examples/composite-hover-virtual-focus-events/test.ts
@@ -13,7 +13,7 @@ test("events", async () => {
   externalButton.textContent = "External button";
   document.body.append(externalButton);
 
-  const log = vi.spyOn(console, "log").mockImplementation(() => {});
+  using log = vi.spyOn(console, "log").mockImplementation(() => {});
 
   await press.Tab();
   await press.Tab();
@@ -125,8 +125,6 @@ test("events", async () => {
   expect(q.button("item-1")).toHaveAttribute("data-active-item");
   expect(q.button("item-2")).not.toHaveAttribute("data-focus-visible");
   expect(q.button("item-2")).not.toHaveAttribute("data-active-item");
-
-  log.mockReset();
 
   externalButton.remove();
 });

--- a/examples/composite-virtual-focus-events/test.ts
+++ b/examples/composite-virtual-focus-events/test.ts
@@ -13,7 +13,7 @@ test("events", async () => {
   externalButton.textContent = "External button";
   document.body.append(externalButton);
 
-  const log = vi.spyOn(console, "log").mockImplementation(() => {});
+  using log = vi.spyOn(console, "log").mockImplementation(() => {});
 
   await press.Tab();
   await press.Tab();
@@ -53,8 +53,6 @@ test("events", async () => {
       "event: focus | currentTarget: toolbar | target: item-2 | relatedTarget: toolbar",
     ]
   `);
-
-  log.mockReset();
 
   externalButton.remove();
 });

--- a/examples/form-radio/test.ts
+++ b/examples/form-radio/test.ts
@@ -1,14 +1,7 @@
 import { click, press, q } from "@ariakit/test";
-import { beforeEach, expect, test, vi } from "vitest";
+import { expect, test, vi } from "vitest";
 
 const spyOnAlert = () => vi.spyOn(window, "alert").mockImplementation(() => {});
-
-let alert = spyOnAlert();
-
-beforeEach(() => {
-  alert = spyOnAlert();
-  return () => alert.mockClear();
-});
 
 test("focus on the first radio button by tabbing", async () => {
   expect(q.radio("Red")).not.toHaveFocus();
@@ -50,16 +43,19 @@ test("fix error on change", async () => {
 });
 
 test("submit form", async () => {
+  using alert = spyOnAlert();
   await click(q.radio("Green"));
   await click(q.button("Submit"));
   expect(alert).toHaveBeenCalledWith(JSON.stringify({ color: "green" }));
 });
 
 test("reset form on submit", async () => {
+  using alert = spyOnAlert();
   await press.Tab();
   await press.Space();
   await press.Tab();
   await press.Enter();
+  expect(alert).toHaveBeenCalledTimes(1);
   expect(q.radio("Red")).not.toBeChecked();
   expect(q.radio("Green")).not.toBeChecked();
   expect(q.radio("Blue")).not.toBeChecked();

--- a/examples/form-select/test.ts
+++ b/examples/form-select/test.ts
@@ -1,15 +1,8 @@
 import { click, press, q, type } from "@ariakit/test";
-import { beforeEach, expect, test, vi } from "vitest";
+import { expect, test, vi } from "vitest";
 
 const errors = () => q.text.all("Constraints not satisfied");
 const spyOnAlert = () => vi.spyOn(window, "alert").mockImplementation(() => {});
-
-let alert = spyOnAlert();
-
-beforeEach(() => {
-  alert = spyOnAlert();
-  return () => alert.mockClear();
-});
 
 test("click on label", async () => {
   await click(q.text("Favorite fruit"));
@@ -54,6 +47,7 @@ test("submit failed", async () => {
 });
 
 test("submit succeed", async () => {
+  using alert = spyOnAlert();
   await press.Tab();
   await type("John");
   await click(q.combobox());

--- a/examples/form/test.ts
+++ b/examples/form/test.ts
@@ -1,14 +1,7 @@
 import { click, press, q, type } from "@ariakit/test";
-import { beforeEach, expect, test, vi } from "vitest";
+import { expect, test, vi } from "vitest";
 
 const spyOnAlert = () => vi.spyOn(window, "alert").mockImplementation(() => {});
-
-let alert = spyOnAlert();
-
-beforeEach(() => {
-  alert = spyOnAlert();
-  return () => alert.mockClear();
-});
 
 test("focus on the first input by tabbing", async () => {
   expect(q.textbox("Name")).not.toHaveFocus();
@@ -57,6 +50,7 @@ test("reset form on reset", async () => {
 });
 
 test("submit form", async () => {
+  using alert = spyOnAlert();
   await press.Tab();
   await type("John");
   await press.Tab();
@@ -68,11 +62,13 @@ test("submit form", async () => {
 });
 
 test("reset form on submit", async () => {
+  using alert = spyOnAlert();
   await press.Tab();
   await type("John");
   await press.Tab();
   await type("john@example.com");
   await press.Enter();
+  expect(alert).toHaveBeenCalledTimes(1);
   expect(q.textbox("Name")).toHaveValue("");
   expect(q.textbox("Email")).toHaveValue("");
 });

--- a/examples/menu/test.ts
+++ b/examples/menu/test.ts
@@ -1,14 +1,7 @@
 import { click, hover, press, q, type, waitFor } from "@ariakit/test";
-import { beforeEach, expect, test, vi } from "vitest";
+import { expect, test, vi } from "vitest";
 
 const spyOnAlert = () => vi.spyOn(window, "alert").mockImplementation(() => {});
-
-let alert = spyOnAlert();
-
-beforeEach(() => {
-  alert = spyOnAlert();
-  return () => alert.mockClear();
-});
 
 test("show/hide on click", async () => {
   expect(q.menu()).not.toBeInTheDocument();
@@ -180,6 +173,7 @@ test("navigate through items with mouse", async () => {
 });
 
 test("menu item click", async () => {
+  using alert = spyOnAlert();
   await click(q.button("Actions"));
   expect(alert).toHaveBeenCalledTimes(0);
   await click(q.menuitem("Edit"));
@@ -189,6 +183,7 @@ test("menu item click", async () => {
 });
 
 test("menu item enter", async () => {
+  using alert = spyOnAlert();
   await press.Tab();
   await press.Enter();
   expect(alert).toHaveBeenCalledTimes(0);
@@ -199,6 +194,7 @@ test("menu item enter", async () => {
 });
 
 test("menu item space", async () => {
+  using alert = spyOnAlert();
   await press.Tab();
   await press.Space();
   expect(alert).toHaveBeenCalledTimes(0);
@@ -209,6 +205,7 @@ test("menu item space", async () => {
 });
 
 test("menu item hover enter", async () => {
+  using alert = spyOnAlert();
   await click(q.button("Actions"));
   expect(alert).toHaveBeenCalledTimes(0);
   await press.Enter();
@@ -221,6 +218,7 @@ test("menu item hover enter", async () => {
 });
 
 test("menu item hover space", async () => {
+  using alert = spyOnAlert();
   await click(q.button("Actions"));
   expect(alert).toHaveBeenCalledTimes(0);
   await press.Space();

--- a/examples/select-form-disabled/test.ts
+++ b/examples/select-form-disabled/test.ts
@@ -1,14 +1,7 @@
 import { click, press, q } from "@ariakit/test";
-import { beforeEach, expect, test, vi } from "vitest";
+import { expect, test, vi } from "vitest";
 
 const spyOnAlert = () => vi.spyOn(window, "alert").mockImplementation(() => {});
-
-let alert = spyOnAlert();
-
-beforeEach(() => {
-  alert = spyOnAlert();
-  return () => alert.mockClear();
-});
 
 test("disabled select is visually and semantically disabled", () => {
   const button = q.combobox();
@@ -33,6 +26,7 @@ test("disabled select cannot be opened with keyboard", async () => {
 });
 
 test("disabled select does not submit value", async () => {
+  using alert = spyOnAlert();
   await press.Tab();
   await press.Enter();
   expect(alert).toHaveBeenCalledWith(null);

--- a/examples/select-form/test.ts
+++ b/examples/select-form/test.ts
@@ -1,26 +1,21 @@
 import { click, q } from "@ariakit/test";
-import { beforeEach, expect, test, vi } from "vitest";
+import { expect, test, vi } from "vitest";
 
 const spyOnAlert = () => vi.spyOn(window, "alert").mockImplementation(() => {});
-
-let alert = spyOnAlert();
-
-beforeEach(() => {
-  alert = spyOnAlert();
-  return () => alert.mockClear();
-});
 
 test("default value", () => {
   expect(q.combobox()).toHaveTextContent("Apple");
 });
 
 test("submit form", async () => {
+  using alert = spyOnAlert();
   expect(alert).not.toHaveBeenCalled();
   await click(q.button("Submit"));
   expect(alert).toHaveBeenCalledWith("Apple");
 });
 
 test("select another value", async () => {
+  using alert = spyOnAlert();
   await click(q.combobox());
   await click(q.option("Orange"));
   expect(q.listbox()).not.toBeInTheDocument();


### PR DESCRIPTION
## Motivation

Vitest supports explicit resource management for spies, which lets tests restore local mocks automatically when the test scope exits. Several example tests still used manual `mockRestore()` calls or file-level `beforeEach` hooks just to keep `window.alert` mocked.

## Solution

Use `using` for local `vi.spyOn` calls so Vitest restores spies at the end of each test. The alert-based examples now mock `window.alert` only in the tests that exercise submit/menu actions, removing shared mutable mock state while keeping the submit assertions explicit.

## Verification

- `pnpm vitest run examples/command/test.ts examples/command-enter-disabled/test.ts examples/command-space-disabled/test.ts examples/composite-virtual-focus-events/test.ts examples/composite-hover-virtual-focus-events/test.ts examples/form/test.ts examples/select-form-disabled/test.ts examples/select-form/test.ts examples/form-select/test.ts examples/form-radio/test.ts examples/menu/test.ts`
- `pnpm lint-fix`
- `pnpm tsc`