### PR TITLE
Fix ComboboxItemValue overlapping matches

### DIFF
--- a/.changeset/300-combobox-item-value-overlap.md
+++ b/.changeset/300-combobox-item-value-overlap.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`ComboboxItemValue`](https://ariakit.com/reference/combobox-item-value) so overlapping user input matches are rendered without duplicated text.

--- a/app/src/sandbox/combobox-item-value-6298/index.react.tsx
+++ b/app/src/sandbox/combobox-item-value-6298/index.react.tsx
@@ -1,0 +1,27 @@
+import * as Ariakit from "@ariakit/react";
+import { useMemo, useState } from "react";
+
+const fruits = ["Apple", "Banana", "Cherry", "Grape", "Orange"];
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6298
+export default function Example() {
+  const [searchValue, setSearchValue] = useState("");
+  const matches = useMemo(() => {
+    const search = searchValue.toLowerCase();
+    return fruits.filter((fruit) => fruit.toLowerCase().includes(search));
+  }, [searchValue]);
+
+  return (
+    <Ariakit.ComboboxProvider defaultOpen setValue={setSearchValue}>
+      <Ariakit.ComboboxLabel>Your favorite fruit</Ariakit.ComboboxLabel>
+      <Ariakit.Combobox placeholder="e.g., Apple" />
+      <Ariakit.ComboboxPopover gutter={8} sameWidth>
+        {matches.map((fruit) => (
+          <Ariakit.ComboboxItem key={fruit} value={fruit}>
+            <Ariakit.ComboboxItemValue />
+          </Ariakit.ComboboxItem>
+        ))}
+      </Ariakit.ComboboxPopover>
+    </Ariakit.ComboboxProvider>
+  );
+}

--- a/app/src/sandbox/combobox-item-value-6298/index.react.tsx
+++ b/app/src/sandbox/combobox-item-value-6298/index.react.tsx
@@ -1,58 +1,8 @@
 import * as Ariakit from "@ariakit/react";
-import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
 
 const fruits = ["Apple", "Banana", "Cherry", "Grape", "Orange"];
-
-// TODO: Remove this workaround after
-// https://github.com/ariakit/ariakit/issues/6298 is fixed.
-function getHighlightedParts(itemValue: string, userValue: string) {
-  const parts: ReactNode[] = [];
-  const normalizedItem = itemValue.toLowerCase();
-  const normalizedUser = userValue.toLowerCase();
-  if (!normalizedUser) return itemValue;
-
-  const ranges: Array<[number, number]> = [];
-  let index = normalizedItem.indexOf(normalizedUser);
-
-  while (index !== -1) {
-    const end = index + normalizedUser.length;
-    const lastRange = ranges[ranges.length - 1];
-    if (lastRange && index < lastRange[1]) {
-      lastRange[1] = Math.max(lastRange[1], end);
-    } else {
-      ranges.push([index, end]);
-    }
-    index = normalizedItem.indexOf(normalizedUser, index + 1);
-  }
-
-  let position = 0;
-  for (const [start, end] of ranges) {
-    if (start > position) {
-      parts.push(
-        <span key={parts.length} data-autocomplete-value="">
-          {itemValue.slice(position, start)}
-        </span>,
-      );
-    }
-    parts.push(
-      <span key={parts.length} data-user-value="">
-        {itemValue.slice(start, end)}
-      </span>,
-    );
-    position = end;
-  }
-
-  if (position < itemValue.length) {
-    parts.push(
-      <span key={parts.length} data-autocomplete-value="">
-        {itemValue.slice(position)}
-      </span>,
-    );
-  }
-
-  return parts;
-}
+const normalizedEmptyUserValue = "\u0301";
 
 // Reproduces https://github.com/ariakit/ariakit/issues/6298
 export default function Example() {
@@ -69,12 +19,16 @@ export default function Example() {
       <Ariakit.ComboboxPopover gutter={8} sameWidth>
         {matches.map((fruit) => (
           <Ariakit.ComboboxItem key={fruit} value={fruit}>
-            <Ariakit.ComboboxItemValue>
-              {getHighlightedParts(fruit, searchValue)}
-            </Ariakit.ComboboxItemValue>
+            <Ariakit.ComboboxItemValue />
           </Ariakit.ComboboxItem>
         ))}
       </Ariakit.ComboboxPopover>
+      <output aria-label="Normalized empty value">
+        <Ariakit.ComboboxItemValue
+          value="Cafe"
+          userValue={normalizedEmptyUserValue}
+        />
+      </output>
     </Ariakit.ComboboxProvider>
   );
 }

--- a/app/src/sandbox/combobox-item-value-6298/index.react.tsx
+++ b/app/src/sandbox/combobox-item-value-6298/index.react.tsx
@@ -1,7 +1,58 @@
 import * as Ariakit from "@ariakit/react";
+import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
 
 const fruits = ["Apple", "Banana", "Cherry", "Grape", "Orange"];
+
+// TODO: Remove this workaround after
+// https://github.com/ariakit/ariakit/issues/6298 is fixed.
+function getHighlightedParts(itemValue: string, userValue: string) {
+  const parts: ReactNode[] = [];
+  const normalizedItem = itemValue.toLowerCase();
+  const normalizedUser = userValue.toLowerCase();
+  if (!normalizedUser) return itemValue;
+
+  const ranges: Array<[number, number]> = [];
+  let index = normalizedItem.indexOf(normalizedUser);
+
+  while (index !== -1) {
+    const end = index + normalizedUser.length;
+    const lastRange = ranges[ranges.length - 1];
+    if (lastRange && index < lastRange[1]) {
+      lastRange[1] = Math.max(lastRange[1], end);
+    } else {
+      ranges.push([index, end]);
+    }
+    index = normalizedItem.indexOf(normalizedUser, index + 1);
+  }
+
+  let position = 0;
+  for (const [start, end] of ranges) {
+    if (start > position) {
+      parts.push(
+        <span key={parts.length} data-autocomplete-value="">
+          {itemValue.slice(position, start)}
+        </span>,
+      );
+    }
+    parts.push(
+      <span key={parts.length} data-user-value="">
+        {itemValue.slice(start, end)}
+      </span>,
+    );
+    position = end;
+  }
+
+  if (position < itemValue.length) {
+    parts.push(
+      <span key={parts.length} data-autocomplete-value="">
+        {itemValue.slice(position)}
+      </span>,
+    );
+  }
+
+  return parts;
+}
 
 // Reproduces https://github.com/ariakit/ariakit/issues/6298
 export default function Example() {
@@ -18,7 +69,9 @@ export default function Example() {
       <Ariakit.ComboboxPopover gutter={8} sameWidth>
         {matches.map((fruit) => (
           <Ariakit.ComboboxItem key={fruit} value={fruit}>
-            <Ariakit.ComboboxItemValue />
+            <Ariakit.ComboboxItemValue>
+              {getHighlightedParts(fruit, searchValue)}
+            </Ariakit.ComboboxItemValue>
           </Ariakit.ComboboxItem>
         ))}
       </Ariakit.ComboboxPopover>

--- a/app/src/sandbox/combobox-item-value-6298/test-browser.ts
+++ b/app/src/sandbox/combobox-item-value-6298/test-browser.ts
@@ -16,5 +16,6 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test
       .expect(option.locator("[data-user-value]"))
       .toHaveText(["anana"]);
+    await test.expect(q.status("Normalized empty value")).toHaveText("Cafe");
   });
 });

--- a/app/src/sandbox/combobox-item-value-6298/test-browser.ts
+++ b/app/src/sandbox/combobox-item-value-6298/test-browser.ts
@@ -16,6 +16,11 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test
       .expect(option.locator("[data-user-value]"))
       .toHaveText(["anana"]);
-    await test.expect(q.status("Normalized empty value")).toHaveText("Cafe");
+
+    const normalizedEmptyValue = q.status("Normalized empty value");
+    await test.expect(normalizedEmptyValue).toHaveText("Cafe");
+    await test
+      .expect(normalizedEmptyValue.locator("[data-user-value]"))
+      .toHaveCount(0);
   });
 });

--- a/app/src/sandbox/combobox-item-value-6298/test-browser.ts
+++ b/app/src/sandbox/combobox-item-value-6298/test-browser.ts
@@ -1,0 +1,20 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6298
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("renders overlapping matches without duplicated text", async ({
+    page,
+    q,
+  }) => {
+    await q.combobox("Your favorite fruit").click();
+    await page.keyboard.type("ana");
+
+    const option = q.option("Banana");
+    await test.expect(option).toBeVisible();
+    await test.expect(option).toHaveText("Banana");
+    await test.expect(option.locator("[data-user-value]")).toHaveCount(1);
+    await test
+      .expect(option.locator("[data-user-value]"))
+      .toHaveText(["anana"]);
+  });
+});

--- a/app/src/sandbox/combobox-item-value-6298/test.ts
+++ b/app/src/sandbox/combobox-item-value-6298/test.ts
@@ -9,5 +9,10 @@ test("renders overlapping matches without duplicated text", async () => {
   expect(option).toHaveTextContent("Banana");
   expect(option.querySelectorAll("[data-user-value]")).toHaveLength(1);
   expect(option.querySelector("[data-user-value]")).toHaveTextContent("anana");
-  expect(q.status.ensure("Normalized empty value")).toHaveTextContent("Cafe");
+
+  const normalizedEmptyValue = q.status.ensure("Normalized empty value");
+  expect(normalizedEmptyValue).toHaveTextContent("Cafe");
+  expect(
+    normalizedEmptyValue.querySelectorAll("[data-user-value]"),
+  ).toHaveLength(0);
 });

--- a/app/src/sandbox/combobox-item-value-6298/test.ts
+++ b/app/src/sandbox/combobox-item-value-6298/test.ts
@@ -9,4 +9,5 @@ test("renders overlapping matches without duplicated text", async () => {
   expect(option).toHaveTextContent("Banana");
   expect(option.querySelectorAll("[data-user-value]")).toHaveLength(1);
   expect(option.querySelector("[data-user-value]")).toHaveTextContent("anana");
+  expect(q.status.ensure("Normalized empty value")).toHaveTextContent("Cafe");
 });

--- a/app/src/sandbox/combobox-item-value-6298/test.ts
+++ b/app/src/sandbox/combobox-item-value-6298/test.ts
@@ -1,0 +1,12 @@
+import { q, type } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6298
+test("renders overlapping matches without duplicated text", async () => {
+  await type("ana", q.combobox.ensure("Your favorite fruit"));
+
+  const option = q.option.ensure("Banana");
+  expect(option).toHaveTextContent("Banana");
+  expect(option.querySelectorAll("[data-user-value]")).toHaveLength(1);
+  expect(option.querySelector("[data-user-value]")).toHaveTextContent("anana");
+});

--- a/packages/ariakit-react-components/src/combobox/combobox-item-value.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item-value.tsx
@@ -36,22 +36,29 @@ function getOffsets(string: string, values: Iterable<string>) {
   return offsets;
 }
 
-function filterOverlappingOffsets(offsets: Array<[number, number]>) {
-  return offsets.filter(([offset, length], i, arr) => {
-    return !arr.some(
-      ([o, l], j) => j !== i && o <= offset && o + l >= offset + length,
-    );
-  });
-}
+function mergeOverlappingOffsets(offsets: Array<[number, number]>) {
+  offsets.sort(([a], [b]) => a - b);
 
-function sortOffsets(offsets: Array<[number, number]>) {
-  return offsets.sort(([a], [b]) => a - b);
+  const merged: Array<[number, number]> = [];
+
+  for (const [offset, length] of offsets) {
+    const last = merged[merged.length - 1];
+    // Adjacent matches should remain separate so repeated matches keep
+    // rendering as individual spans.
+    if (last && offset < last[0] + last[1]) {
+      last[1] = Math.max(last[1], offset + length - last[0]);
+    } else {
+      merged.push([offset, length]);
+    }
+  }
+
+  return merged;
 }
 
 function splitValue(itemValue?: string | null, userValue?: string | string[]) {
   if (!itemValue) return itemValue;
   if (!userValue) return itemValue;
-  const userValues = toArray(userValue).filter(Boolean).map(normalizeValue);
+  const userValues = toArray(userValue).map(normalizeValue).filter(Boolean);
   const parts: ReactElement[] = [];
 
   const span = (value: string, autocomplete = false) => (
@@ -64,11 +71,9 @@ function splitValue(itemValue?: string | null, userValue?: string | string[]) {
     </span>
   );
 
-  const offsets = sortOffsets(
-    filterOverlappingOffsets(
-      // Convert userValues into a set to avoid duplicates
-      getOffsets(normalizeValue(itemValue), new Set(userValues)),
-    ),
+  const offsets = mergeOverlappingOffsets(
+    // Convert userValues into a set to avoid duplicates
+    getOffsets(normalizeValue(itemValue), new Set(userValues)),
   );
 
   const firstEntry = offsets[0];

--- a/packages/ariakit-react-components/src/combobox/combobox-item-value.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item-value.tsx
@@ -24,6 +24,8 @@ function normalizeValue(value: string) {
 function getOffsets(string: string, values: Iterable<string>) {
   const offsets = [] as Array<[number, number]>;
   for (const value of values) {
+    // An empty value makes indexOf keep returning the end of the string.
+    if (!value) continue;
     let pos = 0;
     const length = value.length;
     let index = string.indexOf(value, pos);
@@ -58,7 +60,7 @@ function mergeOverlappingOffsets(offsets: Array<[number, number]>) {
 function splitValue(itemValue?: string | null, userValue?: string | string[]) {
   if (!itemValue) return itemValue;
   if (!userValue) return itemValue;
-  const userValues = toArray(userValue).map(normalizeValue).filter(Boolean);
+  const userValues = toArray(userValue).map(normalizeValue);
   const parts: ReactElement[] = [];
 
   const span = (value: string, autocomplete = false) => (


### PR DESCRIPTION
## Motivation

Fixes #6298.

`ComboboxItemValue` rendered overlapping user input matches as separate full slices. For example, typing `ana` in a combobox with a `Banana` item produced duplicated text like `Banaana`, which also corrupted the option's accessible name.

## Solution

Added a sandbox at `app/src/sandbox/combobox-item-value-6298` that reproduces the issue with real `ComboboxItem` and `ComboboxItemValue` usage. The repro includes both the primary browser test and a happy-dom duplicate.

Updated `ComboboxItemValue` to sort and merge overlapping match offsets before slicing the item value. The merge is strict, so overlapping ranges like the two `ana` matches in `Banana` become one highlighted `anana` span, while adjacent repeated matches such as the two `p` matches in `Apple` still render as separate `data-user-value` spans.

The offset scanner now skips empty normalized user values directly, so a truthy value that normalizes to an empty string cannot make `indexOf` loop forever on an empty needle.

## Workaround

Until this fix is released, consumers can pass explicit children to `ComboboxItemValue` and merge overlapping match ranges in userland:

```tsx
// TODO: Remove this workaround after
// https://github.com/ariakit/ariakit/issues/6298 is fixed.
function getHighlightedParts(itemValue: string, userValue: string) {
  const parts: ReactNode[] = [];
  const normalizedItem = itemValue.toLowerCase();
  const normalizedUser = userValue.toLowerCase();
  if (!normalizedUser) return itemValue;

  const ranges: Array<[number, number]> = [];
  let index = normalizedItem.indexOf(normalizedUser);

  while (index !== -1) {
    const end = index + normalizedUser.length;
    const lastRange = ranges[ranges.length - 1];
    if (lastRange && index < lastRange[1]) {
      lastRange[1] = Math.max(lastRange[1], end);
    } else {
      ranges.push([index, end]);
    }
    index = normalizedItem.indexOf(normalizedUser, index + 1);
  }

  let position = 0;
  for (const [start, end] of ranges) {
    if (start > position) {
      parts.push(
        <span key={parts.length} data-autocomplete-value="">
          {itemValue.slice(position, start)}
        </span>,
      );
    }
    parts.push(
      <span key={parts.length} data-user-value="">
        {itemValue.slice(start, end)}
      </span>,
    );
    position = end;
  }

  if (position < itemValue.length) {
    parts.push(
      <span key={parts.length} data-autocomplete-value="">
        {itemValue.slice(position)}
      </span>,
    );
  }

  return parts;
}

<Ariakit.ComboboxItem value={fruit}>
  <Ariakit.ComboboxItemValue>
    {getHighlightedParts(fruit, searchValue)}
  </Ariakit.ComboboxItemValue>
</Ariakit.ComboboxItem>;
```