### PR TITLE
Fix Tailwind light band boundary

### DIFF
--- a/.changeset/300-tailwind-light-band-boundary.md
+++ b/.changeset/300-tailwind-light-band-boundary.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/tailwind": patch
+---
+
+Fixed `ak-light-high:` to match layers at the exact lightness boundary shared with `ak-light-low:`.

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/dark
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/dark
@@ -33,6 +33,13 @@
       "#165DFC": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(57.033_80_288.704)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
       "raw calc": "bg-[oklch(0.4268_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(84.1828_3.43_266.444)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
       "raw l/c": "bg-[oklch(0.5096_0.18_264.28)] text-[oklch(1_0_0)] *:text-[lch(97.3245_20_284.288)] rounded-[15px] border-[1px] border-[oklch(1_0.18_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.18_264.28_/_0.1)_0px_0px_0px_0px]",
+      "band boundary variants": {
+        "class": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
+        "children": {
+          "ak-layer-l-27.5": "bg-[oklch(0.275_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[rgb(255,_255,_255)] p-[8px]",
+          "ak-layer-l-85.75": "bg-[oklch(0.8575_0.0091_264.28)] text-[oklch(0_0_0)] p-[8px]"
+        }
+      },
       "ak-layer ak-text": "text-[lch(57.033_80_288.648)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
       "raw ink/edge": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0_/_0.4969)] *:text-[lch(57.033_2.32_268.203)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.35)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.35)_0px_0px_0px_0px]",
       "layer limits": {

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
@@ -33,6 +33,13 @@
       "#165DFC": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(100_80_288.704)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
       "raw calc": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(100_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
       "raw l/c": "bg-[oklch(0.2_0.18_264.28)] text-[oklch(1_0_0)] *:text-[lch(100_79.92_306.787)] rounded-[15px] border-[1px] border-[oklch(1_0.18_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.18_264.28_/_0.4334)_0px_0px_0px_0px]",
+      "band boundary variants": {
+        "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
+        "children": {
+          "ak-layer-l-27.5": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[rgb(255,_255,_255)] p-[8px]",
+          "ak-layer-l-85.75": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] p-[8px]"
+        }
+      },
       "ak-layer ak-text": "text-[lch(100_80_288.648)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
       "raw ink/edge": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(100_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.6834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.6834)_0px_0px_0px_0px]",
       "layer limits": {

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/light
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/light
@@ -33,6 +33,13 @@
       "#165DFC": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(43.4424_80_288.704)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
       "raw calc": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(55.2119_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
       "raw l/c": "bg-[oklch(0.5096_0.18_197.14)] text-[oklch(1_0_0)] *:text-[lch(100_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.18_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.18_197.14_/_0.1)_0px_0px_0px_0px]",
+      "band boundary variants": {
+        "class": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
+        "children": {
+          "ak-layer-l-27.5": "bg-[oklch(0.275_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[rgb(255,_255,_255)] p-[8px]",
+          "ak-layer-l-85.75": "bg-[oklch(0.8575_0.0011_197.14)] text-[oklch(0_0_0)] p-[8px]"
+        }
+      },
       "ak-layer ak-text": "text-[lch(43.4424_80_288.648)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
       "raw ink/edge": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0_/_0.5418)] *:text-[lch(43.4424_0.38_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.35)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.35)_0px_0px_0px_0px]",
       "layer limits": {

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
@@ -33,6 +33,13 @@
       "#165DFC": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_80_288.704)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
       "raw calc": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(100_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
       "raw l/c": "bg-[oklch(0.2_0.18_197.14)] text-[oklch(1_0_0)] *:text-[lch(100_37.79_209.46)] rounded-[15px] border-[1px] border-[oklch(0_0.18_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.18_197.14_/_0.4334)_0px_0px_0px_0px]",
+      "band boundary variants": {
+        "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
+        "children": {
+          "ak-layer-l-27.5": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[rgb(255,_255,_255)] p-[8px]",
+          "ak-layer-l-85.75": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] p-[8px]"
+        }
+      },
       "ak-layer ak-text": "text-[lch(0_80_288.648)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
       "raw ink/edge": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_0.38_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.6834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.6834)_0px_0px_0px_0px]",
       "layer limits": {

--- a/app/src/sandbox/ariakit-tailwind/index.react.tsx
+++ b/app/src/sandbox/ariakit-tailwind/index.react.tsx
@@ -368,6 +368,29 @@ export default function Example() {
             className="ak-layer-l-[0.62] ak-layer-c-[0.18] *:ak-text"
           />
           <Layer
+            label="band boundary variants"
+            className="ak-layer ak-frame ak-frame-p-1 ak-frame-border flex-col"
+          >
+            <Layer className="grid gap-2">
+              <Layer className="ak-layer ak-layer-l-27.5 p-2">
+                <div className="ak-dark-high:bg-red-950 p-2 text-white">
+                  Dark high candidate (layer lightness 0.275)
+                </div>
+                <div className="ak-dark-low:bg-black p-2 text-white">
+                  Dark low candidate (layer lightness 0.275)
+                </div>
+              </Layer>
+              <Layer className="ak-layer ak-layer-l-85.75 p-2">
+                <div className="ak-light-low:bg-red-950 p-2 text-black">
+                  Light low candidate (layer lightness 0.8575)
+                </div>
+                <div className="ak-light-high:bg-black p-2 text-white">
+                  Light high candidate (layer lightness 0.8575)
+                </div>
+              </Layer>
+            </Layer>
+          </Layer>
+          <Layer
             label="ak-layer ak-text"
             className="ak-layer ak-layer-80 ak-text ak-text-blue-600 ak-frame ak-frame-p-1 ak-frame-border"
           />

--- a/app/src/sandbox/ariakit-tailwind/test-chrome.ts
+++ b/app/src/sandbox/ariakit-tailwind/test-chrome.ts
@@ -563,6 +563,27 @@ async function waitForPreviewReady(page: Page) {
 }
 
 withFramework(import.meta.dirname, async ({ test }) => {
+  test("matches exactly one layer band at lightness boundaries", async ({
+    page,
+    q,
+  }) => {
+    await waitForPreviewReady(page);
+    const transparent = "rgba(0, 0, 0, 0)";
+
+    await expect(
+      q.text("Dark high candidate (layer lightness 0.275)"),
+    ).toHaveCSS("background-color", transparent);
+    await expect(
+      q.text("Dark low candidate (layer lightness 0.275)"),
+    ).toHaveCSS("background-color", "rgb(0, 0, 0)");
+    await expect(
+      q.text("Light low candidate (layer lightness 0.8575)"),
+    ).toHaveCSS("background-color", transparent);
+    await expect(
+      q.text("Light high candidate (layer lightness 0.8575)"),
+    ).toHaveCSS("background-color", "rgb(0, 0, 0)");
+  });
+
   for (const scheme of ["light", "dark"] as const) {
     test.describe(`${scheme} scheme`, () => {
       test.use({ colorScheme: scheme });

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -440,7 +440,9 @@ const globalContrastT = fn.div(fn.relu(contrast), CONTRAST_HIGH);
 const bandDarkHigh = getRangeMask(l, 0, DARK_HIGH_MAX_L);
 const bandDarkLow = getRangeMask(l, DARK_HIGH_MAX_L, LA_BASE);
 const bandLightLow = getRangeMask(l, LB_BASE, LIGHT_LOW_MAX_L);
-const bandLightHigh = fn.binary(fn.sub(l, LIGHT_LOW_MAX_L));
+const bandLightHigh = fn.binary(
+  fn.sub(l, roundToDecimals(LIGHT_LOW_MAX_L - 1e-6, 6)),
+);
 
 function getLayerTextLightness() {
   const lightChromaDamping = fn.mul(

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -262,13 +262,18 @@ function getWcagLightnessTarget(parentLightness: number, isDark: boolean) {
 }
 
 /**
- * Returns whether `value` is within `[min, max]`
+ * Returns whether `value` is greater than or equal to `min`. The epsilon keeps
+ * adjacent bands from leaving a gap at shared boundaries.
+ */
+function getMinMask(value: Value, min: number) {
+  return fn.binary(fn.sub(value, roundToDecimals(min - 1e-6, 6)));
+}
+
+/**
+ * Returns whether `value` is within `[min, max)`.
  */
 function getRangeMask(value: Value, min: number, max: number) {
-  return fn.mul(
-    fn.binary(fn.sub(value, roundToDecimals(min - 1e-6, 6))),
-    fn.binary(fn.sub(max, value)),
-  );
+  return fn.mul(getMinMask(value, min), fn.binary(fn.sub(max, value)));
 }
 
 /**
@@ -440,9 +445,7 @@ const globalContrastT = fn.div(fn.relu(contrast), CONTRAST_HIGH);
 const bandDarkHigh = getRangeMask(l, 0, DARK_HIGH_MAX_L);
 const bandDarkLow = getRangeMask(l, DARK_HIGH_MAX_L, LA_BASE);
 const bandLightLow = getRangeMask(l, LB_BASE, LIGHT_LOW_MAX_L);
-const bandLightHigh = fn.binary(
-  fn.sub(l, roundToDecimals(LIGHT_LOW_MAX_L - 1e-6, 6)),
-);
+const bandLightHigh = getMinMask(l, LIGHT_LOW_MAX_L);
 
 function getLayerTextLightness() {
   const lightChromaDamping = fn.mul(

--- a/packages/ariakit-tailwind/src/output.css
+++ b/packages/ariakit-tailwind/src/output.css
@@ -1379,7 +1379,7 @@
 @property --_ak-blh {
   syntax: "*";
   inherits: false;
-  initial-value: clamp(0, ((l - 0.8575) * 1000000), 1);
+  initial-value: clamp(0, ((l - 0.857499) * 1000000), 1);
 }
 
 @property --_ak-contrast-scale {


### PR DESCRIPTION
## Motivation

The `@ariakit/tailwind` lightness band variants should partition the layer lightness scale so each layer matches exactly one band. At `ak-layer-l-85.75`, the light-low upper bound and light-high lower bound both evaluated to zero, so neither `ak-light-low:` nor `ak-light-high:` matched.

Fixes #6348.

## Solution

Shift `bandLightHigh` by the same inclusive lower-bound epsilon used by `getRangeMask`, while keeping the top band one-sided so `l = 1` still belongs to `ak-light-high:`. Rebuild `output.css` so `--_ak-blh` starts at `0.857499` instead of `0.8575`.

Add a Tailwind sandbox regression that checks both sides of the relevant dark and light boundaries: the losing adjacent variant remains transparent and the owning variant applies.
