### PR TITLE
Fix ComboboxGroup invariant message

### DIFF
--- a/.changeset/300-combobox-group-invariant.md
+++ b/.changeset/300-combobox-group-invariant.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed the [`ComboboxGroup`](https://ariakit.com/reference/combobox-group) development error message to name the correct component.

--- a/packages/ariakit-react-components/src/combobox/combobox-group.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-group.tsx
@@ -36,7 +36,7 @@ export const useComboboxGroup = createHook<TagName, ComboboxGroupOptions>(
     invariant(
       store,
       process.env.NODE_ENV !== "production" &&
-        "ComboboxRow must be wrapped in a ComboboxList or ComboboxPopover component",
+        "ComboboxGroup must be wrapped in a ComboboxList or ComboboxPopover component.",
     );
 
     const contentElement = useStoreState(store, "contentElement");


### PR DESCRIPTION
## Motivation

Rendering a [`ComboboxGroup`](https://ariakit.com/reference/combobox-group) without a `ComboboxList` or `ComboboxPopover` store currently reports the wrong component in development:

```txt
ComboboxRow must be wrapped in a ComboboxList or ComboboxPopover component
```

That message was copied from `ComboboxRow`, and it also lacks the trailing period used by sibling combobox invariant messages.

## Solution

Update the `useComboboxGroup` invariant message so it names `ComboboxGroup` and ends with a period. `combobox-row.tsx` is left unchanged because its message correctly names `ComboboxRow` for that component.

A patch changeset is included for `@ariakit/react-components` and `@ariakit/react` because `ComboboxGroup` is a public React component export.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`

No focused test was added for this dev-only message string; there is no existing ComboboxGroup/useComboboxGroup invariant-message test pattern in the repo.
