### PR TITLE
Reuse jsdoc reference storage in watch mode

### DIFF
--- a/app/src/lib/jsdoc-loader.ts
+++ b/app/src/lib/jsdoc-loader.ts
@@ -714,18 +714,20 @@ export function jsdoc(...frameworkOptions: JsDocFrameworkOptions[]) {
         // Rebuild cache
         const componentModules = getComponentModules(packagePath);
         const newCache: FrameworkCache = { components: {} };
-        const entryIdsByComponent: Record<string, string[]> = {};
+        const referencesByComponent = new Map<string, Reference[]>();
 
         for (const data of references) {
-          const nameSlug = slugify(data.name);
-          const id = `${data.framework}/${data.component}/${nameSlug}`;
-          context.store.set({ id, data });
-          const compIds = entryIdsByComponent[data.component] ?? [];
-          compIds.push(id);
-          entryIdsByComponent[data.component] = compIds;
+          const componentReferences =
+            referencesByComponent.get(data.component) ?? [];
+          componentReferences.push(data);
+          referencesByComponent.set(data.component, componentReferences);
         }
 
         for (const comp of componentModules) {
+          const entryIds = storeComponentReferences(
+            context.store,
+            referencesByComponent.get(comp) ?? [],
+          );
           const files = getComponentSourceFilePaths(
             comp,
             packagePath,
@@ -734,7 +736,7 @@ export function jsdoc(...frameworkOptions: JsDocFrameworkOptions[]) {
           );
           newCache.components[comp] = {
             files: getFileMtimes(files),
-            entryIds: entryIdsByComponent[comp] ?? [],
+            entryIds,
           };
         }
 


### PR DESCRIPTION
## Motivation

The jsdoc loader already centralizes reference entry ID generation and store writes in `storeComponentReferences`, but the watch-mode rebuild path duplicated the same `slugify`, ID construction, and `store.set` logic inline.

If the helper's ID scheme changes later, watch mode could drift and write reference entries under IDs that docs routes do not find during development.

## Solution

Group reloaded references by component during watch rebuilds, then call `storeComponentReferences` for each component while building the refreshed cache entries. This keeps watch mode on the shared storage helper while preserving the per-component `entryIds` cache data used for cleanup.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- Ariakit pre-commit review gate: native reviewer and Cursor CLI reviewer returned no findings.
