### PR TITLE
Remove debug console.log calls from the root layout script

### DIFF
--- a/app/src/pages/_layout.astro
+++ b/app/src/pages/_layout.astro
@@ -149,20 +149,18 @@ const { title, headerBorder = false } = Astro.props;
   const themeToggle = document.getElementById("theme-toggle");
   const themeSidebar = document.getElementById("theme-sidebar");
 
-  themeToggle?.addEventListener("click", () => {
+  const toggleSidebar = () => {
     if (!themeSidebar) return;
-    console.log("clicked", themeSidebar.dataset.state);
     themeSidebar.dataset.state =
       themeSidebar.dataset.state !== "open" ? "open" : "closed";
-  });
+  };
+
+  themeToggle?.addEventListener("click", toggleSidebar);
 
   document.addEventListener("keydown", (e) => {
     if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
     if (e.key === "t" || e.key === "T") {
-      if (!themeSidebar) return;
-      console.log("clicked", themeSidebar.dataset.state);
-      themeSidebar.dataset.state =
-        themeSidebar.dataset.state !== "open" ? "open" : "closed";
+      toggleSidebar();
     }
   });
 


### PR DESCRIPTION
## Motivation

The client-side `<script>` in the root layout (`app/src/pages/_layout.astro`) ships on every page of the site. It contained two leftover `console.log("clicked", themeSidebar.dataset.state)` debug calls — one in the theme-toggle click handler and one in the `t`/`T` keydown handler — that pollute the browser console on every theme toggle or `t` keypress in production.

## Solution

Remove both `console.log` calls. Since the open/closed toggle logic was duplicated verbatim across the click and keydown handlers, extract it into a single `toggleSidebar()` helper that both handlers now call. The helper keeps the original `if (!themeSidebar) return;` null guard, so both paths stay null-safe, and the open/closed flip and the keydown modifier-key guard are unchanged. Behavior is identical; only the debug logging is gone and the duplication is removed.

No changeset is included: the `app` workspace is private and is listed in the `ignore` array of `.changeset/config.json`, so it is not versioned or published.
