### PR TITLE
Avoid double-counting recursive script profile frames

### DIFF
--- a/packages/ariakit-scripts/src/perf.test.ts
+++ b/packages/ariakit-scripts/src/perf.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, expect, test } from "vitest";
-import { getIntegerEnv } from "./perf.ts";
+import { getIntegerEnv, parseScriptProfile } from "./perf.ts";
 
 const envName = "PERF_ITERATIONS";
 const originalValue = process.env[envName];
@@ -23,4 +23,64 @@ test("gets integer env values with range validation", () => {
 
   process.env[envName] = "0";
   expect(getIntegerEnv(envName, 1, { min: 0 })).toBe(0);
+});
+
+test("does not double-count recursive script profile frames", () => {
+  const callFrame = {
+    functionName: "recursive",
+    scriptId: "1",
+    url: "https://example.com/app.js",
+    lineNumber: 0,
+    columnNumber: 0,
+  };
+
+  const profile = parseScriptProfile({
+    nodes: [
+      {
+        id: 1,
+        callFrame: {
+          functionName: "(root)",
+          scriptId: "0",
+          url: "",
+          lineNumber: 0,
+          columnNumber: 0,
+        },
+        children: [2],
+      },
+      {
+        id: 2,
+        callFrame: {
+          functionName: "wrapper",
+          scriptId: "1",
+          url: "https://example.com/app.js",
+          lineNumber: 4,
+          columnNumber: 0,
+        },
+        children: [3],
+      },
+      { id: 3, callFrame, children: [4] },
+      { id: 4, callFrame },
+    ],
+    samples: [4],
+    timeDeltas: [5000],
+  });
+
+  expect(profile).toContainEqual({
+    functionName: "recursive",
+    url: "/app.js",
+    line: 1,
+    column: 1,
+    selfTime: 5,
+    totalTime: 5,
+    hitCount: 1,
+  });
+  expect(profile).toContainEqual({
+    functionName: "wrapper",
+    url: "/app.js",
+    line: 5,
+    column: 1,
+    selfTime: 0,
+    totalTime: 5,
+    hitCount: 0,
+  });
 });

--- a/packages/ariakit-scripts/src/perf.ts
+++ b/packages/ariakit-scripts/src/perf.ts
@@ -289,7 +289,9 @@ function getScriptProfileEntry(
   return entry;
 }
 
-function parseScriptProfile(profile: CdpProfile): PerfScriptProfileEntry[] {
+export function parseScriptProfile(
+  profile: CdpProfile,
+): PerfScriptProfileEntry[] {
   const nodes = new Map<number, CdpProfileNode>();
   const parents = new Map<number, number>();
 
@@ -319,11 +321,16 @@ function parseScriptProfile(profile: CdpProfile): PerfScriptProfileEntry[] {
       entry.hitCount += 1;
     }
 
+    const totalTimeKeys = new Set<string>();
     let currentNode: CdpProfileNode | undefined = sampleNode;
     while (currentNode) {
       if (shouldIncludeScriptFrame(currentNode.callFrame)) {
-        const entry = getScriptProfileEntry(entries, currentNode.callFrame);
-        entry.totalTime += timeMs;
+        const key = scriptProfileKey(currentNode.callFrame);
+        if (!totalTimeKeys.has(key)) {
+          totalTimeKeys.add(key);
+          const entry = getScriptProfileEntry(entries, currentNode.callFrame);
+          entry.totalTime += timeMs;
+        }
       }
       const parentId = parents.get(currentNode.id);
       if (parentId == null) break;


### PR DESCRIPTION
## Motivation

Recursive or repeated frames in a sampled script profile can point to the same function location more than once in a single stack. `parseScriptProfile` aggregated total time by function location, so one sample could add its duration to the same entry multiple times and inflate recursive function costs.

## Solution

Track the script profile keys already credited during each sample ancestor walk and only add the sample duration to `totalTime` once per key. The walk still continues through every parent so distinct ancestors keep receiving their inclusive time.

Added a focused regression test with a recursive stack where two nodes share the same call frame.