### PR TITLE
Update getEnabledItem JSDoc

### DIFF
--- a/packages/ariakit-react-components/src/composite/utils.ts
+++ b/packages/ariakit-react-components/src/composite/utils.ts
@@ -7,7 +7,7 @@ export const findFirstEnabledItem = Core.findFirstEnabledItem;
 export const groupItemsByRows = Core.groupItemsByRows;
 
 /**
- * Finds the first enabled item by its id.
+ * Returns the store item with the given id (enabled or not), or `null`.
  */
 export function getEnabledItem(store: CompositeStore, id?: string | null) {
   if (!id) return null;


### PR DESCRIPTION
## Motivation

`getEnabledItem` is documented as finding the first enabled item by id, but the implementation delegates to `store.item(id)`, which returns the item regardless of whether it is disabled.

Because this helper is exported from `@ariakit/react-components/composite/utils`, the stale JSDoc can show misleading editor documentation and may encourage an incorrect behavior change.

## Solution

Update the JSDoc to describe the current and intended behavior: the helper returns the store item with the given id, enabled or not, or `null`.

The runtime code is unchanged.

## Verification

- `pnpm lint-fix`
- Pre-commit reviewer pass: no findings
