### PR TITLE
Fix form store array index detection

### DIFF
--- a/.changeset/300-form-store-array-indexes.md
+++ b/.changeset/300-form-store-array-indexes.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/components": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`useFormStore`](https://ariakit.com/reference/use-form-store) nested value updates so path segments like `-1`, `Infinity`, and `NaN` are treated as object keys instead of array indexes.

--- a/packages/ariakit-components/src/form/form-store.test.ts
+++ b/packages/ariakit-components/src/form/form-store.test.ts
@@ -48,6 +48,18 @@ test("uses object paths for non-array index segments", () => {
   });
 });
 
+test("replaces an existing array container for non-array index segments", () => {
+  const store = createFormStore({});
+
+  store.setValue("users.0.name", "Ada");
+  store.setValue("users.-1.name", "Grace");
+
+  expect(Array.isArray(store.getValue("users"))).toBe(false);
+  expect(store.getState().values).toEqual({
+    users: { "0": { name: "Ada" }, "-1": { name: "Grace" } },
+  });
+});
+
 test("updates nested values with setter functions", () => {
   const store = createFormStore({
     defaultValues: { user: { visits: 1 } },

--- a/packages/ariakit-components/src/form/form-store.test.ts
+++ b/packages/ariakit-components/src/form/form-store.test.ts
@@ -17,6 +17,37 @@ test("gets and sets nested values with array and object paths", () => {
   });
 });
 
+test("supports numeric array path segments at runtime", () => {
+  const store = createFormStore({});
+
+  Reflect.apply(store.setValue, store, [["users", 0, "name"], "Ada"]);
+
+  expect(store.getValue("users.0.name")).toBe("Ada");
+  expect(Array.isArray(store.getValue("users"))).toBe(true);
+  expect(store.getState().values).toEqual({
+    users: [{ name: "Ada" }],
+  });
+});
+
+test("uses object paths for non-array index segments", () => {
+  const store = createFormStore({});
+
+  store.setValue("users.-1.name", "Ada");
+  store.setValue("stats.Infinity.count", 1);
+  store.setValue("meta.NaN.value", true);
+  store.setValue("items.4294967295.name", "Grace");
+
+  expect(store.getValue("users.-1.name")).toBe("Ada");
+  expect(Array.isArray(store.getValue("users"))).toBe(false);
+  expect(Array.isArray(store.getValue("items"))).toBe(false);
+  expect(store.getState().values).toEqual({
+    users: { "-1": { name: "Ada" } },
+    stats: { Infinity: { count: 1 } },
+    meta: { NaN: { value: true } },
+    items: { "4294967295": { name: "Grace" } },
+  });
+});
+
 test("updates nested values with setter functions", () => {
   const store = createFormStore({
     defaultValues: { user: { visits: 1 } },

--- a/packages/ariakit-components/src/form/form-store.ts
+++ b/packages/ariakit-components/src/form/form-store.ts
@@ -6,7 +6,7 @@ import {
   throwOnConflictingProps,
 } from "@ariakit/store";
 import type { Store, StoreOptions, StoreProps } from "@ariakit/store";
-import { applyState, defaultValue, isInteger, isObject } from "@ariakit/utils";
+import { applyState, defaultValue, isObject } from "@ariakit/utils";
 import type {
   AnyObject,
   PickRequired,
@@ -23,6 +23,7 @@ import { createCollectionStore } from "../collection/collection-store.ts";
 import type { DeepMap, DeepPartial, Names, StringLike } from "./types.ts";
 
 type ErrorMessage = string | undefined | null;
+const maxArrayIndex = 2 ** 32 - 2;
 
 function nextFrame() {
   return new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
@@ -52,32 +53,44 @@ export function get<T>(
   return get(values[key], rest, defaultValue);
 }
 
+function isArrayIndex(key: string | number) {
+  if (typeof key !== "string" && typeof key !== "number") return false;
+  const stringKey = String(key);
+  const index = Number(stringKey);
+  return (
+    Number.isInteger(index) &&
+    index >= 0 &&
+    index <= maxArrayIndex &&
+    String(index) === stringKey
+  );
+}
+
 // Returns the existing nested value if it is an array or object, otherwise
-// creates a new container based on whether the next key is an integer.
-function getOrCreateNested(nestedValues: unknown, nextKey: string) {
+// creates a new container based on whether the next key is an array index.
+function getOrCreateNested(nestedValues: unknown, nextKey: string | number) {
   if (Array.isArray(nestedValues) || isObject(nestedValues)) {
     return nestedValues;
   }
-  return isInteger(nextKey) ? [] : {};
+  return isArrayIndex(nextKey) ? [] : {};
 }
 
 function set<T extends FormStoreValues | unknown[]>(
   values: T,
-  path: StringLike | string[],
+  path: StringLike | Array<string | number>,
   value: unknown,
 ): T {
   const [k, ...rest] = Array.isArray(path) ? path : String(path).split(".");
   if (k == null) return values;
   const key = k as keyof T;
-  const isIntegerKey = isInteger(key);
-  const nextValues = isIntegerKey ? values || [] : values || {};
+  const isArrayIndexKey = isArrayIndex(k);
+  const nextValues = isArrayIndexKey ? values || [] : values || {};
   const nestedValues = nextValues[key];
   const nextKey = rest[0];
   const result =
     rest.length && nextKey != null
       ? set(getOrCreateNested(nestedValues, nextKey), rest, value)
       : value;
-  if (isIntegerKey) {
+  if (isArrayIndexKey) {
     const index = Number(key);
     if (values && Array.isArray(values)) {
       const copy = [...values];

--- a/packages/ariakit-utils/src/misc.test.ts
+++ b/packages/ariakit-utils/src/misc.test.ts
@@ -7,7 +7,7 @@ import {
   shallowEqual,
 } from "./misc.ts";
 
-test("isInteger preserves the form path discriminator contract", () => {
+test("isInteger preserves its loose numeric coercion behavior", () => {
   expect(isInteger(0)).toBe(true);
   expect(isInteger(1)).toBe(true);
   expect(isInteger(-1)).toBe(true);


### PR DESCRIPTION
## Motivation

Form store path handling used the exported `isInteger` helper to decide whether a path segment should create or update an array. That helper intentionally preserves loose numeric coercion behavior, so segments such as `-1`, `Infinity`, and `NaN` could be classified as array indexes and write non-index properties onto arrays.

The form store needs a stricter path-index rule than the shared utility.

## Solution

This adds a local `isArrayIndex` predicate for form store paths. It only accepts canonical JavaScript array indexes: string or number segments that are integers, non-negative, within the valid array-index range, and round-trip through `String(index)`.

The regression tests cover:

```ts
store.setValue("users.-1.name", "Ada");
store.setValue("stats.Infinity.count", 1);
store.setValue("meta.NaN.value", true);
store.setValue("items.4294967295.name", "Grace");
```

Those paths now create object keys instead of malformed arrays, while canonical array paths such as `users.0.name` and runtime numeric segments such as `["users", 0, "name"]` still create arrays.
