### PR TITLE
Batch requestAnimationFrame callbacks under happy-dom

### DIFF
--- a/.changeset/200-test-animation-frame-batching.md
+++ b/.changeset/200-test-animation-frame-batching.md
@@ -1,0 +1,9 @@
+---
+"@ariakit/test": patch
+---
+
+Batched `requestAnimationFrame` callbacks under happy-dom
+
+`@ariakit/test` now runs happy-dom's `requestAnimationFrame` callbacks as a batched frame: all callbacks scheduled before a frame run together with a single shared timestamp, and a callback scheduled while the frame is running is deferred to the next frame. This matches the HTML specification, jsdom, and real browsers.
+
+happy-dom otherwise runs each callback as its own task, so components that schedule work in the same frame could observe each other's mid-flight state — for example, an animated [`Dialog`](https://ariakit.com/reference/dialog) and its backdrop reading each other's computed styles while a leave animation is being set up. The batching keeps happy-dom's fast cadence, so test runs are not slowed down.

--- a/examples/dialog-animated-various/test.ts
+++ b/examples/dialog-animated-various/test.ts
@@ -1,11 +1,3 @@
-// @vitest-environment jsdom
-// This suite opts out of the default happy-dom environment. The animation-based
-// leave cases (AnimationLeave/AnimationUnmountLeave) depend on
-// `data-[leave]:animate-out` playing while the dialog closes. Under happy-dom's
-// timer cadence, React commits a transient `mounted: false` render during close
-// that cancels the leave transition, so the animation never plays and the dialog
-// unmounts immediately. jsdom's requestAnimationFrame cadence keeps `mounted`
-// stable through the close, matching real browsers.
 import { click, press, q, sleep } from "@ariakit/test";
 import { expect, test } from "vitest";
 
@@ -35,9 +27,12 @@ test.each([
     !name.endsWith("NoLeave") &&
     (!name.startsWith("Animation") || name.endsWith("Leave"))
   ) {
-    expect(q.dialog(name)).toBeInTheDocument();
-    expect(q.dialog(name)).not.toHaveAttribute("hidden");
-    expect(q.dialog(name)).not.toHaveStyle("display: none");
+    // While it closes, the dialog disables its own tree with `inert`, so it's
+    // matched only by the `hidden` query variant. It's still visually leaving,
+    // which the following assertions verify.
+    expect(q.dialog.hidden(name)).toBeInTheDocument();
+    expect(q.dialog.hidden(name)).not.toHaveAttribute("hidden");
+    expect(q.dialog.hidden(name)).not.toHaveStyle("display: none");
   }
 
   await expect.poll(q.dialog.lazy(name)).not.toBeInTheDocument();

--- a/packages/ariakit-test/src/shims.test.ts
+++ b/packages/ariakit-test/src/shims.test.ts
@@ -34,3 +34,52 @@ test("keeps the browser shims applied after an interaction settles", async () =>
     element.remove();
   }
 });
+
+test("runs animation frame callbacks as a spec-compliant batch", async () => {
+  if (isBrowser) return;
+  const order: string[] = [];
+  const timestamps: number[] = [];
+  await new Promise<void>((resolve) => {
+    requestAnimationFrame((timestamp) => {
+      order.push("a");
+      timestamps.push(timestamp);
+      // Requested while the frame is running, so it must be deferred to the
+      // next frame — after "b", not interleaved before it.
+      requestAnimationFrame(() => {
+        order.push("c");
+        resolve();
+      });
+    });
+    requestAnimationFrame((timestamp) => {
+      order.push("b");
+      timestamps.push(timestamp);
+    });
+  });
+  // "c" is requested during the frame, so it runs after "b" (deferred to the
+  // next frame), which the order asserts. The property unique to batching — and
+  // the real point of this test — is that the same-frame callbacks "a" and "b"
+  // share one timestamp; unbatched, each would get its own.
+  expect(order).toEqual(["a", "b", "c"]);
+  expect(timestamps[0]).toBe(timestamps[1]);
+});
+
+test("cancels a not-yet-run animation frame callback within the same frame", async () => {
+  if (isBrowser) return;
+  const ran: string[] = [];
+  await new Promise<void>((resolve) => {
+    let handleB = 0;
+    requestAnimationFrame(() => {
+      ran.push("a");
+      cancelAnimationFrame(handleB);
+      // Resolve on the next frame, by which point a wrongly-surviving "b" would
+      // already have run in this frame and been recorded.
+      requestAnimationFrame(() => resolve());
+    });
+    handleB = requestAnimationFrame(() => {
+      ran.push("b");
+    });
+  });
+  // "a" cancels "b" before "b" runs, so "b" must be skipped even though both
+  // were requested for the same frame.
+  expect(ran).toEqual(["a"]);
+});

--- a/packages/ariakit-test/src/shims.ts
+++ b/packages/ariakit-test/src/shims.ts
@@ -97,6 +97,7 @@ function applyBrowserShims() {
         patchHappyDOMValidationMessage(),
         patchHappyDOMFormData(),
         patchHappyDOMSelectionChange(),
+        patchHappyDOMAnimationFrame(),
       ]
     : [];
 
@@ -222,6 +223,76 @@ function patchHappyDOMSelectionChange() {
   };
   return () => {
     SelectionPrototype.removeAllRanges = originalRemoveAllRanges;
+  };
+}
+
+// happy-dom schedules each `requestAnimationFrame` callback as its own
+// `setImmediate`, so callbacks registered for the same frame run in separate
+// tasks — and, under React, separate commits — instead of one batch. The HTML
+// spec runs the animation frame callbacks as a batch: it snapshots the
+// callbacks registered before the frame, invokes them all with a single shared
+// timestamp, and defers any callback registered *during* the run to the next
+// frame. jsdom and real browsers behave this way; happy-dom's unbatched
+// behavior makes siblings that schedule work in the same frame observe each
+// other's mid-flight state (e.g. a dialog and its backdrop, which read each
+// other's computed styles while a leave animation is being set up). Restore
+// spec-compliant batching while keeping happy-dom fast: a single 0ms timer per
+// frame rather than a 16ms wall-clock frame (the spec leaves the frame rate
+// implementation-defined, so the fast cadence is still conformant).
+// https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#run-the-animation-frame-callbacks
+function patchHappyDOMAnimationFrame() {
+  const originalRequestAnimationFrame = window.requestAnimationFrame;
+  const originalCancelAnimationFrame = window.cancelAnimationFrame;
+
+  let nextHandle = 1;
+  const pending = new Map<number, FrameRequestCallback>();
+  let flushScheduled = false;
+
+  const flush = () => {
+    flushScheduled = false;
+    // Snapshot only the handles registered before this frame; a callback added
+    // during the flush keeps its entry in `pending` and runs on the next frame.
+    // Re-read each handle from the live map and remove it right before invoking,
+    // so a callback can still cancel another not-yet-run callback in the same
+    // frame (`cancelAnimationFrame` deletes from this same map).
+    const handles = Array.from(pending.keys());
+    const timestamp = window.performance.now();
+    for (const handle of handles) {
+      const callback = pending.get(handle);
+      if (!callback) continue;
+      pending.delete(handle);
+      try {
+        callback(timestamp);
+      } catch (error) {
+        // A throwing callback is reported but must not abort the rest of the
+        // batch; rethrow asynchronously so the frame keeps running.
+        window.setTimeout(() => {
+          throw error;
+        });
+      }
+    }
+  };
+
+  window.requestAnimationFrame = function requestAnimationFrame(callback) {
+    const handle = nextHandle++;
+    pending.set(handle, callback);
+    if (!flushScheduled) {
+      flushScheduled = true;
+      // Schedule through the window's own timer so happy-dom's async task
+      // manager tracks the pending frame; a raw setImmediate would be invisible
+      // to teardown. A 0ms delay stays as fast as the native setImmediate.
+      window.setTimeout(flush, 0);
+    }
+    return handle;
+  };
+
+  window.cancelAnimationFrame = function cancelAnimationFrame(handle) {
+    pending.delete(handle);
+  };
+
+  return () => {
+    window.requestAnimationFrame = originalRequestAnimationFrame;
+    window.cancelAnimationFrame = originalCancelAnimationFrame;
   };
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -66,8 +66,12 @@ const testExcludes = [
 // @ariakit/test simulation layer and provides the DOM every suite needs.
 // Individual tests that hit a deterministic happy-dom divergence opt into jsdom
 // with a `// @vitest-environment jsdom` comment. test-react18 opts the whole
-// suite out via ARIAKIT_TEST_ENV=jsdom: React 18's scheduler is more sensitive
-// to happy-dom's faster timer cadence and flakes some dialog-dismissal tests.
+// suite out via ARIAKIT_TEST_ENV=jsdom: under React 18, hiding a dialog by
+// clicking outside (`store.hide()` runs from a native capture-phase listener)
+// commits with the controlled `open` prop momentarily stale on happy-dom, so the
+// store transiently re-opens and focus is wrongly restored to the trigger. It's
+// deterministic (not a timer-cadence flake) and confirmed correct in real
+// browsers on React 18 and 19, so it's a happy-dom artifact, not an Ariakit bug.
 const environment = process.env.ARIAKIT_TEST_ENV ?? "happy-dom";
 
 // sourcePlugin is typed against the app workspace's Vite copy, while Vitest


### PR DESCRIPTION
## Motivation

happy-dom — the default environment for `@ariakit/test` — schedules each `requestAnimationFrame` callback as its own `setImmediate`, so callbacks registered for the same frame run in separate tasks (and, under React, separate commits) instead of as one batch. The HTML spec, jsdom, and real browsers instead run all callbacks registered before a frame together with a single shared timestamp, deferring callbacks registered during the flush to the next frame.

This divergence broke `examples/dialog-animated-various` on happy-dom. A modal `Dialog` renders a backdrop (a second `DisclosureContent` sharing the store); on close, both set `data-leave` via a double `requestAnimationFrame`, and the backdrop's effect reads the dialog's computed style to decide how long the leave animation lasts:

```ts
const { animationName, animationDuration } = getComputedStyle(dialog);
```

Unbatched, the backdrop's effect ran *before* the dialog's `data-leave` had committed, so `animationName` was empty, the timeout computed to `0`, and the dialog unmounted immediately instead of animating out. The suite was pinned to jsdom (`// @vitest-environment jsdom`) to work around it, and the pin comment misattributed the failure to a transient `mounted: false` from happy-dom's timer cadence. Changing the rAF *delay* doesn't help — the missing behavior is *batching*.

## Solution

Add a `requestAnimationFrame` frame-batching shim to `@ariakit/test`'s happy-dom shims (`patchHappyDOMAnimationFrame`), applied automatically. Following the [HTML spec](https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#run-the-animation-frame-callbacks), it:

- snapshots the callbacks registered before a frame and runs them with a single shared timestamp;
- defers callbacks registered during the flush to the next frame;
- lets `cancelAnimationFrame` cancel a not-yet-run callback in the same frame.

It stays fast — a single `setTimeout(0)` flush per frame rather than a 16ms wall-clock frame (the spec leaves the frame rate implementation-defined, so the fast cadence is still conformant) — so happy-dom test runs aren't slowed.

With batching restored, `examples/dialog-animated-various` is un-pinned from jsdom. Its during-leave lookups switch to `q.dialog.hidden(...)`, because a closing modal dialog disables its own tree with `inert` (which happy-dom reflects to an attribute, like real browsers; jsdom lacks `inert` support) and `q.dialog()` filters `[inert]` elements.

This also corrects the `test-react18` comment in `vitest.config.ts` to the verified reason for that jsdom pin: a React-18 + happy-dom focus-restore artifact (a controlled dialog dismissed by clicking outside transiently re-opens and wrongly restores focus to the trigger), confirmed correct in real browsers on React 18 and 19 — a happy-dom artifact, not an Ariakit bug.

## Verification

- The `@ariakit/test` shims suite — including new batching and same-frame-`cancelAnimationFrame` regression tests — passes on both happy-dom and jsdom.
- `examples/dialog-animated-various` passes 11/11 on happy-dom (un-pinned), faster than under the jsdom pin.
- The full React (742), core (292), and Solid suites pass with the global batching shim; `tsc` and lint are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
