### PR TITLE
Fix preview deploy failing when the branch name is too long

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -56,6 +56,19 @@ jobs:
           if [ -z "$SAFE" ]; then
             SAFE="branch-$(printf "%s" "$HEAD_BRANCH" | shasum | cut -c1-12)"
           fi
+          # Cloudflare joins the alias and worker script name into a single
+          # "<alias>-<script>" label that must total less than 63 characters.
+          # Our longest script is "ariakit-preview" (15 chars), so cap the alias
+          # length at 46: worst case "<46chars>-ariakit-preview" is 62 chars.
+          # When truncating, append a short hash of the full branch name so two
+          # long branches that share a prefix keep distinct aliases.
+          MAX=46
+          if [ "${#SAFE}" -gt "$MAX" ]; then
+            HASH=$(printf "%s" "$HEAD_BRANCH" | shasum | cut -c1-7)
+            # Leave room in the 46-char budget for the "-" separator and hash.
+            SAFE=$(printf "%s" "$SAFE" | cut -c1-"$((MAX - ${#HASH} - 1))" | sed -E 's#-+$##')
+            SAFE="$SAFE-$HASH"
+          fi
           echo "slug=$SAFE" >> "$GITHUB_OUTPUT"
 
       - name: Set up environment


### PR DESCRIPTION
## Motivation

The `deploy-preview` workflow uploads preview versions of the app and Next.js workers to Cloudflare, passing the branch name as a `--preview-alias`. Cloudflare requires the alias name and the worker script name combined to total less than 63 characters. The alias slug was derived from the branch name with no length cap, so a long branch name overflowed the limit and the preview deploy failed:

```
✘ [ERROR] A request to the Cloudflare API (/accounts/***/workers/scripts/ariakit-preview/versions) failed.
  validation failures: Alias name too long. The alias name and script name combined together must total less than 63 characters in length. [code: 10021]
```

## Solution

Cap the generated alias slug. The longest script we upload is `ariakit-preview` (15 chars), so the alias is capped at 46 characters — worst case `<alias>-ariakit-preview` is 62 characters, just under the limit (`ariakit-nextjs` is shorter still). When a branch name exceeds the cap, keep a readable prefix and append a short hash of the full branch name so two long branches that share a prefix still get distinct, deterministic aliases.

```sh
MAX=46
if [ "${#SAFE}" -gt "$MAX" ]; then
  HASH=$(printf "%s" "$HEAD_BRANCH" | shasum | cut -c1-7)
  # Leave room in the 46-char budget for the "-" separator and hash.
  SAFE=$(printf "%s" "$SAFE" | cut -c1-"$((MAX - ${#HASH} - 1))" | sed -E 's#-+$##')
  SAFE="$SAFE-$HASH"
fi
```

Short branch names are unchanged, preserving existing readable preview URLs.

## Notes

- This is scoped to the length error (code 10021). The cap assumes the longest preview script name stays `ariakit-preview` (15 chars), documented in an inline comment next to `MAX`.
- The 7-character (~28-bit) hash makes alias collisions between distinct long branches negligible at PR volume.
- CI-only change, so no changeset is needed (`app`/`nextjs` are in the changeset `ignore` list).
