### PR TITLE
Flatten nested hovercard movement check

### DIFF
--- a/packages/ariakit-react-components/src/hovercard/hovercard.tsx
+++ b/packages/ariakit-react-components/src/hovercard/hovercard.tsx
@@ -65,7 +65,7 @@ function isMovingOnHovercard(
   // The mouse is moving on an element inside the anchor element.
   if (anchor && contains(anchor, target)) return true;
   // The mouse is moving on an element inside a nested hovercard.
-  if (nested?.some((card) => isMovingOnHovercard(target, card, anchor))) {
+  if (nested?.some((card) => hasFocusWithin(card) || contains(card, target))) {
     return true;
   }
   return false;


### PR DESCRIPTION
## Motivation

Nested hovercards are registered into a flattened list, but `isMovingOnHovercard` still used a recursive call when checking that list. Since the recursive call did not forward the nested list, it only repeated checks that were already covered by the flat iteration.

## Solution

Replace the recursive nested hovercard check with a direct membership test that keeps a hovercard visible when a registered nested hovercard contains focus or the current pointer target.

## Testing

- `pnpm lint-fix`
- `pnpm tsc`