### PR TITLE
Test tag delimiter helpers

### DIFF
--- a/packages/ariakit-react-components/src/tag/tag-input.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-input.tsx
@@ -9,7 +9,6 @@ import {
 } from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
 import {
-  toArray,
   getTextboxSelection,
   setSelectionRange,
   getInputType,
@@ -28,6 +27,7 @@ import type { CompositeItemOptions } from "../composite/composite-item.tsx";
 import { useCompositeItem } from "../composite/composite-item.tsx";
 import { useTagContext } from "./tag-context.tsx";
 import type { TagStore } from "./tag-store.ts";
+import { getDelimiters, splitValueByDelimiter } from "./utils.ts";
 
 const TagName = "input" satisfies ElementType;
 type TagName = typeof TagName;
@@ -36,31 +36,6 @@ type HTMLType = HTMLElementTagNameMap[TagName];
 type EventWithValues<T extends SyntheticEvent> = T & {
   values: string[];
 };
-
-const DEFAULT_DELIMITER = ["\n", ";", ",", /\s/];
-
-function getDelimiters(
-  delimiter: TagInputOptions["delimiter"],
-  defaultDelimiter: TagInputOptions["delimiter"] = DEFAULT_DELIMITER,
-) {
-  const finalDelimiter = delimiter === undefined ? defaultDelimiter : delimiter;
-  if (!finalDelimiter) return [];
-  return toArray(finalDelimiter);
-}
-
-function splitValueByDelimiter(value: string, delimiters: (string | RegExp)[]) {
-  for (const delimiter of delimiters) {
-    let match = value.match(delimiter);
-    // Remove delimiter from the start of the string
-    while (match?.index === 0) {
-      value = value.slice(match[0].length);
-      match = value.match(delimiter);
-    }
-    if (!match) continue;
-    return value.split(delimiter);
-  }
-  return [];
-}
 
 /**
  * Returns props to create a `TagInput` component.

--- a/packages/ariakit-react-components/src/tag/utils.test.ts
+++ b/packages/ariakit-react-components/src/tag/utils.test.ts
@@ -36,6 +36,12 @@ test.each([
     expected: [],
   },
   {
+    name: "no matching delimiter",
+    value: "hello",
+    delimiters: [","],
+    expected: [],
+  },
+  {
     name: "capturing-group regex",
     value: "one,two;three",
     delimiters: [/([,;])/],

--- a/packages/ariakit-react-components/src/tag/utils.test.ts
+++ b/packages/ariakit-react-components/src/tag/utils.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "vitest";
+import { getDelimiters, splitValueByDelimiter } from "./utils.ts";
+
+test("getDelimiters", () => {
+  expect(getDelimiters(undefined)).toEqual(["\n", ";", ",", /\s/]);
+  expect(getDelimiters(null)).toEqual([]);
+  expect(getDelimiters("")).toEqual([]);
+  expect(getDelimiters(undefined, null)).toEqual([]);
+  expect(getDelimiters(undefined, ";")).toEqual([";"]);
+  expect(getDelimiters([",", /\s/])).toEqual([",", /\s/]);
+});
+
+test.each([
+  {
+    name: "array first-match-wins",
+    value: "one,two three",
+    delimiters: [/\s/, ","],
+    expected: ["one,two", "three"],
+  },
+  {
+    name: "leading-delimiter strip",
+    value: ",,one,two",
+    delimiters: [","],
+    expected: ["one", "two"],
+  },
+  {
+    name: "trailing delimiter",
+    value: "one,two,",
+    delimiters: [","],
+    expected: ["one", "two", ""],
+  },
+  {
+    name: "value only delimiter",
+    value: ",",
+    delimiters: [","],
+    expected: [],
+  },
+  {
+    name: "capturing-group regex",
+    value: "one,two;three",
+    delimiters: [/([,;])/],
+    expected: ["one", ",", "two", ";", "three"],
+  },
+  {
+    name: "global-flag regex",
+    value: ",one,two",
+    delimiters: [/,/g],
+    expected: ["", "one", "two"],
+  },
+] as const)(
+  "splitValueByDelimiter $name",
+  ({ value, delimiters, expected }) => {
+    expect(splitValueByDelimiter(value, [...delimiters])).toEqual(expected);
+  },
+);

--- a/packages/ariakit-react-components/src/tag/utils.ts
+++ b/packages/ariakit-react-components/src/tag/utils.ts
@@ -1,5 +1,33 @@
-import { isTouchDevice } from "@ariakit/utils";
+import { isTouchDevice, toArray } from "@ariakit/utils";
 import { useEffect, useState } from "react";
+
+type Delimiter = string | RegExp;
+type TagInputDelimiter = Delimiter | null | Delimiter[];
+
+const DEFAULT_DELIMITER: Delimiter[] = ["\n", ";", ",", /\s/];
+
+export function getDelimiters(
+  delimiter: TagInputDelimiter | undefined,
+  defaultDelimiter: TagInputDelimiter | undefined = DEFAULT_DELIMITER,
+) {
+  const finalDelimiter = delimiter === undefined ? defaultDelimiter : delimiter;
+  if (!finalDelimiter) return [];
+  return toArray(finalDelimiter);
+}
+
+export function splitValueByDelimiter(value: string, delimiters: Delimiter[]) {
+  for (const delimiter of delimiters) {
+    let match = value.match(delimiter);
+    // Remove delimiter from the start of the string
+    while (match?.index === 0) {
+      value = value.slice(match[0].length);
+      match = value.match(delimiter);
+    }
+    if (!match) continue;
+    return value.split(delimiter);
+  }
+  return [];
+}
 
 export function useTouchDevice() {
   const [touchDevice, setTouchDevice] = useState(false);


### PR DESCRIPTION
## Motivation

The tag delimiter helpers contain edge-case logic that is only exercised indirectly today. Direct coverage makes delimiter normalization and splitting behavior easier to preserve across future tag input changes.

## Solution

Move `getDelimiters` and `splitValueByDelimiter` into the existing tag utilities module, then import them from `TagInput`. Add focused Vitest coverage for default, null, and empty delimiters, first matching delimiter precedence, leading and trailing delimiters, delimiter-only input, no matching delimiter, capturing groups, and global regex delimiters.

## Verification

- `pnpm lint-fix`
- `pnpm test packages/ariakit-react-components/src/tag/utils.test.ts`
- `pnpm test examples/combobox-tabs/test.ts`
- `pnpm tsc`
