### PR TITLE
Reduce the default delay between simulated test interactions

### DIFF
--- a/.changeset/200-reduce-default-sleep.md
+++ b/.changeset/200-reduce-default-sleep.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/test": patch
+---
+
+Slightly reduced the default delay between simulated interactions in non-browser test environments, speeding up test suites.

--- a/packages/ariakit-test/src/sleep.ts
+++ b/packages/ariakit-test/src/sleep.ts
@@ -1,6 +1,10 @@
 import { isBrowser, nextFrame, wrapAsync } from "./__utils.ts";
 
-const defaultMs = isBrowser ? 150 : 10;
+// The two animation frames in sleep() provide most of the settle time between
+// simulated interactions, so this delay is kept small in non-browser
+// environments — but not zero, as a few milliseconds remain load-bearing for
+// some interactions, such as hiding a dialog by clicking outside.
+const defaultMs = isBrowser ? 150 : 8;
 
 export function sleep(ms = defaultMs) {
   return wrapAsync(async () => {


### PR DESCRIPTION
## Motivation

`@ariakit/test` simulates real user interaction, and the `click`, `type`, `press`, etc. helpers call `sleep()` between simulated events to mimic a real user's timing. `sleep()` waits two animation frames around a small `setTimeout` delay; in non-browser test environments (jsdom/happy-dom) that delay was `10ms`.

The two frames use the native `requestAnimationFrame` (~16ms each, matching a real browser's ~60Hz cadence), and they provide the settle time tests actually rely on. The fixed `setTimeout` delay on top is mostly slack.

## Solution

Reduce the non-browser default delay from `10ms` to `8ms`, keeping both real frames so the simulation stays faithful to real browser timing. The browser/Playwright path (`150ms`) is unchanged.

`8ms` is the floor: at `0ms` the dialog hide-on-outside-click flow breaks deterministically, and `5ms` is flaky — those few milliseconds are load-bearing settle time. A comment documents this so it isn't trimmed further.

## Result

Measured with an interleaved A/B (`10` vs `8`, repeated, to control for run-to-run variance): the full `test-react` suite goes from ~45.4s to ~44.2s locally — a consistent **~1.2s (~2.6%)** improvement. Small but real and reproducible.

All 723 tests pass. The most timing-sensitive tests held up over many repeated runs: `dialog-combobox-command-menu` (hide-on-outside-click) 0/20 failures, and the combobox concurrent-filter examples (`useTransition`/`useDeferredValue`) 0/8.

Since `8` is the floor and CI runners are slower than local, CI is the final confirmation here.
