### PR TITLE
Fix SelectRenderer ARIA counts for mixed groups

### DIFF
--- a/.changeset/300-select-renderer-aria-count.md
+++ b/.changeset/300-select-renderer-aria-count.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/react-components": patch
+---
+
+Fixed virtualized `CompositeRenderer` and `SelectRenderer` to report correct `aria-setsize` and `aria-posinset` values when grouped items are followed by standalone items.

--- a/app/src/sandbox/select-renderer-6301/index.react.tsx
+++ b/app/src/sandbox/select-renderer-6301/index.react.tsx
@@ -1,0 +1,84 @@
+import * as Ariakit from "@ariakit/react";
+import { SelectRenderer } from "@ariakit/react-components/select/select-renderer";
+import type { SelectRendererItemObject } from "@ariakit/react-components/select/select-renderer";
+
+interface FruitItem extends SelectRendererItemObject {
+  id: string;
+  label?: string;
+  items?: FruitItem[];
+}
+
+function getItem(value: string): FruitItem {
+  return { id: `item-${value.toLowerCase()}`, value };
+}
+
+const citrusItems = ["Lemon", "Lime", "Orange"].map(getItem);
+const otherItems = ["Apple", "Banana"].map(getItem);
+
+const items: readonly FruitItem[] = [
+  {
+    id: "group-citrus",
+    label: "Citrus",
+    itemSize: 40,
+    paddingStart: 44,
+    items: citrusItems,
+  },
+  ...otherItems,
+];
+
+const defaultItems = [...citrusItems, ...otherItems];
+
+export default function Example() {
+  const select = Ariakit.useSelectStore({ defaultItems, defaultValue: "" });
+
+  return (
+    <>
+      <Ariakit.SelectLabel store={select}>Fruit</Ariakit.SelectLabel>
+      <Ariakit.Select store={select} />
+      <Ariakit.SelectPopover
+        store={select}
+        gutter={4}
+        sameWidth
+        style={{ background: "white", border: "1px solid gray" }}
+      >
+        <SelectRenderer store={select} items={items}>
+          {(item) => {
+            if (item.items) {
+              const { label, ...groupProps } = item;
+              return (
+                <SelectRenderer
+                  key={groupProps.id}
+                  {...groupProps}
+                  render={(props) => (
+                    <Ariakit.SelectGroup {...props}>
+                      <Ariakit.SelectGroupLabel>
+                        {label}
+                      </Ariakit.SelectGroupLabel>
+                      {props.children}
+                    </Ariakit.SelectGroup>
+                  )}
+                >
+                  {({ value, ...optionProps }) => (
+                    <Ariakit.SelectItem
+                      key={optionProps.id}
+                      value={value}
+                      {...optionProps}
+                    />
+                  )}
+                </SelectRenderer>
+              );
+            }
+            const { value, ...optionProps } = item;
+            return (
+              <Ariakit.SelectItem
+                key={optionProps.id}
+                value={value}
+                {...optionProps}
+              />
+            );
+          }}
+        </SelectRenderer>
+      </Ariakit.SelectPopover>
+    </>
+  );
+}

--- a/app/src/sandbox/select-renderer-6301/index.react.tsx
+++ b/app/src/sandbox/select-renderer-6301/index.react.tsx
@@ -45,6 +45,7 @@ export default function Example() {
           store={select}
           items={items}
           initialItems={items.length}
+          persistentIndices={[1]}
         >
           {(item) => {
             if (item.items) {

--- a/app/src/sandbox/select-renderer-6301/index.react.tsx
+++ b/app/src/sandbox/select-renderer-6301/index.react.tsx
@@ -28,6 +28,19 @@ const items: readonly FruitItem[] = [
 
 const defaultItems = [...citrusItems, ...otherItems];
 
+const totalCount = items.reduce(
+  (count, item) => count + (item.items?.length ?? 1),
+  0,
+);
+
+function getPosInSet(index: number) {
+  let position = 1;
+  for (const item of items.slice(0, index)) {
+    position += item.items?.length ?? 1;
+  }
+  return position;
+}
+
 export default function Example() {
   const select = Ariakit.useSelectStore({ defaultItems, defaultValue: "" });
 
@@ -55,6 +68,8 @@ export default function Example() {
                   key={groupProps.id}
                   {...groupProps}
                   initialItems={item.items.length}
+                  aria-setsize={totalCount}
+                  aria-posinset={getPosInSet(item.index)}
                   render={(props) => (
                     <Ariakit.SelectGroup {...props}>
                       <Ariakit.SelectGroupLabel>
@@ -80,6 +95,8 @@ export default function Example() {
                 key={optionProps.id}
                 value={value}
                 {...optionProps}
+                aria-setsize={totalCount}
+                aria-posinset={getPosInSet(item.index)}
               />
             );
           }}

--- a/app/src/sandbox/select-renderer-6301/index.react.tsx
+++ b/app/src/sandbox/select-renderer-6301/index.react.tsx
@@ -41,7 +41,11 @@ export default function Example() {
         sameWidth
         style={{ background: "white", border: "1px solid gray" }}
       >
-        <SelectRenderer store={select} items={items}>
+        <SelectRenderer
+          store={select}
+          items={items}
+          initialItems={items.length}
+        >
           {(item) => {
             if (item.items) {
               const { label, ...groupProps } = item;
@@ -49,6 +53,7 @@ export default function Example() {
                 <SelectRenderer
                   key={groupProps.id}
                   {...groupProps}
+                  initialItems={item.items.length}
                   render={(props) => (
                     <Ariakit.SelectGroup {...props}>
                       <Ariakit.SelectGroupLabel>

--- a/app/src/sandbox/select-renderer-6301/index.react.tsx
+++ b/app/src/sandbox/select-renderer-6301/index.react.tsx
@@ -28,19 +28,6 @@ const items: readonly FruitItem[] = [
 
 const defaultItems = [...citrusItems, ...otherItems];
 
-const totalCount = items.reduce(
-  (count, item) => count + (item.items?.length ?? 1),
-  0,
-);
-
-function getPosInSet(index: number) {
-  let position = 1;
-  for (const item of items.slice(0, index)) {
-    position += item.items?.length ?? 1;
-  }
-  return position;
-}
-
 export default function Example() {
   const select = Ariakit.useSelectStore({ defaultItems, defaultValue: "" });
 
@@ -68,8 +55,6 @@ export default function Example() {
                   key={groupProps.id}
                   {...groupProps}
                   initialItems={item.items.length}
-                  aria-setsize={totalCount}
-                  aria-posinset={getPosInSet(item.index)}
                   render={(props) => (
                     <Ariakit.SelectGroup {...props}>
                       <Ariakit.SelectGroupLabel>
@@ -95,8 +80,6 @@ export default function Example() {
                 key={optionProps.id}
                 value={value}
                 {...optionProps}
-                aria-setsize={totalCount}
-                aria-posinset={getPosInSet(item.index)}
               />
             );
           }}

--- a/app/src/sandbox/select-renderer-6301/test-browser.ts
+++ b/app/src/sandbox/select-renderer-6301/test-browser.ts
@@ -1,0 +1,20 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+const options = ["Lemon", "Lime", "Orange", "Apple", "Banana"] as const;
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/6301
+  test("sets sequential option positions across groups and leaves", async ({
+    q,
+  }) => {
+    await q.combobox("Fruit").click();
+
+    for (const [index, name] of options.entries()) {
+      const option = q.option(name);
+      await test.expect(option).toHaveAttribute("aria-setsize", "5");
+      await test
+        .expect(option)
+        .toHaveAttribute("aria-posinset", `${index + 1}`);
+    }
+  });
+});

--- a/app/src/sandbox/select-renderer-6301/test.ts
+++ b/app/src/sandbox/select-renderer-6301/test.ts
@@ -1,0 +1,15 @@
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+const options = ["Lemon", "Lime", "Orange", "Apple", "Banana"] as const;
+
+// https://github.com/ariakit/ariakit/issues/6301
+test("sets sequential option positions across groups and leaves", async () => {
+  await click(q.combobox("Fruit"));
+
+  for (const [index, name] of options.entries()) {
+    const option = q.option.ensure(name);
+    expect(option).toHaveAttribute("aria-setsize", "5");
+    expect(option).toHaveAttribute("aria-posinset", `${index + 1}`);
+  }
+});

--- a/packages/ariakit-react-components/src/composite/composite-renderer.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-renderer.tsx
@@ -51,12 +51,12 @@ function countItems(items?: number | readonly Item[]): number[] {
     return Array.from({ length: items }, (_, index) => index + 1);
   }
   return items.reduce<number[]>((count, item, index) => {
+    const prevCount = count[index - 1] ?? 0;
     const object = getItemObject(item);
     if (!object.items) {
-      count[index] = index + 1;
+      count[index] = prevCount + 1;
       return count;
     }
-    const prevCount = count[index - 1] ?? 0;
     const itemsCount = countItems(object.items)[object.items.length - 1] ?? 0;
     count[index] = prevCount + itemsCount;
     return count;


### PR DESCRIPTION
## Motivation

`SelectRenderer` and `CompositeRenderer` emitted invalid `aria-setsize` and `aria-posinset` values when a virtualized list had a grouped item followed by ungrouped items.

For a rendered item tree like `[group(Lemon, Lime, Orange), Apple, Banana]`, the cumulative count reset when it reached `Apple`. That made the options announce a set size of 3 instead of 5, with duplicated or out-of-range positions across the group boundary.

Fixes #6301.

## Solution

Add `app/src/sandbox/select-renderer-6301` with both browser and happy-dom coverage for the reported user-facing behavior. The sandbox renders a `Citrus` group followed by standalone `Apple` and `Banana` items, then asserts the five options are announced as positions 1 through 5 in a set of 5.

Update `countItems` in `CompositeRenderer` so leaf items accumulate from the previous cumulative count, matching the existing grouped-item branch. Pure leaf lists keep the same counts, while mixed group/leaf lists now produce the correct cumulative sequence.

## Workaround

Until the library fix is released, compute the cumulative count in userland and override the ARIA attributes after spreading the renderer item props. For nested groups, pass the corrected base position into the nested renderer; it will offset each child item correctly within the group.

```tsx
const totalCount = items.reduce(
  (count, item) => count + (item.items?.length ?? 1),
  0,
);

function getPosInSet(index: number) {
  let position = 1;
  for (const item of items.slice(0, index)) {
    position += item.items?.length ?? 1;
  }
  return position;
}

// TODO: Remove once https://github.com/ariakit/ariakit/issues/6301 is fixed.
<SelectRenderer
  {...groupProps}
  aria-setsize={totalCount}
  aria-posinset={getPosInSet(item.index)}
/>

// TODO: Remove once https://github.com/ariakit/ariakit/issues/6301 is fixed.
<Ariakit.SelectItem
  value={value}
  {...optionProps}
  aria-setsize={totalCount}
  aria-posinset={getPosInSet(item.index)}
/>
```
