### PR TITLE
Share form array field name matching

### DIFF
--- a/.changeset/300-form-utils-export.md
+++ b/.changeset/300-form-utils-export.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/react-components": patch
+---
+
+Added `@ariakit/react-components/form/utils` with form array field name helpers.

--- a/app/src/sandbox/form-push-remove-6219/index.react.tsx
+++ b/app/src/sandbox/form-push-remove-6219/index.react.tsx
@@ -9,7 +9,7 @@ import { useState } from "react";
 export default function Example() {
   const form = ak.useFormStore({
     defaultValues: {
-      tags: ["React"],
+      tags: ["React", "Vue"],
       tags2: ["Solid"],
       "c++": ["11", "14"],
     },
@@ -29,15 +29,20 @@ export default function Example() {
 
       <fieldset>
         <legend>Tags</legend>
-        {tags.map((_, index) => {
+        {tags.map((tag, index) => {
+          if (tag == null) return null;
           const name = `tags.${index}`;
           return (
-            <ak.FormInput
-              key={index}
-              name={name}
-              aria-label={name}
-              onFocus={() => setFocused(name)}
-            />
+            <div key={index}>
+              <ak.FormInput
+                name={name}
+                aria-label={name}
+                onFocus={() => setFocused(name)}
+              />
+              <ak.FormRemove name="tags" index={index}>
+                Remove {name}
+              </ak.FormRemove>
+            </div>
           );
         })}
         <ak.FormPush name="tags" value="">

--- a/app/src/sandbox/form-push-remove-6219/test-browser.ts
+++ b/app/src/sandbox/form-push-remove-6219/test-browser.ts
@@ -12,6 +12,15 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.status()).toHaveText(/^Focused field: tags\.\d+$/);
   });
 
+  test("FormRemove keeps focus within the target array, not a sibling sharing the name prefix", async ({
+    q,
+  }) => {
+    // Removing from `tags` must move focus to another `tags` field and never
+    // leak into the `tags2` sibling, whose name shares the `tags` prefix.
+    await q.button("Remove tags.0").click();
+    await test.expect(q.textbox("tags.1")).toBeFocused();
+  });
+
   test("FormPush keeps focus within an array whose name has regex metacharacters", async ({
     q,
   }) => {

--- a/app/src/sandbox/form-push-remove-6219/test.ts
+++ b/app/src/sandbox/form-push-remove-6219/test.ts
@@ -15,6 +15,13 @@ test("FormPush keeps focus within the target array, not a sibling sharing the na
   expect(activeFieldName()).toMatch(/^tags\.\d+$/);
 });
 
+test("FormRemove keeps focus within the target array, not a sibling sharing the name prefix", async () => {
+  // Removing from `tags` must move focus to another `tags` field and never
+  // leak into the `tags2` sibling, whose name shares the `tags` prefix.
+  await click(q.button("Remove tags.0"));
+  expect(activeFieldName()).toBe("tags.1");
+});
+
 test("FormPush keeps focus within an array whose name has regex metacharacters", async () => {
   // The `c++` array name contains regex metacharacters. Building the auto-focus
   // matcher must not throw, and focus must stay within the array.

--- a/packages/ariakit-react-components/package.json
+++ b/packages/ariakit-react-components/package.json
@@ -149,6 +149,7 @@
     "./form/form-reset": "./src/form/form-reset.tsx",
     "./form/form-store": "./src/form/form-store.ts",
     "./form/form-submit": "./src/form/form-submit.tsx",
+    "./form/utils": "./src/form/utils.ts",
     "./group/group": "./src/group/group.tsx",
     "./group/group-label": "./src/group/group-label.tsx",
     "./group/group-label-context": "./src/group/group-label-context.tsx",

--- a/packages/ariakit-react-components/src/form/form-remove.tsx
+++ b/packages/ariakit-react-components/src/form/form-remove.tsx
@@ -12,7 +12,7 @@ import type { ButtonOptions } from "../button/button.tsx";
 import { useButton } from "../button/button.tsx";
 import { useFormContext } from "./form-context.tsx";
 import type { FormStore, FormStoreState } from "./form-store.ts";
-import { getArrayFieldIndex } from "./utils.ts";
+import { getArrayFieldIndex, isArrayFieldName } from "./utils.ts";
 
 const TagName = "button" satisfies ElementType;
 type TagName = typeof TagName;
@@ -23,13 +23,8 @@ function findNextOrPreviousField(
   name: string,
   index: number,
 ) {
-  const prefix = `${name}.`;
-  // Match the exact array boundary so sibling arrays whose names share this
-  // prefix (e.g. `tags` and `tags2`) aren't matched.
   const fields = items?.filter(
-    (item) =>
-      item.type === "field" &&
-      (item.name === name || item.name.startsWith(prefix)),
+    (item) => item.type === "field" && isArrayFieldName(item.name, name),
   );
   const nextField = fields?.find(
     (field) => getArrayFieldIndex(field.name, name) > index,

--- a/packages/ariakit-react-components/src/form/utils.test.ts
+++ b/packages/ariakit-react-components/src/form/utils.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "vitest";
+import { getArrayFieldIndex, isArrayFieldName } from "./utils.ts";
+
+test.each([
+  ["tags", "tags", true],
+  ["tags.0", "tags", true],
+  ["tags.0.name", "tags", true],
+  ["tags2", "tags", false],
+  ["tags2.0", "tags", false],
+  ["c++.0", "c++", true],
+  ["a(b.0", "a(b", true],
+] as const)(
+  "isArrayFieldName(%s, %s) returns %s",
+  (fieldName, name, expected) => {
+    expect(isArrayFieldName(fieldName, name)).toBe(expected);
+  },
+);
+
+test.each([
+  ["tags.0", "tags", 0],
+  ["tags.10.name", "tags", 10],
+  ["c++.1", "c++", 1],
+  ["a(b.2", "a(b", 2],
+] as const)(
+  "getArrayFieldIndex(%s, %s) returns %i",
+  (fieldName, name, expected) => {
+    expect(getArrayFieldIndex(fieldName, name)).toBe(expected);
+  },
+);
+
+test.each([
+  ["tags", "tags"],
+  ["tags.x", "tags"],
+  ["tags2.0", "tags"],
+] as const)("getArrayFieldIndex(%s, %s) returns NaN", (fieldName, name) => {
+  expect(getArrayFieldIndex(fieldName, name)).toBeNaN();
+});

--- a/packages/ariakit-react-components/src/form/utils.ts
+++ b/packages/ariakit-react-components/src/form/utils.ts
@@ -1,6 +1,17 @@
-// Reads the array index off the known `name.` prefix without interpolating the
-// user-controlled name into a RegExp, which could throw on regex metacharacters
-// (e.g. `a(b`). Returns `NaN` when the field doesn't belong to the array.
+/**
+ * Checks whether `fieldName` belongs to the array field `name`, matching the
+ * exact array boundary so sibling arrays whose names share this prefix (e.g.
+ * `tags` and `tags2`) aren't matched.
+ */
+export function isArrayFieldName(fieldName: string, name: string) {
+  return fieldName === name || fieldName.startsWith(`${name}.`);
+}
+
+/**
+ * Reads the array index off the known `name.` prefix without interpolating the
+ * user-controlled name into a RegExp, which could throw on regex metacharacters
+ * (e.g. `a(b`). Returns `NaN` when the field doesn't belong to the array.
+ */
 export function getArrayFieldIndex(fieldName: string, name: string) {
   const prefix = `${name}.`;
   if (!fieldName.startsWith(prefix)) return Number.NaN;


### PR DESCRIPTION
## Motivation

`FormRemove` and the form array helpers rely on subtle field-name matching rules: an array field should match either its exact name or the exact `name.` boundary so a sibling such as `tags2` is not treated as part of `tags`. Keeping that rule local to `FormRemove` makes future drift more likely as the form array focus helpers evolve.

The new `@ariakit/react-components/form/utils` subpath also makes these shared form array helpers available consistently with the existing lower-level utility subpaths such as `@ariakit/react-components/composite/utils`.

## Solution

Added `isArrayFieldName` beside `getArrayFieldIndex` in `packages/ariakit-react-components/src/form/utils.ts`, documented the shared boundary rule there, and updated `FormRemove` to use it when selecting next/previous focus targets.

Added direct utility coverage for sibling prefixes and regex metacharacter names, plus focused sandbox coverage for `FormRemove` in the existing `form-push-remove-6219` repro. Added a patch changeset for the new public utility subpath.

Verification:

- `pnpm lint-fix`
- `pnpm test-react packages/ariakit-react-components/src/form/utils.test.ts app/src/sandbox/form-push-remove-6219/test.ts`
- `pnpm tsc`
- `APP_PORT=4321 NEXTJS_PORT=3000 pnpm -F app run test src/sandbox/form-push-remove-6219/test-browser.ts --project=chrome`
- `pnpm build`
