### PR TITLE
Preserve dollar sequences in docs markdown injection

### DIFF
--- a/packages/ariakit-scripts/src/docs.test.ts
+++ b/packages/ariakit-scripts/src/docs.test.ts
@@ -311,7 +311,12 @@ test("injects generated markdown into a readme", () => {
   writeFileSync(
     join(sourcePath, "foo.ts"),
     [
-      "/** Foo helper. */",
+      "/**",
+      " * Foo helper.",
+      " * @example",
+      ' * const price = "$$50";',
+      ' * const replacement = "$&";',
+      " */",
       "export function foo() {",
       "  return true;",
       "}",
@@ -337,6 +342,8 @@ test("injects generated markdown into a readme", () => {
   expect(readme).toContain("<!-- ariakit-docs:end -->");
   expect(readme).toContain("### `foo`");
   expect(readme).toContain("Foo helper.");
+  expect(readme).toContain('const price = "$$50";');
+  expect(readme).toContain('const replacement = "$&";');
   expect(readme).not.toContain("Old docs");
 });
 

--- a/packages/ariakit-scripts/src/docs.ts
+++ b/packages/ariakit-scripts/src/docs.ts
@@ -789,7 +789,7 @@ export function injectDocsMarkdown(options: InjectDocsOptions = {}) {
         `${startMarker} must appear before ${endMarker} in ${readmePath}`,
       );
     }
-    nextReadme = readme.replace(pattern, block);
+    nextReadme = readme.replace(pattern, () => block);
   } else {
     nextReadme = `${readme.trimEnd()}\n\n${block}\n`;
   }


### PR DESCRIPTION
## Motivation

`injectDocsMarkdown` replaces an existing docs marker block by passing generated markdown as the string replacement to `String.replace`. String replacements interpret sequences such as `$$` and `$&`, so future generated API docs containing those sequences could silently corrupt package readmes.

## Solution

Use a replacer function so the generated docs block is inserted verbatim, and extend the existing readme injection test with generated markdown containing `$$` and `$&` sequences.

## Testing

- `pnpm lint-fix`
- `pnpm test packages/ariakit-scripts/src/docs.test.ts`
- `pnpm tsc`
