### PR TITLE
Speed up the perf workflow's Chrome and Node jobs

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -6,6 +6,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build app
@@ -56,31 +60,6 @@ jobs:
           path: nextjs/.open-next
           retention-days: 7
           include-hidden-files: true
-
-  build-packages:
-    name: Build packages
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Set up environment
-        uses: ./.github/workflows/setup
-
-      - name: Build packages
-        run: pnpm build
-
-      - name: Upload package artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: package-build
-          path: |
-            packages/*/dist
-            packages/*/solid
-            packages/*/package.json
-          retention-days: 7
 
   chrome-baseline:
     name: Prepare Chrome baseline
@@ -248,16 +227,10 @@ jobs:
             cp "$file" "$BASELINE_DIR/$file"
           done
 
-      - name: Build baseline packages
-        working-directory: ${{ runner.temp }}/perf-node-baseline
-        run: pnpm build
-
       - name: Pack baseline artifacts
         run: |
           cd "$BASELINE_DIR"
           tar -czf "$RUNNER_TEMP/perf-node-baseline-build.tar.gz" \
-            packages/*/dist \
-            packages/*/solid \
             packages/*/package.json \
             vitest.bench.config.ts \
             packages/*/benchmark
@@ -270,9 +243,18 @@ jobs:
           retention-days: 7
 
   chrome:
-    name: Chrome
+    name: Chrome (shard ${{ matrix.shard }})
     needs: [build, build-nextjs, chrome-baseline]
     runs-on: ubuntu-latest
+    strategy:
+      # Let both shards finish even if one fails, so each shard's logs and
+      # uploaded rounds stay available for debugging. Chrome perf is still
+      # all-or-nothing: chrome-merge only runs when every shard succeeded.
+      fail-fast: false
+      matrix:
+        # Raise the shard count (and PERF_SHARD_TOTAL below) as the number of
+        # perf-chrome test files grows; the file partition handles any count.
+        shard: [1, 2]
     permissions:
       actions: read
       contents: read
@@ -285,12 +267,16 @@ jobs:
       # enough signal for noisy results.
       PERF_ITERATIONS: 5
       PERF_WARMUP: 1
-      PERF_RESULTS_TITLE: Chrome
+      # Each shard benchmarks a disjoint subset of the perf test files and runs
+      # its own interleaved baseline-vs-current rounds on this one runner, so the
+      # paired same-runner comparison is preserved. chrome-merge runs
+      # perf-compare once over every shard's raw round files.
+      PERF_SHARD_INDEX: ${{ matrix.shard }}
+      PERF_SHARD_TOTAL: 2
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Set up environment
@@ -302,11 +288,14 @@ jobs:
           engine: chromium
 
       - name: Set up baseline worktree
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           BASELINE_DIR="$RUNNER_TEMP/perf-baseline"
           echo "BASELINE_DIR=$BASELINE_DIR" >> "$GITHUB_ENV"
-          git worktree add --detach "$BASELINE_DIR" \
-            ${{ github.event.pull_request.base.sha }}
+          git fetch --depth=1 origin "$BASE_SHA" || git fetch origin "$BASE_REF"
+          git worktree add --detach "$BASELINE_DIR" "$BASE_SHA"
 
       - name: Install dependencies (baseline)
         working-directory: ${{ runner.temp }}/perf-baseline
@@ -315,7 +304,7 @@ jobs:
           # so husky's prepare step would otherwise rewrite `core.hooksPath`
           # to a relative path under a temporary worktree.
           HUSKY: 0
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Install Playwright (baseline)
         working-directory: ${{ runner.temp }}/perf-baseline
@@ -354,6 +343,26 @@ jobs:
           mkdir -p app/.perf-results
           shopt -s nullglob
 
+          # Partition the perf test files across shards. The list is computed
+          # from the current checkout and the SAME slice is passed to both the
+          # baseline and current runs below, so every test's baseline and
+          # current measurements stay on this one runner (paired comparison
+          # preserved) no matter how the base and head test sets differ.
+          # Keep this find pattern a superset of the perf `testMatch` in
+          # app/playwright.config.ts; a file it misses would never be sharded.
+          mapfile -t ALL_PERF_FILES < <(
+            cd app && find src -type f \
+              \( -path '*perf*-chrome.ts' -o -path '*perf*-chrome.tsx' \) \
+              | sort
+          )
+          SHARD_FILES=()
+          for idx in "${!ALL_PERF_FILES[@]}"; do
+            if [ "$(( idx % PERF_SHARD_TOTAL ))" -eq "$(( PERF_SHARD_INDEX - 1 ))" ]; then
+              SHARD_FILES+=("${ALL_PERF_FILES[$idx]}")
+            fi
+          done
+          echo "Shard $PERF_SHARD_INDEX/$PERF_SHARD_TOTAL perf files: ${SHARD_FILES[*]:-<none>}"
+
           run_perf_round() {
             local i="$1"
 
@@ -361,10 +370,10 @@ jobs:
             local baseline_failed=0
             if ! (
               cd "$BASELINE_DIR" || exit 1
-              PERF_RESULTS_FILE=baseline-$i.json \
+              PERF_RESULTS_FILE=baseline-$i-s$PERF_SHARD_INDEX.json \
               PERF_ITERATIONS="$PERF_ITERATIONS" \
               PERF_WARMUP="$PERF_WARMUP" \
-              xvfb-run -a pnpm -F app run test-perf --pass-with-no-tests
+              xvfb-run -a pnpm -F app run test-perf --pass-with-no-tests "${SHARD_FILES[@]}"
             ); then
               echo "::warning::Baseline perf run failed for round $i; writing an empty baseline."
               baseline_failed=1
@@ -374,17 +383,17 @@ jobs:
               if [ "$baseline_failed" -eq 0 ]; then
                 echo "::warning::No baseline perf results for round $i; writing an empty baseline."
               fi
-              printf '[]\n' > app/.perf-results/baseline-"$i"-worker0.json
+              printf '[]\n' > app/.perf-results/baseline-"$i"-s"$PERF_SHARD_INDEX"-worker0.json
             else
               cp "${baseline_files[@]}" app/.perf-results/
             fi
             echo "::endgroup::"
 
             echo "::group::Round $i - current"
-            PERF_RESULTS_FILE=current-$i.json \
+            PERF_RESULTS_FILE=current-$i-s$PERF_SHARD_INDEX.json \
             PERF_ITERATIONS="$PERF_ITERATIONS" \
             PERF_WARMUP="$PERF_WARMUP" \
-            xvfb-run -a pnpm -F app run test-perf --pass-with-no-tests
+            xvfb-run -a pnpm -F app run test-perf --pass-with-no-tests "${SHARD_FILES[@]}"
             local current_files=(app/.perf-results/current-"$i"*.json)
             if [ ${#current_files[@]} -eq 0 ]; then
               echo "Missing current perf results for round $i" >&2
@@ -393,11 +402,22 @@ jobs:
             echo "::endgroup::"
           }
 
+          if [ ${#SHARD_FILES[@]} -eq 0 ]; then
+            echo "No perf files assigned to this shard; nothing to benchmark."
+            exit 0
+          fi
+
           for i in $(seq 1 "$PERF_INITIAL_ROUNDS"); do
             run_perf_round "$i"
           done
 
-          echo "::group::Preliminary comparison"
+          # This per-shard comparison only decides whether THIS shard needs
+          # confirmation rounds for its own files; each shard confirms its own
+          # significant deltas. Confirmation is per-shard rather than job-wide,
+          # which still confirms every flagged regression in the shard where it
+          # lives. The published comparison is produced once by chrome-merge
+          # over every shard's raw round files.
+          echo "::group::Preliminary comparison (shard $PERF_SHARD_INDEX)"
           pnpm -F app run perf-compare
           has_significant_changes=$(
             node --input-type=module <<'NODE'
@@ -419,13 +439,66 @@ jobs:
             for i in $(seq "$start_round" "$end_round"); do
               run_perf_round "$i"
             done
-
-            echo "::group::Final comparison"
-            pnpm -F app run perf-compare
-            echo "::endgroup::"
           else
             echo "No significant changes detected; skipping confirmation rounds."
           fi
+
+      - name: Upload shard round results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: perf-chrome-rounds-${{ matrix.shard }}
+          path: |
+            app/.perf-results/baseline-*.json
+            app/.perf-results/current-*.json
+          if-no-files-found: ignore
+          include-hidden-files: true
+          retention-days: 7
+
+  chrome-merge:
+    name: Chrome
+    # Default needs gating: runs only when every shard succeeded, so the
+    # published Chrome comparison always covers the full perf suite. If any
+    # shard fails this job is skipped and the post job reports no Chrome result
+    # rather than a silent partial one; the failed shard stays visibly red.
+    needs: [chrome]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    env:
+      PERF_RESULTS_TITLE: Chrome
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up environment
+        uses: ./.github/workflows/setup
+
+      - name: Download shard round results
+        # Tolerate the case where no shard uploaded rounds (e.g. every shard
+        # failed); the compare step below then logs and skips gracefully.
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          pattern: perf-chrome-rounds-*
+          path: ${{ runner.temp }}/perf-chrome-rounds
+          merge-multiple: true
+
+      - name: Compare interleaved perf results
+        run: |
+          rm -rf app/.perf-results
+          mkdir -p app/.perf-results
+          shopt -s nullglob
+          round_files=("$RUNNER_TEMP"/perf-chrome-rounds/*.json)
+          if [ ${#round_files[@]} -eq 0 ]; then
+            echo "::warning::No Chrome shard round results found; skipping comparison."
+            exit 0
+          fi
+          cp "${round_files[@]}" app/.perf-results/
+          pnpm -F app run perf-compare
 
       - name: Write performance metadata
         if: always()
@@ -445,7 +518,7 @@ jobs:
 
   node:
     name: Node
-    needs: [build-packages, node-baseline]
+    needs: [node-baseline]
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -460,18 +533,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Set up environment
         uses: ./.github/workflows/setup
 
       - name: Set up baseline worktree
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           BASELINE_DIR="$RUNNER_TEMP/perf-node-baseline"
           echo "BASELINE_DIR=$BASELINE_DIR" >> "$GITHUB_ENV"
-          git worktree add --detach "$BASELINE_DIR" \
-            ${{ github.event.pull_request.base.sha }}
+          git fetch --depth=1 origin "$BASE_SHA" || git fetch origin "$BASE_REF"
+          git worktree add --detach "$BASELINE_DIR" "$BASE_SHA"
 
       - name: Install dependencies (baseline)
         working-directory: ${{ runner.temp }}/perf-node-baseline
@@ -480,7 +555,7 @@ jobs:
           # so husky's prepare step would otherwise rewrite `core.hooksPath`
           # to a relative path under a temporary worktree.
           HUSKY: 0
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Download baseline artifacts
         uses: actions/download-artifact@v8
@@ -493,12 +568,6 @@ jobs:
           tar -xzf \
             "${{ runner.temp }}/perf-node-baseline-build/perf-node-baseline-build.tar.gz" \
             -C "$BASELINE_DIR"
-
-      - name: Download package artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: package-build
-          path: packages
 
       - name: Run interleaved benchmarks
         run: |
@@ -563,12 +632,13 @@ jobs:
             for i in $(seq "$start_round" "$end_round"); do
               run_bench_round "$i"
             done
+
+            echo "::group::Final comparison"
+            pnpm exec ariakit perf-compare --node
+            echo "::endgroup::"
           else
             echo "No significant changes detected; skipping confirmation rounds."
           fi
-
-      - name: Compare benchmark results
-        run: pnpm exec ariakit perf-compare --node
 
       - name: Write performance metadata
         if: always()
@@ -590,10 +660,10 @@ jobs:
     name: Post PR comment
     # Add future performance jobs here. Each one should upload a
     # perf-results-* artifact with its comparison files.
-    needs: [chrome, node]
+    needs: [chrome-merge, node]
     if: >
       always() &&
-      (needs.chrome.result == 'success' || needs.node.result == 'success') &&
+      (needs.chrome-merge.result == 'success' || needs.node.result == 'success') &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
@@ -623,7 +693,7 @@ jobs:
         env:
           PERF_RESULTS_DIR: ${{ runner.temp }}/perf-results
           PERF_RESULTS_DEFAULT_TITLE: Chrome
-          PERF_RESULTS_CHROME_ENABLED: ${{ needs.chrome.result == 'success' }}
+          PERF_RESULTS_CHROME_ENABLED: ${{ needs.chrome-merge.result == 'success' }}
           PERF_RESULTS_NODE_ENABLED: ${{ needs.node.result == 'success' }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -243,7 +243,7 @@ jobs:
           retention-days: 7
 
   chrome:
-    name: Chrome (${{ matrix.shard }} / ${{ strategy.job-total }})
+    name: Chrome (${{ matrix.shard }}/${{ strategy.job-total }})
     needs: [build, build-nextjs, chrome-baseline]
     runs-on: ubuntu-latest
     strategy:
@@ -253,8 +253,9 @@ jobs:
       # fine; a failed shard stays visibly red in CI).
       fail-fast: false
       matrix:
-        # Raise the shard count (and PERF_SHARD_TOTAL below) as the number of
-        # perf-chrome test files grows; the file partition handles any count.
+        # `shard` is the only matrix dimension, so the job count equals the
+        # shard count; PERF_SHARD_TOTAL below derives from strategy.job-total.
+        # Raise this list as the number of perf-chrome test files grows.
         shard: [1, 2]
     permissions:
       actions: read
@@ -273,7 +274,7 @@ jobs:
       # paired same-runner comparison is preserved. The post job runs
       # perf-compare once over every shard's raw round files.
       PERF_SHARD_INDEX: ${{ matrix.shard }}
-      PERF_SHARD_TOTAL: 2
+      PERF_SHARD_TOTAL: ${{ strategy.job-total }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -243,13 +243,14 @@ jobs:
           retention-days: 7
 
   chrome:
-    name: Chrome (shard ${{ matrix.shard }})
+    name: Chrome (${{ matrix.shard }} / ${{ strategy.job-total }})
     needs: [build, build-nextjs, chrome-baseline]
     runs-on: ubuntu-latest
     strategy:
       # Let both shards finish even if one fails, so each shard's logs and
-      # uploaded rounds stay available for debugging. Chrome perf is still
-      # all-or-nothing: chrome-merge only runs when every shard succeeded.
+      # uploaded rounds stay available for debugging. The post job compares
+      # whatever rounds the succeeding shards produced (partial results are
+      # fine; a failed shard stays visibly red in CI).
       fail-fast: false
       matrix:
         # Raise the shard count (and PERF_SHARD_TOTAL below) as the number of
@@ -269,7 +270,7 @@ jobs:
       PERF_WARMUP: 1
       # Each shard benchmarks a disjoint subset of the perf test files and runs
       # its own interleaved baseline-vs-current rounds on this one runner, so the
-      # paired same-runner comparison is preserved. chrome-merge runs
+      # paired same-runner comparison is preserved. The post job runs
       # perf-compare once over every shard's raw round files.
       PERF_SHARD_INDEX: ${{ matrix.shard }}
       PERF_SHARD_TOTAL: 2
@@ -415,7 +416,7 @@ jobs:
           # confirmation rounds for its own files; each shard confirms its own
           # significant deltas. Confirmation is per-shard rather than job-wide,
           # which still confirms every flagged regression in the shard where it
-          # lives. The published comparison is produced once by chrome-merge
+          # lives. The published comparison is produced once by the post job
           # over every shard's raw round files.
           echo "::group::Preliminary comparison (shard $PERF_SHARD_INDEX)"
           pnpm -F app run perf-compare
@@ -451,67 +452,6 @@ jobs:
           path: |
             app/.perf-results/baseline-*.json
             app/.perf-results/current-*.json
-          if-no-files-found: ignore
-          include-hidden-files: true
-          retention-days: 7
-
-  chrome-merge:
-    name: Chrome
-    # Default needs gating: runs only when every shard succeeded, so the
-    # published Chrome comparison always covers the full perf suite. If any
-    # shard fails this job is skipped and the post job reports no Chrome result
-    # rather than a silent partial one; the failed shard stays visibly red.
-    needs: [chrome]
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-    env:
-      PERF_RESULTS_TITLE: Chrome
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Set up environment
-        uses: ./.github/workflows/setup
-
-      - name: Download shard round results
-        # Tolerate the case where no shard uploaded rounds (e.g. every shard
-        # failed); the compare step below then logs and skips gracefully.
-        continue-on-error: true
-        uses: actions/download-artifact@v8
-        with:
-          pattern: perf-chrome-rounds-*
-          path: ${{ runner.temp }}/perf-chrome-rounds
-          merge-multiple: true
-
-      - name: Compare interleaved perf results
-        run: |
-          rm -rf app/.perf-results
-          mkdir -p app/.perf-results
-          shopt -s nullglob
-          round_files=("$RUNNER_TEMP"/perf-chrome-rounds/*.json)
-          if [ ${#round_files[@]} -eq 0 ]; then
-            echo "::warning::No Chrome shard round results found; skipping comparison."
-            exit 0
-          fi
-          cp "${round_files[@]}" app/.perf-results/
-          pnpm -F app run perf-compare
-
-      - name: Write performance metadata
-        if: always()
-        run: |
-          mkdir -p app/.perf-results
-          printf '%s\n' "$PERF_RESULTS_TITLE" > app/.perf-results/title.txt
-
-      - name: Upload performance results
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: perf-results-chrome
-          path: app/.perf-results
           if-no-files-found: ignore
           include-hidden-files: true
           retention-days: 7
@@ -658,26 +598,69 @@ jobs:
 
   post:
     name: Post PR comment
-    # Add future performance jobs here. Each one should upload a
-    # perf-results-* artifact with its comparison files.
-    needs: [chrome-merge, node]
+    # Chrome shards upload raw `perf-chrome-rounds-*` artifacts that this job
+    # compares into a Chrome section; the Node job uploads a pre-computed
+    # `perf-results-node` artifact. Future perf jobs can do either.
+    needs: [chrome, node]
     if: >
       always() &&
-      (needs.chrome-merge.result == 'success' || needs.node.result == 'success') &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
     steps:
-      - name: Download performance results
-        id: download-results
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up environment
+        uses: ./.github/workflows/setup
+
+      # Download both engines' artifacts before comparing, so a Chrome-side
+      # problem can never prevent the Node section from being posted.
+      - name: Download Node performance results
+        # Only publish Node results when the Node job fully succeeded. Its
+        # artifact is uploaded with `if: always()` and may hold a stale
+        # preliminary comparison if a later confirmation round failed.
+        if: needs.node.result == 'success'
         continue-on-error: true
         uses: actions/download-artifact@v8
         with:
-          pattern: perf-results-*
-          path: ${{ runner.temp }}/perf-results
-          merge-multiple: false
+          name: perf-results-node
+          path: ${{ runner.temp }}/perf-results/perf-results-node
+
+      - name: Download Chrome shard round results
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          pattern: perf-chrome-rounds-*
+          path: ${{ runner.temp }}/perf-chrome-rounds
+          merge-multiple: true
+
+      - name: Compare Chrome perf results
+        # Never let a Chrome comparison failure abort the job before the Node
+        # section is posted; on failure the Chrome section is simply absent.
+        continue-on-error: true
+        env:
+          PERF_RESULTS_DIR: ${{ runner.temp }}/perf-results
+        run: |
+          shopt -s nullglob
+          rounds=("$RUNNER_TEMP"/perf-chrome-rounds/*.json)
+          if [ ${#rounds[@]} -eq 0 ]; then
+            echo "::warning::No Chrome shard rounds found; skipping Chrome comparison."
+            exit 0
+          fi
+          # Partial results are fine: compare whatever rounds the succeeding
+          # shards produced. Any failed shard stays visibly red in CI.
+          rm -rf app/.perf-results
+          mkdir -p app/.perf-results
+          cp "${rounds[@]}" app/.perf-results/
+          pnpm -F app run perf-compare
+          mkdir -p "$PERF_RESULTS_DIR/perf-results-chrome"
+          cp app/.perf-results/comparison.md "$PERF_RESULTS_DIR/perf-results-chrome/"
+          printf 'Chrome\n' > "$PERF_RESULTS_DIR/perf-results-chrome/title.txt"
 
       - name: Create GitHub App token
         id: app-token
@@ -692,9 +675,6 @@ jobs:
         uses: actions/github-script@v9
         env:
           PERF_RESULTS_DIR: ${{ runner.temp }}/perf-results
-          PERF_RESULTS_DEFAULT_TITLE: Chrome
-          PERF_RESULTS_CHROME_ENABLED: ${{ needs.chrome-merge.result == 'success' }}
-          PERF_RESULTS_NODE_ENABLED: ${{ needs.node.result == 'success' }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -703,14 +683,6 @@ jobs:
 
             const marker = '<!-- perf-results -->';
             const resultsDir = process.env.PERF_RESULTS_DIR;
-            const defaultTitle = process.env.PERF_RESULTS_DEFAULT_TITLE;
-            const enabledArtifacts = new Set();
-            if (process.env.PERF_RESULTS_CHROME_ENABLED === 'true') {
-              enabledArtifacts.add('perf-results-chrome');
-            }
-            if (process.env.PERF_RESULTS_NODE_ENABLED === 'true') {
-              enabledArtifacts.add('perf-results-node');
-            }
 
             function formatName(name) {
               return name
@@ -761,16 +733,11 @@ jobs:
                 groups.set(comparison.title, bodies);
               }
 
-              const rootComparison = path.join(resultsDir, 'comparison.md');
-              const rootTitle = readTitle(resultsDir, defaultTitle);
-              const rootSection = readComparison(rootComparison, rootTitle, {
-                optional: true,
-              });
-              addComparison(rootSection);
-
               for (const entry of entries
                 .filter((entry) => entry.isDirectory())
-                .filter((entry) => enabledArtifacts.has(entry.name))
+                .filter((entry) =>
+                  fs.existsSync(path.join(resultsDir, entry.name, 'comparison.md')),
+                )
                 .sort((a, b) => a.name.localeCompare(b.name))) {
                   const dir = path.join(resultsDir, entry.name);
                   const title = readTitle(dir, formatName(entry.name));

--- a/packages/ariakit-scripts/src/perf-compare.test.ts
+++ b/packages/ariakit-scripts/src/perf-compare.test.ts
@@ -383,7 +383,7 @@ test("merges sharded round files with shard-suffixed names", () => {
   const dir = createTempDir();
   // Mirrors the CI Chrome sharding: each shard writes round files carrying a
   // `-s<shard>` suffix (e.g. baseline-1-s1-worker0.json) for its own subset of
-  // tests, and chrome-merge runs a single comparison over all of them. Locks
+  // tests, and the post job runs a single comparison over all of them. Locks
   // that discoverRoundFiles accepts the suffix, pairs by round index, and
   // merges the shards' disjoint tests into one comparison.
   for (const round of [1, 2]) {

--- a/packages/ariakit-scripts/src/perf-compare.test.ts
+++ b/packages/ariakit-scripts/src/perf-compare.test.ts
@@ -379,6 +379,36 @@ test("aggregates displayed values from shared rounds", () => {
   expect(markdown).toContain("Aggregated across 2 interleaved rounds");
 });
 
+test("merges sharded round files with shard-suffixed names", () => {
+  const dir = createTempDir();
+  // Mirrors the CI Chrome sharding: each shard writes round files carrying a
+  // `-s<shard>` suffix (e.g. baseline-1-s1-worker0.json) for its own subset of
+  // tests, and chrome-merge runs a single comparison over all of them. Locks
+  // that discoverRoundFiles accepts the suffix, pairs by round index, and
+  // merges the shards' disjoint tests into one comparison.
+  for (const round of [1, 2]) {
+    writeJson(dir, `baseline-${round}-s1-worker0.json`, [
+      createResultWithLabel("shard one test", 100),
+    ]);
+    writeJson(dir, `current-${round}-s1-worker0.json`, [
+      createResultWithLabel("shard one test", 101),
+    ]);
+    writeJson(dir, `baseline-${round}-s2-worker0.json`, [
+      createResultWithLabel("shard two test", 100),
+    ]);
+    writeJson(dir, `current-${round}-s2-worker0.json`, [
+      createResultWithLabel("shard two test", 130),
+    ]);
+  }
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain("Aggregated across 2 interleaved rounds");
+  expect(markdown).toContain("shard one test");
+  expect(markdown).toContain("shard two test");
+  expect(markdown).toContain("100.0ms → 130.0ms (+30%) :warning:");
+});
+
 test("does not overstate mixed paired round counts", () => {
   const dir = createTempDir();
   writeJson(dir, "baseline-1-worker0.json", [

--- a/packages/ariakit-store/benchmark/store.bench.ts
+++ b/packages/ariakit-store/benchmark/store.bench.ts
@@ -43,9 +43,13 @@ interface BenchmarkState {
   value: string;
 }
 
+// CI compares these benchmarks across paired baseline/current rounds with a
+// ±10% significance gate (see `ariakit perf-compare --node`). This 1500/400ms
+// budget was validated to stay well under that gate for unchanged code;
+// re-validate run-to-run noise before reducing it further.
 const options = {
-  time: 2000,
-  warmupTime: 500,
+  time: 1500,
+  warmupTime: 400,
 };
 
 const itemIds = Array.from({ length: 100 }, (_, index) => `item-${index}`);


### PR DESCRIPTION
## Motivation

The `perf` workflow's Chrome and Node jobs are the long pole on every PR (~6.7 min and ~6.3 min in recent runs). In both, the actual perf/benchmark rounds dominate (~300s of ~400s); the rest is fixed setup, and the parallel build/baseline jobs finish in 1–2.5 min. The goal is to cut wall-clock time **without** weakening the perf comparison's reliability, which depends on running the baseline (PR base) and current code interleaved on the same runner and gating significance through `ariakit perf-compare` (±10% median delta with per-round sign agreement; Chrome also has a 5ms floor).

## Solution

**Chrome — shard across two runners.** The Chrome job is now a 2-way matrix. Each shard benchmarks a disjoint slice of the perf-chrome test files; the slice is computed once from the head checkout and passed to **both** the baseline and current runs, so every test's baseline/current measurements stay paired on one runner regardless of how the base and head test sets differ. Each shard writes shard-suffixed round files (`baseline-1-s1-worker0.json`) and uploads them raw; the existing `post` PR-comment job downloads every shard's rounds and runs `perf-compare` **once** over them. Partial results are intentional: if a shard fails it stays visibly red as its own matrix job, and `post` still reports whatever rounds the succeeding shards produced.

**Node — leaner, source-based benchmarks.** The tinybench budget drops from 2000/500ms to 1500/400ms (validated to stay well under the ±10% significance gate for unchanged code). The benchmark already resolves `@ariakit/store`/`@ariakit/utils` from source, so the `build-packages` job, the `package-build` download, and the baseline package build were removed as dead weight. The Node section of the comment is gated on the Node job succeeding, so its `if: always()` artifact can't surface a stale preliminary comparison.

**Shared setup trims.** Shallow base-sha `git fetch` instead of full history, `--prefer-offline` baseline installs, and a `cancel-in-progress` concurrency group.

## Reliability

The same-runner paired baseline-vs-current model and the `perf-compare` significance gate are unchanged; nothing about *what* is measured changes. A new `perf-compare` test locks the shard-suffixed round-file contract (round discovery + per-round pairing + disjoint-key merge).
