### PR TITLE
Fix select offscreen typeahead disabled items

### DIFF
--- a/.changeset/300-select-offscreen-typeahead.md
+++ b/.changeset/300-select-offscreen-typeahead.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`SelectPopover`](https://ariakit.com/reference/select-popover) typeahead to skip disabled offscreen [`SelectItem`](https://ariakit.com/reference/select-item) placeholders.

--- a/app/src/sandbox/select-6347/index.react.tsx
+++ b/app/src/sandbox/select-6347/index.react.tsx
@@ -1,5 +1,6 @@
 import * as Ariakit from "@ariakit/react";
 import { SelectItem } from "@ariakit/react-components/select/select-item-offscreen";
+import type { KeyboardEvent } from "react";
 
 const fruits = [
   "Apple",
@@ -42,14 +43,57 @@ const fruits = [
 
 const outOfStock = ["Papaya"];
 
+function isTypeaheadKey(event: KeyboardEvent<HTMLElement>) {
+  if (event.ctrlKey) return false;
+  if (event.altKey) return false;
+  if (event.metaKey) return false;
+  if (event.key === " ") return true;
+  if (event.key.length !== 1) return false;
+  return /^[\p{Letter}\p{Number}]$/u.test(event.key);
+}
+
+function isDisabledItem(item: HTMLElement) {
+  if (item.getAttribute("aria-disabled") === "true") return true;
+  if ("disabled" in item && item.disabled) return true;
+  return false;
+}
+
 export default function Example() {
+  const select = Ariakit.useSelectStore({ defaultValue: "Apple" });
+
+  const onKeyDownCapture = (event: KeyboardEvent<HTMLElement>) => {
+    if (!isTypeaheadKey(event)) return;
+    const contentElement = select.getState().contentElement;
+    if (!contentElement) return;
+    const offscreenItems = contentElement.querySelectorAll<HTMLElement>(
+      "[data-offscreen-id]",
+    );
+    for (const item of offscreenItems) {
+      if (!isDisabledItem(item)) continue;
+      const offscreenId = item.getAttribute("data-offscreen-id");
+      if (!offscreenId) continue;
+      // TODO: Remove this repro-preserving workaround once
+      // https://github.com/ariakit/ariakit/issues/6347 is fixed.
+      item.removeAttribute("data-offscreen-id");
+      queueMicrotask(() => {
+        item.setAttribute("data-offscreen-id", offscreenId);
+      });
+    }
+  };
+
   return (
-    <Ariakit.SelectProvider defaultValue="Apple">
-      <Ariakit.SelectLabel>Fruit</Ariakit.SelectLabel>
-      <Ariakit.Select style={{ display: "block" }} />
+    <>
+      <Ariakit.SelectLabel store={select}>Fruit</Ariakit.SelectLabel>
+      <Ariakit.Select
+        store={select}
+        onKeyDownCapture={onKeyDownCapture}
+        style={{ display: "block" }}
+      />
       <Ariakit.SelectPopover
+        store={select}
         gutter={4}
         sameWidth
+        onKeyDownCapture={onKeyDownCapture}
         style={{
           background: "white",
           border: "1px solid gray",
@@ -59,6 +103,7 @@ export default function Example() {
       >
         {fruits.map((fruit) => (
           <SelectItem
+            store={select}
             key={fruit}
             value={fruit}
             disabled={outOfStock.includes(fruit)}
@@ -67,6 +112,6 @@ export default function Example() {
           />
         ))}
       </Ariakit.SelectPopover>
-    </Ariakit.SelectProvider>
+    </>
   );
 }

--- a/app/src/sandbox/select-6347/index.react.tsx
+++ b/app/src/sandbox/select-6347/index.react.tsx
@@ -1,6 +1,5 @@
 import * as Ariakit from "@ariakit/react";
 import { SelectItem } from "@ariakit/react-components/select/select-item-offscreen";
-import type { KeyboardEvent } from "react";
 
 const fruits = [
   "Apple",
@@ -41,59 +40,38 @@ const fruits = [
   "Watermelon",
 ];
 
-const outOfStock = ["Papaya"];
+const outOfStock = "Papaya";
 
-function isTypeaheadKey(event: KeyboardEvent<HTMLElement>) {
-  if (event.ctrlKey) return false;
-  if (event.altKey) return false;
-  if (event.metaKey) return false;
-  if (event.key === " ") return true;
-  if (event.key.length !== 1) return false;
-  return /^[\p{Letter}\p{Number}]$/u.test(event.key);
+const accessibleFruits = fruits.map((fruit) =>
+  fruit === "Papaya" ? "Pawpaw" : fruit,
+);
+
+const ariaDisabledFruits = fruits.map((fruit) =>
+  fruit === "Papaya" ? "Papaw" : fruit,
+);
+
+interface FixtureProps {
+  accessibleWhenDisabled?: boolean;
+  ariaDisabledFruit?: string;
+  disabledFruit: string;
+  fruits: string[];
+  label: string;
 }
 
-function isDisabledItem(item: HTMLElement) {
-  if (item.getAttribute("aria-disabled") === "true") return true;
-  if ("disabled" in item && item.disabled) return true;
-  return false;
-}
-
-export default function Example() {
-  const select = Ariakit.useSelectStore({ defaultValue: "Apple" });
-
-  const onKeyDownCapture = (event: KeyboardEvent<HTMLElement>) => {
-    if (!isTypeaheadKey(event)) return;
-    const contentElement = select.getState().contentElement;
-    if (!contentElement) return;
-    const offscreenItems = contentElement.querySelectorAll<HTMLElement>(
-      "[data-offscreen-id]",
-    );
-    for (const item of offscreenItems) {
-      if (!isDisabledItem(item)) continue;
-      const offscreenId = item.getAttribute("data-offscreen-id");
-      if (!offscreenId) continue;
-      // TODO: Remove this repro-preserving workaround once
-      // https://github.com/ariakit/ariakit/issues/6347 is fixed.
-      item.removeAttribute("data-offscreen-id");
-      queueMicrotask(() => {
-        item.setAttribute("data-offscreen-id", offscreenId);
-      });
-    }
-  };
-
+function Fixture({
+  accessibleWhenDisabled,
+  ariaDisabledFruit,
+  disabledFruit,
+  fruits,
+  label,
+}: FixtureProps) {
   return (
-    <>
-      <Ariakit.SelectLabel store={select}>Fruit</Ariakit.SelectLabel>
-      <Ariakit.Select
-        store={select}
-        onKeyDownCapture={onKeyDownCapture}
-        style={{ display: "block" }}
-      />
+    <Ariakit.SelectProvider defaultValue="Apple">
+      <Ariakit.SelectLabel>{label}</Ariakit.SelectLabel>
+      <Ariakit.Select style={{ display: "block" }} />
       <Ariakit.SelectPopover
-        store={select}
         gutter={4}
         sameWidth
-        onKeyDownCapture={onKeyDownCapture}
         style={{
           background: "white",
           border: "1px solid gray",
@@ -103,15 +81,40 @@ export default function Example() {
       >
         {fruits.map((fruit) => (
           <SelectItem
-            store={select}
             key={fruit}
             value={fruit}
-            disabled={outOfStock.includes(fruit)}
+            disabled={fruit === disabledFruit}
+            {...(fruit === ariaDisabledFruit
+              ? { "aria-disabled": true }
+              : undefined)}
+            accessibleWhenDisabled={
+              fruit === disabledFruit ? accessibleWhenDisabled : undefined
+            }
             offscreenMode="passive"
             style={{ display: "block", padding: "4px 8px" }}
           />
         ))}
       </Ariakit.SelectPopover>
+    </Ariakit.SelectProvider>
+  );
+}
+
+export default function Example() {
+  return (
+    <>
+      <Fixture disabledFruit={outOfStock} fruits={fruits} label="Fruit" />
+      <Fixture
+        accessibleWhenDisabled
+        disabledFruit="Pawpaw"
+        fruits={accessibleFruits}
+        label="Accessible fruit"
+      />
+      <Fixture
+        ariaDisabledFruit="Papaw"
+        disabledFruit=""
+        fruits={ariaDisabledFruits}
+        label="ARIA disabled fruit"
+      />
     </>
   );
 }

--- a/app/src/sandbox/select-6347/index.react.tsx
+++ b/app/src/sandbox/select-6347/index.react.tsx
@@ -1,0 +1,72 @@
+import * as Ariakit from "@ariakit/react";
+import { SelectItem } from "@ariakit/react-components/select/select-item-offscreen";
+
+const fruits = [
+  "Apple",
+  "Apricot",
+  "Avocado",
+  "Cherry",
+  "Clementine",
+  "Coconut",
+  "Cranberry",
+  "Date",
+  "Dragon fruit",
+  "Durian",
+  "Elderberry",
+  "Fig",
+  "Grape",
+  "Grapefruit",
+  "Guava",
+  "Honeydew",
+  "Jackfruit",
+  "Kiwi",
+  "Kumquat",
+  "Lemon",
+  "Lime",
+  "Lychee",
+  "Mango",
+  "Melon",
+  "Nectarine",
+  "Orange",
+  "Papaya",
+  "Peach",
+  "Pear",
+  "Pineapple",
+  "Plum",
+  "Pomegranate",
+  "Quince",
+  "Raspberry",
+  "Strawberry",
+  "Watermelon",
+];
+
+const outOfStock = ["Papaya"];
+
+export default function Example() {
+  return (
+    <Ariakit.SelectProvider defaultValue="Apple">
+      <Ariakit.SelectLabel>Fruit</Ariakit.SelectLabel>
+      <Ariakit.Select style={{ display: "block" }} />
+      <Ariakit.SelectPopover
+        gutter={4}
+        sameWidth
+        style={{
+          background: "white",
+          border: "1px solid gray",
+          maxHeight: 120,
+          overflow: "auto",
+        }}
+      >
+        {fruits.map((fruit) => (
+          <SelectItem
+            key={fruit}
+            value={fruit}
+            disabled={outOfStock.includes(fruit)}
+            offscreenMode="passive"
+            style={{ display: "block", padding: "4px 8px" }}
+          />
+        ))}
+      </Ariakit.SelectPopover>
+    </Ariakit.SelectProvider>
+  );
+}

--- a/app/src/sandbox/select-6347/test-browser.ts
+++ b/app/src/sandbox/select-6347/test-browser.ts
@@ -1,0 +1,20 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/6347
+  test("typeahead skips disabled offscreen select items", async ({
+    page,
+    q,
+  }) => {
+    await q.combobox("Fruit").click();
+    await test.expect(q.option("Apple")).toHaveAttribute("data-active-item");
+    await test.expect(q.option("Papaya")).toHaveAttribute("data-offscreen");
+
+    await page.keyboard.press("p");
+
+    await test
+      .expect(q.option("Papaya"))
+      .not.toHaveAttribute("data-active-item");
+    await test.expect(q.option("Peach")).toHaveAttribute("data-active-item");
+  });
+});

--- a/app/src/sandbox/select-6347/test-browser.ts
+++ b/app/src/sandbox/select-6347/test-browser.ts
@@ -17,4 +17,37 @@ withFramework(import.meta.dirname, async ({ test }) => {
       .not.toHaveAttribute("data-active-item");
     await test.expect(q.option("Peach")).toHaveAttribute("data-active-item");
   });
+
+  test("typeahead includes accessible disabled offscreen select items", async ({
+    page,
+    q,
+  }) => {
+    await q.combobox("Accessible fruit").click();
+    await test.expect(q.option("Pawpaw")).toHaveAttribute("data-offscreen");
+    await test
+      .expect(q.option("Pawpaw"))
+      .toHaveAttribute("aria-disabled", "true");
+
+    await page.keyboard.press("p");
+
+    await test.expect(q.option("Pawpaw")).toHaveAttribute("data-active-item");
+  });
+
+  test("typeahead skips aria-disabled offscreen select items", async ({
+    page,
+    q,
+  }) => {
+    await q.combobox("ARIA disabled fruit").click();
+    await test.expect(q.option("Papaw")).toHaveAttribute("data-offscreen");
+    await test
+      .expect(q.option("Papaw"))
+      .toHaveAttribute("aria-disabled", "true");
+
+    await page.keyboard.press("p");
+
+    await test
+      .expect(q.option("Papaw"))
+      .not.toHaveAttribute("data-active-item");
+    await test.expect(q.option("Peach")).toHaveAttribute("data-active-item");
+  });
 });

--- a/app/src/sandbox/select-6347/test.ts
+++ b/app/src/sandbox/select-6347/test.ts
@@ -12,3 +12,24 @@ test("typeahead skips disabled offscreen select items", async () => {
   expect(q.option.ensure("Papaya")).not.toHaveAttribute("data-active-item");
   expect(q.option.ensure("Peach")).toHaveAttribute("data-active-item");
 });
+
+test("typeahead includes accessible disabled offscreen select items", async () => {
+  await click(q.combobox("Accessible fruit"));
+  expect(q.option.ensure("Pawpaw")).toHaveAttribute("data-offscreen");
+  expect(q.option.ensure("Pawpaw")).toHaveAttribute("aria-disabled", "true");
+
+  await press("p");
+
+  expect(q.option.ensure("Pawpaw")).toHaveAttribute("data-active-item");
+});
+
+test("typeahead skips aria-disabled offscreen select items", async () => {
+  await click(q.combobox("ARIA disabled fruit"));
+  expect(q.option.ensure("Papaw")).toHaveAttribute("data-offscreen");
+  expect(q.option.ensure("Papaw")).toHaveAttribute("aria-disabled", "true");
+
+  await press("p");
+
+  expect(q.option.ensure("Papaw")).not.toHaveAttribute("data-active-item");
+  expect(q.option.ensure("Peach")).toHaveAttribute("data-active-item");
+});

--- a/app/src/sandbox/select-6347/test.ts
+++ b/app/src/sandbox/select-6347/test.ts
@@ -1,0 +1,14 @@
+import { click, press, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// https://github.com/ariakit/ariakit/issues/6347
+test("typeahead skips disabled offscreen select items", async () => {
+  await click(q.combobox("Fruit"));
+  expect(q.option.ensure("Apple")).toHaveAttribute("data-active-item");
+  expect(q.option.ensure("Papaya")).toHaveAttribute("data-offscreen");
+
+  await press("p");
+
+  expect(q.option.ensure("Papaya")).not.toHaveAttribute("data-active-item");
+  expect(q.option.ensure("Peach")).toHaveAttribute("data-active-item");
+});

--- a/packages/ariakit-react-components/src/composite/composite-item-offscreen.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-item-offscreen.tsx
@@ -1,7 +1,7 @@
 import { useStoreStateObject } from "@ariakit/react-store";
 import { useId, useMergeRefs, forwardRef } from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
-import { getPopupItemRole } from "@ariakit/utils";
+import { disabledFromProps, getPopupItemRole } from "@ariakit/utils";
 import type { ElementType } from "react";
 import type { CollectionItemOptions } from "../collection/collection-item-offscreen.tsx";
 import { useCollectionItemOffscreen } from "../collection/collection-item-offscreen.tsx";
@@ -19,7 +19,13 @@ export function useCompositeItemOffscreen<
   T extends ElementType,
   // oxlint-disable-next-line no-unnecessary-type-parameters
   P extends CompositeItemProps<T>,
->({ store, offscreenMode = "active", disabled, value, ...props }: P) {
+>({
+  store,
+  offscreenMode = "active",
+  disabled: disabledProp,
+  value,
+  ...props
+}: P) {
   const context = useCompositeScopedContext();
   store = store || context;
 
@@ -61,11 +67,14 @@ export function useCompositeItemOffscreen<
   });
 
   if (!offscreenProps.active) {
+    const disabled = disabledFromProps({ disabled: disabledProp, ...props });
+    const trulyDisabled = disabled && !props.accessibleWhenDisabled;
     return {
       ...offscreenProps,
       children: value,
       role: getPopupItemRole(listElement),
       "aria-disabled": disabled || undefined,
+      "data-disabled": trulyDisabled || undefined,
       "data-offscreen-id": storeId,
     };
   }

--- a/packages/ariakit-react-components/src/composite/composite-typeahead.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-typeahead.tsx
@@ -175,10 +175,9 @@ export const useCompositeTypeahead = createHook<
     const offscreenItems = document.querySelectorAll<HTMLElement>(selector);
     // Push the offscreen items to the enabled items list.
     for (const element of offscreenItems) {
-      const disabled =
-        element.ariaDisabled === "true" ||
-        ("disabled" in element && !!element.disabled);
-      enabledItems.push({ id: element.id, element, disabled });
+      if (element.hasAttribute("data-disabled")) continue;
+      if ("disabled" in element && !!element.disabled) continue;
+      enabledItems.push({ id: element.id, element });
     }
     // If there are offscreen items, we need to sort the enabled items based on
     // their DOM position so offscreen elements above the viewport are correctly


### PR DESCRIPTION
## Motivation

Fixes #6347.

Typeahead in a select with passive offscreen items can move the active item onto a disabled option while that option is still an offscreen placeholder. This makes keyboard behavior depend on whether the option has already been rendered into the store.

## Solution

Offscreen composite placeholders now expose a `data-disabled` marker only when they are truly disabled, using the same disabled semantics as rendered items. `CompositeTypeahead` skips those truly disabled offscreen placeholders before matching item text, while still allowing `accessibleWhenDisabled` placeholders to participate in typeahead.

The `select-6347` sandbox covers three paths in both browser and happy-dom tests:

- disabled offscreen `Papaya` is skipped in favor of `Peach`;
- disabled `Pawpaw` with `accessibleWhenDisabled` remains a typeahead target;
- `aria-disabled`-only offscreen `Papaw` is skipped in favor of `Peach`.

## Workaround

Until the library fix lands, render disabled offscreen items with `offscreenMode="active"` so they register in the store and are filtered out by the normal enabled-items logic:

```tsx
{fruits.map((fruit) => {
  const disabled = outOfStock.includes(fruit);
  return (
    <SelectItem
      key={fruit}
      value={fruit}
      disabled={disabled}
      // TODO: Remove this workaround once
      // https://github.com/ariakit/ariakit/issues/6347 is fixed.
      offscreenMode={disabled ? "active" : "passive"}
    />
  );
})}
```
