### PR TITLE
Remove dead Solid build paths and unused build context flags

### DIFF
--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -1,15 +1,13 @@
 import { cpSync } from "node:fs";
 import spawn from "cross-spawn";
-import { solidPlugin } from "esbuild-plugin-solid";
 import { glob } from "glob";
 import { build } from "tsup";
-import { cwd, isFramework, isReact, isSolid } from "./context.js";
+import { cwd, isFramework, isReact } from "./context.js";
 import {
   cleanBuild,
   getCJSDir,
   getESMDir,
   getPublicFiles,
-  getSolidSourceDir,
   getSourcePath,
   makeGitignore,
   makeProxies,
@@ -33,7 +31,6 @@ const sourcePath = getSourcePath(cwd);
 const entry = getPublicFiles(sourcePath);
 const esmDir = getESMDir();
 const cjsDir = getCJSDir();
-const solidSourceDir = getSolidSourceDir();
 
 spawn.sync(
   "tsc",
@@ -120,44 +117,4 @@ function buildReact({ format, outDir }) {
   });
 }
 
-/** @param {{ format: import("tsup").Format, outDir: string }} options */
-function buildSolid({ format, outDir }) {
-  if (!isSolid) return;
-  return build({
-    entry,
-    format,
-    outDir,
-    // dts: true,
-    // tsconfig: "tsconfig.build.json",
-    splitting: true,
-    esbuildOptions(options) {
-      options.chunkNames = "__chunks/[hash]";
-      options.jsx = "preserve";
-    },
-    esbuildPlugins: [solidPlugin({ solid: { generate: "dom" } })],
-  });
-}
-
-function buildSolidSource() {
-  if (!isSolid) return;
-  return build({
-    entry,
-    format: "esm",
-    outDir: solidSourceDir,
-    splitting: true,
-    outExtension() {
-      return { js: ".jsx" };
-    },
-    esbuildOptions(options) {
-      options.chunkNames = "__chunks/[hash]";
-      options.jsx = "preserve";
-    },
-  });
-}
-
-await Promise.all([
-  ...builds.map(buildStandard),
-  ...builds.map(buildReact),
-  ...builds.map(buildSolid),
-  buildSolidSource(),
-]);
+await Promise.all([...builds.map(buildStandard), ...builds.map(buildReact)]);

--- a/scripts/build/context.js
+++ b/scripts/build/context.js
@@ -1,12 +1,10 @@
 export const cwd = process.cwd();
 export const dirName = /** @type {string} */ (cwd.split("/").pop());
 
-export const isCore = ["ariakit-components"].includes(dirName);
 export const isReact = ["ariakit-react", "ariakit-react-components"].includes(
   dirName,
 );
 export const isSolid = ["ariakit-solid", "ariakit-solid-components"].includes(
   dirName,
 );
-export const isTest = ["ariakit-test"].includes(dirName);
 export const isFramework = [isReact, isSolid].includes(true);


### PR DESCRIPTION
## Motivation

After PR #6018, `scripts/build/build.js` is only consumed by `@ariakit/react` (its `build` script runs `node ../../scripts/build/build.js`). For that package, `scripts/build/context.js` evaluates `isReact = true`, `isSolid = false`, and `isFramework = true`. As a result:

- `buildSolid` and `buildSolidSource` both start with `if (!isSolid) return;`, so they always early-return and never execute. Their `esbuild-plugin-solid` import, the `isSolid` context flag, and the `getSolidSourceDir` import plus its `solidSourceDir` local exist solely to support these unreachable functions, which misleads maintainers into thinking the script still builds Solid.
- `scripts/build/context.js` additionally exports `isCore` and `isTest`, which are not imported anywhere (the components and test packages now build via `ariakit build`).

This is a conservative dead-code cleanup that keeps the build script honest about what it actually does. It covers two approved audit findings, T107 and T109, which share `scripts/build/context.js`.

## Solution

In `scripts/build/build.js` (T107):

- Remove the `buildSolid` and `buildSolidSource` functions and their entries in the final `Promise.all`.
- Remove the now-unused `import { solidPlugin } from "esbuild-plugin-solid"`, the `isSolid` import from `./context.js`, the `getSolidSourceDir` import from `./utils.js`, and the `const solidSourceDir = getSolidSourceDir();` local.

In `scripts/build/context.js` (T109):

- Remove the unused `isCore` and `isTest` exports.

Deliberately kept, because they are still live:

- `buildStandard` and `isFramework` — `buildStandard` is still wired into the `Promise.all` and gated by `isFramework`.
- `isReact` and the React build path — the only path that actually runs for `@ariakit/react`.
- `isSolid` in `context.js` — still imported and used by `scripts/build/utils.js`.
- `getSolidSourceDir` and `solidPlugin` definitions — still referenced by `scripts/build/utils.js`, `packages/ariakit-scripts/src/build.ts`, and `vitest.config.ts`.

This is the conservative cleanup; migrating `@ariakit/react` to `ariakit build` (and deleting these scripts entirely) is intentionally out of scope.

## Verification

- `oxlint scripts/build/build.js scripts/build/context.js` passes with no warnings or errors.
- `node --check` passes on both files.
- `pnpm install` then `pnpm --filter @ariakit/react build` (which runs the edited `build.js`) completes successfully and emits the expected artifacts (55 ESM `.js`, 101 CJS `.cjs`, 28 `.d.ts`; both `esm/index.js` and `cjs/index.cjs` present).

No changeset: `scripts/build/` is part of the private `ariakit-monorepo` root, not a published package, and the removed code never executed for the only consumer, so the published `@ariakit/react` output is unchanged.
