### PR TITLE
Make `--ak-edge` inheriting and simplify `PopoverArrow` styling

### DIFF
--- a/.changeset/200-tailwind-edge-inherits.md
+++ b/.changeset/200-tailwind-edge-inherits.md
@@ -2,4 +2,4 @@
 "@ariakit/tailwind": patch
 ---
 
-Made the `--ak-edge` CSS custom property inheriting so non-layer descendants such as popover arrows can read the surrounding layer's edge color directly.
+Made the `--ak-edge` CSS custom property inheriting so descendants of an `.ak-layer` element can read it directly.

--- a/.changeset/200-tailwind-edge-inherits.md
+++ b/.changeset/200-tailwind-edge-inherits.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/tailwind": patch
+---
+
+Made the `--ak-edge` CSS custom property inheriting so non-layer descendants such as popover arrows can read the surrounding layer's edge color directly.

--- a/.changeset/300-popover-arrow-ak-edge.md
+++ b/.changeset/300-popover-arrow-ak-edge.md
@@ -1,5 +1,0 @@
----
-"@ariakit/react-components": patch
----
-
-Updated [`PopoverArrow`](https://ariakit.com/reference/popover-arrow) to read its stroke from `--ak-edge` so it picks up the surrounding popover's edge color when using `@ariakit/tailwind` v0.2.

--- a/.changeset/300-popover-arrow-ak-edge.md
+++ b/.changeset/300-popover-arrow-ak-edge.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/react-components": patch
+---
+
+Updated [`PopoverArrow`](https://ariakit.com/reference/popover-arrow) to read its stroke from `--ak-edge` so it picks up the surrounding popover's edge color when using `@ariakit/tailwind` v0.2.

--- a/.changeset/300-popover-arrow-css-vars.md
+++ b/.changeset/300-popover-arrow-css-vars.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/react-components": patch
+---
+
+Updated `PopoverArrow` to use computed colors directly
+
+[`PopoverArrow`](https://ariakit.com/reference/popover-arrow) and its siblings ([`MenuArrow`](https://ariakit.com/reference/menu-arrow), [`TooltipArrow`](https://ariakit.com/reference/tooltip-arrow), [`HovercardArrow`](https://ariakit.com/reference/hovercard-arrow)) now set `fill` and `stroke` directly from the popover content's computed `background-color` and `border-color`, removing the previous `var(--ak-layer, …)` and `var(--ak-edge, …)` wrappers. Style the arrow with CSS if you need custom theming.

--- a/packages/ariakit-react-components/src/popover/popover-arrow.tsx
+++ b/packages/ariakit-react-components/src/popover/popover-arrow.tsx
@@ -163,7 +163,7 @@ export const usePopoverArrow = createHook<TagName, PopoverArrowOptions>(
         height: "1em",
         pointerEvents: "none",
         fill: `var(--ak-layer, ${fill})`,
-        stroke: `var(--ak-layer-border, ${stroke})`,
+        stroke: `var(--ak-edge, ${stroke})`,
         strokeWidth,
         ...props.style,
       },

--- a/packages/ariakit-react-components/src/popover/popover-arrow.tsx
+++ b/packages/ariakit-react-components/src/popover/popover-arrow.tsx
@@ -128,7 +128,7 @@ export const usePopoverArrow = createHook<TagName, PopoverArrowOptions>(
               // the appearance of borders on HTML elements.
               <path
                 fill="none"
-                stroke={`var(--ak-layer, ${fill})`}
+                stroke={fill}
                 d={POPOVER_ARROW_PATH}
                 mask={`url(#${maskId})`}
               />
@@ -162,8 +162,8 @@ export const usePopoverArrow = createHook<TagName, PopoverArrowOptions>(
         width: "1em",
         height: "1em",
         pointerEvents: "none",
-        fill: `var(--ak-layer, ${fill})`,
-        stroke: `var(--ak-edge, ${stroke})`,
+        fill,
+        stroke,
         strokeWidth,
         ...props.style,
       },

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -591,12 +591,11 @@ const layerColorVars = {
   layerOffset: _ak.prop.canvas("lo"),
   layerPush: _ak.prop.canvas("lp"),
   layer: ak.prop.canvas("layer", { inherits: true }),
-  layerEdge: _ak.prop.black("le", { inherits: true }),
   layerParentContext: _ak.var("lpc"),
   layerEdgeContext: _ak.var("lec"),
   layerEdgeSourceContext: _ak.var("lesc"),
   layerParent: ak.var("layer-parent", "canvas"),
-  edge: ak.prop.black("edge"),
+  edge: ak.prop.black("edge", { inherits: true }),
   text: ak.prop.black("text", { inherits: true }),
   outline: ak.var("outline", "canvastext"),
 };
@@ -1309,7 +1308,6 @@ utility(
   set(vars.layer, layer),
   set(vars.text, vars.layerScheme),
   set(vars.edge, edge),
-  set(vars.layerEdge, vars.edge),
   set(vars.layerBand, layerBand),
   set(vars.layerScheme, layerScheme),
   getBaseDeclarations(vars.layer),
@@ -2069,7 +2067,7 @@ function getFrameBorderingContextDeclarations() {
 
 function getLayerEdgeContextDeclarations() {
   return edgeContext(({ provide }) => [
-    set(provide(vars.layerEdgeContext), vars.layerEdge),
+    set(provide(vars.layerEdgeContext), vars.edge),
     set(provide(vars.layerEdgeSourceContext), 1),
   ]);
 }

--- a/packages/ariakit-tailwind/src/output.css
+++ b/packages/ariakit-tailwind/src/output.css
@@ -119,7 +119,6 @@
   --ak-layer: oklch(from var(--_ak-lp) var(--_ak-sl) clamp(var(--_ak-layer-chroma-min), c, var(--_ak-layer-chroma-max, var(--chroma-p3-max, 0.368))) h);
   --ak-text: var(--_ak-ls);
   --ak-edge: oklch(from oklch(from var(--_ak-edge-color, var(--ak-layer)) clamp(0, (l + ((var(--_ak-edge-push-lightness) + var(--_ak-ecv)) * var(--_ak-epd, -1))), 1) c h) clamp(var(--_ak-edge-lightness-min), var(--_ak-edge-lightness, (l + var(--_ak-edge-relative-lightness) + (clamp(0, (var(--_ak-edge-relative-lightness) * 1000000), 1) * var(--_ak-llfb)))), var(--_ak-edge-lightness-max)) clamp(var(--_ak-edge-chroma-min), var(--_ak-edge-chroma, (c + var(--_ak-edge-relative-chroma))), var(--_ak-edge-chroma-max, var(--chroma-p3-max, 0.368))) var(--_ak-edge-h, calc(h + var(--_ak-edge-relative-hue))) / clamp(0, (var(--_ak-edge-alpha) + var(--_ak-ecv)), 1));
-  --_ak-le: var(--ak-edge);
   --_ak-lbd: oklch(from var(--ak-layer) calc(0.5 + (var(--_ak-bdh) * -0.5) + (var(--_ak-bdl) * -0.25) + (var(--_ak-bll) * 0.25) + (var(--_ak-blh) * 0.5)) 0 0);
   --_ak-ls: oklch(from var(--ak-layer) var(--_ak-tfcl) 0 0);
   --_ak-ll: oklch(from var(--ak-layer) round(l, 0.125) 0 0);
@@ -1142,12 +1141,12 @@
   --_ak-frame-bordering-context: 1;
   @container (style(--_context-1: even)) or (not style(--_context-1)) {
     --_context-1: odd;
-    --_ak-lec-odd: var(--_ak-le);
+    --_ak-lec-odd: var(--ak-edge);
     --_ak-lesc-odd: 1;
   }
   @container style(--_context-1: odd) {
     --_context-1: even;
-    --_ak-lec-even: var(--_ak-le);
+    --_ak-lec-even: var(--ak-edge);
     --_ak-lesc-even: 1;
   }
 }
@@ -1159,12 +1158,12 @@
   --_ak-frame-bordering-context: 1;
   @container (style(--_context-1: even)) or (not style(--_context-1)) {
     --_context-1: odd;
-    --_ak-lec-odd: var(--_ak-le);
+    --_ak-lec-odd: var(--ak-edge);
     --_ak-lesc-odd: 1;
   }
   @container style(--_context-1: odd) {
     --_context-1: even;
-    --_ak-lec-even: var(--_ak-le);
+    --_ak-lec-even: var(--ak-edge);
     --_ak-lesc-even: 1;
   }
 }
@@ -1174,12 +1173,12 @@
   --_ak-frame-bordering-context: 1;
   @container (style(--_context-1: even)) or (not style(--_context-1)) {
     --_context-1: odd;
-    --_ak-lec-odd: var(--_ak-le);
+    --_ak-lec-odd: var(--ak-edge);
     --_ak-lesc-odd: 1;
   }
   @container style(--_context-1: odd) {
     --_context-1: even;
-    --_ak-lec-even: var(--_ak-le);
+    --_ak-lec-even: var(--ak-edge);
     --_ak-lesc-even: 1;
   }
 }
@@ -1190,12 +1189,12 @@
   --_ak-frame-bordering-context: 1;
   @container (style(--_context-1: even)) or (not style(--_context-1)) {
     --_context-1: odd;
-    --_ak-lec-odd: var(--_ak-le);
+    --_ak-lec-odd: var(--ak-edge);
     --_ak-lesc-odd: 1;
   }
   @container style(--_context-1: odd) {
     --_context-1: even;
-    --_ak-lec-even: var(--_ak-le);
+    --_ak-lec-even: var(--ak-edge);
     --_ak-lesc-even: 1;
   }
 }
@@ -1216,12 +1215,12 @@
   --_ak-frame-bordering-context: 1;
   @container (style(--_context-1: even)) or (not style(--_context-1)) {
     --_context-1: odd;
-    --_ak-lec-odd: var(--_ak-le);
+    --_ak-lec-odd: var(--ak-edge);
     --_ak-lesc-odd: 1;
   }
   @container style(--_context-1: odd) {
     --_context-1: even;
-    --_ak-lec-even: var(--_ak-le);
+    --_ak-lec-even: var(--ak-edge);
     --_ak-lesc-even: 1;
   }
 }
@@ -1274,12 +1273,12 @@
   --_ak-frame-bordering-context: 1;
   @container (style(--_context-1: even)) or (not style(--_context-1)) {
     --_context-1: odd;
-    --_ak-lec-odd: var(--_ak-le);
+    --_ak-lec-odd: var(--ak-edge);
     --_ak-lesc-odd: 1;
   }
   @container style(--_context-1: odd) {
     --_context-1: even;
-    --_ak-lec-even: var(--_ak-le);
+    --_ak-lec-even: var(--ak-edge);
     --_ak-lesc-even: 1;
   }
 }
@@ -1571,15 +1570,9 @@
   initial-value: canvas;
 }
 
-@property --_ak-le {
-  syntax: "<color>";
-  inherits: true;
-  initial-value: black;
-}
-
 @property --ak-edge {
   syntax: "<color>";
-  inherits: false;
+  inherits: true;
   initial-value: black;
 }
 


### PR DESCRIPTION
## Motivation

`@ariakit/tailwind` v0.2 replaced `--ak-layer-border`, `--ak-border`, `--ak-ring`, and `--ak-layer-ring` with a unified `--ak-edge` custom property. `PopoverArrow` still consumed the removed `--ak-layer-border`, so its stroke could no longer be themed through the new variable.

A straightforward rename to `--ak-edge` did not work: `--ak-edge` was registered with `inherits: false` and `initial-value: black`, so on the arrow element `var(--ak-edge, fallback)` resolved to `black` (or the layer's edge if inheriting) rather than to the JS-computed fallback. The same is true for any `var(name, fallback)` over a registered property with an `initial-value` — the fallback never fires. A private inheriting mirror `--_ak-le` had been added in #6041 to give non-layer descendants access to the edge color.

## Solution

Two independent changes in this PR:

1. **`@ariakit/tailwind`**: make `--ak-edge` an inheriting CSS custom property and drop the now-redundant `--_ak-le` mirror. Each `.ak-layer` still explicitly sets `--ak-edge`, so nested layers are unaffected. Non-layer descendants that read `var(--ak-edge)` (e.g. `PlaceholderPopoverArrow`, `--ak-popover-ring-color`, `--ak-tab-border-color`) now resolve to the surrounding layer's edge color directly.

2. **`@ariakit/react-components`**: remove the `var(--ak-layer, …)` / `var(--ak-edge, …)` wrappers from `PopoverArrow`'s inline `fill` and `stroke`. The arrow now mirrors the popover content's computed `background-color` and `border-color` directly. Since `var(…, fallback)` cannot fall back when the custom property is registered with an `initial-value`, the wrapper was effectively bypassed in every `@ariakit/tailwind` context anyway. Consumers who want to theme the arrow at runtime can style it with CSS. This applies to `MenuArrow`, `TooltipArrow`, and `HovercardArrow` as well, since they all delegate to `usePopoverArrow`.

## Verification

- `pnpm -F app test-chrome ariakit-tailwind`: zero snapshot drift.
- `pnpm -F app test-perf ariakit-tailwind` vs `origin/main` (for the tailwind change): page-load Scripting -10%, Total -1%; toggle Total +1% (within noise).
- Manual browser check on `/react/previews/popover/_component/`: arrow `fill` and `stroke` match the popover content's computed background and border colors.
- `pnpm tsc` and `pnpm test` clean.