### PR TITLE
Fix Dialog onClose with controlled store

### DIFF
--- a/.changeset/300-dialog-controlled-store-close.md
+++ b/.changeset/300-dialog-controlled-store-close.md
@@ -3,4 +3,4 @@
 "@ariakit/react": patch
 ---
 
-Fixed [`Dialog`](https://ariakit.com/reference/dialog) so programmatic controlled store updates don't trigger [`onClose`](https://ariakit.com/reference/dialog#onclose).
+Fixed [`Dialog`](https://ariakit.com/reference/dialog) so [`onClose`](https://ariakit.com/reference/dialog#onclose) only fires for Ariakit's built-in dismiss mechanisms, such as [`DialogDismiss`](https://ariakit.com/reference/dialog-dismiss), pressing <kbd>Esc</kbd>, or interacting outside the dialog, and no longer fires for programmatic visibility changes like a controlled [`open`](https://ariakit.com/reference/dialog#open) prop changing, `setOpen(false)`, or `store.hide()`.

--- a/.changeset/300-dialog-controlled-store-close.md
+++ b/.changeset/300-dialog-controlled-store-close.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Dialog`](https://ariakit.com/reference/dialog) so programmatic controlled store updates don't trigger [`onClose`](https://ariakit.com/reference/dialog#onclose).

--- a/app/src/sandbox/dialog-3488/index.react.tsx
+++ b/app/src/sandbox/dialog-3488/index.react.tsx
@@ -1,11 +1,17 @@
 import * as Ariakit from "@ariakit/react";
-import { useRef, useState } from "react";
+import { useState } from "react";
+import "./style.css";
 
 export default function Example() {
   const [open, setOpen] = useState(false);
   const [closeCount, setCloseCount] = useState(0);
-  const closingRef = useRef(false);
   const dialog = Ariakit.useDialogStore({ open, setOpen });
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const [popoverCloseCount, setPopoverCloseCount] = useState(0);
+  const popover = Ariakit.usePopoverStore({
+    open: popoverOpen,
+    setOpen: setPopoverOpen,
+  });
 
   return (
     <>
@@ -15,21 +21,13 @@ export default function Example() {
       <p>Close count: {closeCount}</p>
       <Ariakit.Dialog
         store={dialog}
+        unmountOnHide
         onClose={(event) => {
-          // TODO: Remove this guard once
-          // https://github.com/ariakit/ariakit/issues/3488 is fixed. Deferring
-          // the controlled close keeps the programmatic update from running
-          // this handler again.
-          if (closingRef.current) return;
           event.preventDefault();
-          closingRef.current = true;
           setCloseCount((count) => count + 1);
-          queueMicrotask(() => {
-            setOpen(false);
-            closingRef.current = false;
-          });
+          setOpen(false);
         }}
-        className="fixed inset-3 m-auto flex h-fit max-h-[calc(100dvh-1.5rem)] w-96 max-w-[calc(100dvw-1.5rem)] flex-col gap-4 overflow-auto rounded-lg bg-white p-6 text-black shadow-xl"
+        className="dialog-3488 fixed inset-3 m-auto flex h-fit max-h-[calc(100dvh-1.5rem)] w-96 max-w-[calc(100dvw-1.5rem)] flex-col gap-4 overflow-auto rounded-lg bg-white p-6 text-black shadow-xl"
       >
         <Ariakit.DialogHeading className="m-0 text-xl font-semibold">
           Success
@@ -39,7 +37,31 @@ export default function Example() {
           receipt.
         </p>
         <Ariakit.DialogDismiss className="px-2 py-1">OK</Ariakit.DialogDismiss>
+        <Ariakit.DialogDismiss store={dialog} className="px-2 py-1">
+          Close with explicit store
+        </Ariakit.DialogDismiss>
       </Ariakit.Dialog>
+
+      <Ariakit.PopoverDisclosure store={popover} className="px-2 py-1">
+        Show popover
+      </Ariakit.PopoverDisclosure>
+      <p>Popover close count: {popoverCloseCount}</p>
+      <Ariakit.Popover
+        store={popover}
+        onClose={(event) => {
+          event.preventDefault();
+          setPopoverCloseCount((count) => count + 1);
+          setPopoverOpen(false);
+        }}
+        className="fixed m-auto flex max-w-64 flex-col gap-4 rounded-lg bg-white p-4 text-black shadow-xl"
+      >
+        <Ariakit.PopoverHeading className="m-0 text-xl font-semibold">
+          Popover content
+        </Ariakit.PopoverHeading>
+        <Ariakit.PopoverDismiss store={popover} className="px-2 py-1">
+          Close popover with explicit store
+        </Ariakit.PopoverDismiss>
+      </Ariakit.Popover>
     </>
   );
 }

--- a/app/src/sandbox/dialog-3488/index.react.tsx
+++ b/app/src/sandbox/dialog-3488/index.react.tsx
@@ -116,6 +116,9 @@ export default function Example() {
         <Ariakit.PopoverHeading className="m-0 text-xl font-semibold">
           Popover content
         </Ariakit.PopoverHeading>
+        <Ariakit.PopoverDismiss className="px-2 py-1">
+          Close popover
+        </Ariakit.PopoverDismiss>
         <Ariakit.PopoverDismiss store={popover} className="px-2 py-1">
           Close popover with explicit store
         </Ariakit.PopoverDismiss>
@@ -125,6 +128,7 @@ export default function Example() {
         Show parent dialog
       </Ariakit.Button>
       <p>Parent close count: {parentCloseCount}</p>
+      <p>Child close count: {childCloseCount}</p>
       <Ariakit.Dialog
         store={parent}
         unmountOnHide
@@ -145,7 +149,6 @@ export default function Example() {
         >
           Show child dialog
         </Ariakit.Button>
-        <p>Child close count: {childCloseCount}</p>
         <Ariakit.Dialog
           store={child}
           backdrop={false}

--- a/app/src/sandbox/dialog-3488/index.react.tsx
+++ b/app/src/sandbox/dialog-3488/index.react.tsx
@@ -1,9 +1,10 @@
 import * as Ariakit from "@ariakit/react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 export default function Example() {
   const [open, setOpen] = useState(false);
   const [closeCount, setCloseCount] = useState(0);
+  const closingRef = useRef(false);
   const dialog = Ariakit.useDialogStore({ open, setOpen });
 
   return (
@@ -15,9 +16,18 @@ export default function Example() {
       <Ariakit.Dialog
         store={dialog}
         onClose={(event) => {
+          // TODO: Remove this guard once
+          // https://github.com/ariakit/ariakit/issues/3488 is fixed. Deferring
+          // the controlled close keeps the programmatic update from running
+          // this handler again.
+          if (closingRef.current) return;
           event.preventDefault();
+          closingRef.current = true;
           setCloseCount((count) => count + 1);
-          setOpen(false);
+          queueMicrotask(() => {
+            setOpen(false);
+            closingRef.current = false;
+          });
         }}
         className="fixed inset-3 m-auto flex h-fit max-h-[calc(100dvh-1.5rem)] w-96 max-w-[calc(100dvw-1.5rem)] flex-col gap-4 overflow-auto rounded-lg bg-white p-6 text-black shadow-xl"
       >

--- a/app/src/sandbox/dialog-3488/index.react.tsx
+++ b/app/src/sandbox/dialog-3488/index.react.tsx
@@ -2,6 +2,16 @@ import * as Ariakit from "@ariakit/react";
 import { useState } from "react";
 import "./style.css";
 
+function ContextHideButton() {
+  const dialog = Ariakit.useDialogContext();
+
+  return (
+    <Ariakit.Button className="px-2 py-1" onClick={() => dialog?.hide()}>
+      Close programmatically with context
+    </Ariakit.Button>
+  );
+}
+
 export default function Example() {
   const [open, setOpen] = useState(false);
   const [closeCount, setCloseCount] = useState(0);
@@ -40,6 +50,10 @@ export default function Example() {
         <Ariakit.DialogDismiss store={dialog} className="px-2 py-1">
           Close with explicit store
         </Ariakit.DialogDismiss>
+        <Ariakit.Button className="px-2 py-1" onClick={() => setOpen(false)}>
+          Close programmatically with setOpen
+        </Ariakit.Button>
+        <ContextHideButton />
       </Ariakit.Dialog>
 
       <Ariakit.PopoverDisclosure store={popover} className="px-2 py-1">

--- a/app/src/sandbox/dialog-3488/index.react.tsx
+++ b/app/src/sandbox/dialog-3488/index.react.tsx
@@ -16,11 +16,29 @@ export default function Example() {
   const [open, setOpen] = useState(false);
   const [closeCount, setCloseCount] = useState(0);
   const dialog = Ariakit.useDialogStore({ open, setOpen });
+  const [externalOpen, setExternalOpen] = useState(false);
+  const [externalCloseCount, setExternalCloseCount] = useState(0);
+  const external = Ariakit.useDialogStore({
+    open: externalOpen,
+    setOpen: setExternalOpen,
+  });
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [popoverCloseCount, setPopoverCloseCount] = useState(0);
   const popover = Ariakit.usePopoverStore({
     open: popoverOpen,
     setOpen: setPopoverOpen,
+  });
+  const [parentOpen, setParentOpen] = useState(false);
+  const [parentCloseCount, setParentCloseCount] = useState(0);
+  const parent = Ariakit.useDialogStore({
+    open: parentOpen,
+    setOpen: setParentOpen,
+  });
+  const [childOpen, setChildOpen] = useState(false);
+  const [childCloseCount, setChildCloseCount] = useState(0);
+  const child = Ariakit.useDialogStore({
+    open: childOpen,
+    setOpen: setChildOpen,
   });
 
   return (
@@ -56,6 +74,32 @@ export default function Example() {
         <ContextHideButton />
       </Ariakit.Dialog>
 
+      <Ariakit.Button
+        className="px-2 py-1"
+        onClick={() => setExternalOpen(true)}
+      >
+        Show external dialog
+      </Ariakit.Button>
+      <Ariakit.DialogDismiss store={external} className="px-2 py-1">
+        Close external dialog
+      </Ariakit.DialogDismiss>
+      <p>External close count: {externalCloseCount}</p>
+      <Ariakit.Dialog
+        store={external}
+        modal={false}
+        unmountOnHide
+        onClose={(event) => {
+          event.preventDefault();
+          setExternalCloseCount((count) => count + 1);
+          setExternalOpen(false);
+        }}
+        className="fixed inset-3 m-auto flex h-fit max-h-[calc(100dvh-1.5rem)] w-96 max-w-[calc(100dvw-1.5rem)] flex-col gap-4 overflow-auto rounded-lg bg-white p-6 text-black shadow-xl"
+      >
+        <Ariakit.DialogHeading className="m-0 text-xl font-semibold">
+          External dialog
+        </Ariakit.DialogHeading>
+      </Ariakit.Dialog>
+
       <Ariakit.PopoverDisclosure store={popover} className="px-2 py-1">
         Show popover
       </Ariakit.PopoverDisclosure>
@@ -76,6 +120,50 @@ export default function Example() {
           Close popover with explicit store
         </Ariakit.PopoverDismiss>
       </Ariakit.Popover>
+
+      <Ariakit.Button className="px-2 py-1" onClick={() => setParentOpen(true)}>
+        Show parent dialog
+      </Ariakit.Button>
+      <p>Parent close count: {parentCloseCount}</p>
+      <Ariakit.Dialog
+        store={parent}
+        unmountOnHide
+        onClose={(event) => {
+          event.preventDefault();
+          setParentCloseCount((count) => count + 1);
+          setChildOpen(false);
+          setParentOpen(false);
+        }}
+        className="fixed inset-3 m-auto flex h-fit max-h-[calc(100dvh-1.5rem)] w-96 max-w-[calc(100dvw-1.5rem)] flex-col gap-4 overflow-auto rounded-lg bg-white p-6 text-black shadow-xl"
+      >
+        <Ariakit.DialogHeading className="m-0 text-xl font-semibold">
+          Parent dialog
+        </Ariakit.DialogHeading>
+        <Ariakit.Button
+          className="px-2 py-1"
+          onClick={() => setChildOpen(true)}
+        >
+          Show child dialog
+        </Ariakit.Button>
+        <p>Child close count: {childCloseCount}</p>
+        <Ariakit.Dialog
+          store={child}
+          backdrop={false}
+          onClose={(event) => {
+            event.preventDefault();
+            setChildCloseCount((count) => count + 1);
+            setChildOpen(false);
+          }}
+        >
+          <Ariakit.DialogHeading>Child dialog</Ariakit.DialogHeading>
+          <Ariakit.DialogDismiss className="px-2 py-1">
+            Close child
+          </Ariakit.DialogDismiss>
+          <Ariakit.DialogDismiss store={parent} className="px-2 py-1">
+            Close parent from child
+          </Ariakit.DialogDismiss>
+        </Ariakit.Dialog>
+      </Ariakit.Dialog>
     </>
   );
 }

--- a/app/src/sandbox/dialog-3488/index.react.tsx
+++ b/app/src/sandbox/dialog-3488/index.react.tsx
@@ -1,0 +1,35 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+
+export default function Example() {
+  const [open, setOpen] = useState(false);
+  const [closeCount, setCloseCount] = useState(0);
+  const dialog = Ariakit.useDialogStore({ open, setOpen });
+
+  return (
+    <>
+      <Ariakit.Button className="px-2 py-1" onClick={() => setOpen(true)}>
+        Show modal
+      </Ariakit.Button>
+      <p>Close count: {closeCount}</p>
+      <Ariakit.Dialog
+        store={dialog}
+        onClose={(event) => {
+          event.preventDefault();
+          setCloseCount((count) => count + 1);
+          setOpen(false);
+        }}
+        className="fixed inset-3 m-auto flex h-fit max-h-[calc(100dvh-1.5rem)] w-96 max-w-[calc(100dvw-1.5rem)] flex-col gap-4 overflow-auto rounded-lg bg-white p-6 text-black shadow-xl"
+      >
+        <Ariakit.DialogHeading className="m-0 text-xl font-semibold">
+          Success
+        </Ariakit.DialogHeading>
+        <p>
+          Your payment has been successfully processed. We have emailed your
+          receipt.
+        </p>
+        <Ariakit.DialogDismiss className="px-2 py-1">OK</Ariakit.DialogDismiss>
+      </Ariakit.Dialog>
+    </>
+  );
+}

--- a/app/src/sandbox/dialog-3488/preview.astro
+++ b/app/src/sandbox/dialog-3488/preview.astro
@@ -1,0 +1,14 @@
+---
+import PreviewFramework from "#app/components/preview-framework.astro";
+import ReactExample from "./index.react.tsx";
+
+import sourceReact from "./index.react.tsx?source";
+
+export const source = {
+  react: sourceReact,
+};
+---
+
+<PreviewFramework>
+  <ReactExample client:load slot="react" />
+</PreviewFramework>

--- a/app/src/sandbox/dialog-3488/preview.mdx
+++ b/app/src/sandbox/dialog-3488/preview.mdx
@@ -1,0 +1,9 @@
+---
+title: "dialog-3488"
+frameworks:
+  - react
+---
+
+import Preview from "./preview.astro";
+
+<Preview />

--- a/app/src/sandbox/dialog-3488/style.css
+++ b/app/src/sandbox/dialog-3488/style.css
@@ -1,0 +1,8 @@
+.dialog-3488 {
+  opacity: 0;
+  transition: opacity 200ms ease;
+}
+
+.dialog-3488[data-enter] {
+  opacity: 1;
+}

--- a/app/src/sandbox/dialog-3488/test-browser.ts
+++ b/app/src/sandbox/dialog-3488/test-browser.ts
@@ -52,6 +52,26 @@ withFramework(import.meta.dirname, async ({ test }) => {
       .toBeHidden();
     await test.expect(q.text("Close count: 4")).toBeVisible();
 
+    await q.button("Show modal").click();
+    await test.expect(q.dialog("Success")).toBeVisible();
+
+    await q.button("Close programmatically with setOpen").click();
+
+    await test
+      .expect(q.dialog("Success", { includeHidden: true }))
+      .toBeHidden();
+    await test.expect(q.text("Close count: 4")).toBeVisible();
+
+    await q.button("Show modal").click();
+    await test.expect(q.dialog("Success")).toBeVisible();
+
+    await q.button("Close programmatically with context").click();
+
+    await test
+      .expect(q.dialog("Success", { includeHidden: true }))
+      .toBeHidden();
+    await test.expect(q.text("Close count: 4")).toBeVisible();
+
     await q.button("Show popover").click();
     await test.expect(q.dialog("Popover content")).toBeVisible();
 

--- a/app/src/sandbox/dialog-3488/test-browser.ts
+++ b/app/src/sandbox/dialog-3488/test-browser.ts
@@ -1,0 +1,18 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("controlled store dialog calls onClose once when dismissed", async ({
+    q,
+  }) => {
+    // See https://github.com/ariakit/ariakit/issues/3488
+    await q.button("Show modal").click();
+    await test.expect(q.dialog("Success")).toBeVisible();
+
+    await q.button("OK").click();
+
+    await test
+      .expect(q.dialog("Success", { includeHidden: true }))
+      .toBeHidden();
+    await test.expect(q.text("Close count: 1")).toBeVisible();
+  });
+});

--- a/app/src/sandbox/dialog-3488/test-browser.ts
+++ b/app/src/sandbox/dialog-3488/test-browser.ts
@@ -85,12 +85,22 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await q.button("Show popover").click();
     await test.expect(q.dialog("Popover content")).toBeVisible();
 
-    await q.button("Close popover with explicit store").click();
+    await q.button("Close popover").click();
 
     await test
       .expect(q.dialog("Popover content", { includeHidden: true }))
       .toBeHidden();
     await test.expect(q.text("Popover close count: 1")).toBeVisible();
+
+    await q.button("Show popover").click();
+    await test.expect(q.dialog("Popover content")).toBeVisible();
+
+    await q.button("Close popover with explicit store").click();
+
+    await test
+      .expect(q.dialog("Popover content", { includeHidden: true }))
+      .toBeHidden();
+    await test.expect(q.text("Popover close count: 2")).toBeVisible();
 
     await q.button("Show parent dialog").click();
     await test.expect(q.dialog("Parent dialog")).toBeVisible();
@@ -115,5 +125,6 @@ withFramework(import.meta.dirname, async ({ test }) => {
       .expect(q.dialog("Parent dialog", { includeHidden: true }))
       .toBeHidden();
     await test.expect(q.text("Parent close count: 1")).toBeVisible();
+    await test.expect(q.text("Child close count: 1")).toBeVisible();
   });
 });

--- a/app/src/sandbox/dialog-3488/test-browser.ts
+++ b/app/src/sandbox/dialog-3488/test-browser.ts
@@ -12,6 +12,12 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await q.button("OK").click();
 
     await test
+      .expect(q.dialog("Success"))
+      .toHaveAttribute("data-leave", "true");
+    await page.keyboard.press("Escape");
+    await test.expect(q.text("Close count: 1")).toBeVisible();
+
+    await test
       .expect(q.dialog("Success", { includeHidden: true }))
       .toBeHidden();
     await test.expect(q.text("Close count: 1")).toBeVisible();
@@ -25,5 +31,35 @@ withFramework(import.meta.dirname, async ({ test }) => {
       .expect(q.dialog("Success", { includeHidden: true }))
       .toBeHidden();
     await test.expect(q.text("Close count: 2")).toBeVisible();
+
+    await q.button("Show modal").click();
+    await test.expect(q.dialog("Success")).toBeVisible();
+
+    await page.mouse.click(10, 10);
+
+    await test
+      .expect(q.dialog("Success", { includeHidden: true }))
+      .toBeHidden();
+    await test.expect(q.text("Close count: 3")).toBeVisible();
+
+    await q.button("Show modal").click();
+    await test.expect(q.dialog("Success")).toBeVisible();
+
+    await q.button("Close with explicit store").click();
+
+    await test
+      .expect(q.dialog("Success", { includeHidden: true }))
+      .toBeHidden();
+    await test.expect(q.text("Close count: 4")).toBeVisible();
+
+    await q.button("Show popover").click();
+    await test.expect(q.dialog("Popover content")).toBeVisible();
+
+    await q.button("Close popover with explicit store").click();
+
+    await test
+      .expect(q.dialog("Popover content", { includeHidden: true }))
+      .toBeHidden();
+    await test.expect(q.text("Popover close count: 1")).toBeVisible();
   });
 });

--- a/app/src/sandbox/dialog-3488/test-browser.ts
+++ b/app/src/sandbox/dialog-3488/test-browser.ts
@@ -2,6 +2,7 @@ import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
   test("controlled store dialog calls onClose once when dismissed", async ({
+    page,
     q,
   }) => {
     // See https://github.com/ariakit/ariakit/issues/3488
@@ -14,5 +15,15 @@ withFramework(import.meta.dirname, async ({ test }) => {
       .expect(q.dialog("Success", { includeHidden: true }))
       .toBeHidden();
     await test.expect(q.text("Close count: 1")).toBeVisible();
+
+    await q.button("Show modal").click();
+    await test.expect(q.dialog("Success")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+
+    await test
+      .expect(q.dialog("Success", { includeHidden: true }))
+      .toBeHidden();
+    await test.expect(q.text("Close count: 2")).toBeVisible();
   });
 });

--- a/app/src/sandbox/dialog-3488/test-browser.ts
+++ b/app/src/sandbox/dialog-3488/test-browser.ts
@@ -72,6 +72,16 @@ withFramework(import.meta.dirname, async ({ test }) => {
       .toBeHidden();
     await test.expect(q.text("Close count: 4")).toBeVisible();
 
+    await q.button("Show external dialog").click();
+    await test.expect(q.dialog("External dialog")).toBeVisible();
+
+    await q.button("Close external dialog").click();
+
+    await test
+      .expect(q.dialog("External dialog", { includeHidden: true }))
+      .toBeHidden();
+    await test.expect(q.text("External close count: 1")).toBeVisible();
+
     await q.button("Show popover").click();
     await test.expect(q.dialog("Popover content")).toBeVisible();
 
@@ -81,5 +91,29 @@ withFramework(import.meta.dirname, async ({ test }) => {
       .expect(q.dialog("Popover content", { includeHidden: true }))
       .toBeHidden();
     await test.expect(q.text("Popover close count: 1")).toBeVisible();
+
+    await q.button("Show parent dialog").click();
+    await test.expect(q.dialog("Parent dialog")).toBeVisible();
+
+    await q.button("Show child dialog").click();
+    await test.expect(q.dialog("Child dialog")).toBeVisible();
+
+    await q.button("Close child").click();
+
+    await test
+      .expect(q.dialog("Child dialog", { includeHidden: true }))
+      .toBeHidden();
+    await test.expect(q.text("Child close count: 1")).toBeVisible();
+    await test.expect(q.dialog("Parent dialog")).toBeVisible();
+
+    await q.button("Show child dialog").click();
+    await test.expect(q.dialog("Child dialog")).toBeVisible();
+
+    await q.button("Close parent from child").click();
+
+    await test
+      .expect(q.dialog("Parent dialog", { includeHidden: true }))
+      .toBeHidden();
+    await test.expect(q.text("Parent close count: 1")).toBeVisible();
   });
 });

--- a/packages/ariakit-react-components/src/dialog/dialog-context.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog-context.tsx
@@ -1,6 +1,6 @@
 import { createStoreContext } from "@ariakit/react-utils";
 import type { SetState } from "@ariakit/utils";
-import { createContext, useContext } from "react";
+import { createContext } from "react";
 import {
   DisclosureContextProvider,
   DisclosureScopedContextProvider,
@@ -35,11 +35,23 @@ export const DialogContextProvider = ctx.ContextProvider;
 
 export const DialogScopedContextProvider = ctx.ScopedContextProvider;
 
-export const DialogDismissContext = createContext<DialogStore["hide"] | null>(
-  null,
-);
+const dismisses = new WeakMap<DialogStore, DialogStore["hide"]>();
 
-export const useDialogDismissContext = () => useContext(DialogDismissContext);
+export function setDialogDismiss(
+  store: DialogStore,
+  hide: DialogStore["hide"],
+) {
+  dismisses.set(store, hide);
+  return () => {
+    if (dismisses.get(store) !== hide) return;
+    dismisses.delete(store);
+  };
+}
+
+export function getDialogDismiss(store?: DialogStore) {
+  if (!store) return;
+  return dismisses.get(store);
+}
 
 export const DialogHeadingContext = createContext<
   SetState<string | undefined> | undefined

--- a/packages/ariakit-react-components/src/dialog/dialog-context.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog-context.tsx
@@ -1,6 +1,6 @@
 import { createStoreContext } from "@ariakit/react-utils";
 import type { SetState } from "@ariakit/utils";
-import { createContext } from "react";
+import { createContext, useContext } from "react";
 import {
   DisclosureContextProvider,
   DisclosureScopedContextProvider,
@@ -34,6 +34,12 @@ export const useDialogProviderContext = ctx.useProviderContext;
 export const DialogContextProvider = ctx.ContextProvider;
 
 export const DialogScopedContextProvider = ctx.ScopedContextProvider;
+
+export const DialogDismissContext = createContext<DialogStore["hide"] | null>(
+  null,
+);
+
+export const useDialogDismissContext = () => useContext(DialogDismissContext);
 
 export const DialogHeadingContext = createContext<
   SetState<string | undefined> | undefined

--- a/packages/ariakit-react-components/src/dialog/dialog-dismiss.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog-dismiss.tsx
@@ -9,24 +9,12 @@ import type { ElementType, MouseEvent } from "react";
 import { useMemo } from "react";
 import type { ButtonOptions } from "../button/button.tsx";
 import { useButton } from "../button/button.tsx";
-import {
-  useDialogDismissContext,
-  useDialogScopedContext,
-} from "./dialog-context.tsx";
+import { getDialogDismiss, useDialogScopedContext } from "./dialog-context.tsx";
 import type { DialogStore } from "./dialog-store.ts";
 
 const TagName = "button" satisfies ElementType;
 type TagName = typeof TagName;
 type HTMLType = HTMLElementTagNameMap[TagName];
-
-function hasSameContentElement(store?: DialogStore, context?: DialogStore) {
-  if (!store) return false;
-  if (!context) return false;
-  if (store === context) return true;
-  const contentElement = store.getState().contentElement;
-  if (!contentElement) return false;
-  return contentElement === context.getState().contentElement;
-}
 
 /**
  * Returns props to create a `DialogDismiss` component.
@@ -43,16 +31,14 @@ function hasSameContentElement(store?: DialogStore, context?: DialogStore) {
 export const useDialogDismiss = createHook<TagName, DialogDismissOptions>(
   function useDialogDismiss({ store, ...props }) {
     const context = useDialogScopedContext();
-    const dismiss = useDialogDismissContext();
     store = store || context;
-    const hide =
-      hasSameContentElement(store, context) && dismiss ? dismiss : store?.hide;
 
     const onClickProp = props.onClick;
 
     const onClick = useEvent((event: MouseEvent<HTMLType>) => {
       onClickProp?.(event);
       if (event.defaultPrevented) return;
+      const hide = getDialogDismiss(store) || store?.hide;
       hide?.();
     });
 

--- a/packages/ariakit-react-components/src/dialog/dialog-dismiss.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog-dismiss.tsx
@@ -9,7 +9,10 @@ import type { ElementType, MouseEvent } from "react";
 import { useMemo } from "react";
 import type { ButtonOptions } from "../button/button.tsx";
 import { useButton } from "../button/button.tsx";
-import { useDialogScopedContext } from "./dialog-context.tsx";
+import {
+  useDialogDismissContext,
+  useDialogScopedContext,
+} from "./dialog-context.tsx";
 import type { DialogStore } from "./dialog-store.ts";
 
 const TagName = "button" satisfies ElementType;
@@ -40,18 +43,17 @@ function hasSameContentElement(store?: DialogStore, context?: DialogStore) {
 export const useDialogDismiss = createHook<TagName, DialogDismissOptions>(
   function useDialogDismiss({ store, ...props }) {
     const context = useDialogScopedContext();
-    if (hasSameContentElement(store, context)) {
-      store = context;
-    } else {
-      store = store || context;
-    }
+    const dismiss = useDialogDismissContext();
+    store = store || context;
+    const hide =
+      hasSameContentElement(store, context) && dismiss ? dismiss : store?.hide;
 
     const onClickProp = props.onClick;
 
     const onClick = useEvent((event: MouseEvent<HTMLType>) => {
       onClickProp?.(event);
       if (event.defaultPrevented) return;
-      store?.hide();
+      hide?.();
     });
 
     const children = useMemo(

--- a/packages/ariakit-react-components/src/dialog/dialog-dismiss.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog-dismiss.tsx
@@ -16,6 +16,15 @@ const TagName = "button" satisfies ElementType;
 type TagName = typeof TagName;
 type HTMLType = HTMLElementTagNameMap[TagName];
 
+function hasSameContentElement(store?: DialogStore, context?: DialogStore) {
+  if (!store) return false;
+  if (!context) return false;
+  if (store === context) return true;
+  const contentElement = store.getState().contentElement;
+  if (!contentElement) return false;
+  return contentElement === context.getState().contentElement;
+}
+
 /**
  * Returns props to create a `DialogDismiss` component.
  * @see https://ariakit.com/components/dialog
@@ -31,7 +40,11 @@ type HTMLType = HTMLElementTagNameMap[TagName];
 export const useDialogDismiss = createHook<TagName, DialogDismissOptions>(
   function useDialogDismiss({ store, ...props }) {
     const context = useDialogScopedContext();
-    store = store || context;
+    if (hasSameContentElement(store, context)) {
+      store = context;
+    } else {
+      store = store || context;
+    }
 
     const onClickProp = props.onClick;
 

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -49,9 +49,9 @@ import { usePortal } from "../portal/portal.tsx";
 import { DialogBackdrop } from "./dialog-backdrop.tsx";
 import {
   DialogDescriptionContext,
-  DialogDismissContext,
   DialogHeadingContext,
   DialogScopedContextProvider,
+  setDialogDismiss,
   useDialogProviderContext,
 } from "./dialog-context.tsx";
 import type { DialogStore } from "./dialog-store.ts";
@@ -151,6 +151,18 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     store.hide();
   });
   const scopedStore = useMemo(() => ({ ...store, hide }), [store, hide]);
+  useSafeLayoutEffect(() => {
+    const cleanups = [setDialogDismiss(store, hide)];
+    const sourceStore = storeProp || context;
+    if (sourceStore && sourceStore !== store) {
+      cleanups.push(setDialogDismiss(sourceStore, hide));
+    }
+    return () => {
+      for (const cleanup of cleanups) {
+        cleanup();
+      }
+    };
+  }, [context, store, storeProp, hide]);
 
   // domReady can be also the portal node element so it's updated when the
   // portal node changes (like in between re-renders), triggering effects
@@ -566,16 +578,14 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     props,
     (element) => (
       <DialogScopedContextProvider value={store}>
-        <DialogDismissContext.Provider value={hide}>
-          <DialogHeadingContext.Provider value={setHeadingId}>
-            <DialogDescriptionContext.Provider value={setDescriptionId}>
-              {element}
-            </DialogDescriptionContext.Provider>
-          </DialogHeadingContext.Provider>
-        </DialogDismissContext.Provider>
+        <DialogHeadingContext.Provider value={setHeadingId}>
+          <DialogDescriptionContext.Provider value={setDescriptionId}>
+            {element}
+          </DialogDescriptionContext.Provider>
+        </DialogHeadingContext.Provider>
       </DialogScopedContextProvider>
     ),
-    [store, hide],
+    [store],
   );
 
   props = {

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -34,7 +34,7 @@ import type {
   RefObject,
   SyntheticEvent,
 } from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { DisclosureContentOptions } from "../disclosure/disclosure-content.tsx";
 import {
   isHidden,
@@ -121,23 +121,35 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
 }) {
   const context = useDialogProviderContext();
   const ref = useRef<HTMLType>(null);
+  // Tracks whether the dialog was hidden by an outside click or context menu.
+  // When true, focusOnHide skips focus restoration to match native HTML
+  // behavior where trigger buttons don't receive focus when you click outside.
+  // Reset when the dialog opens to avoid stale flags from prevented closes
+  // (e.g., onClose calling event.preventDefault), async closes with
+  // animations, or when autoFocusOnHide is disabled.
+  const interactedOutsideRef = useRef(false);
 
   const store = useDialogStore({
     store: storeProp || context,
     open: openProp,
-    setOpen(open) {
-      if (open) return;
-      const dialog = ref.current;
-      if (!dialog) return;
+  });
+  const hide = useEvent(() => {
+    if (!store.getState().open) return;
+    const dialog = ref.current;
+    if (dialog) {
       const event = new Event("close", { bubbles: false, cancelable: true });
       if (onClose) {
         dialog.addEventListener("close", onClose, { once: true });
       }
       dialog.dispatchEvent(event);
-      if (!event.defaultPrevented) return;
-      store.setOpen(true);
-    },
+      if (event.defaultPrevented) {
+        interactedOutsideRef.current = false;
+        return;
+      }
+    }
+    store.hide();
   });
+  const scopedStore = useMemo(() => ({ ...store, hide }), [store, hide]);
 
   // domReady can be also the portal node element so it's updated when the
   // portal node changes (like in between re-renders), triggering effects
@@ -158,13 +170,6 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
 
   usePreventBodyScroll(contentElement, id, preventBodyScroll && !hidden);
 
-  // Tracks whether the dialog was hidden by an outside click or context menu.
-  // When true, focusOnHide skips focus restoration to match native HTML
-  // behavior where trigger buttons don't receive focus when you click outside.
-  // Reset when the dialog opens to avoid stale flags from prevented closes
-  // (e.g., onClose calling event.preventDefault), async closes with
-  // animations, or when autoFocusOnHide is disabled.
-  const interactedOutsideRef = useRef(false);
   useSafeLayoutEffect(() => {
     return sync(store, ["open"], (state) => {
       if (!state.open) return;
@@ -172,7 +177,7 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     });
   }, [store]);
   useHideOnInteractOutside(
-    store,
+    scopedStore,
     hideOnInteractOutside,
     domReady,
     interactedOutsideRef,
@@ -259,8 +264,8 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     // If there's already a DialogDismiss component, it does nothing.
     const existingDismiss = dialog.querySelector("[data-dialog-dismiss]");
     if (existingDismiss) return;
-    return prependHiddenDismiss(dialog, store.hide);
-  }, [store, modal, mounted, domReady]);
+    return prependHiddenDismiss(dialog, hide);
+  }, [hide, modal, mounted, domReady]);
 
   // When the dialog is animated, the open state will be false and the mounted
   // state will be true. The dialog will still be visible until the animation is
@@ -511,7 +516,7 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
       };
       if (!isValidTarget()) return;
       if (!hideOnEscapeProp(event)) return;
-      store.hide();
+      hide();
     };
     // We're attatching the listener to the document instead of the dialog
     // element so we can listen to the Escape key anywhere in the document, even
@@ -519,7 +524,7 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     // call `event.stopPropagation()` on the `hideOnEscape` function prop.
     const win = contentElement ? getWindow(contentElement) : undefined;
     return addGlobalEventListener("keydown", onKeyDown, true, win);
-  }, [store, domReady, mounted, contentElement, hideOnEscapeProp]);
+  }, [store, domReady, mounted, contentElement, hideOnEscapeProp, hide]);
 
   // Resets the heading levels inside the modal dialog so they start with h1.
   props = useWrapElement(
@@ -559,7 +564,7 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
   props = useWrapElement(
     props,
     (element) => (
-      <DialogScopedContextProvider value={store}>
+      <DialogScopedContextProvider value={scopedStore}>
         <DialogHeadingContext.Provider value={setHeadingId}>
           <DialogDescriptionContext.Provider value={setDescriptionId}>
             {element}
@@ -567,7 +572,7 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
         </DialogHeadingContext.Provider>
       </DialogScopedContextProvider>
     ),
-    [store],
+    [scopedStore],
   );
 
   props = {
@@ -687,13 +692,16 @@ export interface DialogOptions<T extends ElementType = TagName>
    * event. The only difference is that this event can be canceled with
    * `event.preventDefault()`, which will prevent the dialog from hiding.
    *
-   * It's important to note that this event only fires when the dialog store's
+   * It's important to note that this event only fires when the dialog is
+   * requested to close through Ariakit's built-in dismiss mechanisms, such as
+   * [`DialogDismiss`](https://ariakit.com/reference/dialog-dismiss), pressing
+   * the <kbd>Esc</kbd> key, or interacting outside the dialog. If the
+   * controlled [`open`](https://ariakit.com/reference/dialog#open) prop value
+   * changes, the store
    * [`open`](https://ariakit.com/reference/use-dialog-store#open) state is set
-   * to `false`. If the controlled
-   * [`open`](https://ariakit.com/reference/dialog#open) prop value changes, or
-   * if the dialog's visibility is altered in any other way (such as unmounting
-   * the dialog without adjusting the open state), this event won't be
-   * triggered.
+   * programmatically, or if the dialog's visibility is altered in any other way
+   * (such as unmounting the dialog without adjusting the open state), this
+   * event won't be triggered.
    *
    * Live examples:
    * - [Dialog with scrollable

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -49,6 +49,7 @@ import { usePortal } from "../portal/portal.tsx";
 import { DialogBackdrop } from "./dialog-backdrop.tsx";
 import {
   DialogDescriptionContext,
+  DialogDismissContext,
   DialogHeadingContext,
   DialogScopedContextProvider,
   useDialogProviderContext,
@@ -564,15 +565,17 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
   props = useWrapElement(
     props,
     (element) => (
-      <DialogScopedContextProvider value={scopedStore}>
-        <DialogHeadingContext.Provider value={setHeadingId}>
-          <DialogDescriptionContext.Provider value={setDescriptionId}>
-            {element}
-          </DialogDescriptionContext.Provider>
-        </DialogHeadingContext.Provider>
+      <DialogScopedContextProvider value={store}>
+        <DialogDismissContext.Provider value={hide}>
+          <DialogHeadingContext.Provider value={setHeadingId}>
+            <DialogDescriptionContext.Provider value={setDescriptionId}>
+              {element}
+            </DialogDescriptionContext.Provider>
+          </DialogHeadingContext.Provider>
+        </DialogDismissContext.Provider>
       </DialogScopedContextProvider>
     ),
-    [scopedStore],
+    [store, hide],
   );
 
   props = {
@@ -695,13 +698,13 @@ export interface DialogOptions<T extends ElementType = TagName>
    * It's important to note that this event only fires when the dialog is
    * requested to close through Ariakit's built-in dismiss mechanisms, such as
    * [`DialogDismiss`](https://ariakit.com/reference/dialog-dismiss), pressing
-   * the <kbd>Esc</kbd> key, or interacting outside the dialog. If the
-   * controlled [`open`](https://ariakit.com/reference/dialog#open) prop value
-   * changes, the store
-   * [`open`](https://ariakit.com/reference/use-dialog-store#open) state is set
-   * programmatically, or if the dialog's visibility is altered in any other way
-   * (such as unmounting the dialog without adjusting the open state), this
-   * event won't be triggered.
+   * the <kbd>Esc</kbd> key, or interacting outside the dialog. It doesn't fire
+   * when the dialog's visibility changes programmatically, including when a
+   * controlled [`open`](https://ariakit.com/reference/dialog#open) prop changes,
+   * when [`useDialogStore`](https://ariakit.com/reference/use-dialog-store)
+   * receives a new `open` value, when `setOpen(false)` or `store.hide()` updates
+   * controlled state directly, or when the dialog is unmounted without going
+   * through one of Ariakit's dismiss mechanisms.
    *
    * Live examples:
    * - [Dialog with scrollable

--- a/packages/ariakit-react-components/src/popover/popover.tsx
+++ b/packages/ariakit-react-components/src/popover/popover.tsx
@@ -443,6 +443,16 @@ export const usePopover = createHook<TagName, PopoverOptions>(
       [store, position, wrapperProps],
     );
 
+    props = useWrapElement(
+      props,
+      (element) => (
+        <PopoverScopedContextProvider value={store}>
+          {element}
+        </PopoverScopedContextProvider>
+      ),
+      [store],
+    );
+
     props = {
       // data-placing is not part of the public API. We're setting this here so
       // we can wait for the popover to be positioned before other components
@@ -466,16 +476,6 @@ export const usePopover = createHook<TagName, PopoverOptions>(
       ...props,
       portalRef,
     });
-
-    props = useWrapElement(
-      props,
-      (element) => (
-        <PopoverScopedContextProvider value={store}>
-          {element}
-        </PopoverScopedContextProvider>
-      ),
-      [store],
-    );
 
     return props;
   },

--- a/packages/ariakit-react-components/src/popover/popover.tsx
+++ b/packages/ariakit-react-components/src/popover/popover.tsx
@@ -443,16 +443,6 @@ export const usePopover = createHook<TagName, PopoverOptions>(
       [store, position, wrapperProps],
     );
 
-    props = useWrapElement(
-      props,
-      (element) => (
-        <PopoverScopedContextProvider value={store}>
-          {element}
-        </PopoverScopedContextProvider>
-      ),
-      [store],
-    );
-
     props = {
       // data-placing is not part of the public API. We're setting this here so
       // we can wait for the popover to be positioned before other components
@@ -476,6 +466,16 @@ export const usePopover = createHook<TagName, PopoverOptions>(
       ...props,
       portalRef,
     });
+
+    props = useWrapElement(
+      props,
+      (element) => (
+        <PopoverScopedContextProvider value={store}>
+          {element}
+        </PopoverScopedContextProvider>
+      ),
+      [store],
+    );
 
     return props;
   },


### PR DESCRIPTION
## Motivation

`Dialog` calls `onClose` again when a controlled `open` value passed through `useDialogStore` changes as part of handling a close. This can keep the dialog open and prevents consumers from distinguishing user-initiated closes from programmatic state updates.

## Solution

The `Dialog` close event now runs only for Ariakit's built-in dismiss paths, such as `DialogDismiss`, Escape, outside interactions, and related popover dismissers. Programmatic controlled store updates, including `setOpen(false)` calls from inside `onClose`, no longer re-dispatch `onClose`.

The fix routes built-in dismiss behavior through a scoped `hide` wrapper that dispatches the cancelable `close` event before hiding. Scoped dismissers still respect `event.preventDefault()`, avoid stale outside-interaction state after canceled closes, and no-op while the store is already closing during animated leave.

The regression sandbox covers dismiss button, Escape, outside click, explicit store dismissers, animated leave, and popover-derived dismissers.

## Workaround

When using a controlled `useDialogStore` with an `onClose` handler that calls `event.preventDefault()`, defer the controlled `setOpen(false)` call and guard the programmatic follow-up close event:

```tsx
const closingRef = useRef(false);
const dialog = Ariakit.useDialogStore({ open, setOpen });

<Ariakit.Dialog
  store={dialog}
  onClose={(event) => {
    // TODO: Remove this guard once
    // https://github.com/ariakit/ariakit/issues/3488 is fixed. Deferring
    // the controlled close keeps the programmatic update from running
    // this handler again.
    if (closingRef.current) return;
    event.preventDefault();
    closingRef.current = true;
    queueMicrotask(() => {
      setOpen(false);
      closingRef.current = false;
    });
  }}
/>
```
