### PR TITLE
Fix undo manager stack limit

### DIFF
--- a/.changeset/300-undo-manager-limit.md
+++ b/.changeset/300-undo-manager-limit.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/utils": patch
+---
+
+Fixed [`createUndoManager`](https://ariakit.com/reference/create-undo-manager) to keep the undo stack within the configured limit after executing new actions.

--- a/packages/ariakit-utils/src/undo.test.ts
+++ b/packages/ariakit-utils/src/undo.test.ts
@@ -40,3 +40,52 @@ test("groups consecutive actions under the same group", async () => {
   expect(manager.canRedo()).toBe(true);
   expect(log).toEqual(["do:one", "do:two", "undo:two", "undo:one"]);
 });
+
+test("keeps ungrouped actions within the configured limit", async () => {
+  const log: string[] = [];
+  const manager = createUndoManager({ limit: 2 });
+
+  await manager.execute(createUndoableAction(log, "one"));
+  await manager.execute(createUndoableAction(log, "two"));
+  await manager.execute(createUndoableAction(log, "three"));
+
+  await manager.undo();
+  await manager.undo();
+
+  expect(manager.canUndo()).toBe(false);
+
+  await manager.undo();
+
+  expect(log).toEqual([
+    "do:one",
+    "do:two",
+    "do:three",
+    "undo:three",
+    "undo:two",
+  ]);
+});
+
+test("keeps grouped actions within the limit without dropping unrelated actions", async () => {
+  const log: string[] = [];
+  const manager = createUndoManager({ limit: 2 });
+
+  await manager.execute(createUndoableAction(log, "one"));
+  await manager.execute(createUndoableAction(log, "two"), "group");
+  await manager.execute(createUndoableAction(log, "three"), "group");
+
+  await manager.undo();
+
+  expect(manager.canUndo()).toBe(true);
+
+  await manager.undo();
+
+  expect(manager.canUndo()).toBe(false);
+  expect(log).toEqual([
+    "do:one",
+    "do:two",
+    "do:three",
+    "undo:three",
+    "undo:two",
+    "undo:one",
+  ]);
+});

--- a/packages/ariakit-utils/src/undo.ts
+++ b/packages/ariakit-utils/src/undo.ts
@@ -53,10 +53,6 @@ export function createUndoManager({
   const execute = async (callback: Callback, group?: string) => {
     if (!callback) return;
 
-    while (undoStack.length > limit) {
-      undoStack.shift();
-    }
-
     const sameGroup = group === currentGroup;
     currentGroup = group ?? null;
 
@@ -78,6 +74,10 @@ export function createUndoManager({
         await callback?.();
       };
     });
+
+    while (undoStack.length > limit) {
+      undoStack.shift();
+    }
   };
 
   return {


### PR DESCRIPTION
## Motivation

`createUndoManager().execute()` trimmed the undo stack before appending a new undo entry. When the stack was already at its configured `limit`, an ungrouped action was appended at index `limit`, leaving the stack one entry over the cap until the next execution repeated the same pattern.

## Solution

Move the trim to after a new undo entry is stored so the configured limit applies to the final stack length. Grouped executions still reuse the top stack index, so grouped writes at the cap do not evict unrelated older entries.

Added focused tests for ungrouped overflow and grouped writes at the cap, plus a patch changeset for `@ariakit/utils`.

## Verification

- `pnpm test packages/ariakit-utils/src/undo.test.ts`
- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm -F @ariakit/utils build`
