### PR TITLE
Fix hovercard shadow widget hover

### DIFF
--- a/.changeset/300-hovercard-shadow-widget.md
+++ b/.changeset/300-hovercard-shadow-widget.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Hovercard`](https://ariakit.com/reference/hovercard) so it stays open when hovering content rendered inside an open shadow root. This also applies to components built on it, such as [`Tooltip`](https://ariakit.com/reference/tooltip) and [`Menu`](https://ariakit.com/reference/menu).

--- a/app/src/sandbox/hovercard-shadow-widget-6303/index.react.tsx
+++ b/app/src/sandbox/hovercard-shadow-widget-6303/index.react.tsx
@@ -1,0 +1,59 @@
+import * as Ariakit from "@ariakit/react";
+import type { DetailedHTMLProps, HTMLAttributes } from "react";
+
+declare module "react" {
+  namespace JSX {
+    interface IntrinsicElements {
+      "follow-button": DetailedHTMLProps<
+        HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+    }
+  }
+}
+
+if (
+  typeof customElements !== "undefined" &&
+  !customElements.get("follow-button")
+) {
+  class FollowButton extends HTMLElement {
+    constructor() {
+      super();
+      const shadow = this.attachShadow({ mode: "open" });
+      shadow.innerHTML = `
+        <style>
+          button {
+            font: inherit;
+            padding: 16px 32px;
+          }
+        </style>
+        <button type="button">Follow</button>
+      `;
+    }
+  }
+  customElements.define("follow-button", FollowButton);
+}
+
+export default function Example() {
+  return (
+    <Ariakit.HovercardProvider>
+      <Ariakit.HovercardAnchor
+        href="https://bsky.app/profile/ariakit.com"
+        className="underline"
+      >
+        @ariakit.com
+      </Ariakit.HovercardAnchor>
+      <Ariakit.Hovercard
+        aria-label="Profile card"
+        gutter={8}
+        className="rounded border border-black bg-white p-4"
+      >
+        <Ariakit.HovercardHeading className="font-semibold">
+          Ariakit
+        </Ariakit.HovercardHeading>
+        <p>Toolkit with accessible components.</p>
+        <follow-button />
+      </Ariakit.Hovercard>
+    </Ariakit.HovercardProvider>
+  );
+}

--- a/app/src/sandbox/hovercard-shadow-widget-6303/index.react.tsx
+++ b/app/src/sandbox/hovercard-shadow-widget-6303/index.react.tsx
@@ -1,14 +1,15 @@
 import * as Ariakit from "@ariakit/react";
 import type { DetailedHTMLProps, HTMLAttributes } from "react";
-import { useRef } from "react";
+
+type FollowButtonProps = DetailedHTMLProps<
+  HTMLAttributes<HTMLElement>,
+  HTMLElement
+>;
 
 declare module "react" {
   namespace JSX {
     interface IntrinsicElements {
-      "follow-button": DetailedHTMLProps<
-        HTMLAttributes<HTMLElement>,
-        HTMLElement
-      >;
+      "follow-button": FollowButtonProps;
     }
   }
 }
@@ -36,8 +37,6 @@ if (
 }
 
 export default function Example() {
-  const cardRef = useRef<HTMLDivElement>(null);
-
   return (
     <Ariakit.HovercardProvider>
       <Ariakit.HovercardAnchor
@@ -47,14 +46,8 @@ export default function Example() {
         @ariakit.com
       </Ariakit.HovercardAnchor>
       <Ariakit.Hovercard
-        ref={cardRef}
         aria-label="Profile card"
         gutter={8}
-        hideOnHoverOutside={(event) => {
-          const card = cardRef.current;
-          if (!card) return true;
-          return !event.composedPath().includes(card);
-        }}
         className="rounded border border-black bg-white p-4"
       >
         <Ariakit.HovercardHeading className="font-semibold">

--- a/app/src/sandbox/hovercard-shadow-widget-6303/index.react.tsx
+++ b/app/src/sandbox/hovercard-shadow-widget-6303/index.react.tsx
@@ -1,5 +1,6 @@
 import * as Ariakit from "@ariakit/react";
 import type { DetailedHTMLProps, HTMLAttributes } from "react";
+import { useRef } from "react";
 
 declare module "react" {
   namespace JSX {
@@ -35,6 +36,8 @@ if (
 }
 
 export default function Example() {
+  const cardRef = useRef<HTMLDivElement>(null);
+
   return (
     <Ariakit.HovercardProvider>
       <Ariakit.HovercardAnchor
@@ -44,8 +47,14 @@ export default function Example() {
         @ariakit.com
       </Ariakit.HovercardAnchor>
       <Ariakit.Hovercard
+        ref={cardRef}
         aria-label="Profile card"
         gutter={8}
+        hideOnHoverOutside={(event) => {
+          const card = cardRef.current;
+          if (!card) return true;
+          return !event.composedPath().includes(card);
+        }}
         className="rounded border border-black bg-white p-4"
       >
         <Ariakit.HovercardHeading className="font-semibold">

--- a/app/src/sandbox/hovercard-shadow-widget-6303/test-browser.ts
+++ b/app/src/sandbox/hovercard-shadow-widget-6303/test-browser.ts
@@ -1,0 +1,21 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+const afterHideTimeout = 600;
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // Reproduces https://github.com/ariakit/ariakit/issues/6303
+  test("keeps the hovercard visible when the pointer is over a shadow root widget", async ({
+    page,
+    q,
+  }) => {
+    await q.link("@ariakit.com").hover();
+    await test.expect(q.dialog("Profile card")).toBeVisible();
+
+    await q.text("Toolkit with accessible components.").hover();
+    await q.button("Follow").hover();
+    // The default hide timeout is 500ms.
+    await page.waitForTimeout(afterHideTimeout);
+
+    await test.expect(q.dialog("Profile card")).toBeVisible();
+  });
+});

--- a/packages/ariakit-react-components/src/hovercard/hovercard.tsx
+++ b/packages/ariakit-react-components/src/hovercard/hovercard.tsx
@@ -15,7 +15,6 @@ import {
 import type { Props } from "@ariakit/react-utils";
 import { sync } from "@ariakit/store";
 import {
-  contains,
   addGlobalEventListener,
   hasFocusWithin,
   chain,
@@ -52,20 +51,19 @@ type TagName = typeof TagName;
 type HTMLType = HTMLElementTagNameMap[TagName];
 
 function isMovingOnHovercard(
-  target: Node | null | undefined,
+  path: EventTarget[],
   card: HTMLElement,
   anchor: HTMLElement | null,
   nested?: HTMLElement[],
 ) {
   // The hovercard element has focus so we should keep it visible.
   if (hasFocusWithin(card)) return true;
-  if (!target) return false;
   // The mouse is moving on an element inside the hovercard.
-  if (contains(card, target)) return true;
+  if (path.includes(card)) return true;
   // The mouse is moving on an element inside the anchor element.
-  if (anchor && contains(anchor, target)) return true;
+  if (anchor && path.includes(anchor)) return true;
   // The mouse is moving on an element inside a nested hovercard.
-  if (nested?.some((card) => hasFocusWithin(card) || contains(card, target))) {
+  if (nested?.some((card) => hasFocusWithin(card) || path.includes(card))) {
     return true;
   }
   return false;
@@ -184,13 +182,13 @@ export const useHovercard = createHook<TagName, HovercardOptions>(
         if (!isMouseMoving()) return;
         const { anchorElement, hideTimeout, timeout } = store.getState();
         const enterPoint = enterPointRef.current;
-        const [target] = event.composedPath() as Node[];
+        const path = event.composedPath();
         const anchor = anchorElement;
         // Checks whether the hovercard element has focus or the mouse is moving
         // through valid hovercard elements.
         if (
           isMovingOnHovercard(
-            target,
+            path,
             element,
             anchor,
             nestedHovercardsRef.current,
@@ -200,9 +198,7 @@ export const useHovercard = createHook<TagName, HovercardOptions>(
           // card is open, keep track of the mouse position so we can use the
           // last point before the mouse leaves the anchor element.
           enterPointRef.current =
-            target && anchor && contains(anchor, target)
-              ? getEventPoint(event)
-              : null;
+            anchor && path.includes(anchor) ? getEventPoint(event) : null;
           clearHideTimeout();
           return;
         }
@@ -307,8 +303,8 @@ export const useHovercard = createHook<TagName, HovercardOptions>(
 
     // Register the hovercard as a nested hovercard on the parent hovercard if
     // it's not a modal, is portal and is mounted. We don't need to register
-    // non-portal hovercards because they will be captured by the contains
-    // function in the isMovingOnHovercard function above. This must be a layout
+    // non-portal hovercards because they will be captured by the composed path
+    // check in the isMovingOnHovercard function above. This must be a layout
     // effect so we don't lose mouse move events right after the nested
     // hovercard has been mounted (for example, a submenu that's overlapping its
     // menu button and we keep moving the mouse while the submenu is due to


### PR DESCRIPTION
## Motivation

Fixes #6303.

A hovercard should stay open while the pointer is inside the card. When the card contains a web component with an open shadow root, moving the pointer onto the shadow-root button currently hides the card after the default hover timeout.

The global hovercard mousemove listener was reducing `event.composedPath()` to the innermost target and checking that target with light-DOM containment. Nodes inside an open shadow root are not contained by the light-DOM hovercard element, so Ariakit treated the pointer as outside the card.

## Solution

Adds a React sandbox with a `follow-button` custom element rendered inside a `Hovercard`, plus a Playwright test that follows the reported user path:

```tsx
await q.link("@ariakit.com").hover();
await q.text("Toolkit with accessible components.").hover();
await q.button("Follow").hover();
```

The test waits past the default hover hide timeout and expects the `Profile card` dialog to remain visible.

The library fix keeps the full composed event path and checks whether the hovercard, anchor, or nested hovercards are members of that path. This preserves regular light-DOM behavior while correctly treating pointer events from open shadow-root content as still being inside the hovercard or anchor.

## Workaround

Use a `hideOnHoverOutside` callback and check the event's composed path instead of relying on light-DOM containment. Returning `false` while the composed path includes the hovercard element prevents Ariakit from scheduling the outside-hover hide timeout.

```tsx
const cardRef = useRef<HTMLDivElement>(null);

<Ariakit.Hovercard
  ref={cardRef}
  hideOnHoverOutside={(event) => {
    // TODO: Remove once https://github.com/ariakit/ariakit/issues/6303 is fixed.
    const card = cardRef.current;
    if (!card) return true;
    return !event.composedPath().includes(card);
  }}
/>
```
