### PR TITLE
Fix CompositeSeparator orientation override

### DIFF
--- a/.changeset/300-composite-separator-orientation.md
+++ b/.changeset/300-composite-separator-orientation.md
@@ -1,0 +1,8 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Composite separators honor explicit orientation
+
+Fixed [`CompositeSeparator`](https://ariakit.com/reference/composite-separator) to honor an explicit `orientation` prop instead of always using the composite store-derived default. This also fixes components built on it, including [`ToolbarSeparator`](https://ariakit.com/reference/toolbar-separator), [`MenuSeparator`](https://ariakit.com/reference/menu-separator), [`SelectSeparator`](https://ariakit.com/reference/select-separator), and [`ComboboxSeparator`](https://ariakit.com/reference/combobox-separator).

--- a/app/src/sandbox/toolbar-separator-6302/index.react.tsx
+++ b/app/src/sandbox/toolbar-separator-6302/index.react.tsx
@@ -1,0 +1,28 @@
+import * as Ariakit from "@ariakit/react";
+
+export default function Example() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+      <Ariakit.Toolbar
+        aria-label="Text formatting"
+        style={{ display: "flex", flexWrap: "wrap", gap: 8, width: 240 }}
+      >
+        <Ariakit.ToolbarItem>Bold</Ariakit.ToolbarItem>
+        <Ariakit.ToolbarItem>Italic</Ariakit.ToolbarItem>
+        <Ariakit.ToolbarItem>Underline</Ariakit.ToolbarItem>
+        <Ariakit.ToolbarSeparator
+          aria-label="Row divider"
+          orientation="horizontal"
+          style={{ margin: 0, width: "100%" }}
+        />
+        <Ariakit.ToolbarItem>Undo</Ariakit.ToolbarItem>
+        <Ariakit.ToolbarItem>Redo</Ariakit.ToolbarItem>
+      </Ariakit.Toolbar>
+      <Ariakit.Separator
+        aria-label="Plain divider"
+        orientation="vertical"
+        style={{ height: 32, margin: 0 }}
+      />
+    </div>
+  );
+}

--- a/app/src/sandbox/toolbar-separator-6302/index.react.tsx
+++ b/app/src/sandbox/toolbar-separator-6302/index.react.tsx
@@ -8,11 +8,14 @@ export default function Example() {
         style={{ display: "flex", flexWrap: "wrap", gap: 8, width: 240 }}
       >
         <Ariakit.ToolbarItem>Bold</Ariakit.ToolbarItem>
+        <Ariakit.ToolbarSeparator
+          aria-label="Column divider"
+          style={{ height: 32, margin: 0 }}
+        />
         <Ariakit.ToolbarItem>Italic</Ariakit.ToolbarItem>
         <Ariakit.ToolbarItem>Underline</Ariakit.ToolbarItem>
         <Ariakit.ToolbarSeparator
           aria-label="Row divider"
-          aria-orientation="horizontal"
           orientation="horizontal"
           style={{ margin: 0, width: "100%" }}
         />

--- a/app/src/sandbox/toolbar-separator-6302/index.react.tsx
+++ b/app/src/sandbox/toolbar-separator-6302/index.react.tsx
@@ -12,6 +12,7 @@ export default function Example() {
         <Ariakit.ToolbarItem>Underline</Ariakit.ToolbarItem>
         <Ariakit.ToolbarSeparator
           aria-label="Row divider"
+          aria-orientation="horizontal"
           orientation="horizontal"
           style={{ margin: 0, width: "100%" }}
         />

--- a/app/src/sandbox/toolbar-separator-6302/test-browser.ts
+++ b/app/src/sandbox/toolbar-separator-6302/test-browser.ts
@@ -4,6 +4,10 @@ withFramework(import.meta.dirname, async ({ test }) => {
   // https://github.com/ariakit/ariakit/issues/6302
   test("honors explicit toolbar separator orientation", async ({ q }) => {
     await test
+      .expect(q.separator("Column divider"))
+      .toHaveAttribute("aria-orientation", "vertical");
+
+    await test
       .expect(q.separator("Row divider"))
       .toHaveAttribute("aria-orientation", "horizontal");
 

--- a/app/src/sandbox/toolbar-separator-6302/test-browser.ts
+++ b/app/src/sandbox/toolbar-separator-6302/test-browser.ts
@@ -1,0 +1,14 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/6302
+  test("honors explicit toolbar separator orientation", async ({ q }) => {
+    await test
+      .expect(q.separator("Row divider"))
+      .toHaveAttribute("aria-orientation", "horizontal");
+
+    await test
+      .expect(q.separator("Plain divider"))
+      .toHaveAttribute("aria-orientation", "vertical");
+  });
+});

--- a/app/src/sandbox/toolbar-separator-6302/test.ts
+++ b/app/src/sandbox/toolbar-separator-6302/test.ts
@@ -3,6 +3,11 @@ import { expect, test } from "vitest";
 
 // https://github.com/ariakit/ariakit/issues/6302
 test("honors explicit toolbar separator orientation", () => {
+  expect(q.separator.ensure("Column divider")).toHaveAttribute(
+    "aria-orientation",
+    "vertical",
+  );
+
   expect(q.separator.ensure("Row divider")).toHaveAttribute(
     "aria-orientation",
     "horizontal",

--- a/app/src/sandbox/toolbar-separator-6302/test.ts
+++ b/app/src/sandbox/toolbar-separator-6302/test.ts
@@ -1,0 +1,15 @@
+import { q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// https://github.com/ariakit/ariakit/issues/6302
+test("honors explicit toolbar separator orientation", () => {
+  expect(q.separator.ensure("Row divider")).toHaveAttribute(
+    "aria-orientation",
+    "horizontal",
+  );
+
+  expect(q.separator.ensure("Plain divider")).toHaveAttribute(
+    "aria-orientation",
+    "vertical",
+  );
+});

--- a/packages/ariakit-react-components/src/composite/composite-separator.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-separator.tsx
@@ -28,7 +28,11 @@ type TagName = typeof TagName;
 export const useCompositeSeparator = createHook<
   TagName,
   CompositeSeparatorOptions
->(function useCompositeSeparator({ store, ...props }) {
+>(function useCompositeSeparator({
+  store,
+  orientation: orientationProp,
+  ...props
+}) {
   const context = useCompositeScopedContext();
   store = store || context;
 
@@ -38,8 +42,11 @@ export const useCompositeSeparator = createHook<
       "CompositeSeparator must be wrapped in a Composite component.",
   );
 
-  const orientation = useStoreState(store, (state) =>
-    state.orientation === "horizontal" ? "vertical" : "horizontal",
+  const orientation = useStoreState(
+    store,
+    (state) =>
+      orientationProp ??
+      (state.orientation === "horizontal" ? "vertical" : "horizontal"),
   );
 
   props = useSeparator({ ...props, orientation });


### PR DESCRIPTION
## Motivation

Fixes #6302.

`CompositeSeparator` derives its default orientation from the composite store, but it was overriding an explicit `orientation` prop with that derived value. As a result, components built on it, such as `ToolbarSeparator`, could render the wrong `aria-orientation` even when the user passed an explicit orientation.

```tsx
<Ariakit.ToolbarSeparator
  aria-label="Row divider"
  orientation="horizontal"
/>
```

This should render `aria-orientation="horizontal"`, but it rendered `aria-orientation="vertical"` inside a default horizontal toolbar.

## Solution

`useCompositeSeparator` now treats the store-derived orientation as a true default. It destructures the explicit `orientation` prop and only falls back to the opposite composite orientation when the prop is not provided, matching the documented behavior and the existing `useCompositeRenderer` pattern.

The sandbox repro keeps a default separator assertion so the store-derived orientation remains covered while the explicit row-divider orientation is honored without the workaround.

Verified with:

```sh
pnpm lint-fix
pnpm test-react app/src/sandbox/toolbar-separator-6302/test.ts
APP_PORT=4325 NEXTJS_PORT=3005 pnpm -F app run test -- app/src/sandbox/toolbar-separator-6302/
pnpm tsc
pnpm build
```

## Workaround

Until the library fix is available, pass `aria-orientation` directly alongside the `orientation` prop. `useSeparator` spreads incoming ARIA props after its computed attributes, so this explicit attribute wins.

```tsx
<Ariakit.ToolbarSeparator
  // TODO: Remove once https://github.com/ariakit/ariakit/issues/6302 is fixed.
  aria-orientation="horizontal"
  orientation="horizontal"
/>
```
