### PR TITLE
Fix Dialog restoring focus to the trigger on outside click under React 18

### DIFF
--- a/.changeset/300-dialog-controlled-outside-focus.md
+++ b/.changeset/300-dialog-controlled-outside-focus.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Dialog`](https://ariakit.com/reference/dialog) incorrectly restoring focus to the disclosure element when a controlled dialog was hidden by clicking or right-clicking outside it on React 18.

--- a/examples/dialog/test.ts
+++ b/examples/dialog/test.ts
@@ -1,4 +1,4 @@
-import { click, press, q } from "@ariakit/test";
+import { click, dispatch, press, q, waitFor } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 test("show on disclosure click", async () => {
@@ -47,6 +47,30 @@ test("hide on click outside", async () => {
   await click(document.body);
   expect(q.dialog()).not.toBeInTheDocument();
   expect(q.button("Show modal")).not.toHaveFocus();
+});
+
+test("hide on right-click outside does not restore focus", async () => {
+  await click(q.button("Show modal"));
+  expect(q.dialog()).toBeVisible();
+  await dispatch.contextMenu(document.body);
+  await waitFor(() => expect(q.dialog()).not.toBeInTheDocument());
+  expect(q.button("Show modal")).not.toHaveFocus();
+});
+
+test("restore focus on escape after a previous click-outside hide", async () => {
+  // Hiding by clicking outside must not restore focus to the disclosure.
+  await click(q.button("Show modal"));
+  await click(document.body);
+  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.button("Show modal")).not.toHaveFocus();
+  // Reopening must clear the outside-interaction state so a subsequent keyboard
+  // hide does restore focus to the disclosure (the flag must not leak across
+  // hides).
+  await click(q.button("Show modal"));
+  expect(q.dialog()).toBeVisible();
+  await press.Escape();
+  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.button("Show modal")).toHaveFocus();
 });
 
 test("hide on dismiss button click", async () => {

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -163,14 +163,26 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
   // Tracks whether the dialog was hidden by an outside click or context menu.
   // When true, focusOnHide skips focus restoration to match native HTML
   // behavior where trigger buttons don't receive focus when you click outside.
-  // Reset when the dialog opens to avoid stale flags from prevented closes
-  // (e.g., onClose calling event.preventDefault), async closes with
-  // animations, or when autoFocusOnHide is disabled.
+  // It's cleared again when the dialog genuinely reopens (the deferred reset
+  // below) so a stale flag from a prevented close, an async/animated close, or a
+  // close with autoFocusOnHide disabled can't leak into the next hide.
   const interactedOutsideRef = useRef(false);
   useSafeLayoutEffect(() => {
     return sync(store, ["open"], (state) => {
       if (!state.open) return;
-      interactedOutsideRef.current = false;
+      // Defer the reset and re-check the settled open state. On React 18 the
+      // controlled `open` prop can be momentarily re-applied to the store while
+      // the dialog is hiding (useStoreProps reasserts the prop value during the
+      // commit), producing a transient open:false->true->false within a single
+      // synchronous commit. Clearing the flag synchronously on that spurious
+      // `true` would wipe the interacted-outside marker before focusOnHide reads
+      // it, wrongly restoring focus to the disclosure on outside clicks. By the
+      // time this microtask runs, the synchronous flip has settled, so we only
+      // clear the flag for a genuine reopen (open still true).
+      queueMicrotask(() => {
+        if (!store.getState().open) return;
+        interactedOutsideRef.current = false;
+      });
     });
   }, [store]);
   useHideOnInteractOutside(

--- a/packages/ariakit-react-components/src/dialog/utils/use-hide-on-interact-outside.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/use-hide-on-interact-outside.ts
@@ -131,6 +131,23 @@ export function useHideOnInteractOutside(
   const previousMouseDownRef = usePreviousMouseDownRef(open, contentWindow);
   const props = { store, domReady, capture: true };
 
+  // Hides the dialog and records that it was hidden by an outside pointer
+  // interaction so focusOnHide skips restoring focus to the trigger (matching
+  // native dialogs). store.hide() dispatches the cancelable close event
+  // synchronously; if a controlled onClose prevents it, the dialog is still open
+  // and didn't actually hide, so we clear the flag again to avoid suppressing
+  // focus restoration on a later, real hide (e.g. a router unmount after the
+  // close handler navigates away).
+  const markInteractedOutsideAndHide = () => {
+    if (interactedOutsideRef) {
+      interactedOutsideRef.current = true;
+    }
+    store.hide();
+    if (interactedOutsideRef && store.getState().open) {
+      interactedOutsideRef.current = false;
+    }
+  };
+
   useEventOutside({
     ...props,
     type: "click",
@@ -149,10 +166,7 @@ export function useHideOnInteractOutside(
       // - https://github.com/ariakit/ariakit/issues/2330
       if (!isElementMarked(previousMouseDown, contentElement?.id)) return;
       if (!shouldHideOnInteractOutside(hideOnInteractOutside, event)) return;
-      if (interactedOutsideRef) {
-        interactedOutsideRef.current = true;
-      }
-      store.hide();
+      markInteractedOutsideAndHide();
     },
   });
 
@@ -174,10 +188,7 @@ export function useHideOnInteractOutside(
     type: "contextmenu",
     listener: (event) => {
       if (!shouldHideOnInteractOutside(hideOnInteractOutside, event)) return;
-      if (interactedOutsideRef) {
-        interactedOutsideRef.current = true;
-      }
-      store.hide();
+      markInteractedOutsideAndHide();
     },
   });
 }


### PR DESCRIPTION
## Motivation

A controlled [`Dialog`](https://ariakit.com/reference/dialog) hidden by clicking — or right-clicking — outside it could incorrectly restore focus to its disclosure/trigger button. Native dialogs leave focus where the user clicked, so Ariakit tracks outside interactions in an internal flag that `focusOnHide` reads to skip restoration.

On **React 18**, hiding a *controlled* dialog produces a transient `open: false → true → false` within a single commit: `store.hide()` sets the store's `open` to `false`, but a still-committing render reasserts the controlled `open={true}` prop through `useStoreProps`, flipping the store back to open before it settles closed. The dialog's reset-on-open effect fired on that spurious `true` and cleared the interacted-outside flag *before* `focusOnHide` read it, so focus was wrongly restored.

React 19 and React 18 + jsdom commit the hide without exposing that intermediate `open=true`, so they were unaffected — which is why this only surfaced once the test suites began running on happy-dom (#6196).

```tsx
const [open, setOpen] = useState(false);
<Ariakit.Dialog open={open} onClose={() => setOpen(false)}>…</Ariakit.Dialog>;
// Click (or right-click) outside the dialog:
// Before — focus jumped back to the trigger button.
// After  — focus stays where the user clicked.
```

## Solution

Two changes to the outside-interaction focus handling:

1. **Defer the flag reset and re-check the settled state.** The reset-on-open now runs in a `queueMicrotask` and only clears the flag if `store.getState().open` is still `true` once the synchronous commit has settled. The transient flip has resolved back to `false` by then (so the flag survives for `focusOnHide`), while a genuine reopen stays `true` (so the flag is still cleared and can't leak into a later hide). This mirrors the existing `autoFocusOnShow` microtask in the same component.

2. **Clear the flag when the close is prevented.** `store.hide()` dispatches the cancelable `close` event synchronously, so if the store is still open right after it returns, a controlled `onClose` called `preventDefault()` and the dialog didn't actually hide. The flag is cleared in that case — otherwise it would suppress focus restoration when the dialog is later hidden some other way (e.g. unmounted by a router after the close handler navigates away, as in `dialog-react-router`).

The click and contextmenu interact-outside listeners now share a small `markInteractedOutsideAndHide()` helper.

## Tests

`examples/dialog/test.ts` gains two regression tests: right-click-outside doesn't restore focus, and a reopen after an outside-hide clears the state so a subsequent Escape hide *does* restore focus (the flag must not leak across hides).

Verified across React 18/19 × happy-dom/jsdom: the previously-failing focus assertions in `dialog`, `dialog-details`, `dialog-menu`, `dialog-nested`, and `dialog-nested-various` now pass on React 18 + happy-dom, with no regressions on the full suite elsewhere.

## Out of scope

A separate, pre-existing issue — `autoFocusOnShow` landing on the dialog container instead of the first tabbable element — causes 2 failures in `dialog-hide-warning-store` only under React 18 + happy-dom. It's unrelated to this fix and left for a follow-up (the React 18 CI suite runs on jsdom, where it passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
