### PR TITLE
Improve Ariakit Tailwind layer style recalculation performance

### DIFF
--- a/.changeset/200-tailwind-layer-recalc.md
+++ b/.changeset/200-tailwind-layer-recalc.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/tailwind": patch
+---
+
+Improved the rendering performance of the layer utilities by reducing redundant per-element style work in the generated CSS.

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -473,7 +473,6 @@ function getLayerTextLightness() {
 // Constants registered once as @property initial values. They only depend on
 // color channels or fixed numeric constants.
 const constantMathVars = {
-  textContrastL: _ak.prop("tcl", { initial: TEXT_CONTRAST_L }),
   textForegroundContrastL: _ak.prop("tfcl", {
     initial: TEXT_FOREGROUND_CONTRAST_L,
   }),
@@ -563,7 +562,10 @@ const layerMathVars = {
   layerPushDirectionToLight: _ak.prop.zero("lpdtl"),
   layerPushBaseL: _ak.prop("lpbl", { initial: l }),
   layerPushL: _ak.prop("lpl", { initial: l }),
-  layerIdleContrastValue: _ak.prop.zero("licv", { inherits: true }),
+  // Set and read only within ak-layer (resolving --_ak-li); no descendant
+  // utility reads it, so inheritance would just push a dead value into every
+  // descendant's computed style. Keep it non-inherited (the default).
+  layerIdleContrastValue: _ak.prop.zero("licv"),
   edgeContrastValue: _ak.prop.zero("ecv", { inherits: true }),
   edgePushDirection: _ak.var("epd", -1),
 };

--- a/packages/ariakit-tailwind/src/output.css
+++ b/packages/ariakit-tailwind/src/output.css
@@ -1283,12 +1283,6 @@
   }
 }
 
-@property --_ak-tcl {
-  syntax: "*";
-  inherits: false;
-  initial-value: calc((0.645 - l) * 1000000);
-}
-
 @property --_ak-tfcl {
   syntax: "*";
   inherits: false;
@@ -1488,7 +1482,7 @@
 
 @property --_ak-licv {
   syntax: "<number>";
-  inherits: true;
+  inherits: false;
   initial-value: 0;
 }
 


### PR DESCRIPTION
## Motivation

`@ariakit/tailwind`'s generated CSS performs relative OKLCH/LCH color math on every element that uses the layer/text/edge utilities, so **per-element style recalculation dominates** the package's runtime cost on first paint. This trims avoidable per-element style-system overhead in the layer pipeline without changing any computed colors.

## Solution

Two behavior-preserving cleanups to `input.ts` (and the regenerated `output.css`):

- **Remove a dead registered custom property.** `--_ak-tcl` (`textContrastL`) was registered with `@property` but never read via `var()` — its value is inlined at build time through the `TEXT_CONTRAST_L` JS constant (left untouched). Removing the unused registration drops one `@property` the browser would otherwise initialize.
- **Stop an internal property from inheriting.** `--_ak-licv` (`layerIdleContrastValue`) is only set and read within the `ak-layer` body (it feeds `--_ak-li`); no descendant utility or container style query reads it. With `inherits: true` it was pushed into every descendant's computed style as dead state, so it now uses the non-inheriting default. (`--_ak-ecv` is intentionally left inheriting because the edge value is genuinely consumed by descendants/container paths.)

## Verification

- Computed-style snapshots (light/dark × normal/high-contrast) pass with **zero drift**; WCAG axe checks pass; repo-wide `tsc` passes.
- The CI perf comparison (interleaved rounds, median, direction-agreement) measures a consistent improvement on the `ariakit-tailwind` sandbox: **page load total −117ms (−4%), style recalc −105ms (−4%)**, and toggle −30ms (−1%). It's below CI's "significant change" flag threshold (>10% and >5ms), so the report shows no flagged change, but the direction is consistent. A single-run local measurement was within noise. The changes are strictly *less* per-element style-system work (one fewer registered property, one fewer property inherited across the DOM) and benefit lighter real-world pages proportionally more.

## Other changes considered

Two larger candidates from the same exploration were measured and dropped:

- Hoisting the token-gated forbidden-range offset math into a single per-body computation shrank the generated CSS by ~2 KB but **regressed page-load style recalc by ~13%**, because it turned a token-gated computation into one that runs unconditionally on every layer element. For this style-recalc-bound package, generated-CSS size is not a reliable proxy for runtime cost.
- An algebraic refactor of `getResolvedLightnessOffset` (`A·d − B·d → (A−B)·d`) shifted a computed color by ~0.0017 via a `binary()` boundary flip, so it was rejected to keep zero snapshot drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
