### PR TITLE
Fix app Tailwind source formatting

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -127,6 +127,7 @@
     "nextjs": "workspace:*",
     "pixelmatch": "7.2.0",
     "pngjs": "7.0.0",
+    "prettier-plugin-tailwindcss": "0.8.0",
     "rimraf": "6.1.3",
     "vite": "7.3.5",
     "vitest": "4.1.9",

--- a/app/prettier.config.js
+++ b/app/prettier.config.js
@@ -1,0 +1,4 @@
+export default {
+  plugins: ["prettier-plugin-tailwindcss"],
+  tailwindStylesheet: "./src/styles/global.css",
+};

--- a/app/src/lib/source-plugin.test.ts
+++ b/app/src/lib/source-plugin.test.ts
@@ -9,6 +9,7 @@
  */
 import { join } from "node:path";
 import { expect, test } from "vitest";
+import checkboxCardForm from "#app/examples/checkbox-card/form/index.react.tsx?source";
 import disclosure from "#app/examples/disclosure/index.react.tsx?source";
 
 const EXAMPLES_DIR = join(import.meta.dirname, "../examples/");
@@ -62,6 +63,12 @@ test("disclosure source names", () => {
       "_lib/react-utils/merge-props.ts",
     ]
   `);
+});
+
+test("formats rewritten imports with the app Tailwind config", () => {
+  expect(checkboxCardForm.files["index.tsx"]?.content).toContain(
+    'className="ak-frame flex w-120 max-w-[100cqi] flex-col gap-6 ak-layer ak-frame-card/8 ak-layer-lighten-6 ak-dark:ak-frame-border ak-light:ring"',
+  );
 });
 
 test("disclosure sources", () => {

--- a/app/src/lib/source-plugin.ts
+++ b/app/src/lib/source-plugin.ts
@@ -186,7 +186,11 @@ async function formatWithPrettier(
   if (!parser) return code;
   try {
     const resolvedConfig = (await prettier.resolveConfig(filePath)) ?? {};
-    return await prettier.format(code, { ...resolvedConfig, parser });
+    return await prettier.format(code, {
+      ...resolvedConfig,
+      filepath: filePath,
+      parser,
+    });
   } catch {
     // Fail silently: if Prettier isn't available or config fails, return unformatted code
     return code;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,6 +447,9 @@ importers:
       pngjs:
         specifier: 7.0.0
         version: 7.0.0
+      prettier-plugin-tailwindcss:
+        specifier: 0.8.0
+        version: 0.8.0(prettier@3.8.4)
       rimraf:
         specifier: 6.1.3
         version: 6.1.3


### PR DESCRIPTION
## Motivation

The docs app formats rewritten example sources with Prettier before displaying or exporting them. Without an app-local Prettier config, files under `app/` resolve the root config, which points `prettier-plugin-tailwindcss` at the legacy Tailwind v3 website config.

That makes app examples with Tailwind v4-only utilities and `ak-*` utilities sort differently from the app's real Tailwind setup, so docs code blocks and exports can diverge from the expected v4 class order.

## Solution

Add an app-local Prettier config that keeps config discovery inside `app/` and points the Tailwind plugin at the app's v4 stylesheet:

```js
export default {
  plugins: ["prettier-plugin-tailwindcss"],
  tailwindStylesheet: "./src/styles/global.css",
};
```

The source formatter now passes `filepath` to `prettier.format`, so plugin options can stay anchored to the source file/config path instead of the process working directory. The app workspace also declares `prettier-plugin-tailwindcss` so bare plugin resolution works when app commands run from `app/`.

A regression test covers an example whose imports are rewritten and verifies the flattened source uses the app Tailwind ordering.

## Verification

- `pnpm lint-fix`
- `pnpm test app/src/lib/source-plugin.test.ts`
- `pnpm tsc`
- `pnpm build-app-lite`
