### PR TITLE
Remove dead nullish fallback in getLayerOffsetDeclarations

### DIFF
--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -1335,7 +1335,7 @@ utility(
 
 function getLayerOffsetDeclarations(arbitraryPattern = "[*]") {
   const bareValue = getBarePercentTokenValue();
-  const arbitraryValue = fn.value(arbitraryPattern ?? "[*]");
+  const arbitraryValue = fn.value(arbitraryPattern);
   const bareDelta = fn.mul(bareValue, vars.lightnessOffsetDirection);
   const arbitraryDelta = fn.mul(arbitraryValue, vars.lightnessOffsetDirection);
   const getDeclarations = (


### PR DESCRIPTION
## Motivation

`getLayerOffsetDeclarations` in `packages/ariakit-tailwind/src/input.ts` declares its parameter with a default value (`arbitraryPattern = "[*]"`) and then also applies `?? "[*]"` to that same parameter. Because the default already supplies `"[*]"` whenever the argument is omitted or `undefined`, the `?? "[*]"` fallback can never take effect. Both call sites confirm this: one passes `"[number]"` and the other passes no argument at all, so the parameter is always a non-nullish string inside the body.

## Solution

Drop the redundant `?? "[*]"`, leaving `fn.value(arbitraryPattern)`.

The structurally similar fallback in `getRawPercentDeclarations` is intentionally left untouched: that helper's `arbitraryPattern?: string` parameter has no default, so its `?? "[*]"` is genuinely reachable and meaningful.

This is a pure no-op cleanup. Rebuilding the package with `pnpm -F @ariakit/tailwind build` produces a byte-identical `output.css`, so no shipped behavior changes and no changeset is needed.

## Verification

- `pnpm -F @ariakit/tailwind build` — regenerated `src/output.css` is byte-identical to the committed file (no diff).
- `oxlint --disable-nested-config` and `oxfmt --check` on the changed file — clean.
- `tsc -b` on the `@ariakit/tailwind` package — no type errors.
