### PR TITLE
Fix Form focus stolen by an invalid field on items change after a successful submit

### DIFF
--- a/.changeset/300-form-focus-steal-on-items-change.md
+++ b/.changeset/300-form-focus-steal-on-items-change.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Form`](https://ariakit.com/reference/form) stealing focus into an invalid field when its items changed after a successful submission with [`resetOnSubmit`](https://ariakit.com/reference/form#resetonsubmit) set to `false`, so [`autoFocusOnSubmit`](https://ariakit.com/reference/form#autofocusonsubmit) again focuses the first invalid field only as a result of a failed submission.

--- a/app/src/sandbox/form-6307/index.react.tsx
+++ b/app/src/sandbox/form-6307/index.react.tsx
@@ -1,0 +1,56 @@
+import * as ak from "@ariakit/react";
+import { useState } from "react";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6307
+//
+// With `resetOnSubmit={false}`, a *successful* submit used to leave the form's
+// internal auto-focus flag armed. A later change to the form items — such as
+// mounting the optional nickname field — would then yank focus into the first
+// invalid field, even though no submission happened. The "Add nickname" button
+// should keep focus after being activated.
+export default function Example() {
+  const form = ak.useFormStore({
+    defaultValues: { email: "", nickname: "" },
+  });
+
+  // The email is required. Validation runs through the standard `useValidate`
+  // API so the invalid state is deterministic across environments. `validate()`
+  // resets the errors before running this callback, so it only needs to set the
+  // current violation.
+  form.useValidate(() => {
+    if (!form.getValue(form.names.email)) {
+      form.setError(form.names.email, "Email is required");
+    }
+  });
+
+  // Surface the number of successful submissions so the success is observable in
+  // the preview (and so tests can wait for the submit to fully settle).
+  const successCount = ak.useStoreState(form, "submitSucceed");
+
+  const [showNickname, setShowNickname] = useState(false);
+
+  return (
+    <ak.Form store={form} resetOnSubmit={false}>
+      <output>Successful submissions: {successCount}</output>
+
+      <div>
+        <ak.FormLabel name={form.names.email}>Email</ak.FormLabel>
+        <ak.FormInput name={form.names.email} />
+        <ak.FormError name={form.names.email} />
+      </div>
+
+      {showNickname && (
+        <div>
+          <ak.FormLabel name={form.names.nickname}>Nickname</ak.FormLabel>
+          <ak.FormInput name={form.names.nickname} />
+        </div>
+      )}
+
+      <button type="button" onClick={() => setShowNickname(true)}>
+        Add nickname
+      </button>
+
+      <ak.FormSubmit>Save</ak.FormSubmit>
+    </ak.Form>
+  );
+}

--- a/app/src/sandbox/form-6307/index.react.tsx
+++ b/app/src/sandbox/form-6307/index.react.tsx
@@ -1,6 +1,5 @@
 import * as ak from "@ariakit/react";
 import { useState } from "react";
-import type { FormEvent } from "react";
 
 // Reproduces https://github.com/ariakit/ariakit/issues/6307
 //
@@ -30,36 +29,8 @@ export default function Example() {
 
   const [showNickname, setShowNickname] = useState(false);
 
-  // TODO(https://github.com/ariakit/ariakit/issues/6307): Workaround. Opt out of
-  // the built-in `autoFocusOnSubmit` and focus the first invalid field from
-  // `onSubmit`, tied to the actual submission outcome, so a later items change
-  // can't steal focus. Remove once the library fix is released.
-  const onSubmit = (event: FormEvent) => {
-    event.preventDefault();
-    void form.submit().then((submitted) => {
-      if (submitted) return;
-      const { items } = form.getState();
-      const field = items.find(
-        (item) =>
-          item.type === "field" &&
-          item.element?.getAttribute("aria-invalid") === "true",
-      );
-      const element = field?.element;
-      if (!element) return;
-      element.focus();
-      if (element instanceof HTMLInputElement) {
-        element.select();
-      }
-    });
-  };
-
   return (
-    <ak.Form
-      store={form}
-      resetOnSubmit={false}
-      autoFocusOnSubmit={false}
-      onSubmit={onSubmit}
-    >
+    <ak.Form store={form} resetOnSubmit={false}>
       <output>Successful submissions: {successCount}</output>
 
       <div>

--- a/app/src/sandbox/form-6307/index.react.tsx
+++ b/app/src/sandbox/form-6307/index.react.tsx
@@ -1,5 +1,6 @@
 import * as ak from "@ariakit/react";
 import { useState } from "react";
+import type { FormEvent } from "react";
 
 // Reproduces https://github.com/ariakit/ariakit/issues/6307
 //
@@ -29,8 +30,36 @@ export default function Example() {
 
   const [showNickname, setShowNickname] = useState(false);
 
+  // TODO(https://github.com/ariakit/ariakit/issues/6307): Workaround. Opt out of
+  // the built-in `autoFocusOnSubmit` and focus the first invalid field from
+  // `onSubmit`, tied to the actual submission outcome, so a later items change
+  // can't steal focus. Remove once the library fix is released.
+  const onSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    void form.submit().then((submitted) => {
+      if (submitted) return;
+      const { items } = form.getState();
+      const field = items.find(
+        (item) =>
+          item.type === "field" &&
+          item.element?.getAttribute("aria-invalid") === "true",
+      );
+      const element = field?.element;
+      if (!element) return;
+      element.focus();
+      if (element instanceof HTMLInputElement) {
+        element.select();
+      }
+    });
+  };
+
   return (
-    <ak.Form store={form} resetOnSubmit={false}>
+    <ak.Form
+      store={form}
+      resetOnSubmit={false}
+      autoFocusOnSubmit={false}
+      onSubmit={onSubmit}
+    >
       <output>Successful submissions: {successCount}</output>
 
       <div>

--- a/app/src/sandbox/form-6307/test-browser.ts
+++ b/app/src/sandbox/form-6307/test-browser.ts
@@ -1,0 +1,48 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6307
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("a successful submit does not steal focus on later items changes", async ({
+    page,
+    q,
+  }) => {
+    const email = q.textbox("Email");
+    const addNickname = q.button("Add nickname");
+
+    // 1. Submit with the email empty: the submission fails and the invalid email
+    //    field is focused (correct autoFocusOnSubmit behavior).
+    await q.button("Save").click();
+    await test.expect(email).toBeFocused();
+    await test.expect(email).toHaveAttribute("aria-invalid", "true");
+
+    // 2. Type a valid value, wait for it to be accepted, then submit again. Wait
+    //    for the successful submission to fully settle (with resetOnSubmit={false}
+    //    the form keeps its values) before touching the form again.
+    await email.fill("jane");
+    await test.expect(email).toHaveAttribute("aria-invalid", "false");
+    await q.button("Save").click();
+    await test.expect(q.status()).toHaveText("Successful submissions: 1");
+
+    // 3. Make the email invalid again without submitting.
+    await email.clear();
+    await test.expect(email).toHaveAttribute("aria-invalid", "true");
+
+    // 4. Move focus to the button. This blurs the email and re-runs validation,
+    //    so wait for the field to settle back to invalid before activating it.
+    await addNickname.focus();
+    await test.expect(email).toHaveAttribute("aria-invalid", "true");
+
+    // 5. Activate the button, mounting the optional nickname field and changing
+    //    the form items.
+    await page.keyboard.press("Enter");
+    await test.expect(q.textbox("Nickname")).toBeVisible();
+
+    // The buggy focus steal runs in an effect after the items change, so wait for
+    // it to settle and assert the final focus rather than a pre-steal transient.
+    await page.waitForTimeout(250);
+
+    // Focus must stay on the button and must not be stolen by the invalid email.
+    await test.expect(addNickname).toBeFocused();
+    await test.expect(email).not.toBeFocused();
+  });
+});

--- a/app/src/sandbox/form-6307/test.ts
+++ b/app/src/sandbox/form-6307/test.ts
@@ -1,0 +1,34 @@
+import { click, q, type } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6307
+
+test("a successful submit does not steal focus on later items changes", async () => {
+  const email = q.textbox.ensure("Email");
+
+  // 1. Submit with the email empty: the submission fails and the invalid email
+  //    field is focused (correct autoFocusOnSubmit behavior).
+  await click(q.button("Save"));
+  expect(email).toHaveFocus();
+  expect(email).toHaveAttribute("aria-invalid", "true");
+
+  // 2. Type a valid value, wait for it to be accepted, then submit again. Wait
+  //    for the successful submission to fully settle (with resetOnSubmit={false}
+  //    the form keeps its values) before touching the form again.
+  await type("jane", email);
+  expect(email).toHaveAttribute("aria-invalid", "false");
+  await click(q.button("Save"));
+  expect(q.status()).toHaveTextContent("Successful submissions: 1");
+
+  // 3. Make the email invalid again without submitting.
+  await type("\b\b\b\b", email);
+  expect(email).toHaveAttribute("aria-invalid", "true");
+
+  // 4. Activate "Add nickname", mounting the optional field and changing the
+  //    form items. Focus must stay on the button and must not be stolen by the
+  //    invalid email field.
+  await click(q.button("Add nickname"));
+  expect(q.textbox("Nickname")).toBeInTheDocument();
+  expect(q.button("Add nickname")).toHaveFocus();
+  expect(email).not.toHaveFocus();
+});

--- a/packages/ariakit-react-components/src/form/form.tsx
+++ b/packages/ariakit-react-components/src/form/form.tsx
@@ -89,6 +89,15 @@ export const useForm = createHook<TagName, FormOptions>(function useForm({
 
   const [shouldFocusOnSubmit, setShouldFocusOnSubmit] = useState(false);
 
+  // Clear the flag once a submission succeeds so auto-focus stays tied to the
+  // submission outcome. The flag is armed on every submit but only cleared when
+  // the focus effect finds an invalid field; on success it finds none, so it
+  // would otherwise leak and steal focus on a later `items` change.
+  useEffect(() => {
+    if (!submitSucceed) return;
+    setShouldFocusOnSubmit(false);
+  }, [submitSucceed]);
+
   useEffect(() => {
     if (!shouldFocusOnSubmit) return;
     if (!submitFailed) return;


### PR DESCRIPTION
## Motivation

With [`resetOnSubmit={false}`](https://ariakit.com/reference/form#resetonsubmit), once a form has had one failed submission and then a successful one, any later change to the form's items — for example conditionally mounting an optional [`FormInput`](https://ariakit.com/reference/form-input) — yanks focus into the first `aria-invalid` field, even though no submission is happening. From the user's perspective, focus teleports away from the control they just activated into an error field, with its text selected. This violates the documented [`autoFocusOnSubmit`](https://ariakit.com/reference/form#autofocusonsubmit) contract (focus the first invalid field _when the form is submitted_) and is an accessibility problem (unexpected focus movement).

The root cause is in [`useForm`](https://ariakit.com/reference/form): the submit handler arms an internal `shouldFocusOnSubmit` flag at submit **start**, before the outcome is known, and the only place that clears it is the focus effect's path that actually focuses an invalid element. When a submission succeeds there is no invalid field, so the flag leaks as `true` indefinitely. The other guard, `if (!submitFailed) return`, doesn't help because `submitFailed` is a monotonically increasing counter that is only reset by `reset()`. The default `resetOnSubmit` masks the leak by resetting on success, but with `resetOnSubmit={false}` `submitFailed` stays `> 0` forever after one failure. Because the focus effect depends on `items`, both guards then pass on every later item mount/unmount, and the effect focuses the first `aria-invalid` field it finds.

```tsx
const form = Ariakit.useFormStore({ defaultValues: { email: "", nickname: "" } });
const [showNickname, setShowNickname] = useState(false);

<Ariakit.Form store={form} resetOnSubmit={false}>
  <Ariakit.FormInput name={form.names.email} required />
  {showNickname && <Ariakit.FormInput name={form.names.nickname} />}
  <button type="button" onClick={() => setShowNickname(true)}>Add nickname</button>
  <Ariakit.FormSubmit>Save</Ariakit.FormSubmit>
</Ariakit.Form>
// Submit empty (fails), fix it and submit again (succeeds), make the field
// invalid again, then activate "Add nickname": focus is stolen into the field.
```

## Solution

Clear `shouldFocusOnSubmit` when a submission succeeds, so the auto-focus stays tied to the submission outcome instead of leaking past a successful submit:

```tsx
useEffect(() => {
  if (!submitSucceed) return;
  setShouldFocusOnSubmit(false);
}, [submitSucceed]);
```

`submit()` increments exactly one of `submitSucceed`/`submitFailed` per submission, so this never cancels a failed submission's pending focus and preserves the deliberate retry-on-items-change behavior for failed submits whose invalid field hasn't mounted yet. After a successful submit, mounting or unmounting form items no longer moves focus.

Fixes #6307

## Workaround

Until this fix is released, opt out of [`autoFocusOnSubmit`](https://ariakit.com/reference/form#autofocusonsubmit) and re-implement the failed-submit focus in userland through the [`onSubmit`](https://ariakit.com/reference/form#onsubmit) prop, so the focus is tied to the actual submission outcome instead of a leaked flag:

```tsx
// TODO(https://github.com/ariakit/ariakit/issues/6307): Remove once released.
const onSubmit = (event: React.FormEvent) => {
  event.preventDefault();
  void form.submit().then((submitted) => {
    if (submitted) return;
    const { items } = form.getState();
    const field = items.find(
      (item) =>
        item.type === "field" &&
        item.element?.getAttribute("aria-invalid") === "true",
    );
    const element = field?.element;
    if (!element) return;
    element.focus();
    if (element instanceof HTMLInputElement) {
      element.select();
    }
  });
};

<Ariakit.Form
  store={form}
  resetOnSubmit={false}
  autoFocusOnSubmit={false}
  onSubmit={onSubmit}
>
```

Calling `event.preventDefault()` makes [`Form`](https://ariakit.com/reference/form) skip its built-in submit handling, so the form is submitted only once, by the `onSubmit` handler above.
