### PR TITLE
Fix collection offscreen invariant typo

### DIFF
--- a/.changeset/300-collection-offscreen-invariant-typo.md
+++ b/.changeset/300-collection-offscreen-invariant-typo.md
@@ -1,6 +1,5 @@
 ---
 "@ariakit/react-components": patch
-"@ariakit/react": patch
 ---
 
 Fixed the offscreen [`CollectionItem`](https://ariakit.com/reference/collection-item) invariant message for missing `offscreenRoot` props.

--- a/.changeset/300-collection-offscreen-invariant-typo.md
+++ b/.changeset/300-collection-offscreen-invariant-typo.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed the offscreen [`CollectionItem`](https://ariakit.com/reference/collection-item) invariant message for missing `offscreenRoot` props.

--- a/packages/ariakit-react-components/src/collection/collection-item-offscreen.tsx
+++ b/packages/ariakit-react-components/src/collection/collection-item-offscreen.tsx
@@ -55,7 +55,7 @@ export function useCollectionItemOffscreen<
       invariant(
         offscreenRoot !== undefined,
         process.env.NODE_ENV !== "production" &&
-          "The offscreenRoot prop must provided.",
+          "The offscreenRoot prop must be provided.",
       );
 
       const getOffscreenRoot = () => {


### PR DESCRIPTION
## Motivation

The collection offscreen invariant message has a small grammar typo: `The offscreenRoot prop must provided.`

## Solution

Updated the development-only invariant message to say `The offscreenRoot prop must be provided.` Added a patch changeset for `@ariakit/react-components`, which exposes the offscreen collection item subpath.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm lint-fix` after adding the changeset
