### PR TITLE
Fix flaky perf test timeouts caused by networkidle waits

### DIFF
--- a/app/src/test-utils/preview.ts
+++ b/app/src/test-utils/preview.ts
@@ -1,9 +1,32 @@
 import { readdirSync } from "node:fs";
 import { relative, resolve } from "node:path";
 import { query } from "@ariakit/test/playwright";
+import { errors } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { frameworks, getIndexFile } from "#app/lib/frameworks.ts";
 import { keys } from "#app/lib/object.ts";
 import { test } from "./fixtures.ts";
+
+/**
+ * Navigates to `url` and waits for it to be ready for a browser test. Waits for
+ * the bounded `load` event rather than `networkidle`: under CI contention,
+ * networkidle's unbounded "no requests for 500ms" wait can stall past the test
+ * timeout. After `load`, still wait for network idle so late work (such as
+ * `client:load` island hydration) settles, but cap it so a stalled or chatty
+ * request degrades to a short wait instead of consuming the test budget. Only
+ * the bounded settle timing out is expected; rethrow real failures such as the
+ * page or context closing.
+ *
+ * Kept in sync with the copy in `packages/ariakit-scripts/src/perf.ts`.
+ */
+async function gotoAndSettle(page: Page, url: string) {
+  await page.goto(url, { waitUntil: "load" });
+  await page
+    .waitForLoadState("networkidle", { timeout: 5_000 })
+    .catch((error) => {
+      if (!(error instanceof errors.TimeoutError)) throw error;
+    });
+}
 
 const SRC_DIR = resolve(import.meta.dirname, "..");
 
@@ -48,13 +71,7 @@ export function withFramework(
   for (const framework of frameworkNames) {
     test.describe(framework, { tag: `@${framework}` }, () => {
       test.beforeEach(async ({ page }) => {
-        await page.goto(`/${framework}/previews/${id}/`, {
-          // Perf runs re-navigate this page repeatedly under a single timeout,
-          // where `networkidle`'s unbounded wait can stall on a contended CI
-          // runner. Use the bounded `load` event for them; keep `networkidle`
-          // for visual and browser tests so async content settles first.
-          waitUntil: process.env.PERF_TEST === "true" ? "load" : "networkidle",
-        });
+        await gotoAndSettle(page, `/${framework}/previews/${id}/`);
       });
       return callback({ id, framework, query, test });
     });

--- a/app/src/test-utils/preview.ts
+++ b/app/src/test-utils/preview.ts
@@ -49,7 +49,11 @@ export function withFramework(
     test.describe(framework, { tag: `@${framework}` }, () => {
       test.beforeEach(async ({ page }) => {
         await page.goto(`/${framework}/previews/${id}/`, {
-          waitUntil: "networkidle",
+          // Perf runs re-navigate this page repeatedly under a single timeout,
+          // where `networkidle`'s unbounded wait can stall on a contended CI
+          // runner. Use the bounded `load` event for them; keep `networkidle`
+          // for visual and browser tests so async content settles first.
+          waitUntil: process.env.PERF_TEST === "true" ? "load" : "networkidle",
         });
       });
       return callback({ id, framework, query, test });

--- a/packages/ariakit-scripts/src/perf.ts
+++ b/packages/ariakit-scripts/src/perf.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { errors } from "@playwright/test";
 import type { CDPSession, Page, TestInfo } from "@playwright/test";
 
 const RESULTS_DIR = path.join(process.cwd(), ".perf-results");
@@ -572,19 +573,24 @@ async function collectInpValues(page: Page): Promise<number[]> {
 }
 
 /**
- * Navigates to `url` for a perf measurement. Waits for the bounded `load` event
- * instead of `networkidle`: under CI contention, networkidle's unbounded "no
- * requests for 500ms" wait can stall past the test timeout (these preview pages
- * have no long-lived connections, so `load` already covers them). After `load`,
- * still give late work such as island hydration a chance to settle by waiting
- * for network idle, but cap it so a stalled request degrades to a short wait
- * rather than consuming the entire test budget.
+ * Navigates to `url` and waits for it to be ready for a browser test. Waits for
+ * the bounded `load` event rather than `networkidle`: under CI contention,
+ * networkidle's unbounded "no requests for 500ms" wait can stall past the test
+ * timeout. After `load`, still wait for network idle so late work (such as
+ * `client:load` island hydration) settles, but cap it so a stalled or chatty
+ * request degrades to a short wait instead of consuming the test budget. Only
+ * the bounded settle timing out is expected; rethrow real failures such as the
+ * page or context closing.
+ *
+ * Kept in sync with the copy in `app/src/test-utils/preview.ts`.
  */
-async function gotoForPerf(page: Page, url: string) {
+async function gotoAndSettle(page: Page, url: string) {
   await page.goto(url, { waitUntil: "load" });
   await page
     .waitForLoadState("networkidle", { timeout: 5_000 })
-    .catch(() => {});
+    .catch((error) => {
+      if (!(error instanceof errors.TimeoutError)) throw error;
+    });
 }
 
 /**
@@ -785,7 +791,7 @@ export async function createPerfMeasure(
     for (let i = 0; i < warmup + iterations; i++) {
       if (resetPage) {
         // Re-navigate for a clean state on every iteration.
-        await gotoForPerf(page, url);
+        await gotoAndSettle(page, url);
       }
 
       const result = await measureOnce(page, cdp, interaction, {
@@ -849,7 +855,7 @@ export async function createPerfPageLoadMeasure(
   return createPerfMeasure(
     page,
     async () => {
-      await gotoForPerf(page, url);
+      await gotoAndSettle(page, url);
     },
     results,
     testInfo,

--- a/packages/ariakit-scripts/src/perf.ts
+++ b/packages/ariakit-scripts/src/perf.ts
@@ -572,6 +572,22 @@ async function collectInpValues(page: Page): Promise<number[]> {
 }
 
 /**
+ * Navigates to `url` for a perf measurement. Waits for the bounded `load` event
+ * instead of `networkidle`: under CI contention, networkidle's unbounded "no
+ * requests for 500ms" wait can stall past the test timeout (these preview pages
+ * have no long-lived connections, so `load` already covers them). After `load`,
+ * still give late work such as island hydration a chance to settle by waiting
+ * for network idle, but cap it so a stalled request degrades to a short wait
+ * rather than consuming the entire test budget.
+ */
+async function gotoForPerf(page: Page, url: string) {
+  await page.goto(url, { waitUntil: "load" });
+  await page
+    .waitForLoadState("networkidle", { timeout: 5_000 })
+    .catch(() => {});
+}
+
+/**
  * Runs a single interaction measurement cycle: snapshot CDP metrics before and
  * after the interaction, collect INP entries, and return the deltas.
  */
@@ -769,7 +785,7 @@ export async function createPerfMeasure(
     for (let i = 0; i < warmup + iterations; i++) {
       if (resetPage) {
         // Re-navigate for a clean state on every iteration.
-        await page.goto(url, { waitUntil: "networkidle" });
+        await gotoForPerf(page, url);
       }
 
       const result = await measureOnce(page, cdp, interaction, {
@@ -833,7 +849,7 @@ export async function createPerfPageLoadMeasure(
   return createPerfMeasure(
     page,
     async () => {
-      await page.goto(url, { waitUntil: "networkidle" });
+      await gotoForPerf(page, url);
     },
     results,
     testInfo,


### PR DESCRIPTION
## Motivation

The `perf` workflow's Chrome job intermittently fails because a Playwright perf test exceeds its 120s timeout. It always happens on the heaviest perf page (`ariakit-tailwind`), and the `perf` project runs with `retries: 0` and a single worker, so one stalled test fails the whole job (e.g. [this run](https://github.com/ariakit/ariakit/actions/runs/26605110997/job/78398577072)).

Every preview navigation waited for `waitUntil: "networkidle"`, which resolves only after the browser observes no in-flight requests for 500ms. On the shared 2-core CI runner — where the preview servers and Chrome compete for CPU — that quiet window can take a long time, or never open, on the heaviest page, so a navigation occasionally consumes the entire test budget. In one failing run a single `beforeEach` navigation ate the full 120s; in another, sustained contention timed out both `ariakit-tailwind` tests across rounds. The `page.evaluate` lines in the reported stacks are just where the already-elapsed deadline happened to surface. Playwright itself discourages `networkidle` for exactly this reason — and the same latent hang applies to any browser test, not just perf.

## Solution

Replace the unbounded `networkidle` navigation wait with a bounded `gotoAndSettle` helper used for every preview navigation:

1. Wait for the deterministic `load` event (always fires once the page's resources load).
2. Then perform a *best-effort* `networkidle` settle capped at 5s (`waitForLoadState("networkidle", { timeout: 5_000 })`), so late work — such as `client:load` island hydration — quiesces before measuring/asserting, but a stalled or chatty request degrades to a short wait instead of consuming the test budget. Only the settle timing out is ignored; real failures (page or context closed) are rethrown.

This is applied to **all** app browser tests via the shared `withFramework` beforeEach (`app/src/test-utils/preview.ts`) and to the per-iteration re-navigations in the perf harness (`packages/ariakit-scripts/src/perf.ts`). Because `networkidle` normally settles well under 5s, the page-ready point is unchanged for existing tests; only the pathological unbounded hang is removed. The helper is intentionally duplicated in both files to avoid a cross-package import.

## Notes

- On this PR, the perf-compare baseline runs the base commit (still `networkidle`) while the new run uses the bounded wait, so the `ariakit-tailwind` page-load numbers in the perf comment may shift slightly. This self-corrects once the change is on the base branch, and `perf-compare` only posts a comment — it never fails the job.

## Verification

`pnpm tsc` and `pnpm lint` pass; the `ariakit-tailwind` perf tests and a regular browser test pass locally with the shared helper.
