### PR TITLE
Fix queueBeforeEvent cancel cleanup

### DIFF
--- a/.changeset/300-queue-before-event-cancel.md
+++ b/.changeset/300-queue-before-event-cancel.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/utils": patch
+---
+
+Fixed `queueBeforeEvent` so the cancel function removes the pending event listener as well as the queued timer.

--- a/app/src/sandbox/queue-before-event-6350/index.react.tsx
+++ b/app/src/sandbox/queue-before-event-6350/index.react.tsx
@@ -1,0 +1,52 @@
+import * as Ariakit from "@ariakit/react";
+import { queueBeforeEvent } from "@ariakit/utils";
+import { useRef, useState } from "react";
+
+export default function Example() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const cancelAutoHideRef = useRef<(() => void) | null>(null);
+  const [hintVisible, setHintVisible] = useState(false);
+  const [status, setStatus] = useState("hidden");
+
+  const showShortcuts = () => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    setHintVisible(true);
+    setStatus("visible");
+    cancelAutoHideRef.current = queueBeforeEvent(
+      container,
+      "mousedown",
+      () => {
+        cancelAutoHideRef.current = null;
+        setHintVisible(false);
+        setStatus("auto-hidden");
+      },
+      30_000,
+    );
+  };
+
+  const pinHint = () => {
+    const cancelAutoHide = cancelAutoHideRef.current;
+    if (!cancelAutoHide) return;
+
+    cancelAutoHideRef.current = null;
+    cancelAutoHide();
+    setStatus("pinned");
+  };
+
+  return (
+    <div ref={containerRef}>
+      <Ariakit.Button onClick={showShortcuts}>Show shortcuts</Ariakit.Button>
+      <Ariakit.Button>New document</Ariakit.Button>
+      {hintVisible && (
+        <section aria-label="Keyboard shortcuts" onMouseEnter={pinHint}>
+          <p>
+            Press <kbd>Ctrl</kbd>+<kbd>N</kbd> to create a new document.
+          </p>
+        </section>
+      )}
+      <output>Status: {status}</output>
+    </div>
+  );
+}

--- a/app/src/sandbox/queue-before-event-6350/index.react.tsx
+++ b/app/src/sandbox/queue-before-event-6350/index.react.tsx
@@ -14,22 +14,16 @@ export default function Example() {
 
     setHintVisible(true);
     setStatus("visible");
-    let canceled = false;
-    const cancelAutoHide = queueBeforeEvent(
+    cancelAutoHideRef.current = queueBeforeEvent(
       container,
       "mousedown",
       () => {
-        if (canceled) return;
         cancelAutoHideRef.current = null;
         setHintVisible(false);
         setStatus("auto-hidden");
       },
       30_000,
     );
-    cancelAutoHideRef.current = () => {
-      canceled = true;
-      cancelAutoHide();
-    };
   };
 
   const pinHint = () => {

--- a/app/src/sandbox/queue-before-event-6350/index.react.tsx
+++ b/app/src/sandbox/queue-before-event-6350/index.react.tsx
@@ -14,16 +14,22 @@ export default function Example() {
 
     setHintVisible(true);
     setStatus("visible");
-    cancelAutoHideRef.current = queueBeforeEvent(
+    let canceled = false;
+    const cancelAutoHide = queueBeforeEvent(
       container,
       "mousedown",
       () => {
+        if (canceled) return;
         cancelAutoHideRef.current = null;
         setHintVisible(false);
         setStatus("auto-hidden");
       },
       30_000,
     );
+    cancelAutoHideRef.current = () => {
+      canceled = true;
+      cancelAutoHide();
+    };
   };
 
   const pinHint = () => {

--- a/app/src/sandbox/queue-before-event-6350/test-browser.ts
+++ b/app/src/sandbox/queue-before-event-6350/test-browser.ts
@@ -1,0 +1,19 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/6350
+  test("canceling a queued callback keeps it from running on the next event", async ({
+    q,
+  }) => {
+    await q.button("Show shortcuts").click();
+    const hint = q.region("Keyboard shortcuts");
+    await test.expect(hint).toBeVisible();
+
+    await hint.hover();
+    await test.expect(q.text("Status: pinned")).toBeVisible();
+
+    await q.button("New document").click();
+    await test.expect(q.region("Keyboard shortcuts")).toBeVisible();
+    await test.expect(q.text("Status: pinned")).toBeVisible();
+  });
+});

--- a/app/src/sandbox/queue-before-event-6350/test.ts
+++ b/app/src/sandbox/queue-before-event-6350/test.ts
@@ -1,0 +1,17 @@
+import { click, hover, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// See https://github.com/ariakit/ariakit/issues/6350
+
+test("canceling a queued callback keeps it from running on the next event", async () => {
+  await click(q.button.ensure("Show shortcuts"));
+  const hint = q.region.ensure("Keyboard shortcuts");
+  expect(hint).toBeVisible();
+
+  await hover(hint);
+  expect(q.text("Status: pinned")).toBeVisible();
+
+  await click(q.button.ensure("New document"));
+  expect(q.region("Keyboard shortcuts")).toBeVisible();
+  expect(q.text("Status: pinned")).toBeVisible();
+});

--- a/packages/ariakit-utils/src/events.test.ts
+++ b/packages/ariakit-utils/src/events.test.ts
@@ -1,5 +1,9 @@
-import { expect, test } from "vitest";
-import { isFocusEventOutside, isPortalEvent } from "./events.ts";
+import { expect, test, vi } from "vitest";
+import {
+  isFocusEventOutside,
+  isPortalEvent,
+  queueBeforeEvent,
+} from "./events.ts";
 
 // Regression tests for https://github.com/ariakit/ariakit/issues/5156: a
 // programmatically dispatched event can carry a non-node target/relatedTarget
@@ -36,4 +40,32 @@ test("isPortalEvent keeps a contained text-node target as non-portal", () => {
   const text = container.appendChild(document.createTextNode("hi"));
   const event = { currentTarget: container, target: text };
   expect(isPortalEvent(event)).toBe(false);
+});
+
+// See https://github.com/ariakit/ariakit/issues/6350
+
+function expectCancelToRemoveQueuedEventListener(timeout?: number) {
+  vi.useFakeTimers();
+
+  try {
+    const container = document.createElement("div");
+    const callback = vi.fn();
+    const cancel = queueBeforeEvent(container, "mousedown", callback, timeout);
+
+    cancel();
+    container.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    vi.runAllTimers();
+
+    expect(callback).not.toHaveBeenCalled();
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
+test("queueBeforeEvent cancel removes the queued animation frame listener", () => {
+  expectCancelToRemoveQueuedEventListener();
+});
+
+test("queueBeforeEvent cancel removes the queued timeout listener", () => {
+  expectCancelToRemoveQueuedEventListener(1_000);
 });

--- a/packages/ariakit-utils/src/events.ts
+++ b/packages/ariakit-utils/src/events.ts
@@ -201,7 +201,10 @@ export function queueBeforeEvent(
   // By listening to the event in the capture phase, we make sure the callback
   // is fired before the respective React events.
   element.addEventListener(type, callSync, { once: true, capture: true });
-  return cancelTimer;
+  return () => {
+    cancelTimer();
+    element.removeEventListener(type, callSync, true);
+  };
 }
 
 export function addGlobalEventListener<K extends keyof DocumentEventMap>(


### PR DESCRIPTION
## Motivation

`queueBeforeEvent` returns a cancel function that should prevent the queued callback from running. Before this change, canceling cleared only the timer path and left the capture-phase event listener installed, so a later event could still run the supposedly canceled callback.

Fixes #6350.

## Solution

The repro adds a sandbox that mirrors the reported user interaction, a browser test for the rendered behavior, a happy-dom duplicate for faster feedback, and package-level regression coverage for both the animation-frame and timeout scheduling paths.

The fix updates `queueBeforeEvent` to return a cancel function that clears the queued timer and removes the pending capture-phase event listener. The sandbox workaround was reverted so the repro now exercises the library fix directly.

## Workaround

Until this fix is released, guard the queued callback with a consumer-side flag and wrap the returned cancel function so canceling flips the guard before calling the current `queueBeforeEvent` cancel function:

```tsx
let canceled = false;
const cancelAutoHide = queueBeforeEvent(
  container,
  "mousedown",
  () => {
    // TODO: Remove after https://github.com/ariakit/ariakit/issues/6350 is fixed.
    if (canceled) return;
    cancelAutoHideRef.current = null;
    setHintVisible(false);
    setStatus("auto-hidden");
  },
  30_000,
);
cancelAutoHideRef.current = () => {
  canceled = true;
  cancelAutoHide();
};
```
