### PR TITLE
Add Next.js type checking to CI

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Set up environment
         uses: ./.github/workflows/setup
 
+      - name: Type check Next.js app
+        run: pnpm -F nextjs run tsc
+
       - name: Build Next.js app
         run: pnpm -F nextjs run build-worker
 

--- a/nextjs/next.config.ts
+++ b/nextjs/next.config.ts
@@ -4,9 +4,6 @@ import type { NextConfig } from "next";
 const config: NextConfig = {
   reactCompiler: true,
   typedRoutes: true,
-  typescript: {
-    ignoreBuildErrors: true,
-  },
   cacheComponents: true,
 
   // Allow cross-origin iframe embedding from the Astro app

--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -30,6 +30,7 @@
     "@types/react": "19.2.15",
     "@types/react-dom": "19.2.3",
     "babel-plugin-react-compiler": "1.0.0",
-    "tailwindcss": "4.3.0"
+    "tailwindcss": "4.3.0",
+    "typescript": "6.0.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -568,6 +568,9 @@ importers:
       tailwindcss:
         specifier: 4.3.0
         version: 4.3.0
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/ariakit-components:
     dependencies:


### PR DESCRIPTION
## Motivation

The Next.js app could accumulate type errors without CI coverage. The app workflow built the OpenNext artifact without running the `nextjs` workspace type-check script, and the Next config was set to ignore TypeScript build errors.

## Solution

Run `pnpm -F nextjs run tsc` in the app workflow before building the Next.js artifact. Remove `typescript.ignoreBuildErrors` now that both the standalone type-check and OpenNext build pass with TypeScript validation enabled, and declare `typescript` in the `nextjs` workspace because its `tsc` script invokes it directly.