### PR TITLE
Extract form item hook

### DIFF
--- a/packages/ariakit-react-components/src/form/form-context.tsx
+++ b/packages/ariakit-react-components/src/form/form-context.tsx
@@ -1,9 +1,22 @@
-import { createStoreContext } from "@ariakit/react-utils";
+import type { StringLike } from "@ariakit/components/form/types";
+import { createStoreContext, useId } from "@ariakit/react-utils";
+import { invariant } from "@ariakit/utils";
+import { useCallback, useRef } from "react";
 import {
   CollectionContextProvider,
   CollectionScopedContextProvider,
 } from "../collection/collection-context.tsx";
-import type { FormStore } from "./form-store.ts";
+import type { CollectionItemOptions } from "../collection/collection-item.tsx";
+import type { FormStore, FormStoreItem } from "./form-store.ts";
+
+type FormItemType = FormStoreItem["type"];
+type FormItemGetItem = NonNullable<CollectionItemOptions["getItem"]>;
+
+interface FormItemContextOptions {
+  store?: FormStore;
+  name: StringLike;
+  component: string;
+}
 
 const ctx = createStoreContext<FormStore>(
   [CollectionContextProvider],
@@ -24,6 +37,55 @@ const ctx = createStoreContext<FormStore>(
  * }
  */
 export const useFormContext = ctx.useContext;
+
+export function useFormItemContext({
+  store,
+  name: nameProp,
+  component,
+}: FormItemContextOptions) {
+  const context = useFormContext();
+  const form = store || context;
+
+  invariant(
+    form,
+    process.env.NODE_ENV !== "production" &&
+      `${component} must be wrapped in a Form component.`,
+  );
+
+  const name = String(nameProp);
+
+  return { store: form, name };
+}
+
+interface FormItemOptions extends FormItemContextOptions {
+  id?: string;
+  type: FormItemType;
+  getItem?: CollectionItemOptions["getItem"];
+}
+
+export function useFormItem<T extends HTMLElement>({
+  id: idProp,
+  type,
+  getItem: getItemProp,
+  ...options
+}: FormItemOptions) {
+  const { store, name } = useFormItemContext(options);
+  const id = useId(idProp);
+  const ref = useRef<T>(null);
+
+  const getItem = useCallback<FormItemGetItem>(
+    (item) => {
+      const nextItem = { ...item, id: id || item.id, name, type };
+      if (getItemProp) {
+        return getItemProp(nextItem);
+      }
+      return nextItem;
+    },
+    [id, name, type, getItemProp],
+  );
+
+  return { store, name, id, ref, getItem };
+}
 
 export const useFormScopedContext = ctx.useScopedContext;
 

--- a/packages/ariakit-react-components/src/form/form-control.tsx
+++ b/packages/ariakit-react-components/src/form/form-control.tsx
@@ -3,7 +3,6 @@ import { useStoreState } from "@ariakit/react-store";
 import {
   useBooleanEvent,
   useEvent,
-  useId,
   useMergeRefs,
   createElement,
   createHook,
@@ -11,13 +10,12 @@ import {
   memo,
 } from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
-import { getDocument, cx, invariant } from "@ariakit/utils";
+import { getDocument, cx } from "@ariakit/utils";
 import type { BooleanOrCallback } from "@ariakit/utils";
 import type { ElementType, FocusEvent, RefObject } from "react";
-import { useCallback, useRef } from "react";
 import type { CollectionItemOptions } from "../collection/collection-item.tsx";
 import { useCollectionItem } from "../collection/collection-item.tsx";
-import { useFormContext } from "./form-context.tsx";
+import { useFormItem } from "./form-context.tsx";
 import type { FormStore } from "./form-store.ts";
 
 const TagName = "input" satisfies ElementType;
@@ -77,39 +75,30 @@ export const useFormControl = createHook<TagName, FormControlOptions>(
     touchOnBlur = true,
     ...props
   }) {
-    const context = useFormContext();
-    store = store || context;
-
-    invariant(
+    const {
+      store: form,
+      name,
+      id,
+      ref,
+      getItem,
+    } = useFormItem<HTMLType>({
       store,
-      process.env.NODE_ENV !== "production" &&
-        "FormControl must be wrapped in a Form component.",
-    );
+      name: nameProp,
+      id: props.id,
+      type: "field",
+      getItem: getItemProp,
+      component: "FormControl",
+    });
 
-    const name = String(nameProp);
-    const id = useId(props.id);
-    const ref = useRef<HTMLType>(null);
-
-    store.useValidate(async () => {
+    form.useValidate(async () => {
       const element = getNamedElement(ref, name);
       if (!element) return;
       // Flush microtasks to make sure the validity state is up to date
       await Promise.resolve();
       if ("validity" in element && !element.validity.valid) {
-        store?.setError(name, element.validationMessage);
+        form.setError(name, element.validationMessage);
       }
     });
-
-    const getItem = useCallback<NonNullable<CollectionItemOptions["getItem"]>>(
-      (item) => {
-        const nextItem = { ...item, id: id || item.id, name, type: "field" };
-        if (getItemProp) {
-          return getItemProp(nextItem);
-        }
-        return nextItem;
-      },
-      [id, name, getItemProp],
-    );
 
     const onBlurProp = props.onBlur;
     const touchOnBlurProp = useBooleanEvent(touchOnBlur);
@@ -118,12 +107,12 @@ export const useFormControl = createHook<TagName, FormControlOptions>(
       onBlurProp?.(event);
       if (event.defaultPrevented) return;
       if (!touchOnBlurProp(event)) return;
-      store?.setFieldTouched(name, true);
+      form.setFieldTouched(name, true);
     });
 
-    const label = useItem(store, name, "label");
-    const error = useItem(store, name, "error");
-    const description = useItem(store, name, "description");
+    const label = useItem(form, name, "label");
+    const error = useItem(form, name, "error");
+    const description = useItem(form, name, "description");
     const describedBy = cx(
       error?.id,
       description?.id,
@@ -131,8 +120,8 @@ export const useFormControl = createHook<TagName, FormControlOptions>(
     );
 
     const invalid = useStoreState(
-      store,
-      () => !!store?.getError(name) && store.getFieldTouched(name),
+      form,
+      () => !!form.getError(name) && form.getFieldTouched(name),
     );
 
     props = {
@@ -145,7 +134,12 @@ export const useFormControl = createHook<TagName, FormControlOptions>(
       onBlur,
     };
 
-    props = useCollectionItem<TagName>({ store, ...props, name, getItem });
+    props = useCollectionItem<TagName>({
+      store: form,
+      ...props,
+      name,
+      getItem,
+    });
 
     return props;
   },

--- a/packages/ariakit-react-components/src/form/form-description.tsx
+++ b/packages/ariakit-react-components/src/form/form-description.tsx
@@ -1,6 +1,5 @@
 import type { StringLike } from "@ariakit/components/form/types";
 import {
-  useId,
   useMergeRefs,
   createElement,
   createHook,
@@ -8,12 +7,10 @@ import {
   memo,
 } from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
-import { invariant } from "@ariakit/utils";
 import type { ElementType } from "react";
-import { useCallback, useRef } from "react";
 import type { CollectionItemOptions } from "../collection/collection-item.tsx";
 import { useCollectionItem } from "../collection/collection-item.tsx";
-import { useFormContext } from "./form-context.tsx";
+import { useFormItem } from "./form-context.tsx";
 import type { FormStore } from "./form-store.ts";
 
 const TagName = "div" satisfies ElementType;
@@ -41,34 +38,19 @@ export const useFormDescription = createHook<TagName, FormDescriptionOptions>(
     getItem: getItemProp,
     ...props
   }) {
-    const context = useFormContext();
-    store = store || context;
-
-    invariant(
+    const {
+      store: form,
+      id,
+      ref,
+      getItem,
+    } = useFormItem<HTMLType>({
       store,
-      process.env.NODE_ENV !== "production" &&
-        "FormDescription must be wrapped in a Form component.",
-    );
-
-    const id = useId(props.id);
-    const ref = useRef<HTMLType>(null);
-    const name = String(nameProp);
-
-    const getItem = useCallback<NonNullable<CollectionItemOptions["getItem"]>>(
-      (item) => {
-        const nextItem = {
-          ...item,
-          id: id || item.id,
-          name,
-          type: "description",
-        };
-        if (getItemProp) {
-          return getItemProp(nextItem);
-        }
-        return nextItem;
-      },
-      [id, name, getItemProp],
-    );
+      name: nameProp,
+      id: props.id,
+      type: "description",
+      getItem: getItemProp,
+      component: "FormDescription",
+    });
 
     props = {
       ...props,
@@ -76,7 +58,7 @@ export const useFormDescription = createHook<TagName, FormDescriptionOptions>(
       ref: useMergeRefs(ref, props.ref),
     };
 
-    props = useCollectionItem({ store, ...props, getItem });
+    props = useCollectionItem({ store: form, ...props, getItem });
 
     return props;
   },

--- a/packages/ariakit-react-components/src/form/form-error.tsx
+++ b/packages/ariakit-react-components/src/form/form-error.tsx
@@ -1,7 +1,6 @@
 import type { StringLike } from "@ariakit/components/form/types";
 import { useStoreState } from "@ariakit/react-store";
 import {
-  useId,
   useMergeRefs,
   createElement,
   createHook,
@@ -9,12 +8,10 @@ import {
   memo,
 } from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
-import { invariant } from "@ariakit/utils";
 import type { ElementType } from "react";
-import { useCallback, useRef } from "react";
 import type { CollectionItemOptions } from "../collection/collection-item.tsx";
 import { useCollectionItem } from "../collection/collection-item.tsx";
-import { useFormContext } from "./form-context.tsx";
+import { useFormItem } from "./form-context.tsx";
 import type { FormStore } from "./form-store.ts";
 
 const TagName = "div" satisfies ElementType;
@@ -49,34 +46,25 @@ export const useFormError = createHook<TagName, FormErrorOptions>(
     getItem: getItemProp,
     ...props
   }) {
-    const context = useFormContext();
-    store = store || context;
-
-    invariant(
+    const {
+      store: form,
+      name,
+      id,
+      ref,
+      getItem,
+    } = useFormItem<HTMLType>({
       store,
-      process.env.NODE_ENV !== "production" &&
-        "FormError must be wrapped in a Form component.",
-    );
+      name: nameProp,
+      id: props.id,
+      type: "error",
+      getItem: getItemProp,
+      component: "FormError",
+    });
 
-    const id = useId(props.id);
-    const ref = useRef<HTMLType>(null);
-    const name = String(nameProp);
-
-    const getItem = useCallback<NonNullable<CollectionItemOptions["getItem"]>>(
-      (item) => {
-        const nextItem = { ...item, id: id || item.id, name, type: "error" };
-        if (getItemProp) {
-          return getItemProp(nextItem);
-        }
-        return nextItem;
-      },
-      [id, name, getItemProp],
-    );
-
-    const children = useStoreState(store, () => {
-      const error = store?.getError(name);
+    const children = useStoreState(form, () => {
+      const error = form.getError(name);
       if (error == null) return;
-      if (!store?.getFieldTouched(name)) return;
+      if (!form.getFieldTouched(name)) return;
       return error;
     });
 
@@ -88,7 +76,7 @@ export const useFormError = createHook<TagName, FormErrorOptions>(
       ref: useMergeRefs(ref, props.ref),
     };
 
-    props = useCollectionItem({ store, ...props, getItem });
+    props = useCollectionItem({ store: form, ...props, getItem });
 
     return props;
   },

--- a/packages/ariakit-react-components/src/form/form-input.tsx
+++ b/packages/ariakit-react-components/src/form/form-input.tsx
@@ -6,11 +6,10 @@ import {
   memo,
 } from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
-import { invariant } from "@ariakit/utils";
 import type { ChangeEvent, ElementType } from "react";
 import type { FocusableOptions } from "../focusable/focusable.tsx";
 import { useFocusable } from "../focusable/focusable.tsx";
-import { useFormContext } from "./form-context.tsx";
+import { useFormItemContext } from "./form-context.tsx";
 import type { FormControlOptions } from "./form-control.tsx";
 import { useFormControl } from "./form-control.tsx";
 
@@ -35,25 +34,20 @@ type HTMLType = HTMLElementTagNameMap[TagName];
  */
 export const useFormInput = createHook<TagName, FormInputOptions>(
   function useFormInput({ store, name: nameProp, ...props }) {
-    const context = useFormContext();
-    store = store || context;
-
-    invariant(
+    const { store: form, name } = useFormItemContext({
       store,
-      process.env.NODE_ENV !== "production" &&
-        "FormInput must be wrapped in a Form component.",
-    );
-
-    const name = String(nameProp);
+      name: nameProp,
+      component: "FormInput",
+    });
     const onChangeProp = props.onChange;
 
     const onChange = useEvent((event: ChangeEvent<HTMLType>) => {
       onChangeProp?.(event);
       if (event.defaultPrevented) return;
-      store?.setValue(name, event.target.value);
+      form.setValue(name, event.target.value);
     });
 
-    const value = store.useValue(name);
+    const value = form.useValue(name);
 
     props = {
       value,
@@ -62,7 +56,7 @@ export const useFormInput = createHook<TagName, FormInputOptions>(
     };
 
     props = useFocusable<TagName>(props);
-    props = useFormControl({ store, name, ...props });
+    props = useFormControl({ store: form, name, ...props });
 
     return props;
   },

--- a/packages/ariakit-react-components/src/form/form-label.tsx
+++ b/packages/ariakit-react-components/src/form/form-label.tsx
@@ -2,7 +2,6 @@ import type { StringLike } from "@ariakit/components/form/types";
 import { useStoreState } from "@ariakit/react-store";
 import {
   useEvent,
-  useId,
   useMergeRefs,
   useTagName,
   createElement,
@@ -11,12 +10,11 @@ import {
   memo,
 } from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
-import { getFirstTabbableIn, invariant } from "@ariakit/utils";
+import { getFirstTabbableIn } from "@ariakit/utils";
 import type { ElementType, MouseEvent } from "react";
-import { useCallback, useRef } from "react";
 import type { CollectionItemOptions } from "../collection/collection-item.tsx";
 import { useCollectionItem } from "../collection/collection-item.tsx";
-import { useFormContext } from "./form-context.tsx";
+import { useFormItem } from "./form-context.tsx";
 import type { FormStore } from "./form-store.ts";
 
 const TagName = "label" satisfies ElementType;
@@ -57,31 +55,22 @@ export const useFormLabel = createHook<TagName, FormLabelOptions>(
     getItem: getItemProp,
     ...props
   }) {
-    const context = useFormContext();
-    store = store || context;
-
-    invariant(
+    const {
+      store: form,
+      name,
+      id,
+      ref,
+      getItem,
+    } = useFormItem<HTMLType>({
       store,
-      process.env.NODE_ENV !== "production" &&
-        "FormLabel must be wrapped in a Form component.",
-    );
+      name: nameProp,
+      id: props.id,
+      type: "label",
+      getItem: getItemProp,
+      component: "FormLabel",
+    });
 
-    const id = useId(props.id);
-    const ref = useRef<HTMLType>(null);
-    const name = String(nameProp);
-
-    const getItem = useCallback<NonNullable<CollectionItemOptions["getItem"]>>(
-      (item) => {
-        const nextItem = { ...item, id: id || item.id, name, type: "label" };
-        if (getItemProp) {
-          return getItemProp(nextItem);
-        }
-        return nextItem;
-      },
-      [id, name, getItemProp],
-    );
-
-    const field = useStoreState(store, (state) =>
+    const field = useStoreState(form, (state) =>
       state.items.find((item) => item.type === "field" && item.name === name),
     );
     const fieldTagName = useTagName(field?.element, "input");
@@ -125,7 +114,7 @@ export const useFormLabel = createHook<TagName, FormLabelOptions>(
       };
     }
 
-    props = useCollectionItem<TagName>({ store, ...props, getItem });
+    props = useCollectionItem<TagName>({ store: form, ...props, getItem });
 
     return props;
   },


### PR DESCRIPTION
## Motivation

Several React form hooks repeat the same setup for resolving the form store, asserting the surrounding form context, normalizing the field name, creating an id/ref pair, and building collection items for form fields, labels, errors, and descriptions.

## Solution

Extract shared form item setup into internal helpers in `form-context.tsx`. The field, label, error, and description hooks now call `useFormItem` for the common store/name/id/ref/getItem behavior, while `FormInput` uses `useFormItemContext` for the shared store/name preamble before delegating to `useFormControl`.

The helper keeps explicit ids flowing through `useId(props.id)`, preserves the per-component invariant messages, and leaves each component's `useCollectionItem` call local to the component.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm -F @ariakit/react-components build`
- `pnpm test examples/form/test.ts examples/form-select/test.ts examples/form-radio/test.ts`
- `APP_PORT=4321 NEXTJS_PORT=3001 pnpm -F app test src/sandbox/form-3607/test-browser.ts --project=chrome`
