### PR TITLE
Add slanted polygon vertex tests

### DIFF
--- a/packages/ariakit-react-components/src/hovercard/utils/polygon.test.ts
+++ b/packages/ariakit-react-components/src/hovercard/utils/polygon.test.ts
@@ -67,6 +67,9 @@ test("isPointInPolygon handles horizontal rays crossing slanted vertices", () =>
   expect(isPointInPolygon([3.5, 1], topPolygon)).toBe(true);
   expect(isPointInPolygon([3, 2], topPolygon)).toBe(true);
   expect(isPointInPolygon([5, 2], topPolygon)).toBe(false);
+  // The apex [3, 0] is a local extremum, so the horizontal ray grazing it must
+  // not be counted as a crossing. Without the vy guard this point would toggle.
+  expect(isPointInPolygon([5, 0], topPolygon)).toBe(false);
 
   const leftPolygon: Polygon = [
     [0, 3],
@@ -81,6 +84,25 @@ test("isPointInPolygon handles horizontal rays crossing slanted vertices", () =>
   expect(isPointInPolygon([1, 3], leftPolygon)).toBe(true);
   expect(isPointInPolygon([1, 3.5], leftPolygon)).toBe(true);
   expect(isPointInPolygon([1, 5], leftPolygon)).toBe(false);
+
+  // Mirror of topPolygon with a downward apex, exercising the same vertex guard
+  // on the opposite (y < vy) branch.
+  const bottomPolygon: Polygon = [
+    [3, 6],
+    [2, 4],
+    [2, 2],
+    [4, 2],
+    [4, 4],
+  ];
+
+  expect(isPointInPolygon([3, 6], bottomPolygon)).toBe(true);
+  expect(isPointInPolygon([2.5, 5], bottomPolygon)).toBe(true);
+  expect(isPointInPolygon([3.5, 5], bottomPolygon)).toBe(true);
+  expect(isPointInPolygon([3, 4], bottomPolygon)).toBe(true);
+  expect(isPointInPolygon([5, 4], bottomPolygon)).toBe(false);
+  // The downward apex [3, 6] is also a local extremum, so its grazing ray must
+  // not toggle either.
+  expect(isPointInPolygon([5, 6], bottomPolygon)).toBe(false);
 });
 
 test("isPointInPolygon returns false for malformed polygons", () => {

--- a/packages/ariakit-react-components/src/hovercard/utils/polygon.test.ts
+++ b/packages/ariakit-react-components/src/hovercard/utils/polygon.test.ts
@@ -53,6 +53,36 @@ test("isPointInPolygon", () => {
   expect(isPointInPolygon([5, 5], polygon)).toBe(false);
 });
 
+test("isPointInPolygon handles horizontal rays crossing slanted vertices", () => {
+  const topPolygon: Polygon = [
+    [3, 0],
+    [2, 2],
+    [2, 4],
+    [4, 4],
+    [4, 2],
+  ];
+
+  expect(isPointInPolygon([3, 0], topPolygon)).toBe(true);
+  expect(isPointInPolygon([2.5, 1], topPolygon)).toBe(true);
+  expect(isPointInPolygon([3.5, 1], topPolygon)).toBe(true);
+  expect(isPointInPolygon([3, 2], topPolygon)).toBe(true);
+  expect(isPointInPolygon([5, 2], topPolygon)).toBe(false);
+
+  const leftPolygon: Polygon = [
+    [0, 3],
+    [2, 2],
+    [4, 2],
+    [4, 4],
+    [2, 4],
+  ];
+
+  expect(isPointInPolygon([0, 3], leftPolygon)).toBe(true);
+  expect(isPointInPolygon([1, 2.5], leftPolygon)).toBe(true);
+  expect(isPointInPolygon([1, 3], leftPolygon)).toBe(true);
+  expect(isPointInPolygon([1, 3.5], leftPolygon)).toBe(true);
+  expect(isPointInPolygon([1, 5], leftPolygon)).toBe(false);
+});
+
 test("isPointInPolygon returns false for malformed polygons", () => {
   const polygon: Array<Point | undefined> = [
     [2, 2],


### PR DESCRIPTION
## Motivation

isPointInPolygon only had an axis-aligned rectangle test, which does not exercise the slanted-vertex branches used by hovercard transit polygons when pointer movement approaches diagonally.

## Solution

Add a focused test with getElementPolygon-style top, left, and bottom approach polygons. The assertions cover apex vertices, slanted edges, and horizontal rays crossing slanted vertices so both vertex-crossing toggle paths are covered. Outside points on each apex's horizontal ray also pin the `vy` extremum-suppression guard on both the `y > vy` (top) and `y < vy` (bottom) branches, so removing the guard makes the suite fail.
