### PR TITLE
Wait for Tailwind preview readiness in contrast tests

### DIFF
--- a/app/src/sandbox/ariakit-tailwind/test-chrome.ts
+++ b/app/src/sandbox/ariakit-tailwind/test-chrome.ts
@@ -569,6 +569,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
       test("no color contrast violations (WCAG AA)", async ({ page }) => {
         test.setTimeout(60_000);
+        await waitForPreviewReady(page);
         const results = await new AxeBuilder({ page })
           .withRules(["color-contrast"])
           .analyze();
@@ -585,11 +586,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
         const label = contrast ? " (high contrast)" : "";
         test(`computed styles${label}`, async ({ page }) => {
           if (contrast) {
-            const cdp = await page.context().newCDPSession(page);
-            await cdp.send("Emulation.setEmulatedMedia", {
-              features: [{ name: "prefers-contrast", value: "more" }],
-            });
-            await page.reload({ waitUntil: "networkidle" });
+            await page.emulateMedia({ contrast: "more" });
           }
           await waitForPreviewReady(page);
           const tree = await page.evaluate(extractComputedCSS);


### PR DESCRIPTION
## Motivation

The Tailwind sandbox Chrome tests use `waitForPreviewReady` as their explicit readiness contract before reading computed styles, but the axe color-contrast test was running immediately after shared navigation. That made the accessibility gate depend on the preview's current static SSR behavior instead of the file's own hydration and label-stability check.

The high-contrast computed-style test also used a CDP media override followed by `page.reload({ waitUntil: "networkidle" })`. The shared navigation helper documents why unbounded `networkidle` waits can stall under CI contention, so this test was carrying the same timeout risk in a local reload path.

## Solution

Wait for `waitForPreviewReady(page)` before running the axe `color-contrast` scan, matching the sibling computed-style snapshot test.

For the high-contrast computed-style snapshot, use Playwright's media emulation directly:

```ts
await page.emulateMedia({ contrast: "more" });
```

This exercises the same `prefers-contrast: more` CSS path without a CDP session or extra navigation. The existing readiness wait still runs before computed styles are extracted.

## Testing

- `pnpm lint-fix`
- `APP_PORT=4322 NEXTJS_PORT=3001 pnpm -F app run test-chrome src/sandbox/ariakit-tailwind/test-chrome.ts`
