### PR TITLE
Run store cleanup when re-registering listeners

### DIFF
--- a/.changeset/300-store-cleanup-reregister.md
+++ b/.changeset/300-store-cleanup-reregister.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/store": patch
+"@ariakit/solid-store": patch
+---
+
+Fixed `sync` and `batch` to run a listener's pending cleanup before re-registering the same listener.

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -362,6 +362,16 @@ export function createStore<S extends State>(
     }
   };
 
+  const getCleanupPrevState = (prevState: S, stateBeforeCleanups: S) => {
+    let cleanupPrevState: S | undefined;
+    for (const key of getKeys(state)) {
+      if (isSameValue(state[key], stateBeforeCleanups[key])) continue;
+      cleanupPrevState ??= { ...prevState };
+      cleanupPrevState[key] = state[key];
+    }
+    return cleanupPrevState;
+  };
+
   // Runs a listener's initial synchronous invocation while preventing reentrant
   // dispatch from running the same listener before the new registration is
   // complete.
@@ -376,8 +386,39 @@ export function createStore<S extends State>(
       const count = group.suspendCounts.get(listener) ?? 0;
       group.suspendCounts.set(listener, count + 1);
     }
+    let cleanupPrevState: S | undefined;
     try {
-      runListener(group, listener, prevState);
+      const stateBeforeCleanups = state;
+      runPendingCleanups(group, listener);
+      cleanupPrevState = getCleanupPrevState(prevState, stateBeforeCleanups);
+      const initialPrevState = cleanupPrevState ?? prevState;
+      // Keep this inline so dispatches can stay on the single-call runListener
+      // hot path while initial runs can refresh their post-cleanup baseline.
+      let listenerRunVersion = group.listenerRunVersion;
+      if (group.runDepth) {
+        group.listenerRunVersion += 1;
+        listenerRunVersion = group.listenerRunVersion;
+        group.listenerRunVersions.set(listener, listenerRunVersion);
+      }
+      group.runDepth += 1;
+      let cleanup: void | (() => void);
+      try {
+        cleanup = listener(state, initialPrevState);
+      } finally {
+        group.runDepth -= 1;
+      }
+      if (group.listenerRunVersion !== listenerRunVersion) {
+        const currentRunVersion = group.listenerRunVersions.get(listener);
+        if (currentRunVersion && currentRunVersion > listenerRunVersion) {
+          cleanup?.();
+          return cleanupPrevState;
+        }
+      }
+      if (cleanup) {
+        group.disposables.set(listener, cleanup);
+      } else if (group.disposables.size) {
+        group.disposables.delete(listener);
+      }
     } finally {
       if (shouldSuspend) {
         const suspendCounts = group.suspendCounts;
@@ -392,6 +433,7 @@ export function createStore<S extends State>(
         }
       }
     }
+    return cleanupPrevState;
   };
 
   const storeSync: StoreSync<S> = (keys, listener) => {
@@ -409,7 +451,14 @@ export function createStore<S extends State>(
     if (!batchListenerGroup.listeners.size && !inDispatch) {
       prevStateBatch = state;
     }
-    runInitialListener(batchListenerGroup, listener, prevStateBatch);
+    const cleanupPrevState = runInitialListener(
+      batchListenerGroup,
+      listener,
+      prevStateBatch,
+    );
+    if (cleanupPrevState) {
+      prevStateBatch = cleanupPrevState;
+    }
     return registerListener(keys, listener, batchListenerGroup);
   };
 

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -48,6 +48,7 @@ interface ListenerGroup<S> {
   listenerVersion: number;
   listenerRunVersion: number;
   listenerRunVersions: WeakMap<Listener<S>, number>;
+  runDepth: number;
 }
 
 interface StoreInternals<S = State> {
@@ -148,6 +149,7 @@ export function createStore<S extends State>(
     listenerVersion: 0,
     listenerRunVersion: 0,
     listenerRunVersions: new WeakMap(),
+    runDepth: 0,
   };
   const batchListenerGroup: ListenerGroup<S> = {
     listeners: new Set(),
@@ -156,6 +158,7 @@ export function createStore<S extends State>(
     listenerVersion: 0,
     listenerRunVersion: 0,
     listenerRunVersions: new WeakMap(),
+    runDepth: 0,
   };
 
   const storeSetup: StoreSetup = (callback) => {
@@ -327,20 +330,34 @@ export function createStore<S extends State>(
     listener: Listener<S>,
     prevState: S,
   ) => {
+    // Pending cleanups run before this invocation owns the cleanup slot.
+    // Cleanup-triggered dispatches should settle before the run-depth check.
     runPendingCleanups(group, listener);
-    group.listenerRunVersion += 1;
-    const listenerRunVersion = group.listenerRunVersion;
-    group.listenerRunVersions.set(listener, listenerRunVersion);
-    const cleanup = listener(state, prevState);
+    let listenerRunVersion = group.listenerRunVersion;
+    if (group.runDepth) {
+      group.listenerRunVersion += 1;
+      listenerRunVersion = group.listenerRunVersion;
+      group.listenerRunVersions.set(listener, listenerRunVersion);
+    }
+    group.runDepth += 1;
+    let cleanup: void | (() => void);
+    try {
+      cleanup = listener(state, prevState);
+    } finally {
+      group.runDepth -= 1;
+    }
     // A reentrant same-listener run owns the current cleanup slot, even when it
     // cleared the slot by returning nothing.
-    if (group.listenerRunVersions.get(listener) !== listenerRunVersion) {
-      cleanup?.();
-      return;
+    if (group.listenerRunVersion !== listenerRunVersion) {
+      const currentRunVersion = group.listenerRunVersions.get(listener);
+      if (currentRunVersion && currentRunVersion > listenerRunVersion) {
+        cleanup?.();
+        return;
+      }
     }
     if (cleanup) {
       group.disposables.set(listener, cleanup);
-    } else {
+    } else if (group.disposables.size) {
       group.disposables.delete(listener);
     }
   };

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -99,10 +99,12 @@ function getCleanupPrevState<S extends State>(
   prevState: S,
   state: S,
   stateBeforeCleanup: S,
+  updatedKey?: UpdatedKey<S>,
 ) {
   let cleanupPrevState: S | undefined;
   for (const key of getKeys(state)) {
     if (isSameValue(state[key], stateBeforeCleanup[key])) continue;
+    if (updatedKey !== undefined && hasUpdatedKey([key], updatedKey)) continue;
     cleanupPrevState ??= { ...prevState };
     cleanupPrevState[key] = state[key];
   }
@@ -311,6 +313,7 @@ function notifyStoreListener<S extends State>(
   state: S,
   prevState: S,
   getState?: () => S,
+  updatedKey?: UpdatedKey<S>,
 ) {
   if (group.suspendCounts?.has(listener)) return;
   const { disposables } = group;
@@ -324,7 +327,8 @@ function notifyStoreListener<S extends State>(
     state = getState?.() ?? state;
     if (state !== stateBeforeCleanup) {
       prevState =
-        getCleanupPrevState(prevState, state, stateBeforeCleanup) ?? prevState;
+        getCleanupPrevState(prevState, state, stateBeforeCleanup, updatedKey) ??
+        prevState;
     }
   }
   const result = listener(state, prevState);
@@ -356,7 +360,14 @@ function runLiveListeners<S extends State>({
       if (!hasUpdatedKey(keys, updatedKey)) continue;
     }
     notifiedListeners?.add(listener);
-    notifyStoreListener(group, listener, getState(), prevState, getState);
+    notifyStoreListener(
+      group,
+      listener,
+      getState(),
+      prevState,
+      getState,
+      updatedKey,
+    );
   }
 }
 
@@ -666,7 +677,14 @@ export function createStore<S extends State>(
           if (frame.notifiedListeners?.has(listener)) continue;
           frame.currentListener = listener;
           frame.notifiedListeners?.add(listener);
-          notifyStoreListener(group, listener, state, prevState, getState);
+          notifyStoreListener(
+            group,
+            listener,
+            state,
+            prevState,
+            getState,
+            updatedKey,
+          );
           if (!group.allKeysListeners?.size && !frame.recoverToLive) continue;
           const notifiedListeners =
             frame.notifiedListeners ?? getFastPathNotifiedListeners(frame);

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -45,11 +45,6 @@ interface ListenerGroup<S> {
   suspendCounts?: Map<Listener<S>, number>;
   disposables: Map<Listener<S>, () => void>;
   listenerKeys: WeakMap<Listener<S>, Array<keyof S> | null>;
-  listenerVersion: number;
-  listenerGenerations: WeakMap<Listener<S>, number>;
-  listenerRunVersion: number;
-  listenerRunVersions: WeakMap<Listener<S>, number>;
-  runDepth: number;
 }
 
 interface FastPathFrame<S> {
@@ -98,6 +93,20 @@ function hasUpdatedKey<S>(
 
 function isSameValue(value: unknown, other: unknown) {
   return value === other || (value !== value && other !== other);
+}
+
+function getCleanupPrevState<S extends State>(
+  prevState: S,
+  state: S,
+  stateBeforeCleanup: S,
+) {
+  let cleanupPrevState: S | undefined;
+  for (const key of getKeys(state)) {
+    if (isSameValue(state[key], stateBeforeCleanup[key])) continue;
+    cleanupPrevState ??= { ...prevState };
+    cleanupPrevState[key] = state[key];
+  }
+  return cleanupPrevState;
 }
 
 const MAX_REPAIR_PASSES = 100;
@@ -272,63 +281,59 @@ function addFastPathKeyedListener<S>({
   }
 }
 
-function runPendingCleanups<S>(group: ListenerGroup<S>, listener: Listener<S>) {
+function runPendingCleanup<S>(group: ListenerGroup<S>, listener: Listener<S>) {
   if (!group.disposables.size) return;
-  while (true) {
-    const cleanup = group.disposables.get(listener);
-    if (!cleanup) break;
-    group.disposables.delete(listener);
-    cleanup();
-  }
+  const cleanup = group.disposables.get(listener);
+  if (!cleanup) return;
+  group.disposables.delete(listener);
+  cleanup();
 }
 
-function getListenerGeneration<S>(
+function setListenerCleanup<S>(
   group: ListenerGroup<S>,
   listener: Listener<S>,
+  cleanup: () => void,
 ) {
-  return group.listenerGenerations.get(listener) ?? 0;
+  const currentCleanup = group.disposables.get(listener);
+  if (!currentCleanup) {
+    group.disposables.set(listener, cleanup);
+    return;
+  }
+  group.disposables.set(listener, () => {
+    currentCleanup();
+    cleanup();
+  });
 }
 
-function notifyStoreListener<S>(
+function notifyStoreListener<S extends State>(
   group: ListenerGroup<S>,
   listener: Listener<S>,
-  getState: () => S,
+  state: S,
   prevState: S,
+  getState?: () => S,
 ) {
   if (group.suspendCounts?.has(listener)) return;
-  // Pending cleanups run before this invocation owns the cleanup slot.
-  // Cleanup-triggered dispatches should settle before the run-depth check.
-  runPendingCleanups(group, listener);
-  let listenerRunVersion = group.listenerRunVersion;
-  if (group.runDepth) {
-    group.listenerRunVersion += 1;
-    listenerRunVersion = group.listenerRunVersion;
-    group.listenerRunVersions.set(listener, listenerRunVersion);
-  }
-  group.runDepth += 1;
-  let cleanup: void | (() => void);
-  try {
-    cleanup = listener(getState(), prevState);
-  } finally {
-    group.runDepth -= 1;
-  }
-  // A reentrant same-listener run owns the current cleanup slot, even when it
-  // cleared the slot by returning nothing.
-  if (group.listenerRunVersion !== listenerRunVersion) {
-    const currentRunVersion = group.listenerRunVersions.get(listener);
-    if (currentRunVersion && currentRunVersion > listenerRunVersion) {
-      cleanup?.();
-      return;
+  const { disposables } = group;
+  // Skip the cleanup lookup when no listener has registered a cleanup.
+  // The `.size` gate keeps an empty disposables map off this hot path.
+  const cleanup = disposables.size ? disposables.get(listener) : undefined;
+  if (cleanup) {
+    disposables.delete(listener);
+    const stateBeforeCleanup = state;
+    cleanup();
+    state = getState?.() ?? state;
+    if (state !== stateBeforeCleanup) {
+      prevState =
+        getCleanupPrevState(prevState, state, stateBeforeCleanup) ?? prevState;
     }
   }
-  if (cleanup) {
-    group.disposables.set(listener, cleanup);
-  } else if (group.disposables.size) {
-    group.disposables.delete(listener);
+  const result = listener(state, prevState);
+  if (result) {
+    setListenerCleanup(group, listener, result);
   }
 }
 
-interface RunLiveListenersParams<S> {
+interface RunLiveListenersParams<S extends State> {
   group: ListenerGroup<S>;
   getState: () => S;
   prevState: S;
@@ -336,7 +341,7 @@ interface RunLiveListenersParams<S> {
   notifiedListeners?: Set<Listener<S>>;
 }
 
-function runLiveListeners<S>({
+function runLiveListeners<S extends State>({
   group,
   getState,
   prevState,
@@ -344,27 +349,14 @@ function runLiveListeners<S>({
   notifiedListeners,
 }: RunLiveListenersParams<S>) {
   const allKeysListeners = group.allKeysListeners;
-  const startVersion = group.listenerVersion;
-  const processedListeners: Array<[Listener<S>, number]> = [];
-  let processedListenerMap: Map<Listener<S>, number> | undefined;
   for (const listener of group.listeners) {
     if (notifiedListeners?.has(listener)) continue;
     if (!allKeysListeners?.has(listener)) {
       const keys = group.listenerKeys.get(listener);
       if (!hasUpdatedKey(keys, updatedKey)) continue;
     }
-    if (group.listenerVersion !== startVersion) {
-      processedListenerMap ??= new Map(processedListeners);
-      const processedGeneration = processedListenerMap.get(listener);
-      if (processedGeneration === getListenerGeneration(group, listener)) {
-        continue;
-      }
-    }
-    const generation = getListenerGeneration(group, listener);
-    processedListeners.push([listener, generation]);
-    processedListenerMap?.set(listener, generation);
     notifiedListeners?.add(listener);
-    notifyStoreListener(group, listener, getState, prevState);
+    notifyStoreListener(group, listener, getState(), prevState, getState);
   }
 }
 
@@ -390,21 +382,11 @@ export function createStore<S extends State>(
     listeners: new Set(),
     disposables: new Map(),
     listenerKeys: new WeakMap(),
-    listenerVersion: 0,
-    listenerGenerations: new WeakMap(),
-    listenerRunVersion: 0,
-    listenerRunVersions: new WeakMap(),
-    runDepth: 0,
   };
   const batchListenerGroup: ListenerGroup<S> = {
     listeners: new Set(),
     disposables: new Map(),
     listenerKeys: new WeakMap(),
-    listenerVersion: 0,
-    listenerGenerations: new WeakMap(),
-    listenerRunVersion: 0,
-    listenerRunVersions: new WeakMap(),
-    runDepth: 0,
   };
 
   const storeSetup: StoreSetup = (callback) => {
@@ -569,11 +551,6 @@ export function createStore<S extends State>(
       group.allKeysListeners.add(listener);
     }
     group.listenerKeys.set(listener, listenerKeysValue);
-    if (!wasRegistered) {
-      const generation = getListenerGeneration(group, listener) + 1;
-      group.listenerGenerations.set(listener, generation);
-    }
-    group.listenerVersion += 1;
     return () => {
       group.disposables.get(listener)?.();
       group.disposables.delete(listener);
@@ -585,22 +562,11 @@ export function createStore<S extends State>(
       }
       group.listenerKeys.delete(listener);
       group.listeners.delete(listener);
-      group.listenerVersion += 1;
     };
   };
 
   const storeSubscribe: StoreSubscribe<S> = (keys, listener) =>
     registerListener(keys, listener);
-
-  const getCleanupPrevState = (prevState: S, stateBeforeCleanups: S) => {
-    let cleanupPrevState: S | undefined;
-    for (const key of getKeys(state)) {
-      if (isSameValue(state[key], stateBeforeCleanups[key])) continue;
-      cleanupPrevState ??= { ...prevState };
-      cleanupPrevState[key] = state[key];
-    }
-    return cleanupPrevState;
-  };
 
   // Runs a listener's initial synchronous invocation while preventing reentrant
   // dispatch from running the same listener before the new registration is
@@ -619,36 +585,18 @@ export function createStore<S extends State>(
     let cleanupPrevState: S | undefined;
     try {
       const stateBeforeCleanups = state;
-      runPendingCleanups(group, listener);
-      cleanupPrevState = getCleanupPrevState(prevState, stateBeforeCleanups);
+      runPendingCleanup(group, listener);
+      if (state !== stateBeforeCleanups) {
+        cleanupPrevState = getCleanupPrevState(
+          prevState,
+          state,
+          stateBeforeCleanups,
+        );
+      }
       const initialPrevState = cleanupPrevState ?? prevState;
-      // Keep this inline so dispatches can stay on the single-call
-      // notifyStoreListener hot path while initial runs can refresh their
-      // post-cleanup baseline.
-      let listenerRunVersion = group.listenerRunVersion;
-      if (group.runDepth) {
-        group.listenerRunVersion += 1;
-        listenerRunVersion = group.listenerRunVersion;
-        group.listenerRunVersions.set(listener, listenerRunVersion);
-      }
-      group.runDepth += 1;
-      let cleanup: void | (() => void);
-      try {
-        cleanup = listener(state, initialPrevState);
-      } finally {
-        group.runDepth -= 1;
-      }
-      if (group.listenerRunVersion !== listenerRunVersion) {
-        const currentRunVersion = group.listenerRunVersions.get(listener);
-        if (currentRunVersion && currentRunVersion > listenerRunVersion) {
-          cleanup?.();
-          return cleanupPrevState;
-        }
-      }
+      const cleanup = listener(state, initialPrevState);
       if (cleanup) {
-        group.disposables.set(listener, cleanup);
-      } else if (group.disposables.size) {
-        group.disposables.delete(listener);
+        setListenerCleanup(group, listener, cleanup);
       }
     } finally {
       if (shouldSuspend) {
@@ -664,7 +612,6 @@ export function createStore<S extends State>(
         }
       }
     }
-    return cleanupPrevState;
   };
 
   const storeSync: StoreSync<S> = (keys, listener) => {
@@ -682,14 +629,7 @@ export function createStore<S extends State>(
     if (!batchListenerGroup.listeners.size && !inDispatch) {
       prevStateBatch = state;
     }
-    const cleanupPrevState = runInitialListener(
-      batchListenerGroup,
-      listener,
-      prevStateBatch,
-    );
-    if (cleanupPrevState) {
-      prevStateBatch = cleanupPrevState;
-    }
+    runInitialListener(batchListenerGroup, listener, prevStateBatch);
     return registerListener(keys, listener, batchListenerGroup);
   };
 
@@ -726,7 +666,7 @@ export function createStore<S extends State>(
           if (frame.notifiedListeners?.has(listener)) continue;
           frame.currentListener = listener;
           frame.notifiedListeners?.add(listener);
-          notifyStoreListener(group, listener, getState, prevState);
+          notifyStoreListener(group, listener, state, prevState, getState);
           if (!group.allKeysListeners?.size && !frame.recoverToLive) continue;
           const notifiedListeners =
             frame.notifiedListeners ?? getFastPathNotifiedListeners(frame);

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -42,6 +42,7 @@ interface ListenerGroup<S> {
   listeners: Set<Listener<S>>;
   listenersByKey?: ListenerMap<S>;
   allKeysListeners?: Set<Listener<S>>;
+  suspendedListeners?: Set<Listener<S>>;
   disposables: Map<Listener<S>, () => void>;
   listenerKeys: WeakMap<Listener<S>, Array<keyof S> | null>;
 }
@@ -282,15 +283,27 @@ export function createStore<S extends State>(
   const storeSubscribe: StoreSubscribe<S> = (keys, listener) =>
     registerListener(keys, listener);
 
-  // Records the cleanup returned by a listener's initial synchronous run, or
-  // clears any cleanup left from a previous registration of the same listener
-  // so it can't fire after the listener has been re-registered. Shared by
-  // storeSync and storeBatch, which differ only in their listener group.
-  const reconcileInitialCleanup = (
+  const runPendingCleanups = (
     group: ListenerGroup<S>,
     listener: Listener<S>,
-    cleanup: void | (() => void),
   ) => {
+    if (!group.disposables.size) return;
+    while (true) {
+      const cleanup = group.disposables.get(listener);
+      if (!cleanup) break;
+      group.disposables.delete(listener);
+      cleanup();
+    }
+  };
+
+  const runListener = (
+    group: ListenerGroup<S>,
+    listener: Listener<S>,
+    prevState: S,
+  ) => {
+    runPendingCleanups(group, listener);
+    const cleanup = listener(state, prevState);
+    runPendingCleanups(group, listener);
     if (cleanup) {
       group.disposables.set(listener, cleanup);
     } else {
@@ -298,9 +311,34 @@ export function createStore<S extends State>(
     }
   };
 
+  // Runs a listener's initial synchronous invocation while preventing reentrant
+  // dispatch from running the same listener before the new registration is
+  // complete.
+  const runInitialListener = (
+    group: ListenerGroup<S>,
+    listener: Listener<S>,
+    prevState: S,
+  ) => {
+    const shouldSuspend = group.listeners.has(listener);
+    if (shouldSuspend) {
+      group.suspendedListeners ??= new Set();
+      group.suspendedListeners.add(listener);
+    }
+    try {
+      runListener(group, listener, prevState);
+    } finally {
+      if (shouldSuspend) {
+        const suspendedListeners = group.suspendedListeners;
+        suspendedListeners?.delete(listener);
+        if (!suspendedListeners?.size) {
+          delete group.suspendedListeners;
+        }
+      }
+    }
+  };
+
   const storeSync: StoreSync<S> = (keys, listener) => {
-    const cleanup = listener(state, state);
-    reconcileInitialCleanup(syncListenerGroup, listener, cleanup);
+    runInitialListener(syncListenerGroup, listener, state);
     return registerListener(keys, listener);
   };
 
@@ -314,8 +352,7 @@ export function createStore<S extends State>(
     if (!batchListenerGroup.listeners.size && !inDispatch) {
       prevStateBatch = state;
     }
-    const cleanup = listener(state, prevStateBatch);
-    reconcileInitialCleanup(batchListenerGroup, listener, cleanup);
+    runInitialListener(batchListenerGroup, listener, prevStateBatch);
     return registerListener(keys, listener, batchListenerGroup);
   };
 
@@ -336,42 +373,29 @@ export function createStore<S extends State>(
     prevState: S,
     updatedKey: UpdatedKey<S>,
   ) => {
-    const { disposables } = group;
     if (!(updatedKey instanceof Set) && !group.allKeysListeners?.size) {
       const keyedListeners = group.listenersByKey?.get(updatedKey);
       if (!keyedListeners) return;
+      const processedListeners = new Set<Listener<S>>();
       for (const listener of keyedListeners) {
-        // Skip the cleanup lookup when no listener has registered a cleanup.
-        // The `.size` gate keeps an empty disposables map off this hot path.
-        const cleanup = disposables.size
-          ? disposables.get(listener)
-          : undefined;
-        if (cleanup) cleanup();
-        const result = listener(state, prevState);
-        if (result) {
-          disposables.set(listener, result);
-        } else if (cleanup) {
-          disposables.delete(listener);
-        }
+        if (processedListeners.has(listener)) continue;
+        processedListeners.add(listener);
+        if (group.suspendedListeners?.has(listener)) continue;
+        runListener(group, listener, prevState);
       }
       return;
     }
     const allKeysListeners = group.allKeysListeners;
+    const processedListeners = new Set<Listener<S>>();
     for (const listener of group.listeners) {
       if (!allKeysListeners?.has(listener)) {
         const keys = group.listenerKeys.get(listener);
         if (!hasUpdatedKey(keys, updatedKey)) continue;
       }
-      // Skip the cleanup lookup when no listener has registered a cleanup.
-      // The `.size` gate keeps an empty disposables map off this hot path.
-      const cleanup = disposables.size ? disposables.get(listener) : undefined;
-      if (cleanup) cleanup();
-      const result = listener(state, prevState);
-      if (result) {
-        disposables.set(listener, result);
-      } else if (cleanup) {
-        disposables.delete(listener);
-      }
+      if (processedListeners.has(listener)) continue;
+      processedListeners.add(listener);
+      if (group.suspendedListeners?.has(listener)) continue;
+      runListener(group, listener, prevState);
     }
   };
 

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -42,9 +42,12 @@ interface ListenerGroup<S> {
   listeners: Set<Listener<S>>;
   listenersByKey?: ListenerMap<S>;
   allKeysListeners?: Set<Listener<S>>;
-  suspendedListeners?: Set<Listener<S>>;
+  suspendCounts?: Map<Listener<S>, number>;
   disposables: Map<Listener<S>, () => void>;
   listenerKeys: WeakMap<Listener<S>, Array<keyof S> | null>;
+  listenerVersion: number;
+  listenerRunVersion: number;
+  listenerRunVersions: WeakMap<Listener<S>, number>;
 }
 
 interface StoreInternals<S = State> {
@@ -140,11 +143,17 @@ export function createStore<S extends State>(
     listeners: new Set(),
     disposables: new Map(),
     listenerKeys: new WeakMap(),
+    listenerVersion: 0,
+    listenerRunVersion: 0,
+    listenerRunVersions: new WeakMap(),
   };
   const batchListenerGroup: ListenerGroup<S> = {
     listeners: new Set(),
     disposables: new Map(),
     listenerKeys: new WeakMap(),
+    listenerVersion: 0,
+    listenerRunVersion: 0,
+    listenerRunVersions: new WeakMap(),
   };
 
   const storeSetup: StoreSetup = (callback) => {
@@ -267,6 +276,7 @@ export function createStore<S extends State>(
       group.allKeysListeners.add(listener);
     }
     group.listenerKeys.set(listener, listenerKeysValue);
+    group.listenerVersion += 1;
     return () => {
       group.disposables.get(listener)?.();
       group.disposables.delete(listener);
@@ -277,6 +287,7 @@ export function createStore<S extends State>(
       }
       group.listenerKeys.delete(listener);
       group.listeners.delete(listener);
+      group.listenerVersion += 1;
     };
   };
 
@@ -302,8 +313,16 @@ export function createStore<S extends State>(
     prevState: S,
   ) => {
     runPendingCleanups(group, listener);
+    group.listenerRunVersion += 1;
+    const listenerRunVersion = group.listenerRunVersion;
+    group.listenerRunVersions.set(listener, listenerRunVersion);
     const cleanup = listener(state, prevState);
-    runPendingCleanups(group, listener);
+    // A reentrant same-listener run owns the current cleanup slot, even when it
+    // cleared the slot by returning nothing.
+    if (group.listenerRunVersions.get(listener) !== listenerRunVersion) {
+      cleanup?.();
+      return;
+    }
     if (cleanup) {
       group.disposables.set(listener, cleanup);
     } else {
@@ -321,17 +340,23 @@ export function createStore<S extends State>(
   ) => {
     const shouldSuspend = group.listeners.has(listener);
     if (shouldSuspend) {
-      group.suspendedListeners ??= new Set();
-      group.suspendedListeners.add(listener);
+      group.suspendCounts ??= new Map();
+      const count = group.suspendCounts.get(listener) ?? 0;
+      group.suspendCounts.set(listener, count + 1);
     }
     try {
       runListener(group, listener, prevState);
     } finally {
       if (shouldSuspend) {
-        const suspendedListeners = group.suspendedListeners;
-        suspendedListeners?.delete(listener);
-        if (!suspendedListeners?.size) {
-          delete group.suspendedListeners;
+        const suspendCounts = group.suspendCounts;
+        const count = suspendCounts?.get(listener);
+        if (count && count > 1) {
+          suspendCounts?.set(listener, count - 1);
+        } else {
+          suspendCounts?.delete(listener);
+        }
+        if (!suspendCounts?.size) {
+          delete group.suspendCounts;
         }
       }
     }
@@ -376,25 +401,37 @@ export function createStore<S extends State>(
     if (!(updatedKey instanceof Set) && !group.allKeysListeners?.size) {
       const keyedListeners = group.listenersByKey?.get(updatedKey);
       if (!keyedListeners) return;
-      const processedListeners = new Set<Listener<S>>();
+      const startVersion = group.listenerVersion;
+      const processedListeners: Array<Listener<S>> = [];
+      let processedListenerSet: Set<Listener<S>> | undefined;
       for (const listener of keyedListeners) {
-        if (processedListeners.has(listener)) continue;
-        processedListeners.add(listener);
-        if (group.suspendedListeners?.has(listener)) continue;
+        if (group.listenerVersion !== startVersion) {
+          processedListenerSet ??= new Set(processedListeners);
+          if (processedListenerSet.has(listener)) continue;
+        }
+        processedListeners.push(listener);
+        processedListenerSet?.add(listener);
+        if (group.suspendCounts?.has(listener)) continue;
         runListener(group, listener, prevState);
       }
       return;
     }
     const allKeysListeners = group.allKeysListeners;
-    const processedListeners = new Set<Listener<S>>();
+    const startVersion = group.listenerVersion;
+    const processedListeners: Array<Listener<S>> = [];
+    let processedListenerSet: Set<Listener<S>> | undefined;
     for (const listener of group.listeners) {
       if (!allKeysListeners?.has(listener)) {
         const keys = group.listenerKeys.get(listener);
         if (!hasUpdatedKey(keys, updatedKey)) continue;
       }
-      if (processedListeners.has(listener)) continue;
-      processedListeners.add(listener);
-      if (group.suspendedListeners?.has(listener)) continue;
+      if (group.listenerVersion !== startVersion) {
+        processedListenerSet ??= new Set(processedListeners);
+        if (processedListenerSet.has(listener)) continue;
+      }
+      processedListeners.push(listener);
+      processedListenerSet?.add(listener);
+      if (group.suspendCounts?.has(listener)) continue;
       runListener(group, listener, prevState);
     }
   };

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -576,29 +576,66 @@ test("does not leak sync cleanup when re-registration listener updates state", (
   expect(active).toBe(0);
 });
 
-test("does not duplicate sync cleanup when re-registering during dispatch", () => {
+test("keeps dispatch cleanup updates out of the outer rerun diff", () => {
   const store = createStore({ count: 0, enabled: false });
+  const changes: Array<[number, number, boolean, boolean]> = [];
+  let updateOnCleanup = true;
+
+  sync(store, ["count", "enabled"], (state, prevState) => {
+    changes.push([
+      state.count,
+      prevState.count,
+      state.enabled,
+      prevState.enabled,
+    ]);
+    return () => {
+      if (!updateOnCleanup) return;
+      updateOnCleanup = false;
+      store.setState("enabled", true);
+    };
+  });
+  changes.length = 0;
+
+  store.setState("count", 1);
+
+  expect(changes).toEqual([
+    [1, 1, true, false],
+    [1, 0, true, true],
+  ]);
+});
+
+test("does not drain cleanups installed by re-registration cleanups", () => {
+  const store = createStore({ count: 0 });
   const events: string[] = [];
+  let active = 0;
   let runCount = 0;
-  let reRegister = false;
+  let registerFromCleanup = true;
 
   const listener = () => {
+    active += 1;
     runCount += 1;
     const id = runCount;
     events.push(`run ${id}`);
-    if (reRegister) {
-      reRegister = false;
-      sync(store, ["count", "enabled"], listener);
-    }
-    return () => events.push(`cleanup ${id}`);
+    return () => {
+      active -= 1;
+      events.push(`cleanup ${id}`);
+      if (!registerFromCleanup) return;
+      registerFromCleanup = false;
+      sync(store, ["count"], listener);
+    };
   };
 
-  const unsubscribe = sync(store, ["count"], listener);
+  const first = sync(store, ["count"], listener);
+  const second = sync(store, ["count"], listener);
 
-  reRegister = true;
-  store.setState("count", 1);
-  unsubscribe();
+  expect(events).toEqual(["run 1", "cleanup 1", "run 2", "run 3"]);
+  expect(active).toBe(2);
 
+  second();
+  expect(active).toBe(0);
+
+  first();
+  expect(active).toBe(0);
   expect(events).toEqual([
     "run 1",
     "cleanup 1",
@@ -607,145 +644,6 @@ test("does not duplicate sync cleanup when re-registering during dispatch", () =
     "cleanup 2",
     "cleanup 3",
   ]);
-});
-
-test("does not rerun a re-registered sync listener in the same dispatch", () => {
-  const store = createStore({ count: 0, enabled: false });
-  const events: string[] = [];
-  let runCount = 0;
-  let reRegister = false;
-
-  const listener = () => {
-    runCount += 1;
-    const id = runCount;
-    events.push(`run ${id}`);
-    if (reRegister) {
-      reRegister = false;
-      sync(store, ["count", "enabled"], listener);
-    }
-    return () => events.push(`cleanup ${id}`);
-  };
-
-  const unsubscribe = sync(store, ["count"], listener);
-  sync(store, ["count"], () => {
-    events.push("other");
-  });
-  events.length = 0;
-
-  reRegister = true;
-  store.setState("count", 1);
-  unsubscribe();
-
-  expect(events).toEqual([
-    "cleanup 1",
-    "run 2",
-    "run 3",
-    "cleanup 2",
-    "other",
-    "cleanup 3",
-  ]);
-});
-
-test("keeps a sync listener suspended through nested re-registration", () => {
-  const store = createStore({ count: 0, enabled: false });
-  const events: string[] = [];
-  let runCount = 0;
-  let reRegister = false;
-
-  const listener = () => {
-    runCount += 1;
-    const id = runCount;
-    events.push(`run ${id}`);
-    if (reRegister) {
-      reRegister = false;
-      sync(store, ["count", "enabled"], listener);
-      store.setState("count", 1);
-    }
-    return () => events.push(`cleanup ${id}`);
-  };
-
-  const first = sync(store, ["count"], listener);
-  events.length = 0;
-
-  reRegister = true;
-  const second = sync(store, ["count", "enabled"], listener);
-  second();
-  first();
-
-  expect(events).toEqual([
-    "cleanup 1",
-    "run 2",
-    "run 3",
-    "cleanup 2",
-    "cleanup 3",
-  ]);
-});
-
-test("preserves newer sync cleanup after a reentrant state update", () => {
-  const store = createStore({ count: 0, other: 0 });
-  const events: string[] = [];
-  let runCount = 0;
-  let updateOther = false;
-
-  sync(store, null, (state) => {
-    runCount += 1;
-    const id = runCount;
-    events.push(`run ${id}:${state.count}/${state.other}`);
-    if (updateOther) {
-      updateOther = false;
-      store.setState("other", 1);
-    }
-    return () => events.push(`cleanup ${id}:${state.count}/${state.other}`);
-  });
-  events.length = 0;
-
-  updateOther = true;
-  store.setState("count", 1);
-  store.setState("count", 2);
-
-  expect(events).toEqual([
-    "cleanup 1:0/0",
-    "run 2:1/0",
-    "run 3:1/1",
-    "cleanup 2:1/0",
-    "cleanup 3:1/1",
-    "run 4:2/1",
-  ]);
-});
-
-test("preserves cleared sync cleanup after a reentrant state update", () => {
-  const store = createStore({ count: 0, other: 0 });
-  const events: string[] = [];
-  let runCount = 0;
-  let updateOther = false;
-
-  sync(store, null, (state) => {
-    runCount += 1;
-    const id = runCount;
-    events.push(`run ${id}:${state.count}/${state.other}`);
-    if (updateOther) {
-      updateOther = false;
-      store.setState("other", 1);
-    }
-    if (state.other) return;
-    return () => events.push(`cleanup ${id}:${state.count}/${state.other}`);
-  });
-  events.length = 0;
-
-  updateOther = true;
-  store.setState("count", 1);
-
-  expect(events).toEqual([
-    "cleanup 1:0/0",
-    "run 2:1/0",
-    "run 3:1/1",
-    "cleanup 2:1/0",
-  ]);
-
-  events.length = 0;
-  store.setState("count", 2);
-
-  expect(events).toEqual(["run 4:2/1"]);
 });
 
 test("runs a pending batch cleanup when re-registering a listener", () => {
@@ -770,6 +668,48 @@ test("runs a pending batch cleanup when re-registering a listener", () => {
   expect(active).toBe(0);
 });
 
+test("does not drain batch cleanups installed by re-registration cleanups", () => {
+  const store = createStore({ count: 0 });
+  const events: string[] = [];
+  let active = 0;
+  let runCount = 0;
+  let registerFromCleanup = true;
+
+  const listener = () => {
+    active += 1;
+    runCount += 1;
+    const id = runCount;
+    events.push(`run ${id}`);
+    return () => {
+      active -= 1;
+      events.push(`cleanup ${id}`);
+      if (!registerFromCleanup) return;
+      registerFromCleanup = false;
+      batch(store, ["count"], listener);
+    };
+  };
+
+  const first = batch(store, ["count"], listener);
+  const second = batch(store, ["count"], listener);
+
+  expect(events).toEqual(["run 1", "cleanup 1", "run 2", "run 3"]);
+  expect(active).toBe(2);
+
+  second();
+  expect(active).toBe(0);
+
+  first();
+  expect(active).toBe(0);
+  expect(events).toEqual([
+    "run 1",
+    "cleanup 1",
+    "run 2",
+    "run 3",
+    "cleanup 2",
+    "cleanup 3",
+  ]);
+});
+
 test("keeps batch re-registration cleanup updates out of the initial diff", async () => {
   const store = createStore({ count: 0, enabled: false });
   const changes: Array<[number, number]> = [];
@@ -787,11 +727,13 @@ test("keeps batch re-registration cleanup updates out of the initial diff", asyn
   changes.length = 0;
 
   const second = batch(store, ["count", "enabled"], listener);
+  expect(changes).toEqual([]);
+
   await flushBatch();
   second();
   first();
 
-  expect(changes).toEqual([]);
+  expect(changes).toEqual([[1, 0]]);
 });
 
 test("preserves pending batch diffs after re-registration cleanup updates another key", async () => {
@@ -827,80 +769,63 @@ test("preserves pending batch diffs after re-registration cleanup updates anothe
 
   expect(changes).toEqual([
     [1, 0, true, true],
-    [1, 0, true, true],
+    [1, 0, true, false],
   ]);
 });
 
-test("does not duplicate batch cleanup when re-registering during dispatch", async () => {
+test("preserves re-registration cleanup updates for other batch listeners", async () => {
   const store = createStore({ count: 0, enabled: false });
-  const events: string[] = [];
-  let runCount = 0;
-  let reRegister = false;
+  const changes: Array<[number, number]> = [];
 
-  const listener = () => {
-    runCount += 1;
-    const id = runCount;
-    events.push(`run ${id}`);
-    if (reRegister) {
-      reRegister = false;
-      batch(store, ["count", "enabled"], listener);
-    }
-    return () => events.push(`cleanup ${id}`);
-  };
-
-  const unsubscribe = batch(store, ["count"], listener);
-
-  reRegister = true;
-  store.setState("count", 1);
-  await flushBatch();
-  unsubscribe();
-
-  expect(events).toEqual([
-    "run 1",
-    "cleanup 1",
-    "run 2",
-    "run 3",
-    "cleanup 2",
-    "cleanup 3",
-  ]);
-});
-
-test("does not rerun a re-registered batch listener in the same dispatch", async () => {
-  const store = createStore({ count: 0, enabled: false });
-  const events: string[] = [];
-  let runCount = 0;
-  let reRegister = false;
-
-  const listener = () => {
-    runCount += 1;
-    const id = runCount;
-    events.push(`run ${id}`);
-    if (reRegister) {
-      reRegister = false;
-      batch(store, ["count", "enabled"], listener);
-    }
-    return () => events.push(`cleanup ${id}`);
-  };
-
-  const unsubscribe = batch(store, ["count"], listener);
-  batch(store, ["count"], () => {
-    events.push("other");
+  batch(store, ["count"], (state, prevState) => {
+    changes.push([state.count, prevState.count]);
   });
-  events.length = 0;
+  changes.length = 0;
 
-  reRegister = true;
-  store.setState("count", 1);
+  const listener = () => {
+    return () => {
+      store.setState("count", 1);
+    };
+  };
+
+  const first = batch(store, ["enabled"], listener);
+  const second = batch(store, ["count", "enabled"], listener);
+
+  expect(changes).toEqual([]);
+
   await flushBatch();
-  unsubscribe();
+  second();
+  first();
 
-  expect(events).toEqual([
-    "cleanup 1",
-    "run 2",
-    "run 3",
-    "cleanup 2",
-    "other",
-    "cleanup 3",
-  ]);
+  expect(changes).toEqual([[1, 0]]);
+});
+
+test("preserves pending same-key batch diffs after re-registration cleanup", async () => {
+  const store = createStore({ count: 0 });
+  const changes: Array<[number, number]> = [];
+
+  const listener = (state: { count: number }, prevState: { count: number }) => {
+    if (state.count !== prevState.count) {
+      changes.push([state.count, prevState.count]);
+    }
+    return () => {
+      store.setState("count", 2);
+    };
+  };
+
+  const first = batch(store, ["count"], listener);
+  changes.length = 0;
+
+  store.setState("count", 1);
+  const second = batch(store, ["count"], listener);
+
+  expect(changes).toEqual([]);
+
+  await flushBatch();
+  second();
+  first();
+
+  expect(changes).toEqual([[2, 0]]);
 });
 
 test("registers a batch listener during dispatch and still sees the in-flight diff", async () => {

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -467,9 +467,256 @@ test("re-registers a listener without dragging a stale cleanup forward", () => {
   sync(store, null, listener);
   store.setState("count", 2);
 
-  // "cleanup 2" must not appear: re-registering without a cleanup must clear
-  // the stale cleanup from the previous registration.
-  expect(events).toEqual(["run 1", "cleanup 1", "run 2", "run 3", "run 4"]);
+  // "cleanup 2" must fire before "run 3" so the previous registration
+  // doesn't leak its pending cleanup.
+  expect(events).toEqual([
+    "run 1",
+    "cleanup 1",
+    "run 2",
+    "cleanup 2",
+    "run 3",
+    "run 4",
+  ]);
+});
+
+test("runs a pending sync cleanup when re-registering a listener", () => {
+  const store = createStore({ count: 0, enabled: false });
+  let active = 0;
+
+  const listener = () => {
+    active += 1;
+    return () => {
+      active -= 1;
+    };
+  };
+
+  const first = sync(store, ["count"], listener);
+  const second = sync(store, ["count", "enabled"], listener);
+
+  expect(active).toBe(1);
+
+  second();
+  first();
+
+  expect(active).toBe(0);
+});
+
+test("does not leak sync cleanup when re-registration cleanup updates state", () => {
+  const store = createStore({ count: 0, enabled: false });
+  let active = 0;
+  let updateOnCleanup = true;
+
+  const listener = () => {
+    active += 1;
+    return () => {
+      active -= 1;
+      if (!updateOnCleanup) return;
+      updateOnCleanup = false;
+      store.setState("count", (count) => count + 1);
+    };
+  };
+
+  const first = sync(store, ["count"], listener);
+  const second = sync(store, ["count", "enabled"], listener);
+
+  expect(active).toBe(1);
+
+  second();
+  first();
+
+  expect(active).toBe(0);
+});
+
+test("does not leak sync cleanup when re-registration listener updates state", () => {
+  const store = createStore({ count: 0, enabled: false });
+  let active = 0;
+  let updateOnRun = false;
+
+  const listener = () => {
+    active += 1;
+    if (updateOnRun) {
+      updateOnRun = false;
+      store.setState("count", (count) => count + 1);
+    }
+    return () => {
+      active -= 1;
+    };
+  };
+
+  const first = sync(store, ["count"], listener);
+  updateOnRun = true;
+  const second = sync(store, ["count", "enabled"], listener);
+
+  expect(active).toBe(1);
+
+  second();
+  first();
+
+  expect(active).toBe(0);
+});
+
+test("does not duplicate sync cleanup when re-registering during dispatch", () => {
+  const store = createStore({ count: 0, enabled: false });
+  const events: string[] = [];
+  let runCount = 0;
+  let reRegister = false;
+
+  const listener = () => {
+    runCount += 1;
+    const id = runCount;
+    events.push(`run ${id}`);
+    if (reRegister) {
+      reRegister = false;
+      sync(store, ["count", "enabled"], listener);
+    }
+    return () => events.push(`cleanup ${id}`);
+  };
+
+  const unsubscribe = sync(store, ["count"], listener);
+
+  reRegister = true;
+  store.setState("count", 1);
+  unsubscribe();
+
+  expect(events).toEqual([
+    "run 1",
+    "cleanup 1",
+    "run 2",
+    "run 3",
+    "cleanup 3",
+    "cleanup 2",
+  ]);
+});
+
+test("does not rerun a re-registered sync listener in the same dispatch", () => {
+  const store = createStore({ count: 0, enabled: false });
+  const events: string[] = [];
+  let runCount = 0;
+  let reRegister = false;
+
+  const listener = () => {
+    runCount += 1;
+    const id = runCount;
+    events.push(`run ${id}`);
+    if (reRegister) {
+      reRegister = false;
+      sync(store, ["count", "enabled"], listener);
+    }
+    return () => events.push(`cleanup ${id}`);
+  };
+
+  const unsubscribe = sync(store, ["count"], listener);
+  sync(store, ["count"], () => {
+    events.push("other");
+  });
+  events.length = 0;
+
+  reRegister = true;
+  store.setState("count", 1);
+  unsubscribe();
+
+  expect(events).toEqual([
+    "cleanup 1",
+    "run 2",
+    "run 3",
+    "cleanup 3",
+    "other",
+    "cleanup 2",
+  ]);
+});
+
+test("runs a pending batch cleanup when re-registering a listener", () => {
+  const store = createStore({ count: 0, enabled: false });
+  let active = 0;
+
+  const listener = () => {
+    active += 1;
+    return () => {
+      active -= 1;
+    };
+  };
+
+  const first = batch(store, ["count"], listener);
+  const second = batch(store, ["count", "enabled"], listener);
+
+  expect(active).toBe(1);
+
+  second();
+  first();
+
+  expect(active).toBe(0);
+});
+
+test("does not duplicate batch cleanup when re-registering during dispatch", async () => {
+  const store = createStore({ count: 0, enabled: false });
+  const events: string[] = [];
+  let runCount = 0;
+  let reRegister = false;
+
+  const listener = () => {
+    runCount += 1;
+    const id = runCount;
+    events.push(`run ${id}`);
+    if (reRegister) {
+      reRegister = false;
+      batch(store, ["count", "enabled"], listener);
+    }
+    return () => events.push(`cleanup ${id}`);
+  };
+
+  const unsubscribe = batch(store, ["count"], listener);
+
+  reRegister = true;
+  store.setState("count", 1);
+  await flushBatch();
+  unsubscribe();
+
+  expect(events).toEqual([
+    "run 1",
+    "cleanup 1",
+    "run 2",
+    "run 3",
+    "cleanup 3",
+    "cleanup 2",
+  ]);
+});
+
+test("does not rerun a re-registered batch listener in the same dispatch", async () => {
+  const store = createStore({ count: 0, enabled: false });
+  const events: string[] = [];
+  let runCount = 0;
+  let reRegister = false;
+
+  const listener = () => {
+    runCount += 1;
+    const id = runCount;
+    events.push(`run ${id}`);
+    if (reRegister) {
+      reRegister = false;
+      batch(store, ["count", "enabled"], listener);
+    }
+    return () => events.push(`cleanup ${id}`);
+  };
+
+  const unsubscribe = batch(store, ["count"], listener);
+  batch(store, ["count"], () => {
+    events.push("other");
+  });
+  events.length = 0;
+
+  reRegister = true;
+  store.setState("count", 1);
+  await flushBatch();
+  unsubscribe();
+
+  expect(events).toEqual([
+    "cleanup 1",
+    "run 2",
+    "run 3",
+    "cleanup 3",
+    "other",
+    "cleanup 2",
+  ]);
 });
 
 test("registers a batch listener during dispatch and still sees the in-flight diff", async () => {

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -604,6 +604,52 @@ test("keeps dispatch cleanup updates out of the outer rerun diff", () => {
   ]);
 });
 
+test("preserves the dispatched key diff after cleanup updates it", () => {
+  const store = createStore({ count: 0 });
+  const changes: Array<[number, number]> = [];
+  let updateOnCleanup = true;
+
+  sync(store, ["count"], (state, prevState) => {
+    changes.push([state.count, prevState.count]);
+    return () => {
+      if (!updateOnCleanup) return;
+      updateOnCleanup = false;
+      store.setState("count", 2);
+    };
+  });
+  changes.length = 0;
+
+  store.setState("count", 1);
+
+  expect(changes).toEqual([
+    [2, 1],
+    [2, 0],
+  ]);
+});
+
+test("preserves an empty-string key diff after cleanup updates it", () => {
+  const store = createStore({ "": 0 });
+  const changes: Array<[number, number]> = [];
+  let updateOnCleanup = true;
+
+  sync(store, [""], (state, prevState) => {
+    changes.push([state[""], prevState[""]]);
+    return () => {
+      if (!updateOnCleanup) return;
+      updateOnCleanup = false;
+      store.setState("", 2);
+    };
+  });
+  changes.length = 0;
+
+  store.setState("", 1);
+
+  expect(changes).toEqual([
+    [2, 1],
+    [2, 0],
+  ]);
+});
+
 test("does not drain cleanups installed by re-registration cleanups", () => {
   const store = createStore({ count: 0 });
   const events: string[] = [];

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -527,6 +527,27 @@ test("does not leak sync cleanup when re-registration cleanup updates state", ()
   expect(active).toBe(0);
 });
 
+test("keeps sync re-registration cleanup updates out of the initial diff", () => {
+  const store = createStore({ count: 0, enabled: false });
+  const changes: Array<[number, number]> = [];
+
+  const listener = (state: { count: number }, prevState: { count: number }) => {
+    changes.push([state.count, prevState.count]);
+    return () => {
+      store.setState("count", (count) => (count === 0 ? count + 1 : count));
+    };
+  };
+
+  const first = sync(store, ["count"], listener);
+  changes.length = 0;
+
+  const second = sync(store, ["count", "enabled"], listener);
+  second();
+  first();
+
+  expect(changes).toEqual([[1, 1]]);
+});
+
 test("does not leak sync cleanup when re-registration listener updates state", () => {
   const store = createStore({ count: 0, enabled: false });
   let active = 0;
@@ -747,6 +768,67 @@ test("runs a pending batch cleanup when re-registering a listener", () => {
   first();
 
   expect(active).toBe(0);
+});
+
+test("keeps batch re-registration cleanup updates out of the initial diff", async () => {
+  const store = createStore({ count: 0, enabled: false });
+  const changes: Array<[number, number]> = [];
+
+  const listener = (state: { count: number }, prevState: { count: number }) => {
+    if (state.count !== prevState.count) {
+      changes.push([state.count, prevState.count]);
+    }
+    return () => {
+      store.setState("count", (count) => (count === 0 ? count + 1 : count));
+    };
+  };
+
+  const first = batch(store, ["count"], listener);
+  changes.length = 0;
+
+  const second = batch(store, ["count", "enabled"], listener);
+  await flushBatch();
+  second();
+  first();
+
+  expect(changes).toEqual([]);
+});
+
+test("preserves pending batch diffs after re-registration cleanup updates another key", async () => {
+  const store = createStore({ count: 0, enabled: false });
+  const changes: Array<[number, number, boolean, boolean]> = [];
+
+  const listener = (
+    state: { count: number; enabled: boolean },
+    prevState: { count: number; enabled: boolean },
+  ) => {
+    changes.push([
+      state.count,
+      prevState.count,
+      state.enabled,
+      prevState.enabled,
+    ]);
+    return () => {
+      store.setState("enabled", true);
+    };
+  };
+
+  const first = batch(store, ["count", "enabled"], listener);
+  changes.length = 0;
+
+  store.setState("count", 1);
+  const second = batch(store, ["count", "enabled"], listener);
+
+  expect(changes).toEqual([[1, 0, true, true]]);
+
+  await flushBatch();
+  second();
+  first();
+
+  expect(changes).toEqual([
+    [1, 0, true, true],
+    [1, 0, true, true],
+  ]);
 });
 
 test("does not duplicate batch cleanup when re-registering during dispatch", async () => {

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -583,8 +583,8 @@ test("does not duplicate sync cleanup when re-registering during dispatch", () =
     "cleanup 1",
     "run 2",
     "run 3",
-    "cleanup 3",
     "cleanup 2",
+    "cleanup 3",
   ]);
 });
 
@@ -619,10 +619,112 @@ test("does not rerun a re-registered sync listener in the same dispatch", () => 
     "cleanup 1",
     "run 2",
     "run 3",
-    "cleanup 3",
-    "other",
     "cleanup 2",
+    "other",
+    "cleanup 3",
   ]);
+});
+
+test("keeps a sync listener suspended through nested re-registration", () => {
+  const store = createStore({ count: 0, enabled: false });
+  const events: string[] = [];
+  let runCount = 0;
+  let reRegister = false;
+
+  const listener = () => {
+    runCount += 1;
+    const id = runCount;
+    events.push(`run ${id}`);
+    if (reRegister) {
+      reRegister = false;
+      sync(store, ["count", "enabled"], listener);
+      store.setState("count", 1);
+    }
+    return () => events.push(`cleanup ${id}`);
+  };
+
+  const first = sync(store, ["count"], listener);
+  events.length = 0;
+
+  reRegister = true;
+  const second = sync(store, ["count", "enabled"], listener);
+  second();
+  first();
+
+  expect(events).toEqual([
+    "cleanup 1",
+    "run 2",
+    "run 3",
+    "cleanup 2",
+    "cleanup 3",
+  ]);
+});
+
+test("preserves newer sync cleanup after a reentrant state update", () => {
+  const store = createStore({ count: 0, other: 0 });
+  const events: string[] = [];
+  let runCount = 0;
+  let updateOther = false;
+
+  sync(store, null, (state) => {
+    runCount += 1;
+    const id = runCount;
+    events.push(`run ${id}:${state.count}/${state.other}`);
+    if (updateOther) {
+      updateOther = false;
+      store.setState("other", 1);
+    }
+    return () => events.push(`cleanup ${id}:${state.count}/${state.other}`);
+  });
+  events.length = 0;
+
+  updateOther = true;
+  store.setState("count", 1);
+  store.setState("count", 2);
+
+  expect(events).toEqual([
+    "cleanup 1:0/0",
+    "run 2:1/0",
+    "run 3:1/1",
+    "cleanup 2:1/0",
+    "cleanup 3:1/1",
+    "run 4:2/1",
+  ]);
+});
+
+test("preserves cleared sync cleanup after a reentrant state update", () => {
+  const store = createStore({ count: 0, other: 0 });
+  const events: string[] = [];
+  let runCount = 0;
+  let updateOther = false;
+
+  sync(store, null, (state) => {
+    runCount += 1;
+    const id = runCount;
+    events.push(`run ${id}:${state.count}/${state.other}`);
+    if (updateOther) {
+      updateOther = false;
+      store.setState("other", 1);
+    }
+    if (state.other) return;
+    return () => events.push(`cleanup ${id}:${state.count}/${state.other}`);
+  });
+  events.length = 0;
+
+  updateOther = true;
+  store.setState("count", 1);
+
+  expect(events).toEqual([
+    "cleanup 1:0/0",
+    "run 2:1/0",
+    "run 3:1/1",
+    "cleanup 2:1/0",
+  ]);
+
+  events.length = 0;
+  store.setState("count", 2);
+
+  expect(events).toEqual(["run 4:2/1"]);
 });
 
 test("runs a pending batch cleanup when re-registering a listener", () => {
@@ -676,8 +778,8 @@ test("does not duplicate batch cleanup when re-registering during dispatch", asy
     "cleanup 1",
     "run 2",
     "run 3",
-    "cleanup 3",
     "cleanup 2",
+    "cleanup 3",
   ]);
 });
 
@@ -713,9 +815,9 @@ test("does not rerun a re-registered batch listener in the same dispatch", async
     "cleanup 1",
     "run 2",
     "run 3",
-    "cleanup 3",
-    "other",
     "cleanup 2",
+    "other",
+    "cleanup 3",
   ]);
 });
 


### PR DESCRIPTION
## Motivation

Fixes #6323.

`@ariakit/store` listeners can return cleanup functions, and those cleanups are expected to run before the listener runs again and when it unsubscribes. Re-registering the same `sync` or `batch` listener was the one path that could overwrite or delete the previous cleanup without running it, leaking paired resources such as event listeners, observers, or timers.

## Solution

This runs a listener's pending cleanup before the initial run performed by `sync` and `batch` re-registration. If that cleanup updates the store, the cleanup-only state changes are folded into the initial run's previous-state snapshot so the re-registered listener doesn't observe those changes as part of its own initial diff.

Nested re-registration during cleanup is handled as a single cleanup drain: cleanups installed by nested registrations are preserved and composed with the outer cleanup instead of being immediately drained or overwritten. The dispatch hot path stays close to `main`; the broader dispatch-time re-registration deduplication from earlier revisions was removed to avoid the benchmark regression called out in review.

Regression coverage includes `sync` and `batch` re-registration, nested cleanup re-registration, cleanup-driven state updates, batch baseline preservation for other listeners, and pending same-key batch diffs.
