### PR TITLE
Restrict perf baseline reuse to push artifacts

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -91,13 +91,17 @@ jobs:
               workflow_id: 'app.yml',
               branch: branchRef,
               head_sha: baseSha,
+              // Only push runs build exactly at head_sha. Pull request runs
+              // check out the merge ref, so their artifacts are not a build
+              // of base.sha and would corrupt stacked PR baselines.
+              event: 'push',
               status: 'success',
               per_page: 1,
             });
             const run = runs.data.workflow_runs[0];
             if (!run) {
               core.notice(
-                `No successful app.yml run found for base SHA ${baseSha}. ` +
+                `No successful push app.yml run found for base SHA ${baseSha}. ` +
                   'Building base artifacts in this job.',
               );
               return;


### PR DESCRIPTION
## Motivation

The perf workflow reuses `app.yml` artifacts for a pull request's base SHA. `app.yml` also runs on `pull_request` events, where the default checkout builds the synthetic merge ref even though the workflow run reports the PR head SHA.

On stacked PRs, that can make the baseline artifact include unrelated main changes instead of being a build of the target base SHA, which corrupts the Chrome perf comparison.

## Solution

Filter the `app.yml` workflow-run lookup to `push` events. Push runs build exactly at `head_sha`, so main-targeted PRs can still use the fast artifact path:

```js
await github.rest.actions.listWorkflowRuns({
  workflow_id: "app.yml",
  branch: branchRef,
  head_sha: baseSha,
  event: "push",
});
```

Stacked PRs without a push run for their base branch now fall back to the existing in-job baseline build from `github.event.pull_request.base.sha`. The fallback notice also says that no successful push `app.yml` run was found, so CI logs reflect the new lookup contract.
