### PR TITLE
Remove Shiki token htmlStyle any cast

### DIFF
--- a/app/src/components/code-block-content.astro
+++ b/app/src/components/code-block-content.astro
@@ -134,7 +134,7 @@ const MULTI_TOKEN_HIGHLIGHT_CLASS = "ak-layer ak-layer-6 ak-edge-25";
 const LINE_DIV_BASE_CLASS = "pe-14 [content-visibility:auto] h-(--line-height)";
 
 function getTokenColors(token: ThemedToken) {
-  const style = token.htmlStyle as any;
+  const style = token.htmlStyle;
   const dark = style?.["--shiki-dark"] || token.color;
   const light = style?.color || token.color;
   return { dark, light } as const;


### PR DESCRIPTION
## Motivation

`getTokenColors` cast Shiki token `htmlStyle` to `any` before reading color CSS properties, but Shiki already exposes the needed optional record type. The cast bypasses type checking unnecessarily.

## Solution

Use `token.htmlStyle` directly and keep the existing optional color lookups with the `token.color` fallback, preserving runtime behavior.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
