### PR TITLE
Add keyed listener dispatch characterization

### DIFF
--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -524,6 +524,24 @@ test("fires a re-keyed listener for the currently dispatched key", () => {
   expect(events).toEqual(["first", "second"]);
 });
 
+test("fires a keyed listener added during the keyed fast path", () => {
+  const store = createStore({ count: 0 });
+  const events: string[] = [];
+
+  const second = () => {
+    events.push("second");
+  };
+
+  subscribe(store, ["count"], () => {
+    events.push("first");
+    subscribe(store, ["count"], second);
+  });
+
+  store.setState("count", 1);
+
+  expect(events).toEqual(["first", "second"]);
+});
+
 test("unsubscribes a keyed listener from inside another keyed listener", () => {
   const store = createStore({ count: 0 });
   const events: string[] = [];


### PR DESCRIPTION
## Motivation

The store keyed listener fast path iterates the live keyed listener set. Existing tests cover re-keying and removal during dispatch, but not adding a new listener for the same key while that fast path is running.

## Solution

Add a focused characterization test that registers only keyed `count` listeners, then subscribes another `count` listener during a `setState` dispatch and asserts it fires in the same dispatch.

## Verification

- `pnpm lint-fix`
- `pnpm test packages/ariakit-store/src/test.ts`
- `pnpm tsc`