### PR TITLE
Pin changesets action in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         run: gh auth setup-git
 
       - name: Create PR or publish to npm
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
         with:
           title: Publish
           commit: Publish


### PR DESCRIPTION
## Motivation

The release workflow was still running `changesets/action@v1`, leaving the most privileged third-party action in the publishing path on a mutable upstream branch. The rest of the repository already pins third-party GitHub Actions to full commit SHAs so updates happen through reviewable dependency PRs.

## Solution

Pin `changesets/action` to the full commit SHA that the upstream `v1` branch and the `v1.9.0` tag currently resolve to:

```yaml
uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
```

This keeps the release workflow on the same action code it runs today while preventing future upstream branch movement from changing Ariakit's publishing workflow without review.

## Verification

- `git ls-remote https://github.com/changesets/action refs/heads/v1 'refs/tags/v1.9.0^{}'`
- `pnpm lint-fix`
- `pnpm exec prettier --check .github/workflows/release.yml`
