### PR TITLE
Fix type dirty change dispatch

### DIFF
--- a/.changeset/300-type-dirty-change.md
+++ b/.changeset/300-type-dirty-change.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/test": patch
+---
+
+Fixed `type` so readonly fields, prevented keydowns, non-text-field targets, and no-op deletion keys no longer cause `blur` or `focus` to dispatch a `change` event when the value did not change.

--- a/packages/ariakit-test/readme.md
+++ b/packages/ariakit-test/readme.md
@@ -56,7 +56,7 @@ The `@ariakit/test/react` entry point renders React components for testing, and 
 function blur(element?: DirtiableElement | null): Promise<void>;
 ```
 
-Removes focus from an element, simulating a real user moving focus away from it. When no element is passed, the currently focused element (`document.activeElement`) is used. If the element was typed into since it gained focus, a `change` event is dispatched before it's blurred.
+Removes focus from an element, simulating a real user moving focus away from it. When no element is passed, the currently focused element (`document.activeElement`) is used. If typing changed the element's value since it gained focus, a `change` event is dispatched before it's blurred.
 
 Example:
 
@@ -135,7 +135,7 @@ await dispatch(q.textbox(), new Event("selectstart", { bubbles: true }));
 function focus(element: Element | null): Promise<void>;
 ```
 
-Moves focus to an element, simulating a real user focusing it. Elements that aren't focusable are ignored, and focusing the already focused element is a no-op. If another element was typed into since it gained focus, its pending `change` event is dispatched before focus moves.
+Moves focus to an element, simulating a real user focusing it. Elements that aren't focusable are ignored, and focusing the already focused element is a no-op. If typing changed another element's value since it gained focus, its pending `change` event is dispatched before focus moves.
 
 Example:
 

--- a/packages/ariakit-test/src/blur.ts
+++ b/packages/ariakit-test/src/blur.ts
@@ -6,8 +6,8 @@ import { dispatch } from "./dispatch.ts";
 /**
  * Removes focus from an element, simulating a real user moving focus away from
  * it. When no element is passed, the currently focused element
- * (`document.activeElement`) is used. If the element was typed into since it
- * gained focus, a `change` event is dispatched before it's blurred.
+ * (`document.activeElement`) is used. If typing changed the element's value
+ * since it gained focus, a `change` event is dispatched before it's blurred.
  * @example
  * ```ts
  * await type("hello", q.textbox());

--- a/packages/ariakit-test/src/focus.ts
+++ b/packages/ariakit-test/src/focus.ts
@@ -6,8 +6,8 @@ import { dispatch } from "./dispatch.ts";
 /**
  * Moves focus to an element, simulating a real user focusing it. Elements that
  * aren't focusable are ignored, and focusing the already focused element is a
- * no-op. If another element was typed into since it gained focus, its pending
- * `change` event is dispatched before focus moves.
+ * no-op. If typing changed another element's value since it gained focus, its
+ * pending `change` event is dispatched before focus moves.
  * @example
  * ```ts
  * await focus(q.textbox());

--- a/packages/ariakit-test/src/type.test.ts
+++ b/packages/ariakit-test/src/type.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { blur } from "./blur.ts";
+import { press } from "./press.ts";
+import { type } from "./type.ts";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+function createInput(value = "") {
+  const input = document.createElement("input");
+  input.value = value;
+  document.body.append(input);
+  return input;
+}
+
+function trackChange(element: Element) {
+  const onChange = vi.fn();
+  element.addEventListener("change", onChange);
+  return onChange;
+}
+
+test("type does not dispatch change after typing into a readonly field", async () => {
+  const input = createInput("locked");
+  const onChange = trackChange(input);
+  input.readOnly = true;
+
+  await type("abc", input);
+  await blur(input);
+
+  expect(input.value).toBe("locked");
+  expect(onChange).not.toHaveBeenCalled();
+});
+
+test("type does not dispatch change after a prevented keydown", async () => {
+  const input = createInput();
+  const onChange = trackChange(input);
+  input.addEventListener("keydown", (event) => {
+    event.preventDefault();
+  });
+
+  await type("abc", input);
+  await blur(input);
+
+  expect(input.value).toBe("");
+  expect(onChange).not.toHaveBeenCalled();
+});
+
+test("type does not dispatch change after typing on a non-text field", async () => {
+  const target = document.createElement("div");
+  const onChange = trackChange(target);
+  target.tabIndex = 0;
+  target.textContent = "Delta";
+  document.body.append(target);
+
+  await type("d", target);
+  await blur(target);
+
+  expect(onChange).not.toHaveBeenCalled();
+});
+
+test.each([
+  { name: "Backspace", pressKey: press.Backspace },
+  { name: "Delete", pressKey: press.Delete },
+])(
+  "press.$name does not dispatch change after a no-op edit",
+  async ({ pressKey }) => {
+    const input = createInput();
+    const onChange = trackChange(input);
+
+    await pressKey(input);
+    await blur(input);
+
+    expect(input.value).toBe("");
+    expect(onChange).not.toHaveBeenCalled();
+  },
+);
+
+test("type dispatches change on blur after editing a text field", async () => {
+  const input = createInput("a");
+  const onChange = trackChange(input);
+  input.setSelectionRange(input.value.length, input.value.length);
+
+  await type("b", input);
+  await blur(input);
+
+  expect(input.value).toBe("ab");
+  expect(onChange).toHaveBeenCalledOnce();
+});
+
+test("type marks the text field that receives text after focus moves", async () => {
+  const firstInput = createInput();
+  const secondInput = createInput();
+  const onFirstInputChange = trackChange(firstInput);
+  const onSecondInputChange = trackChange(secondInput);
+  firstInput.addEventListener("keydown", () => {
+    secondInput.focus();
+  });
+
+  await type("a", firstInput);
+  await blur(secondInput);
+
+  expect(firstInput.value).toBe("");
+  expect(secondInput.value).toBe("a");
+  expect(onFirstInputChange).not.toHaveBeenCalled();
+  expect(onSecondInputChange).toHaveBeenCalledOnce();
+});

--- a/packages/ariakit-test/src/type.ts
+++ b/packages/ariakit-test/src/type.ts
@@ -62,9 +62,6 @@ export function type(
 
     await focus(element);
 
-    // Set element dirty so blur() can dispatch a change event
-    element.dirty = true;
-
     const restoreEmailInput = workAroundEmailInput(element);
 
     for (const char of text) {
@@ -80,7 +77,7 @@ export function type(
       element = getActiveElement(element) || element;
 
       if (isTextField(element)) {
-        const input = element as TextField;
+        const input = element as DirtiableElement & TextField;
         const [start, end] = [
           input.selectionStart ?? 0,
           input.selectionEnd ?? 0,
@@ -113,6 +110,10 @@ export function type(
           value = `${firstPart}${char}${lastPart}`;
         }
 
+        // Capture this before dispatch.compositionUpdate(), which applies
+        // target.value when creating the event.
+        const valueChanged = value !== input.value;
+
         if (defaultAllowed && !input.readOnly) {
           if (inputType === "insertText") {
             defaultAllowed = await dispatch.keyPress(input, {
@@ -129,6 +130,9 @@ export function type(
             });
           }
           if (defaultAllowed) {
+            if (valueChanged) {
+              input.dirty = true;
+            }
             await dispatch.input(input, {
               data: char,
               target: {


### PR DESCRIPTION
## Motivation

Fixes #6355.

`type()` in `@ariakit/test` marked the target dirty before any keystroke changed a value. That made `blur()` and `focus()` dispatch native `change` events for interactions that browsers do not treat as changes, such as readonly fields, prevented keydowns, non-text-field typeahead targets, and no-op deletion keys.

## Solution

Mark the active text field dirty only after the simulated keystroke is allowed and the computed value differs from the field's current value. This keeps the existing `input` event stream intact while making the pending `change` behavior match real value changes, including the case where keydown moves focus before text is inserted.

This also updates the generated `@ariakit/test` docs and adds regression coverage for the suppressed cases plus a positive edit-on-blur case.

## Verification

- `pnpm test packages/ariakit-test/src/type.test.ts` failed on the broken implementation for the expected regression cases, then passed after the fix.
- `pnpm lint-fix`
- `pnpm test packages/ariakit-test/src`
- `pnpm test-react packages/ariakit-test/src`
- `pnpm test packages/ariakit-scripts/src/docs.test.ts`
- `pnpm tsc`
- `pnpm -F @ariakit/test build`