### PR TITLE
Enforce separate `import type` statements via oxlint

### DIFF
--- a/app/src/components/content-admonition.astro
+++ b/app/src/components/content-admonition.astro
@@ -8,8 +8,10 @@
  *
  * SPDX-License-Identifier: UNLICENSED
  */
-import { Icon, type IconName } from "#app/icons/icon.react.tsx";
-import { AdmonitionTypeSchema, type AdmonitionType } from "#app/lib/schemas.ts";
+import { Icon } from "#app/icons/icon.react.tsx";
+import type { IconName } from "#app/icons/icon.react.tsx";
+import { AdmonitionTypeSchema } from "#app/lib/schemas.ts";
+import type { AdmonitionType } from "#app/lib/schemas.ts";
 import type { HTMLAttributes } from "astro/types";
 
 interface Props extends HTMLAttributes<"blockquote"> {

--- a/app/src/components/meta.astro
+++ b/app/src/components/meta.astro
@@ -8,10 +8,8 @@
  *
  * SPDX-License-Identifier: UNLICENSED
  */
-import {
-  getOGImageItem,
-  type GetOGImageItemParams,
-} from "#app/pages/og-image/api.ts";
+import { getOGImageItem } from "#app/pages/og-image/api.ts";
+import type { GetOGImageItemParams } from "#app/pages/og-image/api.ts";
 
 interface Props extends GetOGImageItemParams {
   title?: string;

--- a/app/src/components/page-card-component.astro
+++ b/app/src/components/page-card-component.astro
@@ -11,7 +11,8 @@
 import PageCard from "#app/components/page-card.astro";
 import { filterPreviews } from "#app/lib/content.ts";
 import type { Framework } from "#app/lib/schemas.ts";
-import { type CollectionEntry, getCollection } from "astro:content";
+import { getCollection } from "astro:content";
+import type { CollectionEntry } from "astro:content";
 import pluralize from "pluralize";
 
 interface Props {

--- a/app/src/components/page-card-example.astro
+++ b/app/src/components/page-card-example.astro
@@ -11,7 +11,8 @@
 import PageCard from "#app/components/page-card.astro";
 import { filterPreviews } from "#app/lib/content.ts";
 import type { Framework } from "#app/lib/schemas.ts";
-import { type CollectionEntry, getCollection } from "astro:content";
+import { getCollection } from "astro:content";
+import type { CollectionEntry } from "astro:content";
 import pluralize from "pluralize";
 import type { ComponentProps } from "react";
 

--- a/app/src/components/reference-content.astro
+++ b/app/src/components/reference-content.astro
@@ -26,8 +26,8 @@ import {
   getReferenceItemId,
   getReferenceItemKind,
   getReferenceSections,
-  type ReferenceSection,
 } from "#app/lib/reference.ts";
+import type { ReferenceSection } from "#app/lib/reference.ts";
 import type { Reference } from "#app/lib/schemas.ts";
 import { getReferencePath } from "#app/lib/url.ts";
 import type { CollectionEntry } from "astro:content";

--- a/app/src/components/reference-item.astro
+++ b/app/src/components/reference-item.astro
@@ -8,10 +8,11 @@
  *
  * SPDX-License-Identifier: UNLICENSED
  */
-import { type ReferenceItem as ReferenceSectionItem } from "#app/lib/reference.ts";
+import type { ReferenceItem as ReferenceSectionItem } from "#app/lib/reference.ts";
 import { getReferencePath } from "#app/lib/url.ts";
 import type { ComponentProps } from "astro/types";
-import { getEntry, type CollectionEntry } from "astro:content";
+import { getEntry } from "astro:content";
+import type { CollectionEntry } from "astro:content";
 import { encode } from "html-entities";
 import pluralize from "pluralize";
 import ContentAdmonition from "./content-admonition.astro";

--- a/app/src/lib/content.ts
+++ b/app/src/lib/content.ts
@@ -8,11 +8,8 @@
  * SPDX-License-Identifier: UNLICENSED
  */
 import { invariant } from "@ariakit/utils";
-import {
-  createMarkdownProcessor,
-  type MarkdownProcessor,
-  type RehypePlugin,
-} from "@astrojs/markdown-remark";
+import { createMarkdownProcessor } from "@astrojs/markdown-remark";
+import type { MarkdownProcessor, RehypePlugin } from "@astrojs/markdown-remark";
 import type { CollectionEntry } from "astro:content";
 import { toText } from "hast-util-to-text";
 import rehypeParse from "rehype-parse";

--- a/app/src/pages/admin/teams.astro
+++ b/app/src/pages/admin/teams.astro
@@ -11,7 +11,8 @@
 import { InlineLink } from "#app/components/inline-link.react.tsx";
 import { Icon } from "#app/icons/icon.react.tsx";
 import { isAdmin } from "#app/lib/auth.ts";
-import { clerkClient, type Organization } from "@clerk/astro/server";
+import { clerkClient } from "@clerk/astro/server";
+import type { Organization } from "@clerk/astro/server";
 import LayoutPagination from "./_layout-pagination.astro";
 import {
   getClerkInstanceUrl,

--- a/app/src/pages/plus/checkout/[...checkout].astro
+++ b/app/src/pages/plus/checkout/[...checkout].astro
@@ -22,8 +22,8 @@ import {
   PlusCheckoutStepSchema,
   PlusTypeSchema,
   URLSchema,
-  type PlusCheckoutStep,
 } from "#app/lib/schemas.ts";
+import type { PlusCheckoutStep } from "#app/lib/schemas.ts";
 import { capitalize } from "#app/lib/string.ts";
 import { getPlusPrice, processCheckout } from "#app/lib/stripe.ts";
 import { getPlusAccountPath, getPlusCheckoutPath } from "#app/lib/url.ts";

--- a/app/src/sandbox/ariakit-tailwind/test-chrome.ts
+++ b/app/src/sandbox/ariakit-tailwind/test-chrome.ts
@@ -1,5 +1,6 @@
 import { AxeBuilder } from "@axe-core/playwright";
-import { expect, type Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { withFramework } from "#app/test-utils/preview.ts";
 
 type ColorContrastViolationMap = Record<string, string>;

--- a/app/src/test-utils/fixtures.ts
+++ b/app/src/test-utils/fixtures.ts
@@ -2,13 +2,16 @@ import {
   appendResults,
   createPerfMeasure,
   createPerfPageLoadMeasure,
-  type PerfMeasureOptions,
-  type PerfMetrics,
-  type PerfResult,
+} from "@ariakit/scripts/perf";
+import type {
+  PerfMeasureOptions,
+  PerfMetrics,
+  PerfResult,
 } from "@ariakit/scripts/perf";
 import { query } from "@ariakit/test/playwright";
 import { test as base } from "@playwright/test";
-import { visual, type ScreenshotOptions } from "./visual.ts";
+import { visual } from "./visual.ts";
+import type { ScreenshotOptions } from "./visual.ts";
 
 export const test = base.extend<{
   visual: (options?: ScreenshotOptions) => Promise<void>;

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     "consistent-return": "off",
     "no-unnecessary-type-arguments": "off",
     "consistent-type-imports": ["error", { fixStyle: "separate-type-imports" }],
+    "consistent-type-specifier-style": ["error", "prefer-top-level"],
     "no-unused-vars": [
       "error",
       {

--- a/packages/ariakit-scripts/src/build.ts
+++ b/packages/ariakit-scripts/src/build.ts
@@ -1,7 +1,8 @@
 import { lstatSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { join, relative, sep } from "node:path";
-import { build as rolldownBuild, type Plugin } from "rolldown";
+import { build as rolldownBuild } from "rolldown";
+import type { Plugin } from "rolldown";
 import { dts } from "rolldown-plugin-dts";
 import solidPlugin from "vite-plugin-solid";
 

--- a/packages/ariakit-scripts/src/perf-compare.ts
+++ b/packages/ariakit-scripts/src/perf-compare.ts
@@ -6,14 +6,13 @@ import {
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
-import {
-  mergeScriptProfiles,
-  mergeSelectorProfiles,
-  type PerfMetrics,
-  type PerfProfiles,
-  type PerfResult,
-  type PerfScriptProfileEntry,
-  type PerfSelectorProfileEntry,
+import { mergeScriptProfiles, mergeSelectorProfiles } from "./perf.ts";
+import type {
+  PerfMetrics,
+  PerfProfiles,
+  PerfResult,
+  PerfScriptProfileEntry,
+  PerfSelectorProfileEntry,
 } from "./perf.ts";
 
 const RESULTS_DIR = path.join(process.cwd(), ".perf-results");

--- a/packages/ariakit-scripts/src/react18.ts
+++ b/packages/ariakit-scripts/src/react18.ts
@@ -12,7 +12,8 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { delimiter, dirname, isAbsolute, join, relative, sep } from "node:path";
-import { watch, type FSWatcher } from "chokidar";
+import { watch } from "chokidar";
+import type { FSWatcher } from "chokidar";
 
 interface PackageJson {
   scripts?: Record<string, string>;


### PR DESCRIPTION
## Motivation

Type-only imports should live in their own top-level `import type { … }` statements, separate from value imports. We already had `consistent-type-imports` (`fixStyle: "separate-type-imports"`), but that rule only rewrites imports whose specifiers are *all* type-only — it does not flag mixed imports that inline the `type` keyword, such as `import { foo, type Bar } from "…"`. As a result, inline type specifiers were still permitted and had crept into the codebase.

## Solution

Enable the `import` plugin's `consistent-type-specifier-style` rule with `prefer-top-level`, next to the existing `consistent-type-imports`. Together they enforce that every type import is a separate top-level `import type` statement. The rule is auto-fixable, so `pnpm lint-fix` rewrote the existing inline specifiers, e.g.:

```ts
// before
import { build as rolldownBuild, type Plugin } from "rolldown";

// after
import { build as rolldownBuild } from "rolldown";
import type { Plugin } from "rolldown";
```

## Changes

- `oxlint.config.ts`: add `"consistent-type-specifier-style": ["error", "prefer-top-level"]`.
- 6 TypeScript files: auto-fixed by `pnpm lint-fix`.
- 8 `.astro` files: fixed manually (see note below).

## Note on `.astro` files

oxlint cannot parse `.astro` files (they are excluded via `ignorePatterns: ["website", "**/*.astro"]`), so the rule cannot autofix or enforce them. The `.astro` files that contained inline type imports were split by hand for consistency. Because the rule does not run on those paths, future inline type imports in `.astro`/`website` files won't be caught automatically and should be flagged in review.

No changeset: only the dev lint config and private workspaces (`app`, `@ariakit/scripts`) changed, and type imports are erased at build, so published output is unaffected.
