### PR TITLE
Optimize test select text walking

### DIFF
--- a/.changeset/200-test-select-performance.md
+++ b/.changeset/200-test-select-performance.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/test": patch
+---
+
+Improved text selection performance in `@ariakit/test`.

--- a/packages/ariakit-test/src/__tests__/select.test.react.tsx
+++ b/packages/ariakit-test/src/__tests__/select.test.react.tsx
@@ -1,0 +1,24 @@
+import { expect, test, vi } from "vitest";
+import { q, render } from "../react.tsx";
+import { select } from "../select.ts";
+
+test("select", async () => {
+  await render(
+    <div>
+      first <span>second</span> third
+    </div>,
+  );
+
+  const element = q.text(/first/);
+  const createNodeIterator = vi.spyOn(document, "createNodeIterator");
+  const onSelectionChange = vi.fn();
+  document.addEventListener("selectionchange", onSelectionChange);
+
+  await select("second third", element);
+
+  const selection = document.getSelection();
+
+  expect(createNodeIterator).toHaveBeenCalledTimes(1);
+  expect(onSelectionChange).toHaveBeenCalledTimes(1);
+  expect(selection?.toString()).toBe("second third");
+});

--- a/packages/ariakit-test/src/__tests__/select.test.react.tsx
+++ b/packages/ariakit-test/src/__tests__/select.test.react.tsx
@@ -14,11 +14,15 @@ test("select", async () => {
   const onSelectionChange = vi.fn();
   document.addEventListener("selectionchange", onSelectionChange);
 
-  await select("second third", element);
+  try {
+    await select("second third", element);
 
-  const selection = document.getSelection();
+    const selection = document.getSelection();
 
-  expect(createNodeIterator).toHaveBeenCalledTimes(1);
-  expect(onSelectionChange).toHaveBeenCalledTimes(1);
-  expect(selection?.toString()).toBe("second third");
+    expect(createNodeIterator).toHaveBeenCalledTimes(1);
+    expect(onSelectionChange).toHaveBeenCalledTimes(1);
+    expect(selection?.toString()).toBe("second third");
+  } finally {
+    document.removeEventListener("selectionchange", onSelectionChange);
+  }
 });

--- a/packages/ariakit-test/src/select.ts
+++ b/packages/ariakit-test/src/select.ts
@@ -32,46 +32,38 @@ export function select(
 
     const startIndex = element.textContent?.indexOf(text) ?? -1;
     const selection = document.getSelection();
+    const endIndex = startIndex + text.length;
+    let index = startIndex;
+    let node: Node | null = null;
+    let charCount = 0;
+    let startContainer: Node | null = null;
+    let startOffset = -1;
+    let endContainer: Node | null = null;
+    let endOffset = -1;
+    const iterator = document.createNodeIterator(element, NodeFilter.SHOW_TEXT);
+
+    while (
+      index >= 0 &&
+      index < endIndex &&
+      charCount < endIndex &&
+      (node = iterator.nextNode())
+    ) {
+      const textContent = node.textContent;
+      if (!textContent) continue;
+      charCount += textContent.length;
+      if (index > charCount) continue;
+      if (!startContainer) {
+        startContainer = node;
+        startOffset = index - charCount + textContent.length;
+      }
+      endContainer = node;
+      endOffset = endIndex - charCount + textContent.length;
+      index++;
+    }
+
     const range = document.createRange();
 
-    for (let i = 1; i <= text.length; i++) {
-      const iterator = document.createNodeIterator(
-        element,
-        NodeFilter.SHOW_TEXT,
-      );
-      const textSlice = text.slice(0, i);
-      const endIndex = startIndex + textSlice.length;
-      let index = startIndex;
-      let node: Node | null = null;
-      let charCount = 0;
-      let startContainer: Node | null = null;
-      let startOffset = -1;
-      let endContainer: Node | null = null;
-      let endOffset = -1;
-
-      while (
-        index >= 0 &&
-        index < endIndex &&
-        charCount < endIndex &&
-        (node = iterator.nextNode())
-      ) {
-        const textContent = node.textContent;
-        if (!textContent) continue;
-        charCount += textContent.length;
-        if (index > charCount) continue;
-        if (!startContainer) {
-          startContainer = node;
-          startOffset = index - charCount + textContent.length;
-        }
-        endContainer = node;
-        endOffset = endIndex - charCount + textContent.length;
-        index++;
-      }
-
-      if (!startContainer || !endContainer) continue;
-
-      await hover(element, options);
-
+    if (startContainer && endContainer) {
       range.setStart(startContainer, startOffset);
       range.setEnd(endContainer, endOffset);
       selection?.removeAllRanges();
@@ -83,10 +75,6 @@ export function select(
     await mouseUp(element, options);
 
     await dispatch.click(element, { detail: 1, ...options });
-
-    // Fires selectionchange again
-    selection?.removeAllRanges();
-    selection?.addRange(range);
 
     await sleep();
   });


### PR DESCRIPTION
## Motivation

`@ariakit/test` `select()` walked text nodes once per selected character, rebuilding a node iterator and replaying hover work on every iteration. Long selections therefore scaled poorly and fired repeated selection updates while only the final range mattered.

## Solution

Compute the final selection range with a single text-node walk that preserves the existing start/end container and offset math. The helper now applies the range once, and the new focused test verifies a split-text-node selection, one node iterator creation, one `selectionchange`, and the final selected text.
