### PR TITLE
Fix CollectionRenderer measured gap padding

### DIFF
--- a/.changeset/300-collection-renderer-gap-padding.md
+++ b/.changeset/300-collection-renderer-gap-padding.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/react-components": patch
+---
+
+Fixed `CollectionRenderer`, `CompositeRenderer`, and `SelectRenderer` to position measured virtualized items correctly when `gap` is combined with `paddingStart` or `padding`.

--- a/app/src/sandbox/collection-renderer-6337/index.react.tsx
+++ b/app/src/sandbox/collection-renderer-6337/index.react.tsx
@@ -1,0 +1,94 @@
+import { CollectionRenderer } from "@ariakit/react-components/collection/collection-renderer";
+
+const GAP = 10;
+const PADDING = 20;
+const ITEM_HEIGHT = 32;
+
+const measuredItems = Array.from({ length: 8 }, (_, index) => ({
+  id: `measured-item-${index + 1}`,
+}));
+
+const fixedItems = Array.from({ length: 8 }, (_, index) => ({
+  id: `fixed-item-${index + 1}`,
+}));
+
+const wrapperStyle = {
+  display: "flex",
+  gap: 16,
+} as const;
+
+const sectionStyle = {
+  display: "grid",
+  gap: 8,
+} as const;
+
+const scrollerStyle = {
+  width: 200,
+  height: 200,
+  overflowY: "auto",
+  border: "1px solid gray",
+} as const;
+
+const itemStyle = {
+  boxSizing: "border-box",
+  display: "block",
+  width: "100%",
+  height: ITEM_HEIGHT,
+  background: "#eee",
+} as const;
+
+export default function Example() {
+  return (
+    <div style={wrapperStyle}>
+      <section style={sectionStyle}>
+        <h2>Measured</h2>
+        <div style={scrollerStyle}>
+          <CollectionRenderer
+            id="measured-renderer"
+            items={measuredItems}
+            initialItems={measuredItems.length}
+            gap={GAP}
+            padding={PADDING}
+          >
+            {(item) => (
+              <button
+                key={item.id}
+                id={item.id}
+                ref={item.ref}
+                style={{ ...itemStyle, ...item.style }}
+                type="button"
+              >
+                Measured {item.index + 1}
+              </button>
+            )}
+          </CollectionRenderer>
+        </div>
+      </section>
+      <section style={sectionStyle}>
+        <h2>Fixed</h2>
+        <div style={scrollerStyle}>
+          <CollectionRenderer
+            id="fixed-renderer"
+            items={fixedItems}
+            initialItems={fixedItems.length}
+            itemSize={ITEM_HEIGHT}
+            gap={GAP}
+            padding={PADDING}
+          >
+            {(item) => (
+              <button
+                key={item.id}
+                id={item.id}
+                ref={item.ref}
+                style={{ ...itemStyle, ...item.style }}
+                type="button"
+              >
+                Fixed {item.index + 1}
+              </button>
+            )}
+          </CollectionRenderer>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/src/sandbox/collection-renderer-6337/index.react.tsx
+++ b/app/src/sandbox/collection-renderer-6337/index.react.tsx
@@ -38,6 +38,11 @@ const itemStyle = {
 } as const;
 
 export default function Example() {
+  // TODO: Remove this workaround once issue #6337 is fixed.
+  // https://github.com/ariakit/ariakit/issues/6337
+  // The measured path currently adds GAP before the first item when
+  // paddingStart is set, so subtract GAP to preserve the expected visual
+  // padding.
   return (
     <div style={wrapperStyle}>
       <section style={sectionStyle}>
@@ -48,7 +53,8 @@ export default function Example() {
             items={measuredItems}
             initialItems={measuredItems.length}
             gap={GAP}
-            padding={PADDING}
+            paddingStart={PADDING - GAP}
+            paddingEnd={PADDING}
           >
             {(item) => (
               <button

--- a/app/src/sandbox/collection-renderer-6337/index.react.tsx
+++ b/app/src/sandbox/collection-renderer-6337/index.react.tsx
@@ -38,11 +38,6 @@ const itemStyle = {
 } as const;
 
 export default function Example() {
-  // TODO: Remove this workaround once issue #6337 is fixed.
-  // https://github.com/ariakit/ariakit/issues/6337
-  // The measured path currently adds GAP before the first item when
-  // paddingStart is set, so subtract GAP to preserve the expected visual
-  // padding.
   return (
     <div style={wrapperStyle}>
       <section style={sectionStyle}>
@@ -53,8 +48,7 @@ export default function Example() {
             items={measuredItems}
             initialItems={measuredItems.length}
             gap={GAP}
-            paddingStart={PADDING - GAP}
-            paddingEnd={PADDING}
+            padding={PADDING}
           >
             {(item) => (
               <button

--- a/app/src/sandbox/collection-renderer-6337/test-browser.ts
+++ b/app/src/sandbox/collection-renderer-6337/test-browser.ts
@@ -1,0 +1,23 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// https://github.com/ariakit/ariakit/issues/6337
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("measured and fixed renderers agree on offsets and total height", async ({
+    page,
+    q,
+  }) => {
+    // Expected values follow the fixed-size formula:
+    // paddingStart + itemSize * index + gap * index.
+    await test.expect(q.button("Measured 1")).toHaveCSS("top", "20px");
+    await test.expect(q.button("Measured 2")).toHaveCSS("top", "62px");
+    await test.expect(q.button("Fixed 1")).toHaveCSS("top", "20px");
+    await test.expect(q.button("Fixed 2")).toHaveCSS("top", "62px");
+
+    await test
+      .expect(page.locator("#measured-renderer"))
+      .toHaveCSS("height", "366px");
+    await test
+      .expect(page.locator("#fixed-renderer"))
+      .toHaveCSS("height", "366px");
+  });
+});

--- a/packages/ariakit-react-components/src/collection/collection-renderer.tsx
+++ b/packages/ariakit-react-components/src/collection/collection-renderer.tsx
@@ -394,7 +394,9 @@ function getData<T extends Item>(props: {
     const prevRendered = itemData?.rendered ?? false;
 
     const setSize = (size: number, rendered = prevRendered) => {
-      start = start ? start + props.gap : start;
+      if (index > 0) {
+        start += props.gap;
+      }
       const end = start + size;
       const nextItemData = { index, rendered, start, end };
       if (!shallowEqual(itemData, nextItemData)) {


### PR DESCRIPTION
## Motivation

`CollectionRenderer` added one extra `gap` before the first measured item when `paddingStart` was set and `itemSize` was omitted.

With `gap={10}`, `padding={20}`, and measured 32px items, the measured renderer placed the first item at `30px` instead of matching the fixed-size renderer at `20px`. This also inflated the total renderer size by one `gap`, and the same measured path is used by `CompositeRenderer` and `SelectRenderer`.

Fixes #6337.

## Solution

Add a focused sandbox and browser test that compare a measured `CollectionRenderer` against an otherwise identical fixed-size `CollectionRenderer`.

Then change the measured data path to add `gap` based on the item index instead of the current offset. `index > 0` means the item is not the first item, so the measured path now follows the same convention as the fixed-size formula:

```ts
paddingStart + itemSize * index + gap * index
```

The sandbox workaround from the intermediate commit has been removed, so the regression test now passes through the library fix.

## Workaround

Until this fix is released, subtract the gap from the measured renderer's start padding and keep the original end padding:

```tsx
// TODO: Remove this workaround once
// https://github.com/ariakit/ariakit/issues/6337 is fixed.
<CollectionRenderer
  items={items}
  gap={GAP}
  paddingStart={PADDING - GAP}
  paddingEnd={PADDING}
>
  {renderItem}
</CollectionRenderer>
```

This compensates for the extra first-item gap in the measured path. It only works when `PADDING - GAP` stays greater than `0`; if all item sizes are known, passing `itemSize` bypasses the measured path instead.
