### PR TITLE
Fix Tailwind inherited edge context

### DIFF
--- a/.changeset/300-tailwind-edge-inherit-context.md
+++ b/.changeset/300-tailwind-edge-inherit-context.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/tailwind": patch
+---
+
+Fixed `ak-edge-inherit` so descendant layers keep the inherited edge color.

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/dark
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/dark
@@ -52,7 +52,14 @@
         "children": {
           "20": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
           "push": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
-          "host": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+          "nested layer": {
+            "class": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
+            "children": {
+              "child": "bg-[oklch(0.4595_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(1_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
+              "override": "bg-[oklch(0.4595_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(0.827_0.194_149.214_/_0.4)] p-[4px] shadow-[oklch(0.827_0.194_149.214_/_0.4)_0px_0px_0px_0px]"
+            }
+          },
+          "host": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.4)_0px_0px_0px_0px]"
         }
       },
       "bordering inherit": {

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
@@ -52,7 +52,14 @@
         "children": {
           "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
           "push": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
-          "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+          "nested layer": {
+            "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
+            "children": {
+              "child": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(1_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
+              "override": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(1_0.194_149.214_/_0.7334)] p-[4px] shadow-[oklch(1_0.194_149.214_/_0.7334)_0px_0px_0px_0px]"
+            }
+          },
+          "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.7334)_0px_0px_0px_0px]"
         }
       },
       "bordering inherit": {

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/light
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/light
@@ -52,7 +52,14 @@
         "children": {
           "20": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
           "push": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.2_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(0.2_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
-          "host": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+          "nested layer": {
+            "class": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
+            "children": {
+              "child": "bg-[oklch(0.4595_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
+              "override": "bg-[oklch(0.4595_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(0.827_0.194_149.214_/_0.4)] p-[4px] shadow-[oklch(0.827_0.194_149.214_/_0.4)_0px_0px_0px_0px]"
+            }
+          },
+          "host": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.4)_0px_0px_0px_0px]"
         }
       },
       "bordering inherit": {

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
@@ -52,7 +52,14 @@
         "children": {
           "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
           "push": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.5334_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(0.5334_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
-          "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+          "nested layer": {
+            "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
+            "children": {
+              "child": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
+              "override": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(1_0.194_149.214_/_0.7334)] p-[4px] shadow-[oklch(1_0.194_149.214_/_0.7334)_0px_0px_0px_0px]"
+            }
+          },
+          "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.7334)_0px_0px_0px_0px]"
         }
       },
       "bordering inherit": {

--- a/app/src/sandbox/ariakit-tailwind/index.react.tsx
+++ b/app/src/sandbox/ariakit-tailwind/index.react.tsx
@@ -428,6 +428,19 @@ export default function Example() {
               label="push"
               className="ak-layer ak-layer-20 ak-edge-inherit ak-edge-push-20 ak-frame ak-frame-p-1 ak-frame-border"
             />
+            <Layer
+              label="nested layer"
+              className="ak-layer ak-layer-20 ak-edge-inherit ak-frame ak-frame-p-1 ak-frame-border flex-col"
+            >
+              <Layer
+                label="child"
+                className="ak-layer ak-layer-20 ak-frame ak-frame-p-1 ak-frame-border"
+              />
+              <Layer
+                label="override"
+                className="ak-layer ak-layer-20 ak-edge-green-600 ak-edge-push-20 ak-edge-40 ak-frame ak-frame-p-1 ak-frame-border"
+              />
+            </Layer>
             <div className="ak-edge-inherit">
               <Layer
                 label="host"

--- a/packages/ariakit-tailwind/readme.md
+++ b/packages/ariakit-tailwind/readme.md
@@ -320,16 +320,16 @@ Controls the opacity of text inside a layer — useful for secondary text, capti
 
 ### Setting the edge color
 
-| Utility                 | Description                                                                                                                                                   |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ak-edge-<number>`      | Sets edge alpha (`0`–`100`, default `10`).                                                                                                                    |
-| `ak-edge-alpha-<value>` | Explicit alpha alias for `ak-edge-<number>`. Useful for custom properties (`ak-edge-alpha-(--alpha)`). Arbitrary/custom-property values are raw alpha values. |
-| `ak-edge-<color>`       | Applies a specific edge color.                                                                                                                                |
-| `ak-edge-color-<color>` | Explicit color-only alias. Useful for custom properties (`ak-edge-color-(--edge-color)`).                                                                     |
-| `ak-edge-<chroma>`      | Sets chroma from a named preset.                                                                                                                              |
-| `ak-edge-<hue>`         | Sets hue from a named preset.                                                                                                                                 |
-| `ak-edge-raw`           | Applies the color exactly as specified — shorthand for `ak-edge-100` + `ak-edge-push-0`.                                                                      |
-| `ak-edge-inherit`       | Uses the parent layer edge as the current edge color while preserving the parent edge alpha and lightness.                                                    |
+| Utility                 | Description                                                                                                                                                                              |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ak-edge-<number>`      | Sets edge alpha (`0`–`100`, default `10`).                                                                                                                                               |
+| `ak-edge-alpha-<value>` | Explicit alpha alias for `ak-edge-<number>`. Useful for custom properties (`ak-edge-alpha-(--alpha)`). Arbitrary/custom-property values are raw alpha values.                            |
+| `ak-edge-<color>`       | Applies a specific edge color.                                                                                                                                                           |
+| `ak-edge-color-<color>` | Explicit color-only alias. Useful for custom properties (`ak-edge-color-(--edge-color)`).                                                                                                |
+| `ak-edge-<chroma>`      | Sets chroma from a named preset.                                                                                                                                                         |
+| `ak-edge-<hue>`         | Sets hue from a named preset.                                                                                                                                                            |
+| `ak-edge-raw`           | Applies the color exactly as specified — shorthand for `ak-edge-100` + `ak-edge-push-0`.                                                                                                 |
+| `ak-edge-inherit`       | Uses the parent layer edge as the current edge color while preserving the parent edge alpha and lightness for the element and descendant layers until they set their own edge utilities. |
 
 ### Adjustments
 

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -599,6 +599,12 @@ const layerColorVars = {
   outline: ak.var("outline", "canvastext"),
 };
 
+const edgeContextVars = {
+  edgeColorContext: _ak.var("ecc"),
+  edgePushLContext: _ak.var("eplc", 1),
+  edgeAlphaContext: _ak.var("eac", 0.1),
+};
+
 const layerContrastMathVars = {
   layerContrastDirection: _ak.prop.number("lcd", { initial: 0 }),
   layerContrastParentL: _ak.prop.number("lcpl", { initial: 0 }),
@@ -651,6 +657,7 @@ const vars = {
   ...layerMathVars,
   ...themeTokenVars,
   ...layerColorVars,
+  ...edgeContextVars,
   ...layerContrastMathVars,
   ...outlineMathVars,
   ...textMathVars,
@@ -688,7 +695,7 @@ const inputs = {
   edgeRelativeL: _ak.prop("edge-relative-lightness", { initial: 0 }),
   edgeRelativeC: _ak.prop("edge-relative-chroma", { initial: 0 }),
   edgeRelativeH: _ak.prop("edge-relative-hue", { initial: 0 }),
-  edgePushL: _ak.prop("edge-push-lightness", { initial: 1 }),
+  edgePushL: _ak.prop("edge-push-lightness", vars.edgePushLContext),
   edgeLMin: _ak.prop("edge-lightness-min", { initial: 0 }),
   edgeLMax: _ak.prop("edge-lightness-max", { initial: 1 }),
   edgeCMin: _ak.prop("edge-chroma-min", { initial: 0 }),
@@ -696,7 +703,7 @@ const inputs = {
   edgeL: _ak.prop("edge-lightness"),
   edgeC: _ak.prop("edge-chroma"),
   edgeH: _ak.prop("edge-h"),
-  edgeA: _ak.prop("edge-alpha", { initial: 0.1 }),
+  edgeA: _ak.prop("edge-alpha", vars.edgeAlphaContext),
   textPushL: _ak.prop("text-push-lightness", { initial: 0 }),
   textA: _ak.prop("text-alpha", { initial: 1 }),
   textColor: _ak.prop("text-color"),
@@ -1224,7 +1231,10 @@ const layerColorDeclarations = [
   set(vars.layerPush, layerPush),
 ];
 
-const edgeBaseColor = fn.var(inputs.edgeColor, vars.layer);
+const edgeBaseColor = fn.var(
+  inputs.edgeColor,
+  fn.var(vars.edgeColorContext, vars.layer),
+);
 // Borders get a small extra push from the current contrast preference so they
 // stay perceptible even when the user does not specify an edge push value.
 const edgeDirectionalDelta = fn.add(inputs.edgePushL, vars.edgeContrastValue);
@@ -1639,10 +1649,15 @@ utility(
   "edge-inherit",
   layerContext.read(({ inherit }) => {
     const parentEdge = inherit(vars.layerEdgeContext, vars.layer);
+    const inheritedEdgePushL = fn.neg(vars.edgeContrastValue);
+    const inheritedEdgeAlpha = fn.sub(alpha, vars.edgeContrastValue);
     return [
+      set(vars.edgeColorContext, parentEdge),
+      set(vars.edgePushLContext, inheritedEdgePushL),
+      set(vars.edgeAlphaContext, inheritedEdgeAlpha),
       set(inputs.edgeColor, parentEdge),
-      set(inputs.edgePushL, fn.neg(vars.edgeContrastValue)),
-      set(inputs.edgeA, fn.sub(alpha, vars.edgeContrastValue)),
+      set(inputs.edgePushL, inheritedEdgePushL),
+      set(inputs.edgeA, inheritedEdgeAlpha),
     ];
   }),
 );

--- a/packages/ariakit-tailwind/src/output.css
+++ b/packages/ariakit-tailwind/src/output.css
@@ -118,7 +118,7 @@
   @apply ring-[color:var(--ak-edge)];
   --ak-layer: oklch(from var(--_ak-lp) var(--_ak-sl) clamp(var(--_ak-layer-chroma-min), c, var(--_ak-layer-chroma-max, var(--chroma-p3-max, 0.368))) h);
   --ak-text: var(--_ak-ls);
-  --ak-edge: oklch(from oklch(from var(--_ak-edge-color, var(--ak-layer)) clamp(0, (l + ((var(--_ak-edge-push-lightness) + var(--_ak-ecv)) * var(--_ak-epd, -1))), 1) c h) clamp(var(--_ak-edge-lightness-min), var(--_ak-edge-lightness, (l + var(--_ak-edge-relative-lightness) + (clamp(0, (var(--_ak-edge-relative-lightness) * 1000000), 1) * var(--_ak-llfb)))), var(--_ak-edge-lightness-max)) clamp(var(--_ak-edge-chroma-min), var(--_ak-edge-chroma, (c + var(--_ak-edge-relative-chroma))), var(--_ak-edge-chroma-max, var(--chroma-p3-max, 0.368))) var(--_ak-edge-h, calc(h + var(--_ak-edge-relative-hue))) / clamp(0, (var(--_ak-edge-alpha) + var(--_ak-ecv)), 1));
+  --ak-edge: oklch(from oklch(from var(--_ak-edge-color, var(--_ak-ecc, var(--ak-layer))) clamp(0, (l + ((var(--_ak-edge-push-lightness, var(--_ak-eplc, 1)) + var(--_ak-ecv)) * var(--_ak-epd, -1))), 1) c h) clamp(var(--_ak-edge-lightness-min), var(--_ak-edge-lightness, (l + var(--_ak-edge-relative-lightness) + (clamp(0, (var(--_ak-edge-relative-lightness) * 1000000), 1) * var(--_ak-llfb)))), var(--_ak-edge-lightness-max)) clamp(var(--_ak-edge-chroma-min), var(--_ak-edge-chroma, (c + var(--_ak-edge-relative-chroma))), var(--_ak-edge-chroma-max, var(--chroma-p3-max, 0.368))) var(--_ak-edge-h, calc(h + var(--_ak-edge-relative-hue))) / clamp(0, (var(--_ak-edge-alpha, var(--_ak-eac, 0.1)) + var(--_ak-ecv)), 1));
   --_ak-lbd: oklch(from var(--ak-layer) calc(0.5 + (var(--_ak-bdh) * -0.5) + (var(--_ak-bdl) * -0.25) + (var(--_ak-bll) * 0.25) + (var(--_ak-blh) * 0.5)) 0 0);
   --_ak-ls: oklch(from var(--ak-layer) var(--_ak-tfcl) 0 0);
   --_ak-ll: oklch(from var(--ak-layer) round(l, 0.125) 0 0);
@@ -441,11 +441,17 @@
 
 @utility ak-edge-inherit {
   @container (style(--_context-0: even)) or (not style(--_context-0)) {
+    --_ak-ecc: var(--_ak-lec-even, var(--ak-layer));
+    --_ak-eplc: calc(var(--_ak-ecv) * -1);
+    --_ak-eac: calc(alpha - var(--_ak-ecv));
     --_ak-edge-color: var(--_ak-lec-even, var(--ak-layer));
     --_ak-edge-push-lightness: calc(var(--_ak-ecv) * -1);
     --_ak-edge-alpha: calc(alpha - var(--_ak-ecv));
   }
   @container style(--_context-0: odd) {
+    --_ak-ecc: var(--_ak-lec-odd, var(--ak-layer));
+    --_ak-eplc: calc(var(--_ak-ecv) * -1);
+    --_ak-eac: calc(alpha - var(--_ak-ecv));
     --_ak-edge-color: var(--_ak-lec-odd, var(--ak-layer));
     --_ak-edge-push-lightness: calc(var(--_ak-ecv) * -1);
     --_ak-edge-alpha: calc(alpha - var(--_ak-ecv));
@@ -1763,7 +1769,6 @@
 @property --_ak-edge-push-lightness {
   syntax: "*";
   inherits: false;
-  initial-value: 1;
 }
 
 @property --_ak-edge-lightness-min {
@@ -1807,7 +1812,6 @@
 @property --_ak-edge-alpha {
   syntax: "*";
   inherits: false;
-  initial-value: 0.1;
 }
 
 @property --_ak-text-push-lightness {


### PR DESCRIPTION
## Motivation

`ak-edge-inherit` should make an element use the parent layer edge. It worked on the element itself, but descendant `ak-layer` elements inside an `ak-edge-inherit` host fell back to their own layer-derived edge color, so the inherited edge was lost in nested compositions.

## Solution

Carry the inherited edge color, push, and alpha through explicit edge context defaults that descendant layers can use when they do not set their own edge inputs. The Tailwind sandbox now covers direct inherit, nested inherited layers, explicit edge overrides, and non-layer host wrappers across light, dark, and high-contrast computed-style snapshots.

## Testing

- `pnpm -F @ariakit/tailwind build`
- `APP_PORT=4322 pnpm -F app test-chrome ariakit-tailwind --grep-invert wcag --workers=1 -u`
- `APP_PORT=4322 pnpm -F app test-chrome ariakit-tailwind --workers=1`
- `pnpm lint-fix`
- `pnpm tsc`
- `git diff --check`

The perf suite was not run; this is a targeted behavior fix rather than a performance change.
