### PR TITLE
Remove invalid Next.js X-Frame-Options header

### DIFF
--- a/nextjs/next.config.ts
+++ b/nextjs/next.config.ts
@@ -13,10 +13,6 @@ const config: NextConfig = {
         source: "/:path*",
         headers: [
           {
-            key: "X-Frame-Options",
-            value: "ALLOWALL",
-          },
-          {
             key: "Content-Security-Policy",
             // Allow embedding from ariakit.com/ariakit.org domains and workers.dev
             value:


### PR DESCRIPTION
## Motivation

The Next.js app currently sends `X-Frame-Options: ALLOWALL`, but `ALLOWALL` is not a valid `X-Frame-Options` token. Browsers ignore the invalid value, so the header is misleading and does not contribute to the iframe policy.

## Solution

Remove the invalid `X-Frame-Options` header from `nextjs/next.config.ts` and keep relying on the existing `Content-Security-Policy` `frame-ancestors` directive for the allowed embedding origins.

## Verification

- `pnpm lint-fix`
- `pnpm -F nextjs run tsc`
- `pnpm -F nextjs run build-worker`
