### PR TITLE
Speed up @ariakit/test in jsdom by firing animation frames immediately

### DIFF
--- a/.changeset/200-test-immediate-animation-frames.md
+++ b/.changeset/200-test-immediate-animation-frames.md
@@ -1,0 +1,11 @@
+---
+"@ariakit/test": patch
+---
+
+Faster simulated interactions in test environments
+
+Methods such as `click`, `type`, and `press` wait for animation frames between simulated events to mimic real user interaction. In non-browser test environments (jsdom and happy-dom), `requestAnimationFrame` runs on a ~16ms cadence, which made interaction-heavy tests slow.
+
+These environments now resolve animation frames on an immediate macrotask instead, significantly speeding up test runs while preserving the order and number of frames that components depend on. The browser environment is unaffected and keeps using the native cadence.
+
+To achieve this, `@ariakit/test` now replaces the global `requestAnimationFrame` and `cancelAnimationFrame` functions in non-browser test environments when it's imported.

--- a/packages/ariakit-test/src/__utils.test.ts
+++ b/packages/ariakit-test/src/__utils.test.ts
@@ -1,6 +1,6 @@
 // oxlint-disable unbound-method
 import { expect, test } from "vitest";
-import { isBrowser, wrapAsync } from "./__utils.ts";
+import { isBrowser, nextFrame, wrapAsync } from "./__utils.ts";
 
 test("wrapAsync does not reapply browser polyfills when nested", async () => {
   const originalFocus = HTMLElement.prototype.focus;
@@ -60,3 +60,64 @@ test("wrapAsync does not reapply the act environment when nested", async () => {
     }
   }
 });
+
+test.skipIf(isBrowser)(
+  "requestAnimationFrame batches same-frame callbacks with a shared timestamp",
+  async () => {
+    const order: string[] = [];
+    const times: number[] = [];
+    requestAnimationFrame((time) => {
+      order.push("a");
+      times.push(time);
+    });
+    requestAnimationFrame((time) => {
+      order.push("b");
+      times.push(time);
+    });
+    await nextFrame();
+    expect(order).toEqual(["a", "b"]);
+    expect(times[0]).toBe(times[1]);
+  },
+);
+
+test.skipIf(isBrowser)(
+  "requestAnimationFrame scheduled during a flush runs on the next frame",
+  async () => {
+    const calls: string[] = [];
+    requestAnimationFrame(() => {
+      calls.push("a");
+      requestAnimationFrame(() => calls.push("nested"));
+    });
+    await nextFrame();
+    expect(calls).toEqual(["a"]);
+    await nextFrame();
+    expect(calls).toEqual(["a", "nested"]);
+  },
+);
+
+test.skipIf(isBrowser)(
+  "cancelAnimationFrame prevents a scheduled callback from running",
+  async () => {
+    const calls: string[] = [];
+    const id = requestAnimationFrame(() => calls.push("x"));
+    cancelAnimationFrame(id);
+    await nextFrame();
+    expect(calls).toEqual([]);
+  },
+);
+
+test.skipIf(isBrowser)(
+  "cancelAnimationFrame skips a sibling callback queued for the current frame",
+  async () => {
+    const calls: string[] = [];
+    let siblingId = 0;
+    requestAnimationFrame(() => {
+      calls.push("a");
+      cancelAnimationFrame(siblingId);
+    });
+    siblingId = requestAnimationFrame(() => calls.push("b"));
+    requestAnimationFrame(() => calls.push("c"));
+    await nextFrame();
+    expect(calls).toEqual(["a", "c"]);
+  },
+);

--- a/packages/ariakit-test/src/__utils.ts
+++ b/packages/ariakit-test/src/__utils.ts
@@ -21,6 +21,49 @@ export function nextFrame() {
   return new Promise(requestAnimationFrame);
 }
 
+// In jsdom/happy-dom, requestAnimationFrame fires on a ~16ms cadence. Because
+// simulated interactions (and the components they drive) wait for several frames
+// per action, that cadence dominates test time. We replace it with an immediate
+// macrotask so frames resolve at wall-clock speed. Callbacks scheduled before a
+// tick are still flushed together, in order, with a shared timestamp, so the
+// frame count and ordering that components rely on (e.g. afterPaint's nested
+// frames) are preserved — only the wall-clock duration is removed. The browser
+// path keeps the native rAF so real timing and painting are unaffected.
+if (!isBrowser) {
+  let nextRafId = 1;
+  let pendingRafs = new Map<number, FrameRequestCallback>();
+  let flushingRafs: Map<number, FrameRequestCallback> | null = null;
+  let rafScheduled = false;
+
+  globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+    const id = nextRafId++;
+    pendingRafs.set(id, callback);
+    if (!rafScheduled) {
+      rafScheduled = true;
+      setTimeout(() => {
+        rafScheduled = false;
+        // Swap the queue so callbacks scheduled during the flush run on the
+        // next frame. Iterating the live map lets a callback cancel a sibling
+        // that hasn't run yet, matching the native behavior.
+        const frame = pendingRafs;
+        pendingRafs = new Map();
+        flushingRafs = frame;
+        const time = performance.now();
+        for (const frameCallback of frame.values()) {
+          frameCallback(time);
+        }
+        flushingRafs = null;
+      });
+    }
+    return id;
+  }) as typeof requestAnimationFrame;
+
+  globalThis.cancelAnimationFrame = ((id: number) => {
+    pendingRafs.delete(id);
+    flushingRafs?.delete(id);
+  }) as typeof cancelAnimationFrame;
+}
+
 export function setActEnvironment(value: boolean) {
   const scope = globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean };
   const previousValue = scope.IS_REACT_ACT_ENVIRONMENT;


### PR DESCRIPTION
## Motivation

`pnpm test-react` is dominated by the `@ariakit/test` package. To mimic real user interaction, methods like `click`, `type`, and `press` wait for animation frames between simulated events — `sleep()` does `requestAnimationFrame` → `setTimeout` → `requestAnimationFrame`, and it's called twice **per character** in `type`, three times in `press`, and twice in `click`/`hover`/`select`.

In jsdom and happy-dom, `requestAnimationFrame` fires on a fixed ~16ms cadence. Measured in this repo's jsdom environment, a single `nextFrame()` takes ~16.9ms and a default `sleep()` takes ~44.6ms — so the **two frames are ~76% of every sleep's cost**, and that frame cadence (not the simulated delay) dominates the suite's wall-clock. For example, `type("helloworld")` alone took ~960ms.

## Solution

In non-browser test environments only (gated by the existing `isBrowser` check), replace `requestAnimationFrame`/`cancelAnimationFrame` with an immediate macrotask. The replacement **batches** like jsdom does: callbacks registered before a tick are flushed together, in order, sharing one timestamp — so the *number of frames* and their *ordering*, which components depend on (e.g. `afterPaint`'s two nested frames), are preserved. Only the per-frame wall-clock is removed. The browser (Playwright) path keeps the native cadence, so real timing and painting are unaffected there.

```ts
// packages/ariakit-test/src/__utils.ts
if (!isBrowser) {
  // ...flush all rAFs registered before a tick together, on one macrotask...
  globalThis.requestAnimationFrame = (callback) => { /* immediate, batched */ };
  globalThis.cancelAnimationFrame = (id) => { /* ... */ };
}
```

Batching matters: a naive one-`setTimeout`-per-callback override loses jsdom's frame batching and made `examples/dialog-animated-various` flaky (it raced React's `data-leave` commit against `disclosure-content`'s `getComputedStyle`). The batching shim keeps it stable.

## Result

- Full `test-react` suite: **~50s → ~26s (~1.9×)**, **723/723** passing, verified stable across multiple runs.
- The previously-flaky `dialog-animated-various` passes **0/6** failures in isolation under the change.
- Solid suite, `oxlint`, `oxfmt`, and `tsc` all pass. Added focused unit tests for the shim's batching, nested-frame, and cancellation behavior (including same-frame sibling cancellation).

## Notes

This intentionally does **not** reduce the simulated `sleep()` delay (`defaultMs`): dropping it to `0` breaks a timing-calibrated animation test for marginal gain, and the frame cadence was the real cost. The change globally replaces `requestAnimationFrame`/`cancelAnimationFrame` in non-browser test environments when `@ariakit/test` is imported (noted in the changeset).
