### PR TITLE
Remove unnecessary store dependency from TabPanel scroll-restoration effect

### DIFF
--- a/packages/ariakit-react-components/src/tab/tab-panel.tsx
+++ b/packages/ariakit-react-components/src/tab/tab-panel.tsx
@@ -123,7 +123,7 @@ export const useTabPanel = createHook<TagName, TabPanelOptions>(
       return () => {
         element.removeEventListener("scroll", onScroll);
       };
-    }, [scrollRestoration, mounted, tabId, getScrollElement, store]);
+    }, [scrollRestoration, mounted, tabId, getScrollElement]);
 
     const [hasTabbableChildren, setHasTabbableChildren] = useState(false);
 


### PR DESCRIPTION
## Motivation

The scroll-restoration `useEffect` in `TabPanel` listed `store` in its dependency array, but the effect body never references `store`. Its only store access goes through `getScrollElement`, a stable `useEvent` callback that is already in the deps. Because the memoized tab store object identity can change when the store or panels references change, including `store` re-attached the scroll listener more often than necessary and obscured the effect's real dependencies.

## Solution

Remove `store` from the dependency array of the scroll-restoration effect, leaving `[scrollRestoration, mounted, tabId, getScrollElement]`.

This is a behavior-neutral cleanup: the listener re-attach was idempotent (same handler, same element via the stable `getScrollElement`), so dropping the unused dependency changes no observable behavior. React's exhaustive-deps lint only flags missing used deps, not extra ones, so removing the unused `store` keeps lint clean.

## Verification

- `oxlint` reports 0 warnings / 0 errors on the changed file.
- `tsc -b` (via `pnpm tsc`) passes.

No changeset is included because this is an internal refactor with no user-facing behavior change.