### PR TITLE
Remove placeholder blog post

### DIFF
--- a/blog/first-post.md
+++ b/blog/first-post.md
@@ -1,5 +1,0 @@
-# First post
-
-Test
-
-<a href="../examples/button/index.react.tsx" data-playground>Example</a>


### PR DESCRIPTION
## Motivation

The `blog/first-post.md` file was a leftover placeholder containing only a title ("First post"), a one-word body ("Test"), and a playground link. The `blog/` directory it lived in is not wired into anything: no route, redirect, RSS feed, sitemap, or content loader reads from it, and it is not part of any published package. Keeping dead placeholder content like this around invites accidental publication and adds noise to the repository.

## Solution

Remove `blog/first-post.md`. This empties the `blog/` directory, so git drops it entirely. The change is intentionally limited to deleting this one unreferenced file.

## Verification

I confirmed `blog/` is referenced by nothing in scope before removing the file:

- No route, redirect, RSS feed, sitemap, or content loader reads the root `blog/` directory. The website's page enumeration (`website/build-pages/config.js`) sources only `guide`, `components`, `examples`, and `reference`; `website/app/sitemap.ts` derives URLs from that config plus tags; `website/redirects.js` has no `/blog` entry.
- After deletion, `git grep` finds no remaining references to `first-post` anywhere in the repository.
- The unrelated `blog` strings in `examples/menubar-navigation` (demo `#/blog/...` anchors) and in `website/` (`get-page-title.js`, `[category]/page.tsx`, the commented-out footer link, `icons/blog.tsx`) refer to a hypothetical `/blog` site category, not the root `blog/` content directory, and are untouched here.

## Note on an orphaned Tailwind glob

The only remaining reference to the `blog/` path is a content glob in the root `tailwind.config.cjs`:

```js
path.join(__dirname, "blog/**/*.{ts,tsx,md}"),
```

With `blog/` gone this glob simply matches nothing, so it does not affect the Tailwind output or break any build. I left it in place because `tailwind.config.cjs` is shared root tooling (consumed by `postcss.config.cjs`, `prettier.config.js`, and the website app), and dropping the line is optional cleanup outside the scope of this change. (For reference: this glob lives in the root `tailwind.config.cjs`, not in `website/tailwind.config.cjs`, which does not exist.)

No changeset is included: this removes dead, never-shipped repository content outside any published package, so it is not a consumer-facing change.
