### PR TITLE
Allow apex domains to embed Next.js previews

### DIFF
--- a/app/src/lib/nextjs.ts
+++ b/app/src/lib/nextjs.ts
@@ -60,8 +60,8 @@ interface GetNextjsUrlFromRequestParams {
  * - {alias}.ariakit-preview.workers.dev → {alias}.ariakit-nextjs.workers.dev
  * - ariakit-preview.workers.dev → ariakit-nextjs.workers.dev
  * - next.ariakit.com → nextjs.ariakit.com
- * - *.ariakit.com → nextjs.ariakit.com
- * - *.ariakit.org → nextjs.ariakit.com (legacy, redirected during migration)
+ * - ariakit.com and *.ariakit.com → nextjs.ariakit.com
+ * - ariakit.org and *.ariakit.org → nextjs.ariakit.com (legacy, redirected during migration)
  */
 export function getNextjsUrlFromRequest({
   requestUrl,

--- a/nextjs/next.config.ts
+++ b/nextjs/next.config.ts
@@ -18,9 +18,9 @@ const config: NextConfig = {
           },
           {
             key: "Content-Security-Policy",
-            // Allow embedding from any ariakit.com/ariakit.org subdomain and workers.dev
+            // Allow embedding from ariakit.com/ariakit.org domains and workers.dev
             value:
-              "frame-ancestors 'self' https://*.ariakit.com https://*.ariakit.org https://*.workers.dev http://localhost:*",
+              "frame-ancestors 'self' https://ariakit.com https://*.ariakit.com https://ariakit.org https://*.ariakit.org https://*.workers.dev http://localhost:*",
           },
         ],
       },


### PR DESCRIPTION
## Motivation

The Next.js preview CSP allowed Ariakit subdomains in `frame-ancestors`, but CSP wildcard host sources do not include the bare apex domains. `getNextjsUrlFromRequest` already treats `ariakit.com` and `ariakit.org` as valid docs hosts, so previews embedded from either apex could be blocked.

## Solution

Add explicit `https://ariakit.com` and `https://ariakit.org` origins to the Next.js `frame-ancestors` directive alongside the existing wildcard entries. Also update the nearby Next.js host mapping comment so the documented apex-plus-subdomain behavior stays aligned.

No changeset is included because this only changes the private docs/Next.js app configuration.
