### PR TITLE
Fix `form.names.*` crash on symbol access

### DIFF
--- a/.changeset/300-form-names-symbol.md
+++ b/.changeset/300-form-names-symbol.md
@@ -4,4 +4,12 @@
 "@ariakit/react": patch
 ---
 
-Fixed [`useFormStore`](https://ariakit.com/reference/use-form-store) [`names`](https://ariakit.com/reference/use-form-store#names) values throwing `Cannot convert a Symbol value to a string` when a symbol key was read from them, such as when React probes a name rendered as a React child for `Symbol.iterator`. Absent symbol keys now resolve to `undefined` like a plain object, so string coercion such as `` `${form.names.email}` `` keeps working while raw access degrades gracefully.
+`form.names.*` paths no longer crash on symbol access
+
+Fixed [`useFormStore`](https://ariakit.com/reference/use-form-store) [`names`](https://ariakit.com/reference/use-form-store#names) values throwing `Cannot convert a Symbol value to a string` when an absent symbol key was read from them. This happened whenever something probed a symbol on a raw name — most notably when React reads `Symbol.iterator` to reconcile a name rendered as a React child, but also `Object.prototype.toString.call(name)` and `Array.from(name)`.
+
+Absent symbol keys now resolve to `undefined`, matching plain-object semantics, so those probes degrade gracefully. The documented string coercion keeps working, so coerce a name before rendering or inspecting it outside Ariakit props:
+
+```tsx
+<p>This field submits as {`${form.names.email}`}.</p>
+```

--- a/.changeset/300-form-names-symbol.md
+++ b/.changeset/300-form-names-symbol.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/components": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`useFormStore`](https://ariakit.com/reference/use-form-store) [`names`](https://ariakit.com/reference/use-form-store#names) values throwing `Cannot convert a Symbol value to a string` when a symbol key was read from them, such as when React probes a name rendered as a React child for `Symbol.iterator`. Absent symbol keys now resolve to `undefined` like a plain object, so string coercion such as `` `${form.names.email}` `` keeps working while raw access degrades gracefully.

--- a/app/src/sandbox/form-names-6308/index.react.tsx
+++ b/app/src/sandbox/form-names-6308/index.react.tsx
@@ -2,18 +2,25 @@ import * as ak from "@ariakit/react";
 import { Component, useState } from "react";
 import type { ReactNode } from "react";
 
-// Workaround for https://github.com/ariakit/ariakit/issues/6308
+// Reproduces https://github.com/ariakit/ariakit/issues/6308
 //
-// `form.names.*` values are documented string-like field paths, but the proxy
-// throws "Cannot convert a Symbol value to a string" when an absent *symbol*
-// key is read — which happens when react-dom probes a rendered child for
-// `Symbol.iterator`, or when `Object.prototype.toString.call(...)` probes
-// `Symbol.toStringTag`. Coercing the name to a string with `String(...)` before
-// it reaches either operation avoids the crash until the library fix lands.
+// `form.names.*` values are documented string-like field paths. Accessing an
+// absent *symbol* key on one must return `undefined` like a plain object would,
+// instead of throwing "Cannot convert a Symbol value to a string" from the
+// names proxy. Two ordinary things an app does hit that absent-symbol access:
 //
-// The error boundary wraps only the rendered name; with the workaround applied
-// it stays inert, but it is what keeps the rest of the paragraph mounted (and
-// the crash localized) without the coercion.
+// - Rendering a raw name as a React child ("Show field name"): react-dom probes
+//   the child for `Symbol.iterator` to decide whether it is iterable. The proxy
+//   used to throw there, tearing down the surrounding tree, instead of letting
+//   React raise its own "Objects are not valid as a React child" error.
+// - Inspecting a name with `Object.prototype.toString.call(...)` ("Inspect field
+//   name"): it probes `Symbol.toStringTag` and should resolve to "[object
+//   Object]" rather than throwing.
+//
+// The error boundary wraps only the rendered name so the rest of the paragraph
+// stays mounted: the bug puts the Symbol coercion crash in its place, while both
+// the userland workaround (coercing the name) and the library fix keep that
+// crash away.
 class NameBoundary extends Component<
   { children: ReactNode },
   { error: Error | null }
@@ -37,6 +44,15 @@ export default function Example() {
   const [fieldNameVisible, setFieldNameVisible] = useState(false);
   const [objectTag, setObjectTag] = useState<string>();
 
+  // Rendering a raw name as a React child is intentionally invalid here:
+  // `form.names.email` is typed as a string-like object, not a string, so
+  // TypeScript already flags it — the documented cue to coerce with
+  // `${form.names.email}`. Leaving it un-coerced exercises react-dom's
+  // `Symbol.iterator` probe on the names proxy, the path the fix for
+  // https://github.com/ariakit/ariakit/issues/6308 keeps from crashing.
+  // @ts-expect-error -- StringLike is not assignable to ReactNode.
+  const rawFieldName: ReactNode = form.names.email;
+
   return (
     <ak.Form store={form}>
       <ak.FormLabel name={form.names.email}>Email</ak.FormLabel>
@@ -49,8 +65,7 @@ export default function Example() {
         <p>
           This value is submitted as{" "}
           <NameBoundary>
-            {/* TODO(#6308): remove String() once the names proxy fix lands. */}
-            <code>{String(form.names.email)}</code>
+            <code>{rawFieldName}</code>
           </NameBoundary>
         </p>
       )}
@@ -58,8 +73,7 @@ export default function Example() {
       <button
         type="button"
         onClick={() =>
-          // TODO(#6308): remove String() once the names proxy fix lands.
-          setObjectTag(Object.prototype.toString.call(String(form.names.email)))
+          setObjectTag(Object.prototype.toString.call(form.names.email))
         }
       >
         Inspect field name

--- a/app/src/sandbox/form-names-6308/index.react.tsx
+++ b/app/src/sandbox/form-names-6308/index.react.tsx
@@ -1,0 +1,83 @@
+import * as ak from "@ariakit/react";
+import { Component, useState } from "react";
+import type { ReactNode } from "react";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6308
+//
+// `form.names.*` values are documented string-like field paths. Accessing an
+// absent *symbol* key on one must return `undefined` like a plain object would,
+// instead of throwing "Cannot convert a Symbol value to a string" from the
+// names proxy. Two ordinary things an app does hit that absent-symbol access:
+//
+// - Rendering a raw name as a React child ("Show field name"): react-dom probes
+//   the child for `Symbol.iterator` to decide whether it is iterable. The proxy
+//   used to throw there, tearing down the surrounding tree, instead of letting
+//   React raise its own "Objects are not valid as a React child" error.
+// - Inspecting a name with `Object.prototype.toString.call(...)` ("Inspect field
+//   name"): it probes `Symbol.toStringTag` and should resolve to "[object
+//   Object]" rather than throwing.
+//
+// The error boundary wraps only the rendered name so the rest of the paragraph
+// stays mounted: the bug puts the Symbol coercion crash in its place, while both
+// the userland workaround (coercing the name) and the library fix keep that
+// crash away.
+class NameBoundary extends Component<
+  { children: ReactNode },
+  { error: Error | null }
+> {
+  state: { error: Error | null } = { error: null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  render() {
+    if (this.state.error) {
+      return <span role="alert">Render error: {this.state.error.message}</span>;
+    }
+    return this.props.children;
+  }
+}
+
+export default function Example() {
+  const form = ak.useFormStore({ defaultValues: { email: "" } });
+  const [fieldNameVisible, setFieldNameVisible] = useState(false);
+  const [objectTag, setObjectTag] = useState<string>();
+
+  // Rendering a raw name as a React child is intentionally invalid here:
+  // `form.names.email` is typed as a string-like object, not a string, so
+  // TypeScript already flags it — the documented cue to coerce with
+  // `${form.names.email}`. Keeping it un-coerced reproduces the runtime crash
+  // from https://github.com/ariakit/ariakit/issues/6308.
+  // @ts-expect-error -- StringLike is not assignable to ReactNode.
+  const rawFieldName: ReactNode = form.names.email;
+
+  return (
+    <ak.Form store={form}>
+      <ak.FormLabel name={form.names.email}>Email</ak.FormLabel>
+      <ak.FormInput type="email" name={form.names.email} required />
+
+      <button type="button" onClick={() => setFieldNameVisible(true)}>
+        Show field name
+      </button>
+      {fieldNameVisible && (
+        <p>
+          This value is submitted as{" "}
+          <NameBoundary>
+            <code>{rawFieldName}</code>
+          </NameBoundary>
+        </p>
+      )}
+
+      <button
+        type="button"
+        onClick={() =>
+          setObjectTag(Object.prototype.toString.call(form.names.email))
+        }
+      >
+        Inspect field name
+      </button>
+      {objectTag != null && <output>{objectTag}</output>}
+    </ak.Form>
+  );
+}

--- a/app/src/sandbox/form-names-6308/index.react.tsx
+++ b/app/src/sandbox/form-names-6308/index.react.tsx
@@ -2,25 +2,18 @@ import * as ak from "@ariakit/react";
 import { Component, useState } from "react";
 import type { ReactNode } from "react";
 
-// Reproduces https://github.com/ariakit/ariakit/issues/6308
+// Workaround for https://github.com/ariakit/ariakit/issues/6308
 //
-// `form.names.*` values are documented string-like field paths. Accessing an
-// absent *symbol* key on one must return `undefined` like a plain object would,
-// instead of throwing "Cannot convert a Symbol value to a string" from the
-// names proxy. Two ordinary things an app does hit that absent-symbol access:
+// `form.names.*` values are documented string-like field paths, but the proxy
+// throws "Cannot convert a Symbol value to a string" when an absent *symbol*
+// key is read — which happens when react-dom probes a rendered child for
+// `Symbol.iterator`, or when `Object.prototype.toString.call(...)` probes
+// `Symbol.toStringTag`. Coercing the name to a string with `String(...)` before
+// it reaches either operation avoids the crash until the library fix lands.
 //
-// - Rendering a raw name as a React child ("Show field name"): react-dom probes
-//   the child for `Symbol.iterator` to decide whether it is iterable. The proxy
-//   used to throw there, tearing down the surrounding tree, instead of letting
-//   React raise its own "Objects are not valid as a React child" error.
-// - Inspecting a name with `Object.prototype.toString.call(...)` ("Inspect field
-//   name"): it probes `Symbol.toStringTag` and should resolve to "[object
-//   Object]" rather than throwing.
-//
-// The error boundary wraps only the rendered name so the rest of the paragraph
-// stays mounted: the bug puts the Symbol coercion crash in its place, while both
-// the userland workaround (coercing the name) and the library fix keep that
-// crash away.
+// The error boundary wraps only the rendered name; with the workaround applied
+// it stays inert, but it is what keeps the rest of the paragraph mounted (and
+// the crash localized) without the coercion.
 class NameBoundary extends Component<
   { children: ReactNode },
   { error: Error | null }
@@ -44,14 +37,6 @@ export default function Example() {
   const [fieldNameVisible, setFieldNameVisible] = useState(false);
   const [objectTag, setObjectTag] = useState<string>();
 
-  // Rendering a raw name as a React child is intentionally invalid here:
-  // `form.names.email` is typed as a string-like object, not a string, so
-  // TypeScript already flags it — the documented cue to coerce with
-  // `${form.names.email}`. Keeping it un-coerced reproduces the runtime crash
-  // from https://github.com/ariakit/ariakit/issues/6308.
-  // @ts-expect-error -- StringLike is not assignable to ReactNode.
-  const rawFieldName: ReactNode = form.names.email;
-
   return (
     <ak.Form store={form}>
       <ak.FormLabel name={form.names.email}>Email</ak.FormLabel>
@@ -64,7 +49,8 @@ export default function Example() {
         <p>
           This value is submitted as{" "}
           <NameBoundary>
-            <code>{rawFieldName}</code>
+            {/* TODO(#6308): remove String() once the names proxy fix lands. */}
+            <code>{String(form.names.email)}</code>
           </NameBoundary>
         </p>
       )}
@@ -72,7 +58,8 @@ export default function Example() {
       <button
         type="button"
         onClick={() =>
-          setObjectTag(Object.prototype.toString.call(form.names.email))
+          // TODO(#6308): remove String() once the names proxy fix lands.
+          setObjectTag(Object.prototype.toString.call(String(form.names.email)))
         }
       >
         Inspect field name

--- a/app/src/sandbox/form-names-6308/test-browser.ts
+++ b/app/src/sandbox/form-names-6308/test-browser.ts
@@ -1,0 +1,38 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6308
+//
+// The bug is a catastrophic Symbol coercion crash, so the regression these tests
+// lock in is its *absence*. Both the userland workaround (coercing the name) and
+// the library fix avoid that crash but reach it differently — the workaround
+// renders the path text, the fix surfaces React's own invalid-child error — so
+// the assertions accept either graceful outcome rather than one exact message.
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("rendering a raw form.names.* value does not crash with a Symbol coercion error", async ({
+    q,
+  }) => {
+    // Rendering `{form.names.email}` makes react-dom probe the value for
+    // `Symbol.iterator`; accessing that absent symbol must not throw "Cannot
+    // convert a Symbol value to a string". The paragraph text survives in every
+    // case because the boundary only wraps the name, so wait for it first — that
+    // commit also carries the boundary fallback, making the negative assertion
+    // below non-racy.
+    await q.button("Show field name").click();
+    const submittedAs = q.text(/This value is submitted as/);
+    await test.expect(submittedAs).toBeVisible();
+    await test
+      .expect(submittedAs)
+      .not.toContainText("Cannot convert a Symbol value to a string");
+  });
+
+  test("inspecting a form.names.* value resolves to an object tag instead of throwing", async ({
+    q,
+  }) => {
+    // `Object.prototype.toString.call(name)` probes `Symbol.toStringTag`, which
+    // must resolve gracefully so the call returns an `[object …]` tag instead of
+    // throwing inside the proxy (the fix yields "[object Object]", a coercing
+    // workaround "[object String]").
+    await q.button("Inspect field name").click();
+    await test.expect(q.status()).toHaveText(/^\[object \w+\]$/);
+  });
+});

--- a/app/src/sandbox/form-names-6308/test.ts
+++ b/app/src/sandbox/form-names-6308/test.ts
@@ -1,0 +1,17 @@
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6308
+//
+// happy-dom duplicate of the Object.prototype.toString path in
+// `test-browser.ts`. The raw-React-child render path stays browser-only: after
+// the fix React raises its invalid-child error, whose dev-mode console.error
+// would trip `failOnConsole` here even though the Symbol crash is gone.
+test("inspecting a form.names.* value resolves to an object tag instead of throwing", async () => {
+  // `Object.prototype.toString.call(name)` probes `Symbol.toStringTag`, which
+  // must resolve gracefully so the call returns an `[object …]` tag instead of
+  // throwing "Cannot convert a Symbol value to a string" (the fix yields
+  // "[object Object]", a coercing workaround "[object String]").
+  await click(q.button("Inspect field name"));
+  expect(q.status.ensure()).toHaveTextContent(/^\[object \w+\]$/);
+});

--- a/packages/ariakit-components/src/form/form-store.test.ts
+++ b/packages/ariakit-components/src/form/form-store.test.ts
@@ -80,6 +80,29 @@ test("pushes values and preserves array holes when removing values", () => {
   expect(store.getValue("tags")).toEqual([null, "two"]);
 });
 
+test("names coerce to their dot-joined path and ignore other symbols", () => {
+  const store = createFormStore({ defaultValues: { user: { name: "" } } });
+  const { names } = store;
+
+  // Documented string coercion paths all resolve to the field path. The
+  // template literal intentionally coerces the string-like name object.
+  // oxlint-disable-next-line restrict-template-expressions
+  expect(`${names.user.name}`).toBe("user.name");
+  expect(String(names.user.name)).toBe("user.name");
+  expect(names.user.name.toString()).toBe("user.name");
+  expect(names.user.name.valueOf()).toBe("user.name");
+
+  // Absent symbol keys resolve to `undefined` like a plain object would, so
+  // probing one never throws "Cannot convert a Symbol value to a string".
+  expect(Reflect.get(names.user.name, Symbol.iterator)).toBe(undefined);
+  expect(Object.prototype.toString.call(names.user.name)).toBe(
+    "[object Object]",
+  );
+
+  // Repeated access returns the same cached proxy.
+  expect(names.user).toBe(names.user);
+});
+
 test("marks nested values as touched on submit", async () => {
   const store = createFormStore({
     defaultValues: {

--- a/packages/ariakit-components/src/form/form-store.ts
+++ b/packages/ariakit-components/src/form/form-store.ts
@@ -125,13 +125,24 @@ function setAll<T extends FormStoreValues, V>(values: T, value: V) {
   return result as DeepMap<T, V>;
 }
 
-function getNameHandler(
-  cache: FormStoreValues,
-  prevKeys: Array<string | symbol> = [],
-) {
+function getNameHandler(cache: FormStoreValues, prevKeys: string[] = []) {
   const handler: ProxyHandler<FormStoreValues> = {
     get(target, key) {
-      if (["toString", "valueOf", Symbol.toPrimitive].includes(key)) {
+      if (typeof key === "symbol") {
+        // Support string coercion through `Symbol.toPrimitive`, but resolve
+        // every other symbol to `undefined` like a plain object would. Joining
+        // the key path below would otherwise throw "Cannot convert a Symbol
+        // value to a string" for probes such as `Symbol.iterator` (used when
+        // rendering a name as a React child) or `Symbol.toStringTag`.
+        if (key === Symbol.toPrimitive) {
+          return () => prevKeys.join(".");
+        }
+        return undefined;
+      }
+      if (key === "toString") {
+        return () => prevKeys.join(".");
+      }
+      if (key === "valueOf") {
         return () => prevKeys.join(".");
       }
       const nextKeys = [...prevKeys, key];


### PR DESCRIPTION
## Motivation

The `names` object returned by [`useFormStore`](https://ariakit.com/reference/use-form-store) is a `Proxy` whose values are documented string-like field paths (`form.names.email` stringifies to `"email"`). Its `get` trap special-cases only `toString`, `valueOf`, and `Symbol.toPrimitive`, then unconditionally runs `nextKeys.join(".")`. `Array.prototype.join` string-converts every element, which throws `TypeError: Cannot convert a Symbol value to a string` for any other symbol key — so reading an absent symbol crashes instead of returning `undefined` like a plain object would.

React triggers exactly this: when reconciling an object child it probes `child[Symbol.iterator]` to decide whether the child is iterable. So rendering a raw name as a React child crashes the whole tree before React can raise its own actionable "Objects are not valid as a React child" error:

```tsx
// Crashes the tree with "Cannot convert a Symbol value to a string"
<code>{form.names.email}</code>
```

The same crash hits `Object.prototype.toString.call(name)` (probes `Symbol.toStringTag`) and `Array.from(name)`, even though the documented `StringLike` contract only promises `toString`/`valueOf`.

## Solution

Handle symbols explicitly at the top of the `get` trap in `getNameHandler`: keep `Symbol.toPrimitive` returning the path-joining function, and return `undefined` for every other symbol so they never reach `nextKeys.join(".")`. This matches plain-object semantics — an absent symbol key resolves to `undefined` — so user code that inspects or iterates a name degrades gracefully, and rendering a raw name surfaces React's standard "Objects are not valid as a React child" error (which points at coercing with `` `${form.names.email}` ``). All documented coercion paths (template literals, `String()`, concatenation, `toString()`, `valueOf()`) keep working, as does proxy cache identity (`names.a === names.a`).

## Workaround

Coerce the name to a string before it reaches any operation that reads a symbol on it (rendering it as a React child, `Object.prototype.toString.call`, `Array.from`, …). Template literals and `String()` go through the supported `Symbol.toPrimitive` path:

```tsx
// TODO: remove once https://github.com/ariakit/ariakit/issues/6308 is fixed.
<code>{`${form.names.email}`}</code>
// or
<code>{String(form.names.email)}</code>
```

Closes #6308.

