### PR TITLE
Stabilize OG image generation

### DIFF
--- a/app/src/pages/[...preview].astro
+++ b/app/src/pages/[...preview].astro
@@ -40,7 +40,7 @@ const fullscreen = entry.data.fullscreen;
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/icon.svg" />
     <title>Preview {title} - Ariakit</title>
   </head>
   <body

--- a/app/src/pages/admin/_layout.astro
+++ b/app/src/pages/admin/_layout.astro
@@ -38,7 +38,7 @@ const pages = [
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/icon.svg" />
     <title>Ariakit</title>
   </head>
   <body class="ak-container-size-default/2">

--- a/app/src/pages/og-image/[...path].astro
+++ b/app/src/pages/og-image/[...path].astro
@@ -46,11 +46,12 @@ const Thumbnail2 = await importThumbnail("popover");
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/icon.svg" />
     <title>{title ? `${title} - Ariakit` : "Ariakit"}</title>
   </head>
   <body class="flex items-center justify-center">
     <div
+      data-og-image
       class="h-[315px] w-[600px] ak-layer ring overflow-clip relative isolate"
     >
       {

--- a/app/src/pages/og-image/_generate-images.ts
+++ b/app/src/pages/og-image/_generate-images.ts
@@ -10,7 +10,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import pixelmatch from "pixelmatch";
-import type { Page } from "playwright";
+import type { Page, Response } from "playwright";
 import { chromium } from "playwright";
 import { PNG } from "pngjs";
 import { getFramework } from "#app/lib/frameworks.ts";
@@ -25,6 +25,21 @@ const PUBLIC_DIR = path.resolve(process.cwd(), "public");
 const MAX_DIFF_PIXEL_RATIO = 0.001;
 const MAX_BLANK_PIXEL_RATIO = 0.995;
 const MAX_SCREENSHOT_ATTEMPTS = 3;
+
+function getServerError(response: Response) {
+  const status = response.status();
+  if (status < 500) return;
+  return `${status} ${response.request().method()} ${response.url()}`;
+}
+
+function assertNoServerErrors(item: OGImageItem, serverErrors: string[]) {
+  if (!serverErrors.length) return;
+  throw new Error(
+    `Server errors while rendering ${item.path}:\n${[
+      ...new Set(serverErrors),
+    ].join("\n")}`,
+  );
+}
 
 function isBlankImage(buffer: Buffer) {
   const image = PNG.sync.read(buffer);
@@ -118,6 +133,7 @@ async function getItemsToGenerate() {
 
 async function waitForImageReady(page: Page, item: OGImageItem) {
   await page.waitForLoadState("load");
+  await page.waitForSelector("[data-og-image]");
   const expectedText = getExpectedText(item);
   if (expectedText) {
     await page.waitForFunction(
@@ -133,21 +149,56 @@ async function waitForImageReady(page: Page, item: OGImageItem) {
       });
     });
   });
+  const errorText = await page.evaluate(() => {
+    const overlay = document.querySelector("vite-error-overlay");
+    if (overlay) {
+      return (
+        overlay.shadowRoot?.textContent?.trim() ||
+        overlay.textContent?.trim() ||
+        "Vite error overlay detected"
+      );
+    }
+    const text = document.body.textContent?.trim();
+    if (!text) return;
+    if (!text.includes("An error occurred.")) return;
+    if (!text.includes("Stack Trace")) return;
+    return text;
+  });
+  if (errorText) {
+    throw new Error(
+      `Error overlay while rendering ${item.path}:\n${errorText.slice(0, 500)}`,
+    );
+  }
 }
 
 async function screenshotImage(page: Page, item: OGImageItem, url: string) {
   let lastError: unknown;
   for (let attempt = 1; attempt <= MAX_SCREENSHOT_ATTEMPTS; attempt += 1) {
+    const serverErrors: string[] = [];
+    const handleResponse = (response: Response) => {
+      const error = getServerError(response);
+      if (error) {
+        serverErrors.push(error);
+      }
+    };
     try {
-      await page.goto(url, { waitUntil: "load" });
+      page.on("response", handleResponse);
+      const response = await page.goto(url, { waitUntil: "load" });
+      if (response) {
+        handleResponse(response);
+      }
+      assertNoServerErrors(item, serverErrors);
       await waitForImageReady(page, item);
       const buffer = await page.screenshot({ type: "png", timeout: 60_000 });
+      assertNoServerErrors(item, serverErrors);
       if (!isBlankImage(buffer)) {
         return buffer;
       }
       lastError = undefined;
     } catch (error) {
       lastError = error;
+    } finally {
+      page.off("response", handleResponse);
     }
     if (attempt < MAX_SCREENSHOT_ATTEMPTS) {
       await page.waitForTimeout(500 * attempt);

--- a/app/src/pages/og-image/_generate-images.ts
+++ b/app/src/pages/og-image/_generate-images.ts
@@ -131,24 +131,7 @@ async function getItemsToGenerate() {
   }
 }
 
-async function waitForImageReady(page: Page, item: OGImageItem) {
-  await page.waitForLoadState("load");
-  await page.waitForSelector("[data-og-image]");
-  const expectedText = getExpectedText(item);
-  if (expectedText) {
-    await page.waitForFunction(
-      (text) => document.body.textContent?.includes(text) ?? false,
-      expectedText,
-    );
-  }
-  await page.evaluate(async () => {
-    await document.fonts.ready;
-    await new Promise((resolve) => {
-      requestAnimationFrame(() => {
-        requestAnimationFrame(resolve);
-      });
-    });
-  });
+async function assertNoErrorOverlay(page: Page, item: OGImageItem) {
   const errorText = await page.evaluate(() => {
     const overlay = document.querySelector("vite-error-overlay");
     if (overlay) {
@@ -169,6 +152,28 @@ async function waitForImageReady(page: Page, item: OGImageItem) {
       `Error overlay while rendering ${item.path}:\n${errorText.slice(0, 500)}`,
     );
   }
+}
+
+async function waitForImageReady(page: Page, item: OGImageItem) {
+  await page.waitForLoadState("load");
+  await assertNoErrorOverlay(page, item);
+  await page.waitForSelector("[data-og-image]");
+  const expectedText = getExpectedText(item);
+  if (expectedText) {
+    await page.waitForFunction(
+      (text) => document.body.textContent?.includes(text) ?? false,
+      expectedText,
+    );
+  }
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+    await new Promise((resolve) => {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(resolve);
+      });
+    });
+  });
+  await assertNoErrorOverlay(page, item);
 }
 
 async function screenshotImage(page: Page, item: OGImageItem, url: string) {

--- a/app/src/pages/plus/account/_layout.astro
+++ b/app/src/pages/plus/account/_layout.astro
@@ -70,7 +70,7 @@ const teams = await getCurrentUserTeams(Astro);
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/icon.svg" />
     <title>Ariakit</title>
   </head>
   <body

--- a/app/src/pages/plus/checkout/_layout.astro
+++ b/app/src/pages/plus/checkout/_layout.astro
@@ -53,7 +53,7 @@ const signedIn = isSignedIn(Astro);
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/icon.svg" />
     <title>Ariakit</title>
   </head>
   <body


### PR DESCRIPTION
## Motivation

The OG image workflow accepted an Astro dev error page as a valid screenshot after the Astro monorepo update. The bot PR at #6012 updated `react_examples.png` to an error overlay because standalone pages still linked to `/favicon.svg`, which is not present in `app/public` and now returns a dev-server 500.

## Solution

Point the remaining standalone favicon links at the existing `/icon.svg` asset so the OG page and related layouts no longer trigger the missing-asset 500.

Harden the OG image generator so it only accepts the intended OG template, fails on Vite/Astro error overlays, and reports 5xx responses immediately instead of saving their rendered error pages as PNG output.

## Verification

- `OG_IMAGE_BASE_URL=http://localhost:4322 pnpm -F app run og-image-generate`
- `pnpm lint-fix`
- `pnpm tsc`
- Pre-commit review pass with native Codex and Cursor reviewers
