### PR TITLE
Document the numeric changeset filename convention in the contributing guide

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -482,14 +482,20 @@ When adding new features or fixing bugs, we'll need to bump the package versions
 
 > The action of adding a new example doesn't require a version bump. Only changes to the codebase that affect the public API or existing behavior (e.g., bugs) do.
 
-Let's craft a fresh changeset file for our component. You can use any name for the file, but it should begin with the pull request number, followed by a dash:
+Let's craft a fresh changeset file for our component. Name the file with a numeric prefix that determines its order in the changelog (lower numbers appear earlier), followed by a dash and a short kebab-case description:
 
-`.changeset/1271-my-component.md`
+- `100-` for major changes
+- `200-` for minor changes, such as features and improvements
+- `300-` for patch changes, such as bug fixes
+
+While the packages are still in `v0`, mark minor and patch changes as `patch` and major changes as `minor` in the frontmatter. The numeric prefix still reflects the actual change type:
+
+`.changeset/200-my-component.md`
 
 ```markdown
 ---
-"@ariakit/react": minor
 "@ariakit/react-components": patch
+"@ariakit/react": patch
 ---
 
 Added `MyComponent` component.


### PR DESCRIPTION
## Motivation

The "Versioning" section of `contributing.md` didn't match how changesets are actually written in this repository:

- It told contributors to name changeset files after the pull request number (`.changeset/1271-my-component.md`), but every file in `.changeset` uses a numeric ordering prefix (`100-`/`200-`/`300-`).
- Its example frontmatter mixed bump types for the two mirror packages (`@ariakit/react: minor`, `@ariakit/react-components: patch`), whereas real dual-package entries give both packages the same bump, and while the packages are in `v0` minor changes are marked `patch`.

```
Before: .changeset/1271-my-component.md
        "@ariakit/react": minor
        "@ariakit/react-components": patch

After:  .changeset/200-my-component.md
        "@ariakit/react-components": patch
        "@ariakit/react": patch
```

## Solution

Update the section to describe the conventions used across the repo:

- Name files with a numeric prefix that sets changelog order — `100-` major, `200-` minor, `300-` patch — followed by a dash and a short kebab-case description, instead of the PR number.
- State the `v0` frontmatter rule (mark minor and patch changes as `patch`, major as `minor`) **before** the example, so the `200-`-prefixed example with `patch` frontmatter reads consistently rather than looking contradictory.
- Use `.changeset/200-my-component.md` with matching `patch` bumps for both packages, in the package order used by most existing changesets.

Docs-only change, so no changeset is included.