### PR TITLE
Remove dead duplicate MenuItemCheckedContext in menubar-context

### DIFF
--- a/packages/ariakit-react-components/src/menubar/menubar-context.tsx
+++ b/packages/ariakit-react-components/src/menubar/menubar-context.tsx
@@ -1,5 +1,4 @@
 import { createStoreContext } from "@ariakit/react-utils";
-import { createContext } from "react";
 import {
   CompositeContextProvider,
   CompositeScopedContextProvider,
@@ -33,7 +32,3 @@ export const useMenubarProviderContext = menubar.useProviderContext;
 export const MenubarContextProvider = menubar.ContextProvider;
 
 export const MenubarScopedContextProvider = menubar.ScopedContextProvider;
-
-export const MenuItemCheckedContext = createContext<boolean | undefined>(
-  undefined,
-);


### PR DESCRIPTION
## Motivation

The menubar module's `menubar-context.tsx` exported a `MenuItemCheckedContext` (`createContext<boolean | undefined>(undefined)`) that was never imported anywhere. The menu module already defines an identical context in `menu-context.tsx`, which is what [`MenuItemCheck`](https://ariakit.com/reference/menu-item-check) (via `menu-item-check.tsx`) and [`MenuItemRadio`](https://ariakit.com/reference/menu-item-radio) (via `menu-item-radio.tsx`) actually consume.

Having two same-named context objects in sibling modules is a latent mis-import footgun: a future import could easily reach for the wrong one and silently read the wrong provider.

## Solution

Remove the dead duplicate `MenuItemCheckedContext` export from `menubar-context.tsx`, leaving `menu-context.tsx` as the single source of truth. The `react` `createContext` import is removed as well, because `MenubarContext` in this file is built with `createStoreContext` (not `createContext`), so `createContext` becomes unused after the deletion.

## Why no compatibility re-export and no changeset

`@ariakit/react-components` does expose `./menubar/menubar-context` as a package subpath, so in principle a direct deep import of `MenuItemCheckedContext` from that path was possible. This change still ships without a compatibility re-export or a changeset, on purpose:

- A compatibility re-export (e.g. re-exporting `MenuItemCheckedContext` from `menu-context.tsx`) would re-introduce two import sites for the same context object — precisely the mis-import footgun this change exists to remove.
- `@ariakit/react-components` is explicitly an internal package that does not follow semver ("breaking changes may occur in patch and minor versions"; consumers are directed to [`@ariakit/react`](https://www.npmjs.com/package/@ariakit/react)). `MenuItemCheckedContext` was never documented, never referenced anywhere in the monorepo from `menubar-context.tsx`, and is not re-exported by `@ariakit/react`'s public entry (only `useMenubarContext` is). Per the repo changeset guidance, internal-only changes that don't alter a package's public API don't warrant a changeset.

## Verification

- `oxlint --disable-nested-config` on the changed file: 0 warnings, 0 errors (confirms the removed `createContext` import is not left unused).
- `oxfmt --check` on the changed file: clean.
- `tsc -b`: clean (exit 0).
- `git grep` confirms `MenuItemCheckedContext` now resolves only to `menu/menu-context.tsx` and its two consumers; nothing imports it from `menubar-context.tsx`.
