### PR TITLE
Work around Astro cold dev optimizer reload that breaks React hooks

### DIFF
--- a/app/astro.config.ts
+++ b/app/astro.config.ts
@@ -64,6 +64,26 @@ export default defineConfig({
       tailwindcss(),
       sourcePlugin(join(import.meta.dirname, "src/examples/")),
     ],
+    // TODO: Remove this workaround once
+    // https://github.com/withastro/astro/issues/16853 is fixed. These bare
+    // specifiers are missed by the SSR dependency optimizer's initial scan.
+    // Some are re-exported from Astro virtual modules (astro:transitions,
+    // astro:actions); others are imported directly (astro/zod in
+    // content.config.ts, astro-remote in markdown.astro). With the Cloudflare
+    // adapter they get optimized lazily during the first cold dev request, and
+    // the mid-request optimizer reload resets React's hook dispatcher,
+    // producing "Invalid hook call" errors. Pre-including them forces the
+    // optimizer to bundle them at startup so no reload happens mid-request. The
+    // Cloudflare adapter merges this list into the SSR environment's
+    // optimizeDeps.include.
+    optimizeDeps: {
+      include: [
+        "astro/virtual-modules/transitions.js",
+        "astro/actions/runtime/entrypoints/server.js",
+        "astro/zod",
+        "astro-remote",
+      ],
+    },
   },
 
   markdown: {


### PR DESCRIPTION
## Motivation

The website (`app`) uses `@astrojs/cloudflare` + `@astrojs/react` + `<ClientRouter />`. On the first dev request after the Vite SSR dependency-optimizer cache is empty (a "cold" request, e.g. right after `astro dev` starts or after deleting `node_modules/.vite`), a few Astro virtual modules that re-export bare specifiers — `astro:transitions`, `astro:actions`, `astro/zod`, and `astro-remote` (used in `markdown.astro`) — are missed by the SSR optimizer's initial scan and only discovered while the request is being served. Each late discovery forces a mid-request optimizer reload, which resets React's module-singleton hook dispatcher:

```
[vite] ✨ new dependencies optimized: astro/virtual-modules/transitions.js
[vite] ✨ optimized dependencies changed. reloading
[ERROR] [vite] Invalid hook call. Hooks can only be called inside of the body of a function component.
[ERROR] [vite] TypeError: Cannot read properties of null (reading 'useContext')
```

The cold request then renders a broken page (locally it returned `HTTP 200` with **0 bytes**); a refresh is clean. This is the upstream bug [withastro/astro#16853](https://github.com/withastro/astro/issues/16853), currently open (P2: has workaround). It is dev-only — production builds are unaffected — but the noisy errors and broken first render are disruptive during local development.

## Solution

Pre-include the late-discovered modules in `vite.optimizeDeps.include`. The `@astrojs/cloudflare` adapter merges that list into the **SSR** environment's `optimizeDeps.include`, so the modules are bundled at startup and never trigger a mid-request reload:

```ts
optimizeDeps: {
  include: [
    "astro/virtual-modules/transitions.js",
    "astro/actions/runtime/entrypoints/server.js",
    "astro/zod",
    "astro-remote",
  ],
},
```

A `TODO` comment points at the upstream issue so the workaround can be removed once it is fixed.

This is the workaround documented in the upstream issue. It is the minimal hook: it changes only the SSR optimizer's pre-bundle set, not application behavior, and does not affect the production build.

## Verification

With a freshly cleared `node_modules/.vite`, running `astro dev` and making a cold request to `/`:

- **Before:** the reload cascade above plus `Invalid hook call` errors; `HTTP 200`, 0 bytes.
- **After:** no mid-request reloads, no errors; `HTTP 200` with a fully rendered page. All four modules appear pre-bundled in the SSR optimizer metadata (`node_modules/.vite/deps_ssr/_metadata.json`), including `astro-remote`, which the homepage does not import.
