### PR TITLE
Remove radio store rest destructure

### DIFF
--- a/packages/ariakit-components/src/radio/radio-store.ts
+++ b/packages/ariakit-components/src/radio/radio-store.ts
@@ -12,9 +12,7 @@ import { createCompositeStore } from "../composite/composite-store.ts";
 /**
  * Creates a radio store.
  */
-export function createRadioStore({
-  ...props
-}: RadioStoreProps = {}): RadioStore {
+export function createRadioStore(props: RadioStoreProps = {}): RadioStore {
   const syncState = props.store?.getState();
 
   const composite = createCompositeStore({


### PR DESCRIPTION
## Motivation

`createRadioStore` destructures its props parameter into a rest object without extracting any keys. This creates an identical shallow copy before the function uses it as the original props object, unlike sibling stores that only destructure when they extract named keys.

## Solution

Use a direct `props: RadioStoreProps = {}` parameter and keep the existing references unchanged. This removes the no-op copy while preserving the default value and runtime behavior.