### PR TITLE
Remove dialog tree walk isValidElement export

### DIFF
--- a/.changeset/100-walk-tree-outside-valid-element.md
+++ b/.changeset/100-walk-tree-outside-valid-element.md
@@ -1,0 +1,21 @@
+---
+"@ariakit/react-components": minor
+---
+
+Removed `isValidElement` from `dialog/utils/walk-tree-outside`
+
+**BREAKING** if you import `isValidElement` from `@ariakit/react-components/dialog/utils/walk-tree-outside`.
+
+The helper was intended for internal dialog tree walking and has been removed from the public subpath exports to avoid confusion with React's `isValidElement`.
+
+Before:
+
+```ts
+import { isValidElement } from "@ariakit/react-components/dialog/utils/walk-tree-outside";
+```
+
+After:
+
+```ts
+// No public replacement import is available.
+```

--- a/packages/ariakit-react-components/src/dialog/utils/walk-tree-outside.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/walk-tree-outside.ts
@@ -23,7 +23,7 @@ function inSnapshot(id: string, element: Element) {
   } while (true);
 }
 
-export function isValidElement(
+function shouldWalkElement(
   id: string,
   element: Element,
   ignoredElements: Elements,
@@ -57,7 +57,7 @@ export function walkTreeOutside(
       ancestorCallback?.(element.parentElement, originalElement);
       if (!hasAncestorAlready) {
         for (const child of element.parentElement.children) {
-          if (isValidElement(id, child, elements)) {
+          if (shouldWalkElement(id, child, elements)) {
             callback(child, originalElement);
           }
         }


### PR DESCRIPTION
## Motivation

`packages/ariakit-react-components/src/dialog/utils/walk-tree-outside.ts` exports a helper named `isValidElement` even though the helper only decides whether a DOM element should be visited during dialog tree walking. The exported name also reads like React's `isValidElement`, and the published subpath means removing it should be documented as a public API removal.

## Solution

Rename the helper to `shouldWalkElement`, make it module-private, and update the internal tree-walk call site. Add a breaking changeset for `@ariakit/react-components` documenting the removed named export from `@ariakit/react-components/dialog/utils/walk-tree-outside`.

No runtime behavior changes.
