### PR TITLE
Remove duplicate popoverElement dependency

### DIFF
--- a/packages/ariakit-react-components/src/popover/popover.tsx
+++ b/packages/ariakit-react-components/src/popover/popover.tsx
@@ -407,7 +407,6 @@ export const usePopover = createHook<TagName, PopoverOptions>(
       popoverElement,
       arrowElement,
       anchorElement,
-      popoverElement,
       placement,
       mounted,
       domReady,


### PR DESCRIPTION
## Motivation

The Popover positioning `useSafeLayoutEffect` dependency array listed `popoverElement` twice. This is harmless at runtime, but it makes the hand-maintained dependency list noisier than necessary.

## Solution

Remove the redundant second `popoverElement` entry while keeping the dependency array otherwise unchanged. No changeset is included because this is a non-user-facing maintenance cleanup.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm test-react run examples/popover/test.ts examples/popover-standalone/test.ts app/src/examples/popover/_component/test.ts`