### PR TITLE
Add type-safe findInOrder overloads

### DIFF
--- a/app/src/lib/array.test.ts
+++ b/app/src/lib/array.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2025-present Ariakit FZ-LLC. All Rights Reserved.
+ *
+ * This software is proprietary. See the license.md file in the root of this
+ * package for licensing terms.
+ *
+ * SPDX-License-Identifier: UNLICENSED
+ */
+
+import { expect, expectTypeOf, test } from "vitest";
+import { findInOrder } from "./array.ts";
+
+interface Item {
+  id: number;
+  label: string | null;
+}
+
+const items: Item[] = [
+  { id: 1, label: "one" },
+  { id: 2, label: null },
+];
+
+test("findInOrder finds property values in order", () => {
+  expect(findInOrder(items, "id", [2, 1])).toBe(items[1]);
+  expect(findInOrder(items, "label", [null, "one"])).toBe(items[0]);
+});
+
+test("findInOrder preserves property and selector value types", () => {
+  expectTypeOf(findInOrder(items, "id", [1])).toEqualTypeOf<Item | null>();
+  expectTypeOf(
+    findInOrder(items, (item) => item.label, ["one"]),
+  ).toEqualTypeOf<Item | null>();
+
+  const expectInvalidFindInOrderTypes = () => {
+    // @ts-expect-error Invalid value for property key.
+    findInOrder(items, "id", ["1"]);
+    // @ts-expect-error Invalid value for selector.
+    findInOrder(items, (item) => item.id, ["1"]);
+  };
+
+  expectTypeOf(expectInvalidFindInOrderTypes).toEqualTypeOf<() => void>();
+});

--- a/app/src/lib/array.ts
+++ b/app/src/lib/array.ts
@@ -7,11 +7,21 @@
  *
  * SPDX-License-Identifier: UNLICENSED
  */
+export function findInOrder<T, K extends keyof T>(
+  array: T[],
+  key: K,
+  values: T[K][],
+): T | null;
 export function findInOrder<T, Value>(
   array: T[],
-  key: keyof T | ((item: T) => Value),
+  key: (item: T) => Value,
   values: Value[],
-) {
+): T | null;
+export function findInOrder<T>(
+  array: T[],
+  key: keyof T | ((item: T) => unknown),
+  values: unknown[],
+): T | null {
   for (const value of values) {
     const item = array.find((item) => {
       if (value == null) return false;

--- a/app/src/lib/array.ts
+++ b/app/src/lib/array.ts
@@ -7,11 +7,23 @@
  *
  * SPDX-License-Identifier: UNLICENSED
  */
+/**
+ * Returns the first item whose property value matches a value in `values`.
+ *
+ * Values are tried in order, so the match for the earliest value wins.
+ * `null` and `undefined` values are skipped.
+ */
 export function findInOrder<T, K extends keyof T>(
   array: T[],
   key: K,
   values: T[K][],
 ): T | null;
+/**
+ * Returns the first item whose selected value matches a value in `values`.
+ *
+ * Values are tried in order, so the match for the earliest value wins.
+ * `null` and `undefined` values are skipped.
+ */
 export function findInOrder<T, Value>(
   array: T[],
   key: (item: T) => Value,


### PR DESCRIPTION
## Motivation

`findInOrder` allowed property-key callers to pass values unrelated to the selected property type. That left mismatched comparisons like `item[key] === value` unchecked by TypeScript.

## Solution

Add overloads so property-key calls require `values` to be `T[K][]`, while selector calls remain generic over the selector return type. The runtime implementation is unchanged, including the `value == null` guard.

The PR also adds focused app lib coverage for ordered matching, null skipping, and invalid value types.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm test app/src/lib/array.test.ts`
