### PR TITLE
Rename `includesHidden` test query variant to `hidden`

### DIFF
--- a/.changeset/100-test-hidden-query.md
+++ b/.changeset/100-test-hidden-query.md
@@ -1,0 +1,23 @@
+---
+"@ariakit/test": minor
+---
+
+Renamed the `includesHidden` query variant to `hidden`
+
+**BREAKING** if you use the `includesHidden` role-query variant from `@ariakit/test`.
+
+The role-query variant that also matches elements hidden from the accessibility tree (such as `inert` or `aria-hidden` elements) has been renamed from `includesHidden` to `hidden`.
+
+Before:
+
+```ts
+q.dialog.includesHidden("Settings");
+q.menuitemcheckbox.all.includesHidden();
+```
+
+After:
+
+```ts
+q.dialog.hidden("Settings");
+q.menuitemcheckbox.all.hidden();
+```

--- a/app/src/sandbox/dialog-reopen-focus-state/test.ts
+++ b/app/src/sandbox/dialog-reopen-focus-state/test.ts
@@ -7,7 +7,7 @@ test("resets outside-interaction focus tracking when reopened", async () => {
 
   await click(q.button.ensure("Focus inside"));
   await click(q.button.ensure("Close dialog"));
-  await expect.poll(q.dialog.includesHidden.lazy("Dialog")).not.toBeVisible();
+  await expect.poll(q.dialog.hidden.lazy("Dialog")).not.toBeVisible();
 
   await click(q.button.ensure("Open dialog"));
   expect(q.dialog("Dialog")).toBeVisible();
@@ -18,7 +18,7 @@ test("resets outside-interaction focus tracking when reopened", async () => {
 
   try {
     input.focus();
-    await expect.poll(q.dialog.includesHidden.lazy("Dialog")).not.toBeVisible();
+    await expect.poll(q.dialog.hidden.lazy("Dialog")).not.toBeVisible();
   } finally {
     input.remove();
   }

--- a/examples/combobox-tabs-animated/test.ts
+++ b/examples/combobox-tabs-animated/test.ts
@@ -12,13 +12,11 @@ test("selected tab is restored only after the animation ends", async () => {
   expect(q.tabpanel("Examples 31")).toBeVisible();
   await press.Escape();
   expect(q.combobox()).toHaveAttribute("data-active-item");
-  const examplesTab = q.tab.includesHidden("Examples 31");
+  const examplesTab = q.tab.hidden("Examples 31");
   expect(examplesTab).not.toHaveFocus();
   expect(examplesTab).not.toHaveAttribute("data-active-item");
   expect(examplesTab).toHaveAttribute("aria-selected", "true");
-  await expect
-    .poll(q.dialog.includesHidden.lazy("Pages"))
-    .not.toBeInTheDocument();
+  await expect.poll(q.dialog.hidden.lazy("Pages")).not.toBeInTheDocument();
   await press.ArrowDown();
   await press.ArrowDown();
   expect(q.tab("Components 16")).toHaveFocus();

--- a/examples/dialog-combobox-command-menu/test.ts
+++ b/examples/dialog-combobox-command-menu/test.ts
@@ -15,8 +15,8 @@ test("open dialog with click and hide with esc", async () => {
   expect(q.group("Suggestions")).toBeVisible();
   await press.Escape();
   // The dialog is closing and therefore inert, so query the option inside it
-  // with `includesHidden` to assert it's no longer the active item.
-  expect(q.option.includesHidden("Search Contacts")).not.toHaveAttribute(
+  // with `hidden` to assert it's no longer the active item.
+  expect(q.option.hidden("Search Contacts")).not.toHaveAttribute(
     "data-active-item",
   );
   expect(q.button("Open Command Menu")).toHaveFocus();
@@ -29,8 +29,8 @@ test("open dialog with click and hide by clicking outside", async () => {
   expect(q.combobox("Search for apps and commands...")).toHaveFocus();
   await click(document.body);
   // The dialog is closing and therefore inert, so query the option inside it
-  // with `includesHidden` to assert it's no longer the active item.
-  expect(q.option.includesHidden("Search Contacts")).not.toHaveAttribute(
+  // with `hidden` to assert it's no longer the active item.
+  expect(q.option.hidden("Search Contacts")).not.toHaveAttribute(
     "data-active-item",
   );
   expect(q.button("Open Command Menu")).not.toHaveFocus();

--- a/examples/dialog-hide-warning/test.ts
+++ b/examples/dialog-hide-warning/test.ts
@@ -21,7 +21,7 @@ test("try to hide the dialog with Escape after filling in the form", async () =>
   await click(q.button("Post"));
   await type("Hello");
   await press.Escape();
-  expect(q.dialog.includesHidden("Post")).toBeVisible();
+  expect(q.dialog.hidden("Post")).toBeVisible();
   expect(q.dialog("Post")).not.toBeInTheDocument();
   expect(q.dialog("Save post?")).toBeVisible();
   expect(q.button("Save")).toHaveFocus();
@@ -30,7 +30,7 @@ test("try to hide the dialog with Escape after filling in the form", async () =>
   expect(q.dialog("Post")).toBeVisible();
   expect(q.textbox()).toHaveFocus();
   await press.Escape();
-  expect(q.dialog.includesHidden("Post")).toBeVisible();
+  expect(q.dialog.hidden("Post")).toBeVisible();
   expect(q.dialog("Post")).not.toBeInTheDocument();
   expect(q.dialog("Save post?")).toBeVisible();
   expect(q.button("Save")).toHaveFocus();
@@ -44,7 +44,7 @@ test("try to hide the dialog by clicking outside after filling in the form", asy
   await click(q.button("Post"));
   await type("Hello");
   await click(backdrop());
-  expect(q.dialog.includesHidden("Post")).toBeVisible();
+  expect(q.dialog.hidden("Post")).toBeVisible();
   expect(q.dialog("Post")).not.toBeInTheDocument();
   expect(q.dialog("Save post?")).toBeVisible();
   expect(q.button("Save")).toHaveFocus();
@@ -53,7 +53,7 @@ test("try to hide the dialog by clicking outside after filling in the form", asy
   expect(q.dialog("Post")).toBeVisible();
   expect(q.textbox()).toHaveFocus();
   await click(backdrop());
-  expect(q.dialog.includesHidden("Post")).toBeVisible();
+  expect(q.dialog.hidden("Post")).toBeVisible();
   expect(q.dialog("Post")).not.toBeInTheDocument();
   expect(q.dialog("Save post?")).toBeVisible();
   expect(q.button("Save")).toHaveFocus();
@@ -67,7 +67,7 @@ test("try to hide the dialog by clicking on the dismiss button after filling in 
   await click(q.button("Post"));
   await type("Hello");
   await click(q.button("Dismiss popup"));
-  expect(q.dialog.includesHidden("Post")).toBeVisible();
+  expect(q.dialog.hidden("Post")).toBeVisible();
   expect(q.dialog("Post")).not.toBeInTheDocument();
   expect(q.dialog("Save post?")).toBeVisible();
   expect(q.button("Save")).toHaveFocus();

--- a/examples/dialog-nested-various/test.ts
+++ b/examples/dialog-nested-various/test.ts
@@ -2,7 +2,7 @@ import { click, press, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 function getBackdrop(name: string) {
-  const dialog = q.dialog.includesHidden(name);
+  const dialog = q.dialog.hidden(name);
   const selector = `[data-backdrop="${dialog?.id}"]`;
   return document.querySelector<HTMLElement>(selector);
 }
@@ -33,28 +33,28 @@ test.each(["nested", "sibling"])(
   async (name) => {
     await click(q.button("Open dialog"));
     await click(q.button(name));
-    expect(q.dialog.includesHidden("Dialog")).toBeVisible();
+    expect(q.dialog.hidden("Dialog")).toBeVisible();
     expect(q.dialog("Dialog")).not.toBeInTheDocument();
     expect(q.button("Close")).toHaveFocus();
     expect(q.dialog(name)).toBeVisible();
     expectModalStyle(true);
     await click(q.button(`${name} ${name}`));
-    expect(q.dialog.includesHidden("Dialog")).toBeVisible();
-    expect(q.dialog.includesHidden(name)).toBeVisible();
+    expect(q.dialog.hidden("Dialog")).toBeVisible();
+    expect(q.dialog.hidden(name)).toBeVisible();
     expect(q.button("Close")).toHaveFocus();
     expect(q.dialog("Dialog")).not.toBeInTheDocument();
     expect(q.dialog(name)).not.toBeInTheDocument();
     expect(q.dialog(`${name} ${name}`)).toBeVisible();
     expectModalStyle(true);
     await press.Escape();
-    expect(q.dialog.includesHidden(`${name} ${name}`)).not.toBeVisible();
-    expect(q.dialog.includesHidden("Dialog")).toBeVisible();
+    expect(q.dialog.hidden(`${name} ${name}`)).not.toBeVisible();
+    expect(q.dialog.hidden("Dialog")).toBeVisible();
     expect(q.button(`${name} ${name}`)).toHaveFocus();
     expect(q.dialog("Dialog")).not.toBeInTheDocument();
     expect(q.dialog(name)).toBeVisible();
     expectModalStyle(true);
     await press.Escape();
-    expect(q.dialog.includesHidden(name)).not.toBeVisible();
+    expect(q.dialog.hidden(name)).not.toBeVisible();
     expect(q.button(name)).toHaveFocus();
     expect(q.dialog("Dialog")).toBeVisible();
     expectModalStyle(true);
@@ -71,35 +71,33 @@ test.each(["nested", "sibling"])(
   async (name) => {
     await click(q.button("Open dialog"));
     await click(q.button(`${name} unmount`));
-    expect(q.dialog.includesHidden("Dialog")).toBeVisible();
+    expect(q.dialog.hidden("Dialog")).toBeVisible();
     expect(q.button("Close")).toHaveFocus();
     expect(q.dialog("Dialog")).not.toBeInTheDocument();
     expect(q.dialog(`${name} unmount`)).toBeVisible();
     expectModalStyle(true);
     await click(q.button(`${name} unmount ${name}`));
-    expect(q.dialog.includesHidden("Dialog")).toBeVisible();
-    expect(q.dialog.includesHidden(`${name} unmount`)).toBeVisible();
+    expect(q.dialog.hidden("Dialog")).toBeVisible();
+    expect(q.dialog.hidden(`${name} unmount`)).toBeVisible();
     expect(q.button("Close")).toHaveFocus();
     expect(q.dialog("Dialog")).not.toBeInTheDocument();
     expect(q.dialog(`${name} unmount`)).not.toBeInTheDocument();
     expect(q.dialog(`${name} unmount ${name}`)).toBeVisible();
     expectModalStyle(true);
     await press.Escape();
-    expect(
-      q.dialog.includesHidden(`${name} unmount ${name}`),
-    ).not.toBeInTheDocument();
+    expect(q.dialog.hidden(`${name} unmount ${name}`)).not.toBeInTheDocument();
     expect(q.button(`${name} unmount ${name}`)).toHaveFocus();
-    expect(q.dialog.includesHidden("Dialog")).toBeVisible();
+    expect(q.dialog.hidden("Dialog")).toBeVisible();
     expect(q.dialog("Dialog")).not.toBeInTheDocument();
     expect(q.dialog(`${name} unmount`)).toBeVisible();
     expectModalStyle(true);
     await press.Escape();
-    expect(q.dialog.includesHidden(`${name} unmount`)).not.toBeInTheDocument();
+    expect(q.dialog.hidden(`${name} unmount`)).not.toBeInTheDocument();
     expect(q.button(`${name} unmount`)).toHaveFocus();
     expect(q.dialog("Dialog")).toBeVisible();
     expectModalStyle(true);
     await press.Escape();
-    expect(q.dialog.includesHidden("Dialog")).not.toBeInTheDocument();
+    expect(q.dialog.hidden("Dialog")).not.toBeInTheDocument();
     expect(q.button("Open dialog")).toHaveFocus();
     expectModalStyle(false);
   },
@@ -109,8 +107,7 @@ test.each(["nested", "sibling"])(
 test.each(["nested", "sibling"])(
   "show %s no portal dialog and hide with escape",
   async (name) => {
-    const maybeNoRole =
-      name === "nested" ? q.none.includesHidden : q.dialog.includesHidden;
+    const maybeNoRole = name === "nested" ? q.none.hidden : q.dialog.hidden;
     await click(q.button("Open dialog"));
     await click(q.button(`${name} no portal`));
     expect(maybeNoRole("Dialog")).toBeVisible();
@@ -133,16 +130,14 @@ test.each(["nested", "sibling"])(
     expect(q.dialog(`${name} no portal ${name}`)).toBeVisible();
     expectModalStyle(true);
     await press.Escape();
-    expect(
-      q.dialog.includesHidden(`${name} no portal ${name}`),
-    ).not.toBeVisible();
+    expect(q.dialog.hidden(`${name} no portal ${name}`)).not.toBeVisible();
     expect(q.button(`${name} no portal ${name}`)).toHaveFocus();
     expect(getBackdrop(`${name} no portal ${name}`)).not.toBeVisible();
     expect(maybeNoRole("Dialog")).toBeVisible();
     expect(q.dialog(`${name} no portal`)).toBeVisible();
     expectModalStyle(true);
     await press.Escape();
-    expect(q.dialog.includesHidden(`${name} no portal`)).not.toBeVisible();
+    expect(q.dialog.hidden(`${name} no portal`)).not.toBeVisible();
     expect(q.button(`${name} no portal`)).toHaveFocus();
     expect(getBackdrop(`${name} no portal`)).not.toBeVisible();
     expect(q.dialog("Dialog")).toBeVisible();
@@ -158,8 +153,7 @@ test.each(["nested", "sibling"])(
 test.each(["nested", "sibling"])(
   "show %s no portal portal dialog and hide with escape",
   async (name) => {
-    const maybeNoRole =
-      name === "nested" ? q.none.includesHidden : q.dialog.includesHidden;
+    const maybeNoRole = name === "nested" ? q.none.hidden : q.dialog.hidden;
     await click(q.button("Open dialog"));
     await click(q.button(`${name} no portal portal`));
     expect(q.button("Close")).toHaveFocus();
@@ -171,22 +165,20 @@ test.each(["nested", "sibling"])(
     expectModalStyle(true);
     await click(q.button(`${name} no portal portal ${name}`));
     expect(maybeNoRole("Dialog")).toBeVisible();
-    expect(q.dialog.includesHidden(`${name} no portal portal`)).toBeVisible();
+    expect(q.dialog.hidden(`${name} no portal portal`)).toBeVisible();
     expect(q.button("Close")).toHaveFocus();
     expect(q.dialog(`${name} no portal portal ${name}`)).toBeVisible();
     expectModalStyle(true);
     await press.Escape();
     expect(
-      q.dialog.includesHidden(`${name} no portal portal ${name}`),
+      q.dialog.hidden(`${name} no portal portal ${name}`),
     ).not.toBeVisible();
     expect(q.button(`${name} no portal portal ${name}`)).toHaveFocus();
     expect(maybeNoRole("Dialog")).toBeVisible();
     expect(q.dialog(`${name} no portal portal`)).toBeVisible();
     expectModalStyle(true);
     await press.Escape();
-    expect(
-      q.dialog.includesHidden(`${name} no portal portal`),
-    ).not.toBeVisible();
+    expect(q.dialog.hidden(`${name} no portal portal`)).not.toBeVisible();
     expect(q.button(`${name} no portal portal`)).toHaveFocus();
     expect(q.dialog("Dialog")).toBeVisible();
     expectModalStyle(true);
@@ -203,21 +195,21 @@ test.each(["nested", "sibling"])(
   async (name) => {
     await click(q.button("Open dialog"));
     await click(q.button(`${name} no backdrop`));
-    expect(q.dialog.includesHidden("Dialog")).toBeVisible();
+    expect(q.dialog.hidden("Dialog")).toBeVisible();
     expect(q.button("Close")).toHaveFocus();
     expect(q.dialog("Dialog")).not.toBeInTheDocument();
     expect(q.dialog(`${name} no backdrop`)).toBeVisible();
     expectModalStyle(true);
     await click(q.button(`${name} no backdrop ${name}`));
-    expect(q.dialog.includesHidden("Dialog")).toBeVisible();
-    expect(q.dialog.includesHidden(`${name} no backdrop`)).toBeVisible();
+    expect(q.dialog.hidden("Dialog")).toBeVisible();
+    expect(q.dialog.hidden(`${name} no backdrop`)).toBeVisible();
     expect(q.button("Close")).toHaveFocus();
     expect(q.dialog("Dialog")).not.toBeInTheDocument();
     expect(q.dialog(`${name} no backdrop`)).not.toBeInTheDocument();
     expect(q.dialog(`${name} no backdrop ${name}`)).toBeVisible();
     expectModalStyle(true);
     await click(document.body);
-    expect(q.dialog.includesHidden("Dialog")).not.toBeInTheDocument();
+    expect(q.dialog.hidden("Dialog")).not.toBeInTheDocument();
     expect(q.button("Open dialog")).not.toHaveFocus();
     expect(q.dialog(`${name} no backdrop ${name}`)).not.toBeInTheDocument();
     expect(q.dialog(`${name} no backdrop`)).not.toBeInTheDocument();
@@ -236,7 +228,7 @@ test.each(["nested", "sibling"])(
     expectModalStyle(true);
     await click(q.button(`${name} dismiss ${name}`));
     await expect
-      .poll(q.dialog.includesHidden.lazy(`${name} dismiss`))
+      .poll(q.dialog.hidden.lazy(`${name} dismiss`))
       .not.toBeVisible();
     await expect.poll(q.button.lazy("Close")).toHaveFocus();
     expect(q.dialog(`${name} dismiss ${name}`)).toBeVisible();
@@ -253,20 +245,18 @@ test.each(["sibling"])(
   async (name) => {
     await click(q.button("Open dialog"));
     await click(q.button(`${name} dismiss unmount`));
-    expect(q.dialog.includesHidden("Dialog")).not.toBeInTheDocument();
+    expect(q.dialog.hidden("Dialog")).not.toBeInTheDocument();
     expect(q.button("Close")).toHaveFocus();
     expect(q.dialog(`${name} dismiss unmount`)).toBeVisible();
     expectModalStyle(true);
     await click(q.button(`${name} dismiss unmount ${name}`));
-    expect(
-      q.dialog.includesHidden(`${name} dismiss unmount`),
-    ).not.toBeInTheDocument();
+    expect(q.dialog.hidden(`${name} dismiss unmount`)).not.toBeInTheDocument();
     expect(q.button("Close")).toHaveFocus();
     expect(q.dialog(`${name} dismiss unmount ${name}`)).toBeVisible();
     expectModalStyle(true);
     await press.Escape();
     expect(
-      q.dialog.includesHidden(`${name} dismiss unmount ${name}`),
+      q.dialog.hidden(`${name} dismiss unmount ${name}`),
     ).not.toBeInTheDocument();
     expect(q.button("Open dialog")).toHaveFocus();
     expectModalStyle(false);

--- a/examples/dialog-nested/test.ts
+++ b/examples/dialog-nested/test.ts
@@ -38,7 +38,7 @@ test("show confirm dialog", async () => {
   await click(q.button("View Cart"));
   expect(q.dialog("Remove product")).not.toBeInTheDocument();
   await click(q.button("Remove Warm Jacket"));
-  expect(q.dialog.includesHidden("Your Shopping Cart")).toBeVisible();
+  expect(q.dialog.hidden("Your Shopping Cart")).toBeVisible();
   expect(q.dialog("Your Shopping Cart")).not.toBeInTheDocument();
   expect(q.dialog("Remove product")).toBeVisible();
   expect(q.button("Cancel")).toHaveFocus();

--- a/examples/menu-framer-motion/test.ts
+++ b/examples/menu-framer-motion/test.ts
@@ -8,7 +8,7 @@ test("show/hide on click", async () => {
   expect(q.menu()).toHaveFocus();
   await click(q.button("Options"));
   expect(q.button("Options")).toHaveFocus();
-  expect(q.menu.includesHidden()).toBeVisible();
+  expect(q.menu.hidden()).toBeVisible();
   await expect.poll(q.menu).not.toBeInTheDocument();
 });
 
@@ -34,7 +34,7 @@ test("show/hide on space", { retry: 2 }, async () => {
   await press.ShiftTab();
   await press.Space();
   expect(q.button("Options")).toHaveFocus();
-  expect(q.menu.includesHidden()).toBeVisible();
+  expect(q.menu.hidden()).toBeVisible();
   await expect.poll(q.menu).not.toBeInTheDocument();
 });
 
@@ -52,6 +52,6 @@ test("hide on click outside", async () => {
   await click(q.button("Options"));
   await click(document.body);
   expect(q.button("Options")).not.toHaveFocus();
-  expect(q.menu.includesHidden()).toBeVisible();
+  expect(q.menu.hidden()).toBeVisible();
   await expect.poll(q.menu).not.toBeInTheDocument();
 });

--- a/examples/menu-tooltip-various/test.ts
+++ b/examples/menu-tooltip-various/test.ts
@@ -43,8 +43,8 @@ describe.each(labels)("%s", (label) => {
     await click(q.button(label));
     expect(q.menu(label)).toBeVisible();
     expect(q.tooltip(label)).not.toBeInTheDocument();
-    await hover(q.button.includesHidden(label));
-    await hover(q.button.includesHidden(label));
+    await hover(q.button.hidden(label));
+    await hover(q.button.hidden(label));
     expect(q.tooltip(label)).not.toBeInTheDocument();
   });
 
@@ -55,8 +55,8 @@ describe.each(labels)("%s", (label) => {
     expect(q.menu(label)).toBeVisible();
     expect(q.tooltip(label)).not.toBeInTheDocument();
     await hoverOutside();
-    await hover(q.button.includesHidden(label));
-    await hover(q.button.includesHidden(label));
+    await hover(q.button.hidden(label));
+    await hover(q.button.hidden(label));
     if (label.includes("modal")) {
       expect(q.tooltip(label)).not.toBeInTheDocument();
     } else {

--- a/examples/menu-values-test/test.ts
+++ b/examples/menu-values-test/test.ts
@@ -11,8 +11,8 @@ beforeEach(() => {
 });
 
 function getVisualState() {
-  const checkboxes = q.menuitemcheckbox.all.includesHidden();
-  const radios = q.menuitemradio.all.includesHidden();
+  const checkboxes = q.menuitemcheckbox.all.hidden();
+  const radios = q.menuitemradio.all.hidden();
   return [...checkboxes, ...radios].reduce<Record<string, string | string[]>>(
     (acc, element: HTMLElement | HTMLInputElement) => {
       if (!("name" in element)) return acc;
@@ -58,7 +58,7 @@ test("interact with checkboxControlled items", async () => {
   await click(q.button("Menu"));
   await click(q.menuitemcheckbox("Apple (checkboxControlled)"));
   await click(q.menuitemcheckbox("Banana (checkboxControlled)"));
-  await click(q.menuitemcheckbox.includesHidden("Grape (checkboxControlled)"));
+  await click(q.menuitemcheckbox.hidden("Grape (checkboxControlled)"));
   await click(q.menuitemcheckbox("Orange (checkboxControlled)"));
   expect(getVisualState().checkboxControlled).toEqual(["Orange"]);
   expect(log.mock.lastCall?.at(0).checkboxControlled).toEqual(["Orange"]);
@@ -72,9 +72,7 @@ test("interact with checkboxUncontrolled items", async () => {
   await click(q.button("Menu"));
   await click(q.menuitemcheckbox("Apple (checkboxUncontrolled)"));
   await click(q.menuitemcheckbox("Banana (checkboxUncontrolled)"));
-  await click(
-    q.menuitemcheckbox.includesHidden("Grape (checkboxUncontrolled)"),
-  );
+  await click(q.menuitemcheckbox.hidden("Grape (checkboxUncontrolled)"));
   await click(q.menuitemcheckbox("Orange (checkboxUncontrolled)"));
   expect(getVisualState().checkboxUncontrolled).toEqual([
     "Apple",
@@ -97,7 +95,7 @@ test("interact with checkboxParent items", async () => {
   await click(q.button("Menu"));
   await click(q.menuitemcheckbox("Apple (checkboxParent)"));
   await click(q.menuitemcheckbox("Banana (checkboxParent)"));
-  await click(q.menuitemcheckbox.includesHidden("Grape (checkboxParent)"));
+  await click(q.menuitemcheckbox.hidden("Grape (checkboxParent)"));
   await click(q.menuitemcheckbox("Orange (checkboxParent)"));
   expect(getVisualState().checkboxParent).toEqual(["Banana"]);
   expect(log.mock.lastCall?.at(0).checkboxParent).toEqual(["Banana"]);
@@ -118,7 +116,7 @@ test("interact with radioControlled items", async () => {
   expect(getVisualState().radioControlled).toBe("Banana");
   expect(log.mock.calls).toHaveLength(0);
   log.mockClear();
-  await click(q.menuitemradio.includesHidden("Grape (radioControlled)"));
+  await click(q.menuitemradio.hidden("Grape (radioControlled)"));
   expect(getVisualState().radioControlled).toBe("Banana");
   expect(log.mock.calls).toHaveLength(0);
   log.mockClear();
@@ -142,7 +140,7 @@ test("interact with radioUncontrolled items", async () => {
   expect(getVisualState().radioUncontrolled).toBe("Banana");
   expect(log.mock.lastCall?.at(0).radioUncontrolled).toBe("Banana");
   log.mockClear();
-  await click(q.menuitemradio.includesHidden("Grape (radioUncontrolled)"));
+  await click(q.menuitemradio.hidden("Grape (radioUncontrolled)"));
   expect(getVisualState().radioUncontrolled).toBe("Banana");
   expect(log.mock.calls).toHaveLength(0);
   log.mockClear();
@@ -162,7 +160,7 @@ test("interact with radioParent items", async () => {
   expect(getVisualState().radioParent).toBe("Orange");
   expect(log.mock.calls).toHaveLength(0);
   log.mockClear();
-  await click(q.menuitemradio.includesHidden("Grape (radioParent)"));
+  await click(q.menuitemradio.hidden("Grape (radioParent)"));
   expect(getVisualState().radioParent).toBe("Orange");
   expect(log.mock.calls).toHaveLength(0);
   log.mockClear();

--- a/examples/tab-disabled/test.ts
+++ b/examples/tab-disabled/test.ts
@@ -10,7 +10,7 @@ test("navigate through tabs with keyboard", async () => {
   await press.ArrowRight();
   expect(q.tab("Meat")).toHaveFocus();
   expect(q.tab("Meat")).toHaveAttribute("aria-selected", "false");
-  expect(q.tabpanel.includesHidden("Meat")).not.toBeVisible();
+  expect(q.tabpanel.hidden("Meat")).not.toBeVisible();
   expect(q.tab("Vegetables")).toHaveAttribute("aria-selected", "true");
   expect(q.tabpanel("Vegetables")).toBeVisible();
 

--- a/examples/tooltip-framer-motion/test.ts
+++ b/examples/tooltip-framer-motion/test.ts
@@ -23,7 +23,7 @@ test("show tooltip on focus", async () => {
   await press.Tab();
   expect(q.tooltip(tooltip)).toBeVisible();
   await click(document.body);
-  expect(q.tooltip.includesHidden(tooltip)).toBeVisible();
+  expect(q.tooltip.hidden(tooltip)).toBeVisible();
   await expect.poll(q.tooltip.lazy(tooltip)).not.toBeInTheDocument();
 });
 

--- a/packages/ariakit-test/readme.md
+++ b/packages/ariakit-test/readme.md
@@ -268,7 +268,7 @@ const query: QueryObject;
 
 Queries the DOM by ARIA role, accessible name, text, or label, built on top of Testing Library. Call a role method such as `query.button(name)` or `query.dialog()` to get the matching element (or `null`), passing a string or `RegExp` to match its accessible name. Use `query.text()` and `query.labeled()` to query by text content or associated label, and `query.within(element)` to scope queries to a subtree.
 
-Every query also exposes `.lazy` (return a reusable function that runs the query when called), `.all` (return all matches), `.wait` (resolve once the element appears), and `.ensure` (throw when it's missing) variants, and role queries additionally expose `.includesHidden` to include otherwise-hidden elements.
+Every query also exposes `.lazy` (return a reusable function that runs the query when called), `.all` (return all matches), `.wait` (resolve once the element appears), and `.ensure` (throw when it's missing) variants, and role queries additionally expose `.hidden` to include otherwise-hidden elements.
 
 Example:
 

--- a/packages/ariakit-test/src/query.test.ts
+++ b/packages/ariakit-test/src/query.test.ts
@@ -23,7 +23,7 @@ test("lazy role queries run when called", () => {
 
 test("lazy role query variants run the matching variant", () => {
   const dialog = q.dialog.ensure.lazy("Visible");
-  const hiddenDialog = q.dialog.includesHidden.lazy("Hidden");
+  const hiddenDialog = q.dialog.hidden.lazy("Hidden");
   const dialogs = q.dialog.all.lazy("Visible");
 
   document.body.innerHTML = `

--- a/packages/ariakit-test/src/query.ts
+++ b/packages/ariakit-test/src/query.ts
@@ -148,9 +148,9 @@ function matchName(name: string | RegExp, accessibleName: string | null) {
   return name.test(accessibleName);
 }
 
-function getNameOption(name?: string | RegExp, includesHidden?: boolean) {
+function getNameOption(name?: string | RegExp, hidden?: boolean) {
   return (accessibleName: string, element: Element | HTMLInputElement) => {
-    if (!includesHidden && element.closest("[inert]")) return false;
+    if (!hidden && element.closest("[inert]")) return false;
     if (!name) return true;
     if (matchName(name, accessibleName)) return true;
     if (element.getAttribute("aria-label")) return false;
@@ -180,7 +180,7 @@ function createRoleQuery(role: AriaRole, queries = documentQueries) {
     };
   };
 
-  const createIncludesHidden = <T extends ReturnType<typeof createQuery>>(
+  const createHiddenQuery = <T extends ReturnType<typeof createQuery>>(
     query: T,
   ) =>
     assignLazy(
@@ -196,31 +196,31 @@ function createRoleQuery(role: AriaRole, queries = documentQueries) {
   const ensureAllQuery = assignLazy(createQuery(queries.getAllByRole));
 
   const all = Object.assign(allQuery, {
-    includesHidden: createIncludesHidden(allQuery),
+    hidden: createHiddenQuery(allQuery),
     wait: Object.assign(waitAllQuery, {
-      includesHidden: createIncludesHidden(waitAllQuery),
+      hidden: createHiddenQuery(waitAllQuery),
     }),
     ensure: Object.assign(ensureAllQuery, {
-      includesHidden: createIncludesHidden(ensureAllQuery),
+      hidden: createHiddenQuery(ensureAllQuery),
     }),
   });
 
   const wait = Object.assign(waitQuery, {
-    includesHidden: createIncludesHidden(waitQuery),
+    hidden: createHiddenQuery(waitQuery),
     all: Object.assign(waitAllQuery, {
-      includesHidden: createIncludesHidden(waitAllQuery),
+      hidden: createHiddenQuery(waitAllQuery),
     }),
   });
 
   const ensure = Object.assign(ensureQuery, {
-    includesHidden: createIncludesHidden(ensureQuery),
+    hidden: createHiddenQuery(ensureQuery),
     all: Object.assign(ensureAllQuery, {
-      includesHidden: createIncludesHidden(ensureAllQuery),
+      hidden: createHiddenQuery(ensureAllQuery),
     }),
   });
 
   return Object.assign(query, {
-    includesHidden: createIncludesHidden(query),
+    hidden: createHiddenQuery(query),
     all,
     wait,
     ensure,
@@ -300,8 +300,7 @@ function createQueryObject(queries = documentQueries): QueryObject {
  * Every query also exposes `.lazy` (return a reusable function that runs the
  * query when called), `.all` (return all matches), `.wait` (resolve once the
  * element appears), and `.ensure` (throw when it's missing) variants, and role
- * queries additionally expose `.includesHidden` to include otherwise-hidden
- * elements.
+ * queries additionally expose `.hidden` to include otherwise-hidden elements.
  * @example
  * ```ts
  * const dialog = query.dialog.lazy("Settings");


### PR DESCRIPTION
## Motivation

`@ariakit/test` role queries expose a variant that also matches elements normally filtered out — those hidden from the accessibility tree (via the underlying Testing Library `hidden` option) and those inside an `[inert]` subtree. It was named `includesHidden`, which is long and noisy at call sites that repeat it many times:

```ts
expect(q.dialog.includesHidden("Post")).toBeVisible();
const checkboxes = q.menuitemcheckbox.all.includesHidden();
```

## Solution

Rename the variant to `hidden`. It reads cleaner, and it mirrors Testing Library's own `hidden` option name, so the intent is familiar:

```ts
expect(q.dialog.hidden("Post")).toBeVisible();
const checkboxes = q.menuitemcheckbox.all.hidden();
```

The behavior is unchanged — this is a pure rename. `.hidden` is attached at the same surface `.includesHidden` had (base query plus the `.all`, `.wait`, `.ensure` variants and their combinations), and still composes with `.lazy`. Internals were renamed to match (`createIncludesHidden` → `createHiddenQuery`), and the JSDoc/readme and every in-repo call site were updated.

## Breaking changes

**BREAKING** if you use the `includesHidden` role-query variant from `@ariakit/test`.

Before:

```ts
q.dialog.includesHidden("Settings");
q.menuitemcheckbox.all.includesHidden();
```

After:

```ts
q.dialog.hidden("Settings");
q.menuitemcheckbox.all.hidden();
```

## Notes

Two pre-existing, non-blocking items surfaced during review and were intentionally left out of this rename-only PR (recorded here as possible follow-ups):

- The variant merges options as `{ hidden: true, ...options }`, so a caller-supplied `hidden` option still wins. This precedence predates the rename and no caller relies on it; making the variant authoritative (`{ ...options, hidden: true }`) would be a separate, deliberate semantics change.
- The query overview JSDoc/readme example does not demonstrate `.hidden` (it also doesn't enumerate `.ensure`/`.all`/`.wait`); adding a usage example would be a docs-only follow-up.
