### PR TITLE
Split Tailwind sandbox behavior checks

### DIFF
--- a/app/src/sandbox/ariakit-tailwind-frame-cover-rtl/index.react.tsx
+++ b/app/src/sandbox/ariakit-tailwind-frame-cover-rtl/index.react.tsx
@@ -1,0 +1,52 @@
+import "./style.css";
+
+interface FrameCoverCardProps {
+  coverPosition: "start" | "end";
+  dir: "ltr" | "rtl";
+  label: string;
+}
+
+function FrameCover() {
+  return <div className="ak-frame-cover ak-layer-blue-600 w-24 shrink-0" />;
+}
+
+function FrameCoverCard({ coverPosition, dir, label }: FrameCoverCardProps) {
+  return (
+    <section
+      aria-label={label}
+      dir={dir}
+      className="ak-layer ak-frame ak-frame-xl/2 ak-frame-border ak-frame-row flex h-16 w-80"
+    >
+      {coverPosition === "start" && <FrameCover />}
+      <div className="grow" />
+      {coverPosition === "end" && <FrameCover />}
+    </section>
+  );
+}
+
+export default function Example() {
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <FrameCoverCard
+        coverPosition="start"
+        dir="ltr"
+        label="LTR frame row start cover"
+      />
+      <FrameCoverCard
+        coverPosition="start"
+        dir="rtl"
+        label="RTL frame row start cover"
+      />
+      <FrameCoverCard
+        coverPosition="end"
+        dir="ltr"
+        label="LTR frame row end cover"
+      />
+      <FrameCoverCard
+        coverPosition="end"
+        dir="rtl"
+        label="RTL frame row end cover"
+      />
+    </div>
+  );
+}

--- a/app/src/sandbox/ariakit-tailwind-frame-cover-rtl/style.css
+++ b/app/src/sandbox/ariakit-tailwind-frame-cover-rtl/style.css
@@ -1,0 +1,23 @@
+@import "tailwindcss" source(none);
+@import "@ariakit/tailwind";
+
+@source "./index.react.tsx";
+
+@theme {
+  --spacing: 0.25rem;
+  --spacing-px: 1px;
+  --radius: 0.25rem;
+}
+
+@theme inline {
+  --radius-none: 0;
+  --radius-xs: calc(var(--radius) * 0.5);
+  --radius-sm: calc(var(--radius) * 1);
+  --radius-md: calc(var(--radius) * 1.5);
+  --radius-lg: calc(var(--radius) * 2);
+  --radius-xl: calc(var(--radius) * 3);
+  --radius-2xl: calc(var(--radius) * 4);
+  --radius-3xl: calc(var(--radius) * 6);
+  --radius-4xl: calc(var(--radius) * 8);
+  --radius-full: calc(var(--radius) * infinity);
+}

--- a/app/src/sandbox/ariakit-tailwind-frame-cover-rtl/test-chrome.ts
+++ b/app/src/sandbox/ariakit-tailwind-frame-cover-rtl/test-chrome.ts
@@ -1,0 +1,75 @@
+import { expect } from "@playwright/test";
+import type { Locator } from "@playwright/test";
+import { withFramework } from "#app/test-utils/preview.ts";
+
+interface FrameCoverMetrics {
+  borderBottomLeftRadius: string;
+  borderBottomRightRadius: string;
+  borderTopLeftRadius: string;
+  borderTopRightRadius: string;
+  leftGap: number;
+  marginLeft: string;
+  marginRight: string;
+  rightGap: number;
+}
+
+async function getFrameCoverMetrics(frame: Locator) {
+  const cover = frame.locator(".ak-frame-cover");
+  await expect(cover).toBeVisible();
+  return cover.evaluate<FrameCoverMetrics>((element) => {
+    const frame = element.parentElement;
+    if (!frame) {
+      throw new Error("Frame not found");
+    }
+    const coverRect = element.getBoundingClientRect();
+    const frameRect = frame.getBoundingClientRect();
+    const style = getComputedStyle(element);
+    return {
+      borderBottomLeftRadius: style.borderBottomLeftRadius,
+      borderBottomRightRadius: style.borderBottomRightRadius,
+      borderTopLeftRadius: style.borderTopLeftRadius,
+      borderTopRightRadius: style.borderTopRightRadius,
+      leftGap: Math.round(coverRect.left - frameRect.left),
+      marginLeft: style.marginLeft,
+      marginRight: style.marginRight,
+      rightGap: Math.round(frameRect.right - coverRect.right),
+    };
+  });
+}
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("mirrors frame cover stretch in RTL rows", async ({ q }) => {
+    const ltrStart = await getFrameCoverMetrics(
+      q.region("LTR frame row start cover"),
+    );
+    const rtlStart = await getFrameCoverMetrics(
+      q.region("RTL frame row start cover"),
+    );
+    const ltrEnd = await getFrameCoverMetrics(
+      q.region("LTR frame row end cover"),
+    );
+    const rtlEnd = await getFrameCoverMetrics(
+      q.region("RTL frame row end cover"),
+    );
+
+    expect(rtlStart.rightGap).toBe(ltrStart.leftGap);
+    expect(rtlStart.marginRight).toBe(ltrStart.marginLeft);
+    expect(rtlStart.marginLeft).toBe(ltrStart.marginRight);
+    expect(rtlStart.borderTopRightRadius).toBe(ltrStart.borderTopLeftRadius);
+    expect(rtlStart.borderBottomRightRadius).toBe(
+      ltrStart.borderBottomLeftRadius,
+    );
+    expect(rtlStart.borderTopLeftRadius).toBe(ltrStart.borderTopRightRadius);
+    expect(rtlStart.borderBottomLeftRadius).toBe(
+      ltrStart.borderBottomRightRadius,
+    );
+
+    expect(rtlEnd.leftGap).toBe(ltrEnd.rightGap);
+    expect(rtlEnd.marginLeft).toBe(ltrEnd.marginRight);
+    expect(rtlEnd.marginRight).toBe(ltrEnd.marginLeft);
+    expect(rtlEnd.borderTopLeftRadius).toBe(ltrEnd.borderTopRightRadius);
+    expect(rtlEnd.borderBottomLeftRadius).toBe(ltrEnd.borderBottomRightRadius);
+    expect(rtlEnd.borderTopRightRadius).toBe(ltrEnd.borderTopLeftRadius);
+    expect(rtlEnd.borderBottomRightRadius).toBe(ltrEnd.borderBottomLeftRadius);
+  });
+});

--- a/app/src/sandbox/ariakit-tailwind-layer-band-boundaries/index.react.tsx
+++ b/app/src/sandbox/ariakit-tailwind-layer-band-boundaries/index.react.tsx
@@ -1,0 +1,31 @@
+import "./style.css";
+
+export default function Example() {
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <section
+        aria-label="band boundary variants"
+        className="ak-layer ak-frame ak-frame-p-1 ak-frame-border flex-col"
+      >
+        <div className="grid gap-2">
+          <section className="ak-layer ak-layer-l-27.5 p-2">
+            <div className="ak-dark-high:bg-red-950 p-2 text-white">
+              Dark high candidate (layer lightness 0.275)
+            </div>
+            <div className="ak-dark-low:bg-black p-2 text-white">
+              Dark low candidate (layer lightness 0.275)
+            </div>
+          </section>
+          <section className="ak-layer ak-layer-l-85.75 p-2">
+            <div className="ak-light-low:bg-red-950 p-2 text-black">
+              Light low candidate (layer lightness 0.8575)
+            </div>
+            <div className="ak-light-high:bg-black p-2 text-white">
+              Light high candidate (layer lightness 0.8575)
+            </div>
+          </section>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/src/sandbox/ariakit-tailwind-layer-band-boundaries/index.react.tsx
+++ b/app/src/sandbox/ariakit-tailwind-layer-band-boundaries/index.react.tsx
@@ -5,7 +5,7 @@ export default function Example() {
     <div className="flex flex-col gap-4 p-4">
       <section
         aria-label="band boundary variants"
-        className="ak-layer ak-frame ak-frame-p-1 ak-frame-border flex-col"
+        className="ak-layer ak-frame ak-frame-p-1 ak-frame-border"
       >
         <div className="grid gap-2">
           <section className="ak-layer ak-layer-l-27.5 p-2">

--- a/app/src/sandbox/ariakit-tailwind-layer-band-boundaries/style.css
+++ b/app/src/sandbox/ariakit-tailwind-layer-band-boundaries/style.css
@@ -1,0 +1,23 @@
+@import "tailwindcss" source(none);
+@import "@ariakit/tailwind";
+
+@source "./index.react.tsx";
+
+@theme {
+  --spacing: 0.25rem;
+  --spacing-px: 1px;
+  --radius: 0.25rem;
+}
+
+@theme inline {
+  --radius-none: 0;
+  --radius-xs: calc(var(--radius) * 0.5);
+  --radius-sm: calc(var(--radius) * 1);
+  --radius-md: calc(var(--radius) * 1.5);
+  --radius-lg: calc(var(--radius) * 2);
+  --radius-xl: calc(var(--radius) * 3);
+  --radius-2xl: calc(var(--radius) * 4);
+  --radius-3xl: calc(var(--radius) * 6);
+  --radius-4xl: calc(var(--radius) * 8);
+  --radius-full: calc(var(--radius) * infinity);
+}

--- a/app/src/sandbox/ariakit-tailwind-layer-band-boundaries/test-chrome.ts
+++ b/app/src/sandbox/ariakit-tailwind-layer-band-boundaries/test-chrome.ts
@@ -1,0 +1,23 @@
+import { expect } from "@playwright/test";
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("matches exactly one layer band at lightness boundaries", async ({
+    q,
+  }) => {
+    const transparent = "rgba(0, 0, 0, 0)";
+
+    await expect(
+      q.text("Dark high candidate (layer lightness 0.275)"),
+    ).toHaveCSS("background-color", transparent);
+    await expect(
+      q.text("Dark low candidate (layer lightness 0.275)"),
+    ).toHaveCSS("background-color", "rgb(0, 0, 0)");
+    await expect(
+      q.text("Light low candidate (layer lightness 0.8575)"),
+    ).toHaveCSS("background-color", transparent);
+    await expect(
+      q.text("Light high candidate (layer lightness 0.8575)"),
+    ).toHaveCSS("background-color", "rgb(0, 0, 0)");
+  });
+});

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/dark
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/dark
@@ -49,13 +49,6 @@
       "#165DFC": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(57.033_80_288.704)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
       "raw calc": "bg-[oklch(0.4268_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(84.1828_3.43_266.444)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
       "raw l/c": "bg-[oklch(0.5096_0.18_264.28)] text-[oklch(1_0_0)] *:text-[lch(97.3245_20_284.288)] rounded-[15px] border-[1px] border-[oklch(1_0.18_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.18_264.28_/_0.1)_0px_0px_0px_0px]",
-      "band boundary variants": {
-        "class": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-        "children": {
-          "ak-layer-l-27.5": "bg-[oklch(0.275_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[rgb(255,_255,_255)] p-[8px]",
-          "ak-layer-l-85.75": "bg-[oklch(0.8575_0.0091_264.28)] text-[oklch(0_0_0)] p-[8px]"
-        }
-      },
       "ak-layer ak-text": "text-[lch(57.033_80_288.648)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
       "raw ink/edge": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0_/_0.4969)] *:text-[lch(57.033_2.32_268.203)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.35)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.35)_0px_0px_0px_0px]",
       "layer limits": {

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
@@ -49,13 +49,6 @@
       "#165DFC": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(100_80_288.704)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
       "raw calc": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(100_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
       "raw l/c": "bg-[oklch(0.2_0.18_264.28)] text-[oklch(1_0_0)] *:text-[lch(100_79.92_306.787)] rounded-[15px] border-[1px] border-[oklch(1_0.18_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.18_264.28_/_0.4334)_0px_0px_0px_0px]",
-      "band boundary variants": {
-        "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-        "children": {
-          "ak-layer-l-27.5": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[rgb(255,_255,_255)] p-[8px]",
-          "ak-layer-l-85.75": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] p-[8px]"
-        }
-      },
       "ak-layer ak-text": "text-[lch(100_80_288.648)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
       "raw ink/edge": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(100_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.6834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.6834)_0px_0px_0px_0px]",
       "layer limits": {

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/light
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/light
@@ -49,13 +49,6 @@
       "#165DFC": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(43.4424_80_288.704)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
       "raw calc": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(55.2119_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
       "raw l/c": "bg-[oklch(0.5096_0.18_197.14)] text-[oklch(1_0_0)] *:text-[lch(100_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.18_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.18_197.14_/_0.1)_0px_0px_0px_0px]",
-      "band boundary variants": {
-        "class": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-        "children": {
-          "ak-layer-l-27.5": "bg-[oklch(0.275_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[rgb(255,_255,_255)] p-[8px]",
-          "ak-layer-l-85.75": "bg-[oklch(0.8575_0.0011_197.14)] text-[oklch(0_0_0)] p-[8px]"
-        }
-      },
       "ak-layer ak-text": "text-[lch(43.4424_80_288.648)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
       "raw ink/edge": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0_/_0.5418)] *:text-[lch(43.4424_0.38_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.35)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.35)_0px_0px_0px_0px]",
       "layer limits": {

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
@@ -49,13 +49,6 @@
       "#165DFC": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_80_288.704)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
       "raw calc": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(100_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
       "raw l/c": "bg-[oklch(0.2_0.18_197.14)] text-[oklch(1_0_0)] *:text-[lch(100_37.79_209.46)] rounded-[15px] border-[1px] border-[oklch(0_0.18_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.18_197.14_/_0.4334)_0px_0px_0px_0px]",
-      "band boundary variants": {
-        "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-        "children": {
-          "ak-layer-l-27.5": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[rgb(255,_255,_255)] p-[8px]",
-          "ak-layer-l-85.75": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] p-[8px]"
-        }
-      },
       "ak-layer ak-text": "text-[lch(0_80_288.648)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
       "raw ink/edge": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_0.38_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.6834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.6834)_0px_0px_0px_0px]",
       "layer limits": {

--- a/app/src/sandbox/ariakit-tailwind/index.react.tsx
+++ b/app/src/sandbox/ariakit-tailwind/index.react.tsx
@@ -45,30 +45,6 @@ function Cell(props: CellProps) {
   );
 }
 
-interface FrameCoverCardProps {
-  coverPosition: "start" | "end";
-  dir: "ltr" | "rtl";
-  label: string;
-}
-
-function FrameCover() {
-  return <div className="ak-frame-cover ak-layer-blue-600 w-24 shrink-0" />;
-}
-
-function FrameCoverCard({ coverPosition, dir, label }: FrameCoverCardProps) {
-  return (
-    <section
-      aria-label={label}
-      dir={dir}
-      className="ak-layer ak-frame ak-frame-xl/2 ak-frame-border ak-frame-row flex h-16 w-80"
-    >
-      {coverPosition === "start" && <FrameCover />}
-      <div className="grow" />
-      {coverPosition === "end" && <FrameCover />}
-    </section>
-  );
-}
-
 function Layers() {
   return (
     <>
@@ -298,26 +274,6 @@ function Layers() {
 export default function Example() {
   return (
     <div className="flex flex-col gap-4 p-4">
-      <FrameCoverCard
-        coverPosition="start"
-        dir="ltr"
-        label="LTR frame row start cover"
-      />
-      <FrameCoverCard
-        coverPosition="start"
-        dir="rtl"
-        label="RTL frame row start cover"
-      />
-      <FrameCoverCard
-        coverPosition="end"
-        dir="ltr"
-        label="LTR frame row end cover"
-      />
-      <FrameCoverCard
-        coverPosition="end"
-        dir="rtl"
-        label="RTL frame row end cover"
-      />
       <Layer
         label="edge inherit root no source"
         className="ak-layer ak-layer-20 ak-edge-inherit ak-frame ak-frame-p-1 ak-frame-border"
@@ -448,29 +404,6 @@ export default function Example() {
             label="raw l/c"
             className="ak-layer-l-[0.62] ak-layer-c-[0.18] *:ak-text"
           />
-          <Layer
-            label="band boundary variants"
-            className="ak-layer ak-frame ak-frame-p-1 ak-frame-border flex-col"
-          >
-            <Layer className="grid gap-2">
-              <Layer className="ak-layer ak-layer-l-27.5 p-2">
-                <div className="ak-dark-high:bg-red-950 p-2 text-white">
-                  Dark high candidate (layer lightness 0.275)
-                </div>
-                <div className="ak-dark-low:bg-black p-2 text-white">
-                  Dark low candidate (layer lightness 0.275)
-                </div>
-              </Layer>
-              <Layer className="ak-layer ak-layer-l-85.75 p-2">
-                <div className="ak-light-low:bg-red-950 p-2 text-black">
-                  Light low candidate (layer lightness 0.8575)
-                </div>
-                <div className="ak-light-high:bg-black p-2 text-white">
-                  Light high candidate (layer lightness 0.8575)
-                </div>
-              </Layer>
-            </Layer>
-          </Layer>
           <Layer
             label="ak-layer ak-text"
             className="ak-layer ak-layer-80 ak-text ak-text-blue-600 ak-frame ak-frame-p-1 ak-frame-border"

--- a/app/src/sandbox/ariakit-tailwind/test-chrome.ts
+++ b/app/src/sandbox/ariakit-tailwind/test-chrome.ts
@@ -1,20 +1,9 @@
 import { AxeBuilder } from "@axe-core/playwright";
 import { expect } from "@playwright/test";
-import type { Locator, Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { withFramework } from "#app/test-utils/preview.ts";
 
 type ColorContrastViolationMap = Record<string, string>;
-
-interface FrameCoverMetrics {
-  borderBottomLeftRadius: string;
-  borderBottomRightRadius: string;
-  borderTopLeftRadius: string;
-  borderTopRightRadius: string;
-  leftGap: number;
-  marginLeft: string;
-  marginRight: string;
-  rightGap: number;
-}
 
 interface AxeViolation {
   nodes: AxeViolationNode[];
@@ -573,88 +562,7 @@ async function waitForPreviewReady(page: Page) {
   });
 }
 
-async function getFrameCoverMetrics(frame: Locator) {
-  const cover = frame.locator(".ak-frame-cover");
-  await expect(cover).toBeVisible();
-  return cover.evaluate<FrameCoverMetrics>((element) => {
-    const frame = element.parentElement;
-    if (!frame) {
-      throw new Error("Frame not found");
-    }
-    const coverRect = element.getBoundingClientRect();
-    const frameRect = frame.getBoundingClientRect();
-    const style = getComputedStyle(element);
-    return {
-      borderBottomLeftRadius: style.borderBottomLeftRadius,
-      borderBottomRightRadius: style.borderBottomRightRadius,
-      borderTopLeftRadius: style.borderTopLeftRadius,
-      borderTopRightRadius: style.borderTopRightRadius,
-      leftGap: Math.round(coverRect.left - frameRect.left),
-      marginLeft: style.marginLeft,
-      marginRight: style.marginRight,
-      rightGap: Math.round(frameRect.right - coverRect.right),
-    };
-  });
-}
-
 withFramework(import.meta.dirname, async ({ test }) => {
-  test("mirrors frame cover stretch in RTL rows", async ({ page, q }) => {
-    await waitForPreviewReady(page);
-    const ltrStart = await getFrameCoverMetrics(
-      q.region("LTR frame row start cover"),
-    );
-    const rtlStart = await getFrameCoverMetrics(
-      q.region("RTL frame row start cover"),
-    );
-    const ltrEnd = await getFrameCoverMetrics(
-      q.region("LTR frame row end cover"),
-    );
-    const rtlEnd = await getFrameCoverMetrics(
-      q.region("RTL frame row end cover"),
-    );
-
-    expect(rtlStart.rightGap).toBe(ltrStart.leftGap);
-    expect(rtlStart.marginRight).toBe(ltrStart.marginLeft);
-    expect(rtlStart.marginLeft).toBe(ltrStart.marginRight);
-    expect(rtlStart.borderTopRightRadius).toBe(ltrStart.borderTopLeftRadius);
-    expect(rtlStart.borderBottomRightRadius).toBe(
-      ltrStart.borderBottomLeftRadius,
-    );
-    expect(rtlStart.borderTopLeftRadius).toBe(ltrStart.borderTopRightRadius);
-    expect(rtlStart.borderBottomLeftRadius).toBe(
-      ltrStart.borderBottomRightRadius,
-    );
-
-    expect(rtlEnd.leftGap).toBe(ltrEnd.rightGap);
-    expect(rtlEnd.marginLeft).toBe(ltrEnd.marginRight);
-    expect(rtlEnd.marginRight).toBe(ltrEnd.marginLeft);
-    expect(rtlEnd.borderTopLeftRadius).toBe(ltrEnd.borderTopRightRadius);
-    expect(rtlEnd.borderBottomLeftRadius).toBe(ltrEnd.borderBottomRightRadius);
-    expect(rtlEnd.borderTopRightRadius).toBe(ltrEnd.borderTopLeftRadius);
-    expect(rtlEnd.borderBottomRightRadius).toBe(ltrEnd.borderBottomLeftRadius);
-  });
-
-  test("matches exactly one layer band at lightness boundaries", async ({
-    page,
-    q,
-  }) => {
-    await waitForPreviewReady(page);
-    const transparent = "rgba(0, 0, 0, 0)";
-
-    await expect(
-      q.text("Dark high candidate (layer lightness 0.275)"),
-    ).toHaveCSS("background-color", transparent);
-    await expect(
-      q.text("Dark low candidate (layer lightness 0.275)"),
-    ).toHaveCSS("background-color", "rgb(0, 0, 0)");
-    await expect(
-      q.text("Light low candidate (layer lightness 0.8575)"),
-    ).toHaveCSS("background-color", transparent);
-    await expect(
-      q.text("Light high candidate (layer lightness 0.8575)"),
-    ).toHaveCSS("background-color", "rgb(0, 0, 0)");
-  });
-
   for (const scheme of ["light", "dark"] as const) {
     test.describe(`${scheme} scheme`, () => {
       test.use({ colorScheme: scheme });

--- a/app/src/styles/global.css
+++ b/app/src/styles/global.css
@@ -10,9 +10,7 @@
 @import "./ariakit.css";
 
 @source not "./styles.json";
-@source not "../sandbox/ariakit-tailwind";
-@source not "../sandbox/ariakit-tailwind-frame-cover-rtl";
-@source not "../sandbox/ariakit-tailwind-layer-band-boundaries";
+@source not "../sandbox/ariakit-tailwind*";
 
 @theme {
   --color-canvas: oklch(99.33% 0.0011 197.14);

--- a/app/src/styles/global.css
+++ b/app/src/styles/global.css
@@ -11,6 +11,8 @@
 
 @source not "./styles.json";
 @source not "../sandbox/ariakit-tailwind";
+@source not "../sandbox/ariakit-tailwind-frame-cover-rtl";
+@source not "../sandbox/ariakit-tailwind-layer-band-boundaries";
 
 @theme {
   --color-canvas: oklch(99.33% 0.0011 197.14);


### PR DESCRIPTION
## Motivation

The `ariakit-tailwind` sandbox currently mixes the broad computed-style snapshot matrix with a couple of behavior-specific checks. That makes the main sandbox larger than it needs to be for snapshot and perf coverage, and it hides focused regressions inside an omnibus fixture.

## Solution

Move the two behavior-specific checks into focused sandboxes:

- `ariakit-tailwind-frame-cover-rtl` covers RTL `ak-frame-cover` row geometry.
- `ariakit-tailwind-layer-band-boundaries` covers exact layer-band boundary variant matching.

The main `ariakit-tailwind` sandbox now keeps the WCAG and computed-style snapshot matrix, with snapshots updated to drop the moved band-boundary subtree. The app global Tailwind source exclusions also include the new focused sandboxes so their test-only `@ariakit/tailwind` utilities stay isolated to their local `style.css` files.

## Testing

- `APP_PORT=4321 NEXTJS_PORT=3000 pnpm -F app test-chrome ariakit-tailwind`
- `pnpm lint-fix`
- `pnpm tsc`
- `git diff --check`
