### PR TITLE
Resolve duplicate perf labels with exact probing

### DIFF
--- a/packages/ariakit-scripts/src/perf.test.ts
+++ b/packages/ariakit-scripts/src/perf.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, expect, test } from "vitest";
-import { getIntegerEnv, parseScriptProfile } from "./perf.ts";
+import {
+  getIntegerEnv,
+  getUniquePerfLabel,
+  parseScriptProfile,
+} from "./perf.ts";
 
 const envName = "PERF_ITERATIONS";
 const originalValue = process.env[envName];
@@ -23,6 +27,12 @@ test("gets integer env values with range validation", () => {
 
   process.env[envName] = "0";
   expect(getIntegerEnv(envName, 1, { min: 0 })).toBe(0);
+});
+
+test("resolves duplicate perf labels with exact label counts", () => {
+  expect(getUniquePerfLabel(["foo #2"], "foo")).toBe("foo");
+  expect(getUniquePerfLabel(["foo", "foo #2"], "foo")).toBe("foo #3");
+  expect(getUniquePerfLabel(["foo", "foo #3"], "foo")).toBe("foo #2");
 });
 
 test("does not double-count recursive script profile frames", () => {

--- a/packages/ariakit-scripts/src/perf.ts
+++ b/packages/ariakit-scripts/src/perf.ts
@@ -215,24 +215,15 @@ export function getUniquePerfLabel(
   labels: Iterable<string>,
   baseLabel: string,
 ): string {
-  const occurrences = new Map<string, number>();
+  const used = new Set(labels);
+  if (!used.has(baseLabel)) return baseLabel;
 
-  for (const label of labels) {
-    occurrences.set(label, (occurrences.get(label) ?? 0) + 1);
-  }
-
-  const duplicateCount = occurrences.get(baseLabel) ?? 0;
-  if (duplicateCount === 0) return baseLabel;
-
-  let suffix = duplicateCount + 1;
-  let label = `${baseLabel} #${suffix}`;
-
-  while (occurrences.has(label)) {
+  let suffix = 2;
+  while (used.has(`${baseLabel} #${suffix}`)) {
     suffix += 1;
-    label = `${baseLabel} #${suffix}`;
   }
 
-  return label;
+  return `${baseLabel} #${suffix}`;
 }
 
 function isTruthyEnv(name: string): boolean {

--- a/packages/ariakit-scripts/src/perf.ts
+++ b/packages/ariakit-scripts/src/perf.ts
@@ -211,6 +211,30 @@ export function computeMedianMetrics(all: PerfMetrics[]): PerfMetrics {
   };
 }
 
+export function getUniquePerfLabel(
+  labels: Iterable<string>,
+  baseLabel: string,
+): string {
+  const occurrences = new Map<string, number>();
+
+  for (const label of labels) {
+    occurrences.set(label, (occurrences.get(label) ?? 0) + 1);
+  }
+
+  const duplicateCount = occurrences.get(baseLabel) ?? 0;
+  if (duplicateCount === 0) return baseLabel;
+
+  let suffix = duplicateCount + 1;
+  let label = `${baseLabel} #${suffix}`;
+
+  while (occurrences.has(label)) {
+    suffix += 1;
+    label = `${baseLabel} #${suffix}`;
+  }
+
+  return label;
+}
+
 function isTruthyEnv(name: string): boolean {
   return process.env[name] === "true" || process.env[name] === "1";
 }
@@ -834,11 +858,10 @@ export async function createPerfMeasure(
 
   const testTitle = testInfo.titlePath.filter(Boolean).join(" > ");
   const baseLabel = label ?? testTitle;
-  const duplicateCount = results.filter(
-    (r) => r.label === baseLabel || r.label.startsWith(`${baseLabel} #`),
-  ).length;
-  const resolvedLabel =
-    duplicateCount === 0 ? baseLabel : `${baseLabel} #${duplicateCount + 1}`;
+  const resolvedLabel = getUniquePerfLabel(
+    results.map((result) => result.label),
+    baseLabel,
+  );
 
   results.push({
     testFile: path.relative(process.cwd(), testInfo.file),


### PR DESCRIPTION
## Motivation

Perf measurements de-duplicate repeated labels by checking whether previous labels equal the base label or start with the generated suffix prefix. That makes a hand-authored label like `foo #2` look like a duplicate of `foo`, which can inflate the suffix assigned to later measurements.

## Solution

Add a small `getUniquePerfLabel` helper that tracks used labels exactly and then probes ` #N` suffixes until it finds an unused label. `createPerfMeasure` now uses that helper instead of the broad `startsWith` check, so `foo` and a literal `foo #2` can coexist while repeated `foo` measurements still get unique labels.

A focused `perf.test.ts` regression covers the literal suffix case and suffix probing.

## Verification

- `pnpm lint-fix`
- `pnpm test packages/ariakit-scripts/src/perf.test.ts`
- `pnpm tsc`

No changeset: `@ariakit/scripts` is ignored by the changeset config and this is an internal private scripts package change.
