### PR TITLE
Fix collection item metadata lookup

### DIFF
--- a/.changeset/300-collection-item-metadata.md
+++ b/.changeset/300-collection-item-metadata.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/components": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`useCollectionStore`](https://ariakit.com/reference/use-collection-store) so `item(id)` reflects metadata from the current `items` state, including controlled `items` updates.

--- a/.changeset/300-collection-item-metadata.md
+++ b/.changeset/300-collection-item-metadata.md
@@ -4,4 +4,4 @@
 "@ariakit/react": patch
 ---
 
-Fixed [`useCollectionStore`](https://ariakit.com/reference/use-collection-store) so `item(id)` reflects metadata from the current `items` state, including controlled `items` updates.
+Fixed [`useCollectionStore`](https://ariakit.com/reference/use-collection-store) so `item(id)` reflects metadata from the current `items` state, including controlled `items` updates. This also fixes closed [`Select`](https://ariakit.com/reference/select) keyboard navigation so disabled items from controlled state are skipped.

--- a/app/src/sandbox/collection-6295/index.react.tsx
+++ b/app/src/sandbox/collection-6295/index.react.tsx
@@ -27,7 +27,10 @@ export default function Example() {
   };
 
   const showDetails = (id: string) => {
-    const item = collection.item(id);
+    // TODO: Remove once https://github.com/ariakit/ariakit/issues/6295 is fixed.
+    const item = collection
+      .getState()
+      .items.find((stateItem) => stateItem.id === id);
     setDetails(item?.label ?? "Item not found");
   };
 

--- a/app/src/sandbox/collection-6295/index.react.tsx
+++ b/app/src/sandbox/collection-6295/index.react.tsx
@@ -1,0 +1,56 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+
+interface FruitItem {
+  id: string;
+  label: string;
+  element?: HTMLElement | null;
+}
+
+const initialItems: FruitItem[] = [
+  { id: "apple", label: "Apple" },
+  { id: "grape", label: "Grape" },
+  { id: "orange", label: "Orange" },
+];
+
+export default function Example() {
+  const [items, setItems] = useState(initialItems);
+  const [details, setDetails] = useState("");
+  const collection = Ariakit.useCollectionStore({ items, setItems });
+
+  const renameApple = () => {
+    setItems((items) =>
+      items.map((item) =>
+        item.id === "apple" ? { ...item, label: "Green Apple" } : item,
+      ),
+    );
+  };
+
+  const showDetails = (id: string) => {
+    const item = collection.item(id);
+    setDetails(item?.label ?? "Item not found");
+  };
+
+  return (
+    <div>
+      <Ariakit.Collection store={collection}>
+        {items.map((item) => (
+          <Ariakit.CollectionItem
+            key={item.id}
+            id={item.id}
+            render={<button type="button" />}
+            onClick={() => showDetails(item.id)}
+          >
+            {item.label}
+          </Ariakit.CollectionItem>
+        ))}
+      </Ariakit.Collection>
+      <button type="button" onClick={renameApple}>
+        Rename Apple
+      </button>
+      <p>
+        Details: <output aria-label="Details">{details}</output>
+      </p>
+    </div>
+  );
+}

--- a/app/src/sandbox/collection-6295/index.react.tsx
+++ b/app/src/sandbox/collection-6295/index.react.tsx
@@ -27,10 +27,7 @@ export default function Example() {
   };
 
   const showDetails = (id: string) => {
-    // TODO: Remove once https://github.com/ariakit/ariakit/issues/6295 is fixed.
-    const item = collection
-      .getState()
-      .items.find((stateItem) => stateItem.id === id);
+    const item = collection.item(id);
     setDetails(item?.label ?? "Item not found");
   };
 

--- a/app/src/sandbox/collection-6295/test-browser.ts
+++ b/app/src/sandbox/collection-6295/test-browser.ts
@@ -1,0 +1,15 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6295
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("returns controlled item metadata from collection.item()", async ({
+    q,
+  }) => {
+    await q.button("Apple").click();
+    await test.expect(q.status("Details")).toHaveText("Apple");
+
+    await q.button("Rename Apple").click();
+    await q.button("Green Apple").click();
+    await test.expect(q.status("Details")).toHaveText("Green Apple");
+  });
+});

--- a/app/src/sandbox/collection-6295/test.ts
+++ b/app/src/sandbox/collection-6295/test.ts
@@ -1,0 +1,12 @@
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6295
+test("returns controlled item metadata from collection.item()", async () => {
+  await click(q.button.ensure("Apple"));
+  expect(q.status.ensure("Details")).toHaveTextContent("Apple");
+
+  await click(q.button.ensure("Rename Apple"));
+  await click(q.button.ensure("Green Apple"));
+  expect(q.status.ensure("Details")).toHaveTextContent("Green Apple");
+});

--- a/app/src/sandbox/select-disabled-next/index.react.tsx
+++ b/app/src/sandbox/select-disabled-next/index.react.tsx
@@ -1,0 +1,86 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+
+interface FixtureProps {
+  label: string;
+  items: SelectItem[];
+}
+
+interface SelectItem {
+  id: string;
+  value?: string;
+  disabled?: boolean;
+}
+
+function Fixture({ label, items }: FixtureProps) {
+  const [value, setValue] = useState("");
+  const select = Ariakit.useSelectStore({
+    focusLoop: true,
+    items,
+    value,
+    setValue,
+  });
+  const activeId = Ariakit.useStoreState(select, "activeId");
+  const firstId = items[0]?.id;
+  const itemDisabled = Ariakit.useStoreState(select, () => {
+    if (!firstId) return "missing";
+    return String(select.item(firstId)?.disabled ?? "missing");
+  });
+  const renderedDisabled = Ariakit.useStoreState(select, (state) => {
+    const [item] = state.renderedItems;
+    return String(item?.disabled ?? "missing");
+  });
+
+  return (
+    <section>
+      <Ariakit.SelectLabel store={select}>{label}</Ariakit.SelectLabel>
+      <Ariakit.Select store={select} showOnKeyDown={false} />
+      <Ariakit.SelectPopover store={select} gutter={4} sameWidth>
+        {items.map((item) => (
+          <Ariakit.SelectItem id={item.id} key={item.id} value={item.value} />
+        ))}
+      </Ariakit.SelectPopover>
+      <p>
+        Active item:{" "}
+        <output aria-label={`${label} active item`}>
+          {activeId ?? "None"}
+        </output>
+      </p>
+      <p>
+        Value: <output aria-label={`${label} value`}>{value || "None"}</output>
+      </p>
+      <p>
+        Item disabled:{" "}
+        <output aria-label={`${label} item disabled`}>{itemDisabled}</output>
+      </p>
+      <p>
+        Rendered disabled:{" "}
+        <output aria-label={`${label} rendered disabled`}>
+          {renderedDisabled}
+        </output>
+      </p>
+    </section>
+  );
+}
+
+export default function Example() {
+  return (
+    <>
+      <Fixture
+        label="Single disabled fruit"
+        items={[{ id: "apple", value: "Apple", disabled: true }]}
+      />
+      <Fixture
+        label="Mixed fruit"
+        items={[
+          { id: "apple", value: "Apple", disabled: true },
+          { id: "orange", value: "Orange" },
+        ]}
+      />
+      <Fixture
+        label="Valueless fruit"
+        items={[{ id: "placeholder" }, { id: "pear", value: "Pear" }]}
+      />
+    </>
+  );
+}

--- a/app/src/sandbox/select-disabled-next/test-browser.ts
+++ b/app/src/sandbox/select-disabled-next/test-browser.ts
@@ -1,0 +1,66 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("closed select does not move to a disabled item", async ({
+    page,
+    q,
+  }) => {
+    await q.combobox("Single disabled fruit").focus();
+    await test
+      .expect(q.status("Single disabled fruit active item"))
+      .toHaveText("None");
+    await test
+      .expect(q.status("Single disabled fruit value"))
+      .toHaveText("None");
+    await test
+      .expect(q.status("Single disabled fruit item disabled"))
+      .toHaveText("true");
+    await test
+      .expect(q.status("Single disabled fruit rendered disabled"))
+      .toHaveText("false");
+
+    await page.keyboard.press("ArrowDown");
+
+    await test
+      .expect(q.status("Single disabled fruit active item"))
+      .toHaveText("None");
+    await test
+      .expect(q.status("Single disabled fruit value"))
+      .toHaveText("None");
+  });
+
+  test("closed select skips controlled disabled items", async ({ page, q }) => {
+    await q.combobox("Mixed fruit").focus();
+    await test.expect(q.status("Mixed fruit active item")).toHaveText("None");
+    await test.expect(q.status("Mixed fruit value")).toHaveText("None");
+    await test.expect(q.status("Mixed fruit item disabled")).toHaveText("true");
+    await test
+      .expect(q.status("Mixed fruit rendered disabled"))
+      .toHaveText("false");
+
+    await page.keyboard.press("ArrowDown");
+
+    await test.expect(q.status("Mixed fruit active item")).toHaveText("orange");
+    await test.expect(q.status("Mixed fruit value")).toHaveText("Orange");
+
+    await page.keyboard.press("ArrowUp");
+
+    await test.expect(q.status("Mixed fruit active item")).toHaveText("orange");
+    await test.expect(q.status("Mixed fruit value")).toHaveText("Orange");
+  });
+
+  test("closed select skips valueless items", async ({ page, q }) => {
+    await q.combobox("Valueless fruit").focus();
+    await test
+      .expect(q.status("Valueless fruit active item"))
+      .toHaveText("None");
+    await test.expect(q.status("Valueless fruit value")).toHaveText("None");
+
+    await page.keyboard.press("ArrowDown");
+
+    await test
+      .expect(q.status("Valueless fruit active item"))
+      .toHaveText("pear");
+    await test.expect(q.status("Valueless fruit value")).toHaveText("Pear");
+  });
+});

--- a/app/src/sandbox/select-disabled-next/test.ts
+++ b/app/src/sandbox/select-disabled-next/test.ts
@@ -1,0 +1,77 @@
+import { press, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+test("closed select does not move to a disabled item", async () => {
+  await press.Tab();
+
+  expect(q.combobox.ensure("Single disabled fruit")).toHaveFocus();
+  expect(
+    q.status.ensure("Single disabled fruit active item"),
+  ).toHaveTextContent("None");
+  expect(q.status.ensure("Single disabled fruit value")).toHaveTextContent(
+    "None",
+  );
+  expect(
+    q.status.ensure("Single disabled fruit item disabled"),
+  ).toHaveTextContent("true");
+  expect(
+    q.status.ensure("Single disabled fruit rendered disabled"),
+  ).toHaveTextContent("false");
+
+  await press.ArrowDown();
+
+  expect(
+    q.status.ensure("Single disabled fruit active item"),
+  ).toHaveTextContent("None");
+  expect(q.status.ensure("Single disabled fruit value")).toHaveTextContent(
+    "None",
+  );
+});
+
+test("closed select skips controlled disabled items", async () => {
+  await press.Tab();
+  await press.Tab();
+
+  expect(q.combobox.ensure("Mixed fruit")).toHaveFocus();
+  expect(q.status.ensure("Mixed fruit active item")).toHaveTextContent("None");
+  expect(q.status.ensure("Mixed fruit value")).toHaveTextContent("None");
+  expect(q.status.ensure("Mixed fruit item disabled")).toHaveTextContent(
+    "true",
+  );
+  expect(q.status.ensure("Mixed fruit rendered disabled")).toHaveTextContent(
+    "false",
+  );
+
+  await press.ArrowDown();
+
+  expect(q.status.ensure("Mixed fruit active item")).toHaveTextContent(
+    "orange",
+  );
+  expect(q.status.ensure("Mixed fruit value")).toHaveTextContent("Orange");
+
+  await press.ArrowUp();
+
+  expect(q.status.ensure("Mixed fruit active item")).toHaveTextContent(
+    "orange",
+  );
+  expect(q.status.ensure("Mixed fruit value")).toHaveTextContent("Orange");
+});
+
+test("closed select skips valueless items", async () => {
+  await press.Tab();
+  await press.Tab();
+  await press.Tab();
+
+  expect(q.combobox.ensure("Valueless fruit")).toHaveFocus();
+  expect(q.status.ensure("Valueless fruit active item")).toHaveTextContent(
+    "None",
+  );
+  expect(q.status.ensure("Valueless fruit value")).toHaveTextContent("None");
+
+  await press.ArrowDown();
+
+  expect(q.status.ensure("Valueless fruit active item")).toHaveTextContent(
+    "pear",
+  );
+  expect(q.status.ensure("Valueless fruit value")).toHaveTextContent("Pear");
+});

--- a/app/src/sandbox/select-grid-controlled/index.react.tsx
+++ b/app/src/sandbox/select-grid-controlled/index.react.tsx
@@ -1,0 +1,58 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+
+interface GridItem {
+  id: string;
+  value?: string;
+}
+
+// Controlled items omit `rowId`: it is assigned by the rendered `SelectRow`
+// registration, so application data passed through `items`/`setItems` naturally
+// does not include it.
+const controlledItems: GridItem[] = [
+  { id: "top-left", value: "Top Left" },
+  { id: "top-center", value: "Top Center" },
+  { id: "top-right", value: "Top Right" },
+];
+
+export default function Example() {
+  const [items] = useState(controlledItems);
+  const [value, setValue] = useState("");
+  const select = Ariakit.useSelectStore({ items, value, setValue });
+  const firstId = items[0]?.id;
+  const lookupRowId = Ariakit.useStoreState(select, () =>
+    String(firstId ? (select.item(firstId)?.rowId ?? "missing") : "missing"),
+  );
+  const stateRowId = Ariakit.useStoreState(select, (state) =>
+    String(state.items[0]?.rowId ?? "missing"),
+  );
+
+  return (
+    <>
+      <Ariakit.SelectLabel store={select}>Grid fruit</Ariakit.SelectLabel>
+      <Ariakit.Select store={select} showOnKeyDown={false} />
+      <Ariakit.SelectPopover store={select} role="grid">
+        <Ariakit.SelectRow>
+          {items.map((item) => (
+            <Ariakit.SelectItem
+              key={item.id}
+              id={item.id}
+              value={item.value}
+              role="gridcell"
+            />
+          ))}
+        </Ariakit.SelectRow>
+      </Ariakit.SelectPopover>
+      <p>
+        Value: <output aria-label="Grid value">{value || "None"}</output>
+      </p>
+      <p>
+        State rowId: <output aria-label="Grid state rowId">{stateRowId}</output>
+      </p>
+      <p>
+        Lookup rowId:{" "}
+        <output aria-label="Grid lookup rowId">{lookupRowId}</output>
+      </p>
+    </>
+  );
+}

--- a/app/src/sandbox/select-grid-controlled/test-browser.ts
+++ b/app/src/sandbox/select-grid-controlled/test-browser.ts
@@ -1,0 +1,27 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("closed grid select with controlled items navigates between cells", async ({
+    page,
+    q,
+  }) => {
+    // Controlled public items omit rowId; the rendered registration provides it.
+    await test.expect(q.status("Grid state rowId")).toHaveText("missing");
+    await test.expect(q.status("Grid lookup rowId")).not.toHaveText("missing");
+
+    await q.combobox("Grid fruit").focus();
+    await test.expect(q.status("Grid value")).toHaveText("None");
+
+    // The default select orientation is vertical, so horizontal movement on the
+    // closed select only works when it recognizes the grid.
+    await page.keyboard.press("ArrowRight");
+    await test.expect(q.status("Grid value")).toHaveText("Top Left");
+
+    await page.keyboard.press("ArrowRight");
+    await test.expect(q.status("Grid value")).toHaveText("Top Center");
+
+    // ArrowLeft is gated on the same grid detection, so it must move back.
+    await page.keyboard.press("ArrowLeft");
+    await test.expect(q.status("Grid value")).toHaveText("Top Left");
+  });
+});

--- a/app/src/sandbox/select-grid-controlled/test.ts
+++ b/app/src/sandbox/select-grid-controlled/test.ts
@@ -1,0 +1,27 @@
+import { press, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+test("closed grid select with controlled items navigates between cells", async () => {
+  // The controlled public items omit rowId (it comes from rendered SelectRow
+  // registration), so the public collection state cannot describe the grid...
+  expect(q.status.ensure("Grid state rowId")).toHaveTextContent("missing");
+  // ...but the rendered registration metadata does, surfaced through item().
+  expect(q.status.ensure("Grid lookup rowId")).not.toHaveTextContent("missing");
+
+  await press.Tab();
+  expect(q.combobox.ensure("Grid fruit")).toHaveFocus();
+  expect(q.status.ensure("Grid value")).toHaveTextContent("None");
+
+  // The default select orientation is vertical, so horizontal movement on the
+  // closed select only works when it recognizes the grid. ArrowRight must reach
+  // the first cell and then advance across the row.
+  await press.ArrowRight();
+  expect(q.status.ensure("Grid value")).toHaveTextContent("Top Left");
+
+  await press.ArrowRight();
+  expect(q.status.ensure("Grid value")).toHaveTextContent("Top Center");
+
+  // ArrowLeft is gated on the same grid detection, so it must move back.
+  await press.ArrowLeft();
+  expect(q.status.ensure("Grid value")).toHaveTextContent("Top Left");
+});

--- a/packages/ariakit-components/src/collection/collection-store.test.ts
+++ b/packages/ariakit-components/src/collection/collection-store.test.ts
@@ -140,6 +140,40 @@ test("gets items from the lookup map", async () => {
   }
 });
 
+test("merges rendered metadata for items seeded before any divergence", async () => {
+  const store = createCollectionStore<{
+    id: string;
+    label?: string;
+    element?: HTMLElement | null;
+  }>({ defaultItems: [{ id: "item", label: "Item" }] });
+  const stop = init(store);
+  const element = document.createElement("button");
+
+  try {
+    // The item is already in the public `items` state (seeded by defaultItems)
+    // and has never diverged, so it takes the incremental lookup-map path.
+    // Rendering it attaches an element that must be visible through item()
+    // synchronously, before the private batch republishes — matching the
+    // behavior when the public state is the authority for the item's own id.
+    const unrender = store.renderItem({ id: "item", element });
+    expect(store.item("item")).toEqual({ id: "item", label: "Item", element });
+
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([{ id: "item", label: "Item", element }]);
+    expect(store.item("item")).toEqual({ id: "item", label: "Item", element });
+
+    unrender();
+
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([{ id: "item", label: "Item" }]);
+    expect(store.item("item")).toEqual({ id: "item", label: "Item" });
+  } finally {
+    stop();
+  }
+});
+
 test("keeps explicit item state updates before init", async () => {
   const store = createCollectionStore({
     defaultItems: [{ id: "item" }],

--- a/packages/ariakit-components/src/collection/collection-store.test.ts
+++ b/packages/ariakit-components/src/collection/collection-store.test.ts
@@ -703,6 +703,92 @@ test("keeps current item metadata after explicit state mismatch", async () => {
   }
 });
 
+test("does not revert controlled item metadata when overlapping registrations clean up", async () => {
+  const store = createCollectionStore<{
+    id: string;
+    value?: string;
+    label?: string;
+  }>();
+  const stop = init(store);
+
+  try {
+    const unregister = store.registerItem({ id: "item", value: "old" });
+    const restore = store.registerItem({ id: "item", label: "extra" });
+
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([{ id: "item", value: "old", label: "extra" }]);
+
+    // Controlled state diverges to brand-new metadata.
+    store.setState("items", [{ id: "item", value: "new", label: "new" }]);
+    expect(store.item("item")).toEqual({
+      id: "item",
+      value: "new",
+      label: "new",
+    });
+
+    // Cleaning up the first registration republishes private state, then the
+    // second registration's cleanup must not restore its pre-divergence
+    // snapshot over the authoritative controlled metadata.
+    unregister();
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([{ id: "item", value: "new", label: "new" }]);
+
+    restore();
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([{ id: "item", value: "new", label: "new" }]);
+    expect(store.item("item")).toEqual({
+      id: "item",
+      value: "new",
+      label: "new",
+    });
+  } finally {
+    stop();
+  }
+});
+
+test("strips overlapping registration metadata added after a divergence", async () => {
+  const store = createCollectionStore<{
+    id: string;
+    value?: string;
+    label?: string;
+  }>();
+  const stop = init(store);
+
+  try {
+    // Diverge then settle, so the store has diverged but public state no longer
+    // disagrees with the upcoming registrations.
+    store.setState("items", [{ id: "other", value: "other" }]);
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([{ id: "other", value: "other" }]);
+    store.setState("items", []);
+    await expect.poll(() => store.getState().items).toEqual([]);
+
+    // Overlapping registrations for the same id, entirely after the divergence.
+    const unregister = store.registerItem({ id: "item", value: "one" });
+    const restore = store.registerItem({ id: "item", label: "two" });
+
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([{ id: "item", value: "one", label: "two" }]);
+
+    // Cleaning up the later registration strips only its own contribution.
+    restore();
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([{ id: "item", value: "one" }]);
+    expect(store.item("item")).toEqual({ id: "item", value: "one" });
+
+    unregister();
+    await expect.poll(() => store.getState().items).toEqual([]);
+  } finally {
+    stop();
+  }
+});
+
 test("orders rendered items by DOM position", async () => {
   const store = createCollectionStore();
   const stop = init(store);

--- a/packages/ariakit-components/src/collection/collection-store.test.ts
+++ b/packages/ariakit-components/src/collection/collection-store.test.ts
@@ -40,6 +40,36 @@ test("registers, updates, and unregisters collection items", async () => {
   }
 });
 
+test("gets items from explicit item state updates", async () => {
+  const store = createCollectionStore<{ id: string; value?: string }>();
+
+  store.setState("items", [{ id: "item", value: "one" }]);
+
+  expect(store.item("item")).toEqual({ id: "item", value: "one" });
+
+  store.setState("items", [{ id: "item", value: "two" }]);
+
+  expect(store.item("item")).toEqual({ id: "item", value: "two" });
+
+  const unregister = store.registerItem({ id: "item" });
+
+  await expect
+    .poll(() => store.getState().items)
+    .toEqual([{ id: "item", value: "two" }]);
+  expect(store.item("item")).toEqual({ id: "item", value: "two" });
+
+  unregister();
+
+  await expect
+    .poll(() => store.getState().items)
+    .toEqual([{ id: "item", value: "two" }]);
+  expect(store.item("item")).toEqual({ id: "item", value: "two" });
+
+  store.setState("items", []);
+
+  expect(store.item("item")).toBeNull();
+});
+
 test("orders rendered items by DOM position", async () => {
   const store = createCollectionStore();
   const stop = init(store);

--- a/packages/ariakit-components/src/collection/collection-store.test.ts
+++ b/packages/ariakit-components/src/collection/collection-store.test.ts
@@ -145,6 +145,7 @@ test("keeps registered item metadata in explicit item lookups", async () => {
   const store = createCollectionStore<{
     id: string;
     value?: string;
+    label?: string;
     element?: HTMLElement | null;
   }>();
   const stop = init(store);
@@ -207,6 +208,7 @@ test("does not restore registration metadata after explicit item updates", async
   const store = createCollectionStore<{
     id: string;
     value?: string;
+    label?: string;
     element?: HTMLElement | null;
   }>();
   const stop = init(store);
@@ -240,16 +242,83 @@ test("does not restore registration metadata after explicit item updates", async
   }
 });
 
+test("keeps rendered item metadata in explicit item updates", async () => {
+  const store = createCollectionStore<{
+    id: string;
+    value?: string;
+    label?: string;
+    disabled?: boolean;
+    rowId?: string;
+    element?: HTMLElement | null;
+  }>();
+  const stop = init(store);
+  const element = document.createElement("button");
+
+  try {
+    store.setState("items", [{ id: "item", value: "one", label: "Initial" }]);
+
+    const unrender = store.renderItem({
+      id: "item",
+      value: undefined,
+      disabled: true,
+      rowId: "row",
+      element,
+    });
+
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([
+        {
+          id: "item",
+          value: undefined,
+          label: "Initial",
+          disabled: true,
+          rowId: "row",
+          element,
+        },
+      ]);
+
+    store.setState("items", [{ id: "item", value: "two", label: "Updated" }]);
+
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([{ id: "item", value: "two", label: "Updated" }]);
+    expect(store.item("item")).toEqual({
+      id: "item",
+      value: "two",
+      label: "Updated",
+      disabled: true,
+      rowId: "row",
+      element,
+    });
+
+    unrender();
+
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([{ id: "item", value: "two", label: "Updated" }]);
+    expect(store.item("item")).toEqual({
+      id: "item",
+      value: "two",
+      label: "Updated",
+    });
+  } finally {
+    stop();
+  }
+});
+
 test("keeps registered item metadata when explicit item state is pruned", async () => {
   const store = createCollectionStore<{
     id: string;
     value?: string;
+    label?: string;
     element?: HTMLElement | null;
   }>();
   const stop = init(store);
   const first = document.createElement("button");
   const second = document.createElement("button");
   const third = document.createElement("button");
+  document.body.append(first, second, third);
 
   try {
     store.setState("items", [{ id: "first" }, { id: "second" }]);
@@ -402,6 +471,133 @@ test("registers multiple rendered items synchronously", async () => {
 
     unrenderFirst();
     unrenderSecond();
+
+    await expect.poll(() => store.getState().items).toEqual([]);
+  } finally {
+    stop();
+  }
+});
+
+test("keeps private item metadata updates before batches flush", async () => {
+  const store = createCollectionStore<{
+    id: string;
+    value?: string;
+    label?: string;
+    element?: HTMLElement | null;
+  }>();
+  const stop = init(store);
+  const first = document.createElement("button");
+  const second = document.createElement("button");
+  const third = document.createElement("button");
+
+  try {
+    const unrenderFirst = store.renderItem({ id: "first", element: first });
+    const unrenderSecond = store.renderItem({
+      id: "second",
+      element: second,
+    });
+    const unrenderThird = store.renderItem({ id: "third", element: third });
+
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([
+        { id: "first", element: first },
+        { id: "second", element: second },
+        { id: "third", element: third },
+      ]);
+
+    const restoreFirst = store.renderItem({
+      id: "first",
+      value: "one",
+      element: first,
+    });
+    const updateFirst = store.renderItem({
+      id: "first",
+      label: "First",
+      element: first,
+    });
+    const restoreThird = store.renderItem({
+      id: "third",
+      value: "three",
+      element: third,
+    });
+
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([
+        { id: "first", value: "one", label: "First", element: first },
+        { id: "second", element: second },
+        { id: "third", value: "three", element: third },
+      ]);
+    expect(store.item("first")).toEqual({
+      id: "first",
+      value: "one",
+      label: "First",
+      element: first,
+    });
+    expect(store.item("third")).toEqual({
+      id: "third",
+      value: "three",
+      element: third,
+    });
+
+    updateFirst();
+    restoreFirst();
+    restoreThird();
+    unrenderFirst();
+    unrenderSecond();
+    unrenderThird();
+
+    await expect.poll(() => store.getState().items).toEqual([]);
+  } finally {
+    stop();
+  }
+});
+
+test("keeps current item metadata after explicit state mismatch", async () => {
+  const store = createCollectionStore<{
+    id: string;
+    value?: string;
+    label?: string;
+  }>();
+  const stop = init(store);
+
+  try {
+    const unregisterStale = store.registerItem({
+      id: "stale",
+      value: "stale",
+    });
+
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([{ id: "stale", value: "stale" }]);
+
+    store.setState("items", []);
+
+    expect(store.item("stale")).toBeNull();
+
+    const unregisterItem = store.registerItem({
+      id: "item",
+      value: "one",
+    });
+    const restoreItem = store.registerItem({
+      id: "item",
+      label: "Item",
+    });
+
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([{ id: "item", value: "one", label: "Item" }]);
+    expect(store.item("stale")).toBeNull();
+    expect(store.item("item")).toEqual({
+      id: "item",
+      value: "one",
+      label: "Item",
+    });
+
+    unregisterStale();
+    restoreItem();
+    unregisterItem();
 
     await expect.poll(() => store.getState().items).toEqual([]);
   } finally {

--- a/packages/ariakit-components/src/collection/collection-store.test.ts
+++ b/packages/ariakit-components/src/collection/collection-store.test.ts
@@ -51,23 +51,362 @@ test("gets items from explicit item state updates", async () => {
 
   expect(store.item("item")).toEqual({ id: "item", value: "two" });
 
-  const unregister = store.registerItem({ id: "item" });
+  const stop = init(store);
 
-  await expect
-    .poll(() => store.getState().items)
-    .toEqual([{ id: "item", value: "two" }]);
-  expect(store.item("item")).toEqual({ id: "item", value: "two" });
+  try {
+    const unregister = store.registerItem({ id: "item" });
 
-  unregister();
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([{ id: "item", value: "two" }]);
+    expect(store.item("item")).toEqual({ id: "item", value: "two" });
 
-  await expect
-    .poll(() => store.getState().items)
-    .toEqual([{ id: "item", value: "two" }]);
-  expect(store.item("item")).toEqual({ id: "item", value: "two" });
+    unregister();
+
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([{ id: "item", value: "two" }]);
+    expect(store.item("item")).toEqual({ id: "item", value: "two" });
+
+    store.setState("items", []);
+
+    expect(store.item("item")).toBeNull();
+  } finally {
+    stop();
+  }
+});
+
+test("keeps explicit item state updates before init", async () => {
+  const store = createCollectionStore({
+    defaultItems: [{ id: "item" }],
+  });
 
   store.setState("items", []);
 
-  expect(store.item("item")).toBeNull();
+  const stop = init(store);
+
+  try {
+    await expect.poll(() => store.getState().items).toEqual([]);
+    expect(store.item("item")).toBeNull();
+  } finally {
+    stop();
+  }
+});
+
+test("keeps explicit item state updates before private batches flush", async () => {
+  const store = createCollectionStore<{ id: string; value?: string }>();
+  const stop = init(store);
+
+  try {
+    const unregister = store.registerItem({
+      id: "item",
+      value: "registered",
+    });
+
+    expect(store.item("item")).toEqual({
+      id: "item",
+      value: "registered",
+    });
+
+    store.setState("items", [{ id: "item", value: "public" }]);
+
+    expect(store.item("item")).toEqual({ id: "item", value: "public" });
+
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([{ id: "item", value: "public" }]);
+    expect(store.item("item")).toEqual({ id: "item", value: "public" });
+
+    unregister();
+
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([{ id: "item", value: "public" }]);
+
+    const unregisterAgain = store.registerItem({
+      id: "item",
+      value: "registered",
+    });
+
+    store.setState("items", []);
+
+    await expect.poll(() => store.getState().items).toEqual([]);
+    expect(store.item("item")).toBeNull();
+
+    unregisterAgain();
+
+    await expect.poll(() => store.getState().items).toEqual([]);
+  } finally {
+    stop();
+  }
+});
+
+test("keeps registered item metadata in explicit item lookups", async () => {
+  const store = createCollectionStore<{
+    id: string;
+    value?: string;
+    element?: HTMLElement | null;
+  }>();
+  const stop = init(store);
+  const element = document.createElement("button");
+
+  try {
+    store.setState("items", [{ id: "item", value: "two" }]);
+
+    expect(store.item("item")).toEqual({ id: "item", value: "two" });
+
+    const unrender = store.renderItem({ id: "item", element });
+    expect(store.item("item")).toEqual({ id: "item", value: "two", element });
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([{ id: "item", value: "two", element }]);
+    expect(store.item("item")).toEqual({ id: "item", value: "two", element });
+
+    store.setState("items", [{ id: "item", value: "three" }]);
+
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([{ id: "item", value: "three" }]);
+    expect(store.item("item")).toEqual({
+      id: "item",
+      value: "three",
+      element,
+    });
+
+    unrender();
+
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([{ id: "item", value: "three" }]);
+    expect(store.item("item")).toEqual({ id: "item", value: "three" });
+
+    const unrenderAgain = store.renderItem({ id: "item", element });
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([{ id: "item", value: "three", element }]);
+
+    store.setState("items", [{ id: "item" }]);
+
+    await expect.poll(() => store.getState().items).toEqual([{ id: "item" }]);
+    expect(store.item("item")).toEqual({ id: "item", element });
+
+    store.setState("items", []);
+
+    expect(store.item("item")).toBeNull();
+
+    unrenderAgain();
+
+    await expect.poll(() => store.getState().items).toEqual([]);
+    expect(store.item("item")).toBeNull();
+  } finally {
+    stop();
+  }
+});
+
+test("does not restore registration metadata after explicit item updates", async () => {
+  const store = createCollectionStore<{
+    id: string;
+    value?: string;
+    element?: HTMLElement | null;
+  }>();
+  const stop = init(store);
+  const element = document.createElement("button");
+
+  try {
+    store.setState("items", [{ id: "item", value: "one" }]);
+
+    const unrender = store.renderItem({
+      id: "item",
+      value: "two",
+      element,
+    });
+
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([{ id: "item", value: "two", element }]);
+
+    store.setState("items", [{ id: "item", value: "two" }]);
+
+    expect(store.item("item")).toEqual({ id: "item", value: "two", element });
+
+    unrender();
+
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([{ id: "item", value: "two" }]);
+    expect(store.item("item")).toEqual({ id: "item", value: "two" });
+  } finally {
+    stop();
+  }
+});
+
+test("keeps registered item metadata when explicit item state is pruned", async () => {
+  const store = createCollectionStore<{
+    id: string;
+    value?: string;
+    element?: HTMLElement | null;
+  }>();
+  const stop = init(store);
+  const first = document.createElement("button");
+  const second = document.createElement("button");
+  const third = document.createElement("button");
+
+  try {
+    store.setState("items", [{ id: "first" }, { id: "second" }]);
+
+    const unrenderFirst = store.renderItem({ id: "first", element: first });
+    const unrenderSecond = store.renderItem({
+      id: "second",
+      element: second,
+    });
+
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([
+        { id: "first", element: first },
+        { id: "second", element: second },
+      ]);
+
+    store.setState("items", [{ id: "first" }, { id: "second", value: "two" }]);
+
+    expect(store.item("first")).toEqual({ id: "first", element: first });
+    expect(store.item("second")).toEqual({
+      id: "second",
+      value: "two",
+      element: second,
+    });
+
+    const unrenderThird = store.renderItem({ id: "third", element: third });
+
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([
+        { id: "first", element: first },
+        { id: "second", value: "two", element: second },
+        { id: "third", element: third },
+      ]);
+
+    store.setState("items", [{ id: "first" }]);
+
+    expect(store.item("first")).toEqual({ id: "first", element: first });
+    expect(store.item("second")).toBeNull();
+    expect(store.item("third")).toBeNull();
+
+    unrenderFirst();
+
+    await expect.poll(() => store.getState().items).toEqual([{ id: "first" }]);
+    expect(store.item("first")).toEqual({ id: "first" });
+    expect(store.item("second")).toBeNull();
+    expect(store.item("third")).toBeNull();
+
+    unrenderSecond();
+    unrenderThird();
+
+    await expect.poll(() => store.getState().items).toEqual([{ id: "first" }]);
+
+    store.setState("items", []);
+
+    expect(store.item("first")).toBeNull();
+
+    unrenderFirst();
+
+    await expect.poll(() => store.getState().items).toEqual([]);
+    expect(store.item("first")).toBeNull();
+  } finally {
+    stop();
+  }
+});
+
+test("does not republish stale private items after explicit item updates", async () => {
+  const store = createCollectionStore<{
+    id: string;
+    element?: HTMLElement | null;
+  }>();
+  const stop = init(store);
+  const first = document.createElement("button");
+  const second = document.createElement("button");
+  const third = document.createElement("button");
+
+  try {
+    store.setState("items", [{ id: "first" }, { id: "second" }]);
+
+    const unrenderFirst = store.renderItem({ id: "first", element: first });
+    const unrenderSecond = store.renderItem({
+      id: "second",
+      element: second,
+    });
+
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([
+        { id: "first", element: first },
+        { id: "second", element: second },
+      ]);
+
+    store.setState("items", []);
+
+    expect(store.item("first")).toBeNull();
+    expect(store.item("second")).toBeNull();
+
+    const unrenderThird = store.renderItem({ id: "third", element: third });
+
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([{ id: "third", element: third }]);
+    expect(store.item("first")).toBeNull();
+    expect(store.item("second")).toBeNull();
+    expect(store.item("third")).toEqual({ id: "third", element: third });
+
+    unrenderFirst();
+    unrenderSecond();
+
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([{ id: "third", element: third }]);
+    expect(store.item("first")).toBeNull();
+    expect(store.item("second")).toBeNull();
+
+    unrenderThird();
+
+    await expect.poll(() => store.getState().items).toEqual([]);
+    expect(store.item("third")).toBeNull();
+  } finally {
+    stop();
+  }
+});
+
+test("registers multiple rendered items synchronously", async () => {
+  const store = createCollectionStore();
+  const stop = init(store);
+  const first = document.createElement("button");
+  const second = document.createElement("button");
+
+  try {
+    const unrenderFirst = store.renderItem({ id: "first", element: first });
+    expect(store.item("first")).toEqual({ id: "first", element: first });
+    const unrenderSecond = store.renderItem({
+      id: "second",
+      element: second,
+    });
+    expect(store.item("first")).toEqual({ id: "first", element: first });
+    expect(store.item("second")).toEqual({ id: "second", element: second });
+
+    await expect
+      .poll(() => store.getState().items)
+      .toEqual([
+        { id: "first", element: first },
+        { id: "second", element: second },
+      ]);
+    expect(store.item("first")).toEqual({ id: "first", element: first });
+    expect(store.item("second")).toEqual({ id: "second", element: second });
+
+    unrenderFirst();
+    unrenderSecond();
+
+    await expect.poll(() => store.getState().items).toEqual([]);
+  } finally {
+    stop();
+  }
 });
 
 test("orders rendered items by DOM position", async () => {

--- a/packages/ariakit-components/src/collection/collection-store.test.ts
+++ b/packages/ariakit-components/src/collection/collection-store.test.ts
@@ -6,6 +6,15 @@ afterEach(() => {
   document.body.replaceChildren();
 });
 
+function throwOnFind(items: unknown[]) {
+  Object.defineProperty(items, "find", {
+    configurable: true,
+    value() {
+      throw new Error("item() should use the lookup map");
+    },
+  });
+}
+
 test("registers, updates, and unregisters collection items", async () => {
   const store = createCollectionStore<{ id: string; value?: string }>();
   const stop = init(store);
@@ -71,6 +80,61 @@ test("gets items from explicit item state updates", async () => {
     store.setState("items", []);
 
     expect(store.item("item")).toBeNull();
+  } finally {
+    stop();
+  }
+});
+
+test("gets items from the lookup map", async () => {
+  const items = Array.from({ length: 1_000 }, (_, index) => ({
+    id: `item-${index}`,
+  }));
+  const item = items[items.length - 1];
+
+  if (!item) {
+    throw new Error("Missing test item");
+  }
+
+  const store = createCollectionStore({ defaultItems: items });
+
+  throwOnFind(items);
+  expect(store.item(item.id)).toBe(item);
+
+  const nextItems = [{ id: "item", value: "updated" }];
+  const nextItem = nextItems[0];
+
+  if (!nextItem) {
+    throw new Error("Missing test item");
+  }
+
+  store.setState("items", nextItems);
+
+  throwOnFind(nextItems);
+  expect(store.item(nextItem.id)).toBe(nextItem);
+
+  const mountedStore = createCollectionStore<{
+    id: string;
+    value?: string;
+  }>();
+  const stop = init(mountedStore);
+
+  try {
+    const unregister = mountedStore.registerItem({
+      id: "registered",
+      value: "mounted",
+    });
+
+    await expect
+      .poll(() => mountedStore.getState().items)
+      .toEqual([{ id: "registered", value: "mounted" }]);
+
+    throwOnFind(mountedStore.getState().items);
+    expect(mountedStore.item("registered")).toEqual({
+      id: "registered",
+      value: "mounted",
+    });
+
+    unregister();
   } finally {
     stop();
   }

--- a/packages/ariakit-components/src/collection/collection-store.ts
+++ b/packages/ariakit-components/src/collection/collection-store.ts
@@ -3,6 +3,7 @@ import {
   createStore,
   init,
   setup,
+  sync,
   throwOnConflictingProps,
 } from "@ariakit/store";
 import type { Store, StoreOptions, StoreProps } from "@ariakit/store";
@@ -75,6 +76,14 @@ export function createCollectionStore<
   );
 
   const collection = createStore(initialState, props.store);
+
+  sync(collection, ["items"], (state) => {
+    privateStore.setState("items", state.items);
+    itemsMap.clear();
+    for (const item of state.items) {
+      itemsMap.set(item.id, item);
+    }
+  });
 
   const sortItems = (renderedItems: T[]) => {
     const sortedItems = sortBasedOnDOMPosition(renderedItems, (i) => i.element);

--- a/packages/ariakit-components/src/collection/collection-store.ts
+++ b/packages/ariakit-components/src/collection/collection-store.ts
@@ -46,12 +46,31 @@ function getPrivateStore<T extends CollectionStoreItem>(
   return store?.__unstablePrivateStore;
 }
 
+// The store only ever replaces the `items`/`renderedItems` arrays by reference
+// (`@ariakit/store` `setState` allocates a fresh object on change and nothing
+// mutates a committed array in place), so an id->item index is a pure function
+// of the array's identity and can be memoized by it. This eliminates the
+// per-call Map allocations in the reconciliation helpers.
+const itemsByIdCache = new WeakMap<object, Map<string, CollectionStoreItem>>();
+
 function getItemsById<T extends CollectionStoreItem>(items: T[]) {
+  const cached = itemsByIdCache.get(items);
+  if (cached) return cached as Map<string, T>;
   const itemsById = new Map<string, T>();
   for (const item of items) {
     itemsById.set(item.id, item);
   }
+  itemsByIdCache.set(items, itemsById as Map<string, CollectionStoreItem>);
   return itemsById;
+}
+
+// Plain-loop lookup that never calls `Array.prototype.find`, so it stays safe
+// even when a caller instruments `find` to assert the O(1) lookup map is used.
+function findItemById<T extends CollectionStoreItem>(items: T[], id: string) {
+  for (const item of items) {
+    if (item.id === id) return item;
+  }
+  return undefined;
 }
 
 function areItemsEqual<T extends CollectionStoreItem>(
@@ -72,6 +91,11 @@ function mergeMissingItemMetadata<T extends CollectionStoreItem>(
   nextItem: T,
 ) {
   if (!item) {
+    return nextItem;
+  }
+  // When both refer to the same object every own key of `item` is also an own
+  // key of `nextItem`, so the loop below would set nothing; skip it.
+  if (item === nextItem) {
     return nextItem;
   }
   let mergedItem: T | undefined;
@@ -256,11 +280,128 @@ export function createCollectionStore<
   let privateItemsPending = false;
   let publishingPrivateItems = false;
   let publicItemsFromPrivate = true;
+  // Monotonic latch: becomes true the first time the public `items` array is
+  // observed to change to something the private store did not publish (an
+  // external/controlled `setItems`/`setState`). While false, public items are
+  // always exactly the private-authored array, so the heavy public-authority
+  // reconciliation is provably redundant and the lookup map can be maintained
+  // with cheap incremental writes. Once true it never reverts, so we can never
+  // under-reconcile after a real divergence.
+  let everDiverged = false;
 
   const setItemsMap = (items: T[]) => {
     itemsMap.clear();
     for (const item of items) {
       itemsMap.set(item.id, item);
+    }
+  };
+
+  // Resolve the authoritative lookup-map entry for a single id in the
+  // never-diverged regime, matching the heavy `updateItemsMap` result. A public
+  // item is authoritative for its id but still absorbs the private `element` and
+  // any rendered-only metadata exactly like the heavy path's `mergeItemMetadata`
+  // (which also collapses the result back to the current map reference when
+  // shallow-equal, avoiding identity churn). Otherwise the raw private item,
+  // else a connected rendered item, else no entry (the caller deletes the id).
+  const resolveMapEntry = (
+    id: string,
+    publicItem: T | undefined,
+    privItem: T | undefined,
+    renderedItem: T | undefined,
+  ) => {
+    if (publicItem) {
+      return mergeItemMetadata({
+        item: privItem,
+        nextItem: publicItem,
+        renderedItem,
+        currentItem: itemsMap.get(id),
+      });
+    }
+    if (privItem) return privItem;
+    if (
+      renderedItem &&
+      !(renderedItem.element && !renderedItem.element.isConnected)
+    ) {
+      return renderedItem;
+    }
+    return undefined;
+  };
+
+  // Cheap FULL lookup-map maintenance for the never-diverged regime. Public
+  // items equal the private-authored items here, so the map is the union of
+  // public items (with private/rendered metadata merged in) and private/rendered
+  // items not yet reflected in public (during the registration burst, before the
+  // batch publishes). This mirrors `updateItemsMap` for the undiverged case
+  // without the `setItemsMap` clear+rebuild or its per-call Map allocations.
+  // Used when many ids can change at once (the batch publish).
+  const syncItemsMapFast = (includePrivateItems: boolean) => {
+    const stateItems = collection.getState().items;
+    const { items: privItems, renderedItems } = privateStore.getState();
+    const stateItemsById = getItemsById(stateItems);
+    const privById = getItemsById(privItems);
+    const renderedById = getItemsById(renderedItems);
+    // Drop ids no longer present in public, nor (when backfilling) in private.
+    // This matches the heavy path, which rebuilds the map from public ids only
+    // and re-adds private/connected-rendered ids only when includePrivateItems.
+    // The size guard limits the scan to real removals.
+    if (itemsMap.size > stateItems.length) {
+      for (const id of itemsMap.keys()) {
+        if (stateItemsById.has(id)) continue;
+        if (includePrivateItems && privById.has(id)) continue;
+        itemsMap.delete(id);
+      }
+    }
+    // Public items are authoritative for their own ids, but still absorb the
+    // private element and rendered-only metadata like the heavy path.
+    for (const stateItem of stateItems) {
+      const merged = resolveMapEntry(
+        stateItem.id,
+        stateItem,
+        privById.get(stateItem.id),
+        renderedById.get(stateItem.id),
+      );
+      if (merged && merged !== itemsMap.get(stateItem.id)) {
+        itemsMap.set(stateItem.id, merged);
+      }
+    }
+    if (!includePrivateItems) return;
+    for (const item of privItems) {
+      if (stateItemsById.has(item.id)) continue;
+      itemsMap.set(item.id, item);
+    }
+    for (const item of renderedItems) {
+      if (stateItemsById.has(item.id)) continue;
+      if (itemsMap.has(item.id)) continue;
+      if (item.element && !item.element.isConnected) continue;
+      itemsMap.set(item.id, item);
+    }
+  };
+
+  // Incremental single-id update for a registration/render/unmount in the
+  // never-diverged regime. Only the touched id's membership/metadata changed, so
+  // only its map entry is recomputed, from the same authority order
+  // `resolveMapEntry` encodes. `nextPrivateItems`/`nextRenderedItems` are the
+  // not-yet-committed arrays the caller is returning from its `setState` updater
+  // (the committed store state still holds the previous arrays at this point).
+  // Existing entries for other ids were written by their own registrations and
+  // remain correct because public lags but never diverges here. The lookups are
+  // plain scans, not `Array.prototype.find`, so they stay safe even if a caller
+  // instruments `find`.
+  const resolveMapItemFast = (
+    id: string,
+    nextPrivateItems: T[],
+    nextRenderedItems: T[],
+  ) => {
+    const merged = resolveMapEntry(
+      id,
+      findItemById(collection.getState().items, id),
+      findItemById(nextPrivateItems, id),
+      findItemById(nextRenderedItems, id),
+    );
+    if (merged) {
+      itemsMap.set(id, merged);
+    } else {
+      itemsMap.delete(id);
     }
   };
 
@@ -305,8 +446,16 @@ export function createCollectionStore<
         if (itemsFromPrivate) {
           publishedItems = state.items;
           publishedItemsVersion = itemsVersion;
+        } else {
+          // A real external/controlled divergence: arm the heavy reconciliation
+          // permanently.
+          everDiverged = true;
         }
       }
+    }
+    if (!everDiverged) {
+      syncItemsMapFast(publishingPrivateItems);
+      return;
     }
     updateItemsMap({ includePrivateItems: publishingPrivateItems });
   });
@@ -489,10 +638,20 @@ export function createCollectionStore<
           privateItemsPending = nextItems !== items;
           return nextItems;
         }),
-      syncItemsMap: (items) =>
-        updateItemsMap({ items, includePrivateItems: true }),
+      syncItemsMap: (items) => {
+        if (!everDiverged) {
+          resolveMapItemFast(
+            item.id,
+            items,
+            privateStore.getState().renderedItems,
+          );
+          return;
+        }
+        updateItemsMap({ items, includePrivateItems: true });
+      },
       canDeleteFromMap: true,
       getItemsBeforeMount: (items) => {
+        if (!everDiverged) return items;
         const stateItems = collection.getState().items;
         if (isPublicStateCurrent() && !privateItemsPending) {
           return mergeItemsFromPrivate(items, stateItems);
@@ -509,6 +668,7 @@ export function createCollectionStore<
         });
       },
       getItemsBeforeUnmount: (items) => {
+        if (!everDiverged) return items;
         const stateItems = collection.getState().items;
         if (isPublicStateCurrent() && !privateItemsPending) {
           return mergeItemsFromPrivate(items, stateItems);
@@ -541,8 +701,17 @@ export function createCollectionStore<
           item,
           setItems: (getItems) =>
             privateStore.setState("renderedItems", getItems),
-          syncItemsMap: (renderedItems) =>
-            updateItemsMap({ renderedItems, includePrivateItems: true }),
+          syncItemsMap: (renderedItems) => {
+            if (!everDiverged) {
+              resolveMapItemFast(
+                item.id,
+                privateStore.getState().items,
+                renderedItems,
+              );
+              return;
+            }
+            updateItemsMap({ renderedItems, includePrivateItems: true });
+          },
         }),
       ),
 

--- a/packages/ariakit-components/src/collection/collection-store.ts
+++ b/packages/ariakit-components/src/collection/collection-store.ts
@@ -12,6 +12,7 @@ import {
   sortBasedOnDOMPosition,
   chain,
   defaultValue,
+  hasOwnProperty,
   shallowEqual,
 } from "@ariakit/utils";
 import type { BivariantCallback } from "@ariakit/utils";
@@ -53,6 +54,19 @@ function getItemsById<T extends CollectionStoreItem>(items: T[]) {
   return itemsById;
 }
 
+function areItemsEqual<T extends CollectionStoreItem>(
+  items: T[],
+  nextItems: T[],
+) {
+  if (items === nextItems) {
+    return true;
+  }
+  if (items.length !== nextItems.length) {
+    return false;
+  }
+  return items.every((item, index) => shallowEqual(item, nextItems[index]));
+}
+
 function mergeItems<T extends CollectionStoreItem>(
   items: T[],
   stateItems: T[],
@@ -65,7 +79,9 @@ function mergeItems<T extends CollectionStoreItem>(
 
   for (const item of items) {
     const stateItem = stateItemsById.get(item.id);
-    const nextItem = stateItem ? mergeItemMetadata(item, stateItem) : item;
+    const nextItem = stateItem
+      ? mergeItemMetadataByPrivate(item, stateItem)
+      : item;
     if (nextItem !== item) {
       nextItems ??= items.slice(0, index);
     }
@@ -85,14 +101,20 @@ function mergeItems<T extends CollectionStoreItem>(
 function mergeItemsByState<T extends CollectionStoreItem>(
   items: T[],
   stateItems: T[],
+  privateItems: T[] = [],
 ) {
   const itemsById = getItemsById(items);
+  const privateItemsById = getItemsById(privateItems);
   const nextItems: T[] = [];
   let hasChanges = items.length !== stateItems.length;
   let index = 0;
 
   for (const stateItem of stateItems) {
-    const item = mergeItemMetadata(itemsById.get(stateItem.id), stateItem);
+    const item = mergeItemMetadata(
+      itemsById.get(stateItem.id),
+      stateItem,
+      privateItemsById.get(stateItem.id),
+    );
     nextItems.push(item);
     if (item !== items[index]) {
       hasChanges = true;
@@ -103,41 +125,117 @@ function mergeItemsByState<T extends CollectionStoreItem>(
   return hasChanges ? nextItems : items;
 }
 
+interface MergeItemsByStateWithPrivateItemParams<
+  T extends CollectionStoreItem,
+> {
+  items: T[];
+  stateItems: T[];
+  id: string;
+  privateItems?: T[];
+}
+
+function mergeItemsByStateWithPrivateItem<T extends CollectionStoreItem>({
+  items,
+  stateItems,
+  id,
+  privateItems,
+}: MergeItemsByStateWithPrivateItemParams<T>) {
+  const nextItems = mergeItemsByState(items, stateItems, privateItems);
+  if (stateItems.some((item) => item.id === id)) {
+    return nextItems;
+  }
+  const item = items.find((item) => item.id === id);
+  if (!item) {
+    return nextItems;
+  }
+  if (nextItems.includes(item)) {
+    return nextItems;
+  }
+  return [...nextItems, item];
+}
+
 function mergeItemMetadata<T extends CollectionStoreItem>(
   item: T | undefined,
   nextItem: T,
+  privateItem?: T,
 ): T;
 function mergeItemMetadata<T extends CollectionStoreItem>(
   item: T | undefined,
   nextItem?: T,
+  privateItem?: T,
 ): T | undefined;
 function mergeItemMetadata<T extends CollectionStoreItem>(
   item: T | undefined,
   nextItem?: T,
+  privateItem?: T,
 ) {
   if (!nextItem) return;
   if (!item) {
-    return nextItem;
+    return mergeItemMetadataByPrivateItem(privateItem, nextItem);
   }
+  let mergedItem: T = nextItem;
   if (nextItem.element !== undefined) {
-    return nextItem;
+    return mergeItemMetadataByPrivateItem(privateItem, nextItem, item);
   }
   const { element } = item;
-  if (element == null) {
-    return nextItem;
+  if (element != null) {
+    mergedItem = { ...nextItem, element };
   }
-  const mergedItem = { ...nextItem, element };
+  mergedItem = mergeItemMetadataByPrivateItem(privateItem, mergedItem, item);
   if (shallowEqual(mergedItem, item)) {
     return item;
   }
   return mergedItem;
 }
 
+function mergeItemMetadataByPrivateItem<T extends CollectionStoreItem>(
+  item: T | undefined,
+  nextItem: T,
+  currentItem?: T,
+) {
+  if (!item) {
+    return nextItem;
+  }
+  let mergedItem: T | undefined;
+
+  for (const key in item) {
+    if (!hasOwnProperty(item, key)) continue;
+    if (key === "id") continue;
+    if (hasOwnProperty(nextItem, key)) continue;
+    mergedItem ??= { ...nextItem };
+    mergedItem[key] = item[key];
+  }
+
+  if (!mergedItem) {
+    return nextItem;
+  }
+  if (currentItem && shallowEqual(mergedItem, currentItem)) {
+    return currentItem;
+  }
+  if (shallowEqual(mergedItem, nextItem)) {
+    return nextItem;
+  }
+  return mergedItem;
+}
+
+function mergeItemMetadataByPrivate<T extends CollectionStoreItem>(
+  item: T,
+  nextItem: T,
+) {
+  const mergedItem = { ...nextItem, ...item };
+  if (shallowEqual(mergedItem, item)) {
+    return item;
+  }
+  return mergedItem;
+}
+
+type MergeItemAction = "mount" | "unmount";
+
 interface MergeItemWithStoreParams<T extends CollectionStoreItem> {
   item: T;
-  setItems: (getItems: (items: T[]) => T[]) => void;
+  setItems: (getItems: (items: T[]) => T[], action: MergeItemAction) => void;
   canDeleteFromMap?: boolean;
-  getItemsBeforeMount?: (items: T[]) => T[];
+  getItemsBeforeMount?: (items: T[], item: T) => T[];
   getItemsBeforeUnmount?: (items: T[]) => T[];
   getRestoredItem?: (item?: T) => T | undefined;
 }
@@ -180,12 +278,23 @@ export function createCollectionStore<
   let pendingItemsFromState = false;
 
   sync(collection, ["items"], (state) => {
+    const privateState = privateStore.getState();
     const privateItems = new Map(
-      privateStore.getState().items.map((item) => [item.id, item]),
+      privateState.items.map((item) => [item.id, item]),
+    );
+    const renderedItems = new Map(
+      privateState.renderedItems.map((item) => [item.id, item]),
     );
     itemsMap.clear();
     for (const item of state.items) {
-      itemsMap.set(item.id, mergeItemMetadata(privateItems.get(item.id), item));
+      itemsMap.set(
+        item.id,
+        mergeItemMetadata(
+          privateItems.get(item.id),
+          item,
+          renderedItems.get(item.id),
+        ),
+      );
     }
   });
 
@@ -198,12 +307,14 @@ export function createCollectionStore<
   setup(collection, () => {
     privateStore.setState("items", (items) => {
       const stateItems = collection.getState().items;
+      const { renderedItems } = privateStore.getState();
+      const stateItemsFromPublished = areItemsEqual(stateItems, publishedItems);
       pendingItemsBase = stateItems;
-      pendingItemsFromState = stateItems !== publishedItems;
-      if (stateItems === publishedItems) {
+      pendingItemsFromState = !stateItemsFromPublished;
+      if (stateItemsFromPublished) {
         return mergeItems(items, stateItems);
       }
-      return mergeItemsByState(items, stateItems);
+      return mergeItemsByState(items, stateItems, renderedItems);
     });
     return init(privateStore);
   });
@@ -214,10 +325,17 @@ export function createCollectionStore<
   setup(privateStore, () => {
     return batch(privateStore, ["items"], (state) => {
       const stateItems = collection.getState().items;
-      const shouldPublishPrivateItems = stateItems === pendingItemsBase;
+      const shouldPublishPrivateItems = areItemsEqual(
+        stateItems,
+        pendingItemsBase,
+      );
       const nextItems = shouldPublishPrivateItems
         ? state.items
-        : mergeItemsByState(state.items, stateItems);
+        : mergeItemsByState(
+            state.items,
+            stateItems,
+            privateStore.getState().renderedItems,
+          );
       const nextItemsFromState =
         pendingItemsFromState || !shouldPublishPrivateItems;
       if (nextItems !== state.items) {
@@ -284,7 +402,7 @@ export function createCollectionStore<
   }: MergeItemWithStoreParams<T>) => {
     let prevItem: T | undefined;
     setItems((items) => {
-      items = getItemsBeforeMount?.(items) || items;
+      items = getItemsBeforeMount?.(items, item) || items;
       const index = items.findIndex(({ id }) => id === item.id);
       const nextItems = items.slice();
       if (index !== -1) {
@@ -297,7 +415,7 @@ export function createCollectionStore<
         itemsMap.set(item.id, item);
       }
       return nextItems;
-    });
+    }, "mount");
     const unmergeItem = () => {
       setItems((items) => {
         items = getItemsBeforeUnmount?.(items) || items;
@@ -337,7 +455,7 @@ export function createCollectionStore<
         nextItems[index] = restoredItem;
         itemsMap.set(item.id, restoredItem);
         return nextItems;
-      });
+      }, "unmount");
     };
     return unmergeItem;
   };
@@ -346,10 +464,14 @@ export function createCollectionStore<
     let registeredItems: T[] | undefined;
     return mergeItemWithStore({
       item,
-      setItems: (getItems) =>
+      setItems: (getItems, action) =>
         privateStore.setState("items", (items) => {
           pendingItemsBase = collection.getState().items;
-          pendingItemsFromState = false;
+          if (action === "mount") {
+            pendingItemsFromState = false;
+          } else {
+            pendingItemsFromState = !areItemsEqual(pendingItemsBase, items);
+          }
           const nextItems = getItems(items);
           registeredItems = nextItems;
           return nextItems;
@@ -357,10 +479,16 @@ export function createCollectionStore<
       canDeleteFromMap: true,
       getItemsBeforeMount: (items) => {
         const stateItems = collection.getState().items;
-        if (stateItems === publishedItems) {
+        if (areItemsEqual(stateItems, publishedItems)) {
           return mergeItems(items, stateItems);
         }
-        return mergeItemsByState(items, stateItems);
+        const { renderedItems } = privateStore.getState();
+        return mergeItemsByStateWithPrivateItem({
+          items,
+          stateItems,
+          id: item.id,
+          privateItems: renderedItems,
+        });
       },
       getItemsBeforeUnmount: (items) => {
         const stateItems = collection.getState().items;
@@ -370,7 +498,14 @@ export function createCollectionStore<
         if (stateItems === publishedItems && !publishedItemsFromState) {
           return items;
         }
-        return mergeItemsByState(items, stateItems);
+        if (
+          stateItems === publishedItems &&
+          !stateItems.some(({ id }) => id === item.id)
+        ) {
+          return items;
+        }
+        const { renderedItems } = privateStore.getState();
+        return mergeItemsByState(items, stateItems, renderedItems);
       },
       getRestoredItem: (prevItem) => {
         const { items } = collection.getState();
@@ -404,18 +539,34 @@ export function createCollectionStore<
       if (!id) return null;
       let item = itemsMap.get(id);
       const stateItems = collection.getState().items;
+      const privateState = privateStore.getState();
+      const renderedItem = privateState.renderedItems.find(
+        (item) => item.id === id,
+      );
       const stateItem = stateItems.find((item) => item.id === id);
       if (stateItem) {
-        item = mergeItemMetadata(item, stateItem);
+        item = mergeItemMetadata(item, stateItem, renderedItem);
         if (item) {
           itemsMap.set(id, item);
         }
         return item || null;
       }
-      if (
-        stateItems === pendingItemsBase ||
-        (stateItems === publishedItems && !publishedItemsFromState)
-      ) {
+      const privateItem = privateState.items.find((item) => item.id === id);
+      const canUsePrivateItems =
+        (stateItems === pendingItemsBase && !pendingItemsFromState) ||
+        (stateItems === publishedItems && !publishedItemsFromState);
+      if (privateItem && canUsePrivateItems) {
+        itemsMap.set(id, privateItem);
+        return privateItem;
+      }
+      if (renderedItem?.element?.isConnected && canUsePrivateItems) {
+        itemsMap.set(id, renderedItem);
+        return renderedItem;
+      }
+      if (canUsePrivateItems) {
+        if (item?.element && !item.element.isConnected) {
+          return null;
+        }
         return item || null;
       }
       return null;

--- a/packages/ariakit-components/src/collection/collection-store.ts
+++ b/packages/ariakit-components/src/collection/collection-store.ts
@@ -87,12 +87,19 @@ function mergeMissingItemMetadata<T extends CollectionStoreItem>(
   return mergedItem || nextItem;
 }
 
-function mergeItemMetadata<T extends CollectionStoreItem>(
-  item: T | undefined,
-  nextItem: T,
-  renderedItem?: T,
-  currentItem?: T,
-) {
+interface MergeItemMetadataParams<T extends CollectionStoreItem> {
+  item: T | undefined;
+  nextItem: T;
+  renderedItem?: T;
+  currentItem?: T;
+}
+
+function mergeItemMetadata<T extends CollectionStoreItem>({
+  item,
+  nextItem,
+  renderedItem,
+  currentItem,
+}: MergeItemMetadataParams<T>) {
   let mergedItem = nextItem;
   if (nextItem.element === undefined) {
     const element = item?.element;
@@ -173,14 +180,15 @@ function mergeItemsFromState<T extends CollectionStoreItem>({
   let index = 0;
 
   for (const stateItem of stateItems) {
-    const item = mergeItemMetadata(
-      itemsById.get(stateItem.id),
-      stateItem,
-      renderedItemsById.get(stateItem.id),
-      items[index],
-    );
+    const currentItem = items[index];
+    const item = mergeItemMetadata({
+      item: itemsById.get(stateItem.id),
+      nextItem: stateItem,
+      renderedItem: renderedItemsById.get(stateItem.id),
+      currentItem,
+    });
     nextItems.push(item);
-    if (item !== items[index]) {
+    if (item !== currentItem) {
       hasChanges = true;
     }
     index += 1;

--- a/packages/ariakit-components/src/collection/collection-store.ts
+++ b/packages/ariakit-components/src/collection/collection-store.ts
@@ -12,6 +12,7 @@ import {
   sortBasedOnDOMPosition,
   chain,
   defaultValue,
+  shallowEqual,
 } from "@ariakit/utils";
 import type { BivariantCallback } from "@ariakit/utils";
 
@@ -42,6 +43,103 @@ function getPrivateStore<T extends CollectionStoreItem>(
   },
 ) {
   return store?.__unstablePrivateStore;
+}
+
+function getItemsById<T extends CollectionStoreItem>(items: T[]) {
+  const itemsById = new Map<string, T>();
+  for (const item of items) {
+    itemsById.set(item.id, item);
+  }
+  return itemsById;
+}
+
+function mergeItems<T extends CollectionStoreItem>(
+  items: T[],
+  stateItems: T[],
+) {
+  const itemsById = getItemsById(items);
+  const stateItemsById = getItemsById(stateItems);
+
+  let nextItems: T[] | undefined;
+  let index = 0;
+
+  for (const item of items) {
+    const stateItem = stateItemsById.get(item.id);
+    const nextItem = stateItem ? mergeItemMetadata(item, stateItem) : item;
+    if (nextItem !== item) {
+      nextItems ??= items.slice(0, index);
+    }
+    nextItems?.push(nextItem);
+    index += 1;
+  }
+
+  for (const stateItem of stateItems) {
+    if (itemsById.has(stateItem.id)) continue;
+    nextItems ??= items.slice();
+    nextItems.push(stateItem);
+  }
+
+  return nextItems || items;
+}
+
+function mergeItemsByState<T extends CollectionStoreItem>(
+  items: T[],
+  stateItems: T[],
+) {
+  const itemsById = getItemsById(items);
+  const nextItems: T[] = [];
+  let hasChanges = items.length !== stateItems.length;
+  let index = 0;
+
+  for (const stateItem of stateItems) {
+    const item = mergeItemMetadata(itemsById.get(stateItem.id), stateItem);
+    nextItems.push(item);
+    if (item !== items[index]) {
+      hasChanges = true;
+    }
+    index += 1;
+  }
+
+  return hasChanges ? nextItems : items;
+}
+
+function mergeItemMetadata<T extends CollectionStoreItem>(
+  item: T | undefined,
+  nextItem: T,
+): T;
+function mergeItemMetadata<T extends CollectionStoreItem>(
+  item: T | undefined,
+  nextItem?: T,
+): T | undefined;
+function mergeItemMetadata<T extends CollectionStoreItem>(
+  item: T | undefined,
+  nextItem?: T,
+) {
+  if (!nextItem) return;
+  if (!item) {
+    return nextItem;
+  }
+  if (nextItem.element !== undefined) {
+    return nextItem;
+  }
+  const { element } = item;
+  if (element == null) {
+    return nextItem;
+  }
+  const mergedItem = { ...nextItem, element };
+  if (shallowEqual(mergedItem, item)) {
+    return item;
+  }
+  return mergedItem;
+}
+
+interface MergeItemWithStoreParams<T extends CollectionStoreItem> {
+  item: T;
+  setItems: (getItems: (items: T[]) => T[]) => void;
+  canDeleteFromMap?: boolean;
+  getItemsBeforeMount?: (items: T[]) => T[];
+  getItemsBeforeUnmount?: (items: T[]) => T[];
+  getRestoredItem?: (item?: T) => T | undefined;
 }
 
 /**
@@ -76,12 +174,18 @@ export function createCollectionStore<
   );
 
   const collection = createStore(initialState, props.store);
+  let publishedItems = collection.getState().items;
+  let publishedItemsFromState = false;
+  let pendingItemsBase = publishedItems;
+  let pendingItemsFromState = false;
 
   sync(collection, ["items"], (state) => {
-    privateStore.setState("items", state.items);
+    const privateItems = new Map(
+      privateStore.getState().items.map((item) => [item.id, item]),
+    );
     itemsMap.clear();
     for (const item of state.items) {
-      itemsMap.set(item.id, item);
+      itemsMap.set(item.id, mergeItemMetadata(privateItems.get(item.id), item));
     }
   });
 
@@ -91,14 +195,39 @@ export function createCollectionStore<
     collection.setState("renderedItems", sortedItems);
   };
 
-  setup(collection, () => init(privateStore));
+  setup(collection, () => {
+    privateStore.setState("items", (items) => {
+      const stateItems = collection.getState().items;
+      pendingItemsBase = stateItems;
+      pendingItemsFromState = stateItems !== publishedItems;
+      if (stateItems === publishedItems) {
+        return mergeItems(items, stateItems);
+      }
+      return mergeItemsByState(items, stateItems);
+    });
+    return init(privateStore);
+  });
 
   // Use the private store to register items and then batch the changes to the
   // public store so we don't trigger multiple updates on the store when adding
   // multiple items.
   setup(privateStore, () => {
     return batch(privateStore, ["items"], (state) => {
-      collection.setState("items", state.items);
+      const stateItems = collection.getState().items;
+      const shouldPublishPrivateItems = stateItems === pendingItemsBase;
+      const nextItems = shouldPublishPrivateItems
+        ? state.items
+        : mergeItemsByState(state.items, stateItems);
+      const nextItemsFromState =
+        pendingItemsFromState || !shouldPublishPrivateItems;
+      if (nextItems !== state.items) {
+        pendingItemsBase = nextItems;
+        pendingItemsFromState = true;
+        privateStore.setState("items", nextItems);
+      }
+      publishedItems = nextItems;
+      publishedItemsFromState = nextItemsFromState;
+      collection.setState("items", nextItems);
     });
   });
 
@@ -145,13 +274,17 @@ export function createCollectionStore<
     });
   });
 
-  const mergeItem = (
-    item: T,
-    setItems: (getItems: (items: T[]) => T[]) => void,
+  const mergeItemWithStore = ({
+    item,
+    setItems,
     canDeleteFromMap = false,
-  ) => {
+    getItemsBeforeMount,
+    getItemsBeforeUnmount,
+    getRestoredItem,
+  }: MergeItemWithStoreParams<T>) => {
     let prevItem: T | undefined;
     setItems((items) => {
+      items = getItemsBeforeMount?.(items) || items;
       const index = items.findIndex(({ id }) => id === item.id);
       const nextItems = items.slice();
       if (index !== -1) {
@@ -167,29 +300,91 @@ export function createCollectionStore<
     });
     const unmergeItem = () => {
       setItems((items) => {
+        items = getItemsBeforeUnmount?.(items) || items;
         if (!prevItem) {
+          const restoredItem = getRestoredItem?.();
+          if (restoredItem) {
+            const index = items.findIndex(({ id }) => id === item.id);
+            if (index !== -1) {
+              const nextItems = items.slice();
+              nextItems[index] = restoredItem;
+              itemsMap.set(item.id, restoredItem);
+              return nextItems;
+            }
+          }
           if (canDeleteFromMap) {
             itemsMap.delete(item.id);
           }
           return items.filter(({ id }) => id !== item.id);
         }
         const index = items.findIndex(({ id }) => id === item.id);
-        if (index === -1) return items;
+        if (index === -1) {
+          if (canDeleteFromMap) {
+            itemsMap.delete(item.id);
+          }
+          return items;
+        }
+        const restoredItem = getRestoredItem
+          ? getRestoredItem(prevItem)
+          : prevItem;
+        if (!restoredItem) {
+          if (canDeleteFromMap) {
+            itemsMap.delete(item.id);
+          }
+          return items.filter(({ id }) => id !== item.id);
+        }
         const nextItems = items.slice();
-        nextItems[index] = prevItem;
-        itemsMap.set(item.id, prevItem);
+        nextItems[index] = restoredItem;
+        itemsMap.set(item.id, restoredItem);
         return nextItems;
       });
     };
     return unmergeItem;
   };
 
-  const registerItem: CollectionStore<T>["registerItem"] = (item) =>
-    mergeItem(
+  const registerItem: CollectionStore<T>["registerItem"] = (item) => {
+    let registeredItems: T[] | undefined;
+    return mergeItemWithStore({
       item,
-      (getItems) => privateStore.setState("items", getItems),
-      true,
-    );
+      setItems: (getItems) =>
+        privateStore.setState("items", (items) => {
+          pendingItemsBase = collection.getState().items;
+          pendingItemsFromState = false;
+          const nextItems = getItems(items);
+          registeredItems = nextItems;
+          return nextItems;
+        }),
+      canDeleteFromMap: true,
+      getItemsBeforeMount: (items) => {
+        const stateItems = collection.getState().items;
+        if (stateItems === publishedItems) {
+          return mergeItems(items, stateItems);
+        }
+        return mergeItemsByState(items, stateItems);
+      },
+      getItemsBeforeUnmount: (items) => {
+        const stateItems = collection.getState().items;
+        if (stateItems === registeredItems) {
+          return items;
+        }
+        if (stateItems === publishedItems && !publishedItemsFromState) {
+          return items;
+        }
+        return mergeItemsByState(items, stateItems);
+      },
+      getRestoredItem: (prevItem) => {
+        const { items } = collection.getState();
+        if (items === registeredItems) {
+          return prevItem;
+        }
+        if (items === publishedItems && !publishedItemsFromState) {
+          return prevItem;
+        }
+        const stateItem = items.find(({ id }) => id === item.id);
+        return stateItem;
+      },
+    });
+  };
 
   return {
     ...collection,
@@ -198,22 +393,32 @@ export function createCollectionStore<
     renderItem: (item) =>
       chain(
         registerItem(item),
-        mergeItem(item, (getItems) =>
-          privateStore.setState("renderedItems", getItems),
-        ),
+        mergeItemWithStore({
+          item,
+          setItems: (getItems) =>
+            privateStore.setState("renderedItems", getItems),
+        }),
       ),
 
     item: (id) => {
       if (!id) return null;
       let item = itemsMap.get(id);
-      if (!item) {
-        const { items } = privateStore.getState();
-        item = items.find((item) => item.id === id);
+      const stateItems = collection.getState().items;
+      const stateItem = stateItems.find((item) => item.id === id);
+      if (stateItem) {
+        item = mergeItemMetadata(item, stateItem);
         if (item) {
           itemsMap.set(id, item);
         }
+        return item || null;
       }
-      return item || null;
+      if (
+        stateItems === pendingItemsBase ||
+        (stateItems === publishedItems && !publishedItemsFromState)
+      ) {
+        return item || null;
+      }
+      return null;
     },
 
     // @ts-expect-error Internal

--- a/packages/ariakit-components/src/collection/collection-store.ts
+++ b/packages/ariakit-components/src/collection/collection-store.ts
@@ -67,7 +67,61 @@ function areItemsEqual<T extends CollectionStoreItem>(
   return items.every((item, index) => shallowEqual(item, nextItems[index]));
 }
 
-function mergeItems<T extends CollectionStoreItem>(
+function mergeMissingItemMetadata<T extends CollectionStoreItem>(
+  item: T | undefined,
+  nextItem: T,
+) {
+  if (!item) {
+    return nextItem;
+  }
+  let mergedItem: T | undefined;
+
+  for (const key in item) {
+    if (!hasOwnProperty(item, key)) continue;
+    if (key === "id") continue;
+    if (hasOwnProperty(nextItem, key)) continue;
+    mergedItem ??= { ...nextItem };
+    mergedItem[key] = item[key];
+  }
+
+  return mergedItem || nextItem;
+}
+
+function mergeItemMetadata<T extends CollectionStoreItem>(
+  item: T | undefined,
+  nextItem: T,
+  renderedItem?: T,
+  currentItem?: T,
+) {
+  let mergedItem = nextItem;
+  if (nextItem.element === undefined) {
+    const element = item?.element;
+    if (element != null) {
+      mergedItem = { ...nextItem, element };
+    }
+  }
+  mergedItem = mergeMissingItemMetadata(renderedItem, mergedItem);
+  if (currentItem && shallowEqual(mergedItem, currentItem)) {
+    return currentItem;
+  }
+  if (shallowEqual(mergedItem, nextItem)) {
+    return nextItem;
+  }
+  return mergedItem;
+}
+
+function mergeItemWithPrivateMetadata<T extends CollectionStoreItem>(
+  item: T,
+  stateItem: T,
+) {
+  const mergedItem = { ...stateItem, ...item };
+  if (shallowEqual(mergedItem, item)) {
+    return item;
+  }
+  return mergedItem;
+}
+
+function mergeItemsFromPrivate<T extends CollectionStoreItem>(
   items: T[],
   stateItems: T[],
 ) {
@@ -80,7 +134,7 @@ function mergeItems<T extends CollectionStoreItem>(
   for (const item of items) {
     const stateItem = stateItemsById.get(item.id);
     const nextItem = stateItem
-      ? mergeItemMetadataByPrivate(item, stateItem)
+      ? mergeItemWithPrivateMetadata(item, stateItem)
       : item;
     if (nextItem !== item) {
       nextItems ??= items.slice(0, index);
@@ -98,13 +152,22 @@ function mergeItems<T extends CollectionStoreItem>(
   return nextItems || items;
 }
 
-function mergeItemsByState<T extends CollectionStoreItem>(
-  items: T[],
-  stateItems: T[],
-  privateItems: T[] = [],
-) {
+interface MergeItemsFromStateParams<T extends CollectionStoreItem> {
+  items: T[];
+  stateItems: T[];
+  renderedItems?: T[];
+  preserveId?: string;
+}
+
+function mergeItemsFromState<T extends CollectionStoreItem>({
+  items,
+  stateItems,
+  renderedItems = [],
+  preserveId,
+}: MergeItemsFromStateParams<T>) {
   const itemsById = getItemsById(items);
-  const privateItemsById = getItemsById(privateItems);
+  const renderedItemsById = getItemsById(renderedItems);
+  const stateItemsById = getItemsById(stateItems);
   const nextItems: T[] = [];
   let hasChanges = items.length !== stateItems.length;
   let index = 0;
@@ -113,7 +176,8 @@ function mergeItemsByState<T extends CollectionStoreItem>(
     const item = mergeItemMetadata(
       itemsById.get(stateItem.id),
       stateItem,
-      privateItemsById.get(stateItem.id),
+      renderedItemsById.get(stateItem.id),
+      items[index],
     );
     nextItems.push(item);
     if (item !== items[index]) {
@@ -122,118 +186,23 @@ function mergeItemsByState<T extends CollectionStoreItem>(
     index += 1;
   }
 
+  if (preserveId && !stateItemsById.has(preserveId)) {
+    const item = itemsById.get(preserveId);
+    if (item && !nextItems.includes(item)) {
+      nextItems.push(item);
+      if (item !== items[index]) {
+        hasChanges = true;
+      }
+    }
+  }
+
   return hasChanges ? nextItems : items;
 }
 
-interface MergeItemsByStateWithPrivateItemParams<
-  T extends CollectionStoreItem,
-> {
-  items: T[];
-  stateItems: T[];
-  id: string;
-  privateItems?: T[];
-}
-
-function mergeItemsByStateWithPrivateItem<T extends CollectionStoreItem>({
-  items,
-  stateItems,
-  id,
-  privateItems,
-}: MergeItemsByStateWithPrivateItemParams<T>) {
-  const nextItems = mergeItemsByState(items, stateItems, privateItems);
-  if (stateItems.some((item) => item.id === id)) {
-    return nextItems;
-  }
-  const item = items.find((item) => item.id === id);
-  if (!item) {
-    return nextItems;
-  }
-  if (nextItems.includes(item)) {
-    return nextItems;
-  }
-  return [...nextItems, item];
-}
-
-function mergeItemMetadata<T extends CollectionStoreItem>(
-  item: T | undefined,
-  nextItem: T,
-  privateItem?: T,
-): T;
-function mergeItemMetadata<T extends CollectionStoreItem>(
-  item: T | undefined,
-  nextItem?: T,
-  privateItem?: T,
-): T | undefined;
-function mergeItemMetadata<T extends CollectionStoreItem>(
-  item: T | undefined,
-  nextItem?: T,
-  privateItem?: T,
-) {
-  if (!nextItem) return;
-  if (!item) {
-    return mergeItemMetadataByPrivateItem(privateItem, nextItem);
-  }
-  let mergedItem: T = nextItem;
-  if (nextItem.element !== undefined) {
-    return mergeItemMetadataByPrivateItem(privateItem, nextItem, item);
-  }
-  const { element } = item;
-  if (element != null) {
-    mergedItem = { ...nextItem, element };
-  }
-  mergedItem = mergeItemMetadataByPrivateItem(privateItem, mergedItem, item);
-  if (shallowEqual(mergedItem, item)) {
-    return item;
-  }
-  return mergedItem;
-}
-
-function mergeItemMetadataByPrivateItem<T extends CollectionStoreItem>(
-  item: T | undefined,
-  nextItem: T,
-  currentItem?: T,
-) {
-  if (!item) {
-    return nextItem;
-  }
-  let mergedItem: T | undefined;
-
-  for (const key in item) {
-    if (!hasOwnProperty(item, key)) continue;
-    if (key === "id") continue;
-    if (hasOwnProperty(nextItem, key)) continue;
-    mergedItem ??= { ...nextItem };
-    mergedItem[key] = item[key];
-  }
-
-  if (!mergedItem) {
-    return nextItem;
-  }
-  if (currentItem && shallowEqual(mergedItem, currentItem)) {
-    return currentItem;
-  }
-  if (shallowEqual(mergedItem, nextItem)) {
-    return nextItem;
-  }
-  return mergedItem;
-}
-
-function mergeItemMetadataByPrivate<T extends CollectionStoreItem>(
-  item: T,
-  nextItem: T,
-) {
-  const mergedItem = { ...nextItem, ...item };
-  if (shallowEqual(mergedItem, item)) {
-    return item;
-  }
-  return mergedItem;
-}
-
-type MergeItemAction = "mount" | "unmount";
-
 interface MergeItemWithStoreParams<T extends CollectionStoreItem> {
   item: T;
-  setItems: (getItems: (items: T[]) => T[], action: MergeItemAction) => void;
+  setItems: (getItems: (items: T[]) => T[]) => void;
+  syncItemsMap?: (items: T[]) => void;
   canDeleteFromMap?: boolean;
   getItemsBeforeMount?: (items: T[], item: T) => T[];
   getItemsBeforeUnmount?: (items: T[]) => T[];
@@ -273,29 +242,65 @@ export function createCollectionStore<
 
   const collection = createStore(initialState, props.store);
   let publishedItems = collection.getState().items;
-  let publishedItemsFromState = false;
-  let pendingItemsBase = publishedItems;
-  let pendingItemsFromState = false;
+  let itemsVersion = 0;
+  let publishedItemsVersion = 0;
+  let pendingItemsVersion = 0;
+  let privateItemsPending = false;
+  let publishingPrivateItems = false;
+  let publicItemsFromPrivate = true;
 
-  sync(collection, ["items"], (state) => {
-    const privateState = privateStore.getState();
-    const privateItems = new Map(
-      privateState.items.map((item) => [item.id, item]),
-    );
-    const renderedItems = new Map(
-      privateState.renderedItems.map((item) => [item.id, item]),
-    );
+  const setItemsMap = (items: T[]) => {
     itemsMap.clear();
-    for (const item of state.items) {
-      itemsMap.set(
-        item.id,
-        mergeItemMetadata(
-          privateItems.get(item.id),
-          item,
-          renderedItems.get(item.id),
-        ),
-      );
+    for (const item of items) {
+      itemsMap.set(item.id, item);
     }
+  };
+
+  const isPublicStateCurrent = () =>
+    publicItemsFromPrivate && itemsVersion === publishedItemsVersion;
+
+  const updateItemsMap = ({
+    items = privateStore.getState().items,
+    renderedItems = privateStore.getState().renderedItems,
+    includePrivateItems = false,
+  } = {}) => {
+    const stateItems = collection.getState().items;
+    const nextItems = mergeItemsFromState({
+      items,
+      stateItems,
+      renderedItems,
+    });
+    setItemsMap(nextItems);
+    if (!includePrivateItems) return;
+    if (!publishingPrivateItems && itemsVersion !== pendingItemsVersion) return;
+    const stateItemsById = getItemsById(stateItems);
+    for (const item of items) {
+      if (stateItemsById.has(item.id)) continue;
+      itemsMap.set(item.id, item);
+    }
+    if (!publicItemsFromPrivate) return;
+    for (const item of renderedItems) {
+      if (stateItemsById.has(item.id)) continue;
+      if (itemsMap.has(item.id)) continue;
+      if (item.element && !item.element.isConnected) continue;
+      itemsMap.set(item.id, item);
+    }
+  };
+
+  sync(collection, ["items"], (state, prevState) => {
+    if (state.items !== prevState.items) {
+      itemsVersion += 1;
+      if (!publishingPrivateItems) {
+        const itemsFromPrivate =
+          !privateItemsPending && areItemsEqual(state.items, publishedItems);
+        publicItemsFromPrivate = itemsFromPrivate;
+        if (itemsFromPrivate) {
+          publishedItems = state.items;
+          publishedItemsVersion = itemsVersion;
+        }
+      }
+    }
+    updateItemsMap({ includePrivateItems: publishingPrivateItems });
   });
 
   const sortItems = (renderedItems: T[]) => {
@@ -308,13 +313,11 @@ export function createCollectionStore<
     privateStore.setState("items", (items) => {
       const stateItems = collection.getState().items;
       const { renderedItems } = privateStore.getState();
-      const stateItemsFromPublished = areItemsEqual(stateItems, publishedItems);
-      pendingItemsBase = stateItems;
-      pendingItemsFromState = !stateItemsFromPublished;
-      if (stateItemsFromPublished) {
-        return mergeItems(items, stateItems);
+      pendingItemsVersion = itemsVersion;
+      if (isPublicStateCurrent()) {
+        return mergeItemsFromPrivate(items, stateItems);
       }
-      return mergeItemsByState(items, stateItems, renderedItems);
+      return mergeItemsFromState({ items, stateItems, renderedItems });
     });
     return init(privateStore);
   });
@@ -325,27 +328,30 @@ export function createCollectionStore<
   setup(privateStore, () => {
     return batch(privateStore, ["items"], (state) => {
       const stateItems = collection.getState().items;
-      const shouldPublishPrivateItems = areItemsEqual(
-        stateItems,
-        pendingItemsBase,
-      );
-      const nextItems = shouldPublishPrivateItems
-        ? state.items
-        : mergeItemsByState(
-            state.items,
-            stateItems,
-            privateStore.getState().renderedItems,
-          );
-      const nextItemsFromState =
-        pendingItemsFromState || !shouldPublishPrivateItems;
-      if (nextItems !== state.items) {
-        pendingItemsBase = nextItems;
-        pendingItemsFromState = true;
-        privateStore.setState("items", nextItems);
+      if (itemsVersion !== pendingItemsVersion) {
+        const nextItems = mergeItemsFromState({
+          items: state.items,
+          stateItems,
+          renderedItems: privateStore.getState().renderedItems,
+        });
+        pendingItemsVersion = -1;
+        privateItemsPending = false;
+        if (nextItems !== state.items) {
+          privateStore.setState("items", nextItems);
+          updateItemsMap({ items: nextItems });
+        }
+        return;
       }
-      publishedItems = nextItems;
-      publishedItemsFromState = nextItemsFromState;
-      collection.setState("items", nextItems);
+      try {
+        publishingPrivateItems = true;
+        collection.setState("items", state.items);
+        publishedItems = state.items;
+        publishedItemsVersion = itemsVersion;
+        privateItemsPending = false;
+        publicItemsFromPrivate = true;
+      } finally {
+        publishingPrivateItems = false;
+      }
     });
   });
 
@@ -395,6 +401,7 @@ export function createCollectionStore<
   const mergeItemWithStore = ({
     item,
     setItems,
+    syncItemsMap,
     canDeleteFromMap = false,
     getItemsBeforeMount,
     getItemsBeforeUnmount,
@@ -409,13 +416,12 @@ export function createCollectionStore<
         prevItem = items[index];
         const nextItem = { ...prevItem, ...item };
         nextItems[index] = nextItem;
-        itemsMap.set(item.id, nextItem);
       } else {
         nextItems.push(item);
-        itemsMap.set(item.id, item);
       }
+      syncItemsMap?.(nextItems);
       return nextItems;
-    }, "mount");
+    });
     const unmergeItem = () => {
       setItems((items) => {
         items = getItemsBeforeUnmount?.(items) || items;
@@ -426,95 +432,90 @@ export function createCollectionStore<
             if (index !== -1) {
               const nextItems = items.slice();
               nextItems[index] = restoredItem;
-              itemsMap.set(item.id, restoredItem);
+              syncItemsMap?.(nextItems);
               return nextItems;
             }
           }
-          if (canDeleteFromMap) {
+          if (canDeleteFromMap && !syncItemsMap) {
             itemsMap.delete(item.id);
           }
-          return items.filter(({ id }) => id !== item.id);
+          const nextItems = items.filter(({ id }) => id !== item.id);
+          syncItemsMap?.(nextItems);
+          return nextItems;
         }
         const index = items.findIndex(({ id }) => id === item.id);
         if (index === -1) {
-          if (canDeleteFromMap) {
+          if (canDeleteFromMap && !syncItemsMap) {
             itemsMap.delete(item.id);
           }
+          syncItemsMap?.(items);
           return items;
         }
         const restoredItem = getRestoredItem
           ? getRestoredItem(prevItem)
           : prevItem;
         if (!restoredItem) {
-          if (canDeleteFromMap) {
+          if (canDeleteFromMap && !syncItemsMap) {
             itemsMap.delete(item.id);
           }
-          return items.filter(({ id }) => id !== item.id);
+          const nextItems = items.filter(({ id }) => id !== item.id);
+          syncItemsMap?.(nextItems);
+          return nextItems;
         }
         const nextItems = items.slice();
         nextItems[index] = restoredItem;
-        itemsMap.set(item.id, restoredItem);
+        syncItemsMap?.(nextItems);
         return nextItems;
-      }, "unmount");
+      });
     };
     return unmergeItem;
   };
 
   const registerItem: CollectionStore<T>["registerItem"] = (item) => {
-    let registeredItems: T[] | undefined;
     return mergeItemWithStore({
       item,
-      setItems: (getItems, action) =>
+      setItems: (getItems) =>
         privateStore.setState("items", (items) => {
-          pendingItemsBase = collection.getState().items;
-          if (action === "mount") {
-            pendingItemsFromState = false;
-          } else {
-            pendingItemsFromState = !areItemsEqual(pendingItemsBase, items);
-          }
+          pendingItemsVersion = itemsVersion;
           const nextItems = getItems(items);
-          registeredItems = nextItems;
+          privateItemsPending = nextItems !== items;
           return nextItems;
         }),
+      syncItemsMap: (items) =>
+        updateItemsMap({ items, includePrivateItems: true }),
       canDeleteFromMap: true,
       getItemsBeforeMount: (items) => {
         const stateItems = collection.getState().items;
-        if (areItemsEqual(stateItems, publishedItems)) {
-          return mergeItems(items, stateItems);
+        if (isPublicStateCurrent() && !privateItemsPending) {
+          return mergeItemsFromPrivate(items, stateItems);
+        }
+        if (isPublicStateCurrent()) {
+          return items;
         }
         const { renderedItems } = privateStore.getState();
-        return mergeItemsByStateWithPrivateItem({
+        return mergeItemsFromState({
           items,
           stateItems,
-          id: item.id,
-          privateItems: renderedItems,
+          renderedItems,
+          preserveId: item.id,
         });
       },
       getItemsBeforeUnmount: (items) => {
         const stateItems = collection.getState().items;
-        if (stateItems === registeredItems) {
-          return items;
+        if (isPublicStateCurrent() && !privateItemsPending) {
+          return mergeItemsFromPrivate(items, stateItems);
         }
-        if (stateItems === publishedItems && !publishedItemsFromState) {
-          return items;
-        }
-        if (
-          stateItems === publishedItems &&
-          !stateItems.some(({ id }) => id === item.id)
-        ) {
+        if (isPublicStateCurrent()) {
           return items;
         }
         const { renderedItems } = privateStore.getState();
-        return mergeItemsByState(items, stateItems, renderedItems);
+        return mergeItemsFromState({ items, stateItems, renderedItems });
       },
       getRestoredItem: (prevItem) => {
+        if (isPublicStateCurrent()) {
+          return prevItem;
+        }
         const { items } = collection.getState();
-        if (items === registeredItems) {
-          return prevItem;
-        }
-        if (items === publishedItems && !publishedItemsFromState) {
-          return prevItem;
-        }
         const stateItem = items.find(({ id }) => id === item.id);
         return stateItem;
       },
@@ -532,44 +533,15 @@ export function createCollectionStore<
           item,
           setItems: (getItems) =>
             privateStore.setState("renderedItems", getItems),
+          syncItemsMap: (renderedItems) =>
+            updateItemsMap({ renderedItems, includePrivateItems: true }),
         }),
       ),
 
     item: (id) => {
       if (!id) return null;
-      let item = itemsMap.get(id);
-      const stateItems = collection.getState().items;
-      const privateState = privateStore.getState();
-      const renderedItem = privateState.renderedItems.find(
-        (item) => item.id === id,
-      );
-      const stateItem = stateItems.find((item) => item.id === id);
-      if (stateItem) {
-        item = mergeItemMetadata(item, stateItem, renderedItem);
-        if (item) {
-          itemsMap.set(id, item);
-        }
-        return item || null;
-      }
-      const privateItem = privateState.items.find((item) => item.id === id);
-      const canUsePrivateItems =
-        (stateItems === pendingItemsBase && !pendingItemsFromState) ||
-        (stateItems === publishedItems && !publishedItemsFromState);
-      if (privateItem && canUsePrivateItems) {
-        itemsMap.set(id, privateItem);
-        return privateItem;
-      }
-      if (renderedItem?.element?.isConnected && canUsePrivateItems) {
-        itemsMap.set(id, renderedItem);
-        return renderedItem;
-      }
-      if (canUsePrivateItems) {
-        if (item?.element && !item.element.isConnected) {
-          return null;
-        }
-        return item || null;
-      }
-      return null;
+      const item = itemsMap.get(id);
+      return item || null;
     },
 
     // @ts-expect-error Internal

--- a/packages/ariakit-components/src/collection/collection-store.ts
+++ b/packages/ariakit-components/src/collection/collection-store.ts
@@ -238,7 +238,7 @@ interface MergeItemWithStoreParams<T extends CollectionStoreItem> {
   canDeleteFromMap?: boolean;
   getItemsBeforeMount?: (items: T[], item: T) => T[];
   getItemsBeforeUnmount?: (items: T[]) => T[];
-  getRestoredItem?: (item?: T) => T | undefined;
+  getRestoredItem?: (item?: T, currentItem?: T) => T | undefined;
 }
 
 /**
@@ -609,7 +609,7 @@ export function createCollectionStore<
           return items;
         }
         const restoredItem = getRestoredItem
-          ? getRestoredItem(prevItem)
+          ? getRestoredItem(prevItem, items[index])
           : prevItem;
         if (!restoredItem) {
           if (canDeleteFromMap && !syncItemsMap) {
@@ -679,13 +679,26 @@ export function createCollectionStore<
         const { renderedItems } = privateStore.getState();
         return mergeItemsFromState({ items, stateItems, renderedItems });
       },
-      getRestoredItem: (prevItem) => {
+      getRestoredItem: (prevItem, currentItem) => {
+        // Once the public `items` state has diverged from registration, it is
+        // authoritative. If a controlled/explicit update has overwritten this
+        // registration's merge (the current item no longer equals the value this
+        // registration produced at mount), don't rewind to the stale snapshot;
+        // restore from the current public item instead. Otherwise (undiverged,
+        // or the snapshot is still intact) keep the existing rewind behavior. The
+        // removal case (no `prevItem`) is unaffected.
+        if (
+          everDiverged &&
+          prevItem &&
+          currentItem &&
+          !shallowEqual(currentItem, { ...prevItem, ...item })
+        ) {
+          return findItemById(collection.getState().items, item.id);
+        }
         if (isPublicStateCurrent()) {
           return prevItem;
         }
-        const { items } = collection.getState();
-        const stateItem = items.find(({ id }) => id === item.id);
-        return stateItem;
+        return findItemById(collection.getState().items, item.id);
       },
     });
   };

--- a/packages/ariakit-react-components/src/composite/composite-typeahead.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-typeahead.tsx
@@ -70,7 +70,11 @@ function isSelfTargetOrItem(event: KeyboardEvent, items: CompositeStoreItem[]) {
 }
 
 function getEnabledItems(items: CompositeStoreItem[]) {
-  return items.filter((item) => !item.disabled);
+  return items.filter((item) => {
+    if (item.disabled) return false;
+    if (!item.element) return true;
+    return item.element.isConnected;
+  });
 }
 
 function itemTextStartsWith(item: CompositeStoreItem, text: string) {

--- a/packages/ariakit-react-components/src/select/select-item.tsx
+++ b/packages/ariakit-react-components/src/select/select-item.tsx
@@ -91,12 +91,7 @@ export const useSelectItem = createHook<TagName, SelectItemOptions>(
         autoFocus(state) {
           if (value == null) return false;
           if (state.value == null) return false;
-          const activeItem = store?.item(state.activeId);
-          if (
-            state.activeId !== id &&
-            activeItem?.value != null &&
-            activeItem.element?.isConnected
-          ) {
+          if (state.activeId !== id && store?.item(state.activeId)) {
             return false;
           }
           if (Array.isArray(state.value)) {

--- a/packages/ariakit-react-components/src/select/select-item.tsx
+++ b/packages/ariakit-react-components/src/select/select-item.tsx
@@ -91,7 +91,12 @@ export const useSelectItem = createHook<TagName, SelectItemOptions>(
         autoFocus(state) {
           if (value == null) return false;
           if (state.value == null) return false;
-          if (state.activeId !== id && store?.item(state.activeId)) {
+          const activeItem = store?.item(state.activeId);
+          if (
+            state.activeId !== id &&
+            activeItem?.value != null &&
+            activeItem.element?.isConnected
+          ) {
             return false;
           }
           if (Array.isArray(state.value)) {

--- a/packages/ariakit-react-components/src/select/select.tsx
+++ b/packages/ariakit-react-components/src/select/select.tsx
@@ -52,7 +52,7 @@ function nextWithValue(store: SelectStore, next: SelectStore["next"]) {
     let i = 0;
     let nextItem = store.item(nextId);
     const firstItem = nextItem;
-    while (nextItem && nextItem.value == null) {
+    while (nextItem && (nextItem.disabled || nextItem.value == null)) {
       const nextId = next(++i);
       if (!nextId) return;
       nextItem = store.item(nextId);

--- a/packages/ariakit-react-components/src/select/select.tsx
+++ b/packages/ariakit-react-components/src/select/select.tsx
@@ -44,20 +44,19 @@ function getSelectedValues(select: HTMLSelectElement) {
 }
 
 // When moving through the items when the select list is closed, we don't want
-// to move to items without value, so we filter them out here.
+// to move to disabled items or items without value, so we filter them out here.
 function nextWithValue(store: SelectStore, next: SelectStore["next"]) {
   return () => {
     const nextId = next();
     if (!nextId) return;
-    let i = 0;
     let nextItem = store.item(nextId);
     const firstItem = nextItem;
     while (nextItem && (nextItem.disabled || nextItem.value == null)) {
-      const nextId = next(++i);
+      const nextId = next({ activeId: nextItem.id });
       if (!nextId) return;
       nextItem = store.item(nextId);
-      // Prevents infinite loop when focusLoop is true
-      if (nextItem === firstItem) break;
+      // Wrapped all the way around without finding a valid item.
+      if (nextItem === firstItem) return;
     }
     return nextItem?.id;
   };

--- a/packages/ariakit-react-components/src/select/select.tsx
+++ b/packages/ariakit-react-components/src/select/select.tsx
@@ -108,8 +108,15 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
     // moveOnKeyDown
     const isVertical = orientation !== "horizontal";
     const isHorizontal = orientation !== "vertical";
-    const isGrid = !!items.find((item) => !item.disabled && item.value != null)
-      ?.rowId;
+    // `rowId` is registration-only metadata from the rendered `SelectRow`, so a
+    // controlled `items` array won't carry it. Read it from the lookup item,
+    // which merges in the rendered metadata, to detect a grid in that case.
+    const valuedItem = items.find(
+      (item) => !item.disabled && item.value != null,
+    );
+    const isGrid = !!(
+      valuedItem && (store.item(valuedItem.id) ?? valuedItem).rowId
+    );
     const moveKeyMap = {
       ArrowUp: (isGrid || isVertical) && nextWithValue(store, store.up),
       ArrowRight: (isGrid || isHorizontal) && nextWithValue(store, store.next),


### PR DESCRIPTION
## Motivation

`collection.item(id)` can return data that disagrees with the collection `items` state when a controlled collection passes metadata through `useCollectionStore({ items, setItems })`. In the issue repro, clicking the rendered Apple item reads through `collection.item("apple")`, but the returned item is missing the `label` metadata and the UI shows `Item not found` instead of `Apple`.

Fixes #6295.

## Solution

The collection store now treats the public `items` state as authoritative while preserving private registration metadata for mounted items. When public items change, the id lookup is rebuilt from the public array and merged with registered elements only for ids that still exist in public state.

Registration batches reconcile against the latest public state before publishing, so controlled metadata replacements, removals, pre-init updates, and pending private batches keep `collection.item(id)` current without losing mounted DOM elements. Composite typeahead now ignores disconnected rendered metadata exposed by the stricter collection reconciliation, and closed Select keyboard navigation skips controlled disabled or valueless metadata without returning a rejected item after wrap.

The sandbox in `app/src/sandbox/collection-6295` reproduces the user-visible flow from the issue: render controlled collection items, click an item, rename Apple through controlled state, then click the updated item again. The coverage includes both the primary browser test and a happy-dom duplicate, plus core collection-store regressions for direct item state updates, registered element preservation, removals, pre-init updates, and pending private batches. The `app/src/sandbox/select-disabled-next` sandbox covers the closed Select navigation regression for disabled and valueless controlled metadata.

## Workaround

Until the library fix lands, avoid `collection.item(id)` when the metadata source of truth is the collection `items` state. Read the public state directly and find the item by id:

```tsx
function showDetails(id: string) {
  // TODO: Remove once https://github.com/ariakit/ariakit/issues/6295 is fixed.
  const item = collection
    .getState()
    .items.find((stateItem) => stateItem.id === id);
  setDetails(item?.label ?? "Item not found");
}
```
