### PR TITLE
Align pick implementation signature

### DIFF
--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -571,7 +571,7 @@ export function pick<
  * Creates a new store with a subset of the current store state and keeps them
  * in sync.
  */
-export function pick(store: Store, ...args: Parameters<StorePick>) {
+export function pick(store?: Store, ...args: Parameters<StorePick>) {
   if (!store) return;
   return getInternal(store, "pick")(...args);
 }


### PR DESCRIPTION
## Motivation

`pick` accepts nullable stores in its public overload and already returns early at runtime when no store is passed, but its implementation signature still requires `Store`. The sibling public helpers use optional implementation signatures, so `pick` is inconsistent.

## Solution

Update the `pick` implementation signature to accept an optional `Store`, matching the overload and existing runtime guard without changing behavior.
