### PR TITLE
Reset dialog outside focus state on reopen

### DIFF
--- a/.changeset/300-dialog-reopen-focus-state.md
+++ b/.changeset/300-dialog-reopen-focus-state.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Dialog`](https://ariakit.com/reference/dialog) to reset outside-interaction focus tracking when reused dialogs reopen.

--- a/app/src/sandbox/dialog-reopen-focus-state/index.react.tsx
+++ b/app/src/sandbox/dialog-reopen-focus-state/index.react.tsx
@@ -1,0 +1,23 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+
+export default function Example() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Ariakit.Button onClick={() => setOpen(true)}>Open dialog</Ariakit.Button>
+      <Ariakit.Dialog
+        open={open}
+        onClose={() => setOpen(false)}
+        unmountOnHide={false}
+        autoFocusOnShow={false}
+        autoFocusOnHide={false}
+      >
+        <Ariakit.DialogHeading>Dialog</Ariakit.DialogHeading>
+        <button type="button">Focus inside</button>
+        <Ariakit.DialogDismiss>Close dialog</Ariakit.DialogDismiss>
+      </Ariakit.Dialog>
+    </>
+  );
+}

--- a/app/src/sandbox/dialog-reopen-focus-state/test.ts
+++ b/app/src/sandbox/dialog-reopen-focus-state/test.ts
@@ -1,0 +1,29 @@
+import { click, q, waitFor } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+test("resets outside-interaction focus tracking when reopened", async () => {
+  await click(q.button.ensure("Open dialog"));
+  expect(q.dialog("Dialog")).toBeVisible();
+
+  await click(q.button.ensure("Focus inside"));
+  await click(q.button.ensure("Close dialog"));
+  await waitFor(() =>
+    expect(q.dialog.includesHidden("Dialog")).not.toBeVisible(),
+  );
+
+  await click(q.button.ensure("Open dialog"));
+  expect(q.dialog("Dialog")).toBeVisible();
+
+  const input = document.createElement("input");
+  input.setAttribute("aria-label", "Dynamic outside input");
+  document.body.append(input);
+
+  try {
+    input.focus();
+    await waitFor(() =>
+      expect(q.dialog.includesHidden("Dialog")).not.toBeVisible(),
+    );
+  } finally {
+    input.remove();
+  }
+});

--- a/packages/ariakit-react-components/src/dialog/utils/use-hide-on-interact-outside.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/use-hide-on-interact-outside.ts
@@ -68,6 +68,7 @@ function useEventOutside({
     if (!open) return;
     if (!domReady) return;
     if (!contentElement) return;
+    focusedRef.current = false;
     const onFocus = () => {
       focusedRef.current = true;
     };


### PR DESCRIPTION
## Motivation

Reused dialogs can keep stale outside-interaction focus state after they close. If a dialog receives focus during one open cycle, closes, and then reopens without remounting, the next open cycle can start as though the dialog has already been focused.

That makes newly inserted, unmarked outside elements more lenient than they would be for a fresh dialog instance.

## Solution

Reset the `focusedRef` gate when the outside-interaction listeners are set up for an open dialog, after `open`, `domReady`, and `contentElement` are available. Cleanup remains limited to removing the listener so the reset is tied to setup rather than teardown.

Added a React sandbox regression test that reuses the same mounted dialog, primes the focus gate, closes and reopens it, then focuses a newly inserted outside input before any new inside focus.

## Testing

- `pnpm lint-fix`
- `pnpm test-react app/src/sandbox/dialog-reopen-focus-state/test.ts app/src/sandbox/menu-radio-default-checked/test.ts app/src/sandbox/tooltip-4894/test.ts app/src/sandbox/hovercard-nested-listener/test.ts`
- `pnpm tsc`
- `pnpm build`
