### PR TITLE
Reorder setPrice replacement price creation

### DIFF
--- a/app/src/actions/admin.ts
+++ b/app/src/actions/admin.ts
@@ -358,9 +358,44 @@ async function setPrice(input: SetPriceInput) {
     if (replacedPrice === price.id) return null;
     return replacedPrice;
   };
-  const deactivateReplacedPrice = async (priceId: string | null) => {
+  const deactivateReplacedPrice = async (
+    priceId: string | null,
+    expectedProduct: string,
+    expectedCurrency: string,
+  ) => {
     if (!priceId) return;
     const price = await stripe.prices.retrieve(priceId);
+    const product = objectId(price.product);
+    if (product !== expectedProduct) {
+      logger.error(
+        "Skipping replaced price for %s (%s): expected product %s, got %s",
+        key,
+        priceId,
+        expectedProduct,
+        product,
+      );
+      return;
+    }
+    if (price.currency !== expectedCurrency) {
+      logger.error(
+        "Skipping replaced price for %s (%s): expected currency %s, got %s",
+        key,
+        priceId,
+        expectedCurrency,
+        price.currency,
+      );
+      return;
+    }
+    if (price.lookup_key && price.lookup_key !== key) {
+      logger.error(
+        "Skipping replaced price for %s (%s): expected lookup key %s, got %s",
+        key,
+        priceId,
+        key,
+        price.lookup_key,
+      );
+      return;
+    }
     if (price.active) {
       await deactivatePrice(price.id);
     }
@@ -372,7 +407,11 @@ async function setPrice(input: SetPriceInput) {
     const replacedPrice = getReplacedPrice(price);
     if (price.active) {
       await cachePrice(price);
-      await deactivateReplacedPrice(replacedPrice);
+      await deactivateReplacedPrice(
+        replacedPrice,
+        objectId(price.product),
+        price.currency,
+      );
     }
     if (price.active && price.unit_amount === amountWithCents) {
       logger.info("Price %s is already set to %s", key, formattedAmount);
@@ -430,7 +469,11 @@ async function setPrice(input: SetPriceInput) {
   await cachePrice(newPrice);
   if (price) {
     if (!price.active) {
-      await deactivateReplacedPrice(getReplacedPrice(price));
+      await deactivateReplacedPrice(
+        getReplacedPrice(price),
+        objectId(newPrice.product),
+        newPrice.currency,
+      );
     } else {
       await deactivatePrice(price.id);
     }

--- a/app/src/actions/admin.ts
+++ b/app/src/actions/admin.ts
@@ -345,7 +345,6 @@ async function setPrice(input: SetPriceInput) {
       }),
       formattedAmount,
     );
-    await stripe.prices.update(price.id, { active: false });
   } else {
     logger.info("Creating new price %s at %s", key, formattedAmount);
   }
@@ -364,15 +363,21 @@ async function setPrice(input: SetPriceInput) {
 
   const taxBehavior = "exclusive";
 
-  // Create a new price
-  const newPrice = await stripe.prices.create({
-    currency,
-    product,
-    lookup_key: key,
-    unit_amount: amountWithCents,
-    tax_behavior: taxBehavior,
-    transfer_lookup_key: true,
-  });
+  // Create the replacement first so a failure leaves the old price active.
+  let newPrice: Stripe.Price;
+  try {
+    newPrice = await stripe.prices.create({
+      currency,
+      product,
+      lookup_key: key,
+      unit_amount: amountWithCents,
+      tax_behavior: taxBehavior,
+      transfer_lookup_key: true,
+    });
+  } catch (error) {
+    logger.error("Error creating price %s at %s", key, formattedAmount, error);
+    throw error;
+  }
   await putPrice({
     id: newPrice.id,
     type,
@@ -382,6 +387,19 @@ async function setPrice(input: SetPriceInput) {
     currency,
     taxBehavior,
   });
+  if (price) {
+    try {
+      await stripe.prices.update(price.id, { active: false });
+    } catch (error) {
+      logger.error(
+        "Error deactivating replaced price %s (%s)",
+        key,
+        price.id,
+        error,
+      );
+      throw error;
+    }
+  }
   logger.info("Set price %s to %s", key, formattedAmount);
 }
 

--- a/app/src/actions/admin.ts
+++ b/app/src/actions/admin.ts
@@ -327,11 +327,54 @@ async function setPrice(input: SetPriceInput) {
   const key = getPlusPriceKey({ type, currency, countryCode });
   const amountWithCents = input.amount * 100;
   const formattedAmount = formatCurrency({ amount: input.amount, currency });
+  const taxBehavior = "exclusive";
+  const cachePrice = async (price: Stripe.Price) => {
+    await putPrice({
+      id: price.id,
+      type,
+      key,
+      product: objectId(price.product),
+      amount: price.unit_amount ?? amountWithCents,
+      currency: price.currency,
+      taxBehavior: price.tax_behavior || taxBehavior,
+    });
+  };
+  const deactivatePrice = async (priceId: string) => {
+    try {
+      await stripe.prices.update(priceId, { active: false });
+    } catch (error) {
+      logger.error(
+        "Error deactivating replaced price %s (%s)",
+        key,
+        priceId,
+        error,
+      );
+      throw error;
+    }
+  };
+  const getReplacedPrice = (price: Stripe.Price) => {
+    const replacedPrice = price.metadata.replacedPrice;
+    if (!replacedPrice) return null;
+    if (replacedPrice === price.id) return null;
+    return replacedPrice;
+  };
+  const deactivateReplacedPrice = async (priceId: string | null) => {
+    if (!priceId) return;
+    const price = await stripe.prices.retrieve(priceId);
+    if (price.active) {
+      await deactivatePrice(price.id);
+    }
+  };
   const {
     data: [price],
   } = await stripe.prices.list({ limit: 1, lookup_keys: [key] });
   if (price) {
-    if (price.unit_amount === amountWithCents) {
+    const replacedPrice = getReplacedPrice(price);
+    if (price.active) {
+      await cachePrice(price);
+      await deactivateReplacedPrice(replacedPrice);
+    }
+    if (price.active && price.unit_amount === amountWithCents) {
       logger.info("Price %s is already set to %s", key, formattedAmount);
       return;
     }
@@ -361,43 +404,35 @@ async function setPrice(input: SetPriceInput) {
     }
   }
 
-  const taxBehavior = "exclusive";
-
   // Create the replacement first so a failure leaves the old price active.
   let newPrice: Stripe.Price;
+  const createParams: Stripe.PriceCreateParams = {
+    currency,
+    product,
+    lookup_key: key,
+    unit_amount: amountWithCents,
+    tax_behavior: taxBehavior,
+    transfer_lookup_key: true,
+  };
+  if (price) {
+    createParams.metadata = {
+      replacedPrice: price.active
+        ? price.id
+        : getReplacedPrice(price) || price.id,
+    };
+  }
   try {
-    newPrice = await stripe.prices.create({
-      currency,
-      product,
-      lookup_key: key,
-      unit_amount: amountWithCents,
-      tax_behavior: taxBehavior,
-      transfer_lookup_key: true,
-    });
+    newPrice = await stripe.prices.create(createParams);
   } catch (error) {
     logger.error("Error creating price %s at %s", key, formattedAmount, error);
     throw error;
   }
-  await putPrice({
-    id: newPrice.id,
-    type,
-    key,
-    product,
-    amount: amountWithCents,
-    currency,
-    taxBehavior,
-  });
+  await cachePrice(newPrice);
   if (price) {
-    try {
-      await stripe.prices.update(price.id, { active: false });
-    } catch (error) {
-      logger.error(
-        "Error deactivating replaced price %s (%s)",
-        key,
-        price.id,
-        error,
-      );
-      throw error;
+    if (!price.active) {
+      await deactivateReplacedPrice(getReplacedPrice(price));
+    } else {
+      await deactivatePrice(price.id);
     }
   }
   logger.info("Set price %s to %s", key, formattedAmount);


### PR DESCRIPTION
## Motivation

Updating an existing admin price currently deactivates the old Stripe price before creating the replacement. If replacement creation fails after deactivation succeeds, the lookup key can be left without an active price and the KV cache is not updated, which can break checkout until an admin retries.

## Solution

Create the replacement Stripe price first and rely on `transfer_lookup_key: true` to move the lookup key from the old price. After creation succeeds, cache the replacement price in KV, then deactivate the replaced price. Creation and deactivation failures are logged and rethrown so the old price remains active on create failure and the action does not report success if cleanup fails.

The retry path also repairs partial replacements. Replacement prices created from an existing price record their predecessor in Stripe metadata. When a later admin call sees an active lookup-key price, it refreshes KV before deactivating that recorded predecessor; if the lookup-key holder is inactive, it avoids caching it and carries the predecessor metadata into the next replacement.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
