### PR TITLE
Add heading level computation sandbox tests

### DIFF
--- a/app/src/sandbox/heading-level-computation/index.react.tsx
+++ b/app/src/sandbox/heading-level-computation/index.react.tsx
@@ -1,0 +1,33 @@
+import * as Ariakit from "@ariakit/react";
+import type { ReactNode } from "react";
+
+interface NestedHeadingLevelsProps {
+  children: ReactNode;
+  count: number;
+}
+
+function NestedHeadingLevels({ children, count }: NestedHeadingLevelsProps) {
+  let content = children;
+
+  for (let i = 0; i < count; i += 1) {
+    content = <Ariakit.HeadingLevel>{content}</Ariakit.HeadingLevel>;
+  }
+
+  return <>{content}</>;
+}
+
+export default function Example() {
+  return (
+    <div>
+      <Ariakit.Heading>Standalone heading</Ariakit.Heading>
+
+      <Ariakit.HeadingLevel level={3}>
+        <Ariakit.Heading render={<div />}>Rendered heading</Ariakit.Heading>
+      </Ariakit.HeadingLevel>
+
+      <NestedHeadingLevels count={8}>
+        <Ariakit.Heading>Clamped heading</Ariakit.Heading>
+      </NestedHeadingLevels>
+    </div>
+  );
+}

--- a/app/src/sandbox/heading-level-computation/preview.astro
+++ b/app/src/sandbox/heading-level-computation/preview.astro
@@ -1,0 +1,14 @@
+---
+import PreviewFramework from "#app/components/preview-framework.astro";
+import ReactExample from "./index.react.tsx";
+
+import sourceReact from "./index.react.tsx?source";
+
+export const source = {
+  react: sourceReact,
+};
+---
+
+<PreviewFramework>
+  <ReactExample client:load slot="react" />
+</PreviewFramework>

--- a/app/src/sandbox/heading-level-computation/preview.mdx
+++ b/app/src/sandbox/heading-level-computation/preview.mdx
@@ -1,0 +1,9 @@
+---
+title: "heading-level-computation"
+frameworks:
+  - react
+---
+
+import Preview from "./preview.astro";
+
+<Preview />

--- a/app/src/sandbox/heading-level-computation/test-browser.ts
+++ b/app/src/sandbox/heading-level-computation/test-browser.ts
@@ -1,0 +1,32 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("standalone Heading defaults to native h1 without aria-level", async ({
+    q,
+  }) => {
+    const heading = q.heading("Standalone heading", { level: 1 });
+
+    await test.expect(heading).toBeVisible();
+    await test.expect(heading).toHaveJSProperty("tagName", "H1");
+    await test.expect(heading).not.toHaveAttribute("aria-level");
+  });
+
+  test("Heading rendered as div falls back to role and aria-level", async ({
+    q,
+  }) => {
+    const heading = q.heading("Rendered heading", { level: 3 });
+
+    await test.expect(heading).toBeVisible();
+    await test.expect(heading).toHaveJSProperty("tagName", "DIV");
+    await test.expect(heading).toHaveAttribute("role", "heading");
+    await test.expect(heading).toHaveAttribute("aria-level", "3");
+  });
+
+  test("nested HeadingLevel clamps computed levels to h6", async ({ q }) => {
+    const heading = q.heading("Clamped heading", { level: 6 });
+
+    await test.expect(heading).toBeVisible();
+    await test.expect(heading).toHaveJSProperty("tagName", "H6");
+    await test.expect(heading).not.toHaveAttribute("aria-level");
+  });
+});


### PR DESCRIPTION
## Motivation

The Heading level-computation paths had only shallow example coverage. T038 calls out three untested branches: standalone `Heading` defaulting to level 1, non-native heading fallback attributes, and `HeadingLevel` clamping nested levels at 6.

## Solution

Add a focused `app/src/sandbox/heading-level-computation` React sandbox, following the audit note to keep this coverage under `app/src/sandbox`. The sandbox renders a standalone heading, a `Heading` rendered as a `div` inside an explicit level context, and a deeply nested `HeadingLevel` tree.

The browser test asserts the resulting accessible heading levels, native tag names, and fallback `role="heading"`/`aria-level` attributes.

## Verification

- `pnpm lint-fix`
- `APP_PORT=5173 NEXTJS_PORT=3001 pnpm -F app test src/sandbox/heading-level-computation/test-browser.ts --project=chrome --project=firefox --project=safari`
- `pnpm tsc`
