### PR TITLE
Fix mouseDown selection preservation

### DIFF
--- a/.changeset/300-test-mouse-down-selection.md
+++ b/.changeset/300-test-mouse-down-selection.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/test": patch
+---
+
+Fixed `mouseDown()` preserving or clearing the document selection based on the pressed target, matching browser behavior for native non-text controls and text targets.

--- a/packages/ariakit-test/src/mouse-down.test.ts
+++ b/packages/ariakit-test/src/mouse-down.test.ts
@@ -5,7 +5,7 @@ import { select } from "./select.ts";
 
 const selectionText = "sample paragraph text";
 
-function setup() {
+beforeEach(() => {
   document.body.innerHTML = `
     <p>Keep this ${selectionText} selected.</p>
     <button type="button">Preserve selection</button>
@@ -36,9 +36,7 @@ function setup() {
     <div tabindex="0">Focusable text target</div>
     <p>Plain text target</p>
   `;
-}
-
-beforeEach(setup);
+});
 
 async function selectParagraphText() {
   await select(selectionText, q.text.ensure(/Keep this/));

--- a/packages/ariakit-test/src/mouse-down.test.ts
+++ b/packages/ariakit-test/src/mouse-down.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+import { beforeEach, expect, test } from "vitest";
 import { mouseDown } from "./mouse-down.ts";
 import { q } from "./query.ts";
 import { select } from "./select.ts";
@@ -38,13 +38,14 @@ function setup() {
   `;
 }
 
+beforeEach(setup);
+
 async function selectParagraphText() {
   await select(selectionText, q.text.ensure(/Keep this/));
   expect(document.getSelection()?.toString()).toBe(selectionText);
 }
 
 test("mouseDown on a button preserves the document selection", async () => {
-  setup();
   await selectParagraphText();
   await mouseDown(q.button("Preserve selection"));
   expect(document.getSelection()?.toString()).toBe(selectionText);
@@ -52,56 +53,48 @@ test("mouseDown on a button preserves the document selection", async () => {
 });
 
 test("mouseDown on an editable target clears the document selection", async () => {
-  setup();
   await selectParagraphText();
   await mouseDown(q.textbox("Editable target"));
   expect(document.getSelection()?.toString()).toBe("");
 });
 
 test("mouseDown on an email input clears the document selection", async () => {
-  setup();
   await selectParagraphText();
   await mouseDown(q.textbox("Email target"));
   expect(document.getSelection()?.toString()).toBe("");
 });
 
 test("mouseDown on a non-text input preserves the document selection", async () => {
-  setup();
   await selectParagraphText();
   await mouseDown(q.checkbox("Toggle target"));
   expect(document.getSelection()?.toString()).toBe(selectionText);
 });
 
 test("mouseDown on a select preserves the document selection", async () => {
-  setup();
   await selectParagraphText();
   await mouseDown(q.combobox("Select target"));
   expect(document.getSelection()?.toString()).toBe(selectionText);
 });
 
 test("mouseDown on a link preserves the document selection", async () => {
-  setup();
   await selectParagraphText();
   await mouseDown(q.link("Link target"));
   expect(document.getSelection()?.toString()).toBe(selectionText);
 });
 
 test("mouseDown on an SVG link preserves the document selection", async () => {
-  setup();
   await selectParagraphText();
   await mouseDown(q.link("SVG link target"));
   expect(document.getSelection()?.toString()).toBe(selectionText);
 });
 
 test("mouseDown on a focusable text target clears the document selection", async () => {
-  setup();
   await selectParagraphText();
   await mouseDown(q.text("Focusable text target"));
   expect(document.getSelection()?.toString()).toBe("");
 });
 
 test("mouseDown on a plain text target clears the document selection", async () => {
-  setup();
   await selectParagraphText();
   await mouseDown(q.text("Plain text target"));
   expect(document.getSelection()?.toString()).toBe("");

--- a/packages/ariakit-test/src/mouse-down.test.ts
+++ b/packages/ariakit-test/src/mouse-down.test.ts
@@ -13,6 +13,22 @@ function setup() {
       Editable target
       <input />
     </label>
+    <label>
+      Email target
+      <input type="email" />
+    </label>
+    <label>
+      Toggle target
+      <input type="checkbox" />
+    </label>
+    <label>
+      Select target
+      <select>
+        <option>One</option>
+      </select>
+    </label>
+    <a href="#target">Link target</a>
+    <div tabindex="0">Focusable text target</div>
     <p>Plain text target</p>
   `;
 }
@@ -24,22 +40,51 @@ async function selectParagraphText() {
 
 test("mouseDown on a button preserves the document selection", async () => {
   setup();
-  // TODO: Remove workaround for https://github.com/ariakit/ariakit/issues/6253.
-  // This preserves selection, but it also skips the focus path.
-  q.button
-    .ensure("Preserve selection")
-    .addEventListener("mousedown", (event) => {
-      event.preventDefault();
-    });
   await selectParagraphText();
   await mouseDown(q.button("Preserve selection"));
   expect(document.getSelection()?.toString()).toBe(selectionText);
+  expect(q.button("Preserve selection")).toHaveFocus();
 });
 
 test("mouseDown on an editable target clears the document selection", async () => {
   setup();
   await selectParagraphText();
   await mouseDown(q.textbox("Editable target"));
+  expect(document.getSelection()?.toString()).toBe("");
+});
+
+test("mouseDown on an email input clears the document selection", async () => {
+  setup();
+  await selectParagraphText();
+  await mouseDown(q.textbox("Email target"));
+  expect(document.getSelection()?.toString()).toBe("");
+});
+
+test("mouseDown on a non-text input preserves the document selection", async () => {
+  setup();
+  await selectParagraphText();
+  await mouseDown(q.checkbox("Toggle target"));
+  expect(document.getSelection()?.toString()).toBe(selectionText);
+});
+
+test("mouseDown on a select preserves the document selection", async () => {
+  setup();
+  await selectParagraphText();
+  await mouseDown(q.combobox("Select target"));
+  expect(document.getSelection()?.toString()).toBe(selectionText);
+});
+
+test("mouseDown on a link preserves the document selection", async () => {
+  setup();
+  await selectParagraphText();
+  await mouseDown(q.link("Link target"));
+  expect(document.getSelection()?.toString()).toBe(selectionText);
+});
+
+test("mouseDown on a focusable text target clears the document selection", async () => {
+  setup();
+  await selectParagraphText();
+  await mouseDown(q.text("Focusable text target"));
   expect(document.getSelection()?.toString()).toBe("");
 });
 

--- a/packages/ariakit-test/src/mouse-down.test.ts
+++ b/packages/ariakit-test/src/mouse-down.test.ts
@@ -28,6 +28,11 @@ function setup() {
       </select>
     </label>
     <a href="#target">Link target</a>
+    <svg>
+      <a href="#svg-target">
+        <text>SVG link target</text>
+      </a>
+    </svg>
     <div tabindex="0">Focusable text target</div>
     <p>Plain text target</p>
   `;
@@ -78,6 +83,13 @@ test("mouseDown on a link preserves the document selection", async () => {
   setup();
   await selectParagraphText();
   await mouseDown(q.link("Link target"));
+  expect(document.getSelection()?.toString()).toBe(selectionText);
+});
+
+test("mouseDown on an SVG link preserves the document selection", async () => {
+  setup();
+  await selectParagraphText();
+  await mouseDown(q.link("SVG link target"));
   expect(document.getSelection()?.toString()).toBe(selectionText);
 });
 

--- a/packages/ariakit-test/src/mouse-down.test.ts
+++ b/packages/ariakit-test/src/mouse-down.test.ts
@@ -24,6 +24,13 @@ async function selectParagraphText() {
 
 test("mouseDown on a button preserves the document selection", async () => {
   setup();
+  // TODO: Remove workaround for https://github.com/ariakit/ariakit/issues/6253.
+  // This preserves selection, but it also skips the focus path.
+  q.button
+    .ensure("Preserve selection")
+    .addEventListener("mousedown", (event) => {
+      event.preventDefault();
+    });
   await selectParagraphText();
   await mouseDown(q.button("Preserve selection"));
   expect(document.getSelection()?.toString()).toBe(selectionText);

--- a/packages/ariakit-test/src/mouse-down.test.ts
+++ b/packages/ariakit-test/src/mouse-down.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "vitest";
+import { mouseDown } from "./mouse-down.ts";
+import { q } from "./query.ts";
+import { select } from "./select.ts";
+
+const selectionText = "sample paragraph text";
+
+function setup() {
+  document.body.innerHTML = `
+    <p>Keep this ${selectionText} selected.</p>
+    <button type="button">Preserve selection</button>
+    <label>
+      Editable target
+      <input />
+    </label>
+    <p>Plain text target</p>
+  `;
+}
+
+async function selectParagraphText() {
+  await select(selectionText, q.text.ensure(/Keep this/));
+  expect(document.getSelection()?.toString()).toBe(selectionText);
+}
+
+test("mouseDown on a button preserves the document selection", async () => {
+  setup();
+  await selectParagraphText();
+  await mouseDown(q.button("Preserve selection"));
+  expect(document.getSelection()?.toString()).toBe(selectionText);
+});
+
+test("mouseDown on an editable target clears the document selection", async () => {
+  setup();
+  await selectParagraphText();
+  await mouseDown(q.textbox("Editable target"));
+  expect(document.getSelection()?.toString()).toBe("");
+});
+
+test("mouseDown on a plain text target clears the document selection", async () => {
+  setup();
+  await selectParagraphText();
+  await mouseDown(q.text("Plain text target"));
+  expect(document.getSelection()?.toString()).toBe("");
+});

--- a/packages/ariakit-test/src/mouse-down.ts
+++ b/packages/ariakit-test/src/mouse-down.ts
@@ -3,12 +3,46 @@ import {
   isVisible,
   getClosestFocusable,
   isFocusable,
+  isTextbox,
   invariant,
 } from "@ariakit/utils";
 import { wrapAsync } from "./__utils.ts";
 import { blur } from "./blur.ts";
 import { dispatch } from "./dispatch.ts";
 import { focus } from "./focus.ts";
+
+const selectionClearingInputTypes = [
+  "date",
+  "datetime-local",
+  "email",
+  "month",
+  "number",
+  "password",
+  "search",
+  "tel",
+  "text",
+  "time",
+  "url",
+  "week",
+];
+
+function preservesSelectionOnMouseDown(element: Element) {
+  const control = element.closest<HTMLElement>("button,input,select,a[href]");
+  if (control instanceof HTMLButtonElement) return true;
+  if (control instanceof HTMLSelectElement) return true;
+  if (control instanceof HTMLAnchorElement) return true;
+  if (control instanceof HTMLInputElement) {
+    return !selectionClearingInputTypes.includes(control.type);
+  }
+  return false;
+}
+
+function shouldClearSelection(element: Element) {
+  if (element instanceof HTMLElement && isTextbox(element)) {
+    return true;
+  }
+  return !preservesSelectionOnMouseDown(element);
+}
 
 /**
  * Presses the primary pointer button down on an element, firing `pointerdown` and
@@ -45,11 +79,10 @@ export function mouseDown(element: Element | null, options?: PointerEventInit) {
     // Do not enter this if event.preventDefault() has been called on
     // pointerdown or mousedown.
     if (defaultAllowed) {
-      // Remove current selection
       const selection = getDocument(element).getSelection();
       if (selection?.rangeCount) {
         const range = selection.getRangeAt(0);
-        if (!range.collapsed) {
+        if (!range.collapsed && shouldClearSelection(element)) {
           selection.removeAllRanges();
         }
       }

--- a/packages/ariakit-test/src/mouse-down.ts
+++ b/packages/ariakit-test/src/mouse-down.ts
@@ -27,10 +27,10 @@ const selectionClearingInputTypes = [
 ];
 
 function preservesSelectionOnMouseDown(element: Element) {
-  const control = element.closest<HTMLElement>("button,input,select,a[href]");
+  const control = element.closest("button,input,select,a[href]");
   if (control instanceof HTMLButtonElement) return true;
   if (control instanceof HTMLSelectElement) return true;
-  if (control instanceof HTMLAnchorElement) return true;
+  if (control?.tagName.toLowerCase() === "a") return true;
   if (control instanceof HTMLInputElement) {
     return !selectionClearingInputTypes.includes(control.type);
   }


### PR DESCRIPTION
## Motivation

`@ariakit/test` cleared any non-collapsed document selection during [`mouseDown`](https://ariakit.com/reference/mouse-down), regardless of the pressed target. Real browsers preserve an existing text selection when pressing native non-text controls such as buttons, checkboxes, selects, and links, while text/editable targets and plain text targets clear the selection.

Fixes #6253.

## Solution

Update [`mouseDown`](https://ariakit.com/reference/mouse-down) so selection clearing depends on the pressed target:

- Native non-text controls such as buttons, checkboxes, selects, and links preserve the current document selection.
- Text/editable targets, text-like input types, focusable custom text targets, and plain text targets clear the document selection.
- The normal focus path still runs for native controls, so this does not rely on canceling `mousedown`.

The package-level regression tests cover native button, checkbox, select, and link preservation, plus clearing for editable text inputs, email inputs, focusable text, and plain text targets.

## Workaround

Until `@ariakit/test` with this fix is available, prevent the default `mousedown` behavior on the button target whose click should preserve the current document selection:

```ts
// TODO: Remove workaround for https://github.com/ariakit/ariakit/issues/6253.
// This preserves selection, but it also skips the focus path.
button.addEventListener("mousedown", (event) => {
  event.preventDefault();
});
```

This preserves the selected text because `mouseDown()` skips its default behavior when `mousedown` is canceled. It also skips the simulated focus path, so it is only a selection-preservation workaround.
