### PR TITLE
Guard generated workflow writebacks

### DIFF
--- a/.github/workflows/build-styles.yml
+++ b/.github/workflows/build-styles.yml
@@ -7,6 +7,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -47,10 +48,31 @@ jobs:
           fi
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
 
-      - name: Commit or create PR
+      - name: Verify branch tip
+        id: branch
         if: >
           steps.patch.outputs.has_changes == 'true' &&
           env.WRITEBACK_ALLOWED == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          branch="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
+          git fetch --no-tags origin "$branch"
+          local_sha="$(git rev-parse HEAD)"
+          remote_sha="$(git rev-parse FETCH_HEAD)"
+          if [ "$local_sha" != "$remote_sha" ]; then
+            echo "Branch advanced from $local_sha to $remote_sha; skipping write-back."
+            echo "is_current=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "is_current=true" >> "$GITHUB_OUTPUT"
+          echo "local_sha=$local_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Commit or create PR
+        if: >
+          steps.patch.outputs.has_changes == 'true' &&
+          env.WRITEBACK_ALLOWED == 'true' &&
+          steps.branch.outputs.is_current == 'true'
         uses: ./.github/workflows/commit-or-pr
         with:
           # This write-back step intentionally assumes PRs come from branches
@@ -60,6 +82,7 @@ jobs:
           event: ${{ github.event_name }}
           message: Update styles
           head-branch: ${{ github.head_ref || github.ref_name }}
+          expected-head-sha: ${{ steps.branch.outputs.local_sha }}
           new-branch: chore/update-styles
           paths: app/src/styles/styles.json
           app-client-id: ${{ vars.ARIAKIT_CI_APP_CLIENT_ID }}

--- a/.github/workflows/build-styles.yml
+++ b/.github/workflows/build-styles.yml
@@ -48,31 +48,10 @@ jobs:
           fi
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
 
-      - name: Verify branch tip
-        id: branch
-        if: >
-          steps.patch.outputs.has_changes == 'true' &&
-          env.WRITEBACK_ALLOWED == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          branch="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
-          git fetch --no-tags origin "$branch"
-          local_sha="$(git rev-parse HEAD)"
-          remote_sha="$(git rev-parse FETCH_HEAD)"
-          if [ "$local_sha" != "$remote_sha" ]; then
-            echo "Branch advanced from $local_sha to $remote_sha; skipping write-back."
-            echo "is_current=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "is_current=true" >> "$GITHUB_OUTPUT"
-          echo "local_sha=$local_sha" >> "$GITHUB_OUTPUT"
-
       - name: Commit or create PR
         if: >
           steps.patch.outputs.has_changes == 'true' &&
-          env.WRITEBACK_ALLOWED == 'true' &&
-          steps.branch.outputs.is_current == 'true'
+          env.WRITEBACK_ALLOWED == 'true'
         uses: ./.github/workflows/commit-or-pr
         with:
           # This write-back step intentionally assumes PRs come from branches
@@ -82,7 +61,6 @@ jobs:
           event: ${{ github.event_name }}
           message: Update styles
           head-branch: ${{ github.head_ref || github.ref_name }}
-          expected-head-sha: ${{ steps.branch.outputs.local_sha }}
           new-branch: chore/update-styles
           paths: app/src/styles/styles.json
           app-client-id: ${{ vars.ARIAKIT_CI_APP_CLIENT_ID }}

--- a/.github/workflows/commit-or-pr/action.yml
+++ b/.github/workflows/commit-or-pr/action.yml
@@ -9,13 +9,13 @@ inputs:
     description: Commit message and PR title
     required: true
   head-branch:
-    description: Branch name when committing to existing PR
+    description: Branch name when committing to an existing PR, or base branch when creating a new PR
     required: true
   expected-head-sha:
     description: >
-      Expected current SHA for the head branch when committing to an existing
-      PR. When set, the action refuses to rebase generated changes onto a
-      different branch tip.
+      Expected current SHA for the branch named by head-branch. When set, the
+      action refuses to publish generated changes against a different branch
+      tip.
     required: false
     default: ""
   new-branch:
@@ -65,6 +65,22 @@ runs:
         cd "${{ inputs.working-directory }}"
         git config user.name "ariakito[bot]"
         git config user.email "283989922+ariakito[bot]@users.noreply.github.com"
+
+    - name: Verify base branch
+      shell: bash
+      if: inputs.event == 'push' && inputs.expected-head-sha != ''
+      env:
+        HEAD_REF: ${{ inputs.head-branch }}
+        EXPECTED_HEAD_SHA: ${{ inputs.expected-head-sha }}
+      run: |
+        cd "${{ inputs.working-directory }}"
+        set -e
+        git fetch --no-tags origin "$HEAD_REF"
+        remote_sha="$(git rev-parse FETCH_HEAD)"
+        if [ "$remote_sha" != "$EXPECTED_HEAD_SHA" ]; then
+          echo "Branch advanced from $EXPECTED_HEAD_SHA to $remote_sha; refusing write-back." >&2
+          exit 1
+        fi
 
     - name: Create PR
       if: inputs.event == 'push'

--- a/.github/workflows/commit-or-pr/action.yml
+++ b/.github/workflows/commit-or-pr/action.yml
@@ -13,9 +13,11 @@ inputs:
     required: true
   expected-head-sha:
     description: >
-      Expected current SHA for the branch named by head-branch. When set, the
-      action refuses to publish generated changes against a different branch
-      tip.
+      Expected current SHA for the branch named by head-branch. Defaults to the
+      current checkout's HEAD. The action skips cleanly when the branch has
+      already advanced, and refuses to push if it advances after committing.
+      Pass this explicitly when the checkout HEAD may differ from the commit
+      that generated the outputs.
     required: false
     default: ""
   new-branch:
@@ -49,9 +51,36 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Verify branch tip
+      id: branch
+      shell: bash
+      env:
+        HEAD_REF: ${{ inputs.head-branch }}
+        EXPECTED_HEAD_SHA: ${{ inputs.expected-head-sha }}
+      run: |
+        cd "${{ inputs.working-directory }}"
+        set -e
+        expected_sha="$EXPECTED_HEAD_SHA"
+        if [ -z "$expected_sha" ]; then
+          expected_sha="$(git rev-parse HEAD)"
+        fi
+        git fetch --no-tags origin "$HEAD_REF"
+        remote_sha="$(git rev-parse FETCH_HEAD)"
+        if [ "$remote_sha" != "$expected_sha" ]; then
+          echo "Branch advanced from $expected_sha to $remote_sha; skipping write-back."
+          echo "is_current=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        echo "is_current=true" >> "$GITHUB_OUTPUT"
+        echo "expected_head_sha=$expected_sha" >> "$GITHUB_OUTPUT"
+
     - name: Create GitHub App token
       id: app-token
-      if: inputs.token == '' && inputs.app-client-id != '' && inputs.app-private-key != ''
+      if: >
+        steps.branch.outputs.is_current == 'true' &&
+        inputs.token == '' &&
+        inputs.app-client-id != '' &&
+        inputs.app-private-key != ''
       uses: actions/create-github-app-token@v3
       with:
         client-id: ${{ inputs.app-client-id }}
@@ -60,30 +89,15 @@ runs:
         permission-pull-requests: write
 
     - name: Configure git
+      if: steps.branch.outputs.is_current == 'true'
       shell: bash
       run: |
         cd "${{ inputs.working-directory }}"
         git config user.name "ariakito[bot]"
         git config user.email "283989922+ariakito[bot]@users.noreply.github.com"
 
-    - name: Verify base branch
-      shell: bash
-      if: inputs.event == 'push' && inputs.expected-head-sha != ''
-      env:
-        HEAD_REF: ${{ inputs.head-branch }}
-        EXPECTED_HEAD_SHA: ${{ inputs.expected-head-sha }}
-      run: |
-        cd "${{ inputs.working-directory }}"
-        set -e
-        git fetch --no-tags origin "$HEAD_REF"
-        remote_sha="$(git rev-parse FETCH_HEAD)"
-        if [ "$remote_sha" != "$EXPECTED_HEAD_SHA" ]; then
-          echo "Branch advanced from $EXPECTED_HEAD_SHA to $remote_sha; refusing write-back." >&2
-          exit 1
-        fi
-
     - name: Create PR
-      if: inputs.event == 'push'
+      if: inputs.event == 'push' && steps.branch.outputs.is_current == 'true'
       uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
       with:
         # Push workflows should not write directly to `main`; they publish
@@ -102,7 +116,7 @@ runs:
     - name: Commit changes
       id: commit
       shell: bash
-      if: inputs.event == 'pull_request'
+      if: inputs.event == 'pull_request' && steps.branch.outputs.is_current == 'true'
       env:
         MESSAGE: ${{ inputs.message }}
         PATHS: ${{ inputs.paths }}
@@ -133,7 +147,7 @@ runs:
       env:
         GITHUB_REPOSITORY: ${{ github.repository }}
         HEAD_REF: ${{ inputs.head-branch }}
-        EXPECTED_HEAD_SHA: ${{ inputs.expected-head-sha }}
+        EXPECTED_HEAD_SHA: ${{ steps.branch.outputs.expected_head_sha }}
         GH_TOKEN: ${{ inputs.token != '' && inputs.token || steps.app-token.outputs.token != '' && steps.app-token.outputs.token || github.token }}
       # Rebase onto the latest branch tip so generated-file commits do not
       # fail just because another commit landed while the workflow was running.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -47,10 +48,31 @@ jobs:
           fi
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
 
-      - name: Commit or create PR
+      - name: Verify branch tip
+        id: branch
         if: >
           steps.patch.outputs.has_changes == 'true' &&
           env.WRITEBACK_ALLOWED == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          branch="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
+          git fetch --no-tags origin "$branch"
+          local_sha="$(git rev-parse HEAD)"
+          remote_sha="$(git rev-parse FETCH_HEAD)"
+          if [ "$local_sha" != "$remote_sha" ]; then
+            echo "Branch advanced from $local_sha to $remote_sha; skipping write-back."
+            echo "is_current=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "is_current=true" >> "$GITHUB_OUTPUT"
+          echo "local_sha=$local_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Commit or create PR
+        if: >
+          steps.patch.outputs.has_changes == 'true' &&
+          env.WRITEBACK_ALLOWED == 'true' &&
+          steps.branch.outputs.is_current == 'true'
         uses: ./.github/workflows/commit-or-pr
         with:
           # This write-back step intentionally assumes PRs come from branches
@@ -60,6 +82,7 @@ jobs:
           event: ${{ github.event_name }}
           message: Update docs
           head-branch: ${{ github.head_ref || github.ref_name }}
+          expected-head-sha: ${{ steps.branch.outputs.local_sha }}
           new-branch: chore/update-docs
           paths: packages/*/readme.md
           app-client-id: ${{ vars.ARIAKIT_CI_APP_CLIENT_ID }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,31 +48,10 @@ jobs:
           fi
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
 
-      - name: Verify branch tip
-        id: branch
-        if: >
-          steps.patch.outputs.has_changes == 'true' &&
-          env.WRITEBACK_ALLOWED == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          branch="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
-          git fetch --no-tags origin "$branch"
-          local_sha="$(git rev-parse HEAD)"
-          remote_sha="$(git rev-parse FETCH_HEAD)"
-          if [ "$local_sha" != "$remote_sha" ]; then
-            echo "Branch advanced from $local_sha to $remote_sha; skipping write-back."
-            echo "is_current=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "is_current=true" >> "$GITHUB_OUTPUT"
-          echo "local_sha=$local_sha" >> "$GITHUB_OUTPUT"
-
       - name: Commit or create PR
         if: >
           steps.patch.outputs.has_changes == 'true' &&
-          env.WRITEBACK_ALLOWED == 'true' &&
-          steps.branch.outputs.is_current == 'true'
+          env.WRITEBACK_ALLOWED == 'true'
         uses: ./.github/workflows/commit-or-pr
         with:
           # This write-back step intentionally assumes PRs come from branches
@@ -82,7 +61,6 @@ jobs:
           event: ${{ github.event_name }}
           message: Update docs
           head-branch: ${{ github.head_ref || github.ref_name }}
-          expected-head-sha: ${{ steps.branch.outputs.local_sha }}
           new-branch: chore/update-docs
           paths: packages/*/readme.md
           app-client-id: ${{ vars.ARIAKIT_CI_APP_CLIENT_ID }}

--- a/.github/workflows/og-images.yml
+++ b/.github/workflows/og-images.yml
@@ -77,31 +77,10 @@ jobs:
           fi
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
 
-      - name: Verify branch tip
-        id: branch
-        if: >
-          steps.patch.outputs.has_changes == 'true' &&
-          env.WRITEBACK_ALLOWED == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          branch="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
-          git fetch --no-tags origin "$branch"
-          local_sha="$(git rev-parse HEAD)"
-          remote_sha="$(git rev-parse FETCH_HEAD)"
-          if [ "$local_sha" != "$remote_sha" ]; then
-            echo "Branch advanced from $local_sha to $remote_sha; skipping write-back."
-            echo "is_current=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "is_current=true" >> "$GITHUB_OUTPUT"
-          echo "local_sha=$local_sha" >> "$GITHUB_OUTPUT"
-
       - name: Commit or create PR
         if: >
           steps.patch.outputs.has_changes == 'true' &&
-          env.WRITEBACK_ALLOWED == 'true' &&
-          steps.branch.outputs.is_current == 'true'
+          env.WRITEBACK_ALLOWED == 'true'
         uses: ./.github/workflows/commit-or-pr
         with:
           # This write-back step intentionally assumes PRs come from branches
@@ -111,7 +90,6 @@ jobs:
           event: ${{ github.event_name }}
           message: Update OG images
           head-branch: ${{ github.head_ref || github.ref_name }}
-          expected-head-sha: ${{ steps.branch.outputs.local_sha }}
           new-branch: chore/update-og-images
           paths: app/public/og-image
           app-client-id: ${{ vars.ARIAKIT_CI_APP_CLIENT_ID }}

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -204,6 +204,8 @@ jobs:
           event: ${{ inputs.event }}
           message: Update screenshots
           head-branch: ${{ github.head_ref || github.ref_name }}
+          # Use the tip captured before the artifact pipeline. The `pr`
+          # checkout can resolve to a newer branch tip if the branch advances.
           expected-head-sha: ${{ steps.tip.outputs.tip_sha }}
           new-branch: visual/update-screenshots
           app-client-id: ${{ vars.ARIAKIT_CI_APP_CLIENT_ID }}

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -204,6 +204,7 @@ jobs:
           event: ${{ inputs.event }}
           message: Update screenshots
           head-branch: ${{ github.head_ref || github.ref_name }}
+          expected-head-sha: ${{ steps.tip.outputs.tip_sha }}
           new-branch: visual/update-screenshots
           app-client-id: ${{ vars.ARIAKIT_CI_APP_CLIENT_ID }}
           app-private-key: ${{ secrets.ARIAKIT_CI_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Motivation

Generated-file workflows check out a mutable branch tip, generate artifacts, and then call the shared `commit-or-pr` writeback action. Without a final branch-tip guard, a stale run can publish generated output based on older sources after the branch has advanced.

`docs` and `build-styles` were missing the stale-writeback protection already used by `og-images`, `visual` had an early latest-commit gate but no final SHA check at writeback time, and the shared action did not own the clean skip behavior for generated writebacks.

## Solution

Centralize generated writeback staleness handling in `commit-or-pr`:

- cancel superseded `docs` and `build-styles` runs on the same ref
- make `commit-or-pr` verify the branch tip before creating a maintenance PR or committing to a PR branch
- default the expected SHA to the action checkout's `HEAD`, so docs/styles/OG images no longer need duplicate workflow-level verification steps
- keep `expected-head-sha` as an override for workflows like `visual`, where the late `pr` checkout may differ from the commit that generated artifacts
- skip cleanly when the branch has already advanced, while still refusing the pull request push if the branch advances after the generated commit is created

This keeps stale runs from silently publishing generated docs, styles, OG images, or screenshots against a newer branch tip while keeping the guard in one shared action.

## Testing

- `pnpm lint-fix`
- `pnpm lint`
- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |file| YAML.load_file(file); puts "#{file}: ok" }' .github/workflows/commit-or-pr/action.yml .github/workflows/visual.yml .github/workflows/docs.yml .github/workflows/build-styles.yml .github/workflows/og-images.yml`
