### PR TITLE
Fix pointerdown mouse event suppression

### DIFF
--- a/.changeset/300-test-pointerdown-mouse-suppression.md
+++ b/.changeset/300-test-pointerdown-mouse-suppression.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/test": patch
+---
+
+Fixed `click`, `tap`, `mouseDown`, and `mouseUp` to suppress compatibility mouse events after a canceled `pointerdown`.

--- a/packages/ariakit-test/src/__utils.ts
+++ b/packages/ariakit-test/src/__utils.ts
@@ -4,6 +4,8 @@ export type DirtiableElement = Element & { dirty?: boolean };
 
 export type TextField = HTMLInputElement | HTMLTextAreaElement;
 
+const preventMouseEvents = new WeakMap<Document, boolean>();
+
 export const isHappyDOM = typeof window !== "undefined" && "happyDOM" in window;
 
 export const isBrowser =
@@ -103,6 +105,14 @@ export function setActEnvironment(value: boolean) {
     scope.IS_REACT_ACT_ENVIRONMENT = previousValue;
   };
   return restoreActEnvironment;
+}
+
+export function getPreventMouseEvents(document: Document) {
+  return preventMouseEvents.get(document) ?? false;
+}
+
+export function setPreventMouseEvents(document: Document, value: boolean) {
+  preventMouseEvents.set(document, value);
 }
 
 let wrapAsyncDepth = 0;

--- a/packages/ariakit-test/src/mouse-down.test.ts
+++ b/packages/ariakit-test/src/mouse-down.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, expect, test } from "vitest";
+import { click } from "./click.ts";
 import { mouseDown } from "./mouse-down.ts";
+import { mouseUp } from "./mouse-up.ts";
 import { q } from "./query.ts";
 import { select } from "./select.ts";
 
@@ -96,4 +98,81 @@ test("mouseDown on a plain text target clears the document selection", async () 
   await selectParagraphText();
   await mouseDown(q.text("Plain text target"));
   expect(document.getSelection()?.toString()).toBe("");
+});
+
+test("click suppresses mouse events when pointerdown is prevented", async () => {
+  document.body.innerHTML = `
+    <input aria-label="Before" />
+    <button type="button">Press me</button>
+  `;
+
+  const input = q.textbox.ensure("Before");
+  const button = q.button.ensure("Press me");
+  const events: string[] = [];
+  let preventPointerDown = true;
+
+  input.focus();
+
+  button.addEventListener("pointerdown", (event) => {
+    events.push(event.type);
+    if (preventPointerDown) {
+      event.preventDefault();
+    }
+  });
+  button.addEventListener("mousedown", (event) => events.push(event.type));
+  button.addEventListener("focus", (event) => events.push(event.type));
+  button.addEventListener("pointerup", (event) => events.push(event.type));
+  button.addEventListener("mouseup", (event) => events.push(event.type));
+  button.addEventListener("click", (event) => events.push(event.type));
+
+  await click(button);
+
+  expect(events).toEqual(["pointerdown", "pointerup", "click"]);
+  expect(input).toHaveFocus();
+
+  events.length = 0;
+  preventPointerDown = false;
+
+  await click(button);
+
+  expect(events).toEqual([
+    "pointerdown",
+    "mousedown",
+    "focus",
+    "pointerup",
+    "mouseup",
+    "click",
+  ]);
+  expect(button).toHaveFocus();
+});
+
+test("mouseUp suppresses mouseup after a prevented pointerdown", async () => {
+  document.body.innerHTML = `<button type="button">Press me</button>`;
+
+  const button = q.button.ensure("Press me");
+  const events: string[] = [];
+  let preventPointerDown = true;
+
+  button.addEventListener("pointerdown", (event) => {
+    events.push(event.type);
+    if (preventPointerDown) {
+      event.preventDefault();
+    }
+  });
+  button.addEventListener("mousedown", (event) => events.push(event.type));
+  button.addEventListener("pointerup", (event) => events.push(event.type));
+  button.addEventListener("mouseup", (event) => events.push(event.type));
+
+  await mouseDown(button);
+  await mouseUp(button);
+
+  expect(events).toEqual(["pointerdown", "pointerup"]);
+
+  events.length = 0;
+  preventPointerDown = false;
+
+  await mouseDown(button);
+  await mouseUp(button);
+
+  expect(events).toEqual(["pointerdown", "mousedown", "pointerup", "mouseup"]);
 });

--- a/packages/ariakit-test/src/mouse-down.ts
+++ b/packages/ariakit-test/src/mouse-down.ts
@@ -6,7 +6,7 @@ import {
   isTextbox,
   invariant,
 } from "@ariakit/utils";
-import { wrapAsync } from "./__utils.ts";
+import { setPreventMouseEvents, wrapAsync } from "./__utils.ts";
 import { blur } from "./blur.ts";
 import { dispatch } from "./dispatch.ts";
 import { focus } from "./focus.ts";
@@ -67,9 +67,12 @@ export function mouseDown(element: Element | null, options?: PointerEventInit) {
 
     const { disabled } = element as HTMLButtonElement;
 
-    let defaultAllowed = await dispatch.pointerDown(element, options);
+    const pointerDefaultAllowed = await dispatch.pointerDown(element, options);
+    setPreventMouseEvents(getDocument(element), !pointerDefaultAllowed);
 
-    if (!disabled) {
+    let defaultAllowed = pointerDefaultAllowed;
+
+    if (!disabled && pointerDefaultAllowed) {
       // Mouse events are not called on disabled elements
       if (!(await dispatch.mouseDown(element, { detail: 1, ...options }))) {
         defaultAllowed = false;

--- a/packages/ariakit-test/src/mouse-up.ts
+++ b/packages/ariakit-test/src/mouse-up.ts
@@ -1,5 +1,9 @@
-import { isVisible, invariant } from "@ariakit/utils";
-import { wrapAsync } from "./__utils.ts";
+import { getDocument, isVisible, invariant } from "@ariakit/utils";
+import {
+  getPreventMouseEvents,
+  setPreventMouseEvents,
+  wrapAsync,
+} from "./__utils.ts";
 import { dispatch } from "./dispatch.ts";
 
 /**
@@ -24,8 +28,14 @@ export function mouseUp(element: Element | null, options?: PointerEventInit) {
 
     await dispatch.pointerUp(element, options);
 
+    const document = getDocument(element);
+    const preventMouseEvents = getPreventMouseEvents(document);
+    setPreventMouseEvents(document, false);
+
     // mouseup is not called on disabled elements
     if (disabled) return;
+
+    if (preventMouseEvents) return;
 
     await dispatch.mouseUp(element, { detail: 1, ...options });
   });


### PR DESCRIPTION
## Motivation

Fixes #6356.

Canceling `pointerdown` is how components opt out of compatibility mouse events and focus movement during a press. `@ariakit/test` still dispatched `mousedown` and `mouseup` after `pointerdown.preventDefault()`, so tests could observe mouse handlers that real browsers suppress.

## Solution

Track the per-document prevent-mouse-events state when `mouseDown` dispatches `pointerdown`. `mouseDown` skips `mousedown` when `pointerdown` was canceled, and `mouseUp` reads and clears that state before deciding whether to dispatch `mouseup`.

`click` and `tap` still dispatch `click`, matching browser behavior. Focused regression tests cover the suppressed mouse events, unchanged click dispatch, preserved focus, and a later uncanceled press restoring the normal mouse event sequence.
