### PR TITLE
Consolidate Ariakit scripts package helpers

### DIFF
--- a/packages/ariakit-scripts/src/build.ts
+++ b/packages/ariakit-scripts/src/build.ts
@@ -1,19 +1,12 @@
 import { lstatSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { readdir } from "node:fs/promises";
-import { join, sep } from "node:path";
+import { join } from "node:path";
 import { build as rolldownBuild } from "rolldown";
 import type { Plugin } from "rolldown";
 import { dts } from "rolldown-plugin-dts";
 import solidPlugin from "vite-plugin-solid";
-
-interface PackageJson {
-  name: string;
-  scripts?: Record<string, string>;
-  exports?: Record<string, unknown>;
-  dependencies?: Record<string, string>;
-  peerDependencies?: Record<string, string>;
-  [key: string]: unknown;
-}
+import { normalizePath, readPackageJson } from "./utils.ts";
+import type { PackageJson } from "./utils.ts";
 
 interface PublicFile {
   name: string;
@@ -48,10 +41,6 @@ const npmIgnoreEntries = [
 // Use the neutral platform for published libraries so Rolldown doesn't inline
 // runtime process.env.NODE_ENV checks for browser builds.
 const buildPlatform = "neutral";
-
-function normalizePath(path: string) {
-  return path.split(sep).join("/");
-}
 
 function removeExtension(path: string) {
   return path.replace(/\.[^.]+$/, "");
@@ -117,11 +106,6 @@ function matchesNpmIgnoreEntry(path: string, entry: string) {
 
 function isNpmIgnored(path: string) {
   return npmIgnoreEntries.some((entry) => matchesNpmIgnoreEntry(path, entry));
-}
-
-function readPackageJson(rootPath: string): PackageJson {
-  const packageJsonPath = join(rootPath, "package.json");
-  return JSON.parse(readFileSync(packageJsonPath, "utf-8"));
 }
 
 function writePackageJson(rootPath: string, packageJson: PackageJson) {

--- a/packages/ariakit-scripts/src/dev.ts
+++ b/packages/ariakit-scripts/src/dev.ts
@@ -1,17 +1,13 @@
 import { spawn } from "node:child_process";
-import { readFileSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { createServer } from "node:net";
-import { isAbsolute, join, relative, sep } from "node:path";
+import { isAbsolute, join, relative } from "node:path";
 import { watch } from "chokidar";
 import { cleanPackage } from "./build.ts";
+import { normalizePath, readPackageJson } from "./utils.ts";
 
 interface DevOptions {
   clean?: boolean;
-}
-
-interface PackageJson {
-  scripts?: Record<string, string>;
 }
 
 interface CleanPackage {
@@ -20,14 +16,6 @@ interface CleanPackage {
 }
 
 const packageChangeGlobs = ["packages/*/package.json", "packages/*/src/**"];
-
-function normalizePath(path: string) {
-  return path.split(sep).join("/");
-}
-
-function readPackageJson(rootPath: string): PackageJson {
-  return JSON.parse(readFileSync(join(rootPath, "package.json"), "utf-8"));
-}
 
 function getCleanPackage(rootPath: string): CleanPackage | undefined {
   try {

--- a/packages/ariakit-scripts/src/react18.ts
+++ b/packages/ariakit-scripts/src/react18.ts
@@ -369,10 +369,7 @@ function printHelp() {
   );
 }
 
-async function getReact18Command(
-  rootPath: string,
-  args: string[],
-): Promise<React18Command> {
+function getReact18Command(rootPath: string, args: string[]): React18Command {
   const [command, ...commandArgs] = stripLeadingSeparator(args);
 
   if (!command) {
@@ -514,7 +511,7 @@ export async function react18(args: string[]) {
     { cwd: workspacePath },
   );
 
-  const command = await getReact18Command(workspacePath, args);
+  const command = getReact18Command(workspacePath, args);
   const watcher = startWorkspaceWatcher(rootPath, workspacePath);
 
   try {

--- a/packages/ariakit-scripts/src/react18.ts
+++ b/packages/ariakit-scripts/src/react18.ts
@@ -4,24 +4,21 @@ import {
   mkdir,
   copyFile,
   readdir,
-  readFile,
   readlink,
   rm,
   symlink,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { delimiter, dirname, isAbsolute, join, relative, sep } from "node:path";
+import { delimiter, dirname, isAbsolute, join, relative } from "node:path";
 import { watch } from "chokidar";
 import type { FSWatcher } from "chokidar";
-
-interface PackageJson {
-  scripts?: Record<string, string>;
-  dependencies?: Record<string, string>;
-  devDependencies?: Record<string, string>;
-  optionalDependencies?: Record<string, string>;
-  [key: string]: unknown;
-}
+import {
+  normalizePath,
+  readPackageJson,
+  readPackageJsonAsync,
+} from "./utils.ts";
+import type { PackageJson } from "./utils.ts";
 
 interface React18Command {
   bin: string;
@@ -63,10 +60,6 @@ const pathKey =
 
 function log(message: string) {
   console.error(`[react18] ${message}`);
-}
-
-function normalizePath(path: string) {
-  return path.split(sep).join("/");
 }
 
 function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
@@ -294,13 +287,8 @@ function getDependencyVersion(packageJson: PackageJson, name: string) {
   throw new Error(`${name} must be declared in website/package.json`);
 }
 
-async function readPackageJson(path: string) {
-  const contents = await readFile(path, "utf-8");
-  return JSON.parse(contents) as PackageJson;
-}
-
 async function getReact18DependencyVersions(rootPath: string) {
-  const packageJson = await readPackageJson(
+  const packageJson = await readPackageJsonAsync(
     join(rootPath, "website/package.json"),
   );
 
@@ -338,7 +326,7 @@ async function rewritePackageJson(
   path: string,
   versions: Record<string, string>,
 ) {
-  const packageJson = await readPackageJson(path);
+  const packageJson = await readPackageJsonAsync(path);
 
   if (!updateReactDependencies(packageJson, versions)) return false;
 
@@ -358,10 +346,6 @@ async function rewriteReactDependencies(rootPath: string) {
   }
 
   return updatedCount;
-}
-
-async function readRootPackageJson(rootPath: string) {
-  return await readPackageJson(join(rootPath, "package.json"));
 }
 
 function stripLeadingSeparator(args: string[]) {
@@ -395,7 +379,7 @@ async function getReact18Command(
     throw new Error("Missing command. Use `ariakit react18 <script>`.");
   }
 
-  const packageJson = await readRootPackageJson(rootPath);
+  const packageJson = readPackageJson(rootPath);
   // `react18` and `test-react-18` scripts would recurse here. Run the
   // underlying test script directly instead.
   if (command === "react18" || command === "test-react-18") {

--- a/packages/ariakit-scripts/src/react18.ts
+++ b/packages/ariakit-scripts/src/react18.ts
@@ -16,7 +16,7 @@ import type { FSWatcher } from "chokidar";
 import {
   normalizePath,
   readPackageJson,
-  readPackageJsonAsync,
+  readPackageJsonFile,
 } from "./utils.ts";
 import type { PackageJson } from "./utils.ts";
 
@@ -288,7 +288,7 @@ function getDependencyVersion(packageJson: PackageJson, name: string) {
 }
 
 async function getReact18DependencyVersions(rootPath: string) {
-  const packageJson = await readPackageJsonAsync(
+  const packageJson = await readPackageJsonFile(
     join(rootPath, "website/package.json"),
   );
 
@@ -326,7 +326,7 @@ async function rewritePackageJson(
   path: string,
   versions: Record<string, string>,
 ) {
-  const packageJson = await readPackageJsonAsync(path);
+  const packageJson = await readPackageJsonFile(path);
 
   if (!updateReactDependencies(packageJson, versions)) return false;
 

--- a/packages/ariakit-scripts/src/utils.ts
+++ b/packages/ariakit-scripts/src/utils.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { join, sep } from "node:path";
+
+export interface PackageJson {
+  name: string;
+  scripts?: Record<string, string>;
+  exports?: Record<string, unknown>;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+export function normalizePath(path: string) {
+  return path.split(sep).join("/");
+}
+
+/**
+ * Reads the package.json file inside the provided package directory.
+ */
+export function readPackageJson(rootPath: string): PackageJson {
+  const packageJsonPath = join(rootPath, "package.json");
+  return JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+}
+
+/**
+ * Reads a package.json file from a fully resolved file path.
+ */
+export async function readPackageJsonAsync(path: string): Promise<PackageJson> {
+  const contents = await readFile(path, "utf-8");
+  return JSON.parse(contents);
+}

--- a/packages/ariakit-scripts/src/utils.ts
+++ b/packages/ariakit-scripts/src/utils.ts
@@ -28,7 +28,7 @@ export function readPackageJson(rootPath: string): PackageJson {
 /**
  * Reads a package.json file from a fully resolved file path.
  */
-export async function readPackageJsonAsync(path: string): Promise<PackageJson> {
+export async function readPackageJsonFile(path: string): Promise<PackageJson> {
   const contents = await readFile(path, "utf-8");
   return JSON.parse(contents);
 }


### PR DESCRIPTION
## Motivation

The Ariakit scripts package had duplicated `normalizePath` and package JSON parsing helpers across `build.ts`, `dev.ts`, and `react18.ts`. Keeping those copies separate makes small behavior or typing changes easier to drift over time.

## Solution

Add an internal `utils.ts` module for the shared path normalization and sync/async package JSON readers. The existing scripts now import those helpers, with `react18.ts` using the sync directory reader for root package metadata and the async file-path reader for discovered package files.

No changeset is included because this is an internal refactor with no shipped behavior change.
