### PR TITLE
Derive disclosure aria-expanded synchronously

### DIFF
--- a/.changeset/300-disclosure-default-open-expanded.md
+++ b/.changeset/300-disclosure-default-open-expanded.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Disclosure`](https://ariakit.com/reference/disclosure) to render `aria-expanded="true"` on the server when initially open.

--- a/.changeset/300-disclosure-default-open-expanded.md
+++ b/.changeset/300-disclosure-default-open-expanded.md
@@ -3,4 +3,4 @@
 "@ariakit/react": patch
 ---
 
-Fixed [`Disclosure`](https://ariakit.com/reference/disclosure) to render `aria-expanded="true"` on the server when initially open.
+Fixed [`Disclosure`](https://ariakit.com/reference/disclosure) and disclosure-based components to render `aria-expanded="true"` on the server and the initial client render when initially open.

--- a/app/src/examples/disclosure/group/test-browser.ts
+++ b/app/src/examples/disclosure/group/test-browser.ts
@@ -7,12 +7,21 @@ withFramework(import.meta.dirname, async ({ test }) => {
   });
 
   test("open @visual", async ({ page, q, visual }) => {
-    await q.button(/^What do "lifetime access"/).click();
+    const lifetimeButton = q.button(/^What do "lifetime access"/);
+    const teamButton = q.button(/^How does the Team license/);
+    const upgradeButton = q.button(/^Can I upgrade/);
+    await lifetimeButton.click();
+    await test.expect(lifetimeButton).toHaveAttribute("aria-expanded", "true");
+    await test.expect(teamButton).toHaveAttribute("aria-expanded", "false");
+    await test.expect(upgradeButton).toHaveAttribute("aria-expanded", "false");
     await test.expect(q.text(/Lifetime access and/)).toBeVisible();
     // Avoid hover state
     await page.mouse.move(0, 0);
     await visual();
-    await q.button(/^How does the Team license/).click();
+    await teamButton.click();
+    await test.expect(lifetimeButton).toHaveAttribute("aria-expanded", "true");
+    await test.expect(teamButton).toHaveAttribute("aria-expanded", "true");
+    await test.expect(upgradeButton).toHaveAttribute("aria-expanded", "false");
     await test.expect(q.text(/When you purchase a team/)).toBeVisible();
     // Avoid hover state
     await page.mouse.move(0, 0);

--- a/app/src/examples/disclosure/test.ts
+++ b/app/src/examples/disclosure/test.ts
@@ -1,7 +1,98 @@
-import { click, press, q } from "@ariakit/test";
+import * as ak from "@ariakit/react";
+import { click, press, q, waitFor } from "@ariakit/test";
+import { render } from "@ariakit/test/react";
+import { createElement, useState } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { expect, test } from "vitest";
+import Example from "./index.react.tsx";
 
 const content = () => q.text(/Create an account/);
+
+function SharedStoreDisclosures() {
+  const store = ak.useDisclosureStore();
+  return createElement(
+    "div",
+    null,
+    createElement(ak.Disclosure, { store }, "Shared first"),
+    createElement(ak.Disclosure, { store }, "Shared second"),
+  );
+}
+
+function ReclaimDisconnectedDisclosure() {
+  const [firstMounted, setFirstMounted] = useState(true);
+  const store = ak.useDisclosureStore();
+  return createElement(
+    "div",
+    null,
+    firstMounted &&
+      createElement(ak.Disclosure, { store }, "Disconnected first"),
+    createElement(ak.Disclosure, { store }, "Disconnected second"),
+    createElement("button", { onClick: store.hide }, "Hide shared"),
+    createElement(
+      "button",
+      { onClick: () => setFirstMounted(false) },
+      "Unmount shared first",
+    ),
+    createElement("button", { onClick: store.show }, "Show shared"),
+  );
+}
+
+test("renders default open disclosure as expanded on server", () => {
+  const html = renderToStaticMarkup(createElement(Example));
+  expect(html).toContain('aria-expanded="true"');
+});
+
+test("marks only the active shared-store disclosure as expanded", async () => {
+  const { unmount } = await render(createElement(SharedStoreDisclosures));
+  try {
+    const firstDisclosure = q.button("Shared first");
+    const secondDisclosure = q.button("Shared second");
+
+    expect(q.button.all(/^Shared /)).toHaveLength(2);
+
+    await click(firstDisclosure);
+    expect(firstDisclosure).toHaveAttribute("aria-expanded", "true");
+    expect(secondDisclosure).toHaveAttribute("aria-expanded", "false");
+
+    await click(secondDisclosure);
+    expect(firstDisclosure).toHaveAttribute("aria-expanded", "false");
+    expect(secondDisclosure).toHaveAttribute("aria-expanded", "false");
+
+    await click(secondDisclosure);
+    expect(firstDisclosure).toHaveAttribute("aria-expanded", "false");
+    expect(secondDisclosure).toHaveAttribute("aria-expanded", "true");
+  } finally {
+    unmount();
+  }
+});
+
+test("reclaims disconnected disclosure element on programmatic open", async () => {
+  const { unmount } = await render(
+    createElement(ReclaimDisconnectedDisclosure),
+  );
+  try {
+    const firstDisclosure = q.button("Disconnected first");
+    const secondDisclosure = q.button("Disconnected second");
+
+    await click(firstDisclosure);
+    expect(firstDisclosure).toHaveAttribute("aria-expanded", "true");
+    expect(secondDisclosure).toHaveAttribute("aria-expanded", "false");
+
+    await click(q.button("Hide shared"));
+    expect(firstDisclosure).toHaveAttribute("aria-expanded", "false");
+    expect(secondDisclosure).toHaveAttribute("aria-expanded", "false");
+
+    await click(q.button("Unmount shared first"));
+    expect(q.button("Disconnected first")).not.toBeInTheDocument();
+
+    await click(q.button("Show shared"));
+    await waitFor(() => {
+      expect(secondDisclosure).toHaveAttribute("aria-expanded", "true");
+    });
+  } finally {
+    unmount();
+  }
+});
 
 test("show/hide on click", async () => {
   expect(content()).toBeVisible();

--- a/app/src/examples/disclosure/test.ts
+++ b/app/src/examples/disclosure/test.ts
@@ -3,7 +3,7 @@ import { click, press, q, waitFor } from "@ariakit/test";
 import { render } from "@ariakit/test/react";
 import { createElement, useState } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import Example from "./index.react.tsx";
 
 const content = () => q.text(/Create an account/);
@@ -38,8 +38,25 @@ function ReclaimDisconnectedDisclosure() {
 }
 
 test("renders default open disclosure as expanded on server", () => {
-  const html = renderToStaticMarkup(createElement(Example));
-  expect(html).toContain('aria-expanded="true"');
+  const originalError = console.error;
+  const consoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation((...args: Parameters<typeof console.error>) => {
+      const [message] = args;
+      if (
+        typeof message === "string" &&
+        message.includes("useLayoutEffect does nothing on the server")
+      ) {
+        return;
+      }
+      originalError(...args);
+    });
+  try {
+    const html = renderToStaticMarkup(createElement(Example));
+    expect(html).toMatch(/<button\b[^>]*aria-expanded="true"/);
+  } finally {
+    consoleError.mockRestore();
+  }
 });
 
 test("marks only the active shared-store disclosure as expanded", async () => {

--- a/packages/ariakit-react-components/src/disclosure/disclosure.tsx
+++ b/packages/ariakit-react-components/src/disclosure/disclosure.tsx
@@ -12,7 +12,7 @@ import type { Props } from "@ariakit/react-utils";
 import { invariant } from "@ariakit/utils";
 import type { BooleanOrCallback } from "@ariakit/utils";
 import type { ElementType, MouseEvent } from "react";
-import { useEffect, useRef } from "react";
+import { useEffect, useState } from "react";
 import type { ButtonOptions } from "../button/button.tsx";
 import { useButton } from "../button/button.tsx";
 import { useDisclosureProviderContext } from "./disclosure-context.tsx";
@@ -46,19 +46,19 @@ export const useDisclosure = createHook<TagName, DisclosureOptions>(
         "Disclosure must receive a `store` prop or be wrapped in a DisclosureProvider component.",
     );
 
-    const ref = useRef<HTMLType>(null);
+    const [element, setElement] = useState<HTMLType | null>(null);
     const disclosureElement = useStoreState(store, "disclosureElement");
     const open = useStoreState(store, "open");
     const expanded =
-      open && (disclosureElement == null || disclosureElement === ref.current);
+      open && (disclosureElement == null || disclosureElement === element);
 
     // Assigns the disclosure element whenever it's undefined or disconnected
     // from the DOM. Re-run on open changes so a stale disconnected disclosure
     // element is claimed before deriving aria-expanded for the next open state.
     useEffect(() => {
       if (disclosureElement?.isConnected) return;
-      store?.setDisclosureElement(ref.current);
-    }, [disclosureElement, store, open]);
+      store?.setDisclosureElement(element);
+    }, [disclosureElement, store, open, element]);
 
     const onClickProp = props.onClick;
     const toggleOnClickProp = useBooleanEvent(toggleOnClick);
@@ -80,7 +80,7 @@ export const useDisclosure = createHook<TagName, DisclosureOptions>(
       "aria-controls": contentElement?.id,
       ...metadataProps,
       ...props,
-      ref: useMergeRefs(ref, props.ref),
+      ref: useMergeRefs(setElement, props.ref),
       onClick,
     };
 

--- a/packages/ariakit-react-components/src/disclosure/disclosure.tsx
+++ b/packages/ariakit-react-components/src/disclosure/disclosure.tsx
@@ -12,7 +12,7 @@ import type { Props } from "@ariakit/react-utils";
 import { invariant } from "@ariakit/utils";
 import type { BooleanOrCallback } from "@ariakit/utils";
 import type { ElementType, MouseEvent } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import type { ButtonOptions } from "../button/button.tsx";
 import { useButton } from "../button/button.tsx";
 import { useDisclosureProviderContext } from "./disclosure-context.tsx";
@@ -47,21 +47,17 @@ export const useDisclosure = createHook<TagName, DisclosureOptions>(
     );
 
     const ref = useRef<HTMLType>(null);
-    const [expanded, setExpanded] = useState(false);
     const disclosureElement = useStoreState(store, "disclosureElement");
     const open = useStoreState(store, "open");
+    const expanded =
+      open && (disclosureElement == null || disclosureElement === ref.current);
 
     // Assigns the disclosure element whenever it's undefined or disconnected
-    // from the DOM. If the current element is the disclosure element, it will
-    // get the `aria-expanded` attribute set to `true` when the disclosure
-    // content is open.
+    // from the DOM. Re-run on open changes so a stale disconnected disclosure
+    // element is claimed before deriving aria-expanded for the next open state.
     useEffect(() => {
-      let isCurrentDisclosure = disclosureElement === ref.current;
-      if (!disclosureElement?.isConnected) {
-        store?.setDisclosureElement(ref.current);
-        isCurrentDisclosure = true;
-      }
-      setExpanded(open && isCurrentDisclosure);
+      if (disclosureElement?.isConnected) return;
+      store?.setDisclosureElement(ref.current);
     }, [disclosureElement, store, open]);
 
     const onClickProp = props.onClick;


### PR DESCRIPTION
## Motivation

A default-open [`Disclosure`](https://ariakit.com/reference/disclosure) rendered `aria-expanded="false"` on the server and first client paint because the value was initialized with local state and corrected only after an effect. This exposed an incorrect accessibility state while the content was already open.

## Solution

Derive `aria-expanded` directly from the disclosure store's `open` state and the current disclosure button element, while keeping the effect focused on claiming a missing or disconnected disclosure element. The current button element is tracked through the merged ref callback so render does not read `ref.current`.

This preserves shared-store multi-button ownership once a disclosure element has been claimed while making the initial rendered state match `defaultOpen`.

The tests now cover server-rendered default-open output, shared-store multi-button ownership, and reclaiming a disconnected disclosure element on programmatic open. The disclosure group browser test also asserts that unopened buttons remain collapsed while opened items are expanded.
