### PR TITLE
Remove unused dialog tree helper

### DIFF
--- a/.changeset/100-disable-tree-outside.md
+++ b/.changeset/100-disable-tree-outside.md
@@ -1,0 +1,21 @@
+---
+"@ariakit/react-components": minor
+---
+
+Removed `disableTreeOutside` from `dialog/utils/disable-tree`
+
+**BREAKING** if you import `disableTreeOutside` from `@ariakit/react-components/dialog/utils/disable-tree`.
+
+The helper was intended for internal dialog tree management and is no longer used now that modal [`Dialog`](https://ariakit.com/reference/dialog) components mark and disable outside elements in a single tree walk.
+
+Before:
+
+```ts
+import { disableTreeOutside } from "@ariakit/react-components/dialog/utils/disable-tree";
+```
+
+After:
+
+```ts
+// No public replacement import is available.
+```

--- a/packages/ariakit-react-components/src/dialog/utils/disable-tree.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/disable-tree.ts
@@ -84,30 +84,8 @@ function addRoleNoneCleanup(
   cleanups.push(setAttribute(ancestor, "role", "none"));
 }
 
-export function disableTreeOutside(id: string, elements: Elements) {
-  const cleanups: Array<() => void> = [];
-  const ids = elements.map((el) => el?.id);
-
-  walkTreeOutside(
-    id,
-    elements,
-    (element) => {
-      addDisabledElementCleanup({ cleanups, element, elements, ids });
-    },
-    (ancestor) => {
-      addRoleNoneCleanup(cleanups, ancestor, elements);
-    },
-  );
-
-  const restoreTreeOutside = () => {
-    restoreCleanups(cleanups);
-  };
-
-  return restoreTreeOutside;
-}
-
 // Marks and disables the element tree outside the dialog in a single walk.
-// Modal dialogs always need both markTreeOutside and disableTreeOutside, so
+// Modal dialogs always need both marking and disabling outside elements, so
 // this combines their callbacks to avoid walking the tree twice on open.
 export function markAndDisableTreeOutside(id: string, elements: Elements) {
   const cleanups: Array<() => void> = [];

--- a/packages/ariakit-react-components/src/dialog/utils/orchestrate.test.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/orchestrate.test.ts
@@ -1,8 +1,5 @@
 import { afterEach, expect, test } from "vitest";
-import {
-  disableTreeOutside,
-  markAndDisableTreeOutside,
-} from "./disable-tree.ts";
+import { markAndDisableTreeOutside } from "./disable-tree.ts";
 import { isElementMarked, markTreeOutside } from "./mark-tree-outside.ts";
 import { assignStyle, setAttribute } from "./orchestrate.ts";
 import { supportsInert } from "./supports-inert.ts";
@@ -225,46 +222,6 @@ test("markTreeOutside restores previous marks after nested cleanup", () => {
 
   expect(isElementMarked(outside, "one")).toBe(false);
   expect(isElementMarked(outside, "two")).toBe(false);
-});
-
-test("disableTreeOutside skips focus traps and restores disabled elements", () => {
-  document.body.innerHTML = `
-    <div id="root">
-      <div id="dialog"></div>
-      <span id="focus-trap" data-focus-trap="dialog"></span>
-      <section id="outside">
-        <button id="button">Button</button>
-      </section>
-    </div>
-  `;
-
-  const dialog = getElement("dialog");
-  const focusTrap = getElement("focus-trap");
-  const outside = getElement("outside");
-
-  const restoreTree = disableTreeOutside("dialog", [dialog]);
-
-  // disableTreeOutside only disables elements; it doesn't mark them.
-  expect(isElementMarked(outside, "dialog")).toBe(false);
-
-  if (supportsInert()) {
-    expect(outside.inert).toBe(true);
-    expect(focusTrap.inert).toBe(false);
-  } else {
-    expect(outside.getAttribute("aria-hidden")).toBe("true");
-    expect(outside.style.pointerEvents).toBe("none");
-    expect(focusTrap.hasAttribute("aria-hidden")).toBe(false);
-    expect(focusTrap.style.pointerEvents).toBe("");
-  }
-
-  restoreTree();
-
-  if (supportsInert()) {
-    expect(outside.inert).toBe(false);
-  } else {
-    expect(outside.hasAttribute("aria-hidden")).toBe(false);
-    expect(outside.style.pointerEvents).toBe("");
-  }
 });
 
 test("markAndDisableTreeOutside skips focus traps and restores disabled elements", () => {


### PR DESCRIPTION
## Motivation

The dialog open performance work in #6288 moved modal dialogs to `markAndDisableTreeOutside` so opening no longer runs separate mark and disable tree walks. The older `disableTreeOutside` helper is now unused, but still exported from `@ariakit/react-components/dialog/utils/disable-tree` and has a dedicated test that only covers the dead helper.

## Solution

Remove `disableTreeOutside` and its obsolete test. Keep `markAndDisableTreeOutside` as the single helper used by modal dialogs and update its comment to describe the combined marking and disabling pass.

Add a changeset documenting the removal of the subpath export.
