### PR TITLE
Publish packages recursively with pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "clean": "pnpm -r run --if-present clean",
     "changeset": "changeset",
     "version": "changeset version && pnpm install --lockfile-only --ignore-scripts",
-    "publish": "pnpm run build && changeset publish",
+    "publish": "pnpm run build && ariakit publish",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/packages/ariakit-scripts/src/index.ts
+++ b/packages/ariakit-scripts/src/index.ts
@@ -3,6 +3,7 @@
 import { program } from "commander";
 import { build, clean } from "./build.ts";
 import { dev } from "./dev.ts";
+import { publish } from "./publish.ts";
 
 program.name("ariakit");
 
@@ -26,5 +27,11 @@ program
   .option("--clean", "Clean and watch package builds", true)
   .option("--no-clean", "Use current package exports without cleaning")
   .action(dev);
+
+program
+  .command("publish")
+  .description("Publish packages")
+  .option("--dry-run", "Prepare packages without publishing")
+  .action(publish);
 
 program.parse();

--- a/packages/ariakit-scripts/src/publish-test.ts
+++ b/packages/ariakit-scripts/src/publish-test.ts
@@ -1,0 +1,117 @@
+import { chmodSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, test, vi } from "vitest";
+import { publish } from "./publish.ts";
+
+interface PublishFixture {
+  binPath: string;
+  rootPath: string;
+}
+
+const originalCwd = process.cwd();
+const originalPath = process.env.PATH;
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  process.env.PATH = originalPath;
+  process.exitCode = undefined;
+  vi.restoreAllMocks();
+});
+
+async function createPublishFixture(): Promise<PublishFixture> {
+  const rootPath = await mkdtemp(join(tmpdir(), "ariakit-publish-"));
+  const binPath = join(rootPath, "bin");
+  mkdirSync(binPath);
+
+  await writeFile(
+    join(binPath, "pnpm"),
+    `#!/bin/sh
+printf '%s\\n' "$@" > pnpm-args.txt
+cat > pnpm-publish-summary.json <<'JSON'
+{"publishedPackages":[{"name":"@ariakit/a","version":"1.0.0"},{"name":"@ariakit/b","version":"2.0.0"}]}
+JSON
+`,
+  );
+
+  await writeFile(
+    join(binPath, "git"),
+    `#!/bin/sh
+if [ "$1" = "rev-parse" ]; then
+  exit 1
+fi
+if [ "$1" = "tag" ]; then
+  printf '%s\\n' "$2" >> git-tags.txt
+fi
+`,
+  );
+
+  chmodSync(join(binPath, "pnpm"), 0o755);
+  chmodSync(join(binPath, "git"), 0o755);
+
+  process.chdir(rootPath);
+  process.env.PATH = `${binPath}:${originalPath ?? ""}`;
+
+  return { binPath, rootPath };
+}
+
+test("publishes packages through pnpm and prints changesets tag output", async () => {
+  const { rootPath } = await createPublishFixture();
+  const logs: unknown[][] = [];
+  vi.spyOn(console, "log").mockImplementation((...args) => {
+    logs.push(args);
+  });
+
+  publish();
+
+  const tags = readFileSync(join(rootPath, "git-tags.txt"), "utf-8")
+    .trim()
+    .split("\n");
+
+  expect(tags).toEqual(["@ariakit/a@1.0.0", "@ariakit/b@2.0.0"]);
+  expect(logs).toContainEqual(["New tag: ", "@ariakit/a@1.0.0"]);
+  expect(logs).toContainEqual(["New tag: ", "@ariakit/b@2.0.0"]);
+  expect(existsSync(join(rootPath, "pnpm-publish-summary.json"))).toBe(false);
+
+  await rm(rootPath, { recursive: true, force: true });
+});
+
+test("passes dry-run to pnpm without creating tags", async () => {
+  const { rootPath } = await createPublishFixture();
+
+  publish({ dryRun: true });
+
+  const args = readFileSync(join(rootPath, "pnpm-args.txt"), "utf-8")
+    .trim()
+    .split("\n");
+
+  expect(args).toContain("--dry-run");
+  expect(existsSync(join(rootPath, "git-tags.txt"))).toBe(false);
+  expect(existsSync(join(rootPath, "pnpm-publish-summary.json"))).toBe(false);
+
+  await rm(rootPath, { recursive: true, force: true });
+});
+
+test("fails before publishing in changesets pre mode", async () => {
+  const { rootPath } = await createPublishFixture();
+  const errors: unknown[][] = [];
+  mkdirSync(join(rootPath, ".changeset"));
+  await writeFile(
+    join(rootPath, ".changeset/pre.json"),
+    JSON.stringify({ mode: "pre", tag: "next" }),
+  );
+  vi.spyOn(console, "error").mockImplementation((...args) => {
+    errors.push(args);
+  });
+
+  publish();
+
+  expect(process.exitCode).toBe(1);
+  expect(errors).toContainEqual([
+    "ariakit publish does not support Changesets pre mode yet.",
+  ]);
+  expect(existsSync(join(rootPath, "pnpm-args.txt"))).toBe(false);
+
+  await rm(rootPath, { recursive: true, force: true });
+});

--- a/packages/ariakit-scripts/src/publish.ts
+++ b/packages/ariakit-scripts/src/publish.ts
@@ -1,0 +1,139 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface PublishOptions {
+  dryRun?: boolean;
+}
+
+interface PublishedPackage {
+  name: string;
+  version: string;
+}
+
+interface PublishSummary {
+  publishedPackages?: Array<{
+    name?: unknown;
+    version?: unknown;
+  }>;
+}
+
+interface PreState {
+  mode?: unknown;
+}
+
+function getSummaryPath() {
+  return resolve("pnpm-publish-summary.json");
+}
+
+function getPreStatePath() {
+  return resolve(".changeset", "pre.json");
+}
+
+function removePublishSummary() {
+  rmSync(getSummaryPath(), { force: true });
+}
+
+function fail(message: string) {
+  console.error(message);
+  process.exitCode = 1;
+}
+
+function run(command: string, args: string[]) {
+  const result = spawnSync(command, args, { stdio: "inherit" });
+
+  if (result.error) {
+    console.error(result.error);
+    return 1;
+  }
+
+  return result.status ?? 1;
+}
+
+function isPublishedPackage(pkg: {
+  name?: unknown;
+  version?: unknown;
+}): pkg is PublishedPackage {
+  return typeof pkg.name === "string" && typeof pkg.version === "string";
+}
+
+function readPublishedPackages() {
+  const summaryPath = getSummaryPath();
+  if (!existsSync(summaryPath)) return [];
+
+  const summary: PublishSummary = JSON.parse(
+    readFileSync(summaryPath, "utf-8"),
+  );
+  const packages = summary.publishedPackages ?? [];
+  return packages.filter(isPublishedPackage);
+}
+
+function isInPreMode() {
+  const preStatePath = getPreStatePath();
+  if (!existsSync(preStatePath)) return false;
+
+  const preState: PreState = JSON.parse(readFileSync(preStatePath, "utf-8"));
+  return preState.mode === "pre";
+}
+
+function tagExists(tag: string) {
+  const result = spawnSync(
+    "git",
+    ["rev-parse", "-q", "--verify", `refs/tags/${tag}`],
+    { stdio: "ignore" },
+  );
+  return result.status === 0;
+}
+
+function createTag(tag: string) {
+  if (tagExists(tag)) return;
+
+  const status = run("git", ["tag", tag]);
+
+  if (status !== 0) {
+    process.exit(status);
+  }
+}
+
+export function publish(options: PublishOptions = {}) {
+  if (isInPreMode()) {
+    fail("ariakit publish does not support Changesets pre mode yet.");
+    return;
+  }
+
+  const publishArgs = options.dryRun ? ["--dry-run"] : [];
+  removePublishSummary();
+
+  const status = run("pnpm", [
+    "publish",
+    "-r",
+    "--access",
+    "public",
+    "--no-git-checks",
+    "--report-summary",
+    ...publishArgs,
+  ]);
+
+  if (status !== 0) {
+    process.exitCode = status;
+    return;
+  }
+
+  const publishedPackages = readPublishedPackages();
+  removePublishSummary();
+
+  if (!publishedPackages.length) {
+    console.warn("No unpublished projects to publish");
+    return;
+  }
+
+  if (options.dryRun) return;
+
+  console.log(`Creating git tag${publishedPackages.length > 1 ? "s" : ""}...`);
+
+  for (const pkg of publishedPackages) {
+    const tag = `${pkg.name}@${pkg.version}`;
+    createTag(tag);
+    console.log("New tag: ", tag);
+  }
+}


### PR DESCRIPTION
## Motivation

The release workflow can partially publish dependent packages even when one of their dependency packages fails during publish. This is the same class of problem discussed in [changesets/changesets#238](https://github.com/changesets/changesets/issues/238): package publishes should follow dependency order so dependents are not released ahead of failed dependencies.

## Solution

Move the publish step into `@ariakit/scripts` as `ariakit publish` and use `pnpm publish -r` for recursive workspace publishing. pnpm handles workspace publish ordering, while the wrapper uses `--report-summary` to create the local git tags and emit the `New tag:` lines that `changesets/action` already parses for pushing tags and creating GitHub releases.

The wrapper fails before publishing when Changesets pre mode is active. That keeps prereleases from accidentally being published under `latest` until pre-mode tag handling is explicitly supported.

## Verification

- `pnpm lint-fix`
- `pnpm test packages/ariakit-scripts/src/publish-test.ts`
- `pnpm exec ariakit publish --dry-run`
- `pnpm tsc`
- `git diff --check`
