### PR TITLE
Fix TagList freeze from getClosestFocusable infinite loop

### DIFF
--- a/.changeset/300-get-closest-focusable-loop.md
+++ b/.changeset/300-get-closest-focusable-loop.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/utils": patch
+---
+
+Fixed `getClosestFocusable` freezing the page in an infinite loop when walking up from an element that matched the focusable selector but was not actually focusable, such as a box-less `display: contents` element (reachable through `TagList`'s click handler).

--- a/app/src/sandbox/tag-list-6311/index.react.tsx
+++ b/app/src/sandbox/tag-list-6311/index.react.tsx
@@ -4,33 +4,15 @@ import { TagList } from "@ariakit/react-components/tag/tag-list";
 import { TagListLabel } from "@ariakit/react-components/tag/tag-list-label";
 import { TagProvider } from "@ariakit/react-components/tag/tag-provider";
 import { TagRemove } from "@ariakit/react-components/tag/tag-remove";
-import { useRef, useState } from "react";
+import { useState } from "react";
 
 // Reproduces https://github.com/ariakit/ariakit/issues/6311
 export default function Example() {
   const [values, setValues] = useState(["JavaScript", "React"]);
-  const inputRef = useRef<HTMLInputElement>(null);
   return (
     <TagProvider values={values} setValues={setValues}>
       <TagListLabel>Tags</TagListLabel>
-      <TagList
-        // TODO: Remove this workaround once the fix for
-        // https://github.com/ariakit/ariakit/issues/6311 is released.
-        onMouseDown={(event) => {
-          const target = event.target as HTMLElement;
-          // Let the built-in handler run when the click lands on a tag or the
-          // input, where getClosestFocusable terminates immediately. Tags use
-          // role="option" (or role="listitem" on touch devices).
-          if (target.closest("[role='option'], [role='listitem'], input")) {
-            return;
-          }
-          // Otherwise skip the built-in handler (which would hang walking past
-          // the display: contents wrapper) and replicate its outcome: focus
-          // the input. preventDefault keeps the mousedown from blurring it.
-          event.preventDefault();
-          inputRef.current?.focus();
-        }}
-      >
+      <TagList>
         {/* Layout-neutral wrapper (e.g. rendered by a sortable/grouping
             integration): display: contents keeps the tag list layout intact,
             and tabIndex makes it match the focusable selector. Because the
@@ -45,7 +27,7 @@ export default function Example() {
             </Tag>
           ))}
         </div>
-        <TagInput ref={inputRef} aria-label="New tag" />
+        <TagInput aria-label="New tag" />
       </TagList>
       <output>Tags: {values.length ? values.join(", ") : "none"}</output>
     </TagProvider>

--- a/app/src/sandbox/tag-list-6311/index.react.tsx
+++ b/app/src/sandbox/tag-list-6311/index.react.tsx
@@ -4,15 +4,33 @@ import { TagList } from "@ariakit/react-components/tag/tag-list";
 import { TagListLabel } from "@ariakit/react-components/tag/tag-list-label";
 import { TagProvider } from "@ariakit/react-components/tag/tag-provider";
 import { TagRemove } from "@ariakit/react-components/tag/tag-remove";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 // Reproduces https://github.com/ariakit/ariakit/issues/6311
 export default function Example() {
   const [values, setValues] = useState(["JavaScript", "React"]);
+  const inputRef = useRef<HTMLInputElement>(null);
   return (
     <TagProvider values={values} setValues={setValues}>
       <TagListLabel>Tags</TagListLabel>
-      <TagList>
+      <TagList
+        // TODO: Remove this workaround once the fix for
+        // https://github.com/ariakit/ariakit/issues/6311 is released.
+        onMouseDown={(event) => {
+          const target = event.target as HTMLElement;
+          // Let the built-in handler run when the click lands on a tag or the
+          // input, where getClosestFocusable terminates immediately. Tags use
+          // role="option" (or role="listitem" on touch devices).
+          if (target.closest("[role='option'], [role='listitem'], input")) {
+            return;
+          }
+          // Otherwise skip the built-in handler (which would hang walking past
+          // the display: contents wrapper) and replicate its outcome: focus
+          // the input. preventDefault keeps the mousedown from blurring it.
+          event.preventDefault();
+          inputRef.current?.focus();
+        }}
+      >
         {/* Layout-neutral wrapper (e.g. rendered by a sortable/grouping
             integration): display: contents keeps the tag list layout intact,
             and tabIndex makes it match the focusable selector. Because the
@@ -27,7 +45,7 @@ export default function Example() {
             </Tag>
           ))}
         </div>
-        <TagInput aria-label="New tag" />
+        <TagInput ref={inputRef} aria-label="New tag" />
       </TagList>
       <output>Tags: {values.length ? values.join(", ") : "none"}</output>
     </TagProvider>

--- a/app/src/sandbox/tag-list-6311/index.react.tsx
+++ b/app/src/sandbox/tag-list-6311/index.react.tsx
@@ -1,0 +1,35 @@
+import { Tag } from "@ariakit/react-components/tag/tag";
+import { TagInput } from "@ariakit/react-components/tag/tag-input";
+import { TagList } from "@ariakit/react-components/tag/tag-list";
+import { TagListLabel } from "@ariakit/react-components/tag/tag-list-label";
+import { TagProvider } from "@ariakit/react-components/tag/tag-provider";
+import { TagRemove } from "@ariakit/react-components/tag/tag-remove";
+import { useState } from "react";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6311
+export default function Example() {
+  const [values, setValues] = useState(["JavaScript", "React"]);
+  return (
+    <TagProvider values={values} setValues={setValues}>
+      <TagListLabel>Tags</TagListLabel>
+      <TagList>
+        {/* Layout-neutral wrapper (e.g. rendered by a sortable/grouping
+            integration): display: contents keeps the tag list layout intact,
+            and tabIndex makes it match the focusable selector. Because the
+            wrapper generates no box, isFocusable still rejects it — the exact
+            selector/focusability mismatch that froze getClosestFocusable. */}
+        <div tabIndex={-1} style={{ display: "contents" }}>
+          <span>Frontend:</span>
+          {values.map((value) => (
+            <Tag key={value} value={value}>
+              {value}
+              <TagRemove />
+            </Tag>
+          ))}
+        </div>
+        <TagInput aria-label="New tag" />
+      </TagList>
+      <output>Tags: {values.length ? values.join(", ") : "none"}</output>
+    </TagProvider>
+  );
+}

--- a/app/src/sandbox/tag-list-6311/test-browser.ts
+++ b/app/src/sandbox/tag-list-6311/test-browser.ts
@@ -1,0 +1,24 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6311
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("focuses the input and stays responsive when clicking non-focusable content inside a display:contents wrapper", async ({
+    page,
+    q,
+  }) => {
+    // Clicking the non-focusable label used to freeze the page: TagList's
+    // mousedown handler calls getClosestFocusable, which spun forever on the
+    // display: contents wrapper that matches the focusable selector but fails
+    // isFocusable. A frozen renderer makes this click time out.
+    await q.text("Frontend:").click();
+
+    // Focus moves to the tag input (TagList's documented mousedown behavior).
+    await test.expect(q.textbox("New tag")).toBeFocused();
+
+    // The page is still responsive: a new tag can be added through the input.
+    await page.keyboard.type("TypeScript,");
+    await test
+      .expect(q.text("Tags: JavaScript, React, TypeScript"))
+      .toBeVisible();
+  });
+});

--- a/packages/ariakit-utils/src/focus.test.ts
+++ b/packages/ariakit-utils/src/focus.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, expect, test } from "vitest";
-import { getFirstTabbableIn, isTabbable } from "./focus.ts";
+import {
+  getClosestFocusable,
+  getFirstTabbableIn,
+  isTabbable,
+} from "./focus.ts";
 
 function setVisible(element: Element) {
   Object.defineProperty(element, "checkVisibility", {
@@ -140,4 +144,34 @@ test("getFirstTabbableIn returns null for empty containers", () => {
 
   expect(getFirstTabbableIn(container)).toBe(null);
   expect(getFirstTabbableIn(container, true, true)).toBe(null);
+});
+
+test("getClosestFocusable walks past a selector-matching but non-focusable ancestor", () => {
+  const button = document.createElement("button");
+  // Box-less wrapper (e.g. display: contents) that matches the focusable
+  // selector via [tabindex] but is reported as not visible, so isFocusable
+  // rejects it. Self-inclusive closest() used to re-return it forever.
+  const wrapper = document.createElement("div");
+  wrapper.tabIndex = -1;
+  const inner = document.createElement("span");
+  wrapper.append(inner);
+  button.append(wrapper);
+  document.body.append(button);
+
+  setVisible(button);
+  setNotVisible(wrapper);
+
+  expect(getClosestFocusable(inner)).toBe(button);
+});
+
+test("getClosestFocusable returns null when no focusable ancestor exists", () => {
+  const wrapper = document.createElement("div");
+  wrapper.tabIndex = -1;
+  const inner = document.createElement("span");
+  wrapper.append(inner);
+  document.body.append(wrapper);
+
+  setNotVisible(wrapper);
+
+  expect(getClosestFocusable(inner)).toBe(null);
 });

--- a/packages/ariakit-utils/src/focus.ts
+++ b/packages/ariakit-utils/src/focus.ts
@@ -343,8 +343,13 @@ export function getPreviousTabbable(
  * Returns the closest focusable element.
  */
 export function getClosestFocusable(element?: HTMLElement | null) {
+  // Start each search from the parent so the loop always advances strictly
+  // upward. The current element was already rejected by `isFocusable`, and the
+  // self-inclusive `closest` would otherwise re-return a selector-matching but
+  // non-focusable element (e.g. a box-less `display: contents` ancestor),
+  // looping forever.
   while (element && !isFocusable(element)) {
-    element = element.closest<HTMLElement>(selector);
+    element = element.parentElement?.closest<HTMLElement>(selector) ?? null;
   }
   return element || null;
 }


### PR DESCRIPTION
## Motivation

Clicking non-focusable content inside a [`TagList`](https://ariakit.com/reference/tag-list) can freeze the page. `TagList`'s default `onMouseDown` handler calls `getClosestFocusable(event.target)` on every click, and `getClosestFocusable` walks up the tree like this:

```ts
export function getClosestFocusable(element?: HTMLElement | null) {
  while (element && !isFocusable(element)) {
    element = element.closest<HTMLElement>(selector);
  }
  return element || null;
}
```

`Element.prototype.closest` tests the element itself before walking up. So whenever the loop lands on an element that matches the focusable `selector` but is rejected by `isFocusable`, `element.closest(selector)` returns that exact same element and the `while` loop spins forever — a synchronous infinite loop that blocks the renderer until the browser kills the tab.

The mismatch is real: `isFocusable` rejects a selector-matching element when it is not visible (`isVisible` delegates to `checkVisibility()`, which is `false` for box-less elements such as `display: contents`) or when it has an `[inert]` ancestor. So a layout-neutral `display: contents` wrapper carrying a `tabIndex` (e.g. rendered by a sortable/grouping integration) inside a `TagList` freezes the page on the first `mousedown` over any non-focusable content it wraps.

```tsx
<TagList>
  {/* display: contents matches [tabindex] but isFocusable rejects it */}
  <div tabIndex={-1} style={{ display: "contents" }}>
    <span>Frontend:</span>
    {/* ...tags... */}
  </div>
  <TagInput aria-label="New tag" />
</TagList>
```

Closes #6311.

## Solution

Make the loop always advance strictly upward by starting each `closest()` search from the parent. The current element was already rejected by `isFocusable` in the loop condition, so re-testing it via the self-inclusive `closest()` can only return the same rejected node:

```diff
 export function getClosestFocusable(element?: HTMLElement | null) {
   while (element && !isFocusable(element)) {
-    element = element.closest<HTMLElement>(selector);
+    element = element.parentElement?.closest<HTMLElement>(selector) ?? null;
   }
   return element || null;
 }
```

This is behavior-identical in every previously terminating case: a focusable start element is still returned as-is (the loop never runs), and for a non-matching element `element.closest(selector)` and `element.parentElement?.closest(selector)` resolve to the same nearest matching ancestor. Termination is now guaranteed because each iteration moves to a strict ancestor and `parentElement` is `null` at the document/shadow/fragment root.

## Tests

`app/src/sandbox/tag-list-6311/` reproduces the issue, and its cross-browser Playwright test clicks the non-focusable label and expects focus to move to the tag input while the page stays responsive. The test fails on the current code (the click times out against the frozen renderer) in chrome, firefox, and safari, and passes with the fix.

A happy-dom duplicate is intentionally omitted: the trigger needs real-browser `checkVisibility() === false` for box-less `display: contents` elements, which happy-dom does not model.

## Workaround

Until the fix is released, the cleanest option is to avoid the trigger DOM shape: don't put focusable-selector attributes (`tabindex`, `href`, `contenteditable`, …) on elements that generate no box (`display: contents`). Move the `tabIndex` to a real box element instead.

If the wrapper genuinely needs to stay box-less and focusable, intercept `TagList`'s `onMouseDown` to skip the built-in handler for clicks on non-focusable content and replicate its outcome by focusing the input directly. This assumes the list contains Ariakit `Tag`s plus the `TagInput`:

```tsx
const inputRef = useRef<HTMLInputElement>(null);

<TagList
  // TODO: Remove once the fix for
  // https://github.com/ariakit/ariakit/issues/6311 is released.
  onMouseDown={(event) => {
    const target = event.target as HTMLElement;
    // Let the built-in handler run when the click lands on a tag or the
    // input, where getClosestFocusable terminates immediately. Tags use
    // role="option" (or role="listitem" on touch devices).
    if (target.closest("[role='option'], [role='listitem'], input")) return;
    // Otherwise skip the built-in handler (which would hang walking past the
    // display: contents wrapper) and replicate its outcome: focus the input.
    // preventDefault keeps the mousedown from blurring it.
    event.preventDefault();
    inputRef.current?.focus();
  }}
>
  {/* ... */}
  <TagInput ref={inputRef} aria-label="New tag" />
</TagList>
```
