### PR TITLE
Fix release publish for scripts workspace dependency

### DIFF
--- a/packages/ariakit-scripts/package.json
+++ b/packages/ariakit-scripts/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@ariakit/scripts",
+  "version": "0.0.0",
   "private": true,
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Motivation

The release workflow fails while publishing packages that declare `@ariakit/scripts` as a workspace devDependency. pnpm needs the target workspace package to have a version when it rewrites `workspace:*` during pack/publish, but `@ariakit/scripts` did not define one.

## Solution

Add a private placeholder version to `@ariakit/scripts` so pnpm can resolve the workspace protocol during package packing while keeping the scripts package unpublished.

## Verification

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm -r --filter "@ariakit/*" pack --dry-run`
- Packed `@ariakit/components` into a temporary directory and confirmed `@ariakit/scripts` rewrites to `0.0.0` in the packed manifest
- `pnpm lint-fix`
- `git diff --check`
