### PR TITLE
Document form removeValue null slots

### DIFF
--- a/.changeset/300-form-remove-value-docs.md
+++ b/.changeset/300-form-remove-value-docs.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/components": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Documented that [`removeValue`](https://ariakit.com/reference/use-form-store#removevalue) preserves array length by replacing removed items with `null`.

--- a/packages/ariakit-components/src/form/form-store.ts
+++ b/packages/ariakit-components/src/form/form-store.ts
@@ -476,8 +476,9 @@ export interface FormStoreFunctions<
    * The array length is preserved: the removed index is replaced with `null`
    * so indices stay stable for field keys, touched state, errors, and
    * [`FormRemove`](https://ariakit.com/reference/form-remove) focus handling.
-   * Filter out `null` values before submitting if your payload should omit
-   * removed items.
+   * Validation and submission callbacks receive these `null` entries in
+   * `state.values`, so filter them only when your payload should omit removed
+   * items.
    * @example
    * store.removeValue("tags", 0);
    * store.removeValue("tags", 1);

--- a/packages/ariakit-components/src/form/form-store.ts
+++ b/packages/ariakit-components/src/form/form-store.ts
@@ -476,9 +476,8 @@ export interface FormStoreFunctions<
    * The array length is preserved: the removed index is replaced with `null`
    * so indices stay stable for field keys, touched state, errors, and
    * [`FormRemove`](https://ariakit.com/reference/form-remove) focus handling.
-   * Validation and submission callbacks receive these `null` entries in
-   * `state.values`, so filter them only when your payload should omit removed
-   * items.
+   * Filter out `null` values before submitting if your payload should omit
+   * removed items.
    * @example
    * store.removeValue("tags", 0);
    * store.removeValue("tags", 1);

--- a/packages/ariakit-components/src/form/form-store.ts
+++ b/packages/ariakit-components/src/form/form-store.ts
@@ -472,6 +472,12 @@ export interface FormStoreFunctions<
   pushValue: <T>(name: StringLike, value: T) => void;
   /**
    * Removes a value from an array field.
+   *
+   * The array length is preserved: the removed index is replaced with `null`
+   * so indices stay stable for field keys, touched state, errors, and
+   * [`FormRemove`](https://ariakit.com/reference/form-remove) focus handling.
+   * Filter out `null` values before submitting if your payload should omit
+   * removed items.
    * @example
    * store.removeValue("tags", 0);
    * store.removeValue("tags", 1);

--- a/packages/ariakit-react-components/src/form/form-remove.tsx
+++ b/packages/ariakit-react-components/src/form/form-remove.tsx
@@ -62,9 +62,10 @@ function findPushButton(
  * const values = useStoreState(store, "values");
  *
  * <Form store={store}>
- *   {values.languages.map((_, i) => (
- *     <FormInput key={i} name={store.names.languages[i]} />
- *   ))}
+ *   {values.languages.map((language, i) => {
+ *     if (language == null) return null;
+ *     return <FormInput key={i} name={store.names.languages[i]} />;
+ *   })}
  *   <Role {...props}>Remove first language</Role>
  * </Form>
  * ```
@@ -136,7 +137,7 @@ export const useFormRemove = createHook<TagName, FormRemoveOptions>(
  * prop to `false`.
  * @see https://ariakit.com/components/form
  * @example
- * ```jsx {13}
+ * ```jsx {15}
  * const form = useFormStore({
  *   defaultValues: {
  *     languages: ["JavaScript", "PHP"],
@@ -146,12 +147,15 @@ export const useFormRemove = createHook<TagName, FormRemoveOptions>(
  * const values = useStoreState(form, "values");
  *
  * <Form store={form}>
- *   {values.languages.map((_, i) => (
- *     <div key={i}>
- *       <FormInput name={form.names.languages[i]} />
- *       <FormRemove name={form.names.languages} index={i} />
- *     </div>
- *   ))}
+ *   {values.languages.map((language, i) => {
+ *     if (language == null) return null;
+ *     return (
+ *       <div key={i}>
+ *         <FormInput name={form.names.languages[i]} />
+ *         <FormRemove name={form.names.languages} index={i} />
+ *       </div>
+ *     );
+ *   })}
  * </Form>
  * ```
  */


### PR DESCRIPTION
## Motivation

`removeValue` preserves array indices by replacing removed array slots with `null`, but its reference docs only said it removes a value from an array. Consumers could assume it splices and be surprised by null entries and unchanged length.

## Solution

Document the null-slot behavior in the FormStore JSDoc: length is preserved, removed slots become `null`, indices stay stable for field keys, touched state, errors, and `FormRemove` focus handling, and consumers should filter `null` values before submission if needed.

This also updates the `FormRemove` reference examples because they iterate the same array shape that `removeValue` leaves behind. The examples now skip `null` slots while preserving the original index used by `FormInput` and `FormRemove`.

## Testing

- `pnpm lint-fix`
- Pre-commit PR review gate: Codex reviewer clean; Cursor reviewer clean
