### PR TITLE
Guard nested wrapAsync polyfills

### DIFF
--- a/.changeset/300-wrap-async-polyfills.md
+++ b/.changeset/300-wrap-async-polyfills.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/test": patch
+---
+
+Fixed nested test helpers to reuse browser polyfills and act-environment overrides instead of reapplying them.

--- a/packages/ariakit-test/src/__tests__/__utils.test.ts
+++ b/packages/ariakit-test/src/__tests__/__utils.test.ts
@@ -1,0 +1,62 @@
+// oxlint-disable unbound-method
+import { expect, test } from "vitest";
+import { isBrowser, wrapAsync } from "../__utils.ts";
+
+test("wrapAsync does not reapply browser polyfills when nested", async () => {
+  const originalFocus = HTMLElement.prototype.focus;
+  const originalGetClientRects = Element.prototype.getClientRects;
+
+  await wrapAsync(async () => {
+    const focus = HTMLElement.prototype.focus;
+    const getClientRects = Element.prototype.getClientRects;
+
+    if (!isBrowser) {
+      expect(focus).not.toBe(originalFocus);
+      expect(getClientRects).not.toBe(originalGetClientRects);
+    }
+
+    await wrapAsync(async () => {
+      expect(HTMLElement.prototype.focus).toBe(focus);
+      expect(Element.prototype.getClientRects).toBe(getClientRects);
+    });
+
+    expect(HTMLElement.prototype.focus).toBe(focus);
+    expect(Element.prototype.getClientRects).toBe(getClientRects);
+  });
+
+  expect(HTMLElement.prototype.focus).toBe(originalFocus);
+  expect(Element.prototype.getClientRects).toBe(originalGetClientRects);
+});
+
+test("wrapAsync does not reapply the act environment when nested", async () => {
+  const scope = globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean };
+  const descriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "IS_REACT_ACT_ENVIRONMENT",
+  );
+  const values: Array<boolean | undefined> = [];
+  let value: boolean | undefined = true;
+
+  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
+    configurable: true,
+    get: () => value,
+    set: (nextValue: boolean | undefined) => {
+      values.push(nextValue);
+      value = nextValue;
+    },
+  });
+
+  try {
+    await wrapAsync(async () => {
+      await wrapAsync(async () => {});
+    });
+
+    expect(values).toEqual([false, true]);
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", descriptor);
+    } else {
+      delete scope.IS_REACT_ACT_ENVIRONMENT;
+    }
+  }
+});

--- a/packages/ariakit-test/src/__utils.ts
+++ b/packages/ariakit-test/src/__utils.ts
@@ -89,13 +89,43 @@ export function applyBrowserPolyfills() {
   };
 }
 
+let wrapAsyncDepth = 0;
+let restoreCurrentWrapAsyncEnvironment = noop;
+
+function setupWrapAsyncEnvironment() {
+  wrapAsyncDepth += 1;
+  if (wrapAsyncDepth > 1) return;
+
+  let restoreActEnvironment = noop;
+
+  try {
+    restoreActEnvironment = setActEnvironment(false);
+    const removeBrowserPolyfills = applyBrowserPolyfills();
+
+    restoreCurrentWrapAsyncEnvironment = () => {
+      restoreActEnvironment();
+      removeBrowserPolyfills();
+    };
+  } catch (error) {
+    wrapAsyncDepth -= 1;
+    restoreActEnvironment();
+    throw error;
+  }
+}
+
+function restoreWrapAsyncEnvironment() {
+  wrapAsyncDepth -= 1;
+  if (wrapAsyncDepth) return;
+
+  restoreCurrentWrapAsyncEnvironment();
+  restoreCurrentWrapAsyncEnvironment = noop;
+}
+
 export async function wrapAsync<T>(fn: () => Promise<T>) {
-  const restoreActEnvironment = setActEnvironment(false);
-  const removeBrowserPolyfills = applyBrowserPolyfills();
+  setupWrapAsyncEnvironment();
   try {
     return await fn();
   } finally {
-    restoreActEnvironment();
-    removeBrowserPolyfills();
+    restoreWrapAsyncEnvironment();
   }
 }


### PR DESCRIPTION
## Motivation

Nested `@ariakit/test` helpers call each other through `wrapAsync`. Each nesting level was reapplying the browser polyfills for `HTMLElement.prototype.focus` and `Element.prototype.getClientRects`, stacking wrappers that captured already-patched methods as originals. The React act-environment override had the same repeated setup/restore shape.

## Solution

Track `wrapAsync` nesting depth at the module level so the browser polyfills and act-environment override are applied only when entering the outermost `wrapAsync` call and restored only after the outermost call finishes. The setup path also keeps the depth counter balanced if setup throws.

Added focused regression coverage for nested polyfill stability, restoration, and single act-environment setup/restore.

## Verification

- `pnpm lint-fix`
- `pnpm test packages/ariakit-test/src/__tests__/__utils.test.ts`
- `pnpm tsc`
- `pnpm test`
- `pnpm build`