### PR TITLE
Fix Tab active id sync

### DIFF
--- a/.changeset/300-tab-active-id-focus.md
+++ b/.changeset/300-tab-active-id-focus.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/components": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Tab`](https://ariakit.com/reference/tab) keyboard navigation after a controlled [`selectedId`](https://ariakit.com/reference/tab-provider#selectedid) update while a tab has DOM focus.

--- a/.changeset/300-tab-active-id-focus.md
+++ b/.changeset/300-tab-active-id-focus.md
@@ -4,4 +4,4 @@
 "@ariakit/react": patch
 ---
 
-Fixed [`Tab`](https://ariakit.com/reference/tab) keyboard navigation after a controlled [`selectedId`](https://ariakit.com/reference/tab-provider#selectedid) update while a tab has DOM focus.
+Fixed [`Tab`](https://ariakit.com/reference/tab) to move focus to the selected tab after a controlled [`selectedId`](https://ariakit.com/reference/tab-provider#selectedid) update while a tab has DOM focus.

--- a/app/src/sandbox/tab-4213/index.react.tsx
+++ b/app/src/sandbox/tab-4213/index.react.tsx
@@ -19,7 +19,18 @@ export default function Example() {
   return (
     <ak.TabProvider store={tab}>
       <ak.TabList aria-label="Groceries">
-        <ak.Tab id="fruits">Fruits</ak.Tab>
+        <ak.Tab
+          id="fruits"
+          onKeyDown={(event) => {
+            if (event.key.toLowerCase() !== "d") return;
+            setSelectedTab("dairy");
+          }}
+        >
+          Fruits
+        </ak.Tab>
+        <ak.Tab id="dairy" disabled>
+          Dairy
+        </ak.Tab>
         <ak.Tab id="vegetables">Vegetables</ak.Tab>
         <ak.Tab id="meat">Meat</ak.Tab>
       </ak.TabList>
@@ -37,6 +48,7 @@ export default function Example() {
         Carrots, onions, and potatoes
       </ak.TabPanel>
       <ak.TabPanel tabId="meat">Beef, chicken, and pork</ak.TabPanel>
+      <ak.TabPanel tabId="dairy">Milk, cheese, and yogurt</ak.TabPanel>
       {/* WebKit keeps focus on the clicked button only when explicitly tabbable. */}
       <button
         type="button"

--- a/app/src/sandbox/tab-4213/index.react.tsx
+++ b/app/src/sandbox/tab-4213/index.react.tsx
@@ -37,13 +37,14 @@ export default function Example() {
         Carrots, onions, and potatoes
       </ak.TabPanel>
       <ak.TabPanel tabId="meat">Beef, chicken, and pork</ak.TabPanel>
-      <label>
-        Outside note
-        <input
-          type="text"
-          onFocus={() => setTimeout(() => setSelectedTab("vegetables"), 100)}
-        />
-      </label>
+      {/* WebKit keeps focus on the clicked button only when explicitly tabbable. */}
+      <button
+        type="button"
+        tabIndex={0}
+        onClick={() => setSelectedTab("vegetables")}
+      >
+        Select vegetables
+      </button>
     </ak.TabProvider>
   );
 }

--- a/app/src/sandbox/tab-4213/index.react.tsx
+++ b/app/src/sandbox/tab-4213/index.react.tsx
@@ -28,6 +28,9 @@ export default function Example() {
         Carrots, onions, and potatoes
       </ak.TabPanel>
       <ak.TabPanel tabId="meat">Beef, chicken, and pork</ak.TabPanel>
+      <button type="button" onClick={() => setSelectedTab("vegetables")}>
+        Select vegetables
+      </button>
     </ak.TabProvider>
   );
 }

--- a/app/src/sandbox/tab-4213/index.react.tsx
+++ b/app/src/sandbox/tab-4213/index.react.tsx
@@ -49,9 +49,9 @@ export default function Example() {
       </ak.TabPanel>
       <ak.TabPanel tabId="meat">Beef, chicken, and pork</ak.TabPanel>
       <ak.TabPanel tabId="dairy">Milk, cheese, and yogurt</ak.TabPanel>
-      {/* WebKit keeps focus on the clicked button only when explicitly tabbable. */}
       <button
         type="button"
+        // WebKit keeps focus on the clicked button only when explicitly tabbable.
         tabIndex={0}
         onClick={() => setSelectedTab("vegetables")}
       >

--- a/app/src/sandbox/tab-4213/index.react.tsx
+++ b/app/src/sandbox/tab-4213/index.react.tsx
@@ -37,9 +37,13 @@ export default function Example() {
         Carrots, onions, and potatoes
       </ak.TabPanel>
       <ak.TabPanel tabId="meat">Beef, chicken, and pork</ak.TabPanel>
-      <button type="button" onClick={() => setSelectedTab("vegetables")}>
-        Select vegetables
-      </button>
+      <label>
+        Outside note
+        <input
+          type="text"
+          onFocus={() => setTimeout(() => setSelectedTab("vegetables"), 100)}
+        />
+      </label>
     </ak.TabProvider>
   );
 }

--- a/app/src/sandbox/tab-4213/index.react.tsx
+++ b/app/src/sandbox/tab-4213/index.react.tsx
@@ -9,12 +9,28 @@ export default function Example() {
     selectedId: selectedTab,
     setSelectedId: setSelectedTab,
   });
+  const activeId = ak.useStoreState(tab, "activeId");
+  const renderedItems = ak.useStoreState(tab, "renderedItems");
 
   useEffect(() => {
     if (selectedTab !== "vegetables") return;
     const timeout = setTimeout(() => setSelectedTab("meat"), 100);
     return () => clearTimeout(timeout);
   }, [selectedTab]);
+
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => {
+      const activeElement =
+        renderedItems[0]?.element?.ownerDocument.activeElement;
+      const focusedItem = renderedItems.find(
+        (item) => item.element === activeElement,
+      );
+      if (!focusedItem) return;
+      if (activeId === focusedItem.id) return;
+      tab.setActiveId(focusedItem.id);
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [activeId, renderedItems, tab]);
 
   return (
     <ak.TabProvider store={tab}>

--- a/app/src/sandbox/tab-4213/index.react.tsx
+++ b/app/src/sandbox/tab-4213/index.react.tsx
@@ -23,7 +23,16 @@ export default function Example() {
         <ak.Tab id="vegetables">Vegetables</ak.Tab>
         <ak.Tab id="meat">Meat</ak.Tab>
       </ak.TabList>
-      <ak.TabPanel tabId="fruits">Apples, grapes, and oranges</ak.TabPanel>
+      <ak.TabPanel tabId="fruits" alwaysVisible>
+        Apples, grapes, and oranges
+        <label>
+          Fruit note
+          <input
+            type="text"
+            onFocus={() => setTimeout(() => setSelectedTab("vegetables"), 100)}
+          />
+        </label>
+      </ak.TabPanel>
       <ak.TabPanel tabId="vegetables">
         Carrots, onions, and potatoes
       </ak.TabPanel>

--- a/app/src/sandbox/tab-4213/index.react.tsx
+++ b/app/src/sandbox/tab-4213/index.react.tsx
@@ -1,0 +1,33 @@
+import * as ak from "@ariakit/react";
+import { useEffect, useState } from "react";
+
+export default function Example() {
+  const [selectedTab, setSelectedTab] = useState<string | null | undefined>(
+    "fruits",
+  );
+  const tab = ak.useTabStore({
+    selectedId: selectedTab,
+    setSelectedId: setSelectedTab,
+  });
+
+  useEffect(() => {
+    if (selectedTab !== "vegetables") return;
+    const timeout = setTimeout(() => setSelectedTab("meat"), 100);
+    return () => clearTimeout(timeout);
+  }, [selectedTab]);
+
+  return (
+    <ak.TabProvider store={tab}>
+      <ak.TabList aria-label="Groceries">
+        <ak.Tab id="fruits">Fruits</ak.Tab>
+        <ak.Tab id="vegetables">Vegetables</ak.Tab>
+        <ak.Tab id="meat">Meat</ak.Tab>
+      </ak.TabList>
+      <ak.TabPanel tabId="fruits">Apples, grapes, and oranges</ak.TabPanel>
+      <ak.TabPanel tabId="vegetables">
+        Carrots, onions, and potatoes
+      </ak.TabPanel>
+      <ak.TabPanel tabId="meat">Beef, chicken, and pork</ak.TabPanel>
+    </ak.TabProvider>
+  );
+}

--- a/app/src/sandbox/tab-4213/index.react.tsx
+++ b/app/src/sandbox/tab-4213/index.react.tsx
@@ -9,28 +9,12 @@ export default function Example() {
     selectedId: selectedTab,
     setSelectedId: setSelectedTab,
   });
-  const activeId = ak.useStoreState(tab, "activeId");
-  const renderedItems = ak.useStoreState(tab, "renderedItems");
 
   useEffect(() => {
     if (selectedTab !== "vegetables") return;
     const timeout = setTimeout(() => setSelectedTab("meat"), 100);
     return () => clearTimeout(timeout);
   }, [selectedTab]);
-
-  useEffect(() => {
-    const frame = requestAnimationFrame(() => {
-      const activeElement =
-        renderedItems[0]?.element?.ownerDocument.activeElement;
-      const focusedItem = renderedItems.find(
-        (item) => item.element === activeElement,
-      );
-      if (!focusedItem) return;
-      if (activeId === focusedItem.id) return;
-      tab.setActiveId(focusedItem.id);
-    });
-    return () => cancelAnimationFrame(frame);
-  }, [activeId, renderedItems, tab]);
 
   return (
     <ak.TabProvider store={tab}>

--- a/app/src/sandbox/tab-4213/preview.astro
+++ b/app/src/sandbox/tab-4213/preview.astro
@@ -1,0 +1,14 @@
+---
+import PreviewFramework from "#app/components/preview-framework.astro";
+import ReactExample from "./index.react.tsx";
+
+import sourceReact from "./index.react.tsx?source";
+
+export const source = {
+  react: sourceReact,
+};
+---
+
+<PreviewFramework>
+  <ReactExample client:load slot="react" />
+</PreviewFramework>

--- a/app/src/sandbox/tab-4213/preview.mdx
+++ b/app/src/sandbox/tab-4213/preview.mdx
@@ -1,0 +1,9 @@
+---
+title: "tab-4213"
+frameworks:
+  - react
+---
+
+import Preview from "./preview.astro";
+
+<Preview />

--- a/app/src/sandbox/tab-4213/test-browser.ts
+++ b/app/src/sandbox/tab-4213/test-browser.ts
@@ -22,7 +22,20 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await button.click();
     await test.expect(button).toBeFocused();
 
+    // Selecting Vegetables triggers a delayed controlled update to Meat.
     await test.expect(q.tab("Meat")).toHaveAttribute("aria-selected", "true");
     await test.expect(button).toBeFocused();
+  });
+
+  test("does not move focus after controlled tab selection inside a tab panel", async ({
+    page,
+    q,
+  }) => {
+    const textbox = page.getByRole("textbox", { name: "Fruit note" });
+    await textbox.focus();
+    await test.expect(textbox).toBeFocused();
+
+    await test.expect(q.tab("Meat")).toHaveAttribute("aria-selected", "true");
+    await test.expect(textbox).toBeFocused();
   });
 });

--- a/app/src/sandbox/tab-4213/test-browser.ts
+++ b/app/src/sandbox/tab-4213/test-browser.ts
@@ -20,7 +20,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
     page,
     q,
   }) => {
-    const button = page.getByRole("button", { name: "Select vegetables" });
+    const button = q.button("Select vegetables");
     await button.click();
     await test.expect(button).toBeFocused();
 
@@ -29,10 +29,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
   });
 
   test("does not move focus after controlled tab selection inside a tab panel", async ({
-    page,
     q,
   }) => {
-    const textbox = page.getByRole("textbox", { name: "Fruit note" });
+    const textbox = q.textbox("Fruit note");
     await textbox.focus();
     await test.expect(textbox).toBeFocused();
 

--- a/app/src/sandbox/tab-4213/test-browser.ts
+++ b/app/src/sandbox/tab-4213/test-browser.ts
@@ -17,7 +17,6 @@ withFramework(import.meta.dirname, async ({ test }) => {
   });
 
   test("does not move focus after controlled tab selection outside the tab list", async ({
-    page,
     q,
   }) => {
     const button = q.button("Select vegetables");

--- a/app/src/sandbox/tab-4213/test-browser.ts
+++ b/app/src/sandbox/tab-4213/test-browser.ts
@@ -2,18 +2,27 @@ import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
   // https://github.com/ariakit/ariakit/issues/4213
-  test("keeps keyboard navigation in sync after controlled tab selection", async ({
-    page,
-    q,
-  }) => {
+  test("moves focus after controlled tab selection", async ({ page, q }) => {
     await q.tab("Vegetables").click();
     await test.expect(q.tab("Vegetables")).toBeFocused();
 
     await test.expect(q.tab("Meat")).toHaveAttribute("aria-selected", "true");
-    await test.expect(q.tab("Vegetables")).toBeFocused();
+    await test.expect(q.tab("Meat")).toBeFocused();
 
     await page.keyboard.press("ArrowRight");
 
-    await test.expect(q.tab("Meat")).toBeFocused();
+    await test.expect(q.tab("Fruits")).toBeFocused();
+  });
+
+  test("does not move focus after controlled tab selection outside the tab list", async ({
+    page,
+    q,
+  }) => {
+    const button = page.getByRole("button", { name: "Select vegetables" });
+    await button.click();
+    await test.expect(button).toBeFocused();
+
+    await test.expect(q.tab("Meat")).toHaveAttribute("aria-selected", "true");
+    await test.expect(button).toBeFocused();
   });
 });

--- a/app/src/sandbox/tab-4213/test-browser.ts
+++ b/app/src/sandbox/tab-4213/test-browser.ts
@@ -18,12 +18,12 @@ withFramework(import.meta.dirname, async ({ test }) => {
     page,
     q,
   }) => {
-    const textbox = page.getByRole("textbox", { name: "Outside note" });
-    await textbox.focus();
-    await test.expect(textbox).toBeFocused();
+    const button = page.getByRole("button", { name: "Select vegetables" });
+    await button.click();
+    await test.expect(button).toBeFocused();
 
     await test.expect(q.tab("Meat")).toHaveAttribute("aria-selected", "true");
-    await test.expect(textbox).toBeFocused();
+    await test.expect(button).toBeFocused();
   });
 
   test("does not move focus after controlled tab selection inside a tab panel", async ({

--- a/app/src/sandbox/tab-4213/test-browser.ts
+++ b/app/src/sandbox/tab-4213/test-browser.ts
@@ -1,0 +1,19 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/4213
+  test("keeps keyboard navigation in sync after controlled tab selection", async ({
+    page,
+    q,
+  }) => {
+    await q.tab("Vegetables").click();
+    await test.expect(q.tab("Vegetables")).toBeFocused();
+
+    await test.expect(q.tab("Meat")).toHaveAttribute("aria-selected", "true");
+    await test.expect(q.tab("Vegetables")).toBeFocused();
+
+    await page.keyboard.press("ArrowRight");
+
+    await test.expect(q.tab("Meat")).toBeFocused();
+  });
+});

--- a/app/src/sandbox/tab-4213/test-browser.ts
+++ b/app/src/sandbox/tab-4213/test-browser.ts
@@ -18,13 +18,12 @@ withFramework(import.meta.dirname, async ({ test }) => {
     page,
     q,
   }) => {
-    const button = page.getByRole("button", { name: "Select vegetables" });
-    await button.click();
-    await test.expect(button).toBeFocused();
+    const textbox = page.getByRole("textbox", { name: "Outside note" });
+    await textbox.focus();
+    await test.expect(textbox).toBeFocused();
 
-    // Selecting Vegetables triggers a delayed controlled update to Meat.
     await test.expect(q.tab("Meat")).toHaveAttribute("aria-selected", "true");
-    await test.expect(button).toBeFocused();
+    await test.expect(textbox).toBeFocused();
   });
 
   test("does not move focus after controlled tab selection inside a tab panel", async ({

--- a/app/src/sandbox/tab-4213/test-browser.ts
+++ b/app/src/sandbox/tab-4213/test-browser.ts
@@ -3,8 +3,10 @@ import { withFramework } from "#app/test-utils/preview.ts";
 withFramework(import.meta.dirname, async ({ test }) => {
   // https://github.com/ariakit/ariakit/issues/4213
   test("moves focus after controlled tab selection", async ({ page, q }) => {
-    await q.tab("Vegetables").click();
+    await q.tab("Vegetables").focus();
     await test.expect(q.tab("Vegetables")).toBeFocused();
+
+    await q.tab("Vegetables").click();
 
     await test.expect(q.tab("Meat")).toHaveAttribute("aria-selected", "true");
     await test.expect(q.tab("Meat")).toBeFocused();
@@ -36,5 +38,18 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
     await test.expect(q.tab("Meat")).toHaveAttribute("aria-selected", "true");
     await test.expect(textbox).toBeFocused();
+  });
+
+  test("does not move focus after controlled selection of a disabled tab", async ({
+    page,
+    q,
+  }) => {
+    await q.tab("Fruits").focus();
+    await test.expect(q.tab("Fruits")).toBeFocused();
+
+    await page.keyboard.press("d");
+
+    await test.expect(q.tab("Dairy")).toHaveAttribute("aria-selected", "true");
+    await test.expect(q.tab("Fruits")).toBeFocused();
   });
 });

--- a/packages/ariakit-components/src/tab/tab-store.ts
+++ b/packages/ariakit-components/src/tab/tab-store.ts
@@ -31,6 +31,11 @@ function getFocusedTab(items: TabStoreItem[]) {
   return items.find((item) => item.element === activeElement);
 }
 
+function getTabById(items: TabStoreItem[], id: string | null | undefined) {
+  if (id == null) return;
+  return items.find((item) => item.id === id);
+}
+
 export function createTabStore({
   composite: parentComposite,
   combobox,
@@ -126,10 +131,11 @@ export function createTabStore({
       // activeId state with the initial selectedId state. The parent composite
       // widget should handle the initial activeId state.
       if (parentComposite && state.selectedId === prev.selectedId) return;
-      const { renderedItems } = tab.getState();
+      const { activeId, renderedItems } = tab.getState();
       const focusedTab = getFocusedTab(renderedItems);
-      if (focusedTab) {
-        tab.setState("activeId", focusedTab.id);
+      const selectedTab = getTabById(renderedItems, state.selectedId);
+      if (focusedTab && selectedTab && activeId !== selectedTab.id) {
+        composite.move(selectedTab.id);
         return;
       }
       tab.setState("activeId", state.selectedId);
@@ -259,8 +265,9 @@ export interface TabStoreState extends CompositeStoreState<TabStoreItem> {
 export interface TabStoreFunctions extends CompositeStoreFunctions<TabStoreItem> {
   /**
    * Sets the
-   * [`selectedId`](https://ariakit.com/reference/tab-provider#selectedid) state
-   * without moving focus. If you want to move focus, use the
+   * [`selectedId`](https://ariakit.com/reference/tab-provider#selectedid) state.
+   * If another tab has DOM focus, focus will move to the selected tab. If you
+   * want to always move focus, use the
    * [`select`](https://ariakit.com/reference/use-tab-store#select) function
    * instead.
    * @example
@@ -284,7 +291,7 @@ export interface TabStoreFunctions extends CompositeStoreFunctions<TabStoreItem>
   /**
    * Selects the tab for the given id and moves focus to it. If you want to set
    * the [`selectedId`](https://ariakit.com/reference/tab-provider#selectedid)
-   * state without moving focus, use the
+   * state without always moving focus, use the
    * [`setSelectedId`](https://ariakit.com/reference/use-tab-store#setselectedid-1)
    * function instead.
    * @example

--- a/packages/ariakit-components/src/tab/tab-store.ts
+++ b/packages/ariakit-components/src/tab/tab-store.ts
@@ -25,6 +25,12 @@ import type {
 import { createCompositeStore } from "../composite/composite-store.ts";
 import type { SelectStore } from "../select/select-store.ts";
 
+function getFocusedTab(items: TabStoreItem[]) {
+  const activeElement = items[0]?.element?.ownerDocument.activeElement;
+  if (!activeElement) return;
+  return items.find((item) => item.element === activeElement);
+}
+
 export function createTabStore({
   composite: parentComposite,
   combobox,
@@ -120,6 +126,12 @@ export function createTabStore({
       // activeId state with the initial selectedId state. The parent composite
       // widget should handle the initial activeId state.
       if (parentComposite && state.selectedId === prev.selectedId) return;
+      const { renderedItems } = tab.getState();
+      const focusedTab = getFocusedTab(renderedItems);
+      if (focusedTab) {
+        tab.setState("activeId", focusedTab.id);
+        return;
+      }
       tab.setState("activeId", state.selectedId);
     }),
   );

--- a/packages/ariakit-components/src/tab/tab-store.ts
+++ b/packages/ariakit-components/src/tab/tab-store.ts
@@ -36,6 +36,15 @@ function getTabById(items: TabStoreItem[], id: string | null | undefined) {
   return items.find((item) => item.id === id);
 }
 
+function isEnabledTab(
+  item: TabStoreItem | null | undefined,
+): item is TabStoreItem {
+  if (!item) return false;
+  if (item.disabled) return false;
+  if (item.dimmed) return false;
+  return true;
+}
+
 export function createTabStore({
   composite: parentComposite,
   combobox,
@@ -108,9 +117,7 @@ export function createTabStore({
       if (!selectOnMove) return;
       if (!activeId) return;
       const tabItem = composite.item(activeId);
-      if (!tabItem) return;
-      if (tabItem.dimmed) return;
-      if (tabItem.disabled) return;
+      if (!isEnabledTab(tabItem)) return;
       tab.setState("selectedId", tabItem.id);
     }),
   );
@@ -134,7 +141,11 @@ export function createTabStore({
       const { activeId, renderedItems } = tab.getState();
       const focusedTab = getFocusedTab(renderedItems);
       const selectedTab = getTabById(renderedItems, state.selectedId);
-      if (focusedTab && selectedTab && activeId !== selectedTab.id) {
+      if (
+        focusedTab &&
+        isEnabledTab(selectedTab) &&
+        activeId !== selectedTab.id
+      ) {
         composite.move(selectedTab.id);
         return;
       }
@@ -149,15 +160,13 @@ export function createTabStore({
       // First, we try to set selectedId based on the current active tab.
       const { activeId, renderedItems } = tab.getState();
       const tabItem = composite.item(activeId);
-      if (tabItem && !tabItem.disabled && !tabItem.dimmed) {
+      if (isEnabledTab(tabItem)) {
         tab.setState("selectedId", tabItem.id);
       }
       // If there's no active tab or the active tab is dimmed, we get the
       // first enabled tab instead.
       else {
-        const tabItem = renderedItems.find(
-          (item) => !item.disabled && !item.dimmed,
-        );
+        const tabItem = renderedItems.find(isEnabledTab);
         tab.setState("selectedId", tabItem?.id);
       }
     }),
@@ -266,8 +275,8 @@ export interface TabStoreFunctions extends CompositeStoreFunctions<TabStoreItem>
   /**
    * Sets the
    * [`selectedId`](https://ariakit.com/reference/tab-provider#selectedid) state.
-   * If another tab has DOM focus, focus will move to the selected tab. If you
-   * want to always move focus, use the
+   * If another tab has DOM focus and the selected tab is enabled, focus will
+   * move to the selected tab. If you want to always move focus, use the
    * [`select`](https://ariakit.com/reference/use-tab-store#select) function
    * instead.
    * @example


### PR DESCRIPTION
## Motivation

Fixes #4213.

A controlled tab selection update can make DOM focus and the tab store's active item diverge. When a user presses an arrow key after that mismatch, keyboard navigation starts from the selected tab instead of the focused tab.

The later issue discussion settled on matching synchronous tab selection behavior when the tab list is already in use: if a tab has DOM focus and `selectedId` changes, focus should move to the newly selected tab. This is also consistent with `store.select(tabId)`, which already selects a tab and moves focus to it.

## Solution

When `selectedId` changes, the tab store now checks whether one of the rendered tabs currently has DOM focus and whether the new selected tab is rendered. If both are true, it moves focus to the selected tab through the composite move path.

If focus is outside the tab item, the store only syncs `activeId` with `selectedId` and does not steal DOM focus. This preserves the existing behavior where tabbing into the tab list later lands on the selected tab.

The regression sandbox covers these paths:

- A delayed controlled update while Vegetables has focus selects Meat and moves focus to Meat.
- A controlled update triggered from a focusable button outside the tab list updates selection without moving focus away from the button.
- A controlled update triggered from an input inside an always-visible tab panel updates selection without moving focus away from the input.

## Workaround

Until this fix is released, consumers that need the focus-moving behavior can use the tab store's `select` function when changing tabs programmatically:

```tsx
// TODO: Remove once https://github.com/ariakit/ariakit/issues/4213 is fixed.
tab.select(tabId);
```

For controlled tabs, make sure the controlled `selectedId` state is updated from `setSelectedId` so the store selection and application state stay in sync.
