### PR TITLE
Fix stuck `data-active` on `Command` when Space keyup is short-circuited

### DIFF
--- a/.changeset/300-command-stuck-active-state.md
+++ b/.changeset/300-command-stuck-active-state.md
@@ -3,4 +3,4 @@
 "@ariakit/react": patch
 ---
 
-Fixed [`Command`](https://ariakit.com/reference/command) staying stuck in the active (`data-active`) state when the Space key is released while the Meta key is held, or after the element becomes disabled between keydown and keyup.
+Fixed [`Command`](https://ariakit.com/reference/command) and the components that build on it, such as [`Button`](https://ariakit.com/reference/button), staying stuck in the active (`data-active`) state when the Space key is released while the Meta key is held, or after the element becomes disabled between keydown and keyup.

--- a/.changeset/300-command-stuck-active-state.md
+++ b/.changeset/300-command-stuck-active-state.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Command`](https://ariakit.com/reference/command) staying stuck in the active (`data-active`) state when the Space key is released while the Meta key is held, or after the element becomes disabled between keydown and keyup.

--- a/app/src/sandbox/command-6217/index.react.tsx
+++ b/app/src/sandbox/command-6217/index.react.tsx
@@ -6,50 +6,18 @@ export default function Example() {
   // Becomes disabled on the Space keydown to reproduce the case where the
   // element turns disabled between keydown and keyup.
   const [disabled, setDisabled] = useState(false);
-
-  // TODO: Remove this workaround once
-  // https://github.com/ariakit/ariakit/issues/6217 is fixed. Command's onKeyUp
-  // can short-circuit (Meta held on release, or the element became disabled
-  // mid-press) before clearing its internal active state, leaving `data-active`
-  // stuck. Shadow `data-active` with our own state — Command lets consumer props
-  // override it — and clear it on every Space keyup, which runs before those
-  // short-circuit guards.
-  const [metaActive, setMetaActive] = useState(false);
-  const [pressActive, setPressActive] = useState(false);
-
   return (
     <div>
-      <Ariakit.Command
-        className="button"
-        render={<div />}
-        data-active={metaActive || undefined}
-        onKeyDown={(event) => {
-          if (event.key === " ") {
-            setMetaActive(true);
-          }
-        }}
-        onKeyUp={(event) => {
-          if (event.key === " ") {
-            setMetaActive(false);
-          }
-        }}
-      >
+      <Ariakit.Command className="button" render={<div />}>
         Meta release
       </Ariakit.Command>
       <Ariakit.Command
         className="button"
         render={<div />}
         disabled={disabled}
-        data-active={pressActive || undefined}
         onKeyDown={(event) => {
           if (event.key === " ") {
             setDisabled(true);
-            setPressActive(true);
-          }
-        }}
-        onKeyUp={(event) => {
-          if (event.key === " ") {
-            setPressActive(false);
           }
         }}
       >

--- a/app/src/sandbox/command-6217/index.react.tsx
+++ b/app/src/sandbox/command-6217/index.react.tsx
@@ -6,18 +6,50 @@ export default function Example() {
   // Becomes disabled on the Space keydown to reproduce the case where the
   // element turns disabled between keydown and keyup.
   const [disabled, setDisabled] = useState(false);
+
+  // TODO: Remove this workaround once
+  // https://github.com/ariakit/ariakit/issues/6217 is fixed. Command's onKeyUp
+  // can short-circuit (Meta held on release, or the element became disabled
+  // mid-press) before clearing its internal active state, leaving `data-active`
+  // stuck. Shadow `data-active` with our own state — Command lets consumer props
+  // override it — and clear it on every Space keyup, which runs before those
+  // short-circuit guards.
+  const [metaActive, setMetaActive] = useState(false);
+  const [pressActive, setPressActive] = useState(false);
+
   return (
     <div>
-      <Ariakit.Command className="button" render={<div />}>
+      <Ariakit.Command
+        className="button"
+        render={<div />}
+        data-active={metaActive || undefined}
+        onKeyDown={(event) => {
+          if (event.key === " ") {
+            setMetaActive(true);
+          }
+        }}
+        onKeyUp={(event) => {
+          if (event.key === " ") {
+            setMetaActive(false);
+          }
+        }}
+      >
         Meta release
       </Ariakit.Command>
       <Ariakit.Command
         className="button"
         render={<div />}
         disabled={disabled}
+        data-active={pressActive || undefined}
         onKeyDown={(event) => {
           if (event.key === " ") {
             setDisabled(true);
+            setPressActive(true);
+          }
+        }}
+        onKeyUp={(event) => {
+          if (event.key === " ") {
+            setPressActive(false);
           }
         }}
       >

--- a/app/src/sandbox/command-6217/index.react.tsx
+++ b/app/src/sandbox/command-6217/index.react.tsx
@@ -1,0 +1,28 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+import "./style.css";
+
+export default function Example() {
+  // Becomes disabled on the Space keydown to reproduce the case where the
+  // element turns disabled between keydown and keyup.
+  const [disabled, setDisabled] = useState(false);
+  return (
+    <div>
+      <Ariakit.Command className="button" render={<div />}>
+        Meta release
+      </Ariakit.Command>
+      <Ariakit.Command
+        className="button"
+        render={<div />}
+        disabled={disabled}
+        onKeyDown={(event) => {
+          if (event.key === " ") {
+            setDisabled(true);
+          }
+        }}
+      >
+        Disable on press
+      </Ariakit.Command>
+    </div>
+  );
+}

--- a/app/src/sandbox/command-6217/style.css
+++ b/app/src/sandbox/command-6217/style.css
@@ -1,0 +1,11 @@
+.button {
+  display: inline-flex;
+  cursor: pointer;
+  padding: 8px 16px;
+  border-radius: 6px;
+  background-color: #ddd;
+}
+
+.button[data-active] {
+  background-color: #aaa;
+}

--- a/app/src/sandbox/command-6217/test.ts
+++ b/app/src/sandbox/command-6217/test.ts
@@ -1,0 +1,55 @@
+import { dispatch, focus, q, sleep } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// See https://github.com/ariakit/ariakit/issues/6217
+
+test("releasing Space with Meta held clears data-active", async () => {
+  const command = q.text.ensure("Meta release");
+  await focus(command);
+  expect(command).toHaveFocus();
+
+  // Pressing Space sets the active ("pressed") state on a non-native command via
+  // onKeyDown.
+  await dispatch.keyDown(command, {
+    key: " ",
+    bubbles: true,
+    cancelable: true,
+  });
+  await sleep();
+  expect(command).toHaveAttribute("data-active");
+
+  // Releasing Space while Meta is held short-circuits onKeyUp's `metaKey` guard.
+  // Releasing the key should always clear the active state, otherwise the element
+  // stays stuck in a visually "pressed" state.
+  await dispatch.keyUp(command, {
+    key: " ",
+    metaKey: true,
+    bubbles: true,
+    cancelable: true,
+  });
+  await sleep();
+  expect(command).not.toHaveAttribute("data-active");
+});
+
+test("releasing Space clears data-active when the element becomes disabled mid-press", async () => {
+  const command = q.text.ensure("Disable on press");
+  await focus(command);
+  expect(command).toHaveFocus();
+
+  // Pressing Space sets the active state and disables the element (the example
+  // flips `disabled` in its own keydown handler).
+  await dispatch.keyDown(command, {
+    key: " ",
+    bubbles: true,
+    cancelable: true,
+  });
+  await sleep();
+  expect(command).toHaveAttribute("data-active");
+  expect(command).toHaveAttribute("aria-disabled", "true");
+
+  // Now that the element is disabled, releasing Space short-circuits onKeyUp's
+  // `disabled` guard. The active state must still be cleared.
+  await dispatch.keyUp(command, { key: " ", bubbles: true, cancelable: true });
+  await sleep();
+  expect(command).not.toHaveAttribute("data-active");
+});

--- a/packages/ariakit-react-components/src/command/command.tsx
+++ b/packages/ariakit-react-components/src/command/command.tsx
@@ -133,21 +133,30 @@ export const useCommand = createHook<TagName, CommandOptions>(
 
       if (event.defaultPrevented) return;
       if (isDuplicate) return;
-      if (disabled) return;
-      if (event.metaKey) return;
 
       const isSpace = clickOnSpace && event.key === " ";
+      if (!activeRef.current || !isSpace) return;
 
-      if (activeRef.current && isSpace) {
-        activeRef.current = false;
-        if (!isNativeClick(event)) {
-          event.preventDefault();
-          setActive(false);
-          const element = event.currentTarget;
-          const { view, ...eventInit } = event;
-          queueMicrotask(() => fireClickEvent(element, eventInit));
-        }
+      const nativeClick = isNativeClick(event);
+
+      // Clear the active state as soon as Space is released, before the
+      // `disabled` and `metaKey` guards below, so a short-circuited keyup (Meta
+      // still held on release, or the element becoming disabled between keydown
+      // and keyup) can't leave the element stuck in a visually "pressed" state.
+      // Firing the synthetic click is still gated by those guards.
+      activeRef.current = false;
+      if (!nativeClick) {
+        setActive(false);
       }
+
+      if (disabled) return;
+      if (event.metaKey) return;
+      if (nativeClick) return;
+
+      event.preventDefault();
+      const element = event.currentTarget;
+      const { view, ...eventInit } = event;
+      queueMicrotask(() => fireClickEvent(element, eventInit));
     });
 
     props = {


### PR DESCRIPTION
## Motivation

On a non-native [`Command`](https://ariakit.com/reference/command) (e.g. `render={<div />}`), pressing <kbd>Space</kbd> sets the active ("pressed") state in `onKeyDown` (`activeRef.current = true` / `setActive(true)`, which renders `data-active`). The matching reset in `onKeyUp` ran *after* the early-return guards:

```ts
const onKeyUp = useEvent((event) => {
  onKeyUpProp?.(event);
  if (event.defaultPrevented) return;
  if (isDuplicate) return;
  if (disabled) return;      // ← returned before clearing the active state
  if (event.metaKey) return; // ← returned before clearing the active state
  // ...activeRef.current = false; setActive(false)
});
```

So if <kbd>Meta</kbd> was held when <kbd>Space</kbd> was released — or the element became `disabled` between keydown and keyup — `data-active` was never cleared and the element stayed visually "pressed". It is cosmetic only (a later normal <kbd>Space</kbd> press recovers it), but the element should never get stuck in that state.

Reported in #6217.

## Solution

Clear the active state at the top of `onKeyUp`, before the `disabled` / `metaKey` guards, so releasing <kbd>Space</kbd> always clears the pressed state. Firing the synthetic click stays gated behind those guards (and the native-click check), so click behavior is otherwise unchanged.

```ts
const onKeyUp = useEvent((event) => {
  onKeyUpProp?.(event);
  if (event.defaultPrevented) return;
  if (isDuplicate) return;

  const isSpace = clickOnSpace && event.key === " ";
  if (!activeRef.current || !isSpace) return;

  const nativeClick = isNativeClick(event);

  // Always clear the active state, even when the click is short-circuited below.
  activeRef.current = false;
  if (!nativeClick) setActive(false);

  if (disabled) return;
  if (event.metaKey) return;
  if (nativeClick) return;

  event.preventDefault();
  // ...queueMicrotask(() => fireClickEvent(element, eventInit))
});
```

The sandbox under `app/src/sandbox/command-6217/` covers both triggers: releasing <kbd>Space</kbd> while <kbd>Meta</kbd> is held, and releasing <kbd>Space</kbd> after the element became `disabled` mid-press.

## Workaround

Until the fix is released, shadow `Command`'s internal `data-active` with your own state. `Command` lets a consumer-provided `data-active` prop override its internal one, and your `onKeyUp` runs before `Command`'s short-circuiting guards — so clearing your own state on every <kbd>Space</kbd> keyup also clears the visual "pressed" state, even when `Command`'s own reset is skipped. Click behavior is untouched (it's driven by an internal ref, not the attribute).

```tsx
import * as Ariakit from "@ariakit/react";
import { useState } from "react";

function Button() {
  // TODO: Remove once https://github.com/ariakit/ariakit/issues/6217 is fixed.
  const [active, setActive] = useState(false);
  return (
    <Ariakit.Command
      render={<div />}
      data-active={active || undefined}
      onKeyDown={(event) => {
        if (event.key === " ") setActive(true);
      }}
      onKeyUp={(event) => {
        if (event.key === " ") setActive(false);
      }}
    >
      Accessible button
    </Ariakit.Command>
  );
}
```

Fixes #6217
