### PR TITLE
Simplify Changesets changelog hook patch

### DIFF
--- a/.changeset/changelog.cjs
+++ b/.changeset/changelog.cjs
@@ -1,3 +1,18 @@
+/**
+ * Besides the standard Changesets `getReleaseLine` and
+ * `getDependencyReleaseLine` functions, this module exports a non-standard
+ * `getChangelogEntry` hook. It only works because
+ * patches/@changesets__apply-release-plan@7.1.1.patch makes upstream's
+ * getChangelogEntry delegate to it instead of rendering the default
+ * "### Major/Minor/Patch Changes" sections.
+ *
+ * When bumping @changesets/apply-release-plan, regenerate the patch with
+ * `pnpm patch @changesets/apply-release-plan`, re-insert the hook before the
+ * final return of getChangelogEntry in
+ * dist/changesets-apply-release-plan.cjs.js, run `pnpm patch-commit <dir>`,
+ * and verify with
+ * `pnpm test .changeset/get-changelog-entry.test.ts`.
+ */
 /** @type {import("@changesets/types").ChangelogFunctions["getDependencyReleaseLine"]} */
 async function getDependencyReleaseLine(_, dependenciesUpdated) {
   if (dependenciesUpdated.length === 0) return "";

--- a/patches/@changesets__apply-release-plan@7.1.1.patch
+++ b/patches/@changesets__apply-release-plan@7.1.1.patch
@@ -1,71 +1,13 @@
 diff --git a/dist/changesets-apply-release-plan.cjs.js b/dist/changesets-apply-release-plan.cjs.js
+index e71b99fa922361c1d91d591ec15b4ed9c3689779..806942b22f59130b01cf7d5957a118532069dcba 100644
 --- a/dist/changesets-apply-release-plan.cjs.js
 +++ b/dist/changesets-apply-release-plan.cjs.js
-@@ -447,15 +447,63 @@ async function getNewChangelogEntry(releasesWithPackage, changesets, config, cwd
-   } else {
-     throw new Error("Could not resolve changelog generation functions");
-   }
-+  let customGetChangelogEntry = typeof possibleChangelogFunc.getChangelogEntry === "function" ? possibleChangelogFunc.getChangelogEntry : undefined;
-   let commits = await getCommitsThatAddChangesets(changesets.map(cs => cs.id), cwd);
-   let moddedChangesets = changesets.map((cs, i) => _objectSpread2(_objectSpread2({}, cs), {}, {
-     commit: commits[i]
-   }));
-   return Promise.all(releasesWithPackage.map(async release => {
--    let changelog = await getChangelogEntry(cwd, release, releasesWithPackage, moddedChangesets, getChangelogFuncs, changelogOpts, {
--      updateInternalDependencies: config.updateInternalDependencies,
--      onlyUpdatePeerDependentsWhenOutOfRange: config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange
--    });
-+    let changelog;
-+    if (customGetChangelogEntry) {
-+      if (release.type === "none") {
-+        changelog = null;
-+      } else {
-+        const changelogLines = {
-+          major: [],
-+          minor: [],
-+          patch: []
-+        };
-+        moddedChangesets.forEach(cs => {
-+          const rls = cs.releases.find(r => r.name === release.name);
-+          if (rls && rls.type !== "none") {
-+            changelogLines[rls.type].push(getChangelogFuncs.getReleaseLine(cs, rls.type, changelogOpts));
-+          }
-+        });
-+        let dependentReleases = releasesWithPackage.filter(rel => {
-+          var _release$packageJson$, _release$packageJson$2;
-+          const dependencyVersionRange = (_release$packageJson$ = release.packageJson.dependencies) === null || _release$packageJson$ === void 0 ? void 0 : _release$packageJson$[rel.name];
-+          const peerDependencyVersionRange = (_release$packageJson$2 = release.packageJson.peerDependencies) === null || _release$packageJson$2 === void 0 ? void 0 : _release$packageJson$2[rel.name];
-+          const versionRange = dependencyVersionRange || peerDependencyVersionRange;
-+          const usesWorkspaceRange = versionRange === null || versionRange === void 0 ? void 0 : versionRange.startsWith("workspace:");
-+          return versionRange && (usesWorkspaceRange || validRange__default["default"](versionRange) !== null) && shouldUpdateDependencyBasedOnConfig(cwd, {
-+            type: rel.type,
-+            version: rel.newVersion,
-+            oldVersion: rel.oldVersion,
-+            dir: rel.dir
-+          }, {
-+            depVersionRange: versionRange,
-+            depType: dependencyVersionRange ? "dependencies" : "peerDependencies"
-+          }, {
-+            minReleaseType: config.updateInternalDependencies,
-+            onlyUpdatePeerDependentsWhenOutOfRange: config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange
-+          });
-+        });
-+        let relevantChangesetIds = new Set();
-+        dependentReleases.forEach(rel => {
-+          rel.changesets.forEach(cs => {
-+            relevantChangesetIds.add(cs);
-+          });
-+        });
-+        let relevantChangesets = moddedChangesets.filter(cs => relevantChangesetIds.has(cs.id));
-+        changelogLines.patch.push(getChangelogFuncs.getDependencyReleaseLine(relevantChangesets, dependentReleases, changelogOpts));
-+        changelog = await customGetChangelogEntry(release, changelogLines);
-+      }
-+    } else {
-+      changelog = await getChangelogEntry(cwd, release, releasesWithPackage, moddedChangesets, getChangelogFuncs, changelogOpts, {
-+        updateInternalDependencies: config.updateInternalDependencies,
-+        onlyUpdatePeerDependentsWhenOutOfRange: config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange
-+      });
-+    }
-     return _objectSpread2(_objectSpread2({}, release), {}, {
-       changelog
-     });
+@@ -208,5 +208,8 @@ async function getChangelogEntry(cwd, release, releases, changesets, changelogFu
+   });
+   let relevantChangesets = changesets.filter(cs => relevantChangesetIds.has(cs.id));
+   changelogLines.patch.push(changelogFuncs.getDependencyReleaseLine(relevantChangesets, dependentReleases, changelogOpts));
++  if (typeof changelogFuncs.getChangelogEntry === "function") {
++    return changelogFuncs.getChangelogEntry(release, changelogLines);
++  }
+   return [`## ${release.newVersion}`, await generateChangesForVersionTypeMarkdown(changelogLines, "major"), await generateChangesForVersionTypeMarkdown(changelogLines, "minor"), await generateChangesForVersionTypeMarkdown(changelogLines, "patch")].filter(line => line).join("\n");
+ }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ overrides:
   '@ariakit/utils': workspace:*
 
 patchedDependencies:
-  '@changesets/apply-release-plan@7.1.1': 19cb6131207f59da50995e2f93d09dbcaccb346cdc696d59f1aa89e3114f6ac5
+  '@changesets/apply-release-plan@7.1.1': 49623020ff4e712ea6cab5c75197912ea7bb3b8c56dbdccc8d8392671ed4aa38
 
 importers:
 
@@ -70,7 +70,7 @@ importers:
         version: link:packages/ariakit-utils
       '@changesets/apply-release-plan':
         specifier: 7.1.1
-        version: 7.1.1(patch_hash=19cb6131207f59da50995e2f93d09dbcaccb346cdc696d59f1aa89e3114f6ac5)
+        version: 7.1.1(patch_hash=49623020ff4e712ea6cab5c75197912ea7bb3b8c56dbdccc8d8392671ed4aa38)
       '@changesets/cli':
         specifier: 2.31.0
         version: 2.31.0(@types/node@24.13.2)
@@ -11936,7 +11936,7 @@ snapshots:
     dependencies:
       fontkitten: 1.0.3
 
-  '@changesets/apply-release-plan@7.1.1(patch_hash=19cb6131207f59da50995e2f93d09dbcaccb346cdc696d59f1aa89e3114f6ac5)':
+  '@changesets/apply-release-plan@7.1.1(patch_hash=49623020ff4e712ea6cab5c75197912ea7bb3b8c56dbdccc8d8392671ed4aa38)':
     dependencies:
       '@changesets/config': 3.1.4
       '@changesets/get-version-range-type': 0.4.0
@@ -11967,7 +11967,7 @@ snapshots:
 
   '@changesets/cli@2.31.0(@types/node@24.13.2)':
     dependencies:
-      '@changesets/apply-release-plan': 7.1.1(patch_hash=19cb6131207f59da50995e2f93d09dbcaccb346cdc696d59f1aa89e3114f6ac5)
+      '@changesets/apply-release-plan': 7.1.1(patch_hash=49623020ff4e712ea6cab5c75197912ea7bb3b8c56dbdccc8d8392671ed4aa38)
       '@changesets/assemble-release-plan': 6.0.10
       '@changesets/changelog-git': 0.2.1
       '@changesets/config': 3.1.4


### PR DESCRIPTION
## Motivation

The `@changesets/apply-release-plan` patch was reimplementing most of upstream's changelog assembly logic just to call Ariakit's custom `getChangelogEntry` formatter. That made the patch harder to regenerate and easier to drift from upstream internals when Changesets is updated.

## Solution

Move the custom formatter hook back into upstream's existing `getChangelogEntry` helper, after upstream has already built `changelogLines` and before it renders the default Major/Minor/Patch sections. This keeps upstream responsible for release filtering, dependency release detection, and `none` releases while preserving Ariakit's custom changelog format.

Also document the non-standard hook in `.changeset/changelog.cjs` and update the patch hash in `pnpm-lock.yaml`.

## Test Plan

- `pnpm install`
- `pnpm lint-fix`
- `pnpm test .changeset/get-changelog-entry.test.ts`
- `git diff --check`