### PR TITLE
Memoize OG image item lookup

### DIFF
--- a/app/src/lib/og-image-key.test.ts
+++ b/app/src/lib/og-image-key.test.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright 2025-present Ariakit FZ-LLC. All Rights Reserved.
+ *
+ * This software is proprietary. See the license.md file in the root of this
+ * package for licensing terms.
+ *
+ * SPDX-License-Identifier: UNLICENSED
+ */
+import { expect, test } from "vitest";
+import { getOGImageItemKey } from "./og-image-key.ts";
+
+test("getOGImageItemKey preserves strict equality for empty values", () => {
+  const defaultKey = getOGImageItemKey({});
+
+  expect(getOGImageItemKey({ id: "" })).not.toBe(defaultKey);
+  expect(getOGImageItemKey({ id: undefined })).toBe(defaultKey);
+
+  expect(
+    getOGImageItemKey({
+      // @ts-expect-error Testing runtime values outside the typed API.
+      framework: "",
+    }),
+  ).not.toBe(defaultKey);
+  expect(getOGImageItemKey({ framework: undefined })).toBe(defaultKey);
+});

--- a/app/src/lib/og-image-key.ts
+++ b/app/src/lib/og-image-key.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2025-present Ariakit FZ-LLC. All Rights Reserved.
+ *
+ * This software is proprietary. See the license.md file in the root of this
+ * package for licensing terms.
+ *
+ * SPDX-License-Identifier: UNLICENSED
+ */
+import type { Framework } from "./schemas.ts";
+
+export interface GetOGImageItemKeyParams {
+  id?: string;
+  type?: "pages" | "examples" | "components" | "styles";
+  framework?: Framework;
+}
+
+export function getOGImageItemKey({
+  type = "pages",
+  framework,
+  id,
+}: GetOGImageItemKeyParams) {
+  // Preserve strict equality semantics between missing and empty values.
+  return JSON.stringify({ type, framework, id });
+}

--- a/app/src/pages/og-image/api.ts
+++ b/app/src/pages/og-image/api.ts
@@ -11,6 +11,7 @@ import type { APIRoute } from "astro";
 import { getCollection } from "astro:content";
 import { uniq } from "#app/lib/array.ts";
 import { getGuideDetail } from "#app/lib/content.ts";
+import { getOGImageItemKey } from "#app/lib/og-image-key.ts";
 import { trim } from "#app/lib/string.ts";
 
 const types = ["pages", "examples", "components", "styles"] as const;
@@ -36,14 +37,6 @@ export interface GetOGImageItemParams {
 
 let ogImageItemsPromise: Promise<OGImageItem[]> | undefined;
 let ogImageItemMapPromise: Promise<Map<string, OGImageItem>> | undefined;
-
-function getOGImageItemKey({
-  type = "pages",
-  framework,
-  id,
-}: GetOGImageItemParams) {
-  return `${type}|${framework ?? ""}|${id ?? ""}`;
-}
 
 async function getOGImageItemMap(): Promise<Map<string, OGImageItem>> {
   ogImageItemMapPromise ??= getOGImageItems().then((items) => {

--- a/app/src/pages/og-image/api.ts
+++ b/app/src/pages/og-image/api.ts
@@ -34,19 +34,40 @@ export interface GetOGImageItemParams {
   framework?: OGImageItem["framework"];
 }
 
+let ogImageItemsPromise: Promise<OGImageItem[]> | undefined;
+let ogImageItemMapPromise: Promise<Map<string, OGImageItem>> | undefined;
+
+function getOGImageItemKey({
+  type = "pages",
+  framework,
+  id,
+}: GetOGImageItemParams) {
+  return `${type}|${framework ?? ""}|${id ?? ""}`;
+}
+
+async function getOGImageItemMap(): Promise<Map<string, OGImageItem>> {
+  ogImageItemMapPromise ??= getOGImageItems().then((items) => {
+    const itemMap = new Map<string, OGImageItem>();
+    for (const item of items) {
+      const key = getOGImageItemKey(item);
+      if (itemMap.has(key)) continue;
+      itemMap.set(key, item);
+    }
+    return itemMap;
+  });
+  return ogImageItemMapPromise;
+}
+
 export async function getOGImageItem({
   type = "pages",
   framework,
   id,
 }: GetOGImageItemParams) {
-  const items = await getOGImageItems();
-  return items.find(
-    (item) =>
-      item.type === type && item.framework === framework && item.id === id,
-  );
+  const itemMap = await getOGImageItemMap();
+  return itemMap.get(getOGImageItemKey({ type, framework, id }));
 }
 
-export async function getOGImageItems(): Promise<OGImageItem[]> {
+async function computeOGImageItems(): Promise<OGImageItem[]> {
   const components = await getCollection("components");
   const examples = await getCollection("examples");
   const entries = [...components, ...examples];
@@ -128,6 +149,11 @@ export async function getOGImageItems(): Promise<OGImageItem[]> {
     ...componentIndexes,
     ...genericPages,
   ];
+}
+
+export function getOGImageItems(): Promise<OGImageItem[]> {
+  ogImageItemsPromise ??= computeOGImageItems();
+  return ogImageItemsPromise;
 }
 
 export const GET: APIRoute = async () => {


### PR DESCRIPTION
## Motivation

Rendering page metadata currently calls `getOGImageItem()` for many pages during the app build. Each lookup rebuilds the full flattened OG image item list before finding a single item, duplicating content collection work across pages.

## Solution

Cache the `getOGImageItems()` computation at module scope so all callers share the same promise during a build. Add a cached lookup map keyed by type, framework, and id so individual metadata lookups are O(1) while preserving the previous first-match behavior for duplicate generic page keys.

Verified with:

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm build-app-lite`