### PR TITLE
Add guide to Changesets ignore list

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,6 +10,7 @@
   "ignore": [
     "website",
     "app",
+    "guide",
     "examples",
     "nextjs",
     "@ariakit/scripts",


### PR DESCRIPTION
## Motivation

The `guide` workspace is private and versioned `0.0.0`, like the other private workspaces already listed in `.changeset/config.json`'s `ignore` array. Because it was omitted, Changesets could offer `guide` in `pnpm changeset` and honor a changeset that would produce release noise for a never-published package.

## Solution

Add `guide` to the existing explicit Changesets `ignore` array. This keeps the current per-package configuration style instead of changing global private package behavior.

## Verification

- `pnpm lint-fix`
- `pnpm exec changeset status --since=origin/main`