### PR TITLE
Fix Tailwind root push direction

### DIFF
--- a/.changeset/300-tailwind-root-push-direction.md
+++ b/.changeset/300-tailwind-root-push-direction.md
@@ -2,4 +2,4 @@
 "@ariakit/tailwind": patch
 ---
 
-Fixed root pushed layers in `@ariakit/tailwind` to escape the forbidden lightness band in the same direction as nested dark layers. In browsers with CSS `if()` support, root pushed layers also use their own source direction for high-contrast bias and edge colors. Browsers without CSS `if()` support also avoid extra source-direction color work.
+Fixed `ak-layer-push-*` and `ak-state-push-*` in `@ariakit/tailwind` to escape the forbidden lightness band based on the current layer, regardless of the parent layer.

--- a/.changeset/300-tailwind-root-push-direction.md
+++ b/.changeset/300-tailwind-root-push-direction.md
@@ -2,4 +2,4 @@
 "@ariakit/tailwind": patch
 ---
 
-Fixed root pushed layers in `@ariakit/tailwind` to escape the forbidden lightness band in the same direction as nested dark layers. In browsers with CSS `if()` support, root pushed layers also use their own source direction for high-contrast bias and edge colors.
+Fixed root pushed layers in `@ariakit/tailwind` to escape the forbidden lightness band in the same direction as nested dark layers. In browsers with CSS `if()` support, root pushed layers also use their own source direction for high-contrast bias and edge colors. Browsers without CSS `if()` support also avoid extra source-direction color work.

--- a/.changeset/300-tailwind-root-push-direction.md
+++ b/.changeset/300-tailwind-root-push-direction.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/tailwind": patch
+---
+
+Fixed root pushed layers in `@ariakit/tailwind` to escape the forbidden lightness band in the same direction as nested dark layers.

--- a/.changeset/300-tailwind-root-push-direction.md
+++ b/.changeset/300-tailwind-root-push-direction.md
@@ -2,4 +2,4 @@
 "@ariakit/tailwind": patch
 ---
 
-Fixed root pushed layers in `@ariakit/tailwind` to escape the forbidden lightness band in the same direction as nested dark layers.
+Fixed root pushed layers in `@ariakit/tailwind` to escape the forbidden lightness band in the same direction as nested dark layers. In browsers with CSS `if()` support, root pushed layers also use their own source direction for high-contrast bias and edge colors.

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/dark
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/dark
@@ -1,7 +1,7 @@
 {
   "edge inherit root no source": "bg-[oklch(0.3634_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-  "parentless dark layer push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
-  "parentless dark state push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+  "wrapped dark layer push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+  "wrapped dark state push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
   "dark push control": {
     "class": "bg-[oklch(0.13_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
     "children": {

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/dark
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/dark
@@ -1,9 +1,9 @@
 {
   "edge inherit root no source": "bg-[oklch(0.3634_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-  "wrapped dark layer push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
-  "wrapped dark state push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+  "parentless dark layer push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+  "parentless dark state push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
   "dark push control": {
-    "class": "bg-[oklch(0.13_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+    "class": "bg-[oklch(0.13_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
     "children": {
       "nested dark layer push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
       "nested dark state push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]"

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/dark
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/dark
@@ -1,12 +1,19 @@
 {
   "edge inherit root no source": "bg-[oklch(0.3634_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-  "parentless dark layer push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
-  "parentless dark state push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+  "parentless dark layer push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+  "parentless dark state push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
   "dark push control": {
-    "class": "bg-[oklch(0.13_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+    "class": "bg-[oklch(0.13_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
     "children": {
       "nested dark layer push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
       "nested dark state push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]"
+    }
+  },
+  "light push control": {
+    "class": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
+    "children": {
+      "light parent dark layer push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+      "light parent dark state push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]"
     }
   },
   "edge inherit no source": {

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/dark
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/dark
@@ -1,9 +1,9 @@
 {
   "edge inherit root no source": "bg-[oklch(0.3634_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-  "parentless dark layer push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
-  "parentless dark state push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+  "parentless dark layer push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+  "parentless dark state push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
   "dark push control": {
-    "class": "bg-[oklch(0.13_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+    "class": "bg-[oklch(0.13_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
     "children": {
       "nested dark layer push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
       "nested dark state push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]"

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/dark
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/dark
@@ -1,5 +1,14 @@
 {
   "edge inherit root no source": "bg-[oklch(0.3634_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
+  "parentless dark layer push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+  "parentless dark state push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+  "dark push control": {
+    "class": "bg-[oklch(0.13_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+    "children": {
+      "nested dark layer push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+      "nested dark state push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]"
+    }
+  },
   "edge inherit no source": {
     "class": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)]",
     "children": {

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
@@ -1,7 +1,7 @@
 {
   "edge inherit root no source": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-  "parentless dark layer push": "bg-[oklch(0.9_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
-  "parentless dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+  "wrapped dark layer push": "bg-[oklch(0.9_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+  "wrapped dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
   "dark push control": {
     "class": "bg-[oklch(0_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
     "children": {

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
@@ -1,9 +1,9 @@
 {
   "edge inherit root no source": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-  "wrapped dark layer push": "bg-[oklch(0.9_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
-  "wrapped dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+  "parentless dark layer push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+  "parentless dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
   "dark push control": {
-    "class": "bg-[oklch(0_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+    "class": "bg-[oklch(0_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
     "children": {
       "nested dark layer push": "bg-[oklch(0.9_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
       "nested dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]"

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
@@ -1,12 +1,19 @@
 {
   "edge inherit root no source": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-  "parentless dark layer push": "bg-[oklch(0.9_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
-  "parentless dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+  "parentless dark layer push": "bg-[oklch(0.9_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+  "parentless dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
   "dark push control": {
-    "class": "bg-[oklch(0_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+    "class": "bg-[oklch(0_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
     "children": {
       "nested dark layer push": "bg-[oklch(0.9_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
       "nested dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]"
+    }
+  },
+  "light push control": {
+    "class": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
+    "children": {
+      "light parent dark layer push": "bg-[oklch(0.9_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+      "light parent dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]"
     }
   },
   "edge inherit no source": {

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
@@ -1,5 +1,14 @@
 {
   "edge inherit root no source": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
+  "parentless dark layer push": "bg-[oklch(0.9_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+  "parentless dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+  "dark push control": {
+    "class": "bg-[oklch(0_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+    "children": {
+      "nested dark layer push": "bg-[oklch(0.9_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+      "nested dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]"
+    }
+  },
   "edge inherit no source": {
     "class": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)]",
     "children": {

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
@@ -1,9 +1,9 @@
 {
   "edge inherit root no source": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-  "parentless dark layer push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
-  "parentless dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+  "parentless dark layer push": "bg-[oklch(0.9_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+  "parentless dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
   "dark push control": {
-    "class": "bg-[oklch(0_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+    "class": "bg-[oklch(0_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
     "children": {
       "nested dark layer push": "bg-[oklch(0.9_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
       "nested dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]"

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/light
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/light
@@ -1,9 +1,9 @@
 {
   "edge inherit root no source": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-  "parentless dark layer push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
-  "parentless dark state push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+  "parentless dark layer push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+  "parentless dark state push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
   "dark push control": {
-    "class": "bg-[oklch(0.13_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+    "class": "bg-[oklch(0.13_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
     "children": {
       "nested dark layer push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
       "nested dark state push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]"

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/light
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/light
@@ -1,9 +1,9 @@
 {
   "edge inherit root no source": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-  "parentless dark layer push": "bg-[oklch(0.5437_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
-  "parentless dark state push": "bg-[oklch(0.5437_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+  "wrapped dark layer push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+  "wrapped dark state push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
   "dark push control": {
-    "class": "bg-[oklch(0.13_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+    "class": "bg-[oklch(0.13_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
     "children": {
       "nested dark layer push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
       "nested dark state push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]"

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/light
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/light
@@ -1,9 +1,9 @@
 {
   "edge inherit root no source": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-  "wrapped dark layer push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
-  "wrapped dark state push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+  "parentless dark layer push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+  "parentless dark state push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
   "dark push control": {
-    "class": "bg-[oklch(0.13_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+    "class": "bg-[oklch(0.13_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
     "children": {
       "nested dark layer push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
       "nested dark state push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]"

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/light
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/light
@@ -1,12 +1,19 @@
 {
   "edge inherit root no source": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-  "parentless dark layer push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
-  "parentless dark state push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+  "parentless dark layer push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+  "parentless dark state push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
   "dark push control": {
-    "class": "bg-[oklch(0.13_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+    "class": "bg-[oklch(0.13_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
     "children": {
       "nested dark layer push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
       "nested dark state push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]"
+    }
+  },
+  "light push control": {
+    "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
+    "children": {
+      "light parent dark layer push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+      "light parent dark state push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]"
     }
   },
   "edge inherit no source": {
@@ -66,7 +73,7 @@
           "offset max bounds": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
           "state offset": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
           "state push zero": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-          "state push": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
+          "state push": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
           "contrast push": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
         }
       },
@@ -144,7 +151,7 @@
           "state desaturate": "bg-[oklch(0.55_0_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_260_/_0.1)] p-[4px] shadow-[oklch(0_0_260_/_0.1)_0px_0px_0px_0px]",
           "state hue": "bg-[oklch(0.5321_0.08_350)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.08_350_/_0.1)] p-[4px] shadow-[oklch(0_0.08_350_/_0.1)_0px_0px_0px_0px]",
           "layer push": "bg-[oklch(0.75_0.08_260)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.08_260_/_0.1)] p-[4px] shadow-[oklch(0_0.08_260_/_0.1)_0px_0px_0px_0px]",
-          "state push": "bg-[oklch(0.5321_0.08_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.08_260_/_0.1)] p-[4px] shadow-[oklch(0_0.08_260_/_0.1)_0px_0px_0px_0px]",
+          "state push": "bg-[oklch(0.734_0.08_260)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.08_260_/_0.1)] p-[4px] shadow-[oklch(0_0.08_260_/_0.1)_0px_0px_0px_0px]",
           "contrast base": "bg-[oklch(0.9_0.08_260)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.08_260_/_0.1)] p-[4px] shadow-[oklch(0_0.08_260_/_0.1)_0px_0px_0px_0px]",
           "layer contrast": "bg-[oklch(0.8_0.08_260)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.08_260_/_0.1)] p-[4px] shadow-[oklch(0_0.08_260_/_0.1)_0px_0px_0px_0px]"
         }

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/light
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/light
@@ -1,5 +1,14 @@
 {
   "edge inherit root no source": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
+  "parentless dark layer push": "bg-[oklch(0.5437_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+  "parentless dark state push": "bg-[oklch(0.5437_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+  "dark push control": {
+    "class": "bg-[oklch(0.13_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+    "children": {
+      "nested dark layer push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]",
+      "nested dark state push": "bg-[oklch(0.7281_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.1)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.1)_0px_0px_0px_0px]"
+    }
+  },
   "edge inherit no source": {
     "class": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)]",
     "children": {

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
@@ -1,12 +1,19 @@
 {
   "edge inherit root no source": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-  "parentless dark layer push": "bg-[oklch(0.9_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
-  "parentless dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+  "parentless dark layer push": "bg-[oklch(0.9_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+  "parentless dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
   "dark push control": {
-    "class": "bg-[oklch(0_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+    "class": "bg-[oklch(0_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
     "children": {
       "nested dark layer push": "bg-[oklch(0.9_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
       "nested dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]"
+    }
+  },
+  "light push control": {
+    "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
+    "children": {
+      "light parent dark layer push": "bg-[oklch(0.9_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+      "light parent dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]"
     }
   },
   "edge inherit no source": {
@@ -143,7 +150,7 @@
           "state saturate": "bg-[oklch(0.2_0.368_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.368_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.368_260_/_0.4334)_0px_0px_0px_0px]",
           "state desaturate": "bg-[oklch(0.2_0_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_260_/_0.4334)] p-[4px] shadow-[oklch(0_0_260_/_0.4334)_0px_0px_0px_0px]",
           "state hue": "bg-[oklch(0.2_0.08_350)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.08_350_/_0.4334)] p-[4px] shadow-[oklch(0_0.08_350_/_0.4334)_0px_0px_0px_0px]",
-          "layer push": "bg-[oklch(1_0.08_260)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.08_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.08_260_/_0.4334)_0px_0px_0px_0px]",
+          "layer push": "bg-[oklch(0.9_0.08_260)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.08_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.08_260_/_0.4334)_0px_0px_0px_0px]",
           "state push": "bg-[oklch(1_0.08_260)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.08_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.08_260_/_0.4334)_0px_0px_0px_0px]",
           "contrast base": "bg-[oklch(1_0.08_260)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.08_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.08_260_/_0.4334)_0px_0px_0px_0px]",
           "layer contrast": "bg-[oklch(0.1332_0.08_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.08_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.08_260_/_0.4334)_0px_0px_0px_0px]"

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
@@ -1,9 +1,9 @@
 {
   "edge inherit root no source": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-  "parentless dark layer push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
-  "parentless dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+  "parentless dark layer push": "bg-[oklch(0.9_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+  "parentless dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
   "dark push control": {
-    "class": "bg-[oklch(0_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+    "class": "bg-[oklch(0_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
     "children": {
       "nested dark layer push": "bg-[oklch(0.9_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
       "nested dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]"

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
@@ -1,9 +1,9 @@
 {
   "edge inherit root no source": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-  "parentless dark layer push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
-  "parentless dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+  "wrapped dark layer push": "bg-[oklch(0.9_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+  "wrapped dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
   "dark push control": {
-    "class": "bg-[oklch(0_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+    "class": "bg-[oklch(0_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
     "children": {
       "nested dark layer push": "bg-[oklch(0.9_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
       "nested dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]"

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
@@ -1,9 +1,9 @@
 {
   "edge inherit root no source": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-  "wrapped dark layer push": "bg-[oklch(0.9_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
-  "wrapped dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+  "parentless dark layer push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+  "parentless dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
   "dark push control": {
-    "class": "bg-[oklch(0_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+    "class": "bg-[oklch(0_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
     "children": {
       "nested dark layer push": "bg-[oklch(0.9_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
       "nested dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]"

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
@@ -1,5 +1,14 @@
 {
   "edge inherit root no source": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
+  "parentless dark layer push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+  "parentless dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+  "dark push control": {
+    "class": "bg-[oklch(0_0.028_261.692)] text-[oklch(1_0_0)] border-[1px] border-[oklch(0_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(0_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+    "children": {
+      "nested dark layer push": "bg-[oklch(0.9_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]",
+      "nested dark state push": "bg-[oklch(1_0.028_261.692)] text-[oklch(0_0_0)] border-[1px] border-[oklch(1_0.028_261.692_/_0.4334)] p-[4px] shadow-[oklch(1_0.028_261.692_/_0.4334)_0px_0px_0px_0px]"
+    }
+  },
   "edge inherit no source": {
     "class": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)]",
     "children": {

--- a/app/src/sandbox/ariakit-tailwind/index.react.tsx
+++ b/app/src/sandbox/ariakit-tailwind/index.react.tsx
@@ -301,6 +301,19 @@ export default function Example() {
             className="ak-layer ak-layer-gray-950 ak-state-push-50 ak-frame ak-frame-p-1 ak-frame-border"
           />
         </Layer>
+        <Layer
+          label="light push control"
+          className="ak-layer ak-layer-l-100 ak-frame ak-frame-p-1 ak-frame-border flex-col"
+        >
+          <Layer
+            label="light parent dark layer push"
+            className="ak-layer ak-layer-gray-950 ak-layer-push-50 ak-frame ak-frame-p-1 ak-frame-border"
+          />
+          <Layer
+            label="light parent dark state push"
+            className="ak-layer ak-layer-gray-950 ak-state-push-50 ak-frame ak-frame-p-1 ak-frame-border"
+          />
+        </Layer>
       </div>
       <Layer
         label="edge inherit no source"

--- a/app/src/sandbox/ariakit-tailwind/index.react.tsx
+++ b/app/src/sandbox/ariakit-tailwind/index.react.tsx
@@ -278,6 +278,29 @@ export default function Example() {
         label="edge inherit root no source"
         className="ak-layer ak-layer-20 ak-edge-inherit ak-frame ak-frame-p-1 ak-frame-border"
       />
+      <div className="flex flex-wrap items-start gap-4">
+        <Layer
+          label="parentless dark layer push"
+          className="ak-layer ak-layer-gray-950 ak-layer-push-50 ak-frame ak-frame-p-1 ak-frame-border"
+        />
+        <Layer
+          label="parentless dark state push"
+          className="ak-layer ak-layer-gray-950 ak-state-push-50 ak-frame ak-frame-p-1 ak-frame-border"
+        />
+        <Layer
+          label="dark push control"
+          className="ak-layer ak-layer-gray-950 ak-frame ak-frame-p-1 ak-frame-border flex-col"
+        >
+          <Layer
+            label="nested dark layer push"
+            className="ak-layer ak-layer-gray-950 ak-layer-push-50 ak-frame ak-frame-p-1 ak-frame-border"
+          />
+          <Layer
+            label="nested dark state push"
+            className="ak-layer ak-layer-gray-950 ak-state-push-50 ak-frame ak-frame-p-1 ak-frame-border"
+          />
+        </Layer>
+      </div>
       <Layer
         label="edge inherit no source"
         className="ak-layer ak-layer-blue-600 flex-col"

--- a/app/src/sandbox/ariakit-tailwind/index.react.tsx
+++ b/app/src/sandbox/ariakit-tailwind/index.react.tsx
@@ -278,13 +278,14 @@ export default function Example() {
         label="edge inherit root no source"
         className="ak-layer ak-layer-20 ak-edge-inherit ak-frame ak-frame-p-1 ak-frame-border"
       />
-      <div className="ak-layer ak-layer-gray-950 flex flex-wrap items-start gap-4">
+      {/* Test-only isolation from the preview body's ak-layer context. */}
+      <div className="[--_ak-ls:transparent] flex flex-wrap items-start gap-4">
         <Layer
-          label="wrapped dark layer push"
+          label="parentless dark layer push"
           className="ak-layer ak-layer-gray-950 ak-layer-push-50 ak-frame ak-frame-p-1 ak-frame-border"
         />
         <Layer
-          label="wrapped dark state push"
+          label="parentless dark state push"
           className="ak-layer ak-layer-gray-950 ak-state-push-50 ak-frame ak-frame-p-1 ak-frame-border"
         />
         <Layer

--- a/app/src/sandbox/ariakit-tailwind/index.react.tsx
+++ b/app/src/sandbox/ariakit-tailwind/index.react.tsx
@@ -278,13 +278,13 @@ export default function Example() {
         label="edge inherit root no source"
         className="ak-layer ak-layer-20 ak-edge-inherit ak-frame ak-frame-p-1 ak-frame-border"
       />
-      <div className="flex flex-wrap items-start gap-4">
+      <div className="ak-layer ak-layer-gray-950 flex flex-wrap items-start gap-4">
         <Layer
-          label="parentless dark layer push"
+          label="wrapped dark layer push"
           className="ak-layer ak-layer-gray-950 ak-layer-push-50 ak-frame ak-frame-p-1 ak-frame-border"
         />
         <Layer
-          label="parentless dark state push"
+          label="wrapped dark state push"
           className="ak-layer ak-layer-gray-950 ak-state-push-50 ak-frame ak-frame-p-1 ak-frame-border"
         />
         <Layer

--- a/app/src/sandbox/ariakit-tailwind/index.react.tsx
+++ b/app/src/sandbox/ariakit-tailwind/index.react.tsx
@@ -278,7 +278,7 @@ export default function Example() {
         label="edge inherit root no source"
         className="ak-layer ak-layer-20 ak-edge-inherit ak-frame ak-frame-p-1 ak-frame-border"
       />
-      {/* Test-only isolation from the preview body's ak-layer context. */}
+      {/* Test-only isolation from inherited layer scheme context. */}
       <div className="[--_ak-ls:transparent] flex flex-wrap items-start gap-4">
         <Layer
           label="parentless dark layer push"

--- a/app/src/sandbox/ariakit-tailwind/test-chrome.ts
+++ b/app/src/sandbox/ariakit-tailwind/test-chrome.ts
@@ -567,28 +567,51 @@ withFramework(import.meta.dirname, async ({ test }) => {
     test.describe(`${scheme} scheme`, () => {
       test.use({ colorScheme: scheme });
 
-      test("pushes parentless dark layers toward the light boundary", async ({
-        page,
-        q,
-      }) => {
-        await waitForPreviewReady(page);
-        const cases = [
-          ["parentless dark layer push", "nested dark layer push"],
-          ["parentless dark state push", "nested dark state push"],
-        ] as const;
+      for (const contrast of [false, true]) {
+        const label = contrast ? " in high contrast" : "";
+        test(`pushes parentless dark layers toward the light boundary${label}`, async ({
+          page,
+          q,
+        }) => {
+          if (contrast) {
+            const cdp = await page.context().newCDPSession(page);
+            await cdp.send("Emulation.setEmulatedMedia", {
+              features: [{ name: "prefers-contrast", value: "more" }],
+            });
+            await page.reload({ waitUntil: "networkidle" });
+          }
+          await waitForPreviewReady(page);
+          const cases = [
+            ["parentless dark layer push", "nested dark layer push"],
+            ["parentless dark state push", "nested dark state push"],
+          ] as const;
 
-        for (const [parentlessLabel, nestedLabel] of cases) {
-          const parentlessPush = q.region(parentlessLabel);
-          const nestedPush = q.region(nestedLabel);
-          const nestedBackgroundColor = await nestedPush.evaluate((element) => {
-            return getComputedStyle(element).backgroundColor;
-          });
-          await expect(parentlessPush).toHaveCSS(
-            "background-color",
-            nestedBackgroundColor,
-          );
-        }
-      });
+          for (const [parentlessLabel, nestedLabel] of cases) {
+            const parentlessPush = q.region(parentlessLabel);
+            const nestedPush = q.region(nestedLabel);
+            const nestedStyles = await nestedPush.evaluate((element) => {
+              const style = getComputedStyle(element);
+              return {
+                backgroundColor: style.backgroundColor,
+                borderTopColor: style.borderTopColor,
+                boxShadow: style.boxShadow,
+              };
+            });
+            await expect(parentlessPush).toHaveCSS(
+              "background-color",
+              nestedStyles.backgroundColor,
+            );
+            await expect(parentlessPush).toHaveCSS(
+              "border-top-color",
+              nestedStyles.borderTopColor,
+            );
+            await expect(parentlessPush).toHaveCSS(
+              "box-shadow",
+              nestedStyles.boxShadow,
+            );
+          }
+        });
+      }
 
       test("no color contrast violations (WCAG AA)", async ({ page }) => {
         test.setTimeout(60_000);

--- a/app/src/sandbox/ariakit-tailwind/test-chrome.ts
+++ b/app/src/sandbox/ariakit-tailwind/test-chrome.ts
@@ -567,23 +567,23 @@ withFramework(import.meta.dirname, async ({ test }) => {
     test.describe(`${scheme} scheme`, () => {
       test.use({ colorScheme: scheme });
 
-      test("pushes parentless dark layers toward the light boundary", async ({
+      test("pushes wrapped dark layers toward the light boundary", async ({
         page,
         q,
       }) => {
         await waitForPreviewReady(page);
         const cases = [
-          ["parentless dark layer push", "nested dark layer push"],
-          ["parentless dark state push", "nested dark state push"],
+          ["wrapped dark layer push", "nested dark layer push"],
+          ["wrapped dark state push", "nested dark state push"],
         ] as const;
 
-        for (const [parentlessLabel, nestedLabel] of cases) {
-          const parentlessPush = q.region(parentlessLabel);
+        for (const [wrappedLabel, nestedLabel] of cases) {
+          const wrappedPush = q.region(wrappedLabel);
           const nestedPush = q.region(nestedLabel);
           const nestedBackgroundColor = await nestedPush.evaluate((element) => {
             return getComputedStyle(element).backgroundColor;
           });
-          await expect(parentlessPush).toHaveCSS(
+          await expect(wrappedPush).toHaveCSS(
             "background-color",
             nestedBackgroundColor,
           );

--- a/app/src/sandbox/ariakit-tailwind/test-chrome.ts
+++ b/app/src/sandbox/ariakit-tailwind/test-chrome.ts
@@ -567,59 +567,6 @@ withFramework(import.meta.dirname, async ({ test }) => {
     test.describe(`${scheme} scheme`, () => {
       test.use({ colorScheme: scheme });
 
-      for (const contrast of [false, true]) {
-        const label = contrast ? " in high contrast" : "";
-        test(`pushes dark layers toward the light boundary regardless of parent${label}`, async ({
-          page,
-          q,
-        }) => {
-          if (contrast) {
-            const cdp = await page.context().newCDPSession(page);
-            await cdp.send("Emulation.setEmulatedMedia", {
-              features: [{ name: "prefers-contrast", value: "more" }],
-            });
-            await page.reload({ waitUntil: "networkidle" });
-          }
-          await waitForPreviewReady(page);
-          const cases = [
-            [
-              "parentless dark layer push",
-              "nested dark layer push",
-              "light parent dark layer push",
-            ],
-            [
-              "parentless dark state push",
-              "nested dark state push",
-              "light parent dark state push",
-            ],
-          ] as const;
-
-          for (const [
-            parentlessLabel,
-            darkParentLabel,
-            lightParentLabel,
-          ] of cases) {
-            const parentlessPush = q.region(parentlessLabel);
-            const darkParentPush = q.region(darkParentLabel);
-            const lightParentPush = q.region(lightParentLabel);
-            const referenceStyles = await darkParentPush.evaluate((element) => {
-              const style = getComputedStyle(element);
-              return {
-                backgroundColor: style.backgroundColor,
-              };
-            });
-            await expect(parentlessPush).toHaveCSS(
-              "background-color",
-              referenceStyles.backgroundColor,
-            );
-            await expect(lightParentPush).toHaveCSS(
-              "background-color",
-              referenceStyles.backgroundColor,
-            );
-          }
-        });
-      }
-
       test("no color contrast violations (WCAG AA)", async ({ page }) => {
         test.setTimeout(60_000);
         const results = await new AxeBuilder({ page })

--- a/app/src/sandbox/ariakit-tailwind/test-chrome.ts
+++ b/app/src/sandbox/ariakit-tailwind/test-chrome.ts
@@ -567,23 +567,23 @@ withFramework(import.meta.dirname, async ({ test }) => {
     test.describe(`${scheme} scheme`, () => {
       test.use({ colorScheme: scheme });
 
-      test("pushes wrapped dark layers toward the light boundary", async ({
+      test("pushes parentless dark layers toward the light boundary", async ({
         page,
         q,
       }) => {
         await waitForPreviewReady(page);
         const cases = [
-          ["wrapped dark layer push", "nested dark layer push"],
-          ["wrapped dark state push", "nested dark state push"],
+          ["parentless dark layer push", "nested dark layer push"],
+          ["parentless dark state push", "nested dark state push"],
         ] as const;
 
-        for (const [wrappedLabel, nestedLabel] of cases) {
-          const wrappedPush = q.region(wrappedLabel);
+        for (const [parentlessLabel, nestedLabel] of cases) {
+          const parentlessPush = q.region(parentlessLabel);
           const nestedPush = q.region(nestedLabel);
           const nestedBackgroundColor = await nestedPush.evaluate((element) => {
             return getComputedStyle(element).backgroundColor;
           });
-          await expect(wrappedPush).toHaveCSS(
+          await expect(parentlessPush).toHaveCSS(
             "background-color",
             nestedBackgroundColor,
           );

--- a/app/src/sandbox/ariakit-tailwind/test-chrome.ts
+++ b/app/src/sandbox/ariakit-tailwind/test-chrome.ts
@@ -569,7 +569,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
       for (const contrast of [false, true]) {
         const label = contrast ? " in high contrast" : "";
-        test(`pushes parentless dark layers toward the light boundary${label}`, async ({
+        test(`pushes dark layers toward the light boundary regardless of parent${label}`, async ({
           page,
           q,
         }) => {
@@ -582,32 +582,39 @@ withFramework(import.meta.dirname, async ({ test }) => {
           }
           await waitForPreviewReady(page);
           const cases = [
-            ["parentless dark layer push", "nested dark layer push"],
-            ["parentless dark state push", "nested dark state push"],
+            [
+              "parentless dark layer push",
+              "nested dark layer push",
+              "light parent dark layer push",
+            ],
+            [
+              "parentless dark state push",
+              "nested dark state push",
+              "light parent dark state push",
+            ],
           ] as const;
 
-          for (const [parentlessLabel, nestedLabel] of cases) {
+          for (const [
+            parentlessLabel,
+            darkParentLabel,
+            lightParentLabel,
+          ] of cases) {
             const parentlessPush = q.region(parentlessLabel);
-            const nestedPush = q.region(nestedLabel);
-            const nestedStyles = await nestedPush.evaluate((element) => {
+            const darkParentPush = q.region(darkParentLabel);
+            const lightParentPush = q.region(lightParentLabel);
+            const referenceStyles = await darkParentPush.evaluate((element) => {
               const style = getComputedStyle(element);
               return {
                 backgroundColor: style.backgroundColor,
-                borderTopColor: style.borderTopColor,
-                boxShadow: style.boxShadow,
               };
             });
             await expect(parentlessPush).toHaveCSS(
               "background-color",
-              nestedStyles.backgroundColor,
+              referenceStyles.backgroundColor,
             );
-            await expect(parentlessPush).toHaveCSS(
-              "border-top-color",
-              nestedStyles.borderTopColor,
-            );
-            await expect(parentlessPush).toHaveCSS(
-              "box-shadow",
-              nestedStyles.boxShadow,
+            await expect(lightParentPush).toHaveCSS(
+              "background-color",
+              referenceStyles.backgroundColor,
             );
           }
         });

--- a/app/src/sandbox/ariakit-tailwind/test-chrome.ts
+++ b/app/src/sandbox/ariakit-tailwind/test-chrome.ts
@@ -567,6 +567,29 @@ withFramework(import.meta.dirname, async ({ test }) => {
     test.describe(`${scheme} scheme`, () => {
       test.use({ colorScheme: scheme });
 
+      test("pushes parentless dark layers toward the light boundary", async ({
+        page,
+        q,
+      }) => {
+        await waitForPreviewReady(page);
+        const cases = [
+          ["parentless dark layer push", "nested dark layer push"],
+          ["parentless dark state push", "nested dark state push"],
+        ] as const;
+
+        for (const [parentlessLabel, nestedLabel] of cases) {
+          const parentlessPush = q.region(parentlessLabel);
+          const nestedPush = q.region(nestedLabel);
+          const nestedBackgroundColor = await nestedPush.evaluate((element) => {
+            return getComputedStyle(element).backgroundColor;
+          });
+          await expect(parentlessPush).toHaveCSS(
+            "background-color",
+            nestedBackgroundColor,
+          );
+        }
+      });
+
       test("no color contrast violations (WCAG AA)", async ({ page }) => {
         test.setTimeout(60_000);
         const results = await new AxeBuilder({ page })

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -539,7 +539,6 @@ const layerMathVars = {
   contrastT: _ak.prop.zero("ct", { inherits: true }),
   contrastPushScale: _ak.prop.number("cps", { inherits: true, initial: 1 }),
   layerContrastBias: _ak.var("lcb"),
-  layerSourceDirectionToLight: _ak.prop.zero("lsdtl"),
   forbiddenLa: _ak.var("fla"),
   forbiddenLb: _ak.var("flb"),
   offsetDirectionToLight: _ak.var("odtl"),
@@ -558,11 +557,6 @@ const layerMathVars = {
 
   layerIdlePushResolvedL: _ak.prop("liprl"),
   layerPushValue: _ak.prop.zero("lpv"),
-  // Shared by the idle and state push pipelines. Keep this unregistered and
-  // fallback to offsetDirectionToLight at each call site because that fallback
-  // contains the relative color `l` keyword and only resolves inside the
-  // pushed lightness calc.
-  layerPushDirectionToLight: _ak.var("lpdtl"),
   layerPushBaseL: _ak.prop("lpbl", { initial: l }),
   layerPushL: _ak.prop("lpl", { initial: l }),
   edgeContrastValue: _ak.prop.zero("ecv", { inherits: true }),
@@ -581,7 +575,6 @@ const themeTokenVars = {
 // Color pipeline stages and exported visual tokens.
 const layerColorVars = {
   layerIdleBase: _ak.prop.canvas("lib"),
-  layerSourceDirection: _ak.prop.black("lsd"),
   layerIdleOffset: _ak.prop.canvas("lio"),
   layerIdle: _ak.prop.canvas("li"),
   layerL: _ak.prop.canvas("ll", { inherits: true }),
@@ -1110,11 +1103,6 @@ const forbiddenLb = fn.min(
 const layerBaseColor = fn.var(inputs.layerColor, vars.layerParent);
 const layerIdleBase = fn.oklch(layerBaseColor, idleLayerChannels);
 const layerIdleMixed = fn.var(inputs.layerMix, vars.layerIdleBase);
-const layerSourceDirection = fn.oklch(vars.layerIdleBase, {
-  l: fn.clamp01(vars.lightnessOffsetDirection),
-  c: 0,
-  h: 0,
-});
 
 function getLayerIdleOffsetL() {
   return fn.var(
@@ -1157,16 +1145,19 @@ function getContrastL(selfRelativeL: Value, contrastValue: Value) {
   );
 }
 
+const layerContrastInactive = fn.sub(
+  1,
+  fn.mul(vars.layerContrastDirection, vars.layerContrastDirection),
+);
+const layerIdleContrastBias = fn.mul(
+  vars.layerContrastBias,
+  layerContrastInactive,
+);
+
 const layerIdle = fn.oklch(vars.layerIdleOffset, {
   l: fn.add(
     getContrastL(l, getPushValue(inputs.layerIdleContrastL)),
-    fn.mul(
-      vars.layerContrastBias,
-      fn.sub(
-        1,
-        fn.mul(vars.layerContrastDirection, vars.layerContrastDirection),
-      ),
-    ),
+    fn.mul(layerIdleContrastBias, fn.sub(1, vars.layerIdlePushEnabled)),
   ),
 });
 
@@ -1215,35 +1206,6 @@ function getBaseDeclarations(sourceColor: string | VarProperty) {
   ];
 }
 
-function getLayerIdleContrastBiasDirection() {
-  const directionToLight = fn.var(
-    vars.layerPushDirectionToLight,
-    vars.layerSourceDirectionToLight,
-  );
-  const pushDirection = fn.sub(fn.double(directionToLight), 1);
-  return fn.add(
-    vars.lightnessOffsetDirection,
-    fn.mul(
-      vars.layerIdlePushEnabled,
-      fn.sub(pushDirection, vars.lightnessOffsetDirection),
-    ),
-  );
-}
-
-function getLayerSourceDirectionToLight() {
-  return fn.if(
-    [
-      [fn.style(vars.layerSourceDirection, fn.oklch({ l: 1 })), 1],
-      [fn.style(vars.layerSourceDirection, fn.oklch({ l: 0 })), 0],
-    ],
-    0,
-  );
-}
-
-function getLayerSourcePushDirection() {
-  return fn.sub(fn.double(vars.layerSourceDirectionToLight), 1);
-}
-
 // Assign derived math first so later color stages can reference short vars.
 const layerMathDeclarations = [
   // Set contrastT explicitly so the 5+ references inside this body resolve
@@ -1256,7 +1218,7 @@ const layerMathDeclarations = [
     fn.mul(
       fn.neg(vars.contrastT),
       CONTRAST_SCALE,
-      getLayerIdleContrastBiasDirection(),
+      vars.lightnessOffsetDirection,
     ),
   ),
   set(vars.forbiddenLa, forbiddenLa),
@@ -1291,7 +1253,7 @@ const edgeBaseColor = fn.var(inputs.edgeColor, vars.layer);
 const edgeDirectionalDelta = fn.add(inputs.edgePushL, vars.edgeContrastValue);
 const edgeDirectionalShift = fn.mul(
   edgeDirectionalDelta,
-  fn.var(vars.edgePushDirection, getLayerSourcePushDirection()),
+  vars.edgePushDirection,
 );
 // The directional push and the relative adjustments share one relative color:
 // the pushed lightness feeds getLayerL as the base expression, skipping one
@@ -1370,24 +1332,8 @@ utility(
   getBaseDeclarations(vars.layer),
   layerMathDeclarations,
   layerColorDeclarations,
-  at.supports(
-    IF_SUPPORTS_CONDITION,
-    // Parentless layers need to query their own computed source color. Container
-    // style queries only see ancestors, so browsers without if() keep the
-    // existing parent/variant fallback for this direction.
-    set(vars.layerSourceDirection, layerSourceDirection),
-    set(vars.layerSourceDirectionToLight, getLayerSourceDirectionToLight()),
-  ),
-  at.variant(
-    light,
-    set(vars.layerPushDirectionToLight, 0),
-    set(vars.edgePushDirection, -1),
-  ),
-  at.variant(
-    dark,
-    set(vars.layerPushDirectionToLight, 1),
-    set(vars.edgePushDirection, 1),
-  ),
+  at.variant(light, set(vars.edgePushDirection, -1)),
+  at.variant(dark, set(vars.edgePushDirection, 1)),
   layerContext(({ provide, inherit }) => [
     set(provide(vars.layerParentContext), vars.layer),
     set(vars.layerParent, inherit(vars.layerParentContext)),
@@ -1532,12 +1478,12 @@ utility(
   ),
   set(
     vars.layerIdlePushL,
-    getPushL(
-      vars.layerIdlePushBaseL,
-      fn.var(vars.layerPushDirectionToLight, vars.offsetDirectionToLight),
-    ),
+    getPushL(vars.layerIdlePushBaseL, vars.offsetDirectionToLight),
   ),
-  set(vars.layerIdlePushResolvedL, vars.layerIdlePushL),
+  set(
+    vars.layerIdlePushResolvedL,
+    fn.add(vars.layerIdlePushL, layerIdleContrastBias),
+  ),
 );
 
 utility(
@@ -1675,10 +1621,7 @@ utility(
   ),
   set(
     vars.layerPushL,
-    getPushL(
-      vars.layerPushBaseL,
-      fn.var(vars.layerPushDirectionToLight, vars.offsetDirectionToLight),
-    ),
+    getPushL(vars.layerPushBaseL, vars.offsetDirectionToLight),
   ),
 );
 

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -557,10 +557,11 @@ const layerMathVars = {
 
   layerIdlePushResolvedL: _ak.prop("liprl"),
   layerPushValue: _ak.prop.zero("lpv"),
-  // Shared by the idle and state push pipelines: both always receive the same
-  // value (offsetDirectionToLight by default, 0/1 under the light/dark
-  // variants), so one property serves both getPushL call sites.
-  layerPushDirectionToLight: _ak.prop.zero("lpdtl"),
+  // Shared by the idle and state push pipelines. Keep this unregistered and
+  // fallback to offsetDirectionToLight at each call site because that fallback
+  // contains the relative color `l` keyword and only resolves inside the
+  // pushed lightness calc.
+  layerPushDirectionToLight: _ak.var("lpdtl"),
   layerPushBaseL: _ak.prop("lpbl", { initial: l }),
   layerPushL: _ak.prop("lpl", { initial: l }),
   edgeContrastValue: _ak.prop.zero("ecv", { inherits: true }),
@@ -591,7 +592,9 @@ const layerColorVars = {
   layerTextLContext: _ak.var("ltlc"),
   layerTextLContextEven: _ak.prop.canvas("ltlc-even", { inherits: true }),
   layerTextLContextOdd: _ak.prop.canvas("ltlc-odd", { inherits: true }),
-  layerScheme: _ak.prop.black("ls", { inherits: true }),
+  // This must not match the light/dark style queries until an ancestor layer
+  // provides an actual scheme color.
+  layerScheme: _ak.prop.color("ls", { inherits: true, initial: "transparent" }),
   layerBand: _ak.prop.black("lbd", { inherits: true }),
   layerBase: _ak.prop.canvas("lb"),
   layerOffset: _ak.prop.canvas("lo"),
@@ -1203,7 +1206,11 @@ function getBaseDeclarations(sourceColor: string | VarProperty) {
 }
 
 function getLayerIdleContrastBiasDirection() {
-  const pushDirection = fn.sub(fn.double(vars.layerPushDirectionToLight), 1);
+  const directionToLight = fn.var(
+    vars.layerPushDirectionToLight,
+    vars.offsetDirectionToLight,
+  );
+  const pushDirection = fn.sub(fn.double(directionToLight), 1);
   return fn.add(
     vars.lightnessOffsetDirection,
     fn.mul(
@@ -1220,7 +1227,6 @@ const layerMathDeclarations = [
   // contrast-scale math at each call site.
   set(vars.contrastT, fn.mul(globalContrastT, disabledVars.contrastScale)),
   set(vars.contrastPushScale, fn.add(1, fn.mul(vars.contrastT, 3.334))),
-  set(vars.layerPushDirectionToLight, vars.offsetDirectionToLight),
   set(
     vars.layerContrastBias,
     fn.mul(
@@ -1494,7 +1500,10 @@ utility(
   ),
   set(
     vars.layerIdlePushL,
-    getPushL(vars.layerIdlePushBaseL, vars.layerPushDirectionToLight),
+    getPushL(
+      vars.layerIdlePushBaseL,
+      fn.var(vars.layerPushDirectionToLight, vars.offsetDirectionToLight),
+    ),
   ),
   set(vars.layerIdlePushResolvedL, vars.layerIdlePushL),
 );
@@ -1634,7 +1643,10 @@ utility(
   ),
   set(
     vars.layerPushL,
-    getPushL(vars.layerPushBaseL, vars.layerPushDirectionToLight),
+    getPushL(
+      vars.layerPushBaseL,
+      fn.var(vars.layerPushDirectionToLight, vars.offsetDirectionToLight),
+    ),
   ),
 );
 

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -539,6 +539,7 @@ const layerMathVars = {
   contrastT: _ak.prop.zero("ct", { inherits: true }),
   contrastPushScale: _ak.prop.number("cps", { inherits: true, initial: 1 }),
   layerContrastBias: _ak.var("lcb"),
+  layerSourceDirectionToLight: _ak.prop.zero("lsdtl"),
   forbiddenLa: _ak.var("fla"),
   forbiddenLb: _ak.var("flb"),
   offsetDirectionToLight: _ak.var("odtl"),
@@ -580,6 +581,7 @@ const themeTokenVars = {
 // Color pipeline stages and exported visual tokens.
 const layerColorVars = {
   layerIdleBase: _ak.prop.canvas("lib"),
+  layerSourceDirection: _ak.prop.black("lsd"),
   layerIdleOffset: _ak.prop.canvas("lio"),
   layerIdle: _ak.prop.canvas("li"),
   layerL: _ak.prop.canvas("ll", { inherits: true }),
@@ -791,6 +793,9 @@ const light = createVariant(
   "ak-light",
   at.container(fn.style(vars.layerScheme, "oklch(0 0 0)"), set("@slot")),
 );
+
+// Parses as a valid declaration only in browsers that support if().
+const IF_SUPPORTS_CONDITION = "(color: if(else: red))";
 
 const darkHigh = createVariant(
   "ak-dark-high",
@@ -1105,6 +1110,11 @@ const forbiddenLb = fn.min(
 const layerBaseColor = fn.var(inputs.layerColor, vars.layerParent);
 const layerIdleBase = fn.oklch(layerBaseColor, idleLayerChannels);
 const layerIdleMixed = fn.var(inputs.layerMix, vars.layerIdleBase);
+const layerSourceDirection = fn.oklch(vars.layerIdleBase, {
+  l: fn.clamp01(vars.lightnessOffsetDirection),
+  c: 0,
+  h: 0,
+});
 
 function getLayerIdleOffsetL() {
   return fn.var(
@@ -1208,7 +1218,7 @@ function getBaseDeclarations(sourceColor: string | VarProperty) {
 function getLayerIdleContrastBiasDirection() {
   const directionToLight = fn.var(
     vars.layerPushDirectionToLight,
-    vars.offsetDirectionToLight,
+    vars.layerSourceDirectionToLight,
   );
   const pushDirection = fn.sub(fn.double(directionToLight), 1);
   return fn.add(
@@ -1218,6 +1228,20 @@ function getLayerIdleContrastBiasDirection() {
       fn.sub(pushDirection, vars.lightnessOffsetDirection),
     ),
   );
+}
+
+function getLayerSourceDirectionToLight() {
+  return fn.if(
+    [
+      [fn.style(vars.layerSourceDirection, fn.oklch({ l: 1 })), 1],
+      [fn.style(vars.layerSourceDirection, fn.oklch({ l: 0 })), 0],
+    ],
+    0,
+  );
+}
+
+function getLayerSourcePushDirection() {
+  return fn.sub(fn.double(vars.layerSourceDirectionToLight), 1);
 }
 
 // Assign derived math first so later color stages can reference short vars.
@@ -1255,6 +1279,7 @@ const layerMathDeclarations = [
 // Build the layered color stages from idle -> base -> offset -> final.
 const layerColorDeclarations = [
   set(vars.layerIdleBase, layerIdleBase),
+  set(vars.layerSourceDirection, layerSourceDirection),
   set(vars.layerIdleOffset, layerIdleOffset),
   set(vars.layerIdle, layerIdle),
   set(vars.layerBase, layerState),
@@ -1267,7 +1292,7 @@ const edgeBaseColor = fn.var(inputs.edgeColor, vars.layer);
 const edgeDirectionalDelta = fn.add(inputs.edgePushL, vars.edgeContrastValue);
 const edgeDirectionalShift = fn.mul(
   edgeDirectionalDelta,
-  vars.edgePushDirection,
+  fn.var(vars.edgePushDirection, getLayerSourcePushDirection()),
 );
 // The directional push and the relative adjustments share one relative color:
 // the pushed lightness feeds getLayerL as the base expression, skipping one
@@ -1346,6 +1371,13 @@ utility(
   getBaseDeclarations(vars.layer),
   layerMathDeclarations,
   layerColorDeclarations,
+  at.supports(
+    IF_SUPPORTS_CONDITION,
+    // Parentless layers need to query their own computed source color. Container
+    // style queries only see ancestors, so browsers without if() keep the
+    // existing parent/variant fallback for this direction.
+    set(vars.layerSourceDirectionToLight, getLayerSourceDirectionToLight()),
+  ),
   at.variant(
     light,
     set(vars.layerPushDirectionToLight, 0),
@@ -1838,9 +1870,6 @@ function getTextDirectional() {
     c: fn.min(c, vars.textChromaCap),
   });
 }
-
-// Parses as a valid declaration only in browsers that support if().
-const IF_SUPPORTS_CONDITION = "(color: if(else: red))";
 
 const textLightnessSteps = getTextLightnessSteps();
 

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -1279,7 +1279,6 @@ const layerMathDeclarations = [
 // Build the layered color stages from idle -> base -> offset -> final.
 const layerColorDeclarations = [
   set(vars.layerIdleBase, layerIdleBase),
-  set(vars.layerSourceDirection, layerSourceDirection),
   set(vars.layerIdleOffset, layerIdleOffset),
   set(vars.layerIdle, layerIdle),
   set(vars.layerBase, layerState),
@@ -1376,6 +1375,7 @@ utility(
     // Parentless layers need to query their own computed source color. Container
     // style queries only see ancestors, so browsers without if() keep the
     // existing parent/variant fallback for this direction.
+    set(vars.layerSourceDirection, layerSourceDirection),
     set(vars.layerSourceDirectionToLight, getLayerSourceDirectionToLight()),
   ),
   at.variant(

--- a/packages/ariakit-tailwind/src/output.css
+++ b/packages/ariakit-tailwind/src/output.css
@@ -118,14 +118,14 @@
   @apply ring-[color:var(--ak-edge)];
   --ak-layer: oklch(from var(--_ak-lo) calc(var(--_ak-lpl) + (clamp(0, (min((var(--_ak-lpl) - var(--_ak-fla)), (var(--_ak-flb) - var(--_ak-lpl))) * 1000000), 1) * ((var(--_ak-fla) + (clamp(0, ((var(--_ak-lpl) - ((var(--_ak-fla) + var(--_ak-flb)) / 2)) * 1000000), 1) * (var(--_ak-flb) - var(--_ak-fla)))) - var(--_ak-lpl)))) clamp(var(--_ak-layer-chroma-min), c, var(--_ak-layer-chroma-max, var(--chroma-p3-max, 0.368))) h);
   --ak-text: var(--_ak-ls);
-  --ak-edge: oklch(from var(--_ak-edge-color, var(--ak-layer)) clamp(var(--_ak-edge-lightness-min), var(--_ak-edge-lightness, (clamp(0, (l + ((var(--_ak-edge-push-lightness) + var(--_ak-ecv)) * var(--_ak-epd, -1))), 1) + var(--_ak-edge-relative-lightness) + (clamp(0, (var(--_ak-edge-relative-lightness) * 1000000), 1) * max(0, (0.13 - clamp(0, (l + ((var(--_ak-edge-push-lightness) + var(--_ak-ecv)) * var(--_ak-epd, -1))), 1)))))), var(--_ak-edge-lightness-max)) clamp(var(--_ak-edge-chroma-min), var(--_ak-edge-chroma, (c + var(--_ak-edge-relative-chroma))), var(--_ak-edge-chroma-max, var(--chroma-p3-max, 0.368))) var(--_ak-edge-h, calc(h + var(--_ak-edge-relative-hue))) / clamp(0, (var(--_ak-edge-alpha) + var(--_ak-ecv)), 1));
+  --ak-edge: oklch(from var(--_ak-edge-color, var(--ak-layer)) clamp(var(--_ak-edge-lightness-min), var(--_ak-edge-lightness, (clamp(0, (l + ((var(--_ak-edge-push-lightness) + var(--_ak-ecv)) * var(--_ak-epd, ((var(--_ak-lsdtl) * 2) - 1)))), 1) + var(--_ak-edge-relative-lightness) + (clamp(0, (var(--_ak-edge-relative-lightness) * 1000000), 1) * max(0, (0.13 - clamp(0, (l + ((var(--_ak-edge-push-lightness) + var(--_ak-ecv)) * var(--_ak-epd, ((var(--_ak-lsdtl) * 2) - 1)))), 1)))))), var(--_ak-edge-lightness-max)) clamp(var(--_ak-edge-chroma-min), var(--_ak-edge-chroma, (c + var(--_ak-edge-relative-chroma))), var(--_ak-edge-chroma-max, var(--chroma-p3-max, 0.368))) var(--_ak-edge-h, calc(h + var(--_ak-edge-relative-hue))) / clamp(0, (var(--_ak-edge-alpha) + var(--_ak-ecv)), 1));
   --_ak-lbd: oklch(from var(--ak-layer) calc(0.5 + (var(--_ak-bdh) * -0.5) + (var(--_ak-bdl) * -0.25) + (var(--_ak-bll) * 0.25) + (var(--_ak-blh) * 0.5)) 0 0);
   --_ak-ls: oklch(from var(--ak-layer) var(--_ak-tfcl) 0 0);
   --_ak-ll: oklch(from var(--ak-layer) round(l, 0.125) 0 0);
   --_ak-ltl: lch(from var(--ak-layer) round(down, var(--_ak-ltlv), 3.125) 0 0);
   --_ak-ct: calc((max(0, var(--contrast, 0)) / 100) * var(--_ak-contrast-scale));
   --_ak-cps: calc(1 + (var(--_ak-ct) * 3.334));
-  --_ak-lcb: calc((var(--_ak-ct) * -1) * 0.3334 * (var(--_ak-lod) + (var(--_ak-lipe) * (((var(--_ak-lpdtl, var(--_ak-odtl)) * 2) - 1) - var(--_ak-lod)))));
+  --_ak-lcb: calc((var(--_ak-ct) * -1) * 0.3334 * (var(--_ak-lod) + (var(--_ak-lipe) * (((var(--_ak-lpdtl, var(--_ak-lsdtl)) * 2) - 1) - var(--_ak-lod)))));
   --_ak-fla: max(0.2, (var(--_ak-flab) - (var(--_ak-ct) * 0.35)));
   --_ak-flb: min(0.9, (var(--_ak-flbb) + (var(--_ak-ct) * 0.175)));
   --_ak-odtl: clamp(0, var(--_ak-lod), 1);
@@ -133,10 +133,14 @@
   --_ak-eb: calc(var(--_ak-flb) + (var(--_ak-odtl) * (var(--_ak-fla) - var(--_ak-flb))));
   --_ak-ecv: calc(var(--_ak-ct) * 0.3334);
   --_ak-lib: oklch(from var(--_ak-layer-color, var(--ak-layer-parent, canvas)) var(--_ak-layer-lightness, calc(l + var(--_ak-layer-idle-relative-lightness) + (clamp(0, (var(--_ak-layer-idle-relative-lightness) * 1000000), 1) * var(--_ak-llfb)))) var(--_ak-layer-chroma, calc(c + var(--_ak-layer-idle-relative-chroma))) var(--_ak-layer-hue, calc(h + var(--_ak-layer-idle-relative-hue))));
+  --_ak-lsd: oklch(from var(--_ak-lib) clamp(0, var(--_ak-lod), 1) 0 0);
   --_ak-lio: oklch(from var(--_ak-layer-mix, var(--_ak-lib)) var(--_ak-liprl, var(--_ak-layer-idle-lightness-offset-resolved, clamp(var(--_ak-layer-lightness-min), (l + var(--_ak-layer-idle-lightness-offset) + (clamp(0, (var(--_ak-layer-idle-lightness-offset) * 1000000), 1) * var(--_ak-llfb))), var(--_ak-layer-lightness-max)))) c h);
   --_ak-li: oklch(from var(--_ak-lio) calc((((l + (var(--_ak-lcd) * max(0, ((clamp(0, (var(--_ak-lcpl) + ((var(--_ak-layer-idle-contrast-lightness) * var(--_ak-cps)) * var(--_ak-lcd))), 1) - l) * var(--_ak-lcd))))) * (var(--_ak-lcd) * var(--_ak-lcd))) + (l * (1 - (var(--_ak-lcd) * var(--_ak-lcd))))) + (var(--_ak-lcb) * (1 - (var(--_ak-lcd) * var(--_ak-lcd))))) c h);
   --_ak-lb: oklch(from oklch(from var(--_ak-li) calc(l + var(--_ak-layer-relative-lightness) + (clamp(0, (var(--_ak-layer-relative-lightness) * 1000000), 1) * var(--_ak-llfb))) calc(c + var(--_ak-layer-relative-chroma)) calc(h + var(--_ak-layer-relative-hue))) calc(l + (clamp(0, (min((l - var(--_ak-fla)), (var(--_ak-flb) - l)) * 1000000), 1) * ((var(--_ak-fla) + (clamp(0, ((l - ((var(--_ak-fla) + var(--_ak-flb)) / 2)) * 1000000), 1) * (var(--_ak-flb) - var(--_ak-fla)))) - l))) c h);
   --_ak-lo: oklch(from var(--_ak-lb) var(--_ak-layer-lightness-offset-resolved, calc(l + var(--_ak-layer-lightness-offset) + (clamp(0, (var(--_ak-layer-lightness-offset) * 1000000), 1) * var(--_ak-llfb)))) c h);
+  @supports (color: if(else: red)) {
+    --_ak-lsdtl: if(style(--_ak-lsd: oklch(1 0 0)): 1; style(--_ak-lsd: oklch(0 0 0)): 0; else: 0);
+  }
   @variant ak-light {
     --_ak-lpdtl: 0;
     --_ak-epd: -1;
@@ -1417,6 +1421,12 @@
   initial-value: 1;
 }
 
+@property --_ak-lsdtl {
+  syntax: "<number>";
+  inherits: false;
+  initial-value: 0;
+}
+
 @property --_ak-lill {
   syntax: "*";
   inherits: false;
@@ -1486,6 +1496,12 @@
   syntax: "<color>";
   inherits: false;
   initial-value: canvas;
+}
+
+@property --_ak-lsd {
+  syntax: "<color>";
+  inherits: false;
+  initial-value: black;
 }
 
 @property --_ak-lio {

--- a/packages/ariakit-tailwind/src/output.css
+++ b/packages/ariakit-tailwind/src/output.css
@@ -133,12 +133,12 @@
   --_ak-eb: calc(var(--_ak-flb) + (var(--_ak-odtl) * (var(--_ak-fla) - var(--_ak-flb))));
   --_ak-ecv: calc(var(--_ak-ct) * 0.3334);
   --_ak-lib: oklch(from var(--_ak-layer-color, var(--ak-layer-parent, canvas)) var(--_ak-layer-lightness, calc(l + var(--_ak-layer-idle-relative-lightness) + (clamp(0, (var(--_ak-layer-idle-relative-lightness) * 1000000), 1) * var(--_ak-llfb)))) var(--_ak-layer-chroma, calc(c + var(--_ak-layer-idle-relative-chroma))) var(--_ak-layer-hue, calc(h + var(--_ak-layer-idle-relative-hue))));
-  --_ak-lsd: oklch(from var(--_ak-lib) clamp(0, var(--_ak-lod), 1) 0 0);
   --_ak-lio: oklch(from var(--_ak-layer-mix, var(--_ak-lib)) var(--_ak-liprl, var(--_ak-layer-idle-lightness-offset-resolved, clamp(var(--_ak-layer-lightness-min), (l + var(--_ak-layer-idle-lightness-offset) + (clamp(0, (var(--_ak-layer-idle-lightness-offset) * 1000000), 1) * var(--_ak-llfb))), var(--_ak-layer-lightness-max)))) c h);
   --_ak-li: oklch(from var(--_ak-lio) calc((((l + (var(--_ak-lcd) * max(0, ((clamp(0, (var(--_ak-lcpl) + ((var(--_ak-layer-idle-contrast-lightness) * var(--_ak-cps)) * var(--_ak-lcd))), 1) - l) * var(--_ak-lcd))))) * (var(--_ak-lcd) * var(--_ak-lcd))) + (l * (1 - (var(--_ak-lcd) * var(--_ak-lcd))))) + (var(--_ak-lcb) * (1 - (var(--_ak-lcd) * var(--_ak-lcd))))) c h);
   --_ak-lb: oklch(from oklch(from var(--_ak-li) calc(l + var(--_ak-layer-relative-lightness) + (clamp(0, (var(--_ak-layer-relative-lightness) * 1000000), 1) * var(--_ak-llfb))) calc(c + var(--_ak-layer-relative-chroma)) calc(h + var(--_ak-layer-relative-hue))) calc(l + (clamp(0, (min((l - var(--_ak-fla)), (var(--_ak-flb) - l)) * 1000000), 1) * ((var(--_ak-fla) + (clamp(0, ((l - ((var(--_ak-fla) + var(--_ak-flb)) / 2)) * 1000000), 1) * (var(--_ak-flb) - var(--_ak-fla)))) - l))) c h);
   --_ak-lo: oklch(from var(--_ak-lb) var(--_ak-layer-lightness-offset-resolved, calc(l + var(--_ak-layer-lightness-offset) + (clamp(0, (var(--_ak-layer-lightness-offset) * 1000000), 1) * var(--_ak-llfb)))) c h);
   @supports (color: if(else: red)) {
+    --_ak-lsd: oklch(from var(--_ak-lib) clamp(0, var(--_ak-lod), 1) 0 0);
     --_ak-lsdtl: if(style(--_ak-lsd: oklch(1 0 0)): 1; style(--_ak-lsd: oklch(0 0 0)): 0; else: 0);
   }
   @variant ak-light {

--- a/packages/ariakit-tailwind/src/output.css
+++ b/packages/ariakit-tailwind/src/output.css
@@ -125,8 +125,7 @@
   --_ak-ltl: lch(from var(--ak-layer) round(down, var(--_ak-ltlv), 3.125) 0 0);
   --_ak-ct: calc((max(0, var(--contrast, 0)) / 100) * var(--_ak-contrast-scale));
   --_ak-cps: calc(1 + (var(--_ak-ct) * 3.334));
-  --_ak-lpdtl: var(--_ak-odtl);
-  --_ak-lcb: calc((var(--_ak-ct) * -1) * 0.3334 * (var(--_ak-lod) + (var(--_ak-lipe) * (((var(--_ak-lpdtl) * 2) - 1) - var(--_ak-lod)))));
+  --_ak-lcb: calc((var(--_ak-ct) * -1) * 0.3334 * (var(--_ak-lod) + (var(--_ak-lipe) * (((var(--_ak-lpdtl, var(--_ak-odtl)) * 2) - 1) - var(--_ak-lod)))));
   --_ak-fla: max(0.2, (var(--_ak-flab) - (var(--_ak-ct) * 0.35)));
   --_ak-flb: min(0.9, (var(--_ak-flbb) + (var(--_ak-ct) * 0.175)));
   --_ak-odtl: clamp(0, var(--_ak-lod), 1);
@@ -250,7 +249,7 @@
   --_ak-lipe: 1;
   --_ak-lipv: calc(var(--_ak-layer-idle-push-lightness) * var(--_ak-cps));
   --_ak-lipbl: clamp(var(--_ak-layer-lightness-min), (l + (var(--_ak-layer-idle-lightness-offset) + (var(--_ak-lipv) * var(--_ak-lod))) + (clamp(0, ((var(--_ak-layer-idle-lightness-offset) + (var(--_ak-lipv) * var(--_ak-lod))) * 1000000), 1) * var(--_ak-llfb))), var(--_ak-layer-lightness-max));
-  --_ak-lipl: clamp(0, (var(--_ak-lipbl) + (clamp(0, (min((var(--_ak-lipbl) - var(--_ak-fla)), (var(--_ak-flb) - var(--_ak-lipbl))) * 1000000), 1) * ((var(--_ak-fla) + (var(--_ak-lpdtl) * var(--_ak-bw))) - var(--_ak-lipbl)))), 1);
+  --_ak-lipl: clamp(0, (var(--_ak-lipbl) + (clamp(0, (min((var(--_ak-lipbl) - var(--_ak-fla)), (var(--_ak-flb) - var(--_ak-lipbl))) * 1000000), 1) * ((var(--_ak-fla) + (var(--_ak-lpdtl, var(--_ak-odtl)) * var(--_ak-bw))) - var(--_ak-lipbl)))), 1);
   --_ak-liprl: var(--_ak-lipl);
 }
 
@@ -398,7 +397,7 @@
   --_ak-layer-push-lightness: --value([*]);
   --_ak-lpv: calc(var(--_ak-layer-push-lightness) * var(--_ak-cps));
   --_ak-lpbl: calc(l + (var(--_ak-lpv) * var(--_ak-lod)) + (clamp(0, ((var(--_ak-lpv) * var(--_ak-lod)) * 1000000), 1) * var(--_ak-llfb)));
-  --_ak-lpl: clamp(0, (var(--_ak-lpbl) + (clamp(0, (min((var(--_ak-lpbl) - var(--_ak-fla)), (var(--_ak-flb) - var(--_ak-lpbl))) * 1000000), 1) * ((var(--_ak-fla) + (var(--_ak-lpdtl) * var(--_ak-bw))) - var(--_ak-lpbl)))), 1);
+  --_ak-lpl: clamp(0, (var(--_ak-lpbl) + (clamp(0, (min((var(--_ak-lpbl) - var(--_ak-fla)), (var(--_ak-flb) - var(--_ak-lpbl))) * 1000000), 1) * ((var(--_ak-fla) + (var(--_ak-lpdtl, var(--_ak-odtl)) * var(--_ak-bw))) - var(--_ak-lpbl)))), 1);
 }
 
 @utility ak-state-saturate-* {
@@ -1465,12 +1464,6 @@
   initial-value: 0;
 }
 
-@property --_ak-lpdtl {
-  syntax: "<number>";
-  inherits: false;
-  initial-value: 0;
-}
-
 @property --_ak-lpbl {
   syntax: "*";
   inherits: false;
@@ -1534,7 +1527,7 @@
 @property --_ak-ls {
   syntax: "<color>";
   inherits: true;
-  initial-value: black;
+  initial-value: transparent;
 }
 
 @property --_ak-lbd {

--- a/packages/ariakit-tailwind/src/output.css
+++ b/packages/ariakit-tailwind/src/output.css
@@ -118,14 +118,14 @@
   @apply ring-[color:var(--ak-edge)];
   --ak-layer: oklch(from var(--_ak-lo) calc(var(--_ak-lpl) + (clamp(0, (min((var(--_ak-lpl) - var(--_ak-fla)), (var(--_ak-flb) - var(--_ak-lpl))) * 1000000), 1) * ((var(--_ak-fla) + (clamp(0, ((var(--_ak-lpl) - ((var(--_ak-fla) + var(--_ak-flb)) / 2)) * 1000000), 1) * (var(--_ak-flb) - var(--_ak-fla)))) - var(--_ak-lpl)))) clamp(var(--_ak-layer-chroma-min), c, var(--_ak-layer-chroma-max, var(--chroma-p3-max, 0.368))) h);
   --ak-text: var(--_ak-ls);
-  --ak-edge: oklch(from var(--_ak-edge-color, var(--ak-layer)) clamp(var(--_ak-edge-lightness-min), var(--_ak-edge-lightness, (clamp(0, (l + ((var(--_ak-edge-push-lightness) + var(--_ak-ecv)) * var(--_ak-epd, ((var(--_ak-lsdtl) * 2) - 1)))), 1) + var(--_ak-edge-relative-lightness) + (clamp(0, (var(--_ak-edge-relative-lightness) * 1000000), 1) * max(0, (0.13 - clamp(0, (l + ((var(--_ak-edge-push-lightness) + var(--_ak-ecv)) * var(--_ak-epd, ((var(--_ak-lsdtl) * 2) - 1)))), 1)))))), var(--_ak-edge-lightness-max)) clamp(var(--_ak-edge-chroma-min), var(--_ak-edge-chroma, (c + var(--_ak-edge-relative-chroma))), var(--_ak-edge-chroma-max, var(--chroma-p3-max, 0.368))) var(--_ak-edge-h, calc(h + var(--_ak-edge-relative-hue))) / clamp(0, (var(--_ak-edge-alpha) + var(--_ak-ecv)), 1));
+  --ak-edge: oklch(from var(--_ak-edge-color, var(--ak-layer)) clamp(var(--_ak-edge-lightness-min), var(--_ak-edge-lightness, (clamp(0, (l + ((var(--_ak-edge-push-lightness) + var(--_ak-ecv)) * var(--_ak-epd, -1))), 1) + var(--_ak-edge-relative-lightness) + (clamp(0, (var(--_ak-edge-relative-lightness) * 1000000), 1) * max(0, (0.13 - clamp(0, (l + ((var(--_ak-edge-push-lightness) + var(--_ak-ecv)) * var(--_ak-epd, -1))), 1)))))), var(--_ak-edge-lightness-max)) clamp(var(--_ak-edge-chroma-min), var(--_ak-edge-chroma, (c + var(--_ak-edge-relative-chroma))), var(--_ak-edge-chroma-max, var(--chroma-p3-max, 0.368))) var(--_ak-edge-h, calc(h + var(--_ak-edge-relative-hue))) / clamp(0, (var(--_ak-edge-alpha) + var(--_ak-ecv)), 1));
   --_ak-lbd: oklch(from var(--ak-layer) calc(0.5 + (var(--_ak-bdh) * -0.5) + (var(--_ak-bdl) * -0.25) + (var(--_ak-bll) * 0.25) + (var(--_ak-blh) * 0.5)) 0 0);
   --_ak-ls: oklch(from var(--ak-layer) var(--_ak-tfcl) 0 0);
   --_ak-ll: oklch(from var(--ak-layer) round(l, 0.125) 0 0);
   --_ak-ltl: lch(from var(--ak-layer) round(down, var(--_ak-ltlv), 3.125) 0 0);
   --_ak-ct: calc((max(0, var(--contrast, 0)) / 100) * var(--_ak-contrast-scale));
   --_ak-cps: calc(1 + (var(--_ak-ct) * 3.334));
-  --_ak-lcb: calc((var(--_ak-ct) * -1) * 0.3334 * (var(--_ak-lod) + (var(--_ak-lipe) * (((var(--_ak-lpdtl, var(--_ak-lsdtl)) * 2) - 1) - var(--_ak-lod)))));
+  --_ak-lcb: calc((var(--_ak-ct) * -1) * 0.3334 * var(--_ak-lod));
   --_ak-fla: max(0.2, (var(--_ak-flab) - (var(--_ak-ct) * 0.35)));
   --_ak-flb: min(0.9, (var(--_ak-flbb) + (var(--_ak-ct) * 0.175)));
   --_ak-odtl: clamp(0, var(--_ak-lod), 1);
@@ -134,19 +134,13 @@
   --_ak-ecv: calc(var(--_ak-ct) * 0.3334);
   --_ak-lib: oklch(from var(--_ak-layer-color, var(--ak-layer-parent, canvas)) var(--_ak-layer-lightness, calc(l + var(--_ak-layer-idle-relative-lightness) + (clamp(0, (var(--_ak-layer-idle-relative-lightness) * 1000000), 1) * var(--_ak-llfb)))) var(--_ak-layer-chroma, calc(c + var(--_ak-layer-idle-relative-chroma))) var(--_ak-layer-hue, calc(h + var(--_ak-layer-idle-relative-hue))));
   --_ak-lio: oklch(from var(--_ak-layer-mix, var(--_ak-lib)) var(--_ak-liprl, var(--_ak-layer-idle-lightness-offset-resolved, clamp(var(--_ak-layer-lightness-min), (l + var(--_ak-layer-idle-lightness-offset) + (clamp(0, (var(--_ak-layer-idle-lightness-offset) * 1000000), 1) * var(--_ak-llfb))), var(--_ak-layer-lightness-max)))) c h);
-  --_ak-li: oklch(from var(--_ak-lio) calc((((l + (var(--_ak-lcd) * max(0, ((clamp(0, (var(--_ak-lcpl) + ((var(--_ak-layer-idle-contrast-lightness) * var(--_ak-cps)) * var(--_ak-lcd))), 1) - l) * var(--_ak-lcd))))) * (var(--_ak-lcd) * var(--_ak-lcd))) + (l * (1 - (var(--_ak-lcd) * var(--_ak-lcd))))) + (var(--_ak-lcb) * (1 - (var(--_ak-lcd) * var(--_ak-lcd))))) c h);
+  --_ak-li: oklch(from var(--_ak-lio) calc((((l + (var(--_ak-lcd) * max(0, ((clamp(0, (var(--_ak-lcpl) + ((var(--_ak-layer-idle-contrast-lightness) * var(--_ak-cps)) * var(--_ak-lcd))), 1) - l) * var(--_ak-lcd))))) * (var(--_ak-lcd) * var(--_ak-lcd))) + (l * (1 - (var(--_ak-lcd) * var(--_ak-lcd))))) + ((var(--_ak-lcb) * (1 - (var(--_ak-lcd) * var(--_ak-lcd)))) * (1 - var(--_ak-lipe)))) c h);
   --_ak-lb: oklch(from oklch(from var(--_ak-li) calc(l + var(--_ak-layer-relative-lightness) + (clamp(0, (var(--_ak-layer-relative-lightness) * 1000000), 1) * var(--_ak-llfb))) calc(c + var(--_ak-layer-relative-chroma)) calc(h + var(--_ak-layer-relative-hue))) calc(l + (clamp(0, (min((l - var(--_ak-fla)), (var(--_ak-flb) - l)) * 1000000), 1) * ((var(--_ak-fla) + (clamp(0, ((l - ((var(--_ak-fla) + var(--_ak-flb)) / 2)) * 1000000), 1) * (var(--_ak-flb) - var(--_ak-fla)))) - l))) c h);
   --_ak-lo: oklch(from var(--_ak-lb) var(--_ak-layer-lightness-offset-resolved, calc(l + var(--_ak-layer-lightness-offset) + (clamp(0, (var(--_ak-layer-lightness-offset) * 1000000), 1) * var(--_ak-llfb)))) c h);
-  @supports (color: if(else: red)) {
-    --_ak-lsd: oklch(from var(--_ak-lib) clamp(0, var(--_ak-lod), 1) 0 0);
-    --_ak-lsdtl: if(style(--_ak-lsd: oklch(1 0 0)): 1; style(--_ak-lsd: oklch(0 0 0)): 0; else: 0);
-  }
   @variant ak-light {
-    --_ak-lpdtl: 0;
     --_ak-epd: -1;
   }
   @variant ak-dark {
-    --_ak-lpdtl: 1;
     --_ak-epd: 1;
   }
   @container (style(--_context-0: even)) or (not style(--_context-0)) {
@@ -253,8 +247,8 @@
   --_ak-lipe: 1;
   --_ak-lipv: calc(var(--_ak-layer-idle-push-lightness) * var(--_ak-cps));
   --_ak-lipbl: clamp(var(--_ak-layer-lightness-min), (l + (var(--_ak-layer-idle-lightness-offset) + (var(--_ak-lipv) * var(--_ak-lod))) + (clamp(0, ((var(--_ak-layer-idle-lightness-offset) + (var(--_ak-lipv) * var(--_ak-lod))) * 1000000), 1) * var(--_ak-llfb))), var(--_ak-layer-lightness-max));
-  --_ak-lipl: clamp(0, (var(--_ak-lipbl) + (clamp(0, (min((var(--_ak-lipbl) - var(--_ak-fla)), (var(--_ak-flb) - var(--_ak-lipbl))) * 1000000), 1) * ((var(--_ak-fla) + (var(--_ak-lpdtl, var(--_ak-odtl)) * var(--_ak-bw))) - var(--_ak-lipbl)))), 1);
-  --_ak-liprl: var(--_ak-lipl);
+  --_ak-lipl: clamp(0, (var(--_ak-lipbl) + (clamp(0, (min((var(--_ak-lipbl) - var(--_ak-fla)), (var(--_ak-flb) - var(--_ak-lipbl))) * 1000000), 1) * ((var(--_ak-fla) + (var(--_ak-odtl) * var(--_ak-bw))) - var(--_ak-lipbl)))), 1);
+  --_ak-liprl: calc(var(--_ak-lipl) + (var(--_ak-lcb) * (1 - (var(--_ak-lcd) * var(--_ak-lcd)))));
 }
 
 @utility ak-layer-contrast {
@@ -401,7 +395,7 @@
   --_ak-layer-push-lightness: --value([*]);
   --_ak-lpv: calc(var(--_ak-layer-push-lightness) * var(--_ak-cps));
   --_ak-lpbl: calc(l + (var(--_ak-lpv) * var(--_ak-lod)) + (clamp(0, ((var(--_ak-lpv) * var(--_ak-lod)) * 1000000), 1) * var(--_ak-llfb)));
-  --_ak-lpl: clamp(0, (var(--_ak-lpbl) + (clamp(0, (min((var(--_ak-lpbl) - var(--_ak-fla)), (var(--_ak-flb) - var(--_ak-lpbl))) * 1000000), 1) * ((var(--_ak-fla) + (var(--_ak-lpdtl, var(--_ak-odtl)) * var(--_ak-bw))) - var(--_ak-lpbl)))), 1);
+  --_ak-lpl: clamp(0, (var(--_ak-lpbl) + (clamp(0, (min((var(--_ak-lpbl) - var(--_ak-fla)), (var(--_ak-flb) - var(--_ak-lpbl))) * 1000000), 1) * ((var(--_ak-fla) + (var(--_ak-odtl) * var(--_ak-bw))) - var(--_ak-lpbl)))), 1);
 }
 
 @utility ak-state-saturate-* {
@@ -1421,12 +1415,6 @@
   initial-value: 1;
 }
 
-@property --_ak-lsdtl {
-  syntax: "<number>";
-  inherits: false;
-  initial-value: 0;
-}
-
 @property --_ak-lill {
   syntax: "*";
   inherits: false;
@@ -1496,12 +1484,6 @@
   syntax: "<color>";
   inherits: false;
   initial-value: canvas;
-}
-
-@property --_ak-lsd {
-  syntax: "<color>";
-  inherits: false;
-  initial-value: black;
 }
 
 @property --_ak-lio {


### PR DESCRIPTION
## Motivation

`@ariakit/tailwind` resolved dark `ak-layer-push-*` and `ak-state-push-*` utilities from parent layer context. A root layer such as `ak-layer ak-layer-gray-950 ak-layer-push-50` escaped the forbidden lightness band toward the dark boundary, while the same dark layer nested under a dark parent escaped toward the light boundary.

A light parent could also force a dark current layer to escape in the wrong direction. The push direction should come from the current layer, not from whether an ancestor currently matches `ak-light` or `ak-dark`.

Fixes #6343.

## Solution

The push calculations now use the current layer's own offset direction at the `ak-layer-push-*` and `ak-state-push-*` call sites. This keeps the relative-color `l` channel in the expression where it is valid and avoids carrying a parent-derived push direction through a separate variable.

The high-contrast bias for `ak-layer-push-*` is folded into the pre-push lightness value, so it also follows the current layer without needing a CSS `if()` self-query. The previous self-source direction plumbing and generated `@supports (color: if(...))` block for push direction were removed.

Parentless edge direction remains unsupported: edge colors keep the existing variant/default direction behavior. The regression test now checks the pushed background result across parentless, dark-parent, and light-parent cases for both layer and state push in normal and high-contrast modes, while snapshots continue to record the edge output.

## Workaround

For versions without this fix, give the pushed root layer a parent `ak-layer` with the same scheme so the old parent-based direction matches the current layer.

```tsx
// TODO: Remove this wrapper after https://github.com/ariakit/ariakit/issues/6343 is fixed.
<div className="ak-layer ak-layer-gray-950">
  <div className="ak-layer ak-layer-gray-950 ak-layer-push-50" />
  <div className="ak-layer ak-layer-gray-950 ak-state-push-50" />
</div>
```
