### PR TITLE
Profile uncontrolled composite perf interactions

### DIFF
--- a/app/src/sandbox/composite-perf/perf-chrome.ts
+++ b/app/src/sandbox/composite-perf/perf-chrome.ts
@@ -1,5 +1,6 @@
 import type { query } from "@ariakit/test/playwright";
 import { expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { withFramework } from "#app/test-utils/preview.ts";
 
 const itemCount = 400;
@@ -7,31 +8,74 @@ const updateCount = 20;
 type Query = ReturnType<typeof query>;
 
 withFramework(import.meta.dirname, async ({ test }) => {
-  test("mount composite", async ({ q, perf }) => {
+  const mountComposite = async (q: Query) => {
     const mountButton = q.button("Mount composite");
     const lastItem = q.button(`Item ${itemCount}`);
 
+    await mountButton.click();
+    await expect(lastItem).toBeVisible();
+  };
+
+  const setupComposite = async (q: Query) => {
+    await q.button("Mount composite").click();
+    await expect(q.button("Item 1")).toBeVisible();
+  };
+
+  const moveAcrossItems = async (q: Query, page: Page) => {
+    const lastItem = q.button(`Item ${itemCount}`);
+    for (let i = 1; i < itemCount; i++) {
+      await page.keyboard.press("ArrowRight");
+    }
+    await expect(lastItem).toBeFocused();
+  };
+
+  test("mount composite", async ({ q, perf }) => {
     await perf.measure(async () => {
-      await mountButton.click();
-      await expect(lastItem).toBeVisible();
+      await mountComposite(q);
     });
   });
 
+  test("mount composite (script profile)", async ({ q, perf }) => {
+    await perf.measure(
+      async () => {
+        await mountComposite(q);
+      },
+      {
+        scriptProfile: true,
+        profileLimit: 20,
+      },
+    );
+  });
+
   test("move across items", async ({ q, page, perf }) => {
-    const mountButton = q.button("Mount composite");
     const firstItem = q.button("Item 1");
-    const lastItem = q.button(`Item ${itemCount}`);
 
     await perf.measure(
       async () => {
-        for (let i = 1; i < itemCount; i++) {
-          await page.keyboard.press("ArrowRight");
-        }
-        await expect(lastItem).toBeFocused();
+        await moveAcrossItems(q, page);
       },
       {
         setup: async () => {
-          await mountButton.click();
+          await setupComposite(q);
+          await firstItem.focus();
+          await expect(firstItem).toBeFocused();
+        },
+      },
+    );
+  });
+
+  test("move across items (script profile)", async ({ q, page, perf }) => {
+    const firstItem = q.button("Item 1");
+
+    await perf.measure(
+      async () => {
+        await moveAcrossItems(q, page);
+      },
+      {
+        scriptProfile: true,
+        profileLimit: 20,
+        setup: async () => {
+          await setupComposite(q);
           await firstItem.focus();
           await expect(firstItem).toBeFocused();
         },
@@ -64,14 +108,6 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
   test("update controlled items", async ({ q, perf }) => {
     await perf.measure(() => updateControlledItems(q), {
-      setup: () => setupControlledComposite(q),
-    });
-  });
-
-  test("update controlled items (script profile)", async ({ q, perf }) => {
-    await perf.measure(() => updateControlledItems(q), {
-      scriptProfile: true,
-      profileLimit: 20,
       setup: () => setupControlledComposite(q),
     });
   });

--- a/app/src/sandbox/composite-perf/perf-chrome.ts
+++ b/app/src/sandbox/composite-perf/perf-chrome.ts
@@ -7,28 +7,41 @@ const itemCount = 400;
 const updateCount = 20;
 type Query = ReturnType<typeof query>;
 
+async function mountComposite(q: Query) {
+  const mountButton = q.button("Mount composite");
+  const lastItem = q.button(`Item ${itemCount}`);
+
+  await mountButton.click();
+  await expect(lastItem).toBeVisible();
+}
+
+async function setupComposite(q: Query) {
+  await q.button("Mount composite").click();
+  await expect(q.button("Item 1")).toBeVisible();
+}
+
+async function moveAcrossItems(q: Query, page: Page) {
+  const lastItem = q.button(`Item ${itemCount}`);
+  for (let i = 1; i < itemCount; i++) {
+    await page.keyboard.press("ArrowRight");
+  }
+  await expect(lastItem).toBeFocused();
+}
+
+async function setupControlledComposite(q: Query) {
+  await q.button("Mount controlled composite").click();
+  await expect(q.button(`Item ${itemCount}`)).toBeVisible();
+}
+
+async function updateControlledItems(q: Query) {
+  const updateButton = q.button("Update items");
+  for (let i = 0; i < updateCount; i++) {
+    await updateButton.click();
+  }
+  await expect(q.status("Updates")).toHaveText(String(updateCount));
+}
+
 withFramework(import.meta.dirname, async ({ test }) => {
-  const mountComposite = async (q: Query) => {
-    const mountButton = q.button("Mount composite");
-    const lastItem = q.button(`Item ${itemCount}`);
-
-    await mountButton.click();
-    await expect(lastItem).toBeVisible();
-  };
-
-  const setupComposite = async (q: Query) => {
-    await q.button("Mount composite").click();
-    await expect(q.button("Item 1")).toBeVisible();
-  };
-
-  const moveAcrossItems = async (q: Query, page: Page) => {
-    const lastItem = q.button(`Item ${itemCount}`);
-    for (let i = 1; i < itemCount; i++) {
-      await page.keyboard.press("ArrowRight");
-    }
-    await expect(lastItem).toBeFocused();
-  };
-
   test("mount composite", async ({ q, perf }) => {
     await perf.measure(async () => {
       await mountComposite(q);
@@ -92,19 +105,6 @@ withFramework(import.meta.dirname, async ({ test }) => {
       await expect(lastItem).toBeVisible();
     });
   });
-
-  const setupControlledComposite = async (q: Query) => {
-    await q.button("Mount controlled composite").click();
-    await expect(q.button(`Item ${itemCount}`)).toBeVisible();
-  };
-
-  const updateControlledItems = async (q: Query) => {
-    const updateButton = q.button("Update items");
-    for (let i = 0; i < updateCount; i++) {
-      await updateButton.click();
-    }
-    await expect(q.status("Updates")).toHaveText(String(updateCount));
-  };
 
   test("update controlled items", async ({ q, perf }) => {
     await perf.measure(() => updateControlledItems(q), {


### PR DESCRIPTION
## Motivation

The composite perf report currently spends the React script profile slot on the controlled item update path. For the current investigation, the more useful script profiles are the uncontrolled mount and keyboard movement paths.

## Solution

Add script-profile variants for the existing `mount composite` and `move across items` perf tests. The profiled and unprofiled cases now share helpers so they exercise the same uncontrolled interactions.

Remove `update controlled items (script profile)` while keeping the unprofiled controlled update baseline.

## Verification

```sh
pnpm lint-fix
pnpm -F app run test-perf src/sandbox/composite-perf/perf-chrome.ts
```
