### PR TITLE
Fix menubar store example variable

### DIFF
--- a/packages/ariakit-react-components/src/menu/menu-bar-store.ts
+++ b/packages/ariakit-react-components/src/menu/menu-bar-store.ts
@@ -27,8 +27,8 @@ export function useMenuBarStoreProps<T extends Core.MenuBarStore>(
  * instead.
  * @example
  * ```jsx
- * const menu = useMenuBarStore();
- * <MenuBar store={menu} />
+ * const menubar = useMenuBarStore();
+ * <MenuBar store={menubar} />
  * ```
  */
 export function useMenuBarStore(props: MenuBarStoreProps = {}): MenuBarStore {

--- a/packages/ariakit-react-components/src/menubar/menubar-store.ts
+++ b/packages/ariakit-react-components/src/menubar/menubar-store.ts
@@ -22,9 +22,9 @@ export function useMenubarStoreProps<T extends Core.MenubarStore>(
  * @see https://ariakit.com/components/menubar
  * @example
  * ```jsx
- * const menu = useMenubarStore();
+ * const menubar = useMenubarStore();
  *
- * <Menubar store={menu} />
+ * <Menubar store={menubar} />
  * ```
  */
 export function useMenubarStore(props: MenubarStoreProps = {}): MenubarStore {


### PR DESCRIPTION
## Motivation

The `useMenubarStore` JSDoc example used `menu` as the store variable name, which is misleading because menubars and menus are adjacent but distinct concepts. The deprecated `useMenuBarStore` example copied the same confusing pattern.

## Solution

Rename the example variable to `menubar` in both store examples so the docs match the component concept being controlled.