### PR TITLE
Fix Button form status on keyboard submit

### DIFF
--- a/.changeset/300-button-form-status.md
+++ b/.changeset/300-button-form-status.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Button`](https://ariakit.com/reference/button) to preserve React form pending state when submitted with the keyboard.

--- a/app/src/sandbox/button-form-status-4540/index.react.tsx
+++ b/app/src/sandbox/button-form-status-4540/index.react.tsx
@@ -72,7 +72,7 @@ export default function Example() {
         <AriakitButton>AriakitButton</AriakitButton>
       </Form>
       <Form label="AriakitButton focusable">
-        <AriakitButton accessibleWhenDisabled>
+        <AriakitButton accessibleWhenDisabled onClick={countClicks}>
           AriakitButton (focusable)
         </AriakitButton>
       </Form>

--- a/app/src/sandbox/button-form-status-4540/index.react.tsx
+++ b/app/src/sandbox/button-form-status-4540/index.react.tsx
@@ -5,12 +5,7 @@ import { useFormStatus } from "react-dom";
 function AriakitButton(props: Ariakit.ButtonProps) {
   const { pending } = useFormStatus();
   return (
-    <Ariakit.Button
-      type="submit"
-      disabled={pending}
-      onFocusVisible={(event) => event.preventDefault()}
-      {...props}
-    >
+    <Ariakit.Button type="submit" disabled={pending} {...props}>
       {pending ? "Pending" : props.children}
     </Ariakit.Button>
   );

--- a/app/src/sandbox/button-form-status-4540/index.react.tsx
+++ b/app/src/sandbox/button-form-status-4540/index.react.tsx
@@ -1,0 +1,69 @@
+import * as Ariakit from "@ariakit/react";
+import type { ComponentProps } from "react";
+import { useFormStatus } from "react-dom";
+
+function AriakitButton(props: Ariakit.ButtonProps) {
+  const { pending } = useFormStatus();
+  return (
+    <Ariakit.Button type="submit" disabled={pending} {...props}>
+      {pending ? "Pending" : props.children}
+    </Ariakit.Button>
+  );
+}
+
+interface NativeButtonProps extends ComponentProps<"button"> {
+  accessibleWhenDisabled?: boolean;
+}
+
+function NativeButton({ accessibleWhenDisabled, ...props }: NativeButtonProps) {
+  const { pending } = useFormStatus();
+  if (accessibleWhenDisabled) {
+    props["aria-disabled"] = pending;
+  } else {
+    props.disabled = pending;
+  }
+  return (
+    <button type="submit" {...props}>
+      {pending ? "Pending" : props.children}
+    </button>
+  );
+}
+
+interface FormProps extends ComponentProps<"form"> {
+  label: string;
+}
+
+function Form({ label, ...props }: FormProps) {
+  return (
+    <form
+      aria-label={label}
+      action={async () => {
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+      }}
+      {...props}
+    />
+  );
+}
+
+export default function Example() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+      <Form label="AriakitButton">
+        <AriakitButton>AriakitButton</AriakitButton>
+      </Form>
+      <Form label="AriakitButton focusable">
+        <AriakitButton accessibleWhenDisabled>
+          AriakitButton (focusable)
+        </AriakitButton>
+      </Form>
+      <Form label="NativeButton">
+        <NativeButton>NativeButton</NativeButton>
+      </Form>
+      <Form label="NativeButton focusable">
+        <NativeButton accessibleWhenDisabled>
+          NativeButton (focusable)
+        </NativeButton>
+      </Form>
+    </div>
+  );
+}

--- a/app/src/sandbox/button-form-status-4540/index.react.tsx
+++ b/app/src/sandbox/button-form-status-4540/index.react.tsx
@@ -5,7 +5,12 @@ import { useFormStatus } from "react-dom";
 function AriakitButton(props: Ariakit.ButtonProps) {
   const { pending } = useFormStatus();
   return (
-    <Ariakit.Button type="submit" disabled={pending} {...props}>
+    <Ariakit.Button
+      type="submit"
+      disabled={pending}
+      onFocusVisible={(event) => event.preventDefault()}
+      {...props}
+    >
       {pending ? "Pending" : props.children}
     </Ariakit.Button>
   );

--- a/app/src/sandbox/button-form-status-4540/index.react.tsx
+++ b/app/src/sandbox/button-form-status-4540/index.react.tsx
@@ -1,5 +1,5 @@
 import * as Ariakit from "@ariakit/react";
-import type { ComponentProps } from "react";
+import type { ComponentProps, MouseEvent } from "react";
 import { useFormStatus } from "react-dom";
 
 function AriakitButton(props: Ariakit.ButtonProps) {
@@ -15,7 +15,11 @@ interface NativeButtonProps extends ComponentProps<"button"> {
   accessibleWhenDisabled?: boolean;
 }
 
-function NativeButton({ accessibleWhenDisabled, ...props }: NativeButtonProps) {
+function NativeButton({
+  accessibleWhenDisabled,
+  onClick,
+  ...props
+}: NativeButtonProps) {
   const { pending } = useFormStatus();
   if (accessibleWhenDisabled) {
     props["aria-disabled"] = pending;
@@ -23,7 +27,17 @@ function NativeButton({ accessibleWhenDisabled, ...props }: NativeButtonProps) {
     props.disabled = pending;
   }
   return (
-    <button type="submit" {...props}>
+    <button
+      type="submit"
+      {...props}
+      onClick={(event) => {
+        if (accessibleWhenDisabled && pending) {
+          event.preventDefault();
+          return;
+        }
+        onClick?.(event);
+      }}
+    >
       {pending ? "Pending" : props.children}
     </button>
   );
@@ -45,6 +59,12 @@ function Form({ label, ...props }: FormProps) {
   );
 }
 
+function countClicks(event: MouseEvent<HTMLButtonElement>) {
+  const { currentTarget } = event;
+  const clickCount = Number(currentTarget.dataset.clickCount ?? 0) + 1;
+  currentTarget.dataset.clickCount = String(clickCount);
+}
+
 export default function Example() {
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
@@ -60,7 +80,7 @@ export default function Example() {
         <NativeButton>NativeButton</NativeButton>
       </Form>
       <Form label="NativeButton focusable">
-        <NativeButton accessibleWhenDisabled>
+        <NativeButton accessibleWhenDisabled onClick={countClicks}>
           NativeButton (focusable)
         </NativeButton>
       </Form>

--- a/app/src/sandbox/button-form-status-4540/preview.astro
+++ b/app/src/sandbox/button-form-status-4540/preview.astro
@@ -1,0 +1,14 @@
+---
+import PreviewFramework from "#app/components/preview-framework.astro";
+import ReactExample from "./index.react.tsx";
+
+import sourceReact from "./index.react.tsx?source";
+
+export const source = {
+  react: sourceReact,
+};
+---
+
+<PreviewFramework>
+  <ReactExample client:load slot="react" />
+</PreviewFramework>

--- a/app/src/sandbox/button-form-status-4540/preview.mdx
+++ b/app/src/sandbox/button-form-status-4540/preview.mdx
@@ -1,0 +1,9 @@
+---
+title: Button with form status
+frameworks:
+  - react
+---
+
+import Preview from "./preview.astro";
+
+<Preview />

--- a/app/src/sandbox/button-form-status-4540/test-browser.ts
+++ b/app/src/sandbox/button-form-status-4540/test-browser.ts
@@ -30,6 +30,23 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
     await test.expect(button).toHaveText("Pending");
   });
 
+  test("focusable button prevents activation while pending", async ({
+    page,
+    q,
+  }) => {
+    const form = query(q.form("AriakitButton focusable"));
+    const button = form.button();
+
+    await button.focus();
+    await page.keyboard.press("Enter");
+    await test.expect(button).toHaveText("Pending");
+    await test.expect(button).toHaveAttribute("data-click-count", "1");
+
+    await page.keyboard.press("Enter");
+
+    await test.expect(button).toHaveAttribute("data-click-count", "1");
+  });
+
   test("focusable native button prevents activation while pending", async ({
     page,
     q,

--- a/app/src/sandbox/button-form-status-4540/test-browser.ts
+++ b/app/src/sandbox/button-form-status-4540/test-browser.ts
@@ -1,0 +1,32 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ query, test }) => {
+  test("button shows pending state when submitted with Enter", async ({
+    page,
+    q,
+  }) => {
+    const form = query(q.form("AriakitButton"));
+    const button = form.button();
+
+    await button.focus();
+    await page.keyboard.press("Enter");
+
+    await test.expect(button).toHaveText("Pending");
+  });
+
+  test("focusable button keeps pending state after losing focus", async ({
+    page,
+    q,
+  }) => {
+    const form = query(q.form("AriakitButton focusable"));
+    const button = form.button();
+
+    await button.focus();
+    await page.keyboard.press("Enter");
+    await test.expect(button).toHaveText("Pending");
+
+    await page.keyboard.press("Tab");
+
+    await test.expect(button).toHaveText("Pending");
+  });
+});

--- a/app/src/sandbox/button-form-status-4540/test-browser.ts
+++ b/app/src/sandbox/button-form-status-4540/test-browser.ts
@@ -29,4 +29,21 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
 
     await test.expect(button).toHaveText("Pending");
   });
+
+  test("focusable native button prevents activation while pending", async ({
+    page,
+    q,
+  }) => {
+    const form = query(q.form("NativeButton focusable"));
+    const button = form.button();
+
+    await button.focus();
+    await page.keyboard.press("Enter");
+    await test.expect(button).toHaveText("Pending");
+    await test.expect(button).toHaveAttribute("data-click-count", "1");
+
+    await page.keyboard.press("Enter");
+
+    await test.expect(button).toHaveAttribute("data-click-count", "1");
+  });
 });

--- a/packages/ariakit-react-components/src/focusable/focusable.tsx
+++ b/packages/ariakit-react-components/src/focusable/focusable.tsx
@@ -239,6 +239,12 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
     const [focusVisible, setFocusVisible] = useState(false);
     const focusVisibleRef = useRef(false);
     const nativeSubmitObserverCleanupRef = useRef<(() => void) | null>(null);
+    const cleanupFocusVisible = useEvent((element: HTMLElement | null) => {
+      nativeSubmitObserverCleanupRef.current?.();
+      nativeSubmitObserverCleanupRef.current = null;
+      focusVisibleRef.current = false;
+      element?.removeAttribute("data-focus-visible");
+    });
 
     // When the focusable element is disabled, it doesn't trigger a blur event
     // so we can't set focusVisible to false there. Instead, we have to do it
@@ -246,15 +252,11 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
     useEffect(() => {
       if (!focusable) return;
       if (!trulyDisabled) return;
-      const element = ref.current;
-      nativeSubmitObserverCleanupRef.current?.();
-      nativeSubmitObserverCleanupRef.current = null;
-      focusVisibleRef.current = false;
-      element?.removeAttribute("data-focus-visible");
+      cleanupFocusVisible(ref.current);
       if (focusVisible) {
         setFocusVisible(false);
       }
-    }, [focusable, trulyDisabled, focusVisible]);
+    }, [focusable, trulyDisabled, focusVisible, cleanupFocusVisible]);
 
     // When an element that has focus becomes hidden, it doesn't trigger a blur
     // event so we can't set focusVisible to false there. We observe the element
@@ -320,10 +322,7 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
         if (typeof IntersectionObserver !== "undefined") {
           const observer = new IntersectionObserver(() => {
             if (isFocusable(element)) return;
-            nativeSubmitObserverCleanupRef.current?.();
-            nativeSubmitObserverCleanupRef.current = null;
-            focusVisibleRef.current = false;
-            element.removeAttribute("data-focus-visible");
+            cleanupFocusVisible(element);
           });
           observer.observe(element);
           nativeSubmitObserverCleanupRef.current = () => observer.disconnect();
@@ -380,10 +379,7 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
       // Since we set the data-focus-visible attribute on the element in the
       // handleFocusVisible function, we remove it directly here. Otherwise, the
       // attribute might not be removed on lower-end devices.
-      nativeSubmitObserverCleanupRef.current?.();
-      nativeSubmitObserverCleanupRef.current = null;
-      focusVisibleRef.current = false;
-      event.currentTarget.removeAttribute("data-focus-visible");
+      cleanupFocusVisible(event.currentTarget);
       setFocusVisible(false);
     });
 

--- a/packages/ariakit-react-components/src/focusable/focusable.tsx
+++ b/packages/ariakit-react-components/src/focusable/focusable.tsx
@@ -119,6 +119,18 @@ function needsSafariTabIndex(tagName?: string, inputType?: string) {
   return false;
 }
 
+function isNativeSubmitControl(element: HTMLElement) {
+  if (element.tagName === "BUTTON") {
+    const { type } = element as HTMLButtonElement;
+    return type === "submit";
+  }
+  if (element.tagName === "INPUT") {
+    const { type } = element as HTMLInputElement;
+    return type === "submit" || type === "image";
+  }
+  return false;
+}
+
 function getTabIndex({
   focusable,
   trulyDisabled,
@@ -225,13 +237,21 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
     const disabled = focusable && disabledFromProps(props);
     const trulyDisabled = disabled && !accessibleWhenDisabled;
     const [focusVisible, setFocusVisible] = useState(false);
+    const focusVisibleRef = useRef(false);
+    const nativeSubmitObserverCleanupRef = useRef<(() => void) | null>(null);
 
     // When the focusable element is disabled, it doesn't trigger a blur event
     // so we can't set focusVisible to false there. Instead, we have to do it
     // here by checking the element's disabled attribute.
     useEffect(() => {
       if (!focusable) return;
-      if (trulyDisabled && focusVisible) {
+      if (!trulyDisabled) return;
+      const element = ref.current;
+      nativeSubmitObserverCleanupRef.current?.();
+      nativeSubmitObserverCleanupRef.current = null;
+      focusVisibleRef.current = false;
+      element?.removeAttribute("data-focus-visible");
+      if (focusVisible) {
         setFocusVisible(false);
       }
     }, [focusable, trulyDisabled, focusVisible]);
@@ -248,12 +268,17 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
       if (typeof IntersectionObserver === "undefined") return;
       const observer = new IntersectionObserver(() => {
         if (!isFocusable(element)) {
+          focusVisibleRef.current = false;
           setFocusVisible(false);
         }
       });
       observer.observe(element);
       return () => observer.disconnect();
     }, [focusable, focusVisible]);
+
+    useEffect(() => {
+      return () => nativeSubmitObserverCleanupRef.current?.();
+    }, []);
 
     // Disable events when the element is disabled.
     const onKeyPressCapture = useDisableEvent(
@@ -286,6 +311,25 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
       // other data attributes like data-active-item. See
       // https://github.com/ariakit/ariakit/issues/4083
       element.dataset.focusVisible = "true";
+      focusVisibleRef.current = true;
+      // React 19's useFormStatus may lose the pending state when local
+      // component state changes while a native submit control is pending.
+      if (isNativeSubmitControl(element)) {
+        nativeSubmitObserverCleanupRef.current?.();
+        nativeSubmitObserverCleanupRef.current = null;
+        if (typeof IntersectionObserver !== "undefined") {
+          const observer = new IntersectionObserver(() => {
+            if (isFocusable(element)) return;
+            nativeSubmitObserverCleanupRef.current?.();
+            nativeSubmitObserverCleanupRef.current = null;
+            focusVisibleRef.current = false;
+            element.removeAttribute("data-focus-visible");
+          });
+          observer.observe(element);
+          nativeSubmitObserverCleanupRef.current = () => observer.disconnect();
+        }
+        return;
+      }
       setFocusVisible(true);
     };
 
@@ -296,6 +340,7 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
       if (event.defaultPrevented) return;
       if (!focusable) return;
       if (focusVisible) return;
+      if (focusVisibleRef.current) return;
       if (event.metaKey) return;
       if (event.altKey) return;
       if (event.ctrlKey) return;
@@ -335,6 +380,9 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
       // Since we set the data-focus-visible attribute on the element in the
       // handleFocusVisible function, we remove it directly here. Otherwise, the
       // attribute might not be removed on lower-end devices.
+      nativeSubmitObserverCleanupRef.current?.();
+      nativeSubmitObserverCleanupRef.current = null;
+      focusVisibleRef.current = false;
       event.currentTarget.removeAttribute("data-focus-visible");
       setFocusVisible(false);
     });


### PR DESCRIPTION
## Motivation

Ariakit [`Button`](https://ariakit.com/reference/button) does not work correctly with React's `useFormStatus` when the form is submitted from the keyboard. Pressing Enter on the button does not consistently expose the pending state, and an `accessibleWhenDisabled` button can lose the pending label after focus moves away.

Fixes #4540.

## Solution

Added a React sandbox that reproduces the keyboard submission behavior with `useFormStatus` and covers both the regular submit button and the `accessibleWhenDisabled` case.

`Focusable` now preserves the imperative `data-focus-visible` behavior for native submit controls without committing a React focus-visible state update while React form status is pending. It keeps a ref-backed focus-visible flag so repeat keydown handling and hidden/disabled cleanup still behave like the state-backed path, and it removes the sandbox workaround so the tests exercise the library fix directly.

## Workaround

Preventing Ariakit's focus-visible handler from updating internal focus-visible state lets React keep the form submission pending state when the button is submitted from the keyboard.

```tsx
<Button
  type="submit"
  disabled={pending}
  // TODO: Remove once https://github.com/ariakit/ariakit/issues/4540 is fixed.
  onFocusVisible={(event) => event.preventDefault()}
>
  {pending ? "Pending" : children}
</Button>
```
