### PR TITLE
Name CustomCheckbox forwardRef

### DIFF
--- a/app/src/sandbox/focusable-click-focus/index.react.tsx
+++ b/app/src/sandbox/focusable-click-focus/index.react.tsx
@@ -2,10 +2,11 @@ import * as Ariakit from "@ariakit/react";
 import type { ComponentProps } from "react";
 import { forwardRef, useState } from "react";
 
-const CustomCheckbox = forwardRef<
-  HTMLInputElement,
-  ComponentProps<"input"> & { type?: string }
->((props, ref) => <input ref={ref} type="checkbox" {...props} />);
+const CustomCheckbox = forwardRef<HTMLInputElement, ComponentProps<"input">>(
+  function CustomCheckbox(props, ref) {
+    return <input ref={ref} type="checkbox" {...props} />;
+  },
+);
 
 export default function Example() {
   const [checked, setChecked] = useState(false);

--- a/app/src/sandbox/focusable-click-focus/index.react.tsx
+++ b/app/src/sandbox/focusable-click-focus/index.react.tsx
@@ -4,7 +4,7 @@ import { forwardRef, useState } from "react";
 
 const CustomCheckbox = forwardRef<HTMLInputElement, ComponentProps<"input">>(
   function CustomCheckbox(props, ref) {
-    return <input ref={ref} type="checkbox" {...props} />;
+    return <input ref={ref} {...props} type="checkbox" />;
   },
 );
 


### PR DESCRIPTION
## Motivation

The focusable-click-focus sandbox wraps an input with `React.forwardRef`, but the render function is anonymous, so React DevTools reports the component as `ForwardRef`. Its props type also widens the input props with a redundant `type` override even though the component always renders a checkbox input.

## Solution

Name the `forwardRef` render function `CustomCheckbox` and type its props directly as `ComponentProps<"input">`. The component still renders an input with `type="checkbox"` while avoiding the extra type widening.
