### PR TITLE
Fix mergeImports semicolon rewriting

### DIFF
--- a/app/src/lib/source.test.ts
+++ b/app/src/lib/source.test.ts
@@ -195,6 +195,29 @@ test("mergeImports filters imports", () => {
   `);
 });
 
+test("mergeImports terminates rewritten mixed imports", () => {
+  const code = [
+    'import { A, type T } from "keep";',
+    'import { B } from "move";',
+    "export const value = A + B;",
+  ].join("\n");
+  expect(mergeImports(code, (p) => (p === "move" ? "moved" : false)))
+    .toMatchInlineSnapshot(`
+    "import { A } from "keep";
+    import type { T } from "keep";
+    import { B } from "moved";
+    export const value = A + B;"
+  `);
+});
+
+test("mergeImports removes transformed imports at EOF", () => {
+  expect(mergeImports('import { A } from "x"', (p) => p))
+    .toMatchInlineSnapshot(`
+    "import { A } from "x";
+    "
+  `);
+});
+
 test("mergeImports ignores specific imports", () => {
   const code = [
     'import "side-effect";',
@@ -246,6 +269,24 @@ test("mergeFiles removes internal imports between merged files", () => {
     export function a() {
       return b + 1;
     }
+    "
+  `);
+});
+
+test("mergeFiles removes internal imports at EOF", () => {
+  const files = {
+    "/path/to/utils/a.ts": {
+      id: "/path/to/utils/a.ts",
+      content: 'import { b } from "./b";',
+    },
+    "/path/to/utils/b.ts": {
+      id: "/path/to/utils/b.ts",
+      content: "export const b = 1;",
+    },
+  };
+  const merged = mergeFiles(files);
+  expect(merged["/path/to/utils.ts"]?.content).toMatchInlineSnapshot(`
+    "export const b = 1;
     "
   `);
 });

--- a/app/src/lib/source.test.ts
+++ b/app/src/lib/source.test.ts
@@ -210,6 +210,33 @@ test("mergeImports terminates rewritten mixed imports", () => {
   `);
 });
 
+test("mergeImports preserves attributes on remaining imports", () => {
+  const code = [
+    'import { A, type T } from "./data.json" with { type: "json" };',
+    "export const value = A;",
+  ].join("\n");
+  expect(
+    mergeImports(code, (_path, type) =>
+      type === "import-type" ? "./types" : false,
+    ),
+  ).toMatchInlineSnapshot(`
+    "import { A } from "./data.json" with { type: "json" };
+    import type { T } from "./types";
+    export const value = A;"
+  `);
+});
+
+test("mergeImports consumes attributes on transformed type imports", () => {
+  const code = [
+    'import type { T } from "./data.json" with { type: "json" };',
+    "export const value: T = {};",
+  ].join("\n");
+  expect(mergeImports(code, () => "./types")).toMatchInlineSnapshot(`
+    "import type { T } from "./types";
+    export const value: T = {};"
+  `);
+});
+
 test("mergeImports removes transformed imports at EOF", () => {
   expect(mergeImports('import { A } from "x"', (p) => p))
     .toMatchInlineSnapshot(`

--- a/app/src/lib/source.test.ts
+++ b/app/src/lib/source.test.ts
@@ -226,7 +226,19 @@ test("mergeImports preserves attributes on remaining imports", () => {
   `);
 });
 
-test("mergeImports consumes attributes on transformed type imports", () => {
+test("mergeImports preserves attributes on hoisted imports", () => {
+  const code = [
+    'import { A, type T } from "./data.json" with { type: "json" };',
+    "export const value = A;",
+  ].join("\n");
+  expect(mergeImports(code, (p) => p)).toMatchInlineSnapshot(`
+    "import type { T } from "./data.json" with { type: "json" };
+    import { A } from "./data.json" with { type: "json" };
+    export const value = A;"
+  `);
+});
+
+test("mergeImports drops attributes when transformed type imports change paths", () => {
   const code = [
     'import type { T } from "./data.json" with { type: "json" };',
     "export const value: T = {};",
@@ -588,6 +600,17 @@ test("hoistImports hoists import type namespace", () => {
   ].join("\n");
   expect(hoistImports(code)).toBe(
     'import type * as React from "react";\n\nexport const a = 1;',
+  );
+});
+
+test("hoistImports preserves import attributes", () => {
+  const code = [
+    'import { A } from "./data.json" with { type: "json" };',
+    "",
+    "export const value = A;",
+  ].join("\n");
+  expect(hoistImports(code)).toBe(
+    'import { A } from "./data.json" with { type: "json" };\n\nexport const value = A;',
   );
 });
 

--- a/app/src/lib/source.ts
+++ b/app/src/lib/source.ts
@@ -759,8 +759,6 @@ function stripInternalImports(
   const removeMatchingImports = (pattern: RegExp) => {
     body = body.replace(pattern, (match, ...args) => {
       const groups = args[args.length - 1] as RegExpExecArray["groups"];
-      const offset = (args[args.length - 3] as number) ?? 0;
-      const fullText = (args[args.length - 2] as string) ?? body;
       const specifier = getPathFromGroups(groups);
       if (!specifier) return match;
 
@@ -775,12 +773,7 @@ function stripInternalImports(
         );
       }
 
-      // Some import patterns consume the trailing semicolon. Others leave it
-      // behind for cleanSemicolonOnlyLines to remove.
-      const unmatchedSemicolon = /^[\t ]*;/.test(
-        fullText.slice(offset + match.length),
-      );
-      return unmatchedSemicolon ? "" : ";";
+      return ";";
     });
   };
 

--- a/app/src/lib/source.ts
+++ b/app/src/lib/source.ts
@@ -20,11 +20,12 @@ import type { StyleDependency } from "./styles.ts";
 // interpolation).
 const PATH_QUOTED = String.raw`(?:'(?<single>[^']+)'|"(?<double>[^"]+)"|\`(?<template>(?:[^\`$]|\$(?!\{))+?)\`)`;
 const FROM_CLAUSE = String.raw`\s+from\s+${PATH_QUOTED}`;
+const IMPORT_ATTRIBUTES = String.raw`(?<attributes>\s+(?:with|assert)\s+\{[\s\S]*?\})?`;
 
 // Import patterns
 const IMPORT_SIDE_EFFECT = new RegExp(String.raw`import\s+${PATH_QUOTED}`, "g");
 const IMPORT_NAMED = new RegExp(
-  String.raw`import\s+(?!type\b)\{[\s\S]*?\}${FROM_CLAUSE}[\t ]*;?`,
+  String.raw`import\s+(?!type\b)\{[\s\S]*?\}${FROM_CLAUSE}${IMPORT_ATTRIBUTES}[\t ]*;?`,
   "g",
 );
 const IMPORT_FROM_ANY = new RegExp(
@@ -32,7 +33,7 @@ const IMPORT_FROM_ANY = new RegExp(
   "g",
 );
 const IMPORT_TYPE_NAMED = new RegExp(
-  String.raw`import\s+type\s+\{[\s\S]*?\}${FROM_CLAUSE}`,
+  String.raw`import\s+type\s+\{[\s\S]*?\}${FROM_CLAUSE}${IMPORT_ATTRIBUTES}[\t ]*;?`,
   "g",
 );
 const IMPORT_TYPE_NAMESPACE = new RegExp(
@@ -191,6 +192,10 @@ function getQuoteFromGroups(groups: RegExpExecArray["groups"]): string {
   if (groups?.single != null) return "'";
   if (groups?.double != null) return '"';
   return "`";
+}
+
+function getAttributesFromGroups(groups: RegExpExecArray["groups"]): string {
+  return groups?.attributes ?? "";
 }
 
 /**
@@ -415,7 +420,7 @@ function buildHoistedImports(
 function buildRemainingImport(
   remainingRuntime: string[],
   remainingType: string[],
-  modulePath: string,
+  moduleSource: string,
 ): string {
   // All specifiers transformed - remove the line
   if (remainingRuntime.length === 0 && remainingType.length === 0) {
@@ -425,18 +430,18 @@ function buildRemainingImport(
   // Both kinds remain - split into two lines
   if (remainingRuntime.length > 0 && remainingType.length > 0) {
     return [
-      `import { ${remainingRuntime.join(", ")} } from "${modulePath}";`,
-      `import type { ${remainingType.join(", ")} } from "${modulePath}";`,
+      `import { ${remainingRuntime.join(", ")} } from ${moduleSource};`,
+      `import type { ${remainingType.join(", ")} } from ${moduleSource};`,
     ].join("\n");
   }
 
   // Only runtime specifiers remain
   if (remainingRuntime.length > 0) {
-    return `import { ${remainingRuntime.join(", ")} } from "${modulePath}";`;
+    return `import { ${remainingRuntime.join(", ")} } from ${moduleSource};`;
   }
 
   // Only type specifiers remain
-  return `import type { ${remainingType.join(", ")} } from "${modulePath}";`;
+  return `import type { ${remainingType.join(", ")} } from ${moduleSource};`;
 }
 
 /**
@@ -559,7 +564,7 @@ export function mergeImports(
         if (transformed === false) return match;
 
         // Entire declaration is transformed - remove it (will be hoisted)
-        return "";
+        return ";";
       }
 
       const { runtime, typeOnly } = parseNamedSpecifiers(inside);
@@ -573,8 +578,12 @@ export function mergeImports(
       // Keep specifiers that weren't transformed
       const remainingRuntime = transformedValue === false ? runtime : [];
       const remainingType = transformedType === false ? typeOnly : [];
+      const attributes = getAttributesFromGroups(groups);
+      const source = `"${path}"${attributes}`;
 
-      return buildRemainingImport(remainingRuntime, remainingType, path) || ";";
+      return (
+        buildRemainingImport(remainingRuntime, remainingType, source) || ";"
+      );
     });
   };
 

--- a/app/src/lib/source.ts
+++ b/app/src/lib/source.ts
@@ -755,6 +755,8 @@ function stripInternalImports(
         );
       }
 
+      // Some import patterns consume the trailing semicolon. Others leave it
+      // behind for cleanSemicolonOnlyLines to remove.
       const unmatchedSemicolon = /^[\t ]*;/.test(
         fullText.slice(offset + match.length),
       );

--- a/app/src/lib/source.ts
+++ b/app/src/lib/source.ts
@@ -23,13 +23,16 @@ const FROM_CLAUSE = String.raw`\s+from\s+${PATH_QUOTED}`;
 const IMPORT_ATTRIBUTES = String.raw`(?<attributes>\s+(?:with|assert)\s+\{[\s\S]*?\})?`;
 
 // Import patterns
-const IMPORT_SIDE_EFFECT = new RegExp(String.raw`import\s+${PATH_QUOTED}`, "g");
+const IMPORT_SIDE_EFFECT = new RegExp(
+  String.raw`import\s+${PATH_QUOTED}${IMPORT_ATTRIBUTES}[\t ]*;?`,
+  "g",
+);
 const IMPORT_NAMED = new RegExp(
   String.raw`import\s+(?!type\b)\{[\s\S]*?\}${FROM_CLAUSE}${IMPORT_ATTRIBUTES}[\t ]*;?`,
   "g",
 );
 const IMPORT_FROM_ANY = new RegExp(
-  String.raw`import\s+(?!type\b)[^;]*?${FROM_CLAUSE}`,
+  String.raw`import\s+(?!type\b)[^;]*?${FROM_CLAUSE}${IMPORT_ATTRIBUTES}[\t ]*;?`,
   "g",
 );
 const IMPORT_TYPE_NAMED = new RegExp(
@@ -37,7 +40,7 @@ const IMPORT_TYPE_NAMED = new RegExp(
   "g",
 );
 const IMPORT_TYPE_NAMESPACE = new RegExp(
-  String.raw`import\s+type\s+\*\s+as\s+[^;]*?${FROM_CLAUSE}`,
+  String.raw`import\s+type\s+\*\s+as\s+[^;]*?${FROM_CLAUSE}${IMPORT_ATTRIBUTES}[\t ]*;?`,
   "g",
 );
 const IMPORT_DYNAMIC = new RegExp(
@@ -196,6 +199,10 @@ function getQuoteFromGroups(groups: RegExpExecArray["groups"]): string {
 
 function getAttributesFromGroups(groups: RegExpExecArray["groups"]): string {
   return groups?.attributes ?? "";
+}
+
+function buildModuleSource(path: string, attributes = ""): string {
+  return `"${path}"${attributes}`;
 }
 
 /**
@@ -391,22 +398,22 @@ function buildHoistedImports(
   valueNamed: Map<string, Set<string>>,
   typeNamed: Map<string, Set<string>>,
 ): string {
-  const allPaths = sortStrings(
+  const allSources = sortStrings(
     new Set<string>([...valueNamed.keys(), ...typeNamed.keys()]),
   );
 
   const lines: string[] = [];
-  for (const modulePath of allPaths) {
-    const typeNames = typeNamed.get(modulePath);
-    const valueNames = valueNamed.get(modulePath);
+  for (const moduleSource of allSources) {
+    const typeNames = typeNamed.get(moduleSource);
+    const valueNames = valueNamed.get(moduleSource);
 
     if (typeNames?.size) {
       const sorted = sortStrings(typeNames).join(", ");
-      lines.push(`import type { ${sorted} } from "${modulePath}";`);
+      lines.push(`import type { ${sorted} } from ${moduleSource};`);
     }
     if (valueNames?.size) {
       const sorted = sortStrings(valueNames).join(", ");
-      lines.push(`import { ${sorted} } from "${modulePath}";`);
+      lines.push(`import { ${sorted} } from ${moduleSource};`);
     }
   }
 
@@ -494,7 +501,7 @@ export function mergeImports(
   content: string,
   transform: (path: string, type: ImportPathType) => string | false,
 ): string {
-  // Collect value and type-only named imports keyed by the final transformed path
+  // Collect value and type-only named imports keyed by the final module source
   const valueNamed = new Map<string, Set<string>>();
   const typeNamed = new Map<string, Set<string>>();
 
@@ -502,12 +509,15 @@ export function mergeImports(
     originalPath: string,
     names: string[],
     type: ImportPathType,
+    attributes = "",
   ) => {
     const transformedPath = transform(originalPath, type);
     if (transformedPath === false) return;
 
     const collector = type === "import" ? valueNamed : typeNamed;
-    const specifiers = getOrCreate(collector, transformedPath, () => new Set());
+    const nextAttributes = transformedPath === originalPath ? attributes : "";
+    const moduleSource = buildModuleSource(transformedPath, nextAttributes);
+    const specifiers = getOrCreate(collector, moduleSource, () => new Set());
     for (const name of names) {
       specifiers.add(name);
     }
@@ -521,20 +531,21 @@ export function mergeImports(
       const inside = extractSpecifiersInsideBraces(match[0]);
       if (inside == null) continue;
 
+      const attributes = getAttributesFromGroups(match.groups);
       if (isTypeOnly) {
         const items = parseTypeOnlySpecifiers(inside);
         if (items.length) {
-          addSpecifiers(path, items, "import-type");
+          addSpecifiers(path, items, "import-type", attributes);
         }
         continue;
       }
 
       const { runtime, typeOnly } = parseNamedSpecifiers(inside);
       if (runtime.length) {
-        addSpecifiers(path, runtime, "import");
+        addSpecifiers(path, runtime, "import", attributes);
       }
       if (typeOnly.length) {
-        addSpecifiers(path, typeOnly, "import-type");
+        addSpecifiers(path, typeOnly, "import-type", attributes);
       }
     }
   };
@@ -579,7 +590,7 @@ export function mergeImports(
       const remainingRuntime = transformedValue === false ? runtime : [];
       const remainingType = transformedType === false ? typeOnly : [];
       const attributes = getAttributesFromGroups(groups);
-      const source = `"${path}"${attributes}`;
+      const source = buildModuleSource(path, attributes);
 
       return (
         buildRemainingImport(remainingRuntime, remainingType, source) || ";"
@@ -876,16 +887,8 @@ export function hoistImports(content: string): string {
   let body = content;
 
   const extractImports = (pattern: RegExp) => {
-    body = body.replace(pattern, (match, ...args) => {
-      const offset = (args[args.length - 3] as number) ?? 0;
-      const fullText = (args[args.length - 2] as string) ?? body;
-
-      let statement = match;
-      // Include trailing semicolon if present
-      if (fullText[offset + match.length] === ";") {
-        statement += ";";
-      }
-      imports.add(statement);
+    body = body.replace(pattern, (match) => {
+      imports.add(match);
       return "";
     });
   };

--- a/app/src/lib/source.ts
+++ b/app/src/lib/source.ts
@@ -24,7 +24,7 @@ const FROM_CLAUSE = String.raw`\s+from\s+${PATH_QUOTED}`;
 // Import patterns
 const IMPORT_SIDE_EFFECT = new RegExp(String.raw`import\s+${PATH_QUOTED}`, "g");
 const IMPORT_NAMED = new RegExp(
-  String.raw`import\s+(?!type\b)\{[\s\S]*?\}${FROM_CLAUSE}`,
+  String.raw`import\s+(?!type\b)\{[\s\S]*?\}${FROM_CLAUSE}[\t ]*;?`,
   "g",
 );
 const IMPORT_FROM_ANY = new RegExp(
@@ -156,7 +156,7 @@ function getOrCreate<K, V>(map: Map<K, V>, key: K, factory: () => V): V {
  * deleting import declarations via regex replacements.
  */
 function cleanSemicolonOnlyLines(text: string): string {
-  return text.replace(/^[\t ]*;[\t ]*\r?\n/gm, "");
+  return text.replace(/^[\t ]*;[\t ]*(?:\r?\n|$)/gm, "");
 }
 
 /**
@@ -425,18 +425,18 @@ function buildRemainingImport(
   // Both kinds remain - split into two lines
   if (remainingRuntime.length > 0 && remainingType.length > 0) {
     return [
-      `import { ${remainingRuntime.join(", ")} } from "${modulePath}"`,
-      `import type { ${remainingType.join(", ")} } from "${modulePath}"`,
+      `import { ${remainingRuntime.join(", ")} } from "${modulePath}";`,
+      `import type { ${remainingType.join(", ")} } from "${modulePath}";`,
     ].join("\n");
   }
 
   // Only runtime specifiers remain
   if (remainingRuntime.length > 0) {
-    return `import { ${remainingRuntime.join(", ")} } from "${modulePath}"`;
+    return `import { ${remainingRuntime.join(", ")} } from "${modulePath}";`;
   }
 
   // Only type specifiers remain
-  return `import type { ${remainingType.join(", ")} } from "${modulePath}"`;
+  return `import type { ${remainingType.join(", ")} } from "${modulePath}";`;
 }
 
 /**
@@ -574,7 +574,7 @@ export function mergeImports(
       const remainingRuntime = transformedValue === false ? runtime : [];
       const remainingType = transformedType === false ? typeOnly : [];
 
-      return buildRemainingImport(remainingRuntime, remainingType, path);
+      return buildRemainingImport(remainingRuntime, remainingType, path) || ";";
     });
   };
 
@@ -739,6 +739,8 @@ function stripInternalImports(
   const removeMatchingImports = (pattern: RegExp) => {
     body = body.replace(pattern, (match, ...args) => {
       const groups = args[args.length - 1] as RegExpExecArray["groups"];
+      const offset = (args[args.length - 3] as number) ?? 0;
+      const fullText = (args[args.length - 2] as string) ?? body;
       const specifier = getPathFromGroups(groups);
       if (!specifier) return match;
 
@@ -753,7 +755,10 @@ function stripInternalImports(
         );
       }
 
-      return "";
+      const unmatchedSemicolon = /^[\t ]*;/.test(
+        fullText.slice(offset + match.length),
+      );
+      return unmatchedSemicolon ? "" : ";";
     });
   };
 


### PR DESCRIPTION
## Motivation

`mergeImports` can rewrite a mixed runtime/type import into separate runtime and type import declarations. When that happens, the runtime declaration may be emitted without a semicolon because the original import regex leaves the source semicolon outside the replacement span.

The same rewrite paths also need to handle import attributes. For example, preserving only the runtime side of `import { A, type T } from "./data.json" with { type: "json" };` must not leave a dangling `with ...` suffix after the rebuilt import, and hoisting an unchanged JSON import must not drop its required attribute.

## Solution

Terminate all import declarations emitted by `buildRemainingImport` and let import matchers absorb optional original semicolons so rewritten imports do not inherit or duplicate punctuation. The import matchers now also consume optional import attributes so rewrites and hoisting preserve or remove the full declaration suffix instead of leaving fragments behind.

Named imports that are hoisted to the same module source keep their import attributes. When a transform changes the module path, attributes are intentionally not copied to the new module source. The cleanup path removes semicolon-only marker lines at EOF, preserving existing import-removal behavior when named imports are fully hoisted or stripped.

Added focused tests for mixed-import rewriting, remaining and hoisted import attributes, changed-path attribute dropping, `hoistImports`, and EOF cleanup paths in both `mergeImports` and `mergeFiles`.

## Testing

- `pnpm exec vitest run app/src/lib/source.test.ts`
- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm test`
