### PR TITLE
Preserve Stripe error response bodies in dev

### DIFF
--- a/app/src/lib/stripe.ts
+++ b/app/src/lib/stripe.ts
@@ -60,7 +60,7 @@ function createHttpClient(enabled: boolean) {
         info(url.pathname);
       } else {
         error(url.pathname, response.status);
-        error(response.status, await response.text());
+        error(response.status, await response.clone().text());
       }
       return response;
     },


### PR DESCRIPTION
## Motivation

In development, the Stripe HTTP client wrapper logs non-2xx response bodies. Reading `response.text()` on the original response consumes its body stream before the Stripe SDK can parse the error payload, so callers can receive a generic invalid JSON/body-used error instead of the typed Stripe error.

## Solution

Read the log body from `response.clone().text()` so the logger consumes a cloned stream and the original `Response` remains available for the Stripe SDK.

## Testing

- `pnpm lint-fix`
- `pnpm tsc`