### PR TITLE
Fix store all-keys dispatch listeners

### DIFF
--- a/.changeset/300-store-all-keys-dispatch.md
+++ b/.changeset/300-store-all-keys-dispatch.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/store": patch
+---
+
+Fixed `subscribe` callbacks registered for all keys during a keyed store dispatch so they observe the in-flight update.

--- a/app/src/sandbox/store-6317/index.react.tsx
+++ b/app/src/sandbox/store-6317/index.react.tsx
@@ -11,11 +11,6 @@ export default function Example() {
     let unsubscribeLogger: (() => void) | undefined;
     let loggerAttached = false;
 
-    // TODO: Remove once https://github.com/ariakit/ariakit/issues/6317 is
-    // fixed. This forces the slow notification path, which delivers the
-    // in-flight dispatch to all-keys listeners registered during it.
-    const unsubscribeFastPathWorkaround = subscribe(likes, null, () => {});
-
     // Keep the rendered count in sync and lazily attach the whole-store logger
     // on the first user change. The logger should still observe the dispatch
     // that attached it.
@@ -35,7 +30,6 @@ export default function Example() {
     return () => {
       unsubscribeCount();
       unsubscribeLogger?.();
-      unsubscribeFastPathWorkaround();
     };
   }, [likes]);
 

--- a/app/src/sandbox/store-6317/index.react.tsx
+++ b/app/src/sandbox/store-6317/index.react.tsx
@@ -1,0 +1,49 @@
+import * as Ariakit from "@ariakit/react";
+import { createStore, subscribe, sync } from "@ariakit/store";
+import { useEffect, useState } from "react";
+
+export default function Example() {
+  const [likes] = useState(() => createStore({ count: 0 }));
+  const [count, setCount] = useState(() => likes.getState().count);
+  const [log, setLog] = useState<string[]>([]);
+
+  useEffect(() => {
+    let unsubscribeLogger: (() => void) | undefined;
+    let loggerAttached = false;
+
+    // Keep the rendered count in sync and lazily attach the whole-store logger
+    // on the first user change. The logger should still observe the dispatch
+    // that attached it.
+    const unsubscribeCount = sync(likes, ["count"], (state) => {
+      setCount(state.count);
+      if (loggerAttached) return;
+      if (!state.count) return;
+      loggerAttached = true;
+      unsubscribeLogger = subscribe(likes, null, (state, prevState) => {
+        setLog((entries) => [
+          ...entries,
+          `${prevState.count} -> ${state.count}`,
+        ]);
+      });
+    });
+
+    return () => {
+      unsubscribeCount();
+      unsubscribeLogger?.();
+    };
+  }, [likes]);
+
+  return (
+    <div>
+      <Ariakit.Button
+        onClick={() => likes.setState("count", (count) => count + 1)}
+      >
+        Like ({count})
+      </Ariakit.Button>
+      <p>
+        Activity log:{" "}
+        <output>{log.length ? log.join(", ") : "No activity yet"}</output>
+      </p>
+    </div>
+  );
+}

--- a/app/src/sandbox/store-6317/index.react.tsx
+++ b/app/src/sandbox/store-6317/index.react.tsx
@@ -11,6 +11,11 @@ export default function Example() {
     let unsubscribeLogger: (() => void) | undefined;
     let loggerAttached = false;
 
+    // TODO: Remove once https://github.com/ariakit/ariakit/issues/6317 is
+    // fixed. This forces the slow notification path, which delivers the
+    // in-flight dispatch to all-keys listeners registered during it.
+    const unsubscribeFastPathWorkaround = subscribe(likes, null, () => {});
+
     // Keep the rendered count in sync and lazily attach the whole-store logger
     // on the first user change. The logger should still observe the dispatch
     // that attached it.
@@ -30,6 +35,7 @@ export default function Example() {
     return () => {
       unsubscribeCount();
       unsubscribeLogger?.();
+      unsubscribeFastPathWorkaround();
     };
   }, [likes]);
 

--- a/app/src/sandbox/store-6317/test-browser.ts
+++ b/app/src/sandbox/store-6317/test-browser.ts
@@ -1,0 +1,15 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6317
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("notifies an all-keys listener subscribed during a keyed dispatch", async ({
+    q,
+  }) => {
+    await test.expect(q.text("No activity yet")).toBeVisible();
+
+    await q.button("Like (0)").click();
+
+    await test.expect(q.button("Like (1)")).toBeVisible();
+    await test.expect(q.text("0 -> 1")).toBeVisible();
+  });
+});

--- a/app/src/sandbox/store-6317/test.ts
+++ b/app/src/sandbox/store-6317/test.ts
@@ -1,0 +1,12 @@
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6317
+test("notifies an all-keys listener subscribed during a keyed dispatch", async () => {
+  expect(q.text("No activity yet")).toBeVisible();
+
+  await click(q.button.ensure("Like (0)"));
+
+  expect(q.button("Like (1)")).toBeVisible();
+  expect(q.text("0 -> 1")).toBeVisible();
+});

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -46,6 +46,16 @@ interface ListenerGroup<S> {
   listenerKeys: WeakMap<Listener<S>, Array<keyof S> | null>;
 }
 
+interface FastPathFrame<S> {
+  group: ListenerGroup<S>;
+  keyedListeners: Set<Listener<S>>;
+  updatedKey: keyof S;
+  currentListener: Listener<S> | null;
+  notifiedListeners?: Set<Listener<S>>;
+  recoverToLive?: boolean;
+  recovering?: boolean;
+}
+
 interface StoreInternals<S = State> {
   setup: StoreSetup;
   init: StoreInit;
@@ -257,6 +267,129 @@ export function createStore<S extends State>(
     }
   };
 
+  // The keyed fast path only tracks notified listeners if it has to recover
+  // into live listener iteration. Registration/disposal hooks preserve every
+  // active frame for the listener group before re-keying mutates its bucket.
+  const fastPathFrames: Array<FastPathFrame<S>> = [];
+
+  const getFastPathNotifiedListeners = (frame: FastPathFrame<S>) => {
+    const notifiedListeners = new Set<Listener<S>>();
+    const currentListener = frame.currentListener;
+    if (!currentListener) return notifiedListeners;
+    for (const listener of frame.keyedListeners) {
+      notifiedListeners.add(listener);
+      if (listener === currentListener) {
+        return notifiedListeners;
+      }
+    }
+    notifiedListeners.clear();
+    notifiedListeners.add(currentListener);
+    return notifiedListeners;
+  };
+
+  const preserveFastPathNotifiedListeners = (frame: FastPathFrame<S>) => {
+    frame.notifiedListeners ??= getFastPathNotifiedListeners(frame);
+  };
+
+  // An existing listener re-keyed to all keys after its insertion-order slot
+  // has passed should stay skipped, matching the live slow path.
+  const hasFastPathPassedListener = (
+    frame: FastPathFrame<S>,
+    listener: Listener<S>,
+  ) => {
+    if (!frame.currentListener) return false;
+    let foundCurrentKeyedListener = false;
+    for (const currentListener of frame.keyedListeners) {
+      if (currentListener === frame.currentListener) {
+        foundCurrentKeyedListener = true;
+        continue;
+      }
+      if (!foundCurrentKeyedListener) continue;
+      if (currentListener === listener) return false;
+    }
+    let foundListener = false;
+    for (const currentListener of frame.group.listeners) {
+      if (currentListener === frame.currentListener) return foundListener;
+      if (currentListener === listener) {
+        foundListener = true;
+      }
+    }
+    return false;
+  };
+
+  const preserveFastPathFrames = (
+    group: ListenerGroup<S>,
+    listener?: Listener<S>,
+  ) => {
+    for (const frame of fastPathFrames) {
+      if (frame.group !== group) continue;
+      if (frame.recovering) continue;
+      if (listener && !frame.keyedListeners.has(listener)) continue;
+      preserveFastPathNotifiedListeners(frame);
+      for (const currentListener of frame.group.listeners) {
+        if (currentListener === frame.currentListener) break;
+        if (!hasFastPathPassedListener(frame, currentListener)) continue;
+        frame.notifiedListeners?.add(currentListener);
+      }
+    }
+  };
+
+  const preserveFastPathPassedListeners = (
+    group: ListenerGroup<S>,
+    listener: Listener<S>,
+  ) => {
+    for (const frame of fastPathFrames) {
+      if (frame.group !== group) continue;
+      if (frame.recovering) continue;
+      if (!hasFastPathPassedListener(frame, listener)) continue;
+      preserveFastPathNotifiedListeners(frame);
+      frame.notifiedListeners?.add(listener);
+    }
+  };
+
+  const preserveFastPathPassedKeyedListeners = (
+    group: ListenerGroup<S>,
+    keys: Array<keyof S>,
+    listener: Listener<S>,
+  ) => {
+    const wasRegistered = group.listeners.has(listener);
+    for (const frame of fastPathFrames) {
+      if (frame.group !== group) continue;
+      if (frame.recovering) continue;
+      if (!keys.includes(frame.updatedKey)) continue;
+      if (hasFastPathPassedListener(frame, listener)) {
+        preserveFastPathNotifiedListeners(frame);
+        frame.notifiedListeners?.add(listener);
+      } else if (wasRegistered) {
+        preserveFastPathNotifiedListeners(frame);
+        frame.recoverToLive = true;
+      }
+    }
+  };
+
+  const clearFastPathNotifiedListener = (
+    group: ListenerGroup<S>,
+    listener: Listener<S>,
+  ) => {
+    for (const frame of fastPathFrames) {
+      if (frame.group !== group) continue;
+      frame.notifiedListeners?.delete(listener);
+    }
+  };
+
+  const addFastPathKeyedListener = (
+    group: ListenerGroup<S>,
+    keys: Array<keyof S>,
+    listener: Listener<S>,
+  ) => {
+    for (const frame of fastPathFrames) {
+      if (frame.group !== group) continue;
+      if (frame.recovering) continue;
+      if (!keys.includes(frame.updatedKey)) continue;
+      frame.keyedListeners.add(listener);
+    }
+  };
+
   // Registers `listener` in `group` and returns its unsubscribe. Three jobs:
   // (1) snapshot `keys` as a defensive copy (or null for an all-keys listener);
   // (2) index the listener — re-registering the same listener first clears its
@@ -269,13 +402,27 @@ export function createStore<S extends State>(
     group = syncListenerGroup,
   ) => {
     const listenerKeysValue = keys ? [...keys] : null;
-    if (group.listeners.has(listener)) {
+    const wasRegistered = group.listeners.has(listener);
+    if (!wasRegistered) {
+      clearFastPathNotifiedListener(group, listener);
+    }
+    if (!listenerKeysValue) {
+      if (wasRegistered) {
+        preserveFastPathFrames(group);
+      }
+      preserveFastPathPassedListeners(group, listener);
+    } else {
+      preserveFastPathPassedKeyedListeners(group, listenerKeysValue, listener);
+    }
+    if (wasRegistered) {
+      preserveFastPathFrames(group, listener);
       deleteListenerIndexes(group, listener, group.listenerKeys.get(listener));
     }
     group.listeners.add(listener);
     if (listenerKeysValue) {
       group.listenersByKey ??= new Map();
       addKeyedListener(group.listenersByKey, listenerKeysValue, listener);
+      addFastPathKeyedListener(group, listenerKeysValue, listener);
     } else {
       group.allKeysListeners ??= new Set();
       group.allKeysListeners.add(listener);
@@ -284,6 +431,7 @@ export function createStore<S extends State>(
     return () => {
       group.disposables.get(listener)?.();
       group.disposables.delete(listener);
+      preserveFastPathFrames(group, listener);
       const currentKeys = group.listenerKeys.get(listener);
       deleteListenerIndexes(group, listener, listenerKeysValue);
       if (currentKeys !== listenerKeysValue) {
@@ -352,56 +500,8 @@ export function createStore<S extends State>(
     updatedKey: UpdatedKey<S>,
   ) => {
     const { disposables } = group;
-    if (!(updatedKey instanceof Set) && !group.allKeysListeners?.size) {
-      const keyedListeners = group.listenersByKey?.get(updatedKey);
-      if (!keyedListeners) return;
-      const notifiedListeners = new Set<Listener<S>>();
-      for (const listener of keyedListeners) {
-        notifiedListeners.add(listener);
-        // Skip the cleanup lookup when no listener has registered a cleanup.
-        // The `.size` gate keeps an empty disposables map off this hot path.
-        const cleanup = disposables.size
-          ? disposables.get(listener)
-          : undefined;
-        if (cleanup) cleanup();
-        const result = listener(state, prevState);
-        if (result) {
-          disposables.set(listener, result);
-        } else if (cleanup) {
-          disposables.delete(listener);
-        }
-      }
-      const allKeysListeners = group.allKeysListeners;
-      if (allKeysListeners?.size) {
-        for (const listener of group.listeners) {
-          if (notifiedListeners.has(listener)) continue;
-          if (!allKeysListeners.has(listener)) {
-            const keys = group.listenerKeys.get(listener);
-            if (!hasUpdatedKey(keys, updatedKey)) continue;
-          }
-          notifiedListeners.add(listener);
-          // Skip the cleanup lookup when no listener has registered a cleanup.
-          // The `.size` gate keeps an empty disposables map off this hot path.
-          const cleanup = disposables.size
-            ? disposables.get(listener)
-            : undefined;
-          if (cleanup) cleanup();
-          const result = listener(state, prevState);
-          if (result) {
-            disposables.set(listener, result);
-          } else if (cleanup) {
-            disposables.delete(listener);
-          }
-        }
-      }
-      return;
-    }
-    const allKeysListeners = group.allKeysListeners;
-    for (const listener of group.listeners) {
-      if (!allKeysListeners?.has(listener)) {
-        const keys = group.listenerKeys.get(listener);
-        if (!hasUpdatedKey(keys, updatedKey)) continue;
-      }
+
+    const notifyListener = (listener: Listener<S>) => {
       // Skip the cleanup lookup when no listener has registered a cleanup.
       // The `.size` gate keeps an empty disposables map off this hot path.
       const cleanup = disposables.size ? disposables.get(listener) : undefined;
@@ -412,7 +512,61 @@ export function createStore<S extends State>(
       } else if (cleanup) {
         disposables.delete(listener);
       }
+    };
+
+    const runLiveListeners = (notifiedListeners?: Set<Listener<S>>) => {
+      const allKeysListeners = group.allKeysListeners;
+      for (const listener of group.listeners) {
+        if (notifiedListeners?.has(listener)) continue;
+        if (!allKeysListeners?.has(listener)) {
+          const keys = group.listenerKeys.get(listener);
+          if (!hasUpdatedKey(keys, updatedKey)) continue;
+        }
+        notifiedListeners?.add(listener);
+        notifyListener(listener);
+      }
+    };
+
+    if (!(updatedKey instanceof Set) && !group.allKeysListeners?.size) {
+      const keyedListeners = group.listenersByKey?.get(updatedKey);
+      if (!keyedListeners) return;
+
+      const frame: FastPathFrame<S> = {
+        group,
+        keyedListeners,
+        updatedKey,
+        currentListener: null,
+      };
+      let frameActive = true;
+      fastPathFrames.push(frame);
+
+      const removeFrame = () => {
+        if (!frameActive) return;
+        fastPathFrames.pop();
+        frameActive = false;
+      };
+
+      try {
+        for (const listener of keyedListeners) {
+          if (frame.notifiedListeners?.has(listener)) continue;
+          frame.currentListener = listener;
+          frame.notifiedListeners?.add(listener);
+          notifyListener(listener);
+          if (!group.allKeysListeners?.size && !frame.recoverToLive) continue;
+          const notifiedListeners =
+            frame.notifiedListeners ?? getFastPathNotifiedListeners(frame);
+          frame.notifiedListeners = notifiedListeners;
+          frame.recovering = true;
+          runLiveListeners(notifiedListeners);
+          return;
+        }
+      } finally {
+        removeFrame();
+      }
+      return;
     }
+
+    runLiveListeners();
   };
 
   // `fromStores` marks an update that originated from an extended parent store

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -129,6 +129,189 @@ function deleteKeyedListener<S>(
   }
 }
 
+function getFastPathNotifiedListeners<S>(frame: FastPathFrame<S>) {
+  const notifiedListeners = new Set<Listener<S>>();
+  const currentListener = frame.currentListener;
+  if (!currentListener) return notifiedListeners;
+  for (const listener of frame.keyedListeners) {
+    notifiedListeners.add(listener);
+    if (listener === currentListener) {
+      return notifiedListeners;
+    }
+  }
+  notifiedListeners.clear();
+  notifiedListeners.add(currentListener);
+  return notifiedListeners;
+}
+
+function preserveFastPathNotifiedListeners<S>(frame: FastPathFrame<S>) {
+  frame.notifiedListeners ??= getFastPathNotifiedListeners(frame);
+}
+
+// An existing listener re-keyed to all keys after its insertion-order slot has
+// passed should stay skipped, matching the live slow path.
+function hasFastPathPassedListener<S>(
+  frame: FastPathFrame<S>,
+  listener: Listener<S>,
+) {
+  if (!frame.currentListener) return false;
+  let foundCurrentKeyedListener = false;
+  for (const currentListener of frame.keyedListeners) {
+    if (currentListener === frame.currentListener) {
+      foundCurrentKeyedListener = true;
+      continue;
+    }
+    if (!foundCurrentKeyedListener) continue;
+    if (currentListener === listener) return false;
+  }
+  let foundListener = false;
+  for (const currentListener of frame.group.listeners) {
+    if (currentListener === frame.currentListener) return foundListener;
+    if (currentListener === listener) {
+      foundListener = true;
+    }
+  }
+  return false;
+}
+
+function preserveFastPathFrames<S>(
+  fastPathFrames: Array<FastPathFrame<S>>,
+  group: ListenerGroup<S>,
+  listener?: Listener<S>,
+) {
+  for (const frame of fastPathFrames) {
+    if (frame.group !== group) continue;
+    if (frame.recovering) continue;
+    if (listener && !frame.keyedListeners.has(listener)) continue;
+    preserveFastPathNotifiedListeners(frame);
+    for (const currentListener of frame.group.listeners) {
+      if (currentListener === frame.currentListener) break;
+      if (!hasFastPathPassedListener(frame, currentListener)) continue;
+      frame.notifiedListeners?.add(currentListener);
+    }
+  }
+}
+
+function preserveFastPathPassedListeners<S>(
+  fastPathFrames: Array<FastPathFrame<S>>,
+  group: ListenerGroup<S>,
+  listener: Listener<S>,
+) {
+  for (const frame of fastPathFrames) {
+    if (frame.group !== group) continue;
+    if (frame.recovering) continue;
+    if (!hasFastPathPassedListener(frame, listener)) continue;
+    preserveFastPathNotifiedListeners(frame);
+    frame.notifiedListeners?.add(listener);
+  }
+}
+
+interface PreserveFastPathPassedKeyedListenersParams<S> {
+  fastPathFrames: Array<FastPathFrame<S>>;
+  group: ListenerGroup<S>;
+  keys: Array<keyof S>;
+  listener: Listener<S>;
+}
+
+function preserveFastPathPassedKeyedListeners<S>({
+  fastPathFrames,
+  group,
+  keys,
+  listener,
+}: PreserveFastPathPassedKeyedListenersParams<S>) {
+  const wasRegistered = group.listeners.has(listener);
+  for (const frame of fastPathFrames) {
+    if (frame.group !== group) continue;
+    if (frame.recovering) continue;
+    if (!keys.includes(frame.updatedKey)) continue;
+    if (hasFastPathPassedListener(frame, listener)) {
+      preserveFastPathNotifiedListeners(frame);
+      frame.notifiedListeners?.add(listener);
+    } else if (wasRegistered) {
+      preserveFastPathNotifiedListeners(frame);
+      frame.recoverToLive = true;
+    }
+  }
+}
+
+function clearFastPathNotifiedListener<S>(
+  fastPathFrames: Array<FastPathFrame<S>>,
+  group: ListenerGroup<S>,
+  listener: Listener<S>,
+) {
+  for (const frame of fastPathFrames) {
+    if (frame.group !== group) continue;
+    frame.notifiedListeners?.delete(listener);
+  }
+}
+
+interface AddFastPathKeyedListenerParams<S> {
+  fastPathFrames: Array<FastPathFrame<S>>;
+  group: ListenerGroup<S>;
+  keys: Array<keyof S>;
+  listener: Listener<S>;
+}
+
+function addFastPathKeyedListener<S>({
+  fastPathFrames,
+  group,
+  keys,
+  listener,
+}: AddFastPathKeyedListenerParams<S>) {
+  for (const frame of fastPathFrames) {
+    if (frame.group !== group) continue;
+    if (frame.recovering) continue;
+    if (!keys.includes(frame.updatedKey)) continue;
+    frame.keyedListeners.add(listener);
+  }
+}
+
+function notifyStoreListener<S>(
+  group: ListenerGroup<S>,
+  listener: Listener<S>,
+  state: S,
+  prevState: S,
+) {
+  const { disposables } = group;
+  // Skip the cleanup lookup when no listener has registered a cleanup.
+  // The `.size` gate keeps an empty disposables map off this hot path.
+  const cleanup = disposables.size ? disposables.get(listener) : undefined;
+  if (cleanup) cleanup();
+  const result = listener(state, prevState);
+  if (result) {
+    disposables.set(listener, result);
+  } else if (cleanup) {
+    disposables.delete(listener);
+  }
+}
+
+interface RunLiveListenersParams<S> {
+  group: ListenerGroup<S>;
+  getState: () => S;
+  prevState: S;
+  updatedKey: UpdatedKey<S>;
+  notifiedListeners?: Set<Listener<S>>;
+}
+
+function runLiveListeners<S>({
+  group,
+  getState,
+  prevState,
+  updatedKey,
+  notifiedListeners,
+}: RunLiveListenersParams<S>) {
+  const allKeysListeners = group.allKeysListeners;
+  for (const listener of group.listeners) {
+    if (notifiedListeners?.has(listener)) continue;
+    if (!allKeysListeners?.has(listener)) {
+      const keys = group.listenerKeys.get(listener);
+      if (!hasUpdatedKey(keys, updatedKey)) continue;
+    }
+    notifiedListeners?.add(listener);
+    notifyStoreListener(group, listener, getState(), prevState);
+  }
+}
+
 /**
  * Creates a store.
  * @param initialState Initial state.
@@ -272,124 +455,6 @@ export function createStore<S extends State>(
   // active frame for the listener group before re-keying mutates its bucket.
   const fastPathFrames: Array<FastPathFrame<S>> = [];
 
-  const getFastPathNotifiedListeners = (frame: FastPathFrame<S>) => {
-    const notifiedListeners = new Set<Listener<S>>();
-    const currentListener = frame.currentListener;
-    if (!currentListener) return notifiedListeners;
-    for (const listener of frame.keyedListeners) {
-      notifiedListeners.add(listener);
-      if (listener === currentListener) {
-        return notifiedListeners;
-      }
-    }
-    notifiedListeners.clear();
-    notifiedListeners.add(currentListener);
-    return notifiedListeners;
-  };
-
-  const preserveFastPathNotifiedListeners = (frame: FastPathFrame<S>) => {
-    frame.notifiedListeners ??= getFastPathNotifiedListeners(frame);
-  };
-
-  // An existing listener re-keyed to all keys after its insertion-order slot
-  // has passed should stay skipped, matching the live slow path.
-  const hasFastPathPassedListener = (
-    frame: FastPathFrame<S>,
-    listener: Listener<S>,
-  ) => {
-    if (!frame.currentListener) return false;
-    let foundCurrentKeyedListener = false;
-    for (const currentListener of frame.keyedListeners) {
-      if (currentListener === frame.currentListener) {
-        foundCurrentKeyedListener = true;
-        continue;
-      }
-      if (!foundCurrentKeyedListener) continue;
-      if (currentListener === listener) return false;
-    }
-    let foundListener = false;
-    for (const currentListener of frame.group.listeners) {
-      if (currentListener === frame.currentListener) return foundListener;
-      if (currentListener === listener) {
-        foundListener = true;
-      }
-    }
-    return false;
-  };
-
-  const preserveFastPathFrames = (
-    group: ListenerGroup<S>,
-    listener?: Listener<S>,
-  ) => {
-    for (const frame of fastPathFrames) {
-      if (frame.group !== group) continue;
-      if (frame.recovering) continue;
-      if (listener && !frame.keyedListeners.has(listener)) continue;
-      preserveFastPathNotifiedListeners(frame);
-      for (const currentListener of frame.group.listeners) {
-        if (currentListener === frame.currentListener) break;
-        if (!hasFastPathPassedListener(frame, currentListener)) continue;
-        frame.notifiedListeners?.add(currentListener);
-      }
-    }
-  };
-
-  const preserveFastPathPassedListeners = (
-    group: ListenerGroup<S>,
-    listener: Listener<S>,
-  ) => {
-    for (const frame of fastPathFrames) {
-      if (frame.group !== group) continue;
-      if (frame.recovering) continue;
-      if (!hasFastPathPassedListener(frame, listener)) continue;
-      preserveFastPathNotifiedListeners(frame);
-      frame.notifiedListeners?.add(listener);
-    }
-  };
-
-  const preserveFastPathPassedKeyedListeners = (
-    group: ListenerGroup<S>,
-    keys: Array<keyof S>,
-    listener: Listener<S>,
-  ) => {
-    const wasRegistered = group.listeners.has(listener);
-    for (const frame of fastPathFrames) {
-      if (frame.group !== group) continue;
-      if (frame.recovering) continue;
-      if (!keys.includes(frame.updatedKey)) continue;
-      if (hasFastPathPassedListener(frame, listener)) {
-        preserveFastPathNotifiedListeners(frame);
-        frame.notifiedListeners?.add(listener);
-      } else if (wasRegistered) {
-        preserveFastPathNotifiedListeners(frame);
-        frame.recoverToLive = true;
-      }
-    }
-  };
-
-  const clearFastPathNotifiedListener = (
-    group: ListenerGroup<S>,
-    listener: Listener<S>,
-  ) => {
-    for (const frame of fastPathFrames) {
-      if (frame.group !== group) continue;
-      frame.notifiedListeners?.delete(listener);
-    }
-  };
-
-  const addFastPathKeyedListener = (
-    group: ListenerGroup<S>,
-    keys: Array<keyof S>,
-    listener: Listener<S>,
-  ) => {
-    for (const frame of fastPathFrames) {
-      if (frame.group !== group) continue;
-      if (frame.recovering) continue;
-      if (!keys.includes(frame.updatedKey)) continue;
-      frame.keyedListeners.add(listener);
-    }
-  };
-
   // Registers `listener` in `group` and returns its unsubscribe. Three jobs:
   // (1) snapshot `keys` as a defensive copy (or null for an all-keys listener);
   // (2) index the listener — re-registering the same listener first clears its
@@ -404,25 +469,35 @@ export function createStore<S extends State>(
     const listenerKeysValue = keys ? [...keys] : null;
     const wasRegistered = group.listeners.has(listener);
     if (!wasRegistered) {
-      clearFastPathNotifiedListener(group, listener);
+      clearFastPathNotifiedListener(fastPathFrames, group, listener);
     }
     if (!listenerKeysValue) {
       if (wasRegistered) {
-        preserveFastPathFrames(group);
+        preserveFastPathFrames(fastPathFrames, group);
       }
-      preserveFastPathPassedListeners(group, listener);
+      preserveFastPathPassedListeners(fastPathFrames, group, listener);
     } else {
-      preserveFastPathPassedKeyedListeners(group, listenerKeysValue, listener);
+      preserveFastPathPassedKeyedListeners({
+        fastPathFrames,
+        group,
+        keys: listenerKeysValue,
+        listener,
+      });
     }
     if (wasRegistered) {
-      preserveFastPathFrames(group, listener);
+      preserveFastPathFrames(fastPathFrames, group, listener);
       deleteListenerIndexes(group, listener, group.listenerKeys.get(listener));
     }
     group.listeners.add(listener);
     if (listenerKeysValue) {
       group.listenersByKey ??= new Map();
       addKeyedListener(group.listenersByKey, listenerKeysValue, listener);
-      addFastPathKeyedListener(group, listenerKeysValue, listener);
+      addFastPathKeyedListener({
+        fastPathFrames,
+        group,
+        keys: listenerKeysValue,
+        listener,
+      });
     } else {
       group.allKeysListeners ??= new Set();
       group.allKeysListeners.add(listener);
@@ -431,7 +506,7 @@ export function createStore<S extends State>(
     return () => {
       group.disposables.get(listener)?.();
       group.disposables.delete(listener);
-      preserveFastPathFrames(group, listener);
+      preserveFastPathFrames(fastPathFrames, group, listener);
       const currentKeys = group.listenerKeys.get(listener);
       deleteListenerIndexes(group, listener, listenerKeysValue);
       if (currentKeys !== listenerKeysValue) {
@@ -499,34 +574,6 @@ export function createStore<S extends State>(
     prevState: S,
     updatedKey: UpdatedKey<S>,
   ) => {
-    const { disposables } = group;
-
-    const notifyListener = (listener: Listener<S>) => {
-      // Skip the cleanup lookup when no listener has registered a cleanup.
-      // The `.size` gate keeps an empty disposables map off this hot path.
-      const cleanup = disposables.size ? disposables.get(listener) : undefined;
-      if (cleanup) cleanup();
-      const result = listener(state, prevState);
-      if (result) {
-        disposables.set(listener, result);
-      } else if (cleanup) {
-        disposables.delete(listener);
-      }
-    };
-
-    const runLiveListeners = (notifiedListeners?: Set<Listener<S>>) => {
-      const allKeysListeners = group.allKeysListeners;
-      for (const listener of group.listeners) {
-        if (notifiedListeners?.has(listener)) continue;
-        if (!allKeysListeners?.has(listener)) {
-          const keys = group.listenerKeys.get(listener);
-          if (!hasUpdatedKey(keys, updatedKey)) continue;
-        }
-        notifiedListeners?.add(listener);
-        notifyListener(listener);
-      }
-    };
-
     if (!(updatedKey instanceof Set) && !group.allKeysListeners?.size) {
       const keyedListeners = group.listenersByKey?.get(updatedKey);
       if (!keyedListeners) return;
@@ -537,36 +584,35 @@ export function createStore<S extends State>(
         updatedKey,
         currentListener: null,
       };
-      let frameActive = true;
       fastPathFrames.push(frame);
-
-      const removeFrame = () => {
-        if (!frameActive) return;
-        fastPathFrames.pop();
-        frameActive = false;
-      };
 
       try {
         for (const listener of keyedListeners) {
           if (frame.notifiedListeners?.has(listener)) continue;
           frame.currentListener = listener;
           frame.notifiedListeners?.add(listener);
-          notifyListener(listener);
+          notifyStoreListener(group, listener, state, prevState);
           if (!group.allKeysListeners?.size && !frame.recoverToLive) continue;
           const notifiedListeners =
             frame.notifiedListeners ?? getFastPathNotifiedListeners(frame);
           frame.notifiedListeners = notifiedListeners;
           frame.recovering = true;
-          runLiveListeners(notifiedListeners);
+          runLiveListeners({
+            group,
+            getState,
+            prevState,
+            updatedKey,
+            notifiedListeners,
+          });
           return;
         }
       } finally {
-        removeFrame();
+        fastPathFrames.pop();
       }
       return;
     }
 
-    runLiveListeners();
+    runLiveListeners({ group, getState, prevState, updatedKey });
   };
 
   // `fromStores` marks an update that originated from an extended parent store

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -355,7 +355,9 @@ export function createStore<S extends State>(
     if (!(updatedKey instanceof Set) && !group.allKeysListeners?.size) {
       const keyedListeners = group.listenersByKey?.get(updatedKey);
       if (!keyedListeners) return;
+      const notifiedListeners = new Set<Listener<S>>();
       for (const listener of keyedListeners) {
+        notifiedListeners.add(listener);
         // Skip the cleanup lookup when no listener has registered a cleanup.
         // The `.size` gate keeps an empty disposables map off this hot path.
         const cleanup = disposables.size
@@ -367,6 +369,29 @@ export function createStore<S extends State>(
           disposables.set(listener, result);
         } else if (cleanup) {
           disposables.delete(listener);
+        }
+      }
+      const allKeysListeners = group.allKeysListeners;
+      if (allKeysListeners?.size) {
+        for (const listener of group.listeners) {
+          if (notifiedListeners.has(listener)) continue;
+          if (!allKeysListeners.has(listener)) {
+            const keys = group.listenerKeys.get(listener);
+            if (!hasUpdatedKey(keys, updatedKey)) continue;
+          }
+          notifiedListeners.add(listener);
+          // Skip the cleanup lookup when no listener has registered a cleanup.
+          // The `.size` gate keeps an empty disposables map off this hot path.
+          const cleanup = disposables.size
+            ? disposables.get(listener)
+            : undefined;
+          if (cleanup) cleanup();
+          const result = listener(state, prevState);
+          if (result) {
+            disposables.set(listener, result);
+          } else if (cleanup) {
+            disposables.delete(listener);
+          }
         }
       }
       return;

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -542,10 +542,7 @@ test("fires a keyed listener added during the keyed fast path", () => {
   expect(events).toEqual(["first", "second"]);
 });
 
-// TODO: Re-enable when fixing https://github.com/ariakit/ariakit/issues/6317.
-// The workaround commit keeps library code unchanged while the sandbox
-// demonstrates the userland workaround.
-test.skip("fires an all-keys listener added during the keyed fast path", () => {
+test("fires an all-keys listener added during the keyed fast path", () => {
   const store = createStore({ count: 0 });
   const events: string[] = [];
 
@@ -561,6 +558,64 @@ test.skip("fires an all-keys listener added during the keyed fast path", () => {
   store.setState("count", 1);
 
   expect(events).toEqual(["first", "second"]);
+});
+
+test("does not refire a keyed listener re-keyed to all keys", () => {
+  const store = createStore({ count: 0 });
+  const events: string[] = [];
+
+  const listener = () => {
+    events.push("listener");
+    subscribe(store, null, listener);
+  };
+
+  subscribe(store, ["count"], listener);
+
+  store.setState("count", 1);
+
+  expect(events).toEqual(["listener"]);
+});
+
+test("does not refire an earlier listener re-keyed to all keys", () => {
+  const store = createStore({ count: 0 });
+  const events: string[] = [];
+
+  const first = () => {
+    events.push("first");
+  };
+
+  subscribe(store, ["count"], first);
+  subscribe(store, ["count"], () => {
+    events.push("second");
+    subscribe(store, null, first);
+  });
+
+  store.setState("count", 1);
+
+  expect(events).toEqual(["first", "second"]);
+});
+
+test("fires a keyed listener added by an all-keys listener", () => {
+  const store = createStore({ count: 0 });
+  const events: string[] = [];
+
+  const third = () => {
+    events.push("third");
+  };
+
+  const second = () => {
+    events.push("second");
+    subscribe(store, ["count"], third);
+  };
+
+  subscribe(store, ["count"], () => {
+    events.push("first");
+    subscribe(store, null, second);
+  });
+
+  store.setState("count", 1);
+
+  expect(events).toEqual(["first", "second", "third"]);
 });
 
 test("unsubscribes a keyed listener from inside another keyed listener", () => {

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -1069,6 +1069,54 @@ test("keeps outer recovery state during reentrant dispatch", () => {
   expect(getEvents(true)).toEqual(["second", "nested"]);
 });
 
+test("uses live state after reentrant recovered listeners", () => {
+  const getEvents = (forceSlowPath = false) => {
+    const store = createStore({ count: 0, label: "a" });
+    const events: string[] = [];
+    let updated = false;
+
+    const first = (state: { label: string }) => {
+      events.push(`first:${state.label}`);
+      if (!updated) {
+        updated = true;
+        store.setState("label", "b");
+      }
+    };
+
+    const second = (state: { label: string }) => {
+      events.push(`second:${state.label}`);
+    };
+
+    if (forceSlowPath) {
+      subscribe(store, null, () => {});
+    }
+    subscribe(store, ["count"], () => {
+      events.push("keyed");
+      subscribe(store, null, first);
+      subscribe(store, null, second);
+    });
+
+    store.setState("count", 1);
+
+    return events;
+  };
+
+  expect(getEvents()).toEqual([
+    "keyed",
+    "first:a",
+    "first:b",
+    "second:b",
+    "second:b",
+  ]);
+  expect(getEvents(true)).toEqual([
+    "keyed",
+    "first:a",
+    "first:b",
+    "second:b",
+    "second:b",
+  ]);
+});
+
 test("fires a keyed listener added by an all-keys listener", () => {
   const store = createStore({ count: 0 });
   const events: string[] = [];

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -542,6 +542,24 @@ test("fires a keyed listener added during the keyed fast path", () => {
   expect(events).toEqual(["first", "second"]);
 });
 
+test("fires an all-keys listener added during the keyed fast path", () => {
+  const store = createStore({ count: 0 });
+  const events: string[] = [];
+
+  const second = () => {
+    events.push("second");
+  };
+
+  subscribe(store, ["count"], () => {
+    events.push("first");
+    subscribe(store, null, second);
+  });
+
+  store.setState("count", 1);
+
+  expect(events).toEqual(["first", "second"]);
+});
+
 test("unsubscribes a keyed listener from inside another keyed listener", () => {
   const store = createStore({ count: 0 });
   const events: string[] = [];

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -595,6 +595,480 @@ test("does not refire an earlier listener re-keyed to all keys", () => {
   expect(events).toEqual(["first", "second"]);
 });
 
+test("does not fire an earlier other-key listener re-keyed to all keys", () => {
+  const getEvents = (forceSlowPath = false) => {
+    const store = createStore({ count: 0, label: "" });
+    const events: string[] = [];
+
+    const first = () => {
+      events.push("first");
+    };
+
+    if (forceSlowPath) {
+      subscribe(store, null, () => {});
+    }
+    subscribe(store, ["label"], first);
+    subscribe(store, ["count"], () => {
+      events.push("second");
+      subscribe(store, null, first);
+    });
+
+    store.setState("count", 1);
+
+    return events;
+  };
+
+  expect(getEvents()).toEqual(["second"]);
+  expect(getEvents(true)).toEqual(["second"]);
+});
+
+test("preserves listener order when all-keys listeners are added", () => {
+  const getEvents = (forceSlowPath = false) => {
+    const store = createStore({ count: 0 });
+    const events: string[] = [];
+
+    const third = () => {
+      events.push("third");
+    };
+
+    const fourth = () => {
+      events.push("fourth");
+    };
+
+    if (forceSlowPath) {
+      subscribe(store, null, () => {});
+    }
+    subscribe(store, ["count"], () => {
+      events.push("first");
+      subscribe(store, null, third);
+    });
+    subscribe(store, ["count"], () => {
+      events.push("second");
+      subscribe(store, ["count"], fourth);
+    });
+
+    store.setState("count", 1);
+
+    return events;
+  };
+
+  expect(getEvents()).toEqual(["first", "second", "third", "fourth"]);
+  expect(getEvents(true)).toEqual(["first", "second", "third", "fourth"]);
+});
+
+test("continues after a keyed listener unsubscribes before recovery", () => {
+  const store = createStore({ count: 0 });
+  const events: string[] = [];
+  let dispose = () => {};
+
+  dispose = subscribe(store, ["count"], () => {
+    events.push("first");
+    dispose();
+    subscribe(store, null, () => {
+      events.push("third");
+    });
+  });
+  subscribe(store, ["count"], () => {
+    events.push("second");
+  });
+
+  store.setState("count", 1);
+
+  expect(events).toEqual(["first", "second", "third"]);
+});
+
+test("fires a keyed listener added after the active bucket empties", () => {
+  const getEvents = (forceSlowPath = false) => {
+    const store = createStore({ count: 0 });
+    const events: string[] = [];
+    let dispose = () => {};
+
+    const second = () => {
+      events.push("second");
+    };
+
+    if (forceSlowPath) {
+      subscribe(store, null, () => {});
+    }
+    dispose = subscribe(store, ["count"], () => {
+      events.push("first");
+      dispose();
+      subscribe(store, ["count"], second);
+    });
+
+    store.setState("count", 1);
+
+    return events;
+  };
+
+  expect(getEvents()).toEqual(["first", "second"]);
+  expect(getEvents(true)).toEqual(["first", "second"]);
+});
+
+test("fires a current-key listener re-keyed before recovery", () => {
+  const store = createStore({ count: 0, label: "" });
+  const events: string[] = [];
+
+  const first = () => {
+    events.push("first");
+  };
+
+  subscribe(store, ["label"], first);
+  subscribe(store, ["count"], () => {
+    events.push("second");
+    subscribe(store, null, () => {
+      events.push("third");
+    });
+  });
+  subscribe(store, ["count"], first);
+
+  store.setState("count", 1);
+
+  expect(events).toEqual(["second", "first", "third"]);
+});
+
+test("does not refire an earlier listener re-keyed to the current key", () => {
+  const getEvents = (forceSlowPath = false) => {
+    const store = createStore({ count: 0 });
+    const events: string[] = [];
+
+    const first = () => {
+      events.push("first");
+    };
+
+    if (forceSlowPath) {
+      subscribe(store, null, () => {});
+    }
+    subscribe(store, ["count"], first);
+    subscribe(store, ["count"], () => {
+      events.push("second");
+      subscribe(store, ["count"], first);
+    });
+
+    store.setState("count", 1);
+
+    return events;
+  };
+
+  expect(getEvents()).toEqual(["first", "second"]);
+  expect(getEvents(true)).toEqual(["first", "second"]);
+});
+
+test("preserves order when a pending listener re-keys to current key", () => {
+  const getEvents = (forceSlowPath = false) => {
+    const store = createStore({ count: 0 });
+    const events: string[] = [];
+
+    const second = () => {
+      events.push("second");
+    };
+
+    if (forceSlowPath) {
+      subscribe(store, null, () => {});
+    }
+    subscribe(store, ["count"], () => {
+      events.push("first");
+      subscribe(store, ["count"], second);
+    });
+    subscribe(store, ["count"], second);
+    subscribe(store, ["count"], () => {
+      events.push("third");
+    });
+
+    store.setState("count", 1);
+
+    return events;
+  };
+
+  expect(getEvents()).toEqual(["first", "second", "third"]);
+  expect(getEvents(true)).toEqual(["first", "second", "third"]);
+});
+
+test("fires a keyed listener freshly re-subscribed after unsubscribe", () => {
+  const getEvents = (forceSlowPath = false) => {
+    const store = createStore({ count: 0 });
+    const events: string[] = [];
+    let dispose = () => {};
+
+    const listener = () => {
+      events.push("listener");
+      dispose();
+      if (events.length === 1) {
+        subscribe(store, ["count"], listener);
+      }
+    };
+
+    if (forceSlowPath) {
+      subscribe(store, null, () => {});
+    }
+    dispose = subscribe(store, ["count"], listener);
+
+    store.setState("count", 1);
+
+    return events;
+  };
+
+  expect(getEvents()).toEqual(["listener", "listener"]);
+  expect(getEvents(true)).toEqual(["listener", "listener"]);
+});
+
+test("fires an all-keys listener freshly re-subscribed after unsubscribe", () => {
+  const getEvents = (forceSlowPath = false) => {
+    const store = createStore({ count: 0 });
+    const events: string[] = [];
+    let dispose = () => {};
+
+    const listener = () => {
+      events.push("listener");
+      dispose();
+      if (events.length === 1) {
+        subscribe(store, null, listener);
+      }
+    };
+
+    if (forceSlowPath) {
+      subscribe(store, null, () => {});
+    }
+    dispose = subscribe(store, ["count"], listener);
+
+    store.setState("count", 1);
+
+    return events;
+  };
+
+  expect(getEvents()).toEqual(["listener", "listener"]);
+  expect(getEvents(true)).toEqual(["listener", "listener"]);
+});
+
+test("does not fire an earlier other-key listener re-keyed to current key", () => {
+  const getEvents = (forceSlowPath = false) => {
+    const store = createStore({ count: 0, label: "" });
+    const events: string[] = [];
+
+    const first = () => {
+      events.push("first");
+    };
+
+    if (forceSlowPath) {
+      subscribe(store, null, () => {});
+    }
+    subscribe(store, ["label"], first);
+    subscribe(store, ["count"], () => {
+      events.push("second");
+      subscribe(store, ["count"], first);
+    });
+
+    store.setState("count", 1);
+
+    return events;
+  };
+
+  expect(getEvents()).toEqual(["second"]);
+  expect(getEvents(true)).toEqual(["second"]);
+});
+
+test("fires a pending keyed listener re-keyed to all keys", () => {
+  const store = createStore({ count: 0, label: "" });
+  const events: string[] = [];
+
+  const first = () => {
+    events.push("first");
+  };
+
+  subscribe(store, ["label"], first);
+  subscribe(store, ["count"], () => {
+    events.push("second");
+    subscribe(store, null, first);
+  });
+  subscribe(store, ["count"], first);
+
+  store.setState("count", 1);
+
+  expect(events).toEqual(["second", "first"]);
+});
+
+test("does not refire keyed listeners before self-unsubscribe recovery", () => {
+  const getEvents = (forceSlowPath = false) => {
+    const store = createStore({ count: 0 });
+    const events: string[] = [];
+    let dispose = () => {};
+
+    if (forceSlowPath) {
+      subscribe(store, null, () => {});
+    }
+    subscribe(store, ["count"], () => {
+      events.push("first");
+    });
+    dispose = subscribe(store, ["count"], () => {
+      events.push("second");
+      dispose();
+      subscribe(store, null, () => {
+        events.push("third");
+      });
+    });
+
+    store.setState("count", 1);
+
+    return events;
+  };
+
+  expect(getEvents()).toEqual(["first", "second", "third"]);
+  expect(getEvents(true)).toEqual(["first", "second", "third"]);
+});
+
+test("continues after the current listener re-keys before recovery", () => {
+  const getEvents = (forceSlowPath = false) => {
+    const store = createStore({ count: 0, label: "" });
+    const events: string[] = [];
+
+    const first = () => {
+      events.push("first");
+      subscribe(store, ["label"], first);
+      subscribe(store, null, () => {
+        events.push("fourth");
+      });
+    };
+
+    if (forceSlowPath) {
+      subscribe(store, null, () => {});
+    }
+    subscribe(store, ["count"], first);
+    subscribe(store, ["count"], () => {
+      events.push("second");
+    });
+    subscribe(store, ["count"], () => {
+      events.push("third");
+    });
+
+    store.setState("count", 1);
+
+    return events;
+  };
+
+  expect(getEvents()).toEqual(["first", "second", "third", "fourth"]);
+  expect(getEvents(true)).toEqual(["first", "second", "third", "fourth"]);
+});
+
+test("continues after the current listener unsubscribes before re-keying", () => {
+  const getEvents = (forceSlowPath = false) => {
+    const store = createStore({ count: 0, label: "" });
+    const events: string[] = [];
+    let dispose = () => {};
+
+    const second = () => {
+      events.push("second");
+    };
+
+    if (forceSlowPath) {
+      subscribe(store, null, () => {});
+    }
+    dispose = subscribe(store, ["count"], () => {
+      events.push("first");
+      dispose();
+      subscribe(store, null, second);
+    });
+    subscribe(store, ["label"], second);
+
+    store.setState("count", 1);
+
+    return events;
+  };
+
+  expect(getEvents()).toEqual(["first", "second"]);
+  expect(getEvents(true)).toEqual(["first", "second"]);
+});
+
+test("does not fire earlier listener re-keyed after current unsubscribe", () => {
+  const getEvents = (forceSlowPath = false) => {
+    const store = createStore({ count: 0, label: "" });
+    const events: string[] = [];
+    let dispose = () => {};
+
+    const first = () => {
+      events.push("first");
+    };
+
+    if (forceSlowPath) {
+      subscribe(store, null, () => {});
+    }
+    subscribe(store, ["label"], first);
+    dispose = subscribe(store, ["count"], () => {
+      events.push("second");
+      dispose();
+      subscribe(store, null, first);
+    });
+
+    store.setState("count", 1);
+
+    return events;
+  };
+
+  expect(getEvents()).toEqual(["second"]);
+  expect(getEvents(true)).toEqual(["second"]);
+});
+
+test("fires a recovered listener freshly re-subscribed after unsubscribe", () => {
+  const getEvents = (forceSlowPath = false) => {
+    const store = createStore({ count: 0 });
+    const events: string[] = [];
+    let dispose = () => {};
+
+    const second = () => {
+      events.push("second");
+      dispose();
+      if (events.length === 2) {
+        dispose = subscribe(store, null, second);
+      }
+    };
+
+    if (forceSlowPath) {
+      subscribe(store, null, () => {});
+    }
+    subscribe(store, ["count"], () => {
+      events.push("first");
+      dispose = subscribe(store, null, second);
+    });
+
+    store.setState("count", 1);
+
+    return events;
+  };
+
+  expect(getEvents()).toEqual(["first", "second", "second"]);
+  expect(getEvents(true)).toEqual(["first", "second", "second"]);
+});
+
+test("keeps outer recovery state during reentrant dispatch", () => {
+  const getEvents = (forceSlowPath = false) => {
+    const store = createStore({ count: 0, label: "", nested: 0 });
+    const events: string[] = [];
+
+    const first = () => {
+      events.push("first");
+    };
+
+    if (forceSlowPath) {
+      subscribe(store, null, () => {});
+    }
+    subscribe(store, ["label"], first);
+    subscribe(store, ["count"], () => {
+      events.push("second");
+      store.setState("nested", 1);
+    });
+    subscribe(store, ["nested"], () => {
+      events.push("nested");
+      subscribe(store, null, first);
+    });
+
+    store.setState("count", 1);
+
+    return events;
+  };
+
+  expect(getEvents()).toEqual(["second", "nested"]);
+  expect(getEvents(true)).toEqual(["second", "nested"]);
+});
+
 test("fires a keyed listener added by an all-keys listener", () => {
   const store = createStore({ count: 0 });
   const events: string[] = [];

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -542,7 +542,10 @@ test("fires a keyed listener added during the keyed fast path", () => {
   expect(events).toEqual(["first", "second"]);
 });
 
-test("fires an all-keys listener added during the keyed fast path", () => {
+// TODO: Re-enable when fixing https://github.com/ariakit/ariakit/issues/6317.
+// The workaround commit keeps library code unchanged while the sandbox
+// demonstrates the userland workaround.
+test.skip("fires an all-keys listener added during the keyed fast path", () => {
   const store = createStore({ count: 0 });
   const events: string[] = [];
 


### PR DESCRIPTION
## Motivation

A `@ariakit/store` listener registered for all keys with `subscribe(store, null, listener)` could miss the in-flight dispatch when it was added from a keyed listener during the keyed fast path.

The keyed listener observed the change, but the newly registered all-keys listener did not:

```ts
subscribe(store, ["count"], () => {
  subscribe(store, null, second);
});
store.setState("count", 1);
```

This made direct `@ariakit/store` consumers see different behavior depending on whether an unrelated all-keys listener already existed on the same store.

## Solution

`runListeners` now continues through the live listener set when all-keys listeners appear during the keyed fast path. It skips listeners already notified by the keyed bucket and applies the same all-keys/keyed filtering used by the existing slow path, so listeners registered by the new all-keys listener can also observe the in-flight dispatch.

This PR includes:

- a direct `@ariakit/store` unit repro for an all-keys listener added during the keyed fast path;
- additional unit coverage for re-keying and nested listener registrations during the recovery pass;
- a React sandbox matching the user-visible lazy logger scenario;
- browser and happy-dom sandbox tests for the reported behavior;
- a patch changeset for `@ariakit/store`.

Fixes #6317.

## Workaround

Before this fix is released, pre-register a no-op all-keys listener before the first state change. This forces the slow notification path, whose live listener iteration delivers the in-flight dispatch to all-keys listeners registered during it.

```ts
// TODO: Remove once https://github.com/ariakit/ariakit/issues/6317 is fixed.
subscribe(store, null, () => {});
```
