### PR TITLE
Run activation behavior for clicks on disabled controls under happy-dom

### DIFF
--- a/.changeset/200-test-disabled-click.md
+++ b/.changeset/200-test-disabled-click.md
@@ -2,8 +2,10 @@
 "@ariakit/test": patch
 ---
 
-Ran `click` listeners on disabled controls under happy-dom
+Ran `click` listeners and activation on disabled controls under happy-dom
 
-`@ariakit/test` now runs the event listeners for a `click` dispatched on a disabled `button` or `input` under happy-dom, without activating the control. This matches jsdom and real browsers, which only bar clicks queued from user interaction on a disabled control — not a scripted `dispatchEvent`.
+`@ariakit/test` now runs both the event listeners and the activation behavior for a `click` dispatched on a disabled `button` or `input` under happy-dom. This matches jsdom and real browsers, which only bar clicks queued from user interaction on a disabled control — not a scripted `dispatchEvent`.
 
-happy-dom otherwise drops such a click entirely, so a test couldn't observe a click reaching a control that became disabled mid-interaction.
+A disabled `checkbox`/`radio` now toggles before its click listener runs (which still sees it disabled) and fires `input`/`change`, reverting — and restoring the rest of the radio group — when a listener calls `preventDefault()`. Disabled submit/reset controls run their listeners without submitting or resetting the form.
+
+happy-dom otherwise drops such a click entirely, so a test couldn't observe a click reaching a control that became disabled mid-interaction, and a disabled checkbox wouldn't toggle.

--- a/packages/ariakit-test/src/dispatch.ts
+++ b/packages/ariakit-test/src/dispatch.ts
@@ -256,15 +256,15 @@ const pointerEvents = [
 ];
 
 // happy-dom drops a `click` dispatched on a disabled `<button>`/`<input>`: their
-// per-class `dispatchEvent` returns `false` before invoking any listener. The
+// per-class `dispatchEvent` returns `false` before invoking any listener or
+// running the control's activation behavior (capricorn86/happy-dom#2190). The
 // HTML spec only bars clicks queued from user interaction on a disabled control,
 // not a scripted `dispatchEvent` — so jsdom and real browsers still run the
-// listeners (skipping only the control's activation behavior). Route the click
-// through the base `EventTarget` dispatch, which runs the listeners across its
-// propagation phases without the disabled short-circuit, and without the
-// control's activation. Scoped to events `@ariakit/test` dispatches, so
+// listeners *and* the activation behavior (a disabled checkbox/radio toggles).
+// Reinstate both for the events `@ariakit/test` dispatches. Scoping it here means
 // happy-dom's own internal click re-dispatches (e.g. a label forwarding to its
-// control) keep their behavior — `click` relies on that to avoid a double click.
+// control) still drop on a disabled control — `click` relies on that to avoid a
+// double click.
 function fireEventAllowingDisabledClick(
   element: NonNullable<Target>,
   event: Event,
@@ -277,9 +277,102 @@ function fireEventAllowingDisabledClick(
       element instanceof HTMLInputElement) &&
     element.disabled
   ) {
-    return window.EventTarget.prototype.dispatchEvent.call(element, event);
+    return dispatchDisabledControlClick(element, event);
   }
   return fireEvent(element, event);
+}
+
+// Collect the radios whose checked state to snapshot before selecting `radio`, so
+// the activation's effect can be detected and reverted. Selecting a radio unchecks
+// a same-name peer through happy-dom's `checked` setter, scoped to the control's
+// form or, lacking one, the root node. Snapshotting every same-name radio in the
+// root node is a superset of whatever that setter unchecks, so the post-selection
+// diff captures exactly the peer that changed regardless of how happy-dom scopes
+// the group — including radios linked to a form by the `form` attribute, where
+// happy-dom's scope diverges from `radio.form`. `getRootNode()` returns a
+// `ParentNode` (the document, a shadow root, or a detached tree root).
+function getRadioGroup(radio: HTMLInputElement) {
+  if (!radio.name) return [radio];
+  const root = radio.getRootNode() as ParentNode;
+  const radios = Array.from(
+    root.querySelectorAll<HTMLInputElement>("input[type='radio']"),
+  ).filter((control) => control.name === radio.name);
+  return radios.includes(radio) ? radios : [radio, ...radios];
+}
+
+// Run the listeners and reinstate the checkbox/radio activation happy-dom skips
+// for a click on a disabled control, mirroring the spec ordering real browsers
+// follow. The listeners run through the base `EventTarget` dispatch, which skips
+// happy-dom's disabled short-circuit and keeps `disabled` reading `true`
+// throughout. A checkbox is toggled (and a radio selected) *before* the click is
+// dispatched so listeners observe the new `checked` value; `preventDefault()`
+// reverts it. Selecting a radio also unchecks a peer, so the controls the
+// activation actually changed are captured and only those are reverted — leaving
+// any control a listener changes during the click untouched, as in a browser.
+// When not prevented, `input`/`change` fire for the value that changed.
+// Submit/reset controls have no such activation (and real browsers don't
+// submit/reset a disabled control), so they only run their listeners.
+function dispatchDisabledControlClick(
+  element: HTMLButtonElement | HTMLInputElement,
+  event: Event,
+) {
+  const dispatchThroughBase = () =>
+    window.EventTarget.prototype.dispatchEvent.call(element, event);
+
+  const input =
+    element instanceof HTMLInputElement &&
+    (element.type === "checkbox" || element.type === "radio")
+      ? element
+      : null;
+  if (!input) return dispatchThroughBase();
+
+  const isCheckbox = input.type === "checkbox";
+  // A radio selection unchecks a same-name peer, so snapshot the whole group (a
+  // checkbox only affects itself) to detect that peer below.
+  const group = isCheckbox ? [input] : getRadioGroup(input);
+  const snapshot = group.map((control) => ({
+    control,
+    checked: control.checked,
+    indeterminate: control.indeterminate,
+  }));
+
+  const wasChecked = input.checked;
+  input.checked = isCheckbox ? !wasChecked : true;
+  if (isCheckbox) {
+    input.indeterminate = false;
+  }
+
+  // Exactly the controls the activation changed: the toggled control plus the
+  // radio peer happy-dom just unchecked. Reverting only these keeps a prevented
+  // click from clobbering state a listener changes during the dispatch.
+  const activated = snapshot.filter(
+    ({ control, checked, indeterminate }) =>
+      control.checked !== checked || control.indeterminate !== indeterminate,
+  );
+
+  const defaultAllowed = dispatchThroughBase();
+
+  if (!defaultAllowed) {
+    for (const { control, checked, indeterminate } of activated) {
+      control.checked = checked;
+      control.indeterminate = indeterminate;
+    }
+    return defaultAllowed;
+  }
+
+  // Real browsers fire `input`/`change` only when the value changed: a checkbox
+  // always toggles; a radio only when it wasn't already selected. Dispatch each
+  // through `withWindowEvent` so happy-dom's missing `window.event` reflects the
+  // event being dispatched (as in jsdom/browsers), not the outer click.
+  if (input.isConnected && (isCheckbox || !wasChecked)) {
+    const fireActivationEvent = (type: "input" | "change") => {
+      const activationEvent = createEvent[type](input);
+      withWindowEvent(activationEvent, () => fireEvent(input, activationEvent));
+    };
+    fireActivationEvent("input");
+    fireActivationEvent("change");
+  }
+  return defaultAllowed;
 }
 
 function baseDispatch(element: Target, event: Event): Promise<boolean> {

--- a/packages/ariakit-test/src/shims.test.ts
+++ b/packages/ariakit-test/src/shims.test.ts
@@ -253,6 +253,53 @@ test("reverts a disabled checkbox toggle in either direction when a click listen
   }
 });
 
+test("clears and restores a disabled checkbox's indeterminate state on a scripted click", async () => {
+  if (isBrowser) return;
+  // A scripted click on a disabled indeterminate checkbox clears `indeterminate`
+  // (and toggles `checked`) before the click listener runs; preventDefault()
+  // restores both. Verified on Chromium, Firefox, and WebKit.
+  for (const prevent of [false, true]) {
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.disabled = true;
+    checkbox.indeterminate = true;
+    let indeterminateDuringClick: boolean | undefined;
+    let checkedDuringClick: boolean | undefined;
+    let inputEvents = 0;
+    let changeEvents = 0;
+    checkbox.addEventListener("input", () => inputEvents++);
+    checkbox.addEventListener("change", () => changeEvents++);
+    checkbox.addEventListener("click", (event) => {
+      indeterminateDuringClick = checkbox.indeterminate;
+      checkedDuringClick = checkbox.checked;
+      if (prevent) event.preventDefault();
+    });
+    document.body.append(checkbox);
+    try {
+      const defaultAllowed = await dispatch.click(checkbox);
+      // Cleared and toggled before the listener runs, regardless of prevention.
+      expect(indeterminateDuringClick).toBe(false);
+      expect(checkedDuringClick).toBe(true);
+      if (prevent) {
+        // preventDefault restores both the checked and indeterminate state.
+        expect(defaultAllowed).toBe(false);
+        expect(checkbox.checked).toBe(false);
+        expect(checkbox.indeterminate).toBe(true);
+        expect(inputEvents).toBe(0);
+        expect(changeEvents).toBe(0);
+      } else {
+        expect(defaultAllowed).toBe(true);
+        expect(checkbox.checked).toBe(true);
+        expect(checkbox.indeterminate).toBe(false);
+        expect(inputEvents).toBe(1);
+        expect(changeEvents).toBe(1);
+      }
+    } finally {
+      checkbox.remove();
+    }
+  }
+});
+
 test("selects a disabled radio on click and fires events only when it changes", async () => {
   if (isBrowser) return;
   const radio = document.createElement("input");

--- a/packages/ariakit-test/src/shims.test.ts
+++ b/packages/ariakit-test/src/shims.test.ts
@@ -182,8 +182,17 @@ test("toggles a disabled checkbox in either direction for a scripted click", asy
     let disabledDuringClick: boolean | undefined;
     let inputEvents = 0;
     let changeEvents = 0;
-    checkbox.addEventListener("input", () => inputEvents++);
-    checkbox.addEventListener("change", () => changeEvents++);
+    let eventTypeDuringInput: string | undefined;
+    let eventTypeDuringChange: string | undefined;
+    const currentEventType = () => (window as { event?: Event }).event?.type;
+    checkbox.addEventListener("input", () => {
+      inputEvents++;
+      eventTypeDuringInput = currentEventType();
+    });
+    checkbox.addEventListener("change", () => {
+      changeEvents++;
+      eventTypeDuringChange = currentEventType();
+    });
     checkbox.addEventListener("click", () => {
       checkedDuringClick = checkbox.checked;
       disabledDuringClick = checkbox.disabled;
@@ -198,6 +207,10 @@ test("toggles a disabled checkbox in either direction for a scripted click", asy
       expect(checkbox.checked).toBe(!initiallyChecked);
       expect(inputEvents).toBe(1);
       expect(changeEvents).toBe(1);
+      // Each activation event exposes itself on window.event while its listener
+      // runs, like jsdom/browsers — not the outer click event.
+      expect(eventTypeDuringInput).toBe("input");
+      expect(eventTypeDuringChange).toBe("change");
     } finally {
       checkbox.remove();
     }
@@ -322,6 +335,77 @@ test("restores a disabled radio group when a click listener prevents the selecti
     expect(clickedInput).toBe(0);
   } finally {
     form.remove();
+  }
+});
+
+test("restores a disabled radio group linked by the form attribute when prevented", async () => {
+  if (isBrowser) return;
+  // Radios linked to a form by the `form` attribute (instead of nesting) are
+  // still grouped by happy-dom's `checked` setter at the root node — a scope that
+  // differs from the radio's resolved `form`. The snapshot must cover that scope
+  // so preventDefault restores the previously-selected peer rather than leaving
+  // the whole group unchecked.
+  const form = document.createElement("form");
+  form.id = "radio-group-form";
+  const selected = document.createElement("input");
+  const clicked = document.createElement("input");
+  selected.type = clicked.type = "radio";
+  selected.name = clicked.name = "choice";
+  selected.setAttribute("form", form.id);
+  clicked.setAttribute("form", form.id);
+  selected.disabled = clicked.disabled = true;
+  selected.checked = true;
+  // Appended as siblings of the form, not descendants — associated only via the
+  // form attribute, so happy-dom groups them at the document root.
+  document.body.append(form, selected, clicked);
+  clicked.addEventListener("click", (event) => event.preventDefault());
+  try {
+    await dispatch.click(clicked);
+    expect(selected.checked).toBe(true);
+    expect(clicked.checked).toBe(false);
+  } finally {
+    form.remove();
+    selected.remove();
+    clicked.remove();
+  }
+});
+
+test("reverts only the activation's changes, preserving listener changes to other radios", async () => {
+  if (isBrowser) return;
+  // A prevented click reverts only what the activation changed (the clicked radio
+  // and the peer it unchecked), not state a listener changes during the click. A
+  // same-name radio in another scope (a separate group) is flipped by the
+  // listener here and must keep the listener's value after preventDefault.
+  const form = document.createElement("form");
+  const selected = document.createElement("input");
+  const clicked = document.createElement("input");
+  selected.type = clicked.type = "radio";
+  selected.name = clicked.name = "pick";
+  selected.disabled = clicked.disabled = true;
+  const outside = document.createElement("input");
+  outside.type = "radio";
+  outside.name = "pick";
+  form.append(selected, clicked);
+  document.body.append(form, outside);
+  // Select the out-of-form radio first (its root-wide scope would otherwise clear
+  // the in-form one), then the in-form radio, leaving both selected.
+  outside.checked = true;
+  selected.checked = true;
+  clicked.addEventListener("click", (event) => {
+    // A listener change to a radio outside the clicked radio's group.
+    outside.checked = false;
+    event.preventDefault();
+  });
+  try {
+    await dispatch.click(clicked);
+    // The clicked radio's own group is reverted...
+    expect(selected.checked).toBe(true);
+    expect(clicked.checked).toBe(false);
+    // ...but the listener's change to the out-of-scope radio is preserved.
+    expect(outside.checked).toBe(false);
+  } finally {
+    form.remove();
+    outside.remove();
   }
 });
 

--- a/packages/ariakit-test/src/shims.test.ts
+++ b/packages/ariakit-test/src/shims.test.ts
@@ -136,34 +136,238 @@ test("cancels a not-yet-run animation frame callback within the same frame", asy
   expect(ran).toEqual(["a"]);
 });
 
-test("fires listeners for a click dispatched on a disabled control", async () => {
+test("runs the listener for a click dispatched on a disabled button", async () => {
   if (isBrowser) return;
-  // happy-dom drops a scripted click on a disabled <button>/<input> entirely;
-  // jsdom and real browsers still run the listeners (skipping only the control's
-  // activation behavior). `dispatch` normalizes that (see dispatch.ts).
+  // happy-dom drops a scripted click on a disabled <button>/<input> entirely.
+  // jsdom and real browsers (verified on Chromium, Firefox, and WebKit) still run
+  // the listeners — only clicks queued from a real user interaction are barred. A
+  // plain button has no activation behavior, so the click just reaches the
+  // listener (the case PR #6271 needed for a disabled `Command`). `dispatch`
+  // normalizes that (see dispatch.ts).
   const button = document.createElement("button");
   button.disabled = true;
   let buttonClicks = 0;
-  button.addEventListener("click", () => buttonClicks++);
-
-  const checkbox = document.createElement("input");
-  checkbox.type = "checkbox";
-  checkbox.disabled = true;
-  let checkboxClicks = 0;
-  checkbox.addEventListener("click", () => checkboxClicks++);
-
-  document.body.append(button, checkbox);
+  let disabledDuringClick: boolean | undefined;
+  button.addEventListener("click", () => {
+    buttonClicks++;
+    disabledDuringClick = button.disabled;
+  });
+  document.body.append(button);
   try {
-    await dispatch.click(button);
-    await dispatch.click(checkbox);
+    const defaultAllowed = await dispatch.click(button);
     expect(buttonClicks).toBe(1);
-    expect(checkboxClicks).toBe(1);
-    // The listener runs, but the disabled checkbox isn't toggled — a browser
-    // doesn't activate a disabled control.
-    expect(checkbox.checked).toBe(false);
+    // The button stays disabled throughout, and nothing cancels the click, so the
+    // default action is allowed — as in a browser.
+    expect(disabledDuringClick).toBe(true);
+    expect(defaultAllowed).toBe(true);
   } finally {
     button.remove();
-    checkbox.remove();
+  }
+});
+
+test("toggles a disabled checkbox in either direction for a scripted click", async () => {
+  if (isBrowser) return;
+  // jsdom and real browsers (verified on Chromium, Firefox, and WebKit) run the
+  // activation behavior for a scripted click on a disabled checkbox: it toggles
+  // before the click listener runs (which still sees it disabled) and fires
+  // input/change, only barring clicks queued from a real user interaction.
+  // happy-dom drops the click entirely; `dispatch` normalizes that (see
+  // dispatch.ts). Covers both toggle directions.
+  for (const initiallyChecked of [false, true]) {
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.disabled = true;
+    checkbox.checked = initiallyChecked;
+    let checkedDuringClick: boolean | undefined;
+    let disabledDuringClick: boolean | undefined;
+    let inputEvents = 0;
+    let changeEvents = 0;
+    checkbox.addEventListener("input", () => inputEvents++);
+    checkbox.addEventListener("change", () => changeEvents++);
+    checkbox.addEventListener("click", () => {
+      checkedDuringClick = checkbox.checked;
+      disabledDuringClick = checkbox.disabled;
+    });
+    document.body.append(checkbox);
+    try {
+      const defaultAllowed = await dispatch.click(checkbox);
+      expect(defaultAllowed).toBe(true);
+      // Toggled before the listener runs, while still disabled.
+      expect(checkedDuringClick).toBe(!initiallyChecked);
+      expect(disabledDuringClick).toBe(true);
+      expect(checkbox.checked).toBe(!initiallyChecked);
+      expect(inputEvents).toBe(1);
+      expect(changeEvents).toBe(1);
+    } finally {
+      checkbox.remove();
+    }
+  }
+});
+
+test("reverts a disabled checkbox toggle in either direction when a click listener prevents it", async () => {
+  if (isBrowser) return;
+  // The checkbox is toggled before the click listener runs, so the listener sees
+  // the flipped value; preventDefault() then cancels the activation, restoring
+  // the previous checked state and firing no input/change — matching jsdom and
+  // real browsers. Covers both toggle directions.
+  for (const initiallyChecked of [false, true]) {
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.disabled = true;
+    checkbox.checked = initiallyChecked;
+    let checkedDuringClick: boolean | undefined;
+    let inputEvents = 0;
+    let changeEvents = 0;
+    checkbox.addEventListener("input", () => inputEvents++);
+    checkbox.addEventListener("change", () => changeEvents++);
+    checkbox.addEventListener("click", (event) => {
+      checkedDuringClick = checkbox.checked;
+      event.preventDefault();
+    });
+    document.body.append(checkbox);
+    try {
+      const defaultAllowed = await dispatch.click(checkbox);
+      expect(defaultAllowed).toBe(false);
+      // Toggled to the flipped value while the listener runs...
+      expect(checkedDuringClick).toBe(!initiallyChecked);
+      // ...then restored to the original value once prevented.
+      expect(checkbox.checked).toBe(initiallyChecked);
+      expect(inputEvents).toBe(0);
+      expect(changeEvents).toBe(0);
+    } finally {
+      checkbox.remove();
+    }
+  }
+});
+
+test("selects a disabled radio on click and fires events only when it changes", async () => {
+  if (isBrowser) return;
+  const radio = document.createElement("input");
+  radio.type = "radio";
+  radio.disabled = true;
+  let radioClicks = 0;
+  let checkedDuringClick: boolean | undefined;
+  let inputEvents = 0;
+  let changeEvents = 0;
+  radio.addEventListener("input", () => inputEvents++);
+  radio.addEventListener("change", () => changeEvents++);
+  radio.addEventListener("click", () => {
+    radioClicks++;
+    checkedDuringClick = radio.checked;
+  });
+  document.body.append(radio);
+  try {
+    const defaultAllowed = await dispatch.click(radio);
+    expect(defaultAllowed).toBe(true);
+    expect(radioClicks).toBe(1);
+    expect(radio.checked).toBe(true);
+    // The radio is selected before the click listener runs, like a browser.
+    expect(checkedDuringClick).toBe(true);
+    expect(inputEvents).toBe(1);
+    expect(changeEvents).toBe(1);
+    // Clicking an already-selected radio still runs the listener (which sees it
+    // selected) but leaves its value unchanged, so it fires no further
+    // input/change events — matching jsdom and real browsers.
+    checkedDuringClick = undefined;
+    await dispatch.click(radio);
+    expect(radioClicks).toBe(2);
+    expect(checkedDuringClick).toBe(true);
+    expect(radio.checked).toBe(true);
+    expect(inputEvents).toBe(1);
+    expect(changeEvents).toBe(1);
+  } finally {
+    radio.remove();
+  }
+});
+
+test("restores a disabled radio group when a click listener prevents the selection", async () => {
+  if (isBrowser) return;
+  // Selecting a radio unchecks its previously-selected peer before the click
+  // listener runs; preventDefault() must restore the whole group, not just the
+  // clicked radio's own previous state. Verified on Chromium, Firefox, and
+  // WebKit.
+  const form = document.createElement("form");
+  const selected = document.createElement("input");
+  const clicked = document.createElement("input");
+  selected.type = clicked.type = "radio";
+  selected.name = clicked.name = "choice";
+  selected.disabled = clicked.disabled = true;
+  selected.checked = true;
+  form.append(selected, clicked);
+  document.body.append(form);
+  let selectedChange = 0;
+  let clickedChange = 0;
+  let clickedInput = 0;
+  let selectedDuringClick: boolean | undefined;
+  let clickedDuringClick: boolean | undefined;
+  selected.addEventListener("change", () => selectedChange++);
+  clicked.addEventListener("change", () => clickedChange++);
+  clicked.addEventListener("input", () => clickedInput++);
+  clicked.addEventListener("click", (event) => {
+    // The clicked radio is selected and its peer unchecked before the listener.
+    selectedDuringClick = selected.checked;
+    clickedDuringClick = clicked.checked;
+    event.preventDefault();
+  });
+  try {
+    const defaultAllowed = await dispatch.click(clicked);
+    expect(defaultAllowed).toBe(false);
+    expect(selectedDuringClick).toBe(false);
+    expect(clickedDuringClick).toBe(true);
+    // preventDefault restores the original group selection.
+    expect(selected.checked).toBe(true);
+    expect(clicked.checked).toBe(false);
+    expect(selectedChange).toBe(0);
+    expect(clickedChange).toBe(0);
+    expect(clickedInput).toBe(0);
+  } finally {
+    form.remove();
+  }
+});
+
+test("doesn't submit or reset a form from a click on a disabled submit/reset control", async () => {
+  if (isBrowser) return;
+  // Real browsers run the click listeners for a scripted click on a disabled
+  // submit/reset control but skip its form-activation behavior — the form is
+  // neither submitted nor reset. happy-dom drops the click for both <button> and
+  // <input> through separate per-class dispatchEvent overrides, so cover both.
+  // Verified on Chromium, Firefox, and WebKit.
+  const form = document.createElement("form");
+  const controls = (["submit", "reset"] as const).flatMap((type) =>
+    ["button", "input"].map((tag) => {
+      const control = document.createElement(tag) as
+        | HTMLButtonElement
+        | HTMLInputElement;
+      control.type = type;
+      control.disabled = true;
+      return control;
+    }),
+  );
+  form.append(...controls);
+  document.body.append(form);
+
+  let controlClicks = 0;
+  let submitEvents = 0;
+  let resetEvents = 0;
+  for (const control of controls) {
+    control.addEventListener("click", () => controlClicks++);
+  }
+  form.addEventListener("submit", (event) => {
+    submitEvents++;
+    event.preventDefault();
+  });
+  form.addEventListener("reset", () => resetEvents++);
+  try {
+    for (const control of controls) {
+      await dispatch.click(control);
+    }
+    // The clicks reach the disabled controls, so their listeners run...
+    expect(controlClicks).toBe(controls.length);
+    // ...but none of them activates the form.
+    expect(submitEvents).toBe(0);
+    expect(resetEvents).toBe(0);
+  } finally {
+    form.remove();
   }
 });
 


### PR DESCRIPTION
## Motivation

[#6271](https://github.com/ariakit/ariakit/pull/6271) added `fireEventAllowingDisabledClick` to `@ariakit/test`'s `dispatch` so a `click` dispatched on a disabled `<button>`/`<input>` under happy-dom runs its listeners (happy-dom otherwise drops such a click entirely). It routed the click through the base `EventTarget.prototype.dispatchEvent`, which runs the listeners but **not** the control's activation behavior, and the accompanying test asserted the wrong browser behavior:

```ts
await dispatch.click(checkbox); // a disabled checkbox
// "The listener runs, but the disabled checkbox isn't toggled — a browser
// doesn't activate a disabled control."
expect(checkbox.checked).toBe(false);
```

That comment and assertion are incorrect. A scripted `dispatchEvent(new MouseEvent("click"))` on a disabled control **does** run the activation behavior in real browsers — only clicks queued from a real user interaction are barred. Verified in Chromium, Firefox, and WebKit (and jsdom matches):

- A disabled checkbox/radio **toggles** before the click listener runs (the listener sees the new value, with `disabled` still `true`) and fires `input`/`change`.
- `preventDefault()` in a listener **reverts** the toggle — restoring the radio peer the selection unchecked — and fires no `input`/`change`.
- Disabled submit/reset controls (`<button>` and `<input>`) run their listeners but **don't** submit/reset the form.

So `dispatch.click()` on a disabled control diverged from real browsers under happy-dom: it fired the listeners but never toggled. This is rooted in the upstream happy-dom bug [capricorn86/happy-dom#2190](https://github.com/capricorn86/happy-dom/issues/2190), whose per-class `HTMLInputElement`/`HTMLButtonElement` `dispatchEvent` `return false` before running anything on a disabled control.

## Solution

`fireEventAllowingDisabledClick` now reinstates the checkbox/radio activation around the base `EventTarget` dispatch (which keeps `disabled` reading `true` while the listeners run), matching the spec ordering real browsers follow:

- Toggle a checkbox / select a radio **before** dispatching the click, so listeners observe the new `checked` value.
- Capture exactly the controls the activation changed (the toggled control plus the one radio peer happy-dom unchecked). If a listener calls `preventDefault()`, revert **only** those controls — leaving any control a listener changed during the click untouched, as in a browser. Otherwise fire `input`/`change` when the value changed.
- Submit/reset controls are left untouched (real browsers don't submit/reset a disabled control), so they keep firing listeners only.

The normalization stays scoped to clicks `@ariakit/test` dispatches, so happy-dom's own internal label→control click forwarding still drops on a disabled control (which `click(label)` relies on to avoid a double click).

The shims tests are rewritten to assert this real browser behavior across all of these cases.

## Workaround

Until this is released, a scripted `dispatch.click()` on a disabled control doesn't run its activation behavior under happy-dom (e.g. a disabled checkbox won't toggle). Temporarily enable the control around the click so happy-dom runs the native activation (toggle plus `input`/`change`), then restore the disabled state:

```ts
// TODO: remove once https://github.com/ariakit/ariakit/issues/6273 is released.
control.disabled = false;
await dispatch.click(control);
control.disabled = true;
```

Note that the control reads as enabled (`disabled === false`) inside the click listener with this workaround, unlike a real browser where it stays disabled.

Fixes #6273
