### PR TITLE
Disable deploy preview checkout credentials

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set commit status (pending)
         # Preview statuses are created eagerly so the commit shows a stable


### PR DESCRIPTION
## Motivation

The deploy preview workflow runs with write permissions for deployments and commit statuses, and the caller passes inherited secrets into the reusable workflow. Unlike the other privileged workflow checkouts in this repository, this checkout still persisted the job token after the initial fetch even though no later step performs authenticated git operations.

## Solution

Set `persist-credentials: false` on the deploy preview `actions/checkout` step. The checkout can still fetch the repository, while later `github-script` and Wrangler steps keep using their explicit token inputs instead of a git-persisted credential.

## Testing

- `git diff --check`
- `pnpm lint-fix`
- Pre-commit review pass with native Codex reviewer and Cursor CLI reviewer
