### PR TITLE
Handle CopyCode clipboard failures

### DIFF
--- a/app/src/components/copy-code.react.tsx
+++ b/app/src/components/copy-code.react.tsx
@@ -26,7 +26,7 @@ export function CopyCode({
   title = label,
   ...props
 }: CopyCodeProps) {
-  const [state, setState] = useState<"idle" | "copying" | "copied">("idle");
+  const [state, setState] = useState<"idle" | "copied">("idle");
 
   useEffect(() => {
     if (state !== "copied") return;
@@ -55,7 +55,11 @@ export function CopyCode({
           props.onClick?.(event);
           if (event.defaultPrevented) return;
           if (state !== "idle") return;
-          await navigator.clipboard.writeText(text);
+          try {
+            await navigator.clipboard.writeText(text);
+          } catch {
+            return;
+          }
           setState("copied");
         }}
       >


### PR DESCRIPTION
## Motivation

`CopyCode` awaited `navigator.clipboard.writeText` directly. When clipboard writes fail because permission is denied, focus is missing, or the context does not allow clipboard access, the async click handler rejects instead of handling the failure.

## Solution

Wrap the clipboard write in `try`/`catch` and only show the copied state after the write succeeds. Failed writes now return without changing state or surfacing an unhandled rejection. The unused `"copying"` state union member was also removed.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- `git diff --check`
