### PR TITLE
Convert GroupOptions to an interface

### DIFF
--- a/packages/ariakit-react-components/src/group/group.tsx
+++ b/packages/ariakit-react-components/src/group/group.tsx
@@ -61,7 +61,9 @@ export const Group = forwardRef(function Group(props: GroupProps) {
   return createElement(TagName, htmlProps);
 });
 
-export type GroupOptions<_T extends ElementType = TagName> = Options;
+export interface GroupOptions<
+  _T extends ElementType = TagName,
+> extends Options {}
 
 export type GroupProps<T extends ElementType = TagName> = Props<
   T,


### PR DESCRIPTION
## Motivation

`GroupOptions` is the only options export in `packages/ariakit-react-components/src/group/group.tsx` declared as a type alias to `Options`. Sibling options exports use interfaces extending their base options, and `CompositeGroupOptions`/`FormGroupOptions` extend `GroupOptions`, so this keeps the options chain consistent.

## Solution

Change `GroupOptions` to an interface that extends `Options` while preserving its generic parameter and public shape.
