### PR TITLE
Preserve import aliases in source merging

### DIFF
--- a/app/src/lib/source.test.ts
+++ b/app/src/lib/source.test.ts
@@ -669,3 +669,47 @@ test("mergeImports handles specifiers containing 'from' substring", () => {
     export const x = transformFrom(fromDate);"
   `);
 });
+
+test("mergeImports preserves aliases in transformed imports", () => {
+  const code = [
+    'import { interests as data } from "./utils/data.ts";',
+    "",
+    "export const x = data;",
+  ].join("\n");
+  expect(
+    mergeImports(code, (p) =>
+      p.startsWith("./utils/") ? "./utils.ts" : false,
+    ),
+  ).toMatchInlineSnapshot(`
+    "import { interests as data } from "./utils.ts";
+
+    export const x = data;"
+  `);
+});
+
+test("mergeImports preserves aliases in untouched imports", () => {
+  const code = [
+    'import { foo as bar, type Baz as Qux } from "keep";',
+    "",
+    "export const y: Qux = bar;",
+  ].join("\n");
+  expect(mergeImports(code, () => false)).toMatchInlineSnapshot(`
+    "import { foo as bar } from "keep";
+    import type { Baz as Qux } from "keep";
+
+    export const y: Qux = bar;"
+  `);
+});
+
+test("mergeImports preserves aliases in type-only imports", () => {
+  const code = [
+    'import type { T as U } from "./x";',
+    "",
+    "export const z: U = 1;",
+  ].join("\n");
+  expect(mergeImports(code, (p) => p)).toMatchInlineSnapshot(`
+    "import type { T as U } from "./x";
+
+    export const z: U = 1;"
+  `);
+});

--- a/app/src/lib/source.ts
+++ b/app/src/lib/source.ts
@@ -234,14 +234,14 @@ interface ParsedSpecifiers {
 }
 
 /**
- * Extracts the base name from an import specifier, handling `as` aliases.
+ * Normalizes an import specifier, collapsing whitespace while preserving `as`
+ * aliases.
  * @example
- * extractSpecifierName("Foo as Bar") // Returns "Foo"
- * extractSpecifierName("Foo") // Returns "Foo"
+ * normalizeSpecifier("Foo  as  Bar") // Returns "Foo as Bar"
+ * normalizeSpecifier("Foo") // Returns "Foo"
  */
-function extractSpecifierName(specifier: string): string {
-  const beforeAs = specifier.split(/\s+as\s+/i)[0] ?? "";
-  return beforeAs.trim();
+function normalizeSpecifier(specifier: string): string {
+  return specifier.trim().replace(/\s+/g, " ");
 }
 
 /**
@@ -249,7 +249,7 @@ function extractSpecifierName(specifier: string): string {
  * names. Handles inline `type` modifiers.
  * @example
  * parseNamedSpecifiers("A, type B, C as D")
- * // Returns { runtime: ["A", "C"], typeOnly: ["B"] }
+ * // Returns { runtime: ["A", "C as D"], typeOnly: ["B"] }
  */
 function parseNamedSpecifiers(inside: string): ParsedSpecifiers {
   const runtime: string[] = [];
@@ -263,7 +263,7 @@ function parseNamedSpecifiers(inside: string): ParsedSpecifiers {
   for (const item of items) {
     const isType = /^type\s+/i.test(item);
     const raw = isType ? item.replace(/^type\s+/i, "") : item;
-    const name = extractSpecifierName(raw);
+    const name = normalizeSpecifier(raw);
     if (!name) continue;
 
     if (isType) {
@@ -284,7 +284,7 @@ function parseTypeOnlySpecifiers(inside: string): string[] {
     .split(",")
     .map((s) => s.trim())
     .filter(Boolean)
-    .map(extractSpecifierName)
+    .map(normalizeSpecifier)
     .filter(Boolean);
 }
 
@@ -480,8 +480,9 @@ function insertHoistedImports(hoisted: string, body: string): string {
  *   specifiers, only the transformed specifiers are hoisted; the remaining
  *   specifiers stay in place and the original import line may be rewritten to
  *   preserve them without duplication.
- * - Deduplicates specifiers by name and sorts both specifier names and module
- *   specifiers lexicographically within each group.
+ * - Deduplicates specifiers by their full text (preserving `as` aliases) and
+ *   sorts both specifiers and module specifiers lexicographically within each
+ *   group.
  * - Preserves overall content by removing the original named import statements
  *   and returning the full transformed content with hoisted imports. Any
  *   orphaned semicolon-only lines left by the removal are also cleaned up to


### PR DESCRIPTION
## Motivation

`mergeImports` strips named import aliases while parsing specifiers. When the source plugin flattens example files and rewrites imports, code like this:

```ts
import { interests as data } from "./utils/data.ts";

export const x = data;
```

can be emitted as `import { interests } from "./utils.ts";` while the body still references `data`. The same parser is also used when rebuilding untouched imports, so aliases from external or otherwise untransformed imports can be lost too.

## Solution

This changes the shared named-specifier parser to keep the full normalized specifier text instead of only the imported name before `as`. Both hoisted imports and remaining imports now preserve aliases such as `interests as data` and `type T as U`.

The `mergeImports` JSDoc now documents that deduplication is based on the full specifier text, and the regression tests cover transformed imports, untouched imports, and type-only imports.

## Testing

- `pnpm test app/src/lib/source.test.ts`
- `pnpm lint-fix`
- `pnpm tsc`
