### PR TITLE
Remove dead example-duplication scaffolding and as-any cast in component page

### DIFF
--- a/app/src/pages/[...component].astro
+++ b/app/src/pages/[...component].astro
@@ -160,7 +160,7 @@ function isLinkItem(
 
 function getReferenceProps(item: SidebarMenuItem) {
   if (!("kind" in item) || item.kind === undefined) return;
-  const { href: _href, ...referenceProps } = item as any;
+  const { href: _href, ...referenceProps } = item;
   return referenceProps;
 }
 
@@ -247,19 +247,10 @@ function isCurrentHref(href: string, pathname = Astro.url.pathname) {
         <div
           class:list={[
             "grid grid-cols-[repeat(auto-fill,minmax(16rem,1fr))] gap-4 ak-container",
-            // "ak-container-size-wider/0",
             "ak-container-size-default/0",
           ]}
         >
-          {[
-            ...examples,
-            // ...examples,
-            // ...examples,
-            // ...examples,
-            // ...examples,
-            // ...examples,
-            // ...examples,
-          ].map((example) => (
+          {examples.map((example) => (
             <PageCardExample entry={example} />
           ))}
         </div>


### PR DESCRIPTION
## Motivation

The component page template (`app/src/pages/[...component].astro`) carried two dev stress-test leftovers:

- The Examples grid spread a single-element array padded with six commented-out `...examples` copies and a commented-out alternative class string. These were used to visually stress-test the grid layout and have no purpose in shipped code.
- `getReferenceProps` cast its argument to `any` to strip `href`, which defeated the `SidebarMenuItem` discriminated-union typing even though the function already narrows on `"kind" in item`.

## Solution

- Replace the padded spread `{[...examples, /* commented copies */].map(...)}` with a direct `{examples.map(...)}`, and delete the commented-out class string from the `class:list`.
- Drop the `as any` cast in `getReferenceProps` and rely on the existing `"kind" in item` narrowing, mirroring how `sidebar-menu.astro` destructures the same shape. The discriminated union makes the destructuring type-safe without the cast, and it also restores proper typing for the downstream `{...referenceProps}` spread into `ReferenceLabel`.

## Verification

`astro check` on the `app` workspace passes with 0 errors.

No changeset: the `app` workspace is private/unpublished (listed in `.changeset/config.json` `ignore`), and this is a pure internal refactor with no user-facing change.
