### PR TITLE
Make the hovercard-nested-listener sandbox reproducible in a browser

### DIFF
--- a/app/src/sandbox/hovercard-nested-listener/index.react.tsx
+++ b/app/src/sandbox/hovercard-nested-listener/index.react.tsx
@@ -1,25 +1,84 @@
 import * as Ariakit from "@ariakit/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+
+// The parent hovercard installs a capture-phase document "mousemove" listener
+// to track hover intent. The regression this sandbox guards against tears that
+// listener down and reinstalls it every time a nested hovercard mounts or
+// unmounts — a synchronous swap with no visible effect. To make it observable,
+// this hook counts capture-phase "mousemove" listener installs on the document
+// and the example renders the count; toggling the nested hovercard must not
+// change it. The count starts at 0 because this hook patches in an effect that
+// runs after the hovercard's own effect has installed the initial listener, so
+// only later reinstalls are counted.
+function useMouseMoveListenerInstalls() {
+  const [installs, setInstalls] = useState(0);
+  useEffect(() => {
+    // Patching addEventListener is the only way to observe listener installs (a
+    // real listener could only observe the events). Keep the original itself so
+    // the exact method is restored on cleanup.
+    // oxlint-disable-next-line unbound-method
+    const originalAddEventListener = document.addEventListener;
+    document.addEventListener = (
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | AddEventListenerOptions,
+    ) => {
+      const capture =
+        options === true || (typeof options === "object" && !!options?.capture);
+      if (type === "mousemove" && capture) {
+        setInstalls((count) => count + 1);
+      }
+      return originalAddEventListener.call(document, type, listener, options);
+    };
+    return () => {
+      document.addEventListener = originalAddEventListener;
+    };
+  }, []);
+  return installs;
+}
+
+function NestedHovercard() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button type="button" onClick={() => setOpen((value) => !value)}>
+        Toggle nested
+      </button>
+      {open && (
+        <Ariakit.HovercardProvider open>
+          <Ariakit.HovercardAnchor>Nested anchor</Ariakit.HovercardAnchor>
+          <Ariakit.Hovercard
+            portal
+            // The nested card is always open here, so its own hover-intent
+            // listeners are unnecessary. Disabling them keeps the install
+            // counter measuring only the parent hovercard's listener.
+            hideOnHoverOutside={false}
+            aria-label="Nested hovercard"
+          >
+            Nested content
+          </Ariakit.Hovercard>
+        </Ariakit.HovercardProvider>
+      )}
+    </>
+  );
+}
 
 export default function Example() {
-  const [showNested, setShowNested] = useState(false);
-
+  const mouseMoveListenerInstalls = useMouseMoveListenerInstalls();
   return (
-    <Ariakit.HovercardProvider open>
-      <Ariakit.HovercardAnchor>Parent anchor</Ariakit.HovercardAnchor>
-      <Ariakit.Hovercard aria-label="Parent hovercard">
-        <button type="button" onClick={() => setShowNested((show) => !show)}>
-          Toggle nested
-        </button>
-        {showNested && (
-          <Ariakit.HovercardProvider open>
-            <Ariakit.HovercardAnchor>Nested anchor</Ariakit.HovercardAnchor>
-            <Ariakit.Hovercard portal aria-label="Nested hovercard">
-              Nested content
-            </Ariakit.Hovercard>
-          </Ariakit.HovercardProvider>
-        )}
-      </Ariakit.Hovercard>
-    </Ariakit.HovercardProvider>
+    <>
+      <p>
+        Parent hovercard mousemove listener installs:{" "}
+        <output aria-label="Parent hovercard mousemove listener installs">
+          {mouseMoveListenerInstalls}
+        </output>
+      </p>
+      <Ariakit.HovercardProvider open>
+        <Ariakit.HovercardAnchor>Parent anchor</Ariakit.HovercardAnchor>
+        <Ariakit.Hovercard aria-label="Parent hovercard">
+          <NestedHovercard />
+        </Ariakit.Hovercard>
+      </Ariakit.HovercardProvider>
+    </>
   );
 }

--- a/app/src/sandbox/hovercard-nested-listener/test-browser.ts
+++ b/app/src/sandbox/hovercard-nested-listener/test-browser.ts
@@ -1,0 +1,22 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// See https://github.com/ariakit/ariakit/pull/6143
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("toggling a nested hovercard does not reinstall the parent mousemove listener", async ({
+    q,
+  }) => {
+    const installs = q.status("Parent hovercard mousemove listener installs");
+    await test.expect(q.dialog("Parent hovercard")).toBeVisible();
+    const initialInstalls = (await installs.textContent()) ?? "";
+
+    // Mounting a nested hovercard must not reinstall the parent's listener.
+    await q.button("Toggle nested").click();
+    await test.expect(q.dialog("Nested hovercard")).toBeVisible();
+    await test.expect(installs).toHaveText(initialInstalls);
+
+    // Unmounting the nested hovercard must not reinstall it either.
+    await q.button("Toggle nested").click();
+    await test.expect(q.dialog("Nested hovercard")).not.toBeAttached();
+    await test.expect(installs).toHaveText(initialInstalls);
+  });
+});

--- a/app/src/sandbox/hovercard-nested-listener/test.ts
+++ b/app/src/sandbox/hovercard-nested-listener/test.ts
@@ -1,37 +1,21 @@
 import { click, q } from "@ariakit/test";
-import { expect, test, vi } from "vitest";
+import { expect, test } from "vitest";
 
-test("does not reinstall mousemove listener when nested hovercards change", async () => {
+// See https://github.com/ariakit/ariakit/pull/6143
+const installCount = () =>
+  q.status.ensure("Parent hovercard mousemove listener installs").textContent;
+
+test("toggling a nested hovercard does not reinstall the parent mousemove listener", async () => {
   expect(q.dialog("Parent hovercard")).toBeVisible();
+  const initialInstalls = installCount();
 
-  const addEventListener = vi.spyOn(document, "addEventListener");
-  const removeEventListener = vi.spyOn(document, "removeEventListener");
+  // Mounting a nested hovercard must not reinstall the parent's listener.
+  await click(q.button("Toggle nested"));
+  await expect.poll(q.dialog.lazy("Nested hovercard")).toBeVisible();
+  expect(installCount()).toBe(initialInstalls);
 
-  try {
-    await click(q.button("Toggle nested"));
-    await expect.poll(q.dialog.lazy("Nested hovercard")).toBeVisible();
-    await click(q.button("Toggle nested"));
-    await expect
-      .poll(q.dialog.lazy("Nested hovercard"))
-      .not.toBeInTheDocument();
-
-    const addedMouseMoveListeners = new Set(
-      addEventListener.mock.calls
-        .filter(([type, , options]) => type === "mousemove" && options === true)
-        .map(([, listener]) => listener),
-    );
-
-    const removedExistingMouseMoveListeners =
-      removeEventListener.mock.calls.filter(
-        ([type, listener, options]) =>
-          type === "mousemove" &&
-          options === true &&
-          !addedMouseMoveListeners.has(listener),
-      );
-
-    expect(removedExistingMouseMoveListeners).toHaveLength(0);
-  } finally {
-    addEventListener.mockRestore();
-    removeEventListener.mockRestore();
-  }
+  // Unmounting the nested hovercard must not reinstall it either.
+  await click(q.button("Toggle nested"));
+  await expect.poll(q.dialog.lazy("Nested hovercard")).not.toBeInTheDocument();
+  expect(installCount()).toBe(initialInstalls);
 });


### PR DESCRIPTION
## Motivation

The `app/src/sandbox/hovercard-nested-listener` sandbox guards the fix from #6143: nested hovercards must not make the parent hovercard tear down and reinstall its document `mousemove` capture listener when they mount or unmount. The test asserted this by spying on the document:

```ts
const addEventListener = vi.spyOn(document, "addEventListener");
const removeEventListener = vi.spyOn(document, "removeEventListener");
// ...assert no pre-existing mousemove listener was removed
```

A real user opening `/react/previews/hovercard-nested-listener` could not reproduce or observe anything, and there was no browser test. The reinstall has **no functional symptom** — the listener is swapped synchronously in the same React commit, and the parent re-render count is identical on the buggy and fixed code (Floating UI repositioning dominates), so there is nothing to assert through normal rendered behavior. The only faithful signal is the listener reinstall itself.

## Solution

Make the otherwise-invisible side effect observable, the way `button-ref-cleanup` surfaces document-listener state as visible UI. The example counts capture-phase document `mousemove` listener installs and renders the count in an `<output>`; toggling the nested hovercard must leave it unchanged:

```tsx
<output aria-label="Parent hovercard mousemove listener installs">
  {mouseMoveListenerInstalls}
</output>
```

The nested card sets `hideOnHoverOutside={false}` (which also defaults `disablePointerEventsOnApproach` to `false`), so it installs zero document listeners and the counter reflects only the parent. The patch keeps and restores the exact original `addEventListener` on cleanup.

`test.ts` now reads the visible counter (no more `vi.spyOn`) and asserts it is invariant across the toggle, and a new `test-browser.ts` asserts the same in a real browser. Both use the same relative-invariance check, and both **fail on the pre-fix code and pass on the fix** (verified in happy-dom and real Chromium).

🤖 Generated with [Claude Code](https://claude.com/claude-code)