### PR TITLE
Sanitize Plus redirect URLs

### DIFF
--- a/app/src/lib/schemas.ts
+++ b/app/src/lib/schemas.ts
@@ -69,18 +69,15 @@ const URL_SCHEMA_BASE = new URL("http://localhost");
 
 export interface NormalizeURLPathOptions {
   base?: string | URL;
-  decode?: boolean;
 }
 
 export function normalizeURLPath(
   value?: string | URL | null,
-  { base = URL_SCHEMA_BASE, decode }: NormalizeURLPathOptions = {},
+  { base = URL_SCHEMA_BASE }: NormalizeURLPathOptions = {},
 ) {
   if (!value) return undefined;
   try {
-    const target =
-      decode && typeof value === "string" ? decodeURIComponent(value) : value;
-    const url = new URL(target, base);
+    const url = new URL(value, base);
     if (url.protocol !== "http:" && url.protocol !== "https:") {
       return undefined;
     }
@@ -95,7 +92,7 @@ export const URLSchema = z
   .string()
   .optional()
   .transform((value) => {
-    return normalizeURLPath(value, { decode: true });
+    return normalizeURLPath(value);
   });
 
 const ReferenceExampleSchema = z.object({

--- a/app/src/lib/schemas.ts
+++ b/app/src/lib/schemas.ts
@@ -65,12 +65,37 @@ export const PromoDataSchema = z.object({
 });
 export type PromoData = z.infer<typeof PromoDataSchema>;
 
+const URL_SCHEMA_BASE = new URL("http://localhost");
+
+export interface NormalizeURLPathOptions {
+  base?: string | URL;
+  decode?: boolean;
+}
+
+export function normalizeURLPath(
+  value?: string | URL | null,
+  { base = URL_SCHEMA_BASE, decode }: NormalizeURLPathOptions = {},
+) {
+  if (!value) return undefined;
+  try {
+    const target =
+      decode && typeof value === "string" ? decodeURIComponent(value) : value;
+    const url = new URL(target, base);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return undefined;
+    }
+    const pathname = `/${url.pathname.replace(/^\/+/, "")}`;
+    return pathname + url.search + url.hash;
+  } catch {
+    return undefined;
+  }
+}
+
 export const URLSchema = z
   .string()
   .optional()
   .transform((value) => {
-    if (!value) return undefined;
-    return decodeURIComponent(value);
+    return normalizeURLPath(value, { decode: true });
   });
 
 const ReferenceExampleSchema = z.object({

--- a/app/src/lib/url.test.ts
+++ b/app/src/lib/url.test.ts
@@ -18,13 +18,15 @@ test.each([
   ["https://evil.com/account?tab=billing#team", "/account?tab=billing#team"],
   ["//evil.com/account?tab=billing#team", "/account?tab=billing#team"],
   ["https://evil.com//account?tab=billing#team", "/account?tab=billing#team"],
-  ["https://evil.com/%5C%5Caccount", "/account"],
+  ["https://evil.com/%5C%5Caccount", "/%5C%5Caccount"],
   ["https://evil.com/foo/..//account", "/account"],
   ["/\\evil.com", "/"],
-  ["/%09/evil.com", "/"],
+  ["/\t/evil.com", "/"],
+  ["/%09/evil.com", "/%09/evil.com"],
+  ["/search?q=%23tag", "/search?q=%23tag"],
   ["/docs?section=plus#pricing", "/docs?section=plus#pricing"],
   ["docs?section=plus#pricing", "/docs?section=plus#pricing"],
-  ["%", undefined],
+  ["%", "/%"],
 ])("URLSchema normalizes %s", (value, expected) => {
   expect(URLSchema.parse(value)).toBe(expected);
 });
@@ -71,4 +73,28 @@ test("getPlusCheckoutPath strips redirect URL network paths", () => {
   );
 
   expect(URLSchema.parse(redirectUrl)).toBe("/evil.com/docs");
+});
+
+test("getPlusCheckoutPath preserves reserved query characters", () => {
+  const path = getPlusCheckoutPath({
+    redirectUrl: "https://next.ariakit.com/search?q=%23tag&x=a%26b",
+  });
+  const redirectUrl = new URL(path, "http://localhost").searchParams.get(
+    "redirect_url",
+  );
+
+  expect(redirectUrl).toBe("/search?q=%23tag&x=a%26b");
+  expect(URLSchema.parse(redirectUrl)).toBe("/search?q=%23tag&x=a%26b");
+});
+
+test("getPlusAccountPath preserves reserved query characters", () => {
+  const path = getPlusAccountPath({
+    redirectUrl: "https://next.ariakit.com/search?q=%23tag&x=a%26b",
+  });
+  const redirectUrl = new URL(path, "http://localhost").searchParams.get(
+    "redirect_url",
+  );
+
+  expect(redirectUrl).toBe("/search?q=%23tag&x=a%26b");
+  expect(URLSchema.parse(redirectUrl)).toBe("/search?q=%23tag&x=a%26b");
 });

--- a/app/src/lib/url.test.ts
+++ b/app/src/lib/url.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2025-present Ariakit FZ-LLC. All Rights Reserved.
+ *
+ * This software is proprietary. See the license.md file in the root of this
+ * package for licensing terms.
+ *
+ * SPDX-License-Identifier: UNLICENSED
+ */
+
+import { expect, test } from "vitest";
+import { URLSchema } from "./schemas.ts";
+import { getPlusAccountPath, getPlusCheckoutPath } from "./url.ts";
+
+test.each([
+  ["javascript:alert(1)", undefined],
+  ["data:text/html,<script>alert(1)</script>", undefined],
+  ["https://evil.com/account?tab=billing#team", "/account?tab=billing#team"],
+  ["//evil.com/account?tab=billing#team", "/account?tab=billing#team"],
+  ["https://evil.com//account?tab=billing#team", "/account?tab=billing#team"],
+  ["https://evil.com/%5C%5Caccount", "/account"],
+  ["https://evil.com/foo/..//account", "/account"],
+  ["/\\evil.com", "/"],
+  ["/%09/evil.com", "/"],
+  ["/docs?section=plus#pricing", "/docs?section=plus#pricing"],
+  ["docs?section=plus#pricing", "/docs?section=plus#pricing"],
+  ["%", undefined],
+])("URLSchema normalizes %s", (value, expected) => {
+  expect(URLSchema.parse(value)).toBe(expected);
+});
+
+test("getPlusCheckoutPath strips redirect URL origins", () => {
+  const path = getPlusCheckoutPath({
+    redirectUrl: "https://next.ariakit.com/docs?section=plus#pricing",
+  });
+  const redirectUrl = new URL(path, "http://localhost").searchParams.get(
+    "redirect_url",
+  );
+
+  expect(URLSchema.parse(redirectUrl)).toBe("/docs?section=plus#pricing");
+});
+
+test("getPlusAccountPath strips redirect URL origins", () => {
+  const path = getPlusAccountPath({
+    redirectUrl: "https://next.ariakit.com/docs?section=plus#pricing",
+  });
+  const redirectUrl = new URL(path, "http://localhost").searchParams.get(
+    "redirect_url",
+  );
+
+  expect(URLSchema.parse(redirectUrl)).toBe("/docs?section=plus#pricing");
+});
+
+test("getPlusCheckoutPath skips non-http redirect URL schemes", () => {
+  const path = getPlusCheckoutPath({
+    redirectUrl: "javascript:alert(1)",
+  });
+  const redirectUrl = new URL(path, "http://localhost").searchParams.get(
+    "redirect_url",
+  );
+
+  expect(redirectUrl).toBeNull();
+});
+
+test("getPlusCheckoutPath strips redirect URL network paths", () => {
+  const path = getPlusCheckoutPath({
+    redirectUrl: "https://next.ariakit.com//evil.com/docs",
+  });
+  const redirectUrl = new URL(path, "http://localhost").searchParams.get(
+    "redirect_url",
+  );
+
+  expect(URLSchema.parse(redirectUrl)).toBe("/evil.com/docs");
+});

--- a/app/src/lib/url.ts
+++ b/app/src/lib/url.ts
@@ -39,7 +39,7 @@ function setRedirectURL(url: URL, redirectUrl?: string | URL) {
   if (!redirectUrl) return;
   const path = normalizeURLPath(redirectUrl, { base: url });
   if (!path) return;
-  url.searchParams.set("redirect_url", encodeURIComponent(path));
+  url.searchParams.set("redirect_url", path);
 }
 
 export interface GetPlusAccountURLParams {

--- a/app/src/lib/url.ts
+++ b/app/src/lib/url.ts
@@ -17,7 +17,11 @@ import {
   getReferenceSlug,
 } from "./reference.ts";
 import type { PlusAccountPath, PlusCheckoutStep, PlusType } from "./schemas.ts";
-import { PlusCheckoutStepSchema, PlusTypeSchema } from "./schemas.ts";
+import {
+  normalizeURLPath,
+  PlusCheckoutStepSchema,
+  PlusTypeSchema,
+} from "./schemas.ts";
 import { trimRight } from "./string.ts";
 
 const DEFAULT_URL = new URL("http://localhost:4321");
@@ -33,7 +37,8 @@ function leadingSlash(path?: string | null) {
 
 function setRedirectURL(url: URL, redirectUrl?: string | URL) {
   if (!redirectUrl) return;
-  const path = new URL(redirectUrl, url).toString().replace(url.origin, "");
+  const path = normalizeURLPath(redirectUrl, { base: url });
+  if (!path) return;
   url.searchParams.set("redirect_url", encodeURIComponent(path));
 }
 


### PR DESCRIPTION
## Motivation

The Plus checkout, account, and billing routes parse the `redirect_url` query parameter and use it in back-link `href`s and the Stripe billing portal `return_url`. The previous parser decoded the value without validating its scheme or origin, which allowed attacker-controlled values such as `javascript:` URLs, external origins, and protocol-relative URLs to reach those flows.

## Solution

Normalize Plus redirect targets through the WHATWG URL parser before using or producing `redirect_url` values. The shared `normalizeURLPath` helper now:

- returns `undefined` for non-HTTP(S) schemes;
- strips every accepted value down to `pathname + search + hash`;
- collapses leading slashes so normalized paths cannot become protocol-relative `//` URLs;
- is used by both `URLSchema` consumers and the Plus URL producer helper.

The producer now lets `URLSearchParams` handle the single percent-encoding layer for `redirect_url` values, so reserved query characters such as `%23` and `%26` round-trip without being decoded into delimiters before URL parsing.

Added focused regression coverage for `javascript:`/`data:` schemes, external origins, protocol-relative URLs, encoded backslashes, network-path-like paths, reserved query characters, malformed percent characters, and producer round-trips for checkout and account redirect URLs.
