### PR TITLE
Improve script profile perf reports

### DIFF
--- a/app/src/sandbox/composite-perf/perf-chrome.ts
+++ b/app/src/sandbox/composite-perf/perf-chrome.ts
@@ -68,9 +68,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     });
   });
 
-  test("update controlled items with script profile", async ({ q, perf }) => {
+  test("update controlled items (script profile)", async ({ q, perf }) => {
     await perf.measure(() => updateControlledItems(q), {
-      label: "update controlled items (script profile)",
       scriptProfile: true,
       profileLimit: 20,
       setup: () => setupControlledComposite(q),

--- a/app/src/sandbox/dialog-perf/perf-chrome.ts
+++ b/app/src/sandbox/dialog-perf/perf-chrome.ts
@@ -24,17 +24,20 @@ withFramework(import.meta.dirname, async ({ test }) => {
     );
   });
 
-  // Same interaction as "open dialog", but with the script profiler enabled so
-  // the PR comment shows where the scripting time goes. Profiling adds
+  // Same interaction as "close dialog", but with the script profiler enabled
+  // so the PR comment shows where the scripting time goes. Profiling adds
   // overhead, so the unprofiled test above is the one to read for timings.
-  test("open dialog with script profile", async ({ q, perf }) => {
+  test("close dialog (script profile)", async ({ q, perf }) => {
     await perf.measure(
       async () => {
-        await q.button("Open dialog").click();
-        await expect(q.dialog("Settings")).toBeVisible();
+        await q.button("Cancel").click();
+        await expect(q.dialog("Settings")).not.toBeVisible();
       },
       {
-        label: "open dialog (script profile)",
+        setup: async () => {
+          await q.button("Open dialog").click();
+          await expect(q.dialog("Settings")).toBeVisible();
+        },
         scriptProfile: true,
         profileLimit: 20,
       },

--- a/app/src/sandbox/dialog-perf/perf-chrome.ts
+++ b/app/src/sandbox/dialog-perf/perf-chrome.ts
@@ -24,20 +24,16 @@ withFramework(import.meta.dirname, async ({ test }) => {
     );
   });
 
-  // Same interaction as "close dialog", but with the script profiler enabled
+  // Same interaction as "open dialog", but with the script profiler enabled
   // so the PR comment shows where the scripting time goes. Profiling adds
   // overhead, so the unprofiled test above is the one to read for timings.
-  test("close dialog (script profile)", async ({ q, perf }) => {
+  test("open dialog (script profile)", async ({ q, perf }) => {
     await perf.measure(
       async () => {
-        await q.button("Cancel").click();
-        await expect(q.dialog("Settings")).not.toBeVisible();
+        await q.button("Open dialog").click();
+        await expect(q.dialog("Settings")).toBeVisible();
       },
       {
-        setup: async () => {
-          await q.button("Open dialog").click();
-          await expect(q.dialog("Settings")).toBeVisible();
-        },
         scriptProfile: true,
         profileLimit: 20,
       },

--- a/packages/ariakit-scripts/src/perf-compare.test.ts
+++ b/packages/ariakit-scripts/src/perf-compare.test.ts
@@ -678,7 +678,7 @@ test("merges profiles across rounds", () => {
   expect(markdown).toContain("secondRoundFn");
 });
 
-test("links repo script profile sources to GitHub lines", () => {
+test("renders script profile function names as linked code", () => {
   const dir = createTempDir();
   const profiles: PerfProfiles = {
     script: [
@@ -724,14 +724,95 @@ test("links repo script profile sources to GitHub lines", () => {
   });
 
   expect(markdown).toContain(
-    "[packages/ariakit-react-components/src/dialog/dialog.tsx:12:3](https://github.com/ariakit/ariakit/blob/abc123/packages/ariakit-react-components/src/dialog/dialog.tsx#L12)",
+    "[`Dialog`](https://github.com/ariakit/ariakit/blob/abc123/packages/ariakit-react-components/src/dialog/dialog.tsx#L12)",
   );
   expect(markdown).toContain(
-    "[app/src/sandbox/dialog-perf/index.react.tsx:34:5](https://github.com/ariakit/ariakit/blob/abc123/app/src/sandbox/dialog-perf/index.react.tsx#L34)",
+    "[`DialogPerf`](https://github.com/ariakit/ariakit/blob/abc123/app/src/sandbox/dialog-perf/index.react.tsx#L34)",
   );
   expect(markdown).toContain(
-    String.raw`[app/src/sandbox/dialog\\\[perf\]\|case.tsx:56:7](https://github.com/ariakit/ariakit/blob/abc123/app/src/sandbox/dialog%5C%5Bperf%5D%7Ccase.tsx#L56)`,
+    "[`Escaped`](https://github.com/ariakit/ariakit/blob/abc123/app/src/sandbox/dialog%5C%5Bperf%5D%7Ccase.tsx#L56)",
   );
+  expect(markdown).toContain(
+    "| [`Dialog`](https://github.com/ariakit/ariakit/blob/abc123/packages/ariakit-react-components/src/dialog/dialog.tsx#L12) | 8.0ms | 9.0ms | 2 |",
+  );
+  expect(markdown).not.toContain("| Function | Self | Total | Hits | Source |");
+  expect(markdown).not.toContain("dialog.tsx:12:3");
+});
+
+test("keeps node_modules script profile functions as unlinked code", () => {
+  const dir = createTempDir();
+  const profiles: PerfProfiles = {
+    script: [
+      {
+        functionName: "updateWorkInProgressHook",
+        url: "/node_modules/react-dom/react-dom-client.production.js",
+        line: 4455,
+        column: 10,
+        selfTime: 8,
+        totalTime: 9,
+        hitCount: 2,
+      },
+    ],
+  };
+  writeJson(dir, "baseline-worker0.json", [
+    createResultWithMetrics("profiled", createMetrics(100), profiles),
+  ]);
+  writeJson(dir, "current-worker0.json", [
+    createResultWithMetrics("profiled", createMetrics(100), profiles),
+  ]);
+
+  const markdown = runCompare(dir, [], {
+    GITHUB_REPOSITORY: "ariakit/ariakit",
+    GITHUB_SHA: "abc123",
+  });
+
+  expect(markdown).toContain(
+    "| `updateWorkInProgressHook` | 8.0ms | 9.0ms | 2 |",
+  );
+  expect(markdown).not.toContain("react-dom-client.production.js");
+});
+
+test("omits metric tables for script profile comparisons", () => {
+  const dir = createTempDir();
+  const profiles: PerfProfiles = {
+    script: [createScriptProfileEntry("profiledFn", 8)],
+  };
+  writeJson(dir, "baseline-worker0.json", [
+    createResultWithMetrics("profiled", createMetrics(100), profiles),
+  ]);
+  writeJson(dir, "current-worker0.json", [
+    createResultWithMetrics("profiled", createMetrics(130), profiles),
+  ]);
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain("No significant performance changes detected.");
+  expect(markdown).toContain("### profiled");
+  expect(markdown).toContain("#### Script profile");
+  expect(markdown).toContain("| `profiledFn` | 8.0ms | 8.0ms | 1 |");
+  expect(markdown).not.toContain("| Metric | Baseline | Current | Delta |");
+  expect(markdown).not.toContain("+30.0ms (+30%)");
+});
+
+test("omits new test metric rows for script profile results", () => {
+  const dir = createTempDir();
+  const profiles: PerfProfiles = {
+    script: [createScriptProfileEntry("profiledFn", 8)],
+  };
+  writeJson(dir, "current-worker0.json", [
+    createResultWithLabel("regular", 100),
+    createResultWithMetrics("profiled", createMetrics(130), profiles),
+  ]);
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain("### New tests (no baseline)");
+  expect(markdown).toContain("| Test | Scripting | Rendering | Total |");
+  expect(markdown).toContain("| regular | 100.0ms | 0.0ms | 100.0ms |");
+  expect(markdown).toContain("#### profiled");
+  expect(markdown).toContain("#### Script profile");
+  expect(markdown).toContain("| `profiledFn` | 8.0ms | 8.0ms | 1 |");
+  expect(markdown).not.toContain("| profiled | 130.0ms | 0.0ms | 130.0ms |");
 });
 
 test("warns when only one side has profile data for a test", () => {
@@ -742,11 +823,37 @@ test("warns when only one side has profile data for a test", () => {
     }),
   ]);
   writeJson(dir, "current-worker0.json", [
-    createResultWithMetrics("profile-mismatch", createMetrics(100)),
+    createResultWithMetrics("profile-mismatch", createMetrics(130)),
   ]);
 
   const markdown = runCompare(dir);
 
   expect(markdown).toContain("Profile data differs between baseline");
   expect(markdown).toContain("| profile-mismatch | script | yes | no |");
+  expect(markdown).toContain("No significant performance changes detected.");
+  expect(markdown).not.toContain("### profile-mismatch");
+  expect(markdown).not.toContain("| Metric | Baseline | Current | Delta |");
+  expect(markdown).not.toContain("+30.0ms (+30%)");
+});
+
+test("omits metric tables when only current has script profile data", () => {
+  const dir = createTempDir();
+  const profiles: PerfProfiles = {
+    script: [createScriptProfileEntry("currentProfile", 8)],
+  };
+  writeJson(dir, "baseline-worker0.json", [
+    createResultWithMetrics("profile-mismatch", createMetrics(100)),
+  ]);
+  writeJson(dir, "current-worker0.json", [
+    createResultWithMetrics("profile-mismatch", createMetrics(130), profiles),
+  ]);
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain("Profile data differs between baseline");
+  expect(markdown).toContain("| profile-mismatch | script | no | yes |");
+  expect(markdown).toContain("No significant performance changes detected.");
+  expect(markdown).toContain("| `currentProfile` | 8.0ms | 8.0ms | 1 |");
+  expect(markdown).not.toContain("| Metric | Baseline | Current | Delta |");
+  expect(markdown).not.toContain("+30.0ms (+30%)");
 });

--- a/packages/ariakit-scripts/src/perf-compare.test.ts
+++ b/packages/ariakit-scripts/src/perf-compare.test.ts
@@ -32,8 +32,20 @@ interface PerfScriptProfileEntry {
   hitCount: number;
 }
 
+interface PerfSelectorProfileEntry {
+  selector: string;
+  styleSheetId: string;
+  styleSheetUrl: string;
+  elapsed: number;
+  matchAttempts: number;
+  matchCount: number;
+  slowPathNonMatchPercent: number;
+  invalidationCount: number;
+}
+
 interface PerfProfiles {
   script?: PerfScriptProfileEntry[];
+  selectors?: PerfSelectorProfileEntry[];
 }
 
 interface PerfResult {
@@ -42,6 +54,8 @@ interface PerfResult {
   label: string;
   metrics: PerfMetrics;
   raw: PerfMetrics[];
+  scriptProfile?: boolean;
+  selectorProfile?: boolean;
   profiles?: PerfProfiles;
 }
 
@@ -111,6 +125,21 @@ function createScriptProfileEntry(
     selfTime,
     totalTime: selfTime,
     hitCount: 1,
+  };
+}
+
+function createSelectorProfileEntry(
+  selector = ".item",
+): PerfSelectorProfileEntry {
+  return {
+    selector,
+    styleSheetId: "1",
+    styleSheetUrl: "app/src/sandbox/example/style.css",
+    elapsed: 8,
+    matchAttempts: 10,
+    matchCount: 2,
+    slowPathNonMatchPercent: 20,
+    invalidationCount: 0,
   };
 }
 
@@ -815,6 +844,36 @@ test("omits new test metric rows for script profile results", () => {
   expect(markdown).not.toContain("| profiled | 130.0ms | 0.0ms | 130.0ms |");
 });
 
+test("omits new test metric rows for selector profile results", () => {
+  const dir = createTempDir();
+  const profiles: PerfProfiles = {
+    selectors: [createSelectorProfileEntry(".item")],
+  };
+  writeJson(dir, "current-worker0.json", [
+    createResultWithLabel("regular", 100),
+    {
+      ...createResultWithMetrics(
+        "selector-profiled",
+        createMetrics(130),
+        profiles,
+      ),
+      selectorProfile: true,
+    },
+  ]);
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain("### New tests (no baseline)");
+  expect(markdown).toContain("| Test | Scripting | Rendering | Total |");
+  expect(markdown).toContain("| regular | 100.0ms | 0.0ms | 100.0ms |");
+  expect(markdown).toContain("#### selector-profiled");
+  expect(markdown).toContain("#### Selector profile");
+  expect(markdown).toContain("| .item | 8.0ms | 10 | 2 | 20% |");
+  expect(markdown).not.toContain(
+    "| selector-profiled | 130.0ms | 0.0ms | 130.0ms |",
+  );
+});
+
 test("warns when only one side has profile data for a test", () => {
   const dir = createTempDir();
   writeJson(dir, "baseline-worker0.json", [
@@ -828,7 +887,7 @@ test("warns when only one side has profile data for a test", () => {
 
   const markdown = runCompare(dir);
 
-  expect(markdown).toContain("Profile data differs between baseline");
+  expect(markdown).toContain("Profile mode differs between baseline");
   expect(markdown).toContain("| profile-mismatch | script | yes | no |");
   expect(markdown).toContain("No significant performance changes detected.");
   expect(markdown).not.toContain("### profile-mismatch");
@@ -850,10 +909,90 @@ test("omits metric tables when only current has script profile data", () => {
 
   const markdown = runCompare(dir);
 
-  expect(markdown).toContain("Profile data differs between baseline");
+  expect(markdown).toContain("Profile mode differs between baseline");
   expect(markdown).toContain("| profile-mismatch | script | no | yes |");
   expect(markdown).toContain("No significant performance changes detected.");
   expect(markdown).toContain("| `currentProfile` | 8.0ms | 8.0ms | 1 |");
+  expect(markdown).not.toContain("| Metric | Baseline | Current | Delta |");
+  expect(markdown).not.toContain("+30.0ms (+30%)");
+});
+
+test("omits metric tables when script profile has no retained entries", () => {
+  const dir = createTempDir();
+  writeJson(dir, "baseline-worker0.json", [
+    createResultWithMetrics("profile-mismatch", createMetrics(100)),
+  ]);
+  writeJson(dir, "current-worker0.json", [
+    {
+      ...createResultWithMetrics("profile-mismatch", createMetrics(130)),
+      scriptProfile: true,
+    },
+  ]);
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain("Profile mode differs between baseline");
+  expect(markdown).toContain("| profile-mismatch | script | no | yes |");
+  expect(markdown).toContain("No significant performance changes detected.");
+  expect(markdown).not.toContain("### profile-mismatch");
+  expect(markdown).not.toContain("| Metric | Baseline | Current | Delta |");
+  expect(markdown).not.toContain("+30.0ms (+30%)");
+});
+
+test("omits metric tables when selector profile has no retained entries", () => {
+  const dir = createTempDir();
+  writeJson(dir, "baseline-worker0.json", [
+    createResultWithMetrics("profile-mismatch", createMetrics(100)),
+  ]);
+  writeJson(dir, "current-worker0.json", [
+    {
+      ...createResultWithMetrics("profile-mismatch", createMetrics(130)),
+      selectorProfile: true,
+    },
+  ]);
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain("Profile mode differs between baseline");
+  expect(markdown).toContain("| profile-mismatch | selectors | no | yes |");
+  expect(markdown).toContain("No significant performance changes detected.");
+  expect(markdown).not.toContain("### profile-mismatch");
+  expect(markdown).not.toContain("| Metric | Baseline | Current | Delta |");
+  expect(markdown).not.toContain("+30.0ms (+30%)");
+});
+
+test("omits metric tables for selector profile comparisons", () => {
+  const dir = createTempDir();
+  const profiles: PerfProfiles = {
+    selectors: [createSelectorProfileEntry(".item")],
+  };
+  writeJson(dir, "baseline-worker0.json", [
+    {
+      ...createResultWithMetrics(
+        "selector-profiled",
+        createMetrics(100),
+        profiles,
+      ),
+      selectorProfile: true,
+    },
+  ]);
+  writeJson(dir, "current-worker0.json", [
+    {
+      ...createResultWithMetrics(
+        "selector-profiled",
+        createMetrics(130),
+        profiles,
+      ),
+      selectorProfile: true,
+    },
+  ]);
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain("No significant performance changes detected.");
+  expect(markdown).toContain("### selector-profiled");
+  expect(markdown).toContain("#### Selector profile");
+  expect(markdown).toContain("| .item | 8.0ms | 10 | 2 | 20% |");
   expect(markdown).not.toContain("| Metric | Baseline | Current | Delta |");
   expect(markdown).not.toContain("+30.0ms (+30%)");
 });

--- a/packages/ariakit-scripts/src/perf-compare.ts
+++ b/packages/ariakit-scripts/src/perf-compare.ts
@@ -40,7 +40,7 @@ interface ComparisonRow {
   perRoundDeltas: number[];
   agreement: number;
   significant: boolean;
-  scriptProfile: boolean;
+  profileMode: boolean;
 }
 
 interface ComparisonSummary {
@@ -385,6 +385,9 @@ function combineResults(results: PerfResult[]): PerfResult | undefined {
     ...first,
     metrics: computeMedianMetrics(results.map((result) => result.metrics)),
     raw: results.flatMap((result) => result.raw),
+    scriptProfile: results.some((result) => result.scriptProfile) || undefined,
+    selectorProfile:
+      results.some((result) => result.selectorProfile) || undefined,
     profiles: mergeProfiles(results),
   };
 }
@@ -609,11 +612,27 @@ function resultKey(result: PerfResult): string {
   return `${result.testFile}::${result.label}`;
 }
 
-function hasProfile(
+function hasProfileData(
   result: PerfResult | undefined,
   profile: "script" | "selectors",
 ): boolean {
   return (result?.profiles?.[profile]?.length ?? 0) > 0;
+}
+
+function hasProfileMode(
+  result: PerfResult | undefined,
+  profile: "script" | "selectors",
+): boolean {
+  if (profile === "script") {
+    return !!result?.scriptProfile || hasProfileData(result, profile);
+  }
+  return !!result?.selectorProfile || hasProfileData(result, profile);
+}
+
+function isProfileMode(result: PerfResult | undefined): boolean {
+  return (
+    hasProfileMode(result, "script") || hasProfileMode(result, "selectors")
+  );
 }
 
 function isRegression(row: ComparisonRow, options: PerfCompareOptions) {
@@ -645,8 +664,8 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
       continue;
     }
     for (const profile of ["script", "selectors"] as const) {
-      const baselineHasProfile = hasProfile(base.result, profile);
-      const currentHasProfile = hasProfile(cur.result, profile);
+      const baselineHasProfile = hasProfileMode(base.result, profile);
+      const currentHasProfile = hasProfileMode(cur.result, profile);
       if (baselineHasProfile === currentHasProfile) continue;
       profileModeMismatches.push({
         testFile: cur.result.testFile,
@@ -668,9 +687,8 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
       continue;
     }
 
-    const scriptProfile =
-      hasProfile(base.result, "script") || hasProfile(cur.result, "script");
-    const primary = !scriptProfile;
+    const profileMode = isProfileMode(base.result) || isProfileMode(cur.result);
+    const primary = !profileMode;
     for (const metric of allMetrics) {
       const baselineValues: number[] = [];
       const currentValues: number[] = [];
@@ -710,7 +728,7 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
         perRoundDeltas,
         agreement,
         significant,
-        scriptProfile,
+        profileMode,
       });
     }
   }
@@ -954,7 +972,7 @@ function formatProfileModeWarning(mismatches: ProfileModeMismatch[]): string[] {
 
   const lines: string[] = [];
   lines.push(
-    ":warning: Profile data differs between baseline and current. Run both sides with the same profiling flags before comparing aggregate metrics.",
+    ":warning: Profile mode differs between baseline and current. Run both sides with the same profiling flags before comparing aggregate metrics.",
   );
   lines.push("");
   lines.push("| Test | Profile | Baseline | Current |");
@@ -990,12 +1008,12 @@ function formatDetailedBreakdown({
     const testRows = rowsByKey.get(key) ?? [];
     const label = testRows[0]?.label ?? key;
     const currentResult = currentByKey.get(key)?.result;
-    const scriptProfile = testRows.some((row) => row.scriptProfile);
+    const profileMode = testRows.some((row) => row.profileMode);
     const profileLines = formatProfiles(currentResult);
-    if (scriptProfile && profileLines.length === 0) continue;
+    if (profileMode && profileLines.length === 0) continue;
     lines.push(`### ${label}`);
     lines.push("");
-    if (!scriptProfile) {
+    if (!profileMode) {
       lines.push("| Metric | Baseline | Current | Delta |");
       lines.push("|--------|----------|---------|-------|");
       for (const metric of allMetrics) {
@@ -1109,7 +1127,7 @@ function formatMarkdown(
   if (newTests.length > 0) {
     const primaryMetrics = getPrimaryMetrics(options);
     const newTestsWithMetrics = newTests.filter(
-      ({ result }) => !hasProfile(result, "script"),
+      ({ result }) => !isProfileMode(result),
     );
     lines.push(`### New ${resultsName} (no baseline)`);
     lines.push("");

--- a/packages/ariakit-scripts/src/perf-compare.ts
+++ b/packages/ariakit-scripts/src/perf-compare.ts
@@ -40,6 +40,7 @@ interface ComparisonRow {
   perRoundDeltas: number[];
   agreement: number;
   significant: boolean;
+  scriptProfile: boolean;
 }
 
 interface ComparisonSummary {
@@ -577,15 +578,31 @@ function escapeLinkText(value: string): string {
     .trim();
 }
 
-function formatSourceCell(item: PerfScriptProfileEntry): string {
-  const source = `${item.url}:${item.line}:${item.column}`;
+function getGitHubSourceUrl(item: PerfScriptProfileEntry): string | undefined {
   const sourceBaseUrl = getGitHubSourceBaseUrl();
   if (!sourceBaseUrl || !isRepoSourcePath(item.url)) {
-    return escapeTableCell(source);
+    return;
   }
-  return `[${escapeLinkText(source)}](${sourceBaseUrl}/${encodeSourcePath(
-    item.url,
-  )}#L${item.line})`;
+  return `${sourceBaseUrl}/${encodeSourcePath(item.url)}#L${item.line}`;
+}
+
+function formatInlineCode(value: string): string {
+  const fenceLength =
+    Math.max(
+      0,
+      ...Array.from(value.matchAll(/`+/g), (match) => match[0].length),
+    ) + 1;
+  const fence = "`".repeat(fenceLength);
+  return `${fence}${value}${fence}`;
+}
+
+function formatFunctionCell(item: PerfScriptProfileEntry): string {
+  const name = formatInlineCode(item.functionName);
+  const sourceUrl = getGitHubSourceUrl(item);
+  if (!sourceUrl) {
+    return escapeTableCell(name);
+  }
+  return `[${escapeLinkText(name)}](${sourceUrl})`;
 }
 
 function resultKey(result: PerfResult): string {
@@ -593,10 +610,10 @@ function resultKey(result: PerfResult): string {
 }
 
 function hasProfile(
-  result: AggregatedPerfResult,
+  result: PerfResult | undefined,
   profile: "script" | "selectors",
-) {
-  return (result.result.profiles?.[profile]?.length ?? 0) > 0;
+): boolean {
+  return (result?.profiles?.[profile]?.length ?? 0) > 0;
 }
 
 function isRegression(row: ComparisonRow, options: PerfCompareOptions) {
@@ -628,8 +645,8 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
       continue;
     }
     for (const profile of ["script", "selectors"] as const) {
-      const baselineHasProfile = hasProfile(base, profile);
-      const currentHasProfile = hasProfile(cur, profile);
+      const baselineHasProfile = hasProfile(base.result, profile);
+      const currentHasProfile = hasProfile(cur.result, profile);
       if (baselineHasProfile === currentHasProfile) continue;
       profileModeMismatches.push({
         testFile: cur.result.testFile,
@@ -651,6 +668,9 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
       continue;
     }
 
+    const scriptProfile =
+      hasProfile(base.result, "script") || hasProfile(cur.result, "script");
+    const primary = !scriptProfile;
     for (const metric of allMetrics) {
       const baselineValues: number[] = [];
       const currentValues: number[] = [];
@@ -674,7 +694,7 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
         baseline: baseVal,
         current: curVal,
         minDelta,
-        primary: primaryMetrics.includes(metric),
+        primary: primary && primaryMetrics.includes(metric),
         percent,
         perRoundDeltas,
       });
@@ -690,6 +710,7 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
         perRoundDeltas,
         agreement,
         significant,
+        scriptProfile,
       });
     }
   }
@@ -885,12 +906,12 @@ function formatScriptProfile(result: PerfResult): string[] {
   const lines: string[] = [];
   lines.push("#### Script profile");
   lines.push("");
-  lines.push("| Function | Self | Total | Hits | Source |");
-  lines.push("|----------|------|-------|------|--------|");
+  lines.push("| Function | Self | Total | Hits |");
+  lines.push("|----------|------|-------|------|");
 
   for (const item of profile) {
     lines.push(
-      `| ${escapeTableCell(item.functionName)} | ${formatMs(item.selfTime)} | ${formatMs(item.totalTime)} | ${item.hitCount} | ${formatSourceCell(item)} |`,
+      `| ${formatFunctionCell(item)} | ${formatMs(item.selfTime)} | ${formatMs(item.totalTime)} | ${item.hitCount} |`,
     );
   }
 
@@ -968,28 +989,34 @@ function formatDetailedBreakdown({
   for (const key of keys) {
     const testRows = rowsByKey.get(key) ?? [];
     const label = testRows[0]?.label ?? key;
+    const currentResult = currentByKey.get(key)?.result;
+    const scriptProfile = testRows.some((row) => row.scriptProfile);
+    const profileLines = formatProfiles(currentResult);
+    if (scriptProfile && profileLines.length === 0) continue;
     lines.push(`### ${label}`);
     lines.push("");
-    lines.push("| Metric | Baseline | Current | Delta |");
-    lines.push("|--------|----------|---------|-------|");
-    for (const metric of allMetrics) {
-      const row = testRows.find((r) => r.metric === metric);
-      if (!row) continue;
-      const prefix = RENDERING_SUB_METRICS.has(metric) ? "- " : "";
-      const metricLabel = `${prefix}${getMetricLabel(metric, options)}`;
-      const deltaStr = formatDelta(
-        row.delta,
-        row.percent,
-        row.baseline,
-        options,
-      );
-      const icon = getSignificanceIcon(row, options);
-      lines.push(
-        `| ${metricLabel} | ${formatMetricValue(row.baseline, options)} | ${formatMetricValue(row.current, options)} | ${deltaStr}${icon} |`,
-      );
+    if (!scriptProfile) {
+      lines.push("| Metric | Baseline | Current | Delta |");
+      lines.push("|--------|----------|---------|-------|");
+      for (const metric of allMetrics) {
+        const row = testRows.find((r) => r.metric === metric);
+        if (!row) continue;
+        const prefix = RENDERING_SUB_METRICS.has(metric) ? "- " : "";
+        const metricLabel = `${prefix}${getMetricLabel(metric, options)}`;
+        const deltaStr = formatDelta(
+          row.delta,
+          row.percent,
+          row.baseline,
+          options,
+        );
+        const icon = getSignificanceIcon(row, options);
+        lines.push(
+          `| ${metricLabel} | ${formatMetricValue(row.baseline, options)} | ${formatMetricValue(row.current, options)} | ${deltaStr}${icon} |`,
+        );
+      }
+      lines.push("");
     }
-    lines.push("");
-    lines.push(...formatProfiles(currentByKey.get(key)?.result));
+    lines.push(...profileLines);
   }
   return lines;
 }
@@ -1081,18 +1108,21 @@ function formatMarkdown(
 
   if (newTests.length > 0) {
     const primaryMetrics = getPrimaryMetrics(options);
+    const newTestsWithMetrics = newTests.filter(
+      ({ result }) => !hasProfile(result, "script"),
+    );
     lines.push(`### New ${resultsName} (no baseline)`);
     lines.push("");
     if (options.node) {
-      lines.push(...formatNodeResultTables(newTests, options));
-    } else {
+      lines.push(...formatNodeResultTables(newTestsWithMetrics, options));
+    } else if (newTestsWithMetrics.length > 0) {
       const headers = [
         resultName,
         ...primaryMetrics.map((metric) => getMetricLabel(metric, options)),
       ];
       lines.push(`| ${headers.join(" | ")} |`);
       lines.push(`| ${headers.map(() => "---").join(" | ")} |`);
-      for (const { result } of newTests) {
+      for (const { result } of newTestsWithMetrics) {
         const cells: string[] = [result.label];
         for (const metric of primaryMetrics) {
           cells.push(formatMetricValue(result.metrics[metric], options));

--- a/packages/ariakit-scripts/src/perf.ts
+++ b/packages/ariakit-scripts/src/perf.ts
@@ -119,6 +119,8 @@ export interface PerfResult {
   label: string;
   metrics: PerfMetrics;
   raw: PerfMetrics[];
+  scriptProfile?: boolean;
+  selectorProfile?: boolean;
   profiles?: PerfProfiles;
 }
 
@@ -1154,6 +1156,8 @@ export async function createPerfMeasure(
     label: resolvedLabel,
     metrics: medianMetrics,
     raw: allMetrics,
+    scriptProfile: scriptProfile || undefined,
+    selectorProfile: selectorProfile || undefined,
     profiles: createProfiles(scriptProfiles, selectorProfiles, profileLimit),
   });
 


### PR DESCRIPTION
## Motivation

Performance comments currently show script-profile results with custom labels such as `open dialog (script profile)`, which drops the inferred file and framework prefix used by the normal perf tests.

Those profiled runs also include metric comparison tables even though profiling adds overhead and the corresponding unprofiled test usually owns the timing comparison. The script-profile table also spends a separate column on source links, making the function column less useful to scan.

## Solution

Remove the custom labels from the script-profile perf tests so Playwright title inference produces labels like `sandbox/dialog-perf/perf-chrome.ts > react > open dialog (script profile)`. The dialog script-profile case still measures the open-dialog interaction; it now relies on the inferred full label instead of a custom short one.

Persist profile mode on perf results so the comparison logic can distinguish a profiled run from an unprofiled run even when Chrome retains no profile rows. Profiled comparisons are now attribution-only for both script and selector profiling: they do not contribute significant metric changes, and their detailed timing tables are omitted. New profiled tests are also omitted from the new-test metric table while still rendering any available profile blocks.

The script-profile table now removes the Source column and renders every function name as code. Repo sources link from the function name to the GitHub line, while `node_modules` functions remain unlinked.
