### PR TITLE
Fix ToolbarContainer empty deletion focus

### DIFF
--- a/.changeset/300-toolbar-container-empty-delete.md
+++ b/.changeset/300-toolbar-container-empty-delete.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`ToolbarContainer`](https://ariakit.com/reference/toolbar-container) so pressing <kbd>Backspace</kbd> or <kbd>Delete</kbd> on a focused container with an empty text field no longer steals focus from the field on the next typed character.

--- a/app/src/sandbox/toolbar-container-6300/index.react.tsx
+++ b/app/src/sandbox/toolbar-container-6300/index.react.tsx
@@ -1,4 +1,39 @@
 import * as Ariakit from "@ariakit/react";
+import * as React from "react";
+
+interface FontFamilyContainerProps {
+  label: string;
+  defaultValue?: string;
+}
+
+function FontFamilyContainer({
+  label,
+  defaultValue,
+}: FontFamilyContainerProps) {
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  return (
+    <Ariakit.ToolbarContainer
+      aria-label={label}
+      role="group"
+      onKeyDown={(event) => {
+        if (event.key !== "Backspace" && event.key !== "Delete") return;
+        if (event.target !== event.currentTarget) return;
+        const input = inputRef.current;
+        if (!input) return;
+        if (input.value) return;
+        // TODO: Remove this workaround after
+        // https://github.com/ariakit/ariakit/issues/6300 is fixed.
+        event.preventDefault();
+        input.focus();
+      }}
+    >
+      <label>
+        {label} <input ref={inputRef} defaultValue={defaultValue} />
+      </label>
+    </Ariakit.ToolbarContainer>
+  );
+}
 
 export default function Example() {
   return (
@@ -8,11 +43,7 @@ export default function Example() {
         aria-label="Empty text formatting"
         style={{ display: "flex", gap: 8 }}
       >
-        <Ariakit.ToolbarContainer aria-label="Empty font family" role="group">
-          <label>
-            Empty font family <input />
-          </label>
-        </Ariakit.ToolbarContainer>
+        <FontFamilyContainer label="Empty font family" />
         <Ariakit.ToolbarItem>Apply</Ariakit.ToolbarItem>
       </Ariakit.Toolbar>
       <button type="button">Before filled toolbar</button>
@@ -20,11 +51,7 @@ export default function Example() {
         aria-label="Filled text formatting"
         style={{ display: "flex", gap: 8 }}
       >
-        <Ariakit.ToolbarContainer aria-label="Font family" role="group">
-          <label>
-            Font family <input defaultValue="Inter" />
-          </label>
-        </Ariakit.ToolbarContainer>
+        <FontFamilyContainer label="Font family" defaultValue="Inter" />
         <Ariakit.ToolbarItem>Apply</Ariakit.ToolbarItem>
       </Ariakit.Toolbar>
     </>

--- a/app/src/sandbox/toolbar-container-6300/index.react.tsx
+++ b/app/src/sandbox/toolbar-container-6300/index.react.tsx
@@ -1,39 +1,4 @@
 import * as Ariakit from "@ariakit/react";
-import * as React from "react";
-
-interface FontFamilyContainerProps {
-  label: string;
-  defaultValue?: string;
-}
-
-function FontFamilyContainer({
-  label,
-  defaultValue,
-}: FontFamilyContainerProps) {
-  const inputRef = React.useRef<HTMLInputElement>(null);
-
-  return (
-    <Ariakit.ToolbarContainer
-      aria-label={label}
-      role="group"
-      onKeyDown={(event) => {
-        if (event.key !== "Backspace" && event.key !== "Delete") return;
-        if (event.target !== event.currentTarget) return;
-        const input = inputRef.current;
-        if (!input) return;
-        if (input.value) return;
-        // TODO: Remove this workaround after
-        // https://github.com/ariakit/ariakit/issues/6300 is fixed.
-        event.preventDefault();
-        input.focus();
-      }}
-    >
-      <label>
-        {label} <input ref={inputRef} defaultValue={defaultValue} />
-      </label>
-    </Ariakit.ToolbarContainer>
-  );
-}
 
 export default function Example() {
   return (
@@ -43,7 +8,11 @@ export default function Example() {
         aria-label="Empty text formatting"
         style={{ display: "flex", gap: 8 }}
       >
-        <FontFamilyContainer label="Empty font family" />
+        <Ariakit.ToolbarContainer aria-label="Empty font family" role="group">
+          <label>
+            Empty font family <input />
+          </label>
+        </Ariakit.ToolbarContainer>
         <Ariakit.ToolbarItem>Apply</Ariakit.ToolbarItem>
       </Ariakit.Toolbar>
       <button type="button">Before filled toolbar</button>
@@ -51,7 +20,11 @@ export default function Example() {
         aria-label="Filled text formatting"
         style={{ display: "flex", gap: 8 }}
       >
-        <FontFamilyContainer label="Font family" defaultValue="Inter" />
+        <Ariakit.ToolbarContainer aria-label="Font family" role="group">
+          <label>
+            Font family <input defaultValue="Inter" />
+          </label>
+        </Ariakit.ToolbarContainer>
         <Ariakit.ToolbarItem>Apply</Ariakit.ToolbarItem>
       </Ariakit.Toolbar>
     </>

--- a/app/src/sandbox/toolbar-container-6300/index.react.tsx
+++ b/app/src/sandbox/toolbar-container-6300/index.react.tsx
@@ -1,0 +1,32 @@
+import * as Ariakit from "@ariakit/react";
+
+export default function Example() {
+  return (
+    <>
+      <button type="button">Before empty toolbar</button>
+      <Ariakit.Toolbar
+        aria-label="Empty text formatting"
+        style={{ display: "flex", gap: 8 }}
+      >
+        <Ariakit.ToolbarContainer aria-label="Empty font family" role="group">
+          <label>
+            Empty font family <input />
+          </label>
+        </Ariakit.ToolbarContainer>
+        <Ariakit.ToolbarItem>Apply</Ariakit.ToolbarItem>
+      </Ariakit.Toolbar>
+      <button type="button">Before filled toolbar</button>
+      <Ariakit.Toolbar
+        aria-label="Filled text formatting"
+        style={{ display: "flex", gap: 8 }}
+      >
+        <Ariakit.ToolbarContainer aria-label="Font family" role="group">
+          <label>
+            Font family <input defaultValue="Inter" />
+          </label>
+        </Ariakit.ToolbarContainer>
+        <Ariakit.ToolbarItem>Apply</Ariakit.ToolbarItem>
+      </Ariakit.Toolbar>
+    </>
+  );
+}

--- a/app/src/sandbox/toolbar-container-6300/test-browser.ts
+++ b/app/src/sandbox/toolbar-container-6300/test-browser.ts
@@ -1,0 +1,26 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6300
+withFramework(import.meta.dirname, async ({ test }) => {
+  for (const key of ["Backspace", "Delete"]) {
+    test(`keeps focus in the field after ${key} on an empty container field`, async ({
+      page,
+      q,
+    }) => {
+      const container = q.group("Empty font family");
+      const input = q.textbox("Empty font family");
+
+      await q.button("Before empty toolbar").focus();
+      await page.keyboard.press("Tab");
+
+      await test.expect(container).toBeFocused();
+      await page.keyboard.press(key);
+      await test.expect(input).toBeFocused();
+
+      await page.keyboard.press("a");
+
+      await test.expect(input).toHaveValue("a");
+      await test.expect(input).toBeFocused();
+    });
+  }
+});

--- a/app/src/sandbox/toolbar-container-6300/test-chrome.ts
+++ b/app/src/sandbox/toolbar-container-6300/test-chrome.ts
@@ -1,0 +1,28 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6300
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("keeps focus in the field after Backspace clears the field first", async ({
+    page,
+    q,
+  }) => {
+    const container = q.group("Font family");
+    const input = q.textbox("Font family");
+
+    await q.button("Before filled toolbar").focus();
+    await page.keyboard.press("Tab");
+
+    await test.expect(container).toBeFocused();
+    await page.keyboard.press("Backspace");
+    await test.expect(input).toHaveValue("");
+    await test.expect(container).toBeFocused();
+
+    await page.keyboard.press("Backspace");
+    await test.expect(input).toBeFocused();
+
+    await page.keyboard.press("a");
+
+    await test.expect(input).toHaveValue("a");
+    await test.expect(input).toBeFocused();
+  });
+});

--- a/packages/ariakit-react-components/src/composite/composite-container.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-container.tsx
@@ -182,8 +182,17 @@ export const useCompositeContainer = createHook<
           open();
           // We need to move focus back to the container as soon as the
           // delete/backspace key is captured by the text field.
-          const onInput = () => queueMicrotask(() => container.focus());
+          const cleanup = () => {
+            container.removeEventListener("input", onInput);
+            container.removeEventListener("keyup", cleanup);
+          };
+          const onInput = () => {
+            cleanup();
+            queueMicrotask(() => container.focus());
+          };
           container.addEventListener("input", onInput, { once: true });
+          container.addEventListener("keyup", cleanup, { once: true });
+          setTimeout(cleanup, 0);
         }
       }
     }

--- a/packages/ariakit-react-components/src/composite/composite-container.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-container.tsx
@@ -180,8 +180,15 @@ export const useCompositeContainer = createHook<
         if (!tabbable) return;
         if (isTextField(tabbable) || tabbable.isContentEditable) {
           open();
-          // We need to move focus back to the container as soon as the
-          // delete/backspace key is captured by the text field.
+          // Move focus back only when this delete/backspace changes the
+          // editable element. If it's already empty, no input event fires;
+          // leaving the listener armed would let the next input event steal
+          // focus back to the container (#6300).
+          //
+          // Remove the listener on keyup, before the next key can produce
+          // input. The timer is only a fallback for cases where keyup never
+          // reaches the container, such as when focus leaves while the key is
+          // held; relying on the timer alone can race the next input event.
           const cleanup = () => {
             container.removeEventListener("input", onInput);
             container.removeEventListener("keyup", cleanup);


### PR DESCRIPTION
## Motivation

Pressing <kbd>Backspace</kbd> or <kbd>Delete</kbd> on a focused [`ToolbarContainer`](https://ariakit.com/reference/toolbar-container) opens its inner field and registers a one-shot `input` listener to move focus back to the container after the deletion.

When the field is already empty, the key press does not fire an `input` event, so that listener stays armed. The next typed character lands in the field, then the stale listener moves focus back to the container.

Fixes #6300.

## Solution

This adds a focused sandbox repro under `app/src/sandbox/toolbar-container-6300/` and bounds the stale listener lifetime in `CompositeContainer`.

The repro covers:

- <kbd>Backspace</kbd> and <kbd>Delete</kbd> on an already-empty field across desktop browser projects.
- The reported filled-field sequence in Chrome, where the first <kbd>Backspace</kbd> clears `Inter`, the second <kbd>Backspace</kbd> used to arm the stale listener, and typing was interrupted.

The library fix removes the one-shot `input` listener on the matching <kbd>keyup</kbd>, with a zero-delay timer as a fallback. When the deletion actually changes the field value, the `input` handler still moves focus back to the container. When no `input` event fires because the field is empty, the listener is cleaned up before it can steal focus from the next typed character.

## Workaround

Intercept <kbd>Backspace</kbd> and <kbd>Delete</kbd> when the `ToolbarContainer` itself has focus and the inner field is empty. Preventing the default action makes Ariakit skip the built-in deletion path, so it does not register a stale `input` listener, then focus the field directly.

```tsx
const inputRef = React.useRef<HTMLInputElement>(null);

<Ariakit.ToolbarContainer
  aria-label="Font family"
  role="group"
  onKeyDown={(event) => {
    if (event.key !== "Backspace" && event.key !== "Delete") return;
    if (event.target !== event.currentTarget) return;
    const input = inputRef.current;
    if (!input) return;
    if (input.value) return;
    // TODO: Remove this workaround after
    // https://github.com/ariakit/ariakit/issues/6300 is fixed.
    event.preventDefault();
    input.focus();
  }}
>
  <label>
    Font family <input ref={inputRef} />
  </label>
</Ariakit.ToolbarContainer>
```
