### PR TITLE
Fix tooltip controlled open crash

### DIFF
--- a/.changeset/300-tooltip-controlled-open.md
+++ b/.changeset/300-tooltip-controlled-open.md
@@ -3,4 +3,4 @@
 "@ariakit/react": patch
 ---
 
-Fixed [`TooltipProvider`](https://ariakit.com/reference/tooltip-provider) to avoid a re-entrant loop when multiple tooltips are forced open at the same time while preserving the default one-open-tooltip behavior for controlled tooltips that accept close updates.
+Fixed [`TooltipProvider`](https://ariakit.com/reference/tooltip-provider) to avoid a re-entrant loop when multiple tooltips are forced open at the same time.

--- a/.changeset/300-tooltip-controlled-open.md
+++ b/.changeset/300-tooltip-controlled-open.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`TooltipProvider`](https://ariakit.com/reference/tooltip-provider) to avoid closing other controlled open tooltips when multiple tooltips are mounted at the same time.

--- a/.changeset/300-tooltip-controlled-open.md
+++ b/.changeset/300-tooltip-controlled-open.md
@@ -3,4 +3,4 @@
 "@ariakit/react": patch
 ---
 
-Fixed [`TooltipProvider`](https://ariakit.com/reference/tooltip-provider) to avoid closing other controlled open tooltips when multiple tooltips are mounted at the same time.
+Fixed [`TooltipProvider`](https://ariakit.com/reference/tooltip-provider) to avoid a re-entrant loop when multiple tooltips are forced open at the same time while preserving the default one-open-tooltip behavior for controlled tooltips that accept close updates.

--- a/app/src/sandbox/tooltip-4894/index.react.tsx
+++ b/app/src/sandbox/tooltip-4894/index.react.tsx
@@ -2,12 +2,12 @@ import * as Ariakit from "@ariakit/react";
 import { StrictMode, useState } from "react";
 
 export default function Example() {
-  const [closeRequests, setCloseRequests] = useState(0);
+  const [activeTooltip, setActiveTooltip] = useState<"one" | "two" | null>(
+    null,
+  );
 
-  const setOpen = (open: boolean) => {
-    if (open) return;
-    setCloseRequests((count) => count + 1);
-  };
+  const openFirstTooltip = () => setActiveTooltip("one");
+  const openSecondTooltip = () => setActiveTooltip("two");
 
   return (
     <StrictMode>
@@ -19,13 +19,19 @@ export default function Example() {
           padding: 40,
         }}
       >
-        <div>Close requests: {closeRequests}</div>
+        <button type="button" onClick={openFirstTooltip}>
+          Open first tooltip
+        </button>
+        <button type="button" onClick={openSecondTooltip}>
+          Open second tooltip
+        </button>
+        {/* TODO: Remove this one-at-a-time workaround once https://github.com/ariakit/ariakit/issues/4894 is fixed. */}
         <div style={{ display: "flex", gap: 40 }}>
-          <Ariakit.TooltipProvider open setOpen={setOpen}>
+          <Ariakit.TooltipProvider open={activeTooltip === "one"}>
             <Ariakit.TooltipAnchor>one</Ariakit.TooltipAnchor>
             <Ariakit.Tooltip>HELLO!</Ariakit.Tooltip>
           </Ariakit.TooltipProvider>
-          <Ariakit.TooltipProvider open setOpen={setOpen}>
+          <Ariakit.TooltipProvider open={activeTooltip === "two"}>
             <Ariakit.TooltipAnchor>two</Ariakit.TooltipAnchor>
             <Ariakit.Tooltip>HELLO 222!</Ariakit.Tooltip>
           </Ariakit.TooltipProvider>

--- a/app/src/sandbox/tooltip-4894/index.react.tsx
+++ b/app/src/sandbox/tooltip-4894/index.react.tsx
@@ -2,11 +2,25 @@ import * as Ariakit from "@ariakit/react";
 import { StrictMode, useState } from "react";
 
 export default function Example() {
-  const [closeRequests, setCloseRequests] = useState(0);
+  const [showForcedTooltips, setShowForcedTooltips] = useState(false);
+  const [forcedCloseRequests, setForcedCloseRequests] = useState(0);
+  const [managedTooltips, setManagedTooltips] = useState({
+    one: false,
+    two: false,
+  });
 
-  const setOpen = (open: boolean) => {
+  const setForcedOpen = (open: boolean) => {
     if (open) return;
-    setCloseRequests((count) => count + 1);
+    setForcedCloseRequests((count) => count + 1);
+  };
+
+  const setManagedOpen =
+    (key: keyof typeof managedTooltips) => (open: boolean) => {
+      setManagedTooltips((tooltips) => ({ ...tooltips, [key]: open }));
+    };
+
+  const openManagedTooltip = (key: keyof typeof managedTooltips) => () => {
+    setManagedTooltips((tooltips) => ({ ...tooltips, [key]: true }));
   };
 
   return (
@@ -19,15 +33,48 @@ export default function Example() {
           padding: 40,
         }}
       >
-        <div>Close requests: {closeRequests}</div>
+        <div>Forced close requests: {forcedCloseRequests}</div>
+        <button type="button" onClick={() => setShowForcedTooltips(true)}>
+          Show forced tooltips
+        </button>
+        {showForcedTooltips && (
+          <div style={{ display: "flex", gap: 40 }}>
+            <Ariakit.TooltipProvider open setOpen={setForcedOpen}>
+              <Ariakit.TooltipAnchor>forced one</Ariakit.TooltipAnchor>
+              <Ariakit.Tooltip>FORCED ONE</Ariakit.Tooltip>
+            </Ariakit.TooltipProvider>
+            <Ariakit.TooltipProvider open setOpen={setForcedOpen}>
+              <Ariakit.TooltipAnchor>forced two</Ariakit.TooltipAnchor>
+              <Ariakit.Tooltip>FORCED TWO</Ariakit.Tooltip>
+            </Ariakit.TooltipProvider>
+            <Ariakit.TooltipProvider open setOpen={setForcedOpen}>
+              <Ariakit.TooltipAnchor>forced three</Ariakit.TooltipAnchor>
+              <Ariakit.Tooltip>FORCED THREE</Ariakit.Tooltip>
+            </Ariakit.TooltipProvider>
+          </div>
+        )}
+        <div style={{ display: "flex", gap: 8 }}>
+          <button type="button" onClick={openManagedTooltip("one")}>
+            Open managed one
+          </button>
+          <button type="button" onClick={openManagedTooltip("two")}>
+            Open managed two
+          </button>
+        </div>
         <div style={{ display: "flex", gap: 40 }}>
-          <Ariakit.TooltipProvider open setOpen={setOpen}>
-            <Ariakit.TooltipAnchor>one</Ariakit.TooltipAnchor>
-            <Ariakit.Tooltip>HELLO!</Ariakit.Tooltip>
+          <Ariakit.TooltipProvider
+            open={managedTooltips.one}
+            setOpen={setManagedOpen("one")}
+          >
+            <Ariakit.TooltipAnchor>managed one</Ariakit.TooltipAnchor>
+            <Ariakit.Tooltip>MANAGED ONE</Ariakit.Tooltip>
           </Ariakit.TooltipProvider>
-          <Ariakit.TooltipProvider open setOpen={setOpen}>
-            <Ariakit.TooltipAnchor>two</Ariakit.TooltipAnchor>
-            <Ariakit.Tooltip>HELLO 222!</Ariakit.Tooltip>
+          <Ariakit.TooltipProvider
+            open={managedTooltips.two}
+            setOpen={setManagedOpen("two")}
+          >
+            <Ariakit.TooltipAnchor>managed two</Ariakit.TooltipAnchor>
+            <Ariakit.Tooltip>MANAGED TWO</Ariakit.Tooltip>
           </Ariakit.TooltipProvider>
         </div>
       </div>

--- a/app/src/sandbox/tooltip-4894/index.react.tsx
+++ b/app/src/sandbox/tooltip-4894/index.react.tsx
@@ -1,0 +1,36 @@
+import * as Ariakit from "@ariakit/react";
+import { StrictMode, useState } from "react";
+
+export default function Example() {
+  const [closeRequests, setCloseRequests] = useState(0);
+
+  const setOpen = (open: boolean) => {
+    if (open) return;
+    setCloseRequests((count) => count + 1);
+  };
+
+  return (
+    <StrictMode>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 40,
+          padding: 40,
+        }}
+      >
+        <div>Close requests: {closeRequests}</div>
+        <div style={{ display: "flex", gap: 40 }}>
+          <Ariakit.TooltipProvider open setOpen={setOpen}>
+            <Ariakit.TooltipAnchor>one</Ariakit.TooltipAnchor>
+            <Ariakit.Tooltip>HELLO!</Ariakit.Tooltip>
+          </Ariakit.TooltipProvider>
+          <Ariakit.TooltipProvider open setOpen={setOpen}>
+            <Ariakit.TooltipAnchor>two</Ariakit.TooltipAnchor>
+            <Ariakit.Tooltip>HELLO 222!</Ariakit.Tooltip>
+          </Ariakit.TooltipProvider>
+        </div>
+      </div>
+    </StrictMode>
+  );
+}

--- a/app/src/sandbox/tooltip-4894/index.react.tsx
+++ b/app/src/sandbox/tooltip-4894/index.react.tsx
@@ -2,12 +2,12 @@ import * as Ariakit from "@ariakit/react";
 import { StrictMode, useState } from "react";
 
 export default function Example() {
-  const [activeTooltip, setActiveTooltip] = useState<"one" | "two" | null>(
-    null,
-  );
+  const [closeRequests, setCloseRequests] = useState(0);
 
-  const openFirstTooltip = () => setActiveTooltip("one");
-  const openSecondTooltip = () => setActiveTooltip("two");
+  const setOpen = (open: boolean) => {
+    if (open) return;
+    setCloseRequests((count) => count + 1);
+  };
 
   return (
     <StrictMode>
@@ -19,19 +19,13 @@ export default function Example() {
           padding: 40,
         }}
       >
-        <button type="button" onClick={openFirstTooltip}>
-          Open first tooltip
-        </button>
-        <button type="button" onClick={openSecondTooltip}>
-          Open second tooltip
-        </button>
-        {/* TODO: Remove this one-at-a-time workaround once https://github.com/ariakit/ariakit/issues/4894 is fixed. */}
+        <div>Close requests: {closeRequests}</div>
         <div style={{ display: "flex", gap: 40 }}>
-          <Ariakit.TooltipProvider open={activeTooltip === "one"}>
+          <Ariakit.TooltipProvider open setOpen={setOpen}>
             <Ariakit.TooltipAnchor>one</Ariakit.TooltipAnchor>
             <Ariakit.Tooltip>HELLO!</Ariakit.Tooltip>
           </Ariakit.TooltipProvider>
-          <Ariakit.TooltipProvider open={activeTooltip === "two"}>
+          <Ariakit.TooltipProvider open setOpen={setOpen}>
             <Ariakit.TooltipAnchor>two</Ariakit.TooltipAnchor>
             <Ariakit.Tooltip>HELLO 222!</Ariakit.Tooltip>
           </Ariakit.TooltipProvider>

--- a/app/src/sandbox/tooltip-4894/preview.astro
+++ b/app/src/sandbox/tooltip-4894/preview.astro
@@ -1,0 +1,14 @@
+---
+import PreviewFramework from "#app/components/preview-framework.astro";
+import ReactExample from "./index.react.tsx";
+
+import sourceReact from "./index.react.tsx?source";
+
+export const source = {
+  react: sourceReact,
+};
+---
+
+<PreviewFramework>
+  <ReactExample client:load slot="react" />
+</PreviewFramework>

--- a/app/src/sandbox/tooltip-4894/preview.mdx
+++ b/app/src/sandbox/tooltip-4894/preview.mdx
@@ -1,0 +1,9 @@
+---
+title: "tooltip-4894"
+frameworks:
+  - react
+---
+
+import Preview from "./preview.astro";
+
+<Preview />

--- a/app/src/sandbox/tooltip-4894/test-browser.ts
+++ b/app/src/sandbox/tooltip-4894/test-browser.ts
@@ -2,9 +2,15 @@ import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
   // See https://github.com/ariakit/ariakit/issues/4894
-  test("does not hide multiple controlled open tooltips", async ({ q }) => {
+  test("works around the crash by opening one controlled tooltip at a time", async ({
+    q,
+  }) => {
+    await q.button("Open first tooltip").click();
     await test.expect(q.tooltip("HELLO!")).toBeVisible();
+    await test.expect(q.tooltip("HELLO 222!")).not.toBeVisible();
+
+    await q.button("Open second tooltip").click();
+    await test.expect(q.tooltip("HELLO!")).not.toBeVisible();
     await test.expect(q.tooltip("HELLO 222!")).toBeVisible();
-    await test.expect(q.text("Close requests: 0")).toBeVisible();
   });
 });

--- a/app/src/sandbox/tooltip-4894/test-browser.ts
+++ b/app/src/sandbox/tooltip-4894/test-browser.ts
@@ -1,0 +1,10 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // See https://github.com/ariakit/ariakit/issues/4894
+  test("does not hide multiple controlled open tooltips", async ({ q }) => {
+    await test.expect(q.tooltip("HELLO!")).toBeVisible();
+    await test.expect(q.tooltip("HELLO 222!")).toBeVisible();
+    await test.expect(q.text("Close requests: 0")).toBeVisible();
+  });
+});

--- a/app/src/sandbox/tooltip-4894/test-browser.ts
+++ b/app/src/sandbox/tooltip-4894/test-browser.ts
@@ -2,9 +2,40 @@ import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
   // See https://github.com/ariakit/ariakit/issues/4894
-  test("does not hide multiple controlled open tooltips", async ({ q }) => {
-    await test.expect(q.tooltip("HELLO!")).toBeVisible();
-    await test.expect(q.tooltip("HELLO 222!")).toBeVisible();
-    await test.expect(q.text("Close requests: 0")).toBeVisible();
+  test("does not loop when multiple tooltips are forced open", async ({
+    q,
+  }) => {
+    await q.button("Show forced tooltips").click();
+    await test.expect(q.tooltip("FORCED ONE")).toBeVisible();
+    await test.expect(q.tooltip("FORCED TWO")).toBeVisible();
+    await test.expect(q.tooltip("FORCED THREE")).toBeVisible();
+    await test.expect(q.text(/Forced close requests: [1-9]\d*/)).toBeVisible();
+  });
+
+  test("hides controlled tooltips that accept setOpen updates", async ({
+    q,
+  }) => {
+    await q.button("Open managed one").click();
+    await test.expect(q.tooltip("MANAGED ONE")).toBeVisible();
+    await test.expect(q.tooltip("MANAGED TWO")).not.toBeVisible();
+
+    await q.button("Open managed two").click();
+    await test.expect(q.tooltip("MANAGED ONE")).not.toBeVisible();
+    await test.expect(q.tooltip("MANAGED TWO")).toBeVisible();
+  });
+
+  test("keeps managed tooltips active after forced tooltips reopen", async ({
+    q,
+  }) => {
+    await q.button("Show forced tooltips").click();
+    await q.button("Open managed one").click();
+    await test.expect(q.tooltip("MANAGED ONE")).toBeVisible();
+
+    await q.button("Open managed two").click();
+    await test.expect(q.tooltip("MANAGED ONE")).not.toBeVisible();
+    await test.expect(q.tooltip("MANAGED TWO")).toBeVisible();
+    await test.expect(q.tooltip("FORCED ONE")).toBeVisible();
+    await test.expect(q.tooltip("FORCED TWO")).toBeVisible();
+    await test.expect(q.tooltip("FORCED THREE")).toBeVisible();
   });
 });

--- a/app/src/sandbox/tooltip-4894/test-browser.ts
+++ b/app/src/sandbox/tooltip-4894/test-browser.ts
@@ -2,15 +2,9 @@ import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
   // See https://github.com/ariakit/ariakit/issues/4894
-  test("works around the crash by opening one controlled tooltip at a time", async ({
-    q,
-  }) => {
-    await q.button("Open first tooltip").click();
+  test("does not hide multiple controlled open tooltips", async ({ q }) => {
     await test.expect(q.tooltip("HELLO!")).toBeVisible();
-    await test.expect(q.tooltip("HELLO 222!")).not.toBeVisible();
-
-    await q.button("Open second tooltip").click();
-    await test.expect(q.tooltip("HELLO!")).not.toBeVisible();
     await test.expect(q.tooltip("HELLO 222!")).toBeVisible();
+    await test.expect(q.text("Close requests: 0")).toBeVisible();
   });
 });

--- a/app/src/sandbox/tooltip-4894/test.ts
+++ b/app/src/sandbox/tooltip-4894/test.ts
@@ -1,9 +1,34 @@
-import { q } from "@ariakit/test";
+import { click, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 // See https://github.com/ariakit/ariakit/issues/4894
-test("does not hide multiple controlled open tooltips", () => {
-  expect(q.tooltip("HELLO!")).toBeVisible();
-  expect(q.tooltip("HELLO 222!")).toBeVisible();
-  expect(q.text("Close requests: 0")).toBeVisible();
+test("does not loop when multiple tooltips are forced open", async () => {
+  await click(q.button("Show forced tooltips"));
+  expect(q.tooltip("FORCED ONE")).toBeVisible();
+  expect(q.tooltip("FORCED TWO")).toBeVisible();
+  expect(q.tooltip("FORCED THREE")).toBeVisible();
+  expect(q.text(/Forced close requests: [1-9]\d*/)).toBeVisible();
+});
+
+test("hides controlled tooltips that accept setOpen updates", async () => {
+  await click(q.button("Open managed one"));
+  expect(q.tooltip("MANAGED ONE")).toBeVisible();
+  expect(q.tooltip("MANAGED TWO")).not.toBeInTheDocument();
+
+  await click(q.button("Open managed two"));
+  expect(q.tooltip("MANAGED ONE")).not.toBeInTheDocument();
+  expect(q.tooltip("MANAGED TWO")).toBeVisible();
+});
+
+test("keeps managed tooltips active after forced tooltips reopen", async () => {
+  await click(q.button("Show forced tooltips"));
+  await click(q.button("Open managed one"));
+  expect(q.tooltip("MANAGED ONE")).toBeVisible();
+
+  await click(q.button("Open managed two"));
+  expect(q.tooltip("MANAGED ONE")).not.toBeInTheDocument();
+  expect(q.tooltip("MANAGED TWO")).toBeVisible();
+  expect(q.tooltip("FORCED ONE")).toBeVisible();
+  expect(q.tooltip("FORCED TWO")).toBeVisible();
+  expect(q.tooltip("FORCED THREE")).toBeVisible();
 });

--- a/app/src/sandbox/tooltip-4894/test.ts
+++ b/app/src/sandbox/tooltip-4894/test.ts
@@ -1,13 +1,9 @@
-import { click, q } from "@ariakit/test";
+import { q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 // See https://github.com/ariakit/ariakit/issues/4894
-test("works around the crash by opening one controlled tooltip at a time", async () => {
-  await click(q.button("Open first tooltip"));
+test("does not hide multiple controlled open tooltips", () => {
   expect(q.tooltip("HELLO!")).toBeVisible();
-  expect(q.tooltip("HELLO 222!")).not.toBeInTheDocument();
-
-  await click(q.button("Open second tooltip"));
-  expect(q.tooltip("HELLO!")).not.toBeInTheDocument();
   expect(q.tooltip("HELLO 222!")).toBeVisible();
+  expect(q.text("Close requests: 0")).toBeVisible();
 });

--- a/app/src/sandbox/tooltip-4894/test.ts
+++ b/app/src/sandbox/tooltip-4894/test.ts
@@ -1,0 +1,9 @@
+import { q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// See https://github.com/ariakit/ariakit/issues/4894
+test("does not hide multiple controlled open tooltips", () => {
+  expect(q.tooltip("HELLO!")).toBeVisible();
+  expect(q.tooltip("HELLO 222!")).toBeVisible();
+  expect(q.text("Close requests: 0")).toBeVisible();
+});

--- a/app/src/sandbox/tooltip-4894/test.ts
+++ b/app/src/sandbox/tooltip-4894/test.ts
@@ -1,9 +1,13 @@
-import { q } from "@ariakit/test";
+import { click, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 // See https://github.com/ariakit/ariakit/issues/4894
-test("does not hide multiple controlled open tooltips", () => {
+test("works around the crash by opening one controlled tooltip at a time", async () => {
+  await click(q.button("Open first tooltip"));
   expect(q.tooltip("HELLO!")).toBeVisible();
+  expect(q.tooltip("HELLO 222!")).not.toBeInTheDocument();
+
+  await click(q.button("Open second tooltip"));
+  expect(q.tooltip("HELLO!")).not.toBeInTheDocument();
   expect(q.tooltip("HELLO 222!")).toBeVisible();
-  expect(q.text("Close requests: 0")).toBeVisible();
 });

--- a/app/src/sandbox/tooltip-4894/test.ts
+++ b/app/src/sandbox/tooltip-4894/test.ts
@@ -2,7 +2,10 @@ import { click, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 // See https://github.com/ariakit/ariakit/issues/4894
-test("does not loop when multiple tooltips are forced open", async () => {
+// In jsdom, this documents the stable forced-open state. The mixed test below
+// fails without the re-entrant loop guard, and test-browser.ts covers the pure
+// forced-open flow in a real browser.
+test("keeps multiple forced tooltips visible", async () => {
   await click(q.button("Show forced tooltips"));
   expect(q.tooltip("FORCED ONE")).toBeVisible();
   expect(q.tooltip("FORCED TWO")).toBeVisible();

--- a/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
+++ b/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
@@ -13,6 +13,7 @@ import { useEffect, useRef } from "react";
 import type { HovercardAnchorOptions } from "../hovercard/hovercard-anchor.tsx";
 import { useHovercardAnchor } from "../hovercard/hovercard-anchor.tsx";
 import { useTooltipProviderContext } from "./tooltip-context.tsx";
+import { isTooltipStoreOpenControlled } from "./tooltip-store.ts";
 import type { TooltipStore } from "./tooltip-store.ts";
 
 const TagName = "div" satisfies ElementType;
@@ -81,7 +82,10 @@ export const useTooltipAnchor = createHook<TagName, TooltipAnchorOptions>(
           // active one and set the current one as the active tooltip.
           if (state.mounted) {
             const { activeStore } = globalStore.getState();
-            if (activeStore !== store) {
+            if (
+              activeStore !== store &&
+              !isTooltipStoreOpenControlled(activeStore)
+            ) {
               activeStore?.hide();
             }
             return globalStore.setState("activeStore", store);

--- a/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
+++ b/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
@@ -79,7 +79,9 @@ export const useTooltipAnchor = createHook<TagName, TooltipAnchorOptions>(
         sync(store, ["mounted", "skipTimeout"], (state) => {
           if (!store) return;
           // If the current tooltip is open, we should immediately hide the
-          // active one and set the current one as the active tooltip.
+          // active one and set the current one as the active tooltip. We
+          // skip controlled open stores because useStoreProps would force
+          // them open again, causing a re-entrant loop between tooltips.
           if (state.mounted) {
             const { activeStore } = globalStore.getState();
             if (

--- a/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
+++ b/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
@@ -39,6 +39,8 @@ function hideStore(store: TooltipStore | null) {
   if (!store) return;
   hidingStores.add(store);
   store.hide();
+  // Cleanup runs after `hide()` so controlled `open` props still see this
+  // store in `hidingStores` when their batch microtask forces them open again.
   queueMicrotask(() => hidingStores.delete(store));
 }
 

--- a/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
+++ b/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
@@ -96,11 +96,8 @@ export const useTooltipAnchor = createHook<TagName, TooltipAnchorOptions>(
           if (state.mounted) {
             const { activeStore } = globalStore.getState();
             if (activeStore !== store) {
-              if (hidingStores.has(store)) {
-                return;
-              } else {
-                hideStore(activeStore);
-              }
+              if (hidingStores.has(store)) return;
+              hideStore(activeStore);
             }
             return globalStore.setState("activeStore", store);
           }

--- a/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
+++ b/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
@@ -13,7 +13,6 @@ import { useEffect, useRef } from "react";
 import type { HovercardAnchorOptions } from "../hovercard/hovercard-anchor.tsx";
 import { useHovercardAnchor } from "../hovercard/hovercard-anchor.tsx";
 import { useTooltipProviderContext } from "./tooltip-context.tsx";
-import { isTooltipStoreOpenControlled } from "./tooltip-store.ts";
 import type { TooltipStore } from "./tooltip-store.ts";
 
 const TagName = "div" satisfies ElementType;
@@ -26,12 +25,21 @@ const globalStore = createStore<{ activeStore: TooltipStore | null }>({
   activeStore: null,
 });
 
+const hidingStores = new WeakSet<TooltipStore>();
+
 function createRemoveStoreCallback(store: TooltipStore) {
   return () => {
     const { activeStore } = globalStore.getState();
     if (activeStore !== store) return;
     globalStore.setState("activeStore", null);
   };
+}
+
+function hideStore(store: TooltipStore | null) {
+  if (!store) return;
+  hidingStores.add(store);
+  store.hide();
+  queueMicrotask(() => hidingStores.delete(store));
 }
 
 /**
@@ -79,16 +87,18 @@ export const useTooltipAnchor = createHook<TagName, TooltipAnchorOptions>(
         sync(store, ["mounted", "skipTimeout"], (state) => {
           if (!store) return;
           // If the current tooltip is open, we should immediately hide the
-          // active one and set the current one as the active tooltip. We
-          // skip controlled open stores because useStoreProps would force
-          // them open again, causing a re-entrant loop between tooltips.
+          // active one and set the current one as the active tooltip. If a
+          // tooltip we just hid gets forced open again, we leave the current
+          // active store in place to avoid a re-entrant loop between forced
+          // open tooltips.
           if (state.mounted) {
             const { activeStore } = globalStore.getState();
-            if (
-              activeStore !== store &&
-              !isTooltipStoreOpenControlled(activeStore)
-            ) {
-              activeStore?.hide();
+            if (activeStore !== store) {
+              if (hidingStores.has(store)) {
+                return;
+              } else {
+                hideStore(activeStore);
+              }
             }
             return globalStore.setState("activeStore", store);
           }

--- a/packages/ariakit-react-components/src/tooltip/tooltip-store.ts
+++ b/packages/ariakit-react-components/src/tooltip/tooltip-store.ts
@@ -1,7 +1,6 @@
 import * as Core from "@ariakit/components/tooltip/tooltip-store";
 import { useStore, useStoreProps } from "@ariakit/react-store";
 import type { Store } from "@ariakit/react-store";
-import { useSafeLayoutEffect } from "@ariakit/react-utils";
 import type {
   HovercardStoreFunctions,
   HovercardStoreOptions,
@@ -9,31 +8,11 @@ import type {
 } from "../hovercard/hovercard-store.ts";
 import { useHovercardStoreProps } from "../hovercard/hovercard-store.ts";
 
-const controlledOpenStores = new WeakSet<object>();
-
-export function isTooltipStoreOpenControlled(store: object | null | undefined) {
-  if (!store) return false;
-  return controlledOpenStores.has(store);
-}
-
 export function useTooltipStoreProps<T extends Core.TooltipStore>(
   store: T,
   update: () => void,
   props: TooltipStoreProps,
 ) {
-  const openControlled = props.open !== undefined;
-
-  useSafeLayoutEffect(() => {
-    if (openControlled) {
-      controlledOpenStores.add(store);
-    } else {
-      controlledOpenStores.delete(store);
-    }
-    return () => {
-      controlledOpenStores.delete(store);
-    };
-  }, [store, openControlled]);
-
   useStoreProps(store, props, "type");
   useStoreProps(store, props, "skipTimeout");
   return useHovercardStoreProps(store, update, props);

--- a/packages/ariakit-react-components/src/tooltip/tooltip-store.ts
+++ b/packages/ariakit-react-components/src/tooltip/tooltip-store.ts
@@ -1,6 +1,7 @@
 import * as Core from "@ariakit/components/tooltip/tooltip-store";
 import { useStore, useStoreProps } from "@ariakit/react-store";
 import type { Store } from "@ariakit/react-store";
+import { useSafeLayoutEffect } from "@ariakit/react-utils";
 import type {
   HovercardStoreFunctions,
   HovercardStoreOptions,
@@ -8,11 +9,31 @@ import type {
 } from "../hovercard/hovercard-store.ts";
 import { useHovercardStoreProps } from "../hovercard/hovercard-store.ts";
 
+const controlledOpenStores = new WeakSet<object>();
+
+export function isTooltipStoreOpenControlled(store: object | null | undefined) {
+  if (!store) return false;
+  return controlledOpenStores.has(store);
+}
+
 export function useTooltipStoreProps<T extends Core.TooltipStore>(
   store: T,
   update: () => void,
   props: TooltipStoreProps,
 ) {
+  const openControlled = props.open !== undefined;
+
+  useSafeLayoutEffect(() => {
+    if (openControlled) {
+      controlledOpenStores.add(store);
+    } else {
+      controlledOpenStores.delete(store);
+    }
+    return () => {
+      controlledOpenStores.delete(store);
+    };
+  }, [store, openControlled]);
+
   useStoreProps(store, props, "type");
   useStoreProps(store, props, "skipTimeout");
   return useHovercardStoreProps(store, update, props);


### PR DESCRIPTION
## Motivation

Issue #4894 reports that rendering multiple forced-open tooltips can freeze or crash the page. The tooltip global active-store logic tries to hide the previously mounted tooltip, but `open={true}` immediately forces it open again, which can create a re-entrant loop.

Fixes #4894

## Solution

This adds a `tooltip-4894` sandbox with both browser coverage and a Vitest test that also runs under the React 18 test matrix.

The sandbox covers three cases:

- Multiple tooltips forced open with `open={true}` stay visible without looping.
- Controlled tooltips with `open` and `setOpen` still participate in the default one-open-tooltip behavior when they accept `setOpen(false)`.
- Managed controlled tooltips still close each other even after forced-open tooltips reopen.

The library fix keeps the normal active-tooltip `hide()` path. When a store that Ariakit just tried to hide is forced open again in the same turn, Ariakit leaves the current active store in place instead of issuing a reciprocal `hide()` that would restart the loop.

## Workaround

Until the library fix is released, avoid forcing multiple tooltip providers open at the same time. Instead, keep one active tooltip in state and derive each provider's `open` prop from that state:

```tsx
// TODO: Remove once https://github.com/ariakit/ariakit/issues/4894 is fixed.
const [activeTooltip, setActiveTooltip] = useState<"one" | "two" | null>(null);

<TooltipProvider open={activeTooltip === "one"}>
  <TooltipAnchor onClick={() => setActiveTooltip("one")}>one</TooltipAnchor>
  <Tooltip>HELLO!</Tooltip>
</TooltipProvider>
<TooltipProvider open={activeTooltip === "two"}>
  <TooltipAnchor onClick={() => setActiveTooltip("two")}>two</TooltipAnchor>
  <Tooltip>HELLO 222!</Tooltip>
</TooltipProvider>
```

This workaround trades simultaneous visible tooltips for a stable one-at-a-time controlled tooltip flow.