### PR TITLE
Fix merged store init reentrancy

### DIFF
--- a/.changeset/300-merged-store-init.md
+++ b/.changeset/300-merged-store-init.md
@@ -1,0 +1,9 @@
+---
+"@ariakit/store": patch
+"@ariakit/solid-store": patch
+---
+
+Fixed merged stores to keep values in sync when `sync` listeners update parent
+stores during initialization, including composed stores used by
+[`Select`](https://ariakit.com/reference/select) and
+[`Combobox`](https://ariakit.com/reference/combobox).

--- a/app/package.json
+++ b/app/package.json
@@ -55,6 +55,7 @@
     "@ariakit/solid": "workspace:*",
     "@ariakit/solid-components": "workspace:*",
     "@ariakit/solid-utils": "workspace:*",
+    "@ariakit/store": "workspace:*",
     "@ariakit/tailwind": "workspace:*",
     "@ariakit/utils": "workspace:*",
     "@astrojs/check": "0.9.9",

--- a/app/src/sandbox/select-combobox-6313/index.react.tsx
+++ b/app/src/sandbox/select-combobox-6313/index.react.tsx
@@ -13,10 +13,7 @@ function ValueFollowsHighlight() {
     if (!select) return;
     return sync(select, ["activeId"], (state) => {
       if (!state.activeId) return;
-      const { activeId } = state;
-      // TODO: Remove this workaround when
-      // https://github.com/ariakit/ariakit/issues/6313 is fixed.
-      queueMicrotask(() => select.setValue(activeId));
+      select.setValue(state.activeId);
     });
   }, [select]);
 

--- a/app/src/sandbox/select-combobox-6313/index.react.tsx
+++ b/app/src/sandbox/select-combobox-6313/index.react.tsx
@@ -13,7 +13,10 @@ function ValueFollowsHighlight() {
     if (!select) return;
     return sync(select, ["activeId"], (state) => {
       if (!state.activeId) return;
-      select.setValue(state.activeId);
+      const { activeId } = state;
+      // TODO: Remove this workaround when
+      // https://github.com/ariakit/ariakit/issues/6313 is fixed.
+      queueMicrotask(() => select.setValue(activeId));
     });
   }, [select]);
 

--- a/app/src/sandbox/select-combobox-6313/index.react.tsx
+++ b/app/src/sandbox/select-combobox-6313/index.react.tsx
@@ -1,0 +1,65 @@
+import * as Ariakit from "@ariakit/react";
+import { sync } from "@ariakit/store";
+import { useLayoutEffect, useMemo, useState } from "react";
+
+const list = ["Apple", "Banana", "Cherry", "Grape", "Lemon", "Orange"];
+
+// The descendant layout effect runs before SelectProvider initializes, so this
+// store-level listener exposes reentrant writes during the initial parent push.
+function ValueFollowsHighlight() {
+  const select = Ariakit.useSelectContext();
+
+  useLayoutEffect(() => {
+    if (!select) return;
+    return sync(select, ["activeId"], (state) => {
+      if (!state.activeId) return;
+      select.setValue(state.activeId);
+    });
+  }, [select]);
+
+  return null;
+}
+
+export default function Example() {
+  const [searchValue, setSearchValue] = useState("");
+  // The highlighted item should be committed during init so both stores render
+  // Banana after the first paint.
+  const select = Ariakit.useSelectStore({
+    defaultValue: "Apple",
+    defaultActiveId: "Banana",
+  });
+  const value = Ariakit.useStoreState(select, "value");
+
+  const matches = useMemo(() => {
+    const search = searchValue.toLowerCase();
+    return list.filter((item) => item.toLowerCase().includes(search));
+  }, [searchValue]);
+
+  return (
+    <>
+      <Ariakit.ComboboxProvider setValue={setSearchValue}>
+        <Ariakit.SelectProvider store={select}>
+          <ValueFollowsHighlight />
+          <Ariakit.SelectLabel>Favorite fruit</Ariakit.SelectLabel>
+          <Ariakit.Select />
+          <Ariakit.SelectPopover gutter={4} sameWidth>
+            <Ariakit.Combobox placeholder="Search..." />
+            <Ariakit.ComboboxList>
+              {matches.map((item) => (
+                <Ariakit.SelectItem
+                  key={item}
+                  id={item}
+                  value={item}
+                  render={<Ariakit.ComboboxItem />}
+                />
+              ))}
+            </Ariakit.ComboboxList>
+          </Ariakit.SelectPopover>
+        </Ariakit.SelectProvider>
+      </Ariakit.ComboboxProvider>
+      <p>
+        Committed value: <output>{value}</output>
+      </p>
+    </>
+  );
+}

--- a/app/src/sandbox/select-combobox-6313/test-browser.ts
+++ b/app/src/sandbox/select-combobox-6313/test-browser.ts
@@ -1,0 +1,11 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// See https://github.com/ariakit/ariakit/issues/6313
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("keeps hoisted and provider select values in sync after init", async ({
+    q,
+  }) => {
+    await test.expect(q.combobox("Favorite fruit")).toHaveText("Banana");
+    await test.expect(q.text("Committed value: Banana")).toBeVisible();
+  });
+});

--- a/app/src/sandbox/select-combobox-6313/test-browser.ts
+++ b/app/src/sandbox/select-combobox-6313/test-browser.ts
@@ -6,6 +6,6 @@ withFramework(import.meta.dirname, async ({ test }) => {
     q,
   }) => {
     await test.expect(q.combobox("Favorite fruit")).toHaveText("Banana");
-    await test.expect(q.text("Committed value: Banana")).toBeVisible();
+    await test.expect(q.status()).toHaveText("Banana");
   });
 });

--- a/app/src/sandbox/select-combobox-6313/test.ts
+++ b/app/src/sandbox/select-combobox-6313/test.ts
@@ -4,5 +4,5 @@ import { expect, test } from "vitest";
 // See https://github.com/ariakit/ariakit/issues/6313
 test("keeps hoisted and provider select values in sync after init", () => {
   expect(q.combobox.ensure("Favorite fruit")).toHaveTextContent("Banana");
-  expect(q.text.ensure("Committed value: Banana")).toBeVisible();
+  expect(q.status.ensure()).toHaveTextContent("Banana");
 });

--- a/app/src/sandbox/select-combobox-6313/test.ts
+++ b/app/src/sandbox/select-combobox-6313/test.ts
@@ -1,0 +1,8 @@
+import { q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// See https://github.com/ariakit/ariakit/issues/6313
+test("keeps hoisted and provider select values in sync after init", () => {
+  expect(q.combobox.ensure("Favorite fruit")).toHaveTextContent("Banana");
+  expect(q.text.ensure("Committed value: Banana")).toBeVisible();
+});

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -193,11 +193,10 @@ export function createStore<S extends State>(
         }
         continue;
       }
-      let didSyncInitialState = false;
       desyncs.push(
-        sync(store, keys, (state, prevState) => {
+        subscribe(store, keys, (state, prevState) => {
           for (const key of keys) {
-            if (didSyncInitialState && state[key] === prevState[key]) continue;
+            if (state[key] === prevState[key]) continue;
             setState(
               key,
               state[key],
@@ -206,9 +205,23 @@ export function createStore<S extends State>(
               true,
             );
           }
-          didSyncInitialState = true;
         }),
       );
+      // Register before the initial push, then read each key from live parent
+      // state. Child sync listeners can write back to the parent while an
+      // earlier key is being pushed; a stale snapshot would overwrite those
+      // reentrant updates.
+      for (const key of keys) {
+        const liveState = store?.getState?.();
+        if (!liveState) continue;
+        setState(
+          key,
+          liveState[key],
+          // @ts-expect-error - Not public API. This is just to prevent
+          // infinite loops.
+          true,
+        );
+      }
     }
 
     const teardowns: Array<void | (() => void)> = [];

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -604,6 +604,62 @@ test("syncs reentrant parent setStates to an earlier key during a child's initia
   cleanup();
 });
 
+test("syncs reentrant multi-parent setStates during a child's initial push", () => {
+  const first = createStore({ a: "first-a", b: "first-b" });
+  const second = createStore({ c: "second-c" });
+  const child = createStore(
+    { a: "child-a", b: "child-b", c: "child-c" },
+    first,
+    second,
+  );
+
+  sync(child, ["a"], (state) => {
+    if (state.a === "first-a") {
+      first.setState("b", "updated-b");
+    }
+  });
+
+  const cleanup = init(child);
+
+  expect(child.getState()).toEqual({
+    a: "first-a",
+    b: "updated-b",
+    c: "second-c",
+  });
+  expect(first.getState()).toEqual({ a: "first-a", b: "updated-b" });
+  expect(second.getState()).toEqual({ c: "second-c" });
+
+  cleanup();
+});
+
+test("syncs reentrant multi-parent setStates to an earlier key during a child's initial push", () => {
+  const first = createStore({ a: "first-a", b: "first-b" });
+  const second = createStore({ c: "second-c" });
+  const child = createStore(
+    { a: "child-a", b: "child-b", c: "child-c" },
+    first,
+    second,
+  );
+
+  sync(child, ["b"], (state) => {
+    if (state.b === "first-b") {
+      first.setState("a", "updated-a");
+    }
+  });
+
+  const cleanup = init(child);
+
+  expect(child.getState()).toEqual({
+    a: "updated-a",
+    b: "first-b",
+    c: "second-c",
+  });
+  expect(first.getState()).toEqual({ a: "updated-a", b: "first-b" });
+  expect(second.getState()).toEqual({ c: "second-c" });
+
+  cleanup();
+});
+
 test("fires a sync listener registered on the parent after init with the child already updated", () => {
   const parent = createStore({ count: 0 });
   const child = createStore({ count: 0 }, parent);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,6 +233,9 @@ importers:
       '@ariakit/solid-utils':
         specifier: workspace:*
         version: link:../packages/ariakit-solid-utils
+      '@ariakit/store':
+        specifier: workspace:*
+        version: link:../packages/ariakit-store
       '@ariakit/tailwind':
         specifier: workspace:*
         version: link:../packages/ariakit-tailwind


### PR DESCRIPTION
## Motivation

Issue #6313 reports that reentrant writes made while a child store initializes from multiple partially-overlapping parent stores can be lost or overwritten. This can leave the child and parent stores with different values after the initial push.

A real composition can hit this when a hoisted `Select` store is passed to a `SelectProvider` inside a `ComboboxProvider`, and a descendant store-level `sync` listener writes `activeId` back to `value` during provider initialization.

Fixes #6313.

## Solution

The grouped multi-parent init path now registers a parent `subscribe` listener before the initial parent-to-child push. It then pushes each shared key from a fresh parent state read, so child `sync` listeners that reentrantly write back to the parent are preserved instead of being overwritten by a stale snapshot.

This keeps the grouped listener optimization while matching the existing single-parent reentrancy behavior.

The PR also adds coverage for the reported behavior:

- focused `@ariakit/store` tests that mirror the existing single-parent reentrancy cases against the grouped multi-parent path;
- a `Select` + `Combobox` sandbox that reproduces the user-visible mismatch between a hoisted select store and the provider store;
- matching happy-dom and browser tests for the sandbox.

## Workaround

Until this fix is available in a release, users can defer store writes made from an initialization-time `sync` listener so they run after the parent/child wiring is complete.

```tsx
return sync(select, ["activeId"], (state) => {
  if (!state.activeId) return;
  const { activeId } = state;
  // TODO: Remove this workaround when
  // https://github.com/ariakit/ariakit/issues/6313 is fixed.
  queueMicrotask(() => select.setValue(activeId));
});
```
