### PR TITLE
Disable oxlint underscore dangle rule

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     "no-unassigned-import": "off",
     "react-in-jsx-scope": "off",
     "no-shadow": "off",
+    "no-underscore-dangle": "off",
     "iframe-missing-sandbox": "off",
     "consistent-return": "off",
     "no-unnecessary-type-arguments": "off",


### PR DESCRIPTION
## Motivation

Oxlint reports `no-underscore-dangle` warnings for intentional Ariakit identifiers that use leading double underscores, such as unstable/private store fields. These names are deliberate, so the warnings add noise to lint output without identifying actionable issues.

## Solution

Disable the oxlint `no-underscore-dangle` rule globally in the root lint config, alongside the other repository-wide oxlint rule overrides.
