### PR TITLE
Use TypeScript for Changesets changelog

### DIFF
--- a/.changeset/changelog.ts
+++ b/.changeset/changelog.ts
@@ -1,3 +1,9 @@
+import type {
+  GetDependencyReleaseLine,
+  GetReleaseLine,
+  ModCompWithPackage,
+} from "@changesets/types";
+
 /**
  * Besides the standard Changesets `getReleaseLine` and
  * `getDependencyReleaseLine` functions, this module exports a non-standard
@@ -13,36 +19,41 @@
  * and verify with
  * `pnpm test .changeset/get-changelog-entry.test.ts`.
  */
-/** @type {import("@changesets/types").ChangelogFunctions["getDependencyReleaseLine"]} */
-async function getDependencyReleaseLine(_, dependenciesUpdated) {
-  if (dependenciesUpdated.length === 0) return "";
-  const updatedDepenenciesList = dependenciesUpdated.map(
-    (dependency) => `\`${dependency.name}@${dependency.newVersion}\``,
-  );
-  return `- Updated dependencies: ${updatedDepenenciesList.join(", ")}`;
+
+interface ChangelogLines {
+  major: Array<Promise<string>>;
+  minor: Array<Promise<string>>;
+  patch: Array<Promise<string>>;
 }
 
-/** @type {import("@changesets/types").ChangelogFunctions["getReleaseLine"]} */
-async function getReleaseLine(changeset) {
+export async function getDependencyReleaseLine(
+  _: Parameters<GetDependencyReleaseLine>[0],
+  dependenciesUpdated: Parameters<GetDependencyReleaseLine>[1],
+) {
+  if (dependenciesUpdated.length === 0) return "";
+  const updatedDependenciesList = dependenciesUpdated.map(
+    (dependency) => `\`${dependency.name}@${dependency.newVersion}\``,
+  );
+  return `- Updated dependencies: ${updatedDependenciesList.join(", ")}`;
+}
+
+export async function getReleaseLine(changeset: Parameters<GetReleaseLine>[0]) {
   const [firstLine, ...nextLines] = changeset.summary
     .split("\n")
-    .map((l) => l.trimEnd());
+    .map((line) => line.trimEnd());
 
   if (!nextLines.length) return `- ${firstLine}`;
 
   return `### ${firstLine}\n${nextLines.join("\n")}`;
 }
 
-/**
- * @param {Array<Promise<string>} changelogLines
- */
-async function getChangelogText(changelogLines) {
+async function getChangelogText(changelogLines: Array<Promise<string>>) {
   const lines = await Promise.all(changelogLines);
   if (!lines.length) return "";
 
-  const isOverviewLine = (l) => l.startsWith("### Overview\n");
-  const isHeadingLine = (l) => l.startsWith("###");
-  const isOtherLine = (l) => !l.startsWith("###");
+  const isOverviewLine = (line: string) => line.startsWith("### Overview\n");
+  const isHeadingLine = (line: string) => line.startsWith("###");
+  const isOtherLine = (line: string) => !line.startsWith("###");
 
   const headingLines = lines
     .filter(isHeadingLine)
@@ -51,7 +62,7 @@ async function getChangelogText(changelogLines) {
       if (isOverviewLine(b)) return 1;
       return 0;
     })
-    .map((l) => l.replace("### Overview\n\n", ""));
+    .map((line) => line.replace("### Overview\n\n", ""));
 
   const otherLines = lines.filter(isOtherLine);
   if (!headingLines.length && !otherLines.length) return "";
@@ -65,11 +76,10 @@ async function getChangelogText(changelogLines) {
   return `${heading}\n\n### Other updates\n\n${other}`;
 }
 
-/**
- * @param {import("@changesets/types").ModCompWithPackage} release
- * @param {Record<"major" | "minor" | "patch", Array<Promise<string>>} changelogLines
- */
-async function getChangelogEntry(release, changelogLines) {
+export async function getChangelogEntry(
+  release: ModCompWithPackage,
+  changelogLines: ChangelogLines,
+) {
   // const date = new Date().toLocaleDateString("en-US", {
   //   month: "long",
   //   day: "numeric",
@@ -78,9 +88,3 @@ async function getChangelogEntry(release, changelogLines) {
   const text = await getChangelogText(Object.values(changelogLines).flat());
   return `## ${release.newVersion}\n\n${text}`;
 }
-
-module.exports = {
-  getDependencyReleaseLine,
-  getReleaseLine,
-  getChangelogEntry,
-};

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.0.0/schema.json",
-  "changelog": "./changelog.cjs",
+  "changelog": "./changelog.ts",
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.changeset/get-changelog-entry.test.ts
+++ b/.changeset/get-changelog-entry.test.ts
@@ -82,9 +82,9 @@ test("changesets getChangelogEntry hook", async () => {
     const applyReleasePlan = (await import("@changesets/apply-release-plan"))
       .default as unknown as (...args: any[]) => Promise<string[]>;
 
-    // Minimal config that points to our repo's .changeset/changelog.cjs
+    // Minimal config that points to our repo's .changeset/changelog.ts
     const config = {
-      changelog: ["./changelog.cjs", {}],
+      changelog: ["./changelog.ts", {}],
       updateInternalDependencies: "patch",
       ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
         onlyUpdatePeerDependentsWhenOutOfRange: true,

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@ariakit/utils": "workspace:*",
     "@changesets/apply-release-plan": "7.1.1",
     "@changesets/cli": "2.31.0",
+    "@changesets/types": "6.1.0",
     "@playwright/test": "1.60.0",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       '@changesets/cli':
         specifier: 2.31.0
         version: 2.31.0(@types/node@24.13.2)
+      '@changesets/types':
+        specifier: 6.1.0
+        version: 6.1.0
       '@playwright/test':
         specifier: 1.60.0
         version: 1.60.0

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,5 +1,6 @@
 {
   "extends": "./tsconfig.base.json",
+  "include": ["**/*", ".changeset/*.ts"],
   "exclude": [
     "website",
     "app",


### PR DESCRIPTION
## Motivation

The repository runs on Node 24, which can execute TypeScript files directly. The custom Changesets changelog module still used a CommonJS `.cjs` file with JSDoc type references, even though the release tooling can load the configured changelog path from Node.

Using TypeScript keeps this release helper aligned with the rest of the root tooling and lets the custom hook contract be checked by the repository TypeScript build.

## Solution

Rename `.changeset/changelog.cjs` to `.changeset/changelog.ts` and convert the module to ESM named exports. Update Changesets config and the changelog integration test to point at `./changelog.ts`.

Add `@changesets/types` as a direct root dev dependency for the new type imports, and include `.changeset/*.ts` in `tsconfig.node.json` so `pnpm tsc` checks the changelog helper.

## Verification

- `pnpm lint-fix`
- `pnpm test .changeset/get-changelog-entry.test.ts`
- `pnpm exec tsc -p tsconfig.node.json --listFiles | rg '\.changeset/changelog\.ts'`
- `pnpm tsc`