### PR TITLE
Add Composite Chrome performance tests

### DIFF
--- a/app/src/sandbox/composite-perf/index.react.tsx
+++ b/app/src/sandbox/composite-perf/index.react.tsx
@@ -8,6 +8,20 @@ const items = Array.from(
   (_, index) => `Item ${index + 1}`,
 );
 
+interface ControlledItem {
+  id: string;
+  label: string;
+  rev?: number;
+}
+
+const controlledItems: ControlledItem[] = Array.from(
+  { length: itemCount },
+  (_, index) => {
+    const number = index + 1;
+    return { id: `item-${number}`, label: `Item ${number}` };
+  },
+);
+
 function CompositeFixture() {
   return (
     <Ariakit.CompositeProvider orientation="horizontal">
@@ -22,14 +36,58 @@ function CompositeFixture() {
   );
 }
 
+function ControlledCompositeFixture() {
+  const [items, setItems] = useState(controlledItems);
+  const [updates, setUpdates] = useState(0);
+  const composite = Ariakit.useCompositeStore({
+    items,
+    setItems,
+    orientation: "horizontal",
+  });
+
+  const updateItems = () => {
+    const rev = updates + 1;
+    setItems((items) => items.map((item) => ({ ...item, rev })));
+    setUpdates(rev);
+  };
+
+  return (
+    <>
+      <Ariakit.Button className="button" onClick={updateItems}>
+        Update items
+      </Ariakit.Button>
+      <output aria-label="Updates">{updates}</output>
+      <Ariakit.Composite
+        store={composite}
+        aria-label="Controlled composite items"
+        className="composite"
+      >
+        {items.map((item) => (
+          <Ariakit.CompositeItem key={item.id} id={item.id} className="item">
+            {item.label}
+          </Ariakit.CompositeItem>
+        ))}
+      </Ariakit.Composite>
+    </>
+  );
+}
+
 export default function Example() {
   const [mounted, setMounted] = useState(false);
+  const [controlledMounted, setControlledMounted] = useState(false);
   return (
     <div className="root">
       <Ariakit.Button className="button" onClick={() => setMounted(true)}>
         Mount composite
       </Ariakit.Button>
+      <Ariakit.Button
+        className="button"
+        onClick={() => setControlledMounted(true)}
+      >
+        Mount controlled composite
+      </Ariakit.Button>
       {mounted ? <CompositeFixture /> : null}
+      {controlledMounted ? <ControlledCompositeFixture /> : null}
     </div>
   );
 }

--- a/app/src/sandbox/composite-perf/index.react.tsx
+++ b/app/src/sandbox/composite-perf/index.react.tsx
@@ -1,0 +1,31 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+import "./style.css";
+
+const items = Array.from({ length: 400 }, (_, index) => `Item ${index + 1}`);
+
+function CompositeFixture() {
+  return (
+    <Ariakit.CompositeProvider orientation="horizontal">
+      <Ariakit.Composite aria-label="Composite items" className="composite">
+        {items.map((item) => (
+          <Ariakit.CompositeItem key={item} className="item">
+            {item}
+          </Ariakit.CompositeItem>
+        ))}
+      </Ariakit.Composite>
+    </Ariakit.CompositeProvider>
+  );
+}
+
+export default function Example() {
+  const [mounted, setMounted] = useState(false);
+  return (
+    <div className="root">
+      <Ariakit.Button className="button" onClick={() => setMounted(true)}>
+        Mount composite
+      </Ariakit.Button>
+      {mounted ? <CompositeFixture /> : null}
+    </div>
+  );
+}

--- a/app/src/sandbox/composite-perf/index.react.tsx
+++ b/app/src/sandbox/composite-perf/index.react.tsx
@@ -2,7 +2,11 @@ import * as Ariakit from "@ariakit/react";
 import { useState } from "react";
 import "./style.css";
 
-const items = Array.from({ length: 400 }, (_, index) => `Item ${index + 1}`);
+const itemCount = 400;
+const items = Array.from(
+  { length: itemCount },
+  (_, index) => `Item ${index + 1}`,
+);
 
 function CompositeFixture() {
   return (

--- a/app/src/sandbox/composite-perf/perf-chrome.ts
+++ b/app/src/sandbox/composite-perf/perf-chrome.ts
@@ -1,10 +1,12 @@
 import { expect } from "@playwright/test";
 import { withFramework } from "#app/test-utils/preview.ts";
 
+const itemCount = 400;
+
 withFramework(import.meta.dirname, async ({ test }) => {
   test("mount composite", async ({ q, perf }) => {
     const mountButton = q.button("Mount composite");
-    const lastItem = q.button("Item 400");
+    const lastItem = q.button(`Item ${itemCount}`);
 
     await perf.measure(async () => {
       await mountButton.click();
@@ -12,15 +14,17 @@ withFramework(import.meta.dirname, async ({ test }) => {
     });
   });
 
-  test("move to next item", async ({ q, page, perf }) => {
+  test("move across items", async ({ q, page, perf }) => {
     const mountButton = q.button("Mount composite");
     const firstItem = q.button("Item 1");
-    const secondItem = q.button("Item 2");
+    const lastItem = q.button(`Item ${itemCount}`);
 
     await perf.measure(
       async () => {
-        await page.keyboard.press("ArrowRight");
-        await expect(secondItem).toBeFocused();
+        for (let i = 1; i < itemCount; i++) {
+          await page.keyboard.press("ArrowRight");
+        }
+        await expect(lastItem).toBeFocused();
       },
       {
         setup: async () => {

--- a/app/src/sandbox/composite-perf/perf-chrome.ts
+++ b/app/src/sandbox/composite-perf/perf-chrome.ts
@@ -1,0 +1,34 @@
+import { expect } from "@playwright/test";
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("mount composite", async ({ q, perf }) => {
+    const mountButton = q.button("Mount composite");
+    const lastItem = q.button("Item 400");
+
+    await perf.measure(async () => {
+      await mountButton.click();
+      await expect(lastItem).toBeVisible();
+    });
+  });
+
+  test("move to next item", async ({ q, page, perf }) => {
+    const mountButton = q.button("Mount composite");
+    const firstItem = q.button("Item 1");
+    const secondItem = q.button("Item 2");
+
+    await perf.measure(
+      async () => {
+        await page.keyboard.press("ArrowRight");
+        await expect(secondItem).toBeFocused();
+      },
+      {
+        setup: async () => {
+          await mountButton.click();
+          await firstItem.focus();
+          await expect(firstItem).toBeFocused();
+        },
+      },
+    );
+  });
+});

--- a/app/src/sandbox/composite-perf/perf-chrome.ts
+++ b/app/src/sandbox/composite-perf/perf-chrome.ts
@@ -1,7 +1,10 @@
+import type { query } from "@ariakit/test/playwright";
 import { expect } from "@playwright/test";
 import { withFramework } from "#app/test-utils/preview.ts";
 
 const itemCount = 400;
+const updateCount = 20;
+type Query = ReturnType<typeof query>;
 
 withFramework(import.meta.dirname, async ({ test }) => {
   test("mount composite", async ({ q, perf }) => {
@@ -34,5 +37,43 @@ withFramework(import.meta.dirname, async ({ test }) => {
         },
       },
     );
+  });
+
+  test("mount controlled composite", async ({ q, perf }) => {
+    const mountButton = q.button("Mount controlled composite");
+    const lastItem = q.button(`Item ${itemCount}`);
+
+    await perf.measure(async () => {
+      await mountButton.click();
+      await expect(lastItem).toBeVisible();
+    });
+  });
+
+  const setupControlledComposite = async (q: Query) => {
+    await q.button("Mount controlled composite").click();
+    await expect(q.button(`Item ${itemCount}`)).toBeVisible();
+  };
+
+  const updateControlledItems = async (q: Query) => {
+    const updateButton = q.button("Update items");
+    for (let i = 0; i < updateCount; i++) {
+      await updateButton.click();
+    }
+    await expect(q.status("Updates")).toHaveText(String(updateCount));
+  };
+
+  test("update controlled items", async ({ q, perf }) => {
+    await perf.measure(() => updateControlledItems(q), {
+      setup: () => setupControlledComposite(q),
+    });
+  });
+
+  test("update controlled items with script profile", async ({ q, perf }) => {
+    await perf.measure(() => updateControlledItems(q), {
+      label: "update controlled items (script profile)",
+      scriptProfile: true,
+      profileLimit: 20,
+      setup: () => setupControlledComposite(q),
+    });
   });
 });

--- a/app/src/sandbox/composite-perf/style.css
+++ b/app/src/sandbox/composite-perf/style.css
@@ -1,0 +1,41 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: flex-start;
+  padding: 1rem;
+}
+
+.button,
+.item {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid hsl(204 10% 80%);
+  background: white;
+  color: hsl(204 10% 10%);
+  font: inherit;
+}
+
+.button {
+  border-radius: 0.5rem;
+  padding: 0.5rem 1rem;
+}
+
+.composite {
+  display: grid;
+  grid-template-columns: repeat(20, 3.5rem);
+  gap: 0.25rem;
+}
+
+.item {
+  min-width: 0;
+  height: 2rem;
+  border-radius: 0.25rem;
+  padding: 0;
+}
+
+.item:focus-visible {
+  outline: 2px solid hsl(204 100% 40%);
+  outline-offset: 1px;
+}


### PR DESCRIPTION
## Motivation

`Composite` and `CompositeItem` are low-level building blocks used by higher-level widgets, but the Chrome perf workflow does not directly benchmark their mount or keyboard movement cost at scale.

The uncontrolled path also does not cover controlled `items`/`setItems` updates, where collection-store reconciliation can do substantially different work from normal private item registration.

## Solution

Add a `composite-perf` sandbox with lazy-mounted 400-item horizontal Composite fixtures:

- an uncontrolled fixture for baseline mount and sustained keyboard traversal from `Item 1` to `Item 400`;
- a controlled fixture backed by `useCompositeStore({ items, setItems })`, with an `Update items` control that replaces metadata on all items without changing their rendered labels.

The Chrome perf suite now measures uncontrolled mount, sustained uncontrolled navigation, controlled mount, controlled item updates, and a script-profile variant for the controlled update case. The update case repeats the controlled replacement enough times to clear the perf comparator's absolute-delta floor, while the profiled variant is kept separate for attribution.
