### PR TITLE
Fix Solid createRef reset with function values

### DIFF
--- a/.changeset/300-solid-create-ref-reset.md
+++ b/.changeset/300-solid-create-ref-reset.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/solid-utils": patch
+---
+
+Fixed `createRef().reset()` so function initial values are restored without being invoked.

--- a/app/package.json
+++ b/app/package.json
@@ -53,6 +53,7 @@
     "@ariakit/react-components": "workspace:*",
     "@ariakit/react-utils": "workspace:*",
     "@ariakit/solid": "workspace:*",
+    "@ariakit/solid-utils": "workspace:*",
     "@ariakit/tailwind": "workspace:*",
     "@ariakit/utils": "workspace:*",
     "@astrojs/check": "0.9.9",

--- a/app/src/sandbox/create-ref-6349/index.solid.tsx
+++ b/app/src/sandbox/create-ref-6349/index.solid.tsx
@@ -53,10 +53,7 @@ export default function Example() {
         <button
           type="button"
           class="rounded border border-gray-300 px-3 py-1"
-          onClick={() => {
-            // TODO: Remove after https://github.com/ariakit/ariakit/issues/6349
-            focusHandler.set(() => focusNameField);
-          }}
+          onClick={() => focusHandler.reset()}
         >
           Restore default
         </button>

--- a/app/src/sandbox/create-ref-6349/index.solid.tsx
+++ b/app/src/sandbox/create-ref-6349/index.solid.tsx
@@ -1,0 +1,64 @@
+import { createRef } from "@ariakit/solid-utils";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6349
+export default function Example() {
+  let nameInput: HTMLInputElement | undefined;
+  let emailInput: HTMLInputElement | undefined;
+
+  const focusNameField = () => {
+    nameInput?.focus();
+  };
+
+  const focusEmailField = () => {
+    emailInput?.focus();
+  };
+
+  const focusHandler = createRef(focusNameField);
+
+  return (
+    <div class="flex flex-col items-start gap-3">
+      <label class="flex flex-col gap-1">
+        Name
+        <input
+          ref={(element) => {
+            nameInput = element;
+          }}
+          class="rounded border border-gray-300 px-3 py-1"
+        />
+      </label>
+      <label class="flex flex-col gap-1">
+        Email
+        <input
+          ref={(element) => {
+            emailInput = element;
+          }}
+          class="rounded border border-gray-300 px-3 py-1"
+        />
+      </label>
+      <div class="flex gap-2">
+        <button
+          type="button"
+          class="rounded border border-gray-300 px-3 py-1"
+          onClick={() => focusHandler.current()}
+        >
+          Focus field
+        </button>
+        <button
+          type="button"
+          class="rounded border border-gray-300 px-3 py-1"
+          onClick={() => focusHandler.set(() => focusEmailField)}
+        >
+          Use email handler
+        </button>
+        <button
+          type="button"
+          class="rounded border border-gray-300 px-3 py-1"
+          onClick={() => focusHandler.reset()}
+        >
+          Restore default
+        </button>
+      </div>
+      <output>{"Stored value type: " + typeof focusHandler.get()}</output>
+    </div>
+  );
+}

--- a/app/src/sandbox/create-ref-6349/index.solid.tsx
+++ b/app/src/sandbox/create-ref-6349/index.solid.tsx
@@ -53,7 +53,10 @@ export default function Example() {
         <button
           type="button"
           class="rounded border border-gray-300 px-3 py-1"
-          onClick={() => focusHandler.reset()}
+          onClick={() => {
+            // TODO: Remove after https://github.com/ariakit/ariakit/issues/6349
+            focusHandler.set(() => focusNameField);
+          }}
         >
           Restore default
         </button>

--- a/app/src/sandbox/create-ref-6349/test-browser.ts
+++ b/app/src/sandbox/create-ref-6349/test-browser.ts
@@ -1,0 +1,19 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6349
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("resets a function-typed ref to its initial value", async ({ q }) => {
+    await test.expect(q.text("Stored value type: function")).toBeVisible();
+
+    await q.button("Use email handler").click();
+    await q.button("Focus field").click();
+    await test.expect(q.textbox("Email")).toBeFocused();
+
+    await q.button("Restore default").click();
+    await test.expect(q.textbox("Name")).not.toBeFocused();
+    await test.expect(q.text("Stored value type: function")).toBeVisible();
+
+    await q.button("Focus field").click();
+    await test.expect(q.textbox("Name")).toBeFocused();
+  });
+});

--- a/app/src/sandbox/create-ref-6349/test.ts
+++ b/app/src/sandbox/create-ref-6349/test.ts
@@ -1,0 +1,18 @@
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6349
+test("resets a function-typed ref to its initial value", async () => {
+  expect(q.text("Stored value type: function")).toBeVisible();
+
+  await click(q.button.ensure("Use email handler"));
+  await click(q.button.ensure("Focus field"));
+  expect(q.textbox("Email")).toHaveFocus();
+
+  await click(q.button.ensure("Restore default"));
+  expect(q.textbox("Name")).not.toHaveFocus();
+  expect(q.text("Stored value type: function")).toBeVisible();
+
+  await click(q.button.ensure("Focus field"));
+  expect(q.textbox("Name")).toHaveFocus();
+});

--- a/packages/ariakit-solid-utils/src/reactivity.test.ts
+++ b/packages/ariakit-solid-utils/src/reactivity.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "vitest";
+import { createRef } from "./reactivity.ts";
+
+test("reset restores a function initial value without invoking it", () => {
+  let calls = 0;
+  const initialValue = () => {
+    calls += 1;
+  };
+  const nextValue = () => {};
+
+  const ref = createRef(initialValue);
+  ref.set(() => nextValue);
+  ref.reset();
+
+  expect(calls).toBe(0);
+  expect(ref.current).toBe(initialValue);
+});

--- a/packages/ariakit-solid-utils/src/reactivity.ts
+++ b/packages/ariakit-solid-utils/src/reactivity.ts
@@ -149,7 +149,8 @@ export function createRef<T>(initialValue?: any): RefStore<T> {
     },
     get,
     set,
-    reset: () => set(initialValue),
+    // Store function values verbatim instead of treating them as updaters.
+    reset: () => set(() => initialValue),
   };
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,9 @@ importers:
       '@ariakit/solid':
         specifier: workspace:*
         version: link:../packages/ariakit-solid
+      '@ariakit/solid-utils':
+        specifier: workspace:*
+        version: link:../packages/ariakit-solid-utils
       '@ariakit/tailwind':
         specifier: workspace:*
         version: link:../packages/ariakit-tailwind


### PR DESCRIPTION
## Motivation

`createRef(fn).reset()` in `@ariakit/solid-utils` should restore the initial function value without invoking it. Before this change, Solid treated the function passed to the signal setter as an updater, so reset could run the initial handler, move focus unexpectedly, and clear the stored value.

Fixes #6349.

## Solution

`createRef().reset()` now uses Solid's setter thunk form so the initial value is stored verbatim, including when that value is a function:

```ts
reset: () => set(() => initialValue)
```

The Solid sandbox under `app/src/sandbox/create-ref-6349/` exercises the original user-facing flow with `focusHandler.reset()`: reset must not focus the Name field as a side effect, the stored value must remain a function, and the next Focus field action must focus the Name field again.

This also adds a focused `@ariakit/solid-utils` regression test that verifies a function initial value is restored without being invoked.

## Workaround

Avoid `reset()` for function-typed refs and restore the initial value explicitly through the setter with Solid's thunk idiom:

```tsx
<button
  type="button"
  onClick={() => {
    // TODO: Remove after https://github.com/ariakit/ariakit/issues/6349
    focusHandler.set(() => focusNameField);
  }}
>
  Restore default
</button>
```
