### PR TITLE
Scope composite typeahead buffer to store

### DIFF
--- a/.changeset/300-composite-typeahead-buffer.md
+++ b/.changeset/300-composite-typeahead-buffer.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`CompositeTypeahead`](https://ariakit.com/reference/composite-typeahead) so typeahead text from one composite no longer affects another composite rendered on the same page.

--- a/app/src/sandbox/composite-typeahead-buffer/index.react.tsx
+++ b/app/src/sandbox/composite-typeahead-buffer/index.react.tsx
@@ -28,7 +28,7 @@ export default function Example() {
     <>
       <Fixture items={["Alpha", "Alpine", "Apricot"]} label="First composite" />
       <Fixture
-        items={["Banana", "Blueberry", "Blackberry"]}
+        items={["Cherry", "Banana", "Blueberry"]}
         label="Second composite"
       />
     </>

--- a/app/src/sandbox/composite-typeahead-buffer/index.react.tsx
+++ b/app/src/sandbox/composite-typeahead-buffer/index.react.tsx
@@ -1,0 +1,36 @@
+import * as Ariakit from "@ariakit/react";
+
+interface FixtureProps {
+  items: string[];
+  label: string;
+}
+
+function Fixture({ items, label }: FixtureProps) {
+  const store = Ariakit.useCompositeStore();
+
+  return (
+    <section aria-label={label}>
+      <Ariakit.Composite
+        aria-label={label}
+        render={<Ariakit.CompositeTypeahead />}
+        store={store}
+      >
+        {items.map((item) => (
+          <Ariakit.CompositeItem key={item}>{item}</Ariakit.CompositeItem>
+        ))}
+      </Ariakit.Composite>
+    </section>
+  );
+}
+
+export default function Example() {
+  return (
+    <>
+      <Fixture items={["Alpha", "Alpine", "Apricot"]} label="First composite" />
+      <Fixture
+        items={["Banana", "Blueberry", "Blackberry"]}
+        label="Second composite"
+      />
+    </>
+  );
+}

--- a/app/src/sandbox/composite-typeahead-buffer/test.ts
+++ b/app/src/sandbox/composite-typeahead-buffer/test.ts
@@ -1,6 +1,8 @@
 import { dispatch, press, q } from "@ariakit/test";
 import { expect, test, vi } from "vitest";
 
+// Dispatch only keydown events so this stays compatible with fake timers;
+// @ariakit/test's type helper waits on timer sleeps between key steps.
 function typeahead(key: string) {
   const activeElement = document.activeElement;
   if (!activeElement) throw new Error("No active element");
@@ -14,6 +16,8 @@ function typeahead(key: string) {
 test("keeps typeahead characters scoped to each composite instance", async () => {
   await press.Tab();
 
+  // Keep the first composite's "ap" buffer alive so the old global buffer
+  // would leak into the second composite during the "b" keydown below.
   vi.useFakeTimers();
 
   try {
@@ -25,6 +29,8 @@ test("keeps typeahead characters scoped to each composite instance", async () =>
     await typeahead("p");
     expect(q.button("Apricot")).toHaveFocus();
 
+    // Cherry must not start with "b", otherwise same-initial looping would
+    // reset a leaked buffer and hide the regression.
     q.button.ensure("Cherry").focus();
     expect(q.button("Cherry")).toHaveFocus();
 

--- a/app/src/sandbox/composite-typeahead-buffer/test.ts
+++ b/app/src/sandbox/composite-typeahead-buffer/test.ts
@@ -1,0 +1,20 @@
+import { click, press, q, type } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+test("keeps typeahead characters scoped to each composite instance", async () => {
+  await press.Tab();
+
+  expect(q.button("Alpha")).toHaveFocus();
+
+  await type("a");
+  expect(q.button("Alpine")).toHaveFocus();
+
+  await type("p");
+  expect(q.button("Apricot")).toHaveFocus();
+
+  await click(q.button("Banana"));
+  expect(q.button("Banana")).toHaveFocus();
+
+  await type("b");
+  expect(q.button("Blueberry")).toHaveFocus();
+});

--- a/app/src/sandbox/composite-typeahead-buffer/test.ts
+++ b/app/src/sandbox/composite-typeahead-buffer/test.ts
@@ -1,20 +1,36 @@
-import { click, press, q, type } from "@ariakit/test";
-import { expect, test } from "vitest";
+import { dispatch, press, q } from "@ariakit/test";
+import { expect, test, vi } from "vitest";
+
+function typeahead(key: string) {
+  const activeElement = document.activeElement;
+  if (!activeElement) throw new Error("No active element");
+  return dispatch.keyDown(activeElement, {
+    bubbles: true,
+    cancelable: true,
+    key,
+  });
+}
 
 test("keeps typeahead characters scoped to each composite instance", async () => {
   await press.Tab();
 
-  expect(q.button("Alpha")).toHaveFocus();
+  vi.useFakeTimers();
 
-  await type("a");
-  expect(q.button("Alpine")).toHaveFocus();
+  try {
+    expect(q.button("Alpha")).toHaveFocus();
 
-  await type("p");
-  expect(q.button("Apricot")).toHaveFocus();
+    await typeahead("a");
+    expect(q.button("Alpine")).toHaveFocus();
 
-  await click(q.button("Banana"));
-  expect(q.button("Banana")).toHaveFocus();
+    await typeahead("p");
+    expect(q.button("Apricot")).toHaveFocus();
 
-  await type("b");
-  expect(q.button("Blueberry")).toHaveFocus();
+    q.button.ensure("Cherry").focus();
+    expect(q.button("Cherry")).toHaveFocus();
+
+    await typeahead("b");
+    expect(q.button("Banana")).toHaveFocus();
+  } finally {
+    vi.useRealTimers();
+  }
 });

--- a/examples/menubar/test.ts
+++ b/examples/menubar/test.ts
@@ -88,6 +88,21 @@ test("show/hide on key down", async () => {
   expect(q.menu("File")).toBeVisible();
 });
 
+test("typeahead from menu button continues after focus moves to menu", async () => {
+  await press.Tab();
+  await press.Enter();
+  await press.ShiftTab();
+
+  expect(q.menu("File")).toBeVisible();
+  expect(q.menuitem("File")).toHaveFocus();
+
+  await type("s");
+  expect(q.menuitem("Save Page As")).toHaveFocus();
+
+  await type("h");
+  expect(q.menuitem("Share")).toHaveFocus();
+});
+
 test("show/hide on hover", async () => {
   await hover(q.menuitem("File"));
   expect(q.menu("File")).not.toBeInTheDocument();

--- a/packages/ariakit-react-components/src/composite/composite-typeahead.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-typeahead.tsx
@@ -15,7 +15,6 @@ import {
   removeUndefinedValues,
 } from "@ariakit/utils";
 import type { ElementType, KeyboardEvent } from "react";
-import { useRef } from "react";
 import { useCompositeScopedContext } from "./composite-context.tsx";
 import type { CompositeStore, CompositeStoreItem } from "./composite-store.ts";
 import { flipItems } from "./utils.ts";
@@ -24,18 +23,35 @@ const TagName = "div" satisfies ElementType;
 type TagName = typeof TagName;
 type HTMLType = HTMLElementTagNameMap[TagName];
 
-let chars = "";
-
-function clearChars() {
-  chars = "";
+interface TypeaheadState {
+  chars: string;
+  cleanupTimeout: number;
 }
 
-function isValidTypeaheadEvent(event: KeyboardEvent) {
+const typeaheadStates = new WeakMap<CompositeStore, TypeaheadState>();
+
+function getTypeaheadState(store: CompositeStore) {
+  let typeaheadState = typeaheadStates.get(store);
+  if (!typeaheadState) {
+    typeaheadState = { chars: "", cleanupTimeout: 0 };
+    typeaheadStates.set(store, typeaheadState);
+  }
+  return typeaheadState;
+}
+
+function clearChars(typeaheadState: TypeaheadState) {
+  typeaheadState.chars = "";
+}
+
+function isValidTypeaheadEvent(
+  event: KeyboardEvent,
+  typeaheadState: TypeaheadState,
+) {
   const target = event.target as HTMLElement | null;
   if (target && isTextField(target)) return false;
   // If the spacebar is pressed, we'll only consider it a valid typeahead event
   // if there were already other characters typed.
-  if (event.key === " " && chars.length) return true;
+  if (event.key === " " && typeaheadState.chars.length) return true;
   return (
     event.key.length === 1 &&
     !event.ctrlKey &&
@@ -73,24 +89,33 @@ function itemTextStartsWith(item: CompositeStoreItem, text: string) {
     .startsWith(text.toLowerCase());
 }
 
-function getSameInitialItems(
-  items: CompositeStoreItem[],
-  char: string,
-  activeId?: string | null,
-) {
+interface GetSameInitialItemsParams {
+  activeId?: string | null;
+  char: string;
+  items: CompositeStoreItem[];
+  typeaheadState: TypeaheadState;
+}
+
+function getSameInitialItems({
+  activeId,
+  char,
+  items,
+  typeaheadState,
+}: GetSameInitialItemsParams) {
   if (!activeId) return items;
   const activeItem = items.find((item) => item.id === activeId);
   if (!activeItem) return items;
   if (!itemTextStartsWith(activeItem, char)) return items;
+  const { chars } = typeaheadState;
   // Typing "oo" will match "oof" instead of moving to the next item.
   if (chars !== char && itemTextStartsWith(activeItem, chars)) return items;
   // If we're looping through the items, we'll want to reset the chars so "oo"
   // becomes just "o".
-  chars = char;
+  typeaheadState.chars = char;
   // flipItems will put the previous items at the end of the list so we can loop
   // through them.
   return flipItems(
-    items.filter((item) => itemTextStartsWith(item, chars)),
+    items.filter((item) => itemTextStartsWith(item, char)),
     activeId,
   ).filter((item) => item.id !== activeId);
 }
@@ -122,7 +147,6 @@ export const useCompositeTypeahead = createHook<
   );
 
   const onKeyDownCaptureProp = props.onKeyDownCapture;
-  const cleanupTimeoutRef = useRef(0);
 
   // We have to listen to the event in the capture phase because the event
   // might be handled by a child component. For example, the space key may
@@ -133,8 +157,9 @@ export const useCompositeTypeahead = createHook<
     if (event.defaultPrevented) return;
     if (!typeahead) return;
     if (!store) return;
-    if (!isValidTypeaheadEvent(event)) {
-      return clearChars();
+    const typeaheadState = getTypeaheadState(store);
+    if (!isValidTypeaheadEvent(event, typeaheadState)) {
+      return clearChars(typeaheadState);
     }
     const { renderedItems, items, activeId, id } = store.getState();
     // We typically want to use the rendered items, as they're already sorted.
@@ -161,27 +186,36 @@ export const useCompositeTypeahead = createHook<
     if (offscreenItems.length) {
       enabledItems = sortBasedOnDOMPosition(enabledItems, (i) => i.element);
     }
-    if (!isSelfTargetOrItem(event, enabledItems)) return clearChars();
+    if (!isSelfTargetOrItem(event, enabledItems)) {
+      return clearChars(typeaheadState);
+    }
     event.preventDefault();
     // We need to clear the previous cleanup timeout so we can append the
     // pressed char to the existing one.
-    window.clearTimeout(cleanupTimeoutRef.current);
+    window.clearTimeout(typeaheadState.cleanupTimeout);
     // Schedule a new cleanup timeout. After a short delay we'll reset the
     // characters so the next one counts as a new start character.
-    cleanupTimeoutRef.current = window.setTimeout(() => {
-      chars = "";
+    typeaheadState.cleanupTimeout = window.setTimeout(() => {
+      clearChars(typeaheadState);
     }, 500);
     // Always consider the lowercase version of the key.
     const char = event.key.toLowerCase();
-    chars += char;
-    enabledItems = getSameInitialItems(enabledItems, char, activeId);
-    const item = enabledItems.find((item) => itemTextStartsWith(item, chars));
+    typeaheadState.chars += char;
+    enabledItems = getSameInitialItems({
+      activeId,
+      char,
+      items: enabledItems,
+      typeaheadState,
+    });
+    const item = enabledItems.find((item) =>
+      itemTextStartsWith(item, typeaheadState.chars),
+    );
     if (item) {
       store.move(item.id);
     } else {
       // Immediately clear the characters so the next keypress starts a new
       // search.
-      clearChars();
+      clearChars(typeaheadState);
     }
   });
 


### PR DESCRIPTION
## Motivation

`CompositeTypeahead` used a module-level character buffer. That made typeahead text and cleanup timing leak across unrelated composite widgets rendered on the same page.

At the same time, some Ariakit surfaces install `useCompositeTypeahead` more than once for the same composite store, such as a menubar `MenuButton` and its `MenuList`. Those surfaces still need a shared buffer so a multi-character search can continue after focus moves from the button into the menu.

## Solution

This scopes typeahead state to the `CompositeStore` with a `WeakMap`, storing both the accumulated characters and the cleanup timeout for each store. Separate composite stores now get independent buffers, while multiple typeahead hooks that operate on the same store keep sharing one sequence.

The PR also adds regression coverage for both sides of the behavior:

- a sandbox with two composites proving the second one starts with a fresh buffer;
- a menubar test proving the buffer continues after the first typed character moves focus from the menu button into its menu list.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm test-react examples/menubar/test.ts examples/menu/test.ts examples/select/test.ts app/src/sandbox/composite-typeahead-buffer/test.ts`
