### PR TITLE
Extract admin avatar URL helper

### DIFF
--- a/app/src/pages/admin/_utils.ts
+++ b/app/src/pages/admin/_utils.ts
@@ -77,6 +77,13 @@ export function getStripeDashboardUrl() {
   return `https://dashboard.stripe.com`;
 }
 
+export function getAvatarUrl(imageUrl: string, size = 32) {
+  const url = new URL(imageUrl);
+  url.searchParams.set("width", String(size));
+  url.searchParams.set("height", String(size));
+  return url.toString();
+}
+
 interface GetPageUrlsOptions {
   totalCount: number;
   limit: number;

--- a/app/src/pages/admin/teams.astro
+++ b/app/src/pages/admin/teams.astro
@@ -12,9 +12,9 @@ import { InlineLink } from "#app/components/inline-link.react.tsx";
 import { Icon } from "#app/icons/icon.react.tsx";
 import { isAdmin } from "#app/lib/auth.ts";
 import { clerkClient } from "@clerk/astro/server";
-import type { Organization } from "@clerk/astro/server";
 import LayoutPagination from "./_layout-pagination.astro";
 import {
+  getAvatarUrl,
   getClerkInstanceUrl,
   getPageUrls,
   getPaginationData,
@@ -51,13 +51,6 @@ async function getTeamData() {
 }
 
 const teams = await getTeamData();
-
-function getTeamAvatarUrl(team: Organization) {
-  const url = new URL(team.imageUrl);
-  url.searchParams.set("width", "32");
-  url.searchParams.set("height", "32");
-  return url.toString();
-}
 ---
 
 <LayoutPagination
@@ -80,7 +73,7 @@ function getTeamAvatarUrl(team: Organization) {
               <div class="ak-frame ak-frame-card/card ak-layer ak-layer-lighten-6 size-full flex flex-col gap-2">
                 <div class="flex items-center gap-2">
                   <img
-                    src={getTeamAvatarUrl(team)}
+                    src={getAvatarUrl(team.imageUrl)}
                     alt=""
                     class="size-[1em] object-cover rounded-full"
                   />

--- a/app/src/pages/admin/users.astro
+++ b/app/src/pages/admin/users.astro
@@ -15,6 +15,7 @@ import { clerkClient } from "@clerk/astro/server";
 import { formatDistanceToNow } from "date-fns";
 import LayoutPagination from "./_layout-pagination.astro";
 import {
+  getAvatarUrl,
   getClerkInstanceUrl,
   getPageUrls,
   getPaginationData,
@@ -53,13 +54,6 @@ async function getUserData() {
 }
 
 const users = await getUserData();
-
-function getUserAvatarUrl(user: User) {
-  const url = new URL(user.imageUrl);
-  url.searchParams.set("width", "32");
-  url.searchParams.set("height", "32");
-  return url.toString();
-}
 ---
 
 <LayoutPagination
@@ -79,7 +73,7 @@ function getUserAvatarUrl(user: User) {
           <div class="ak-frame ak-frame-card/card ak-layer ak-layer-lighten-6 size-full flex flex-col gap-2">
             <div class="flex items-center gap-2">
               <img
-                src={getUserAvatarUrl(user)}
+                src={getAvatarUrl(user.imageUrl)}
                 alt=""
                 class="size-[1em] object-cover rounded-full"
               />


### PR DESCRIPTION
## Motivation

The admin users and teams pages each carried the same avatar URL resizing logic. The users page implementation also depended on an ambient global `User` type in its page-local helper.

## Solution

Add a shared `getAvatarUrl(imageUrl, size)` helper in `app/src/pages/admin/_utils.ts` and use it from both admin pages. The helper preserves the existing `width=32` and `height=32` behavior by default while removing the duplicated page-local functions and narrowing the call sites to the `imageUrl` string they actually need.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm build-app-lite`
