### PR TITLE
Optimize ComboboxItemValue offset matching

### DIFF
--- a/.changeset/300-combobox-item-value-offsets.md
+++ b/.changeset/300-combobox-item-value-offsets.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Improved [`ComboboxItemValue`](https://ariakit.com/reference/combobox-item-value) rendering performance.

--- a/examples/combobox-item-value/test.ts
+++ b/examples/combobox-item-value/test.ts
@@ -12,3 +12,13 @@ test("show highlighted text", async () => {
   await press.Enter();
   expect(q.combobox()).toHaveValue("Apple");
 });
+
+test("show repeated highlighted text", async () => {
+  await press.Tab();
+  await type("p");
+  await press.ArrowDown();
+  expect(q.option("Apple")).toHaveFocus();
+  expect(q.option("Apple")?.innerHTML).toMatchInlineSnapshot(
+    `"<span><span data-autocomplete-value="">A</span><span data-user-value="">p</span><span data-user-value="">p</span><span data-autocomplete-value="">le</span></span>"`,
+  );
+});

--- a/packages/ariakit-react-components/src/combobox/combobox-item-value.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item-value.tsx
@@ -26,12 +26,11 @@ function getOffsets(string: string, values: Iterable<string>) {
   for (const value of values) {
     let pos = 0;
     const length = value.length;
-    while (string.indexOf(value, pos) !== -1) {
-      const index = string.indexOf(value, pos);
-      if (index !== -1) {
-        offsets.push([index, length]);
-      }
+    let index = string.indexOf(value, pos);
+    while (index !== -1) {
+      offsets.push([index, length]);
       pos = index + 1;
+      index = string.indexOf(value, pos);
     }
   }
   return offsets;


### PR DESCRIPTION
## Motivation

`ComboboxItemValue` computes match offsets while rendering highlighted item values. The previous `getOffsets` loop performed the same substring search twice per match and kept an unreachable `-1` guard.

## Solution

Store each `indexOf` result in a local variable, push offsets only while the result is valid, then compute the next match once after advancing the position.

This also adds example coverage for repeated matches so the multi-match highlighting path remains covered.

## Testing

- `pnpm lint-fix`
- `pnpm test examples/combobox-item-value/test.ts`
- `pnpm tsc`
