### PR TITLE
Optimize useStoreState key subscriptions

### DIFF
--- a/.changeset/200-use-store-state-key-subscriptions.md
+++ b/.changeset/200-use-store-state-key-subscriptions.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/react-store": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Improved [`useStoreState`](https://ariakit.com/reference/use-store-state) performance when subscribing to individual store keys.

--- a/packages/ariakit-react-store/package.json
+++ b/packages/ariakit-react-store/package.json
@@ -34,8 +34,10 @@
   },
   "devDependencies": {
     "@ariakit/scripts": "workspace:*",
+    "@ariakit/test": "workspace:*",
     "@types/use-sync-external-store": "1.5.0",
-    "react": "19.2.6"
+    "react": "19.2.6",
+    "vitest": "4.1.7"
   },
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/packages/ariakit-react-store/src/index.tsx
+++ b/packages/ariakit-react-store/src/index.tsx
@@ -118,21 +118,22 @@ export function useStoreState(
   store: StateStore,
   keyOrSelector: StateKey | ((state?: AnyObject) => any) = identity,
 ) {
+  const key = typeof keyOrSelector === "string" ? keyOrSelector : null;
+  const selector = typeof keyOrSelector === "function" ? keyOrSelector : null;
+
   const storeSubscribe = React.useCallback(
     (callback: () => void) => {
       if (!store) return noopSubscribe();
-      return subscribe(store, null, callback);
+      return subscribe(store, key == null ? null : [key], callback);
     },
-    [store],
+    [store, key],
   );
 
   const getSnapshot = () => {
-    const key = typeof keyOrSelector === "string" ? keyOrSelector : null;
-    const selector = typeof keyOrSelector === "function" ? keyOrSelector : null;
     const state = store?.getState();
     if (selector) return selector(state);
     if (!state) return;
-    if (!key) return;
+    if (key == null) return;
     if (!hasOwnProperty(state, key)) return;
     return state[key];
   };

--- a/packages/ariakit-react-store/src/use-store-state.test.react.tsx
+++ b/packages/ariakit-react-store/src/use-store-state.test.react.tsx
@@ -1,0 +1,114 @@
+import { createStore, subscribe } from "@ariakit/store";
+import type * as StoreModule from "@ariakit/store";
+import { render } from "@ariakit/test/react";
+import { act } from "react";
+import { beforeEach, expect, test, vi } from "vitest";
+import { useStoreState, useStoreStateObject } from "./index.tsx";
+
+vi.mock("@ariakit/store", async (importOriginal) => {
+  const store = await importOriginal<typeof StoreModule>();
+  return {
+    ...store,
+    subscribe: vi.fn(store.subscribe),
+  };
+});
+
+const subscribeMock = vi.mocked(subscribe);
+
+beforeEach(() => {
+  subscribeMock.mockClear();
+});
+
+async function runReactAct(callback: () => void) {
+  const scope = globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean };
+  const previousValue = scope.IS_REACT_ACT_ENVIRONMENT;
+  scope.IS_REACT_ACT_ENVIRONMENT = true;
+  try {
+    await act(async () => callback());
+  } finally {
+    scope.IS_REACT_ACT_ENVIRONMENT = previousValue;
+  }
+}
+
+test("useStoreState subscribes to string keys", async () => {
+  const store = createStore({ count: 0, label: "a" });
+
+  const Test = () => {
+    useStoreState(store, "count");
+    return null;
+  };
+
+  await render(<Test />);
+
+  expect(subscribeMock).toHaveBeenCalledWith(
+    store,
+    ["count"],
+    expect.any(Function),
+  );
+});
+
+test("useStoreState rerenders only when the selected key changes", async () => {
+  const store = createStore({ count: 0, label: "a" });
+  const renderedValues: number[] = [];
+
+  const Test = () => {
+    const count = useStoreState(store, "count");
+    renderedValues.push(count);
+    return null;
+  };
+
+  await render(<Test />);
+
+  expect(renderedValues).toEqual([0]);
+
+  await runReactAct(() => {
+    store.setState("label", "b");
+  });
+
+  expect(renderedValues).toEqual([0]);
+
+  await runReactAct(() => {
+    store.setState("count", 1);
+  });
+
+  expect(renderedValues).toEqual([0, 1]);
+});
+
+test("useStoreState keeps all-keys subscriptions for whole-state reads", async () => {
+  const store = createStore({ count: 0, label: "a" });
+
+  const Test = () => {
+    useStoreState(store);
+    return null;
+  };
+
+  await render(<Test />);
+
+  expect(subscribeMock).toHaveBeenCalledWith(store, null, expect.any(Function));
+});
+
+test("useStoreState keeps all-keys subscriptions for selectors", async () => {
+  const store = createStore({ count: 0, label: "a" });
+
+  const Test = () => {
+    useStoreState(store, (state) => state?.count);
+    return null;
+  };
+
+  await render(<Test />);
+
+  expect(subscribeMock).toHaveBeenCalledWith(store, null, expect.any(Function));
+});
+
+test("useStoreStateObject keeps all-keys subscriptions", async () => {
+  const store = createStore({ count: 0, label: "a" });
+
+  const Test = () => {
+    useStoreStateObject(store, { count: "count" });
+    return null;
+  };
+
+  await render(<Test />);
+
+  expect(subscribeMock).toHaveBeenCalledWith(store, null, expect.any(Function));
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -647,12 +647,18 @@ importers:
       '@ariakit/scripts':
         specifier: workspace:*
         version: link:../ariakit-scripts
+      '@ariakit/test':
+        specifier: workspace:*
+        version: link:../ariakit-test
       '@types/use-sync-external-store':
         specifier: 1.5.0
         version: 1.5.0
       react:
         specifier: 19.2.6
         version: 19.2.6
+      vitest:
+        specifier: 4.1.7
+        version: 4.1.7(@types/node@24.12.4)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.14(@types/node@24.12.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.4))
 
   packages/ariakit-react-utils:
     dependencies:


### PR DESCRIPTION
## Motivation

`@ariakit/store` has a keyed listener dispatch path that can avoid scanning unrelated listeners when updates touch a single state key. `useStoreState(store, "key")` was still subscribing as an all-keys listener, so normal keyed React subscriptions prevented that fast path from being used.

## Solution

`useStoreState` now subscribes with `[key]` when the second argument is a string key. Whole-state reads, selector reads, and `useStoreStateObject` continue to subscribe with `null` because they can observe arbitrary state changes.

The new React-store tests assert the subscription keys for each mode and cover the keyed render behavior. The React-store package now declares the test-only dependencies it imports, and the test filename follows the package ignore pattern so it is not included in npm packs.
