### PR TITLE
Remove React template TypeScript suppression

### DIFF
--- a/templates/react/vite.config.ts
+++ b/templates/react/vite.config.ts
@@ -4,6 +4,5 @@ import { defineConfig } from "vite";
 
 // https://vite.dev/config/
 export default defineConfig({
-  // @ts-ignore
   plugins: [tailwindcss(), react()],
 });


### PR DESCRIPTION
## Motivation

The React starter template currently includes a blanket TypeScript suppression above the Vite plugins array, even though the pinned plugin versions type-check without it. Keeping the suppression teaches users to hide type errors and could mask future issues.

## Solution

Remove the unnecessary `// @ts-ignore` line and leave the existing plugins configuration unchanged.
