### PR TITLE
Fix Dialog unmount animation without explicit store

### DIFF
--- a/.changeset/300-dialog-unmount-animation.md
+++ b/.changeset/300-dialog-unmount-animation.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Dialog`](https://ariakit.com/reference/dialog) to preserve closing animations when using [`unmountOnHide`](https://ariakit.com/reference/dialog#unmountonhide) with the controlled [`open`](https://ariakit.com/reference/dialog#open) and [`onClose`](https://ariakit.com/reference/dialog#onclose) props and no explicit store.

--- a/app/src/sandbox/dialog-3403/index.react.tsx
+++ b/app/src/sandbox/dialog-3403/index.react.tsx
@@ -1,0 +1,61 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+import "./style.css";
+
+function DialogWithStore() {
+  const dialog = Ariakit.useDialogStore();
+  return (
+    <div>
+      <Ariakit.Button className="button" onClick={dialog.show}>
+        Show dialog with store
+      </Ariakit.Button>
+      <Ariakit.Dialog
+        store={dialog}
+        unmountOnHide
+        backdrop={<div className="backdrop" />}
+        className="dialog"
+      >
+        <Ariakit.DialogHeading className="heading">
+          Dialog with store
+        </Ariakit.DialogHeading>
+        <p>This dialog waits for the closing animation before unmounting.</p>
+        <Ariakit.DialogDismiss className="button">Close</Ariakit.DialogDismiss>
+      </Ariakit.Dialog>
+    </div>
+  );
+}
+
+function DialogWithoutStore() {
+  const [open, setOpen] = useState(false);
+  return (
+    <div>
+      <Ariakit.Button className="button" onClick={() => setOpen(true)}>
+        Show dialog without store
+      </Ariakit.Button>
+      <Ariakit.Dialog
+        open={open}
+        onClose={() => setOpen(false)}
+        unmountOnHide
+        backdrop={<div className="backdrop" />}
+        className="dialog"
+      >
+        <Ariakit.DialogHeading className="heading">
+          Dialog without store
+        </Ariakit.DialogHeading>
+        <p>
+          This dialog should wait for the closing animation before unmounting.
+        </p>
+        <Ariakit.DialogDismiss className="button">Close</Ariakit.DialogDismiss>
+      </Ariakit.Dialog>
+    </div>
+  );
+}
+
+export default function Example() {
+  return (
+    <div className="root">
+      <DialogWithStore />
+      <DialogWithoutStore />
+    </div>
+  );
+}

--- a/app/src/sandbox/dialog-3403/index.react.tsx
+++ b/app/src/sandbox/dialog-3403/index.react.tsx
@@ -25,29 +25,26 @@ function DialogWithStore() {
   );
 }
 
-function DialogWithWorkaround() {
+function DialogWithoutStore() {
   const [open, setOpen] = useState(false);
-  // TODO: Remove this explicit store workaround once
-  // https://github.com/ariakit/ariakit/issues/3403 is fixed.
-  const dialog = Ariakit.useDialogStore({
-    open,
-    setOpen,
-  });
   return (
     <div>
       <Ariakit.Button className="button" onClick={() => setOpen(true)}>
-        Show dialog with workaround
+        Show dialog without store
       </Ariakit.Button>
       <Ariakit.Dialog
-        store={dialog}
+        open={open}
+        onClose={() => setOpen(false)}
         unmountOnHide
         backdrop={<div className="backdrop" />}
         className="dialog"
       >
         <Ariakit.DialogHeading className="heading">
-          Dialog with workaround
+          Dialog without store
         </Ariakit.DialogHeading>
-        <p>This dialog waits for the closing animation before unmounting.</p>
+        <p>
+          This dialog should wait for the closing animation before unmounting.
+        </p>
         <Ariakit.DialogDismiss className="button">Close</Ariakit.DialogDismiss>
       </Ariakit.Dialog>
     </div>
@@ -58,7 +55,7 @@ export default function Example() {
   return (
     <div className="root">
       <DialogWithStore />
-      <DialogWithWorkaround />
+      <DialogWithoutStore />
     </div>
   );
 }

--- a/app/src/sandbox/dialog-3403/index.react.tsx
+++ b/app/src/sandbox/dialog-3403/index.react.tsx
@@ -25,26 +25,29 @@ function DialogWithStore() {
   );
 }
 
-function DialogWithoutStore() {
+function DialogWithWorkaround() {
   const [open, setOpen] = useState(false);
+  // TODO: Remove this explicit store workaround once
+  // https://github.com/ariakit/ariakit/issues/3403 is fixed.
+  const dialog = Ariakit.useDialogStore({
+    open,
+    setOpen,
+  });
   return (
     <div>
       <Ariakit.Button className="button" onClick={() => setOpen(true)}>
-        Show dialog without store
+        Show dialog with workaround
       </Ariakit.Button>
       <Ariakit.Dialog
-        open={open}
-        onClose={() => setOpen(false)}
+        store={dialog}
         unmountOnHide
         backdrop={<div className="backdrop" />}
         className="dialog"
       >
         <Ariakit.DialogHeading className="heading">
-          Dialog without store
+          Dialog with workaround
         </Ariakit.DialogHeading>
-        <p>
-          This dialog should wait for the closing animation before unmounting.
-        </p>
+        <p>This dialog waits for the closing animation before unmounting.</p>
         <Ariakit.DialogDismiss className="button">Close</Ariakit.DialogDismiss>
       </Ariakit.Dialog>
     </div>
@@ -55,7 +58,7 @@ export default function Example() {
   return (
     <div className="root">
       <DialogWithStore />
-      <DialogWithoutStore />
+      <DialogWithWorkaround />
     </div>
   );
 }

--- a/app/src/sandbox/dialog-3403/index.react.tsx
+++ b/app/src/sandbox/dialog-3403/index.react.tsx
@@ -51,11 +51,43 @@ function DialogWithoutStore() {
   );
 }
 
+function RouteDialogWithoutUnmountOnHide() {
+  const [route, setRoute] = useState("/");
+  return (
+    <div>
+      <Ariakit.Button className="button" onClick={() => setRoute("/plus")}>
+        Show route dialog without unmountOnHide
+      </Ariakit.Button>
+      <Ariakit.Dialog
+        open={route === "/plus"}
+        onClose={(event) => {
+          event.preventDefault();
+          setRoute("/");
+        }}
+        backdrop={false}
+        className="dialog"
+        render={(props) => (
+          <div hidden={props.hidden}>
+            <div {...props} />
+          </div>
+        )}
+      >
+        <Ariakit.DialogHeading className="heading">
+          Route dialog without unmountOnHide
+        </Ariakit.DialogHeading>
+        <p>This dialog should keep the previous route close behavior.</p>
+        <Ariakit.DialogDismiss className="button">Close</Ariakit.DialogDismiss>
+      </Ariakit.Dialog>
+    </div>
+  );
+}
+
 export default function Example() {
   return (
     <div className="root">
       <DialogWithStore />
       <DialogWithoutStore />
+      <RouteDialogWithoutUnmountOnHide />
     </div>
   );
 }

--- a/app/src/sandbox/dialog-3403/preview.astro
+++ b/app/src/sandbox/dialog-3403/preview.astro
@@ -1,0 +1,14 @@
+---
+import PreviewFramework from "#app/components/preview-framework.astro";
+import ReactExample from "./index.react.tsx";
+
+import sourceReact from "./index.react.tsx?source";
+
+export const source = {
+  react: sourceReact,
+};
+---
+
+<PreviewFramework>
+  <ReactExample client:load slot="react" />
+</PreviewFramework>

--- a/app/src/sandbox/dialog-3403/preview.mdx
+++ b/app/src/sandbox/dialog-3403/preview.mdx
@@ -1,0 +1,9 @@
+---
+title: "dialog-3403"
+frameworks:
+  - react
+---
+
+import Preview from "./preview.astro";
+
+<Preview />

--- a/app/src/sandbox/dialog-3403/style.css
+++ b/app/src/sandbox/dialog-3403/style.css
@@ -1,0 +1,60 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid hsl(204 10% 80%);
+  border-radius: 0.5rem;
+  background: white;
+  padding: 0.5rem 1rem;
+  font: inherit;
+}
+
+.backdrop {
+  background: hsl(204 10% 10% / 0.1);
+  opacity: 0;
+  transition: opacity 200ms ease;
+}
+
+.backdrop[data-enter] {
+  opacity: 1;
+}
+
+.dialog {
+  position: fixed;
+  inset: 0.75rem;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 24rem;
+  height: fit-content;
+  max-width: calc(100vw - 1.5rem);
+  margin: auto;
+  border-radius: 1rem;
+  background: white;
+  padding: 1.5rem;
+  color: hsl(204 10% 10%);
+  opacity: 0;
+  transform: scale(0.95);
+  transition:
+    opacity 200ms ease,
+    transform 200ms ease;
+}
+
+.dialog[data-enter] {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.heading {
+  margin: 0;
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+}

--- a/app/src/sandbox/dialog-3403/test-browser.ts
+++ b/app/src/sandbox/dialog-3403/test-browser.ts
@@ -15,13 +15,13 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(dialog).toHaveAttribute("data-leave", "true");
   });
 
-  test("controlled dialog without explicit store waits for leave transition before unmount", async ({
+  test("controlled dialog with workaround waits for leave transition before unmount", async ({
     q,
   }) => {
     // See https://github.com/ariakit/ariakit/issues/3403
-    await q.button("Show dialog without store").click();
+    await q.button("Show dialog with workaround").click();
 
-    const dialog = q.dialog("Dialog without store", { includeHidden: true });
+    const dialog = q.dialog("Dialog with workaround", { includeHidden: true });
     await test.expect(dialog).toBeVisible();
 
     await q.button("Close").click();

--- a/app/src/sandbox/dialog-3403/test-browser.ts
+++ b/app/src/sandbox/dialog-3403/test-browser.ts
@@ -30,4 +30,20 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(dialog).toHaveAttribute("data-leave", "true");
     await test.expect(dialog).not.toBeAttached();
   });
+
+  test("route dialog without unmountOnHide preserves close behavior", async ({
+    q,
+    page,
+  }) => {
+    await q.button("Show route dialog without unmountOnHide").click();
+
+    const dialog = q.dialog("Route dialog without unmountOnHide", {
+      includeHidden: true,
+    });
+    await test.expect(dialog).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await test.expect(dialog).toBeAttached();
+    await test.expect(dialog).not.toBeVisible();
+  });
 });

--- a/app/src/sandbox/dialog-3403/test-browser.ts
+++ b/app/src/sandbox/dialog-3403/test-browser.ts
@@ -13,19 +13,21 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await q.button("Close").click();
     await test.expect(dialog).toBeAttached();
     await test.expect(dialog).toHaveAttribute("data-leave", "true");
+    await test.expect(dialog).not.toBeAttached();
   });
 
-  test("controlled dialog with workaround waits for leave transition before unmount", async ({
+  test("controlled dialog without explicit store waits for leave transition before unmount", async ({
     q,
   }) => {
     // See https://github.com/ariakit/ariakit/issues/3403
-    await q.button("Show dialog with workaround").click();
+    await q.button("Show dialog without store").click();
 
-    const dialog = q.dialog("Dialog with workaround", { includeHidden: true });
+    const dialog = q.dialog("Dialog without store", { includeHidden: true });
     await test.expect(dialog).toBeVisible();
 
     await q.button("Close").click();
     await test.expect(dialog).toBeAttached();
     await test.expect(dialog).toHaveAttribute("data-leave", "true");
+    await test.expect(dialog).not.toBeAttached();
   });
 });

--- a/app/src/sandbox/dialog-3403/test-browser.ts
+++ b/app/src/sandbox/dialog-3403/test-browser.ts
@@ -1,0 +1,31 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("dialog with explicit store waits for leave transition before unmount", async ({
+    q,
+  }) => {
+    // See https://github.com/ariakit/ariakit/issues/3403
+    await q.button("Show dialog with store").click();
+
+    const dialog = q.dialog("Dialog with store", { includeHidden: true });
+    await test.expect(dialog).toBeVisible();
+
+    await q.button("Close").click();
+    await test.expect(dialog).toBeAttached();
+    await test.expect(dialog).toHaveAttribute("data-leave", "true");
+  });
+
+  test("controlled dialog without explicit store waits for leave transition before unmount", async ({
+    q,
+  }) => {
+    // See https://github.com/ariakit/ariakit/issues/3403
+    await q.button("Show dialog without store").click();
+
+    const dialog = q.dialog("Dialog without store", { includeHidden: true });
+    await test.expect(dialog).toBeVisible();
+
+    await q.button("Close").click();
+    await test.expect(dialog).toBeAttached();
+    await test.expect(dialog).toHaveAttribute("data-leave", "true");
+  });
+});

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -628,13 +628,30 @@ export function createDialogComponent<T extends DialogOptions>(
  * </Dialog>
  * ```
  */
-export const Dialog = createDialogComponent(
-  forwardRef(function Dialog(props: DialogProps) {
-    const htmlProps = useDialog(props);
-    return createElement(TagName, htmlProps);
-  }),
+const DialogImpl = forwardRef(function DialogImpl(props: DialogProps) {
+  const htmlProps = useDialog(props);
+  return createElement(TagName, htmlProps);
+});
+
+const DialogWithStore = createDialogComponent(
+  DialogImpl,
   useDialogProviderContext,
 );
+
+const DialogWithInternalStore = forwardRef(function DialogWithInternalStore(
+  props: DialogProps,
+) {
+  const store = useDialogStore({ open: props.open });
+  return <DialogWithStore {...props} store={store} />;
+});
+
+export const Dialog = forwardRef(function Dialog(props: DialogProps) {
+  const context = useDialogProviderContext();
+  if (props.store || context) {
+    return <DialogWithStore {...props} />;
+  }
+  return <DialogWithInternalStore {...props} />;
+});
 
 export interface DialogOptions<T extends ElementType = TagName>
   extends FocusableOptions<T>, PortalOptions<T>, DisclosureContentOptions<T> {

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -647,7 +647,8 @@ const DialogWithInternalStore = forwardRef(function DialogWithInternalStore(
 
 export const Dialog = forwardRef(function Dialog(props: DialogProps) {
   const context = useDialogProviderContext();
-  if (props.store || context) {
+  // The hoisted store is only needed for the unmountOnHide mounted-state gate.
+  if (props.store || context || !props.unmountOnHide) {
     return <DialogWithStore {...props} />;
   }
   return <DialogWithInternalStore {...props} />;

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -608,6 +608,23 @@ export function createDialogComponent<T extends DialogOptions>(
   });
 }
 
+const DialogImpl = forwardRef(function DialogImpl(props: DialogProps) {
+  const htmlProps = useDialog(props);
+  return createElement(TagName, htmlProps);
+});
+
+const DialogWithStore = createDialogComponent(
+  DialogImpl,
+  useDialogProviderContext,
+);
+
+const DialogWithInternalStore = forwardRef(function DialogWithInternalStore(
+  props: DialogProps,
+) {
+  const store = useDialogStore({ open: props.open });
+  return <DialogWithStore {...props} store={store} />;
+});
+
 /**
  * Renders a dialog similar to the native `dialog` element that's rendered in a
  * [`portal`](https://ariakit.com/reference/dialog#portal) by default.
@@ -628,23 +645,6 @@ export function createDialogComponent<T extends DialogOptions>(
  * </Dialog>
  * ```
  */
-const DialogImpl = forwardRef(function DialogImpl(props: DialogProps) {
-  const htmlProps = useDialog(props);
-  return createElement(TagName, htmlProps);
-});
-
-const DialogWithStore = createDialogComponent(
-  DialogImpl,
-  useDialogProviderContext,
-);
-
-const DialogWithInternalStore = forwardRef(function DialogWithInternalStore(
-  props: DialogProps,
-) {
-  const store = useDialogStore({ open: props.open });
-  return <DialogWithStore {...props} store={store} />;
-});
-
 export const Dialog = forwardRef(function Dialog(props: DialogProps) {
   const context = useDialogProviderContext();
   // The hoisted store is only needed for the unmountOnHide mounted-state gate.


### PR DESCRIPTION
## Motivation

Fixes #3403.

A controlled `Dialog` using `open`, `onClose`, and `unmountOnHide` currently unmounts immediately when it closes if the consumer does not pass an explicit dialog store. That skips the leave transition, while the same animated dialog works when controlled through `useDialogStore`.

## Solution

This adds a sandbox regression for the reported behavior in `app/src/sandbox/dialog-3403`. The sandbox compares the explicit-store dialog with the controlled no-explicit-store dialog and verifies both stay mounted with `data-leave` during the closing animation before unmounting. It also includes a route-shaped controlled dialog without `unmountOnHide` to cover the unchanged default close behavior.

The `Dialog` component now creates and passes an internal dialog store through the same mounted-state gate used by explicit stores only when `unmountOnHide` is enabled and no `store` prop or `DialogProvider` context is available. This lets `unmountOnHide` observe `mounted` while the leave animation is running instead of falling back to the controlled `open` prop after it has already changed to `false`, while preserving the previous path for dialogs that do not use `unmountOnHide`.

## Workaround

Create the dialog store manually with the controlled `open` state and pass it to `Dialog` instead of passing `open` and `onClose` directly to `Dialog`:

```tsx
const [open, setOpen] = useState(false);
// TODO: Remove this explicit store workaround once
// https://github.com/ariakit/ariakit/issues/3403 is fixed.
const dialog = Ariakit.useDialogStore({
  open,
  setOpen,
});

<Ariakit.Button onClick={() => setOpen(true)}>Show dialog</Ariakit.Button>
<Ariakit.Dialog store={dialog} unmountOnHide>
  {/* ... */}
</Ariakit.Dialog>
```
