### PR TITLE
Hoist popup role lookup constants

### DIFF
--- a/.changeset/200-popup-role-helpers.md
+++ b/.changeset/200-popup-role-helpers.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/utils": patch
+---
+
+Improved the repeated-call performance of popup role helpers in `@ariakit/utils`.

--- a/packages/ariakit-utils/src/dom.ts
+++ b/packages/ariakit-utils/src/dom.ts
@@ -255,6 +255,14 @@ export function getTextboxSelection(element: HTMLElement) {
   return { start, end };
 }
 
+const allowedPopupRoles = ["dialog", "menu", "listbox", "tree", "grid"];
+
+const itemRoleByPopupRole = {
+  menu: "menuitem",
+  listbox: "option",
+  tree: "treeitem",
+};
+
 /**
  * Returns the popup role from the element's role attribute, if it has one.
  */
@@ -262,7 +270,6 @@ export function getPopupRole(
   element?: Element | null,
   fallback?: AriaHasPopup,
 ) {
-  const allowedPopupRoles = ["dialog", "menu", "listbox", "tree", "grid"];
   const role = element?.getAttribute("role");
   if (role && allowedPopupRoles.indexOf(role) !== -1) {
     return role as "dialog" | "menu" | "listbox" | "tree" | "grid";
@@ -277,11 +284,6 @@ export function getPopupItemRole(
   element?: Element | null,
   fallback?: AriaRole,
 ) {
-  const itemRoleByPopupRole = {
-    menu: "menuitem",
-    listbox: "option",
-    tree: "treeitem",
-  };
   const popupRole = getPopupRole(element);
   if (!popupRole) return fallback;
   const key = popupRole as keyof typeof itemRoleByPopupRole;


### PR DESCRIPTION
## Motivation

The popup role helpers in `@ariakit/utils` allocated their lookup array and object every time they ran. These helpers are public and are also used by menu, combobox, select, and dialog internals, so repeated calls should avoid unnecessary allocations.

## Solution

Hoist the allowed popup role list and popup item role map to module scope while preserving the existing `indexOf` lookup behavior. Add an `@ariakit/utils` patch changeset for the shipped repeated-call performance improvement.
