### PR TITLE
Reuse state negation helpers

### DIFF
--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -1437,13 +1437,12 @@ const layerLighten = utility(
 
 utility("layer-darken-*", getNegatedDeclarations(layerLighten));
 
-utility("state-lighten-*", getRawPercentDeclarations(inputs.layerRelativeL));
-
-utility(
-  "state-darken-*",
-  set(inputs.layerRelativeL, fn.neg(getBarePercentTokenValue())),
-  set(inputs.layerRelativeL, fn.neg(fn.value("[*]"))),
+const stateLighten = utility(
+  "state-lighten-*",
+  getRawPercentDeclarations(inputs.layerRelativeL),
 );
+
+utility("state-darken-*", getNegatedDeclarations(stateLighten));
 
 /**
  * Moves a hue toward a target by percentage on the shortest circular path.
@@ -1630,19 +1629,12 @@ utility(
   ),
 );
 
-utility(
+const stateSaturate = utility(
   "state-saturate-*",
   getRawPercentDeclarations(inputs.layerRelativeC, CHROMA_TOKEN_OPTIONS),
 );
 
-utility(
-  "state-desaturate-*",
-  set(
-    inputs.layerRelativeC,
-    fn.neg(getBarePercentTokenValue(CHROMA_TOKEN_OPTIONS)),
-  ),
-  set(inputs.layerRelativeC, fn.neg(fn.value("[*]"))),
-);
+utility("state-desaturate-*", getNegatedDeclarations(stateSaturate));
 
 utility(
   "edge-*",


### PR DESCRIPTION
## Motivation

`state-darken-*` and `state-desaturate-*` duplicate the negation logic that the rest of the Tailwind color utilities derive with `getNegatedDeclarations`. Keeping these two utilities hand-written creates drift risk and makes them look intentionally different from the surrounding `layer`, `edge`, `text`, and `outline` utilities.

## Solution

Capture `state-lighten-*` and `state-saturate-*` in local constants, then derive `state-darken-*` and `state-desaturate-*` with `getNegatedDeclarations`.

Rebuilding `@ariakit/tailwind` leaves `packages/ariakit-tailwind/src/output.css` unchanged, so the emitted utilities stay byte-identical.
