### PR TITLE
Fix Select moveOnKeyDown default docs

### DIFF
--- a/.changeset/300-select-move-on-key-down-default.md
+++ b/.changeset/300-select-move-on-key-down-default.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed the documented [`Select`](https://ariakit.com/reference/select#moveonkeydown) `moveOnKeyDown` default to match the runtime behavior.

--- a/packages/ariakit-react-components/src/select/select.tsx
+++ b/packages/ariakit-react-components/src/select/select.tsx
@@ -347,7 +347,7 @@ export interface SelectOptions<T extends ElementType = TagName>
    * the [`SelectList`](https://ariakit.com/reference/select-list) or
    * [`SelectPopover`](https://ariakit.com/reference/select-popover) components
    * are hidden.
-   * @default false
+   * @default true
    */
   moveOnKeyDown?: BooleanOrCallback<KeyboardEvent<HTMLElement>>;
   /**


### PR DESCRIPTION
## Motivation

`Select` defaults `moveOnKeyDown` to `true` in `useSelect`, but the public JSDoc currently says `@default false`:

```tsx
moveOnKeyDown = true
```

The JSDoc feeds the published TypeScript declarations and generated reference docs, so users see the opposite of the shipped keyboard behavior.

## Solution

Update the `moveOnKeyDown` JSDoc default to `true` and add a patch changeset for `@ariakit/react-components` and `@ariakit/react`.

```tsx
/**
 * @default true
 */
moveOnKeyDown?: BooleanOrCallback<KeyboardEvent<HTMLElement>>;
```
