### PR TITLE
Fix iframe text field detection

### DIFF
--- a/.changeset/300-iframe-text-fields.md
+++ b/.changeset/300-iframe-text-fields.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/utils": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed text field detection for elements rendered inside same-origin iframes. This fixes [`Composite`](https://ariakit.com/reference/composite) keyboard navigation for iframe text fields, including components built on it such as [`Toolbar`](https://ariakit.com/reference/toolbar), and prevents [`Command`](https://ariakit.com/reference/command) and [`Combobox`](https://ariakit.com/reference/combobox) from treating iframe text fields as non-text fields.

--- a/app/src/sandbox/toolbar-iframe-6316/index.react.tsx
+++ b/app/src/sandbox/toolbar-iframe-6316/index.react.tsx
@@ -1,0 +1,47 @@
+import * as Ariakit from "@ariakit/react";
+import { useEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
+
+function FormattingToolbar() {
+  return (
+    <Ariakit.Toolbar
+      aria-label="Formatting"
+      style={{ display: "flex", gap: 8 }}
+    >
+      <Ariakit.ToolbarItem>Bold</Ariakit.ToolbarItem>
+      <Ariakit.ToolbarItem render={<input type="text" aria-label="Find" />} />
+      <Ariakit.ToolbarItem>Italic</Ariakit.ToolbarItem>
+    </Ariakit.Toolbar>
+  );
+}
+
+export default function Example() {
+  const [iframe, setIframe] = useState<HTMLIFrameElement | null>(null);
+
+  useEffect(() => {
+    if (!iframe) return;
+    const doc = iframe.contentDocument;
+    if (!doc?.body) return;
+    const root = createRoot(doc.body);
+    root.render(<FormattingToolbar />);
+    return () => {
+      setTimeout(() => root.unmount());
+    };
+  }, [iframe]);
+
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <FormattingToolbar />
+      <iframe
+        ref={setIframe}
+        title="Embedded editor"
+        style={{
+          border: "1px solid",
+          display: "block",
+          height: 80,
+          width: 360,
+        }}
+      />
+    </div>
+  );
+}

--- a/app/src/sandbox/toolbar-iframe-6316/index.react.tsx
+++ b/app/src/sandbox/toolbar-iframe-6316/index.react.tsx
@@ -1,6 +1,22 @@
 import * as Ariakit from "@ariakit/react";
+import type { KeyboardEvent } from "react";
 import { useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
+
+// TODO: Remove this workaround once
+// https://github.com/ariakit/ariakit/issues/6316 is fixed.
+// Iframe inputs skip Ariakit's built-in text boundary check, so re-check the
+// caret before allowing toolbar focus to move.
+function shouldMoveOnKeyPress(event: KeyboardEvent<HTMLElement>) {
+  const input = event.currentTarget as HTMLInputElement;
+  if (event.key === "ArrowLeft") {
+    return (input.selectionStart ?? 0) === 0;
+  }
+  if (event.key === "ArrowRight") {
+    return (input.selectionEnd ?? 0) === input.value.length;
+  }
+  return true;
+}
 
 function FormattingToolbar() {
   return (
@@ -9,7 +25,10 @@ function FormattingToolbar() {
       style={{ display: "flex", gap: 8 }}
     >
       <Ariakit.ToolbarItem>Bold</Ariakit.ToolbarItem>
-      <Ariakit.ToolbarItem render={<input type="text" aria-label="Find" />} />
+      <Ariakit.ToolbarItem
+        render={<input type="text" aria-label="Find" />}
+        moveOnKeyPress={shouldMoveOnKeyPress}
+      />
       <Ariakit.ToolbarItem>Italic</Ariakit.ToolbarItem>
     </Ariakit.Toolbar>
   );

--- a/app/src/sandbox/toolbar-iframe-6316/index.react.tsx
+++ b/app/src/sandbox/toolbar-iframe-6316/index.react.tsx
@@ -1,22 +1,6 @@
 import * as Ariakit from "@ariakit/react";
-import type { KeyboardEvent } from "react";
 import { useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
-
-// TODO: Remove this workaround once
-// https://github.com/ariakit/ariakit/issues/6316 is fixed.
-// Iframe inputs skip Ariakit's built-in text boundary check, so re-check the
-// caret before allowing toolbar focus to move.
-function shouldMoveOnKeyPress(event: KeyboardEvent<HTMLElement>) {
-  const input = event.currentTarget as HTMLInputElement;
-  if (event.key === "ArrowLeft") {
-    return (input.selectionStart ?? 0) === 0;
-  }
-  if (event.key === "ArrowRight") {
-    return (input.selectionEnd ?? 0) === input.value.length;
-  }
-  return true;
-}
 
 function FormattingToolbar() {
   return (
@@ -25,10 +9,7 @@ function FormattingToolbar() {
       style={{ display: "flex", gap: 8 }}
     >
       <Ariakit.ToolbarItem>Bold</Ariakit.ToolbarItem>
-      <Ariakit.ToolbarItem
-        render={<input type="text" aria-label="Find" />}
-        moveOnKeyPress={shouldMoveOnKeyPress}
-      />
+      <Ariakit.ToolbarItem render={<input type="text" aria-label="Find" />} />
       <Ariakit.ToolbarItem>Italic</Ariakit.ToolbarItem>
     </Ariakit.Toolbar>
   );

--- a/app/src/sandbox/toolbar-iframe-6316/test-browser.ts
+++ b/app/src/sandbox/toolbar-iframe-6316/test-browser.ts
@@ -49,7 +49,7 @@ async function expectToolbarInputNavigation({
 
 // https://github.com/ariakit/ariakit/issues/6316
 withFramework(import.meta.dirname, async ({ test, query }) => {
-  test("ToolbarItem input navigates at text boundaries inside iframes", async ({
+  test("ToolbarItem input navigates at text boundaries in the parent document", async ({
     page,
     q,
   }) => {
@@ -59,7 +59,13 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
       input: q.textbox("Find"),
       previousItem: q.button("Bold"),
     });
+  });
 
+  test("ToolbarItem input navigates at text boundaries inside iframes", async ({
+    page,
+  }) => {
+    // Keep this isolated from the parent-document control so the test enters
+    // the iframe the same way a user would in the reported reproduction.
     const frame = query(page.frameLocator("iframe[title='Embedded editor']"));
 
     await expectToolbarInputNavigation({

--- a/app/src/sandbox/toolbar-iframe-6316/test-browser.ts
+++ b/app/src/sandbox/toolbar-iframe-6316/test-browser.ts
@@ -12,6 +12,20 @@ interface ExpectToolbarInputNavigationParams {
   expect: Expect;
   input: Locator;
   previousItem: Locator;
+  nextItem: Locator;
+}
+
+async function setSelection(input: Locator, start: number, end = start) {
+  await input.evaluate(
+    (element, range) => {
+      if (!(element instanceof HTMLInputElement)) {
+        throw new Error("Expected an input element");
+      }
+      const input = element;
+      input.setSelectionRange(range.start, range.end);
+    },
+    { start, end },
+  );
 }
 
 function getSelectionStart(input: Locator) {
@@ -28,10 +42,28 @@ async function expectToolbarInputNavigation({
   expect,
   input,
   previousItem,
+  nextItem,
 }: ExpectToolbarInputNavigationParams) {
   await input.click();
   await page.keyboard.type("hi");
+  await setSelection(input, 0);
 
+  await page.keyboard.press("ArrowRight");
+
+  await expect(input).toBeFocused();
+  await expect.poll(() => getSelectionStart(input)).toBe(1);
+
+  await page.keyboard.press("ArrowRight");
+
+  await expect(input).toBeFocused();
+  await expect.poll(() => getSelectionStart(input)).toBe(2);
+
+  await page.keyboard.press("ArrowRight");
+
+  await expect(nextItem).toBeFocused();
+
+  await input.focus();
+  await setSelection(input, 2);
   await page.keyboard.press("ArrowLeft");
 
   await expect(input).toBeFocused();
@@ -58,6 +90,7 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
       expect: test.expect,
       input: q.textbox("Find"),
       previousItem: q.button("Bold"),
+      nextItem: q.button("Italic"),
     });
   });
 
@@ -73,6 +106,7 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
       expect: test.expect,
       input: frame.textbox("Find"),
       previousItem: frame.button("Bold"),
+      nextItem: frame.button("Italic"),
     });
   });
 });

--- a/app/src/sandbox/toolbar-iframe-6316/test-browser.ts
+++ b/app/src/sandbox/toolbar-iframe-6316/test-browser.ts
@@ -1,19 +1,5 @@
-import type {
-  Locator,
-  Page,
-  expect as playwrightExpect,
-} from "@playwright/test";
+import type { Locator } from "@playwright/test";
 import { withFramework } from "#app/test-utils/preview.ts";
-
-type Expect = typeof playwrightExpect;
-
-interface ExpectToolbarInputNavigationParams {
-  page: Page;
-  expect: Expect;
-  input: Locator;
-  previousItem: Locator;
-  nextItem: Locator;
-}
 
 async function setSelection(input: Locator, start: number, end = start) {
   await input.evaluate(
@@ -37,61 +23,49 @@ function getSelectionStart(input: Locator) {
   });
 }
 
-async function expectToolbarInputNavigation({
-  page,
-  expect,
-  input,
-  previousItem,
-  nextItem,
-}: ExpectToolbarInputNavigationParams) {
-  await input.click();
-  await page.keyboard.type("hi");
-  await setSelection(input, 0);
-
-  await page.keyboard.press("ArrowRight");
-
-  await expect(input).toBeFocused();
-  await expect.poll(() => getSelectionStart(input)).toBe(1);
-
-  await page.keyboard.press("ArrowRight");
-
-  await expect(input).toBeFocused();
-  await expect.poll(() => getSelectionStart(input)).toBe(2);
-
-  await page.keyboard.press("ArrowRight");
-
-  await expect(nextItem).toBeFocused();
-
-  await input.focus();
-  await setSelection(input, 2);
-  await page.keyboard.press("ArrowLeft");
-
-  await expect(input).toBeFocused();
-  await expect.poll(() => getSelectionStart(input)).toBe(1);
-
-  await page.keyboard.press("ArrowLeft");
-
-  await expect(input).toBeFocused();
-  await expect.poll(() => getSelectionStart(input)).toBe(0);
-
-  await page.keyboard.press("ArrowLeft");
-
-  await expect(previousItem).toBeFocused();
-}
-
 // https://github.com/ariakit/ariakit/issues/6316
 withFramework(import.meta.dirname, async ({ test, query }) => {
   test("ToolbarItem input navigates at text boundaries in the parent document", async ({
     page,
     q,
   }) => {
-    await expectToolbarInputNavigation({
-      page,
-      expect: test.expect,
-      input: q.textbox("Find"),
-      previousItem: q.button("Bold"),
-      nextItem: q.button("Italic"),
-    });
+    const input = q.textbox("Find");
+    const previousItem = q.button("Bold");
+    const nextItem = q.button("Italic");
+
+    await input.click();
+    await page.keyboard.type("hi");
+    await setSelection(input, 0);
+
+    await page.keyboard.press("ArrowRight");
+
+    await test.expect(input).toBeFocused();
+    await test.expect.poll(() => getSelectionStart(input)).toBe(1);
+
+    await page.keyboard.press("ArrowRight");
+
+    await test.expect(input).toBeFocused();
+    await test.expect.poll(() => getSelectionStart(input)).toBe(2);
+
+    await page.keyboard.press("ArrowRight");
+
+    await test.expect(nextItem).toBeFocused();
+
+    await input.focus();
+    await setSelection(input, 2);
+    await page.keyboard.press("ArrowLeft");
+
+    await test.expect(input).toBeFocused();
+    await test.expect.poll(() => getSelectionStart(input)).toBe(1);
+
+    await page.keyboard.press("ArrowLeft");
+
+    await test.expect(input).toBeFocused();
+    await test.expect.poll(() => getSelectionStart(input)).toBe(0);
+
+    await page.keyboard.press("ArrowLeft");
+
+    await test.expect(previousItem).toBeFocused();
   });
 
   test("ToolbarItem input navigates at text boundaries inside iframes", async ({
@@ -100,13 +74,42 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     // Keep this isolated from the parent-document control so the test enters
     // the iframe the same way a user would in the reported reproduction.
     const frame = query(page.frameLocator("iframe[title='Embedded editor']"));
+    const input = frame.textbox("Find");
+    const previousItem = frame.button("Bold");
+    const nextItem = frame.button("Italic");
 
-    await expectToolbarInputNavigation({
-      page,
-      expect: test.expect,
-      input: frame.textbox("Find"),
-      previousItem: frame.button("Bold"),
-      nextItem: frame.button("Italic"),
-    });
+    await input.click();
+    await page.keyboard.type("hi");
+    await setSelection(input, 0);
+
+    await page.keyboard.press("ArrowRight");
+
+    await test.expect(input).toBeFocused();
+    await test.expect.poll(() => getSelectionStart(input)).toBe(1);
+
+    await page.keyboard.press("ArrowRight");
+
+    await test.expect(input).toBeFocused();
+    await test.expect.poll(() => getSelectionStart(input)).toBe(2);
+
+    await page.keyboard.press("ArrowRight");
+
+    await test.expect(nextItem).toBeFocused();
+
+    await input.focus();
+    await setSelection(input, 2);
+    await page.keyboard.press("ArrowLeft");
+
+    await test.expect(input).toBeFocused();
+    await test.expect.poll(() => getSelectionStart(input)).toBe(1);
+
+    await page.keyboard.press("ArrowLeft");
+
+    await test.expect(input).toBeFocused();
+    await test.expect.poll(() => getSelectionStart(input)).toBe(0);
+
+    await page.keyboard.press("ArrowLeft");
+
+    await test.expect(previousItem).toBeFocused();
   });
 });

--- a/app/src/sandbox/toolbar-iframe-6316/test-browser.ts
+++ b/app/src/sandbox/toolbar-iframe-6316/test-browser.ts
@@ -1,0 +1,72 @@
+import type {
+  Locator,
+  Page,
+  expect as playwrightExpect,
+} from "@playwright/test";
+import { withFramework } from "#app/test-utils/preview.ts";
+
+type Expect = typeof playwrightExpect;
+
+interface ExpectToolbarInputNavigationParams {
+  page: Page;
+  expect: Expect;
+  input: Locator;
+  previousItem: Locator;
+}
+
+function getSelectionStart(input: Locator) {
+  return input.evaluate((element) => {
+    if (!(element instanceof HTMLInputElement)) {
+      throw new Error("Expected an input element");
+    }
+    return element.selectionStart;
+  });
+}
+
+async function expectToolbarInputNavigation({
+  page,
+  expect,
+  input,
+  previousItem,
+}: ExpectToolbarInputNavigationParams) {
+  await input.click();
+  await page.keyboard.type("hi");
+
+  await page.keyboard.press("ArrowLeft");
+
+  await expect(input).toBeFocused();
+  await expect.poll(() => getSelectionStart(input)).toBe(1);
+
+  await page.keyboard.press("ArrowLeft");
+
+  await expect(input).toBeFocused();
+  await expect.poll(() => getSelectionStart(input)).toBe(0);
+
+  await page.keyboard.press("ArrowLeft");
+
+  await expect(previousItem).toBeFocused();
+}
+
+// https://github.com/ariakit/ariakit/issues/6316
+withFramework(import.meta.dirname, async ({ test, query }) => {
+  test("ToolbarItem input navigates at text boundaries inside iframes", async ({
+    page,
+    q,
+  }) => {
+    await expectToolbarInputNavigation({
+      page,
+      expect: test.expect,
+      input: q.textbox("Find"),
+      previousItem: q.button("Bold"),
+    });
+
+    const frame = query(page.frameLocator("iframe[title='Embedded editor']"));
+
+    await expectToolbarInputNavigation({
+      page,
+      expect: test.expect,
+      input: frame.textbox("Find"),
+      previousItem: frame.button("Bold"),
+    });
+  });
+});

--- a/packages/ariakit-utils/src/dom.ts
+++ b/packages/ariakit-utils/src/dom.ts
@@ -186,10 +186,11 @@ export function isTextField(
   element: Element,
 ): element is HTMLInputElement | HTMLTextAreaElement {
   try {
-    const isTextInput =
-      element instanceof HTMLInputElement && element.selectionStart !== null;
-    const isTextArea = element.tagName === "TEXTAREA";
-    return isTextInput || isTextArea || false;
+    // Use tag names instead of realm-bound constructors so text fields from
+    // same-origin child frames are recognized.
+    if (element.tagName === "TEXTAREA") return true;
+    if (element.tagName !== "INPUT") return false;
+    return (element as HTMLInputElement).selectionStart !== null;
   } catch (_error) {
     // Safari throws an exception when trying to get `selectionStart` on
     // non-text <input> elements (which, understandably, don't have the text


### PR DESCRIPTION
## Motivation

Text fields rendered into a same-origin iframe were misclassified as non-text fields when Ariakit code ran in the parent window. The browser repro for #6316 shows the parent-document toolbar behaving correctly while the iframe-rendered toolbar moved focus out of the input instead of moving the caret.

## Solution

Added `toolbar-iframe-6316`, a React sandbox that renders the same `Toolbar` in the parent document and in an iframe document. The browser tests keep the parent-document case as a passing control and isolate the iframe case.

Updated `isTextField` to use realm-safe tag-name checks before probing `selectionStart`, avoiding `instanceof HTMLInputElement` so inputs created by same-origin child frames are recognized. The sandbox workaround was then removed, and the iframe tests pass through the library fix.

Fixes #6316.

## Workaround

Consumers can reimplement the text-boundary check in userland with [`moveOnKeyPress`](https://ariakit.com/reference/composite-item#moveonkeypress). Reading `selectionStart` and `selectionEnd` directly avoids the realm-bound text-field check.

```tsx
import type { KeyboardEvent } from "react";

// TODO: Remove this workaround once
// https://github.com/ariakit/ariakit/issues/6316 is fixed.
function shouldMoveOnKeyPress(event: KeyboardEvent<HTMLElement>) {
  const input = event.currentTarget as HTMLInputElement;
  if (event.key === "ArrowLeft") {
    return (input.selectionStart ?? 0) === 0;
  }
  if (event.key === "ArrowRight") {
    return (input.selectionEnd ?? 0) === input.value.length;
  }
  return true;
}

<Ariakit.ToolbarItem
  render={<input type="text" aria-label="Find" />}
  moveOnKeyPress={shouldMoveOnKeyPress}
/>;
```
