### PR TITLE
Dedupe composite and tabbable helpers

### DIFF
--- a/.changeset/300-previous-tabbable-fallback.md
+++ b/.changeset/300-previous-tabbable-fallback.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/utils": patch
+---
+
+Renamed the `getPreviousTabbable` fallback parameter to `fallbackToLast` to match its behavior.

--- a/packages/ariakit-components/src/composite/composite-store.ts
+++ b/packages/ariakit-components/src/composite/composite-store.ts
@@ -30,6 +30,9 @@ interface NextOptions extends Pick<
 
 export const NULL_ITEM = { id: null as unknown as string };
 
+/**
+ * Finds the first enabled item.
+ */
 export function findFirstEnabledItem(
   items: CompositeStoreItem[],
   excludeId?: string,
@@ -55,6 +58,15 @@ function getItemsInRow(items: CompositeStoreItem[], rowId?: string) {
   return items.filter((item) => item.rowId === rowId);
 }
 
+/**
+ * Moves all the items before the passed `id` to the end of the array. This is
+ * useful when we want to loop through the items in the same row or column as
+ * the first items will be placed after the last items.
+ *
+ * The null item that's inserted when `shouldInsertNullItem` is set to `true`
+ * represents the composite container itself. When the active item is null, the
+ * composite container has focus.
+ */
 export function flipItems(
   items: CompositeStoreItem[],
   activeId: string,
@@ -68,6 +80,9 @@ export function flipItems(
   ];
 }
 
+/**
+ * Creates a two-dimensional array with items grouped by their rowId's.
+ */
 export function groupItemsByRows(items: CompositeStoreItem[]) {
   const rows: CompositeStoreItem[][] = [];
   for (const item of items) {

--- a/packages/ariakit-components/src/composite/composite-store.ts
+++ b/packages/ariakit-components/src/composite/composite-store.ts
@@ -28,9 +28,12 @@ interface NextOptions extends Pick<
   skip?: number;
 }
 
-const NULL_ITEM = { id: null as unknown as string };
+export const NULL_ITEM = { id: null as unknown as string };
 
-function findFirstEnabledItem(items: CompositeStoreItem[], excludeId?: string) {
+export function findFirstEnabledItem(
+  items: CompositeStoreItem[],
+  excludeId?: string,
+) {
   return items.find((item) => {
     if (excludeId) {
       return !item.disabled && item.id !== excludeId;
@@ -52,7 +55,7 @@ function getItemsInRow(items: CompositeStoreItem[], rowId?: string) {
   return items.filter((item) => item.rowId === rowId);
 }
 
-function flipItems(
+export function flipItems(
   items: CompositeStoreItem[],
   activeId: string,
   shouldInsertNullItem = false,
@@ -65,7 +68,7 @@ function flipItems(
   ];
 }
 
-function groupItemsByRows(items: CompositeStoreItem[]) {
+export function groupItemsByRows(items: CompositeStoreItem[]) {
   const rows: CompositeStoreItem[][] = [];
   for (const item of items) {
     const row = rows.find((currentRow) => currentRow[0]?.rowId === item.rowId);

--- a/packages/ariakit-react-components/src/composite/utils.ts
+++ b/packages/ariakit-react-components/src/composite/utils.ts
@@ -1,44 +1,10 @@
+import * as Core from "@ariakit/components/composite/composite-store";
 import { getDocument, isTextField } from "@ariakit/utils";
-import type { CompositeStore, CompositeStoreItem } from "./composite-store.ts";
+import type { CompositeStore } from "./composite-store.ts";
 
-const NULL_ITEM = { id: null as unknown as string };
-
-/**
- * Moves all the items before the passed `id` to the end of the array. This is
- * useful when we want to loop through the items in the same row or column as
- * the first items will be placed after the last items.
- *
- * The null item that's inserted when `shouldInsertNullItem` is set to `true`
- * represents the composite container itself. When the active item is null, the
- * composite container has focus.
- */
-export function flipItems(
-  items: CompositeStoreItem[],
-  activeId: string,
-  shouldInsertNullItem = false,
-) {
-  const index = items.findIndex((item) => item.id === activeId);
-  return [
-    ...items.slice(index + 1),
-    ...(shouldInsertNullItem ? [NULL_ITEM] : []),
-    ...items.slice(0, index),
-  ];
-}
-
-/**
- * Finds the first enabled item.
- */
-export function findFirstEnabledItem(
-  items: CompositeStoreItem[],
-  excludeId?: string,
-) {
-  return items.find((item) => {
-    if (excludeId) {
-      return !item.disabled && item.id !== excludeId;
-    }
-    return !item.disabled;
-  });
-}
+export const flipItems = Core.flipItems;
+export const findFirstEnabledItem = Core.findFirstEnabledItem;
+export const groupItemsByRows = Core.groupItemsByRows;
 
 /**
  * Finds the first enabled item by its id.
@@ -46,22 +12,6 @@ export function findFirstEnabledItem(
 export function getEnabledItem(store: CompositeStore, id?: string | null) {
   if (!id) return null;
   return store.item(id) || null;
-}
-
-/**
- * Creates a two-dimensional array with items grouped by their rowId's.
- */
-export function groupItemsByRows(items: CompositeStoreItem[]) {
-  const rows: CompositeStoreItem[][] = [];
-  for (const item of items) {
-    const row = rows.find((currentRow) => currentRow[0]?.rowId === item.rowId);
-    if (row) {
-      row.push(item);
-    } else {
-      rows.push([item]);
-    }
-  }
-  return rows;
 }
 
 /**

--- a/packages/ariakit-utils/readme.md
+++ b/packages/ariakit-utils/readme.md
@@ -1048,7 +1048,7 @@ Returns the previous tabbable element in `container`.
 
 ```ts
 function getPreviousTabbable(
-  fallbackToFirst?: boolean,
+  fallbackToLast?: boolean,
   fallbackToFocusable?: boolean,
 ): HTMLElement | null;
 ```

--- a/packages/ariakit-utils/src/focus.ts
+++ b/packages/ariakit-utils/src/focus.ts
@@ -211,6 +211,36 @@ export function getLastTabbable(fallbackToFocusable?: boolean) {
   return getLastTabbableIn(document.body, false, fallbackToFocusable);
 }
 
+interface GetTabbableInDirectionParams {
+  container: HTMLElement;
+  includeContainer?: boolean;
+  reverse?: boolean;
+  fallbackToEdge?: boolean;
+  fallbackToFocusable?: boolean;
+}
+
+function getTabbableInDirection({
+  container,
+  includeContainer,
+  reverse,
+  fallbackToEdge,
+  fallbackToFocusable,
+}: GetTabbableInDirectionParams) {
+  const activeElement = getActiveElement(container);
+  const allFocusable = getAllFocusableIn(container, includeContainer);
+  if (reverse) {
+    allFocusable.reverse();
+  }
+  const activeIndex = allFocusable.indexOf(activeElement as HTMLElement);
+  const candidates = allFocusable.slice(activeIndex + 1);
+  return (
+    candidates.find(isTabbable) ||
+    (fallbackToEdge ? allFocusable.find(isTabbable) : null) ||
+    (fallbackToFocusable ? candidates[0] : null) ||
+    null
+  );
+}
+
 /**
  * Returns the next tabbable element in `container`.
  */
@@ -220,16 +250,12 @@ export function getNextTabbableIn(
   fallbackToFirst?: boolean,
   fallbackToFocusable?: boolean,
 ) {
-  const activeElement = getActiveElement(container);
-  const allFocusable = getAllFocusableIn(container, includeContainer);
-  const activeIndex = allFocusable.indexOf(activeElement as HTMLElement);
-  const nextFocusableElements = allFocusable.slice(activeIndex + 1);
-  return (
-    nextFocusableElements.find(isTabbable) ||
-    (fallbackToFirst ? allFocusable.find(isTabbable) : null) ||
-    (fallbackToFocusable ? nextFocusableElements[0] : null) ||
-    null
-  );
+  return getTabbableInDirection({
+    container,
+    includeContainer,
+    fallbackToEdge: fallbackToFirst,
+    fallbackToFocusable,
+  });
 }
 
 /**
@@ -257,29 +283,26 @@ export function getPreviousTabbableIn(
   fallbackToLast?: boolean,
   fallbackToFocusable?: boolean,
 ) {
-  const activeElement = getActiveElement(container);
-  const allFocusable = getAllFocusableIn(container, includeContainer).reverse();
-  const activeIndex = allFocusable.indexOf(activeElement as HTMLElement);
-  const previousFocusableElements = allFocusable.slice(activeIndex + 1);
-  return (
-    previousFocusableElements.find(isTabbable) ||
-    (fallbackToLast ? allFocusable.find(isTabbable) : null) ||
-    (fallbackToFocusable ? previousFocusableElements[0] : null) ||
-    null
-  );
+  return getTabbableInDirection({
+    container,
+    includeContainer,
+    reverse: true,
+    fallbackToEdge: fallbackToLast,
+    fallbackToFocusable,
+  });
 }
 
 /**
  * Returns the previous tabbable element in the document.
  */
 export function getPreviousTabbable(
-  fallbackToFirst?: boolean,
+  fallbackToLast?: boolean,
   fallbackToFocusable?: boolean,
 ) {
   return getPreviousTabbableIn(
     document.body,
     false,
-    fallbackToFirst,
+    fallbackToLast,
     fallbackToFocusable,
   );
 }


### PR DESCRIPTION
## Motivation

Composite navigation helpers are duplicated between the core composite store and React composite utilities. The tabbable focus helpers also duplicate the same directional lookup logic, and the public previous-tabbable fallback parameter is named after the opposite edge.

## Solution

Export the shared composite navigation helpers from the core composite store and alias them from the React utilities so there is one implementation. Add a shared direction-aware tabbable helper, rename the public previous fallback parameter to `fallbackToLast`, update the utils README signature, and add a patch changeset for `@ariakit/utils`.

## Verification

- `pnpm lint-fix`
- `pnpm build`
- `pnpm tsc`
- `pnpm test app/src/examples/combobox-group/test.ts`
- `pnpm test`

## Pre-commit review

The usual separate native-reviewer gate was avoided after an explicit coordination update instructed this top-level thread not to create or rely on subagent/native-reviewer threads. I completed the remaining pre-commit review locally with read-only commands in this thread.
