### PR TITLE
Fix scroll container detection for elements inside iframes

### DIFF
--- a/.changeset/300-composite-iframe-paging.md
+++ b/.changeset/300-composite-iframe-paging.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Composite`](https://ariakit.com/reference/composite) keyboard paging and [`Combobox`](https://ariakit.com/reference/combobox) scroll behavior for elements rendered inside a same-origin iframe.

--- a/.changeset/300-scrolling-element-iframe.md
+++ b/.changeset/300-scrolling-element-iframe.md
@@ -2,4 +2,4 @@
 "@ariakit/utils": patch
 ---
 
-Fixed `getScrollingElement` to resolve the scroll container from the element's own document instead of the top-level page, correcting [`Composite`](https://ariakit.com/reference/composite) keyboard paging and [`Combobox`](https://ariakit.com/reference/combobox) scroll behavior for elements rendered inside a same-origin iframe.
+Fixed `getScrollingElement` to resolve the scroll container from the element's own document instead of the top-level page, so scroll-aware behavior works correctly for elements rendered inside a same-origin iframe.

--- a/.changeset/300-scrolling-element-iframe.md
+++ b/.changeset/300-scrolling-element-iframe.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/utils": patch
+---
+
+Fixed `getScrollingElement` to resolve the scroll container from the element's own document instead of the top-level page, correcting [`Composite`](https://ariakit.com/reference/composite) keyboard paging and [`Combobox`](https://ariakit.com/reference/combobox) scroll behavior for elements rendered inside a same-origin iframe.

--- a/app/src/sandbox/composite-iframe-6312/index.react.tsx
+++ b/app/src/sandbox/composite-iframe-6312/index.react.tsx
@@ -10,6 +10,11 @@ function EmbeddedList() {
       role="toolbar"
       aria-orientation="vertical"
       aria-label="Embedded items"
+      // Workaround for https://github.com/ariakit/ariakit/issues/6312: give an
+      // ancestor inside the iframe a bounded height and `overflow-y: auto` so
+      // `getScrollingElement` finds an in-frame scroller before falling back to
+      // the outer page's document.
+      style={{ height: "100vh", overflowY: "auto" }}
     >
       {Array.from({ length: 100 }, (_, index) => (
         <Ariakit.CompositeItem

--- a/app/src/sandbox/composite-iframe-6312/index.react.tsx
+++ b/app/src/sandbox/composite-iframe-6312/index.react.tsx
@@ -1,0 +1,57 @@
+import * as Ariakit from "@ariakit/react";
+import { useEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
+
+function EmbeddedList() {
+  const composite = Ariakit.useCompositeStore({ orientation: "vertical" });
+  return (
+    <Ariakit.Composite
+      store={composite}
+      role="toolbar"
+      aria-orientation="vertical"
+      aria-label="Embedded items"
+    >
+      {Array.from({ length: 100 }, (_, index) => (
+        <Ariakit.CompositeItem
+          key={index}
+          style={{
+            boxSizing: "border-box",
+            display: "block",
+            height: 50,
+            margin: 0,
+            width: "100%",
+          }}
+        >
+          Item {index + 1}
+        </Ariakit.CompositeItem>
+      ))}
+    </Ariakit.Composite>
+  );
+}
+
+export default function Example() {
+  const [iframe, setIframe] = useState<HTMLIFrameElement | null>(null);
+
+  useEffect(() => {
+    if (!iframe) return;
+    // Same-origin embedded widget (react-frame-component style): the list is
+    // taller than the iframe viewport and there's no overflow container inside,
+    // so the iframe's own document is the scroller.
+    const doc = iframe.contentDocument;
+    if (!doc?.body) return;
+    doc.body.style.margin = "0";
+    const root = createRoot(doc.body);
+    root.render(<EmbeddedList />);
+    return () => {
+      setTimeout(() => root.unmount());
+    };
+  }, [iframe]);
+
+  return (
+    <iframe
+      ref={setIframe}
+      title="Embedded list"
+      style={{ border: "1px solid", display: "block", height: 220, width: 320 }}
+    />
+  );
+}

--- a/app/src/sandbox/composite-iframe-6312/index.react.tsx
+++ b/app/src/sandbox/composite-iframe-6312/index.react.tsx
@@ -10,11 +10,6 @@ function EmbeddedList() {
       role="toolbar"
       aria-orientation="vertical"
       aria-label="Embedded items"
-      // Workaround for https://github.com/ariakit/ariakit/issues/6312: give an
-      // ancestor inside the iframe a bounded height and `overflow-y: auto` so
-      // `getScrollingElement` finds an in-frame scroller before falling back to
-      // the outer page's document.
-      style={{ height: "100vh", overflowY: "auto" }}
     >
       {Array.from({ length: 100 }, (_, index) => (
         <Ariakit.CompositeItem

--- a/app/src/sandbox/composite-iframe-6312/test-browser.ts
+++ b/app/src/sandbox/composite-iframe-6312/test-browser.ts
@@ -1,0 +1,22 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// https://github.com/ariakit/ariakit/issues/6312
+withFramework(import.meta.dirname, async ({ test, query }) => {
+  test("PageDown pages by the iframe's own scroller, not the outer page", async ({
+    page,
+  }) => {
+    // The composite lives inside a same-origin iframe whose own document is the
+    // scroller (no in-frame overflow container).
+    const frame = query(page.frameLocator("iframe[title='Embedded list']"));
+
+    await frame.button("Item 1").click();
+    await test.expect(frame.button("Item 1")).toBeFocused();
+
+    await page.keyboard.press("PageDown");
+
+    // With a 220px iframe viewport and 50px items, one page down lands on
+    // Item 7. Before the fix, paging used the outer page's much taller viewport
+    // and jumped far past it.
+    await test.expect(frame.button("Item 7")).toBeFocused();
+  });
+});

--- a/packages/ariakit-utils/src/dom.test.ts
+++ b/packages/ariakit-utils/src/dom.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, expect, test } from "vitest";
 import {
+  getScrollingElement,
   getTextboxSelection,
   getTextboxValue,
   isTextField,
@@ -56,6 +57,25 @@ test("reads selection offsets from contenteditable elements", () => {
 
   expect(getTextboxValue(editor)).toBe("hello world");
   expect(getTextboxSelection(editor)).toEqual({ start: 3, end: 8 });
+});
+
+test("getScrollingElement falls back to the element's own document, not the global one", () => {
+  const iframe = document.createElement("iframe");
+  document.body.append(iframe);
+  const frameDoc = iframe.contentDocument;
+  expect(frameDoc).toBeTruthy();
+  if (!frameDoc?.body) {
+    throw new Error("Expected iframe document body");
+  }
+
+  // The element lives inside the iframe with no in-frame overflow container, so
+  // the ancestor walk bottoms out at the document fallback. That fallback must
+  // resolve against the iframe's own document, not the top-level page's.
+  const item = frameDoc.createElement("div");
+  frameDoc.body.append(item);
+
+  const scroller = getScrollingElement(item);
+  expect(scroller?.ownerDocument).toBe(frameDoc);
 });
 
 test("setSelectionRange skips input types that do not support text selection", () => {

--- a/packages/ariakit-utils/src/dom.ts
+++ b/packages/ariakit-utils/src/dom.ts
@@ -322,10 +322,17 @@ export function getScrollingElement(
     const { overflowX } = getComputedStyle(element);
     if (isScrollableOverflow(overflowX)) return element;
   }
+  // When no scrollable ancestor is found, fall back to the scrolling element of
+  // the element's own document rather than the global one. For an element
+  // inside an iframe, `parentElement` never crosses the frame boundary, so the
+  // recursion bottoms out at the iframe's `<html>` and would otherwise resolve
+  // against the top-level page's scroller. `getDocument` returns the same global
+  // `document` for top-level elements, so this leaves the common case unchanged.
+  const doc = getDocument(element);
   return (
     getScrollingElement(element.parentElement) ||
-    document.scrollingElement ||
-    document.body
+    doc.scrollingElement ||
+    doc.body
   );
 }
 


### PR DESCRIPTION
## Motivation

When a composite widget is rendered inside a same-origin iframe (embedded widgets, sandboxed preview panes, `react-frame-component`-style hosting) and the iframe's own document is the scroll container — there's no `overflow: auto/scroll` ancestor inside the frame — pressing <kbd>PageDown</kbd>/<kbd>PageUp</kbd> on a [`CompositeItem`](https://ariakit.com/reference/composite-item) moves focus by a page computed from the **top-level page's viewport** instead of the iframe's. In a 720px-tall window with a 220px-tall iframe, PageDown from Item 1 (50px items) jumps far past one iframe page instead of landing about one iframe page down.

The root cause is in `getScrollingElement` (`@ariakit/utils`): when the ancestor walk finds no overflow container, it falls back to the **global** `document.scrollingElement` rather than the element's own document. For an element inside an iframe, the walk reaches the iframe's `<html>` (computed `overflow: visible`, so the check fails), the recursion bottoms out at `null`, and the outer page's scrolling element is returned — even though the file already has `getDocument` for exactly this, and other helpers there are already frame-aware (e.g. `getActiveElement`).

No caller normalizes the bad result, so several behaviors degrade in the iframe scenario:

- Composite PageUp/PageDown computes the page size and offset from the wrong scroller.
- `Combobox` attaches its "user scrolled" guards (`wheel`/`touchmove`/`scroll`) to the outer page's `<html>`, which never receives the iframe's scroll events.
- `isPartiallyHidden`/`scrollIntoViewIfNeeded` compare the item's iframe-relative rect against the outer scroller's rect, mixing coordinate spaces.
- The experimental `CollectionRenderer` resolves its virtualization viewport from the wrong scroller's `ownerDocument`.

## Solution

Resolve the document fallback in `getScrollingElement` against the element's own document with `getDocument` (already defined in the same file and the established idiom for the other element-relative helpers there). Because `parentElement` never crosses frame boundaries, the recursion always stays within one document, so this precisely targets the fallback:

```ts
const doc = getDocument(element);
return (
  getScrollingElement(element.parentElement) ||
  doc.scrollingElement ||
  doc.body
);
```

For elements in the top-level document, `getDocument` returns the same global `document`, so mainline behavior is unchanged. All consumers (composite paging, combobox scroll guards, `isPartiallyHidden`, `CollectionRenderer`) improve without modification.

## Workaround

Until this fix is released, give the composite — or any ancestor inside the iframe document — a bounded height and `overflow-y: auto`, so `getScrollingElement` finds an in-frame scroller before reaching the document fallback:

```tsx
<Ariakit.Composite
  store={composite}
  // TODO: Remove once https://github.com/ariakit/ariakit/issues/6312 is fixed.
  style={{ height: "100vh", overflowY: "auto" }}
>
  {/* ... */}
</Ariakit.Composite>
```

## Tests

- `app/src/sandbox/composite-iframe-6312/` — a Composite rendered into a same-origin iframe whose own document is the scroller. The browser test clicks Item 1, presses PageDown, and asserts focus lands on Item 7 (one iframe page down for a 220px viewport with 50px items). It fails before the fix because paging used the outer page's much taller viewport.
- `packages/ariakit-utils/src/dom.test.ts` — a happy-dom unit test asserting `getScrollingElement` for an element inside an iframe resolves to the iframe's own document, not the global one.

Fixes #6312
