### PR TITLE
Refactor native button disabled props

### DIFF
--- a/app/src/sandbox/button-form-status-4540/index.react.tsx
+++ b/app/src/sandbox/button-form-status-4540/index.react.tsx
@@ -21,15 +21,14 @@ function NativeButton({
   ...props
 }: NativeButtonProps) {
   const { pending } = useFormStatus();
-  if (accessibleWhenDisabled) {
-    props["aria-disabled"] = pending;
-  } else {
-    props.disabled = pending;
-  }
+  const disabledProps = accessibleWhenDisabled
+    ? { "aria-disabled": pending }
+    : { disabled: pending };
   return (
     <button
       type="submit"
       {...props}
+      {...disabledProps}
       onClick={(event) => {
         if (accessibleWhenDisabled && pending) {
           event.preventDefault();


### PR DESCRIPTION
## Motivation

The `button-form-status-4540` sandbox's `NativeButton` mutates the rest `props` object during render when deriving pending disabled attributes. This is not part of the repro behavior and models a fragile render-time mutation pattern.

## Solution

Compute the pending disabled attributes in a local `disabledProps` object and spread them after the caller props. This preserves the previous override order while avoiding in-place mutation.
