### PR TITLE
Update Renovate automerge rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,8 +30,7 @@
         "/rehype/",
         "/remark/",
         "/unified/",
-        "/unist/",
-        "/react-markdown/"
+        "/unist/"
       ]
     },
     {
@@ -84,30 +83,27 @@
         "@wordpress/components",
         "cross-env",
         "cross-spawn",
-        "dotenv",
         "motion",
         "fs-extra",
         "glob",
         "jsdom",
         "lodash-es",
         "match-sorter",
-        "null-loader",
         "react",
         "react-dom",
         "react-router",
         "react-shadow",
         "react-toastify",
+        "rolldown",
+        "rolldown-plugin-dts",
         "pnpm",
         "textarea-caret",
         "tsup",
         "typescript",
         "playwright",
-        "webpack",
         "zod",
-        "/^@babel//",
         "/^@playwright//",
         "/^@radix-ui//",
-        "/^@rollup//",
         "/^@testing-library//",
         "/^@types//",
         "/^@vitest//",
@@ -146,7 +142,7 @@
     },
     {
       "matchManagers": ["github-actions"],
-      "matchPackageNames": ["actions/**", "github/**"],
+      "matchPackageNames": ["actions/**"],
       "pinDigests": false
     }
   ]


### PR DESCRIPTION
## Motivation

The Renovate configuration still includes grouping and automerge matchers for dependencies and action patterns that are no longer active outside the disabled legacy website package. Rolldown is now used by `@ariakit/scripts`, but its direct packages are not covered by the automerge allowlist.

## Solution

Remove stale or disabled-only Renovate package matchers and add `rolldown` plus `rolldown-plugin-dts` to the existing automerge package rule.

## Verification

- `jq empty renovate.json`
- `pnpm exec oxfmt --check renovate.json`
- Custom stale-matcher scan for active workspace manifests and GitHub Actions references
