### PR TITLE
Scan examples workspace in Renovate and group React types

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,15 @@
   "minimumReleaseAge": "3 days",
   "semanticCommits": "disabled",
   "postUpdateOptions": ["pnpmDedupe"],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/__tests__/**",
+    "**/test/**",
+    "**/tests/**",
+    "**/__fixtures__/**"
+  ],
   "packageRules": [
     {
       "matchFileNames": ["website/package.json"],
@@ -56,7 +65,12 @@
     },
     {
       "groupName": "react",
-      "matchPackageNames": ["react", "react-dom"]
+      "matchPackageNames": [
+        "react",
+        "react-dom",
+        "@types/react",
+        "@types/react-dom"
+      ]
     },
     {
       "groupName": "vite",


### PR DESCRIPTION
## Motivation

Renovate never updates the top-level `examples/` workspace. Our config extends `config:recommended`, which bundles the `:ignoreModulesAndTests` preset, and that preset's default `ignorePaths` includes `**/examples/**` — which matches our top-level `examples/` pnpm workspace. So Renovate silently skips `examples/package.json` entirely: every dependency there has to be bumped by hand, and a partial React update can leave the lockfile carrying two React versions (one kept alive solely by `examples/`).

You can see the gap in the Renovate Dependency Dashboard's "Detected Dependencies" — every pnpm workspace member is listed _except_ `examples/` (even the fully-disabled `website/` is listed).

Separately, `react`/`react-dom` live in our custom `react` group while `@types/react`/`@types/react-dom` fall into Renovate's built-in "react monorepo" group. That splits one React update across two PRs and lets runtime React bump without its types (or vice versa).

## Solution

- Override `ignorePaths` to the documented `:ignoreModulesAndTests` default **minus** `**/examples/**`, so the `examples/` workspace is scanned. `ignorePaths` replaces (does not merge with) the inherited preset value, so the other seven default globs are re-listed verbatim. The repo has exactly one `package.json` under any `examples/`-named path (`examples/package.json`), so nothing nested is newly exposed.
- Add `@types/react` and `@types/react-dom` to the custom `react` group so runtime React and its types always move together in a single PR.

`examples/` intentionally stays on React 19: it is exercised in place by the default `test-react` suite through the React 19 `@ariakit/test` harness, so its `react` must match the harness (pinning it to React 18 makes react@18 hooks run inside react-dom@19 and fails the suite). The legacy `website/` workspace renders these examples under its own React 18 via Next.js's forced single-React alias and remains fully disabled in Renovate.

## Verification

- `renovate-config-validator` passes against the updated config.
