### PR TITLE
Fix store superseded fan-out propagation

### DIFF
--- a/.changeset/300-store-superseded-fan-out.md
+++ b/.changeset/300-store-superseded-fan-out.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/store": patch
+"@ariakit/solid-store": patch
+---
+
+Fixed `createStore` to keep parent stores in sync when a parent listener rewrites a value during a multi-parent fan-out.

--- a/app/src/sandbox/store-6331/index.react.tsx
+++ b/app/src/sandbox/store-6331/index.react.tsx
@@ -44,11 +44,6 @@ export default function Example() {
         className="rounded bg-blue-600 px-3 py-1 text-white"
         onClick={() => {
           quantityStore.setState("quantity", (quantity) => quantity + 3);
-          // TODO: Remove after https://github.com/ariakit/ariakit/issues/6331
-          // is fixed.
-          const finalQuantity = quantityStore.getState().quantity;
-          cartStore.setState("quantity", finalQuantity);
-          summaryStore.setState("quantity", finalQuantity);
         }}
       >
         Add 3

--- a/app/src/sandbox/store-6331/index.react.tsx
+++ b/app/src/sandbox/store-6331/index.react.tsx
@@ -44,6 +44,11 @@ export default function Example() {
         className="rounded bg-blue-600 px-3 py-1 text-white"
         onClick={() => {
           quantityStore.setState("quantity", (quantity) => quantity + 3);
+          // TODO: Remove after https://github.com/ariakit/ariakit/issues/6331
+          // is fixed.
+          const finalQuantity = quantityStore.getState().quantity;
+          cartStore.setState("quantity", finalQuantity);
+          summaryStore.setState("quantity", finalQuantity);
         }}
       >
         Add 3

--- a/app/src/sandbox/store-6331/index.react.tsx
+++ b/app/src/sandbox/store-6331/index.react.tsx
@@ -1,0 +1,63 @@
+import * as Ariakit from "@ariakit/react";
+import type { Store } from "@ariakit/store";
+import { createStore, init, sync } from "@ariakit/store";
+import { useEffect, useState } from "react";
+
+const MAX_IN_STOCK = 5;
+
+interface QuantityState {
+  quantity: number;
+}
+
+const cartStore = createStore<QuantityState>({ quantity: 0 });
+const summaryStore = createStore<QuantityState>({ quantity: 0 });
+const quantityStore = createStore<QuantityState>(
+  { quantity: 0 },
+  cartStore,
+  summaryStore,
+);
+
+sync(cartStore, ["quantity"], (state) => {
+  if (state.quantity <= MAX_IN_STOCK) return;
+  cartStore.setState("quantity", MAX_IN_STOCK);
+});
+
+function useQuantity(store: Store<QuantityState>) {
+  const [quantity, setQuantity] = useState(() => store.getState().quantity);
+  useEffect(() => {
+    return sync(store, ["quantity"], (state) => {
+      setQuantity(state.quantity);
+    });
+  }, [store]);
+  return quantity;
+}
+
+export default function Example() {
+  useEffect(() => init(quantityStore), []);
+  const quantity = useQuantity(quantityStore);
+  const cartQuantity = useQuantity(cartStore);
+  const summaryQuantity = useQuantity(summaryStore);
+
+  return (
+    <div className="flex flex-col items-start gap-3">
+      <Ariakit.Button
+        className="rounded bg-blue-600 px-3 py-1 text-white"
+        onClick={() => {
+          quantityStore.setState("quantity", (quantity) => quantity + 3);
+        }}
+      >
+        Add 3
+      </Ariakit.Button>
+      <p>
+        Selected: <output aria-label="Selected">{quantity}</output>
+      </p>
+      <p>
+        Cart: <output aria-label="Cart">{cartQuantity}</output>
+      </p>
+      <p>
+        Order summary:{" "}
+        <output aria-label="Order summary">{summaryQuantity}</output>
+      </p>
+    </div>
+  );
+}

--- a/app/src/sandbox/store-6331/test-browser.ts
+++ b/app/src/sandbox/store-6331/test-browser.ts
@@ -1,0 +1,18 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6331
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("keeps parent stores in sync when a parent clamps the child value", async ({
+    q,
+  }) => {
+    await q.button("Add 3").click();
+    await test.expect(q.status("Selected")).toHaveText("3");
+    await test.expect(q.status("Cart")).toHaveText("3");
+    await test.expect(q.status("Order summary")).toHaveText("3");
+
+    await q.button("Add 3").click();
+    await test.expect(q.status("Selected")).toHaveText("5");
+    await test.expect(q.status("Cart")).toHaveText("5");
+    await test.expect(q.status("Order summary")).toHaveText("5");
+  });
+});

--- a/app/src/sandbox/store-6331/test.ts
+++ b/app/src/sandbox/store-6331/test.ts
@@ -1,0 +1,15 @@
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6331
+test("keeps parent stores in sync when a parent clamps the child value", async () => {
+  await click(q.button.ensure("Add 3"));
+  expect(q.status.ensure("Selected")).toHaveTextContent("3");
+  expect(q.status.ensure("Cart")).toHaveTextContent("3");
+  expect(q.status.ensure("Order summary")).toHaveTextContent("3");
+
+  await click(q.button.ensure("Add 3"));
+  expect(q.status.ensure("Selected")).toHaveTextContent("5");
+  expect(q.status.ensure("Cart")).toHaveTextContent("5");
+  expect(q.status.ensure("Order summary")).toHaveTextContent("5");
+});

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -84,6 +84,8 @@ function isSameValue(value: unknown, other: unknown) {
   return value === other || (value !== value && other !== other);
 }
 
+const MAX_REPAIR_PASSES = 100;
+
 function addKeyedListener<S>(
   map: ListenerMap<S>,
   keys: Array<keyof S> | null,
@@ -423,11 +425,28 @@ export function createStore<S extends State>(
         for (const store of stores) {
           store?.setState?.(key, nextValue);
           // Parent fan-out can reenter this child with a newer value for the
-          // same key. That nested update owns the final notification and
-          // propagation, so stop replaying the stale outer value.
+          // same key. That nested update owns the final notification, so stop
+          // replaying the stale outer value.
           if (isSameValue(state[key], nextValue)) continue;
           superseded = true;
           break;
+        }
+        // A fromStores-driven supersede can't fan out on its own. Push the
+        // latest committed value to every parent until a repair pass completes
+        // without another rewrite. Keep this bounded because parent listeners
+        // can fight over a key indefinitely.
+        if (superseded) {
+          for (let pass = 0; pass < MAX_REPAIR_PASSES; pass += 1) {
+            let changed = false;
+            for (const store of stores) {
+              const previousValue = state[key];
+              store?.setState?.(key, state[key]);
+              if (!isSameValue(state[key], previousValue)) {
+                changed = true;
+              }
+            }
+            if (!changed) break;
+          }
         }
       }
 

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -436,16 +436,26 @@ export function createStore<S extends State>(
         // without another rewrite. Keep this bounded because parent listeners
         // can fight over a key indefinitely.
         if (superseded) {
-          for (let pass = 0; pass < MAX_REPAIR_PASSES; pass += 1) {
+          let pass = 0;
+          for (; pass < MAX_REPAIR_PASSES; pass += 1) {
             let changed = false;
             for (const store of stores) {
               const previousValue = state[key];
-              store?.setState?.(key, state[key]);
+              store?.setState?.(key, previousValue);
               if (!isSameValue(state[key], previousValue)) {
                 changed = true;
               }
             }
             if (!changed) break;
+          }
+          if (
+            process.env.NODE_ENV !== "production" &&
+            pass === MAX_REPAIR_PASSES
+          ) {
+            console.warn(
+              "Parent stores did not converge after a superseded fan-out; " +
+                "a parent listener may be rewriting this key in a cycle.",
+            );
           }
         }
       }

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -1121,10 +1121,6 @@ test("keeps parent stores in sync after parent-driven supersede", () => {
   });
 
   child.setState("count", 10);
-  // TODO: Remove after https://github.com/ariakit/ariakit/issues/6331 is fixed.
-  const finalCount = child.getState().count;
-  first.setState("count", finalCount);
-  second.setState("count", finalCount);
 
   expect(child.getState().count).toBe(5);
   expect(first.getState().count).toBe(5);
@@ -1146,15 +1142,131 @@ test("keeps earlier parent stores in sync after later parent supersede", () => {
   });
 
   child.setState("count", 10);
-  // TODO: Remove after https://github.com/ariakit/ariakit/issues/6331 is fixed.
-  const finalCount = child.getState().count;
-  first.setState("count", finalCount);
-  second.setState("count", finalCount);
 
   expect(child.getState().count).toBe(5);
   expect(first.getState().count).toBe(5);
   expect(second.getState().count).toBe(5);
 
+  unsubscribeSecond();
+  cleanup();
+});
+
+test("keeps parent stores in sync after cascading parent supersede", () => {
+  const first = createStore({ count: 0 });
+  const second = createStore({ count: 0 });
+  const child = createStore({ count: 0 }, first, second);
+
+  const cleanup = init(child);
+  const unsubscribeFirst = sync(first, ["count"], (state) => {
+    if (state.count !== 5) return;
+    first.setState("count", 4);
+  });
+  const unsubscribeSecond = sync(second, ["count"], (state) => {
+    if (state.count <= 5) return;
+    second.setState("count", 5);
+  });
+
+  child.setState("count", 10);
+
+  expect(child.getState().count).toBe(4);
+  expect(first.getState().count).toBe(4);
+  expect(second.getState().count).toBe(4);
+
+  unsubscribeFirst();
+  unsubscribeSecond();
+  cleanup();
+});
+
+test("restarts parent repair after later parent supersede", () => {
+  const first = createStore({ count: 0 });
+  const second = createStore({ count: 0 });
+  const child = createStore({ count: 0 }, first, second);
+
+  const cleanup = init(child);
+  const unsubscribeFirst = sync(first, ["count"], (state) => {
+    if (state.count <= 5) return;
+    first.setState("count", 5);
+  });
+  const unsubscribeSecond = sync(second, ["count"], (state) => {
+    if (state.count !== 5) return;
+    second.setState("count", 4);
+  });
+
+  child.setState("count", 10);
+
+  expect(child.getState().count).toBe(4);
+  expect(first.getState().count).toBe(4);
+  expect(second.getState().count).toBe(4);
+
+  unsubscribeFirst();
+  unsubscribeSecond();
+  cleanup();
+});
+
+test("continues parent repair after finite cascades", () => {
+  const first = createStore({ count: 0 });
+  const second = createStore({ count: 0 });
+  const child = createStore({ count: 0 }, first, second);
+
+  const cleanup = init(child);
+  const unsubscribeFirst = sync(first, ["count"], (state) => {
+    if (state.count === 5) {
+      first.setState("count", 2);
+    } else if (state.count === 3) {
+      first.setState("count", 1);
+    }
+  });
+  const unsubscribeSecond = sync(second, ["count"], (state) => {
+    if (state.count === 10) {
+      second.setState("count", 5);
+    } else if (state.count === 2) {
+      second.setState("count", 3);
+    } else if (state.count === 1) {
+      second.setState("count", 0);
+    }
+  });
+
+  child.setState("count", 10);
+
+  expect(child.getState().count).toBe(0);
+  expect(first.getState().count).toBe(0);
+  expect(second.getState().count).toBe(0);
+
+  unsubscribeFirst();
+  unsubscribeSecond();
+  cleanup();
+});
+
+test("continues parent repair after one-shot cycles", () => {
+  const first = createStore({ count: 0 });
+  const second = createStore({ count: 0 });
+  const child = createStore({ count: 0 }, first, second);
+
+  const cleanup = init(child);
+  let didRewriteFirst = false;
+  let didRewriteSecond = false;
+  const unsubscribeFirst = sync(first, ["count"], (state) => {
+    if (state.count !== 5) return;
+    if (didRewriteFirst) return;
+    didRewriteFirst = true;
+    first.setState("count", 4);
+  });
+  const unsubscribeSecond = sync(second, ["count"], (state) => {
+    if (state.count === 10) {
+      second.setState("count", 5);
+    } else if (state.count === 4 && !didRewriteSecond) {
+      didRewriteSecond = true;
+      second.setState("count", 5);
+    }
+  });
+
+  child.setState("count", 10);
+
+  expect(child.getState().count).toBe(5);
+  expect(first.getState().count).toBe(5);
+  expect(second.getState().count).toBe(5);
+
+  unsubscribeFirst();
   unsubscribeSecond();
   cleanup();
 });

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -1109,6 +1109,48 @@ test("skips superseded same-key child notifications after parent fan-out", () =>
   cleanup();
 });
 
+test("keeps parent stores in sync after parent-driven supersede", () => {
+  const first = createStore({ count: 0 });
+  const second = createStore({ count: 0 });
+  const child = createStore({ count: 0 }, first, second);
+
+  const cleanup = init(child);
+  const unsubscribeFirst = sync(first, ["count"], (state) => {
+    if (state.count <= 5) return;
+    first.setState("count", 5);
+  });
+
+  child.setState("count", 10);
+
+  expect(child.getState().count).toBe(5);
+  expect(first.getState().count).toBe(5);
+  expect(second.getState().count).toBe(5);
+
+  unsubscribeFirst();
+  cleanup();
+});
+
+test("keeps earlier parent stores in sync after later parent supersede", () => {
+  const first = createStore({ count: 0 });
+  const second = createStore({ count: 0 });
+  const child = createStore({ count: 0 }, first, second);
+
+  const cleanup = init(child);
+  const unsubscribeSecond = sync(second, ["count"], (state) => {
+    if (state.count <= 5) return;
+    second.setState("count", 5);
+  });
+
+  child.setState("count", 10);
+
+  expect(child.getState().count).toBe(5);
+  expect(first.getState().count).toBe(5);
+  expect(second.getState().count).toBe(5);
+
+  unsubscribeSecond();
+  cleanup();
+});
+
 test("refreshes child batch baseline after superseded same-key fan-out", async () => {
   const parent = createStore({ count: 0 });
   const child = createStore({ count: 0 }, parent);

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -1271,6 +1271,70 @@ test("continues parent repair after one-shot cycles", () => {
   cleanup();
 });
 
+test("warns when parent repair does not converge", () => {
+  const first = createStore({ count: 0 });
+  const second = createStore({ count: 0 });
+  const child = createStore({ count: 0 }, first, second);
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+  const cleanup = init(child);
+  const unsubscribeFirst = sync(first, ["count"], (state) => {
+    if (state.count === 1) return;
+    first.setState("count", 1);
+  });
+  const unsubscribeSecond = sync(second, ["count"], (state) => {
+    if (state.count === 2) return;
+    second.setState("count", 2);
+  });
+
+  child.setState("count", 10);
+
+  expect(warn).toHaveBeenCalledOnce();
+  expect(warn).toHaveBeenLastCalledWith(
+    "Parent stores did not converge after a superseded fan-out; " +
+      "a parent listener may be rewriting this key in a cycle.",
+  );
+  expect(child.getState().count).toBe(2);
+  expect(first.getState().count).toBe(1);
+  expect(second.getState().count).toBe(2);
+
+  warn.mockRestore();
+  unsubscribeFirst();
+  unsubscribeSecond();
+  cleanup();
+});
+
+test("does not warn when parent repair does not converge in production", () => {
+  const first = createStore({ count: 0 });
+  const second = createStore({ count: 0 });
+  const child = createStore({ count: 0 }, first, second);
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+  vi.stubEnv("NODE_ENV", "production");
+
+  const cleanup = init(child);
+  const unsubscribeFirst = sync(first, ["count"], (state) => {
+    if (state.count === 1) return;
+    first.setState("count", 1);
+  });
+  const unsubscribeSecond = sync(second, ["count"], (state) => {
+    if (state.count === 2) return;
+    second.setState("count", 2);
+  });
+
+  child.setState("count", 10);
+
+  expect(warn).not.toHaveBeenCalled();
+  expect(child.getState().count).toBe(2);
+  expect(first.getState().count).toBe(1);
+  expect(second.getState().count).toBe(2);
+
+  warn.mockRestore();
+  unsubscribeFirst();
+  unsubscribeSecond();
+  cleanup();
+});
+
 test("refreshes child batch baseline after superseded same-key fan-out", async () => {
   const parent = createStore({ count: 0 });
   const child = createStore({ count: 0 }, parent);

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -1121,6 +1121,10 @@ test("keeps parent stores in sync after parent-driven supersede", () => {
   });
 
   child.setState("count", 10);
+  // TODO: Remove after https://github.com/ariakit/ariakit/issues/6331 is fixed.
+  const finalCount = child.getState().count;
+  first.setState("count", finalCount);
+  second.setState("count", finalCount);
 
   expect(child.getState().count).toBe(5);
   expect(first.getState().count).toBe(5);
@@ -1142,6 +1146,10 @@ test("keeps earlier parent stores in sync after later parent supersede", () => {
   });
 
   child.setState("count", 10);
+  // TODO: Remove after https://github.com/ariakit/ariakit/issues/6331 is fixed.
+  const finalCount = child.getState().count;
+  first.setState("count", finalCount);
+  second.setState("count", finalCount);
 
   expect(child.getState().count).toBe(5);
   expect(first.getState().count).toBe(5);


### PR DESCRIPTION
## Motivation

Fixes #6331.

A child store created with multiple parent stores can leave one parent stale when another parent listener rewrites the same key during fan-out. The rewrite reaches the child through the parent-to-child sync path, which intentionally does not fan back out, while the original fan-out stops replaying the stale value. That can leave sibling parent stores permanently out of sync.

## Solution

Add regression coverage at both the store and user-facing sandbox levels:

- store tests for first-parent, later-parent, cascading, and repeated repair rewrites;
- a React sandbox matching the reported cart/order-summary flow;
- happy-dom and browser tests that click "Add 3" twice and assert that every visible output converges to the clamped value.

Fix `createStore` so a superseded parent fan-out repairs every parent with the latest committed child value. The repair runs until a full pass completes without another rewrite, with a bounded safety cap so parent listeners that fight over a key cannot spin forever.

## Workaround

For users who cannot update immediately, after writing to the merged child store, read the child's final value and push it to every parent store. Parents that already hold the value no-op.

```tsx
quantityStore.setState("quantity", (quantity) => quantity + 3);
// TODO: Remove after https://github.com/ariakit/ariakit/issues/6331 is fixed.
const finalQuantity = quantityStore.getState().quantity;
cartStore.setState("quantity", finalQuantity);
summaryStore.setState("quantity", finalQuantity);
```

## Verification

```sh
pnpm test packages/ariakit-store/src/test.ts
pnpm test-react app/src/sandbox/store-6331/test.ts
APP_PORT=4326 NEXTJS_PORT=3008 pnpm -F app run test-chrome app/src/sandbox/store-6331/test-browser.ts
pnpm tsc
```
