### PR TITLE
Remove duplicate docs declaration formatter

### DIFF
--- a/packages/ariakit-scripts/src/docs.ts
+++ b/packages/ariakit-scripts/src/docs.ts
@@ -456,12 +456,6 @@ function referencesIdentifier(text: string, name: string) {
   ).test(text);
 }
 
-function formatLocalTypeDeclaration(declaration: LocalTypeDeclaration) {
-  return truncateDeclarationText(
-    removeExportKeyword(removeJsDoc(declaration.getText()).trim()),
-  );
-}
-
 function getSignatureTypeParameterNames(declarations: Node[]) {
   const names = new Set<string>();
   for (const declaration of declarations) {
@@ -522,7 +516,7 @@ function addReferencedLocalTypes(items: SignatureItem[]) {
   const referencedTypes = getReferencedLocalTypes(items);
   const signatures = items.map((item) => item.text);
   const localTypeSignatures = referencedTypes
-    .map(formatLocalTypeDeclaration)
+    .map(formatDeclarationText)
     .join("\n\n");
 
   if (!localTypeSignatures) return signatures;


### PR DESCRIPTION
## Motivation

`packages/ariakit-scripts/src/docs.ts` had two helpers that performed the same declaration text normalization. Keeping both names means future changes to JSDoc stripping, export removal, or truncation could accidentally update one path but not the other.

## Solution

Remove the local-only formatter and have referenced local types use the existing `formatDeclarationText` helper. `LocalTypeDeclaration` nodes are assignable to `Node`, so the generated signature text remains identical.

## Verification

- `pnpm lint-fix`
- `pnpm test packages/ariakit-scripts/src/docs.test.ts`
- `pnpm tsc`
- `pnpm run docs`