### PR TITLE
Fix website returning 200 for unknown documentation pages

### DIFF
--- a/website/app/(main)/[category]/[page]/page.tsx
+++ b/website/app/(main)/[category]/[page]/page.tsx
@@ -18,6 +18,12 @@ import { getNextPageMetadata } from "@/lib/get-next-page-metadata.ts";
 
 const { pages } = pagesConfig;
 
+// Return a 404 for params that aren't generated below. This route already
+// calls notFound() for unknown pages, but on-demand rendering resolves it to a
+// soft 404 with a 200 status; disabling dynamic params returns a real 404 at
+// the routing layer instead.
+export const dynamicParams = false;
+
 function getPageNames(page: Page) {
   return getPageEntryFilesCached(page).map(getPageName);
 }


### PR DESCRIPTION
## Motivation

In the `website` workspace, not-found pages under the `/[category]/[page]` route returned HTTP `200` instead of `404`. For example:

```
GET https://ariakit.com/reference/this-api-does-not-exist-xyz → 200
```

This is a soft 404: the full layout renders with an empty main area, but the status code tells crawlers and tooling the page is valid.

The route at `website/app/(main)/[category]/[page]/page.tsx` already calls `notFound()` for unknown pages:

```tsx
const file = getFile(config, page);
if (!file) return notFound();
const content = getContent(config, file, page);
if (!content) return notFound();
```

But the route defaults to `dynamicParams = true`, so params that aren't generated by `generateStaticParams` are rendered on demand. During that on-demand render the `notFound()` is swallowed by the `@modal` parallel slot in `website/app/(main)/layout.tsx` (its `default.tsx` always resolves), so the response ends up a soft 404 with a `200` status. The single-segment route `(main)/[category]/page.tsx` was unaffected and already returned `404`.

## Solution

Opt the route out of on-demand rendering so unknown params return a real `404` at the routing layer, before the page (and the parallel slot) render:

```tsx
export const dynamicParams = false;
```

Every real page is already generated by `generateStaticParams` (confirmed on production: `dialog`, `use-dialog-store`, `dialog-provider`, etc. are all served as `PRERENDER`), so no valid page is affected — only unknown params now `404`.

## Verification

Ran the `website` dev server locally:

| URL | Before | After |
| --- | --- | --- |
| `/reference/dialog`, `/reference/use-dialog-store`, `/components/dialog`, `/examples/dialog`, `/guide/styling` | `200` | `200` |
| `/reference/this-api-does-not-exist-xyz` | `200` | `404` |
| `/components/…`, `/examples/…`, `/guide/…` (unknown) | `200` | `404` |
| `/nonexistentcategory/foo` | `200` | `404` |
| `/nonexistentcategory` (single segment) | `404` | `404` |

## Notes

- Scope is limited to the two-segment `[category]/[page]` route. Other dynamic routes already return `404` for unknown params (verified on production): the single-segment category route `/[category]` and the `/tags/[tag]` route both 404 correctly today, so they are intentionally left unchanged. The soft-404 only affects this route.
- No automated test is added: the legacy `website` Playwright harness does not discover any tests locally in this environment (its browser e2e is being migrated to the `app` workspace), so a regression test could not be authored and validated here. The fix was instead verified with the dev server (table above) against the confirmed production `200` baseline.
