### PR TITLE
Type nested hovercard registration element

### DIFF
--- a/packages/ariakit-react-components/src/hovercard/hovercard.tsx
+++ b/packages/ariakit-react-components/src/hovercard/hovercard.tsx
@@ -311,7 +311,7 @@ export const useHovercard = createHook<TagName, HovercardOptions>(
     }, [modal, portal, mounted, domReady]);
 
     const registerNestedHovercard = useCallback(
-      (element: any) => {
+      (element: HTMLElement) => {
         setNestedHovercards((prevElements) => [...prevElements, element]);
         const parentUnregister = registerOnParent?.(element);
         return () => {


### PR DESCRIPTION
## Motivation

The nested hovercard registration callback is exposed through a context typed as accepting an `HTMLElement`, and nested hovercards are stored in an `HTMLElement[]` before being passed to DOM helpers such as `contains` and `hasFocusWithin`. The local callback still accepted `any`, which weakened that contract.

## Solution

Narrow `registerNestedHovercard`'s `element` parameter to `HTMLElement` so it matches `NestedHovercardContext` and the actual `HTMLDivElement` caller. This is a type-only change with no runtime behavior change.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- Ariakit pre-commit review gate: native Codex reviewer and Cursor CLI reviewer returned no findings.
