### PR TITLE
Decouple tooltip skip timeout sync

### DIFF
--- a/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
+++ b/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
@@ -106,6 +106,8 @@ export const useTooltipAnchor = createHook<TagName, TooltipAnchorOptions>(
           // timeout to hide the active tooltip in the global store. This is so
           // we can show other tooltips without a delay when there's already an
           // active tooltip (see the showOnHover method below).
+          // Read skipTimeout lazily because this sync only subscribes to
+          // mounted.
           const id = setTimeout(removeStore, store.getState().skipTimeout);
           return () => clearTimeout(id);
         }),

--- a/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
+++ b/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
@@ -87,7 +87,7 @@ export const useTooltipAnchor = createHook<TagName, TooltipAnchorOptions>(
         // the component unmounts. This is useful, for example, to avoid
         // showing tooltips immediately on serial tests.
         removeStore,
-        sync(store, ["mounted", "skipTimeout"], (state) => {
+        sync(store, ["mounted"], (state) => {
           if (!store) return;
           // If the current tooltip is open, we should immediately hide the
           // active one and set the current one as the active tooltip. If a
@@ -106,7 +106,7 @@ export const useTooltipAnchor = createHook<TagName, TooltipAnchorOptions>(
           // timeout to hide the active tooltip in the global store. This is so
           // we can show other tooltips without a delay when there's already an
           // active tooltip (see the showOnHover method below).
-          const id = setTimeout(removeStore, state.skipTimeout);
+          const id = setTimeout(removeStore, store.getState().skipTimeout);
           return () => clearTimeout(id);
         }),
       );


### PR DESCRIPTION
## Motivation

The tooltip anchor active-store coordination sync subscribes to both `mounted` and `skipTimeout`, but `skipTimeout` is only used after the tooltip becomes hidden. When `skipTimeout` changes while the tooltip is open, the callback re-runs the mounted branch and re-reads the active tooltip store without changing behavior.

## Solution

Subscribe the coordination sync only to `mounted` and read `skipTimeout` lazily with `store.getState().skipTimeout` when scheduling the hidden-state timeout.

Changing `skipTimeout` while the tooltip is already hidden no longer re-schedules the pending skip-window timeout with the new duration. That edge behavior is undocumented and untested; the normal mounted/hidden transition still uses the current `skipTimeout` at scheduling time.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`