### PR TITLE
Add lazy test queries

### DIFF
--- a/.changeset/200-test-lazy-queries.md
+++ b/.changeset/200-test-lazy-queries.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/test": patch
+---
+
+Added `.lazy` to `@ariakit/test` queries so a query can be stored and re-run later by calling the returned function.

--- a/packages/ariakit-test/readme.md
+++ b/packages/ariakit-test/readme.md
@@ -255,13 +255,11 @@ type Query = ReturnType<typeof createRoleQuery>;
 
 type TextQuery = ReturnType<typeof createTextQuery>;
 
-type LabeledQuery = ReturnType<typeof createLabeledQuery>;
-
 type RoleQueries = Record<AriaRole, Query>;
 
 interface QueryObject extends RoleQueries {
   text: TextQuery;
-  labeled: LabeledQuery;
+  labeled: TextQuery;
   within: (element?: HTMLElement | null) => QueryObject;
 }
 
@@ -270,13 +268,14 @@ const query: QueryObject;
 
 Queries the DOM by ARIA role, accessible name, text, or label, built on top of Testing Library. Call a role method such as `query.button(name)` or `query.dialog()` to get the matching element (or `null`), passing a string or `RegExp` to match its accessible name. Use `query.text()` and `query.labeled()` to query by text content or associated label, and `query.within(element)` to scope queries to a subtree.
 
-Every query also exposes `.all` (return all matches), `.wait` (resolve once the element appears), and `.ensure` (throw when it's missing) variants, and role queries additionally expose `.includesHidden` to include otherwise-hidden elements.
+Every query also exposes `.lazy` (return a reusable function that runs the query when called), `.all` (return all matches), `.wait` (resolve once the element appears), and `.ensure` (throw when it's missing) variants, and role queries additionally expose `.includesHidden` to include otherwise-hidden elements.
 
 Example:
 
 ```ts
 await click(query.button("Open"));
-expect(query.dialog()).toBeVisible();
+const dialog = query.dialog.lazy();
+expect(dialog()).toBeVisible();
 // Wait for an element to appear, or scope a query to a subtree:
 await query.alert.wait();
 query.within(query.dialog()).button("Close");
@@ -293,13 +292,11 @@ type Query = ReturnType<typeof createRoleQuery>;
 
 type TextQuery = ReturnType<typeof createTextQuery>;
 
-type LabeledQuery = ReturnType<typeof createLabeledQuery>;
-
 type RoleQueries = Record<AriaRole, Query>;
 
 interface QueryObject extends RoleQueries {
   text: TextQuery;
-  labeled: LabeledQuery;
+  labeled: TextQuery;
   within: (element?: HTMLElement | null) => QueryObject;
 }
 
@@ -312,7 +309,8 @@ Example:
 
 ```ts
 await click(q.button("Open"));
-expect(q.dialog()).toBeVisible();
+const dialog = q.dialog.lazy();
+expect(dialog()).toBeVisible();
 ```
 
 <div align="right">

--- a/packages/ariakit-test/readme.md
+++ b/packages/ariakit-test/readme.md
@@ -273,12 +273,13 @@ Every query also exposes `.lazy` (return a reusable function that runs the query
 Example:
 
 ```ts
-await click(query.button("Open"));
-const dialog = query.dialog.lazy();
+const dialog = query.dialog.lazy("Settings");
+expect(dialog()).not.toBeInTheDocument();
+await click(query.button("Open settings"));
 expect(dialog()).toBeVisible();
 // Wait for an element to appear, or scope a query to a subtree:
 await query.alert.wait();
-query.within(query.dialog()).button("Close");
+query.within(dialog()).button("Close");
 ```
 
 <div align="right">
@@ -308,8 +309,9 @@ Short alias for `query`. Queries the DOM by ARIA role, accessible name, text, or
 Example:
 
 ```ts
-await click(q.button("Open"));
-const dialog = q.dialog.lazy();
+const dialog = q.dialog.lazy("Settings");
+expect(dialog()).not.toBeInTheDocument();
+await click(q.button("Open settings"));
 expect(dialog()).toBeVisible();
 ```
 

--- a/packages/ariakit-test/src/query.test.ts
+++ b/packages/ariakit-test/src/query.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, expect, test } from "vitest";
+import { q } from "./query.ts";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+test("lazy role queries run when called", () => {
+  const dialog = q.dialog.lazy("Name");
+
+  expect(dialog()).toBeNull();
+
+  document.body.innerHTML = `<div role="dialog" aria-label="Name">First</div>`;
+  const firstDialog = dialog();
+
+  expect(firstDialog).toHaveTextContent("First");
+
+  document.body.innerHTML = `<div role="dialog" aria-label="Name">Second</div>`;
+
+  expect(dialog()).not.toBe(firstDialog);
+  expect(dialog()).toHaveTextContent("Second");
+});
+
+test("lazy role query variants run the matching variant", () => {
+  const dialog = q.dialog.ensure.lazy("Visible");
+  const hiddenDialog = q.dialog.includesHidden.lazy("Hidden");
+  const dialogs = q.dialog.all.lazy("Visible");
+
+  document.body.innerHTML = `
+    <div role="dialog" aria-label="Hidden" inert>Hidden</div>
+    <div role="dialog" aria-label="Visible">Visible</div>
+  `;
+
+  expect(dialog()).toHaveTextContent("Visible");
+  expect(hiddenDialog()).toHaveTextContent("Hidden");
+  expect(dialogs()).toHaveLength(1);
+});
+
+test("lazy role queries can be scoped with within", () => {
+  document.body.innerHTML = `
+    <section role="region" aria-label="Wrapper"></section>
+    <div role="dialog" aria-label="Scoped">Outside</div>
+  `;
+
+  const region = q.region.ensure("Wrapper");
+  const dialog = q.within(region).dialog.lazy("Scoped");
+
+  expect(dialog()).toBeNull();
+
+  region.innerHTML = `<div role="dialog" aria-label="Scoped">Inside</div>`;
+
+  expect(dialog()).toHaveTextContent("Inside");
+});
+
+test("lazy text and label queries run when called", () => {
+  const text = q.text.lazy<HTMLButtonElement>("Submit");
+  const input = q.labeled.lazy<HTMLInputElement>("Email");
+
+  expect(text()).toBeNull();
+  expect(input()).toBeNull();
+
+  document.body.innerHTML = `
+    <button>Submit</button>
+    <label>Email<input /></label>
+  `;
+
+  expect(text()).toHaveTextContent("Submit");
+  expect(text()).toBeInstanceOf(HTMLButtonElement);
+  expect(input()).toBeInstanceOf(HTMLInputElement);
+});

--- a/packages/ariakit-test/src/query.test.ts
+++ b/packages/ariakit-test/src/query.test.ts
@@ -68,3 +68,40 @@ test("lazy text and label queries run when called", () => {
   expect(text()).toBeInstanceOf(HTMLButtonElement);
   expect(input()).toBeInstanceOf(HTMLInputElement);
 });
+
+test("lazy text and label query variants run the matching variant", async () => {
+  const text = q.text.ensure.lazy("Ready");
+  const texts = q.text.all.lazy("Submit");
+  const waitedTexts = q.text.wait.all.lazy("Submit");
+  const allWaitedTexts = q.text.all.wait.lazy("Submit");
+  const ensuredTexts = q.text.ensure.all.lazy("Submit");
+  const allEnsuredTexts = q.text.all.ensure.lazy("Submit");
+  const label = q.labeled.ensure.lazy<HTMLInputElement>("Name");
+  const labels = q.labeled.all.lazy<HTMLInputElement>("Email");
+  const waitedLabels = q.labeled.wait.all.lazy<HTMLInputElement>("Email");
+  const allWaitedLabels = q.labeled.all.wait.lazy<HTMLInputElement>("Email");
+  const ensuredLabels = q.labeled.ensure.all.lazy<HTMLInputElement>("Email");
+  const allEnsuredLabels = q.labeled.all.ensure.lazy<HTMLInputElement>("Email");
+
+  document.body.innerHTML = `
+    <button>Submit</button>
+    <button>Submit</button>
+    <span>Ready</span>
+    <label>Name<input /></label>
+    <label>Email<input /></label>
+    <label>Email<input /></label>
+  `;
+
+  expect(text()).toHaveTextContent("Ready");
+  expect(texts()).toHaveLength(2);
+  await expect(waitedTexts()).resolves.toHaveLength(2);
+  await expect(allWaitedTexts()).resolves.toHaveLength(2);
+  expect(ensuredTexts()).toHaveLength(2);
+  expect(allEnsuredTexts()).toHaveLength(2);
+  expect(label()).toBeInstanceOf(HTMLInputElement);
+  expect(labels()).toHaveLength(2);
+  await expect(waitedLabels()).resolves.toHaveLength(2);
+  await expect(allWaitedLabels()).resolves.toHaveLength(2);
+  expect(ensuredLabels()).toHaveLength(2);
+  expect(allEnsuredLabels()).toHaveLength(2);
+});

--- a/packages/ariakit-test/src/query.ts
+++ b/packages/ariakit-test/src/query.ts
@@ -304,12 +304,13 @@ function createQueryObject(queries = documentQueries): QueryObject {
  * elements.
  * @example
  * ```ts
- * await click(query.button("Open"));
- * const dialog = query.dialog.lazy();
+ * const dialog = query.dialog.lazy("Settings");
+ * expect(dialog()).not.toBeInTheDocument();
+ * await click(query.button("Open settings"));
  * expect(dialog()).toBeVisible();
  * // Wait for an element to appear, or scope a query to a subtree:
  * await query.alert.wait();
- * query.within(query.dialog()).button("Close");
+ * query.within(dialog()).button("Close");
  * ```
  */
 export const query = createQueryObject();
@@ -319,8 +320,9 @@ export const query = createQueryObject();
  * label.
  * @example
  * ```ts
- * await click(q.button("Open"));
- * const dialog = q.dialog.lazy();
+ * const dialog = q.dialog.lazy("Settings");
+ * expect(dialog()).not.toBeInTheDocument();
+ * await click(q.button("Open settings"));
  * expect(dialog()).toBeVisible();
  * ```
  */

--- a/packages/ariakit-test/src/query.ts
+++ b/packages/ariakit-test/src/query.ts
@@ -1,9 +1,11 @@
-// oxlint-disable unbound-method
+// oxlint-disable unbound-method typescript/no-unnecessary-type-parameters
 import { invariant } from "@ariakit/utils";
 import type {
   ByRoleMatcher,
   ByRoleOptions,
-  getQueriesForElement,
+  Matcher,
+  SelectorMatcherOptions,
+  waitForOptions,
 } from "@testing-library/dom";
 import { queries as baseQueries } from "@testing-library/dom";
 import type { AriaRole } from "./__aria-role.ts";
@@ -11,17 +13,130 @@ import { roles } from "./__aria-role.ts";
 
 type Query = ReturnType<typeof createRoleQuery>;
 type TextQuery = ReturnType<typeof createTextQuery>;
-type LabeledQuery = ReturnType<typeof createLabeledQuery>;
 type RoleQueries = Record<AriaRole, Query>;
-type ElementQueries = ReturnType<
-  typeof getQueriesForElement<typeof baseQueries>
->;
+type AnyQuery = (...args: any[]) => any;
+type LazyQuery<T extends AnyQuery> = (
+  ...args: Parameters<T>
+) => () => ReturnType<T>;
+
+interface ElementQueries {
+  queryByRole: RoleNullableMethod;
+  queryAllByRole: RoleArrayMethod;
+  findByRole: RoleWaitValueMethod;
+  findAllByRole: RoleWaitArrayMethod;
+  getByRole: RoleValueMethod;
+  getAllByRole: RoleArrayMethod;
+  queryByText: TextNullableMethod;
+  queryAllByText: TextArrayMethod;
+  findByText: TextWaitValueMethod;
+  findAllByText: TextWaitArrayMethod;
+  getByText: TextValueMethod;
+  getAllByText: TextArrayMethod;
+  queryByLabelText: TextNullableMethod;
+  queryAllByLabelText: TextArrayMethod;
+  findByLabelText: TextWaitValueMethod;
+  findAllByLabelText: TextWaitArrayMethod;
+  getByLabelText: TextValueMethod;
+  getAllByLabelText: TextArrayMethod;
+}
+
+interface RoleNullableMethod {
+  (role: ByRoleMatcher, options?: ByRoleOptions): HTMLElement | null;
+}
+
+interface RoleArrayMethod {
+  (role: ByRoleMatcher, options?: ByRoleOptions): HTMLElement[];
+}
+
+interface RoleValueMethod {
+  (role: ByRoleMatcher, options?: ByRoleOptions): HTMLElement;
+}
+
+interface RoleWaitArrayMethod {
+  (
+    role: ByRoleMatcher,
+    options?: ByRoleOptions,
+    waitForElementOptions?: waitForOptions,
+  ): Promise<HTMLElement[]>;
+}
+
+interface RoleWaitValueMethod {
+  (
+    role: ByRoleMatcher,
+    options?: ByRoleOptions,
+    waitForElementOptions?: waitForOptions,
+  ): Promise<HTMLElement>;
+}
+
+interface TextNullableMethod {
+  <T extends HTMLElement = HTMLElement>(...args: TextQueryArgs): T | null;
+}
+
+interface TextNullableQuery extends TextNullableMethod {
+  lazy<T extends HTMLElement = HTMLElement>(
+    ...args: TextQueryArgs
+  ): () => T | null;
+}
+
+interface TextArrayMethod {
+  <T extends HTMLElement = HTMLElement>(...args: TextQueryArgs): T[];
+}
+
+interface TextArrayQuery extends TextArrayMethod {
+  lazy<T extends HTMLElement = HTMLElement>(...args: TextQueryArgs): () => T[];
+}
+
+interface TextValueMethod {
+  <T extends HTMLElement = HTMLElement>(...args: TextQueryArgs): T;
+}
+
+interface TextValueQuery extends TextValueMethod {
+  lazy<T extends HTMLElement = HTMLElement>(...args: TextQueryArgs): () => T;
+}
+
+interface TextWaitValueMethod {
+  <T extends HTMLElement = HTMLElement>(...args: TextWaitQueryArgs): Promise<T>;
+}
+
+interface TextWaitValueQuery extends TextWaitValueMethod {
+  lazy<T extends HTMLElement = HTMLElement>(
+    ...args: TextWaitQueryArgs
+  ): () => Promise<T>;
+}
+
+interface TextWaitArrayMethod {
+  <T extends HTMLElement = HTMLElement>(
+    ...args: TextWaitQueryArgs
+  ): Promise<T[]>;
+}
+
+interface TextWaitArrayQuery extends TextWaitArrayMethod {
+  lazy<T extends HTMLElement = HTMLElement>(
+    ...args: TextWaitQueryArgs
+  ): () => Promise<T[]>;
+}
+
+interface TextQueryParams {
+  query: TextNullableMethod;
+  all: TextArrayMethod;
+  wait: TextWaitValueMethod;
+  waitAll: TextWaitArrayMethod;
+  ensure: TextValueMethod;
+  ensureAll: TextArrayMethod;
+}
 
 interface QueryObject extends RoleQueries {
   text: TextQuery;
-  labeled: LabeledQuery;
+  labeled: TextQuery;
   within: (element?: HTMLElement | null) => QueryObject;
 }
+
+type TextQueryArgs = [id: Matcher, options?: SelectorMatcherOptions];
+type TextWaitQueryArgs = [
+  id: Matcher,
+  options?: SelectorMatcherOptions,
+  waitForElementOptions?: waitForOptions,
+];
 
 function createQueries(container?: HTMLElement) {
   return Object.entries(baseQueries).reduce((queries, [key, query]) => {
@@ -32,6 +147,60 @@ function createQueries(container?: HTMLElement) {
 }
 
 const documentQueries = createQueries();
+
+function createLazyQuery<T extends AnyQuery>(query: T): LazyQuery<T> {
+  return (...args) => {
+    return () => query(...args);
+  };
+}
+
+function assignLazy<T extends AnyQuery>(query: T) {
+  return Object.assign(query, { lazy: createLazyQuery(query) });
+}
+
+function createTextNullableQuery(query: TextNullableMethod): TextNullableQuery {
+  return Object.assign(query, {
+    lazy: <T extends HTMLElement = HTMLElement>(...args: TextQueryArgs) => {
+      return () => query<T>(...args);
+    },
+  });
+}
+
+function createTextArrayQuery(query: TextArrayMethod): TextArrayQuery {
+  return Object.assign(query, {
+    lazy: <T extends HTMLElement = HTMLElement>(...args: TextQueryArgs) => {
+      return () => query<T>(...args);
+    },
+  });
+}
+
+function createTextValueQuery(query: TextValueMethod): TextValueQuery {
+  return Object.assign(query, {
+    lazy: <T extends HTMLElement = HTMLElement>(...args: TextQueryArgs) => {
+      return () => query<T>(...args);
+    },
+  });
+}
+
+function createTextWaitValueQuery(
+  query: TextWaitValueMethod,
+): TextWaitValueQuery {
+  return Object.assign(query, {
+    lazy: <T extends HTMLElement = HTMLElement>(...args: TextWaitQueryArgs) => {
+      return () => query<T>(...args);
+    },
+  });
+}
+
+function createTextWaitArrayQuery(
+  query: TextWaitArrayMethod,
+): TextWaitArrayQuery {
+  return Object.assign(query, {
+    lazy: <T extends HTMLElement = HTMLElement>(...args: TextWaitQueryArgs) => {
+      return () => query<T>(...args);
+    },
+  });
+}
 
 function matchName(name: string | RegExp, accessibleName: string | null) {
   if (accessibleName == null) return false;
@@ -73,17 +242,20 @@ function createRoleQuery(role: AriaRole, queries = documentQueries) {
     };
   };
 
-  const createIncludesHidden =
-    <T extends ReturnType<typeof createQuery>>(query: T) =>
-    (name?: string | RegExp, options?: ByRoleOptions): ReturnType<T> =>
-      query(name, { hidden: true, ...options });
+  const createIncludesHidden = <T extends ReturnType<typeof createQuery>>(
+    query: T,
+  ) =>
+    assignLazy(
+      (name?: string | RegExp, options?: ByRoleOptions): ReturnType<T> =>
+        query(name, { hidden: true, ...options }),
+    );
 
-  const query = createQuery(queries.queryByRole);
-  const allQuery = createQuery(queries.queryAllByRole);
-  const waitQuery = createQuery(queries.findByRole);
-  const waitAllQuery = createQuery(queries.findAllByRole);
-  const ensureQuery = createQuery(queries.getByRole);
-  const ensureAllQuery = createQuery(queries.getAllByRole);
+  const query = assignLazy(createQuery(queries.queryByRole));
+  const allQuery = assignLazy(createQuery(queries.queryAllByRole));
+  const waitQuery = assignLazy(createQuery(queries.findByRole));
+  const waitAllQuery = assignLazy(createQuery(queries.findAllByRole));
+  const ensureQuery = assignLazy(createQuery(queries.getByRole));
+  const ensureAllQuery = assignLazy(createQuery(queries.getAllByRole));
 
   const all = Object.assign(allQuery, {
     includesHidden: createIncludesHidden(allQuery),
@@ -124,44 +296,56 @@ function createRoleQueries(queries = documentQueries) {
   }, {} as RoleQueries);
 }
 
-function createTextQuery(queries = documentQueries) {
-  const all = Object.assign(queries.queryAllByText, {
-    wait: queries.findAllByText,
-    ensure: queries.getAllByText,
+function createTextQuery(params: TextQueryParams) {
+  const query = createTextNullableQuery(params.query);
+  const allQuery = createTextArrayQuery(params.all);
+  const waitQuery = createTextWaitValueQuery(params.wait);
+  const waitAllQuery = createTextWaitArrayQuery(params.waitAll);
+  const ensureQuery = createTextValueQuery(params.ensure);
+  const ensureAllQuery = createTextArrayQuery(params.ensureAll);
+
+  const all = Object.assign(allQuery, {
+    wait: waitAllQuery,
+    ensure: ensureAllQuery,
   });
 
-  const wait = Object.assign(queries.findByText, {
-    all: queries.findAllByText,
+  const wait = Object.assign(waitQuery, {
+    all: waitAllQuery,
   });
 
-  const ensure = Object.assign(queries.getByText, {
-    all: queries.getAllByText,
+  const ensure = Object.assign(ensureQuery, {
+    all: ensureAllQuery,
   });
 
-  return Object.assign(queries.queryByText, { all, wait, ensure });
+  return Object.assign(query, { all, wait, ensure });
+}
+
+function createTextQueryObject(queries = documentQueries) {
+  return createTextQuery({
+    query: queries.queryByText,
+    all: queries.queryAllByText,
+    wait: queries.findByText,
+    waitAll: queries.findAllByText,
+    ensure: queries.getByText,
+    ensureAll: queries.getAllByText,
+  });
 }
 
 function createLabeledQuery(queries = documentQueries) {
-  const all = Object.assign(queries.queryAllByLabelText, {
-    wait: queries.findAllByLabelText,
-    ensure: queries.getAllByLabelText,
+  return createTextQuery({
+    query: queries.queryByLabelText,
+    all: queries.queryAllByLabelText,
+    wait: queries.findByLabelText,
+    waitAll: queries.findAllByLabelText,
+    ensure: queries.getByLabelText,
+    ensureAll: queries.getAllByLabelText,
   });
-
-  const wait = Object.assign(queries.findByLabelText, {
-    all: queries.findAllByLabelText,
-  });
-
-  const ensure = Object.assign(queries.getByLabelText, {
-    all: queries.getAllByLabelText,
-  });
-
-  return Object.assign(queries.queryByLabelText, { all, wait, ensure });
 }
 
 function createQueryObject(queries = documentQueries): QueryObject {
   return {
     ...createRoleQueries(queries),
-    text: createTextQuery(queries),
+    text: createTextQueryObject(queries),
     labeled: createLabeledQuery(queries),
     within: (element?: HTMLElement | null) => {
       invariant(element, "Unable to create queries for null element");
@@ -178,14 +362,16 @@ function createQueryObject(queries = documentQueries): QueryObject {
  * to query by text content or associated label, and `query.within(element)` to
  * scope queries to a subtree.
  *
- * Every query also exposes `.all` (return all matches), `.wait` (resolve once the
+ * Every query also exposes `.lazy` (return a reusable function that runs the
+ * query when called), `.all` (return all matches), `.wait` (resolve once the
  * element appears), and `.ensure` (throw when it's missing) variants, and role
  * queries additionally expose `.includesHidden` to include otherwise-hidden
  * elements.
  * @example
  * ```ts
  * await click(query.button("Open"));
- * expect(query.dialog()).toBeVisible();
+ * const dialog = query.dialog.lazy();
+ * expect(dialog()).toBeVisible();
  * // Wait for an element to appear, or scope a query to a subtree:
  * await query.alert.wait();
  * query.within(query.dialog()).button("Close");
@@ -199,7 +385,8 @@ export const query = createQueryObject();
  * @example
  * ```ts
  * await click(q.button("Open"));
- * expect(q.dialog()).toBeVisible();
+ * const dialog = q.dialog.lazy();
+ * expect(dialog()).toBeVisible();
  * ```
  */
 export const q = query;

--- a/packages/ariakit-test/src/query.ts
+++ b/packages/ariakit-test/src/query.ts
@@ -90,7 +90,6 @@ interface TextVariant<
 }
 
 interface TextQueryParams {
-  query: TextMethod<"nullable", TextQueryArgs>;
   all: TextMethod<"array", TextQueryArgs>;
   wait: TextMethod<"waitValue", TextWaitQueryArgs>;
   waitAll: TextMethod<"waitArray", TextWaitQueryArgs>;
@@ -235,33 +234,31 @@ function createRoleQueries(queries = documentQueries) {
   }, {} as RoleQueries);
 }
 
-function createTextQuery(params: TextQueryParams) {
-  const query = assignTextLazy(params.query);
+function createTextQuery(
+  defaultQuery: TextMethod<"nullable", TextQueryArgs>,
+  params: TextQueryParams,
+) {
+  const query = assignTextLazy(defaultQuery);
   const allQuery = assignTextLazy(params.all);
-  const waitQuery = assignTextLazy(params.wait);
-  const waitAllQuery = assignTextLazy(params.waitAll);
-  const ensureQuery = assignTextLazy(params.ensure);
-  const ensureAllQuery = assignTextLazy(params.ensureAll);
+
+  const wait = Object.assign(assignTextLazy(params.wait), {
+    all: assignTextLazy(params.waitAll),
+  });
+
+  const ensure = Object.assign(assignTextLazy(params.ensure), {
+    all: assignTextLazy(params.ensureAll),
+  });
 
   const all = Object.assign(allQuery, {
-    wait: waitAllQuery,
-    ensure: ensureAllQuery,
-  });
-
-  const wait = Object.assign(waitQuery, {
-    all: waitAllQuery,
-  });
-
-  const ensure = Object.assign(ensureQuery, {
-    all: ensureAllQuery,
+    wait: wait.all,
+    ensure: ensure.all,
   });
 
   return Object.assign(query, { all, wait, ensure });
 }
 
 function createTextQueryObject(queries = documentQueries) {
-  return createTextQuery({
-    query: queries.queryByText,
+  return createTextQuery(queries.queryByText, {
     all: queries.queryAllByText,
     wait: queries.findByText,
     waitAll: queries.findAllByText,
@@ -271,8 +268,7 @@ function createTextQueryObject(queries = documentQueries) {
 }
 
 function createLabeledQuery(queries = documentQueries) {
-  return createTextQuery({
-    query: queries.queryByLabelText,
+  return createTextQuery(queries.queryByLabelText, {
     all: queries.queryAllByLabelText,
     wait: queries.findByLabelText,
     waitAll: queries.findAllByLabelText,

--- a/packages/ariakit-test/src/query.ts
+++ b/packages/ariakit-test/src/query.ts
@@ -18,6 +18,14 @@ type AnyQuery = (...args: any[]) => any;
 type LazyQuery<T extends AnyQuery> = (
   ...args: Parameters<T>
 ) => () => ReturnType<T>;
+type TextKind = "array" | "nullable" | "value" | "waitArray" | "waitValue";
+type TextResult<Kind extends TextKind, T extends HTMLElement> = {
+  array: T[];
+  nullable: T | null;
+  value: T;
+  waitArray: Promise<T[]>;
+  waitValue: Promise<T>;
+}[Kind];
 
 interface ElementQueries {
   queryByRole: RoleNullableMethod;
@@ -26,18 +34,18 @@ interface ElementQueries {
   findAllByRole: RoleWaitArrayMethod;
   getByRole: RoleValueMethod;
   getAllByRole: RoleArrayMethod;
-  queryByText: TextNullableMethod;
-  queryAllByText: TextArrayMethod;
-  findByText: TextWaitValueMethod;
-  findAllByText: TextWaitArrayMethod;
-  getByText: TextValueMethod;
-  getAllByText: TextArrayMethod;
-  queryByLabelText: TextNullableMethod;
-  queryAllByLabelText: TextArrayMethod;
-  findByLabelText: TextWaitValueMethod;
-  findAllByLabelText: TextWaitArrayMethod;
-  getByLabelText: TextValueMethod;
-  getAllByLabelText: TextArrayMethod;
+  queryByText: TextMethod<"nullable", TextQueryArgs>;
+  queryAllByText: TextMethod<"array", TextQueryArgs>;
+  findByText: TextMethod<"waitValue", TextWaitQueryArgs>;
+  findAllByText: TextMethod<"waitArray", TextWaitQueryArgs>;
+  getByText: TextMethod<"value", TextQueryArgs>;
+  getAllByText: TextMethod<"array", TextQueryArgs>;
+  queryByLabelText: TextMethod<"nullable", TextQueryArgs>;
+  queryAllByLabelText: TextMethod<"array", TextQueryArgs>;
+  findByLabelText: TextMethod<"waitValue", TextWaitQueryArgs>;
+  findAllByLabelText: TextMethod<"waitArray", TextWaitQueryArgs>;
+  getByLabelText: TextMethod<"value", TextQueryArgs>;
+  getAllByLabelText: TextMethod<"array", TextQueryArgs>;
 }
 
 interface RoleNullableMethod {
@@ -68,61 +76,26 @@ interface RoleWaitValueMethod {
   ): Promise<HTMLElement>;
 }
 
-interface TextNullableMethod {
-  <T extends HTMLElement = HTMLElement>(...args: TextQueryArgs): T | null;
+interface TextMethod<Kind extends TextKind, Args extends unknown[]> {
+  <T extends HTMLElement = HTMLElement>(...args: Args): TextResult<Kind, T>;
 }
 
-interface TextNullableQuery extends TextNullableMethod {
+interface TextVariant<
+  Kind extends TextKind,
+  Args extends unknown[],
+> extends TextMethod<Kind, Args> {
   lazy<T extends HTMLElement = HTMLElement>(
-    ...args: TextQueryArgs
-  ): () => T | null;
-}
-
-interface TextArrayMethod {
-  <T extends HTMLElement = HTMLElement>(...args: TextQueryArgs): T[];
-}
-
-interface TextArrayQuery extends TextArrayMethod {
-  lazy<T extends HTMLElement = HTMLElement>(...args: TextQueryArgs): () => T[];
-}
-
-interface TextValueMethod {
-  <T extends HTMLElement = HTMLElement>(...args: TextQueryArgs): T;
-}
-
-interface TextValueQuery extends TextValueMethod {
-  lazy<T extends HTMLElement = HTMLElement>(...args: TextQueryArgs): () => T;
-}
-
-interface TextWaitValueMethod {
-  <T extends HTMLElement = HTMLElement>(...args: TextWaitQueryArgs): Promise<T>;
-}
-
-interface TextWaitValueQuery extends TextWaitValueMethod {
-  lazy<T extends HTMLElement = HTMLElement>(
-    ...args: TextWaitQueryArgs
-  ): () => Promise<T>;
-}
-
-interface TextWaitArrayMethod {
-  <T extends HTMLElement = HTMLElement>(
-    ...args: TextWaitQueryArgs
-  ): Promise<T[]>;
-}
-
-interface TextWaitArrayQuery extends TextWaitArrayMethod {
-  lazy<T extends HTMLElement = HTMLElement>(
-    ...args: TextWaitQueryArgs
-  ): () => Promise<T[]>;
+    ...args: Args
+  ): () => TextResult<Kind, T>;
 }
 
 interface TextQueryParams {
-  query: TextNullableMethod;
-  all: TextArrayMethod;
-  wait: TextWaitValueMethod;
-  waitAll: TextWaitArrayMethod;
-  ensure: TextValueMethod;
-  ensureAll: TextArrayMethod;
+  query: TextMethod<"nullable", TextQueryArgs>;
+  all: TextMethod<"array", TextQueryArgs>;
+  wait: TextMethod<"waitValue", TextWaitQueryArgs>;
+  waitAll: TextMethod<"waitArray", TextWaitQueryArgs>;
+  ensure: TextMethod<"value", TextQueryArgs>;
+  ensureAll: TextMethod<"array", TextQueryArgs>;
 }
 
 interface QueryObject extends RoleQueries {
@@ -158,45 +131,11 @@ function assignLazy<T extends AnyQuery>(query: T) {
   return Object.assign(query, { lazy: createLazyQuery(query) });
 }
 
-function createTextNullableQuery(query: TextNullableMethod): TextNullableQuery {
+function assignTextLazy<Kind extends TextKind, Args extends unknown[]>(
+  query: TextMethod<Kind, Args>,
+): TextVariant<Kind, Args> {
   return Object.assign(query, {
-    lazy: <T extends HTMLElement = HTMLElement>(...args: TextQueryArgs) => {
-      return () => query<T>(...args);
-    },
-  });
-}
-
-function createTextArrayQuery(query: TextArrayMethod): TextArrayQuery {
-  return Object.assign(query, {
-    lazy: <T extends HTMLElement = HTMLElement>(...args: TextQueryArgs) => {
-      return () => query<T>(...args);
-    },
-  });
-}
-
-function createTextValueQuery(query: TextValueMethod): TextValueQuery {
-  return Object.assign(query, {
-    lazy: <T extends HTMLElement = HTMLElement>(...args: TextQueryArgs) => {
-      return () => query<T>(...args);
-    },
-  });
-}
-
-function createTextWaitValueQuery(
-  query: TextWaitValueMethod,
-): TextWaitValueQuery {
-  return Object.assign(query, {
-    lazy: <T extends HTMLElement = HTMLElement>(...args: TextWaitQueryArgs) => {
-      return () => query<T>(...args);
-    },
-  });
-}
-
-function createTextWaitArrayQuery(
-  query: TextWaitArrayMethod,
-): TextWaitArrayQuery {
-  return Object.assign(query, {
-    lazy: <T extends HTMLElement = HTMLElement>(...args: TextWaitQueryArgs) => {
+    lazy: <T extends HTMLElement = HTMLElement>(...args: Args) => {
       return () => query<T>(...args);
     },
   });
@@ -297,12 +236,12 @@ function createRoleQueries(queries = documentQueries) {
 }
 
 function createTextQuery(params: TextQueryParams) {
-  const query = createTextNullableQuery(params.query);
-  const allQuery = createTextArrayQuery(params.all);
-  const waitQuery = createTextWaitValueQuery(params.wait);
-  const waitAllQuery = createTextWaitArrayQuery(params.waitAll);
-  const ensureQuery = createTextValueQuery(params.ensure);
-  const ensureAllQuery = createTextArrayQuery(params.ensureAll);
+  const query = assignTextLazy(params.query);
+  const allQuery = assignTextLazy(params.all);
+  const waitQuery = assignTextLazy(params.wait);
+  const waitAllQuery = assignTextLazy(params.waitAll);
+  const ensureQuery = assignTextLazy(params.ensure);
+  const ensureAllQuery = assignTextLazy(params.ensureAll);
 
   const all = Object.assign(allQuery, {
     wait: waitAllQuery,


### PR DESCRIPTION
## Motivation

`@ariakit/test` queries can be stored as elements today, but that captures the current DOM result instead of re-running the lookup later. Tests that need to reuse a query across DOM updates currently have to wrap the query by hand:

```ts
const dialog = () => q.dialog("Name");
```

## Solution

Add a `.lazy` helper to the DOM query API so role, text, and label queries can produce reusable callbacks directly:

```ts
const dialog = q.dialog.lazy("Name");
expect(dialog()).toBeVisible();
```

The new helper is available on query variants such as `.all`, `.wait`, `.ensure`, and role `.includesHidden`. Text and label lazy queries preserve their generic element typing, and the implementation avoids relying on newer Testing Library generic aliases so the package remains compatible with its supported `@testing-library/dom` range.

Tests cover re-querying after DOM changes, scoped `within` queries, role variants, and generic text/label lazy queries.
