### PR TITLE
Prevent inline combobox blur listener churn

### DIFF
--- a/.changeset/300-combobox-inline-autocomplete-listeners.md
+++ b/.changeset/300-combobox-inline-autocomplete-listeners.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Improved [`Combobox`](https://ariakit.com/reference/combobox) inline autocomplete performance while typing.

--- a/packages/ariakit-react-components/src/combobox/__tests__/combobox.test.react.tsx
+++ b/packages/ariakit-react-components/src/combobox/__tests__/combobox.test.react.tsx
@@ -1,0 +1,100 @@
+import { q, render, waitFor } from "@ariakit/test/react";
+import { expect, test } from "vitest";
+import { ComboboxItem } from "../combobox-item.tsx";
+import { ComboboxList } from "../combobox-list.tsx";
+import { ComboboxProvider } from "../combobox-provider.tsx";
+import { Combobox } from "../combobox.tsx";
+
+type AddEventListenerArgs = Parameters<HTMLElement["addEventListener"]>;
+type RemoveEventListenerArgs = Parameters<HTMLElement["removeEventListener"]>;
+
+interface TestComboboxProps {
+  value: string;
+}
+
+function TestCombobox({ value }: TestComboboxProps) {
+  return (
+    <ComboboxProvider value={value}>
+      <Combobox autoSelect autoComplete="both" />
+      <ComboboxList>
+        <ComboboxItem value="Apple" />
+        <ComboboxItem value="Apricot" />
+      </ComboboxList>
+    </ComboboxProvider>
+  );
+}
+
+test("does not tear down the focusout listener on inline value updates", async () => {
+  let combobox: HTMLElement | null = null;
+  let unmount = () => {};
+  const container = document.createElement("div");
+  // oxlint-disable-next-line typescript/unbound-method
+  const originalAddEventListener = HTMLElement.prototype.addEventListener;
+  // oxlint-disable-next-line typescript/unbound-method
+  const originalRemoveEventListener = HTMLElement.prototype.removeEventListener;
+  const focusoutListeners = new Set<EventListenerOrEventListenerObject>();
+  const removedFocusoutListeners: EventListenerOrEventListenerObject[] = [];
+  document.body.appendChild(container);
+
+  HTMLElement.prototype.addEventListener = function (
+    this: HTMLElement,
+    ...args: AddEventListenerArgs
+  ) {
+    const [event, listener, options] = args;
+    const capture = typeof options === "boolean" ? options : !!options?.capture;
+    if (
+      event === "focusout" &&
+      this.getAttribute("role") === "combobox" &&
+      !capture
+    ) {
+      focusoutListeners.add(listener);
+    }
+    return originalAddEventListener.apply(this, args);
+  };
+
+  HTMLElement.prototype.removeEventListener = function (
+    this: HTMLElement,
+    ...args: RemoveEventListenerArgs
+  ) {
+    const [event, listener] = args;
+    if (
+      event === "focusout" &&
+      this === combobox &&
+      focusoutListeners.has(listener)
+    ) {
+      removedFocusoutListeners.push(listener);
+    }
+    return originalRemoveEventListener.apply(this, args);
+  };
+
+  try {
+    const rendered = await render(<TestCombobox value="" />, { container });
+    unmount = rendered.unmount;
+
+    const local = q.within(container);
+    combobox = local.combobox();
+    if (!combobox) {
+      throw new Error();
+    }
+    await waitFor(() => {
+      expect(focusoutListeners.size).toBeGreaterThan(0);
+    });
+
+    removedFocusoutListeners.length = 0;
+
+    await rendered.rerender(<TestCombobox value="a" />);
+    await waitFor(() => {
+      const currentCombobox = local.combobox();
+      if (!(currentCombobox instanceof HTMLInputElement)) {
+        throw new Error();
+      }
+      expect(currentCombobox.value).toBe("a");
+    });
+    expect(removedFocusoutListeners).toHaveLength(0);
+  } finally {
+    unmount();
+    container.remove();
+    HTMLElement.prototype.addEventListener = originalAddEventListener;
+    HTMLElement.prototype.removeEventListener = originalRemoveEventListener;
+  }
+});

--- a/packages/ariakit-react-components/src/combobox/combobox.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox.tsx
@@ -469,27 +469,35 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
 
     // If it has inline auto completion, set the store value when the combobox
     // input or the combobox list lose focus.
+    const onFocusOut = useEvent((event: FocusEvent) => {
+      const combobox = ref.current;
+      if (!combobox) return;
+      const currentElements = [combobox, contentElement].filter(
+        (element): element is HTMLElement => !!element,
+      );
+      if (
+        currentElements.every((element) => isFocusEventOutside(event, element))
+      ) {
+        store?.setValue(value);
+      }
+    });
+
     useEffect(() => {
       if (!inline) return;
       const combobox = ref.current;
       if (!combobox) return;
       const elements = [combobox, contentElement].filter(
-        (value): value is HTMLElement => !!value,
+        (element): element is HTMLElement => !!element,
       );
-      const onBlur = (event: FocusEvent) => {
-        if (elements.every((el) => isFocusEventOutside(event, el))) {
-          store?.setValue(value);
-        }
-      };
       for (const element of elements) {
-        element.addEventListener("focusout", onBlur);
+        element.addEventListener("focusout", onFocusOut);
       }
       return () => {
         for (const element of elements) {
-          element.removeEventListener("focusout", onBlur);
+          element.removeEventListener("focusout", onFocusOut);
         }
       };
-    }, [inline, contentElement, store, value]);
+    }, [inline, contentElement, onFocusOut]);
 
     const canShow = (event: SyntheticEvent) => {
       const currentTarget = event.currentTarget as HTMLType;


### PR DESCRIPTION
## Motivation

Inline Combobox autocomplete updates the computed input value while the user types. The native `focusout` listener that commits the inline-completed value on blur depended on that computed value, so React cleaned up and reattached the listener on every value update.

## Solution

Move the blur commit logic into a stable `useEvent` handler. The effect now subscribes based on the inline mode and current content element, while the handler reads the latest Combobox value, store, input element, and content element when `focusout` fires.

Add a regression test that tracks the Combobox `focusout` listener and verifies an inline value update does not remove it. Add a changeset for `@ariakit/react-components` and the `@ariakit/react` re-export.

## Verification

- `pnpm lint-fix`
- `pnpm test packages/ariakit-react-components/src/combobox/__tests__/combobox.test.react.tsx app/src/examples/combobox-group/test.ts`
- `pnpm tsc`
- `pnpm build`
