### PR TITLE
Add ToolbarContainer focus sandbox

### DIFF
--- a/app/src/sandbox/toolbar-container-focus/index.react.tsx
+++ b/app/src/sandbox/toolbar-container-focus/index.react.tsx
@@ -1,0 +1,35 @@
+import * as Ariakit from "@ariakit/react";
+import "./style.css";
+
+export default function Example() {
+  return (
+    <div className="wrapper">
+      <button type="button">Before toolbar</button>
+      <Ariakit.Toolbar aria-label="Text formatting" className="toolbar">
+        <Ariakit.ToolbarContainer
+          aria-label="Font family"
+          className="toolbar-container"
+        >
+          <label className="field">
+            <span>Font family</span>
+            <input defaultValue="Inter" />
+          </label>
+        </Ariakit.ToolbarContainer>
+        <Ariakit.ToolbarItem
+          className="input"
+          render={<input aria-label="Text size" defaultValue="Medium" />}
+        />
+        <Ariakit.ToolbarItem className="button">Apply</Ariakit.ToolbarItem>
+      </Ariakit.Toolbar>
+      <Ariakit.Toolbar
+        aria-label="Vertical formatting"
+        className="toolbar vertical"
+        orientation="vertical"
+      >
+        <Ariakit.ToolbarItem className="button">Move up</Ariakit.ToolbarItem>
+        <Ariakit.ToolbarItem className="button">Move down</Ariakit.ToolbarItem>
+        <Ariakit.ToolbarItem className="button">Reset</Ariakit.ToolbarItem>
+      </Ariakit.Toolbar>
+    </div>
+  );
+}

--- a/app/src/sandbox/toolbar-container-focus/index.react.tsx
+++ b/app/src/sandbox/toolbar-container-focus/index.react.tsx
@@ -9,6 +9,7 @@ export default function Example() {
         <Ariakit.ToolbarContainer
           aria-label="Font family"
           className="toolbar-container"
+          role="group"
         >
           <label className="field">
             <span>Font family</span>

--- a/app/src/sandbox/toolbar-container-focus/preview.astro
+++ b/app/src/sandbox/toolbar-container-focus/preview.astro
@@ -1,0 +1,14 @@
+---
+import PreviewFramework from "#app/components/preview-framework.astro";
+import ReactExample from "./index.react.tsx";
+
+import sourceReact from "./index.react.tsx?source";
+
+export const source = {
+  react: sourceReact,
+};
+---
+
+<PreviewFramework>
+  <ReactExample client:load slot="react" />
+</PreviewFramework>

--- a/app/src/sandbox/toolbar-container-focus/preview.mdx
+++ b/app/src/sandbox/toolbar-container-focus/preview.mdx
@@ -1,0 +1,9 @@
+---
+title: Toolbar container focus
+frameworks:
+  - react
+---
+
+import Preview from "./preview.astro";
+
+<Preview />

--- a/app/src/sandbox/toolbar-container-focus/style.css
+++ b/app/src/sandbox/toolbar-container-focus/style.css
@@ -1,0 +1,45 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.toolbar {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.toolbar.vertical {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.toolbar-container,
+.button,
+.input {
+  border: 1px solid rgb(209 213 219);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font: inherit;
+}
+
+.toolbar-container {
+  background: rgb(249 250 251);
+}
+
+.button {
+  background: rgb(243 244 246);
+}
+
+.field {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.field input,
+.input {
+  min-width: 120px;
+}

--- a/app/src/sandbox/toolbar-container-focus/test-browser.ts
+++ b/app/src/sandbox/toolbar-container-focus/test-browser.ts
@@ -38,9 +38,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
     page,
     q,
   }) => {
-    const container = page.locator(
-      "[data-composite-container][aria-label='Font family']",
-    );
+    const container = q.group("Font family");
     const input = q.textbox("Font family");
 
     await q.button("Before toolbar").focus();
@@ -66,9 +64,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
     page,
     q,
   }) => {
-    const container = page.locator(
-      "[data-composite-container][aria-label='Font family']",
-    );
+    const container = q.group("Font family");
     const input = q.textbox("Text size");
     const apply = q.button("Apply");
 

--- a/app/src/sandbox/toolbar-container-focus/test-browser.ts
+++ b/app/src/sandbox/toolbar-container-focus/test-browser.ts
@@ -1,0 +1,125 @@
+import type { Locator } from "@playwright/test";
+import { withFramework } from "#app/test-utils/preview.ts";
+
+async function setSelection(input: Locator, start: number, end = start) {
+  await input.evaluate(
+    (element, range) => {
+      if (!(element instanceof HTMLInputElement)) {
+        throw new Error("Expected an input element");
+      }
+      const input = element;
+      input.setSelectionRange(range.start, range.end);
+    },
+    { start, end },
+  );
+}
+
+async function setSelectionToEnd(input: Locator) {
+  await input.evaluate((element) => {
+    if (!(element instanceof HTMLInputElement)) {
+      throw new Error("Expected an input element");
+    }
+    const input = element;
+    input.setSelectionRange(input.value.length, input.value.length);
+  });
+}
+
+function getSelectionStart(input: Locator) {
+  return input.evaluate((element) => {
+    if (!(element instanceof HTMLInputElement)) {
+      throw new Error("Expected an input element");
+    }
+    return element.selectionStart;
+  });
+}
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("ToolbarContainer keeps its inner input out of the tab order until opened", async ({
+    page,
+    q,
+  }) => {
+    const container = page.locator(
+      "[data-composite-container][aria-label='Font family']",
+    );
+    const input = q.textbox("Font family");
+
+    await q.button("Before toolbar").focus();
+    await page.keyboard.press("Tab");
+
+    await test.expect(container).toBeFocused();
+    await test.expect(input).not.toBeFocused();
+
+    await page.keyboard.press("a");
+    await test.expect(input).toBeFocused();
+
+    await page.keyboard.press("Escape");
+    await test.expect(container).toBeFocused();
+
+    await page.keyboard.press("Enter");
+    await test.expect(input).toBeFocused();
+
+    await page.keyboard.press("Enter");
+    await test.expect(container).toBeFocused();
+  });
+
+  test("ToolbarItem rendered as input navigates only at text boundaries", async ({
+    page,
+    q,
+  }) => {
+    const container = page.locator(
+      "[data-composite-container][aria-label='Font family']",
+    );
+    const input = q.textbox("Text size");
+    const apply = q.button("Apply");
+
+    await input.focus();
+    await setSelection(input, 1);
+
+    await page.keyboard.press("ArrowRight");
+
+    await test.expect(input).toBeFocused();
+    await test.expect.poll(() => getSelectionStart(input)).toBe(2);
+
+    await setSelectionToEnd(input);
+    await page.keyboard.press("ArrowRight");
+
+    await test.expect(apply).toBeFocused();
+
+    await input.focus();
+    await setSelection(input, 1);
+
+    await page.keyboard.press("ArrowLeft");
+
+    await test.expect(input).toBeFocused();
+    await test.expect.poll(() => getSelectionStart(input)).toBe(0);
+
+    await setSelection(input, 0);
+    await page.keyboard.press("ArrowLeft");
+
+    await test.expect(container).toBeFocused();
+  });
+
+  test("vertical toolbar moves with up and down arrows only", async ({
+    page,
+    q,
+  }) => {
+    const toolbar = q.toolbar("Vertical formatting");
+    const moveUp = q.button("Move up");
+    const moveDown = q.button("Move down");
+
+    await test.expect(toolbar).toHaveAttribute("aria-orientation", "vertical");
+
+    await moveUp.focus();
+    await page.keyboard.press("ArrowRight");
+    await test.expect(moveUp).toBeFocused();
+
+    await page.keyboard.press("ArrowDown");
+    await test.expect(moveDown).toBeFocused();
+
+    await page.keyboard.press("ArrowLeft");
+    await test.expect(moveDown).toBeFocused();
+
+    await page.keyboard.press("ArrowUp");
+    await test.expect(moveUp).toBeFocused();
+  });
+});


### PR DESCRIPTION
## Motivation

T060 identified missing sandbox coverage for `ToolbarContainer` focus behavior and vertical `Toolbar` orientation. The audit note asked for this coverage under `app/src/sandbox`, so this PR adds a focused sandbox instead of changing the public examples.

## Solution

Add a React sandbox at `app/src/sandbox/toolbar-container-focus` that exercises a `ToolbarContainer` with an inner input, a `ToolbarItem` rendered as a text input, and a vertical toolbar. The browser tests cover the container staying as the tab stop until opened, Enter/Escape returning focus to the container, text-input arrow navigation only roving at caret boundaries, and vertical orientation using Up/Down while ignoring Left/Right.

## Testing

- `pnpm lint-fix`
- `pnpm tsc`
- `APP_PORT=4872 NEXTJS_PORT=3872 pnpm -F app test --project=chrome --project=firefox --project=safari src/sandbox/toolbar-container-focus/test-browser.ts`
