### PR TITLE
Fix form JSDoc examples

### DIFF
--- a/.changeset/300-form-jsdoc-examples.md
+++ b/.changeset/300-form-jsdoc-examples.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed documentation comments and examples for [`FormError`](https://ariakit.com/reference/form-error), [`FormSubmit`](https://ariakit.com/reference/form-submit), [`FormLabel`](https://ariakit.com/reference/form-label), and [`FormProvider`](https://ariakit.com/reference/form-provider).

--- a/packages/ariakit-react-components/src/form/form-error.tsx
+++ b/packages/ariakit-react-components/src/form/form-error.tsx
@@ -19,7 +19,7 @@ type TagName = typeof TagName;
 type HTMLType = HTMLElementTagNameMap[TagName];
 
 /**
- * Returns props to create a `FormDescription` component.
+ * Returns props to create a `FormError` component.
  * @see https://ariakit.com/components/form
  * @example
  * ```jsx

--- a/packages/ariakit-react-components/src/form/form-label.tsx
+++ b/packages/ariakit-react-components/src/form/form-label.tsx
@@ -139,7 +139,7 @@ export const useFormLabel = createHook<TagName, FormLabelOptions>(
  * });
  *
  * <Form store={form}>
- *   <FormLabel name={form.names.email}>Email</Role>
+ *   <FormLabel name={form.names.email}>Email</FormLabel>
  *   <FormInput name={form.names.email} />
  * </Form>
  * ```

--- a/packages/ariakit-react-components/src/form/form-provider.tsx
+++ b/packages/ariakit-react-components/src/form/form-provider.tsx
@@ -15,7 +15,7 @@ type Values = FormStoreValues;
  * ```jsx
  * <FormProvider defaultValues={{ email: "" }}>
  *   <Form>
- *     <FormInput />
+ *     <FormInput name="email" />
  *   </Form>
  * </FormProvider>
  * ```

--- a/packages/ariakit-react-components/src/form/form-submit.tsx
+++ b/packages/ariakit-react-components/src/form/form-submit.tsx
@@ -12,7 +12,7 @@ const TagName = "button" satisfies ElementType;
 type TagName = typeof TagName;
 
 /**
- * Returns props to create a `FormReset` component.
+ * Returns props to create a `FormSubmit` component.
  * @see https://ariakit.com/components/form
  * @example
  * ```jsx


### PR DESCRIPTION
## Motivation

Several form JSDoc blocks contradict the components they document. These comments are extracted into the reference docs and also show up in editor hovers, so the current text can mislead users or provide examples that do not parse/type-check.

For example, `useFormError` was described as creating `FormDescription`, `useFormSubmit` was described as creating `FormReset`, the `FormLabel` example closed with `</Role>`, and the `FormProvider` example rendered a `FormInput` without the required `name` prop.

## Solution

Update the affected comments so hook descriptions name their own components, the `FormLabel` example closes the matching JSX tag, and the `FormProvider` example passes `name="email"` to `FormInput`.

This also adds a patch changeset for `@ariakit/react-components` and `@ariakit/react` because the affected form APIs are public.
