### PR TITLE
Improve store update performance

### DIFF
--- a/.changeset/200-store-performance.md
+++ b/.changeset/200-store-performance.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/store": patch
+---
+
+Improved store update performance for keyed subscriptions and merged stores.

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -37,6 +37,8 @@ interface ListenerGroup<S> {
   listeners: Set<Listener<S>>;
   listenersByKey?: ListenerMap<S>;
   allKeysListeners?: Set<Listener<S>>;
+  disposables: WeakMap<Listener<S>, void | (() => void)>;
+  listenerKeys: WeakMap<Listener<S>, Array<keyof S> | null>;
 }
 
 interface StoreInternals<S = State> {
@@ -123,10 +125,16 @@ export function createStore<S extends State>(
   const updatedKeys = new Set<keyof S>();
 
   const setups = new Set<() => void | (() => void)>();
-  const syncListeners: ListenerGroup<S> = { listeners: new Set() };
-  const batchListenerGroup: ListenerGroup<S> = { listeners: new Set() };
-  const disposables = new WeakMap<Listener<S>, void | (() => void)>();
-  const listenerKeys = new WeakMap<Listener<S>, Array<keyof S> | null>();
+  const syncListeners: ListenerGroup<S> = {
+    listeners: new Set(),
+    disposables: new WeakMap(),
+    listenerKeys: new WeakMap(),
+  };
+  const batchListenerGroup: ListenerGroup<S> = {
+    listeners: new Set(),
+    disposables: new WeakMap(),
+    listenerKeys: new WeakMap(),
+  };
 
   const storeSetup: StoreSetup = (callback) => {
     setups.add(callback);
@@ -138,7 +146,7 @@ export function createStore<S extends State>(
     // other stores. However, the store can't be destroyed until all instances
     // are unmounted. See https://github.com/ariakit/ariakit/issues/3147. See
     // select-default-open-controlled tests.
-    const initialized = instances.size;
+    const initializedInstances = instances.size;
     const instance = Symbol();
     instances.add(instance);
 
@@ -148,7 +156,7 @@ export function createStore<S extends State>(
       destroy();
     };
 
-    if (initialized) return maybeDestroy;
+    if (initializedInstances) return maybeDestroy;
 
     const stateKeys = getKeys(state);
     const desyncs: Array<void | (() => void)> = [];
@@ -175,11 +183,11 @@ export function createStore<S extends State>(
         }
         continue;
       }
-      let initialized = false;
+      let didSyncInitialState = false;
       desyncs.push(
         sync(store, keys, (state, prevState) => {
           for (const key of keys) {
-            if (initialized && state[key] === prevState[key]) continue;
+            if (didSyncInitialState && state[key] === prevState[key]) continue;
             setState(
               key,
               state[key],
@@ -188,7 +196,7 @@ export function createStore<S extends State>(
               true,
             );
           }
-          initialized = true;
+          didSyncInitialState = true;
         }),
       );
     }
@@ -225,7 +233,7 @@ export function createStore<S extends State>(
   ) => {
     const listenerKeysValue = keys ? [...keys] : null;
     if (group.listeners.has(listener)) {
-      deleteListenerIndexes(group, listener, listenerKeys.get(listener));
+      deleteListenerIndexes(group, listener, group.listenerKeys.get(listener));
     }
     group.listeners.add(listener);
     if (listenerKeysValue) {
@@ -235,16 +243,16 @@ export function createStore<S extends State>(
       group.allKeysListeners ??= new Set();
       group.allKeysListeners.add(listener);
     }
-    listenerKeys.set(listener, listenerKeysValue);
+    group.listenerKeys.set(listener, listenerKeysValue);
     return () => {
-      disposables.get(listener)?.();
-      disposables.delete(listener);
-      const currentKeys = listenerKeys.get(listener);
+      group.disposables.get(listener)?.();
+      group.disposables.delete(listener);
+      const currentKeys = group.listenerKeys.get(listener);
       deleteListenerIndexes(group, listener, listenerKeysValue);
       if (currentKeys !== listenerKeysValue) {
         deleteListenerIndexes(group, listener, currentKeys);
       }
-      listenerKeys.delete(listener);
+      group.listenerKeys.delete(listener);
       group.listeners.delete(listener);
     };
   };
@@ -253,12 +261,15 @@ export function createStore<S extends State>(
     sub(keys, listener);
 
   const storeSync: StoreSync<S> = (keys, listener) => {
-    disposables.set(listener, listener(state, state));
+    syncListeners.disposables.set(listener, listener(state, state));
     return sub(keys, listener);
   };
 
   const storeBatch: StoreBatch<S> = (keys, listener) => {
-    disposables.set(listener, listener(state, prevStateBatch));
+    batchListenerGroup.disposables.set(
+      listener,
+      listener(state, prevStateBatch),
+    );
     return sub(keys, listener, batchListenerGroup);
   };
 
@@ -270,19 +281,9 @@ export function createStore<S extends State>(
 
   const getState: Store<S>["getState"] = () => state;
 
-  const run = (listener: Listener<S>, prev: S) => {
-    disposables.get(listener)?.();
-    disposables.set(listener, listener(state, prev));
-  };
-
-  const runIfNeeded = (
-    listener: Listener<S>,
-    prevState: S,
-    updatedKey: UpdatedKey<S>,
-  ) => {
-    const keys = listenerKeys.get(listener);
-    if (!hasUpdatedKey(keys, updatedKey)) return;
-    run(listener, prevState);
+  const run = (group: ListenerGroup<S>, listener: Listener<S>, prev: S) => {
+    group.disposables.get(listener)?.();
+    group.disposables.set(listener, listener(state, prev));
   };
 
   const runListeners = (
@@ -295,12 +296,14 @@ export function createStore<S extends State>(
       if (!keyedListeners) return;
       for (const listener of keyedListeners) {
         if (!group.listeners.has(listener)) continue;
-        run(listener, prevState);
+        run(group, listener, prevState);
       }
       return;
     }
     for (const listener of group.listeners) {
-      runIfNeeded(listener, prevState, updatedKey);
+      const keys = group.listenerKeys.get(listener);
+      if (!hasUpdatedKey(keys, updatedKey)) continue;
+      run(group, listener, prevState);
     }
   };
 

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -30,6 +30,14 @@ type StoreOmit<
   S = State,
   K extends ReadonlyArray<keyof S> = ReadonlyArray<keyof S>,
 > = (keys: K) => Store<Omit<S, K[number]>>;
+type ListenerMap<S> = Map<keyof S, Set<Listener<S>>>;
+type UpdatedKey<S> = keyof S | Set<keyof S>;
+
+interface ListenerGroup<S> {
+  listeners: Set<Listener<S>>;
+  listenersByKey?: ListenerMap<S>;
+  allKeysListeners?: Set<Listener<S>>;
+}
 
 interface StoreInternals<S = State> {
   setup: StoreSetup;
@@ -50,6 +58,54 @@ function getInternal<K extends keyof StoreInternals>(
   return internals[key];
 }
 
+function hasUpdatedKey<S>(
+  keys: Array<keyof S> | null | undefined,
+  updatedKey: UpdatedKey<S>,
+) {
+  if (!keys) return true;
+  for (const currentKey of keys) {
+    if (updatedKey instanceof Set) {
+      if (updatedKey.has(currentKey)) return true;
+    } else if (currentKey === updatedKey) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function addKeyedListener<S>(
+  map: ListenerMap<S>,
+  keys: Array<keyof S> | null,
+  listener: Listener<S>,
+) {
+  if (!keys) return;
+  for (const key of keys) {
+    let listeners = map.get(key);
+    if (!listeners) {
+      listeners = new Set();
+      map.set(key, listeners);
+    }
+    listeners.add(listener);
+  }
+}
+
+function deleteKeyedListener<S>(
+  map: ListenerMap<S> | undefined,
+  keys: Array<keyof S> | null | undefined,
+  listener: Listener<S>,
+) {
+  if (!map) return;
+  if (!keys) return;
+  for (const key of keys) {
+    const listeners = map.get(key);
+    if (!listeners) continue;
+    listeners.delete(listener);
+    if (!listeners.size) {
+      map.delete(key);
+    }
+  }
+}
+
 /**
  * Creates a store.
  * @param initialState Initial state.
@@ -61,14 +117,14 @@ export function createStore<S extends State>(
 ): Store<S> {
   let state = initialState;
   let prevStateBatch = state;
-  let lastUpdate = Symbol();
+  let lastUpdate = 0;
   let destroy = noop;
   const instances = new Set<symbol>();
   const updatedKeys = new Set<keyof S>();
 
   const setups = new Set<() => void | (() => void)>();
-  const listeners = new Set<Listener<S>>();
-  const batchListeners = new Set<Listener<S>>();
+  const syncListeners: ListenerGroup<S> = { listeners: new Set() };
+  const batchListenerGroup: ListenerGroup<S> = { listeners: new Set() };
   const disposables = new WeakMap<Listener<S>, void | (() => void)>();
   const listenerKeys = new WeakMap<Listener<S>, Array<keyof S> | null>();
 
@@ -94,13 +150,36 @@ export function createStore<S extends State>(
 
     if (initialized) return maybeDestroy;
 
-    const desyncs = getKeys(state).map((key) =>
-      chain(
-        ...stores.map((store) => {
-          const storeState = store?.getState?.();
-          if (!storeState) return;
-          if (!hasOwnProperty(storeState, key)) return;
-          return sync(store, [key], (state) => {
+    const stateKeys = getKeys(state);
+    const desyncs: Array<void | (() => void)> = [];
+    for (const store of stores) {
+      const storeState = store?.getState?.();
+      if (!storeState) continue;
+      const keys = stateKeys.filter((key) => hasOwnProperty(storeState, key));
+      if (!keys.length) continue;
+      const shouldSyncByKey =
+        stores.length === 1 || keys.length === stateKeys.length;
+      if (shouldSyncByKey) {
+        for (const key of keys) {
+          desyncs.push(
+            sync(store, [key], (state) => {
+              setState(
+                key,
+                state[key],
+                // @ts-expect-error - Not public API. This is just to prevent
+                // infinite loops.
+                true,
+              );
+            }),
+          );
+        }
+        continue;
+      }
+      let initialized = false;
+      desyncs.push(
+        sync(store, keys, (state, prevState) => {
+          for (const key of keys) {
+            if (initialized && state[key] === prevState[key]) continue;
             setState(
               key,
               state[key],
@@ -108,10 +187,11 @@ export function createStore<S extends State>(
               // infinite loops.
               true,
             );
-          });
+          }
+          initialized = true;
         }),
-      ),
-    );
+      );
+    }
 
     const teardowns: Array<void | (() => void)> = [];
     for (const setup of setups) {
@@ -125,18 +205,47 @@ export function createStore<S extends State>(
     return maybeDestroy;
   };
 
+  const deleteListenerIndexes = (
+    group: ListenerGroup<S>,
+    listener: Listener<S>,
+    keys: Array<keyof S> | null | undefined,
+  ) => {
+    if (keys === undefined) return;
+    if (keys) {
+      deleteKeyedListener(group.listenersByKey, keys, listener);
+    } else {
+      group.allKeysListeners?.delete(listener);
+    }
+  };
+
   const sub = (
     keys: Array<keyof S> | null,
     listener: Listener<S>,
-    set = listeners,
+    group = syncListeners,
   ) => {
-    set.add(listener);
-    listenerKeys.set(listener, keys);
+    const listenerKeysValue = keys ? [...keys] : null;
+    if (group.listeners.has(listener)) {
+      deleteListenerIndexes(group, listener, listenerKeys.get(listener));
+    }
+    group.listeners.add(listener);
+    if (listenerKeysValue) {
+      group.listenersByKey ??= new Map();
+      addKeyedListener(group.listenersByKey, listenerKeysValue, listener);
+    } else {
+      group.allKeysListeners ??= new Set();
+      group.allKeysListeners.add(listener);
+    }
+    listenerKeys.set(listener, listenerKeysValue);
     return () => {
       disposables.get(listener)?.();
       disposables.delete(listener);
+      const currentKeys = listenerKeys.get(listener);
+      deleteListenerIndexes(group, listener, listenerKeysValue);
+      if (currentKeys !== listenerKeysValue) {
+        deleteListenerIndexes(group, listener, currentKeys);
+      }
       listenerKeys.delete(listener);
-      set.delete(listener);
+      group.listeners.delete(listener);
     };
   };
 
@@ -150,7 +259,7 @@ export function createStore<S extends State>(
 
   const storeBatch: StoreBatch<S> = (keys, listener) => {
     disposables.set(listener, listener(state, prevStateBatch));
-    return sub(keys, listener, batchListeners);
+    return sub(keys, listener, batchListenerGroup);
   };
 
   const storePick: StorePick<S, ReadonlyArray<keyof S>> = (keys) =>
@@ -160,6 +269,40 @@ export function createStore<S extends State>(
     createStore(_omit(state, keys), finalStore);
 
   const getState: Store<S>["getState"] = () => state;
+
+  const run = (listener: Listener<S>, prev: S) => {
+    disposables.get(listener)?.();
+    disposables.set(listener, listener(state, prev));
+  };
+
+  const runIfNeeded = (
+    listener: Listener<S>,
+    prevState: S,
+    updatedKey: UpdatedKey<S>,
+  ) => {
+    const keys = listenerKeys.get(listener);
+    if (!hasUpdatedKey(keys, updatedKey)) return;
+    run(listener, prevState);
+  };
+
+  const runListeners = (
+    group: ListenerGroup<S>,
+    prevState: S,
+    updatedKey: UpdatedKey<S>,
+  ) => {
+    if (!(updatedKey instanceof Set) && !group.allKeysListeners?.size) {
+      const keyedListeners = group.listenersByKey?.get(updatedKey);
+      if (!keyedListeners) return;
+      for (const listener of keyedListeners) {
+        if (!group.listeners.has(listener)) continue;
+        run(listener, prevState);
+      }
+      return;
+    }
+    for (const listener of group.listeners) {
+      runIfNeeded(listener, prevState, updatedKey);
+    }
+  };
 
   const setState: Store<S>["setState"] = (key, value, fromStores = false) => {
     if (!hasOwnProperty(state, key)) return;
@@ -177,36 +320,24 @@ export function createStore<S extends State>(
     const prevState = state;
     state = { ...state, [key]: nextValue };
 
-    const thisUpdate = Symbol();
-    lastUpdate = thisUpdate;
+    lastUpdate += 1;
+    const thisUpdate = lastUpdate;
     updatedKeys.add(key);
 
-    const run = (listener: Listener<S>, prev: S, uKeys?: Set<keyof S>) => {
-      const keys = listenerKeys.get(listener);
-      const updated = (k: keyof S) => (uKeys ? uKeys.has(k) : k === key);
-      if (!keys || keys.some(updated)) {
-        disposables.get(listener)?.();
-        disposables.set(listener, listener(state, prev));
-      }
-    };
-
-    for (const listener of listeners) {
-      run(listener, prevState);
-    }
+    runListeners(syncListeners, prevState, key);
 
     queueMicrotask(() => {
       // If setState is called again before this microtask runs, skip this
       // update. This is to prevent unnecessary updates when multiple keys are
       // updated in a single microtask.
       if (lastUpdate !== thisUpdate) return;
-      // Take a snapshot of the state before running batch listeners. This is
-      // necessary because batch listeners can setState.
+      // Take snapshots before running batch listeners. This is necessary
+      // because batch listeners can setState.
       const snapshot = state;
-      for (const listener of batchListeners) {
-        run(listener, prevStateBatch, updatedKeys);
-      }
-      prevStateBatch = snapshot;
+      const updatedKeysSnapshot = new Set(updatedKeys);
       updatedKeys.clear();
+      runListeners(batchListenerGroup, prevStateBatch, updatedKeysSnapshot);
+      prevStateBatch = snapshot;
     });
   };
 

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -145,6 +145,26 @@ test("does not notify listeners for strict-equal values", () => {
   expect(store.getState()).toEqual({ count: 0, object: { id: 1 } });
 });
 
+test("passes immutable state snapshots to listeners", () => {
+  const store = createStore({ count: 0, label: "a" });
+  const initialState = store.getState();
+  const calls: Array<[StoreState<typeof store>, StoreState<typeof store>]> = [];
+
+  subscribe(store, null, (state, prevState) => {
+    calls.push([state, prevState]);
+  });
+
+  store.setState("count", 1);
+
+  const nextState = store.getState();
+
+  expect(nextState).not.toBe(initialState);
+  expect(initialState).toEqual({ count: 0, label: "a" });
+  expect(calls).toHaveLength(1);
+  expect(calls[0]?.[0]).toBe(nextState);
+  expect(calls[0]?.[1]).toBe(initialState);
+});
+
 test("subscribes to selected state changes", () => {
   const store = createStore({ count: 0, label: "a" });
   const calls: Array<[number, number]> = [];
@@ -165,6 +185,44 @@ test("subscribes to selected state changes", () => {
   store.setState("count", 2);
 
   expect(calls).toEqual([[1, 0]]);
+});
+
+test("captures selected state keys when subscribing", () => {
+  const store = createStore({ count: 0, label: "a" });
+  const keys: Array<"count" | "label"> = ["count"];
+  const listener = vi.fn();
+
+  subscribe(store, keys, listener);
+
+  keys[0] = "label";
+
+  store.setState("label", "b");
+  expect(listener).not.toHaveBeenCalled();
+
+  store.setState("count", 1);
+  expect(listener).toHaveBeenCalledOnce();
+});
+
+test("keeps reused listener callbacks on their latest keys", () => {
+  const store = createStore({ count: 0, label: "a" });
+  const listener = vi.fn();
+
+  subscribe(store, ["count"], listener);
+  const unsubscribe = subscribe(store, ["label"], listener);
+
+  store.setState("count", 1);
+  expect(listener).not.toHaveBeenCalled();
+
+  store.setState("label", "b");
+  expect(listener).toHaveBeenCalledOnce();
+
+  listener.mockClear();
+  unsubscribe();
+
+  store.setState("count", 2);
+  store.setState("label", "c");
+
+  expect(listener).not.toHaveBeenCalled();
 });
 
 test("sync runs immediately and cleans up before rerun and unsubscribe", () => {
@@ -208,6 +266,27 @@ test("subscribe cleans up before rerun and unsubscribe", () => {
 
   unsubscribe();
   expect(events).toEqual(["run 1", "cleanup 1", "run 2", "cleanup 2"]);
+});
+
+test("sync listeners can set state reentrantly", () => {
+  const store = createStore({ open: false, mounted: false });
+  const calls: Array<[boolean, boolean, boolean, boolean]> = [];
+
+  sync(store, ["open", "mounted"], (state, prevState) => {
+    calls.push([prevState.open, state.open, prevState.mounted, state.mounted]);
+    if (state.mounted !== state.open) {
+      store.setState("mounted", state.open);
+    }
+  });
+
+  store.setState("open", true);
+
+  expect(store.getState()).toEqual({ open: true, mounted: true });
+  expect(calls).toEqual([
+    [false, false, false, false],
+    [false, true, false, false],
+    [true, true, false, true],
+  ]);
 });
 
 test("batch runs immediately and coalesces state changes", async () => {
@@ -260,6 +339,52 @@ test("batch runs immediately and coalesces state changes", async () => {
   await flushBatch();
 
   expect(calls).toHaveLength(2);
+});
+
+test("batch listeners can set state for later batch listeners", async () => {
+  const store = createStore({ count: 0, derived: 0 });
+  const derived = vi.fn();
+
+  batch(store, ["count"], (state) => {
+    store.setState("derived", state.count * 2);
+  });
+
+  batch(store, ["derived"], (state, prevState) => {
+    derived(state.derived, prevState.derived);
+  });
+
+  derived.mockClear();
+
+  store.setState("count", 1);
+  await flushBatch();
+  await flushBatch();
+
+  expect(store.getState()).toEqual({ count: 1, derived: 2 });
+  expect(derived).toHaveBeenCalledOnce();
+  expect(derived).toHaveBeenLastCalledWith(2, 0);
+});
+
+test("batch listeners can set state for earlier batch listeners", async () => {
+  const store = createStore({ count: 0, derived: 0 });
+  const derived = vi.fn();
+
+  batch(store, ["derived"], (state, prevState) => {
+    derived(state.derived, prevState.derived);
+  });
+
+  batch(store, ["count"], (state) => {
+    store.setState("derived", state.count * 2);
+  });
+
+  derived.mockClear();
+
+  store.setState("count", 1);
+  await flushBatch();
+  await flushBatch();
+
+  expect(store.getState()).toEqual({ count: 1, derived: 2 });
+  expect(derived).toHaveBeenCalledOnce();
+  expect(derived).toHaveBeenLastCalledWith(2, 0);
 });
 
 test("does not rerun empty-key sync and batch listeners after registration", async () => {
@@ -347,6 +472,94 @@ test("keeps extended stores in sync while initialized", () => {
 
   parent.setState("count", 3);
   expect(child.getState().count).toBe(2);
+});
+
+test("keeps a shared parent initialized until every child is cleaned up", () => {
+  const parent = createStore({ count: 0 });
+  const events: string[] = [];
+
+  setup(parent, () => {
+    events.push("setup");
+    return () => events.push("teardown");
+  });
+
+  const childA = createStore({ count: 0 }, parent);
+  const childB = createStore({ count: 0 }, parent);
+
+  const cleanupA = init(childA);
+  const cleanupB = init(childB);
+
+  expect(events).toEqual(["setup"]);
+
+  cleanupA();
+  expect(events).toEqual(["setup"]);
+
+  parent.setState("count", 1);
+  expect(childA.getState().count).toBe(0);
+  expect(childB.getState().count).toBe(1);
+
+  cleanupB();
+  expect(events).toEqual(["setup", "teardown"]);
+});
+
+test("initializes extended stores with argument-order precedence", () => {
+  const first = createStore({ count: 1 });
+  const second = createStore({ count: 2 });
+  const child = createStore({ count: 0 }, first, second);
+
+  const cleanup = init(child);
+
+  expect(child.getState().count).toBe(2);
+
+  first.setState("count", 3);
+  expect(child.getState().count).toBe(3);
+
+  second.setState("count", 4);
+  expect(child.getState().count).toBe(4);
+
+  child.setState("count", 5);
+  expect(first.getState().count).toBe(5);
+  expect(second.getState().count).toBe(5);
+
+  cleanup();
+});
+
+test("keeps partial extended stores in sync while initialized", () => {
+  const first = createStore({ first: "first", shared: "first" });
+  const second = createStore({ shared: "second" });
+  const child = createStore(
+    { first: "child", shared: "child", child: "child" },
+    first,
+    second,
+  );
+
+  const cleanup = init(child);
+
+  expect(child.getState()).toEqual({
+    first: "first",
+    shared: "second",
+    child: "child",
+  });
+
+  first.setState("first", "updated first");
+  expect(child.getState().first).toBe("updated first");
+
+  first.setState("shared", "updated first shared");
+  expect(child.getState().shared).toBe("updated first shared");
+
+  second.setState("shared", "updated second shared");
+  expect(child.getState().shared).toBe("updated second shared");
+
+  child.setState("first", "updated child first");
+  child.setState("shared", "updated child shared");
+
+  expect(first.getState()).toEqual({
+    first: "updated child first",
+    shared: "updated child shared",
+  });
+  expect(second.getState()).toEqual({ shared: "updated child shared" });
+
+  cleanup();
 });
 
 test("creates live picked and omitted stores", () => {

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -225,6 +225,47 @@ test("keeps reused listener callbacks on their latest keys", () => {
   expect(listener).not.toHaveBeenCalled();
 });
 
+test("keeps reused callbacks isolated between listener groups", async () => {
+  const store = createStore({ count: 0, label: "a" });
+  const events: string[] = [];
+  let runs = 0;
+  const listener = vi.fn(() => {
+    runs += 1;
+    const run = runs;
+    events.push(`run ${run}`);
+    return () => events.push(`cleanup ${run}`);
+  });
+
+  subscribe(store, null, () => {});
+  subscribe(store, ["count"], listener);
+  batch(store, ["label"], listener);
+
+  expect(events).toEqual(["run 1"]);
+
+  events.length = 0;
+  listener.mockClear();
+
+  store.setState("count", 1);
+
+  expect(events).toEqual(["run 2"]);
+  expect(listener).toHaveBeenCalledOnce();
+
+  events.length = 0;
+
+  await flushBatch();
+
+  expect(events).toEqual([]);
+
+  store.setState("label", "b");
+
+  expect(events).toEqual([]);
+
+  await flushBatch();
+
+  expect(events).toEqual(["cleanup 1", "run 3"]);
+  expect(listener).toHaveBeenCalledTimes(2);
+});
+
 test("sync runs immediately and cleans up before rerun and unsubscribe", () => {
   const store = createStore({ count: 0, label: "a" });
   const events: string[] = [];


### PR DESCRIPTION
## Motivation

`@ariakit/store` is a shared dependency for component stores, and its update path can do unnecessary listener work when many subscriptions are keyed to state that did not change. The existing store tests also did not pin down some reentrant and multi-store behaviors that are important when optimizing internals.

## Solution

Add lazy keyed listener indexes so updates can notify only listeners subscribed to the changed key when possible, keep all-key and batch behavior on the existing broader path, and avoid per-update Symbol allocation. Store initialization now reads source store state once and reduces sync setup for partial multi-source stores while preserving source precedence.

The store tests now cover immutable listener snapshots, captured subscription keys, reused listener callbacks, reentrant sync and batch updates, shared parent init refcounts, partial multi-source stores, and multiple-source initialization precedence.

## Verification

- `pnpm lint-fix`
- `pnpm test ariakit-store`
- `pnpm bench packages/ariakit-store/benchmark/store.bench.ts`
- `pnpm tsc`
- `pnpm test`
- `pnpm exec playwright test --project=chrome --grep-invert @visual` with `pnpm dev`
- `APP_PORT=4321 NEXTJS_PORT=3000 pnpm -F app exec playwright test --project=chrome --grep-invert @visual` with `pnpm dev-app`
