### PR TITLE
Fix shifted Home and End selection

### DIFF
--- a/.changeset/300-test-shift-home-end.md
+++ b/.changeset/300-test-shift-home-end.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/test": patch
+---
+
+Fixed `press` extending text selections past the anchor when pressing Shift+Home or Shift+End.

--- a/packages/ariakit-test/src/press.test.ts
+++ b/packages/ariakit-test/src/press.test.ts
@@ -1,6 +1,14 @@
 import { expect, test, vi } from "vitest";
 import { press } from "./index.ts";
 
+function getTextInput() {
+  const input = document.createElement("input");
+  input.value = "hello world";
+  document.body.append(input);
+  input.focus();
+  return input;
+}
+
 // A scripted click dispatched on a disabled control fires its listeners in jsdom
 // and real browsers; happy-dom drops it, but `dispatch` normalizes that (see
 // dispatch.ts), so these run in the default happy-dom. They guard the disabled
@@ -33,6 +41,28 @@ test("press.down does not activate a control that disables itself on Enter", asy
   await press.down.Enter();
 
   expect(onClick).not.toHaveBeenCalled();
+});
+
+test("press.Home with shiftKey keeps the anchor of a forward selection", async () => {
+  const input = getTextInput();
+  input.setSelectionRange(6, 8, "forward");
+
+  await press.Home(input, { shiftKey: true });
+
+  expect(input.selectionStart).toBe(0);
+  expect(input.selectionEnd).toBe(6);
+  expect(input.selectionDirection).toBe("backward");
+});
+
+test("press.End with shiftKey keeps the anchor of a backward selection", async () => {
+  const input = getTextInput();
+  input.setSelectionRange(4, 6, "backward");
+
+  await press.End(input, { shiftKey: true });
+
+  expect(input.selectionStart).toBe(6);
+  expect(input.selectionEnd).toBe(11);
+  expect(input.selectionDirection).toBe("forward");
 });
 
 test("press.Enter on a textarea emits an Enter keypress charCode", async () => {

--- a/packages/ariakit-test/src/press.ts
+++ b/packages/ariakit-test/src/press.ts
@@ -98,19 +98,34 @@ const keyDownMap: KeyActionMap = {
   },
 
   async Home(element, { shiftKey }) {
-    if (isTextField(element)) {
-      const { value, selectionEnd } = element;
-      const end = Math.min(value.length, shiftKey ? (selectionEnd ?? 0) : 0);
-      setSelectionRange(element, 0, end, "backward");
+    if (!isTextField(element)) return;
+
+    if (!shiftKey) {
+      return setSelectionRange(element, 0, 0);
     }
+
+    const { selectionStart, selectionEnd, selectionDirection } = element;
+    const anchor =
+      selectionDirection === "forward"
+        ? (selectionStart ?? 0)
+        : (selectionEnd ?? 0);
+    setSelectionRange(element, 0, anchor, "backward");
   },
 
   async End(element, { shiftKey }) {
-    if (isTextField(element)) {
-      const { value, selectionStart } = element;
-      const start = shiftKey ? (selectionStart ?? 0) : value.length;
-      setSelectionRange(element, start, value.length, "forward");
+    if (!isTextField(element)) return;
+
+    const length = element.value.length;
+    if (!shiftKey) {
+      return setSelectionRange(element, length, length);
     }
+
+    const { selectionStart, selectionEnd, selectionDirection } = element;
+    const anchor =
+      selectionDirection === "backward"
+        ? (selectionEnd ?? 0)
+        : (selectionStart ?? 0);
+    setSelectionRange(element, anchor, length, "forward");
   },
 
   async ArrowLeft(element, { shiftKey }) {


### PR DESCRIPTION
## Motivation

`press` currently simulates Shift+Home and Shift+End by preserving a fixed selection endpoint instead of the selection anchor. This diverges from browser behavior: a forward selection should keep `selectionStart` as the anchor for Shift+Home, and a backward selection should keep `selectionEnd` as the anchor for Shift+End.

Fixes #6354

## Solution

Update the `Home` and `End` keydown defaults to derive the anchor from `selectionDirection`, matching the existing anchor-aware `ArrowUp` and `ArrowDown` logic.

The regression coverage lives in `packages/ariakit-test/src/press.test.ts` and asserts the package-level `press.Home` and `press.End` behavior directly, without adding an app sandbox.
