### PR TITLE
Fix Tailwind inherit contexts

### DIFF
--- a/.changeset/300-tailwind-inherit-context.md
+++ b/.changeset/300-tailwind-inherit-context.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/tailwind": patch
+---
+
+Fixed `ak-edge-inherit` and `ak-frame-bordering-inherit` to inherit from the nearest ancestor that explicitly configures an edge or frame border/ring width.

--- a/.changeset/300-tailwind-inherit-context.md
+++ b/.changeset/300-tailwind-inherit-context.md
@@ -2,4 +2,4 @@
 "@ariakit/tailwind": patch
 ---
 
-Fixed `ak-edge-inherit` and `ak-frame-bordering-inherit` to inherit from the nearest ancestor that explicitly configures an edge or frame border/ring width.
+Fixed `ak-edge-inherit` and `ak-frame-bordering-inherit` to inherit from the nearest ancestor that explicitly configures a frame border, ring, or bordering width.

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/dark
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/dark
@@ -1,4 +1,17 @@
 {
+  "edge inherit root no source": "bg-[oklch(0.3634_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
+  "edge inherit no source": {
+    "class": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)]",
+    "children": {
+      "host": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+    }
+  },
+  "edge inherit edge no source": {
+    "class": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)]",
+    "children": {
+      "host": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+    }
+  },
   "One-off": {
     "class": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[20px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
     "children": {

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/dark
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/dark
@@ -77,6 +77,12 @@
               "host": "bg-[oklch(0.4595_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(1_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.4)_0px_0px_0px_0px]"
             }
           },
+          "frame source": {
+            "class": "text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0_0)] p-[4px] shadow-[oklch(1_0_0)_0px_0px_0px_0px]",
+            "children": {
+              "host": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(1_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.4)_0px_0px_0px_0px]"
+            }
+          },
           "zero": {
             "class": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
             "children": {

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/dark
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/dark
@@ -52,6 +52,18 @@
         "children": {
           "20": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
           "push": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
+          "skip": {
+            "class": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
+            "children": {
+              "host": "bg-[oklch(0.4595_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(1_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.4)_0px_0px_0px_0px]"
+            }
+          },
+          "zero": {
+            "class": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+            "children": {
+              "host": "bg-[oklch(0.4595_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0_262.881_/_0)] p-[4px] shadow-[oklch(0_0_262.881_/_0)_0px_0px_0px_0px]"
+            }
+          },
           "host": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
         }
       },
@@ -60,6 +72,18 @@
         "children": {
           "20": "bg-[oklch(0.3634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
           "20 (2)": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_4px]",
+          "skip": {
+            "class": "bg-[oklch(0.3634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
+            "children": {
+              "host": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[3px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_4px]"
+            }
+          },
+          "zero": {
+            "class": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
+            "children": {
+              "host": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[3px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+            }
+          },
           "host": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[3px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_4px]"
         }
       },

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/dark
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/dark
@@ -53,15 +53,21 @@
           "20": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
           "push": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
           "skip": {
-            "class": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+            "children": {
+              "host": "bg-[oklch(0.4595_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.4)_0px_0px_0px_0px]"
+            }
+          },
+          "inherit skip": {
+            "class": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
             "children": {
               "host": "bg-[oklch(0.4595_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(1_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.4)_0px_0px_0px_0px]"
             }
           },
           "zero": {
-            "class": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
             "children": {
-              "host": "bg-[oklch(0.4595_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0_262.881_/_0)] p-[4px] shadow-[oklch(0_0_262.881_/_0)_0px_0px_0px_0px]"
+              "host": "bg-[oklch(0.4595_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0_262.881_/_0)] p-[4px] shadow-[oklch(0_0_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "host": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]"

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
@@ -77,6 +77,12 @@
               "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(1_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.7334)_0px_0px_0px_0px]"
             }
           },
+          "frame source": {
+            "class": "text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0_0)] p-[4px] shadow-[oklch(1_0_0)_0px_0px_0px_0px]",
+            "children": {
+              "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(1_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.7334)_0px_0px_0px_0px]"
+            }
+          },
           "zero": {
             "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.3334)_0px_0px_0px_0px]",
             "children": {

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
@@ -53,15 +53,21 @@
           "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
           "push": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
           "skip": {
-            "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.3334)_0px_0px_0px_0px]",
+            "children": {
+              "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.7334)_0px_0px_0px_0px]"
+            }
+          },
+          "inherit skip": {
+            "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.3334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.3334)_0px_0px_0px_0px]",
             "children": {
               "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(1_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.7334)_0px_0px_0px_0px]"
             }
           },
           "zero": {
-            "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.3334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.3334)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.3334)_0px_0px_0px_0px]",
             "children": {
-              "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(1_0.245_262.881_/_0.3334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.3334)_0px_0px_0px_0px]"
+              "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.3334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.3334)_0px_0px_0px_0px]"
             }
           },
           "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
@@ -1,4 +1,17 @@
 {
+  "edge inherit root no source": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
+  "edge inherit no source": {
+    "class": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)]",
+    "children": {
+      "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+    }
+  },
+  "edge inherit edge no source": {
+    "class": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)]",
+    "children": {
+      "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+    }
+  },
   "One-off": {
     "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[20px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
     "children": {

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
@@ -52,6 +52,18 @@
         "children": {
           "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
           "push": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
+          "skip": {
+            "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
+            "children": {
+              "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(1_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(1_0.245_27.325_/_0.7334)_0px_0px_0px_0px]"
+            }
+          },
+          "zero": {
+            "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.3334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.3334)_0px_0px_0px_0px]",
+            "children": {
+              "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(1_0.245_262.881_/_0.3334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.3334)_0px_0px_0px_0px]"
+            }
+          },
           "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
         }
       },
@@ -60,6 +72,18 @@
         "children": {
           "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
           "20 (2)": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_4px]",
+          "skip": {
+            "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
+            "children": {
+              "host": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[3px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_4px]"
+            }
+          },
+          "zero": {
+            "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
+            "children": {
+              "host": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[3px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]"
+            }
+          },
           "host": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[3px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_4px]"
         }
       },

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/light
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/light
@@ -53,15 +53,21 @@
           "20": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
           "push": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.2_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(0.2_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
           "skip": {
-            "class": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+            "children": {
+              "host": "bg-[oklch(0.4595_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.4)_0px_0px_0px_0px]"
+            }
+          },
+          "inherit skip": {
+            "class": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
             "children": {
               "host": "bg-[oklch(0.4595_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.4)_0px_0px_0px_0px]"
             }
           },
           "zero": {
-            "class": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
             "children": {
-              "host": "bg-[oklch(0.4595_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0_262.881_/_0)] p-[4px] shadow-[oklch(0_0_262.881_/_0)_0px_0px_0px_0px]"
+              "host": "bg-[oklch(0.4595_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0_262.881_/_0)] p-[4px] shadow-[oklch(0_0_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "host": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]"

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/light
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/light
@@ -52,6 +52,18 @@
         "children": {
           "20": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
           "push": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.2_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(0.2_0.245_27.325_/_0.4)_0px_0px_0px_0px]",
+          "skip": {
+            "class": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
+            "children": {
+              "host": "bg-[oklch(0.4595_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.4)_0px_0px_0px_0px]"
+            }
+          },
+          "zero": {
+            "class": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+            "children": {
+              "host": "bg-[oklch(0.4595_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0_262.881_/_0)] p-[4px] shadow-[oklch(0_0_262.881_/_0)_0px_0px_0px_0px]"
+            }
+          },
           "host": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
         }
       },
@@ -60,6 +72,18 @@
         "children": {
           "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_4px]",
           "20 (2)": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
+          "skip": {
+            "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
+            "children": {
+              "host": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[7px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+            }
+          },
+          "zero": {
+            "class": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
+            "children": {
+              "host": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[7px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+            }
+          },
           "host": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
         }
       },

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/light
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/light
@@ -1,4 +1,17 @@
 {
+  "edge inherit root no source": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
+  "edge inherit no source": {
+    "class": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)]",
+    "children": {
+      "host": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+    }
+  },
+  "edge inherit edge no source": {
+    "class": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)]",
+    "children": {
+      "host": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+    }
+  },
   "One-off": {
     "class": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[20px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
     "children": {

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/light
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/light
@@ -77,6 +77,12 @@
               "host": "bg-[oklch(0.4595_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.4)_0px_0px_0px_0px]"
             }
           },
+          "frame source": {
+            "class": "text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0_0)] p-[4px] shadow-[oklch(1_0_0)_0px_0px_0px_0px]",
+            "children": {
+              "host": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.245_27.325_/_0.4)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.4)_0px_0px_0px_0px]"
+            }
+          },
           "zero": {
             "class": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
             "children": {

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
@@ -77,6 +77,12 @@
               "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.7334)_0px_0px_0px_0px]"
             }
           },
+          "frame source": {
+            "class": "text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0_0)] p-[4px] shadow-[oklch(1_0_0)_0px_0px_0px_0px]",
+            "children": {
+              "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.7334)_0px_0px_0px_0px]"
+            }
+          },
           "zero": {
             "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.3334)_0px_0px_0px_0px]",
             "children": {

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
@@ -53,15 +53,21 @@
           "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
           "push": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.5334_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(0.5334_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
           "skip": {
-            "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.3334)_0px_0px_0px_0px]",
+            "children": {
+              "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.7334)_0px_0px_0px_0px]"
+            }
+          },
+          "inherit skip": {
+            "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.3334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.3334)_0px_0px_0px_0px]",
             "children": {
               "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.7334)_0px_0px_0px_0px]"
             }
           },
           "zero": {
-            "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.3334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.3334)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.3334)_0px_0px_0px_0px]",
             "children": {
-              "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(1_0.245_262.881_/_0.3334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.3334)_0px_0px_0px_0px]"
+              "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.3334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.3334)_0px_0px_0px_0px]"
             }
           },
           "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
@@ -1,4 +1,17 @@
 {
+  "edge inherit root no source": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
+  "edge inherit no source": {
+    "class": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)]",
+    "children": {
+      "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+    }
+  },
+  "edge inherit edge no source": {
+    "class": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)]",
+    "children": {
+      "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+    }
+  },
   "One-off": {
     "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[20px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
     "children": {

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
@@ -52,6 +52,18 @@
         "children": {
           "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
           "push": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.5334_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(0.5334_0.245_27.325_/_0.7334)_0px_0px_0px_0px]",
+          "skip": {
+            "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
+            "children": {
+              "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.245_27.325_/_0.7334)] p-[4px] shadow-[oklch(0_0.245_27.325_/_0.7334)_0px_0px_0px_0px]"
+            }
+          },
+          "zero": {
+            "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.3334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.3334)_0px_0px_0px_0px]",
+            "children": {
+              "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(1_0.245_262.881_/_0.3334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.3334)_0px_0px_0px_0px]"
+            }
+          },
           "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
         }
       },
@@ -60,6 +72,18 @@
         "children": {
           "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_4px]",
           "20 (2)": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
+          "skip": {
+            "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
+            "children": {
+              "host": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[7px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+            }
+          },
+          "zero": {
+            "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
+            "children": {
+              "host": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[7px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+            }
+          },
           "host": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
         }
       },

--- a/app/src/sandbox/ariakit-tailwind/index.react.tsx
+++ b/app/src/sandbox/ariakit-tailwind/index.react.tsx
@@ -428,6 +428,24 @@ export default function Example() {
               label="push"
               className="ak-layer ak-layer-20 ak-edge-inherit ak-edge-push-20 ak-frame ak-frame-p-1 ak-frame-border"
             />
+            <Layer
+              label="skip"
+              className="ak-layer ak-layer-20 ak-frame ak-frame-p-1 ak-frame-border flex-col"
+            >
+              <Layer
+                label="host"
+                className="ak-layer ak-layer-20 ak-edge-inherit ak-frame ak-frame-p-1 ak-frame-border"
+              />
+            </Layer>
+            <Layer
+              label="zero"
+              className="ak-layer ak-layer-20 ak-edge-0 ak-frame ak-frame-p-1 ak-frame-border flex-col"
+            >
+              <Layer
+                label="host"
+                className="ak-layer ak-layer-20 ak-edge-inherit ak-frame ak-frame-p-1 ak-frame-border"
+              />
+            </Layer>
             <div className="ak-edge-inherit">
               <Layer
                 label="host"
@@ -441,6 +459,24 @@ export default function Example() {
           >
             <Layer className="ak-layer ak-layer-lighten-20 ak-frame ak-frame-p-1 ak-frame-bordering-inherit" />
             <Layer className="ak-layer ak-layer-darken-20 ak-frame ak-frame-p-1 ak-frame-bordering-inherit" />
+            <Layer
+              label="skip"
+              className="ak-layer ak-layer-lighten-20 ak-frame ak-frame-p-1 flex-col"
+            >
+              <Layer
+                label="host"
+                className="ak-layer ak-layer-darken-20 ak-frame ak-frame-p-1 ak-frame-bordering-inherit"
+              />
+            </Layer>
+            <Layer
+              label="zero"
+              className="ak-layer ak-frame ak-frame-p-1 ak-frame-border-0 flex-col"
+            >
+              <Layer
+                label="host"
+                className="ak-layer ak-layer-darken-20 ak-frame ak-frame-p-1 ak-frame-bordering-inherit"
+              />
+            </Layer>
             <div className="ak-frame ak-frame-bordering-inherit">
               <Layer
                 label="host"

--- a/app/src/sandbox/ariakit-tailwind/index.react.tsx
+++ b/app/src/sandbox/ariakit-tailwind/index.react.tsx
@@ -430,7 +430,16 @@ export default function Example() {
             />
             <Layer
               label="skip"
-              className="ak-layer ak-layer-20 ak-frame ak-frame-p-1 ak-frame-border flex-col"
+              className="ak-layer ak-layer-20 ak-edge-0 ak-frame ak-frame-p-1 flex-col"
+            >
+              <Layer
+                label="host"
+                className="ak-layer ak-layer-20 ak-edge-inherit ak-frame ak-frame-p-1 ak-frame-border"
+              />
+            </Layer>
+            <Layer
+              label="inherit skip"
+              className="ak-layer ak-layer-20 ak-edge-0 ak-frame ak-frame-p-1 ak-frame-bordering-inherit flex-col"
             >
               <Layer
                 label="host"
@@ -439,7 +448,7 @@ export default function Example() {
             </Layer>
             <Layer
               label="zero"
-              className="ak-layer ak-layer-20 ak-edge-0 ak-frame ak-frame-p-1 ak-frame-border flex-col"
+              className="ak-layer ak-layer-20 ak-edge-0 ak-frame ak-frame-p-1 ak-frame-border-0 flex-col"
             >
               <Layer
                 label="host"

--- a/app/src/sandbox/ariakit-tailwind/index.react.tsx
+++ b/app/src/sandbox/ariakit-tailwind/index.react.tsx
@@ -275,6 +275,28 @@ export default function Example() {
   return (
     <div className="flex flex-col gap-4 p-4">
       <Layer
+        label="edge inherit root no source"
+        className="ak-layer ak-layer-20 ak-edge-inherit ak-frame ak-frame-p-1 ak-frame-border"
+      />
+      <Layer
+        label="edge inherit no source"
+        className="ak-layer ak-layer-blue-600 flex-col"
+      >
+        <Layer
+          label="host"
+          className="ak-layer ak-layer-20 ak-edge-inherit ak-frame ak-frame-p-1 ak-frame-border"
+        />
+      </Layer>
+      <Layer
+        label="edge inherit edge no source"
+        className="ak-layer ak-layer-blue-600 ak-edge-red-600 ak-edge-40 flex-col"
+      >
+        <Layer
+          label="host"
+          className="ak-layer ak-layer-20 ak-edge-inherit ak-frame ak-frame-p-1 ak-frame-border"
+        />
+      </Layer>
+      <Layer
         label="One-off"
         className="ak-layer ak-frame ak-frame-[1.25rem]/1 ak-frame-border flex-col"
       >

--- a/app/src/sandbox/ariakit-tailwind/index.react.tsx
+++ b/app/src/sandbox/ariakit-tailwind/index.react.tsx
@@ -469,6 +469,15 @@ export default function Example() {
               />
             </Layer>
             <Layer
+              label="frame source"
+              className="ak-frame ak-frame-p-1 ak-frame-border flex-col"
+            >
+              <Layer
+                label="host"
+                className="ak-layer ak-layer-20 ak-edge-inherit ak-frame ak-frame-p-1 ak-frame-border"
+              />
+            </Layer>
+            <Layer
               label="zero"
               className="ak-layer ak-layer-20 ak-edge-0 ak-frame ak-frame-p-1 ak-frame-border-0 flex-col"
             >

--- a/packages/ariakit-tailwind/readme.md
+++ b/packages/ariakit-tailwind/readme.md
@@ -329,7 +329,7 @@ Controls the opacity of text inside a layer — useful for secondary text, capti
 | `ak-edge-<chroma>`      | Sets chroma from a named preset.                                                                                                                              |
 | `ak-edge-<hue>`         | Sets hue from a named preset.                                                                                                                                 |
 | `ak-edge-raw`           | Applies the color exactly as specified — shorthand for `ak-edge-100` + `ak-edge-push-0`.                                                                      |
-| `ak-edge-inherit`       | Uses the nearest ancestor edge as the current edge color, skipping intermediate layers that do not explicitly set an edge.                                    |
+| `ak-edge-inherit`       | Uses the edge from the nearest ancestor that explicitly sets a frame border, ring, or bordering width.                                                        |
 
 ### Adjustments
 
@@ -488,7 +488,7 @@ All three utilities accept no argument (defaults to `1px`), named widths (`0`, `
 | `ak-frame-border` / `ak-frame-border-<width>`       | Applies a border whose width is factored into nested-frame radius calculations.                                                                                            |
 | `ak-frame-ring` / `ak-frame-ring-<width>`           | Applies a ring with the same treatment. Rings draw outside the border-box without shifting layout.                                                                         |
 | `ak-frame-bordering` / `ak-frame-bordering-<width>` | Adaptive edge: chooses border or ring based on parent layer appearance and whether the layer is lightening or darkening, keeping surfaces visually separated across modes. |
-| `ak-frame-bordering-inherit`                        | Inherits the nearest ancestor border or ring width, skipping intermediate frames that do not explicitly set a border, ring, or bordering width.                            |
+| `ak-frame-bordering-inherit`                        | Inherits the nearest ancestor frame border, ring, or bordering width, skipping intermediate frames that do not explicitly set one.                                         |
 
 ### Cover and flow
 

--- a/packages/ariakit-tailwind/readme.md
+++ b/packages/ariakit-tailwind/readme.md
@@ -329,7 +329,7 @@ Controls the opacity of text inside a layer — useful for secondary text, capti
 | `ak-edge-<chroma>`      | Sets chroma from a named preset.                                                                                                                              |
 | `ak-edge-<hue>`         | Sets hue from a named preset.                                                                                                                                 |
 | `ak-edge-raw`           | Applies the color exactly as specified — shorthand for `ak-edge-100` + `ak-edge-push-0`.                                                                      |
-| `ak-edge-inherit`       | Uses the edge from the nearest ancestor that explicitly sets a frame border, ring, or bordering width; falls back to the current edge when none exists.       |
+| `ak-edge-inherit`       | Uses the edge from the nearest ancestor that explicitly sets a frame border, ring, or bordering width; falls back to the current layer edge when none exists. |
 
 ### Adjustments
 

--- a/packages/ariakit-tailwind/readme.md
+++ b/packages/ariakit-tailwind/readme.md
@@ -329,7 +329,7 @@ Controls the opacity of text inside a layer — useful for secondary text, capti
 | `ak-edge-<chroma>`      | Sets chroma from a named preset.                                                                                                                              |
 | `ak-edge-<hue>`         | Sets hue from a named preset.                                                                                                                                 |
 | `ak-edge-raw`           | Applies the color exactly as specified — shorthand for `ak-edge-100` + `ak-edge-push-0`.                                                                      |
-| `ak-edge-inherit`       | Uses the edge from the nearest ancestor that explicitly sets a frame border, ring, or bordering width.                                                        |
+| `ak-edge-inherit`       | Uses the edge from the nearest ancestor that explicitly sets a frame border, ring, or bordering width; falls back to the current edge when none exists.       |
 
 ### Adjustments
 
@@ -488,7 +488,7 @@ All three utilities accept no argument (defaults to `1px`), named widths (`0`, `
 | `ak-frame-border` / `ak-frame-border-<width>`       | Applies a border whose width is factored into nested-frame radius calculations.                                                                                            |
 | `ak-frame-ring` / `ak-frame-ring-<width>`           | Applies a ring with the same treatment. Rings draw outside the border-box without shifting layout.                                                                         |
 | `ak-frame-bordering` / `ak-frame-bordering-<width>` | Adaptive edge: chooses border or ring based on parent layer appearance and whether the layer is lightening or darkening, keeping surfaces visually separated across modes. |
-| `ak-frame-bordering-inherit`                        | Inherits the nearest ancestor frame border, ring, or bordering width, skipping intermediate frames that do not explicitly set one.                                         |
+| `ak-frame-bordering-inherit`                        | Inherits the nearest ancestor frame border, ring, or bordering width, skipping intermediate frames that do not explicitly set one; falls back to `0px`.                    |
 
 ### Cover and flow
 

--- a/packages/ariakit-tailwind/readme.md
+++ b/packages/ariakit-tailwind/readme.md
@@ -329,7 +329,7 @@ Controls the opacity of text inside a layer — useful for secondary text, capti
 | `ak-edge-<chroma>`      | Sets chroma from a named preset.                                                                                                                              |
 | `ak-edge-<hue>`         | Sets hue from a named preset.                                                                                                                                 |
 | `ak-edge-raw`           | Applies the color exactly as specified — shorthand for `ak-edge-100` + `ak-edge-push-0`.                                                                      |
-| `ak-edge-inherit`       | Uses the parent layer edge as the current edge color while preserving the parent edge alpha and lightness.                                                    |
+| `ak-edge-inherit`       | Uses the nearest ancestor edge as the current edge color, skipping intermediate layers that do not explicitly set an edge.                                    |
 
 ### Adjustments
 
@@ -488,7 +488,7 @@ All three utilities accept no argument (defaults to `1px`), named widths (`0`, `
 | `ak-frame-border` / `ak-frame-border-<width>`       | Applies a border whose width is factored into nested-frame radius calculations.                                                                                            |
 | `ak-frame-ring` / `ak-frame-ring-<width>`           | Applies a ring with the same treatment. Rings draw outside the border-box without shifting layout.                                                                         |
 | `ak-frame-bordering` / `ak-frame-bordering-<width>` | Adaptive edge: chooses border or ring based on parent layer appearance and whether the layer is lightening or darkening, keeping surfaces visually separated across modes. |
-| `ak-frame-bordering-inherit`                        | Inherits the parent border or ring width, then chooses whether this element should render that width as a border or a ring.                                                |
+| `ak-frame-bordering-inherit`                        | Inherits the nearest ancestor border or ring width, skipping intermediate frames that do not explicitly set a border, ring, or bordering width.                            |
 
 ### Cover and flow
 

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -591,6 +591,7 @@ const layerColorVars = {
   layerOffset: _ak.prop.canvas("lo"),
   layerPush: _ak.prop.canvas("lp"),
   layer: ak.prop.canvas("layer", { inherits: true }),
+  layerEdge: _ak.prop.black("le", { inherits: true }),
   layerParentContext: _ak.var("lpc"),
   layerEdgeContext: _ak.var("lec"),
   layerEdgeSourceContext: _ak.var("lesc"),
@@ -1297,6 +1298,7 @@ const inkText = fn.oklch(vars.layer, {
 });
 
 const layerContext = createContext();
+const edgeContext = createContext();
 
 utility(
   "layer",
@@ -1307,6 +1309,7 @@ utility(
   set(vars.layer, layer),
   set(vars.text, vars.layerScheme),
   set(vars.edge, edge),
+  set(vars.layerEdge, vars.edge),
   set(vars.layerBand, layerBand),
   set(vars.layerScheme, layerScheme),
   getBaseDeclarations(vars.layer),
@@ -1324,30 +1327,10 @@ utility(
     set(vars.layerPushDirectionToLight, 1),
     set(vars.edgePushDirection, 1),
   ),
-  layerContext(({ provide, inherit }) => {
-    const parentEdge = inherit(vars.layerEdgeContext, vars.edge);
-    const parentEdgeSource = inherit(vars.layerEdgeSourceContext, 0);
-    return [
-      set(provide(vars.layerParentContext), vars.layer),
-      set(
-        provide(vars.layerEdgeContext),
-        fn.colorMix(
-          "oklch",
-          parentEdge,
-          vars.edge,
-          fn.mul(inputs.frameBorderingContext, "100%"),
-        ),
-      ),
-      set(
-        provide(vars.layerEdgeSourceContext),
-        fn.add(
-          fn.mul(parentEdgeSource, fn.invert(inputs.frameBorderingContext)),
-          inputs.frameBorderingContext,
-        ),
-      ),
-      set(vars.layerParent, inherit(vars.layerParentContext)),
-    ];
-  }),
+  layerContext(({ provide, inherit }) => [
+    set(provide(vars.layerParentContext), vars.layer),
+    set(vars.layerParent, inherit(vars.layerParentContext)),
+  ]),
 );
 
 function getLayerOffsetDeclarations(arbitraryPattern = "[*]") {
@@ -1660,8 +1643,8 @@ utility("edge-raw", set(inputs.edgeA, 1), set(inputs.edgePushL, 0));
 
 utility(
   "edge-inherit",
-  layerContext.read(({ inherit }) => {
-    const parentEdge = inherit(vars.layerEdgeContext, vars.edge);
+  edgeContext.read(({ inherit }) => {
+    const parentEdge = inherit(vars.layerEdgeContext, vars.layer);
     const parentEdgeSource = inherit(vars.layerEdgeSourceContext, 0);
     return [
       set(
@@ -1675,16 +1658,13 @@ utility(
       ),
       set(
         inputs.edgePushL,
-        fn.add(
-          fn.invert(parentEdgeSource),
-          fn.mul(parentEdgeSource, fn.neg(vars.edgeContrastValue)),
-        ),
+        fn.sub(1, fn.mul(parentEdgeSource, fn.add1(vars.edgeContrastValue))),
       ),
       set(
         inputs.edgeA,
         fn.add(
-          fn.mul(fn.invert(parentEdgeSource), 0.1),
-          fn.mul(parentEdgeSource, fn.sub(alpha, vars.edgeContrastValue)),
+          0.1,
+          fn.mul(parentEdgeSource, fn.sub(alpha, vars.edgeContrastValue, 0.1)),
         ),
       ),
     ];
@@ -2087,6 +2067,13 @@ function getFrameBorderingContextDeclarations() {
   return set(inputs.frameBorderingContext, 1);
 }
 
+function getLayerEdgeContextDeclarations() {
+  return edgeContext(({ provide }) => [
+    set(provide(vars.layerEdgeContext), fn.important(vars.layerEdge)),
+    set(provide(vars.layerEdgeSourceContext), fn.important(1)),
+  ]);
+}
+
 const LAST_VISIBLE_SELECTOR = "&:not(:has(~ *:not([hidden],template)))";
 
 /**
@@ -2370,23 +2357,27 @@ utility(
   set(inputs.frameBorder, "1px"),
   set.borderWidth(inputs.frameBorder),
   getFrameBorderingContextDeclarations(),
+  getLayerEdgeContextDeclarations(),
 );
 utility(
   "frame-border-*",
   getFrameBorderWidthDeclarations(inputs.frameBorder),
   set.borderWidth(inputs.frameBorder),
   getFrameBorderingContextDeclarations(),
+  getLayerEdgeContextDeclarations(),
 );
 
 utility(
   "frame-ring",
   set(inputs.frameRing, "1px"),
   getFrameBorderingContextDeclarations(),
+  getLayerEdgeContextDeclarations(),
 );
 utility(
   "frame-ring-*",
   getFrameBorderWidthDeclarations(inputs.frameRing),
   getFrameBorderingContextDeclarations(),
+  getLayerEdgeContextDeclarations(),
 );
 
 function getFrameBorderingDarkLight() {
@@ -2422,6 +2413,7 @@ utility(
   set(inputs.frameBordering, "1px"),
   getFrameBorderingDarkLight(),
   getFrameBorderingContextDeclarations(),
+  getLayerEdgeContextDeclarations(),
 );
 
 utility(
@@ -2443,6 +2435,7 @@ utility(
   getFrameBorderWidthDeclarations(inputs.frameBordering),
   getFrameBorderingDarkLight(),
   getFrameBorderingContextDeclarations(),
+  getLayerEdgeContextDeclarations(),
 );
 
 export const input = [

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -634,6 +634,8 @@ const frameVars = {
   frameParentPaddingContext: _ak.var("fppc"),
   frameParentBorderContext: _ak.var("fpbc"),
   frameParentRingContext: _ak.var("fpgc"),
+  frameParentBorderingBorderContext: _ak.var("fpbbc"),
+  frameParentBorderingRingContext: _ak.var("fpbgc"),
   frameParentRowContext: _ak.var("fpwc"),
   frameParentCornerTLContext: _ak.var("fpctl"),
   frameParentCornerTRContext: _ak.var("fpctr"),
@@ -697,6 +699,7 @@ const inputs = {
   edgeC: _ak.prop("edge-chroma"),
   edgeH: _ak.prop("edge-h"),
   edgeA: _ak.prop("edge-alpha", { initial: 0.1 }),
+  edgeContext: _ak.prop.number("edge-context", { initial: 0 }),
   textPushL: _ak.prop("text-push-lightness", { initial: 0 }),
   textA: _ak.prop("text-alpha", { initial: 1 }),
   textColor: _ak.prop("text-color"),
@@ -728,6 +731,9 @@ const inputs = {
   frameBorder: _ak.prop.len("frame-border", { initial: "0px" }),
   frameRing: _ak.prop.len("frame-ring", { initial: "0px" }),
   frameBordering: _ak.prop.len("frame-bordering", { initial: "0px" }),
+  frameBorderingContext: _ak.prop.number("frame-bordering-context", {
+    initial: 0,
+  }),
   frameRow: _ak.prop.number("frame-row", { initial: 0, inherits: true }),
   frameStart: _ak.prop.number("frame-start", { initial: 0 }),
   frameEnd: _ak.prop.number("frame-end", { initial: 0 }),
@@ -1320,11 +1326,22 @@ utility(
     set(vars.layerPushDirectionToLight, 1),
     set(vars.edgePushDirection, 1),
   ),
-  layerContext(({ provide, inherit }) => [
-    set(provide(vars.layerParentContext), vars.layer),
-    set(provide(vars.layerEdgeContext), vars.edge),
-    set(vars.layerParent, inherit(vars.layerParentContext)),
-  ]),
+  layerContext(({ provide, inherit }) => {
+    const parentEdge = inherit(vars.layerEdgeContext, vars.layer);
+    return [
+      set(provide(vars.layerParentContext), vars.layer),
+      set(
+        provide(vars.layerEdgeContext),
+        fn.colorMix(
+          "oklch",
+          parentEdge,
+          vars.edge,
+          fn.mul(inputs.edgeContext, "100%"),
+        ),
+      ),
+      set(vars.layerParent, inherit(vars.layerParentContext)),
+    ];
+  }),
 );
 
 function getLayerOffsetDeclarations(arbitraryPattern = "[*]") {
@@ -1621,19 +1638,37 @@ utility(
   set(inputs.layerRelativeC, fn.neg(fn.value("[*]"))),
 );
 
+function getEdgeContextDeclarations() {
+  return set(inputs.edgeContext, 1);
+}
+
 utility(
   "edge-*",
   set(inputs.edgeC, fn.value(chroma)),
   set(inputs.edgeH, fn.value(hue)),
   set(inputs.edgeColor, fn.value(color, "[color]")),
   set(inputs.edgeA, getBarePercentTokenValue()),
+  getEdgeContextDeclarations(),
 );
 
-utility("edge-color-*", set(inputs.edgeColor, fn.value(color, "[*]")));
+utility(
+  "edge-color-*",
+  set(inputs.edgeColor, fn.value(color, "[*]")),
+  getEdgeContextDeclarations(),
+);
 
-utility("edge-alpha-*", getRawPercentDeclarations(inputs.edgeA));
+utility(
+  "edge-alpha-*",
+  getRawPercentDeclarations(inputs.edgeA),
+  getEdgeContextDeclarations(),
+);
 
-utility("edge-raw", set(inputs.edgeA, 1), set(inputs.edgePushL, 0));
+utility(
+  "edge-raw",
+  set(inputs.edgeA, 1),
+  set(inputs.edgePushL, 0),
+  getEdgeContextDeclarations(),
+);
 
 utility(
   "edge-inherit",
@@ -1645,79 +1680,122 @@ utility(
       set(inputs.edgeA, fn.sub(alpha, vars.edgeContrastValue)),
     ];
   }),
+  getEdgeContextDeclarations(),
 );
 
-const edgeLighten = utility(
+utility(
   "edge-lighten-*",
   getRawPercentDeclarations(inputs.edgeRelativeL),
+  getEdgeContextDeclarations(),
 );
-utility("edge-darken-*", getNegatedDeclarations(edgeLighten));
+
+utility(
+  "edge-darken-*",
+  set(inputs.edgeRelativeL, fn.neg(getBarePercentTokenValue())),
+  set(inputs.edgeRelativeL, fn.neg(fn.value("[*]"))),
+  getEdgeContextDeclarations(),
+);
 
 utility(
   "edge-cool-*",
   set(inputs.edgeH, getHueToward(h, vars.hueCool, getBarePercentTokenValue())),
   set(inputs.edgeH, getHueToward(h, vars.hueCool, fn.value("[*]"))),
+  getEdgeContextDeclarations(),
 );
 
 utility(
   "edge-warm-*",
   set(inputs.edgeH, getHueToward(h, vars.hueWarm, getBarePercentTokenValue())),
   set(inputs.edgeH, getHueToward(h, vars.hueWarm, fn.value("[*]"))),
+  getEdgeContextDeclarations(),
 );
 
-utility("edge-push-*", getRawPercentDeclarations(inputs.edgePushL));
+utility(
+  "edge-push-*",
+  getRawPercentDeclarations(inputs.edgePushL),
+  getEdgeContextDeclarations(),
+);
 
-const edgeSaturate = utility(
+utility(
   "edge-saturate-*",
   getRawPercentDeclarations(inputs.edgeRelativeC, CHROMA_TOKEN_OPTIONS),
+  getEdgeContextDeclarations(),
 );
-utility("edge-desaturate-*", getNegatedDeclarations(edgeSaturate));
+
+utility(
+  "edge-desaturate-*",
+  set(
+    inputs.edgeRelativeC,
+    fn.neg(getBarePercentTokenValue(CHROMA_TOKEN_OPTIONS)),
+  ),
+  set(inputs.edgeRelativeC, fn.neg(fn.value("[*]"))),
+  getEdgeContextDeclarations(),
+);
 
 utility(
   "edge-h-rotate-*",
   set(inputs.edgeRelativeH, getNumericTokenValue("[*]", HUE_TOKEN_OPTIONS)),
+  getEdgeContextDeclarations(),
 );
 
-utility("edge-l-*", getRawPercentDeclarations(inputs.edgeL));
+utility(
+  "edge-l-*",
+  getRawPercentDeclarations(inputs.edgeL),
+  getEdgeContextDeclarations(),
+);
 
 utility(
   "edge-c-*",
   set(inputs.edgeC, fn.value(chroma)),
   getRawPercentDeclarations(inputs.edgeC, CHROMA_TOKEN_OPTIONS),
+  getEdgeContextDeclarations(),
 );
 
 utility(
   "edge-h-*",
   set(inputs.edgeH, fn.value(hue)),
   set(inputs.edgeH, getNumericTokenValue("[*]", HUE_TOKEN_OPTIONS)),
+  getEdgeContextDeclarations(),
 );
 
 utility(
   "edge-max-*",
   set(inputs.edgeCMax, fn.value(chroma)),
   getRawPercentDeclarations(inputs.edgeLMax),
+  getEdgeContextDeclarations(),
 );
 
 utility(
   "edge-min-*",
   set(inputs.edgeCMin, fn.value(chroma)),
   getRawPercentDeclarations(inputs.edgeLMin),
+  getEdgeContextDeclarations(),
 );
 
-utility("edge-max-l-*", getRawPercentDeclarations(inputs.edgeLMax));
+utility(
+  "edge-max-l-*",
+  getRawPercentDeclarations(inputs.edgeLMax),
+  getEdgeContextDeclarations(),
+);
 
-utility("edge-min-l-*", getRawPercentDeclarations(inputs.edgeLMin));
+utility(
+  "edge-min-l-*",
+  getRawPercentDeclarations(inputs.edgeLMin),
+  getEdgeContextDeclarations(),
+);
 
 utility(
   "edge-max-c-*",
   set(inputs.edgeCMax, fn.value(chroma)),
   getRawPercentDeclarations(inputs.edgeCMax, CHROMA_TOKEN_OPTIONS),
+  getEdgeContextDeclarations(),
 );
 
 utility(
   "edge-min-c-*",
   set(inputs.edgeCMin, fn.value(chroma)),
   getRawPercentDeclarations(inputs.edgeCMin, CHROMA_TOKEN_OPTIONS),
+  getEdgeContextDeclarations(),
 );
 
 const textBaseColor = fn.var(inputs.textColor, vars.layer);
@@ -2039,6 +2117,10 @@ function getFrameBorderWidthDeclarations(target: VarProperty) {
 
 const frameContext = createContext();
 
+function getFrameBorderingContextDeclarations() {
+  return set(inputs.frameBorderingContext, 1);
+}
+
 const LAST_VISIBLE_SELECTOR = "&:not(:has(~ *:not([hidden],template)))";
 
 /**
@@ -2185,6 +2267,14 @@ utility(
     );
     const parentPadding = inherit(vars.frameParentPaddingContext, "0px");
     const parentBorder = inherit(vars.frameParentBorderContext, "0px");
+    const parentBorderingBorder = inherit(
+      vars.frameParentBorderingBorderContext,
+      "0px",
+    );
+    const parentBorderingRing = inherit(
+      vars.frameParentBorderingRingContext,
+      "0px",
+    );
     const parentPaddingAndMargin = fn.add(parentPadding, vars.frameMargin);
     const nestedRadius = fn.sub(
       parentRadius,
@@ -2221,6 +2311,7 @@ utility(
       fn.mul(inputs.frameForce, inputs.frameRadius),
       fn.mul(fn.sub(1, inputs.frameForce), cappedRadius),
     );
+    const inheritedBorderingContext = fn.invert(inputs.frameBorderingContext);
     return [
       set(vars.frameAutoRadius, autoRadius),
       set(vars.frameInflatedExcess, inflatedExcess),
@@ -2229,6 +2320,20 @@ utility(
       set(provide(vars.frameParentPaddingContext), vars.framePadding),
       set(provide(vars.frameParentBorderContext), vars.frameBorder),
       set(provide(vars.frameParentRingContext), vars.frameRing),
+      set(
+        provide(vars.frameParentBorderingBorderContext),
+        fn.add(
+          fn.mul(parentBorderingBorder, inheritedBorderingContext),
+          fn.mul(inputs.frameBorder, inputs.frameBorderingContext),
+        ),
+      ),
+      set(
+        provide(vars.frameParentBorderingRingContext),
+        fn.add(
+          fn.mul(parentBorderingRing, inheritedBorderingContext),
+          fn.mul(inputs.frameRing, inputs.frameBorderingContext),
+        ),
+      ),
       set(provide(vars.frameParentRowContext), inputs.frameRow),
       // Default: all corners rounded (non-stretch parents).
       set(provide(vars.frameParentCornerTLContext), 1),
@@ -2298,15 +2403,25 @@ utility(
   "frame-border",
   set(inputs.frameBorder, "1px"),
   set.borderWidth(inputs.frameBorder),
+  getFrameBorderingContextDeclarations(),
 );
 utility(
   "frame-border-*",
   getFrameBorderWidthDeclarations(inputs.frameBorder),
   set.borderWidth(inputs.frameBorder),
+  getFrameBorderingContextDeclarations(),
 );
 
-utility("frame-ring", set(inputs.frameRing, "1px"));
-utility("frame-ring-*", getFrameBorderWidthDeclarations(inputs.frameRing));
+utility(
+  "frame-ring",
+  set(inputs.frameRing, "1px"),
+  getFrameBorderingContextDeclarations(),
+);
+utility(
+  "frame-ring-*",
+  getFrameBorderWidthDeclarations(inputs.frameRing),
+  getFrameBorderingContextDeclarations(),
+);
 
 function getFrameBorderingDarkLight() {
   // When the layer is darkening relative to its parent (ak-layer-darken-*),
@@ -2340,6 +2455,7 @@ utility(
   "frame-bordering",
   set(inputs.frameBordering, "1px"),
   getFrameBorderingDarkLight(),
+  getFrameBorderingContextDeclarations(),
 );
 
 utility(
@@ -2348,18 +2464,20 @@ utility(
     set(
       inputs.frameBordering,
       fn.max(
-        inherit(vars.frameParentBorderContext, "0px"),
-        inherit(vars.frameParentRingContext, "0px"),
+        inherit(vars.frameParentBorderingBorderContext, "0px"),
+        inherit(vars.frameParentBorderingRingContext, "0px"),
       ),
     ),
     ...getFrameBorderingDarkLight(),
   ]),
+  getFrameBorderingContextDeclarations(),
 );
 
 utility(
   "frame-bordering-*",
   getFrameBorderWidthDeclarations(inputs.frameBordering),
   getFrameBorderingDarkLight(),
+  getFrameBorderingContextDeclarations(),
 );
 
 export const input = [

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -593,6 +593,7 @@ const layerColorVars = {
   layer: ak.prop.canvas("layer", { inherits: true }),
   layerParentContext: _ak.var("lpc"),
   layerEdgeContext: _ak.var("lec"),
+  layerEdgeSourceContext: _ak.var("lesc"),
   layerParent: ak.var("layer-parent", "canvas"),
   edge: ak.prop.black("edge"),
   text: ak.prop.black("text", { inherits: true }),
@@ -600,8 +601,8 @@ const layerColorVars = {
 };
 
 const layerContrastMathVars = {
-  layerContrastDirection: _ak.prop.number("lcd", { initial: 0 }),
-  layerContrastParentL: _ak.prop.number("lcpl", { initial: 0 }),
+  layerContrastDirection: _ak.prop.zero("lcd"),
+  layerContrastParentL: _ak.prop.zero("lcpl"),
 };
 
 const outlineMathVars = {
@@ -611,7 +612,7 @@ const outlineMathVars = {
 
 const textMathVars = {
   textContrastDirection: _ak.prop.number("tcd", { initial: 1 }),
-  textParentL: _ak.prop.number("tpl", { initial: 0 }),
+  textParentL: _ak.prop.zero("tpl"),
   textAccessibleL: _ak.prop.number("tal", { initial: LCH_LIGHTNESS_MAX }),
   textChromaCap: _ak.prop.number("tcc", {
     initial: LCH_TEXT_CHROMA_CAP,
@@ -730,13 +731,11 @@ const inputs = {
   frameBorder: _ak.prop.len("frame-border", { initial: "0px" }),
   frameRing: _ak.prop.len("frame-ring", { initial: "0px" }),
   frameBordering: _ak.prop.len("frame-bordering", { initial: "0px" }),
-  frameBorderingContext: _ak.prop.number("frame-bordering-context", {
-    initial: 0,
-  }),
-  frameRow: _ak.prop.number("frame-row", { initial: 0, inherits: true }),
-  frameStart: _ak.prop.number("frame-start", { initial: 0 }),
-  frameEnd: _ak.prop.number("frame-end", { initial: 0 }),
-  frameForce: _ak.prop.number("frame-force", { initial: 0 }),
+  frameBorderingContext: _ak.prop.zero("frame-bordering-context"),
+  frameRow: _ak.prop.zero("frame-row", { inherits: true }),
+  frameStart: _ak.prop.zero("frame-start"),
+  frameEnd: _ak.prop.zero("frame-end"),
+  frameForce: _ak.prop.zero("frame-force"),
 };
 
 const theme = at.theme(
@@ -1326,7 +1325,8 @@ utility(
     set(vars.edgePushDirection, 1),
   ),
   layerContext(({ provide, inherit }) => {
-    const parentEdge = inherit(vars.layerEdgeContext, vars.layer);
+    const parentEdge = inherit(vars.layerEdgeContext, vars.edge);
+    const parentEdgeSource = inherit(vars.layerEdgeSourceContext, 0);
     return [
       set(provide(vars.layerParentContext), vars.layer),
       set(
@@ -1336,6 +1336,13 @@ utility(
           parentEdge,
           vars.edge,
           fn.mul(inputs.frameBorderingContext, "100%"),
+        ),
+      ),
+      set(
+        provide(vars.layerEdgeSourceContext),
+        fn.add(
+          fn.mul(parentEdgeSource, fn.invert(inputs.frameBorderingContext)),
+          inputs.frameBorderingContext,
         ),
       ),
       set(vars.layerParent, inherit(vars.layerParentContext)),
@@ -1654,11 +1661,32 @@ utility("edge-raw", set(inputs.edgeA, 1), set(inputs.edgePushL, 0));
 utility(
   "edge-inherit",
   layerContext.read(({ inherit }) => {
-    const parentEdge = inherit(vars.layerEdgeContext, vars.layer);
+    const parentEdge = inherit(vars.layerEdgeContext, vars.edge);
+    const parentEdgeSource = inherit(vars.layerEdgeSourceContext, 0);
     return [
-      set(inputs.edgeColor, parentEdge),
-      set(inputs.edgePushL, fn.neg(vars.edgeContrastValue)),
-      set(inputs.edgeA, fn.sub(alpha, vars.edgeContrastValue)),
+      set(
+        inputs.edgeColor,
+        fn.colorMix(
+          "oklch",
+          vars.layer,
+          parentEdge,
+          fn.mul(parentEdgeSource, "100%"),
+        ),
+      ),
+      set(
+        inputs.edgePushL,
+        fn.add(
+          fn.invert(parentEdgeSource),
+          fn.mul(parentEdgeSource, fn.neg(vars.edgeContrastValue)),
+        ),
+      ),
+      set(
+        inputs.edgeA,
+        fn.add(
+          fn.mul(fn.invert(parentEdgeSource), 0.1),
+          fn.mul(parentEdgeSource, fn.sub(alpha, vars.edgeContrastValue)),
+        ),
+      ),
     ];
   }),
 );

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -699,7 +699,6 @@ const inputs = {
   edgeC: _ak.prop("edge-chroma"),
   edgeH: _ak.prop("edge-h"),
   edgeA: _ak.prop("edge-alpha", { initial: 0.1 }),
-  edgeContext: _ak.prop.number("edge-context", { initial: 0 }),
   textPushL: _ak.prop("text-push-lightness", { initial: 0 }),
   textA: _ak.prop("text-alpha", { initial: 1 }),
   textColor: _ak.prop("text-color"),
@@ -1336,7 +1335,7 @@ utility(
           "oklch",
           parentEdge,
           vars.edge,
-          fn.mul(inputs.edgeContext, "100%"),
+          fn.mul(inputs.frameBorderingContext, "100%"),
         ),
       ),
       set(vars.layerParent, inherit(vars.layerParentContext)),
@@ -1638,37 +1637,19 @@ utility(
   set(inputs.layerRelativeC, fn.neg(fn.value("[*]"))),
 );
 
-function getEdgeContextDeclarations() {
-  return set(inputs.edgeContext, 1);
-}
-
 utility(
   "edge-*",
   set(inputs.edgeC, fn.value(chroma)),
   set(inputs.edgeH, fn.value(hue)),
   set(inputs.edgeColor, fn.value(color, "[color]")),
   set(inputs.edgeA, getBarePercentTokenValue()),
-  getEdgeContextDeclarations(),
 );
 
-utility(
-  "edge-color-*",
-  set(inputs.edgeColor, fn.value(color, "[*]")),
-  getEdgeContextDeclarations(),
-);
+utility("edge-color-*", set(inputs.edgeColor, fn.value(color, "[*]")));
 
-utility(
-  "edge-alpha-*",
-  getRawPercentDeclarations(inputs.edgeA),
-  getEdgeContextDeclarations(),
-);
+utility("edge-alpha-*", getRawPercentDeclarations(inputs.edgeA));
 
-utility(
-  "edge-raw",
-  set(inputs.edgeA, 1),
-  set(inputs.edgePushL, 0),
-  getEdgeContextDeclarations(),
-);
+utility("edge-raw", set(inputs.edgeA, 1), set(inputs.edgePushL, 0));
 
 utility(
   "edge-inherit",
@@ -1680,122 +1661,79 @@ utility(
       set(inputs.edgeA, fn.sub(alpha, vars.edgeContrastValue)),
     ];
   }),
-  getEdgeContextDeclarations(),
 );
 
-utility(
+const edgeLighten = utility(
   "edge-lighten-*",
   getRawPercentDeclarations(inputs.edgeRelativeL),
-  getEdgeContextDeclarations(),
 );
-
-utility(
-  "edge-darken-*",
-  set(inputs.edgeRelativeL, fn.neg(getBarePercentTokenValue())),
-  set(inputs.edgeRelativeL, fn.neg(fn.value("[*]"))),
-  getEdgeContextDeclarations(),
-);
+utility("edge-darken-*", getNegatedDeclarations(edgeLighten));
 
 utility(
   "edge-cool-*",
   set(inputs.edgeH, getHueToward(h, vars.hueCool, getBarePercentTokenValue())),
   set(inputs.edgeH, getHueToward(h, vars.hueCool, fn.value("[*]"))),
-  getEdgeContextDeclarations(),
 );
 
 utility(
   "edge-warm-*",
   set(inputs.edgeH, getHueToward(h, vars.hueWarm, getBarePercentTokenValue())),
   set(inputs.edgeH, getHueToward(h, vars.hueWarm, fn.value("[*]"))),
-  getEdgeContextDeclarations(),
 );
 
-utility(
-  "edge-push-*",
-  getRawPercentDeclarations(inputs.edgePushL),
-  getEdgeContextDeclarations(),
-);
+utility("edge-push-*", getRawPercentDeclarations(inputs.edgePushL));
 
-utility(
+const edgeSaturate = utility(
   "edge-saturate-*",
   getRawPercentDeclarations(inputs.edgeRelativeC, CHROMA_TOKEN_OPTIONS),
-  getEdgeContextDeclarations(),
 );
-
-utility(
-  "edge-desaturate-*",
-  set(
-    inputs.edgeRelativeC,
-    fn.neg(getBarePercentTokenValue(CHROMA_TOKEN_OPTIONS)),
-  ),
-  set(inputs.edgeRelativeC, fn.neg(fn.value("[*]"))),
-  getEdgeContextDeclarations(),
-);
+utility("edge-desaturate-*", getNegatedDeclarations(edgeSaturate));
 
 utility(
   "edge-h-rotate-*",
   set(inputs.edgeRelativeH, getNumericTokenValue("[*]", HUE_TOKEN_OPTIONS)),
-  getEdgeContextDeclarations(),
 );
 
-utility(
-  "edge-l-*",
-  getRawPercentDeclarations(inputs.edgeL),
-  getEdgeContextDeclarations(),
-);
+utility("edge-l-*", getRawPercentDeclarations(inputs.edgeL));
 
 utility(
   "edge-c-*",
   set(inputs.edgeC, fn.value(chroma)),
   getRawPercentDeclarations(inputs.edgeC, CHROMA_TOKEN_OPTIONS),
-  getEdgeContextDeclarations(),
 );
 
 utility(
   "edge-h-*",
   set(inputs.edgeH, fn.value(hue)),
   set(inputs.edgeH, getNumericTokenValue("[*]", HUE_TOKEN_OPTIONS)),
-  getEdgeContextDeclarations(),
 );
 
 utility(
   "edge-max-*",
   set(inputs.edgeCMax, fn.value(chroma)),
   getRawPercentDeclarations(inputs.edgeLMax),
-  getEdgeContextDeclarations(),
 );
 
 utility(
   "edge-min-*",
   set(inputs.edgeCMin, fn.value(chroma)),
   getRawPercentDeclarations(inputs.edgeLMin),
-  getEdgeContextDeclarations(),
 );
 
-utility(
-  "edge-max-l-*",
-  getRawPercentDeclarations(inputs.edgeLMax),
-  getEdgeContextDeclarations(),
-);
+utility("edge-max-l-*", getRawPercentDeclarations(inputs.edgeLMax));
 
-utility(
-  "edge-min-l-*",
-  getRawPercentDeclarations(inputs.edgeLMin),
-  getEdgeContextDeclarations(),
-);
+utility("edge-min-l-*", getRawPercentDeclarations(inputs.edgeLMin));
 
 utility(
   "edge-max-c-*",
   set(inputs.edgeCMax, fn.value(chroma)),
   getRawPercentDeclarations(inputs.edgeCMax, CHROMA_TOKEN_OPTIONS),
-  getEdgeContextDeclarations(),
 );
 
 utility(
   "edge-min-c-*",
   set(inputs.edgeCMin, fn.value(chroma)),
   getRawPercentDeclarations(inputs.edgeCMin, CHROMA_TOKEN_OPTIONS),
-  getEdgeContextDeclarations(),
 );
 
 const textBaseColor = fn.var(inputs.textColor, vars.layer);
@@ -2470,7 +2408,6 @@ utility(
     ),
     ...getFrameBorderingDarkLight(),
   ]),
-  getFrameBorderingContextDeclarations(),
 );
 
 utility(

--- a/packages/ariakit-tailwind/src/output.css
+++ b/packages/ariakit-tailwind/src/output.css
@@ -157,13 +157,13 @@
   @container (style(--_context-0: even)) or (not style(--_context-0)) {
     --_context-0: odd;
     --_ak-lpc-odd: var(--ak-layer);
-    --_ak-lec-odd: var(--ak-edge);
+    --_ak-lec-odd: color-mix(in oklch, var(--_ak-lec-even, var(--ak-layer)), var(--ak-edge) calc(var(--_ak-edge-context) * 100%));
     --ak-layer-parent: var(--_ak-lpc-even);
   }
   @container style(--_context-0: odd) {
     --_context-0: even;
     --_ak-lpc-even: var(--ak-layer);
-    --_ak-lec-even: var(--ak-edge);
+    --_ak-lec-even: color-mix(in oklch, var(--_ak-lec-odd, var(--ak-layer)), var(--ak-edge) calc(var(--_ak-edge-context) * 100%));
     --ak-layer-parent: var(--_ak-lpc-odd);
   }
 }
@@ -423,20 +423,24 @@
   --_ak-edge-h: --value(--hue-*);
   --_ak-edge-color: --value(--color-*, [color]);
   --_ak-edge-alpha: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
+  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-color-* {
   --_ak-edge-color: --value(--color-*, [*]);
+  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-alpha-* {
   --_ak-edge-alpha: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-edge-alpha: --value([*]);
+  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-raw {
   --_ak-edge-alpha: 1;
   --_ak-edge-push-lightness: 0;
+  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-inherit {
@@ -450,95 +454,113 @@
     --_ak-edge-push-lightness: calc(var(--_ak-ecv) * -1);
     --_ak-edge-alpha: calc(alpha - var(--_ak-ecv));
   }
+  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-lighten-* {
   --_ak-edge-relative-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-edge-relative-lightness: --value([*]);
+  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-darken-* {
   --_ak-edge-relative-lightness: calc((--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * -1);
   --_ak-edge-relative-lightness: calc(--value([*]) * -1);
+  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-cool-* {
   --_ak-edge-h: calc(h + ((mod(((var(--hue-cool, 220) - h) + 540), 360) - 180) * clamp(0, (--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100), 1)));
   --_ak-edge-h: calc(h + ((mod(((var(--hue-cool, 220) - h) + 540), 360) - 180) * clamp(0, --value([*]), 1)));
+  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-warm-* {
   --_ak-edge-h: calc(h + ((mod(((var(--hue-warm, 90) - h) + 540), 360) - 180) * clamp(0, (--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100), 1)));
   --_ak-edge-h: calc(h + ((mod(((var(--hue-warm, 90) - h) + 540), 360) - 180) * clamp(0, --value([*]), 1)));
+  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-push-* {
   --_ak-edge-push-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-edge-push-lightness: --value([*]);
+  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-saturate-* {
   --_ak-edge-relative-chroma: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
   --_ak-edge-relative-chroma: --value([*]);
+  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-desaturate-* {
   --_ak-edge-relative-chroma: calc((--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100) * -1);
   --_ak-edge-relative-chroma: calc(--value([*]) * -1);
+  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-h-rotate-* {
   --_ak-edge-relative-hue: --value(number, [*], "0", "15", "30", "45", "60", "75", "90", "105", "120", "135", "150", "165", "180", "195", "210", "225", "240", "255", "270", "285", "300", "315", "330", "345", "360");
+  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-l-* {
   --_ak-edge-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-edge-lightness: --value([*]);
+  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-c-* {
   --_ak-edge-chroma: --value(--chroma-*);
   --_ak-edge-chroma: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
   --_ak-edge-chroma: --value([*]);
+  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-h-* {
   --_ak-edge-h: --value(--hue-*);
   --_ak-edge-h: --value(number, [*], "0", "15", "30", "45", "60", "75", "90", "105", "120", "135", "150", "165", "180", "195", "210", "225", "240", "255", "270", "285", "300", "315", "330", "345", "360");
+  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-max-* {
   --_ak-edge-chroma-max: --value(--chroma-*);
   --_ak-edge-lightness-max: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-edge-lightness-max: --value([*]);
+  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-min-* {
   --_ak-edge-chroma-min: --value(--chroma-*);
   --_ak-edge-lightness-min: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-edge-lightness-min: --value([*]);
+  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-max-l-* {
   --_ak-edge-lightness-max: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-edge-lightness-max: --value([*]);
+  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-min-l-* {
   --_ak-edge-lightness-min: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-edge-lightness-min: --value([*]);
+  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-max-c-* {
   --_ak-edge-chroma-max: --value(--chroma-*);
   --_ak-edge-chroma-max: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
   --_ak-edge-chroma-max: --value([*]);
+  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-min-c-* {
   --_ak-edge-chroma-min: --value(--chroma-*);
   --_ak-edge-chroma-min: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
   --_ak-edge-chroma-min: --value([*]);
+  --_ak-edge-context: 1;
 }
 
 @utility ak-text {
@@ -1018,6 +1040,8 @@
     --_ak-fppc-odd: var(--ak-frame-padding);
     --_ak-fpbc-odd: var(--ak-frame-border);
     --_ak-fpgc-odd: var(--ak-frame-ring);
+    --_ak-fpbbc-odd: calc((var(--_ak-fpbbc-even, 0px) * (1 - var(--_ak-frame-bordering-context))) + (var(--_ak-frame-border) * var(--_ak-frame-bordering-context)));
+    --_ak-fpbgc-odd: calc((var(--_ak-fpbgc-even, 0px) * (1 - var(--_ak-frame-bordering-context))) + (var(--_ak-frame-ring) * var(--_ak-frame-bordering-context)));
     --_ak-fpwc-odd: var(--_ak-frame-row);
     --_ak-fpctl-odd: 1;
     --_ak-fpctr-odd: 1;
@@ -1033,6 +1057,8 @@
     --_ak-fppc-even: var(--ak-frame-padding);
     --_ak-fpbc-even: var(--ak-frame-border);
     --_ak-fpgc-even: var(--ak-frame-ring);
+    --_ak-fpbbc-even: calc((var(--_ak-fpbbc-odd, 0px) * (1 - var(--_ak-frame-bordering-context))) + (var(--_ak-frame-border) * var(--_ak-frame-bordering-context)));
+    --_ak-fpbgc-even: calc((var(--_ak-fpbgc-odd, 0px) * (1 - var(--_ak-frame-bordering-context))) + (var(--_ak-frame-ring) * var(--_ak-frame-bordering-context)));
     --_ak-fpwc-even: var(--_ak-frame-row);
     --_ak-fpctl-even: 1;
     --_ak-fpctr-even: 1;
@@ -1136,21 +1162,25 @@
 @utility ak-frame-border {
   --_ak-frame-border: 1px;
   border-width: var(--_ak-frame-border);
+  --_ak-frame-bordering-context: 1;
 }
 
 @utility ak-frame-border-* {
   --_ak-frame-border: --value([*]);
   --_ak-frame-border: calc(--value(number, [number], "0", "1", "2", "4", "8") * 1px);
   border-width: var(--_ak-frame-border);
+  --_ak-frame-bordering-context: 1;
 }
 
 @utility ak-frame-ring {
   --_ak-frame-ring: 1px;
+  --_ak-frame-bordering-context: 1;
 }
 
 @utility ak-frame-ring-* {
   --_ak-frame-ring: --value([*]);
   --_ak-frame-ring: calc(--value(number, [number], "0", "1", "2", "4", "8") * 1px);
+  --_ak-frame-bordering-context: 1;
 }
 
 @utility ak-frame-bordering {
@@ -1166,11 +1196,12 @@
     border-width: calc(var(--_ak-fbd) * var(--_ak-frame-bordering));
     --_ak-frame-ring: calc((1 - var(--_ak-fbd)) * var(--_ak-frame-bordering));
   }
+  --_ak-frame-bordering-context: 1;
 }
 
 @utility ak-frame-bordering-inherit {
   @container (style(--_context-1: even)) or (not style(--_context-1)) {
-    --_ak-frame-bordering: max(var(--_ak-fpbc-even, 0px), var(--_ak-fpgc-even, 0px));
+    --_ak-frame-bordering: max(var(--_ak-fpbbc-even, 0px), var(--_ak-fpbgc-even, 0px));
     --_ak-fbd: clamp(0, ((var(--_ak-layer-idle-relative-lightness) * -1) * 1000000), 1);
     @variant ak-dark {
       --_ak-frame-border: calc((1 - var(--_ak-fbd)) * var(--_ak-frame-bordering));
@@ -1184,7 +1215,7 @@
     }
   }
   @container style(--_context-1: odd) {
-    --_ak-frame-bordering: max(var(--_ak-fpbc-odd, 0px), var(--_ak-fpgc-odd, 0px));
+    --_ak-frame-bordering: max(var(--_ak-fpbbc-odd, 0px), var(--_ak-fpbgc-odd, 0px));
     --_ak-fbd: clamp(0, ((var(--_ak-layer-idle-relative-lightness) * -1) * 1000000), 1);
     @variant ak-dark {
       --_ak-frame-border: calc((1 - var(--_ak-fbd)) * var(--_ak-frame-bordering));
@@ -1197,6 +1228,7 @@
       --_ak-frame-ring: calc((1 - var(--_ak-fbd)) * var(--_ak-frame-bordering));
     }
   }
+  --_ak-frame-bordering-context: 1;
 }
 
 @utility ak-frame-bordering-* {
@@ -1213,6 +1245,7 @@
     border-width: calc(var(--_ak-fbd) * var(--_ak-frame-bordering));
     --_ak-frame-ring: calc((1 - var(--_ak-fbd)) * var(--_ak-frame-bordering));
   }
+  --_ak-frame-bordering-context: 1;
 }
 
 @property --_ak-tcl {
@@ -1810,6 +1843,12 @@
   initial-value: 0.1;
 }
 
+@property --_ak-edge-context {
+  syntax: "<number>";
+  inherits: false;
+  initial-value: 0;
+}
+
 @property --_ak-text-push-lightness {
   syntax: "*";
   inherits: false;
@@ -1984,6 +2023,12 @@
   syntax: "<length>";
   inherits: false;
   initial-value: 0px;
+}
+
+@property --_ak-frame-bordering-context {
+  syntax: "<number>";
+  inherits: false;
+  initial-value: 0;
 }
 
 @property --_ak-frame-row {

--- a/packages/ariakit-tailwind/src/output.css
+++ b/packages/ariakit-tailwind/src/output.css
@@ -157,13 +157,15 @@
   @container (style(--_context-0: even)) or (not style(--_context-0)) {
     --_context-0: odd;
     --_ak-lpc-odd: var(--ak-layer);
-    --_ak-lec-odd: color-mix(in oklch, var(--_ak-lec-even, var(--ak-layer)), var(--ak-edge) calc(var(--_ak-frame-bordering-context) * 100%));
+    --_ak-lec-odd: color-mix(in oklch, var(--_ak-lec-even, var(--ak-edge)), var(--ak-edge) calc(var(--_ak-frame-bordering-context) * 100%));
+    --_ak-lesc-odd: calc((var(--_ak-lesc-even, 0) * (1 - var(--_ak-frame-bordering-context))) + var(--_ak-frame-bordering-context));
     --ak-layer-parent: var(--_ak-lpc-even);
   }
   @container style(--_context-0: odd) {
     --_context-0: even;
     --_ak-lpc-even: var(--ak-layer);
-    --_ak-lec-even: color-mix(in oklch, var(--_ak-lec-odd, var(--ak-layer)), var(--ak-edge) calc(var(--_ak-frame-bordering-context) * 100%));
+    --_ak-lec-even: color-mix(in oklch, var(--_ak-lec-odd, var(--ak-edge)), var(--ak-edge) calc(var(--_ak-frame-bordering-context) * 100%));
+    --_ak-lesc-even: calc((var(--_ak-lesc-odd, 0) * (1 - var(--_ak-frame-bordering-context))) + var(--_ak-frame-bordering-context));
     --ak-layer-parent: var(--_ak-lpc-odd);
   }
 }
@@ -441,14 +443,14 @@
 
 @utility ak-edge-inherit {
   @container (style(--_context-0: even)) or (not style(--_context-0)) {
-    --_ak-edge-color: var(--_ak-lec-even, var(--ak-layer));
-    --_ak-edge-push-lightness: calc(var(--_ak-ecv) * -1);
-    --_ak-edge-alpha: calc(alpha - var(--_ak-ecv));
+    --_ak-edge-color: color-mix(in oklch, var(--ak-layer), var(--_ak-lec-even, var(--ak-edge)) calc(var(--_ak-lesc-even, 0) * 100%));
+    --_ak-edge-push-lightness: calc((1 - var(--_ak-lesc-even, 0)) + (var(--_ak-lesc-even, 0) * (var(--_ak-ecv) * -1)));
+    --_ak-edge-alpha: calc(((1 - var(--_ak-lesc-even, 0)) * 0.1) + (var(--_ak-lesc-even, 0) * (alpha - var(--_ak-ecv))));
   }
   @container style(--_context-0: odd) {
-    --_ak-edge-color: var(--_ak-lec-odd, var(--ak-layer));
-    --_ak-edge-push-lightness: calc(var(--_ak-ecv) * -1);
-    --_ak-edge-alpha: calc(alpha - var(--_ak-ecv));
+    --_ak-edge-color: color-mix(in oklch, var(--ak-layer), var(--_ak-lec-odd, var(--ak-edge)) calc(var(--_ak-lesc-odd, 0) * 100%));
+    --_ak-edge-push-lightness: calc((1 - var(--_ak-lesc-odd, 0)) + (var(--_ak-lesc-odd, 0) * (var(--_ak-ecv) * -1)));
+    --_ak-edge-alpha: calc(((1 - var(--_ak-lesc-odd, 0)) * 0.1) + (var(--_ak-lesc-odd, 0) * (alpha - var(--_ak-ecv))));
   }
 }
 

--- a/packages/ariakit-tailwind/src/output.css
+++ b/packages/ariakit-tailwind/src/output.css
@@ -157,13 +157,13 @@
   @container (style(--_context-0: even)) or (not style(--_context-0)) {
     --_context-0: odd;
     --_ak-lpc-odd: var(--ak-layer);
-    --_ak-lec-odd: color-mix(in oklch, var(--_ak-lec-even, var(--ak-layer)), var(--ak-edge) calc(var(--_ak-edge-context) * 100%));
+    --_ak-lec-odd: color-mix(in oklch, var(--_ak-lec-even, var(--ak-layer)), var(--ak-edge) calc(var(--_ak-frame-bordering-context) * 100%));
     --ak-layer-parent: var(--_ak-lpc-even);
   }
   @container style(--_context-0: odd) {
     --_context-0: even;
     --_ak-lpc-even: var(--ak-layer);
-    --_ak-lec-even: color-mix(in oklch, var(--_ak-lec-odd, var(--ak-layer)), var(--ak-edge) calc(var(--_ak-edge-context) * 100%));
+    --_ak-lec-even: color-mix(in oklch, var(--_ak-lec-odd, var(--ak-layer)), var(--ak-edge) calc(var(--_ak-frame-bordering-context) * 100%));
     --ak-layer-parent: var(--_ak-lpc-odd);
   }
 }
@@ -423,24 +423,20 @@
   --_ak-edge-h: --value(--hue-*);
   --_ak-edge-color: --value(--color-*, [color]);
   --_ak-edge-alpha: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
-  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-color-* {
   --_ak-edge-color: --value(--color-*, [*]);
-  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-alpha-* {
   --_ak-edge-alpha: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-edge-alpha: --value([*]);
-  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-raw {
   --_ak-edge-alpha: 1;
   --_ak-edge-push-lightness: 0;
-  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-inherit {
@@ -454,113 +450,95 @@
     --_ak-edge-push-lightness: calc(var(--_ak-ecv) * -1);
     --_ak-edge-alpha: calc(alpha - var(--_ak-ecv));
   }
-  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-lighten-* {
   --_ak-edge-relative-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-edge-relative-lightness: --value([*]);
-  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-darken-* {
   --_ak-edge-relative-lightness: calc((--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * -1);
   --_ak-edge-relative-lightness: calc(--value([*]) * -1);
-  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-cool-* {
   --_ak-edge-h: calc(h + ((mod(((var(--hue-cool, 220) - h) + 540), 360) - 180) * clamp(0, (--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100), 1)));
   --_ak-edge-h: calc(h + ((mod(((var(--hue-cool, 220) - h) + 540), 360) - 180) * clamp(0, --value([*]), 1)));
-  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-warm-* {
   --_ak-edge-h: calc(h + ((mod(((var(--hue-warm, 90) - h) + 540), 360) - 180) * clamp(0, (--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100), 1)));
   --_ak-edge-h: calc(h + ((mod(((var(--hue-warm, 90) - h) + 540), 360) - 180) * clamp(0, --value([*]), 1)));
-  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-push-* {
   --_ak-edge-push-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-edge-push-lightness: --value([*]);
-  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-saturate-* {
   --_ak-edge-relative-chroma: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
   --_ak-edge-relative-chroma: --value([*]);
-  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-desaturate-* {
   --_ak-edge-relative-chroma: calc((--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100) * -1);
   --_ak-edge-relative-chroma: calc(--value([*]) * -1);
-  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-h-rotate-* {
   --_ak-edge-relative-hue: --value(number, [*], "0", "15", "30", "45", "60", "75", "90", "105", "120", "135", "150", "165", "180", "195", "210", "225", "240", "255", "270", "285", "300", "315", "330", "345", "360");
-  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-l-* {
   --_ak-edge-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-edge-lightness: --value([*]);
-  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-c-* {
   --_ak-edge-chroma: --value(--chroma-*);
   --_ak-edge-chroma: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
   --_ak-edge-chroma: --value([*]);
-  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-h-* {
   --_ak-edge-h: --value(--hue-*);
   --_ak-edge-h: --value(number, [*], "0", "15", "30", "45", "60", "75", "90", "105", "120", "135", "150", "165", "180", "195", "210", "225", "240", "255", "270", "285", "300", "315", "330", "345", "360");
-  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-max-* {
   --_ak-edge-chroma-max: --value(--chroma-*);
   --_ak-edge-lightness-max: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-edge-lightness-max: --value([*]);
-  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-min-* {
   --_ak-edge-chroma-min: --value(--chroma-*);
   --_ak-edge-lightness-min: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-edge-lightness-min: --value([*]);
-  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-max-l-* {
   --_ak-edge-lightness-max: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-edge-lightness-max: --value([*]);
-  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-min-l-* {
   --_ak-edge-lightness-min: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-edge-lightness-min: --value([*]);
-  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-max-c-* {
   --_ak-edge-chroma-max: --value(--chroma-*);
   --_ak-edge-chroma-max: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
   --_ak-edge-chroma-max: --value([*]);
-  --_ak-edge-context: 1;
 }
 
 @utility ak-edge-min-c-* {
   --_ak-edge-chroma-min: --value(--chroma-*);
   --_ak-edge-chroma-min: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
   --_ak-edge-chroma-min: --value([*]);
-  --_ak-edge-context: 1;
 }
 
 @utility ak-text {
@@ -1228,7 +1206,6 @@
       --_ak-frame-ring: calc((1 - var(--_ak-fbd)) * var(--_ak-frame-bordering));
     }
   }
-  --_ak-frame-bordering-context: 1;
 }
 
 @utility ak-frame-bordering-* {
@@ -1841,12 +1818,6 @@
   syntax: "*";
   inherits: false;
   initial-value: 0.1;
-}
-
-@property --_ak-edge-context {
-  syntax: "<number>";
-  inherits: false;
-  initial-value: 0;
 }
 
 @property --_ak-text-push-lightness {

--- a/packages/ariakit-tailwind/src/output.css
+++ b/packages/ariakit-tailwind/src/output.css
@@ -119,6 +119,7 @@
   --ak-layer: oklch(from var(--_ak-lp) var(--_ak-sl) clamp(var(--_ak-layer-chroma-min), c, var(--_ak-layer-chroma-max, var(--chroma-p3-max, 0.368))) h);
   --ak-text: var(--_ak-ls);
   --ak-edge: oklch(from oklch(from var(--_ak-edge-color, var(--ak-layer)) clamp(0, (l + ((var(--_ak-edge-push-lightness) + var(--_ak-ecv)) * var(--_ak-epd, -1))), 1) c h) clamp(var(--_ak-edge-lightness-min), var(--_ak-edge-lightness, (l + var(--_ak-edge-relative-lightness) + (clamp(0, (var(--_ak-edge-relative-lightness) * 1000000), 1) * var(--_ak-llfb)))), var(--_ak-edge-lightness-max)) clamp(var(--_ak-edge-chroma-min), var(--_ak-edge-chroma, (c + var(--_ak-edge-relative-chroma))), var(--_ak-edge-chroma-max, var(--chroma-p3-max, 0.368))) var(--_ak-edge-h, calc(h + var(--_ak-edge-relative-hue))) / clamp(0, (var(--_ak-edge-alpha) + var(--_ak-ecv)), 1));
+  --_ak-le: var(--ak-edge);
   --_ak-lbd: oklch(from var(--ak-layer) calc(0.5 + (var(--_ak-bdh) * -0.5) + (var(--_ak-bdl) * -0.25) + (var(--_ak-bll) * 0.25) + (var(--_ak-blh) * 0.5)) 0 0);
   --_ak-ls: oklch(from var(--ak-layer) var(--_ak-tfcl) 0 0);
   --_ak-ll: oklch(from var(--ak-layer) round(l, 0.125) 0 0);
@@ -157,15 +158,11 @@
   @container (style(--_context-0: even)) or (not style(--_context-0)) {
     --_context-0: odd;
     --_ak-lpc-odd: var(--ak-layer);
-    --_ak-lec-odd: color-mix(in oklch, var(--_ak-lec-even, var(--ak-edge)), var(--ak-edge) calc(var(--_ak-frame-bordering-context) * 100%));
-    --_ak-lesc-odd: calc((var(--_ak-lesc-even, 0) * (1 - var(--_ak-frame-bordering-context))) + var(--_ak-frame-bordering-context));
     --ak-layer-parent: var(--_ak-lpc-even);
   }
   @container style(--_context-0: odd) {
     --_context-0: even;
     --_ak-lpc-even: var(--ak-layer);
-    --_ak-lec-even: color-mix(in oklch, var(--_ak-lec-odd, var(--ak-edge)), var(--ak-edge) calc(var(--_ak-frame-bordering-context) * 100%));
-    --_ak-lesc-even: calc((var(--_ak-lesc-odd, 0) * (1 - var(--_ak-frame-bordering-context))) + var(--_ak-frame-bordering-context));
     --ak-layer-parent: var(--_ak-lpc-odd);
   }
 }
@@ -442,15 +439,15 @@
 }
 
 @utility ak-edge-inherit {
-  @container (style(--_context-0: even)) or (not style(--_context-0)) {
-    --_ak-edge-color: color-mix(in oklch, var(--ak-layer), var(--_ak-lec-even, var(--ak-edge)) calc(var(--_ak-lesc-even, 0) * 100%));
-    --_ak-edge-push-lightness: calc((1 - var(--_ak-lesc-even, 0)) + (var(--_ak-lesc-even, 0) * (var(--_ak-ecv) * -1)));
-    --_ak-edge-alpha: calc(((1 - var(--_ak-lesc-even, 0)) * 0.1) + (var(--_ak-lesc-even, 0) * (alpha - var(--_ak-ecv))));
+  @container (style(--_context-1: even)) or (not style(--_context-1)) {
+    --_ak-edge-color: color-mix(in oklch, var(--ak-layer), var(--_ak-lec-even, var(--ak-layer)) calc(var(--_ak-lesc-even, 0) * 100%));
+    --_ak-edge-push-lightness: calc(1 - (var(--_ak-lesc-even, 0) * (var(--_ak-ecv) + 1)));
+    --_ak-edge-alpha: calc(0.1 + (var(--_ak-lesc-even, 0) * (alpha - var(--_ak-ecv) - 0.1)));
   }
-  @container style(--_context-0: odd) {
-    --_ak-edge-color: color-mix(in oklch, var(--ak-layer), var(--_ak-lec-odd, var(--ak-edge)) calc(var(--_ak-lesc-odd, 0) * 100%));
-    --_ak-edge-push-lightness: calc((1 - var(--_ak-lesc-odd, 0)) + (var(--_ak-lesc-odd, 0) * (var(--_ak-ecv) * -1)));
-    --_ak-edge-alpha: calc(((1 - var(--_ak-lesc-odd, 0)) * 0.1) + (var(--_ak-lesc-odd, 0) * (alpha - var(--_ak-ecv))));
+  @container style(--_context-1: odd) {
+    --_ak-edge-color: color-mix(in oklch, var(--ak-layer), var(--_ak-lec-odd, var(--ak-layer)) calc(var(--_ak-lesc-odd, 0) * 100%));
+    --_ak-edge-push-lightness: calc(1 - (var(--_ak-lesc-odd, 0) * (var(--_ak-ecv) + 1)));
+    --_ak-edge-alpha: calc(0.1 + (var(--_ak-lesc-odd, 0) * (alpha - var(--_ak-ecv) - 0.1)));
   }
 }
 
@@ -1011,8 +1008,8 @@
   border-radius: var(--ak-frame-radius);
   margin: var(--ak-frame-margin);
   @apply ring-[length:var(--ak-frame-ring)];
-  @container (style(--_context-1: even)) or (not style(--_context-1)) {
-    --_context-1: odd;
+  @container (style(--_context-2: even)) or (not style(--_context-2)) {
+    --_context-2: odd;
     --_ak-far: max(min(0.125rem, var(--_ak-frame-radius)), max((var(--_ak-fprc-even, var(--_ak-frame-radius)) - (var(--_ak-fppc-even, 0px) + var(--_ak-fpbc-even, 0px) + var(--ak-frame-margin))), 0px));
     --_ak-fie: calc(max(((var(--_ak-fppc-even, 0px) + var(--ak-frame-margin)) - (1rem - 0.5px)), 0px) * 1000000000);
     --ak-frame-radius: calc((var(--_ak-frame-force) * var(--_ak-frame-radius)) + ((1 - var(--_ak-frame-force)) * max((var(--_ak-far) - var(--_ak-fie)), min(var(--_ak-frame-radius), (var(--_ak-far) + var(--_ak-fie))))));
@@ -1028,8 +1025,8 @@
     --_ak-fpcbl-odd: 1;
     --_ak-fpcbr-odd: 1;
   }
-  @container style(--_context-1: odd) {
-    --_context-1: even;
+  @container style(--_context-2: odd) {
+    --_context-2: even;
     --_ak-far: max(min(0.125rem, var(--_ak-frame-radius)), max((var(--_ak-fprc-odd, var(--_ak-frame-radius)) - (var(--_ak-fppc-odd, 0px) + var(--_ak-fpbc-odd, 0px) + var(--ak-frame-margin))), 0px));
     --_ak-fie: calc(max(((var(--_ak-fppc-odd, 0px) + var(--ak-frame-margin)) - (1rem - 0.5px)), 0px) * 1000000000);
     --ak-frame-radius: calc((var(--_ak-frame-force) * var(--_ak-frame-radius)) + ((1 - var(--_ak-frame-force)) * max((var(--_ak-far) - var(--_ak-fie)), min(var(--_ak-frame-radius), (var(--_ak-far) + var(--_ak-fie))))));
@@ -1081,8 +1078,8 @@
 }
 
 @utility ak-frame-cover {
-  @container (style(--_context-1: even)) or (not style(--_context-1)) {
-    --_context-1: odd;
+  @container (style(--_context-2: even)) or (not style(--_context-2)) {
+    --_context-2: odd;
     &:first-child {
       --_ak-frame-start: 1;
     }
@@ -1101,8 +1098,8 @@
     margin: calc(max(var(--_ak-fpwc-even, 0), ((1 - var(--_ak-fpwc-even, 0)) * var(--_ak-frame-start))) * var(--ak-frame-margin)) calc(max((1 - var(--_ak-fpwc-even, 0)), (var(--_ak-fpwc-even, 0) * var(--_ak-frame-end))) * var(--ak-frame-margin)) calc(max(var(--_ak-fpwc-even, 0), ((1 - var(--_ak-fpwc-even, 0)) * var(--_ak-frame-end))) * var(--ak-frame-margin)) calc(max((1 - var(--_ak-fpwc-even, 0)), (var(--_ak-fpwc-even, 0) * var(--_ak-frame-start))) * var(--ak-frame-margin));
     border-radius: calc(var(--_ak-fpctl-odd) * var(--ak-frame-radius)) calc(var(--_ak-fpctr-odd) * var(--ak-frame-radius)) calc(var(--_ak-fpcbr-odd) * var(--ak-frame-radius)) calc(var(--_ak-fpcbl-odd) * var(--ak-frame-radius));
   }
-  @container style(--_context-1: odd) {
-    --_context-1: even;
+  @container style(--_context-2: odd) {
+    --_context-2: even;
     &:first-child {
       --_ak-frame-start: 1;
     }
@@ -1143,6 +1140,16 @@
   --_ak-frame-border: 1px;
   border-width: var(--_ak-frame-border);
   --_ak-frame-bordering-context: 1;
+  @container (style(--_context-1: even)) or (not style(--_context-1)) {
+    --_context-1: odd;
+    --_ak-lec-odd: var(--_ak-le) !important;
+    --_ak-lesc-odd: 1 !important;
+  }
+  @container style(--_context-1: odd) {
+    --_context-1: even;
+    --_ak-lec-even: var(--_ak-le) !important;
+    --_ak-lesc-even: 1 !important;
+  }
 }
 
 @utility ak-frame-border-* {
@@ -1150,17 +1157,47 @@
   --_ak-frame-border: calc(--value(number, [number], "0", "1", "2", "4", "8") * 1px);
   border-width: var(--_ak-frame-border);
   --_ak-frame-bordering-context: 1;
+  @container (style(--_context-1: even)) or (not style(--_context-1)) {
+    --_context-1: odd;
+    --_ak-lec-odd: var(--_ak-le) !important;
+    --_ak-lesc-odd: 1 !important;
+  }
+  @container style(--_context-1: odd) {
+    --_context-1: even;
+    --_ak-lec-even: var(--_ak-le) !important;
+    --_ak-lesc-even: 1 !important;
+  }
 }
 
 @utility ak-frame-ring {
   --_ak-frame-ring: 1px;
   --_ak-frame-bordering-context: 1;
+  @container (style(--_context-1: even)) or (not style(--_context-1)) {
+    --_context-1: odd;
+    --_ak-lec-odd: var(--_ak-le) !important;
+    --_ak-lesc-odd: 1 !important;
+  }
+  @container style(--_context-1: odd) {
+    --_context-1: even;
+    --_ak-lec-even: var(--_ak-le) !important;
+    --_ak-lesc-even: 1 !important;
+  }
 }
 
 @utility ak-frame-ring-* {
   --_ak-frame-ring: --value([*]);
   --_ak-frame-ring: calc(--value(number, [number], "0", "1", "2", "4", "8") * 1px);
   --_ak-frame-bordering-context: 1;
+  @container (style(--_context-1: even)) or (not style(--_context-1)) {
+    --_context-1: odd;
+    --_ak-lec-odd: var(--_ak-le) !important;
+    --_ak-lesc-odd: 1 !important;
+  }
+  @container style(--_context-1: odd) {
+    --_context-1: even;
+    --_ak-lec-even: var(--_ak-le) !important;
+    --_ak-lesc-even: 1 !important;
+  }
 }
 
 @utility ak-frame-bordering {
@@ -1177,10 +1214,20 @@
     --_ak-frame-ring: calc((1 - var(--_ak-fbd)) * var(--_ak-frame-bordering));
   }
   --_ak-frame-bordering-context: 1;
+  @container (style(--_context-1: even)) or (not style(--_context-1)) {
+    --_context-1: odd;
+    --_ak-lec-odd: var(--_ak-le) !important;
+    --_ak-lesc-odd: 1 !important;
+  }
+  @container style(--_context-1: odd) {
+    --_context-1: even;
+    --_ak-lec-even: var(--_ak-le) !important;
+    --_ak-lesc-even: 1 !important;
+  }
 }
 
 @utility ak-frame-bordering-inherit {
-  @container (style(--_context-1: even)) or (not style(--_context-1)) {
+  @container (style(--_context-2: even)) or (not style(--_context-2)) {
     --_ak-frame-bordering: max(var(--_ak-fpbbc-even, 0px), var(--_ak-fpbgc-even, 0px));
     --_ak-fbd: clamp(0, ((var(--_ak-layer-idle-relative-lightness) * -1) * 1000000), 1);
     @variant ak-dark {
@@ -1194,7 +1241,7 @@
       --_ak-frame-ring: calc((1 - var(--_ak-fbd)) * var(--_ak-frame-bordering));
     }
   }
-  @container style(--_context-1: odd) {
+  @container style(--_context-2: odd) {
     --_ak-frame-bordering: max(var(--_ak-fpbbc-odd, 0px), var(--_ak-fpbgc-odd, 0px));
     --_ak-fbd: clamp(0, ((var(--_ak-layer-idle-relative-lightness) * -1) * 1000000), 1);
     @variant ak-dark {
@@ -1225,6 +1272,16 @@
     --_ak-frame-ring: calc((1 - var(--_ak-fbd)) * var(--_ak-frame-bordering));
   }
   --_ak-frame-bordering-context: 1;
+  @container (style(--_context-1: even)) or (not style(--_context-1)) {
+    --_context-1: odd;
+    --_ak-lec-odd: var(--_ak-le) !important;
+    --_ak-lesc-odd: 1 !important;
+  }
+  @container style(--_context-1: odd) {
+    --_context-1: even;
+    --_ak-lec-even: var(--_ak-le) !important;
+    --_ak-lesc-even: 1 !important;
+  }
 }
 
 @property --_ak-tcl {
@@ -1512,6 +1569,12 @@
   syntax: "<color>";
   inherits: true;
   initial-value: canvas;
+}
+
+@property --_ak-le {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: black;
 }
 
 @property --ak-edge {


### PR DESCRIPTION
## Motivation

`ak-edge-inherit` and `ak-frame-bordering-inherit` stopped at the nearest `ak-layer` or `ak-frame` context, even when that intermediate element only had the base utility and did not explicitly configure a frame border, ring, or bordering width. That made nested layers/frames lose the edge or bordering information from the first configured ancestor.

## Solution

Track explicit frame border/ring/bordering configuration separately from the base layer/frame context. Base `ak-layer`/`ak-frame` utilities now pass ancestor values through until a frame border, ring, or bordering width utility marks the current element as explicit, including explicit `0` values.

`ak-edge-inherit` uses that same explicit frame-width source, so edge modifiers alone no longer become inheritance anchors. `ak-frame-bordering-inherit` consumes the inherited width without becoming a new explicit source itself.

The sandbox snapshots cover direct inheritance, skipped intermediates, inherited-bordering intermediates, and explicit zero resets. The README descriptions now document the nearest explicit frame-width ancestor behavior.

## Testing

- `pnpm -F @ariakit/tailwind build`
- `pnpm lint-fix`
- `APP_PORT=4322 pnpm -F app test-chrome ariakit-tailwind --grep-invert wcag -u`
- `APP_PORT=4322 pnpm -F app test-chrome ariakit-tailwind --grep-invert wcag`
- `APP_PORT=4322 pnpm -F app test-chrome ariakit-tailwind -g wcag`
- `pnpm tsc`
- `APP_PORT=4322 PERF_RESULTS_FILE=baseline pnpm -F app test-perf ariakit-tailwind`
- `APP_PORT=4322 pnpm -F app test-perf ariakit-tailwind`
- `pnpm -F app perf-compare`
