### PR TITLE
Read Radio store id non-reactively

### DIFF
--- a/.changeset/200-radio-store-id.md
+++ b/.changeset/200-radio-store-id.md
@@ -1,6 +1,0 @@
----
-"@ariakit/react-components": patch
-"@ariakit/react": patch
----
-
-Improved [`Radio`](https://ariakit.com/reference/radio) rendering performance.

--- a/.changeset/200-radio-store-id.md
+++ b/.changeset/200-radio-store-id.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Improved [`Radio`](https://ariakit.com/reference/radio) rendering performance.

--- a/packages/ariakit-react-components/src/radio/radio.tsx
+++ b/packages/ariakit-react-components/src/radio/radio.tsx
@@ -14,7 +14,7 @@ import type { Props } from "@ariakit/react-utils";
 import { disabledFromProps, removeUndefinedValues } from "@ariakit/utils";
 import type { BivariantCallback } from "@ariakit/utils";
 import type { ChangeEvent, ElementType, FocusEvent, MouseEvent } from "react";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useRef } from "react";
 import type { CompositeItemOptions } from "../composite/composite-item.tsx";
 import { useCompositeItem } from "../composite/composite-item.tsx";
 import { useRadioContext } from "./radio-context.tsx";
@@ -73,7 +73,7 @@ export const useRadio = createHook<TagName, RadioOptions>(function useRadio({
   // Use the store's id as the default name to ensure radios in different
   // groups have unique names. This prevents the browser from treating all
   // radios as a single group. See https://github.com/ariakit/ariakit/issues/3833
-  const storeId = useMemo(() => store?.getState().id, [store]);
+  const storeId = useStoreState(store, "id");
   const name = nameProp ?? storeId;
 
   // When the radio store has a default value, we need to update the active id

--- a/packages/ariakit-react-components/src/radio/radio.tsx
+++ b/packages/ariakit-react-components/src/radio/radio.tsx
@@ -14,7 +14,7 @@ import type { Props } from "@ariakit/react-utils";
 import { disabledFromProps, removeUndefinedValues } from "@ariakit/utils";
 import type { BivariantCallback } from "@ariakit/utils";
 import type { ChangeEvent, ElementType, FocusEvent, MouseEvent } from "react";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import type { CompositeItemOptions } from "../composite/composite-item.tsx";
 import { useCompositeItem } from "../composite/composite-item.tsx";
 import { useRadioContext } from "./radio-context.tsx";
@@ -73,7 +73,7 @@ export const useRadio = createHook<TagName, RadioOptions>(function useRadio({
   // Use the store's id as the default name to ensure radios in different
   // groups have unique names. This prevents the browser from treating all
   // radios as a single group. See https://github.com/ariakit/ariakit/issues/3833
-  const storeId = useStoreState(store, (state) => state?.id);
+  const storeId = useMemo(() => store?.getState().id, [store]);
   const name = nameProp ?? storeId;
 
   // When the radio store has a default value, we need to update the active id


### PR DESCRIPTION
## Motivation

`useRadio` subscribed to the radio store once for checked state and again through a selector callback just to read the store id used as the default native radio name. We can keep the existing store subscription style while making the static id read more direct.

## Solution

Use the `useStoreState(store, "id")` key selector for the default radio name. This preserves the idiomatic `useStoreState` pattern while avoiding a custom selector callback for the store id.
