### PR TITLE
Fix ComboboxSeparator docs listing

### DIFF
--- a/components/combobox.md
+++ b/components/combobox.md
@@ -51,7 +51,7 @@ useComboboxContext()
           <ComboboxItemCheck />
           <ComboboxItemValue />
         </ComboboxItem>
-        <ComboboxSeparator>
+        <ComboboxSeparator />
       </ComboboxRow>
     </ComboboxGroup>
   </ComboboxPopover>


### PR DESCRIPTION
## Motivation

The Combobox API overview uses self-closing tags for leaf components, but the `ComboboxSeparator` entry was missing its closing slash. That makes it look like a wrapper component and can produce invalid JSX if copied.

## Solution

Self-close the `ComboboxSeparator` entry in `components/combobox.md` so it matches the component's leaf behavior and sibling separator listings.

## Verification

- `pnpm lint-fix`