### PR TITLE
Remove dead SelectList role observer

### DIFF
--- a/packages/ariakit-react-components/src/select/select-list.tsx
+++ b/packages/ariakit-react-components/src/select/select-list.tsx
@@ -1,6 +1,5 @@
 import { useStoreState } from "@ariakit/react-store";
 import {
-  useAttribute,
   useBooleanEvent,
   useEvent,
   useId,
@@ -137,18 +136,9 @@ export const useSelectList = createHook<TagName, SelectListOptions>(
     const hasCombobox = !!store.combobox;
     composite = composite ?? (!hasCombobox && childStore !== store);
 
-    const [element, setElement] = useTransactionState(
+    const [, setElement] = useTransactionState(
       composite ? store.setListElement : null,
     );
-
-    const role = useAttribute(element, "role", props.role);
-    const isCompositeRole =
-      role === "listbox" ||
-      role === "menu" ||
-      role === "tree" ||
-      role === "grid";
-    const ariaMultiSelectable =
-      composite || isCompositeRole ? multiSelectable || undefined : undefined;
 
     const hidden = isHidden(mounted, props.hidden, alwaysVisible);
     const style = hidden ? { ...props.style, display: "none" } : props.style;
@@ -156,7 +146,7 @@ export const useSelectList = createHook<TagName, SelectListOptions>(
     if (composite) {
       props = {
         role: "listbox",
-        "aria-multiselectable": ariaMultiSelectable,
+        "aria-multiselectable": multiSelectable || undefined,
         ...props,
       };
     }


### PR DESCRIPTION
## Motivation

`useSelectList` was reading the rendered `role` attribute with `useAttribute`, deriving `isCompositeRole`, and folding that into `ariaMultiSelectable`. That value is only consumed inside the existing `if (composite)` block, where it always reduces to `multiSelectable || undefined` regardless of the observed role.

This left every mounted `SelectList`/`SelectPopover` paying for a state value and `MutationObserver` that could not affect the rendered props.

## Solution

Remove the unused `useAttribute`/role computation and inline the only reachable `aria-multiselectable` value in the composite branch. The existing prop spread order is preserved, so user-provided props keep the same override behavior.

No changeset is included because this is a behavior-preserving internal cleanup.

## Verification

- `pnpm lint-fix`
- `pnpm tsc` (rerun passed after an initial Vite optimizer cache miss in `app/node_modules/.vite-check`)
- `pnpm test-react packages/ariakit-test/src/select.react.test.tsx examples/select-multiple/test.ts examples/select-combobox/test.ts`
