### PR TITLE
Handle Unicode previous code blocks

### DIFF
--- a/app/src/components/content-code-block.astro
+++ b/app/src/components/content-code-block.astro
@@ -9,6 +9,7 @@
  * SPDX-License-Identifier: UNLICENSED
  */
 import * as icons from "#app/icons/icons.ts";
+import { decodeBase64 } from "#app/lib/base64.ts";
 import { isJsxFramework } from "#app/lib/frameworks.ts";
 import { getLangFromFilename, isLangAlias } from "#app/lib/shiki.ts";
 import { invariant } from "@ariakit/utils";
@@ -135,7 +136,7 @@ function parseCodeBlock(html: string): CodeBlockProps {
   const previousCode = attributes.match(/previousCode="([^"]*)"/)?.[1];
   return {
     code: decode(encodedContent).trim(),
-    previousCode: previousCode ? atob(previousCode) : undefined,
+    previousCode: previousCode ? decodeBase64(previousCode) : undefined,
     ...langInfo,
     ...parseMetaString(metaString),
   };

--- a/app/src/lib/base64.ts
+++ b/app/src/lib/base64.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2025-present Ariakit FZ-LLC. All Rights Reserved.
+ *
+ * This software is proprietary. See the license.md file in the root of this
+ * package for licensing terms.
+ *
+ * SPDX-License-Identifier: UNLICENSED
+ */
+import { Buffer } from "node:buffer";
+
+export function encodeBase64(value: string) {
+  return Buffer.from(value, "utf8").toString("base64");
+}
+
+export function decodeBase64(value: string) {
+  return Buffer.from(value, "base64").toString("utf8");
+}

--- a/app/src/lib/rehype.test.ts
+++ b/app/src/lib/rehype.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2025-present Ariakit FZ-LLC. All Rights Reserved.
+ *
+ * This software is proprietary. See the license.md file in the root of this
+ * package for licensing terms.
+ *
+ * SPDX-License-Identifier: UNLICENSED
+ */
+import type { Element, Root } from "hast";
+import { expect, test } from "vitest";
+import { decodeBase64 } from "./base64.ts";
+import { rehypePreviousCode } from "./rehype.ts";
+
+function createCodeBlock(code: string, metastring?: string): Element {
+  return {
+    type: "element",
+    tagName: "pre",
+    properties: {},
+    children: [
+      {
+        type: "element",
+        tagName: "code",
+        properties: { metastring },
+        children: [{ type: "text", value: code }],
+      },
+    ],
+  };
+}
+
+test("rehypePreviousCode encodes Unicode code blocks", () => {
+  const previousCode = "const label = 'Before'; // Move → next";
+  const nextCode = "const label = 'After';";
+  const beforeBlock = createCodeBlock(previousCode, "previousCode");
+  const afterBlock = createCodeBlock(nextCode);
+  const tree: Root = {
+    type: "root",
+    children: [beforeBlock, afterBlock],
+  };
+
+  rehypePreviousCode()(tree);
+
+  expect(tree.children).toEqual([afterBlock]);
+
+  const codeNode = afterBlock.children[0];
+  expect(codeNode?.type).toBe("element");
+  if (codeNode?.type !== "element") return;
+
+  const encodedPreviousCode = codeNode.properties.previousCode;
+  expect(typeof encodedPreviousCode).toBe("string");
+  if (typeof encodedPreviousCode !== "string") return;
+
+  expect(decodeBase64(encodedPreviousCode)).toBe(previousCode);
+});

--- a/app/src/lib/rehype.ts
+++ b/app/src/lib/rehype.ts
@@ -10,6 +10,7 @@
 import type { Element, Root, RootContent, Text } from "hast";
 import { toText } from "hast-util-to-text";
 import { visit } from "unist-util-visit";
+import { encodeBase64 } from "./base64.ts";
 
 interface RehypeAsTagNameOptions {
   tags: string[];
@@ -115,7 +116,7 @@ export function rehypePreviousCode() {
         );
         nodesToRemove.push({ parent, node });
       } else if (previousCode) {
-        codeNode.properties.previousCode = btoa(previousCode);
+        codeNode.properties.previousCode = encodeBase64(previousCode);
         queuePrecedingParagraphForRemoval(
           parent,
           index,


### PR DESCRIPTION
## Motivation

Before/After docs code blocks pass the hidden `previousCode` snippet through a base64 HTML attribute. The previous implementation used `btoa` and `atob`, which only support Latin-1 strings, so a code block containing a Unicode character such as `→` could crash the docs build with `InvalidCharacterError`.

## Solution

Add shared UTF-8 base64 helpers backed by `node:buffer`, then use them for both sides of the `previousCode` round trip:

```ts
encodeBase64(previousCode)
decodeBase64(previousCode)
```

This keeps the attribute format as ordinary base64 while allowing the original code block text to contain Unicode. I also added a focused Vitest regression test that exercises a `previousCode` block containing a Unicode arrow.

## Testing

- `pnpm lint-fix`
- `pnpm test app/src/lib/rehype.test.ts`
- Red check: temporarily restored the broken `btoa` encoder and confirmed `pnpm test app/src/lib/rehype.test.ts` fails with `InvalidCharacterError`
- `pnpm tsc`
- `pnpm build-app-lite`
