### PR TITLE
Run pnpm dedupe after Renovate dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
   "minimumReleaseAge": "3 days",
   "semanticCommits": "disabled",
+  "postUpdateOptions": ["pnpmDedupe"],
   "packageRules": [
     {
       "matchFileNames": ["website/package.json"],


### PR DESCRIPTION
## Motivation

Renovate updates a dependency's version but does not deduplicate the lockfile afterward, so transitive copies pinned to the old version can linger. This surfaced in #6234 (Update vite): bumping the `app` workspace's direct `vite` devDependency from `7.3.3` to `7.3.5` left the Astro toolchain (`@cloudflare/vite-plugin`, `@vitejs/plugin-react`, `vite-plugin-solid`, `vitefu`) still peer-resolved against `vite@7.3.3`, so `app` ended up installing two copies of Vite 7. That duplicate had to be cleaned up manually with `pnpm dedupe`.

The root cause is that `renovate.json` defines no `postUpdateOptions`, so Renovate never runs `pnpm dedupe` as part of an update.

## Solution

Add the `pnpmDedupe` post-update option so Renovate runs `pnpm dedupe` after each dependency update and includes the deduplicated lockfile in the PR:

```json
"postUpdateOptions": ["pnpmDedupe"],
```

This is set at the top level so it applies to every pnpm lockfile update rather than only the `vite` rule, preventing the leftover-duplicate class of issue for any future dependency bump without a manual dedupe pass.

## Notes

The first dependency-update PRs after this lands may carry larger-than-usual lockfile diffs as Renovate dedupes the existing backlog of duplicate sub-trees. That churn is expected and self-correcting, and it stays gated by the repository's normal CI checks.
