### PR TITLE
Fix offscreen CompositeItem prop leaks

### DIFF
--- a/.changeset/300-composite-offscreen-props.md
+++ b/.changeset/300-composite-offscreen-props.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/react-components": patch
+---
+
+Fixed offscreen [`CompositeItem`](https://ariakit.com/reference/composite-item) placeholders to omit internal option props from the DOM while relying on `aria-disabled` instead of the native `disabled` attribute.

--- a/app/src/sandbox/composite-offscreen-props/index.react.tsx
+++ b/app/src/sandbox/composite-offscreen-props/index.react.tsx
@@ -1,0 +1,33 @@
+import * as Ariakit from "@ariakit/react";
+import { CompositeItem } from "@ariakit/react-components/composite/composite-item-offscreen";
+
+export default function Example() {
+  const composite = Ariakit.useCompositeStore();
+
+  return (
+    <Ariakit.Composite
+      aria-label="Actions"
+      store={composite}
+      style={{ height: 40, overflow: "auto" }}
+    >
+      <div style={{ height: 200 }} />
+      <CompositeItem
+        accessibleWhenDisabled
+        clickOnEnter
+        clickOnSpace
+        disabled
+        focusable
+        getItem={(item) => item}
+        id="archive"
+        moveOnKeyPress={() => true}
+        offscreenMode="passive"
+        offscreenRoot={(element) => element.parentElement}
+        onFocusVisible={() => undefined}
+        preventScrollOnKeyDown={() => true}
+        shouldRegisterItem
+        tabbable
+        value="Archive"
+      />
+    </Ariakit.Composite>
+  );
+}

--- a/app/src/sandbox/composite-offscreen-props/test-browser.ts
+++ b/app/src/sandbox/composite-offscreen-props/test-browser.ts
@@ -1,0 +1,36 @@
+import { gotoAndSettle, withFramework } from "#app/test-utils/preview.ts";
+
+const leakedAttributes = [
+  "accessiblewhendisabled",
+  "clickonenter",
+  "clickonspace",
+  "focusable",
+  "shouldregisteritem",
+] as const;
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("omits composite option props from the offscreen placeholder", async ({
+    page,
+    q,
+  }) => {
+    const reactWarnings: string[] = [];
+    page.on("console", (message) => {
+      if (message.type() === "warning" || message.type() === "error") {
+        reactWarnings.push(message.text());
+      }
+    });
+
+    await gotoAndSettle(page, page.url());
+
+    const item = q.button("Archive");
+    await test.expect(item).toHaveAttribute("data-offscreen");
+    await test.expect(item).toHaveAttribute("aria-disabled", "true");
+    await test.expect(item).not.toHaveAttribute("disabled");
+
+    for (const attribute of leakedAttributes) {
+      await test.expect(item).not.toHaveAttribute(attribute);
+    }
+
+    test.expect(reactWarnings).toEqual([]);
+  });
+});

--- a/app/src/sandbox/composite-offscreen-props/test.ts
+++ b/app/src/sandbox/composite-offscreen-props/test.ts
@@ -1,0 +1,22 @@
+import { q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+const leakedAttributes = [
+  "accessiblewhendisabled",
+  "clickonenter",
+  "clickonspace",
+  "focusable",
+  "shouldregisteritem",
+] as const;
+
+test("omits composite option props from the offscreen placeholder", () => {
+  const item = q.button.ensure("Archive");
+
+  expect(item).toHaveAttribute("data-offscreen");
+  expect(item).toHaveAttribute("aria-disabled", "true");
+  expect(item).not.toHaveAttribute("disabled");
+
+  for (const attribute of leakedAttributes) {
+    expect(item).not.toHaveAttribute(attribute);
+  }
+});

--- a/packages/ariakit-react-components/src/composite/composite-item-offscreen.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-item-offscreen.tsx
@@ -96,14 +96,24 @@ export const CompositeItem = forwardRef(function CompositeItem({
   if (active) {
     return <Base.CompositeItem {...allProps} />;
   }
-  // Remove CompositeItem props
+  // Remove CompositeItem props. Custom renders own their native disabled state.
   const {
     store,
+    disabled,
+    shouldRegisterItem,
     rowId,
     preventScrollOnKeyDown,
     moveOnKeyPress,
     tabbable,
+    clickOnEnter,
+    clickOnSpace,
+    focusable,
+    accessibleWhenDisabled,
+    autoFocus,
+    onFocusVisible,
     getItem,
+    // @ts-expect-error This prop may come from a collection renderer.
+    element,
     ...htmlProps
   } = allProps;
   const Component = Role[TagName];


### PR DESCRIPTION
## Motivation

Direct consumers of `@ariakit/react-components/composite/composite-item-offscreen` can render inactive `CompositeItem` placeholders with regular option props such as `disabled`, `focusable`, `clickOnEnter`, `clickOnSpace`, `accessibleWhenDisabled`, `shouldRegisterItem`, and `onFocusVisible`.

The inactive branch previously stripped only part of the `CompositeItem` option surface before spreading props onto a plain button. That left React DOM warnings and stray attributes on inactive placeholders:

```tsx
<CompositeItem
  accessibleWhenDisabled
  clickOnEnter
  clickOnSpace
  disabled
  focusable
  shouldRegisterItem
  onFocusVisible={() => {}}
  offscreenMode="passive"
/>
```

## Solution

Expand the inactive offscreen `CompositeItem` prop strip list to cover the inherited composite, collection, command, and focusable option props before rendering the placeholder button. The placeholder still keeps valid button props such as `value`, while disabled state is represented with `aria-disabled` instead of the native `disabled` attribute.

This also adds a focused `composite-offscreen-props` sandbox with happy-dom and Playwright coverage. The tests assert that the placeholder remains offscreen and aria-disabled, omits the native `disabled` attribute, omits leaked lower-cased option attributes, and emits no React warnings in a browser.

## Testing

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm test-react app/src/sandbox/composite-offscreen-props/test.ts`
- `APP_PORT=4322 NEXTJS_PORT=3001 pnpm -F app run test -- app/src/sandbox/composite-offscreen-props/test-browser.ts`
