### PR TITLE
Fix Solid Group aria-label precedence

### DIFF
--- a/.changeset/300-solid-group-aria-label.md
+++ b/.changeset/300-solid-group-aria-label.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/solid-components": patch
+"@ariakit/solid": patch
+---
+
+Fixed [`Group`](https://ariakit.com/reference/group) to ignore its internal [`GroupLabel`](https://ariakit.com/reference/group-label) reference when `aria-label` is passed.

--- a/app/src/sandbox/group-6327/index.solid.tsx
+++ b/app/src/sandbox/group-6327/index.solid.tsx
@@ -3,8 +3,7 @@ import * as Ariakit from "@ariakit/solid";
 export default function Example() {
   return (
     <Ariakit.Group aria-label="Audio playback settings">
-      {/* TODO: Use GroupLabel after https://github.com/ariakit/ariakit/issues/6327 is fixed. */}
-      <div aria-hidden>Audio</div>
+      <Ariakit.GroupLabel>Audio</Ariakit.GroupLabel>
       <button type="button">Mute</button>
       <button type="button">Boost</button>
     </Ariakit.Group>

--- a/app/src/sandbox/group-6327/index.solid.tsx
+++ b/app/src/sandbox/group-6327/index.solid.tsx
@@ -2,10 +2,19 @@ import * as Ariakit from "@ariakit/solid";
 
 export default function Example() {
   return (
-    <Ariakit.Group aria-label="Audio playback settings">
-      <Ariakit.GroupLabel>Audio</Ariakit.GroupLabel>
-      <button type="button">Mute</button>
-      <button type="button">Boost</button>
-    </Ariakit.Group>
+    <>
+      <Ariakit.Group aria-label="Audio playback settings">
+        <Ariakit.GroupLabel>Audio</Ariakit.GroupLabel>
+        <button type="button">Mute</button>
+        <button type="button">Boost</button>
+      </Ariakit.Group>
+      <Ariakit.Group
+        aria-label="Audio playback settings"
+        aria-labelledby="explicit-group-label"
+      >
+        <Ariakit.GroupLabel>Audio</Ariakit.GroupLabel>
+        <span id="explicit-group-label">Explicit playback settings</span>
+      </Ariakit.Group>
+    </>
   );
 }

--- a/app/src/sandbox/group-6327/index.solid.tsx
+++ b/app/src/sandbox/group-6327/index.solid.tsx
@@ -1,0 +1,11 @@
+import * as Ariakit from "@ariakit/solid";
+
+export default function Example() {
+  return (
+    <Ariakit.Group aria-label="Audio playback settings">
+      <Ariakit.GroupLabel>Audio</Ariakit.GroupLabel>
+      <button type="button">Mute</button>
+      <button type="button">Boost</button>
+    </Ariakit.Group>
+  );
+}

--- a/app/src/sandbox/group-6327/index.solid.tsx
+++ b/app/src/sandbox/group-6327/index.solid.tsx
@@ -3,7 +3,8 @@ import * as Ariakit from "@ariakit/solid";
 export default function Example() {
   return (
     <Ariakit.Group aria-label="Audio playback settings">
-      <Ariakit.GroupLabel>Audio</Ariakit.GroupLabel>
+      {/* TODO: Use GroupLabel after https://github.com/ariakit/ariakit/issues/6327 is fixed. */}
+      <div aria-hidden>Audio</div>
       <button type="button">Mute</button>
       <button type="button">Boost</button>
     </Ariakit.Group>

--- a/app/src/sandbox/group-6327/test-browser.ts
+++ b/app/src/sandbox/group-6327/test-browser.ts
@@ -1,0 +1,15 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // See https://github.com/ariakit/ariakit/issues/6327
+  test("uses aria-label instead of GroupLabel for the group name", async ({
+    q,
+  }) => {
+    const group = q.group("Audio playback settings");
+    await test.expect(group).toBeVisible();
+    await test
+      .expect(group)
+      .toHaveAttribute("aria-label", "Audio playback settings");
+    await test.expect(group).not.toHaveAttribute("aria-labelledby");
+  });
+});

--- a/app/src/sandbox/group-6327/test-browser.ts
+++ b/app/src/sandbox/group-6327/test-browser.ts
@@ -12,4 +12,17 @@ withFramework(import.meta.dirname, async ({ test }) => {
       .toHaveAttribute("aria-label", "Audio playback settings");
     await test.expect(group).not.toHaveAttribute("aria-labelledby");
   });
+
+  test("preserves explicit aria-labelledby when aria-label is passed", async ({
+    q,
+  }) => {
+    const group = q.group("Explicit playback settings");
+    await test.expect(group).toBeVisible();
+    await test
+      .expect(group)
+      .toHaveAttribute("aria-label", "Audio playback settings");
+    await test
+      .expect(group)
+      .toHaveAttribute("aria-labelledby", "explicit-group-label");
+  });
 });

--- a/app/src/sandbox/group-6327/test.ts
+++ b/app/src/sandbox/group-6327/test.ts
@@ -7,3 +7,9 @@ test("uses aria-label instead of GroupLabel for the group name", () => {
   expect(group).toHaveAttribute("aria-label", "Audio playback settings");
   expect(group).not.toHaveAttribute("aria-labelledby");
 });
+
+test("preserves explicit aria-labelledby when aria-label is passed", () => {
+  const group = q.group.ensure("Explicit playback settings");
+  expect(group).toHaveAttribute("aria-label", "Audio playback settings");
+  expect(group).toHaveAttribute("aria-labelledby", "explicit-group-label");
+});

--- a/app/src/sandbox/group-6327/test.ts
+++ b/app/src/sandbox/group-6327/test.ts
@@ -1,0 +1,9 @@
+import { q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// See https://github.com/ariakit/ariakit/issues/6327
+test("uses aria-label instead of GroupLabel for the group name", () => {
+  const group = q.group.ensure("Audio playback settings");
+  expect(group).toHaveAttribute("aria-label", "Audio playback settings");
+  expect(group).not.toHaveAttribute("aria-labelledby");
+});

--- a/packages/ariakit-solid-components/src/group/group.tsx
+++ b/packages/ariakit-solid-components/src/group/group.tsx
@@ -35,7 +35,7 @@ export const useGroup = createHook<TagName, GroupOptions>(
       {
         role: "group" as const,
         get "aria-labelledby"() {
-          return labelId();
+          return props["aria-label"] != null ? undefined : labelId();
         },
       },
       props,


### PR DESCRIPTION
## Motivation

In `@ariakit/solid`, `Group` still rendered the internal `aria-labelledby` from `GroupLabel` when a developer passed an explicit `aria-label`. Because `aria-labelledby` takes precedence in the accessible name computation, the explicit `aria-label` was ignored.

Fixes #6327.

## Solution

Add a Solid regression sandbox under `app/src/sandbox/group-6327` with both browser and happy-dom coverage for the accessible name behavior.

Update Solid `Group` so its internal `aria-labelledby` getter returns `undefined` whenever `aria-label` is present. This mirrors the existing React behavior and keeps the check reactive while still allowing a user-supplied `aria-labelledby` prop to win through the existing `mergeProps` order.

## Workaround

Until the fix is released, avoid combining `GroupLabel` with an explicit `aria-label` on Solid `Group`. Render the visible label as an `aria-hidden` element instead so it does not register an internal `aria-labelledby` value.

```tsx
<Ariakit.Group aria-label="Audio playback settings">
  {/* TODO: Remove after https://github.com/ariakit/ariakit/issues/6327 is fixed. */}
  <div aria-hidden>Audio</div>
  <button type="button">Mute</button>
  <button type="button">Boost</button>
</Ariakit.Group>
```
