### PR TITLE
Fail React build on declaration errors

### DIFF
--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -32,7 +32,7 @@ const entry = getPublicFiles(sourcePath);
 const esmDir = getESMDir();
 const cjsDir = getCJSDir();
 
-spawn.sync(
+const result = spawn.sync(
   "tsc",
   [
     "--emitDeclarationOnly",
@@ -45,6 +45,11 @@ spawn.sync(
   ],
   { stdio: "inherit" },
 );
+
+if (result.error) throw result.error;
+if (result.status !== 0) {
+  process.exit(result.status ?? 1);
+}
 
 cpSync(esmDir, cjsDir, { recursive: true });
 


### PR DESCRIPTION
## Motivation

The legacy `@ariakit/react` build script runs `tsc` to emit declaration files, but it ignored the `cross-spawn` result. If declaration emit failed, the script could still copy partial output, run the JS builds, and let release automation publish a package with missing typings.

## Solution

Capture the `tsc` spawn result and stop before copying declarations or starting `tsup` when the compiler process fails. Spawn errors such as `ENOENT` are thrown, and non-zero compiler statuses are propagated with `process.exit(result.status ?? 1)`.

## Verification

- `pnpm lint-fix`
- `pnpm -F @ariakit/react run build`
- Temporary failure-path check: added a temporary invalid type in `packages/ariakit-react/src/button.ts`, confirmed `pnpm -F @ariakit/react run build` failed at `tsc` with exit status 2 before any `tsup` output, then removed the temporary edit and restored generated package metadata.
- `git diff --check`
