### PR TITLE
Fix FormPush/FormRemove array-field name matching

### DIFF
--- a/.changeset/300-form-array-field-name-matching.md
+++ b/.changeset/300-form-array-field-name-matching.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`FormPush`](https://ariakit.com/reference/form-push) and [`FormRemove`](https://ariakit.com/reference/form-remove) incorrectly matching sibling array fields whose names share a prefix (for example `tags` and `tags2`) and throwing when a field name contained regular expression special characters.

--- a/app/src/sandbox/form-push-remove-6219/index.react.tsx
+++ b/app/src/sandbox/form-push-remove-6219/index.react.tsx
@@ -1,0 +1,87 @@
+import * as ak from "@ariakit/react";
+import { useState } from "react";
+
+// Array-field names are user-controlled (they come from `defaultValues` /
+// `names`), so they can be prefixes of sibling arrays (`tags` vs `tags2`) or
+// contain regex metacharacters (`c++`). FormPush/FormRemove must still match the
+// exact array and focus the right field.
+// See https://github.com/ariakit/ariakit/issues/6219
+export default function Example() {
+  const form = ak.useFormStore({
+    defaultValues: {
+      tags: ["React"],
+      tags2: ["Solid"],
+      "c++": ["11", "14"],
+    },
+  });
+
+  const tags = ak.useStoreState(form, (state) => state.values.tags);
+  const tags2 = ak.useStoreState(form, (state) => state.values.tags2);
+  const versions = ak.useStoreState(form, (state) => state.values["c++"]);
+
+  const [focused, setFocused] = useState("none");
+
+  return (
+    <ak.Form store={form}>
+      {/* Mirrors the focused field so the wrong-focus bug is visible in the
+          preview; the tests assert on the active element directly. */}
+      <output>Focused field: {focused}</output>
+
+      <fieldset>
+        <legend>Tags</legend>
+        {tags.map((_, index) => {
+          const name = `tags.${index}`;
+          return (
+            <ak.FormInput
+              key={index}
+              name={name}
+              aria-label={name}
+              onFocus={() => setFocused(name)}
+            />
+          );
+        })}
+        <ak.FormPush name="tags" value="">
+          Add tag
+        </ak.FormPush>
+      </fieldset>
+
+      <fieldset>
+        <legend>Related tags</legend>
+        {tags2.map((_, index) => {
+          const name = `tags2.${index}`;
+          return (
+            <ak.FormInput
+              key={index}
+              name={name}
+              aria-label={name}
+              onFocus={() => setFocused(name)}
+            />
+          );
+        })}
+      </fieldset>
+
+      <fieldset>
+        <legend>C++ versions</legend>
+        {versions.map((version, index) => {
+          if (version == null) return null;
+          const name = `c++.${index}`;
+          return (
+            <div key={index}>
+              <ak.FormInput
+                name={name}
+                aria-label={name}
+                onFocus={() => setFocused(name)}
+              />
+              <ak.FormRemove name="c++" index={index}>
+                Remove {name}
+              </ak.FormRemove>
+            </div>
+          );
+        })}
+        <ak.FormPush name="c++" value="">
+          Add version
+        </ak.FormPush>
+      </fieldset>
+    </ak.Form>
+  );
+}

--- a/app/src/sandbox/form-push-remove-6219/index.react.tsx
+++ b/app/src/sandbox/form-push-remove-6219/index.react.tsx
@@ -1,23 +1,29 @@
 import * as ak from "@ariakit/react";
 import { useState } from "react";
 
-// Array-field names are user-controlled (they come from `defaultValues` /
-// `names`), so they can be prefixes of sibling arrays (`tags` vs `tags2`) or
-// contain regex metacharacters (`c++`). FormPush/FormRemove must still match the
-// exact array and focus the right field.
-// See https://github.com/ariakit/ariakit/issues/6219
+// Workaround for https://github.com/ariakit/ariakit/issues/6219: FormPush and
+// FormRemove match array fields by loose name prefix and interpolate the raw
+// field name into a RegExp. Until the fix lands, avoid array names that are
+// prefixes of sibling arrays and avoid regex metacharacters in field names.
+// TODO: Restore the `tags2` / `c++` names once the issue above is fixed.
 export default function Example() {
   const form = ak.useFormStore({
     defaultValues: {
       tags: ["React"],
-      tags2: ["Solid"],
-      "c++": ["11", "14"],
+      // `relatedTags` rather than `tags2` so it isn't a prefix sibling of
+      // `tags`.
+      relatedTags: ["Solid"],
+      // `cpp` rather than `c++` so the name has no regex metacharacters.
+      cpp: ["11", "14"],
     },
   });
 
   const tags = ak.useStoreState(form, (state) => state.values.tags);
-  const tags2 = ak.useStoreState(form, (state) => state.values.tags2);
-  const versions = ak.useStoreState(form, (state) => state.values["c++"]);
+  const relatedTags = ak.useStoreState(
+    form,
+    (state) => state.values.relatedTags,
+  );
+  const versions = ak.useStoreState(form, (state) => state.values.cpp);
 
   const [focused, setFocused] = useState("none");
 
@@ -47,8 +53,8 @@ export default function Example() {
 
       <fieldset>
         <legend>Related tags</legend>
-        {tags2.map((_, index) => {
-          const name = `tags2.${index}`;
+        {relatedTags.map((_, index) => {
+          const name = `relatedTags.${index}`;
           return (
             <ak.FormInput
               key={index}
@@ -64,7 +70,7 @@ export default function Example() {
         <legend>C++ versions</legend>
         {versions.map((version, index) => {
           if (version == null) return null;
-          const name = `c++.${index}`;
+          const name = `cpp.${index}`;
           return (
             <div key={index}>
               <ak.FormInput
@@ -72,13 +78,13 @@ export default function Example() {
                 aria-label={name}
                 onFocus={() => setFocused(name)}
               />
-              <ak.FormRemove name="c++" index={index}>
+              <ak.FormRemove name="cpp" index={index}>
                 Remove {name}
               </ak.FormRemove>
             </div>
           );
         })}
-        <ak.FormPush name="c++" value="">
+        <ak.FormPush name="cpp" value="">
           Add version
         </ak.FormPush>
       </fieldset>

--- a/app/src/sandbox/form-push-remove-6219/index.react.tsx
+++ b/app/src/sandbox/form-push-remove-6219/index.react.tsx
@@ -1,29 +1,23 @@
 import * as ak from "@ariakit/react";
 import { useState } from "react";
 
-// Workaround for https://github.com/ariakit/ariakit/issues/6219: FormPush and
-// FormRemove match array fields by loose name prefix and interpolate the raw
-// field name into a RegExp. Until the fix lands, avoid array names that are
-// prefixes of sibling arrays and avoid regex metacharacters in field names.
-// TODO: Restore the `tags2` / `c++` names once the issue above is fixed.
+// Array-field names are user-controlled (they come from `defaultValues` /
+// `names`), so they can be prefixes of sibling arrays (`tags` vs `tags2`) or
+// contain regex metacharacters (`c++`). FormPush/FormRemove must still match the
+// exact array and focus the right field.
+// See https://github.com/ariakit/ariakit/issues/6219
 export default function Example() {
   const form = ak.useFormStore({
     defaultValues: {
       tags: ["React"],
-      // `relatedTags` rather than `tags2` so it isn't a prefix sibling of
-      // `tags`.
-      relatedTags: ["Solid"],
-      // `cpp` rather than `c++` so the name has no regex metacharacters.
-      cpp: ["11", "14"],
+      tags2: ["Solid"],
+      "c++": ["11", "14"],
     },
   });
 
   const tags = ak.useStoreState(form, (state) => state.values.tags);
-  const relatedTags = ak.useStoreState(
-    form,
-    (state) => state.values.relatedTags,
-  );
-  const versions = ak.useStoreState(form, (state) => state.values.cpp);
+  const tags2 = ak.useStoreState(form, (state) => state.values.tags2);
+  const versions = ak.useStoreState(form, (state) => state.values["c++"]);
 
   const [focused, setFocused] = useState("none");
 
@@ -53,8 +47,8 @@ export default function Example() {
 
       <fieldset>
         <legend>Related tags</legend>
-        {relatedTags.map((_, index) => {
-          const name = `relatedTags.${index}`;
+        {tags2.map((_, index) => {
+          const name = `tags2.${index}`;
           return (
             <ak.FormInput
               key={index}
@@ -70,7 +64,7 @@ export default function Example() {
         <legend>C++ versions</legend>
         {versions.map((version, index) => {
           if (version == null) return null;
-          const name = `cpp.${index}`;
+          const name = `c++.${index}`;
           return (
             <div key={index}>
               <ak.FormInput
@@ -78,13 +72,13 @@ export default function Example() {
                 aria-label={name}
                 onFocus={() => setFocused(name)}
               />
-              <ak.FormRemove name="cpp" index={index}>
+              <ak.FormRemove name="c++" index={index}>
                 Remove {name}
               </ak.FormRemove>
             </div>
           );
         })}
-        <ak.FormPush name="cpp" value="">
+        <ak.FormPush name="c++" value="">
           Add version
         </ak.FormPush>
       </fieldset>

--- a/app/src/sandbox/form-push-remove-6219/test.ts
+++ b/app/src/sandbox/form-push-remove-6219/test.ts
@@ -1,0 +1,30 @@
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6219
+
+function activeFieldName() {
+  return document.activeElement?.getAttribute("name") ?? null;
+}
+
+test("FormPush keeps focus within the target array, not a sibling sharing the name prefix", async () => {
+  // `tags` and `tags2` are separate arrays, and `tags` is a prefix of `tags2`.
+  await click(q.button("Add tag"));
+  // Auto-focus must stay on a `tags` field and never leak into the `tags2`
+  // sibling, whose name shares the `tags` prefix.
+  expect(activeFieldName()).toMatch(/^tags\.\d+$/);
+});
+
+test("FormPush keeps focus within an array whose name has regex metacharacters", async () => {
+  // The `c++` array name contains regex metacharacters. Building the auto-focus
+  // matcher must not throw, and focus must stay within the array.
+  await click(q.button("Add version"));
+  expect(activeFieldName()?.startsWith("c++.")).toBe(true);
+});
+
+test("FormRemove moves focus to the next field when the array name has regex metacharacters", async () => {
+  // Removing the first `c++` item must move focus to the next field (`c++.1`)
+  // without throwing on the metacharacter name.
+  await click(q.button("Remove c++.0"));
+  expect(activeFieldName()).toBe("c++.1");
+});

--- a/app/src/sandbox/form-push-remove-6219/test.ts
+++ b/app/src/sandbox/form-push-remove-6219/test.ts
@@ -1,30 +1,31 @@
 import { click, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
-// Reproduces https://github.com/ariakit/ariakit/issues/6219
+// Validates the userland workaround for
+// https://github.com/ariakit/ariakit/issues/6219: with safe field names
+// (`relatedTags` instead of `tags2`, `cpp` instead of `c++`), FormPush and
+// FormRemove behave correctly on the unfixed library.
 
 function activeFieldName() {
   return document.activeElement?.getAttribute("name") ?? null;
 }
 
-test("FormPush keeps focus within the target array, not a sibling sharing the name prefix", async () => {
-  // `tags` and `tags2` are separate arrays, and `tags` is a prefix of `tags2`.
+test("workaround: FormPush keeps focus within the target array when no sibling shares its name prefix", async () => {
+  // `relatedTags` does not start with `tags`, so it isn't matched as part of
+  // the `tags` array and focus stays on a `tags` field.
   await click(q.button("Add tag"));
-  // Auto-focus must stay on a `tags` field and never leak into the `tags2`
-  // sibling, whose name shares the `tags` prefix.
   expect(activeFieldName()).toMatch(/^tags\.\d+$/);
 });
 
-test("FormPush keeps focus within an array whose name has regex metacharacters", async () => {
-  // The `c++` array name contains regex metacharacters. Building the auto-focus
-  // matcher must not throw, and focus must stay within the array.
+test("workaround: FormPush works with an array name free of regex metacharacters", async () => {
+  // `cpp` has no regex metacharacters, so building the auto-focus matcher does
+  // not throw.
   await click(q.button("Add version"));
-  expect(activeFieldName()?.startsWith("c++.")).toBe(true);
+  expect(activeFieldName()?.startsWith("cpp.")).toBe(true);
 });
 
-test("FormRemove moves focus to the next field when the array name has regex metacharacters", async () => {
-  // Removing the first `c++` item must move focus to the next field (`c++.1`)
-  // without throwing on the metacharacter name.
-  await click(q.button("Remove c++.0"));
-  expect(activeFieldName()).toBe("c++.1");
+test("workaround: FormRemove works with an array name free of regex metacharacters", async () => {
+  // `cpp` has no regex metacharacters, so focus moves to the next field.
+  await click(q.button("Remove cpp.0"));
+  expect(activeFieldName()).toBe("cpp.1");
 });

--- a/app/src/sandbox/form-push-remove-6219/test.ts
+++ b/app/src/sandbox/form-push-remove-6219/test.ts
@@ -1,31 +1,30 @@
 import { click, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
-// Validates the userland workaround for
-// https://github.com/ariakit/ariakit/issues/6219: with safe field names
-// (`relatedTags` instead of `tags2`, `cpp` instead of `c++`), FormPush and
-// FormRemove behave correctly on the unfixed library.
+// Reproduces https://github.com/ariakit/ariakit/issues/6219
 
 function activeFieldName() {
   return document.activeElement?.getAttribute("name") ?? null;
 }
 
-test("workaround: FormPush keeps focus within the target array when no sibling shares its name prefix", async () => {
-  // `relatedTags` does not start with `tags`, so it isn't matched as part of
-  // the `tags` array and focus stays on a `tags` field.
+test("FormPush keeps focus within the target array, not a sibling sharing the name prefix", async () => {
+  // `tags` and `tags2` are separate arrays, and `tags` is a prefix of `tags2`.
   await click(q.button("Add tag"));
+  // Auto-focus must stay on a `tags` field and never leak into the `tags2`
+  // sibling, whose name shares the `tags` prefix.
   expect(activeFieldName()).toMatch(/^tags\.\d+$/);
 });
 
-test("workaround: FormPush works with an array name free of regex metacharacters", async () => {
-  // `cpp` has no regex metacharacters, so building the auto-focus matcher does
-  // not throw.
+test("FormPush keeps focus within an array whose name has regex metacharacters", async () => {
+  // The `c++` array name contains regex metacharacters. Building the auto-focus
+  // matcher must not throw, and focus must stay within the array.
   await click(q.button("Add version"));
-  expect(activeFieldName()?.startsWith("cpp.")).toBe(true);
+  expect(activeFieldName()?.startsWith("c++.")).toBe(true);
 });
 
-test("workaround: FormRemove works with an array name free of regex metacharacters", async () => {
-  // `cpp` has no regex metacharacters, so focus moves to the next field.
-  await click(q.button("Remove cpp.0"));
-  expect(activeFieldName()).toBe("cpp.1");
+test("FormRemove moves focus to the next field when the array name has regex metacharacters", async () => {
+  // Removing the first `c++` item must move focus to the next field (`c++.1`)
+  // without throwing on the metacharacter name.
+  await click(q.button("Remove c++.0"));
+  expect(activeFieldName()).toBe("c++.1");
 });

--- a/packages/ariakit-react-components/src/form/form-push.tsx
+++ b/packages/ariakit-react-components/src/form/form-push.tsx
@@ -25,15 +25,22 @@ function getFirstFieldsByName(
   name: string,
 ) {
   if (!items) return [];
+  const prefix = `${name}.`;
   const fields: FormStoreState["items"] = [];
+  const seenIndexes = new Set<string>();
   for (const item of items) {
     if (item.type !== "field") continue;
-    if (!item.name.startsWith(name)) continue;
-    const nameWithIndex = item.name.replace(/(\.\d+)\..+$/, "$1");
-    const regex = new RegExp(`^${nameWithIndex}`);
-    if (!fields.some((i) => regex.test(i.name))) {
-      fields.push(item);
-    }
+    // Match the exact array boundary so sibling arrays whose names share this
+    // prefix (e.g. `tags` and `tags2`) aren't matched.
+    if (item.name !== name && !item.name.startsWith(prefix)) continue;
+    // Keep only the first field of each array index. The index is read off the
+    // known prefix instead of interpolating the user-controlled name into a
+    // RegExp, which could throw on regex metacharacters (e.g. `a(b`).
+    const index =
+      item.name.slice(prefix.length).match(/^\d+/)?.[0] ?? item.name;
+    if (seenIndexes.has(index)) continue;
+    seenIndexes.add(index);
+    fields.push(item);
   }
   return fields;
 }

--- a/packages/ariakit-react-components/src/form/form-remove.tsx
+++ b/packages/ariakit-react-components/src/form/form-remove.tsx
@@ -17,24 +17,36 @@ const TagName = "button" satisfies ElementType;
 type TagName = typeof TagName;
 type HTMLType = HTMLElementTagNameMap[TagName];
 
+// Reads the array index off the known `name.` prefix without interpolating the
+// user-controlled name into a RegExp, which could throw on regex metacharacters
+// (e.g. `a(b`). Returns `NaN` when the field doesn't belong to the array.
+function getArrayFieldIndex(fieldName: string, name: string) {
+  const prefix = `${name}.`;
+  if (!fieldName.startsWith(prefix)) return Number.NaN;
+  const index = fieldName.slice(prefix.length).match(/^\d+/)?.[0];
+  return index ? Number.parseInt(index, 10) : Number.NaN;
+}
+
 function findNextOrPreviousField(
   items: FormStoreState["items"] | undefined,
   name: string,
   index: number,
 ) {
+  const prefix = `${name}.`;
+  // Match the exact array boundary so sibling arrays whose names share this
+  // prefix (e.g. `tags` and `tags2`) aren't matched.
   const fields = items?.filter(
-    (item) => item.type === "field" && item.name.startsWith(name),
+    (item) =>
+      item.type === "field" &&
+      (item.name === name || item.name.startsWith(prefix)),
   );
-  const regex = new RegExp(`^${name}\\.(\\d+)`);
-  const nextField = fields?.find((field) => {
-    const fieldIndex = field.name.replace(regex, "$1");
-    return Number.parseInt(fieldIndex, 10) > index;
-  });
+  const nextField = fields?.find(
+    (field) => getArrayFieldIndex(field.name, name) > index,
+  );
   if (nextField) return nextField;
-  return fields?.reverse().find((field) => {
-    const fieldIndex = field.name.replace(regex, "$1");
-    return Number.parseInt(fieldIndex, 10) < index;
-  });
+  return fields
+    ?.reverse()
+    .find((field) => getArrayFieldIndex(field.name, name) < index);
 }
 
 function findPushButton(


### PR DESCRIPTION
## Motivation

[`FormPush`](https://ariakit.com/reference/form-push) and [`FormRemove`](https://ariakit.com/reference/form-remove) locate the fields of an array by matching field names with a loose prefix check (`item.name.startsWith(name)`) and by building `RegExp`s that interpolate the raw, user-controlled field name. Because field names are user-controlled (via [`defaultValues`](https://ariakit.com/reference/use-form-store#defaultvalues) / [`names`](https://ariakit.com/reference/use-form-store#names)), this causes two bugs:

1. **Sibling prefix collision** — for an array named `tags`, `startsWith("tags")` also matches sibling arrays like `tags2`. After [`FormPush`](https://ariakit.com/reference/form-push) adds an item, its auto-focus can leak into a `tags2` field instead of staying within the `tags` array.
2. **Regex crash** — a field name containing regular expression metacharacters (e.g. `c++`) makes `new RegExp("^c++.0")` throw `SyntaxError: Invalid regular expression: /^c++.0/: Nothing to repeat`, both in [`FormPush`](https://ariakit.com/reference/form-push) auto-focus and [`FormRemove`](https://ariakit.com/reference/form-remove) focus restoration.

```tsx
const form = useFormStore({
  defaultValues: { tags: ["a"], tags2: ["b"], "c++": ["11"] },
});

// Auto-focus can land on a `tags2` field instead of a `tags` field:
<FormPush name="tags" value="" />

// Throws SyntaxError: Invalid regular expression: /^c++.0/: Nothing to repeat
<FormPush name="c++" value="" />
```

## Solution

Match the exact array boundary — a field belongs to `name` only when `item.name === name` or `item.name.startsWith(name + ".")` — and read the array index off that known prefix (`name.`) instead of interpolating the user-controlled name into a `RegExp`.

This keeps auto-focus inside the correct array and stops field names with regex special characters from throwing.

## Workaround

Until this fix is released, avoid array field names that are prefixes of sibling array names, and avoid regex special characters in field names.

```tsx
// TODO: Remove once https://github.com/ariakit/ariakit/issues/6219 is fixed.
const form = useFormStore({
  defaultValues: {
    tags: ["a"],
    // Not a prefix collision with `tags`, and no regex special characters.
    relatedTags: ["b"],
    cpp: ["11"],
  },
});
```

Alternatively, set [`autoFocusOnClick={false}`](https://ariakit.com/reference/form-push#autofocusonclick) on [`FormPush`](https://ariakit.com/reference/form-push)/[`FormRemove`](https://ariakit.com/reference/form-remove) to skip the built-in focus matching entirely (this disables the auto-focus behavior).

Fixes #6219
