### PR TITLE
Trigger trusted package publishes

### DIFF
--- a/.changeset/300-trusted-publishing-provenance.md
+++ b/.changeset/300-trusted-publishing-provenance.md
@@ -1,0 +1,16 @@
+---
+"@ariakit/utils": patch
+"@ariakit/store": patch
+"@ariakit/components": patch
+"@ariakit/react-utils": patch
+"@ariakit/react-store": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+"@ariakit/solid-utils": patch
+"@ariakit/solid-store": patch
+"@ariakit/solid-components": patch
+"@ariakit/solid": patch
+"@ariakit/test": patch
+---
+
+Release artifacts now include npm trusted publishing provenance.


### PR DESCRIPTION
## Motivation

The first split package releases were recovered manually after the release workflow failed. Those versions are published, but the split packages do not have npm trusted-publishing provenance. Packages like `@ariakit/react` also point at those first split package versions, which can leave package-manager trust policies seeing the latest dependency graph as weaker than expected.

## Solution

Add a patch changeset for the split packages and wrappers that should be re-published through the trusted release workflow. The release PR produced from this changeset will publish new latest versions with npm provenance and update wrapper dependencies to point at the newly attested split package releases.

## Verification

- `pnpm changeset status`
- `pnpm lint-fix`
