### PR TITLE
Remove dead disableAccessibilityTreeOutside function

### DIFF
--- a/packages/ariakit-react-components/src/dialog/utils/disable-accessibility-tree-outside.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/disable-accessibility-tree-outside.ts
@@ -1,30 +1,5 @@
-import { isBackdrop } from "./is-backdrop.ts";
 import { setAttribute } from "./orchestrate.ts";
-import { walkTreeOutside } from "./walk-tree-outside.ts";
-
-type Elements = Array<Element | null>;
 
 export function hideElementFromAccessibilityTree(element: Element) {
   return setAttribute(element, "aria-hidden", "true");
-}
-
-export function disableAccessibilityTreeOutside(
-  id: string,
-  elements: Elements,
-) {
-  const cleanups: Array<() => void> = [];
-  const ids = elements.map((el) => el?.id);
-
-  walkTreeOutside(id, elements, (element) => {
-    if (isBackdrop(element, ...ids)) return;
-    cleanups.unshift(hideElementFromAccessibilityTree(element));
-  });
-
-  const restoreAccessibilityTree = () => {
-    for (const cleanup of cleanups) {
-      cleanup();
-    }
-  };
-
-  return restoreAccessibilityTree;
 }


### PR DESCRIPTION
## Motivation

`disableAccessibilityTreeOutside` in `packages/ariakit-react-components/src/dialog/utils/disable-accessibility-tree-outside.ts` was exported but never imported anywhere across the packages or the Solid port. Only the sibling `hideElementFromAccessibilityTree`, defined in the same file, is actually consumed (by `disable-tree.ts`). The dead function added maintenance noise and pulled in helpers that nothing else in the file needed.

## Solution

Delete the unused `disableAccessibilityTreeOutside` function, along with the imports and type that only it relied on:

- Removed the `isBackdrop` and `walkTreeOutside` imports.
- Removed the local `Elements` type alias.
- Kept the `setAttribute` import from `orchestrate.ts` and the exported `hideElementFromAccessibilityTree`, which `disable-tree.ts` still imports and calls.

The file still exists and still exports `hideElementFromAccessibilityTree`, so the auto-generated package subpath export `./dialog/utils/disable-accessibility-tree-outside` is unchanged. This is an internal dead-code cleanup with no public API or behavior change, so no changeset is included.
