### PR TITLE
Add generated utils API docs

### DIFF
--- a/packages/ariakit-scripts/package.json
+++ b/packages/ariakit-scripts/package.json
@@ -14,6 +14,7 @@
     "commander": "14.0.3",
     "rolldown": "1.0.2",
     "rolldown-plugin-dts": "0.25.1",
+    "ts-morph": "28.0.0",
     "vite-plugin-solid": "2.11.12"
   },
   "devDependencies": {

--- a/packages/ariakit-scripts/src/docs.test.ts
+++ b/packages/ariakit-scripts/src/docs.test.ts
@@ -125,6 +125,29 @@ test("omits the table of contents when modules are missing", () => {
   expect(markdown).not.toContain("### Foo exports");
 });
 
+test("uses later JSDoc descriptions after tag-only blocks", () => {
+  const root = createPackage();
+  const sourcePath = join(root, "src");
+  writeFileSync(join(sourcePath, "index.ts"), 'export * from "./foo.ts";\n');
+  writeFileSync(
+    join(sourcePath, "foo.ts"),
+    [
+      "/** @deprecated Use bar instead. */",
+      "/**",
+      " * The real description.",
+      " */",
+      "export function foo() {",
+      "  return true;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+
+  const markdown = generateDocsMarkdown({ rootPath: root });
+
+  expect(markdown).toContain("The real description.");
+});
+
 test("groups untagged exports separately when modules are present", () => {
   const root = createPackage();
   const sourcePath = join(root, "src");
@@ -241,17 +264,19 @@ test("includes local private types referenced by public signatures", () => {
       " * @module Value utilities",
       " */",
       "",
-      "type Value<T> = T | undefined;",
+      "type T = string;",
+      "",
+      "type $Value<T> = T | undefined;",
       "",
       "interface Options {",
-      "  value?: Value<string>;",
+      "  value?: $Value<string>;",
       "}",
       "",
       "/** Creates a value. */",
       "export function createValue<T>(",
       "  { value }: Options = {},",
-      "): Value<T> {",
-      "  return value as Value<T>;",
+      "): $Value<T> {",
+      "  return value as $Value<T>;",
       "}",
       "",
     ].join("\n"),
@@ -259,12 +284,62 @@ test("includes local private types referenced by public signatures", () => {
 
   const markdown = generateDocsMarkdown({ rootPath: root });
 
-  expect(markdown).toContain("type Value<T> = T | undefined;");
+  expect(markdown).toContain("type $Value<T> = T | undefined;");
+  expect(markdown).not.toContain("type T = string;");
   expect(markdown).toContain("interface Options");
-  expect(markdown).toContain("value?: Value<string>;");
+  expect(markdown).toContain("value?: $Value<string>;");
   expect(markdown).toContain(
-    "function createValue<T>({ value }: Options = {}): Value<T>;",
+    "function createValue<T>({ value }: Options = {}): $Value<T>;",
   );
+});
+
+test("does not include private types shadowed by type parameters", () => {
+  const root = createPackage();
+  const sourcePath = join(root, "src");
+  writeFileSync(join(sourcePath, "index.ts"), 'export * from "./value.ts";\n');
+  writeFileSync(
+    join(sourcePath, "value.ts"),
+    [
+      "type T = string;",
+      "",
+      "/** Generic value. */",
+      "export type Value<T> = {",
+      "  value: T;",
+      "};",
+      "",
+    ].join("\n"),
+  );
+
+  const markdown = generateDocsMarkdown({ rootPath: root });
+
+  expect(markdown).toContain("type Value<T> = {");
+  expect(markdown).not.toContain("type T = string;");
+});
+
+test("includes private types referenced by non-generic overloads", () => {
+  const root = createPackage();
+  const sourcePath = join(root, "src");
+  writeFileSync(join(sourcePath, "index.ts"), 'export * from "./value.ts";\n');
+  writeFileSync(
+    join(sourcePath, "value.ts"),
+    [
+      "type T = string;",
+      "",
+      "/** Gets a value. */",
+      "export function getValue<T>(value: T): T;",
+      "export function getValue(): T;",
+      "export function getValue(value?: unknown) {",
+      "  return value;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+
+  const markdown = generateDocsMarkdown({ rootPath: root });
+
+  expect(markdown).toContain("type T = string;");
+  expect(markdown).toContain("function getValue<T>(value: T): T;");
+  expect(markdown).toContain("function getValue(): T;");
 });
 
 test("truncates oversized TypeScript declarations", () => {

--- a/packages/ariakit-scripts/src/docs.test.ts
+++ b/packages/ariakit-scripts/src/docs.test.ts
@@ -1,0 +1,344 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, test } from "vitest";
+import { generateDocsMarkdown, injectDocsMarkdown } from "./docs.ts";
+
+const roots: string[] = [];
+
+function createPackage() {
+  const root = mkdtempSync(join(tmpdir(), "ariakit-docs-"));
+  roots.push(root);
+
+  writeFileSync(
+    join(root, "tsconfig.node.json"),
+    JSON.stringify({
+      compilerOptions: {
+        module: "NodeNext",
+        moduleResolution: "NodeNext",
+        strict: true,
+        target: "ESNext",
+      },
+      include: ["src"],
+    }),
+  );
+  mkdirSync(join(root, "src"));
+
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("generates markdown from exported JSDoc and TypeScript declarations", () => {
+  const root = createPackage();
+  const sourcePath = join(root, "src");
+  writeFileSync(
+    join(sourcePath, "index.ts"),
+    [
+      'export * from "./facade.ts";',
+      'export { add } from "./math.ts";',
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(join(sourcePath, "facade.ts"), 'export * from "./math.ts";\n');
+  writeFileSync(
+    join(sourcePath, "math.ts"),
+    [
+      "/**",
+      " * Math helpers.",
+      " * @module Math utilities",
+      " */",
+      "",
+      "/**",
+      " * Adds two numbers.",
+      " * @example",
+      " * add(1, 2); // 3",
+      " */",
+      "export function add(a: number, b: number) {",
+      "  return a + b;",
+      "}",
+      "",
+      "/**",
+      " * Subtracts two numbers.",
+      " * @example",
+      " * ```ts",
+      " * subtract(2, 1);",
+      " * ```",
+      " */",
+      "export function subtract(a: number, b: number) {",
+      "  return a - b;",
+      "}",
+      "",
+      "/** User name. */",
+      "export type UserName = string;",
+      "",
+    ].join("\n"),
+  );
+
+  const markdown = generateDocsMarkdown({ rootPath: root });
+
+  expect(markdown).toContain("## API reference");
+  expect(markdown).toContain("- [Math utilities](#math-utilities)");
+  expect(markdown).toContain("### Math utilities");
+  expect(markdown).toContain("Math helpers.");
+  expect(markdown).toContain("#### `add`");
+  expect(markdown).toContain("function add(a: number, b: number): number;");
+  expect(markdown).toContain("Adds two numbers.");
+  expect(markdown).toContain("add(1, 2); // 3");
+  expect(markdown.match(/#### `add`/g)).toHaveLength(1);
+  expect(markdown).toContain("#### `subtract`");
+  expect(markdown).toContain("```ts\nsubtract(2, 1);\n```");
+  expect(markdown).not.toContain("```ts\n```ts");
+  expect(markdown).toContain("#### `UserName`");
+  expect(markdown).not.toContain("| Utility");
+});
+
+test("omits the table of contents when modules are missing", () => {
+  const root = createPackage();
+  const sourcePath = join(root, "src");
+  writeFileSync(join(sourcePath, "index.ts"), 'export * from "./foo.ts";\n');
+  writeFileSync(
+    join(sourcePath, "foo.ts"),
+    [
+      "/** Foo helper. */",
+      "export function foo() {",
+      "  return true;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+
+  const markdown = generateDocsMarkdown({ rootPath: root });
+
+  expect(markdown).toContain("#### `foo`");
+  expect(markdown).not.toContain("- [Foo exports]");
+  expect(markdown).not.toContain("### Foo exports");
+});
+
+test("groups untagged exports separately when modules are present", () => {
+  const root = createPackage();
+  const sourcePath = join(root, "src");
+  writeFileSync(
+    join(sourcePath, "index.ts"),
+    ['export * from "./foo.ts";', 'export * from "./bar.ts";', ""].join("\n"),
+  );
+  writeFileSync(
+    join(sourcePath, "foo.ts"),
+    [
+      "/**",
+      " * Foo helpers.",
+      " * @module Foo utilities",
+      " */",
+      "",
+      "/** Foo helper. */",
+      "export function foo() {",
+      "  return true;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(
+    join(sourcePath, "bar.ts"),
+    [
+      "/** Bar helper. */",
+      "export function bar() {",
+      "  return false;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+
+  const markdown = generateDocsMarkdown({ rootPath: root });
+
+  expect(markdown).toContain("- [Foo utilities](#foo-utilities)");
+  expect(markdown).toContain("- [Other exports](#other-exports)");
+  expect(markdown).toContain("### Foo utilities");
+  expect(markdown).toContain("### Other exports");
+  expect(markdown).toContain("#### `foo`");
+  expect(markdown).toContain("#### `bar`");
+});
+
+test("injects generated markdown into a readme", () => {
+  const root = createPackage();
+  const sourcePath = join(root, "src");
+  writeFileSync(join(sourcePath, "index.ts"), 'export * from "./foo.ts";\n');
+  writeFileSync(
+    join(sourcePath, "foo.ts"),
+    [
+      "/** Foo helper. */",
+      "export function foo() {",
+      "  return true;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(
+    join(root, "readme.md"),
+    [
+      "# Test",
+      "",
+      "<!-- ariakit-docs:start -->",
+      "Old docs",
+      "<!-- ariakit-docs:end -->",
+      "",
+    ].join("\n"),
+  );
+
+  injectDocsMarkdown({ rootPath: root });
+
+  const readme = readFileSync(join(root, "readme.md"), "utf-8");
+  expect(readme).toContain("<!-- ariakit-docs:start -->");
+  expect(readme).toContain("<!-- ariakit-docs:end -->");
+  expect(readme).toContain("#### `foo`");
+  expect(readme).toContain("Foo helper.");
+  expect(readme).not.toContain("Old docs");
+});
+
+test("appends generated markdown to a readme without markers", () => {
+  const root = createPackage();
+  const sourcePath = join(root, "src");
+  writeFileSync(join(sourcePath, "index.ts"), 'export * from "./foo.ts";\n');
+  writeFileSync(
+    join(sourcePath, "foo.ts"),
+    [
+      "/** Foo helper. */",
+      "export function foo() {",
+      "  return true;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(join(root, "readme.md"), ["# Test", ""].join("\n"));
+
+  injectDocsMarkdown({ rootPath: root });
+
+  const readme = readFileSync(join(root, "readme.md"), "utf-8");
+  expect(readme).toContain("# Test");
+  expect(readme).toContain("<!-- ariakit-docs:start -->");
+  expect(readme).toContain("#### `foo`");
+  expect(readme).toContain("<!-- ariakit-docs:end -->");
+});
+
+test("includes local private types referenced by public signatures", () => {
+  const root = createPackage();
+  const sourcePath = join(root, "src");
+  writeFileSync(join(sourcePath, "index.ts"), 'export * from "./value.ts";\n');
+  writeFileSync(
+    join(sourcePath, "value.ts"),
+    [
+      "/**",
+      " * Value helpers.",
+      " * @module Value utilities",
+      " */",
+      "",
+      "type Value<T> = T | undefined;",
+      "",
+      "interface Options {",
+      "  value?: Value<string>;",
+      "}",
+      "",
+      "/** Creates a value. */",
+      "export function createValue<T>(",
+      "  { value }: Options = {},",
+      "): Value<T> {",
+      "  return value as Value<T>;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+
+  const markdown = generateDocsMarkdown({ rootPath: root });
+
+  expect(markdown).toContain("type Value<T> = T | undefined;");
+  expect(markdown).toContain("interface Options");
+  expect(markdown).toContain("value?: Value<string>;");
+  expect(markdown).toContain(
+    "function createValue<T>({ value }: Options = {}): Value<T>;",
+  );
+});
+
+test("truncates oversized TypeScript declarations", () => {
+  const root = createPackage();
+  const sourcePath = join(root, "src");
+  const roleValues = Array.from({ length: 35 }, (_, index) => {
+    const suffix = index === 34 ? ";" : "";
+    return `  | "item-${index + 1}"${suffix}`;
+  });
+
+  writeFileSync(join(sourcePath, "index.ts"), 'export * from "./roles.ts";\n');
+  writeFileSync(
+    join(sourcePath, "roles.ts"),
+    [
+      "/**",
+      " * Role helpers.",
+      " * @module Role utilities",
+      " */",
+      "",
+      "/** Supported role names. */",
+      "export type Role =",
+      ...roleValues,
+      "",
+    ].join("\n"),
+  );
+
+  const markdown = generateDocsMarkdown({ rootPath: root });
+
+  expect(markdown).toContain("#### `Role`");
+  expect(markdown).toContain("type Role =");
+  expect(markdown).toContain('  | "item-1"');
+  expect(markdown).toContain("// ...");
+  expect(markdown).toContain('  | "item-35";');
+  expect(markdown).not.toContain('  | "item-20"');
+  expect(markdown).toContain("Supported role names.");
+});
+
+test("throws on partial readme markers", () => {
+  const root = createPackage();
+  const sourcePath = join(root, "src");
+  writeFileSync(join(sourcePath, "index.ts"), 'export * from "./foo.ts";\n');
+  writeFileSync(
+    join(sourcePath, "foo.ts"),
+    [
+      "/** Foo helper. */",
+      "export function foo() {",
+      "  return true;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(
+    join(root, "readme.md"),
+    ["# Test", "", "<!-- ariakit-docs:start -->", ""].join("\n"),
+  );
+
+  expect(() => injectDocsMarkdown({ rootPath: root })).toThrow(
+    "must be present",
+  );
+});
+
+test("@ariakit/utils readme docs are up to date", () => {
+  const root = join(process.cwd(), "packages/ariakit-utils");
+  const readme = readFileSync(join(root, "readme.md"), "utf-8");
+  const startMarker = "<!-- ariakit-docs:start -->";
+  const endMarker = "<!-- ariakit-docs:end -->";
+  const startIndex = readme.indexOf(startMarker);
+  const endIndex = readme.indexOf(endMarker);
+  const markdown = generateDocsMarkdown({ rootPath: root }).trimEnd();
+  const readmeMarkdown = readme
+    .slice(startIndex + startMarker.length, endIndex)
+    .trim();
+
+  expect(startIndex).toBeGreaterThanOrEqual(0);
+  expect(endIndex).toBeGreaterThan(startIndex);
+  expect(readmeMarkdown).toBe(markdown);
+});

--- a/packages/ariakit-scripts/src/docs.ts
+++ b/packages/ariakit-scripts/src/docs.ts
@@ -1,14 +1,12 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, extname, isAbsolute, join, resolve } from "node:path";
-import {
-  Node,
-  Project,
-  SyntaxKind,
-  type FunctionDeclaration,
-  type InterfaceDeclaration,
-  type SourceFile,
-  type TypeAliasDeclaration,
+import { Node, Project, SyntaxKind } from "ts-morph";
+import type {
+  FunctionDeclaration,
+  InterfaceDeclaration,
+  SourceFile,
+  TypeAliasDeclaration,
 } from "ts-morph";
 
 interface GenerateDocsOptions {
@@ -52,6 +50,11 @@ interface JsDocTag {
 interface ModuleInfo {
   description?: string;
   title: string;
+}
+
+interface SignatureItem {
+  declarations: Node[];
+  text: string;
 }
 
 type LocalTypeDeclaration = InterfaceDeclaration | TypeAliasDeclaration;
@@ -217,12 +220,14 @@ function getApiGroups(entrySourceFile: SourceFile) {
 }
 
 function normalizeComment(text: string | undefined) {
-  return text
+  const result = text
     ?.trim()
     .split(/\n\s*\n/g)
     .map((paragraph) => paragraph.replace(/\s*\n\s*/g, " ").trim())
     .filter(Boolean)
     .join("\n\n");
+
+  return result || undefined;
 }
 
 function normalizeJsDocTagText(text: string) {
@@ -365,8 +370,33 @@ function getLocalTypeDeclarations(sourceFile: SourceFile) {
     .sort((a, b) => a.getStart() - b.getStart());
 }
 
+function escapeRegExp(text: string) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function getTypeParameterNames(declaration: Node) {
+  const names = new Set<string>();
+
+  if (
+    !Node.isFunctionDeclaration(declaration) &&
+    !Node.isInterfaceDeclaration(declaration) &&
+    !Node.isTypeAliasDeclaration(declaration)
+  ) {
+    return names;
+  }
+
+  for (const typeParameter of declaration.getTypeParameters()) {
+    names.add(typeParameter.getName());
+  }
+
+  return names;
+}
+
 function referencesIdentifier(text: string, name: string) {
-  return new RegExp(`\\b${name}\\b`).test(text);
+  const identifierCharacter = "A-Za-z0-9_$";
+  return new RegExp(
+    `(^|[^${identifierCharacter}])${escapeRegExp(name)}(?=$|[^${identifierCharacter}])`,
+  ).test(text);
 }
 
 function formatLocalTypeDeclaration(declaration: LocalTypeDeclaration) {
@@ -375,31 +405,54 @@ function formatLocalTypeDeclaration(declaration: LocalTypeDeclaration) {
   );
 }
 
-function getReferencedLocalTypes(text: string, declarations: Node[]) {
-  const localTypes = new Map<string, LocalTypeDeclaration>();
+function getSignatureTypeParameterNames(declarations: Node[]) {
+  const names = new Set<string>();
   for (const declaration of declarations) {
-    for (const localType of getLocalTypeDeclarations(
-      declaration.getSourceFile(),
-    )) {
-      const path = localType.getSourceFile().getFilePath();
-      localTypes.set(`${path}:${localType.getName()}`, localType);
+    for (const name of getTypeParameterNames(declaration)) {
+      names.add(name);
     }
   }
+  return names;
+}
+
+function getReferencedLocalTypes(items: SignatureItem[]) {
+  const localTypes = new Map<string, LocalTypeDeclaration>();
+  for (const item of items) {
+    for (const declaration of item.declarations) {
+      for (const localType of getLocalTypeDeclarations(
+        declaration.getSourceFile(),
+      )) {
+        const path = localType.getSourceFile().getFilePath();
+        localTypes.set(`${path}:${localType.getName()}`, localType);
+      }
+    }
+  }
+
+  const searchItems = items.map((item) => ({
+    ...item,
+    typeParameterNames: getSignatureTypeParameterNames(item.declarations),
+  }));
   const referencedTypes = new Map<string, LocalTypeDeclaration>();
-  let searchText = text;
 
   let foundReference = true;
   while (foundReference) {
     foundReference = false;
 
-    for (const [key, declaration] of localTypes) {
-      const name = declaration.getName();
-      if (referencedTypes.has(key)) continue;
-      if (!referencesIdentifier(searchText, name)) continue;
+    for (const item of searchItems) {
+      for (const [key, declaration] of localTypes) {
+        const name = declaration.getName();
+        if (referencedTypes.has(key)) continue;
+        if (item.typeParameterNames.has(name)) continue;
+        if (!referencesIdentifier(item.text, name)) continue;
 
-      referencedTypes.set(key, declaration);
-      searchText += `\n${declaration.getText()}`;
-      foundReference = true;
+        referencedTypes.set(key, declaration);
+        searchItems.push({
+          declarations: [declaration],
+          text: declaration.getText(),
+          typeParameterNames: getTypeParameterNames(declaration),
+        });
+        foundReference = true;
+      }
     }
   }
 
@@ -408,11 +461,9 @@ function getReferencedLocalTypes(text: string, declarations: Node[]) {
   );
 }
 
-function addReferencedLocalTypes(signatures: string[], declarations: Node[]) {
-  const referencedTypes = getReferencedLocalTypes(
-    signatures.join("\n"),
-    declarations,
-  );
+function addReferencedLocalTypes(items: SignatureItem[]) {
+  const referencedTypes = getReferencedLocalTypes(items);
+  const signatures = items.map((item) => item.text);
   const localTypeSignatures = referencedTypes
     .map(formatLocalTypeDeclaration)
     .join("\n\n");
@@ -447,8 +498,12 @@ function getEntrySignatures(entry: ApiEntry) {
     entry.declarations,
   );
   if (functionDeclarations.length) {
-    const signatures = functionDeclarations.map(formatFunctionSignature);
-    return addReferencedLocalTypes(signatures, functionDeclarations);
+    return addReferencedLocalTypes(
+      functionDeclarations.map((declaration) => ({
+        declarations: [declaration],
+        text: formatFunctionSignature(declaration),
+      })),
+    );
   }
 
   const [declaration] = entry.declarations;
@@ -456,16 +511,20 @@ function getEntrySignatures(entry: ApiEntry) {
 
   const variableSignature = formatVariableSignature(declaration);
   if (variableSignature) {
-    return addReferencedLocalTypes(
-      [truncateDeclarationText(variableSignature)],
-      [declaration],
-    );
+    return addReferencedLocalTypes([
+      {
+        declarations: [declaration],
+        text: truncateDeclarationText(variableSignature),
+      },
+    ]);
   }
 
-  return addReferencedLocalTypes(
-    [formatDeclarationText(declaration)],
-    [declaration],
-  );
+  return addReferencedLocalTypes([
+    {
+      declarations: [declaration],
+      text: formatDeclarationText(declaration),
+    },
+  ]);
 }
 
 function renderCodeBlock(code: string) {

--- a/packages/ariakit-scripts/src/docs.ts
+++ b/packages/ariakit-scripts/src/docs.ts
@@ -1,0 +1,616 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, extname, isAbsolute, join, resolve } from "node:path";
+import {
+  Node,
+  Project,
+  SyntaxKind,
+  type FunctionDeclaration,
+  type InterfaceDeclaration,
+  type SourceFile,
+  type TypeAliasDeclaration,
+} from "ts-morph";
+
+interface GenerateDocsOptions {
+  rootPath?: string;
+  entry?: string;
+  tsconfig?: string;
+}
+
+interface InjectDocsOptions extends GenerateDocsOptions {
+  readme?: string;
+}
+
+interface DocsOptions extends InjectDocsOptions {
+  write?: boolean;
+}
+
+interface ApiEntry {
+  name: string;
+  declarations: Node[];
+}
+
+interface ApiGroup {
+  description?: string;
+  entries: ApiEntry[];
+  title?: string;
+}
+
+interface JsDocParts {
+  description?: string;
+  examples: string[];
+  returns?: string;
+  see: string[];
+}
+
+interface JsDocTag {
+  getCommentText(): string | undefined;
+  getTagName(): string;
+  getText(): string;
+}
+
+interface ModuleInfo {
+  description?: string;
+  title: string;
+}
+
+type LocalTypeDeclaration = InterfaceDeclaration | TypeAliasDeclaration;
+
+const startMarker = "<!-- ariakit-docs:start -->";
+const endMarker = "<!-- ariakit-docs:end -->";
+const maxDeclarationLines = 24;
+const declarationHeadLines = 14;
+const declarationTailLines = 4;
+
+function resolvePath(rootPath: string, path: string) {
+  if (isAbsolute(path)) return path;
+  return resolve(rootPath, path);
+}
+
+function getTsConfigPath(rootPath: string, path?: string) {
+  if (path) return resolvePath(rootPath, path);
+
+  const nodeConfigPath = join(rootPath, "tsconfig.node.json");
+  if (existsSync(nodeConfigPath)) return nodeConfigPath;
+
+  const configPath = join(rootPath, "tsconfig.json");
+  if (existsSync(configPath)) return configPath;
+
+  return undefined;
+}
+
+function createProject(rootPath: string, path?: string) {
+  const tsConfigFilePath = getTsConfigPath(rootPath, path);
+  if (!tsConfigFilePath) return new Project();
+  return new Project({ tsConfigFilePath });
+}
+
+function getEntrySourceFile(project: Project, entryPath: string) {
+  return (
+    project.getSourceFile(entryPath) || project.addSourceFileAtPath(entryPath)
+  );
+}
+
+function getFallbackModuleTitle(sourceFile: SourceFile) {
+  const name = basename(
+    sourceFile.getFilePath(),
+    extname(sourceFile.getFilePath()),
+  );
+  const words = name.split(/[-_]/g).filter(Boolean);
+  return words
+    .map((word) => `${word.charAt(0).toUpperCase()}${word.slice(1)}`)
+    .join(" ");
+}
+
+function getModuleInfo(sourceFile: SourceFile): ModuleInfo | undefined {
+  const text = sourceFile.getFullText();
+  const [firstStatement] = sourceFile.getStatements();
+  const fileHeader = firstStatement
+    ? text.slice(0, firstStatement.getStart())
+    : text;
+  const jsDocPattern = /\/\*\*([\s\S]*?)\*\//g;
+
+  for (const match of fileHeader.matchAll(jsDocPattern)) {
+    const content = normalizeJsDocTagText(match[1] ?? "");
+    const lines = content.split("\n");
+    const descriptionLines: string[] = [];
+    let title: string | undefined;
+
+    for (const line of lines) {
+      if (line.startsWith("@module")) {
+        title = line.replace(/^@module\s*/, "").trim();
+        continue;
+      }
+      if (line.startsWith("@")) continue;
+      descriptionLines.push(line);
+    }
+
+    if (title == null) continue;
+
+    return {
+      title: title || getFallbackModuleTitle(sourceFile),
+      description: normalizeComment(descriptionLines.join("\n")),
+    };
+  }
+
+  return undefined;
+}
+
+function addGroup(
+  groups: ApiGroup[],
+  moduleInfo: ModuleInfo | undefined,
+  entries: ApiEntry[],
+) {
+  if (!entries.length) return;
+
+  const title = moduleInfo?.title;
+  const group = groups.find((group) => group.title === title);
+
+  if (group) {
+    const names = new Set(group.entries.map((entry) => entry.name));
+    for (const entry of entries) {
+      if (names.has(entry.name)) continue;
+      group.entries.push(entry);
+      names.add(entry.name);
+    }
+    return;
+  }
+
+  groups.push({ title, description: moduleInfo?.description, entries });
+}
+
+function getFirstDeclaration(entry: ApiEntry) {
+  return entry.declarations[0];
+}
+
+function compareEntries(a: ApiEntry, b: ApiEntry) {
+  const declarationA = getFirstDeclaration(a);
+  const declarationB = getFirstDeclaration(b);
+
+  if (!declarationA || !declarationB) return 0;
+
+  const fileComparison = declarationA
+    .getSourceFile()
+    .getFilePath()
+    .localeCompare(declarationB.getSourceFile().getFilePath());
+
+  if (fileComparison) return fileComparison;
+  return declarationA.getStart() - declarationB.getStart();
+}
+
+function getApiGroups(entrySourceFile: SourceFile) {
+  const entries = [...entrySourceFile.getExportedDeclarations()]
+    .map(([name, declarations]) => ({ name, declarations }))
+    .sort(compareEntries);
+  const moduleInfoByFile = new Map<string, ModuleInfo | undefined>();
+  const groups: ApiGroup[] = [];
+
+  const getCachedModuleInfo = (sourceFile: SourceFile) => {
+    const path = sourceFile.getFilePath();
+    if (!moduleInfoByFile.has(path)) {
+      moduleInfoByFile.set(path, getModuleInfo(sourceFile));
+    }
+    return moduleInfoByFile.get(path);
+  };
+
+  const hasModules = entries.some((entry) => {
+    const declaration = getFirstDeclaration(entry);
+    if (!declaration) return false;
+    return !!getCachedModuleInfo(declaration.getSourceFile());
+  });
+
+  if (!hasModules) {
+    return [{ entries }];
+  }
+
+  for (const entry of entries) {
+    const declaration = getFirstDeclaration(entry);
+    if (!declaration) continue;
+    const sourceFile = declaration.getSourceFile();
+    const moduleInfo = getCachedModuleInfo(sourceFile) ?? {
+      title: "Other exports",
+    };
+    addGroup(groups, moduleInfo, [entry]);
+  }
+
+  return groups;
+}
+
+function normalizeComment(text: string | undefined) {
+  return text
+    ?.trim()
+    .split(/\n\s*\n/g)
+    .map((paragraph) => paragraph.replace(/\s*\n\s*/g, " ").trim())
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function normalizeJsDocTagText(text: string) {
+  return text
+    .split("\n")
+    .map((line) => line.replace(/^\s*\*\s?/, "").trim())
+    .join("\n")
+    .trim();
+}
+
+function getTagComment(tag: JsDocTag) {
+  const tagName = tag.getTagName();
+  const comment = normalizeComment(tag.getCommentText());
+  if (tagName !== "see" && comment) return comment;
+
+  const rawText = tag.getText();
+  let rawComment = normalizeJsDocTagText(
+    rawText.replace(new RegExp(`^@${tagName}\\b`), ""),
+  );
+  if (tagName === "returns" || tagName === "return") {
+    rawComment = rawComment.replace(/^\{[^}]+\}\s*/, "");
+  }
+  return normalizeComment(rawComment) || comment;
+}
+
+function getJsDocNodes(declaration: Node) {
+  const nodes = [declaration];
+  const variableStatement = declaration.getFirstAncestorByKind(
+    SyntaxKind.VariableStatement,
+  );
+
+  if (variableStatement) {
+    nodes.push(variableStatement);
+  }
+
+  return nodes;
+}
+
+function getJsDocParts(declarations: Node[]): JsDocParts {
+  const parts: JsDocParts = { examples: [], see: [] };
+
+  for (const declaration of declarations) {
+    for (const node of getJsDocNodes(declaration)) {
+      if (!Node.isJSDocable(node)) continue;
+
+      const docs = node.getJsDocs().filter((doc) => {
+        return !doc.getTags().some((tag) => tag.getTagName() === "module");
+      });
+
+      for (const doc of docs) {
+        parts.description ??= normalizeComment(doc.getDescription());
+
+        for (const tag of doc.getTags()) {
+          const tagName = tag.getTagName();
+          if (tagName === "example") {
+            const example = tag.getCommentText()?.trim() ?? getTagComment(tag);
+            if (example) {
+              parts.examples.push(example);
+            }
+            continue;
+          }
+
+          const comment = getTagComment(tag);
+          if (!comment) continue;
+
+          if (tagName === "returns" || tagName === "return") {
+            parts.returns ??= comment;
+          } else if (tagName === "see") {
+            parts.see.push(comment);
+          }
+        }
+      }
+    }
+  }
+
+  return parts;
+}
+
+function formatTypeParameters(declaration: FunctionDeclaration) {
+  const typeParameters = declaration.getTypeParameters();
+  if (!typeParameters.length) return "";
+  return `<${typeParameters.map((typeParameter) => typeParameter.getText()).join(", ")}>`;
+}
+
+function formatReturnType(declaration: FunctionDeclaration) {
+  const returnType = declaration.getReturnTypeNode()?.getText();
+  const inferredReturnType = declaration.getReturnType().getText(declaration);
+  const text = returnType || inferredReturnType;
+  if (!text) return "";
+  return `: ${text}`;
+}
+
+function formatFunctionSignature(declaration: FunctionDeclaration) {
+  const name = declaration.getName() || "default";
+  const parameters = declaration
+    .getParameters()
+    .map((parameter) => parameter.getText())
+    .join(", ");
+
+  return [
+    "function ",
+    name,
+    formatTypeParameters(declaration),
+    "(",
+    parameters,
+    ")",
+    formatReturnType(declaration),
+    ";",
+  ].join("");
+}
+
+function removeJsDoc(text: string) {
+  return text.replace(/^\/\*\*[\s\S]*?\*\/\s*/, "");
+}
+
+function removeExportKeyword(text: string) {
+  return text.replace(/^export\s+/, "");
+}
+
+function truncateDeclarationText(text: string) {
+  const lines = text.split("\n");
+  if (lines.length <= maxDeclarationLines) return text;
+
+  const omittedLines =
+    lines.length - declarationHeadLines - declarationTailLines;
+  if (omittedLines <= 0) return text;
+
+  const indentation = lines[declarationHeadLines]?.match(/^\s*/)?.[0] ?? "";
+
+  return [
+    ...lines.slice(0, declarationHeadLines),
+    `${indentation}// ... ${omittedLines} more lines`,
+    ...lines.slice(-declarationTailLines),
+  ].join("\n");
+}
+
+function getLocalTypeDeclarations(sourceFile: SourceFile) {
+  return [...sourceFile.getTypeAliases(), ...sourceFile.getInterfaces()]
+    .filter((declaration) => !declaration.isExported())
+    .sort((a, b) => a.getStart() - b.getStart());
+}
+
+function referencesIdentifier(text: string, name: string) {
+  return new RegExp(`\\b${name}\\b`).test(text);
+}
+
+function formatLocalTypeDeclaration(declaration: LocalTypeDeclaration) {
+  return truncateDeclarationText(
+    removeExportKeyword(removeJsDoc(declaration.getText()).trim()),
+  );
+}
+
+function getReferencedLocalTypes(text: string, declarations: Node[]) {
+  const localTypes = new Map<string, LocalTypeDeclaration>();
+  for (const declaration of declarations) {
+    for (const localType of getLocalTypeDeclarations(
+      declaration.getSourceFile(),
+    )) {
+      const path = localType.getSourceFile().getFilePath();
+      localTypes.set(`${path}:${localType.getName()}`, localType);
+    }
+  }
+  const referencedTypes = new Map<string, LocalTypeDeclaration>();
+  let searchText = text;
+
+  let foundReference = true;
+  while (foundReference) {
+    foundReference = false;
+
+    for (const [key, declaration] of localTypes) {
+      const name = declaration.getName();
+      if (referencedTypes.has(key)) continue;
+      if (!referencesIdentifier(searchText, name)) continue;
+
+      referencedTypes.set(key, declaration);
+      searchText += `\n${declaration.getText()}`;
+      foundReference = true;
+    }
+  }
+
+  return [...referencedTypes.values()].sort(
+    (a, b) => a.getStart() - b.getStart(),
+  );
+}
+
+function addReferencedLocalTypes(signatures: string[], declarations: Node[]) {
+  const referencedTypes = getReferencedLocalTypes(
+    signatures.join("\n"),
+    declarations,
+  );
+  const localTypeSignatures = referencedTypes
+    .map(formatLocalTypeDeclaration)
+    .join("\n\n");
+
+  if (!localTypeSignatures) return signatures;
+  return [localTypeSignatures, "", ...signatures];
+}
+
+function formatDeclarationText(declaration: Node) {
+  return truncateDeclarationText(
+    removeExportKeyword(removeJsDoc(declaration.getText()).trim()),
+  );
+}
+
+function formatVariableSignature(declaration: Node) {
+  if (!Node.isVariableDeclaration(declaration)) return;
+  const name = declaration.getName();
+  const type = declaration.getType().getText(declaration);
+  return `const ${name}: ${type};`;
+}
+
+function getFunctionSignatureDeclarations(declarations: Node[]) {
+  const functions = declarations.filter(Node.isFunctionDeclaration);
+  if (!functions.length) return [];
+
+  const overloads = functions.filter((declaration) => !declaration.getBody());
+  return overloads.length ? overloads : functions.slice(0, 1);
+}
+
+function getEntrySignatures(entry: ApiEntry) {
+  const functionDeclarations = getFunctionSignatureDeclarations(
+    entry.declarations,
+  );
+  if (functionDeclarations.length) {
+    const signatures = functionDeclarations.map(formatFunctionSignature);
+    return addReferencedLocalTypes(signatures, functionDeclarations);
+  }
+
+  const [declaration] = entry.declarations;
+  if (!declaration) return [];
+
+  const variableSignature = formatVariableSignature(declaration);
+  if (variableSignature) {
+    return addReferencedLocalTypes(
+      [truncateDeclarationText(variableSignature)],
+      [declaration],
+    );
+  }
+
+  return addReferencedLocalTypes(
+    [formatDeclarationText(declaration)],
+    [declaration],
+  );
+}
+
+function renderCodeBlock(code: string) {
+  return ["```ts", code, "```"].join("\n");
+}
+
+function isFencedCodeBlock(code: string) {
+  return /^```[\s\S]*\n```$/.test(code.trim());
+}
+
+function renderExample(example: string) {
+  if (isFencedCodeBlock(example)) return example.trim();
+  return renderCodeBlock(example);
+}
+
+function renderEntry(entry: ApiEntry) {
+  const jsDoc = getJsDocParts(entry.declarations);
+  const signatures = getEntrySignatures(entry);
+  const lines = [`#### \`${entry.name}\``, ""];
+
+  if (signatures.length) {
+    lines.push(renderCodeBlock(signatures.join("\n")), "");
+  }
+
+  if (jsDoc.description) {
+    lines.push(jsDoc.description, "");
+  }
+
+  if (jsDoc.returns) {
+    lines.push(`Returns: ${jsDoc.returns}`, "");
+  }
+
+  for (const see of jsDoc.see) {
+    lines.push(`See: ${see}`, "");
+  }
+
+  for (const example of jsDoc.examples) {
+    lines.push("Example:", "", renderExample(example), "");
+  }
+
+  return lines.join("\n").trimEnd();
+}
+
+function slugifyHeading(heading: string) {
+  return heading
+    .toLowerCase()
+    .replace(/`/g, "")
+    .replace(/[^a-z0-9 -]/g, "")
+    .trim()
+    .replace(/\s+/g, "-");
+}
+
+function renderContents(groups: ApiGroup[]) {
+  return groups
+    .flatMap((group) => {
+      if (!group.title) return [];
+      return `- [${group.title}](#${slugifyHeading(group.title)})`;
+    })
+    .join("\n");
+}
+
+function renderGroup(group: ApiGroup) {
+  const lines = group.title ? [`### ${group.title}`, ""] : [];
+
+  if (group.description) {
+    lines.push(group.description, "");
+  }
+
+  for (const entry of group.entries) {
+    lines.push(renderEntry(entry), "");
+  }
+
+  return lines.join("\n").trimEnd();
+}
+
+function formatMarkdown(markdown: string) {
+  const result = spawnSync("oxfmt", ["--stdin-filepath", "readme.md"], {
+    encoding: "utf-8",
+    input: markdown,
+  });
+
+  if (result.error) return markdown;
+  if (result.status) return markdown;
+  return result.stdout || markdown;
+}
+
+export function generateDocsMarkdown(options: GenerateDocsOptions = {}) {
+  const rootPath = options.rootPath || process.cwd();
+  const entryPath = resolvePath(rootPath, options.entry || "src/index.ts");
+  const project = createProject(rootPath, options.tsconfig);
+  const entrySourceFile = getEntrySourceFile(project, entryPath);
+  const groups = getApiGroups(entrySourceFile);
+  const lines = ["## API reference", ""];
+
+  const contents = renderContents(groups);
+  if (contents) {
+    lines.push(contents, "");
+  }
+
+  for (const group of groups) {
+    lines.push(renderGroup(group), "");
+  }
+
+  return formatMarkdown(`${lines.join("\n").trimEnd()}\n`);
+}
+
+export function injectDocsMarkdown(options: InjectDocsOptions = {}) {
+  const rootPath = options.rootPath || process.cwd();
+  const readmePath = resolvePath(rootPath, options.readme || "readme.md");
+  const markdown = generateDocsMarkdown(options).trimEnd();
+  const readme = readFileSync(readmePath, "utf-8");
+  const block = `${startMarker}\n\n${markdown}\n\n${endMarker}`;
+  const hasStartMarker = readme.includes(startMarker);
+  const hasEndMarker = readme.includes(endMarker);
+
+  let nextReadme: string;
+
+  if (hasStartMarker !== hasEndMarker) {
+    throw new Error(
+      `Both ${startMarker} and ${endMarker} must be present in ${readmePath}`,
+    );
+  }
+
+  if (hasStartMarker && hasEndMarker) {
+    const pattern = new RegExp(`${startMarker}[\\s\\S]*?${endMarker}`);
+    if (!pattern.test(readme)) {
+      throw new Error(
+        `${startMarker} must appear before ${endMarker} in ${readmePath}`,
+      );
+    }
+    nextReadme = readme.replace(pattern, block);
+  } else {
+    nextReadme = `${readme.trimEnd()}\n\n${block}\n`;
+  }
+
+  if (nextReadme !== readme) {
+    writeFileSync(readmePath, nextReadme);
+  }
+}
+
+export function docs(options: DocsOptions = {}) {
+  if (options.write) {
+    injectDocsMarkdown(options);
+    return;
+  }
+
+  console.log(generateDocsMarkdown(options).trimEnd());
+}

--- a/packages/ariakit-scripts/src/index.ts
+++ b/packages/ariakit-scripts/src/index.ts
@@ -29,6 +29,18 @@ program
   .action(dev);
 
 program
+  .command("docs")
+  .description("Generate API markdown from TypeScript JSDoc")
+  .option("--entry <path>", "Entry file path", "src/index.ts")
+  .option("--tsconfig <path>", "TypeScript config path")
+  .option("--readme <path>", "Readme path used with --write", "readme.md")
+  .option("--write", "Inject generated markdown into the readme")
+  .action(async (options) => {
+    const { docs } = await import("./docs.ts");
+    docs(options);
+  });
+
+program
   .command("react18")
   .description("Run a command in an isolated React 18 workspace")
   .argument("[command...]", "Root script or command to run")

--- a/packages/ariakit-utils/package.json
+++ b/packages/ariakit-utils/package.json
@@ -22,7 +22,8 @@
   "sideEffects": false,
   "scripts": {
     "build": "ariakit build --index-only",
-    "clean": "ariakit clean"
+    "clean": "ariakit clean",
+    "docs": "ariakit docs --write"
   },
   "devDependencies": {
     "@ariakit/scripts": "workspace:*"

--- a/packages/ariakit-utils/readme.md
+++ b/packages/ariakit-utils/readme.md
@@ -309,7 +309,7 @@ function setSelectionRange(
 ): void;
 ```
 
-SelectionRange only works on a few types of input. Calling `setSelectionRange` on a unsupported input type may throw an error on certain browsers. To avoid it, we check if its type supports SelectionRange first. It will be a noop to non-supported types until we find a workaround.
+SelectionRange only works on a few types of input. Calling `setSelectionRange` on an unsupported input type may throw an error on certain browsers. To avoid it, we check if its type supports SelectionRange first. It will be a noop to non-supported types until we find a workaround.
 
 See: https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setSelectionRange
 

--- a/packages/ariakit-utils/readme.md
+++ b/packages/ariakit-utils/readme.md
@@ -4,9 +4,19 @@
 
 Shared framework-agnostic utilities used by Ariakit packages.
 
+## Contents
+
+- [Installation](#installation)
+- [Usage](#usage)
+- [API reference](#api-reference)
+
+## Installation
+
 ```sh
 npm i @ariakit/utils
 ```
+
+## Usage
 
 Import helpers from the package root:
 
@@ -15,3 +25,1282 @@ import { invariant } from "@ariakit/utils";
 ```
 
 This package is ESM-only and exposes a single public entrypoint.
+
+<!-- ariakit-docs:start -->
+
+## API reference
+
+- [Array utilities](#array-utilities)
+- [DOM utilities](#dom-utilities)
+- [Event utilities](#event-utilities)
+- [Focus utilities](#focus-utilities)
+- [General utilities](#general-utilities)
+- [Platform utilities](#platform-utilities)
+- [Type utilities](#type-utilities)
+- [Undo utilities](#undo-utilities)
+
+### Array utilities
+
+Array helpers used by Ariakit packages.
+
+#### `toArray`
+
+```ts
+function toArray<T>(arg: T): T extends readonly any[] ? T : T[];
+```
+
+Transforms `arg` into an array if it's not already.
+
+Example:
+
+```ts
+toArray("a"); // ["a"]
+toArray(["a"]); // ["a"]
+```
+
+#### `addItemToArray`
+
+```ts
+function addItemToArray<T extends any[]>(
+  array: T,
+  item: T[number],
+  index = -1,
+): T;
+```
+
+Immutably adds an item to an array.
+
+Returns: A new array with the item in the passed array index.
+
+Example:
+
+```ts
+addItemToArray(["a", "b", "d"], "c", 2); // ["a", "b", "c", "d"]
+```
+
+#### `flatten2DArray`
+
+```ts
+function flatten2DArray<T>(array: T[][]): T[];
+```
+
+Flattens a 2D array into a one-dimensional array.
+
+Returns: A one-dimensional array.
+
+Example:
+
+```ts
+flatten2DArray([["a"], ["b"], ["c"]]); // ["a", "b", "c"]
+```
+
+#### `reverseArray`
+
+```ts
+function reverseArray<T>(array: T[]): T[];
+```
+
+Immutably reverses an array.
+
+Returns: Reversed array.
+
+Example:
+
+```ts
+reverseArray(["a", "b", "c"]); // ["c", "b", "a"]
+```
+
+### DOM utilities
+
+DOM helpers for browser, iframe, text input, popup, and scrolling behavior.
+
+#### `canUseDOM`
+
+```ts
+const canUseDOM: boolean;
+```
+
+It's `true` if it is running in a browser environment or `false` if it is not (SSR).
+
+Example:
+
+```ts
+const title = canUseDOM ? document.title : "";
+```
+
+#### `getDocument`
+
+```ts
+function getDocument(node?: Window | Document | Node | null): Document;
+```
+
+Returns `element.ownerDocument || document`.
+
+#### `getWindow`
+
+```ts
+function getWindow(node?: Window | Document | Node | null): Window;
+```
+
+Returns `element.ownerDocument.defaultView || window`.
+
+#### `getActiveElement`
+
+```ts
+function getActiveElement(
+  node?: Node | null,
+  activeDescendant = false,
+): HTMLElement | null;
+```
+
+Returns `element.ownerDocument.activeElement`.
+
+#### `contains`
+
+```ts
+function contains(parent: Node, child: Node): boolean;
+```
+
+Similar to `Element.prototype.contains`, but a little bit faster when `element` is the same as `child`.
+
+Example:
+
+```ts
+contains(document.getElementById("parent"), document.getElementById("child"));
+```
+
+#### `isFrame`
+
+```ts
+function isFrame(element: Element): element is HTMLIFrameElement;
+```
+
+Checks whether `element` is a frame element.
+
+#### `isButton`
+
+```ts
+function isButton(element: { tagName: string; type?: string }): boolean;
+```
+
+Checks whether `element` is a native HTML button element.
+
+Example:
+
+```ts
+isButton(document.querySelector("button")); // true
+isButton(document.querySelector("input[type='button']")); // true
+isButton(document.querySelector("div")); // false
+isButton(document.querySelector("input[type='text']")); // false
+isButton(document.querySelector("div[role='button']")); // false
+```
+
+#### `isVisible`
+
+```ts
+function isVisible(element: Element): boolean;
+```
+
+Checks if the element is visible or not.
+
+#### `isTextField`
+
+```ts
+function isTextField(
+  element: Element,
+): element is HTMLInputElement | HTMLTextAreaElement;
+```
+
+Check whether the given element is a text field, where text field is defined by the ability to select within the input.
+
+Example:
+
+```ts
+isTextField(document.querySelector("div")); // false
+isTextField(document.querySelector("input")); // true
+isTextField(document.querySelector("input[type='button']")); // false
+isTextField(document.querySelector("textarea")); // true
+```
+
+#### `isTextbox`
+
+```ts
+function isTextbox(element: HTMLElement): boolean;
+```
+
+Check whether the given element is a text field or a content editable element.
+
+#### `getTextboxValue`
+
+```ts
+function getTextboxValue(element: HTMLElement): string;
+```
+
+Returns the value of the text field or content editable element as a string.
+
+#### `getTextboxSelection`
+
+```ts
+function getTextboxSelection(element: HTMLElement): {
+  start: number;
+  end: number;
+};
+```
+
+Returns the start and end offsets of the selection in the element.
+
+#### `getPopupRole`
+
+```ts
+function getPopupRole(
+  element?: Element | null,
+  fallback?: AriaHasPopup,
+): AriaHasPopup;
+```
+
+Returns the popup role from the element's role attribute, if it has one.
+
+#### `getPopupItemRole`
+
+```ts
+function getPopupItemRole(
+  element?: Element | null,
+  fallback?: AriaRole,
+): string | undefined;
+```
+
+Returns the item role attribute based on the popup's role.
+
+#### `scrollIntoViewIfNeeded`
+
+```ts
+function scrollIntoViewIfNeeded(
+  element: Element,
+  arg?: boolean | ScrollIntoViewOptions,
+): void;
+```
+
+Calls `element.scrollIntoView()` if the element is hidden or partly hidden in the viewport.
+
+#### `getScrollingElement`
+
+```ts
+function getScrollingElement(
+  element?: Element | null,
+): HTMLElement | Element | null;
+```
+
+Returns the scrolling container element of a given element.
+
+#### `isPartiallyHidden`
+
+```ts
+function isPartiallyHidden(element: Element): boolean;
+```
+
+Determines whether an element is hidden or partially hidden in the viewport.
+
+#### `setSelectionRange`
+
+```ts
+function setSelectionRange(
+  element: HTMLInputElement | HTMLTextAreaElement,
+  ...args: Parameters<typeof HTMLInputElement.prototype.setSelectionRange>
+): void;
+```
+
+SelectionRange only works on a few types of input. Calling `setSelectionRange` on a unsupported input type may throw an error on certain browsers. To avoid it, we check if its type supports SelectionRange first. It will be a noop to non-supported types until we find a workaround.
+
+See: https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setSelectionRange
+
+#### `sortBasedOnDOMPosition`
+
+```ts
+function sortBasedOnDOMPosition<T>(
+  items: T[],
+  getElement: (item: T) => Element | null | undefined,
+): T[];
+```
+
+Sort the items based on their DOM position.
+
+### Event utilities
+
+Event helpers for dispatching and interpreting browser events.
+
+#### `isPortalEvent`
+
+```ts
+function isPortalEvent(event: Pick<Event, "currentTarget" | "target">): boolean;
+```
+
+Returns `true` if `event` has been fired within a React Portal element.
+
+#### `isSelfTarget`
+
+```ts
+function isSelfTarget(event: Pick<Event, "target" | "currentTarget">): boolean;
+```
+
+Returns `true` if `event.target` and `event.currentTarget` are the same.
+
+#### `isOpeningInNewTab`
+
+```ts
+function isOpeningInNewTab(
+  event: Pick<MouseEvent, "currentTarget" | "metaKey" | "ctrlKey">,
+): boolean;
+```
+
+Checks whether the user event is triggering a page navigation in a new tab.
+
+#### `isDownloading`
+
+```ts
+function isDownloading(
+  event: Pick<MouseEvent, "altKey" | "currentTarget">,
+): boolean;
+```
+
+Checks whether the user event is triggering a download.
+
+#### `fireEvent`
+
+```ts
+function fireEvent(
+  element: Element,
+  type: string,
+  eventInit?: EventInit,
+): boolean;
+```
+
+Creates and dispatches an event.
+
+Example:
+
+```ts
+fireEvent(document.getElementById("id"), "blur", {
+  bubbles: true,
+  cancelable: true,
+});
+```
+
+#### `fireBlurEvent`
+
+```ts
+function fireBlurEvent(element: Element, eventInit?: FocusEventInit): boolean;
+```
+
+Creates and dispatches a blur event.
+
+Example:
+
+```ts
+fireBlurEvent(document.getElementById("id"));
+```
+
+#### `fireFocusEvent`
+
+```ts
+function fireFocusEvent(element: Element, eventInit?: FocusEventInit): boolean;
+```
+
+Creates and dispatches a focus event.
+
+Example:
+
+```ts
+fireFocusEvent(document.getElementById("id"));
+```
+
+#### `fireKeyboardEvent`
+
+```ts
+function fireKeyboardEvent(
+  element: Element,
+  type: string,
+  eventInit?: KeyboardEventInit,
+): boolean;
+```
+
+Creates and dispatches a keyboard event.
+
+Example:
+
+```ts
+fireKeyboardEvent(document.getElementById("id"), "keydown", {
+  key: "ArrowDown",
+  shiftKey: true,
+});
+```
+
+#### `fireClickEvent`
+
+```ts
+function fireClickEvent(
+  element: Element,
+  eventInit?: PointerEventInit,
+): boolean;
+```
+
+Creates and dispatches a click event.
+
+Example:
+
+```ts
+fireClickEvent(document.getElementById("id"));
+```
+
+#### `isFocusEventOutside`
+
+```ts
+function isFocusEventOutside(
+  event: Pick<FocusEvent, "currentTarget" | "relatedTarget">,
+  container?: Element | null,
+): boolean;
+```
+
+Checks whether the focus/blur event is happening from/to outside of the container element.
+
+Example:
+
+```ts
+const element = document.getElementById("id");
+element.addEventListener("blur", (event) => {
+  if (isFocusEventOutside(event)) {
+    // ...
+  }
+});
+```
+
+#### `getInputType`
+
+```ts
+function getInputType(
+  event: Event | { nativeEvent: Event },
+): string | undefined;
+```
+
+Returns the `inputType` property of the event, if available.
+
+#### `queueBeforeEvent`
+
+```ts
+function queueBeforeEvent(
+  element: Element,
+  type: string,
+  callback: () => void,
+  timeout?: number,
+): () => void;
+```
+
+Runs a callback on the next animation frame, but before a certain event.
+
+#### `addGlobalEventListener`
+
+```ts
+function addGlobalEventListener<K extends keyof DocumentEventMap>(
+  type: K,
+  listener: (event: DocumentEventMap[K]) => any,
+  options?: boolean | AddEventListenerOptions,
+  scope?: Window,
+): () => void;
+function addGlobalEventListener(
+  type: string,
+  listener: EventListenerOrEventListenerObject,
+  options?: boolean | AddEventListenerOptions,
+  scope?: Window,
+): () => void;
+```
+
+Adds a global event listener, including on child frames.
+
+### Focus utilities
+
+Focus management helpers for focusable and tabbable elements.
+
+#### `isFocusable`
+
+```ts
+function isFocusable(element: Element): boolean;
+```
+
+Checks whether `element` is focusable or not.
+
+Example:
+
+```ts
+isFocusable(document.querySelector("input")); // true
+isFocusable(document.querySelector("input[tabindex='-1']")); // true
+isFocusable(document.querySelector("input[hidden]")); // false
+isFocusable(document.querySelector("input:disabled")); // false
+```
+
+#### `isTabbable`
+
+```ts
+function isTabbable(
+  element: Element | HTMLElement | HTMLInputElement,
+): element is HTMLElement;
+```
+
+Checks whether `element` is tabbable or not.
+
+Example:
+
+```ts
+isTabbable(document.querySelector("input")); // true
+isTabbable(document.querySelector("input[tabindex='-1']")); // false
+isTabbable(document.querySelector("input[hidden]")); // false
+isTabbable(document.querySelector("input:disabled")); // false
+```
+
+#### `getAllFocusableIn`
+
+```ts
+function getAllFocusableIn(
+  container: HTMLElement,
+  includeContainer?: boolean,
+): HTMLElement[];
+```
+
+Returns all the focusable elements in `container`.
+
+#### `getAllFocusable`
+
+```ts
+function getAllFocusable(includeBody?: boolean): HTMLElement[];
+```
+
+Returns all the focusable elements in the document.
+
+#### `getFirstFocusableIn`
+
+```ts
+function getFirstFocusableIn(
+  container: HTMLElement,
+  includeContainer?: boolean,
+): HTMLElement | null;
+```
+
+Returns the first focusable element in `container`.
+
+#### `getFirstFocusable`
+
+```ts
+function getFirstFocusable(includeBody?: boolean): HTMLElement | null;
+```
+
+Returns the first focusable element in the document.
+
+#### `getAllTabbableIn`
+
+```ts
+function getAllTabbableIn(
+  container: HTMLElement,
+  includeContainer?: boolean,
+  fallbackToFocusable?: boolean,
+): HTMLElement[];
+```
+
+Returns all the tabbable elements in `container`, including the container itself.
+
+#### `getAllTabbable`
+
+```ts
+function getAllTabbable(fallbackToFocusable?: boolean): HTMLElement[];
+```
+
+Returns all the tabbable elements in the document.
+
+#### `getFirstTabbableIn`
+
+```ts
+function getFirstTabbableIn(
+  container: HTMLElement,
+  includeContainer?: boolean,
+  fallbackToFocusable?: boolean,
+): HTMLElement | null;
+```
+
+Returns the first tabbable element in `container`, including the container itself if it's tabbable.
+
+#### `getFirstTabbable`
+
+```ts
+function getFirstTabbable(fallbackToFocusable?: boolean): HTMLElement | null;
+```
+
+Returns the first tabbable element in the document.
+
+#### `getLastTabbableIn`
+
+```ts
+function getLastTabbableIn(
+  container: HTMLElement,
+  includeContainer?: boolean,
+  fallbackToFocusable?: boolean,
+): HTMLElement | null;
+```
+
+Returns the last tabbable element in `container`, including the container itself if it's tabbable.
+
+#### `getLastTabbable`
+
+```ts
+function getLastTabbable(fallbackToFocusable?: boolean): HTMLElement | null;
+```
+
+Returns the last tabbable element in the document.
+
+#### `getNextTabbableIn`
+
+```ts
+function getNextTabbableIn(
+  container: HTMLElement,
+  includeContainer?: boolean,
+  fallbackToFirst?: boolean,
+  fallbackToFocusable?: boolean,
+): HTMLElement | null;
+```
+
+Returns the next tabbable element in `container`.
+
+#### `getNextTabbable`
+
+```ts
+function getNextTabbable(
+  fallbackToFirst?: boolean,
+  fallbackToFocusable?: boolean,
+): HTMLElement | null;
+```
+
+Returns the next tabbable element in the document.
+
+#### `getPreviousTabbableIn`
+
+```ts
+function getPreviousTabbableIn(
+  container: HTMLElement,
+  includeContainer?: boolean,
+  fallbackToLast?: boolean,
+  fallbackToFocusable?: boolean,
+): HTMLElement | null;
+```
+
+Returns the previous tabbable element in `container`.
+
+#### `getPreviousTabbable`
+
+```ts
+function getPreviousTabbable(
+  fallbackToFirst?: boolean,
+  fallbackToFocusable?: boolean,
+): HTMLElement | null;
+```
+
+Returns the previous tabbable element in the document.
+
+#### `getClosestFocusable`
+
+```ts
+function getClosestFocusable(element?: HTMLElement | null): HTMLElement | null;
+```
+
+Returns the closest focusable element.
+
+#### `hasFocus`
+
+```ts
+function hasFocus(element: Element): boolean;
+```
+
+Checks if `element` has focus. Elements that are referenced by `aria-activedescendant` are also considered.
+
+Example:
+
+```ts
+hasFocus(document.getElementById("id"));
+```
+
+#### `hasFocusWithin`
+
+```ts
+function hasFocusWithin(element: Node | Element): boolean;
+```
+
+Checks if `element` has focus within. Elements that are referenced by `aria-activedescendant` are also considered.
+
+Example:
+
+```ts
+hasFocusWithin(document.getElementById("id"));
+```
+
+#### `focusIfNeeded`
+
+```ts
+function focusIfNeeded(element: HTMLElement): void;
+```
+
+Focus on an element only if it's not already focused.
+
+#### `disableFocus`
+
+```ts
+function disableFocus(element: HTMLElement): void;
+```
+
+Disable focus on `element`.
+
+#### `disableFocusIn`
+
+```ts
+function disableFocusIn(
+  container: HTMLElement,
+  includeContainer?: boolean,
+): void;
+```
+
+Makes elements inside container not tabbable.
+
+#### `restoreFocusIn`
+
+```ts
+function restoreFocusIn(container: HTMLElement): void;
+```
+
+Restores tabbable elements inside container that were affected by disableFocusIn.
+
+#### `focusIntoView`
+
+```ts
+function focusIntoView(
+  element: HTMLElement,
+  options?: ScrollIntoViewOptions,
+): void;
+```
+
+Focus on element and scroll into view.
+
+### General utilities
+
+General-purpose helpers for state, objects, strings, scheduling, and assertions.
+
+#### `noop`
+
+```ts
+function noop(..._: any[]): any;
+```
+
+Empty function.
+
+#### `shallowEqual`
+
+```ts
+function shallowEqual(a?: AnyObject, b?: AnyObject): boolean;
+```
+
+Compares two objects.
+
+Example:
+
+```ts
+shallowEqual({ a: "a" }, {}); // false
+shallowEqual({ a: "a" }, { b: "b" }); // false
+shallowEqual({ a: "a" }, { a: "a" }); // true
+shallowEqual({ a: "a" }, { a: "a", b: "b" }); // false
+```
+
+#### `applyState`
+
+```ts
+function applyState<T>(
+  argument: SetStateAction<T>,
+  currentValue: T | (() => T),
+): T;
+```
+
+Receives a `setState` argument and calls it with `currentValue` if it's a function. Otherwise return the argument as the new value.
+
+Example:
+
+```ts
+applyState((value) => value + 1, 1); // 2
+applyState(2, 1); // 2
+```
+
+#### `isObject`
+
+```ts
+function isObject(arg: any): arg is Record<any, unknown>;
+```
+
+Checks whether `arg` is an object or not.
+
+#### `isEmpty`
+
+```ts
+function isEmpty(arg: any): boolean;
+```
+
+Checks whether `arg` is empty or not.
+
+Example:
+
+```ts
+isEmpty([]); // true
+isEmpty(["a"]); // false
+isEmpty({}); // true
+isEmpty({ a: "a" }); // false
+isEmpty(); // true
+isEmpty(null); // true
+isEmpty(undefined); // true
+isEmpty(""); // true
+```
+
+#### `isInteger`
+
+```ts
+function isInteger(arg: any): boolean;
+```
+
+Checks whether `arg` is an integer or not.
+
+Example:
+
+```ts
+isInteger(1); // true
+isInteger(1.5); // false
+isInteger("1"); // true
+isInteger("1.5"); // false
+```
+
+#### `hasOwnProperty`
+
+```ts
+function hasOwnProperty<T extends AnyObject>(
+  object: T,
+  prop: keyof any,
+): prop is keyof T;
+```
+
+Checks whether `prop` is an own property of `obj` or not.
+
+#### `chain`
+
+```ts
+function chain<T>(
+  ...fns: T[]
+): (...args: T extends AnyFunction ? Parameters<T> : never) => void;
+```
+
+Receives functions as arguments and returns a new function that calls all.
+
+#### `cx`
+
+```ts
+function cx(
+  ...args: Array<string | null | false | 0 | undefined>
+): string | undefined;
+```
+
+Returns a string with the truthy values of `args` separated by space.
+
+#### `normalizeString`
+
+```ts
+function normalizeString(str: string): string;
+```
+
+Removes diacritics from a string.
+
+#### `omit`
+
+```ts
+function omit<T extends AnyObject, K extends keyof T>(
+  object: T,
+  keys: ReadonlyArray<K> | K[],
+): Omit<T, K>;
+```
+
+Omits specific keys from an object.
+
+Example:
+
+```ts
+omit({ a: "a", b: "b" }, ["a"]); // { b: "b" }
+```
+
+#### `pick`
+
+```ts
+function pick<T extends AnyObject, K extends keyof T>(
+  object: T,
+  paths: ReadonlyArray<K> | K[],
+): Pick<T, K>;
+```
+
+Picks specific keys from an object.
+
+Example:
+
+```ts
+pick({ a: "a", b: "b" }, ["a"]); // { a: "a" }
+```
+
+#### `identity`
+
+```ts
+function identity<T>(value: T): T;
+```
+
+Returns the same argument.
+
+#### `beforePaint`
+
+```ts
+function beforePaint(cb: () => void = noop): () => void;
+```
+
+Runs right before the next paint.
+
+#### `afterPaint`
+
+```ts
+function afterPaint(cb: () => void = noop): () => void;
+```
+
+Runs after the next paint.
+
+#### `invariant`
+
+```ts
+function invariant(
+  condition: any,
+  message?: string | boolean,
+): asserts condition;
+```
+
+Asserts that a condition is true, otherwise throws an error.
+
+Example:
+
+```ts
+invariant(
+  condition,
+  process.env.NODE_ENV !== "production" && "Invariant failed",
+);
+```
+
+#### `getKeys`
+
+```ts
+function getKeys<T extends object>(obj: T): (keyof T)[];
+```
+
+Similar to `Object.keys` but returns a type-safe array of keys.
+
+#### `isFalsyBooleanCallback`
+
+```ts
+function isFalsyBooleanCallback<T extends unknown[]>(
+  booleanOrCallback?: boolean | ((...args: T) => boolean),
+  ...args: T
+): boolean;
+```
+
+Checks whether a boolean event prop (e.g., hideOnInteractOutside) was intentionally set to false, either with a boolean value or a callback that returns false.
+
+#### `disabledFromProps`
+
+```ts
+function disabledFromProps(props: {
+  disabled?: boolean;
+  "aria-disabled"?: boolean | "true" | "false";
+}): boolean;
+```
+
+Checks whether something is disabled or not based on its props.
+
+#### `disabledFromElement`
+
+```ts
+function disabledFromElement(element: Element): boolean;
+```
+
+Checks whether something is disabled or not based on its DOM attributes.
+
+#### `removeUndefinedValues`
+
+```ts
+function removeUndefinedValues<T extends AnyObject>(obj: T): T;
+```
+
+Removes undefined values from an object.
+
+#### `defaultValue`
+
+```ts
+type DefaultValue<T extends readonly any[], Other = never> = T extends [
+  infer Head,
+  ...infer Rest,
+]
+  ? Rest extends []
+    ? T[number] | Other
+    : undefined extends Head
+      ? DefaultValue<Rest, Exclude<Other | Head, undefined>>
+      : Exclude<T[number], undefined>
+  : never;
+
+function defaultValue<T extends readonly any[]>(...values: T): DefaultValue<T>;
+```
+
+Returns the first value that is not `undefined`.
+
+### Platform utilities
+
+Browser and platform detection helpers.
+
+#### `isTouchDevice`
+
+```ts
+function isTouchDevice(): boolean;
+```
+
+Detects if the device has touch capabilities.
+
+#### `isApple`
+
+```ts
+function isApple(): boolean;
+```
+
+Detects Apple device.
+
+#### `isSafari`
+
+```ts
+function isSafari(): boolean;
+```
+
+Detects Safari browser.
+
+#### `isFirefox`
+
+```ts
+function isFirefox(): boolean;
+```
+
+Detects Firefox browser.
+
+#### `isMac`
+
+```ts
+function isMac(): boolean;
+```
+
+Detects Mac computer.
+
+### Type utilities
+
+Shared type utilities used across Ariakit packages.
+
+#### `AnyObject`
+
+```ts
+type AnyObject = Record<string, any>;
+```
+
+Any object.
+
+#### `EmptyObject`
+
+```ts
+type EmptyObject = Record<keyof any, never>;
+```
+
+Empty object.
+
+#### `AnyFunction`
+
+```ts
+type AnyFunction = (...args: any) => any;
+```
+
+Any function.
+
+#### `BivariantCallback`
+
+```ts
+type BivariantCallback<T extends AnyFunction> = {
+  bivarianceHack(...args: Parameters<T>): ReturnType<T>;
+}["bivarianceHack"];
+```
+
+Workaround for variance issues.
+
+#### `SetStateAction`
+
+```ts
+type SetStateAction<T> = T | BivariantCallback<(prevState: T) => T>;
+```
+
+#### `SetState`
+
+```ts
+type SetState<T> = BivariantCallback<(value: SetStateAction<T>) => void>;
+```
+
+The type of the `setState` function in `[state, setState] = useState()`.
+
+#### `BooleanOrCallback`
+
+```ts
+type BooleanOrCallback<T> = boolean | BivariantCallback<(arg: T) => boolean>;
+```
+
+A boolean value or a callback that returns a boolean value.
+
+#### `StringWithValue`
+
+```ts
+type StringWithValue<T extends string> = T | (string & Record<never, never>);
+```
+
+A string that will provide autocomplete for specific strings.
+
+#### `ToPrimitive`
+
+```ts
+type ToPrimitive<T> = T extends string
+  ? string
+  : T extends number
+    ? number
+    : T extends boolean
+      ? boolean
+      : T extends AnyFunction
+        ? (...args: Parameters<T>) => ReturnType<T>
+        : T;
+```
+
+Transforms a type into a primitive type.
+
+Example:
+
+```ts
+// string
+ToPrimitive<"a">;
+// number
+ToPrimitive<1>;
+```
+
+#### `PickByValue`
+
+```ts
+type PickByValue<T, Value> = {
+  [K in keyof T as [Value] extends [T[K]]
+    ? T[K] extends Value | undefined
+      ? K
+      : never
+    : never]: T[K];
+};
+```
+
+Picks only the properties from a type that have a specific value.
+
+#### `PickRequired`
+
+```ts
+type PickRequired<T, P extends keyof T> = T &
+  {
+    [K in keyof T]: Pick<Required<T>, K>;
+  }[P];
+```
+
+Picks only the required properties from a type.
+
+#### `AriaHasPopup`
+
+```ts
+type AriaHasPopup =
+  | boolean
+  | "false"
+  | "true"
+  | "menu"
+  | "listbox"
+  | "tree"
+  | "grid"
+  | "dialog"
+  | undefined;
+```
+
+Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.
+
+#### `AriaRole`
+
+```ts
+type AriaRole =
+  | "alert"
+  | "alertdialog"
+  | "application"
+  | "article"
+  | "banner"
+  | "button"
+  | "cell"
+  | "checkbox"
+  | "columnheader"
+  | "combobox"
+  | "complementary"
+  | "contentinfo"
+  | "definition"
+  // ... 53 more lines
+  | "tree"
+  | "treegrid"
+  | "treeitem"
+  | (string & {});
+```
+
+All the WAI-ARIA 1.1 role attribute values from https://www.w3.org/TR/wai-aria-1.1/#role_definitions
+
+### Undo utilities
+
+Undo and redo manager utilities.
+
+#### `UndoManager`
+
+```ts
+type Callback = void | (() => Callback | Promise<Callback>);
+
+const UndoManager: {
+  canUndo: () => boolean;
+  canRedo: () => boolean;
+  undo: () => Promise<void>;
+  redo: () => Promise<void>;
+  execute: (callback: Callback, group?: string) => Promise<void>;
+};
+```
+
+Shared undo manager instance.
+
+#### `createUndoManager`
+
+```ts
+type Callback = void | (() => Callback | Promise<Callback>);
+
+interface CreateUndoManagerOptions {
+  limit?: number;
+}
+
+function createUndoManager({ limit = 100 }: CreateUndoManagerOptions = {}): {
+  canUndo: () => boolean;
+  canRedo: () => boolean;
+  undo: () => Promise<void>;
+  redo: () => Promise<void>;
+  execute: (callback: Callback, group?: string) => Promise<void>;
+};
+```
+
+Creates an undo manager with undo and redo stacks.
+
+<!-- ariakit-docs:end -->

--- a/packages/ariakit-utils/src/array.ts
+++ b/packages/ariakit-utils/src/array.ts
@@ -1,4 +1,9 @@
 /**
+ * Array helpers used by Ariakit packages.
+ * @module Array utilities
+ */
+
+/**
  * Transforms `arg` into an array if it's not already.
  * @example
  * toArray("a"); // ["a"]
@@ -13,7 +18,7 @@ export function toArray<T>(arg: T) {
 }
 
 /**
- * Immutably adds an index to an array.
+ * Immutably adds an item to an array.
  * @example
  * addItemToArray(["a", "b", "d"], "c", 2); // ["a", "b", "c", "d"]
  * @returns {Array} A new array with the item in the passed array index.

--- a/packages/ariakit-utils/src/dom.ts
+++ b/packages/ariakit-utils/src/dom.ts
@@ -312,9 +312,9 @@ export function isPartiallyHidden(element: Element) {
 
 /**
  * SelectionRange only works on a few types of input. Calling
- * `setSelectionRange` on a unsupported input type may throw an error on certain
- * browsers. To avoid it, we check if its type supports SelectionRange first. It
- * will be a noop to non-supported types until we find a workaround.
+ * `setSelectionRange` on an unsupported input type may throw an error on
+ * certain browsers. To avoid it, we check if its type supports SelectionRange
+ * first. It will be a noop to non-supported types until we find a workaround.
  *
  * @see
  * https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setSelectionRange

--- a/packages/ariakit-utils/src/dom.ts
+++ b/packages/ariakit-utils/src/dom.ts
@@ -1,3 +1,8 @@
+/**
+ * DOM helpers for browser, iframe, text input, popup, and scrolling behavior.
+ * @module DOM utilities
+ */
+
 import type { AriaHasPopup, AriaRole } from "./types.ts";
 
 /**
@@ -207,7 +212,7 @@ export function getTextboxSelection(element: HTMLElement) {
 }
 
 /**
- * Returns the element's role attribute, if it has one.
+ * Returns the popup role from the element's role attribute, if it has one.
  */
 export function getPopupRole(
   element?: Element | null,

--- a/packages/ariakit-utils/src/events.ts
+++ b/packages/ariakit-utils/src/events.ts
@@ -1,3 +1,8 @@
+/**
+ * Event helpers for dispatching and interpreting browser events.
+ * @module Event utilities
+ */
+
 import { contains } from "./dom.ts";
 import { isApple } from "./platform.ts";
 

--- a/packages/ariakit-utils/src/focus.ts
+++ b/packages/ariakit-utils/src/focus.ts
@@ -1,3 +1,8 @@
+/**
+ * Focus management helpers for focusable and tabbable elements.
+ * @module Focus utilities
+ */
+
 import { contains, getActiveElement, isFrame, isVisible } from "./dom.ts";
 
 const selector =

--- a/packages/ariakit-utils/src/misc.ts
+++ b/packages/ariakit-utils/src/misc.ts
@@ -1,3 +1,9 @@
+/**
+ * General-purpose helpers for state, objects, strings, scheduling, and
+ * assertions.
+ * @module General utilities
+ */
+
 import type {
   AnyFunction,
   AnyObject,
@@ -145,7 +151,7 @@ export function cx(...args: Array<string | null | false | 0 | undefined>) {
 }
 
 /**
- * Removes diatrics from a string.
+ * Removes diacritics from a string.
  */
 export function normalizeString(str: string) {
   return str.normalize("NFD").replace(/[\u0300-\u036f]/g, "");

--- a/packages/ariakit-utils/src/platform.ts
+++ b/packages/ariakit-utils/src/platform.ts
@@ -1,3 +1,8 @@
+/**
+ * Browser and platform detection helpers.
+ * @module Platform utilities
+ */
+
 import { canUseDOM } from "./dom.ts";
 
 /**

--- a/packages/ariakit-utils/src/types.ts
+++ b/packages/ariakit-utils/src/types.ts
@@ -1,4 +1,9 @@
 /**
+ * Shared type utilities used across Ariakit packages.
+ * @module Type utilities
+ */
+
+/**
  * Any object.
  */
 export type AnyObject = Record<string, any>;

--- a/packages/ariakit-utils/src/undo.ts
+++ b/packages/ariakit-utils/src/undo.ts
@@ -1,3 +1,8 @@
+/**
+ * Undo and redo manager utilities.
+ * @module Undo utilities
+ */
+
 type Callback = void | (() => Callback | Promise<Callback>);
 
 interface CreateUndoManagerOptions {
@@ -14,8 +19,14 @@ function createUndoCallback(callback: Callback) {
   };
 }
 
+/**
+ * Shared undo manager instance.
+ */
 export const UndoManager = createUndoManager();
 
+/**
+ * Creates an undo manager with undo and redo stacks.
+ */
 export function createUndoManager({
   limit = 100,
 }: CreateUndoManagerOptions = {}) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -684,6 +684,9 @@ importers:
       rolldown-plugin-dts:
         specifier: 0.25.1
         version: 0.25.1(rolldown@1.0.2)(typescript@6.0.3)
+      ts-morph:
+        specifier: 28.0.0
+        version: 28.0.0
       vite-plugin-solid:
         specifier: 2.11.12
         version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.4))


### PR DESCRIPTION
## Motivation

`@ariakit/utils` exposes a single public entrypoint but its README did not include an API reference. Keeping that reference in sync manually would be error-prone, especially for signatures that should come from TypeScript and descriptions that should come from JSDoc.

## Solution

Add an `ariakit docs` command to `@ariakit/scripts` that generates Markdown from exported TypeScript declarations and JSDoc using `ts-morph`. The command prints Markdown by default and supports `--write` to inject the generated block into a README.

The generator groups exports by file-level `@module` tags, renders a module table of contents only when modules are present, uses headings and paragraphs instead of tables, includes referenced local helper types in public signatures, and truncates oversized declaration blocks such as `AriaRole`. The `@ariakit/utils` source files now define their doc groups with `@module`, and the package README includes the generated API reference.

## Verification

- `pnpm lint-fix`
- `pnpm test packages/ariakit-scripts/src/docs.test.ts`
- `pnpm tsc`
