### PR TITLE
Fix ComboboxDisclosure mousedown prevention

### DIFF
--- a/.changeset/300-combobox-disclosure-mousedown.md
+++ b/.changeset/300-combobox-disclosure-mousedown.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`ComboboxDisclosure`](https://ariakit.com/reference/combobox-disclosure) to honor `event.preventDefault()` in `onMouseDown` before moving focus to the [`Combobox`](https://ariakit.com/reference/combobox) input.

--- a/app/src/sandbox/combobox-disclosure-6296/index.react.tsx
+++ b/app/src/sandbox/combobox-disclosure-6296/index.react.tsx
@@ -8,8 +8,10 @@ export default function Example() {
         <div>
           <Ariakit.Combobox />
           <Ariakit.ComboboxDisclosure
-            onMouseDown={(event) => {
+            onMouseDownCapture={(event) => {
+              // TODO: Remove after https://github.com/ariakit/ariakit/issues/6296.
               event.preventDefault();
+              event.stopPropagation();
             }}
           />
         </div>

--- a/app/src/sandbox/combobox-disclosure-6296/index.react.tsx
+++ b/app/src/sandbox/combobox-disclosure-6296/index.react.tsx
@@ -8,10 +8,8 @@ export default function Example() {
         <div>
           <Ariakit.Combobox />
           <Ariakit.ComboboxDisclosure
-            onMouseDownCapture={(event) => {
-              // TODO: Remove after https://github.com/ariakit/ariakit/issues/6296.
+            onMouseDown={(event) => {
               event.preventDefault();
-              event.stopPropagation();
             }}
           />
         </div>

--- a/app/src/sandbox/combobox-disclosure-6296/index.react.tsx
+++ b/app/src/sandbox/combobox-disclosure-6296/index.react.tsx
@@ -1,0 +1,28 @@
+import * as Ariakit from "@ariakit/react";
+
+export default function Example() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+      <Ariakit.ComboboxProvider>
+        <Ariakit.ComboboxLabel>Fruit</Ariakit.ComboboxLabel>
+        <div>
+          <Ariakit.Combobox />
+          <Ariakit.ComboboxDisclosure
+            onMouseDown={(event) => {
+              event.preventDefault();
+            }}
+          />
+        </div>
+        <Ariakit.ComboboxPopover gutter={4}>
+          <Ariakit.ComboboxItem value="Apple" />
+          <Ariakit.ComboboxItem value="Banana" />
+          <Ariakit.ComboboxItem value="Orange" />
+        </Ariakit.ComboboxPopover>
+      </Ariakit.ComboboxProvider>
+      <label>
+        Notes
+        <input type="text" />
+      </label>
+    </div>
+  );
+}

--- a/app/src/sandbox/combobox-disclosure-6296/test-browser.ts
+++ b/app/src/sandbox/combobox-disclosure-6296/test-browser.ts
@@ -1,0 +1,15 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6296
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("honors prevented mousedown on disclosure", async ({ q }) => {
+    await q.textbox("Notes").click();
+    await test.expect(q.textbox("Notes")).toBeFocused();
+
+    await q.button("Show popup").click();
+
+    await test.expect(q.listbox()).toBeVisible();
+    await test.expect(q.textbox("Notes")).toBeFocused();
+    await test.expect(q.combobox("Fruit")).not.toBeFocused();
+  });
+});

--- a/app/src/sandbox/combobox-disclosure-6296/test.ts
+++ b/app/src/sandbox/combobox-disclosure-6296/test.ts
@@ -1,0 +1,14 @@
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6296
+test("honors prevented mousedown on disclosure", async () => {
+  await click(q.textbox.ensure("Notes"));
+  expect(q.textbox("Notes")).toHaveFocus();
+
+  await click(q.button.ensure("Show popup"));
+
+  expect(q.listbox()).toBeVisible();
+  expect(q.textbox("Notes")).toHaveFocus();
+  expect(q.combobox("Fruit")).not.toHaveFocus();
+});

--- a/packages/ariakit-react-components/src/combobox/combobox-disclosure.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-disclosure.tsx
@@ -70,6 +70,7 @@ export const useComboboxDisclosure = createHook<
 
   const onMouseDown = useEvent((event: MouseEvent<HTMLType>) => {
     onMouseDownProp?.(event);
+    if (event.defaultPrevented) return;
     // We have to prevent the element from getting focused on mousedown.
     event.preventDefault();
     // This will immediately move focus to the combobox input.


### PR DESCRIPTION
## Motivation

`ComboboxDisclosure` invoked a user-provided `onMouseDown` handler and then still moved focus to the [`Combobox`](https://ariakit.com/reference/combobox) input even when that handler called `event.preventDefault()`. This broke the usual Ariakit event composition contract where preventing the event opts out of internal behavior.

Fixes #6296.

## Solution

Added a focused sandbox reproduction that clicks a disclosure whose `onMouseDown` calls `event.preventDefault()`, then asserts the popover opens while focus remains on a separate Notes field.

`useComboboxDisclosure` now returns early when the user `onMouseDown` prevents the event, matching the existing `onClick` behavior in the same component and the broader event composition pattern in Ariakit. When the event is not prevented, the disclosure still prevents native button focus and moves focus to the combobox input as before.

## Workaround

Use `onMouseDownCapture` on [`ComboboxDisclosure`](https://ariakit.com/reference/combobox-disclosure) to prevent native focus on mousedown and stop the event before Ariakit's internal `onMouseDown` handler moves focus to the combobox input.

```tsx
<Ariakit.ComboboxDisclosure
  onMouseDownCapture={(event) => {
    // TODO: Remove after https://github.com/ariakit/ariakit/issues/6296.
    event.preventDefault();
    event.stopPropagation();
  }}
/>
```
