### PR TITLE
Guard dialog cleanup stacks

### DIFF
--- a/.changeset/300-dialog-cleanup-stack.md
+++ b/.changeset/300-dialog-cleanup-stack.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Dialog`](https://ariakit.com/reference/dialog) cleanup so stale nested dialog effects no longer restore page accessibility state while a newer effect is active.

--- a/packages/ariakit-react-components/src/dialog/utils/__tests__/orchestrate.test.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/__tests__/orchestrate.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, expect, test } from "vitest";
 import { disableTreeOutside } from "../disable-tree.ts";
 import { isElementMarked, markTreeOutside } from "../mark-tree-outside.ts";
-import { setAttribute } from "../orchestrate.ts";
+import { assignStyle, setAttribute } from "../orchestrate.ts";
 import { supportsInert } from "../supports-inert.ts";
 import {
   createWalkTreeSnapshot,
@@ -36,10 +36,6 @@ test("orchestrate restores cleanup stacks in LIFO order", () => {
 
   expect(element.getAttribute("data-value")).toBe("three");
 
-  restoreTwo();
-
-  expect(element.getAttribute("data-value")).toBe("three");
-
   restoreThree();
 
   expect(element.getAttribute("data-value")).toBe("two");
@@ -53,7 +49,7 @@ test("orchestrate restores cleanup stacks in LIFO order", () => {
   expect(element.getAttribute("data-value")).toBe("initial");
 });
 
-test("orchestrate ignores the initial cleanup when it is no longer current", () => {
+test("orchestrate defers the initial cleanup until it is current", () => {
   const element = document.createElement("div");
   element.setAttribute("role", "original");
 
@@ -66,11 +62,48 @@ test("orchestrate ignores the initial cleanup when it is no longer current", () 
 
   restoreTwo();
 
-  expect(element.getAttribute("role")).toBe("one");
+  expect(element.getAttribute("role")).toBe("original");
 
   restoreOne();
 
   expect(element.getAttribute("role")).toBe("original");
+});
+
+test("orchestrate skips disposed entries when restoring previous cleanups", () => {
+  const element = document.createElement("div");
+  element.setAttribute("data-value", "initial");
+
+  const restoreOne = setAttribute(element, "data-value", "one");
+  const restoreTwo = setAttribute(element, "data-value", "two");
+  const restoreThree = setAttribute(element, "data-value", "three");
+
+  restoreTwo();
+
+  expect(element.getAttribute("data-value")).toBe("three");
+
+  restoreThree();
+
+  expect(element.getAttribute("data-value")).toBe("one");
+
+  restoreOne();
+
+  expect(element.getAttribute("data-value")).toBe("initial");
+});
+
+test("orchestrate defers stale style cleanups", () => {
+  const element = document.createElement("div");
+  element.style.display = "flex";
+
+  const restoreOne = assignStyle(element, { display: "block" });
+  const restoreTwo = assignStyle(element, { display: "none" });
+
+  restoreOne();
+
+  expect(element.style.display).toBe("none");
+
+  restoreTwo();
+
+  expect(element.style.display).toBe("flex");
 });
 
 test("orchestrate keeps element and key cleanup stacks independent", () => {

--- a/packages/ariakit-react-components/src/dialog/utils/__tests__/orchestrate.test.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/__tests__/orchestrate.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, expect, test } from "vitest";
+import { disableTreeOutside } from "../disable-tree.ts";
+import { isElementMarked, markTreeOutside } from "../mark-tree-outside.ts";
+import { orchestrate, setAttribute } from "../orchestrate.ts";
+import { supportsInert } from "../supports-inert.ts";
+import {
+  createWalkTreeSnapshot,
+  walkTreeOutside,
+} from "../walk-tree-outside.ts";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+function getElement(id: string) {
+  const element = document.getElementById(id);
+  if (!element) throw new Error(`Element not found: ${id}`);
+  return element;
+}
+
+function setAttributeWithOrchestrate(
+  element: Element,
+  attribute: string,
+  value: string,
+) {
+  return orchestrate(element, attribute, () => {
+    const previousValue = element.getAttribute(attribute);
+    element.setAttribute(attribute, value);
+    return () => {
+      if (previousValue == null) {
+        element.removeAttribute(attribute);
+      } else {
+        element.setAttribute(attribute, previousValue);
+      }
+    };
+  });
+}
+
+function getWalkedElementIds(id: string, elements: Array<Element | null>) {
+  const ids: string[] = [];
+  walkTreeOutside(id, elements, (element) => {
+    ids.push(element.id);
+  });
+  return ids;
+}
+
+test("orchestrate restores cleanup stacks in LIFO order", () => {
+  const element = document.createElement("div");
+  element.setAttribute("data-value", "initial");
+
+  const restoreOne = setAttributeWithOrchestrate(element, "data-value", "one");
+  const restoreTwo = setAttributeWithOrchestrate(element, "data-value", "two");
+  const restoreThree = setAttributeWithOrchestrate(
+    element,
+    "data-value",
+    "three",
+  );
+
+  expect(element.getAttribute("data-value")).toBe("three");
+
+  restoreTwo();
+
+  expect(element.getAttribute("data-value")).toBe("three");
+
+  restoreThree();
+
+  expect(element.getAttribute("data-value")).toBe("two");
+
+  restoreTwo();
+
+  expect(element.getAttribute("data-value")).toBe("one");
+
+  restoreOne();
+
+  expect(element.getAttribute("data-value")).toBe("initial");
+});
+
+test("orchestrate ignores the initial cleanup when it is no longer current", () => {
+  const element = document.createElement("div");
+  element.setAttribute("role", "original");
+
+  const restoreOne = setAttribute(element, "role", "one");
+  const restoreTwo = setAttribute(element, "role", "two");
+
+  restoreOne();
+
+  expect(element.getAttribute("role")).toBe("two");
+
+  restoreTwo();
+
+  expect(element.getAttribute("role")).toBe("one");
+
+  restoreOne();
+
+  expect(element.getAttribute("role")).toBe("original");
+});
+
+test("orchestrate keeps element and key cleanup stacks independent", () => {
+  const element = document.createElement("div");
+  const otherElement = document.createElement("div");
+
+  const restoreElementValue = setAttributeWithOrchestrate(
+    element,
+    "data-value",
+    "value",
+  );
+  setAttributeWithOrchestrate(element, "data-other", "other");
+  setAttributeWithOrchestrate(otherElement, "data-value", "other-value");
+
+  restoreElementValue();
+
+  expect(element.hasAttribute("data-value")).toBe(false);
+  expect(element.getAttribute("data-other")).toBe("other");
+  expect(otherElement.getAttribute("data-value")).toBe("other-value");
+});
+
+test("walkTreeOutside skips nested elements that share an ancestor", () => {
+  document.body.innerHTML = `
+    <div id="root">
+      <section id="outside"></section>
+      <div id="dialog">
+        <button id="button"></button>
+      </div>
+      <section id="sibling"></section>
+    </div>
+  `;
+
+  const dialog = getElement("dialog");
+  const button = getElement("button");
+  const walked: string[] = [];
+
+  walkTreeOutside("dialog", [dialog, button], (element, originalElement) => {
+    walked.push(`${originalElement.id}:${element.id}`);
+  });
+
+  expect(walked).toEqual(["dialog:outside", "dialog:sibling"]);
+});
+
+test("walkTreeOutside skips elements outside the active snapshot", () => {
+  document.body.innerHTML = `
+    <div id="root">
+      <div id="dialog"></div>
+      <section id="before"></section>
+    </div>
+  `;
+
+  const dialog = getElement("dialog");
+  const root = getElement("root");
+  const restoreSnapshot = createWalkTreeSnapshot("dialog", [dialog]);
+  const after = document.createElement("section");
+  after.id = "after";
+  root.append(after);
+
+  expect(getWalkedElementIds("dialog", [dialog])).toEqual(["before"]);
+
+  restoreSnapshot();
+
+  expect(getWalkedElementIds("dialog", [dialog])).toEqual(["before", "after"]);
+});
+
+test("markTreeOutside skips backdrops and restores marks", () => {
+  document.body.innerHTML = `
+    <div id="root">
+      <div id="dialog" data-dialog></div>
+      <section id="outside">
+        <span id="outside-child"></span>
+      </section>
+      <div id="backdrop" data-backdrop="dialog"></div>
+    </div>
+  `;
+
+  const dialog = getElement("dialog");
+  const outside = getElement("outside");
+  const outsideChild = getElement("outside-child");
+  const backdrop = getElement("backdrop");
+
+  const restoreMarks = markTreeOutside("dialog", [dialog]);
+
+  expect(isElementMarked(outside, "dialog")).toBe(true);
+  expect(isElementMarked(outsideChild, "dialog")).toBe(true);
+  expect(isElementMarked(backdrop, "dialog")).toBe(false);
+
+  restoreMarks();
+
+  expect(isElementMarked(outside, "dialog")).toBe(false);
+  expect(isElementMarked(outsideChild, "dialog")).toBe(false);
+  expect(isElementMarked(backdrop, "dialog")).toBe(false);
+});
+
+test("markTreeOutside restores previous marks after nested cleanup", () => {
+  document.body.innerHTML = `
+    <div id="root">
+      <div id="dialog-one" data-dialog></div>
+      <div id="dialog-two" data-dialog></div>
+      <section id="outside"></section>
+    </div>
+  `;
+
+  const dialogOne = getElement("dialog-one");
+  const dialogTwo = getElement("dialog-two");
+  const outside = getElement("outside");
+
+  const restoreOne = markTreeOutside("one", [dialogOne]);
+  const restoreTwo = markTreeOutside("two", [dialogTwo]);
+
+  expect(isElementMarked(outside, "one")).toBe(true);
+  expect(isElementMarked(outside, "two")).toBe(true);
+
+  restoreTwo();
+
+  expect(isElementMarked(outside, "one")).toBe(true);
+  expect(isElementMarked(outside, "two")).toBe(false);
+
+  restoreOne();
+
+  expect(isElementMarked(outside, "one")).toBe(false);
+  expect(isElementMarked(outside, "two")).toBe(false);
+});
+
+test("disableTreeOutside skips focus traps and restores disabled elements", () => {
+  document.body.innerHTML = `
+    <div id="root">
+      <div id="dialog"></div>
+      <span id="focus-trap" data-focus-trap="dialog"></span>
+      <section id="outside">
+        <button id="button">Button</button>
+      </section>
+    </div>
+  `;
+
+  const dialog = getElement("dialog");
+  const focusTrap = getElement("focus-trap");
+  const outside = getElement("outside");
+
+  const restoreTree = disableTreeOutside("dialog", [dialog]);
+
+  if (supportsInert()) {
+    expect(outside.inert).toBe(true);
+    expect(focusTrap.inert).toBe(false);
+  } else {
+    expect(outside.getAttribute("aria-hidden")).toBe("true");
+    expect(outside.style.pointerEvents).toBe("none");
+    expect(focusTrap.hasAttribute("aria-hidden")).toBe(false);
+    expect(focusTrap.style.pointerEvents).toBe("");
+  }
+
+  restoreTree();
+
+  if (supportsInert()) {
+    expect(outside.inert).toBe(false);
+  } else {
+    expect(outside.hasAttribute("aria-hidden")).toBe(false);
+    expect(outside.style.pointerEvents).toBe("");
+  }
+});

--- a/packages/ariakit-react-components/src/dialog/utils/__tests__/orchestrate.test.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/__tests__/orchestrate.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, expect, test } from "vitest";
 import { disableTreeOutside } from "../disable-tree.ts";
 import { isElementMarked, markTreeOutside } from "../mark-tree-outside.ts";
-import { orchestrate, setAttribute } from "../orchestrate.ts";
+import { setAttribute } from "../orchestrate.ts";
 import { supportsInert } from "../supports-inert.ts";
 import {
   createWalkTreeSnapshot,
@@ -18,24 +18,6 @@ function getElement(id: string) {
   return element;
 }
 
-function setAttributeWithOrchestrate(
-  element: Element,
-  attribute: string,
-  value: string,
-) {
-  return orchestrate(element, attribute, () => {
-    const previousValue = element.getAttribute(attribute);
-    element.setAttribute(attribute, value);
-    return () => {
-      if (previousValue == null) {
-        element.removeAttribute(attribute);
-      } else {
-        element.setAttribute(attribute, previousValue);
-      }
-    };
-  });
-}
-
 function getWalkedElementIds(id: string, elements: Array<Element | null>) {
   const ids: string[] = [];
   walkTreeOutside(id, elements, (element) => {
@@ -48,13 +30,9 @@ test("orchestrate restores cleanup stacks in LIFO order", () => {
   const element = document.createElement("div");
   element.setAttribute("data-value", "initial");
 
-  const restoreOne = setAttributeWithOrchestrate(element, "data-value", "one");
-  const restoreTwo = setAttributeWithOrchestrate(element, "data-value", "two");
-  const restoreThree = setAttributeWithOrchestrate(
-    element,
-    "data-value",
-    "three",
-  );
+  const restoreOne = setAttribute(element, "data-value", "one");
+  const restoreTwo = setAttribute(element, "data-value", "two");
+  const restoreThree = setAttribute(element, "data-value", "three");
 
   expect(element.getAttribute("data-value")).toBe("three");
 
@@ -99,13 +77,9 @@ test("orchestrate keeps element and key cleanup stacks independent", () => {
   const element = document.createElement("div");
   const otherElement = document.createElement("div");
 
-  const restoreElementValue = setAttributeWithOrchestrate(
-    element,
-    "data-value",
-    "value",
-  );
-  setAttributeWithOrchestrate(element, "data-other", "other");
-  setAttributeWithOrchestrate(otherElement, "data-value", "other-value");
+  const restoreElementValue = setAttribute(element, "data-value", "value");
+  setAttribute(element, "data-other", "other");
+  setAttribute(otherElement, "data-value", "other-value");
 
   restoreElementValue();
 

--- a/packages/ariakit-react-components/src/dialog/utils/orchestrate.test.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/orchestrate.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, expect, test } from "vitest";
-import { disableTreeOutside } from "../disable-tree.ts";
-import { isElementMarked, markTreeOutside } from "../mark-tree-outside.ts";
-import { assignStyle, setAttribute } from "../orchestrate.ts";
-import { supportsInert } from "../supports-inert.ts";
+import { disableTreeOutside } from "./disable-tree.ts";
+import { isElementMarked, markTreeOutside } from "./mark-tree-outside.ts";
+import { assignStyle, setAttribute } from "./orchestrate.ts";
+import { supportsInert } from "./supports-inert.ts";
 import {
   createWalkTreeSnapshot,
   walkTreeOutside,
-} from "../walk-tree-outside.ts";
+} from "./walk-tree-outside.ts";
 
 afterEach(() => {
   document.body.innerHTML = "";

--- a/packages/ariakit-react-components/src/dialog/utils/orchestrate.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/orchestrate.ts
@@ -13,9 +13,12 @@ export function orchestrate(
   const prevCleanup = elementCleanups.get(key);
 
   if (!prevCleanup) {
-    elementCleanups.set(key, setup());
+    const cleanup = setup();
+    elementCleanups.set(key, cleanup);
     return () => {
-      elementCleanups.get(key)?.();
+      const isCurrent = elementCleanups.get(key) === cleanup;
+      if (!isCurrent) return;
+      cleanup();
       elementCleanups.delete(key);
     };
   }

--- a/packages/ariakit-react-components/src/dialog/utils/orchestrate.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/orchestrate.ts
@@ -1,4 +1,27 @@
-const cleanups = new WeakMap<Element, Map<string, () => void>>();
+interface CleanupEntry {
+  cleanup: () => void;
+  disposed: boolean;
+}
+
+const cleanups = new WeakMap<Element, Map<string, CleanupEntry[]>>();
+
+function flushCleanupStack(
+  elementCleanups: Map<string, CleanupEntry[]>,
+  key: string,
+  stack: CleanupEntry[],
+) {
+  while (stack.length) {
+    const entry = stack[stack.length - 1];
+    if (!entry) {
+      elementCleanups.delete(key);
+      return;
+    }
+    if (!entry.disposed) return;
+    stack.pop();
+    entry.cleanup();
+  }
+  elementCleanups.delete(key);
+}
 
 export function orchestrate(
   element: Element,
@@ -10,34 +33,18 @@ export function orchestrate(
   }
 
   const elementCleanups = cleanups.get(element)!;
-  const prevCleanup = elementCleanups.get(key);
+  const stack = elementCleanups.get(key) ?? [];
+  const entry: CleanupEntry = { cleanup: setup(), disposed: false };
 
-  if (!prevCleanup) {
-    const cleanup = setup();
-    elementCleanups.set(key, cleanup);
-    return () => {
-      const isCurrent = elementCleanups.get(key) === cleanup;
-      if (!isCurrent) return;
-      cleanup();
-      elementCleanups.delete(key);
-    };
+  if (!stack.length) {
+    elementCleanups.set(key, stack);
   }
-
-  const cleanup = setup();
-
-  const nextCleanup = () => {
-    cleanup();
-    prevCleanup();
-    elementCleanups.delete(key);
-  };
-
-  elementCleanups.set(key, nextCleanup);
+  stack.push(entry);
 
   return () => {
-    const isCurrent = elementCleanups.get(key) === nextCleanup;
-    if (!isCurrent) return;
-    cleanup();
-    elementCleanups.set(key, prevCleanup);
+    if (!stack.includes(entry)) return;
+    entry.disposed = true;
+    flushCleanupStack(elementCleanups, key, stack);
   };
 }
 


### PR DESCRIPTION
## Motivation

Dialog cleanup utilities stack per-element cleanup functions for inert, aria-hidden, role, and style restoration across nested dialogs. The riskiest tree-walking and cleanup primitives lacked direct unit tests, and the first cleanup registered for a key could still run a newer stacked cleanup when invoked after another setup became current.

## Solution

Add direct jsdom tests for the dialog cleanup primitives: orchestrated LIFO cleanup, stale cleanup no-ops, per-element/key isolation, tree-walk ancestor deduping, snapshot gating, backdrop and focus-trap exclusions, and mark/disable restore behavior.

Update the initial `orchestrate` cleanup path so it checks that its cleanup is still current before running, matching the guard already used by later stacked cleanups. Add a patch changeset for the user-facing Dialog cleanup fix.
