### PR TITLE
Fix store unsubscribe cleanup reentry

### DIFF
--- a/.changeset/300-store-unsubscribe-cleanup.md
+++ b/.changeset/300-store-unsubscribe-cleanup.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/store": patch
+"@ariakit/solid-store": patch
+---
+
+Fixed store listener cleanup disposal so synchronous store updates during unsubscribe do not rerun detached listeners.

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -518,8 +518,9 @@ export function createStore<S extends State>(
   // (1) snapshot `keys` as a defensive copy (or null for an all-keys listener);
   // (2) index the listener — re-registering the same listener first clears its
   // previous index entries so a re-keyed listener is never left in a stale key
-  // bucket; (3) return a disposer that runs any pending cleanup and removes the
-  // listener from the set, the key index, and the disposables/keys maps.
+  // bucket; (3) return a disposer that removes the listener from the set, the
+  // key index, and the disposables/keys maps before running any pending
+  // cleanup.
   const registerListener = (
     keys: Array<keyof S> | null,
     listener: Listener<S>,
@@ -563,7 +564,7 @@ export function createStore<S extends State>(
     }
     group.listenerKeys.set(listener, listenerKeysValue);
     return () => {
-      group.disposables.get(listener)?.();
+      const cleanup = group.disposables.get(listener);
       group.disposables.delete(listener);
       preserveFastPathFrames(fastPathFrames, group, listener);
       const currentKeys = group.listenerKeys.get(listener);
@@ -573,6 +574,7 @@ export function createStore<S extends State>(
       }
       group.listenerKeys.delete(listener);
       group.listeners.delete(listener);
+      cleanup?.();
     };
   };
 

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -290,6 +290,32 @@ test("sync runs immediately and cleans up before rerun and unsubscribe", () => {
   expect(events).toEqual(["0->0", "cleanup 0", "0->1", "cleanup 1"]);
 });
 
+test("detaches sync listeners before unsubscribe cleanups update state", () => {
+  const store = createStore({ count: 0 });
+  const events: string[] = [];
+  let runCount = 0;
+  let nudged = false;
+
+  const unsubscribe = sync(store, ["count"], () => {
+    runCount += 1;
+    const id = runCount;
+    events.push(`run ${id}`);
+    return () => {
+      events.push(`cleanup ${id}`);
+      if (nudged) return;
+      nudged = true;
+      store.setState("count", (count) => count + 1);
+    };
+  });
+
+  expect(events).toEqual(["run 1"]);
+
+  unsubscribe();
+
+  expect(store.getState()).toEqual({ count: 1 });
+  expect(events).toEqual(["run 1", "cleanup 1"]);
+});
+
 test("subscribe cleans up before rerun and unsubscribe", () => {
   const store = createStore({ count: 0 });
   const events: string[] = [];


### PR DESCRIPTION
## Motivation

Fixes #6431.

A store listener cleanup can synchronously update the same store while the listener is being unsubscribed. Before this change, the unsubscribe disposer ran the cleanup while the listener was still registered, so a reentrant store update could run the same cleanup twice and invoke the listener again after `unsubscribe()` had started.

## Solution

The unsubscribe disposer now captures the pending cleanup, removes the listener from the cleanup map, key indexes, listener key map, and listener set, then runs the cleanup after the listener has been fully detached.

A regression test covers the public `sync` API with a cleanup that synchronously updates the store during unsubscribe.

## Verification

- `pnpm lint-fix`
- `pnpm test packages/ariakit-store/src/test.ts`
- `pnpm tsc`
- `pnpm -F @ariakit/store build`
- `git diff --check`
