### PR TITLE
Dedupe Ariakit script helpers

### DIFF
--- a/packages/ariakit-scripts/src/build.ts
+++ b/packages/ariakit-scripts/src/build.ts
@@ -5,6 +5,7 @@ import { build as rolldownBuild } from "rolldown";
 import type { Plugin } from "rolldown";
 import { dts } from "rolldown-plugin-dts";
 import solidPlugin from "vite-plugin-solid";
+import { escapeRegExp } from "./regexp.ts";
 
 interface PackageJson {
   name: string;
@@ -63,10 +64,6 @@ function isTypeScriptSource(filename: string) {
 
 function isPrivateModule(filename: string) {
   return filename.startsWith("__");
-}
-
-function escapeRegExp(value: string) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function matchesBasenamePattern(name: string, pattern: string) {

--- a/packages/ariakit-scripts/src/docs.ts
+++ b/packages/ariakit-scripts/src/docs.ts
@@ -8,6 +8,7 @@ import type {
   SourceFile,
   TypeAliasDeclaration,
 } from "ts-morph";
+import { escapeRegExp } from "./regexp.ts";
 
 interface GenerateDocsOptions {
   rootPath?: string;
@@ -428,10 +429,6 @@ function getLocalTypeDeclarations(sourceFile: SourceFile) {
   return [...sourceFile.getTypeAliases(), ...sourceFile.getInterfaces()]
     .filter((declaration) => !declaration.isExported())
     .sort((a, b) => a.getStart() - b.getStart());
-}
-
-function escapeRegExp(text: string) {
-  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function getTypeParameterNames(declaration: Node) {

--- a/packages/ariakit-scripts/src/perf-compare.ts
+++ b/packages/ariakit-scripts/src/perf-compare.ts
@@ -6,7 +6,12 @@ import {
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
-import { mergeScriptProfiles, mergeSelectorProfiles } from "./perf.ts";
+import {
+  computeMedianMetrics,
+  median,
+  mergeScriptProfiles,
+  mergeSelectorProfiles,
+} from "./perf.ts";
 import type {
   PerfMetrics,
   PerfProfiles,
@@ -14,6 +19,7 @@ import type {
   PerfScriptProfileEntry,
   PerfSelectorProfileEntry,
 } from "./perf.ts";
+import { escapeRegExp } from "./regexp.ts";
 
 const RESULTS_DIR = path.join(process.cwd(), ".perf-results");
 const PROFILE_LIMIT = 10;
@@ -194,10 +200,6 @@ function readJsonFile(filePath: string): unknown {
   }
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 function getNumber(value: unknown): number {
   if (typeof value !== "number") return 0;
   if (!Number.isFinite(value)) return 0;
@@ -351,30 +353,6 @@ function loadRounds(
     }
   }
   return rounds;
-}
-
-function median(values: number[]): number {
-  if (values.length === 0) return 0;
-  const sorted = [...values].sort((a, b) => a - b);
-  const mid = Math.floor(sorted.length / 2);
-  const midValue = sorted[mid];
-  if (midValue == null) return 0;
-  if (sorted.length % 2 !== 0) return midValue;
-  const prevValue = sorted[mid - 1];
-  if (prevValue == null) return midValue;
-  return (prevValue + midValue) / 2;
-}
-
-function computeMedianMetrics(all: PerfMetrics[]): PerfMetrics {
-  return {
-    scripting: median(all.map((m) => m.scripting)),
-    layout: median(all.map((m) => m.layout)),
-    styleRecalc: median(all.map((m) => m.styleRecalc)),
-    painting: median(all.map((m) => m.painting)),
-    rendering: median(all.map((m) => m.rendering)),
-    inp: median(all.map((m) => m.inp)),
-    total: median(all.map((m) => m.total)),
-  };
 }
 
 function mergeProfiles(results: PerfResult[]): PerfProfiles | undefined {

--- a/packages/ariakit-scripts/src/perf.ts
+++ b/packages/ariakit-scripts/src/perf.ts
@@ -187,7 +187,7 @@ function getMetricValue(
   return metric.value;
 }
 
-function median(values: number[]): number {
+export function median(values: number[]): number {
   if (values.length === 0) return 0;
   const sorted = [...values].sort((a, b) => a - b);
   const mid = Math.floor(sorted.length / 2);
@@ -199,7 +199,7 @@ function median(values: number[]): number {
   return (prevValue + midValue) / 2;
 }
 
-function computeMedianMetrics(all: PerfMetrics[]): PerfMetrics {
+export function computeMedianMetrics(all: PerfMetrics[]): PerfMetrics {
   return {
     scripting: median(all.map((m) => m.scripting)),
     layout: median(all.map((m) => m.layout)),

--- a/packages/ariakit-scripts/src/regexp.ts
+++ b/packages/ariakit-scripts/src/regexp.ts
@@ -1,0 +1,3 @@
+export function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
## Motivation

Audit findings T080 and T081 flagged duplicated helper implementations in `@ariakit/scripts`. `median` and `computeMedianMetrics` were duplicated between `perf.ts` and `perf-compare.ts`, and `escapeRegExp` was duplicated across scripts that build dynamic regular expressions.

## Solution

Export `median` and `computeMedianMetrics` from `perf.ts` and import them in `perf-compare.ts`, removing the duplicate local implementations. Move the shared `escapeRegExp` helper into `regexp.ts` and import it from `docs.ts`, `perf-compare.ts`, and `build.ts`.

`regexp.ts` is used instead of `utils.ts` intentionally because the independent T082 PR owns a new `packages/ariakit-scripts/src/utils.ts` file. This keeps the audit PRs mergeable while preserving the helper dedupe.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm test packages/ariakit-scripts/src/build.test.ts packages/ariakit-scripts/src/perf.test.ts packages/ariakit-scripts/src/perf-compare.test.ts packages/ariakit-scripts/src/docs.test.ts`