### PR TITLE
Measure faster INP interactions in perf tests

### DIFF
--- a/packages/ariakit-scripts/src/perf.ts
+++ b/packages/ariakit-scripts/src/perf.ts
@@ -147,6 +147,10 @@ interface ProfilerStopResponse {
   profile: CdpProfile;
 }
 
+interface PerformanceEventObserverInit extends PerformanceObserverInit {
+  durationThreshold?: number;
+}
+
 interface CssStyleSheetHeader {
   styleSheetId: string;
   sourceURL?: string;
@@ -897,7 +901,14 @@ async function measureOnce(
         }
       }
     });
-    observer.observe({ type: "event", buffered: false });
+    // Event Timing observers default to 104ms. These measurements track fast
+    // deliberate interactions, so use the spec-minimum threshold.
+    const observerOptions: PerformanceEventObserverInit = {
+      type: "event",
+      durationThreshold: 16,
+      buffered: false,
+    };
+    observer.observe(observerOptions);
     w.__perfObserver = observer;
   });
 


### PR DESCRIPTION
## Motivation

The perf harness installs an Event Timing observer before each measured interaction, but it does not pass `durationThreshold`. Browser event observers default to 104ms, so the fast interactions these tests measure can be filtered out before Ariakit records them and INP stays at 0.

## Solution

Add a local observer-options type that includes `durationThreshold`, then observe `event` entries with the spec-minimum 16ms threshold while keeping the existing `interactionId` filtering. This lets the perf harness record deliberate interactions below the browser's 104ms default without changing the persisted metric shape.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm test packages/ariakit-scripts/src/perf.test.ts packages/ariakit-scripts/src/perf-compare.test.ts`
- Playwright smoke test with a real click and 24ms handler observed Event Timing entries at 24ms
