### PR TITLE
Fix useStoreState docs tokenizer anchors

### DIFF
--- a/app/src/lib/reference-tokenizer.test.ts
+++ b/app/src/lib/reference-tokenizer.test.ts
@@ -184,6 +184,24 @@ function refs(): CollectionEntry<"references">[] {
   ];
 }
 
+function sharedStateRefs(): CollectionEntry<"references">[] {
+  const storeCombobox = makeRef(
+    "react/combobox/store",
+    createRefData("store", "useComboboxStore", "combobox", {
+      state: [createProp("open"), createProp("mounted")],
+    }),
+  );
+
+  const storeDisclosure = makeRef(
+    "react/disclosure/store",
+    createRefData("store", "useDisclosureStore", "disclosure", {
+      state: [createProp("open"), createProp("mounted")],
+    }),
+  );
+
+  return [storeCombobox, storeDisclosure];
+}
+
 function tokensAt(
   code: string,
   perLine: ReturnType<typeof findCodeReferenceAnchors>,
@@ -197,6 +215,20 @@ function tokensAt(
     }
   });
   return out;
+}
+
+function anchorsWithHrefs(
+  code: string,
+  perLine: ReturnType<typeof findCodeReferenceAnchors>,
+) {
+  const lines = code.trim().split("\n");
+  return perLine.flatMap((ranges, i) => {
+    const line = lines[i] || "";
+    return ranges.map((range) => ({
+      text: line.slice(range.start, range.end),
+      href: range.href,
+    }));
+  });
 }
 
 test("tokenizes useStoreState state key (string) with ak namespace", () => {
@@ -253,6 +285,49 @@ const value = ak.useStoreState(combobox, (state) => state.value);
       },
     ]
   `);
+});
+
+test("does not attribute later useStoreState state keys to previous stores", () => {
+  const code = `
+import * as ak from "@ariakit/react";
+const combobox = ak.useComboboxStore();
+const disclosure = ak.useDisclosureStore();
+const open = ak.useStoreState(combobox, (state) => state.open);
+const mounted = ak.useStoreState(disclosure, "mounted");
+`;
+  const perLine = findCodeReferenceAnchors({
+    code,
+    references: sharedStateRefs(),
+    framework: "react",
+  });
+  const anchors = anchorsWithHrefs(code, perLine);
+  const openAnchors = anchors.filter((anchor) => anchor.text === "open");
+  const mountedAnchors = anchors.filter((anchor) => anchor.text === "mounted");
+
+  expect(openAnchors).toHaveLength(1);
+  expect(openAnchors[0]?.href).toContain("/combobox/");
+  expect(mountedAnchors).toHaveLength(1);
+  expect(mountedAnchors[0]?.href).toContain("/disclosure/");
+});
+
+test("ignores single-argument useStoreState calls when finding state keys", () => {
+  const code = `
+import * as ak from "@ariakit/react";
+const combobox = ak.useComboboxStore();
+const disclosure = ak.useDisclosureStore();
+const state = ak.useStoreState(combobox);
+const mounted = ak.useStoreState(disclosure, "mounted");
+`;
+  const perLine = findCodeReferenceAnchors({
+    code,
+    references: sharedStateRefs(),
+    framework: "react",
+  });
+  const anchors = anchorsWithHrefs(code, perLine);
+  const mountedAnchors = anchors.filter((anchor) => anchor.text === "mounted");
+
+  expect(mountedAnchors).toHaveLength(1);
+  expect(mountedAnchors[0]?.href).toContain("/disclosure/");
 });
 
 test("does not tokenize props on non-Ariakit namespaced components (rac.Disclosure)", () => {

--- a/app/src/lib/reference-tokenizer.ts
+++ b/app/src/lib/reference-tokenizer.ts
@@ -528,7 +528,7 @@ function findUseStoreStateStateRanges(
 
   // String literal variant: useStoreState(store, "value")
   const stringRegex = new RegExp(
-    `useStoreState\\s*\\(\\s*[^,]*,\\s*(["'\`])(${IDENTIFIER_PATTERN})\\1`,
+    `^(?:${IDENTIFIER_PATTERN}\\s*\\.\\s*)?useStoreState\\s*\\(\\s*[^,()]*,\\s*(["'\`])(${IDENTIFIER_PATTERN})\\1`,
   );
   const stringMatch = stringRegex.exec(callText);
   if (stringMatch) {
@@ -546,7 +546,7 @@ function findUseStoreStateStateRanges(
 
   // Arrow selector variant: useStoreState(store, (s) => s.value)
   const arrowRegex = new RegExp(
-    `useStoreState\\s*\\(\\s*[^,]*,\\s*\\(?(${IDENTIFIER_PATTERN})\\)?\\s*=>\\s*\\1\\s*\\.\\s*(${IDENTIFIER_PATTERN})`,
+    `^(?:${IDENTIFIER_PATTERN}\\s*\\.\\s*)?useStoreState\\s*\\(\\s*[^,()]*,\\s*\\(?(${IDENTIFIER_PATTERN})\\)?\\s*=>\\s*\\1\\s*\\.\\s*(${IDENTIFIER_PATTERN})`,
   );
   const arrowMatch = arrowRegex.exec(callText);
   if (arrowMatch) {


### PR DESCRIPTION
## Motivation

The docs reference tokenizer can attribute a state key from a later `useStoreState` call to the previous call's store. This happens because each call is sliced from its start to the end of the file, then the string and arrow selector regexes search that whole slice.

For example, the first call below could incorrectly add a combobox link for the later `mounted` token before the second call adds the disclosure link:

```ts
const open = ak.useStoreState(combobox, (state) => state.open);
const mounted = ak.useStoreState(disclosure, "mounted");
```

A single-argument call has the same leak because the first-argument pattern can cross the closing paren and keep scanning into a later call.

## Solution

Anchor both `useStoreState` state-key patterns to the current call slice, allow the optional namespace prefix used by namespaced calls like `ak.useStoreState`, and prevent the first-argument matcher from crossing commas or parentheses.

The regression tests use two stores with shared `open` and `mounted` state keys so the broken implementation produces duplicate anchors with conflicting hrefs, matching the real failure mode.

## Verification

- Temporarily restored the old regexes and confirmed the new focused tests failed with duplicate `mounted` anchors.
- `pnpm lint-fix`
- `pnpm exec vitest run app/src/lib/reference-tokenizer.test.ts`
- `pnpm tsc`
- Ariakit pre-commit review gate: native reviewer and Cursor CLI reviewer reported no findings.
