### PR TITLE
Fix combobox NFD inline autocomplete

### DIFF
--- a/.changeset/300-combobox-nfd-autocomplete.md
+++ b/.changeset/300-combobox-nfd-autocomplete.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Combobox`](https://ariakit.com/reference/combobox) inline autocomplete so decomposed Unicode input no longer produces misspelled completion values.

--- a/app/src/sandbox/combobox-6315/index.react.tsx
+++ b/app/src/sandbox/combobox-6315/index.react.tsx
@@ -28,6 +28,15 @@ export default function Example() {
           placeholder="e.g., Caramel latte"
           autoSelect
           autoComplete="both"
+          onChange={(event) => {
+            // TODO: Remove this workaround when
+            // https://github.com/ariakit/ariakit/issues/6315 is fixed.
+            const input = event.currentTarget;
+            const nfcValue = input.value.normalize("NFC");
+            if (nfcValue !== input.value) {
+              input.value = nfcValue;
+            }
+          }}
         />
         <Ariakit.ComboboxPopover gutter={8} sameWidth>
           {matches.map((drink) => (

--- a/app/src/sandbox/combobox-6315/index.react.tsx
+++ b/app/src/sandbox/combobox-6315/index.react.tsx
@@ -28,15 +28,6 @@ export default function Example() {
           placeholder="e.g., Caramel latte"
           autoSelect
           autoComplete="both"
-          onChange={(event) => {
-            // TODO: Remove this workaround when
-            // https://github.com/ariakit/ariakit/issues/6315 is fixed.
-            const input = event.currentTarget;
-            const nfcValue = input.value.normalize("NFC");
-            if (nfcValue !== input.value) {
-              input.value = nfcValue;
-            }
-          }}
         />
         <Ariakit.ComboboxPopover gutter={8} sameWidth>
           {matches.map((drink) => (

--- a/app/src/sandbox/combobox-6315/index.react.tsx
+++ b/app/src/sandbox/combobox-6315/index.react.tsx
@@ -1,0 +1,42 @@
+import * as Ariakit from "@ariakit/react";
+import { useMemo, useState } from "react";
+
+const drinks = ["Cafeteria", "Café au lait", "Caramel latte", "Chai tea"];
+
+function normalize(value: string) {
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+}
+
+export default function Example() {
+  const [searchValue, setSearchValue] = useState("");
+  const matches = useMemo(() => {
+    const search = normalize(searchValue);
+    return drinks.filter((drink) => normalize(drink).startsWith(search));
+  }, [searchValue]);
+
+  return (
+    <>
+      <Ariakit.ComboboxProvider setValue={setSearchValue}>
+        <p>
+          Decomposed sample: <b>{"cafe\u0301"}</b>
+        </p>
+        <Ariakit.ComboboxLabel>Your favorite drink</Ariakit.ComboboxLabel>
+        <Ariakit.Combobox
+          placeholder="e.g., Caramel latte"
+          autoSelect
+          autoComplete="both"
+        />
+        <Ariakit.ComboboxPopover gutter={8} sameWidth>
+          {matches.map((drink) => (
+            <Ariakit.ComboboxItem key={drink} value={drink} />
+          ))}
+        </Ariakit.ComboboxPopover>
+      </Ariakit.ComboboxProvider>
+      <button type="button">Save</button>
+      <output>{searchValue}</output>
+    </>
+  );
+}

--- a/app/src/sandbox/combobox-6315/test-browser.ts
+++ b/app/src/sandbox/combobox-6315/test-browser.ts
@@ -12,6 +12,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect
       .poll(async () => {
         const currentValue = await value();
+        if (currentValue == null) return "";
         return expectedValues.includes(currentValue) ? "safe" : currentValue;
       })
       .toBe("safe");

--- a/app/src/sandbox/combobox-6315/test-browser.ts
+++ b/app/src/sandbox/combobox-6315/test-browser.ts
@@ -2,6 +2,8 @@ import { withFramework } from "#app/test-utils/preview.ts";
 
 const decomposedCafe = "cafe\u0301";
 const decomposedCafet = `${decomposedCafe}t`;
+const decomposedCafeteria = `${decomposedCafe}teria`;
+const composedCafeteria = "caféteria";
 
 // https://github.com/ariakit/ariakit/issues/6315
 withFramework(import.meta.dirname, async ({ test }) => {
@@ -25,13 +27,13 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await combobox.pressSequentially(decomposedCafe);
     await expectSafeValue(
       () => combobox.inputValue(),
-      [decomposedCafe, "caféteria"],
+      [decomposedCafe, decomposedCafeteria, composedCafeteria],
     );
 
     await q.button("Save").click();
     await expectSafeValue(
       () => q.status().textContent(),
-      [decomposedCafe, "caféteria"],
+      [decomposedCafe, decomposedCafeteria, composedCafeteria],
     );
   });
 
@@ -44,13 +46,24 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await combobox.pressSequentially(decomposedCafet);
     await expectSafeValue(
       () => combobox.inputValue(),
-      [decomposedCafet, "caféteria"],
+      [decomposedCafet, decomposedCafeteria, composedCafeteria],
     );
 
     await q.button("Save").click();
     await expectSafeValue(
       () => q.status().textContent(),
-      [decomposedCafet, "caféteria"],
+      [decomposedCafet, decomposedCafeteria, composedCafeteria],
     );
+  });
+
+  test("completes unaccented input against accented items", async ({ q }) => {
+    const combobox = q.combobox("Your favorite drink");
+
+    await combobox.click();
+    await combobox.pressSequentially("cafe ");
+    await test.expect(combobox).toHaveValue("cafe au lait");
+
+    await q.button("Save").click();
+    await test.expect(q.status()).toHaveText("cafe au lait");
   });
 });

--- a/app/src/sandbox/combobox-6315/test-browser.ts
+++ b/app/src/sandbox/combobox-6315/test-browser.ts
@@ -1,0 +1,55 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+const decomposedCafe = "cafe\u0301";
+const decomposedCafet = `${decomposedCafe}t`;
+
+// https://github.com/ariakit/ariakit/issues/6315
+withFramework(import.meta.dirname, async ({ test }) => {
+  const expectSafeValue = async (
+    value: () => Promise<string | null>,
+    expectedValues: string[],
+  ) => {
+    await test.expect
+      .poll(async () => {
+        const currentValue = await value();
+        return expectedValues.includes(currentValue) ? "safe" : currentValue;
+      })
+      .toBe("safe");
+  };
+
+  test("does not corrupt decomposed inline completion", async ({ q }) => {
+    const combobox = q.combobox("Your favorite drink");
+
+    await combobox.click();
+    await combobox.pressSequentially(decomposedCafe);
+    await expectSafeValue(
+      () => combobox.inputValue(),
+      [decomposedCafe, "caféteria"],
+    );
+
+    await q.button("Save").click();
+    await expectSafeValue(
+      () => q.status().textContent(),
+      [decomposedCafe, "caféteria"],
+    );
+  });
+
+  test("does not drop completion characters after decomposed input", async ({
+    q,
+  }) => {
+    const combobox = q.combobox("Your favorite drink");
+
+    await combobox.click();
+    await combobox.pressSequentially(decomposedCafet);
+    await expectSafeValue(
+      () => combobox.inputValue(),
+      [decomposedCafet, "caféteria"],
+    );
+
+    await q.button("Save").click();
+    await expectSafeValue(
+      () => q.status().textContent(),
+      [decomposedCafet, "caféteria"],
+    );
+  });
+});

--- a/app/src/sandbox/combobox-6315/test.ts
+++ b/app/src/sandbox/combobox-6315/test.ts
@@ -3,6 +3,8 @@ import { expect, test } from "vitest";
 
 const decomposedCafe = "cafe\u0301";
 const decomposedCafet = `${decomposedCafe}t`;
+const decomposedCafeteria = `${decomposedCafe}teria`;
+const composedCafeteria = "caféteria";
 
 function expectSafeValue(value: string, expectedValues: string[]) {
   expect(expectedValues).toContain(value);
@@ -21,12 +23,17 @@ test("does not corrupt decomposed inline completion", async () => {
 
   await click(combobox);
   await type(decomposedCafe);
-  expectSafeValue(getInputValue(combobox), [decomposedCafe, "caféteria"]);
+  expectSafeValue(getInputValue(combobox), [
+    decomposedCafe,
+    decomposedCafeteria,
+    composedCafeteria,
+  ]);
 
   await click(q.button("Save"));
   expectSafeValue(q.status.ensure().textContent ?? "", [
     decomposedCafe,
-    "caféteria",
+    decomposedCafeteria,
+    composedCafeteria,
   ]);
 });
 
@@ -35,11 +42,27 @@ test("does not drop completion characters after decomposed input", async () => {
 
   await click(combobox);
   await type(decomposedCafet);
-  expectSafeValue(getInputValue(combobox), [decomposedCafet, "caféteria"]);
+  expectSafeValue(getInputValue(combobox), [
+    decomposedCafet,
+    decomposedCafeteria,
+    composedCafeteria,
+  ]);
 
   await click(q.button("Save"));
   expectSafeValue(q.status.ensure().textContent ?? "", [
     decomposedCafet,
-    "caféteria",
+    decomposedCafeteria,
+    composedCafeteria,
   ]);
+});
+
+test("completes unaccented input against accented items", async () => {
+  const combobox = q.combobox.ensure("Your favorite drink");
+
+  await click(combobox);
+  await type("cafe ");
+  expect(getInputValue(combobox)).toBe("cafe au lait");
+
+  await click(q.button("Save"));
+  expect(q.status.ensure()).toHaveTextContent("cafe au lait");
 });

--- a/app/src/sandbox/combobox-6315/test.ts
+++ b/app/src/sandbox/combobox-6315/test.ts
@@ -1,0 +1,38 @@
+import { click, q, type } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+const decomposedCafe = "cafe\u0301";
+const decomposedCafet = `${decomposedCafe}t`;
+
+function expectSafeValue(value: string, expectedValues: string[]) {
+  expect(expectedValues).toContain(value);
+}
+
+// https://github.com/ariakit/ariakit/issues/6315
+test("does not corrupt decomposed inline completion", async () => {
+  const combobox = q.combobox.ensure("Your favorite drink");
+
+  await click(combobox);
+  await type(decomposedCafe);
+  expectSafeValue(combobox.value, [decomposedCafe, "caféteria"]);
+
+  await click(q.button("Save"));
+  expectSafeValue(q.status.ensure().textContent ?? "", [
+    decomposedCafe,
+    "caféteria",
+  ]);
+});
+
+test("does not drop completion characters after decomposed input", async () => {
+  const combobox = q.combobox.ensure("Your favorite drink");
+
+  await click(combobox);
+  await type(decomposedCafet);
+  expectSafeValue(combobox.value, [decomposedCafet, "caféteria"]);
+
+  await click(q.button("Save"));
+  expectSafeValue(q.status.ensure().textContent ?? "", [
+    decomposedCafet,
+    "caféteria",
+  ]);
+});

--- a/app/src/sandbox/combobox-6315/test.ts
+++ b/app/src/sandbox/combobox-6315/test.ts
@@ -8,13 +8,20 @@ function expectSafeValue(value: string, expectedValues: string[]) {
   expect(expectedValues).toContain(value);
 }
 
+function getInputValue(element: HTMLElement) {
+  if (element instanceof HTMLInputElement) {
+    return element.value;
+  }
+  return "";
+}
+
 // https://github.com/ariakit/ariakit/issues/6315
 test("does not corrupt decomposed inline completion", async () => {
   const combobox = q.combobox.ensure("Your favorite drink");
 
   await click(combobox);
   await type(decomposedCafe);
-  expectSafeValue(combobox.value, [decomposedCafe, "caféteria"]);
+  expectSafeValue(getInputValue(combobox), [decomposedCafe, "caféteria"]);
 
   await click(q.button("Save"));
   expectSafeValue(q.status.ensure().textContent ?? "", [
@@ -28,7 +35,7 @@ test("does not drop completion characters after decomposed input", async () => {
 
   await click(combobox);
   await type(decomposedCafet);
-  expectSafeValue(combobox.value, [decomposedCafet, "caféteria"]);
+  expectSafeValue(getInputValue(combobox), [decomposedCafet, "caféteria"]);
 
   await click(q.button("Save"));
   expectSafeValue(q.status.ensure().textContent ?? "", [

--- a/packages/ariakit-react-components/src/combobox/combobox.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox.tsx
@@ -68,10 +68,15 @@ function isFirstItemAutoSelected(
 function hasCompletionString(value?: string, activeValue?: string) {
   if (!activeValue) return false;
   if (value == null) return false;
-  value = normalizeString(value);
+  const normalizedValue = normalizeString(value);
+  const normalizedActiveValue = normalizeString(activeValue);
+  if (normalizedValue.length !== value.length) return false;
+  if (normalizedActiveValue.length !== activeValue.length) return false;
   return (
-    activeValue.length > value.length &&
-    activeValue.toLowerCase().indexOf(value.toLowerCase()) === 0
+    normalizedActiveValue.length > normalizedValue.length &&
+    normalizedActiveValue
+      .toLowerCase()
+      .startsWith(normalizedValue.toLowerCase())
   );
 }
 


### PR DESCRIPTION
## Motivation

Fixes #6315.

`Combobox` inline autocomplete could corrupt decomposed Unicode input when `autoSelect` was used with `autoComplete="inline"` or `autoComplete="both"`. The active item matched after normalization, but the completion slice used the raw input length, so a decomposed query such as `cafe\u0301` could display and commit misspelled values like `caféeria` or `cafétria`.

## Solution

`hasCompletionString` now normalizes both the typed value and active item value before checking whether inline completion is available. It also bails out when normalization changes either raw string length, since the append and highlight code still uses raw string offsets.

This makes decomposed input fail closed to the typed value instead of slicing the active value at the wrong offset. Existing NFC input still completes normally because its raw offsets remain aligned.

The PR keeps a sandbox regression under `app/src/sandbox/combobox-6315` with both happy-dom and browser coverage.

## Workaround

Normalize the input value to NFC from a consumer `onChange` handler. Consumer handlers run before Ariakit reads the input value, so this keeps the raw string length aligned with the inline completion slice.

```tsx
<Ariakit.Combobox
  autoSelect
  autoComplete="both"
  onChange={(event) => {
    // TODO: Remove this workaround when
    // https://github.com/ariakit/ariakit/issues/6315 is fixed.
    const input = event.currentTarget;
    const nfcValue = input.value.normalize("NFC");
    if (nfcValue !== input.value) {
      input.value = nfcValue;
    }
  }}
/>
```
