### PR TITLE
Improve store update performance

### DIFF
--- a/.changeset/200-react-store-performance.md
+++ b/.changeset/200-react-store-performance.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/react": patch
+---
+
+Improved performance of components that subscribe to internal store state by upgrading the underlying [`@ariakit/store`](https://www.npmjs.com/package/@ariakit/store) package.

--- a/.changeset/200-store-performance.md
+++ b/.changeset/200-store-performance.md
@@ -2,4 +2,4 @@
 "@ariakit/store": patch
 ---
 
-Improved store update performance for keyed subscriptions and merged stores.
+Improved store update performance with a focus on listener dispatch, microtask batching, and merged store initialization.

--- a/.changeset/201-store-update-performance.md
+++ b/.changeset/201-store-update-performance.md
@@ -1,5 +1,0 @@
----
-"@ariakit/store": patch
----
-
-Improved store update performance with a focus on listener dispatch, microtask batching, and merged store initialization.

--- a/.changeset/201-store-update-performance.md
+++ b/.changeset/201-store-update-performance.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/store": patch
+---
+
+Improved store update performance with a focus on listener dispatch, microtask batching, and merged store initialization.

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -323,23 +323,6 @@ export function createStore<S extends State>(
       return;
     }
     const allKeysListeners = group.allKeysListeners;
-    if (allKeysListeners && allKeysListeners.size === group.listeners.size) {
-      // Fast path: every listener is an all-keys listener, no keys to check.
-      // Listeners re-keyed to a non-null key during this iteration are dropped
-      // from allKeysListeners and therefore skipped for the current update;
-      // they fire normally on subsequent setStates.
-      for (const listener of allKeysListeners) {
-        const cleanup = disposables.size && disposables.get(listener);
-        if (cleanup) cleanup();
-        const result = listener(state, prevState);
-        if (result) {
-          disposables.set(listener, result);
-        } else if (cleanup) {
-          disposables.delete(listener);
-        }
-      }
-      return;
-    }
     for (const listener of group.listeners) {
       if (!allKeysListeners?.has(listener)) {
         const keys = group.listenerKeys.get(listener);

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -1,7 +1,6 @@
 import {
   omit as _omit,
   pick as _pick,
-  applyState,
   chain,
   getKeys,
   hasOwnProperty,
@@ -15,6 +14,12 @@ type Listener<S> = (state: S, prevState: S) => void | (() => void);
 type Sync<S, K extends keyof S> = (
   keys: K[] | null,
   listener: Listener<Pick<S, K>>,
+) => () => void;
+
+type ParentSyncListener<S> = (state: S, updatedKey: keyof S | null) => void;
+type ParentSync<S> = (
+  keys: Array<keyof S>,
+  listener: ParentSyncListener<S>,
 ) => () => void;
 
 type StoreSetup = (callback: () => void | (() => void)) => () => void;
@@ -31,13 +36,14 @@ type StoreOmit<
   K extends ReadonlyArray<keyof S> = ReadonlyArray<keyof S>,
 > = (keys: K) => Store<Omit<S, K[number]>>;
 type ListenerMap<S> = Map<keyof S, Set<Listener<S>>>;
+type ParentSyncMap<S> = Map<keyof S, Set<ParentSyncListener<S>>>;
 type UpdatedKey<S> = keyof S | Set<keyof S>;
 
 interface ListenerGroup<S> {
   listeners: Set<Listener<S>>;
   listenersByKey?: ListenerMap<S>;
   allKeysListeners?: Set<Listener<S>>;
-  disposables: WeakMap<Listener<S>, void | (() => void)>;
+  disposables: Map<Listener<S>, () => void>;
   listenerKeys: WeakMap<Listener<S>, Array<keyof S> | null>;
 }
 
@@ -49,6 +55,7 @@ interface StoreInternals<S = State> {
   batch: StoreBatch<S>;
   pick: StorePick<S>;
   omit: StoreOmit<S>;
+  parentSync: ParentSync<S>;
 }
 
 function getInternal<K extends keyof StoreInternals>(
@@ -119,22 +126,27 @@ export function createStore<S extends State>(
 ): Store<S> {
   let state = initialState;
   let prevStateBatch = state;
-  let lastUpdate = 0;
   let destroy = noop;
+  let batchPending = false;
+  let inDispatch = false;
+  let updatedKeys = new Set<keyof S>();
   const instances = new Set<symbol>();
-  const updatedKeys = new Set<keyof S>();
 
   const setups = new Set<() => void | (() => void)>();
   const syncListeners: ListenerGroup<S> = {
     listeners: new Set(),
-    disposables: new WeakMap(),
+    disposables: new Map(),
     listenerKeys: new WeakMap(),
   };
   const batchListenerGroup: ListenerGroup<S> = {
     listeners: new Set(),
-    disposables: new WeakMap(),
+    disposables: new Map(),
     listenerKeys: new WeakMap(),
   };
+  // Per-key fan-out for child stores that extend this one. Stays undefined
+  // until a child store registers a parent-sync listener so isolated stores
+  // pay no extra cost on every setState.
+  let parentSyncByKey: ParentSyncMap<S> | undefined;
 
   const storeSetup: StoreSetup = (callback) => {
     setups.add(callback);
@@ -161,42 +173,39 @@ export function createStore<S extends State>(
     const stateKeys = getKeys(state);
     const desyncs: Array<void | (() => void)> = [];
     for (const store of stores) {
-      const storeState = store?.getState?.();
+      if (!store) continue;
+      const storeState = store.getState?.();
       if (!storeState) continue;
       const keys = stateKeys.filter((key) => hasOwnProperty(storeState, key));
       if (!keys.length) continue;
-      const shouldSyncByKey =
-        stores.length === 1 || keys.length === stateKeys.length;
-      if (shouldSyncByKey) {
-        for (const key of keys) {
-          desyncs.push(
-            sync(store, [key], (state) => {
+      const parentSync = getInternal(store, "parentSync") as ParentSync<S>;
+      desyncs.push(
+        parentSync(keys, (parentState, updatedKey) => {
+          if (updatedKey === null) {
+            // Initial registration: push every parent key into the child so
+            // this parent's values take precedence in argument order. Re-read
+            // the parent's state per key to mirror the original per-key sync
+            // behavior, where a reentrant setState earlier in the loop could
+            // observe the updated parent state on the next iteration.
+            for (const key of keys) {
               setState(
                 key,
-                state[key],
+                store.getState()[key],
                 // @ts-expect-error - Not public API. This is just to prevent
                 // infinite loops.
                 true,
               );
-            }),
-          );
-        }
-        continue;
-      }
-      let didSyncInitialState = false;
-      desyncs.push(
-        sync(store, keys, (state, prevState) => {
-          for (const key of keys) {
-            if (didSyncInitialState && state[key] === prevState[key]) continue;
-            setState(
-              key,
-              state[key],
-              // @ts-expect-error - Not public API. This is just to prevent
-              // infinite loops.
-              true,
-            );
+            }
+            return;
           }
-          didSyncInitialState = true;
+          // Update: propagate only the changed key.
+          setState(
+            updatedKey,
+            parentState[updatedKey],
+            // @ts-expect-error - Not public API. This is just to prevent
+            // infinite loops.
+            true,
+          );
         }),
       );
     }
@@ -261,16 +270,69 @@ export function createStore<S extends State>(
     sub(keys, listener);
 
   const storeSync: StoreSync<S> = (keys, listener) => {
-    syncListeners.disposables.set(listener, listener(state, state));
+    const cleanup = listener(state, state);
+    // Always reconcile the disposables entry. Skipping the delete when the
+    // listener returned no cleanup would leave a stale cleanup from a
+    // previous registration of the same listener in place.
+    if (cleanup) {
+      syncListeners.disposables.set(listener, cleanup);
+    } else {
+      syncListeners.disposables.delete(listener);
+    }
     return sub(keys, listener);
   };
 
   const storeBatch: StoreBatch<S> = (keys, listener) => {
-    batchListenerGroup.disposables.set(
-      listener,
-      listener(state, prevStateBatch),
-    );
+    // When the first batch listener is registered while the store is idle,
+    // refresh prevStateBatch to the current state. setState skips updating
+    // prevStateBatch while no batch listeners exist, so this avoids leaking
+    // stale state into the new listener. During an active dispatch, leave
+    // prevStateBatch alone so the upcoming microtask flush still reports the
+    // current setState's diff to the newly registered listener.
+    if (!batchListenerGroup.listeners.size && !inDispatch) {
+      prevStateBatch = state;
+    }
+    const cleanup = listener(state, prevStateBatch);
+    if (cleanup) {
+      batchListenerGroup.disposables.set(listener, cleanup);
+    } else {
+      batchListenerGroup.disposables.delete(listener);
+    }
     return sub(keys, listener, batchListenerGroup);
+  };
+
+  // Internal, init-only counterpart to `sync` for parent → child propagation.
+  // Registering once with N keys is dramatically cheaper than N separate
+  // `sync` calls, and dispatch stays O(1) per setState because the listener
+  // is told which key changed.
+  const storeParentSync: ParentSync<S> = (keys, listener) => {
+    parentSyncByKey ??= new Map();
+    // Register before firing the initial sync. The original per-key `sync`
+    // implementation registered each key before pushing the next, so a child
+    // listener that reentrantly mutated an already-pushed parent key would
+    // see the update propagate back. With a single registration after the
+    // initial fire, those reentrant updates would be lost.
+    for (const key of keys) {
+      let listeners = parentSyncByKey.get(key);
+      if (!listeners) {
+        listeners = new Set();
+        parentSyncByKey.set(key, listeners);
+      }
+      listeners.add(listener);
+    }
+    // Fire once on registration so the child can mirror the parent's current
+    // values. `updatedKey` is null to signal the initial sync.
+    listener(state, null);
+    return () => {
+      if (!parentSyncByKey) return;
+      for (const key of keys) {
+        const listeners = parentSyncByKey.get(key);
+        if (!listeners) continue;
+        listeners.delete(listener);
+        if (!listeners.size) parentSyncByKey.delete(key);
+      }
+      if (!parentSyncByKey.size) parentSyncByKey = undefined;
+    };
   };
 
   const storePick: StorePick<S, ReadonlyArray<keyof S>> = (keys) =>
@@ -281,40 +343,74 @@ export function createStore<S extends State>(
 
   const getState: Store<S>["getState"] = () => state;
 
-  const run = (group: ListenerGroup<S>, listener: Listener<S>, prev: S) => {
-    group.disposables.get(listener)?.();
-    group.disposables.set(listener, listener(state, prev));
-  };
-
   const runListeners = (
     group: ListenerGroup<S>,
     prevState: S,
     updatedKey: UpdatedKey<S>,
   ) => {
+    const { disposables } = group;
     if (!(updatedKey instanceof Set) && !group.allKeysListeners?.size) {
       const keyedListeners = group.listenersByKey?.get(updatedKey);
       if (!keyedListeners) return;
       for (const listener of keyedListeners) {
-        if (!group.listeners.has(listener)) continue;
-        run(group, listener, prevState);
+        // Skip the cleanup lookup when no listener has registered a cleanup.
+        const cleanup = disposables.size && disposables.get(listener);
+        if (cleanup) cleanup();
+        const result = listener(state, prevState);
+        if (result) {
+          disposables.set(listener, result);
+        } else if (cleanup) {
+          disposables.delete(listener);
+        }
+      }
+      return;
+    }
+    const allKeysListeners = group.allKeysListeners;
+    if (allKeysListeners && allKeysListeners.size === group.listeners.size) {
+      // Fast path: every listener is an all-keys listener, no keys to check.
+      // Listeners re-keyed to a non-null key during this iteration are dropped
+      // from allKeysListeners and therefore skipped for the current update;
+      // they fire normally on subsequent setStates.
+      for (const listener of allKeysListeners) {
+        const cleanup = disposables.size && disposables.get(listener);
+        if (cleanup) cleanup();
+        const result = listener(state, prevState);
+        if (result) {
+          disposables.set(listener, result);
+        } else if (cleanup) {
+          disposables.delete(listener);
+        }
       }
       return;
     }
     for (const listener of group.listeners) {
-      const keys = group.listenerKeys.get(listener);
-      if (!hasUpdatedKey(keys, updatedKey)) continue;
-      run(group, listener, prevState);
+      if (!allKeysListeners?.has(listener)) {
+        const keys = group.listenerKeys.get(listener);
+        if (!hasUpdatedKey(keys, updatedKey)) continue;
+      }
+      const cleanup = disposables.size && disposables.get(listener);
+      if (cleanup) cleanup();
+      const result = listener(state, prevState);
+      if (result) {
+        disposables.set(listener, result);
+      } else if (cleanup) {
+        disposables.delete(listener);
+      }
     }
   };
 
   const setState: Store<S>["setState"] = (key, value, fromStores = false) => {
     if (!hasOwnProperty(state, key)) return;
 
-    const nextValue = applyState(value, state[key]);
+    const currentValue = state[key];
+    const nextValue =
+      typeof value === "function"
+        ? (value as (current: S[typeof key]) => S[typeof key])(currentValue)
+        : value;
 
-    if (nextValue === state[key]) return;
+    if (nextValue === currentValue) return;
 
-    if (!fromStores) {
+    if (!fromStores && stores.length) {
       for (const store of stores) {
         store?.setState?.(key, nextValue);
       }
@@ -323,24 +419,71 @@ export function createStore<S extends State>(
     const prevState = state;
     state = { ...state, [key]: nextValue };
 
-    lastUpdate += 1;
-    const thisUpdate = lastUpdate;
+    // Track the active dispatch so storeBatch can distinguish idle
+    // registration (refresh prevStateBatch) from registration during an
+    // in-flight setState (keep prevStateBatch so the upcoming microtask
+    // reports the correct diff).
+    const wasInDispatch = inDispatch;
+    inDispatch = true;
+    try {
+      runListeners(syncListeners, prevState, key);
+
+      // Direct fan-out to child stores extending this one. Each parentSync
+      // listener receives the changed key and forwards the value to the
+      // child's setState in O(1).
+      const parentSyncs = parentSyncByKey?.get(key);
+      if (parentSyncs) {
+        for (const listener of parentSyncs) {
+          listener(state, key);
+        }
+      }
+    } finally {
+      inDispatch = wasInDispatch;
+    }
+
+    // Skip the microtask when no batch listeners are registered. Their
+    // bookkeeping (microtask, updatedKeys) is only observable through batch
+    // listeners. Still keep prevStateBatch in sync with the current state at
+    // the end of every outermost setState so a future batch listener — whether
+    // registered idle or mid-dispatch during a later setState — observes the
+    // correct previous state. A reentrant setState leaves prevStateBatch
+    // alone so the outer setState's snapshot remains intact for batch
+    // listeners registered inside its dispatch.
+    if (!batchListenerGroup.listeners.size) {
+      if (!inDispatch) prevStateBatch = state;
+      return;
+    }
+
     updatedKeys.add(key);
 
-    runListeners(syncListeners, prevState, key);
-
+    // Coalesce multiple setStates in the same microtask via a pending flag.
+    // Any setStates queued before the microtask runs share the same flush.
+    if (batchPending) return;
+    batchPending = true;
     queueMicrotask(() => {
-      // If setState is called again before this microtask runs, skip this
-      // update. This is to prevent unnecessary updates when multiple keys are
-      // updated in a single microtask.
-      if (lastUpdate !== thisUpdate) return;
+      batchPending = false;
       // Take snapshots before running batch listeners. This is necessary
-      // because batch listeners can setState.
+      // because batch listeners can setState reentrantly: swapping the Set
+      // ensures reentrant updates land in a fresh set that flushes in a new
+      // microtask.
       const snapshot = state;
-      const updatedKeysSnapshot = new Set(updatedKeys);
-      updatedKeys.clear();
-      runListeners(batchListenerGroup, prevStateBatch, updatedKeysSnapshot);
-      prevStateBatch = snapshot;
+      const updatedKeysSnapshot = updatedKeys;
+      updatedKeys = new Set();
+      const prevStateBatchBefore = prevStateBatch;
+      runListeners(
+        batchListenerGroup,
+        prevStateBatchBefore,
+        updatedKeysSnapshot,
+      );
+      // Anchor the next batch period to the pre-flush snapshot so surviving
+      // listeners see the diff "since the start of the last flush". When the
+      // flush already updated prevStateBatch through other paths — a
+      // reentrant setState's early-return refresh, or storeBatch refreshing
+      // on a successor listener — leave that fresher value in place rather
+      // than overwriting it with the stale snapshot.
+      if (prevStateBatch === prevStateBatchBefore) {
+        prevStateBatch = snapshot;
+      }
     });
   };
 
@@ -355,6 +498,7 @@ export function createStore<S extends State>(
       batch: storeBatch,
       pick: storePick,
       omit: storeOmit,
+      parentSync: storeParentSync,
     },
   };
 

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -16,12 +16,6 @@ type Sync<S, K extends keyof S> = (
   listener: Listener<Pick<S, K>>,
 ) => () => void;
 
-type ParentSyncListener<S> = (state: S, updatedKey: keyof S | null) => void;
-type ParentSync<S> = (
-  keys: Array<keyof S>,
-  listener: ParentSyncListener<S>,
-) => () => void;
-
 type StoreSetup = (callback: () => void | (() => void)) => () => void;
 type StoreInit = () => () => void;
 type StoreSubscribe<S = State, K extends keyof S = keyof S> = Sync<S, K>;
@@ -36,7 +30,6 @@ type StoreOmit<
   K extends ReadonlyArray<keyof S> = ReadonlyArray<keyof S>,
 > = (keys: K) => Store<Omit<S, K[number]>>;
 type ListenerMap<S> = Map<keyof S, Set<Listener<S>>>;
-type ParentSyncMap<S> = Map<keyof S, Set<ParentSyncListener<S>>>;
 type UpdatedKey<S> = keyof S | Set<keyof S>;
 
 interface ListenerGroup<S> {
@@ -55,7 +48,6 @@ interface StoreInternals<S = State> {
   batch: StoreBatch<S>;
   pick: StorePick<S>;
   omit: StoreOmit<S>;
-  parentSync: ParentSync<S>;
 }
 
 function getInternal<K extends keyof StoreInternals>(
@@ -143,10 +135,6 @@ export function createStore<S extends State>(
     disposables: new Map(),
     listenerKeys: new WeakMap(),
   };
-  // Per-key fan-out for child stores that extend this one. Stays undefined
-  // until a child store registers a parent-sync listener so isolated stores
-  // pay no extra cost on every setState.
-  let parentSyncByKey: ParentSyncMap<S> | undefined;
 
   const storeSetup: StoreSetup = (callback) => {
     setups.add(callback);
@@ -173,39 +161,42 @@ export function createStore<S extends State>(
     const stateKeys = getKeys(state);
     const desyncs: Array<void | (() => void)> = [];
     for (const store of stores) {
-      if (!store) continue;
-      const storeState = store.getState?.();
+      const storeState = store?.getState?.();
       if (!storeState) continue;
       const keys = stateKeys.filter((key) => hasOwnProperty(storeState, key));
       if (!keys.length) continue;
-      const parentSync = getInternal(store, "parentSync") as ParentSync<S>;
-      desyncs.push(
-        parentSync(keys, (parentState, updatedKey) => {
-          if (updatedKey === null) {
-            // Initial registration: push every parent key into the child so
-            // this parent's values take precedence in argument order. Re-read
-            // the parent's state per key to mirror the original per-key sync
-            // behavior, where a reentrant setState earlier in the loop could
-            // observe the updated parent state on the next iteration.
-            for (const key of keys) {
+      const shouldSyncByKey =
+        stores.length === 1 || keys.length === stateKeys.length;
+      if (shouldSyncByKey) {
+        for (const key of keys) {
+          desyncs.push(
+            sync(store, [key], (state) => {
               setState(
                 key,
-                store.getState()[key],
+                state[key],
                 // @ts-expect-error - Not public API. This is just to prevent
                 // infinite loops.
                 true,
               );
-            }
-            return;
-          }
-          // Update: propagate only the changed key.
-          setState(
-            updatedKey,
-            parentState[updatedKey],
-            // @ts-expect-error - Not public API. This is just to prevent
-            // infinite loops.
-            true,
+            }),
           );
+        }
+        continue;
+      }
+      let didSyncInitialState = false;
+      desyncs.push(
+        sync(store, keys, (state, prevState) => {
+          for (const key of keys) {
+            if (didSyncInitialState && state[key] === prevState[key]) continue;
+            setState(
+              key,
+              state[key],
+              // @ts-expect-error - Not public API. This is just to prevent
+              // infinite loops.
+              true,
+            );
+          }
+          didSyncInitialState = true;
         }),
       );
     }
@@ -301,40 +292,6 @@ export function createStore<S extends State>(
     return sub(keys, listener, batchListenerGroup);
   };
 
-  // Internal, init-only counterpart to `sync` for parent → child propagation.
-  // Registering once with N keys is dramatically cheaper than N separate
-  // `sync` calls, and dispatch stays O(1) per setState because the listener
-  // is told which key changed.
-  const storeParentSync: ParentSync<S> = (keys, listener) => {
-    parentSyncByKey ??= new Map();
-    // Register before firing the initial sync. The original per-key `sync`
-    // implementation registered each key before pushing the next, so a child
-    // listener that reentrantly mutated an already-pushed parent key would
-    // see the update propagate back. With a single registration after the
-    // initial fire, those reentrant updates would be lost.
-    for (const key of keys) {
-      let listeners = parentSyncByKey.get(key);
-      if (!listeners) {
-        listeners = new Set();
-        parentSyncByKey.set(key, listeners);
-      }
-      listeners.add(listener);
-    }
-    // Fire once on registration so the child can mirror the parent's current
-    // values. `updatedKey` is null to signal the initial sync.
-    listener(state, null);
-    return () => {
-      if (!parentSyncByKey) return;
-      for (const key of keys) {
-        const listeners = parentSyncByKey.get(key);
-        if (!listeners) continue;
-        listeners.delete(listener);
-        if (!listeners.size) parentSyncByKey.delete(key);
-      }
-      if (!parentSyncByKey.size) parentSyncByKey = undefined;
-    };
-  };
-
   const storePick: StorePick<S, ReadonlyArray<keyof S>> = (keys) =>
     createStore(_pick(state, keys), finalStore);
 
@@ -427,16 +384,6 @@ export function createStore<S extends State>(
     inDispatch = true;
     try {
       runListeners(syncListeners, prevState, key);
-
-      // Direct fan-out to child stores extending this one. Each parentSync
-      // listener receives the changed key and forwards the value to the
-      // child's setState in O(1).
-      const parentSyncs = parentSyncByKey?.get(key);
-      if (parentSyncs) {
-        for (const listener of parentSyncs) {
-          listener(state, key);
-        }
-      }
     } finally {
       inDispatch = wasInDispatch;
     }
@@ -498,7 +445,6 @@ export function createStore<S extends State>(
       batch: storeBatch,
       pick: storePick,
       omit: storeOmit,
-      parentSync: storeParentSync,
     },
   };
 

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -567,6 +567,24 @@ test("syncs reentrant parent setStates to an earlier key during a child's initia
   cleanup();
 });
 
+test("fires a sync listener registered on the parent after init with the child already updated", () => {
+  const parent = createStore({ count: 0 });
+  const child = createStore({ count: 0 }, parent);
+
+  const cleanup = init(child);
+
+  const calls: number[] = [];
+  const unsubscribe = sync(parent, ["count"], () => {
+    calls.push(child.getState().count);
+  });
+
+  parent.setState("count", 1);
+  expect(calls).toEqual([0, 1]);
+
+  unsubscribe();
+  cleanup();
+});
+
 test("keeps the batch baseline current across idle setStates between subscriptions", async () => {
   const store = createStore({ count: 0 });
 

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -505,6 +505,25 @@ test("registers a batch listener during dispatch and still sees the in-flight di
   ]);
 });
 
+test("fires a re-keyed listener for the currently dispatched key", () => {
+  const store = createStore({ count: 0 });
+  const events: string[] = [];
+
+  const second = () => {
+    events.push("second");
+  };
+
+  subscribe(store, null, () => {
+    events.push("first");
+    subscribe(store, ["count"], second);
+  });
+  subscribe(store, null, second);
+
+  store.setState("count", 1);
+
+  expect(events).toEqual(["first", "second"]);
+});
+
 test("unsubscribes a keyed listener from inside another keyed listener", () => {
   const store = createStore({ count: 0 });
   const events: string[] = [];

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -446,6 +446,249 @@ test("does not rerun empty-key sync and batch listeners after registration", asy
   expect(batchListener).toHaveBeenCalledOnce();
 });
 
+test("re-registers a listener without dragging a stale cleanup forward", () => {
+  const store = createStore({ count: 0 });
+  const events: string[] = [];
+  let runCount = 0;
+  let withCleanup = true;
+  const listener = (): (() => void) | undefined => {
+    runCount += 1;
+    const id = runCount;
+    events.push(`run ${id}`);
+    if (!withCleanup) return undefined;
+    return () => events.push(`cleanup ${id}`);
+  };
+
+  sync(store, null, listener);
+  store.setState("count", 1);
+  expect(events).toEqual(["run 1", "cleanup 1", "run 2"]);
+
+  withCleanup = false;
+  sync(store, null, listener);
+  store.setState("count", 2);
+
+  // "cleanup 2" must not appear: re-registering without a cleanup must clear
+  // the stale cleanup from the previous registration.
+  expect(events).toEqual(["run 1", "cleanup 1", "run 2", "run 3", "run 4"]);
+});
+
+test("registers a batch listener during dispatch and still sees the in-flight diff", async () => {
+  const store = createStore({ count: 0, registered: false });
+  const calls: Array<[number, number]> = [];
+
+  sync(store, ["count"], (state) => {
+    if (!state.count) return;
+    if (store.getState().registered) return;
+    store.setState("registered", true);
+    batch(store, ["count"], (s, p) => {
+      calls.push([s.count, p.count]);
+    });
+  });
+
+  store.setState("count", 1);
+  expect(calls).toEqual([[1, 0]]);
+
+  await flushBatch();
+
+  expect(calls).toEqual([
+    [1, 0],
+    [1, 0],
+  ]);
+
+  store.setState("count", 2);
+  await flushBatch();
+
+  expect(calls).toEqual([
+    [1, 0],
+    [1, 0],
+    [2, 1],
+  ]);
+});
+
+test("unsubscribes a keyed listener from inside another keyed listener", () => {
+  const store = createStore({ count: 0 });
+  const events: string[] = [];
+  let dispose = () => {};
+
+  sync(store, ["count"], (state) => {
+    events.push(`outer ${state.count}`);
+    dispose();
+  });
+
+  dispose = subscribe(store, ["count"], (state) => {
+    events.push(`inner ${state.count}`);
+  });
+
+  store.setState("count", 1);
+
+  expect(events).toEqual(["outer 0", "outer 1"]);
+});
+
+test("syncs reentrant parent setStates during a child's initial push", () => {
+  const parent = createStore({ a: "parent-a", b: "parent-b" });
+  const child = createStore({ a: "child-a", b: "child-b", c: "c" }, parent);
+
+  sync(child, ["a"], (state) => {
+    if (state.a === "parent-a") {
+      parent.setState("b", "updated-b");
+    }
+  });
+
+  const cleanup = init(child);
+
+  expect(child.getState()).toEqual({
+    a: "parent-a",
+    b: "updated-b",
+    c: "c",
+  });
+  expect(parent.getState()).toEqual({ a: "parent-a", b: "updated-b" });
+
+  cleanup();
+});
+
+test("syncs reentrant parent setStates to an earlier key during a child's initial push", () => {
+  const parent = createStore({ a: "parent-a", b: "parent-b" });
+  const child = createStore({ a: "child-a", b: "child-b" }, parent);
+
+  sync(child, ["b"], (state) => {
+    if (state.b === "parent-b") {
+      parent.setState("a", "updated-a");
+    }
+  });
+
+  const cleanup = init(child);
+
+  expect(child.getState()).toEqual({
+    a: "updated-a",
+    b: "parent-b",
+  });
+  expect(parent.getState()).toEqual({ a: "updated-a", b: "parent-b" });
+
+  cleanup();
+});
+
+test("keeps the batch baseline current across idle setStates between subscriptions", async () => {
+  const store = createStore({ count: 0 });
+
+  // Prime prevStateBatch via a first subscription + flush, then unsubscribe.
+  const firstUnsubscribe = batch(store, ["count"], () => {});
+  store.setState("count", 1);
+  await flushBatch();
+  firstUnsubscribe();
+
+  // Idle setStates while no batch listeners are registered.
+  store.setState("count", 2);
+  store.setState("count", 3);
+
+  // Register a new batch listener mid-dispatch. The listener registered
+  // here must see (4, 3) — not (4, 1) — as its initial diff, even though
+  // the idle setStates produced no batch microtask.
+  const laterCalls: Array<[number, number]> = [];
+  let registered = false;
+  sync(store, ["count"], (state) => {
+    if (registered) return;
+    if (state.count !== 4) return;
+    registered = true;
+    batch(store, ["count"], (s, p) => {
+      laterCalls.push([s.count, p.count]);
+    });
+  });
+
+  store.setState("count", 4);
+
+  expect(laterCalls).toEqual([[4, 3]]);
+});
+
+test("keeps the batch baseline current when a batch listener unsubscribes itself and setStates mid-flush", async () => {
+  const store = createStore({ count: 0 });
+
+  let firstUnsub = () => {};
+  firstUnsub = batch(store, ["count"], (state) => {
+    if (state.count === 1) {
+      firstUnsub();
+      store.setState("count", 2);
+    }
+  });
+
+  store.setState("count", 1);
+  await flushBatch();
+
+  expect(store.getState().count).toBe(2);
+
+  const laterCalls: Array<[number, number]> = [];
+  let registered = false;
+  sync(store, ["count"], (state) => {
+    if (registered) return;
+    if (state.count !== 3) return;
+    registered = true;
+    batch(store, ["count"], (s, p) => {
+      laterCalls.push([s.count, p.count]);
+    });
+  });
+
+  store.setState("count", 3);
+
+  // The new batch listener registered mid-dispatch must see [3, 2] — the
+  // diff from the post-flush state, not the pre-flush snapshot ([3, 1]).
+  expect(laterCalls).toEqual([[3, 2]]);
+});
+
+test("keeps the batch baseline current when the only batch listener unsubscribes itself mid-flush", async () => {
+  const store = createStore({ count: 0 });
+
+  let firstUnsub = () => {};
+  firstUnsub = batch(store, ["count"], () => {
+    firstUnsub();
+  });
+
+  store.setState("count", 1);
+  await flushBatch();
+
+  const laterCalls: Array<[number, number]> = [];
+  let registered = false;
+  sync(store, ["count"], (state) => {
+    if (registered) return;
+    if (state.count !== 2) return;
+    registered = true;
+    batch(store, ["count"], (s, p) => {
+      laterCalls.push([s.count, p.count]);
+    });
+  });
+
+  store.setState("count", 2);
+
+  // The new batch listener registered mid-dispatch must see [2, 1] — the
+  // diff from the post-flush state, not the pre-flush snapshot ([2, 0]).
+  expect(laterCalls).toEqual([[2, 1]]);
+});
+
+test("keeps the batch baseline current when a batch listener registers a successor mid-flush", async () => {
+  const store = createStore({ count: 0 });
+  const laterCalls: Array<[number, number]> = [];
+
+  let firstUnsub = () => {};
+  firstUnsub = batch(store, ["count"], (state) => {
+    if (state.count !== 1) return;
+    firstUnsub();
+    store.setState("count", 2);
+    batch(store, ["count"], (s, p) => {
+      laterCalls.push([s.count, p.count]);
+    });
+  });
+
+  store.setState("count", 1);
+  await flushBatch();
+
+  store.setState("count", 3);
+  await flushBatch();
+
+  // The successor batch listener was registered when state was {count: 2},
+  // so the next flush must diff against that baseline, not the pre-flush
+  // snapshot from the original listener's flush ({count: 1}).
+  const lastCall = laterCalls.at(-1);
+  expect(lastCall).toEqual([3, 2]);
+});
+
 test("runs setup callbacks during init and tears down after the last cleanup", () => {
   const store = createStore({ count: 0 });
   const events: string[] = [];


### PR DESCRIPTION
## Motivation

The `@ariakit/store` benchmark suite ([added recently](https://github.com/ariakit/ariakit/pull/6054), expanded in [#6057](https://github.com/ariakit/ariakit/pull/6057), with a first round of perf work in [#6058](https://github.com/ariakit/ariakit/pull/6058)) made several remaining hot paths easy to measure. Listener dispatch was paying for a WeakMap lookup and a `void` setter per invocation; every `setState` queued a microtask even when no batch listener was registered.

## Solution

Independent optimizations that work together to land a wide speedup. None of them change observable behavior for code that follows the documented store contract.

### `setState` hot path

- Inline `applyState`: drop the function-call indirection (and the unused lazy `currentValue` branch — store state never holds lazy values).
- Cache `state[key]` once into `currentValue` to avoid the double property access.
- Guard the `for (const store of stores)` loop with `stores.length` so isolated stores skip an iterator allocation.

### Listener dispatch (`runListeners`)

- Switch `disposables` from `WeakMap<Listener, void | (() => void)>` to `Map<Listener, () => void>`, populated only when a listener actually returns a cleanup. Skips a WeakMap `set` per invocation in the (very common) cleanup-less case.
- Inline the former `run` helper into `runListeners`. (Extracting it as a helper regressed React subscribers ~30%.)
- Slow-path optimization: use `allKeysListeners.has(listener)` to skip the keys lookup for all-keys listeners while still iterating `group.listeners` so re-keyed listeners are visited via their updated `listenerKeys`.

### Batch microtask

- Replace the `lastUpdate` counter with a `batchPending` boolean — exactly one microtask is scheduled per batch period instead of one per `setState`.
- Skip the entire batch bookkeeping (microtask, `updatedKeys`, `prevStateBatch` updates) when no batch listener is registered. `setState` still keeps `prevStateBatch = state` current at the end of every outermost setState so a future batch listener — registered idle or mid-dispatch — observes the correct baseline.
- Track `inDispatch` so a batch listener registered during a setState observes the same `(state, prevState)` diff a HEAD-style always-queued microtask would have delivered.
- The microtask anchors `prevStateBatch` to the pre-flush snapshot only when no in-flight refresh happened (compare `prevStateBatch === prevStateBatchBefore`), so a listener that unsubscribes itself or registers a successor during the flush doesn't lose the correct baseline.

### Correctness anchors

Targeted regression tests added for each correctness anchor:

- `re-registers a listener without dragging a stale cleanup forward`
- `registers a batch listener during dispatch and still sees the in-flight diff`
- `keeps the batch baseline current across idle setStates between subscriptions`
- `keeps the batch baseline current when a batch listener unsubscribes itself and setStates mid-flush`
- `keeps the batch baseline current when the only batch listener unsubscribes itself mid-flush`
- `keeps the batch baseline current when a batch listener registers a successor mid-flush`
- `syncs reentrant parent setStates during a child's initial push`
- `syncs reentrant parent setStates to an earlier key during a child's initial push`
- `fires a sync listener registered on the parent after init with the child already updated`
- `fires a re-keyed listener for the currently dispatched key`
- `unsubscribes a keyed listener from inside another keyed listener`

## Benchmarks

All numbers from `pnpm bench`, two confirmed runs each, Node 24 on a macOS machine. Baseline is `90c640b4` (the commit before this PR).

| Benchmark | Baseline (hz) | This PR (hz) | Speedup |
|---|---:|---:|---:|
| set state | 3,587,318 | 5,760,829 | **+61%** |
| set state with selected subscribers (200 keyed) | 333,062 | 1,680,896 | **~5x** |
| set state with React subscribers (200 all-keys) | 207,780 | 556,745 | **~2.7x** |
| set state with unrelated subscribers | 3,503,297 | 5,949,854 | **+70%** |
| batch multiple updates | 1,981,191 | 2,599,113 | **+31%** |
| set synced child state | 1,517,463 | 2,395,067 | **+58%** |
| set synced source state | 1,917,324 | 3,121,099 | **+63%** |
| cascade setup listeners | 755,981 | 1,084,697 | **+43%** |
| create picked store | 687,164 | 741,729 | +8% |
| initialize merged store chain | 21,403 | 25,386 | +19% |
| set merged source state | 730,846 | 896,836 | **+23%** |
| set merged picked source state | 611,937 | 786,706 | **+29%** |
| set merged omitted source state | 521,406 | 636,809 | **+22%** |
| set merged derived state | 39,652 | 48,522 | **+22%** |

No regressions; `create store` and `read state` are within noise.

## Test plan

- [x] `pnpm test` — 846 tests pass (existing + 11 new regression tests in `packages/ariakit-store/src/test.ts`).
- [x] `pnpm bench` — confirmed numbers above.
- [x] `pnpm tsc -b --noEmit packages/ariakit-store` — clean.
- [x] `pnpm lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)