### PR TITLE
Fix test event string defaults

### DIFF
--- a/.changeset/300-test-event-defaults.md
+++ b/.changeset/300-test-event-defaults.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/test": patch
+---
+
+Fixed `@ariakit/test` event helpers to use empty-string defaults instead of `"undefined"` for omitted keyboard and input event string fields.

--- a/packages/ariakit-test/src/dispatch.test.ts
+++ b/packages/ariakit-test/src/dispatch.test.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "vitest";
+import { dispatch, press } from "./index.ts";
+
+test("dispatch.keyDown uses empty strings for omitted keyboard strings", async () => {
+  const button = document.createElement("button");
+  document.body.append(button);
+  let key: string | undefined;
+  let code: string | undefined;
+  button.addEventListener("keydown", (event) => {
+    key = event.key;
+    code = event.code;
+  });
+  try {
+    await dispatch.keyDown(button);
+    expect(key).toBe("");
+    expect(code).toBe("");
+  } finally {
+    button.remove();
+  }
+});
+
+test("dispatch.keyDown preserves provided keyboard strings", async () => {
+  const button = document.createElement("button");
+  document.body.append(button);
+  let key: string | undefined;
+  let code: string | undefined;
+  button.addEventListener("keydown", (event) => {
+    key = event.key;
+    code = event.code;
+  });
+  try {
+    await dispatch.keyDown(button, { key: "m", code: "KeyM" });
+    expect(key).toBe("m");
+    expect(code).toBe("KeyM");
+  } finally {
+    button.remove();
+  }
+});
+
+test("press uses an empty string for omitted keyboard code", async () => {
+  const button = document.createElement("button");
+  document.body.append(button);
+  let key: string | undefined;
+  let code: string | undefined;
+  button.addEventListener("keydown", (event) => {
+    key = event.key;
+    code = event.code;
+  });
+  try {
+    await press("m", button);
+    expect(key).toBe("m");
+    expect(code).toBe("");
+  } finally {
+    button.remove();
+  }
+});
+
+test("press.ArrowUp uses an empty inputType when stepping a number input", async () => {
+  const input = document.createElement("input");
+  input.type = "number";
+  input.value = "5";
+  document.body.append(input);
+  let inputType: string | undefined;
+  input.addEventListener("input", (event) => {
+    if (event instanceof InputEvent) {
+      inputType = event.inputType;
+    }
+  });
+  try {
+    await press.ArrowUp(input);
+    expect(input.value).toBe("6");
+    expect(inputType).toBe("");
+  } finally {
+    input.remove();
+  }
+});
+
+test("dispatch.input preserves provided inputType", async () => {
+  const input = document.createElement("input");
+  document.body.append(input);
+  let inputType: string | undefined;
+  input.addEventListener("input", (event) => {
+    if (event instanceof InputEvent) {
+      inputType = event.inputType;
+    }
+  });
+  try {
+    await dispatch.input(input, { inputType: "insertReplacementText" });
+    expect(inputType).toBe("insertReplacementText");
+  } finally {
+    input.remove();
+  }
+});

--- a/packages/ariakit-test/src/dispatch.ts
+++ b/packages/ariakit-test/src/dispatch.ts
@@ -72,6 +72,10 @@ function sanitizeNumber(n: number | undefined) {
   return n ?? 0;
 }
 
+function sanitizeString(value: string | undefined) {
+  return value ?? "";
+}
+
 function initClipboardEvent(
   event: ClipboardEvent,
   { clipboardData }: ClipboardEventInit,
@@ -88,7 +92,7 @@ function initInputEvent(
   assignProps(event, {
     data,
     isComposing: !!isComposing,
-    inputType: String(inputType),
+    inputType: sanitizeString(inputType),
   });
 }
 
@@ -147,8 +151,8 @@ function initKeyboardEvent(
   { key, code, location, repeat, isComposing, charCode }: KeyboardEventInit,
 ) {
   assignProps(event, {
-    key: String(key),
-    code: String(code),
+    key: sanitizeString(key),
+    code: sanitizeString(code),
     location: sanitizeNumber(location),
     repeat: !!repeat,
     isComposing: !!isComposing,


### PR DESCRIPTION
## Motivation

Fixes #6352.

`@ariakit/test` currently overwrites native event constructor defaults when callers omit selected keyboard and input event string fields. This can make simulated keyboard events expose `event.key`, `event.code`, or `event.inputType` as the literal string `"undefined"`, which differs from browser/default DOM behavior and can make code under test branch incorrectly.

## Solution

Normalize omitted `KeyboardEvent.key`, `KeyboardEvent.code`, and `InputEvent.inputType` values to empty strings before assigning event property getters, while preserving explicitly provided string values.

Added focused `@ariakit/test` regressions covering direct `dispatch.keyDown`, `press` keyboard events, number input arrow stepping, and explicit `inputType` preservation.

## Verification

- `pnpm test packages/ariakit-test/src/dispatch.test.ts` failed before the implementation on the intended omitted key/code/inputType cases.
- `pnpm lint-fix`
- `pnpm test packages/ariakit-test/src/dispatch.test.ts`
- `pnpm test packages/ariakit-test/src`
- `pnpm tsc`
- `pnpm -F @ariakit/test run build`
- `git diff --check`