### PR TITLE
Fix store init disposer cleanup

### DIFF
--- a/.changeset/300-store-init-cleanup.md
+++ b/.changeset/300-store-init-cleanup.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/store": patch
+"@ariakit/solid-store": patch
+---
+
+Fixed `init` cleanups so repeated or stale calls do not rerun store setup teardowns.

--- a/app/package.json
+++ b/app/package.json
@@ -55,6 +55,7 @@
     "@ariakit/solid": "workspace:*",
     "@ariakit/solid-components": "workspace:*",
     "@ariakit/solid-utils": "workspace:*",
+    "@ariakit/store": "workspace:*",
     "@ariakit/tailwind": "workspace:*",
     "@ariakit/utils": "workspace:*",
     "@astrojs/check": "0.9.9",

--- a/app/src/sandbox/store-init-6314/index.react.tsx
+++ b/app/src/sandbox/store-init-6314/index.react.tsx
@@ -1,0 +1,95 @@
+import { useStoreState } from "@ariakit/react";
+import { createStore, init, setup } from "@ariakit/store";
+import { useEffect, useRef, useState } from "react";
+
+interface Hotkey {
+  key: string;
+  handler: () => void;
+}
+
+const hotkeys: Hotkey[] = [];
+
+function dispatchHotkeys(event: KeyboardEvent) {
+  for (const hotkey of hotkeys) {
+    if (hotkey.key === event.key) {
+      hotkey.handler();
+    }
+  }
+}
+
+function createHotkeyCounterStore(key: string) {
+  const store = createStore({ count: 0 });
+  setup(store, () => {
+    const hotkey: Hotkey = {
+      key,
+      handler: () => store.setState("count", (count) => count + 1),
+    };
+    hotkeys.push(hotkey);
+    return () => {
+      hotkeys.splice(hotkeys.indexOf(hotkey), 1);
+    };
+  });
+  return store;
+}
+
+const storeA = createHotkeyCounterStore("a");
+const storeB = createHotkeyCounterStore("b");
+
+function PanelA() {
+  const cleanupRef = useRef<(() => void) | null>(null);
+  const [active, setActive] = useState(true);
+  const count = useStoreState(storeA, "count");
+
+  useEffect(() => {
+    cleanupRef.current = init(storeA);
+    return () => cleanupRef.current?.();
+  }, []);
+
+  return (
+    <section>
+      <p>A count: {count}</p>
+      <p>A active: {active ? "yes" : "no"}</p>
+      <button
+        type="button"
+        onClick={() => {
+          // Keep the stale disposer reference so unmount calls it again.
+          cleanupRef.current?.();
+          setActive(false);
+        }}
+      >
+        Stop hotkey A
+      </button>
+    </section>
+  );
+}
+
+function PanelB() {
+  const count = useStoreState(storeB, "count");
+
+  useEffect(() => init(storeB), []);
+
+  return (
+    <section>
+      <p>B count: {count}</p>
+    </section>
+  );
+}
+
+export default function Example() {
+  const [panelAMounted, setPanelAMounted] = useState(true);
+
+  useEffect(() => {
+    document.addEventListener("keydown", dispatchHotkeys);
+    return () => document.removeEventListener("keydown", dispatchHotkeys);
+  }, []);
+
+  return (
+    <>
+      {panelAMounted && <PanelA />}
+      <PanelB />
+      <button type="button" onClick={() => setPanelAMounted(false)}>
+        Hide panel A
+      </button>
+    </>
+  );
+}

--- a/app/src/sandbox/store-init-6314/index.react.tsx
+++ b/app/src/sandbox/store-init-6314/index.react.tsx
@@ -40,9 +40,15 @@ function PanelA() {
   const [active, setActive] = useState(true);
   const count = useStoreState(storeA, "count");
 
+  const cleanup = () => {
+    cleanupRef.current?.();
+    // TODO: Remove after https://github.com/ariakit/ariakit/issues/6314 lands.
+    cleanupRef.current = null;
+  };
+
   useEffect(() => {
     cleanupRef.current = init(storeA);
-    return () => cleanupRef.current?.();
+    return cleanup;
   }, []);
 
   return (
@@ -52,8 +58,7 @@ function PanelA() {
       <button
         type="button"
         onClick={() => {
-          // Keep the stale disposer reference so unmount calls it again.
-          cleanupRef.current?.();
+          cleanup();
           setActive(false);
         }}
       >

--- a/app/src/sandbox/store-init-6314/index.react.tsx
+++ b/app/src/sandbox/store-init-6314/index.react.tsx
@@ -40,15 +40,9 @@ function PanelA() {
   const [active, setActive] = useState(true);
   const count = useStoreState(storeA, "count");
 
-  const cleanup = () => {
-    cleanupRef.current?.();
-    // TODO: Remove after https://github.com/ariakit/ariakit/issues/6314 lands.
-    cleanupRef.current = null;
-  };
-
   useEffect(() => {
     cleanupRef.current = init(storeA);
-    return cleanup;
+    return () => cleanupRef.current?.();
   }, []);
 
   return (
@@ -58,7 +52,8 @@ function PanelA() {
       <button
         type="button"
         onClick={() => {
-          cleanup();
+          // Keep the stale disposer reference so unmount calls it again.
+          cleanupRef.current?.();
           setActive(false);
         }}
       >

--- a/app/src/sandbox/store-init-6314/test-browser.ts
+++ b/app/src/sandbox/store-init-6314/test-browser.ts
@@ -1,0 +1,29 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/6314
+  test("keeps sibling setup teardowns active after a stale init disposer runs", async ({
+    page,
+    q,
+  }) => {
+    await page.keyboard.press("a");
+    await page.keyboard.press("b");
+    await test.expect(q.text("A count: 1")).toBeVisible();
+    await test.expect(q.text("B count: 1")).toBeVisible();
+
+    await q.button("Stop hotkey A").click();
+    await test.expect(q.text("A active: no")).toBeVisible();
+
+    await page.keyboard.press("a");
+    await test.expect(q.text("A count: 1")).toBeVisible();
+
+    await page.keyboard.press("b");
+    await test.expect(q.text("B count: 2")).toBeVisible();
+
+    await q.button("Hide panel A").click();
+    await test.expect(q.text("A count:")).toHaveCount(0);
+
+    await page.keyboard.press("b");
+    await test.expect(q.text("B count: 3")).toBeVisible();
+  });
+});

--- a/app/src/sandbox/store-init-6314/test.ts
+++ b/app/src/sandbox/store-init-6314/test.ts
@@ -1,0 +1,25 @@
+import { click, press, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// https://github.com/ariakit/ariakit/issues/6314
+test("keeps sibling setup teardowns active after a stale init disposer runs", async () => {
+  await press("a");
+  await press("b");
+  expect(q.text("A count: 1")).toBeVisible();
+  expect(q.text("B count: 1")).toBeVisible();
+
+  await click(q.button.ensure("Stop hotkey A"));
+  expect(q.text("A active: no")).toBeVisible();
+
+  await press("a");
+  expect(q.text("A count: 1")).toBeVisible();
+
+  await press("b");
+  expect(q.text("B count: 2")).toBeVisible();
+
+  await click(q.button.ensure("Hide panel A"));
+  expect(q.text("A count:")).not.toBeInTheDocument();
+
+  await press("b");
+  expect(q.text("B count: 3")).toBeVisible();
+});

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -161,7 +161,7 @@ export function createStore<S extends State>(
     instances.add(instance);
 
     const maybeDestroy = () => {
-      instances.delete(instance);
+      if (!instances.delete(instance)) return;
       if (instances.size) return;
       destroy();
     };

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -779,6 +779,28 @@ test("runs setup callbacks during init and tears down after the last cleanup", (
   expect(events).toEqual(["setup", "teardown", "setup", "teardown"]);
 });
 
+test("does not rerun setup teardowns from stale init cleanups", () => {
+  const store = createStore({ count: 0 });
+  const events: string[] = [];
+
+  setup(store, () => {
+    events.push("setup");
+    return () => events.push("teardown");
+  });
+
+  const cleanupA = init(store);
+  const cleanupB = init(store);
+
+  expect(events).toEqual(["setup"]);
+
+  cleanupA();
+  cleanupB();
+  cleanupA();
+  cleanupB();
+
+  expect(events).toEqual(["setup", "teardown"]);
+});
+
 test("keeps extended stores in sync while initialized", () => {
   const parent = createStore({
     count: 0,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,6 +233,9 @@ importers:
       '@ariakit/solid-utils':
         specifier: workspace:*
         version: link:../packages/ariakit-solid-utils
+      '@ariakit/store':
+        specifier: workspace:*
+        version: link:../packages/ariakit-store
       '@ariakit/tailwind':
         specifier: workspace:*
         version: link:../packages/ariakit-tailwind


### PR DESCRIPTION
## Motivation

The disposer returned by `init` from `@ariakit/store` was not idempotent. A stale or repeated disposer call could run the store destroy chain again after the store had already been torn down, which could re-run consumer setup teardowns and break still-mounted widgets.

Fixes #6314.

## Solution

`createStore` already tracks active `init` calls in a `Set`. This change uses the return value of `Set.delete` as a one-shot guard in the `init` cleanup: if the cleanup's instance is no longer in the set, the cleanup has already run and returns without invoking `destroy()` again.

The PR includes a focused sandbox repro in `app/src/sandbox/store-init-6314`, plus browser and happy-dom tests that exercise the issue through visible hotkey counters. It also adds a direct `@ariakit/store` unit test that verifies repeated stale cleanups only run setup teardowns once.

## Workaround

Make the consumer-side cleanup idempotent by clearing the stored disposer reference as soon as it is called. This prevents later cleanup paths from invoking the same stale disposer again.

```tsx
const cleanup = () => {
  cleanupRef.current?.();
  // TODO: Remove after https://github.com/ariakit/ariakit/issues/6314 lands.
  cleanupRef.current = null;
};

useEffect(() => {
  cleanupRef.current = init(storeA);
  return cleanup;
}, []);

<button
  type="button"
  onClick={() => {
    cleanup();
    setActive(false);
  }}
>
  Stop hotkey A
</button>
```

With this workaround applied in the sandbox, both repro tests pass before the library fix.
