### PR TITLE
Fix Tailwind frame cover RTL rows

### DIFF
--- a/.changeset/300-frame-cover-rtl.md
+++ b/.changeset/300-frame-cover-rtl.md
@@ -2,4 +2,8 @@
 "@ariakit/tailwind": patch
 ---
 
+Frame covers support RTL rows
+
 Fixed `ak-frame-cover` to apply stretch margins and corner rounding to the correct logical sides in RTL rows.
+
+Since `ak-frame-cover` now uses logical CSS properties, override its stretch margin with axis or side utilities such as `mx-*`, `my-*`, `ms-*`, or `me-*` instead of the bare `m-*` shorthand on the same element. Covers should also inherit their frame's `dir` and `writing-mode`; apply direction changes inside the cover when the content needs a different flow.

--- a/.changeset/300-frame-cover-rtl.md
+++ b/.changeset/300-frame-cover-rtl.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/tailwind": patch
+---
+
+Fixed `ak-frame-cover` to apply stretch margins and corner rounding to the correct logical sides in RTL rows.

--- a/app/src/sandbox/ariakit-tailwind/index.react.tsx
+++ b/app/src/sandbox/ariakit-tailwind/index.react.tsx
@@ -45,6 +45,30 @@ function Cell(props: CellProps) {
   );
 }
 
+interface FrameCoverCardProps {
+  coverPosition: "start" | "end";
+  dir: "ltr" | "rtl";
+  label: string;
+}
+
+function FrameCover() {
+  return <div className="ak-frame-cover ak-layer-blue-600 w-24 shrink-0" />;
+}
+
+function FrameCoverCard({ coverPosition, dir, label }: FrameCoverCardProps) {
+  return (
+    <section
+      aria-label={label}
+      dir={dir}
+      className="ak-layer ak-frame ak-frame-xl/2 ak-frame-border ak-frame-row flex h-16 w-80"
+    >
+      {coverPosition === "start" && <FrameCover />}
+      <div className="grow" />
+      {coverPosition === "end" && <FrameCover />}
+    </section>
+  );
+}
+
 function Layers() {
   return (
     <>
@@ -274,6 +298,26 @@ function Layers() {
 export default function Example() {
   return (
     <div className="flex flex-col gap-4 p-4">
+      <FrameCoverCard
+        coverPosition="start"
+        dir="ltr"
+        label="LTR frame row start cover"
+      />
+      <FrameCoverCard
+        coverPosition="start"
+        dir="rtl"
+        label="RTL frame row start cover"
+      />
+      <FrameCoverCard
+        coverPosition="end"
+        dir="ltr"
+        label="LTR frame row end cover"
+      />
+      <FrameCoverCard
+        coverPosition="end"
+        dir="rtl"
+        label="RTL frame row end cover"
+      />
       <Layer
         label="edge inherit root no source"
         className="ak-layer ak-layer-20 ak-edge-inherit ak-frame ak-frame-p-1 ak-frame-border"

--- a/app/src/sandbox/ariakit-tailwind/test-chrome.ts
+++ b/app/src/sandbox/ariakit-tailwind/test-chrome.ts
@@ -1,9 +1,20 @@
 import { AxeBuilder } from "@axe-core/playwright";
 import { expect } from "@playwright/test";
-import type { Page } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
 import { withFramework } from "#app/test-utils/preview.ts";
 
 type ColorContrastViolationMap = Record<string, string>;
+
+interface FrameCoverMetrics {
+  borderBottomLeftRadius: string;
+  borderBottomRightRadius: string;
+  borderTopLeftRadius: string;
+  borderTopRightRadius: string;
+  leftGap: number;
+  marginLeft: string;
+  marginRight: string;
+  rightGap: number;
+}
 
 interface AxeViolation {
   nodes: AxeViolationNode[];
@@ -562,7 +573,67 @@ async function waitForPreviewReady(page: Page) {
   });
 }
 
+async function getFrameCoverMetrics(frame: Locator) {
+  const cover = frame.locator(".ak-frame-cover");
+  await expect(cover).toBeVisible();
+  return cover.evaluate<FrameCoverMetrics>((element) => {
+    const frame = element.parentElement;
+    if (!frame) {
+      throw new Error("Frame not found");
+    }
+    const coverRect = element.getBoundingClientRect();
+    const frameRect = frame.getBoundingClientRect();
+    const style = getComputedStyle(element);
+    return {
+      borderBottomLeftRadius: style.borderBottomLeftRadius,
+      borderBottomRightRadius: style.borderBottomRightRadius,
+      borderTopLeftRadius: style.borderTopLeftRadius,
+      borderTopRightRadius: style.borderTopRightRadius,
+      leftGap: Math.round(coverRect.left - frameRect.left),
+      marginLeft: style.marginLeft,
+      marginRight: style.marginRight,
+      rightGap: Math.round(frameRect.right - coverRect.right),
+    };
+  });
+}
+
 withFramework(import.meta.dirname, async ({ test }) => {
+  test("mirrors frame cover stretch in RTL rows", async ({ page, q }) => {
+    await waitForPreviewReady(page);
+    const ltrStart = await getFrameCoverMetrics(
+      q.region("LTR frame row start cover"),
+    );
+    const rtlStart = await getFrameCoverMetrics(
+      q.region("RTL frame row start cover"),
+    );
+    const ltrEnd = await getFrameCoverMetrics(
+      q.region("LTR frame row end cover"),
+    );
+    const rtlEnd = await getFrameCoverMetrics(
+      q.region("RTL frame row end cover"),
+    );
+
+    expect(rtlStart.rightGap).toBe(ltrStart.leftGap);
+    expect(rtlStart.marginRight).toBe(ltrStart.marginLeft);
+    expect(rtlStart.marginLeft).toBe(ltrStart.marginRight);
+    expect(rtlStart.borderTopRightRadius).toBe(ltrStart.borderTopLeftRadius);
+    expect(rtlStart.borderBottomRightRadius).toBe(
+      ltrStart.borderBottomLeftRadius,
+    );
+    expect(rtlStart.borderTopLeftRadius).toBe(ltrStart.borderTopRightRadius);
+    expect(rtlStart.borderBottomLeftRadius).toBe(
+      ltrStart.borderBottomRightRadius,
+    );
+
+    expect(rtlEnd.leftGap).toBe(ltrEnd.rightGap);
+    expect(rtlEnd.marginLeft).toBe(ltrEnd.marginRight);
+    expect(rtlEnd.marginRight).toBe(ltrEnd.marginLeft);
+    expect(rtlEnd.borderTopLeftRadius).toBe(ltrEnd.borderTopRightRadius);
+    expect(rtlEnd.borderBottomLeftRadius).toBe(ltrEnd.borderBottomRightRadius);
+    expect(rtlEnd.borderTopRightRadius).toBe(ltrEnd.borderTopLeftRadius);
+    expect(rtlEnd.borderBottomRightRadius).toBe(ltrEnd.borderBottomLeftRadius);
+  });
+
   for (const scheme of ["light", "dark"] as const) {
     test.describe(`${scheme} scheme`, () => {
       test.use({ colorScheme: scheme });

--- a/packages/ariakit-tailwind/readme.md
+++ b/packages/ariakit-tailwind/readme.md
@@ -509,6 +509,8 @@ All three utilities accept no argument (defaults to `1px`), named widths (`0`, `
 | `ak-frame-row`   | Flags the frame as a horizontal flow (affects how `cover` / `start` / `end` compute edges). |
 | `ak-frame-col`   | Flags the frame as a vertical flow.                                                         |
 
+`ak-frame-cover` uses logical margin and radius properties so row covers follow the frame direction. When overriding its stretch margin on the same element, prefer axis or side utilities such as `mx-*`, `my-*`, `ms-*`, `me-*`, `mt-*`, `mr-*`, `mb-*`, or `ml-*`; Tailwind sorts the bare `m-*` shorthand before the cover declarations, so it will not reset the logical stretch. Covers should also share the frame's `dir` and `writing-mode`; apply direction changes inside the cover when the content needs a different flow.
+
 ## Variants
 
 Variants apply utilities conditionally based on the parent layer or user preference. Use them like any Tailwind variant: `ak-dark:ak-layer-darken-6`.

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -642,10 +642,10 @@ const frameVars = {
   frameParentBorderingBorderContext: _ak.var("fpbbc"),
   frameParentBorderingRingContext: _ak.var("fpbgc"),
   frameParentRowContext: _ak.var("fpwc"),
-  frameParentCornerTLContext: _ak.var("fpctl"),
-  frameParentCornerTRContext: _ak.var("fpctr"),
-  frameParentCornerBLContext: _ak.var("fpcbl"),
-  frameParentCornerBRContext: _ak.var("fpcbr"),
+  frameParentCornerStartStartContext: _ak.var("fpcss"),
+  frameParentCornerStartEndContext: _ak.var("fpcse"),
+  frameParentCornerEndStartContext: _ak.var("fpces"),
+  frameParentCornerEndEndContext: _ak.var("fpcee"),
   frameAutoRadius: _ak.var("far"),
   frameInflatedExcess: _ak.var("fie"),
   frameBorderingDarkening: _ak.var("fbd"),
@@ -2201,33 +2201,61 @@ function getFrameStretchDeclarations({
 
   // Inherit per-corner flags from the parent stretch element (default: 1 = all
   // corners rounded, provided by the frame utility for non-stretch parents).
-  const parentCornerTL = inherit(vars.frameParentCornerTLContext, 1);
-  const parentCornerTR = inherit(vars.frameParentCornerTRContext, 1);
-  const parentCornerBL = inherit(vars.frameParentCornerBLContext, 1);
-  const parentCornerBR = inherit(vars.frameParentCornerBRContext, 1);
+  const parentCornerStartStart = inherit(
+    vars.frameParentCornerStartStartContext,
+    1,
+  );
+  const parentCornerStartEnd = inherit(
+    vars.frameParentCornerStartEndContext,
+    1,
+  );
+  const parentCornerEndStart = inherit(
+    vars.frameParentCornerEndStartContext,
+    1,
+  );
+  const parentCornerEndEnd = inherit(vars.frameParentCornerEndEndContext, 1);
 
-  // Own corner factors based on edge position and parent layout direction.
-  const ownCornerTL = inputs.frameStart;
-  const ownCornerTR = fn.max(
+  // Own corner factors based on logical edge position and parent layout axis.
+  const ownCornerStartStart = inputs.frameStart;
+  const ownCornerStartEnd = fn.max(
     fn.mul(isCol, inputs.frameStart),
     fn.mul(isRow, inputs.frameEnd),
   );
-  const ownCornerBL = fn.max(
+  const ownCornerEndStart = fn.max(
     fn.mul(isCol, inputs.frameEnd),
     fn.mul(isRow, inputs.frameStart),
   );
-  const ownCornerBR = inputs.frameEnd;
+  const ownCornerEndEnd = inputs.frameEnd;
 
   // Effective corner factors: only round a corner when both this element AND
   // the parent have a rounded corner at the same position.
-  const cornerTL = fn.mul(ownCornerTL, parentCornerTL);
-  const cornerTR = fn.mul(ownCornerTR, parentCornerTR);
-  const cornerBL = fn.mul(ownCornerBL, parentCornerBL);
-  const cornerBR = fn.mul(ownCornerBR, parentCornerBR);
-  const childCornerTL = provide(vars.frameParentCornerTLContext);
-  const childCornerTR = provide(vars.frameParentCornerTRContext);
-  const childCornerBL = provide(vars.frameParentCornerBLContext);
-  const childCornerBR = provide(vars.frameParentCornerBRContext);
+  const cornerStartStart = fn.mul(ownCornerStartStart, parentCornerStartStart);
+  const cornerStartEnd = fn.mul(ownCornerStartEnd, parentCornerStartEnd);
+  const cornerEndStart = fn.mul(ownCornerEndStart, parentCornerEndStart);
+  const cornerEndEnd = fn.mul(ownCornerEndEnd, parentCornerEndEnd);
+  const childCornerStartStart = provide(
+    vars.frameParentCornerStartStartContext,
+  );
+  const childCornerStartEnd = provide(vars.frameParentCornerStartEndContext);
+  const childCornerEndStart = provide(vars.frameParentCornerEndStartContext);
+  const childCornerEndEnd = provide(vars.frameParentCornerEndEndContext);
+
+  const blockStartMargin = fn.mul(
+    fn.max(isRow, fn.mul(isCol, inputs.frameStart)),
+    vars.frameMargin,
+  );
+  const blockEndMargin = fn.mul(
+    fn.max(isRow, fn.mul(isCol, inputs.frameEnd)),
+    vars.frameMargin,
+  );
+  const inlineStartMargin = fn.mul(
+    fn.max(isCol, fn.mul(isRow, inputs.frameStart)),
+    vars.frameMargin,
+  );
+  const inlineEndMargin = fn.mul(
+    fn.max(isCol, fn.mul(isRow, inputs.frameEnd)),
+    vars.frameMargin,
+  );
 
   return [
     rule("&:first-child", set(inputs.frameStart, 1)),
@@ -2245,48 +2273,20 @@ function getFrameStretchDeclarations({
     // the stretch-derived value rather than the frame-* hint radius.
     set(vars.frameRadius, childRadius),
     // Propagate per-corner flags to children.
-    set(childCornerTL, cornerTL),
-    set(childCornerTR, cornerTR),
-    set(childCornerBL, cornerBL),
-    set(childCornerBR, cornerBR),
+    set(childCornerStartStart, cornerStartStart),
+    set(childCornerStartEnd, cornerStartEnd),
+    set(childCornerEndStart, cornerEndStart),
+    set(childCornerEndEnd, cornerEndEnd),
     // Cross-axis margins always applied; main-axis margins only at edges
     // Col: inline = cross, block = main
     // Row: block = cross, inline = main
-    set.margin(
-      fn.join(
-        [
-          fn.mul(
-            fn.max(isRow, fn.mul(isCol, inputs.frameStart)),
-            vars.frameMargin,
-          ),
-          fn.mul(
-            fn.max(isCol, fn.mul(isRow, inputs.frameEnd)),
-            vars.frameMargin,
-          ),
-          fn.mul(
-            fn.max(isRow, fn.mul(isCol, inputs.frameEnd)),
-            vars.frameMargin,
-          ),
-          fn.mul(
-            fn.max(isCol, fn.mul(isRow, inputs.frameStart)),
-            vars.frameMargin,
-          ),
-        ],
-        " ",
-      ),
-    ),
-    // Corner radii: each corner inherits its parent's corner state.
-    set.borderRadius(
-      fn.join(
-        [
-          fn.mul(childCornerTL, vars.frameRadius),
-          fn.mul(childCornerTR, vars.frameRadius),
-          fn.mul(childCornerBR, vars.frameRadius),
-          fn.mul(childCornerBL, vars.frameRadius),
-        ],
-        " ",
-      ),
-    ),
+    set.marginBlock(fn.join([blockStartMargin, blockEndMargin], " ")),
+    set.marginInline(fn.join([inlineStartMargin, inlineEndMargin], " ")),
+    // Corner radii: each logical corner inherits its parent's corner state.
+    set.borderStartStartRadius(fn.mul(childCornerStartStart, vars.frameRadius)),
+    set.borderStartEndRadius(fn.mul(childCornerStartEnd, vars.frameRadius)),
+    set.borderEndStartRadius(fn.mul(childCornerEndStart, vars.frameRadius)),
+    set.borderEndEndRadius(fn.mul(childCornerEndEnd, vars.frameRadius)),
   ];
 }
 
@@ -2376,10 +2376,10 @@ utility(
       ),
       set(provide(vars.frameParentRowContext), inputs.frameRow),
       // Default: all corners rounded (non-stretch parents).
-      set(provide(vars.frameParentCornerTLContext), 1),
-      set(provide(vars.frameParentCornerTRContext), 1),
-      set(provide(vars.frameParentCornerBLContext), 1),
-      set(provide(vars.frameParentCornerBRContext), 1),
+      set(provide(vars.frameParentCornerStartStartContext), 1),
+      set(provide(vars.frameParentCornerStartEndContext), 1),
+      set(provide(vars.frameParentCornerEndStartContext), 1),
+      set(provide(vars.frameParentCornerEndEndContext), 1),
     ];
   }),
 );

--- a/packages/ariakit-tailwind/src/output.css
+++ b/packages/ariakit-tailwind/src/output.css
@@ -1029,10 +1029,10 @@
     --_ak-fpbbc-odd: calc((var(--_ak-fpbbc-even, 0px) * (1 - var(--_ak-frame-bordering-context))) + (var(--_ak-frame-border) * var(--_ak-frame-bordering-context)));
     --_ak-fpbgc-odd: calc((var(--_ak-fpbgc-even, 0px) * (1 - var(--_ak-frame-bordering-context))) + (var(--_ak-frame-ring) * var(--_ak-frame-bordering-context)));
     --_ak-fpwc-odd: var(--_ak-frame-row);
-    --_ak-fpctl-odd: 1;
-    --_ak-fpctr-odd: 1;
-    --_ak-fpcbl-odd: 1;
-    --_ak-fpcbr-odd: 1;
+    --_ak-fpcss-odd: 1;
+    --_ak-fpcse-odd: 1;
+    --_ak-fpces-odd: 1;
+    --_ak-fpcee-odd: 1;
   }
   @container style(--_context-2: odd) {
     --_context-2: even;
@@ -1045,10 +1045,10 @@
     --_ak-fpbbc-even: calc((var(--_ak-fpbbc-odd, 0px) * (1 - var(--_ak-frame-bordering-context))) + (var(--_ak-frame-border) * var(--_ak-frame-bordering-context)));
     --_ak-fpbgc-even: calc((var(--_ak-fpbgc-odd, 0px) * (1 - var(--_ak-frame-bordering-context))) + (var(--_ak-frame-ring) * var(--_ak-frame-bordering-context)));
     --_ak-fpwc-even: var(--_ak-frame-row);
-    --_ak-fpctl-even: 1;
-    --_ak-fpctr-even: 1;
-    --_ak-fpcbl-even: 1;
-    --_ak-fpcbr-even: 1;
+    --_ak-fpcss-even: 1;
+    --_ak-fpcse-even: 1;
+    --_ak-fpces-even: 1;
+    --_ak-fpcee-even: 1;
   }
 }
 
@@ -1099,12 +1099,16 @@
     --_ak-frame-padding: var(--_ak-fppc-even, 0px);
     --ak-frame-margin: calc(((var(--_ak-fppc-even, 0px) + var(--_ak-frame-border)) * -1) + var(--_ak-frame-margin));
     --ak-frame-radius: max((var(--_ak-fprc-even, 0px) - ((var(--_ak-fpbc-even, 0px) - var(--_ak-frame-border)) + var(--_ak-frame-margin))), 0px);
-    --_ak-fpctl-odd: calc(var(--_ak-frame-start) * var(--_ak-fpctl-even, 1));
-    --_ak-fpctr-odd: calc(max(((1 - var(--_ak-fpwc-even, 0)) * var(--_ak-frame-start)), (var(--_ak-fpwc-even, 0) * var(--_ak-frame-end))) * var(--_ak-fpctr-even, 1));
-    --_ak-fpcbl-odd: calc(max(((1 - var(--_ak-fpwc-even, 0)) * var(--_ak-frame-end)), (var(--_ak-fpwc-even, 0) * var(--_ak-frame-start))) * var(--_ak-fpcbl-even, 1));
-    --_ak-fpcbr-odd: calc(var(--_ak-frame-end) * var(--_ak-fpcbr-even, 1));
-    margin: calc(max(var(--_ak-fpwc-even, 0), ((1 - var(--_ak-fpwc-even, 0)) * var(--_ak-frame-start))) * var(--ak-frame-margin)) calc(max((1 - var(--_ak-fpwc-even, 0)), (var(--_ak-fpwc-even, 0) * var(--_ak-frame-end))) * var(--ak-frame-margin)) calc(max(var(--_ak-fpwc-even, 0), ((1 - var(--_ak-fpwc-even, 0)) * var(--_ak-frame-end))) * var(--ak-frame-margin)) calc(max((1 - var(--_ak-fpwc-even, 0)), (var(--_ak-fpwc-even, 0) * var(--_ak-frame-start))) * var(--ak-frame-margin));
-    border-radius: calc(var(--_ak-fpctl-odd) * var(--ak-frame-radius)) calc(var(--_ak-fpctr-odd) * var(--ak-frame-radius)) calc(var(--_ak-fpcbr-odd) * var(--ak-frame-radius)) calc(var(--_ak-fpcbl-odd) * var(--ak-frame-radius));
+    --_ak-fpcss-odd: calc(var(--_ak-frame-start) * var(--_ak-fpcss-even, 1));
+    --_ak-fpcse-odd: calc(max(((1 - var(--_ak-fpwc-even, 0)) * var(--_ak-frame-start)), (var(--_ak-fpwc-even, 0) * var(--_ak-frame-end))) * var(--_ak-fpcse-even, 1));
+    --_ak-fpces-odd: calc(max(((1 - var(--_ak-fpwc-even, 0)) * var(--_ak-frame-end)), (var(--_ak-fpwc-even, 0) * var(--_ak-frame-start))) * var(--_ak-fpces-even, 1));
+    --_ak-fpcee-odd: calc(var(--_ak-frame-end) * var(--_ak-fpcee-even, 1));
+    margin-block: calc(max(var(--_ak-fpwc-even, 0), ((1 - var(--_ak-fpwc-even, 0)) * var(--_ak-frame-start))) * var(--ak-frame-margin)) calc(max(var(--_ak-fpwc-even, 0), ((1 - var(--_ak-fpwc-even, 0)) * var(--_ak-frame-end))) * var(--ak-frame-margin));
+    margin-inline: calc(max((1 - var(--_ak-fpwc-even, 0)), (var(--_ak-fpwc-even, 0) * var(--_ak-frame-start))) * var(--ak-frame-margin)) calc(max((1 - var(--_ak-fpwc-even, 0)), (var(--_ak-fpwc-even, 0) * var(--_ak-frame-end))) * var(--ak-frame-margin));
+    border-start-start-radius: calc(var(--_ak-fpcss-odd) * var(--ak-frame-radius));
+    border-start-end-radius: calc(var(--_ak-fpcse-odd) * var(--ak-frame-radius));
+    border-end-start-radius: calc(var(--_ak-fpces-odd) * var(--ak-frame-radius));
+    border-end-end-radius: calc(var(--_ak-fpcee-odd) * var(--ak-frame-radius));
   }
   @container style(--_context-2: odd) {
     --_context-2: even;
@@ -1119,12 +1123,16 @@
     --_ak-frame-padding: var(--_ak-fppc-odd, 0px);
     --ak-frame-margin: calc(((var(--_ak-fppc-odd, 0px) + var(--_ak-frame-border)) * -1) + var(--_ak-frame-margin));
     --ak-frame-radius: max((var(--_ak-fprc-odd, 0px) - ((var(--_ak-fpbc-odd, 0px) - var(--_ak-frame-border)) + var(--_ak-frame-margin))), 0px);
-    --_ak-fpctl-even: calc(var(--_ak-frame-start) * var(--_ak-fpctl-odd, 1));
-    --_ak-fpctr-even: calc(max(((1 - var(--_ak-fpwc-odd, 0)) * var(--_ak-frame-start)), (var(--_ak-fpwc-odd, 0) * var(--_ak-frame-end))) * var(--_ak-fpctr-odd, 1));
-    --_ak-fpcbl-even: calc(max(((1 - var(--_ak-fpwc-odd, 0)) * var(--_ak-frame-end)), (var(--_ak-fpwc-odd, 0) * var(--_ak-frame-start))) * var(--_ak-fpcbl-odd, 1));
-    --_ak-fpcbr-even: calc(var(--_ak-frame-end) * var(--_ak-fpcbr-odd, 1));
-    margin: calc(max(var(--_ak-fpwc-odd, 0), ((1 - var(--_ak-fpwc-odd, 0)) * var(--_ak-frame-start))) * var(--ak-frame-margin)) calc(max((1 - var(--_ak-fpwc-odd, 0)), (var(--_ak-fpwc-odd, 0) * var(--_ak-frame-end))) * var(--ak-frame-margin)) calc(max(var(--_ak-fpwc-odd, 0), ((1 - var(--_ak-fpwc-odd, 0)) * var(--_ak-frame-end))) * var(--ak-frame-margin)) calc(max((1 - var(--_ak-fpwc-odd, 0)), (var(--_ak-fpwc-odd, 0) * var(--_ak-frame-start))) * var(--ak-frame-margin));
-    border-radius: calc(var(--_ak-fpctl-even) * var(--ak-frame-radius)) calc(var(--_ak-fpctr-even) * var(--ak-frame-radius)) calc(var(--_ak-fpcbr-even) * var(--ak-frame-radius)) calc(var(--_ak-fpcbl-even) * var(--ak-frame-radius));
+    --_ak-fpcss-even: calc(var(--_ak-frame-start) * var(--_ak-fpcss-odd, 1));
+    --_ak-fpcse-even: calc(max(((1 - var(--_ak-fpwc-odd, 0)) * var(--_ak-frame-start)), (var(--_ak-fpwc-odd, 0) * var(--_ak-frame-end))) * var(--_ak-fpcse-odd, 1));
+    --_ak-fpces-even: calc(max(((1 - var(--_ak-fpwc-odd, 0)) * var(--_ak-frame-end)), (var(--_ak-fpwc-odd, 0) * var(--_ak-frame-start))) * var(--_ak-fpces-odd, 1));
+    --_ak-fpcee-even: calc(var(--_ak-frame-end) * var(--_ak-fpcee-odd, 1));
+    margin-block: calc(max(var(--_ak-fpwc-odd, 0), ((1 - var(--_ak-fpwc-odd, 0)) * var(--_ak-frame-start))) * var(--ak-frame-margin)) calc(max(var(--_ak-fpwc-odd, 0), ((1 - var(--_ak-fpwc-odd, 0)) * var(--_ak-frame-end))) * var(--ak-frame-margin));
+    margin-inline: calc(max((1 - var(--_ak-fpwc-odd, 0)), (var(--_ak-fpwc-odd, 0) * var(--_ak-frame-start))) * var(--ak-frame-margin)) calc(max((1 - var(--_ak-fpwc-odd, 0)), (var(--_ak-fpwc-odd, 0) * var(--_ak-frame-end))) * var(--ak-frame-margin));
+    border-start-start-radius: calc(var(--_ak-fpcss-even) * var(--ak-frame-radius));
+    border-start-end-radius: calc(var(--_ak-fpcse-even) * var(--ak-frame-radius));
+    border-end-start-radius: calc(var(--_ak-fpces-even) * var(--ak-frame-radius));
+    border-end-end-radius: calc(var(--_ak-fpcee-even) * var(--ak-frame-radius));
   }
 }
 


### PR DESCRIPTION
## Motivation

Fixes #6338.

`ak-frame-cover` derives its start and end state from logical DOM position, but it emitted physical `margin` and `border-radius` shorthands. In RTL row frames, a leading or trailing cover could therefore stretch and round on the wrong physical side.

## Solution

Emit logical frame-cover geometry instead of physical shorthands while preserving the existing row/column factor math:

```css
margin-block: <block-start> <block-end>;
margin-inline: <inline-start> <inline-end>;
border-start-start-radius: <start-start>;
border-start-end-radius: <start-end>;
border-end-start-radius: <end-start>;
border-end-end-radius: <end-end>;
```

The private corner context variables were renamed from physical corner names to logical corner names, and `packages/ariakit-tailwind/src/output.css` was regenerated.

The Tailwind sandbox now includes LTR/RTL row cover fixtures for both start and end covers, with browser assertions for mirrored gaps, margins, and physical corner radii.

## Notes

Because `ak-frame-cover` now uses logical margin properties, consumers should override its stretch margin with axis or side utilities such as `mx-*`, `my-*`, `ms-*`, or `me-*` instead of a bare `m-*` shorthand on the same element.

Covers should also share the frame's `dir` and `writing-mode`; direction changes for nested content should be applied inside the cover.

## Workaround

The issue already documents a consumer CSS workaround that re-applies the stretch margin and rounding with logical properties. This PR moves that behavior into `@ariakit/tailwind` so consumers do not need the override.
