### PR TITLE
Fix Next.js workspace root inference warning in worktrees

### DIFF
--- a/nextjs/next.config.ts
+++ b/nextjs/next.config.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { initOpenNextCloudflareForDev } from "@opennextjs/cloudflare";
 import type { NextConfig } from "next";
 
@@ -5,6 +6,14 @@ const config: NextConfig = {
   reactCompiler: true,
   typedRoutes: true,
   cacheComponents: true,
+
+  // Pin the Turbopack root to the monorepo root (the parent of this workspace).
+  // Otherwise Next.js walks up the tree collecting every workspace/lockfile and
+  // picks the outermost one as the root. In a git worktree nested under the main
+  // checkout, that outermost match is the main checkout, which is the wrong root.
+  turbopack: {
+    root: join(import.meta.dirname, ".."),
+  },
 
   // Allow cross-origin iframe embedding from the Astro app
   async headers() {


### PR DESCRIPTION
## Motivation

Running `pnpm dev-app` from a git worktree prints a Turbopack warning at startup:

```
Warning: Next.js inferred your workspace root, but it may not be correct.
 We detected multiple lockfiles and selected the directory of
 /Users/.../ariakit/pnpm-workspace.yaml as the root directory.
 To silence this warning, set `turbopack.root` in your Next.js config, or
 consider removing one of the lockfiles if it's not needed.
```

`pnpm dev-app` runs `ariakit dev`, which starts `next dev` in the `nextjs` workspace. Our worktrees live under `<main-checkout>/.claude/worktrees/<name>/`, nested inside the main checkout. When Next.js infers the Turbopack root, its `findRootDirAndLockFiles` helper walks up the directory tree collecting every workspace/lockfile it finds (it checks `pnpm-workspace.yaml` first, then lockfiles) and returns the **outermost** match as the root. Because both the worktree root and the main checkout have their own `pnpm-workspace.yaml`/`pnpm-lock.yaml`, Next.js selects the main checkout — the wrong root for the worktree — and warns.

## Solution

Pin `turbopack.root` in `nextjs/next.config.ts` to the monorepo root, computed relative to the config file so it stays correct in both the main checkout and any worktree:

```ts
import { join } from "node:path";

const config: NextConfig = {
  // ...
  turbopack: {
    root: join(import.meta.dirname, ".."),
  },
};
```

`import.meta.dirname` resolves to the `nextjs/` workspace directory, so `join(..., "..")` is the monorepo root that holds `pnpm-workspace.yaml` and `pnpm-lock.yaml`. This matches the root Next.js would otherwise infer in a normal single checkout, so there is no change in CI or for the main checkout — it only stops Next.js from escaping the worktree. The path style mirrors the existing `join(import.meta.dirname, ...)` convention used in `app/astro.config.ts`.

No changeset: `nextjs` is a private workspace and is listed in `.changeset/config.json`'s `ignore` array.

## Verification

- Ran `next dev` in a nested worktree before and after: the warning is gone and the dev server starts cleanly.
- `pnpm tsc` and `pnpm lint-fix` pass.