### PR TITLE
Fix currency fallback for empty country codes

### DIFF
--- a/app/src/lib/locale.test.ts
+++ b/app/src/lib/locale.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2025-present Ariakit FZ-LLC. All Rights Reserved.
+ *
+ * This software is proprietary. See the license.md file in the root of this
+ * package for licensing terms.
+ *
+ * SPDX-License-Identifier: UNLICENSED
+ */
+
+import { expect, test } from "vitest";
+import { getCountryCode, getCurrency } from "./locale.ts";
+
+test("getCountryCode skips empty header values", () => {
+  const headers = new Headers({
+    "x-country": " ",
+    "cf-ipcountry": "",
+    "x-vercel-ip-country": " br ",
+  });
+
+  expect(getCountryCode(headers)).toBe("br");
+});
+
+test("getCountryCode defaults to US", () => {
+  const headers = new Headers({
+    "x-country": "",
+    "cf-ipcountry": " ",
+  });
+
+  expect(getCountryCode(headers)).toBe("US");
+});
+
+test.each([
+  ["", "USD"],
+  ["T", "USD"],
+  ["XX", "USD"],
+  ["fr", "EUR"],
+  ["GB", "GBP"],
+  ["IN", "INR"],
+])("getCurrency maps %s to %s", (countryCode, currency) => {
+  expect(getCurrency(countryCode)).toBe(currency);
+});

--- a/app/src/lib/locale.ts
+++ b/app/src/lib/locale.ts
@@ -7,12 +7,17 @@
  *
  * SPDX-License-Identifier: UNLICENSED
  */
+const euCountryCodes =
+  "AT BE BG HR CY CZ DK EE FI FR DE GR HU IE IT LV LT LU MT NL PL PT RO SK SI ES SE".split(
+    " ",
+  );
+
 export function getCountryCode(headers: Headers) {
   const countryCode =
-    headers.get("x-country") ??
-    headers.get("cf-ipcountry") ??
-    headers.get("x-vercel-ip-country") ??
-    headers.get("cloudfront-viewer-country") ??
+    headers.get("x-country")?.trim() ||
+    headers.get("cf-ipcountry")?.trim() ||
+    headers.get("x-vercel-ip-country")?.trim() ||
+    headers.get("cloudfront-viewer-country")?.trim() ||
     "US";
   return countryCode;
 }
@@ -21,9 +26,7 @@ export function getCurrency(countryCode: string) {
   countryCode = countryCode.toUpperCase();
   if (countryCode === "GB") return "GBP";
   if (countryCode === "IN") return "INR";
-  const euCodes =
-    "AT BE BG HR CY CZ DK EE FI FR DE GR HU IE IT LV LT LU MT NL PL PT RO SK SI ES SE";
-  if (euCodes.includes(countryCode)) return "EUR";
+  if (euCountryCodes.includes(countryCode)) return "EUR";
   return "USD";
 }
 


### PR DESCRIPTION
## Motivation

Requests with empty geo headers can pass an empty country code into `getCurrency`. Because `getCurrency` checked a space-delimited string with `String.prototype.includes`, empty strings and some one-character values matched the EU code list and selected EUR instead of the USD fallback.

```ts
getCurrency(""); // was "EUR"
getCurrency("T"); // was "EUR"
```

## Solution

Trim and skip empty geo headers before falling back to `US`, and check EU country codes through exact array membership instead of substring matching.

```ts
getCurrency(""); // now "USD"
getCurrency("T"); // now "USD"
```

Added focused locale tests for empty and whitespace headers, degenerate country-code inputs, unknown country codes, and normal EUR/GBP/INR mappings.

## Testing

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm test app/src/lib/locale.test.ts`
