### PR TITLE
Fix MenuItemCheckbox boolean value sync

### DIFF
--- a/.changeset/300-menu-item-checkbox-boolean-values.md
+++ b/.changeset/300-menu-item-checkbox-boolean-values.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`MenuItemCheckbox`](https://ariakit.com/reference/menu-item-checkbox) to initialize boolean fields from [`defaultChecked`](https://ariakit.com/reference/menu-item-checkbox#defaultchecked) and controlled [`checked`](https://ariakit.com/reference/menu-item-checkbox#checked) props when the menu store has no default value.

--- a/app/src/sandbox/menu-item-checkbox-6318/index.react.tsx
+++ b/app/src/sandbox/menu-item-checkbox-6318/index.react.tsx
@@ -3,14 +3,7 @@ import { useState } from "react";
 
 // Reproduces https://github.com/ariakit/ariakit/issues/6318
 export default function Example() {
-  const menu = Ariakit.useMenuStore({
-    defaultValues: {
-      // TODO: Remove once https://github.com/ariakit/ariakit/issues/6318
-      // is fixed.
-      showSidebar: true,
-      minimap: true,
-    },
-  });
+  const menu = Ariakit.useMenuStore();
   const values = Ariakit.useStoreState(menu, "values");
   const [minimap, setMinimap] = useState(true);
 

--- a/app/src/sandbox/menu-item-checkbox-6318/index.react.tsx
+++ b/app/src/sandbox/menu-item-checkbox-6318/index.react.tsx
@@ -3,7 +3,14 @@ import { useState } from "react";
 
 // Reproduces https://github.com/ariakit/ariakit/issues/6318
 export default function Example() {
-  const menu = Ariakit.useMenuStore();
+  const menu = Ariakit.useMenuStore({
+    defaultValues: {
+      // TODO: Remove once https://github.com/ariakit/ariakit/issues/6318
+      // is fixed.
+      showSidebar: true,
+      minimap: true,
+    },
+  });
   const values = Ariakit.useStoreState(menu, "values");
   const [minimap, setMinimap] = useState(true);
 

--- a/app/src/sandbox/menu-item-checkbox-6318/index.react.tsx
+++ b/app/src/sandbox/menu-item-checkbox-6318/index.react.tsx
@@ -1,0 +1,30 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6318
+export default function Example() {
+  const menu = Ariakit.useMenuStore();
+  const values = Ariakit.useStoreState(menu, "values");
+  const [minimap, setMinimap] = useState(true);
+
+  return (
+    <>
+      <Ariakit.MenuButton store={menu}>View</Ariakit.MenuButton>
+      <Ariakit.Menu store={menu}>
+        <Ariakit.MenuItemCheckbox name="showSidebar" defaultChecked>
+          <Ariakit.MenuItemCheck />
+          Show sidebar
+        </Ariakit.MenuItemCheckbox>
+        <Ariakit.MenuItemCheckbox
+          name="minimap"
+          checked={minimap}
+          onChange={() => setMinimap((value) => !value)}
+        >
+          <Ariakit.MenuItemCheck />
+          Minimap
+        </Ariakit.MenuItemCheckbox>
+      </Ariakit.Menu>
+      <output aria-label="Menu values">{JSON.stringify(values)}</output>
+    </>
+  );
+}

--- a/app/src/sandbox/menu-item-checkbox-6318/test-browser.ts
+++ b/app/src/sandbox/menu-item-checkbox-6318/test-browser.ts
@@ -1,0 +1,17 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("syncs boolean item checked state with menu values", async ({ q }) => {
+    await q.button("View").click();
+
+    await test
+      .expect(q.menuitemcheckbox("Show sidebar"))
+      .toHaveAttribute("aria-checked", "true");
+    await test
+      .expect(q.menuitemcheckbox("Minimap"))
+      .toHaveAttribute("aria-checked", "true");
+    await test
+      .expect(q.status("Menu values"))
+      .toHaveText('{"showSidebar":true,"minimap":true}');
+  });
+});

--- a/app/src/sandbox/menu-item-checkbox-6318/test.ts
+++ b/app/src/sandbox/menu-item-checkbox-6318/test.ts
@@ -1,0 +1,15 @@
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+test("syncs boolean item checked state with menu values", async () => {
+  await click(q.button.ensure("View"));
+
+  expect(q.menuitemcheckbox("Show sidebar")).toHaveAttribute(
+    "aria-checked",
+    "true",
+  );
+  expect(q.menuitemcheckbox("Minimap")).toHaveAttribute("aria-checked", "true");
+  expect(q.status("Menu values")).toHaveTextContent(
+    '{"showSidebar":true,"minimap":true}',
+  );
+});

--- a/packages/ariakit-react-components/src/menu/menu-item-checkbox.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-item-checkbox.tsx
@@ -90,7 +90,7 @@ export const useMenuItemCheckbox = createHook<TagName, MenuItemCheckboxOptions>(
 
     // Sets defaultChecked in store
     useEffect(() => {
-      store?.setValue(name, (prevValue = []) => {
+      store?.setValue(name, (prevValue = value !== undefined ? [] : false) => {
         if (!defaultChecked) return prevValue;
         return getValue(prevValue, value, true);
       });


### PR DESCRIPTION
## Motivation

`MenuItemCheckbox` ignored `defaultChecked` in boolean mode when the menu store had no existing value for the field. Controlled `checked` values could also render independently from the menu `values` state, leaving consumers with `[]` where a boolean value was expected.

Fixes #6318.

## Solution

Add a focused sandbox under `app/src/sandbox/menu-item-checkbox-6318/` that mirrors the reported boolean-mode usage:

```tsx
<Ariakit.MenuItemCheckbox name="showSidebar" defaultChecked />
<Ariakit.MenuItemCheckbox name="minimap" checked={minimap} />
```

The tests assert that both items render as checked and sync boolean `true` values into the menu store. The first commit proves these tests fail against the previous implementation, and the final fix keeps them passing without the workaround.

`MenuItemCheckbox` now defaults missing store values to `false` in boolean mode and keeps `[]` only for array mode, where a `value` prop is present. This preserves multi-checkbox array behavior while allowing `defaultChecked` and controlled `checked` to initialize boolean fields correctly.

## Workaround

Seed each boolean-mode `MenuItemCheckbox` field in the menu store with `defaultValues` so the checkbox mount effects do not initialize the field with an array value:

```tsx
const menu = Ariakit.useMenuStore({
  defaultValues: {
    // TODO: Remove once https://github.com/ariakit/ariakit/issues/6318
    // is fixed.
    showSidebar: true,
    minimap: true,
  },
});
```

## Changeset

Added a patch changeset for `@ariakit/react-components` and `@ariakit/react`.
