### PR TITLE
Fix reopened portaled Popover focus when a hidden element comes first

### DIFF
--- a/.changeset/300-popover-reopen-focus.md
+++ b/.changeset/300-popover-reopen-focus.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed a portaled [`Popover`](https://ariakit.com/reference/popover) or [`Dialog`](https://ariakit.com/reference/dialog) not receiving focus when reopened while a non-focusable element (such as a `display: none` file input) comes before the first focusable element in its content. This also fixes [`FormLabel`](https://ariakit.com/reference/form-label) focusing such a hidden element instead of the visible control.

--- a/.changeset/300-tabbable-focusable-fallback.md
+++ b/.changeset/300-tabbable-focusable-fallback.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/utils": patch
+---
+
+Fixed the `fallbackToFocusable` option of `getFirstTabbableIn`, `getAllTabbableIn`, and `getLastTabbableIn` to return focusable elements instead of every raw selector match, so the fallback no longer yields non-focusable elements such as a `display: none` input.

--- a/app/src/sandbox/popover-6310/index.react.tsx
+++ b/app/src/sandbox/popover-6310/index.react.tsx
@@ -18,24 +18,12 @@ import { useRef } from "react";
 // fallback resolves to the hidden file input, so focusing it is a no-op.
 export default function Example() {
   const fileInputRef = useRef<HTMLInputElement>(null);
-  // Workaround for https://github.com/ariakit/ariakit/issues/6310: point
-  // initialFocus at the visible control so autofocus bypasses the broken
-  // focusable fallback. Focusing the button also restores its tab order.
-  const chooseFileRef = useRef<HTMLButtonElement>(null);
   return (
     <Ariakit.PopoverProvider>
       <Ariakit.PopoverDisclosure>Attachments</Ariakit.PopoverDisclosure>
-      <Ariakit.Popover
-        portal
-        aria-label="Attachments"
-        initialFocus={chooseFileRef}
-      >
+      <Ariakit.Popover portal aria-label="Attachments">
         <input ref={fileInputRef} type="file" style={{ display: "none" }} />
-        <button
-          ref={chooseFileRef}
-          type="button"
-          onClick={() => fileInputRef.current?.click()}
-        >
+        <button type="button" onClick={() => fileInputRef.current?.click()}>
           Choose file
         </button>
       </Ariakit.Popover>

--- a/app/src/sandbox/popover-6310/index.react.tsx
+++ b/app/src/sandbox/popover-6310/index.react.tsx
@@ -18,12 +18,24 @@ import { useRef } from "react";
 // fallback resolves to the hidden file input, so focusing it is a no-op.
 export default function Example() {
   const fileInputRef = useRef<HTMLInputElement>(null);
+  // Workaround for https://github.com/ariakit/ariakit/issues/6310: point
+  // initialFocus at the visible control so autofocus bypasses the broken
+  // focusable fallback. Focusing the button also restores its tab order.
+  const chooseFileRef = useRef<HTMLButtonElement>(null);
   return (
     <Ariakit.PopoverProvider>
       <Ariakit.PopoverDisclosure>Attachments</Ariakit.PopoverDisclosure>
-      <Ariakit.Popover portal aria-label="Attachments">
+      <Ariakit.Popover
+        portal
+        aria-label="Attachments"
+        initialFocus={chooseFileRef}
+      >
         <input ref={fileInputRef} type="file" style={{ display: "none" }} />
-        <button type="button" onClick={() => fileInputRef.current?.click()}>
+        <button
+          ref={chooseFileRef}
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+        >
           Choose file
         </button>
       </Ariakit.Popover>

--- a/app/src/sandbox/popover-6310/index.react.tsx
+++ b/app/src/sandbox/popover-6310/index.react.tsx
@@ -1,0 +1,32 @@
+import * as Ariakit from "@ariakit/react";
+import { useRef } from "react";
+
+// See https://github.com/ariakit/ariakit/issues/6310
+//
+// Reproduces a portaled popover whose content starts with a non-focusable
+// element (the common custom file upload pattern: a `display: none`
+// `<input type="file">` followed by a visible "Choose file" button).
+// To see the bug:
+//   1. Click "Attachments": the popover opens and "Choose file" is focused
+//      (correct).
+//   2. Click "Attachments" again to close the popover. Closing moves focus to
+//      the disclosure, which makes the portal disable focus inside it, leaving
+//      "Choose file" with tabindex="-1".
+//   3. Click "Attachments" once more to reopen the popover.
+// Before the fix, reopening leaves focus on the disclosure: autofocus finds no
+// tabbable element (the button is still tabindex="-1") and the focusable
+// fallback resolves to the hidden file input, so focusing it is a no-op.
+export default function Example() {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  return (
+    <Ariakit.PopoverProvider>
+      <Ariakit.PopoverDisclosure>Attachments</Ariakit.PopoverDisclosure>
+      <Ariakit.Popover portal aria-label="Attachments">
+        <input ref={fileInputRef} type="file" style={{ display: "none" }} />
+        <button type="button" onClick={() => fileInputRef.current?.click()}>
+          Choose file
+        </button>
+      </Ariakit.Popover>
+    </Ariakit.PopoverProvider>
+  );
+}

--- a/app/src/sandbox/popover-6310/test-browser.ts
+++ b/app/src/sandbox/popover-6310/test-browser.ts
@@ -1,0 +1,35 @@
+// See https://github.com/ariakit/ariakit/issues/6310
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("reopened portaled popover focuses the first focusable element when a hidden element comes first", async ({
+    q,
+  }) => {
+    // First open: focus correctly lands on the visible button, skipping the
+    // hidden file input that comes before it in the DOM.
+    await q.button("Attachments").click();
+    await test.expect(q.dialog("Attachments")).toBeVisible();
+    await test.expect(q.button("Choose file")).toBeFocused();
+
+    // Closing via the disclosure moves focus out of the portal, which disables
+    // focus inside it and leaves "Choose file" with tabindex="-1". The slow
+    // click reproduces a real click's gap between mousedown (focus leaves the
+    // portal) and mouseup (the popover closes), so the disable runs while the
+    // popover is still visible, like the manual reproduction.
+    await q.button("Attachments").click({ delay: 200 });
+    await test.expect(q.dialog("Attachments")).not.toBeVisible();
+    await test.expect(q.button("Attachments")).toBeFocused();
+    // Guard the bug precondition: the reopen only exercises the broken fallback
+    // when no element inside is tabbable, so confirm the disable actually ran.
+    await test
+      .expect(q.button("Choose file", { includeHidden: true }))
+      .toHaveAttribute("tabindex", "-1");
+
+    // Reopening must move focus to the visible button again, exactly like the
+    // first open did. Before the fix, focus stayed on the disclosure because the
+    // focusable fallback resolved to the hidden file input.
+    await q.button("Attachments").click();
+    await test.expect(q.dialog("Attachments")).toBeVisible();
+    await test.expect(q.button("Choose file")).toBeFocused();
+  });
+});

--- a/app/src/sandbox/popover-6310/test.ts
+++ b/app/src/sandbox/popover-6310/test.ts
@@ -1,0 +1,30 @@
+// See https://github.com/ariakit/ariakit/issues/6310
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+test("reopened portaled popover focuses the first focusable element when a hidden element comes first", async () => {
+  // First open: focus lands on the visible button, skipping the hidden file
+  // input that comes before it in the DOM.
+  await click(q.button.ensure("Attachments"));
+  expect(q.dialog("Attachments")).toBeVisible();
+  expect(q.button("Choose file")).toHaveFocus();
+
+  // Closing via the disclosure moves focus out of the portal, which disables
+  // focus inside it and leaves "Choose file" with tabindex="-1". The click
+  // helper's dwell between mousedown and mouseup lets the disable run while the
+  // popover is still visible, like a real click's gap.
+  await click(q.button.ensure("Attachments"));
+  // Wait for the close to settle: focus returns to the disclosure once the
+  // popover hides.
+  await expect.poll(q.button.lazy("Attachments")).toHaveFocus();
+  // Guard the bug precondition: the reopen only exercises the broken fallback
+  // when no element inside is tabbable, so confirm the disable actually ran.
+  expect(q.button.hidden("Choose file")).toHaveAttribute("tabindex", "-1");
+
+  // Reopening must move focus to the visible button again. Before the fix, focus
+  // stayed on the disclosure because the focusable fallback resolved to the
+  // hidden file input and focusing it is a no-op.
+  await click(q.button.ensure("Attachments"));
+  expect(q.dialog("Attachments")).toBeVisible();
+  expect(q.button("Choose file")).toHaveFocus();
+});

--- a/packages/ariakit-utils/src/focus.test.ts
+++ b/packages/ariakit-utils/src/focus.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, expect, test } from "vitest";
-import { getFirstTabbableIn, isTabbable } from "./focus.ts";
+import {
+  getAllTabbableIn,
+  getFirstTabbableIn,
+  getLastTabbableIn,
+  isTabbable,
+} from "./focus.ts";
 
 function setVisible(element: Element) {
   Object.defineProperty(element, "checkVisibility", {
@@ -129,9 +134,77 @@ test("getFirstTabbableIn falls back to the first focusable candidate", () => {
   setVisible(negative);
 
   // No tabbable elements: without the fallback we get null; with the
-  // fallback we get the first element matching the focusable selector.
+  // fallback we get the first focusable element.
   expect(getFirstTabbableIn(container)).toBe(null);
   expect(getFirstTabbableIn(container, false, true)).toBe(negative);
+});
+
+test("getFirstTabbableIn fallback skips non-focusable candidates", () => {
+  const container = document.createElement("div");
+  container.innerHTML = `
+    <button id="hidden" tabindex="-1">Hidden</button>
+    <button id="visible" tabindex="-1">Visible</button>
+  `;
+  document.body.append(container);
+
+  const hidden = container.querySelector("#hidden");
+  const visible = container.querySelector("#visible");
+  if (!hidden || !visible) {
+    throw new Error("Expected elements");
+  }
+
+  setNotVisible(hidden);
+  setVisible(visible);
+
+  // No tabbable elements (both are tabindex="-1"). The fallback must skip the
+  // non-focusable hidden button and return the first focusable one, not just
+  // the first selector match.
+  expect(getFirstTabbableIn(container, false, true)).toBe(visible);
+});
+
+test("getAllTabbableIn fallback returns only focusable candidates", () => {
+  const container = document.createElement("div");
+  container.innerHTML = `
+    <button id="hidden" tabindex="-1">Hidden</button>
+    <button id="visible" tabindex="-1">Visible</button>
+  `;
+  document.body.append(container);
+
+  const hidden = container.querySelector("#hidden");
+  const visible = container.querySelector("#visible");
+  if (!hidden || !visible) {
+    throw new Error("Expected elements");
+  }
+
+  setNotVisible(hidden);
+  setVisible(visible);
+
+  // No tabbable elements (both are tabindex="-1"). The fallback must drop the
+  // non-focusable hidden button instead of returning every selector match.
+  expect(getAllTabbableIn(container, false, true)).toEqual([visible]);
+});
+
+test("getLastTabbableIn fallback returns the last focusable candidate", () => {
+  const container = document.createElement("div");
+  container.innerHTML = `
+    <button id="visible" tabindex="-1">Visible</button>
+    <button id="hidden" tabindex="-1">Hidden</button>
+  `;
+  document.body.append(container);
+
+  const visible = container.querySelector("#visible");
+  const hidden = container.querySelector("#hidden");
+  if (!visible || !hidden) {
+    throw new Error("Expected elements");
+  }
+
+  setVisible(visible);
+  setNotVisible(hidden);
+
+  // No tabbable elements (both are tabindex="-1"). The fallback must skip the
+  // trailing non-focusable hidden button and return the last focusable one,
+  // not just the last selector match.
+  expect(getLastTabbableIn(container, false, true)).toBe(visible);
 });
 
 test("getFirstTabbableIn returns null for empty containers", () => {

--- a/packages/ariakit-utils/src/focus.ts
+++ b/packages/ariakit-utils/src/focus.ts
@@ -151,7 +151,10 @@ export function getAllTabbableIn(
   });
 
   if (!tabbableElements.length && fallbackToFocusable) {
-    return elements;
+    // Filter the fallback to focusable elements (and expand iframes like the
+    // tabbable path) so callers don't get non-focusable matches such as a
+    // `display: none` input, which a `focus()` call silently ignores.
+    return getAllFocusableIn(container);
   }
   return tabbableElements;
 }
@@ -207,7 +210,10 @@ export function getFirstTabbableIn(
     return element;
   }
   if (fallbackToFocusable) {
-    return elements[0] || null;
+    // Filter the fallback to focusable elements so callers don't get a
+    // non-focusable match such as a `display: none` input, which a `focus()`
+    // call silently ignores.
+    return getFirstFocusableIn(container);
   }
   return null;
 }


### PR DESCRIPTION
## Motivation

A portaled [`Popover`](https://ariakit.com/reference/popover) (default [`preserveTabOrder`](https://ariakit.com/reference/popover#preservetaborder)) whose content starts with a non-focusable selector match — e.g. the common custom file upload pattern of a `display: none` `<input type="file">` followed by a visible "Choose file" button — focuses correctly on the first open. But after closing it from the disclosure and reopening, the popover opens without receiving focus: `document.activeElement` stays on the disclosure and the visible button is left with the `tabindex="-1"` that `preserveTabOrder` set on it, so the content isn't even reachable with <kbd>Tab</kbd>.

```tsx
<Ariakit.Popover portal aria-label="Attachments">
  <input type="file" style={{ display: "none" }} />
  <button type="button">Choose file</button>
</Ariakit.Popover>
```

Under the hood, closing via the disclosure moves focus out of the portal, so the Portal's `focusout` handler runs `disableFocusIn` on an animation frame and sets `tabindex="-1"` on every tabbable element inside. On reopen the Dialog autofocus finds zero tabbable elements and falls back to the focusable path (`getFirstTabbableIn(contentElement, true, portal && preserveTabOrder)`), which is designed for exactly this flow. But the `fallbackToFocusable` branch returns the raw `querySelectorAll` matches without any `isFocusable` filtering, so the first match is the `display: none` file input. Focusing a `display: none` element is a silent no-op, and because the returned element is truthy the dialog's own `|| contentElement` last resort is bypassed — so focus never moves.

This is issue #6310.

## Solution

Make the `fallbackToFocusable` branches of `getFirstTabbableIn`, `getAllTabbableIn`, and `getLastTabbableIn` in `@ariakit/utils` return focusable elements instead of the raw selector matches, delegating to `getFirstFocusableIn` / `getAllFocusableIn` so they filter with `isFocusable` (and expand iframes like the tabbable path). The visible button is focusable even while `preserveTabOrder` keeps it at `tabindex="-1"`, so the fallback now resolves to it; if nothing focusable exists, the dialog's `|| contentElement` last resort takes over.

The helpers are called without `includeContainer`, preserving the prior children-only fallback semantics — the dialog content element is itself focusable at `tabIndex={-1}`, so including it would shadow its children and the `|| contentElement` last resort.

Note: the original report proposed patching only `getAllTabbableIn`, but a later refactor (#6288) gave `getFirstTabbableIn` its own fallback, which is the path the dialog autofocus and `FormLabel` actually use; all three public helpers are fixed for consistency.

## Workaround

Point [`initialFocus`](https://ariakit.com/reference/popover#initialfocus) at the visible control. It's resolved before the broken fallback, and the button is still focusable while `preserveTabOrder` has it at `tabindex="-1"`, so focusing it also restores its tab order:

```tsx
// TODO: Remove once https://github.com/ariakit/ariakit/issues/6310 is fixed.
const chooseFileRef = useRef<HTMLButtonElement>(null);
// ...
<Ariakit.Popover portal aria-label="Attachments" initialFocus={chooseFileRef}>
  <input type="file" style={{ display: "none" }} />
  <button ref={chooseFileRef} type="button">
    Choose file
  </button>
</Ariakit.Popover>
```

Alternatively, rendering the hidden input after the visible button also avoids the bug, but only by accident of DOM order.

Fixes #6310
