### PR TITLE
Add disclosure content transition lifecycle sandbox

### DIFF
--- a/app/src/sandbox/disclosure-content-transition-lifecycle/index.react.tsx
+++ b/app/src/sandbox/disclosure-content-transition-lifecycle/index.react.tsx
@@ -1,0 +1,56 @@
+import * as Ariakit from "@ariakit/react";
+
+interface DisclosureExampleProps {
+  animated?: boolean | number;
+  content: string;
+  label: string;
+  unmountOnHide?: boolean;
+}
+
+function DisclosureExample({
+  animated,
+  content,
+  label,
+  unmountOnHide,
+}: DisclosureExampleProps) {
+  const store = Ariakit.useDisclosureStore({ animated });
+  const animatedState = Ariakit.useStoreState(store, "animated");
+  const animating = Ariakit.useStoreState(store, "animating");
+  const mounted = Ariakit.useStoreState(store, "mounted");
+
+  return (
+    <section
+      aria-label={label}
+      data-animated-state={String(animatedState)}
+      data-animating-state={String(animating)}
+      data-mounted-state={String(mounted)}
+    >
+      <Ariakit.Disclosure store={store}>Toggle {label}</Ariakit.Disclosure>
+      <Ariakit.DisclosureContent store={store} unmountOnHide={unmountOnHide}>
+        {content}
+      </Ariakit.DisclosureContent>
+    </section>
+  );
+}
+
+export default function Example() {
+  return (
+    <div>
+      <DisclosureExample
+        label="No transition"
+        content="No transition content"
+      />
+      <DisclosureExample
+        label="Unmount on hide"
+        content="Unmounted no transition content"
+        unmountOnHide
+      />
+      <DisclosureExample
+        label="Timed unmount"
+        content="Timed unmount content"
+        animated={1000}
+        unmountOnHide
+      />
+    </div>
+  );
+}

--- a/app/src/sandbox/disclosure-content-transition-lifecycle/preview.astro
+++ b/app/src/sandbox/disclosure-content-transition-lifecycle/preview.astro
@@ -1,0 +1,14 @@
+---
+import PreviewFramework from "#app/components/preview-framework.astro";
+import ReactExample from "./index.react.tsx";
+
+import sourceReact from "./index.react.tsx?source";
+
+export const source = {
+  react: sourceReact,
+};
+---
+
+<PreviewFramework>
+  <ReactExample client:load slot="react" />
+</PreviewFramework>

--- a/app/src/sandbox/disclosure-content-transition-lifecycle/preview.mdx
+++ b/app/src/sandbox/disclosure-content-transition-lifecycle/preview.mdx
@@ -1,0 +1,9 @@
+---
+title: "Disclosure content transition lifecycle"
+frameworks:
+  - react
+---
+
+import Preview from "./preview.astro";
+
+<Preview />

--- a/app/src/sandbox/disclosure-content-transition-lifecycle/test-browser.ts
+++ b/app/src/sandbox/disclosure-content-transition-lifecycle/test-browser.ts
@@ -1,0 +1,76 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ query, test }) => {
+  test("restores data-enter after a no-transition close", async ({ q }) => {
+    const section = q.region("No transition");
+    const withinSection = query(section);
+    const content = withinSection.text("No transition content");
+
+    await test.expect(content).toBeHidden();
+    await test.expect(section).toHaveAttribute("data-animated-state", "true");
+
+    await withinSection.button("Toggle No transition").click();
+    await test.expect(content).toBeVisible();
+    await test.expect(content).toHaveAttribute("data-enter", "true");
+    await test.expect(section).toHaveAttribute("data-animated-state", "false");
+    await test.expect(section).toHaveAttribute("data-animating-state", "false");
+
+    await withinSection.button("Toggle No transition").click();
+    await test.expect(content).toBeHidden();
+    await test.expect(content).not.toHaveAttribute("data-enter");
+    await test.expect(section).toHaveAttribute("data-mounted-state", "false");
+
+    await withinSection.button("Toggle No transition").click();
+    await test.expect(content).toBeVisible();
+    await test.expect(content).toHaveAttribute("data-enter", "true");
+  });
+
+  test("unmounts immediately after no-transition enter detection", async ({
+    q,
+  }) => {
+    const section = q.region("Unmount on hide");
+    const withinSection = query(section);
+    const content = withinSection.text("Unmounted no transition content");
+
+    await test.expect(content).not.toBeAttached();
+
+    await withinSection.button("Toggle Unmount on hide").click();
+    await test.expect(content).toBeVisible();
+    await test.expect(content).toHaveAttribute("data-enter", "true");
+    await test.expect(section).toHaveAttribute("data-animated-state", "false");
+    await test.expect(section).toHaveAttribute("data-animating-state", "false");
+
+    await withinSection.button("Toggle Unmount on hide").click();
+    await test.expect(content).not.toBeAttached();
+    await test.expect(section).toHaveAttribute("data-mounted-state", "false");
+    await test.expect(section).toHaveAttribute("data-animating-state", "false");
+
+    await withinSection.button("Toggle Unmount on hide").click();
+    await test.expect(content).toBeVisible();
+    await test.expect(content).toHaveAttribute("data-enter", "true");
+    await test.expect(section).toHaveAttribute("data-animated-state", "false");
+  });
+
+  test("keeps unmountOnHide content mounted for numeric timeouts", async ({
+    q,
+  }) => {
+    const section = q.region("Timed unmount");
+    const withinSection = query(section);
+    const content = withinSection.text("Timed unmount content");
+
+    await test.expect(content).not.toBeAttached();
+    await test.expect(section).toHaveAttribute("data-animated-state", "1000");
+
+    await withinSection.button("Toggle Timed unmount").click();
+    await test.expect(content).toBeVisible();
+    await test.expect(content).toHaveAttribute("data-enter", "true");
+    await test.expect(section).toHaveAttribute("data-animated-state", "1000");
+
+    await withinSection.button("Toggle Timed unmount").click();
+    await test.expect(content).toBeAttached();
+    await test.expect(content).toHaveAttribute("data-leave", "true");
+    await test.expect(section).toHaveAttribute("data-mounted-state", "true");
+    await test.expect(content).not.toBeAttached();
+    await test.expect(section).toHaveAttribute("data-mounted-state", "false");
+  });
+});


### PR DESCRIPTION
## Motivation

DisclosureContent has transition lifecycle branches that need example-level coverage: no-transition reopen should restore `data-enter`, zero-timeout enter detection should disable animation state, and `unmountOnHide` should respect immediate and numeric-timeout timing. The audit requested this coverage in `app/src/sandbox`.

## Solution

Add a React sandbox that renders isolated DisclosureContent cases with no transition styles, `unmountOnHide`, and a numeric animated timeout. Add browser tests that assert `data-enter` open/close/reopen behavior, zero-timeout `animated`/`animating` state, immediate unmount timing, and numeric timeout leave-before-unmount behavior across the preview.

## Verification

- `pnpm lint-fix`
- `APP_PORT=4322 NEXTJS_PORT=3003 pnpm -F app test src/sandbox/disclosure-content-transition-lifecycle/test-browser.ts --project=chrome --project=firefox --project=safari`
- `pnpm tsc`