### PR TITLE
Add tooltip cross-anchor sandbox coverage

### DIFF
--- a/app/src/sandbox/tooltip-cross-anchor/index.react.tsx
+++ b/app/src/sandbox/tooltip-cross-anchor/index.react.tsx
@@ -1,0 +1,40 @@
+import * as Ariakit from "@ariakit/react";
+import { StrictMode } from "react";
+
+const tooltipProps = {
+  showTimeout: 500,
+  skipTimeout: 100,
+};
+
+interface DelayedTooltipProps {
+  anchor: string;
+  tooltip: string;
+}
+
+function DelayedTooltip({ anchor, tooltip }: DelayedTooltipProps) {
+  return (
+    <Ariakit.TooltipProvider {...tooltipProps}>
+      <Ariakit.TooltipAnchor render={<button type="button" />}>
+        {anchor}
+      </Ariakit.TooltipAnchor>
+      <Ariakit.Tooltip>{tooltip}</Ariakit.Tooltip>
+    </Ariakit.TooltipProvider>
+  );
+}
+
+export default function Example() {
+  return (
+    <StrictMode>
+      <div
+        style={{
+          display: "flex",
+          gap: 40,
+          padding: 80,
+        }}
+      >
+        <DelayedTooltip anchor="First anchor" tooltip="First tooltip" />
+        <DelayedTooltip anchor="Second anchor" tooltip="Second tooltip" />
+      </div>
+    </StrictMode>
+  );
+}

--- a/app/src/sandbox/tooltip-cross-anchor/preview.astro
+++ b/app/src/sandbox/tooltip-cross-anchor/preview.astro
@@ -1,0 +1,14 @@
+---
+import PreviewFramework from "#app/components/preview-framework.astro";
+import ReactExample from "./index.react.tsx";
+
+import sourceReact from "./index.react.tsx?source";
+
+export const source = {
+  react: sourceReact,
+};
+---
+
+<PreviewFramework>
+  <ReactExample client:load slot="react" />
+</PreviewFramework>

--- a/app/src/sandbox/tooltip-cross-anchor/preview.mdx
+++ b/app/src/sandbox/tooltip-cross-anchor/preview.mdx
@@ -1,0 +1,9 @@
+---
+title: "tooltip-cross-anchor"
+frameworks:
+  - react
+---
+
+import Preview from "./preview.astro";
+
+<Preview />

--- a/app/src/sandbox/tooltip-cross-anchor/test-browser.ts
+++ b/app/src/sandbox/tooltip-cross-anchor/test-browser.ts
@@ -1,0 +1,31 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+const midwayToShowTimeout = 250;
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("shows another tooltip immediately while one is active", async ({
+    page,
+    q,
+  }) => {
+    await page.mouse.move(0, 0);
+
+    await q.button("First anchor").hover();
+    await test.expect(q.tooltip("First tooltip")).toBeVisible();
+
+    await q.button("Second anchor").hover();
+    await test
+      .expect(q.tooltip("Second tooltip"))
+      .toBeVisible({ timeout: midwayToShowTimeout });
+    await test.expect(q.tooltip("First tooltip")).not.toBeVisible();
+
+    await page.mouse.move(0, 0);
+    await test.expect(q.tooltip("Second tooltip")).not.toBeVisible();
+
+    // This must be greater than skipTimeout and less than showTimeout.
+    await page.waitForTimeout(midwayToShowTimeout);
+    await q.button("First anchor").hover();
+    await page.waitForTimeout(midwayToShowTimeout);
+    await test.expect(q.tooltip("First tooltip")).not.toBeVisible();
+    await test.expect(q.tooltip("First tooltip")).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Motivation

Tooltip anchors use shared active-store coordination so hovering a second independent tooltip can skip the normal show delay while another tooltip is active. T062 identified that this cross-anchor behavior was not covered by the newer app sandbox tests.

## Solution

Add a `tooltip-cross-anchor` app sandbox with two independent `TooltipProvider` pairs configured with a non-zero `showTimeout` and a short `skipTimeout`. The browser test verifies that the second tooltip appears before the show timeout while the first tooltip is active, that the first tooltip is hidden, and that after hovering away past the skip window the next hover waits again.

## Verification

- `pnpm lint-fix`
- `pnpm -F nextjs build-worker`
- `pnpm -F app build-lite`
- `APP_PORT=4465 NEXTJS_PORT=3465 pnpm -F app test-chrome src/sandbox/tooltip-cross-anchor/test-browser.ts`
- `pnpm tsc`