### PR TITLE
Fix changeset reference links pointing to 404 pages

### DIFF
--- a/.changeset/300-composite-renderer-active-ancestor.md
+++ b/.changeset/300-composite-renderer-active-ancestor.md
@@ -2,4 +2,4 @@
 "@ariakit/react-components": patch
 ---
 
-Fixed [`CompositeRenderer`](https://ariakit.com/reference/composite-renderer) to keep the active item's generated ancestor rendered in virtualized composite widgets.
+Fixed `CompositeRenderer` to keep the active item's generated ancestor rendered in virtualized composite widgets.

--- a/.changeset/300-select-renderer-orientation.md
+++ b/.changeset/300-select-renderer-orientation.md
@@ -2,4 +2,4 @@
 "@ariakit/react-components": patch
 ---
 
-Fixed [`SelectRenderer`](https://ariakit.com/reference/select-renderer) and [`CompositeRenderer`](https://ariakit.com/reference/composite-renderer) to apply explicit `orientation` props to the rendered item layout.
+Fixed `SelectRenderer` and `CompositeRenderer` to apply explicit `orientation` props to the rendered item layout.

--- a/.changeset/300-undo-manager-limit.md
+++ b/.changeset/300-undo-manager-limit.md
@@ -2,4 +2,4 @@
 "@ariakit/utils": patch
 ---
 
-Fixed [`createUndoManager`](https://ariakit.com/reference/create-undo-manager) to keep the undo stack within the configured limit after executing new actions.
+Fixed `createUndoManager` to keep the undo stack within the configured limit after executing new actions.


### PR DESCRIPTION
## Motivation

Three changeset entries linked public API names to `ariakit.com/reference/` pages that return HTTP `404`, so the rendered changelog would contain broken links:

- `CompositeRenderer` → `ariakit.com/reference/composite-renderer` (404)
- `SelectRenderer` → `ariakit.com/reference/select-renderer` (404)
- `createUndoManager` → `ariakit.com/reference/create-undo-manager` (404)

The experimental `*Renderer` components have no reference docs, and `createUndoManager` is a lower-level `@ariakit/utils` API with no public reference page, so none of these names should have been linked.

## Solution

Replace the broken Markdown links with plain inline code spans, leaving the surrounding sentences unchanged. This follows the repository changeset convention that an API whose reference page returns `404` must be left as plain inline code rather than linked.

The remaining reference links across all `.changeset/*.md` files were verified to return HTTP `200` (including the `disclosure-content#unmountonhide` anchor), so no other entries needed changes.
