### PR TITLE
Fix TagInput string delimiter matching

### DIFF
--- a/.changeset/300-tag-input-string-delimiters.md
+++ b/.changeset/300-tag-input-string-delimiters.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/react-components": patch
+---
+
+Fixed `TagInput` string delimiters with regex metacharacters so they're matched literally and don't freeze, throw, or fail to split tags.

--- a/app/src/sandbox/tag-input-6333/index.react.tsx
+++ b/app/src/sandbox/tag-input-6333/index.react.tsx
@@ -1,0 +1,42 @@
+import { Tag } from "@ariakit/react-components/tag/tag";
+import { TagInput } from "@ariakit/react-components/tag/tag-input";
+import { TagList } from "@ariakit/react-components/tag/tag-list";
+import { TagListLabel } from "@ariakit/react-components/tag/tag-list-label";
+import { TagProvider } from "@ariakit/react-components/tag/tag-provider";
+import { useId, useState } from "react";
+
+interface TagFieldProps {
+  label: string;
+  delimiter: string;
+}
+
+function TagField({ label, delimiter }: TagFieldProps) {
+  const [values, setValues] = useState<string[]>([]);
+  const statusId = useId();
+
+  return (
+    <TagProvider values={values} setValues={setValues}>
+      <TagListLabel>{label}</TagListLabel>
+      <TagList aria-describedby={statusId}>
+        {values.map((value) => (
+          <Tag key={value} value={value}>
+            {value}
+          </Tag>
+        ))}
+        <TagInput delimiter={delimiter} aria-label={label} />
+      </TagList>
+      <output id={statusId}>
+        {label} values: {values.length ? values.join(", ") : "none"}
+      </output>
+    </TagProvider>
+  );
+}
+
+export default function Example() {
+  return (
+    <div style={{ display: "grid", gap: 16, padding: 16 }}>
+      <TagField label="Dot tags" delimiter="." />
+      <TagField label="Plus tags" delimiter="+" />
+    </div>
+  );
+}

--- a/app/src/sandbox/tag-input-6333/index.react.tsx
+++ b/app/src/sandbox/tag-input-6333/index.react.tsx
@@ -7,7 +7,7 @@ import { useId, useState } from "react";
 
 interface TagFieldProps {
   label: string;
-  delimiter: string;
+  delimiter: string | RegExp;
 }
 
 function TagField({ label, delimiter }: TagFieldProps) {
@@ -35,8 +35,8 @@ function TagField({ label, delimiter }: TagFieldProps) {
 export default function Example() {
   return (
     <div style={{ display: "grid", gap: 16, padding: 16 }}>
-      <TagField label="Dot tags" delimiter="." />
-      <TagField label="Plus tags" delimiter="+" />
+      <TagField label="Dot tags" delimiter={/\./} />
+      <TagField label="Plus tags" delimiter={/[+]/} />
     </div>
   );
 }

--- a/app/src/sandbox/tag-input-6333/index.react.tsx
+++ b/app/src/sandbox/tag-input-6333/index.react.tsx
@@ -37,6 +37,7 @@ export default function Example() {
     <div style={{ display: "grid", gap: 16, padding: 16 }}>
       <TagField label="Dot tags" delimiter="." />
       <TagField label="Plus tags" delimiter="+" />
+      <TagField label="Pipe tags" delimiter="|" />
     </div>
   );
 }

--- a/app/src/sandbox/tag-input-6333/index.react.tsx
+++ b/app/src/sandbox/tag-input-6333/index.react.tsx
@@ -7,7 +7,7 @@ import { useId, useState } from "react";
 
 interface TagFieldProps {
   label: string;
-  delimiter: string | RegExp;
+  delimiter: string;
 }
 
 function TagField({ label, delimiter }: TagFieldProps) {
@@ -35,8 +35,8 @@ function TagField({ label, delimiter }: TagFieldProps) {
 export default function Example() {
   return (
     <div style={{ display: "grid", gap: 16, padding: 16 }}>
-      <TagField label="Dot tags" delimiter={/\./} />
-      <TagField label="Plus tags" delimiter={/[+]/} />
+      <TagField label="Dot tags" delimiter="." />
+      <TagField label="Plus tags" delimiter="+" />
     </div>
   );
 }

--- a/app/src/sandbox/tag-input-6333/test-browser.ts
+++ b/app/src/sandbox/tag-input-6333/test-browser.ts
@@ -19,4 +19,13 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await page.keyboard.type("one+two+");
     await test.expect(q.text("Plus tags values: one, two")).toBeVisible();
   });
+
+  test("does not freeze on string delimiters that match empty regexes", async ({
+    page,
+    q,
+  }) => {
+    await q.textbox("Pipe tags").click();
+    await page.keyboard.type("one|two|");
+    await test.expect(q.text("Pipe tags values: one, two")).toBeVisible();
+  });
 });

--- a/app/src/sandbox/tag-input-6333/test-browser.ts
+++ b/app/src/sandbox/tag-input-6333/test-browser.ts
@@ -1,0 +1,22 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6333
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("splits string delimiters with regex metacharacters literally", async ({
+    page,
+    q,
+  }) => {
+    await q.textbox("Dot tags").click();
+    await page.keyboard.type("one.two.");
+    await test.expect(q.text("Dot tags values: one, two")).toBeVisible();
+  });
+
+  test("does not throw on string delimiters that are invalid regex patterns", async ({
+    page,
+    q,
+  }) => {
+    await q.textbox("Plus tags").click();
+    await page.keyboard.type("one+two+");
+    await test.expect(q.text("Plus tags values: one, two")).toBeVisible();
+  });
+});

--- a/app/src/sandbox/tag-input-6333/test.ts
+++ b/app/src/sandbox/tag-input-6333/test.ts
@@ -11,3 +11,8 @@ test("does not throw on string delimiters that are invalid regex patterns", asyn
   await type("one+two+", q.textbox.ensure("Plus tags"));
   expect(q.text("Plus tags values: one, two")).toBeVisible();
 });
+
+test("does not freeze on string delimiters that match empty regexes", async () => {
+  await type("one|two|", q.textbox.ensure("Pipe tags"));
+  expect(q.text("Pipe tags values: one, two")).toBeVisible();
+});

--- a/app/src/sandbox/tag-input-6333/test.ts
+++ b/app/src/sandbox/tag-input-6333/test.ts
@@ -1,0 +1,13 @@
+import { q, type } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6333
+test("splits string delimiters with regex metacharacters literally", async () => {
+  await type("one.two.", q.textbox.ensure("Dot tags"));
+  expect(q.text("Dot tags values: one, two")).toBeVisible();
+});
+
+test("does not throw on string delimiters that are invalid regex patterns", async () => {
+  await type("one+two+", q.textbox.ensure("Plus tags"));
+  expect(q.text("Plus tags values: one, two")).toBeVisible();
+});

--- a/packages/ariakit-react-components/src/tag/utils.test.ts
+++ b/packages/ariakit-react-components/src/tag/utils.test.ts
@@ -53,6 +53,30 @@ test.each([
     delimiters: [/,/g],
     expected: ["", "one", "two"],
   },
+  {
+    name: "string dot metacharacter delimiter",
+    value: ".one.two.",
+    delimiters: ["."],
+    expected: ["one", "two", ""],
+  },
+  {
+    name: "string plus metacharacter delimiter",
+    value: "+one+two+",
+    delimiters: ["+"],
+    expected: ["one", "two", ""],
+  },
+  {
+    name: "string pipe metacharacter delimiter",
+    value: "|one|two|",
+    delimiters: ["|"],
+    expected: ["one", "two", ""],
+  },
+  {
+    name: "zero-length regex delimiter",
+    value: "abc",
+    delimiters: [/x*/],
+    expected: ["a", "b", "c"],
+  },
 ] as const)(
   "splitValueByDelimiter $name",
   ({ value, delimiters, expected }) => {

--- a/packages/ariakit-react-components/src/tag/utils.ts
+++ b/packages/ariakit-react-components/src/tag/utils.ts
@@ -6,6 +6,11 @@ type TagInputDelimiter = Delimiter | null | Delimiter[];
 
 const DEFAULT_DELIMITER: Delimiter[] = ["\n", ";", ",", /\s/];
 
+interface DelimiterMatch {
+  index?: number;
+  length: number;
+}
+
 export function getDelimiters(
   delimiter: TagInputDelimiter | undefined,
   defaultDelimiter: TagInputDelimiter | undefined = DEFAULT_DELIMITER,
@@ -17,16 +22,33 @@ export function getDelimiters(
 
 export function splitValueByDelimiter(value: string, delimiters: Delimiter[]) {
   for (const delimiter of delimiters) {
-    let match = value.match(delimiter);
-    // Remove delimiter from the start of the string
-    while (match?.index === 0) {
-      value = value.slice(match[0].length);
-      match = value.match(delimiter);
+    let match = matchDelimiter(value, delimiter);
+    // Remove delimiter from the start of the string. Ignore zero-length matches
+    // so patterns like /x*/ don't loop forever.
+    while (match?.index === 0 && match.length > 0) {
+      value = value.slice(match.length);
+      match = matchDelimiter(value, delimiter);
     }
     if (!match) continue;
     return value.split(delimiter);
   }
   return [];
+}
+
+function matchDelimiter(
+  value: string,
+  delimiter: Delimiter,
+): DelimiterMatch | null {
+  if (typeof delimiter === "string") {
+    // String delimiters are split literally, so they must be matched literally
+    // instead of being compiled as regular expressions.
+    const index = value.indexOf(delimiter);
+    if (index === -1) return null;
+    return { index, length: delimiter.length };
+  }
+  const match = value.match(delimiter);
+  if (!match) return null;
+  return { index: match.index, length: match[0].length };
 }
 
 export function useTouchDevice() {


### PR DESCRIPTION
## Motivation

`TagInput` currently treats string delimiters as regular expressions while checking whether an input should split, but later passes the same delimiter to `String.prototype.split`, where strings are matched literally.

This makes delimiters with regex metacharacters behave incorrectly. For example, `delimiter="."` never creates tags from `one.two.`, `delimiter="+"` throws while the user types, and `delimiter="|"` can freeze the page because it creates a zero-length regex match.

Fixes #6333

## Solution

The `splitValueByDelimiter` helper now matches string delimiters literally with `indexOf`, keeping the match step consistent with the later `split` call.

For regular expression delimiters, the existing match behavior is preserved, including the global-regex case where `String.prototype.match` does not expose an `index`. The leading-delimiter strip loop now also ignores zero-length matches so patterns such as `/x*/` cannot loop forever.

The `tag-input-6333` sandbox keeps the original string-delimiter repro, and the added unit coverage includes `.`, `+`, `|`, and a zero-length regex delimiter.

## Workaround

Pass an equivalent regular expression instead of a plain string delimiter so the matching and splitting steps both use regex semantics:

```tsx
// TODO: Remove this workaround once https://github.com/ariakit/ariakit/issues/6333 is fixed.
<TagInput delimiter={/\./} aria-label="Dot tags" />
<TagInput delimiter={/[+]/} aria-label="Plus tags" />
```
