### PR TITLE
Fix combobox item modifier shortcuts

### DIFF
--- a/.changeset/300-combobox-item-modifier-shortcuts.md
+++ b/.changeset/300-combobox-item-modifier-shortcuts.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`ComboboxItem`](https://ariakit.com/reference/combobox-item) so non-paste Ctrl/Cmd character shortcuts preserve focus and the combobox value when virtual focus is disabled, while paste shortcuts still route to the input.

--- a/app/src/sandbox/combobox-6297/index.react.tsx
+++ b/app/src/sandbox/combobox-6297/index.react.tsx
@@ -1,5 +1,17 @@
 import * as Ariakit from "@ariakit/react";
+import type { KeyboardEvent } from "react";
 import { useState } from "react";
+
+function onItemKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+  const modifier = event.ctrlKey || event.metaKey;
+  if (!modifier) return;
+  if (event.key.length !== 1) return;
+  // TODO: Remove this workaround after
+  // https://github.com/ariakit/ariakit/issues/6297 is fixed.
+  // Let paste through so Ariakit can move focus to the input first.
+  if (event.key.toLowerCase() === "v") return;
+  event.preventDefault();
+}
 
 export default function Example() {
   const [value, setValue] = useState("");
@@ -14,9 +26,9 @@ export default function Example() {
         <Ariakit.ComboboxLabel>Fruit</Ariakit.ComboboxLabel>
         <Ariakit.Combobox autoComplete="inline" />
         <Ariakit.ComboboxPopover>
-          <Ariakit.ComboboxItem value="Apple" />
-          <Ariakit.ComboboxItem value="Banana" />
-          <Ariakit.ComboboxItem value="Cherry" />
+          <Ariakit.ComboboxItem value="Apple" onKeyDown={onItemKeyDown} />
+          <Ariakit.ComboboxItem value="Banana" onKeyDown={onItemKeyDown} />
+          <Ariakit.ComboboxItem value="Cherry" onKeyDown={onItemKeyDown} />
         </Ariakit.ComboboxPopover>
       </Ariakit.ComboboxProvider>
       <output>{value}</output>

--- a/app/src/sandbox/combobox-6297/index.react.tsx
+++ b/app/src/sandbox/combobox-6297/index.react.tsx
@@ -1,17 +1,5 @@
 import * as Ariakit from "@ariakit/react";
-import type { KeyboardEvent } from "react";
 import { useState } from "react";
-
-function onItemKeyDown(event: KeyboardEvent<HTMLDivElement>) {
-  const modifier = event.ctrlKey || event.metaKey;
-  if (!modifier) return;
-  if (event.key.length !== 1) return;
-  // TODO: Remove this workaround after
-  // https://github.com/ariakit/ariakit/issues/6297 is fixed.
-  // Let paste through so Ariakit can move focus to the input first.
-  if (event.key.toLowerCase() === "v") return;
-  event.preventDefault();
-}
 
 export default function Example() {
   const [value, setValue] = useState("");
@@ -26,9 +14,9 @@ export default function Example() {
         <Ariakit.ComboboxLabel>Fruit</Ariakit.ComboboxLabel>
         <Ariakit.Combobox autoComplete="inline" />
         <Ariakit.ComboboxPopover>
-          <Ariakit.ComboboxItem value="Apple" onKeyDown={onItemKeyDown} />
-          <Ariakit.ComboboxItem value="Banana" onKeyDown={onItemKeyDown} />
-          <Ariakit.ComboboxItem value="Cherry" onKeyDown={onItemKeyDown} />
+          <Ariakit.ComboboxItem value="Apple" />
+          <Ariakit.ComboboxItem value="Banana" />
+          <Ariakit.ComboboxItem value="Cherry" />
         </Ariakit.ComboboxPopover>
       </Ariakit.ComboboxProvider>
       <output>{value}</output>

--- a/app/src/sandbox/combobox-6297/index.react.tsx
+++ b/app/src/sandbox/combobox-6297/index.react.tsx
@@ -1,0 +1,25 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+
+export default function Example() {
+  const [value, setValue] = useState("");
+
+  return (
+    <>
+      <Ariakit.ComboboxProvider
+        virtualFocus={false}
+        value={value}
+        setValue={setValue}
+      >
+        <Ariakit.ComboboxLabel>Fruit</Ariakit.ComboboxLabel>
+        <Ariakit.Combobox autoComplete="inline" />
+        <Ariakit.ComboboxPopover>
+          <Ariakit.ComboboxItem value="Apple" />
+          <Ariakit.ComboboxItem value="Banana" />
+          <Ariakit.ComboboxItem value="Cherry" />
+        </Ariakit.ComboboxPopover>
+      </Ariakit.ComboboxProvider>
+      <output>{value}</output>
+    </>
+  );
+}

--- a/app/src/sandbox/combobox-6297/test-browser.ts
+++ b/app/src/sandbox/combobox-6297/test-browser.ts
@@ -1,0 +1,31 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+const shortcuts = [
+  { name: "Ctrl+C", press: "Control+C" },
+  { name: "Meta+C", press: "Meta+C" },
+] as const;
+
+// See https://github.com/ariakit/ariakit/issues/6297
+withFramework(import.meta.dirname, async ({ test }) => {
+  for (const shortcut of shortcuts) {
+    test(`${shortcut.name} on a focused item does not commit inline autocomplete`, async ({
+      page,
+      q,
+    }) => {
+      const combobox = q.combobox("Fruit");
+      const apple = q.option("Apple");
+
+      await combobox.click();
+      await page.keyboard.type("b");
+      await test.expect(q.status()).toHaveText("b");
+
+      await page.keyboard.press("ArrowDown");
+      await test.expect(apple).toBeFocused();
+      await test.expect(combobox).toHaveValue("Apple");
+
+      await page.keyboard.press(shortcut.press);
+      await test.expect(apple).toBeFocused();
+      await test.expect(q.status()).toHaveText("b");
+    });
+  }
+});

--- a/app/src/sandbox/combobox-6297/test-browser.ts
+++ b/app/src/sandbox/combobox-6297/test-browser.ts
@@ -5,6 +5,10 @@ const shortcuts = [
   { name: "Meta+C", press: "Meta+C" },
 ] as const;
 
+function isApplePlatform(platform: string) {
+  return /mac|iphone|ipad|ipod/i.test(platform);
+}
+
 // See https://github.com/ariakit/ariakit/issues/6297
 withFramework(import.meta.dirname, async ({ test }) => {
   for (const shortcut of shortcuts) {
@@ -28,4 +32,22 @@ withFramework(import.meta.dirname, async ({ test }) => {
       await test.expect(q.status()).toHaveText("b");
     });
   }
+
+  test("paste shortcut on a focused item moves focus to the input", async ({
+    page,
+    q,
+  }) => {
+    const combobox = q.combobox("Fruit");
+    const apple = q.option("Apple");
+    const platform = await page.evaluate(() => navigator.platform);
+    const pasteShortcut = isApplePlatform(platform) ? "Meta+V" : "Control+V";
+
+    await combobox.click();
+    await page.keyboard.type("b");
+    await page.keyboard.press("ArrowDown");
+    await test.expect(apple).toBeFocused();
+
+    await page.keyboard.press(pasteShortcut);
+    await test.expect(combobox).toBeFocused();
+  });
 });

--- a/app/src/sandbox/combobox-6297/test-chrome.ts
+++ b/app/src/sandbox/combobox-6297/test-chrome.ts
@@ -1,0 +1,31 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+function isApplePlatform(platform: string) {
+  return /mac|iphone|ipad|ipod/i.test(platform);
+}
+
+// See https://github.com/ariakit/ariakit/issues/6297
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("paste shortcut on a focused item pastes into the input", async ({
+    context,
+    page,
+    q,
+  }) => {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+
+    const combobox = q.combobox("Fruit");
+    const apple = q.option("Apple");
+    const platform = await page.evaluate(() => navigator.platform);
+    const pasteShortcut = isApplePlatform(platform) ? "Meta+V" : "Control+V";
+
+    await combobox.click();
+    await page.keyboard.type("b");
+    await page.evaluate(() => navigator.clipboard.writeText("Dragonfruit"));
+    await page.keyboard.press("ArrowDown");
+    await test.expect(apple).toBeFocused();
+
+    await page.keyboard.press(pasteShortcut);
+    await test.expect(combobox).toBeFocused();
+    await test.expect(q.status()).toContainText("Dragonfruit");
+  });
+});

--- a/app/src/sandbox/combobox-6297/test.ts
+++ b/app/src/sandbox/combobox-6297/test.ts
@@ -6,6 +6,10 @@ const shortcuts = [
   { name: "Meta+C", options: { metaKey: true } },
 ] as const;
 
+function isApplePlatform(platform: string) {
+  return /mac|iphone|ipad|ipod/i.test(platform);
+}
+
 // See https://github.com/ariakit/ariakit/issues/6297
 for (const shortcut of shortcuts) {
   test(`${shortcut.name} on a focused item does not commit inline autocomplete`, async () => {
@@ -25,3 +29,18 @@ for (const shortcut of shortcuts) {
     expect(q.status.ensure()).toHaveTextContent("b");
   });
 }
+
+test("paste shortcut on a focused item moves focus to the input", async () => {
+  const combobox = q.combobox.ensure("Fruit");
+  const applePlatform = isApplePlatform(navigator.platform);
+  const options = applePlatform ? { metaKey: true } : { ctrlKey: true };
+
+  await click(combobox);
+  await type("b");
+  await press.ArrowDown();
+  const apple = q.option.ensure("Apple");
+  expect(apple).toHaveFocus();
+
+  await press("v", null, options);
+  expect(combobox).toHaveFocus();
+});

--- a/app/src/sandbox/combobox-6297/test.ts
+++ b/app/src/sandbox/combobox-6297/test.ts
@@ -1,0 +1,27 @@
+import { click, press, q, type } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+const shortcuts = [
+  { name: "Ctrl+C", options: { ctrlKey: true } },
+  { name: "Meta+C", options: { metaKey: true } },
+] as const;
+
+// See https://github.com/ariakit/ariakit/issues/6297
+for (const shortcut of shortcuts) {
+  test(`${shortcut.name} on a focused item does not commit inline autocomplete`, async () => {
+    const combobox = q.combobox.ensure("Fruit");
+
+    await click(combobox);
+    await type("b");
+    expect(q.status.ensure()).toHaveTextContent("b");
+
+    await press.ArrowDown();
+    const apple = q.option.ensure("Apple");
+    expect(apple).toHaveFocus();
+    expect(combobox).toHaveValue("Apple");
+
+    await press("c", null, shortcut.options);
+    expect(apple).toHaveFocus();
+    expect(q.status.ensure()).toHaveTextContent("b");
+  });
+}

--- a/packages/ariakit-react-components/src/combobox/combobox-item.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item.tsx
@@ -15,6 +15,7 @@ import {
   isTextField,
   isDownloading,
   isOpeningInNewTab,
+  isApple,
   invariant,
 } from "@ariakit/utils";
 import type { BooleanOrCallback } from "@ariakit/utils";
@@ -167,8 +168,15 @@ export const useComboboxItem = createHook<TagName, ComboboxItemOptions>(
       // receive DOM focus. Therefore, pressing printable keys will not fill
       // the text field. So we need to programmatically focus on the text
       // field when the user presses printable keys.
-      const printable = event.key.length === 1;
-      if (printable || event.key === "Backspace" || event.key === "Delete") {
+      const printable =
+        event.key.length === 1 && !event.ctrlKey && !event.metaKey;
+      const pc = !isApple();
+      const modifier = pc ? event.ctrlKey : event.metaKey;
+      // If it's cmd/ctrl+v, focus on the text field so the value is pasted
+      // there.
+      const paste = modifier && event.key.toLowerCase() === "v";
+      const deleteKey = event.key === "Backspace" || event.key === "Delete";
+      if (printable || paste || deleteKey) {
         queueMicrotask(() => baseElement.focus());
         if (isTextField(baseElement)) {
           // If the combobox element is a text field, we should update the


### PR DESCRIPTION
## Motivation

Fixes #6297.

When a combobox uses real DOM focus (`virtualFocus={false}`), pressing modifier character shortcuts on a focused `ComboboxItem` was treated like text input because `event.key.length === 1` matched shortcut keys such as `Ctrl+C` and `Meta+C`. This moved focus back to the combobox input and could commit the input's temporary inline autocomplete value to the combobox store.

## Solution

Update `ComboboxItem` so printable key routing ignores Ctrl/Meta character shortcuts, while preserving the existing routing for Backspace/Delete and the platform paste shortcut. Paste still moves focus to the input first so the pasted text lands there.

The regression coverage includes:

- a browser test that verifies `Ctrl+C` and `Meta+C` preserve item focus and the combobox store value in Chrome, Firefox, and Safari
- a happy-dom duplicate for the same modifier shortcut paths
- paste routing coverage, including a Chrome clipboard-backed test that verifies pasted text reaches the input/store

## Workaround

Pass an `onKeyDown` handler to each `ComboboxItem` that prevents the default action for Ctrl/Meta single-character shortcuts, except paste. Ariakit calls the user `onKeyDown` first, so setting `event.defaultPrevented` makes the internal item handler bail before it moves focus back to the input and commits the inline autocomplete value.

```tsx
function onItemKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
  const modifier = event.ctrlKey || event.metaKey;
  if (!modifier) return;
  if (event.key.length !== 1) return;
  // TODO: Remove this workaround after
  // https://github.com/ariakit/ariakit/issues/6297 is fixed.
  // Let paste through so Ariakit can move focus to the input first.
  if (event.key.toLowerCase() === "v") return;
  event.preventDefault();
}

<Ariakit.ComboboxItem value="Apple" onKeyDown={onItemKeyDown} />;
```
