### PR TITLE
Optimize TooltipAnchor label subscription

### DIFF
--- a/.changeset/200-tooltip-anchor-labelledby.md
+++ b/.changeset/200-tooltip-anchor-labelledby.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react": patch
+"@ariakit/react-components": patch
+---
+
+Improved [`TooltipAnchor`](https://ariakit.com/reference/tooltip-anchor) to avoid re-rendering default description tooltip anchors when the tooltip content id changes.

--- a/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
+++ b/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
@@ -150,12 +150,12 @@ export const useTooltipAnchor = createHook<TagName, TooltipAnchorOptions>(
       }
     });
 
-    const type = useStoreState(store, "type");
-    const contentId = useStoreState(store, (state) => state.contentElement?.id);
+    const labelledBy = useStoreState(store, (state) =>
+      state.type === "label" ? state.contentElement?.id : undefined,
+    );
 
     props = {
-      "aria-labelledby":
-        type === "label" && props["aria-label"] == null ? contentId : undefined,
+      "aria-labelledby": props["aria-label"] == null ? labelledBy : undefined,
       ...props,
       onMouseEnter,
       onFocusVisible,


### PR DESCRIPTION
## Motivation

`TooltipAnchor` currently subscribes each anchor to the tooltip content element id even when the tooltip is the default description type. Description tooltips do not use that id for `aria-labelledby`, so those anchors can re-render when the rendered output is unchanged.

## Solution

Derive the generated `aria-labelledby` value in a single store selector that only reads `contentElement.id` when the tooltip type is `label`. This keeps label tooltips behaving the same while making description tooltip anchors insensitive to content id changes.

## Verification

- `pnpm lint-fix`
- `pnpm test examples/tooltip/test.ts examples/tooltip-label/test.ts`
- `pnpm tsc`
- `pnpm build`