### PR TITLE
Fix Popover default values in docs

### DIFF
--- a/packages/ariakit-react-components/src/popover/popover.tsx
+++ b/packages/ariakit-react-components/src/popover/popover.tsx
@@ -527,6 +527,14 @@ export interface PopoverOptions<
    */
   fixed?: boolean;
   /**
+   * @default false
+   */
+  modal?: DialogOptions<T>["modal"];
+  /**
+   * @default false
+   */
+  portal?: DialogOptions<T>["portal"];
+  /**
    * The distance between the popover and the anchor element.
    *
    * Live examples:


### PR DESCRIPTION
## Motivation

The generated docs for popover-backed components can inherit the standalone `Portal` defaults for `modal` and `portal`, even though `Popover` defaults both to `false` when omitted. This makes the `Menu` `portal` prop documentation incorrect in #4424, and #4759 tried to fix it at the `Portal` layer instead.

Fixes #4424.

## Solution

Redeclare `modal` and `portal` on `PopoverOptions` with local `@default false` tags. This overrides the generated default metadata at the Popover layer while retaining the inherited JSDoc descriptions from `Dialog` and `Portal`, so standalone `Portal` and `Dialog` keep their correct defaults.

After this lands, #4759 can be closed.
