### PR TITLE
Remove unused getAllUsers helper

### DIFF
--- a/app/src/lib/auth.ts
+++ b/app/src/lib/auth.ts
@@ -277,32 +277,3 @@ export async function isAdmin(context: APIContext) {
   const orgRole = teams.get(orgId);
   return orgRole === "org:admin";
 }
-
-export interface GetAllUsersParams {
-  context: APIContext;
-  limit?: number;
-  offset?: number;
-}
-
-export async function getAllUsers({
-  context,
-  limit = 100,
-  offset = 0,
-}: GetAllUsersParams) {
-  if (!isClerkEnabled()) return [];
-  const clerk = clerkClient(context);
-  const allUsers: User[] = [];
-  let hasMore = false;
-  do {
-    const users = await clerk.users.getUserList({
-      limit: 100,
-      offset: offset,
-      orderBy: "+created_at",
-    });
-    if (users.data.length === 0) break;
-    allUsers.push(...users.data);
-    offset += users.data.length;
-    hasMore = users.data.length === limit;
-  } while (hasMore);
-  return allUsers;
-}


### PR DESCRIPTION
## Motivation

`getAllUsers` is an unused app auth helper with inconsistent pagination: it always asks Clerk for 100 users while comparing `hasMore` against the caller-provided `limit`. Keeping the dead export leaves a misleading helper in the admin/auth surface.

## Solution

Remove `getAllUsers` and its `GetAllUsersParams` interface after confirming there are no in-repo call sites. The existing admin users page keeps using Clerk's paginated `getUserList` directly.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
