### PR TITLE
Fix duplicate child store listener notifications

### DIFF
--- a/.changeset/300-store-child-listeners.md
+++ b/.changeset/300-store-child-listeners.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/store": patch
+"@ariakit/solid-store": patch
+---
+
+Fixed [`createStore`](https://ariakit.com/reference/create-store) to avoid notifying [`subscribe`](https://ariakit.com/reference/subscribe) and [`sync`](https://ariakit.com/reference/sync) listeners twice when an initialized child store updates shared parent state.

--- a/.changeset/300-store-child-listeners.md
+++ b/.changeset/300-store-child-listeners.md
@@ -3,4 +3,4 @@
 "@ariakit/solid-store": patch
 ---
 
-Fixed [`createStore`](https://ariakit.com/reference/create-store) to avoid notifying [`subscribe`](https://ariakit.com/reference/subscribe) and [`sync`](https://ariakit.com/reference/sync) listeners twice when an initialized child store updates shared parent state.
+Fixed initialized child stores to avoid notifying listeners twice when they update shared parent state.

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -397,6 +397,10 @@ export function createStore<S extends State>(
       }
     }
 
+    // Parent propagation may synchronously sync back into this child store
+    // and notify listeners before this outer setState resumes.
+    if (state[key] === nextValue) return;
+
     const prevState = state;
     state = { ...state, [key]: nextValue };
 

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -128,6 +128,7 @@ export function createStore<S extends State>(
   let batchPending = false;
   let inDispatch = false;
   let updatedKeys = new Set<keyof S>();
+  let localPropagation: { key: keyof S; value: S[keyof S] } | null = null;
   const instances = new Set<symbol>();
 
   const setups = new Set<() => void | (() => void)>();
@@ -386,19 +387,36 @@ export function createStore<S extends State>(
 
     if (nextValue === currentValue) return;
 
+    // During a child-originated fan-out, parent sync listeners echo the same
+    // value back into this child. Let the outer update notify after every
+    // parent has been updated.
+    if (
+      fromStores &&
+      localPropagation?.key === key &&
+      localPropagation.value === nextValue
+    ) {
+      return;
+    }
+
     // Fan a locally-originated change out to extended parent stores so they
     // stay in sync. Both short-circuits are load-bearing: `!fromStores`
     // prevents the parent/child sync loop (storeInit pushes parent updates
     // down with `fromStores`), and `stores.length` skips the iteration
     // entirely on the common store-without-parents path.
     if (!fromStores && stores.length) {
-      for (const store of stores) {
-        store?.setState?.(key, nextValue);
+      const previousLocalPropagation = localPropagation;
+      localPropagation = { key, value: nextValue };
+      try {
+        for (const store of stores) {
+          store?.setState?.(key, nextValue);
+        }
+      } finally {
+        localPropagation = previousLocalPropagation;
       }
     }
 
-    // Parent propagation may synchronously sync back into this child store
-    // and notify listeners before this outer setState resumes.
+    // Other reentrant updates may have already applied this value while
+    // parents were being updated.
     if (state[key] === nextValue) return;
 
     const prevState = state;

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -407,6 +407,12 @@ export function createStore<S extends State>(
         }
       }
 
+      // Parent fan-out can reenter this store and commit nested updates to
+      // other keys before these listeners run, advancing `state` past
+      // `nextState`. Preserve those nested updates in the previous snapshot,
+      // restoring only `key` to its pre-update value so this notification still
+      // reports the original diff. When nothing reentered, reuse `prevState`
+      // directly and skip the allocation.
       const listenerPrevState =
         state === nextState ? prevState : { ...state, [key]: prevState[key] };
       runListeners(syncListenerGroup, listenerPrevState, key);

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -128,7 +128,6 @@ export function createStore<S extends State>(
   let batchPending = false;
   let inDispatch = false;
   let updatedKeys = new Set<keyof S>();
-  let localPropagation: { key: keyof S; value: S[keyof S] } | null = null;
   const instances = new Set<symbol>();
 
   const setups = new Set<() => void | (() => void)>();
@@ -387,48 +386,26 @@ export function createStore<S extends State>(
 
     if (nextValue === currentValue) return;
 
-    // During a child-originated fan-out, parent sync listeners echo the same
-    // value back into this child. Let the outer update notify after every
-    // parent has been updated.
-    if (
-      fromStores &&
-      localPropagation?.key === key &&
-      localPropagation.value === nextValue
-    ) {
-      return;
-    }
-
-    // Fan a locally-originated change out to extended parent stores so they
-    // stay in sync. Both short-circuits are load-bearing: `!fromStores`
-    // prevents the parent/child sync loop (storeInit pushes parent updates
-    // down with `fromStores`), and `stores.length` skips the iteration
-    // entirely on the common store-without-parents path.
-    if (!fromStores && stores.length) {
-      const previousLocalPropagation = localPropagation;
-      localPropagation = { key, value: nextValue };
-      try {
-        for (const store of stores) {
-          store?.setState?.(key, nextValue);
-        }
-      } finally {
-        localPropagation = previousLocalPropagation;
-      }
-    }
-
-    // Other reentrant updates may have already applied this value while
-    // parents were being updated.
-    if (state[key] === nextValue) return;
-
-    const prevState = state;
-    state = { ...state, [key]: nextValue };
-
     // Track the active dispatch so storeBatch can distinguish idle
     // registration (refresh prevStateBatch) from registration during an
     // in-flight setState (keep prevStateBatch so the upcoming microtask
     // reports the correct diff).
     const wasInDispatch = inDispatch;
     inDispatch = true;
+    const prevState = state;
+    state = { ...state, [key]: nextValue };
     try {
+      // Fan a locally-originated change out to extended parent stores so they
+      // stay in sync. Both short-circuits are load-bearing: `!fromStores`
+      // prevents the parent/child sync loop (storeInit pushes parent updates
+      // down with `fromStores`), and `stores.length` skips the iteration
+      // entirely on the common store-without-parents path.
+      if (!fromStores && stores.length) {
+        for (const store of stores) {
+          store?.setState?.(key, nextValue);
+        }
+      }
+
       runListeners(syncListenerGroup, prevState, key);
     } finally {
       inDispatch = wasInDispatch;

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -80,6 +80,10 @@ function hasUpdatedKey<S>(
   return false;
 }
 
+function isSameValue(value: unknown, other: unknown) {
+  return value === other || (value !== value && other !== other);
+}
+
 function addKeyedListener<S>(
   map: ListenerMap<S>,
   keys: Array<keyof S> | null,
@@ -384,7 +388,7 @@ export function createStore<S extends State>(
         ? (value as (current: S[typeof key]) => S[typeof key])(currentValue)
         : value;
 
-    if (nextValue === currentValue) return;
+    if (isSameValue(nextValue, currentValue)) return;
 
     // Track the active dispatch so storeBatch can distinguish idle
     // registration (refresh prevStateBatch) from registration during an
@@ -395,6 +399,7 @@ export function createStore<S extends State>(
     const prevState = state;
     const nextState = { ...state, [key]: nextValue };
     state = nextState;
+    let superseded = false;
     try {
       // Fan a locally-originated change out to extended parent stores so they
       // stay in sync. Both short-circuits are load-bearing: `!fromStores`
@@ -404,6 +409,12 @@ export function createStore<S extends State>(
       if (!fromStores && stores.length) {
         for (const store of stores) {
           store?.setState?.(key, nextValue);
+          // Parent fan-out can reenter this child with a newer value for the
+          // same key. That nested update owns the final notification and
+          // propagation, so stop replaying the stale outer value.
+          if (isSameValue(state[key], nextValue)) continue;
+          superseded = true;
+          break;
         }
       }
 
@@ -413,9 +424,11 @@ export function createStore<S extends State>(
       // restoring only `key` to its pre-update value so this notification still
       // reports the original diff. When nothing reentered, reuse `prevState`
       // directly and skip the allocation.
-      const listenerPrevState =
-        state === nextState ? prevState : { ...state, [key]: prevState[key] };
-      runListeners(syncListenerGroup, listenerPrevState, key);
+      if (!superseded) {
+        const listenerPrevState =
+          state === nextState ? prevState : { ...state, [key]: prevState[key] };
+        runListeners(syncListenerGroup, listenerPrevState, key);
+      }
     } finally {
       inDispatch = wasInDispatch;
     }

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -393,7 +393,8 @@ export function createStore<S extends State>(
     const wasInDispatch = inDispatch;
     inDispatch = true;
     const prevState = state;
-    state = { ...state, [key]: nextValue };
+    const nextState = { ...state, [key]: nextValue };
+    state = nextState;
     try {
       // Fan a locally-originated change out to extended parent stores so they
       // stay in sync. Both short-circuits are load-bearing: `!fromStores`
@@ -406,7 +407,9 @@ export function createStore<S extends State>(
         }
       }
 
-      runListeners(syncListenerGroup, prevState, key);
+      const listenerPrevState =
+        state === nextState ? prevState : { ...state, [key]: prevState[key] };
+      runListeners(syncListenerGroup, listenerPrevState, key);
     } finally {
       inDispatch = wasInDispatch;
     }

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -871,20 +871,28 @@ test("notifies initialized child listeners once for shared local updates", () =>
   const cleanup = init(child);
   const subscribeCalls: Array<[number, number]> = [];
   const syncCalls: Array<[number, number]> = [];
+  const subscribeParentCounts: Array<[number, number]> = [];
+  const syncParentCounts: Array<[number, number]> = [];
 
   const unsubscribeSubscribe = subscribe(
     child,
     ["count"],
     (state, prevState) => {
       subscribeCalls.push([state.count, prevState.count]);
+      subscribeParentCounts.push([
+        first.getState().count,
+        second.getState().count,
+      ]);
     },
   );
   const unsubscribeSync = sync(child, ["count"], (state, prevState) => {
     syncCalls.push([state.count, prevState.count]);
+    syncParentCounts.push([first.getState().count, second.getState().count]);
   });
 
   expect(syncCalls).toEqual([[0, 0]]);
   syncCalls.length = 0;
+  syncParentCounts.length = 0;
 
   child.setState("count", 1);
 
@@ -893,6 +901,8 @@ test("notifies initialized child listeners once for shared local updates", () =>
   expect(second.getState().count).toBe(1);
   expect(subscribeCalls).toEqual([[1, 0]]);
   expect(syncCalls).toEqual([[1, 0]]);
+  expect(subscribeParentCounts).toEqual([[1, 1]]);
+  expect(syncParentCounts).toEqual([[1, 1]]);
 
   unsubscribeSubscribe();
   unsubscribeSync();

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -873,6 +873,8 @@ test("notifies initialized child listeners once for shared local updates", () =>
   const syncCalls: Array<[number, number]> = [];
   const subscribeParentCounts: Array<[number, number]> = [];
   const syncParentCounts: Array<[number, number]> = [];
+  const firstParentChildCounts: number[] = [];
+  const secondParentChildCounts: number[] = [];
 
   const unsubscribeSubscribe = subscribe(
     child,
@@ -889,6 +891,14 @@ test("notifies initialized child listeners once for shared local updates", () =>
     syncCalls.push([state.count, prevState.count]);
     syncParentCounts.push([first.getState().count, second.getState().count]);
   });
+  const unsubscribeFirstParent = sync(first, ["count"], (state) => {
+    if (state.count === 0) return;
+    firstParentChildCounts.push(child.getState().count);
+  });
+  const unsubscribeSecondParent = sync(second, ["count"], (state) => {
+    if (state.count === 0) return;
+    secondParentChildCounts.push(child.getState().count);
+  });
 
   expect(syncCalls).toEqual([[0, 0]]);
   syncCalls.length = 0;
@@ -903,9 +913,47 @@ test("notifies initialized child listeners once for shared local updates", () =>
   expect(syncCalls).toEqual([[1, 0]]);
   expect(subscribeParentCounts).toEqual([[1, 1]]);
   expect(syncParentCounts).toEqual([[1, 1]]);
+  expect(firstParentChildCounts).toEqual([1]);
+  expect(secondParentChildCounts).toEqual([1]);
 
   unsubscribeSubscribe();
   unsubscribeSync();
+  unsubscribeFirstParent();
+  unsubscribeSecondParent();
+  cleanup();
+});
+
+test("keeps child batch diff for listeners registered during parent fan-out", async () => {
+  const parent = createStore({ count: 0 });
+  const child = createStore({ count: 0 }, parent);
+
+  const cleanup = init(child);
+  const calls: Array<[number, number]> = [];
+  let unsubscribeBatch = () => {};
+  let registered = false;
+
+  const unsubscribeParent = sync(parent, ["count"], (state) => {
+    if (state.count === 0) return;
+    if (registered) return;
+    registered = true;
+    unsubscribeBatch = batch(child, ["count"], (state, prevState) => {
+      calls.push([state.count, prevState.count]);
+    });
+  });
+
+  child.setState("count", 1);
+
+  expect(calls).toEqual([[1, 0]]);
+
+  await flushBatch();
+
+  expect(calls).toEqual([
+    [1, 0],
+    [1, 0],
+  ]);
+
+  unsubscribeBatch();
+  unsubscribeParent();
   cleanup();
 });
 

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -863,6 +863,42 @@ test("initializes extended stores with argument-order precedence", () => {
   cleanup();
 });
 
+test("notifies initialized child listeners once for shared local updates", () => {
+  const first = createStore({ count: 0 });
+  const second = createStore({ count: 0 });
+  const child = createStore({ count: 0 }, first, second);
+
+  const cleanup = init(child);
+  const subscribeCalls: Array<[number, number]> = [];
+  const syncCalls: Array<[number, number]> = [];
+
+  const unsubscribeSubscribe = subscribe(
+    child,
+    ["count"],
+    (state, prevState) => {
+      subscribeCalls.push([state.count, prevState.count]);
+    },
+  );
+  const unsubscribeSync = sync(child, ["count"], (state, prevState) => {
+    syncCalls.push([state.count, prevState.count]);
+  });
+
+  expect(syncCalls).toEqual([[0, 0]]);
+  syncCalls.length = 0;
+
+  child.setState("count", 1);
+
+  expect(child.getState().count).toBe(1);
+  expect(first.getState().count).toBe(1);
+  expect(second.getState().count).toBe(1);
+  expect(subscribeCalls).toEqual([[1, 0]]);
+  expect(syncCalls).toEqual([[1, 0]]);
+
+  unsubscribeSubscribe();
+  unsubscribeSync();
+  cleanup();
+});
+
 test("keeps partial extended stores in sync while initialized", () => {
   const first = createStore({ first: "first", shared: "first" });
   const second = createStore({ shared: "second" });

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -957,6 +957,48 @@ test("keeps child batch diff for listeners registered during parent fan-out", as
   cleanup();
 });
 
+test("preserves nested child updates in prevState after parent fan-out", () => {
+  const parent = createStore({ a: "0", b: "0" });
+  const child = createStore({ a: "0", b: "0" }, parent);
+
+  const cleanup = init(child);
+  const calls: Array<{
+    state: { a: string; b: string };
+    prevState: { a: string; b: string };
+  }> = [];
+
+  const unsubscribeChild = sync(child, ["a", "b"], (state, prevState) => {
+    calls.push({
+      state: { a: state.a, b: state.b },
+      prevState: { a: prevState.a, b: prevState.b },
+    });
+  });
+  const unsubscribeParent = sync(parent, ["a"], (state) => {
+    if (state.a !== "1") return;
+    if (child.getState().b === "1") return;
+    child.setState("b", "1");
+  });
+
+  calls.length = 0;
+
+  child.setState("a", "1");
+
+  expect(calls).toEqual([
+    {
+      state: { a: "1", b: "1" },
+      prevState: { a: "1", b: "0" },
+    },
+    {
+      state: { a: "1", b: "1" },
+      prevState: { a: "0", b: "1" },
+    },
+  ]);
+
+  unsubscribeChild();
+  unsubscribeParent();
+  cleanup();
+});
+
 test("keeps partial extended stores in sync while initialized", () => {
   const first = createStore({ first: "first", shared: "first" });
   const second = createStore({ shared: "second" });

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -999,6 +999,108 @@ test("preserves nested child updates in prevState after parent fan-out", () => {
   cleanup();
 });
 
+test("skips superseded same-key child notifications after parent fan-out", () => {
+  const first = createStore({ count: 0 });
+  const second = createStore({ count: 0 });
+  const child = createStore({ count: 0 }, first, second);
+
+  const cleanup = init(child);
+  const calls: Array<[number, number]> = [];
+
+  const unsubscribeChild = sync(child, ["count"], (state, prevState) => {
+    if (state.count === 0) return;
+    calls.push([state.count, prevState.count]);
+  });
+  const unsubscribeParent = sync(first, ["count"], (state) => {
+    if (state.count !== 1) return;
+    if (child.getState().count !== 1) return;
+    child.setState("count", 2);
+  });
+
+  calls.length = 0;
+
+  child.setState("count", 1);
+
+  expect(child.getState().count).toBe(2);
+  expect(first.getState().count).toBe(2);
+  expect(second.getState().count).toBe(2);
+  expect(calls).toEqual([[2, 1]]);
+
+  unsubscribeChild();
+  unsubscribeParent();
+  cleanup();
+});
+
+test("refreshes child batch baseline after superseded same-key fan-out", async () => {
+  const parent = createStore({ count: 0 });
+  const child = createStore({ count: 0 }, parent);
+
+  const cleanup = init(child);
+  const calls: Array<[number, number]> = [];
+  let unsubscribeBatch = () => {};
+  let didSupersede = false;
+  let didRegister = false;
+
+  const unsubscribeParent = sync(parent, ["count"], (state) => {
+    if (state.count === 1 && !didSupersede) {
+      didSupersede = true;
+      child.setState("count", 2);
+    }
+    if (state.count === 3 && !didRegister) {
+      didRegister = true;
+      unsubscribeBatch = batch(child, ["count"], (state, prevState) => {
+        calls.push([state.count, prevState.count]);
+      });
+    }
+  });
+
+  child.setState("count", 1);
+
+  expect(child.getState().count).toBe(2);
+
+  child.setState("count", 3);
+
+  expect(calls).toEqual([[3, 2]]);
+
+  await flushBatch();
+
+  expect(calls).toEqual([
+    [3, 2],
+    [3, 2],
+  ]);
+
+  unsubscribeBatch();
+  unsubscribeParent();
+  cleanup();
+});
+
+test("fans out NaN values to all parent stores", () => {
+  const first = createStore({ count: 0 });
+  const second = createStore({ count: 0 });
+  const child = createStore({ count: 0 }, first, second);
+
+  const cleanup = init(child);
+  const calls: Array<[number, number]> = [];
+
+  const unsubscribeChild = sync(child, ["count"], (state, prevState) => {
+    calls.push([state.count, prevState.count]);
+  });
+
+  calls.length = 0;
+
+  child.setState("count", Number.NaN);
+
+  expect(Number.isNaN(child.getState().count)).toBe(true);
+  expect(Number.isNaN(first.getState().count)).toBe(true);
+  expect(Number.isNaN(second.getState().count)).toBe(true);
+  expect(calls).toHaveLength(1);
+  expect(Number.isNaN(calls[0]?.[0])).toBe(true);
+  expect(calls[0]?.[1]).toBe(0);
+
+  unsubscribeChild();
+  cleanup();
+});
+
 test("keeps partial extended stores in sync while initialized", () => {
   const first = createStore({ first: "first", shared: "first" });
   const second = createStore({ shared: "second" });


### PR DESCRIPTION
## Motivation

When an initialized child store updates a key shared with extended parent stores, the local `setState` propagates the value to those parents. Parent sync listeners can re-enter the child while that fan-out is still in progress.

That can notify child `subscribe` and `sync` listeners twice for the same value, or notify once before every parent has received the propagated state.

## Solution

Child `setState` now commits the new value while the store is marked as actively dispatching, then fans that value out to extended parent stores before notifying the child sync listeners. Parent-to-child echoes from the init wiring now hit the existing `nextValue === currentValue` return, so they do not trigger a second child notification.

This keeps parent listeners observing the already-updated child state, keeps child listeners running once after every parent has been updated, and preserves batch listener diffs for listeners registered from parent callbacks during fan-out. If parent fan-out causes a nested child update before the outer child listeners run, the outer listener snapshot preserves those nested changes while still reporting the original value for the outer key.

The regression tests cover the multi-parent initialized child case for `subscribe` and `sync`, parent listeners reading the child during fan-out, a parent listener registering `batch(child, ...)` while the child update is in flight, and a nested child update preserving listener `prevState` for other keys.

## Verification

- `pnpm lint-fix`
- `pnpm test packages/ariakit-store/src/test.ts`
- `pnpm test`
- `pnpm tsc`
