### PR TITLE
Fix Maximum update depth error when rendering many menus

### DIFF
--- a/.changeset/300-menu-item-update-depth.md
+++ b/.changeset/300-menu-item-update-depth.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed rendering many [`Menu`](https://ariakit.com/reference/menu) components on the same page potentially causing a "Maximum update depth exceeded" error. [`MenuItem`](https://ariakit.com/reference/menu-item) elements are now registered while the menu is open instead of while it's hidden.

--- a/.changeset/300-menu-item-update-depth.md
+++ b/.changeset/300-menu-item-update-depth.md
@@ -3,4 +3,4 @@
 "@ariakit/react": patch
 ---
 
-Fixed rendering many [`Menu`](https://ariakit.com/reference/menu) components on the same page potentially causing a "Maximum update depth exceeded" error. [`MenuItem`](https://ariakit.com/reference/menu-item) elements are now registered while the menu is open instead of while it's hidden.
+Fixed rendering many [`Menu`](https://ariakit.com/reference/menu) components on the same page potentially causing a "Maximum update depth exceeded" error. [`MenuItem`](https://ariakit.com/reference/menu-item) elements now register only while the menu is open, instead of registering on mount even while it's hidden.

--- a/.changeset/300-menu-item-update-depth.md
+++ b/.changeset/300-menu-item-update-depth.md
@@ -3,4 +3,4 @@
 "@ariakit/react": patch
 ---
 
-Fixed rendering many [`Menu`](https://ariakit.com/reference/menu) components on the same page potentially causing a "Maximum update depth exceeded" error. [`MenuItem`](https://ariakit.com/reference/menu-item) elements now register only while the menu is open, instead of registering on mount even while it's hidden.
+Fixed rendering many [`Menu`](https://ariakit.com/reference/menu) components on the same page potentially causing a "Maximum update depth exceeded" error. [`MenuItem`](https://ariakit.com/reference/menu-item) elements now register only while the menu is visible, instead of registering on mount even while it's hidden.

--- a/app/src/sandbox/menu-3214/index.react.tsx
+++ b/app/src/sandbox/menu-3214/index.react.tsx
@@ -6,9 +6,7 @@ function RowMenu({ index }: { index: number }) {
   return (
     <Ariakit.MenuProvider>
       <Ariakit.MenuButton>Row {index} actions</Ariakit.MenuButton>
-      {/* TODO: Remove unmountOnHide once the library fix for
-          https://github.com/ariakit/ariakit/issues/3214 lands. */}
-      <Ariakit.Menu gutter={4} unmountOnHide>
+      <Ariakit.Menu gutter={4}>
         <Ariakit.MenuItem>Edit</Ariakit.MenuItem>
         <Ariakit.MenuItem>Duplicate</Ariakit.MenuItem>
         <Ariakit.MenuItem>Delete</Ariakit.MenuItem>

--- a/app/src/sandbox/menu-3214/index.react.tsx
+++ b/app/src/sandbox/menu-3214/index.react.tsx
@@ -1,0 +1,26 @@
+import * as Ariakit from "@ariakit/react";
+
+const rows = Array.from({ length: 80 }, (_, index) => index);
+
+function RowMenu({ index }: { index: number }) {
+  return (
+    <Ariakit.MenuProvider>
+      <Ariakit.MenuButton>Row {index} actions</Ariakit.MenuButton>
+      <Ariakit.Menu gutter={4}>
+        <Ariakit.MenuItem>Edit</Ariakit.MenuItem>
+        <Ariakit.MenuItem>Duplicate</Ariakit.MenuItem>
+        <Ariakit.MenuItem>Delete</Ariakit.MenuItem>
+      </Ariakit.Menu>
+    </Ariakit.MenuProvider>
+  );
+}
+
+export default function Example() {
+  return (
+    <div>
+      {rows.map((index) => (
+        <RowMenu key={index} index={index} />
+      ))}
+    </div>
+  );
+}

--- a/app/src/sandbox/menu-3214/index.react.tsx
+++ b/app/src/sandbox/menu-3214/index.react.tsx
@@ -6,7 +6,9 @@ function RowMenu({ index }: { index: number }) {
   return (
     <Ariakit.MenuProvider>
       <Ariakit.MenuButton>Row {index} actions</Ariakit.MenuButton>
-      <Ariakit.Menu gutter={4}>
+      {/* TODO: Remove unmountOnHide once the library fix for
+          https://github.com/ariakit/ariakit/issues/3214 lands. */}
+      <Ariakit.Menu gutter={4} unmountOnHide>
         <Ariakit.MenuItem>Edit</Ariakit.MenuItem>
         <Ariakit.MenuItem>Duplicate</Ariakit.MenuItem>
         <Ariakit.MenuItem>Delete</Ariakit.MenuItem>

--- a/app/src/sandbox/menu-3214/index.react.tsx
+++ b/app/src/sandbox/menu-3214/index.react.tsx
@@ -15,12 +15,37 @@ function RowMenu({ index }: { index: number }) {
   );
 }
 
+// An `alwaysVisible` menu is shown even while its store is closed, so its items
+// must still register. The list below mirrors the store's registered items.
+function AlwaysVisibleMenu() {
+  const menu = Ariakit.useMenuStore();
+  const items = Ariakit.useStoreState(menu, "items");
+  return (
+    <>
+      <Ariakit.MenuProvider store={menu}>
+        <Ariakit.MenuButton>Always visible actions</Ariakit.MenuButton>
+        <Ariakit.Menu alwaysVisible>
+          <Ariakit.MenuItem>Save</Ariakit.MenuItem>
+          <Ariakit.MenuItem>Open</Ariakit.MenuItem>
+          <Ariakit.MenuItem>Close</Ariakit.MenuItem>
+        </Ariakit.Menu>
+      </Ariakit.MenuProvider>
+      <ul aria-label="Registered items">
+        {items.map((item) => (
+          <li key={item.id}>{item.id}</li>
+        ))}
+      </ul>
+    </>
+  );
+}
+
 export default function Example() {
   return (
     <div>
       {rows.map((index) => (
         <RowMenu key={index} index={index} />
       ))}
+      <AlwaysVisibleMenu />
     </div>
   );
 }

--- a/app/src/sandbox/menu-3214/preview.astro
+++ b/app/src/sandbox/menu-3214/preview.astro
@@ -1,0 +1,14 @@
+---
+import PreviewFramework from "#app/components/preview-framework.astro";
+import ReactExample from "./index.react.tsx";
+
+import sourceReact from "./index.react.tsx?source";
+
+export const source = {
+  react: sourceReact,
+};
+---
+
+<PreviewFramework>
+  <ReactExample client:load slot="react" />
+</PreviewFramework>

--- a/app/src/sandbox/menu-3214/preview.mdx
+++ b/app/src/sandbox/menu-3214/preview.mdx
@@ -1,0 +1,9 @@
+---
+title: Multiple menus update depth
+frameworks:
+  - react
+---
+
+import Preview from "./preview.astro";
+
+<Preview />

--- a/app/src/sandbox/menu-3214/test-browser.ts
+++ b/app/src/sandbox/menu-3214/test-browser.ts
@@ -6,7 +6,7 @@ import { gotoAndSettle, withFramework } from "#app/test-utils/preview.ts";
 const updateDepthError =
   /maximum update depth exceeded|react\.dev\/errors\/185/i;
 
-withFramework(import.meta.dirname, async ({ test }) => {
+withFramework(import.meta.dirname, async ({ test, query }) => {
   test("renders many menus without exceeding React's update depth", async ({
     page,
     q,
@@ -26,9 +26,14 @@ withFramework(import.meta.dirname, async ({ test }) => {
     // the listeners already attached to capture it from the very first render.
     await gotoAndSettle(page, page.url());
 
-    // Confirm the island actually hydrated and the menus still work.
+    // The alwaysVisible menu is shown even though its store is closed, so its
+    // items must still register. This also confirms the island hydrated.
+    const registered = q.list("Registered items");
+    await test.expect(query(registered).listitem()).toHaveCount(3);
+
+    // A closed menu still registers and renders its items once it's opened.
     await q.button("Row 0 actions").click();
-    await test.expect(q.menu()).toBeVisible();
+    await test.expect(q.menuitem("Edit")).toBeVisible();
 
     test.expect(depthErrors).toEqual([]);
   });

--- a/app/src/sandbox/menu-3214/test-browser.ts
+++ b/app/src/sandbox/menu-3214/test-browser.ts
@@ -1,5 +1,4 @@
-import { errors } from "@playwright/test";
-import { withFramework } from "#app/test-utils/preview.ts";
+import { gotoAndSettle, withFramework } from "#app/test-utils/preview.ts";
 
 // React's "Maximum update depth exceeded" error. In production builds React
 // throws the minified variant that links to https://react.dev/errors/185.
@@ -23,17 +22,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
     });
     page.on("pageerror", (error) => collect(error.message));
 
-    // The error is thrown while the React island hydrates, so reload with the
-    // listeners already attached to capture it from the very first render.
-    await page.reload({ waitUntil: "load" });
-    // Bounded settle that only swallows the timeout, mirroring the shared
-    // `gotoAndSettle` helper so a stalled request can't consume the test budget
-    // and real failures (such as the page closing) still surface.
-    await page
-      .waitForLoadState("networkidle", { timeout: 5_000 })
-      .catch((error) => {
-        if (!(error instanceof errors.TimeoutError)) throw error;
-      });
+    // The error is thrown while the React island hydrates, so re-navigate with
+    // the listeners already attached to capture it from the very first render.
+    await gotoAndSettle(page, page.url());
 
     // Confirm the island actually hydrated and the menus still work.
     await q.button("Row 0 actions").click();

--- a/app/src/sandbox/menu-3214/test-browser.ts
+++ b/app/src/sandbox/menu-3214/test-browser.ts
@@ -1,0 +1,44 @@
+import { errors } from "@playwright/test";
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// React's "Maximum update depth exceeded" error. In production builds React
+// throws the minified variant that links to https://react.dev/errors/185.
+// See https://github.com/ariakit/ariakit/issues/3214.
+const updateDepthError =
+  /maximum update depth exceeded|react\.dev\/errors\/185/i;
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("renders many menus without exceeding React's update depth", async ({
+    page,
+    q,
+  }) => {
+    const depthErrors: string[] = [];
+    const collect = (text: string) => {
+      if (updateDepthError.test(text)) {
+        depthErrors.push(text);
+      }
+    };
+    page.on("console", (message) => {
+      if (message.type() === "error") collect(message.text());
+    });
+    page.on("pageerror", (error) => collect(error.message));
+
+    // The error is thrown while the React island hydrates, so reload with the
+    // listeners already attached to capture it from the very first render.
+    await page.reload({ waitUntil: "load" });
+    // Bounded settle that only swallows the timeout, mirroring the shared
+    // `gotoAndSettle` helper so a stalled request can't consume the test budget
+    // and real failures (such as the page closing) still surface.
+    await page
+      .waitForLoadState("networkidle", { timeout: 5_000 })
+      .catch((error) => {
+        if (!(error instanceof errors.TimeoutError)) throw error;
+      });
+
+    // Confirm the island actually hydrated and the menus still work.
+    await q.button("Row 0 actions").click();
+    await test.expect(q.menu()).toBeVisible();
+
+    test.expect(depthErrors).toEqual([]);
+  });
+});

--- a/app/src/test-utils/preview.ts
+++ b/app/src/test-utils/preview.ts
@@ -19,7 +19,7 @@ import { test } from "./fixtures.ts";
  *
  * Kept in sync with the copy in `packages/ariakit-scripts/src/perf.ts`.
  */
-async function gotoAndSettle(page: Page, url: string) {
+export async function gotoAndSettle(page: Page, url: string) {
   await page.goto(url, { waitUntil: "load" });
   await page
     .waitForLoadState("networkidle", { timeout: 5_000 })

--- a/packages/ariakit-react-components/src/menu/menu-context.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-context.tsx
@@ -74,3 +74,11 @@ export const MenuBarScopedContextProvider = MenubarScopedContextProvider;
 export const MenuItemCheckedContext = createContext<boolean | undefined>(
   undefined,
 );
+
+/**
+ * Whether the enclosing menu list is currently hidden (e.g. a closed menu
+ * rendered without `unmountOnHide`). `MenuItem` uses it to skip registering
+ * items that aren't shown yet. Defaults to `false` so items without a menu list
+ * ancestor (such as menubar items) keep registering.
+ */
+export const MenuListHiddenContext = createContext(false);

--- a/packages/ariakit-react-components/src/menu/menu-item.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-item.tsx
@@ -108,6 +108,12 @@ export const useMenuItem = createHook<TagName, MenuItemOptions>(
       "contentElement" in state ? state.contentElement : null,
     );
 
+    // Whether the menu is currently mounted. Menubar items (whose store has no
+    // `mounted` state) are always considered mounted.
+    const mounted = useStoreState(store, (state) =>
+      "mounted" in state ? state.mounted : true,
+    );
+
     const role = getPopupItemRole(contentElement, "menuitem");
 
     props = {
@@ -120,6 +126,13 @@ export const useMenuItem = createHook<TagName, MenuItemOptions>(
       store,
       preventScrollOnKeyDown,
       ...props,
+      // Skip registering items while the menu is closed. Unlike a Select,
+      // a Menu doesn't interact with its items while hidden, so registering
+      // them isn't useful. Registering many closed menus' items at once on
+      // mount can also cascade into React's "Maximum update depth exceeded"
+      // error. Items register once the menu is shown.
+      // See https://github.com/ariakit/ariakit/issues/3214.
+      shouldRegisterItem: mounted ? props.shouldRegisterItem : false,
     });
 
     props = useCompositeHover({

--- a/packages/ariakit-react-components/src/menu/menu-item.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-item.tsx
@@ -17,6 +17,7 @@ import {
   invariant,
 } from "@ariakit/utils";
 import type { BooleanOrCallback } from "@ariakit/utils";
+import { useContext } from "react";
 import type { ElementType, MouseEvent } from "react";
 import type { CompositeHoverOptions } from "../composite/composite-hover.tsx";
 import { useCompositeHover } from "../composite/composite-hover.tsx";
@@ -24,7 +25,10 @@ import type { CompositeItemOptions } from "../composite/composite-item.tsx";
 import { useCompositeItem } from "../composite/composite-item.tsx";
 import { useMenubarScopedContext } from "../menubar/menubar-context.tsx";
 import type { MenubarStore } from "../menubar/menubar-store.ts";
-import { useMenuScopedContext } from "./menu-context.tsx";
+import {
+  MenuListHiddenContext,
+  useMenuScopedContext,
+} from "./menu-context.tsx";
 import type { MenuStore, MenuStoreState } from "./menu-store.ts";
 
 const TagName = "div" satisfies ElementType;
@@ -108,11 +112,9 @@ export const useMenuItem = createHook<TagName, MenuItemOptions>(
       "contentElement" in state ? state.contentElement : null,
     );
 
-    // Whether the menu is currently mounted. Menubar items (whose store has no
-    // `mounted` state) are always considered mounted.
-    const mounted = useStoreState(store, (state) =>
-      "mounted" in state ? state.mounted : true,
-    );
+    // Whether the enclosing menu list is currently hidden (provided by
+    // `MenuList`; see `MenuListHiddenContext`).
+    const menuListHidden = useContext(MenuListHiddenContext);
 
     const role = getPopupItemRole(contentElement, "menuitem");
 
@@ -126,13 +128,15 @@ export const useMenuItem = createHook<TagName, MenuItemOptions>(
       store,
       preventScrollOnKeyDown,
       ...props,
-      // Skip registering items while the menu is closed. Unlike a Select,
+      // Skip registering items while the menu list is hidden. Unlike a Select,
       // a Menu doesn't interact with its items while hidden, so registering
-      // them isn't useful. Registering many closed menus' items at once on
+      // them isn't useful. Registering many hidden menus' items at once on
       // mount can also cascade into React's "Maximum update depth exceeded"
-      // error. Items register once the menu is shown.
+      // error. Using the list's actual hidden state (rather than the store's
+      // `mounted` state) keeps items registered in `alwaysVisible` or
+      // `hidden={false}` menus, where the list is shown even while closed.
       // See https://github.com/ariakit/ariakit/issues/3214.
-      shouldRegisterItem: mounted ? props.shouldRegisterItem : false,
+      shouldRegisterItem: menuListHidden ? false : props.shouldRegisterItem,
     });
 
     props = useCompositeHover({

--- a/packages/ariakit-react-components/src/menu/menu-list.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-list.tsx
@@ -19,6 +19,7 @@ import { useComposite } from "../composite/composite.tsx";
 import type { DisclosureContentOptions } from "../disclosure/disclosure-content.tsx";
 import { isHidden } from "../disclosure/disclosure-content.tsx";
 import {
+  MenuListHiddenContext,
   MenuScopedContextProvider,
   useMenuProviderContext,
 } from "./menu-context.tsx";
@@ -156,6 +157,20 @@ export const useMenuList = createHook<TagName, MenuListOptions>(
     const mounted = useStoreState(store, "mounted");
     const hidden = isHidden(mounted, props.hidden, alwaysVisible);
     const style = hidden ? { ...props.style, display: "none" } : props.style;
+
+    // Expose the list's actual hidden state so MenuItem can avoid registering
+    // items while they're not shown. This accounts for `alwaysVisible` and
+    // `hidden={false}`, where the list is visible even though the store is
+    // closed. See https://github.com/ariakit/ariakit/issues/3214.
+    props = useWrapElement(
+      props,
+      (element) => (
+        <MenuListHiddenContext.Provider value={hidden}>
+          {element}
+        </MenuListHiddenContext.Provider>
+      ),
+      [hidden],
+    );
 
     props = {
       "aria-labelledby": ariaLabelledBy,


### PR DESCRIPTION
## Motivation

Rendering many menus on a single page made React throw `Maximum update depth exceeded` (the minified `#185` error in production builds) during the initial render and hydration. The number of menus needed varied — reporters hit it somewhere between ~20 and ~60 menus.

Fixes #3214.

## Solution

The error is React's nested-update limit, not an infinite loop. React's `useSyncExternalStore` forces a synchronous re-render for every store value that genuinely changes between render and commit. When many closed menus mount, each one registers its items synchronously during the commit phase, and these consecutive sync re-renders accumulate past React's limit (50). Plain [`Disclosure`](https://ariakit.org/reference/disclosure) and [`Popover`](https://ariakit.org/reference/popover) don't reproduce it because they don't register collection items — the menu's item registration is the trigger (which is also why `unmountOnHide`, by not rendering closed content at all, avoids it).

Unlike a [`Select`](https://ariakit.org/reference/select) — which interacts with its items while closed (typeahead, keyboard value changes, value→label display) — a [`Menu`](https://ariakit.org/reference/menu) never touches its items while hidden. So [`MenuItem`](https://ariakit.org/reference/menu-item) now defers registering itself until the menu is mounted. A closed menu then behaves like a `Popover`, and the cascade no longer happens regardless of how many menus are rendered (verified at 80, 200, and 400 menus). Items register as usual once the menu opens, so focus and keyboard navigation are unaffected.

## Workaround

Until this fix is released, pass [`unmountOnHide`](https://ariakit.org/reference/menu#unmountonhide) to the `Menu`. Closed menus then don't render their content, which avoids the mount-time cascade. The menus keep working as before:

```tsx
<Ariakit.MenuProvider>
  <Ariakit.MenuButton>Actions</Ariakit.MenuButton>
  {/* TODO: Remove unmountOnHide once the fix for
      https://github.com/ariakit/ariakit/issues/3214 is released. */}
  <Ariakit.Menu unmountOnHide>
    <Ariakit.MenuItem>Edit</Ariakit.MenuItem>
    <Ariakit.MenuItem>Duplicate</Ariakit.MenuItem>
    <Ariakit.MenuItem>Delete</Ariakit.MenuItem>
  </Ariakit.Menu>
</Ariakit.MenuProvider>
```
