### PR TITLE
Cache source package lookups by directory

### DIFF
--- a/app/src/lib/source-plugin.ts
+++ b/app/src/lib/source-plugin.ts
@@ -35,7 +35,10 @@ const APP_LIB_PATH = join(import.meta.dirname, "../examples/_lib");
 const NEXTJS_LIB_PATH = join(import.meta.dirname, "../../../nextjs/components");
 
 // Cache for package information to avoid repeated lookups
-const packageCache = new Map<string, any>();
+const packageCache = new Map<
+  string,
+  NonNullable<ReturnType<typeof readPackageUpSync>> | null
+>();
 
 // TypeScript compiler host for resolving modules
 const host = ts.createCompilerHost({});
@@ -73,13 +76,22 @@ function cacheKeyForFile(id: string, content: string) {
   return `${id}?h=${hashContent(content)}`;
 }
 
+function getPackage(source: string) {
+  const packageDir = dirname(source);
+  if (packageCache.has(packageDir)) {
+    return packageCache.get(packageDir) ?? null;
+  }
+  const result = readPackageUpSync({ cwd: packageDir }) ?? null;
+  packageCache.set(packageDir, result);
+  return result;
+}
+
 /**
  * Get the package version from the package.json
  */
 function getPackageVersion(source: string) {
-  const result = packageCache.get(source) || readPackageUpSync({ cwd: source });
+  const result = getPackage(source);
   if (!result) return "latest";
-  packageCache.set(source, result);
   const { version } = result.packageJson;
   if (!version) {
     console.log("No version found for", source);
@@ -91,9 +103,8 @@ function getPackageVersion(source: string) {
  * Get the package name from the package.json
  */
 function getPackageName(source: string) {
-  const result = packageCache.get(source) || readPackageUpSync({ cwd: source });
+  const result = getPackage(source);
   if (!result) return null;
-  packageCache.set(source, result);
   return result.packageJson.name;
 }
 


### PR DESCRIPTION
## Motivation

The source plugin resolves package metadata for every external source file it encounters. Its package cache was keyed by the resolved file path, so files from the same package directory still triggered repeated `readPackageUpSync` walks. Misses were also not cached, so negative lookups repeated the same filesystem work.

## Solution

Add a shared package resolver used by both package name and version lookups. The resolver keys cached results by `dirname(source)` and stores `null` for misses, so repeated calls for the same source directory reuse both positive and negative lookup results.