### PR TITLE
Fix React template package versions

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,19 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@wordpress/components>@ariakit/react': workspace:*
+  '@ariakit/components': workspace:*
+  '@ariakit/react': workspace:*
+  '@ariakit/react-components': workspace:*
+  '@ariakit/react-store': workspace:*
+  '@ariakit/react-utils': workspace:*
+  '@ariakit/solid': workspace:*
+  '@ariakit/solid-components': workspace:*
+  '@ariakit/solid-store': workspace:*
+  '@ariakit/solid-utils': workspace:*
+  '@ariakit/store': workspace:*
+  '@ariakit/tailwind': workspace:*
+  '@ariakit/test': workspace:*
+  '@ariakit/utils': workspace:*
 
 patchedDependencies:
   '@changesets/apply-release-plan@7.1.1': 19cb6131207f59da50995e2f93d09dbcaccb346cdc696d59f1aa89e3114f6ac5
@@ -777,28 +789,49 @@ importers:
 
   templates/react:
     dependencies:
+      '@ariakit/components':
+        specifier: workspace:*
+        version: link:../../packages/ariakit-components
       '@ariakit/react':
         specifier: workspace:*
         version: link:../../packages/ariakit-react
+      '@ariakit/react-components':
+        specifier: workspace:*
+        version: link:../../packages/ariakit-react-components
+      '@ariakit/react-store':
+        specifier: workspace:*
+        version: link:../../packages/ariakit-react-store
+      '@ariakit/react-utils':
+        specifier: workspace:*
+        version: link:../../packages/ariakit-react-utils
+      '@ariakit/store':
+        specifier: workspace:*
+        version: link:../../packages/ariakit-store
       '@ariakit/tailwind':
         specifier: workspace:*
         version: link:../../packages/ariakit-tailwind
+      '@ariakit/test':
+        specifier: workspace:*
+        version: link:../../packages/ariakit-test
+      '@ariakit/utils':
+        specifier: workspace:*
+        version: link:../../packages/ariakit-utils
       react:
-        specifier: 18.3.1
-        version: 18.3.1
+        specifier: 19.2.6
+        version: 19.2.6
       react-dom:
-        specifier: 18.3.1
-        version: 18.3.1(react@18.3.1)
+        specifier: 19.2.6
+        version: 19.2.6(react@19.2.6)
     devDependencies:
       '@tailwindcss/vite':
         specifier: 4.3.0
         version: 4.3.0(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.4))
       '@types/react':
-        specifier: 18.3.29
-        version: 18.3.29
+        specifier: 19.2.15
+        version: 19.2.15
       '@types/react-dom':
-        specifier: 18.3.7
-        version: 18.3.7(@types/react@18.3.29)
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.15)
       '@vitejs/plugin-react':
         specifier: 6.0.2
         version: 6.0.2(babel-plugin-react-compiler@1.0.0)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.4))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -810,9 +810,6 @@ importers:
       '@ariakit/tailwind':
         specifier: workspace:*
         version: link:../../packages/ariakit-tailwind
-      '@ariakit/test':
-        specifier: workspace:*
-        version: link:../../packages/ariakit-test
       '@ariakit/utils':
         specifier: workspace:*
         version: link:../../packages/ariakit-utils
@@ -823,6 +820,9 @@ importers:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
     devDependencies:
+      '@ariakit/test':
+        specifier: workspace:*
+        version: link:../../packages/ariakit-test
       '@tailwindcss/vite':
         specifier: 4.3.0
         version: 4.3.0(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.4))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,19 @@ allowBuilds:
   workerd: true
 
 overrides:
-  "@wordpress/components>@ariakit/react": "workspace:*"
+  "@ariakit/components": "workspace:*"
+  "@ariakit/react": "workspace:*"
+  "@ariakit/react-components": "workspace:*"
+  "@ariakit/react-store": "workspace:*"
+  "@ariakit/react-utils": "workspace:*"
+  "@ariakit/solid": "workspace:*"
+  "@ariakit/solid-components": "workspace:*"
+  "@ariakit/solid-store": "workspace:*"
+  "@ariakit/solid-utils": "workspace:*"
+  "@ariakit/store": "workspace:*"
+  "@ariakit/tailwind": "workspace:*"
+  "@ariakit/test": "workspace:*"
+  "@ariakit/utils": "workspace:*"
 
 patchedDependencies:
   "@changesets/apply-release-plan@7.1.1": "patches/@changesets__apply-release-plan@7.1.1.patch"

--- a/renovate.json
+++ b/renovate.json
@@ -137,7 +137,7 @@
         "@types/react-dom"
       ],
       "matchUpdateTypes": ["major"],
-      "matchFileNames": ["nextjs/**"],
+      "matchFileNames": ["nextjs/**", "templates/**"],
       "enabled": true
     },
     {

--- a/templates/react/package.json
+++ b/templates/react/package.json
@@ -17,12 +17,12 @@
     "@ariakit/react-utils": "latest",
     "@ariakit/store": "latest",
     "@ariakit/tailwind": "latest",
-    "@ariakit/test": "latest",
     "@ariakit/utils": "latest",
     "react": "19.2.6",
     "react-dom": "19.2.6"
   },
   "devDependencies": {
+    "@ariakit/test": "latest",
     "@tailwindcss/vite": "4.3.0",
     "@types/react": "19.2.15",
     "@types/react-dom": "19.2.3",

--- a/templates/react/package.json
+++ b/templates/react/package.json
@@ -10,15 +10,22 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ariakit/react": "workspace:*",
-    "@ariakit/tailwind": "workspace:*",
-    "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "@ariakit/components": "latest",
+    "@ariakit/react": "latest",
+    "@ariakit/react-components": "latest",
+    "@ariakit/react-store": "latest",
+    "@ariakit/react-utils": "latest",
+    "@ariakit/store": "latest",
+    "@ariakit/tailwind": "latest",
+    "@ariakit/test": "latest",
+    "@ariakit/utils": "latest",
+    "react": "19.2.6",
+    "react-dom": "19.2.6"
   },
   "devDependencies": {
     "@tailwindcss/vite": "4.3.0",
-    "@types/react": "18.3.29",
-    "@types/react-dom": "18.3.7",
+    "@types/react": "19.2.15",
+    "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.2",
     "tailwindcss": "4.3.0",
     "typescript": "6.0.3",


### PR DESCRIPTION
## Motivation

The React StackBlitz template is used to test unpublished Ariakit package changes through pkg.pr.new. pkg.pr.new only rewrites packages that are present in the uploaded template `package.json`, and any unpublished internal package left as `workspace:*` breaks the StackBlitz install.

The `--pnpm` experiment confirmed that package packing mode does not rewrite unpublished template dependencies, so the template itself needs valid package specs.

## Solution

Replace the Ariakit `workspace:*` dependencies in `templates/react/package.json` with valid npm specs so the uploaded StackBlitz project can install even when a package was not published by pkg.pr.new for the current PR.

The React template now lists the React-side public Ariakit runtime packages with `latest`, excluding Solid packages, so pkg.pr.new can rewrite changed packages by name while unchanged packages stay installable from npm. `@ariakit/test` is kept in `devDependencies` for pkg.pr.new rewriting without making it a runtime template dependency. Local monorepo installs still use workspace packages through root pnpm overrides for each public Ariakit package. Wildcard override selectors such as `template-*>@ariakit/*` and `@ariakit/*` were tested, but pnpm did not resolve them to workspace links, so the overrides are explicit per package.

This also updates the React template to React 19 and widens the existing Renovate React-major exception from `nextjs/**` to `nextjs/**` and `templates/**`.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm -F template-react build`
- Verified `templates/react/package.json` has no `workspace:*` specs and no `@ariakit/solid*` dependencies.
- Verified `@ariakit/test` is a dev dependency only in the React template.
- Verified `renovate.json` parses as valid JSON.
