### PR TITLE
Isolate app check Vite cache

### DIFF
--- a/app/astro.config.ts
+++ b/app/astro.config.ts
@@ -35,6 +35,7 @@ try {
 
 const port = Number(process.env.APP_PORT) || 4321;
 const hasClerk = process.env.PUBLIC_CLERK_PUBLISHABLE_KEY;
+const viteCacheDir = process.env.APP_VITE_CACHE_DIR;
 
 // https://astro.build/config
 export default defineConfig({
@@ -68,6 +69,7 @@ export default defineConfig({
   },
 
   vite: {
+    cacheDir: viteCacheDir,
     build: {
       // Perf CI enables this so CDP script profiles can resolve source maps.
       sourcemap: process.env.PERF_SOURCE_MAP === "true",

--- a/app/astro.config.ts
+++ b/app/astro.config.ts
@@ -69,6 +69,11 @@ export default defineConfig({
   },
 
   vite: {
+    // TODO: Remove this workaround once Astro isolates optimizer cache writes
+    // across dev and check commands. Running `astro check` while `astro dev`
+    // is active shares Vite's optimized deps cache, so the checker uses a
+    // separate cache directory to avoid invalidating the dev server's optimized
+    // SSR modules.
     cacheDir: viteCacheDir,
     build: {
       // Perf CI enables this so CDP script profiles can resolve source maps.
@@ -79,7 +84,7 @@ export default defineConfig({
       sourcePlugin(join(import.meta.dirname, "src/examples/")),
     ],
     // TODO: Remove this workaround once
-    // https://github.com/withastro/astro/issues/16853 is fixed. These bare
+    // https://github.com/withastro/astro/issues/17166 is fixed. These bare
     // specifiers are missed by the SSR dependency optimizer's initial scan.
     // Some are re-exported from Astro virtual modules (astro:transitions,
     // astro:actions); others are imported directly (astro/zod in

--- a/app/package.json
+++ b/app/package.json
@@ -17,7 +17,7 @@
     "dev-stripe": "concurrently -k -r 'pnpm:dev' 'pnpm:listen-*'",
     "dev-stripe-lite": "concurrently -k -r 'pnpm:dev-lite' 'pnpm:listen-*'",
     "wrangler-types": "wrangler types",
-    "check": "pnpm run wrangler-types && astro check",
+    "check": "pnpm run wrangler-types && cross-env APP_VITE_CACHE_DIR=node_modules/.vite-check astro check",
     "build": "astro build",
     "build-lite": "cross-env DISABLE_REFERENCE_LINKS=true pnpm run build",
     "build-min": "cross-env DISABLE_SYNTAX_HIGHLIGHTING=true pnpm run build-lite",


### PR DESCRIPTION
## Motivation

Running `pnpm tsc` while `pnpm dev-app` is serving the app can corrupt the live dev server's Vite optimized dependency cache. The `tsc` script runs `pnpm -F app run check`, and `astro check` uses the same default `app/node_modules/.vite` cache as `astro dev`.

When the checker re-optimizes dependencies during an active dev request, the dev server can keep references to files that were replaced, causing repeated errors like missing `deps_ssr` files and blank preview pages in Playwright.

## Solution

Expose an app-specific `APP_VITE_CACHE_DIR` environment hook in `astro.config.ts` and run `astro check` with `APP_VITE_CACHE_DIR=node_modules/.vite-check`.

This keeps normal dev/build commands on the default Vite cache while isolating check-time optimizer output from a live `pnpm dev-app` session. The fix is scoped to the reported `dev-app` plus `pnpm tsc` collision, and direct `pnpm -F app run check` now gets the same isolated cache as the root `pnpm tsc` flow.

## Verification

- `pnpm lint-fix`
- Reproduced the original failure before the fix with `APP_PORT=4324 NEXTJS_PORT=3003 pnpm dev-app`, then concurrent `pnpm tsc` and `APP_PORT=4324 NEXTJS_PORT=3003 pnpm -F app test-chrome ariakit-tailwind`: the dev server logged repeated missing `app/node_modules/.vite/deps_ssr/...` errors and the focused Chrome run failed with empty/missing preview DOM.
- Re-ran the same concurrent scenario after the fix from a clean app Vite cache: `pnpm tsc` passed, `APP_PORT=4324 NEXTJS_PORT=3003 pnpm -F app test-chrome ariakit-tailwind` passed 8/8, and the dev server did not log missing optimized dependency errors.
