### PR TITLE
Remove redundant store guards in TagInput and TagRemove

### DIFF
--- a/packages/ariakit-react-components/src/tag/tag-input.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-input.tsx
@@ -123,7 +123,6 @@ export const useTagInput = createHook<TagName, TagInputOptions>(
     const onChange = useEvent((event: ChangeEvent<HTMLType>) => {
       onChangeProp?.(event);
       if (event.defaultPrevented) return;
-      if (!store) return;
       const { value: prevValue } = store.getState();
       const inputType = getInputType(event);
       const currentTarget = event.currentTarget;

--- a/packages/ariakit-react-components/src/tag/tag-remove.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-remove.tsx
@@ -66,7 +66,6 @@ export const useTagRemove = createHook<TagName, TagRemoveOptions>(
     const onClick = useEvent((event: MouseEvent<HTMLType>) => {
       onClickProp?.(event);
       if (event.defaultPrevented) return;
-      if (!store) return;
       if (!value) return;
       if (!removeOnClickProp(event)) return;
       const { inputElement } = store.getState();


### PR DESCRIPTION
## Motivation

The `onChange` handler in `TagInput` and the `onClick` handler in `TagRemove` each contained an `if (!store) return;` line placed immediately after the `invariant(store, ...)` call.

`invariant` is typed `asserts condition` and throws when its condition is falsy, so once `invariant(store, ...)` returns, `store` is already narrowed to non-null at both the type level and at runtime. The extra `if (!store) return;` was therefore unreachable dead code. Sibling handlers in [`Tag`](https://ariakit.com/reference/tag) and [`TagList`](https://ariakit.com/reference/tag-list) already dereference `store` directly after their own `invariant` calls without this guard, so the two handlers were also inconsistent with the rest of the tag components.

## Solution

Removed the redundant `if (!store) return;` line from the [`TagInput`](https://ariakit.com/reference/tag-input) `onChange` handler and the [`TagRemove`](https://ariakit.com/reference/tag-remove) `onClick` handler. This is a behavior-preserving cleanup of unreachable code.

The adjacent `if (!value) return;` guard in `TagRemove` is left untouched: it checks a different variable (`value`, which is `valueProp ?? valueFromContext` and can legitimately be `undefined`) and is not dead code.
