### PR TITLE
Rename trailing value variable

### DIFF
--- a/packages/ariakit-react-components/src/tag/tag-input.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-input.tsx
@@ -147,7 +147,7 @@ export const useTagInput = createHook<TagName, TagInputOptions>(
         const delimiters = getDelimiters(delimiter);
         // Split values and get the trailing value that will remain in the input
         let values = splitValueByDelimiter(value, delimiters);
-        const trailingvalue = values.pop() || "";
+        const trailingValue = values.pop() || "";
         values = values
           .map((value) => value.trim())
           .filter((value) => value !== "");
@@ -163,8 +163,8 @@ export const useTagInput = createHook<TagName, TagInputOptions>(
             store.addValue(tagValue);
           }
           void UndoManager.execute(() => {
-            store.setValue(trailingvalue);
-            if (trailingvalue === prevValue) return;
+            store.setValue(trailingValue);
+            if (trailingValue === prevValue) return;
             return () => store.setValue(prevValue);
           }, inputType);
         }


### PR DESCRIPTION
## Motivation

The tag input implementation has one local variable named `trailingvalue`, which does not match the camelCase style used elsewhere in the file.

## Solution

Rename the local variable to `trailingValue` at its declaration and both usages without changing behavior.