### PR TITLE
Remove placeholder return from setPrice admin action

### DIFF
--- a/app/src/actions/admin.ts
+++ b/app/src/actions/admin.ts
@@ -412,7 +412,6 @@ export const admin = {
         throw new ActionError({ code: "UNAUTHORIZED" });
       }
       await setPrice(input);
-      return "Hello, world!";
     },
   }),
 


### PR DESCRIPTION
## Motivation

The `setPrice` admin action handler in `app/src/actions/admin.ts` ended with a leftover `return "Hello, world!";` scaffolding line. This made the action's inferred return type `string` instead of `void`, misrepresenting its contract. No caller reads the return value — both call sites (`app/src/pages/admin/prices.astro` and `app/src/pages/admin/_price-card.astro`) use the action as an Astro form action via `<form method="post" action={actions.admin.setPrice}>`, and there are no programmatic invocations. Sibling admin actions (`sync`, `setPromo`) already return nothing.

## Solution

Remove the placeholder line so the handler returns void like the other admin actions. This is an internal dead-code removal with no user-facing or runtime behavior change.

No changeset is included: the `app` workspace is private and is listed in `.changeset/config.json`'s `ignore` array.

## Verification

- `pnpm lint` (oxlint + oxfmt --check): passed.
- `pnpm tsc` (`pnpm -F app run check` → `astro check` + `tsc -b`): passed, 0 errors.
