### PR TITLE
Fix TagInput IME composition splitting

### DIFF
--- a/.changeset/300-input-event.md
+++ b/.changeset/300-input-event.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/utils": patch
+---
+
+Added `isInputEvent`.

--- a/.changeset/300-tag-input-ime.md
+++ b/.changeset/300-tag-input-ime.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/react-components": patch
+---
+
+Fixed `TagInput` so IME composition text is not split into tags before the user commits the composed value.

--- a/app/src/sandbox/tag-input-6294/index.react.tsx
+++ b/app/src/sandbox/tag-input-6294/index.react.tsx
@@ -1,0 +1,26 @@
+import { Tag } from "@ariakit/react-components/tag/tag";
+import { TagInput } from "@ariakit/react-components/tag/tag-input";
+import { TagList } from "@ariakit/react-components/tag/tag-list";
+import { TagListLabel } from "@ariakit/react-components/tag/tag-list-label";
+import { TagProvider } from "@ariakit/react-components/tag/tag-provider";
+import { TagRemove } from "@ariakit/react-components/tag/tag-remove";
+import { useState } from "react";
+
+export default function Example() {
+  const [values, setValues] = useState<string[]>([]);
+
+  return (
+    <TagProvider values={values} setValues={setValues}>
+      <TagListLabel>Tags</TagListLabel>
+      <TagList>
+        {values.map((value) => (
+          <Tag key={value} value={value}>
+            {value}
+            <TagRemove />
+          </Tag>
+        ))}
+        <TagInput aria-label="New tag" />
+      </TagList>
+    </TagProvider>
+  );
+}

--- a/app/src/sandbox/tag-input-6294/index.react.tsx
+++ b/app/src/sandbox/tag-input-6294/index.react.tsx
@@ -19,14 +19,7 @@ export default function Example() {
             <TagRemove />
           </Tag>
         ))}
-        <TagInput
-          aria-label="New tag"
-          onChange={(event) => {
-            if ((event.nativeEvent as InputEvent).isComposing) {
-              event.preventDefault();
-            }
-          }}
-        />
+        <TagInput aria-label="New tag" />
       </TagList>
     </TagProvider>
   );

--- a/app/src/sandbox/tag-input-6294/index.react.tsx
+++ b/app/src/sandbox/tag-input-6294/index.react.tsx
@@ -19,7 +19,14 @@ export default function Example() {
             <TagRemove />
           </Tag>
         ))}
-        <TagInput aria-label="New tag" />
+        <TagInput
+          aria-label="New tag"
+          onChange={(event) => {
+            if ((event.nativeEvent as InputEvent).isComposing) {
+              event.preventDefault();
+            }
+          }}
+        />
       </TagList>
     </TagProvider>
   );

--- a/app/src/sandbox/tag-input-6294/test-browser.ts
+++ b/app/src/sandbox/tag-input-6294/test-browser.ts
@@ -1,0 +1,32 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("does not split IME composition text into tags", async ({
+    browserName,
+    page,
+    q,
+  }) => {
+    test.skip(
+      browserName !== "chromium",
+      "CDP IME composition is Chromium-only.",
+    );
+
+    const input = q.textbox("New tag");
+    await input.focus();
+
+    const cdp = await page.context().newCDPSession(page);
+
+    for (const text of ["n", "ni", "ni h", "ni ha", "ni hao"]) {
+      await cdp.send("Input.imeSetComposition", {
+        text,
+        selectionStart: text.length,
+        selectionEnd: text.length,
+      });
+    }
+
+    await cdp.send("Input.insertText", { text: "你好" });
+
+    await test.expect(q.option("ni")).toBeHidden();
+    await test.expect(input).toHaveValue("你好");
+  });
+});

--- a/app/src/sandbox/tag-input-6294/test-chrome.ts
+++ b/app/src/sandbox/tag-input-6294/test-chrome.ts
@@ -1,16 +1,7 @@
 import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
-  test("does not split IME composition text into tags", async ({
-    browserName,
-    page,
-    q,
-  }) => {
-    test.skip(
-      browserName !== "chromium",
-      "CDP IME composition is Chromium-only.",
-    );
-
+  test("does not split IME composition text into tags", async ({ page, q }) => {
     const input = q.textbox("New tag");
     await input.focus();
 

--- a/packages/ariakit-react-components/src/combobox/combobox.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox.tsx
@@ -22,6 +22,7 @@ import {
   isFocusEventOutside,
   queueBeforeEvent,
   hasFocus,
+  isInputEvent,
   invariant,
   isFalsyBooleanCallback,
   noop,
@@ -72,10 +73,6 @@ function hasCompletionString(value?: string, activeValue?: string) {
     activeValue.length > value.length &&
     activeValue.toLowerCase().indexOf(value.toLowerCase()) === 0
   );
-}
-
-function isInputEvent(event: Event): event is InputEvent {
-  return event.type === "input";
 }
 
 function isAriaAutoCompleteValue(

--- a/packages/ariakit-react-components/src/tag/tag-input.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-input.tsx
@@ -12,6 +12,7 @@ import {
   getTextboxSelection,
   setSelectionRange,
   getInputType,
+  isInputEvent,
   invariant,
   UndoManager,
 } from "@ariakit/utils";
@@ -36,10 +37,6 @@ type HTMLType = HTMLElementTagNameMap[TagName];
 type EventWithValues<T extends SyntheticEvent> = T & {
   values: string[];
 };
-
-function isInputEvent(event: Event): event is InputEvent {
-  return event.type === "input";
-}
 
 /**
  * Returns props to create a `TagInput` component.

--- a/packages/ariakit-react-components/src/tag/tag-input.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-input.tsx
@@ -37,6 +37,10 @@ type EventWithValues<T extends SyntheticEvent> = T & {
   values: string[];
 };
 
+function isInputEvent(event: Event): event is InputEvent {
+  return event.type === "input";
+}
+
 /**
  * Returns props to create a `TagInput` component.
  * @see https://ariakit.com/components/tag
@@ -116,6 +120,8 @@ export const useTagInput = createHook<TagName, TagInputOptions>(
           return () => store.setValue(prevValue);
         }, inputType);
       }
+      const nativeEvent = event.nativeEvent;
+      if (isInputEvent(nativeEvent) && nativeEvent.isComposing) return;
       // Add values to the store if the input value ends with a delimiter
       const isTrailingCaret = start === end && start === value.length;
       if (isTrailingCaret) {

--- a/packages/ariakit-utils/readme.md
+++ b/packages/ariakit-utils/readme.md
@@ -69,6 +69,7 @@ This package is ESM-only and exposes a single public entrypoint.
   - [`fireClickEvent`](#fireclickevent)
   - [`isFocusEventOutside`](#isfocuseventoutside)
   - [`getInputType`](#getinputtype)
+  - [`isInputEvent`](#isinputevent)
   - [`queueBeforeEvent`](#queuebeforeevent)
   - [`addGlobalEventListener`](#addglobaleventlistener)
 - [Focus utilities](#focus-utilities)
@@ -764,6 +765,18 @@ function getInputType(
 ```
 
 Returns the `inputType` property of the event, if available.
+
+<div align="right">
+  <a href="#api-reference">&uarr; back to top</a>
+</div>
+
+#### `isInputEvent`
+
+```ts
+function isInputEvent(event: Event): event is InputEvent;
+```
+
+Checks whether the event is an input event.
 
 <div align="right">
   <a href="#api-reference">&uarr; back to top</a>

--- a/packages/ariakit-utils/src/events.test.ts
+++ b/packages/ariakit-utils/src/events.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import { isFocusEventOutside, isPortalEvent } from "./events.ts";
+import { isFocusEventOutside, isInputEvent, isPortalEvent } from "./events.ts";
 
 // Regression tests for https://github.com/ariakit/ariakit/issues/5156: a
 // programmatically dispatched event can carry a non-node target/relatedTarget
@@ -36,4 +36,9 @@ test("isPortalEvent keeps a contained text-node target as non-portal", () => {
   const text = container.appendChild(document.createTextNode("hi"));
   const event = { currentTarget: container, target: text };
   expect(isPortalEvent(event)).toBe(false);
+});
+
+test("isInputEvent checks input events", () => {
+  expect(isInputEvent(new InputEvent("input"))).toBe(true);
+  expect(isInputEvent(new Event("change"))).toBe(false);
 });

--- a/packages/ariakit-utils/src/events.ts
+++ b/packages/ariakit-utils/src/events.ts
@@ -173,6 +173,13 @@ export function getInputType(event: Event | { nativeEvent: Event }) {
 }
 
 /**
+ * Checks whether the event is an input event.
+ */
+export function isInputEvent(event: Event): event is InputEvent {
+  return event.type === "input";
+}
+
+/**
  * Runs a callback on the next animation frame, but before a certain event.
  */
 export function queueBeforeEvent(


### PR DESCRIPTION
## Motivation

`TagInput` ran delimiter splitting while an IME composition was still in progress. With the default whitespace delimiter, CJK preedit text such as `ni hao` could be split before the user committed the final candidate, producing a junk `ni` tag and leaving garbled input text.

Fixes #6294

## Solution

Added a focused `tag-input-6294` sandbox that reproduces the issue with Chromium's real IME composition pipeline through CDP.

`useTagInput` now keeps the input value synced during composition, but skips delimiter splitting while the native input event has `isComposing` set. Once the user commits the composed text, the following input event has `isComposing` unset and goes through the normal path.

A patch changeset is included for `@ariakit/react-components`.

## Workaround

Until the package fix is available, prevent `TagInput` from running its delimiter-splitting logic while the native input event is still composing:

```tsx
<TagInput
  aria-label="New tag"
  onChange={(event) => {
    // TODO: Remove once https://github.com/ariakit/ariakit/issues/6294 is fixed.
    if ((event.nativeEvent as InputEvent).isComposing) {
      event.preventDefault();
    }
  }}
/>
```
