### PR TITLE
Add audit coverage for focus and store utilities

### DIFF
--- a/app/src/sandbox/focus-trap-region/index.react.tsx
+++ b/app/src/sandbox/focus-trap-region/index.react.tsx
@@ -1,0 +1,94 @@
+import * as Ariakit from "@ariakit/react";
+import type { CSSProperties } from "react";
+import { useState } from "react";
+
+const sectionStyle = {
+  display: "grid",
+  gap: 8,
+  padding: 16,
+  border: "1px solid hsl(0 0% 80%)",
+  borderRadius: 8,
+} satisfies CSSProperties;
+
+const regionStyle = {
+  display: "flex",
+  gap: 8,
+  alignItems: "center",
+} satisfies CSSProperties;
+
+export default function Example() {
+  const [multipleEnabled, setMultipleEnabled] = useState(false);
+  const [singleEnabled, setSingleEnabled] = useState(false);
+  const [emptyEnabled, setEmptyEnabled] = useState(false);
+
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <section style={sectionStyle}>
+        <button>Before multiple</button>
+        <Ariakit.FocusTrapRegion
+          aria-label="Multiple focus trap"
+          enabled={multipleEnabled}
+          style={regionStyle}
+        >
+          <label>
+            <input
+              checked={multipleEnabled}
+              onChange={(event) => setMultipleEnabled(event.target.checked)}
+              type="checkbox"
+            />{" "}
+            Trap multiple
+          </label>
+          <Ariakit.Button>Button 1</Ariakit.Button>
+          <Ariakit.Button>Button 2</Ariakit.Button>
+          <label>
+            Multi input
+            <input />
+          </label>
+        </Ariakit.FocusTrapRegion>
+        <button>After multiple</button>
+      </section>
+
+      <section style={sectionStyle}>
+        <label>
+          <input
+            checked={singleEnabled}
+            onChange={(event) => setSingleEnabled(event.target.checked)}
+            type="checkbox"
+          />{" "}
+          Enable single trap
+        </label>
+        <button>Before single</button>
+        <Ariakit.FocusTrapRegion
+          aria-label="Single focus trap"
+          enabled={singleEnabled}
+          style={regionStyle}
+        >
+          <Ariakit.Button>Single button</Ariakit.Button>
+        </Ariakit.FocusTrapRegion>
+        <button>After single</button>
+      </section>
+
+      <section style={sectionStyle}>
+        <label>
+          <input
+            checked={emptyEnabled}
+            onChange={(event) => setEmptyEnabled(event.target.checked)}
+            type="checkbox"
+          />{" "}
+          Enable empty trap
+        </label>
+        <button>Before empty</button>
+        <Ariakit.FocusTrapRegion
+          aria-label="Empty focus trap"
+          enabled={emptyEnabled}
+          role="region"
+          style={regionStyle}
+          tabIndex={-1}
+        >
+          <Ariakit.Button disabled>Disabled button</Ariakit.Button>
+        </Ariakit.FocusTrapRegion>
+        <button>After empty</button>
+      </section>
+    </div>
+  );
+}

--- a/app/src/sandbox/focus-trap-region/index.react.tsx
+++ b/app/src/sandbox/focus-trap-region/index.react.tsx
@@ -34,6 +34,8 @@ export default function Example() {
             <input
               checked={multipleEnabled}
               onChange={(event) => setMultipleEnabled(event.target.checked)}
+              // WebKit focuses the clicked checkbox only when explicitly tabbable.
+              tabIndex={0}
               type="checkbox"
             />{" "}
             Trap multiple

--- a/app/src/sandbox/focus-trap-region/preview.astro
+++ b/app/src/sandbox/focus-trap-region/preview.astro
@@ -1,0 +1,14 @@
+---
+import PreviewFramework from "#app/components/preview-framework.astro";
+import ReactExample from "./index.react.tsx";
+
+import sourceReact from "./index.react.tsx?source";
+
+export const source = {
+  react: sourceReact,
+};
+---
+
+<PreviewFramework>
+  <ReactExample client:load slot="react" />
+</PreviewFramework>

--- a/app/src/sandbox/focus-trap-region/preview.mdx
+++ b/app/src/sandbox/focus-trap-region/preview.mdx
@@ -1,0 +1,9 @@
+---
+title: Focus trap region
+frameworks:
+  - react
+---
+
+import Preview from "./preview.astro";
+
+<Preview />

--- a/app/src/sandbox/focus-trap-region/test-browser.ts
+++ b/app/src/sandbox/focus-trap-region/test-browser.ts
@@ -1,0 +1,66 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("wraps backward from the first tabbable element", async ({
+    page,
+    q,
+  }) => {
+    const checkbox = q.checkbox("Trap multiple");
+    await checkbox.click();
+    await test.expect(checkbox).toBeFocused();
+
+    await page.keyboard.press("Shift+Tab");
+
+    await test.expect(q.textbox("Multi input")).toBeFocused();
+  });
+
+  test("keeps focus on a single tabbable element", async ({ page, q }) => {
+    await q.checkbox("Enable single trap").click();
+
+    const button = q.button("Single button");
+    await button.click();
+    await test.expect(button).toBeFocused();
+
+    await page.keyboard.press("Tab");
+    await test.expect(button).toBeFocused();
+
+    await page.keyboard.press("Shift+Tab");
+    await test.expect(button).toBeFocused();
+  });
+
+  test("keeps focus on an explicitly focusable empty region", async ({
+    page,
+    q,
+  }) => {
+    await q.checkbox("Enable empty trap").click();
+    await q.button("Before empty").focus();
+
+    await page.keyboard.press("Tab");
+
+    await test.expect(q.region("Empty focus trap")).toBeFocused();
+  });
+
+  test("keeps focus when enabled changes inside the region", async ({
+    page,
+    q,
+  }) => {
+    const checkbox = q.checkbox("Trap multiple");
+    await checkbox.focus();
+    await test.expect(checkbox).toBeFocused();
+
+    await page.keyboard.press("Space");
+    await test.expect(checkbox).toBeChecked();
+    await test.expect(checkbox).toBeFocused();
+
+    await page.keyboard.press("Space");
+    await test.expect(checkbox).not.toBeChecked();
+    await test.expect(checkbox).toBeFocused();
+
+    await page.keyboard.press("Space");
+    await test.expect(checkbox).toBeChecked();
+    await test.expect(checkbox).toBeFocused();
+
+    await page.keyboard.press("Shift+Tab");
+    await test.expect(q.textbox("Multi input")).toBeFocused();
+  });
+});

--- a/packages/ariakit-components/src/collection/collection-store.test.ts
+++ b/packages/ariakit-components/src/collection/collection-store.test.ts
@@ -1,0 +1,77 @@
+import { init } from "@ariakit/store";
+import { afterEach, expect, test } from "vitest";
+import { createCollectionStore } from "./collection-store.ts";
+
+function flushBatch() {
+  return new Promise<void>((resolve) => queueMicrotask(resolve));
+}
+
+function nextFrame() {
+  return new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+test("registers, updates, and unregisters collection items", async () => {
+  const store = createCollectionStore<{ id: string; value?: string }>();
+  const stop = init(store);
+
+  try {
+    const unregister = store.registerItem({ id: "item", value: "one" });
+    await flushBatch();
+
+    expect(store.getState().items).toEqual([{ id: "item", value: "one" }]);
+    expect(store.item("item")).toEqual({ id: "item", value: "one" });
+
+    const restore = store.registerItem({ id: "item", value: "two" });
+    await flushBatch();
+
+    expect(store.getState().items).toEqual([{ id: "item", value: "two" }]);
+    expect(store.item("item")).toEqual({ id: "item", value: "two" });
+
+    restore();
+    await flushBatch();
+
+    expect(store.getState().items).toEqual([{ id: "item", value: "one" }]);
+
+    unregister();
+    await flushBatch();
+
+    expect(store.getState().items).toEqual([]);
+    expect(store.item("item")).toBeNull();
+  } finally {
+    stop();
+  }
+});
+
+test("orders rendered items by DOM position", async () => {
+  const store = createCollectionStore();
+  const stop = init(store);
+  const first = document.createElement("button");
+  const second = document.createElement("button");
+  document.body.append(first, second);
+
+  try {
+    const unrenderSecond = store.renderItem({
+      id: "second",
+      element: second,
+    });
+    const unrenderFirst = store.renderItem({ id: "first", element: first });
+    await nextFrame();
+
+    expect(store.getState().renderedItems.map((item) => item.id)).toEqual([
+      "first",
+      "second",
+    ]);
+
+    unrenderFirst();
+    unrenderSecond();
+    await nextFrame();
+
+    expect(store.getState().renderedItems).toEqual([]);
+  } finally {
+    stop();
+  }
+});

--- a/packages/ariakit-components/src/composite/composite-store.test.ts
+++ b/packages/ariakit-components/src/composite/composite-store.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "vitest";
+import type { CompositeStoreItem } from "./composite-store.ts";
+import { createCompositeStore } from "./composite-store.ts";
+
+function createComposite(items: CompositeStoreItem[]) {
+  const store = createCompositeStore();
+  store.setState("renderedItems", items);
+  return store;
+}
+
+test("moves through enabled items in one-dimensional composites", () => {
+  const store = createComposite([
+    { id: "one" },
+    { id: "two", disabled: true },
+    { id: "three" },
+  ]);
+
+  expect(store.next({ activeId: "one" })).toBe("three");
+  expect(store.previous({ activeId: "three" })).toBe("one");
+  expect(store.next({ activeId: "three" })).toBeUndefined();
+  expect(store.previous({ activeId: "one" })).toBeUndefined();
+});
+
+test("loops through items and the base element", () => {
+  const store = createComposite([{ id: "one" }, { id: "two" }]);
+
+  expect(store.next({ activeId: "two", focusLoop: true })).toBe("one");
+  expect(store.previous({ activeId: "one", focusLoop: true })).toBe("two");
+  expect(
+    store.next({
+      activeId: "two",
+      focusLoop: true,
+      includesBaseElement: true,
+    }),
+  ).toBeNull();
+  expect(store.next({ activeId: null })).toBe("one");
+});
+
+test("inverts horizontal navigation in RTL", () => {
+  const store = createComposite([{ id: "one" }, { id: "two" }]);
+
+  expect(store.next({ activeId: "two", rtl: true })).toBe("one");
+  expect(store.previous({ activeId: "one", rtl: true })).toBe("two");
+});
+
+test("wraps across grid rows", () => {
+  const store = createComposite([
+    { id: "a1", rowId: "a" },
+    { id: "a2", rowId: "a" },
+    { id: "b1", rowId: "b" },
+    { id: "b2", rowId: "b" },
+  ]);
+
+  expect(store.next({ activeId: "a2" })).toBeUndefined();
+  expect(store.next({ activeId: "a2", focusWrap: true })).toBe("b1");
+  expect(store.previous({ activeId: "b1", focusWrap: true })).toBe("a2");
+  expect(store.next({ activeId: "b2", focusLoop: true, focusWrap: true })).toBe(
+    "a1",
+  );
+});
+
+test("moves vertically in grids and shifts across uneven rows", () => {
+  const store = createComposite([
+    { id: "a1", rowId: "a" },
+    { id: "a2", rowId: "a" },
+    { id: "a3", rowId: "a" },
+    { id: "b1", rowId: "b" },
+  ]);
+
+  expect(store.down({ activeId: "a1" })).toBe("b1");
+  expect(store.up({ activeId: "b1" })).toBe("a1");
+  expect(store.down({ activeId: "a3" })).toBeUndefined();
+  expect(store.down({ activeId: "a3", focusShift: true })).toBe("b1");
+});

--- a/packages/ariakit-components/src/form/form-store.test.ts
+++ b/packages/ariakit-components/src/form/form-store.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "vitest";
+import { createFormStore } from "./form-store.ts";
+
+test("gets and sets nested values with array and object paths", () => {
+  const store = createFormStore({});
+
+  store.setValue("users.0.name", "Ada");
+  store.setValue("records.01.name", "Grace");
+
+  expect(store.getValue("users.0.name")).toBe("Ada");
+  expect(store.getValue("records.01.name")).toBe("Grace");
+  expect(Array.isArray(store.getValue("users"))).toBe(true);
+  expect(Array.isArray(store.getValue("records"))).toBe(false);
+  expect(store.getState().values).toEqual({
+    users: [{ name: "Ada" }],
+    records: { "01": { name: "Grace" } },
+  });
+});
+
+test("updates nested values with setter functions", () => {
+  const store = createFormStore({
+    defaultValues: { user: { visits: 1 } },
+  });
+
+  store.setValue("user.visits", (visits: number) => visits + 1);
+
+  expect(store.getValue("user.visits")).toBe(2);
+});
+
+test("pushes values and preserves array holes when removing values", () => {
+  const store = createFormStore({});
+
+  store.pushValue("tags", "one");
+  store.pushValue("tags", "two");
+  store.removeValue("tags", 0);
+
+  expect(store.getValue("tags")).toEqual([null, "two"]);
+});
+
+test("marks nested values as touched on submit", async () => {
+  const store = createFormStore({
+    defaultValues: {
+      user: { name: "" },
+      items: [{ name: "" }, { name: "" }],
+    },
+  });
+
+  await store.submit();
+
+  expect(store.getState().touched).toEqual({
+    user: { name: true },
+    items: [{ name: true }, { name: true }],
+  });
+});

--- a/packages/ariakit-utils/src/array.test.ts
+++ b/packages/ariakit-utils/src/array.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "vitest";
+import { addItemToArray, toArray } from "./array.ts";
+
+test("toArray keeps arrays and wraps defined values", () => {
+  const array = ["a", "b"];
+
+  expect(toArray(array)).toBe(array);
+  expect(toArray("a")).toEqual(["a"]);
+  expect(toArray(undefined)).toEqual([]);
+});
+
+test("addItemToArray inserts by index or appends for missing indexes", () => {
+  expect(addItemToArray(["a", "c"], "b", 1)).toEqual(["a", "b", "c"]);
+  expect(addItemToArray(["a", "b"], "c", -1)).toEqual(["a", "b", "c"]);
+  expect(addItemToArray(["a", "b"], "c", 10)).toEqual(["a", "b", "c"]);
+});

--- a/packages/ariakit-utils/src/dom.test.ts
+++ b/packages/ariakit-utils/src/dom.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, expect, test } from "vitest";
+import {
+  getTextboxSelection,
+  getTextboxValue,
+  isTextField,
+  setSelectionRange,
+} from "./dom.ts";
+
+afterEach(() => {
+  document.body.replaceChildren();
+  document.getSelection()?.removeAllRanges();
+});
+
+test("detects text fields without throwing for unsupported inputs", () => {
+  const text = document.createElement("input");
+  text.type = "text";
+  const checkbox = document.createElement("input");
+  checkbox.type = "checkbox";
+  const textarea = document.createElement("textarea");
+
+  expect(isTextField(text)).toBe(true);
+  expect(isTextField(checkbox)).toBe(false);
+  expect(isTextField(textarea)).toBe(true);
+});
+
+test("reads selection offsets from text fields", () => {
+  const input = document.createElement("input");
+  input.value = "abcdef";
+  document.body.append(input);
+
+  setSelectionRange(input, 2, 5);
+
+  expect(getTextboxValue(input)).toBe("abcdef");
+  expect(getTextboxSelection(input)).toEqual({ start: 2, end: 5 });
+});
+
+test("reads selection offsets from contenteditable elements", () => {
+  const editor = document.createElement("div");
+  editor.textContent = "hello world";
+  Object.defineProperty(editor, "isContentEditable", {
+    configurable: true,
+    value: true,
+  });
+  document.body.append(editor);
+
+  const text = editor.firstChild;
+  expect(text).toBeInstanceOf(Text);
+  if (!text) {
+    throw new Error("Expected contenteditable text node");
+  }
+
+  const range = document.createRange();
+  range.setStart(text, 3);
+  range.setEnd(text, 8);
+  document.getSelection()?.addRange(range);
+
+  expect(getTextboxValue(editor)).toBe("hello world");
+  expect(getTextboxSelection(editor)).toEqual({ start: 3, end: 8 });
+});
+
+test("setSelectionRange skips input types that do not support text selection", () => {
+  const color = document.createElement("input");
+  color.type = "color";
+
+  expect(() => setSelectionRange(color, 0, 1)).not.toThrow();
+});

--- a/packages/ariakit-utils/src/focus.test.ts
+++ b/packages/ariakit-utils/src/focus.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, expect, test } from "vitest";
+import { isTabbable } from "./focus.ts";
+
+function setVisible(element: Element) {
+  Object.defineProperty(element, "checkVisibility", {
+    configurable: true,
+    value: () => true,
+  });
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+test("treats only the active unchecked radio as tabbable within a group", () => {
+  const form = document.createElement("form");
+  form.innerHTML = `
+    <input type="radio" name="group" value="a" />
+    <input type="radio" name="group" value="b" />
+    <input type="radio" name="other" value="c" />
+  `;
+  document.body.append(form);
+
+  const [first, second, other] = form.querySelectorAll("input");
+  if (!first) {
+    throw new Error("Expected first radio");
+  }
+  if (!second) {
+    throw new Error("Expected second radio");
+  }
+  if (!other) {
+    throw new Error("Expected other radio");
+  }
+
+  setVisible(first);
+  setVisible(second);
+  setVisible(other);
+
+  expect(isTabbable(first)).toBe(true);
+  expect(isTabbable(second)).toBe(true);
+
+  first.focus();
+
+  expect(isTabbable(first)).toBe(true);
+  expect(isTabbable(second)).toBe(false);
+  expect(isTabbable(other)).toBe(true);
+
+  second.checked = true;
+  second.focus();
+
+  expect(isTabbable(first)).toBe(false);
+  expect(isTabbable(second)).toBe(true);
+});
+
+test("keeps radios outside a form tabbable", () => {
+  const radio = document.createElement("input");
+  radio.type = "radio";
+  radio.name = "standalone";
+  setVisible(radio);
+  document.body.append(radio);
+
+  expect(isTabbable(radio)).toBe(true);
+});

--- a/packages/ariakit-utils/src/misc.test.ts
+++ b/packages/ariakit-utils/src/misc.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "vitest";
+import {
+  applyState,
+  defaultValue,
+  isEmpty,
+  isInteger,
+  shallowEqual,
+} from "./misc.ts";
+
+test("isInteger preserves the form path discriminator contract", () => {
+  expect(isInteger(0)).toBe(true);
+  expect(isInteger(1)).toBe(true);
+  expect(isInteger(-1)).toBe(true);
+  expect(isInteger(1.5)).toBe(false);
+  expect(isInteger(Number.NaN)).toBe(false);
+  expect(isInteger(Infinity)).toBe(true);
+
+  expect(isInteger("0")).toBe(true);
+  expect(isInteger("1")).toBe(true);
+  expect(isInteger("-1")).toBe(true);
+  expect(isInteger("01")).toBe(false);
+  expect(isInteger("")).toBe(false);
+  expect(isInteger("1.5")).toBe(false);
+  expect(isInteger("name")).toBe(false);
+  expect(isInteger("NaN")).toBe(true);
+  expect(isInteger("Infinity")).toBe(true);
+});
+
+test("isEmpty handles nullish, collection, and primitive values", () => {
+  expect(isEmpty(null)).toBe(true);
+  expect(isEmpty(undefined)).toBe(true);
+  expect(isEmpty("")).toBe(true);
+  expect(isEmpty([])).toBe(true);
+  expect(isEmpty({})).toBe(true);
+
+  expect(isEmpty(" ")).toBe(false);
+  expect(isEmpty([0])).toBe(false);
+  expect(isEmpty({ value: undefined })).toBe(false);
+});
+
+test("applyState evaluates updater functions against eager or lazy values", () => {
+  expect(applyState("next", "current")).toBe("next");
+  expect(applyState((value: number) => value + 1, 1)).toBe(2);
+  expect(
+    applyState(
+      (value: number) => value + 1,
+      () => 1,
+    ),
+  ).toBe(2);
+});
+
+test("shallowEqual compares own enumerable values", () => {
+  expect(shallowEqual({ a: 1 }, { a: 1 })).toBe(true);
+  expect(shallowEqual({ a: 1 }, { a: 2 })).toBe(false);
+  expect(shallowEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+  expect(shallowEqual(undefined, { a: 1 })).toBe(false);
+});
+
+test("defaultValue returns the first defined value", () => {
+  expect(defaultValue(undefined, null, "fallback")).toBeNull();
+  expect(defaultValue(undefined, false, true)).toBe(false);
+  expect(defaultValue(undefined, 0, 1)).toBe(0);
+  expect(defaultValue(undefined, undefined)).toBeUndefined();
+});

--- a/packages/ariakit-utils/src/undo.test.ts
+++ b/packages/ariakit-utils/src/undo.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "vitest";
+import { createUndoManager } from "./undo.ts";
+
+function createUndoableAction(log: string[], value: string) {
+  return () => {
+    log.push(`do:${value}`);
+    return () => {
+      log.push(`undo:${value}`);
+    };
+  };
+}
+
+test("clears the redo stack after executing a new action", async () => {
+  const log: string[] = [];
+  const manager = createUndoManager();
+
+  await manager.execute(createUndoableAction(log, "one"));
+  await manager.undo();
+  expect(manager.canRedo()).toBe(true);
+
+  await manager.execute(createUndoableAction(log, "two"));
+
+  expect(manager.canRedo()).toBe(false);
+  await manager.redo();
+  expect(log).toEqual(["do:one", "undo:one", "do:two"]);
+});
+
+test("groups consecutive actions under the same group", async () => {
+  const log: string[] = [];
+  const manager = createUndoManager();
+
+  await manager.execute(createUndoableAction(log, "one"), "group");
+  await manager.execute(createUndoableAction(log, "two"), "group");
+
+  expect(manager.canUndo()).toBe(true);
+
+  await manager.undo();
+
+  expect(manager.canUndo()).toBe(false);
+  expect(manager.canRedo()).toBe(true);
+  expect(log).toEqual(["do:one", "do:two", "undo:two", "undo:one"]);
+});


### PR DESCRIPTION
## Motivation

The audit findings T019, T065, and T073 identified missing focused coverage around FocusTrapRegion edge paths, @ariakit/utils pure/DOM-light helpers, and @ariakit/components store logic.

## Solution

Add a React app sandbox for FocusTrapRegion that exercises backward wrapping, a single tabbable region, an explicitly focusable empty/all-disabled region, and toggling `enabled` while focus stays inside the region.

Add focused Vitest coverage for @ariakit/utils array, DOM text selection, focus tabbability, misc discriminator helpers, and undo-manager behavior. Add @ariakit/components store tests for collection registration/render ordering, composite navigation, and form nested path behavior.

## Verification

- `pnpm lint-fix`
- `pnpm exec vitest packages/ariakit-utils/src/array.test.ts packages/ariakit-utils/src/dom.test.ts packages/ariakit-utils/src/focus.test.ts packages/ariakit-utils/src/misc.test.ts packages/ariakit-utils/src/undo.test.ts packages/ariakit-components/src/collection/collection-store.test.ts packages/ariakit-components/src/composite/composite-store.test.ts packages/ariakit-components/src/form/form-store.test.ts`
- `APP_PORT=4323 NEXTJS_PORT=3004 pnpm -F app test src/sandbox/focus-trap-region/test-browser.ts --project=chrome --workers=1`
- `pnpm tsc`
