### PR TITLE
Fix list markers in RTL layouts

### DIFF
--- a/app/src/lib/styles.test.ts
+++ b/app/src/lib/styles.test.ts
@@ -121,7 +121,7 @@ test("styleDefToCss renders ak-list-item-ol-border utility fully", () => {
         content: "";
         width: var(--ak-list-border-width);
         top: var(--ak-list-border-top);
-        left: calc(
+        inset-inline-start: calc(
           var(--ak-list-item-marker-center) - var(--ak-list-border-width) / 2 +
             var(--ak-frame-padding)
         );

--- a/app/src/styles/ak-list.css
+++ b/app/src/styles/ak-list.css
@@ -145,11 +145,13 @@
 /* ak-list-item elements and variants */
 @utility ak-list-item-ul-marker {
   @apply ak-layer ak-edge-40;
-  @apply absolute left-0 border-b;
+  @apply absolute border-b;
   content: "";
   width: calc(var(--ak-list-leading) * 0.5);
   top: calc(var(--ak-list-leading) * 0.5 + var(--ak-frame-padding));
-  left: calc(var(--ak-list-leading) * 0.25 + var(--ak-frame-padding));
+  inset-inline-start: calc(
+    var(--ak-list-leading) * 0.25 + var(--ak-frame-padding)
+  );
 }
 
 @utility ak-list-item-ul {
@@ -162,7 +164,7 @@
   --ak-list-counter-leading: var(--ak-list-leading);
   font-size-adjust: 0.45;
   top: var(--ak-frame-padding);
-  left: var(--ak-frame-padding);
+  inset-inline-start: var(--ak-frame-padding);
 }
 
 @utility ak-list-item-ol-border {
@@ -178,7 +180,7 @@
     content: "";
     width: var(--ak-list-border-width);
     top: var(--ak-list-border-top);
-    left: calc(
+    inset-inline-start: calc(
       var(--ak-list-item-marker-center) - var(--ak-list-border-width) / 2 +
         var(--ak-frame-padding)
     );

--- a/app/src/styles/styles.json
+++ b/app/src/styles/styles.json
@@ -7351,7 +7351,7 @@
               "value": {}
             },
             {
-              "name": "@apply absolute left-0 border-b",
+              "name": "@apply absolute border-b",
               "value": {}
             },
             {
@@ -7367,8 +7367,8 @@
               "value": "calc(var(--ak-list-leading) * 0.5 + var(--ak-frame-padding))"
             },
             {
-              "name": "left",
-              "value": "calc(var(--ak-list-leading) * 0.25 + var(--ak-frame-padding))"
+              "name": "inset-inline-start",
+              "value": "calc(\n    var(--ak-list-leading) * 0.25 + var(--ak-frame-padding)\n  )"
             }
           ],
           "dependencies": [
@@ -7426,7 +7426,7 @@
               "value": "var(--ak-frame-padding)"
             },
             {
-              "name": "left",
+              "name": "inset-inline-start",
               "value": "var(--ak-frame-padding)"
             }
           ],
@@ -7482,7 +7482,7 @@
                   "value": "var(--ak-list-border-top)"
                 },
                 {
-                  "name": "left",
+                  "name": "inset-inline-start",
                   "value": "calc(\n      var(--ak-list-item-marker-center) - var(--ak-list-border-width) / 2 +\n        var(--ak-frame-padding)\n    )"
                 },
                 {


### PR DESCRIPTION
## Motivation

`ak-list` item content is indented with `padding-inline-start`, so the reserved marker space moves to the right in RTL layouts. The unordered marker, ordered marker, and ordered-list guide line were still positioned with physical `left`, which left the reserved gap empty and placed markers over the item text in RTL.

## Solution

Replace the physical marker and guide-line offsets in `app/src/styles/ak-list.css` with `inset-inline-start`, and remove the now-invalid `left-0` utility from the unordered marker. This preserves LTR placement while allowing RTL layouts to mirror correctly.

The style index was regenerated with `pnpm -F app run build-styles`, and the affected inline snapshot in `app/src/lib/styles.test.ts` was updated.
