### PR TITLE
Document Tailwind layer requirements

### DIFF
--- a/packages/ariakit-tailwind/migrating-to-v02.md
+++ b/packages/ariakit-tailwind/migrating-to-v02.md
@@ -65,19 +65,19 @@ In contexts where bare `ak-layer` previously implied a subtle lighten (e.g., pop
 + ak-layer ak-layer-lighten-6
 ```
 
-### `ak-layer-hover` → `ak-layer ak-state-6`
+### `ak-layer-hover` → `ak-layer hover:ak-state-6`
 
 The hover layer shorthand is replaced by `ak-state-N` for interactive state lightness.
 
 ```diff
 - ak-layer-hover
-+ ak-layer ak-state-6
++ ak-layer hover:ak-state-6
 
 - ak-layer-hover-0.5
-+ ak-layer ak-state-3
++ ak-layer hover:ak-state-3
 ```
 
-When the element already has `ak-layer`, only `ak-state-6` needs to be added.
+When the element already has `ak-layer`, only `hover:ak-state-6` needs to be added.
 
 ### `ak-layer-contrast-primary` → `ak-layer ak-layer-primary ak-layer-contrast`
 
@@ -157,6 +157,13 @@ When `ak-layer` is NOT already on the element and should only appear conditional
 
 <!-- No base ak-layer — need it on data-open for background to appear -->
 <div class="data-open:ak-layer data-open:ak-layer-6">...</div>
+```
+
+`ak-state-*` is different from conditional `ak-layer-*` modifiers: these utilities require the static `ak-layer` class on the same element, so keep `ak-layer` unprefixed and add state modifiers with variants:
+
+```diff
+- hover:ak-layer hover:ak-state-6
++ ak-layer hover:ak-state-6
 ```
 
 ---
@@ -258,32 +265,39 @@ For custom push values, use `ak-text-push-(--value)` instead of `ak-text-(number
 
 ## Edge (border/ring)
 
-### `ak-edge/N` → `ak-edge-N`
+### `ak-edge/N` → `ak-layer ak-edge-N`
 
 ```diff
 - ak-edge/15
-+ ak-edge-15
++ ak-layer ak-edge-15
 ```
 
-### `ak-edge-(--color)/N` → `ak-edge-color-(--color) ak-edge-N`
+### `ak-edge-(--color)/N` → `ak-layer ak-edge-color-(--color) ak-edge-N`
 
 ```diff
 - ak-edge-(--my-color)/10
-+ ak-edge-color-(--my-color) ak-edge-10
++ ak-layer ak-edge-color-(--my-color) ak-edge-10
 ```
 
-### `ak-edge-contrast-primary` → `ak-edge-primary ak-edge-raw`
+### `ak-edge-contrast-primary` → `ak-layer ak-edge-primary ak-edge-raw`
 
 In v0.1, `ak-edge-contrast-<color>` set the edge to a solid color with lightness adjusted for contrast against the layer background. In v0.2, `ak-edge-<color>` sets the color and `ak-edge-raw` locks it to full opacity with no lightness push, matching the old solid behavior.
 
 ```diff
 - ak-edge-contrast-primary
-+ ak-edge-primary ak-edge-raw
++ ak-layer ak-edge-primary ak-edge-raw
 ```
 
 `ak-edge-raw` is shorthand for `ak-edge-100 ak-edge-push-0` — use it when you want the color to be applied exactly as specified. For other combinations, `ak-edge-N` controls alpha (`100` = opaque) and `ak-edge-push-N` controls how far the edge lightness is pushed away from the layer (`0` = the color's natural lightness).
 
 For custom alpha values, use `ak-edge-alpha-(--alpha)` instead of `ak-edge-(number:--alpha)`. The `--alpha` custom property should contain a raw alpha value such as `0.4`.
+
+`ak-edge-*` utilities now require the static `ak-layer` class on the same element:
+
+```diff
+- ak-edge-15
++ ak-layer ak-edge-15
+```
 
 ### CSS variable renames (color)
 

--- a/packages/ariakit-tailwind/readme.md
+++ b/packages/ariakit-tailwind/readme.md
@@ -60,7 +60,7 @@ Ariakit Tailwind revolves around a few families of utilities:
 - **[`ak-layer`](#ak-layer)** turns any element into a _layer_ — a surface with its own background, text, and edge colors. Layers can nest, and lightness modifiers such as `ak-layer-lighten-*`, `ak-layer-darken-*`, and numeric `ak-layer-*` modifiers shift nested surfaces relative to their parent so stacked surfaces read correctly in both light and dark modes.
 - **[`ak-ink`](#ak-ink)** sets the text opacity for the layer's own text. Safe to apply on the same element as `ak-layer` or on a descendant.
 - **[`ak-text`](#ak-text)** colors inline text _inside_ a layer with automatic WCAG contrast. Must go on a descendant, not on the `ak-layer` element itself.
-- **[`ak-edge`](#ak-edge)** colors borders and rings, adapting opacity and contrast to the layer behind them.
+- **[`ak-edge`](#ak-edge)** colors borders and rings, adapting opacity and contrast to the element's own layer. `ak-edge-*` utilities require the static `ak-layer` class on the same element.
 - **[`ak-outline`](#ak-outline)** colors outlines in the same adaptive way.
 - **[`ak-frame`](#ak-frame)** handles radius, padding, margin, borders, and concentric-radius layout.
 
@@ -220,6 +220,8 @@ The explicit `ak-layer-mix-*` longhands configure the mix color, amount, and met
 
 `ak-state-*` utilities are companions to `ak-layer-*` that target interactive states (hover, active, focus). They shift the state layer's lightness, chroma, and hue separately from the idle layer setup. Descendant text and edges still respond to the resulting layer color.
 
+The static `ak-layer` class must be applied to the same element as `ak-state-*`. Keep `ak-layer` unprefixed, then add state utilities with variants such as `hover:` or `active:`.
+
 ```html
 <button class="ak-layer ak-layer-primary hover:ak-state-10 active:ak-state-20">
   Primary action
@@ -305,7 +307,9 @@ Controls the opacity of text inside a layer — useful for secondary text, capti
 
 ## `ak-edge`
 
-`ak-edge` controls border and ring colors for any element inside an [`ak-layer`](#ak-layer). Useful for giving borders their own hue, saturation, or opacity without affecting the surface.
+`ak-edge` controls border and ring colors for the element's own [`ak-layer`](#ak-layer). Useful for giving borders their own hue, saturation, or opacity without affecting the surface.
+
+`ak-edge-*` utilities require the static `ak-layer` class on the same element so the edge color can resolve against that layer.
 
 ```html
 <div class="ak-layer ak-frame ak-frame-border ak-edge-10">10% edge opacity</div>
@@ -527,15 +531,15 @@ Each layer appearance variant also has a `not-*` counterpart, such as
 
 ```html
 <div class="ak-layer ak-layer-canvas">
-  <div class="ak-dark:ak-layer-darken-6 ak-light:ak-layer-lighten-6">
+  <div class="ak-layer ak-dark:ak-layer-darken-6 ak-light:ak-layer-lighten-6">
     Adapts to its parent layer's appearance.
   </div>
 
-  <div class="ak-dark-high:ak-edge-20 ak-light-high:ak-edge-10">
+  <div class="ak-layer ak-dark-high:ak-edge-20 ak-light-high:ak-edge-10">
     Stronger edges on the darkest surfaces.
   </div>
 
-  <div class="not-ak-dark:ak-layer-lighten-6">
+  <div class="ak-layer not-ak-dark:ak-layer-lighten-6">
     Applies inside this layer when the current layer is not dark.
   </div>
 </div>


### PR DESCRIPTION
## Motivation

The `@ariakit/tailwind` docs describe `ak-edge-*` and `ak-state-*` utilities without explicitly stating that they depend on a same-element static `ak-layer`. That can lead readers to apply edge or state modifiers without the layer setup they need.

## Solution

Document the same-element static `ak-layer` requirement in the package README and the v0.2 migration guide. The migration guide now shows `ak-layer` in the affected `ak-edge-*` replacements and uses variant-prefixed `ak-state-*` examples with an unprefixed `ak-layer`.

## Verification

- `pnpm lint-fix`