### PR TITLE
Extract activation target helper

### DIFF
--- a/packages/ariakit-utils/src/events.ts
+++ b/packages/ariakit-utils/src/events.ts
@@ -32,26 +32,32 @@ export function isSelfTarget(
   return event.target === event.currentTarget;
 }
 
+function isActivatableNavigationTarget(
+  element: EventTarget | null,
+): element is HTMLAnchorElement | HTMLButtonElement | HTMLInputElement {
+  const target = element as
+    | HTMLAnchorElement
+    | HTMLButtonElement
+    | HTMLInputElement
+    | null;
+  if (!target) return false;
+  const tagName = target.tagName.toLowerCase();
+  if (tagName === "a") return true;
+  if (tagName === "button" && target.type === "submit") return true;
+  if (tagName === "input" && target.type === "submit") return true;
+  return false;
+}
+
 /**
  * Checks whether the user event is triggering a page navigation in a new tab.
  */
 export function isOpeningInNewTab(
   event: Pick<MouseEvent, "currentTarget" | "metaKey" | "ctrlKey">,
 ) {
-  const element = event.currentTarget as
-    | HTMLAnchorElement
-    | HTMLButtonElement
-    | HTMLInputElement
-    | null;
-  if (!element) return false;
   const isAppleDevice = isApple();
   if (isAppleDevice && !event.metaKey) return false;
   if (!isAppleDevice && !event.ctrlKey) return false;
-  const tagName = element.tagName.toLowerCase();
-  if (tagName === "a") return true;
-  if (tagName === "button" && element.type === "submit") return true;
-  if (tagName === "input" && element.type === "submit") return true;
-  return false;
+  return isActivatableNavigationTarget(event.currentTarget);
 }
 
 /**
@@ -60,18 +66,8 @@ export function isOpeningInNewTab(
 export function isDownloading(
   event: Pick<MouseEvent, "altKey" | "currentTarget">,
 ) {
-  const element = event.currentTarget as
-    | HTMLAnchorElement
-    | HTMLButtonElement
-    | HTMLInputElement
-    | null;
-  if (!element) return false;
-  const tagName = element.tagName.toLowerCase();
   if (!event.altKey) return false;
-  if (tagName === "a") return true;
-  if (tagName === "button" && element.type === "submit") return true;
-  if (tagName === "input" && element.type === "submit") return true;
-  return false;
+  return isActivatableNavigationTarget(event.currentTarget);
 }
 
 /**

--- a/packages/ariakit-utils/src/events.ts
+++ b/packages/ariakit-utils/src/events.ts
@@ -41,6 +41,7 @@ function isActivatableNavigationTarget(
     | HTMLInputElement
     | null;
   if (!target) return false;
+  if (!(target instanceof HTMLElement)) return false;
   const tagName = target.tagName.toLowerCase();
   if (tagName === "a") return true;
   if (tagName === "button" && target.type === "submit") return true;

--- a/packages/ariakit-utils/src/events.ts
+++ b/packages/ariakit-utils/src/events.ts
@@ -3,7 +3,7 @@
  * @module Event utilities
  */
 
-import { contains, isNode } from "./dom.ts";
+import { contains, isElement, isNode } from "./dom.ts";
 import { isApple } from "./platform.ts";
 
 /**
@@ -32,16 +32,12 @@ export function isSelfTarget(
   return event.target === event.currentTarget;
 }
 
-function isActivatableNavigationTarget(
-  element: EventTarget | null,
-): element is HTMLAnchorElement | HTMLButtonElement | HTMLInputElement {
+function isActivatableNavigationTarget(element: EventTarget | null) {
+  if (!isElement(element)) return false;
   const target = element as
     | HTMLAnchorElement
     | HTMLButtonElement
-    | HTMLInputElement
-    | null;
-  if (!target) return false;
-  if (!(target instanceof HTMLElement)) return false;
+    | HTMLInputElement;
   const tagName = target.tagName.toLowerCase();
   if (tagName === "a") return true;
   if (tagName === "button" && target.type === "submit") return true;


### PR DESCRIPTION
## Motivation

`isOpeningInNewTab` and `isDownloading` both duplicated the same `currentTarget` cast, null handling, and navigation-target classification logic for anchors and submit controls. T070 tracks extracting that repeated logic without changing the public helpers' modifier-key behavior.

## Solution

Add a private `isActivatableNavigationTarget` helper in `packages/ariakit-utils/src/events.ts` and have both exported helpers call it after their own modifier-key guard. The helper keeps the existing anchor, submit button, and submit input checks in one place.

Verification:

- `pnpm lint-fix`
- `pnpm build`
- `pnpm tsc`
- `pnpm exec vitest packages/ariakit-utils/src/events.test.ts --run`
