### PR TITLE
Add tab panel lookup

### DIFF
--- a/.changeset/200-tab-panel-lookup.md
+++ b/.changeset/200-tab-panel-lookup.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/components": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Added an associated panel lookup to [`useTabStore`](https://ariakit.com/reference/use-tab-store), improving [`Tab`](https://ariakit.com/reference/tab) performance when resolving controlled panels.

--- a/packages/ariakit-components/src/tab/__tests__/tab-store.test.ts
+++ b/packages/ariakit-components/src/tab/__tests__/tab-store.test.ts
@@ -1,75 +1,106 @@
+import { init } from "@ariakit/store";
 import { expect, test } from "vitest";
 import { createTabStore } from "../tab-store.ts";
 
-test("gets a panel by tab id", () => {
+function flushBatch() {
+  return new Promise<void>((resolve) => queueMicrotask(resolve));
+}
+
+test("gets a panel by tab id", async () => {
   const store = createTabStore();
+  const stop = init(store.panels);
 
-  expect(store.panel("tab-1")).toBeNull();
+  try {
+    expect(store.panel("tab-1")).toBeNull();
 
-  const unregisterPanel1 = store.panels.registerItem({
-    id: "panel-1",
-    tabId: "tab-1",
-  });
-  const unregisterPanel2 = store.panels.registerItem({
-    id: "panel-2",
-    tabId: "tab-1",
-  });
+    const unregisterPanel1 = store.panels.registerItem({
+      id: "panel-1",
+      tabId: "tab-1",
+    });
+    const unregisterPanel2 = store.panels.registerItem({
+      id: "panel-2",
+      tabId: "tab-1",
+    });
+    await flushBatch();
 
-  expect(store.panel("tab-1")?.id).toBe("panel-1");
+    expect(store.panel("tab-1")?.id).toBe("panel-1");
 
-  unregisterPanel1();
+    unregisterPanel1();
+    await flushBatch();
 
-  expect(store.panel("tab-1")?.id).toBe("panel-2");
+    expect(store.panel("tab-1")?.id).toBe("panel-2");
 
-  unregisterPanel2();
+    unregisterPanel2();
+    await flushBatch();
 
-  expect(store.panel("tab-1")).toBeNull();
+    expect(store.panel("tab-1")).toBeNull();
+  } finally {
+    stop();
+  }
 });
 
-test("keeps panel lookups in items order when panel tab ids change", () => {
+test("keeps panel lookups in items order when panel tab ids change", async () => {
   const store = createTabStore();
-  const unregisterPanel1 = store.panels.registerItem({
-    id: "panel-1",
-    tabId: "tab-1",
-  });
-  const unregisterPanel2 = store.panels.registerItem({
-    id: "panel-2",
-    tabId: "tab-2",
-  });
+  const stop = init(store.panels);
 
-  expect(store.panel("tab-1")?.id).toBe("panel-1");
-  expect(store.panel("tab-2")?.id).toBe("panel-2");
+  try {
+    const unregisterPanel1 = store.panels.registerItem({
+      id: "panel-1",
+      tabId: "tab-1",
+    });
+    const unregisterPanel2 = store.panels.registerItem({
+      id: "panel-2",
+      tabId: "tab-2",
+    });
+    await flushBatch();
 
-  const restorePanel1 = store.panels.registerItem({
-    id: "panel-1",
-    tabId: "tab-2",
-  });
+    expect(store.panel("tab-1")?.id).toBe("panel-1");
+    expect(store.panel("tab-2")?.id).toBe("panel-2");
 
-  expect(store.panel("tab-1")).toBeNull();
-  expect(store.panel("tab-2")?.id).toBe("panel-1");
+    const restorePanel1 = store.panels.registerItem({
+      id: "panel-1",
+      tabId: "tab-2",
+    });
+    await flushBatch();
 
-  restorePanel1();
+    expect(store.panel("tab-1")).toBeNull();
+    expect(store.panel("tab-2")?.id).toBe("panel-1");
 
-  expect(store.panel("tab-1")?.id).toBe("panel-1");
-  expect(store.panel("tab-2")?.id).toBe("panel-2");
+    restorePanel1();
+    await flushBatch();
 
-  unregisterPanel1();
-  unregisterPanel2();
+    expect(store.panel("tab-1")?.id).toBe("panel-1");
+    expect(store.panel("tab-2")?.id).toBe("panel-2");
+
+    unregisterPanel1();
+    unregisterPanel2();
+  } finally {
+    stop();
+  }
 });
 
-test("tracks renderItem updates used by orphan panel assignment", () => {
+test("tracks renderItem updates used by orphan panel assignment", async () => {
   const store = createTabStore();
-  const unrenderPanel = store.panels.renderItem({ id: "panel-1" });
+  const stop = init(store.panels);
 
-  expect(store.panel("tab-1")).toBeNull();
+  try {
+    const unrenderPanel = store.panels.renderItem({ id: "panel-1" });
+    await flushBatch();
 
-  store.panels.renderItem({ id: "panel-1", tabId: "tab-1" });
+    expect(store.panel("tab-1")).toBeNull();
 
-  expect(store.panel("tab-1")?.id).toBe("panel-1");
+    store.panels.renderItem({ id: "panel-1", tabId: "tab-1" });
+    await flushBatch();
 
-  unrenderPanel();
+    expect(store.panel("tab-1")?.id).toBe("panel-1");
 
-  expect(store.panel("tab-1")).toBeNull();
+    unrenderPanel();
+    await flushBatch();
+
+    expect(store.panel("tab-1")).toBeNull();
+  } finally {
+    stop();
+  }
 });
 
 test("tracks explicit panel item state updates", () => {

--- a/packages/ariakit-components/src/tab/__tests__/tab-store.test.ts
+++ b/packages/ariakit-components/src/tab/__tests__/tab-store.test.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "vitest";
+import { createTabStore } from "../tab-store.ts";
+
+test("gets a panel by tab id", () => {
+  const store = createTabStore();
+
+  expect(store.panel("tab-1")).toBeNull();
+
+  const unregisterPanel1 = store.panels.registerItem({
+    id: "panel-1",
+    tabId: "tab-1",
+  });
+  const unregisterPanel2 = store.panels.registerItem({
+    id: "panel-2",
+    tabId: "tab-1",
+  });
+
+  expect(store.panel("tab-1")?.id).toBe("panel-1");
+
+  unregisterPanel1();
+
+  expect(store.panel("tab-1")?.id).toBe("panel-2");
+
+  unregisterPanel2();
+
+  expect(store.panel("tab-1")).toBeNull();
+});
+
+test("keeps panel lookups in items order when panel tab ids change", () => {
+  const store = createTabStore();
+  const unregisterPanel1 = store.panels.registerItem({
+    id: "panel-1",
+    tabId: "tab-1",
+  });
+  const unregisterPanel2 = store.panels.registerItem({
+    id: "panel-2",
+    tabId: "tab-2",
+  });
+
+  expect(store.panel("tab-1")?.id).toBe("panel-1");
+  expect(store.panel("tab-2")?.id).toBe("panel-2");
+
+  const restorePanel1 = store.panels.registerItem({
+    id: "panel-1",
+    tabId: "tab-2",
+  });
+
+  expect(store.panel("tab-1")).toBeNull();
+  expect(store.panel("tab-2")?.id).toBe("panel-1");
+
+  restorePanel1();
+
+  expect(store.panel("tab-1")?.id).toBe("panel-1");
+  expect(store.panel("tab-2")?.id).toBe("panel-2");
+
+  unregisterPanel1();
+  unregisterPanel2();
+});
+
+test("tracks renderItem updates used by orphan panel assignment", () => {
+  const store = createTabStore();
+  const unrenderPanel = store.panels.renderItem({ id: "panel-1" });
+
+  expect(store.panel("tab-1")).toBeNull();
+
+  store.panels.renderItem({ id: "panel-1", tabId: "tab-1" });
+
+  expect(store.panel("tab-1")?.id).toBe("panel-1");
+
+  unrenderPanel();
+
+  expect(store.panel("tab-1")).toBeNull();
+});
+
+test("tracks explicit panel item state updates", () => {
+  const store = createTabStore();
+
+  store.panels.setState("items", [{ id: "panel-1", tabId: "tab-1" }]);
+
+  expect(store.panel("tab-1")?.id).toBe("panel-1");
+
+  store.panels.setState("items", [
+    { id: "panel-1", tabId: "tab-1" },
+    { id: "panel-2", tabId: "tab-1" },
+  ]);
+
+  expect(store.panel("tab-1")?.id).toBe("panel-1");
+
+  store.panels.setState("items", []);
+
+  expect(store.panel("tab-1")).toBeNull();
+});

--- a/packages/ariakit-components/src/tab/tab-store.ts
+++ b/packages/ariakit-components/src/tab/tab-store.ts
@@ -45,6 +45,102 @@ function isEnabledTab(
   return true;
 }
 
+function createPanelsStore() {
+  const panels = createCollectionStore<TabStorePanel>();
+  const panelsByTabId = new Map<string, TabStorePanel>();
+  let panelItems = panels.getState().items;
+
+  const syncPanelItems = (items: TabStorePanel[]) => {
+    panelItems = items;
+    panelsByTabId.clear();
+    for (const panel of panelItems) {
+      const { tabId } = panel;
+      if (tabId == null) continue;
+      if (panelsByTabId.has(tabId)) continue;
+      panelsByTabId.set(tabId, panel);
+    }
+  };
+
+  const syncPanelByTabId = (tabId: string | null | undefined) => {
+    if (tabId == null) return;
+    const panel = panelItems.find((item) => item.tabId === tabId);
+    if (panel) {
+      panelsByTabId.set(tabId, panel);
+    } else {
+      panelsByTabId.delete(tabId);
+    }
+  };
+
+  const syncPanelLookup = (
+    previousPanel: TabStorePanel | undefined,
+    nextPanel: TabStorePanel | undefined,
+  ) => {
+    syncPanelByTabId(previousPanel?.tabId);
+    if (nextPanel?.tabId !== previousPanel?.tabId) {
+      syncPanelByTabId(nextPanel?.tabId);
+    }
+  };
+
+  sync(panels, ["items"], (state) => {
+    syncPanelItems(state.items);
+  });
+
+  const mergePanelItem = (item: TabStorePanel) => {
+    // Mirrors collection-store's merge behavior so panel() preserves the
+    // synchronous getter semantics of panels.item().
+    let previousPanel: TabStorePanel | undefined;
+    const index = panelItems.findIndex(({ id }) => id === item.id);
+    if (index !== -1) {
+      previousPanel = panelItems[index];
+      const nextPanel = { ...previousPanel, ...item };
+      const nextItems = panelItems.slice();
+      nextItems[index] = nextPanel;
+      panelItems = nextItems;
+      syncPanelLookup(previousPanel, nextPanel);
+    } else {
+      panelItems = [...panelItems, item];
+      syncPanelLookup(undefined, item);
+    }
+    return () => {
+      const currentPanel = panelItems.find(({ id }) => id === item.id);
+      if (!previousPanel) {
+        panelItems = panelItems.filter(({ id }) => id !== item.id);
+        syncPanelLookup(currentPanel, undefined);
+        return;
+      }
+      const index = panelItems.findIndex(({ id }) => id === item.id);
+      if (index === -1) return;
+      const nextItems = panelItems.slice();
+      nextItems[index] = previousPanel;
+      panelItems = nextItems;
+      syncPanelLookup(currentPanel, previousPanel);
+    };
+  };
+
+  const registerItem = panels.registerItem;
+  const renderItem = panels.renderItem;
+
+  return {
+    panels: {
+      ...panels,
+      registerItem: (item) => {
+        const unregisterItem = registerItem(item);
+        const unmergePanelItem = mergePanelItem(item);
+        return chain(unregisterItem, unmergePanelItem);
+      },
+      renderItem: (item) => {
+        const unrenderItem = renderItem(item);
+        const unmergePanelItem = mergePanelItem(item);
+        return chain(unrenderItem, unmergePanelItem);
+      },
+    } satisfies CollectionStore<TabStorePanel>,
+    panel: (tabId) => {
+      if (tabId == null) return null;
+      return panelsByTabId.get(tabId) || null;
+    },
+  } satisfies Pick<TabStoreFunctions, "panels" | "panel">;
+}
+
 export function createTabStore({
   composite: parentComposite,
   combobox,
@@ -90,7 +186,7 @@ export function createTabStore({
     focusLoop: defaultValue(props.focusLoop, syncState?.focusLoop, true),
   });
 
-  const panels = createCollectionStore<TabStorePanel>();
+  const { panels, panel } = createPanelsStore();
 
   const initialState: TabStoreState = {
     ...composite.getState(),
@@ -223,6 +319,7 @@ export function createTabStore({
     ...composite,
     ...tab,
     panels,
+    panel,
     setSelectedId: (id) => tab.setState("selectedId", id),
     select: (id) => {
       tab.setState("selectedId", id);
@@ -297,6 +394,12 @@ export interface TabStoreFunctions extends CompositeStoreFunctions<TabStoreItem>
    * - [Animated TabPanel](https://ariakit.com/examples/tab-panel-animated)
    */
   panels: CollectionStore<TabStorePanel>;
+  /**
+   * Gets the panel associated with the given tab id.
+   * @example
+   * const panel = store.panel("tab-1");
+   */
+  panel: (tabId: string | null | undefined) => TabStorePanel | null;
   /**
    * Selects the tab for the given id and moves focus to it. If you want to set
    * the [`selectedId`](https://ariakit.com/reference/tab-provider#selectedid)

--- a/packages/ariakit-components/src/tab/tab-store.ts
+++ b/packages/ariakit-components/src/tab/tab-store.ts
@@ -48,92 +48,19 @@ function isEnabledTab(
 function createPanelsStore() {
   const panels = createCollectionStore<TabStorePanel>();
   const panelsByTabId = new Map<string, TabStorePanel>();
-  let panelItems = panels.getState().items;
 
-  const syncPanelItems = (items: TabStorePanel[]) => {
-    panelItems = items;
+  sync(panels, ["items"], (state) => {
     panelsByTabId.clear();
-    for (const panel of panelItems) {
+    for (const panel of state.items) {
       const { tabId } = panel;
       if (tabId == null) continue;
       if (panelsByTabId.has(tabId)) continue;
       panelsByTabId.set(tabId, panel);
     }
-  };
-
-  const syncPanelByTabId = (tabId: string | null | undefined) => {
-    if (tabId == null) return;
-    const panel = panelItems.find((item) => item.tabId === tabId);
-    if (panel) {
-      panelsByTabId.set(tabId, panel);
-    } else {
-      panelsByTabId.delete(tabId);
-    }
-  };
-
-  const syncPanelLookup = (
-    previousPanel: TabStorePanel | undefined,
-    nextPanel: TabStorePanel | undefined,
-  ) => {
-    syncPanelByTabId(previousPanel?.tabId);
-    if (nextPanel?.tabId !== previousPanel?.tabId) {
-      syncPanelByTabId(nextPanel?.tabId);
-    }
-  };
-
-  sync(panels, ["items"], (state) => {
-    syncPanelItems(state.items);
   });
 
-  const mergePanelItem = (item: TabStorePanel) => {
-    // Mirrors collection-store's merge behavior so panel() preserves the
-    // synchronous getter semantics of panels.item().
-    let previousPanel: TabStorePanel | undefined;
-    const index = panelItems.findIndex(({ id }) => id === item.id);
-    if (index !== -1) {
-      previousPanel = panelItems[index];
-      const nextPanel = { ...previousPanel, ...item };
-      const nextItems = panelItems.slice();
-      nextItems[index] = nextPanel;
-      panelItems = nextItems;
-      syncPanelLookup(previousPanel, nextPanel);
-    } else {
-      panelItems = [...panelItems, item];
-      syncPanelLookup(undefined, item);
-    }
-    return () => {
-      const currentPanel = panelItems.find(({ id }) => id === item.id);
-      if (!previousPanel) {
-        panelItems = panelItems.filter(({ id }) => id !== item.id);
-        syncPanelLookup(currentPanel, undefined);
-        return;
-      }
-      const index = panelItems.findIndex(({ id }) => id === item.id);
-      if (index === -1) return;
-      const nextItems = panelItems.slice();
-      nextItems[index] = previousPanel;
-      panelItems = nextItems;
-      syncPanelLookup(currentPanel, previousPanel);
-    };
-  };
-
-  const registerItem = panels.registerItem;
-  const renderItem = panels.renderItem;
-
   return {
-    panels: {
-      ...panels,
-      registerItem: (item) => {
-        const unregisterItem = registerItem(item);
-        const unmergePanelItem = mergePanelItem(item);
-        return chain(unregisterItem, unmergePanelItem);
-      },
-      renderItem: (item) => {
-        const unrenderItem = renderItem(item);
-        const unmergePanelItem = mergePanelItem(item);
-        return chain(unrenderItem, unmergePanelItem);
-      },
-    } satisfies CollectionStore<TabStorePanel>,
+    panels,
     panel: (tabId) => {
       if (tabId == null) return null;
       return panelsByTabId.get(tabId) || null;

--- a/packages/ariakit-react-components/src/tab/tab.tsx
+++ b/packages/ariakit-react-components/src/tab/tab.tsx
@@ -76,10 +76,7 @@ export const useTab = createHook<TagName, TabOptions>(function useTab({
     store?.setSelectedId(id);
   });
 
-  const panelId = useStoreState(
-    store.panels,
-    (state) => state.items.find((item) => item.tabId === id)?.id,
-  );
+  const panelId = useStoreState(store.panels, () => store.panel(id)?.id);
   const shouldRegisterItem = defaultId ? props.shouldRegisterItem : false;
 
   const isActive = useStoreState(


### PR DESCRIPTION
## Motivation

Each `Tab` currently resolves its associated panel by subscribing to the full panels collection and scanning `items` for a matching `tabId`. When panel items change, that makes each tab repeat the same O(N) lookup work.

## Solution

Add a tab-specific `panel(tabId)` lookup to the tab store and keep it synchronized with the panels collection. The lookup preserves the previous first-match-in-items-order behavior, updates through panel registration/rendering and direct panel item state changes, and keeps orphan panel auto-assignment in sync.

`Tab` now reads the associated panel id through this lookup instead of scanning the panels array.

## Verification

- `pnpm lint-fix`
- `pnpm test packages/ariakit-components/src/tab/__tests__/tab-store.test.ts`
- `pnpm tsc`
- `pnpm build`
- `pnpm test`