### PR TITLE
Fix RTL composite base navigation

### DIFF
--- a/.changeset/300-composite-rtl-base-navigation.md
+++ b/.changeset/300-composite-rtl-base-navigation.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Composite`](https://ariakit.com/reference/composite) base-element arrow key navigation in RTL composites, including components built on it such as [`Toolbar`](https://ariakit.com/reference/toolbar) and [`TabList`](https://ariakit.com/reference/tab-list).

--- a/app/src/sandbox/composite-6299/index.react.tsx
+++ b/app/src/sandbox/composite-6299/index.react.tsx
@@ -1,0 +1,23 @@
+import * as Ariakit from "@ariakit/react";
+
+export default function Example() {
+  const composite = Ariakit.useCompositeStore({
+    rtl: true,
+    orientation: "horizontal",
+    defaultActiveId: null,
+  });
+
+  return (
+    <Ariakit.Composite
+      store={composite}
+      role="toolbar"
+      aria-label="Text formatting"
+      dir="rtl"
+      style={{ display: "flex", gap: 8 }}
+    >
+      <Ariakit.CompositeItem>Bold</Ariakit.CompositeItem>
+      <Ariakit.CompositeItem>Italic</Ariakit.CompositeItem>
+      <Ariakit.CompositeItem>Underline</Ariakit.CompositeItem>
+    </Ariakit.Composite>
+  );
+}

--- a/app/src/sandbox/composite-6299/index.react.tsx
+++ b/app/src/sandbox/composite-6299/index.react.tsx
@@ -1,4 +1,5 @@
 import * as Ariakit from "@ariakit/react";
+import type { KeyboardEvent } from "react";
 
 export default function Example() {
   const composite = Ariakit.useCompositeStore({
@@ -7,12 +8,26 @@ export default function Example() {
     defaultActiveId: null,
   });
 
+  // TODO: Remove once https://github.com/ariakit/ariakit/issues/6299 is fixed.
+  function onKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (event.defaultPrevented) return;
+    if (event.target !== event.currentTarget) return;
+    const isLeft = event.key === "ArrowLeft";
+    const isRight = event.key === "ArrowRight";
+    if (!isLeft && !isRight) return;
+    const id = isLeft ? composite.previous() : composite.next();
+    if (id === undefined) return;
+    event.preventDefault();
+    composite.move(id);
+  }
+
   return (
     <Ariakit.Composite
       store={composite}
       role="toolbar"
       aria-label="Text formatting"
       dir="rtl"
+      onKeyDown={onKeyDown}
       style={{ display: "flex", gap: 8 }}
     >
       <Ariakit.CompositeItem>Bold</Ariakit.CompositeItem>

--- a/app/src/sandbox/composite-6299/index.react.tsx
+++ b/app/src/sandbox/composite-6299/index.react.tsx
@@ -1,5 +1,4 @@
 import * as Ariakit from "@ariakit/react";
-import type { KeyboardEvent } from "react";
 
 export default function Example() {
   const composite = Ariakit.useCompositeStore({
@@ -8,26 +7,12 @@ export default function Example() {
     defaultActiveId: null,
   });
 
-  // TODO: Remove once https://github.com/ariakit/ariakit/issues/6299 is fixed.
-  function onKeyDown(event: KeyboardEvent<HTMLDivElement>) {
-    if (event.defaultPrevented) return;
-    if (event.target !== event.currentTarget) return;
-    const isLeft = event.key === "ArrowLeft";
-    const isRight = event.key === "ArrowRight";
-    if (!isLeft && !isRight) return;
-    const id = isLeft ? composite.previous() : composite.next();
-    if (id === undefined) return;
-    event.preventDefault();
-    composite.move(id);
-  }
-
   return (
     <Ariakit.Composite
       store={composite}
       role="toolbar"
       aria-label="Text formatting"
       dir="rtl"
-      onKeyDown={onKeyDown}
       style={{ display: "flex", gap: 8 }}
     >
       <Ariakit.CompositeItem>Bold</Ariakit.CompositeItem>

--- a/app/src/sandbox/composite-6299/test-browser.ts
+++ b/app/src/sandbox/composite-6299/test-browser.ts
@@ -1,0 +1,29 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// https://github.com/ariakit/ariakit/issues/6299
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("enters and traverses an RTL composite from the base element", async ({
+    page,
+    q,
+  }) => {
+    const toolbar = q.toolbar("Text formatting");
+
+    await page.keyboard.press("Tab");
+
+    await test.expect(toolbar).toBeFocused();
+
+    await page.keyboard.press("ArrowLeft");
+    await test.expect(q.button("Bold")).toBeFocused();
+
+    await page.keyboard.press("ArrowLeft");
+    await test.expect(q.button("Italic")).toBeFocused();
+
+    await toolbar.focus();
+
+    await page.keyboard.press("ArrowRight");
+    await test.expect(q.button("Underline")).toBeFocused();
+
+    await page.keyboard.press("ArrowRight");
+    await test.expect(q.button("Italic")).toBeFocused();
+  });
+});

--- a/app/src/sandbox/composite-6299/test-browser.ts
+++ b/app/src/sandbox/composite-6299/test-browser.ts
@@ -2,7 +2,7 @@ import { withFramework } from "#app/test-utils/preview.ts";
 
 // https://github.com/ariakit/ariakit/issues/6299
 withFramework(import.meta.dirname, async ({ test }) => {
-  test("enters and traverses an RTL composite from the base element", async ({
+  test("enters an RTL composite from the base element with ArrowLeft", async ({
     page,
     q,
   }) => {
@@ -17,8 +17,18 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
     await page.keyboard.press("ArrowLeft");
     await test.expect(q.button("Italic")).toBeFocused();
+  });
 
-    await toolbar.focus();
+  // Use a fresh render so the toolbar has no active item when focused.
+  test("enters an RTL composite from the base element with ArrowRight", async ({
+    page,
+    q,
+  }) => {
+    const toolbar = q.toolbar("Text formatting");
+
+    await page.keyboard.press("Tab");
+
+    await test.expect(toolbar).toBeFocused();
 
     await page.keyboard.press("ArrowRight");
     await test.expect(q.button("Underline")).toBeFocused();

--- a/app/src/sandbox/composite-6299/test.ts
+++ b/app/src/sandbox/composite-6299/test.ts
@@ -2,7 +2,7 @@ import { press, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 // https://github.com/ariakit/ariakit/issues/6299
-test("enters and traverses an RTL composite from the base element", async () => {
+test("enters an RTL composite from the base element with ArrowLeft", async () => {
   const toolbar = q.toolbar("Text formatting");
 
   await press.Tab();
@@ -14,8 +14,15 @@ test("enters and traverses an RTL composite from the base element", async () => 
 
   await press.ArrowLeft();
   expect(q.button("Italic")).toHaveFocus();
+});
 
-  toolbar.focus();
+// Use a fresh render so the toolbar has no active item when focused.
+test("enters an RTL composite from the base element with ArrowRight", async () => {
+  const toolbar = q.toolbar("Text formatting");
+
+  await press.Tab();
+
+  expect(toolbar).toHaveFocus();
 
   await press.ArrowRight();
   expect(q.button("Underline")).toHaveFocus();

--- a/app/src/sandbox/composite-6299/test.ts
+++ b/app/src/sandbox/composite-6299/test.ts
@@ -1,0 +1,25 @@
+import { press, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// https://github.com/ariakit/ariakit/issues/6299
+test("enters and traverses an RTL composite from the base element", async () => {
+  const toolbar = q.toolbar("Text formatting");
+
+  await press.Tab();
+
+  expect(toolbar).toHaveFocus();
+
+  await press.ArrowLeft();
+  expect(q.button("Bold")).toHaveFocus();
+
+  await press.ArrowLeft();
+  expect(q.button("Italic")).toHaveFocus();
+
+  toolbar.focus();
+
+  await press.ArrowRight();
+  expect(q.button("Underline")).toHaveFocus();
+
+  await press.ArrowRight();
+  expect(q.button("Italic")).toHaveFocus();
+});

--- a/packages/ariakit-react-components/src/composite/composite.tsx
+++ b/packages/ariakit-react-components/src/composite/composite.tsx
@@ -399,7 +399,7 @@ export const useComposite = createHook<TagName, CompositeOptions>(
       if (event.defaultPrevented) return;
       if (!store) return;
       if (!isSelfTarget(event)) return;
-      const { orientation, renderedItems, activeId } = store.getState();
+      const { orientation, renderedItems, activeId, rtl } = store.getState();
       const activeItem = getEnabledItem(store, activeId);
       if (activeItem?.element?.isConnected) return;
       const isVertical = orientation !== "horizontal";
@@ -423,9 +423,9 @@ export const useComposite = createHook<TagName, CompositeOptions>(
       };
       const keyMap = {
         ArrowUp: (grid || isVertical) && up,
-        ArrowRight: (grid || isHorizontal) && store.first,
+        ArrowRight: (grid || isHorizontal) && (rtl ? store.last : store.first),
         ArrowDown: (grid || isVertical) && store.first,
-        ArrowLeft: (grid || isHorizontal) && store.last,
+        ArrowLeft: (grid || isHorizontal) && (rtl ? store.first : store.last),
         Home: store.first,
         End: store.last,
         PageUp: store.first,


### PR DESCRIPTION
## Motivation

In an RTL composite whose base element can receive focus, pressing `ArrowLeft` or `ArrowRight` from the base entered the item list at the LTR DOM edge. The next press of the same key could then strand focus because item-level navigation and base-entry navigation disagreed about RTL order.

Fixes #6299.

## Solution

The composite base keydown handler now reads `rtl` from the store and swaps the horizontal entry targets only for RTL composites. LTR behavior is unchanged, and `Home`/`End`/paging keys still use DOM-order first/last items.

The regression is covered by a React sandbox with both happy-dom and cross-browser Playwright tests. The tests drive the real toolbar experience from the base element for both `ArrowLeft` and `ArrowRight`.

## Workaround

Handle horizontal arrow keys on the composite base element before Ariakit's built-in base keymap runs, and delegate entry to the store's RTL-aware `previous`/`next` methods:

```tsx
// TODO: Remove once https://github.com/ariakit/ariakit/issues/6299 is fixed.
function onKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
  if (event.defaultPrevented) return;
  if (event.target !== event.currentTarget) return;
  const isLeft = event.key === "ArrowLeft";
  const isRight = event.key === "ArrowRight";
  if (!isLeft && !isRight) return;
  const id = isLeft ? composite.previous() : composite.next();
  if (id === undefined) return;
  event.preventDefault();
  composite.move(id);
}

<Ariakit.Composite store={composite} onKeyDown={onKeyDown} />;
```
