### PR TITLE
Fix package dev watchers

### DIFF
--- a/packages/ariakit-scripts/src/dev.test.ts
+++ b/packages/ariakit-scripts/src/dev.test.ts
@@ -1,0 +1,111 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, test, vi } from "vitest";
+import { shouldIgnorePackageWatchPath, watchPackageChanges } from "./dev.ts";
+
+class FakePackageWatcher {
+  private listeners = new Map<string, ((filename: string) => void)[]>();
+
+  on(event: string, listener: (filename: string) => void) {
+    const listeners = this.listeners.get(event) ?? [];
+    listeners.push(listener);
+    this.listeners.set(event, listeners);
+    return this;
+  }
+
+  emit(event: string, filename: string) {
+    const listeners = this.listeners.get(event);
+    if (!listeners) return;
+
+    for (const listener of listeners) {
+      listener(filename);
+    }
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+test("ignores package watch paths outside source and package json", () => {
+  expect(shouldIgnorePackageWatchPath("packages/foo/node_modules/bar.ts")).toBe(
+    true,
+  );
+  expect(shouldIgnorePackageWatchPath("packages/foo/dist/index.js")).toBe(true);
+  expect(shouldIgnorePackageWatchPath("packages/foo/solid/index.js")).toBe(
+    true,
+  );
+  expect(shouldIgnorePackageWatchPath("packages/foo/coverage/index.html")).toBe(
+    true,
+  );
+  expect(shouldIgnorePackageWatchPath("packages/foo/benchmark/index.ts")).toBe(
+    true,
+  );
+  expect(shouldIgnorePackageWatchPath("packages/foo/readme.md")).toBe(true);
+  expect(shouldIgnorePackageWatchPath("packages/foo/package.json")).toBe(false);
+  expect(
+    shouldIgnorePackageWatchPath("packages/ariakit-solid/src/index.ts"),
+  ).toBe(false);
+  expect(
+    shouldIgnorePackageWatchPath(
+      join(process.cwd(), "packages/ariakit-solid/src/index.ts"),
+    ),
+  ).toBe(false);
+  expect(shouldIgnorePackageWatchPath("packages/foo/src/solid/index.ts")).toBe(
+    false,
+  );
+  expect(shouldIgnorePackageWatchPath("packages/foo/src/dist/index.ts")).toBe(
+    false,
+  );
+  expect(
+    shouldIgnorePackageWatchPath("packages/foo/src/benchmark/index.ts"),
+  ).toBe(false);
+});
+
+test("watches packages and cleans changed package entries", async () => {
+  const rootPath = await mkdtemp(join(tmpdir(), "ariakit-dev-"));
+
+  try {
+    await mkdir(join(rootPath, "packages/foo/src"), { recursive: true });
+    await writeFile(
+      join(rootPath, "packages/foo/package.json"),
+      `${JSON.stringify({ scripts: { clean: "ariakit clean" } }, null, 2)}\n`,
+    );
+
+    vi.useFakeTimers();
+    vi.spyOn(process, "cwd").mockReturnValue(rootPath);
+
+    const watcher = new FakePackageWatcher();
+    const cleanPackages = vi.fn(async (_packages: unknown[]) => {});
+    const watchPackages = vi.fn(() => watcher);
+
+    watchPackageChanges({ cleanPackages, watch: watchPackages });
+
+    expect(watchPackages).toHaveBeenCalledWith("packages", {
+      ignoreInitial: true,
+      ignored: shouldIgnorePackageWatchPath,
+    });
+
+    watcher.emit("change", "packages/foo/readme.md");
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(cleanPackages).not.toHaveBeenCalled();
+
+    watcher.emit("add", "packages/foo/src/new-file.ts");
+    watcher.emit("change", join(rootPath, "packages/foo/package.json"));
+    await vi.advanceTimersByTimeAsync(100);
+
+    const firstCall = cleanPackages.mock.calls[0];
+    expect(firstCall?.[0]).toEqual([
+      {
+        path: join(rootPath, "packages/foo"),
+        type: "ariakit",
+      },
+    ]);
+    expect(cleanPackages).toHaveBeenCalledTimes(1);
+  } finally {
+    await rm(rootPath, { recursive: true, force: true });
+  }
+});

--- a/packages/ariakit-scripts/src/dev.ts
+++ b/packages/ariakit-scripts/src/dev.ts
@@ -15,7 +15,36 @@ interface CleanPackage {
   type: "ariakit" | "script";
 }
 
-const packageChangeGlobs = ["packages/*/package.json", "packages/*/src/**"];
+interface PackageWatcher {
+  on(event: string, listener: (filename: string) => void): PackageWatcher;
+}
+
+interface WatchPackageChangesOptions {
+  cleanPackages?: typeof cleanPackages;
+  watch?: (
+    path: string,
+    options: {
+      ignoreInitial: boolean;
+      ignored: (path: string) => boolean;
+    },
+  ) => PackageWatcher;
+}
+
+const watchedPackageEntries = new Set(["package.json", "src"]);
+
+export function shouldIgnorePackageWatchPath(filename: string) {
+  const relativePath = isAbsolute(filename)
+    ? relative(process.cwd(), filename)
+    : filename;
+  const normalizedPath = normalizePath(relativePath);
+  const [root, packageName, entry] = normalizedPath.split("/");
+
+  if (root !== "packages") return false;
+  if (!packageName) return false;
+  if (!entry) return false;
+
+  return !watchedPackageEntries.has(entry);
+}
 
 function getCleanPackage(rootPath: string): CleanPackage | undefined {
   try {
@@ -56,10 +85,12 @@ async function getCleanPackages() {
 function getPackagePath(filename: string) {
   const path = isAbsolute(filename) ? filename : join(process.cwd(), filename);
   const relativePath = normalizePath(relative(process.cwd(), path));
-  const [root, packageName] = relativePath.split("/");
+  const [root, packageName, entry] = relativePath.split("/");
 
   if (root !== "packages") return;
   if (!packageName) return;
+  if (!entry) return;
+  if (!watchedPackageEntries.has(entry)) return;
 
   return join(process.cwd(), "packages", packageName);
 }
@@ -91,7 +122,9 @@ async function cleanPackages(packages: CleanPackage[]) {
   }
 }
 
-function watchPackageChanges() {
+export function watchPackageChanges(options: WatchPackageChangesOptions = {}) {
+  const watchPackages = options.watch ?? watch;
+  const cleanPackageList = options.cleanPackages ?? cleanPackages;
   let timeout: NodeJS.Timeout | undefined;
   let queue = Promise.resolve();
   const pendingPackagePaths = new Set<string>();
@@ -104,7 +137,7 @@ function watchPackageChanges() {
     pendingPackagePaths.clear();
     if (!packages.length) return;
     queue = queue
-      .then(() => cleanPackages(packages))
+      .then(() => cleanPackageList(packages))
       .catch((error) => console.error(error));
   };
 
@@ -118,7 +151,10 @@ function watchPackageChanges() {
     timeout = setTimeout(runClean, 100);
   };
 
-  watch(packageChangeGlobs, { ignoreInitial: true })
+  watchPackages("packages", {
+    ignoreInitial: true,
+    ignored: shouldIgnorePackageWatchPath,
+  })
     .on("add", scheduleClean)
     .on("change", scheduleClean)
     .on("unlink", scheduleClean)

--- a/scripts/build/package-json-dev.js
+++ b/scripts/build/package-json-dev.js
@@ -1,8 +1,26 @@
-import { join } from "node:path";
+import { isAbsolute, join, relative } from "node:path";
 import { watch } from "chokidar";
 import { globSync } from "glob";
 import { updateSourcePackageJson } from "../../packages/ariakit-scripts/src/build.ts";
 import { readPackageJson, writePackageJson } from "./utils.js";
+
+/** @param {string} path */
+function normalizePath(path) {
+  return path.replace(/\\/g, "/");
+}
+
+/** @param {string} path */
+function shouldIgnoreWatchPath(path) {
+  const relativePath = isAbsolute(path) ? relative(process.cwd(), path) : path;
+  const normalizedPath = normalizePath(relativePath);
+  const [root, packageName, entry] = normalizedPath.split("/");
+
+  if (root !== "packages") return false;
+  if (!packageName) return false;
+  if (!entry) return false;
+
+  return entry !== "src";
+}
 
 /** @param {string} path */
 async function processDevPackage(path) {
@@ -32,7 +50,10 @@ function handleChange(path) {
   void processDevPackage(path);
 }
 
-watch(["packages/*/src/**"], { ignoreInitial: true })
+watch("packages", {
+  ignoreInitial: true,
+  ignored: shouldIgnoreWatchPath,
+})
   .on("add", handleChange)
   .on("unlink", handleChange)
   .on("unlinkDir", handleChange);


### PR DESCRIPTION
## Motivation

The package dev watchers still passed glob patterns to `chokidar.watch()`, but chokidar 5 no longer expands globs. That made the `ariakit dev` package watcher silently miss `packages/*/package.json` and `packages/*/src/**` changes, leaving generated package exports stale until the dev server restarted.

The legacy `dev-package-json` watcher used by the website dev script had the same chokidar glob issue for `packages/*/src/**`.

## Solution

Watch the `packages` directory directly and use chokidar's `ignored` callback to preserve the old watch scopes:

- `ariakit dev` keeps package-root `package.json` and `src` entries visible.
- `dev-package-json` keeps package-root `src` entries visible.
- Other package-root entries such as `node_modules`, `dist`, `solid`, `coverage`, `benchmark`, and readme files are ignored before traversal.

The `ariakit dev` path also keeps a second entry filter before scheduling clean work, and new Vitest coverage verifies the watch target/options, ignored paths, nested `src` folders, debounce behavior, and package clean scheduling through a temp package fixture.

## Verification

- `pnpm test packages/ariakit-scripts/src/dev.test.ts`
- `pnpm lint-fix`
- `pnpm tsc`
- Red-checked the new tests by temporarily restoring the glob watch target and the broad segment ignore behavior, confirming the relevant assertions failed before restoring the fix.