### PR TITLE
Fix docs anchors across marker blocks

### DIFF
--- a/packages/ariakit-scripts/src/docs.test.ts
+++ b/packages/ariakit-scripts/src/docs.test.ts
@@ -12,6 +12,7 @@ import { afterEach, expect, test } from "vitest";
 import {
   generateDocsMarkdown,
   getDocsMarkers,
+  getPrecedingHeadings,
   injectDocsMarkdown,
 } from "./docs.ts";
 
@@ -236,6 +237,160 @@ test("probes past taken suffixes when building contents links", () => {
   expect(markdown).toContain("- [Value](#value)");
   expect(markdown).toContain("  - [`value`](#value-1)");
   expect(markdown).toContain("- [Value 1](#value-1-1)");
+});
+
+test("uses preceding readme headings when building contents links", () => {
+  const root = createPackage();
+  const sourcePath = join(root, "src");
+  writeFileSync(join(sourcePath, "index.ts"), 'export * from "./foo.ts";\n');
+  writeFileSync(
+    join(sourcePath, "foo.ts"),
+    [
+      "/** Foo helper. */",
+      "export function foo() {",
+      "  return true;",
+      "}",
+      "",
+      "/** Bar helper. */",
+      "export function bar() {",
+      "  return false;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(
+    join(root, "readme.md"),
+    [
+      "# Test",
+      "",
+      "## foo",
+      "",
+      "<!-- ariakit-docs:start -->",
+      "<!-- ariakit-docs:end -->",
+      "",
+    ].join("\n"),
+  );
+
+  injectDocsMarkdown({ rootPath: root });
+
+  const readme = readFileSync(join(root, "readme.md"), "utf-8");
+  expect(readme).toContain("- [`foo`](#foo-1)");
+  expect(readme).toContain("- [`bar`](#bar)");
+});
+
+test("ignores later readme headings when building contents links", () => {
+  const root = createPackage();
+  const sourcePath = join(root, "src");
+  writeFileSync(join(sourcePath, "index.ts"), 'export * from "./foo.ts";\n');
+  writeFileSync(
+    join(sourcePath, "foo.ts"),
+    [
+      "/** Foo helper. */",
+      "export function foo() {",
+      "  return true;",
+      "}",
+      "",
+      "/** Bar helper. */",
+      "export function bar() {",
+      "  return false;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(
+    join(root, "readme.md"),
+    [
+      "# Test",
+      "",
+      "<!-- ariakit-docs:start -->",
+      "<!-- ariakit-docs:end -->",
+      "",
+      "## foo",
+      "",
+    ].join("\n"),
+  );
+
+  injectDocsMarkdown({ rootPath: root });
+
+  const readme = readFileSync(join(root, "readme.md"), "utf-8");
+  expect(readme).toContain("- [`foo`](#foo)");
+  expect(readme).not.toContain("- [`foo`](#foo-1)");
+});
+
+test("disambiguates entries and back-to-top links from section headings", () => {
+  const root = createPackage();
+  const sourcePath = join(root, "src");
+  writeFileSync(join(sourcePath, "index.ts"), 'export * from "./foo.ts";\n');
+  writeFileSync(
+    join(sourcePath, "foo.ts"),
+    [
+      "/** Foo helper. */",
+      "export function foo() {",
+      "  return true;",
+      "}",
+      "",
+      "/** Bar helper. */",
+      "export function bar() {",
+      "  return false;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+
+  const markdown = generateDocsMarkdown({
+    rootPath: root,
+    heading: "foo",
+    precedingHeadings: ["foo"],
+  });
+
+  expect(markdown).toContain("- [`foo`](#foo-2)");
+  expect(markdown).toContain('<a href="#foo-1">&uarr; back to top</a>');
+});
+
+test("ignores fenced code when collecting preceding headings", () => {
+  const { start } = getDocsMarkers();
+  const readme = [
+    "# Test",
+    "",
+    "````md",
+    "```sh",
+    "# Not a heading",
+    "```",
+    "````",
+    "",
+    "```",
+    "```ts",
+    "# Also not a heading",
+    "```",
+    "",
+    "## Real heading",
+    "",
+    start,
+    "",
+    "## Later heading",
+    "",
+  ].join("\n");
+
+  expect(getPrecedingHeadings(readme, start)).toEqual(["Test", "Real heading"]);
+});
+
+test("collects setext headings before the docs marker", () => {
+  const { start } = getDocsMarkers();
+  const readme = [
+    "Setext heading",
+    "==============",
+    "",
+    "Another heading",
+    "---------------",
+    "",
+    start,
+    "",
+  ].join("\n");
+
+  expect(getPrecedingHeadings(readme, start)).toEqual([
+    "Setext heading",
+    "Another heading",
+  ]);
 });
 
 test("uses later JSDoc descriptions after tag-only blocks", () => {
@@ -737,6 +892,7 @@ test.skipIf(reactMajor < 19).each(docsPackages)(
       const markdown = generateDocsMarkdown({
         rootPath: root,
         ...target,
+        precedingHeadings: getPrecedingHeadings(readme, start),
       }).trimEnd();
       const readmeMarkdown = readme
         .slice(startIndex + start.length, endIndex)

--- a/packages/ariakit-scripts/src/docs.test.ts
+++ b/packages/ariakit-scripts/src/docs.test.ts
@@ -278,6 +278,44 @@ test("uses preceding readme headings when building contents links", () => {
   expect(readme).toContain("- [`bar`](#bar)");
 });
 
+test("uses rendered link text from preceding readme headings", () => {
+  const root = createPackage();
+  const sourcePath = join(root, "src");
+  writeFileSync(join(sourcePath, "index.ts"), 'export * from "./foo.ts";\n');
+  writeFileSync(
+    join(sourcePath, "foo.ts"),
+    [
+      "/** Foo helper. */",
+      "export function foo() {",
+      "  return true;",
+      "}",
+      "",
+      "/** Bar helper. */",
+      "export function bar() {",
+      "  return false;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(
+    join(root, "readme.md"),
+    [
+      "# Test",
+      "",
+      "## [foo](#details)",
+      "",
+      "<!-- ariakit-docs:start -->",
+      "<!-- ariakit-docs:end -->",
+      "",
+    ].join("\n"),
+  );
+
+  injectDocsMarkdown({ rootPath: root });
+
+  const readme = readFileSync(join(root, "readme.md"), "utf-8");
+  expect(readme).toContain("- [`foo`](#foo-1)");
+});
+
 test("ignores later readme headings when building contents links", () => {
   const root = createPackage();
   const sourcePath = join(root, "src");
@@ -374,23 +412,40 @@ test("ignores fenced code when collecting preceding headings", () => {
   expect(getPrecedingHeadings(readme, start)).toEqual(["Test", "Real heading"]);
 });
 
-test("collects setext headings before the docs marker", () => {
+test("ignores HTML comments when collecting preceding headings", () => {
   const { start } = getDocsMarkers();
   const readme = [
-    "Setext heading",
-    "==============",
+    "# Test",
     "",
-    "Another heading",
-    "---------------",
+    "<!--",
+    "## Hidden heading",
+    "-->",
+    "",
+    "## Real heading <!-- comment -->",
     "",
     start,
     "",
   ].join("\n");
 
-  expect(getPrecedingHeadings(readme, start)).toEqual([
+  expect(getPrecedingHeadings(readme, start)).toEqual(["Test", "Real heading"]);
+});
+
+test("ignores setext-style blocks before the docs marker", () => {
+  const { start } = getDocsMarkers();
+  const readme = [
+    "# Test",
+    "",
     "Setext heading",
-    "Another heading",
-  ]);
+    "==============",
+    "",
+    "- item",
+    "---",
+    "",
+    start,
+    "",
+  ].join("\n");
+
+  expect(getPrecedingHeadings(readme, start)).toEqual(["Test"]);
 });
 
 test("uses later JSDoc descriptions after tag-only blocks", () => {

--- a/packages/ariakit-scripts/src/docs.ts
+++ b/packages/ariakit-scripts/src/docs.ts
@@ -16,6 +16,7 @@ interface GenerateDocsOptions {
   tsconfig?: string;
   heading?: string;
   exclude?: string[];
+  precedingHeadings?: string[];
 }
 
 interface InjectDocsOptions extends GenerateDocsOptions {
@@ -664,7 +665,71 @@ function createSlugger() {
   };
 }
 
-function renderContents(groups: ApiGroup[]) {
+/**
+ * Gets the Markdown headings that render before a generated docs marker.
+ *
+ * GitHub assigns anchors top-down across the rendered document, so generated
+ * docs blocks must be seeded with only the headings that precede them.
+ */
+export function getPrecedingHeadings(readme: string, startMarker: string) {
+  const markerIndex = readme.indexOf(startMarker);
+  const preceding = markerIndex === -1 ? readme : readme.slice(0, markerIndex);
+  const headings: string[] = [];
+  let fence: { character: string; length: number } | undefined;
+  let setextHeadingLines: string[] = [];
+
+  for (const line of preceding.split("\n")) {
+    const fenceMatch = line.match(/^ {0,3}(```+|~~~+)(.*)$/);
+    if (fenceMatch) {
+      const marker = fenceMatch[1];
+      if (!marker) continue;
+      const character = marker.charAt(0);
+      const length = marker.length;
+      if (fence) {
+        const rest = fenceMatch[2] ?? "";
+        if (
+          character === fence.character &&
+          length >= fence.length &&
+          !rest.trim()
+        ) {
+          fence = undefined;
+        }
+      } else {
+        fence = { character, length };
+        setextHeadingLines = [];
+      }
+      continue;
+    }
+
+    if (fence) continue;
+
+    const setextMatch = line.match(/^ {0,3}(=+|-+)\s*$/);
+    if (setextMatch && setextHeadingLines.length) {
+      headings.push(setextHeadingLines.join(" "));
+      setextHeadingLines = [];
+      continue;
+    }
+
+    const headingMatch = line.match(/^ {0,3}#{1,6}\s+(.+?)\s*#*\s*$/);
+    const heading = headingMatch?.[1];
+    if (heading) {
+      headings.push(heading);
+      setextHeadingLines = [];
+      continue;
+    }
+
+    const setextHeadingLine = line.match(/^ {0,3}(\S.*)$/)?.[1]?.trim();
+    if (setextHeadingLine) {
+      setextHeadingLines.push(setextHeadingLine);
+    } else {
+      setextHeadingLines = [];
+    }
+  }
+
+  return headings;
+}
+
+function renderContents(groups: ApiGroup[], slug: (heading: string) => string) {
   const entryCount = groups.reduce(
     (count, group) => count + group.entries.length,
     0,
@@ -672,7 +737,6 @@ function renderContents(groups: ApiGroup[]) {
   // A single entry has nothing to navigate, so the table of contents is noise.
   if (entryCount <= 1) return "";
 
-  const slug = createSlugger();
   const renderEntryContents = (entry: ApiEntry, indent: string) =>
     `${indent}- [\`${entry.name}\`](#${slug(entry.name)})`;
 
@@ -734,8 +798,19 @@ export function generateDocsMarkdown(options: GenerateDocsOptions = {}) {
   const groups = getApiGroups(entrySourceFile, excludedNames);
   const heading = options.heading || defaultHeading;
   const lines = [`## ${heading}`, ""];
+  const slug = createSlugger();
 
-  const contents = renderContents(groups);
+  // GitHub assigns heading anchors top-down across the whole document, so only
+  // headings that precede this generated block can influence its slugs.
+  for (const precedingHeading of options.precedingHeadings ?? []) {
+    slug(precedingHeading);
+  }
+
+  // The section heading renders before the table of contents and members.
+  // Members link back to it, e.g. `#api-reference`.
+  const topAnchor = slug(heading);
+
+  const contents = renderContents(groups, slug);
   if (contents) {
     lines.push(contents, "");
   }
@@ -745,9 +820,6 @@ export function generateDocsMarkdown(options: GenerateDocsOptions = {}) {
   // section heading, so they use `###` to keep the heading levels incremental.
   const hasModules = groups.some((group) => group.title);
   const memberHeading = hasModules ? "####" : "###";
-  // Each member links back to the section heading (which sits above the table
-  // of contents), e.g. `#api-reference` or `#playwright-api-reference`.
-  const topAnchor = slugifyHeading(heading);
 
   for (const group of groups) {
     lines.push(renderGroup(group, memberHeading, topAnchor), "");
@@ -760,8 +832,12 @@ export function injectDocsMarkdown(options: InjectDocsOptions = {}) {
   const rootPath = options.rootPath || process.cwd();
   const readmePath = resolvePath(rootPath, options.readme || "readme.md");
   const { start: startMarker, end: endMarker } = getDocsMarkers(options.marker);
-  const markdown = generateDocsMarkdown(options).trimEnd();
   const readme = readFileSync(readmePath, "utf-8");
+  const precedingHeadings = getPrecedingHeadings(readme, startMarker);
+  const markdown = generateDocsMarkdown({
+    ...options,
+    precedingHeadings,
+  }).trimEnd();
   const block = `${startMarker}\n\n${markdown}\n\n${endMarker}`;
   const hasStartMarker = readme.includes(startMarker);
   const hasEndMarker = readme.includes(endMarker);

--- a/packages/ariakit-scripts/src/docs.ts
+++ b/packages/ariakit-scripts/src/docs.ts
@@ -636,6 +636,7 @@ function renderEntry(entry: ApiEntry, heading: string, topAnchor: string) {
 
 function slugifyHeading(heading: string) {
   return heading
+    .replace(/!?\[([^\]]*)\]\([^)]+\)/g, "$1")
     .toLowerCase()
     .replace(/`/g, "")
     .replace(/[^a-z0-9 -]/g, "")
@@ -666,7 +667,7 @@ function createSlugger() {
 }
 
 /**
- * Gets the Markdown headings that render before a generated docs marker.
+ * Gets the ATX Markdown headings that render before a generated docs marker.
  *
  * GitHub assigns anchors top-down across the rendered document, so generated
  * docs blocks must be seeded with only the headings that precede them.
@@ -676,10 +677,36 @@ export function getPrecedingHeadings(readme: string, startMarker: string) {
   const preceding = markerIndex === -1 ? readme : readme.slice(0, markerIndex);
   const headings: string[] = [];
   let fence: { character: string; length: number } | undefined;
-  let setextHeadingLines: string[] = [];
+  let htmlComment = false;
+
+  const stripHtmlComments = (line: string) => {
+    let nextLine = line;
+    while (true) {
+      if (htmlComment) {
+        const endIndex = nextLine.indexOf("-->");
+        if (endIndex === -1) return "";
+        nextLine = nextLine.slice(endIndex + 3);
+        htmlComment = false;
+      }
+
+      const startIndex = nextLine.indexOf("<!--");
+      if (startIndex === -1) {
+        return nextLine;
+      }
+
+      const endIndex = nextLine.indexOf("-->", startIndex + 4);
+      if (endIndex === -1) {
+        htmlComment = true;
+        return nextLine.slice(0, startIndex);
+      }
+
+      nextLine = nextLine.slice(0, startIndex) + nextLine.slice(endIndex + 3);
+    }
+  };
 
   for (const line of preceding.split("\n")) {
-    const fenceMatch = line.match(/^ {0,3}(```+|~~~+)(.*)$/);
+    const lineWithoutComments = fence ? line : stripHtmlComments(line);
+    const fenceMatch = lineWithoutComments.match(/^ {0,3}(```+|~~~+)(.*)$/);
     if (fenceMatch) {
       const marker = fenceMatch[1];
       if (!marker) continue;
@@ -696,33 +723,18 @@ export function getPrecedingHeadings(readme: string, startMarker: string) {
         }
       } else {
         fence = { character, length };
-        setextHeadingLines = [];
       }
       continue;
     }
 
     if (fence) continue;
 
-    const setextMatch = line.match(/^ {0,3}(=+|-+)\s*$/);
-    if (setextMatch && setextHeadingLines.length) {
-      headings.push(setextHeadingLines.join(" "));
-      setextHeadingLines = [];
-      continue;
-    }
-
-    const headingMatch = line.match(/^ {0,3}#{1,6}\s+(.+?)\s*#*\s*$/);
+    const headingMatch = lineWithoutComments.match(
+      /^ {0,3}#{1,6}\s+(.+?)\s*#*\s*$/,
+    );
     const heading = headingMatch?.[1];
     if (heading) {
       headings.push(heading);
-      setextHeadingLines = [];
-      continue;
-    }
-
-    const setextHeadingLine = line.match(/^ {0,3}(\S.*)$/)?.[1]?.trim();
-    if (setextHeadingLine) {
-      setextHeadingLines.push(setextHeadingLine);
-    } else {
-      setextHeadingLines = [];
     }
   }
 


### PR DESCRIPTION
## Motivation

The docs generator builds table-of-contents links for generated API reference blocks, but GitHub assigns heading anchors across the whole rendered README. When a README has handwritten headings or multiple generated marker blocks with the same heading slug, a per-block slugger can produce links that point to an earlier heading instead of the generated entry.

This is already a latent problem in `@ariakit/test`, where multiple API reference blocks can render entries with the same name. The script also computed member back-to-top links with a raw section-heading slug, so collisions with the section heading could desync those links from GitHub's anchor assignment too.

## Solution

Seed generated docs with the ATX Markdown headings that appear before the target marker, then use the same slugger for the section heading, table of contents, module headings, and member headings. The heading scan ignores fenced code blocks and HTML comments, normalizes simple inline Markdown links to their rendered text before slugging, and only considers headings before the marker so later document content cannot affect earlier generated anchors.

The docs freshness test now mirrors the injection path by computing the same preceding-heading seed for each marker block. Additional regression tests cover preceding versus later heading collisions, section-heading collisions, fenced code blocks, HTML comments, inline link headings, and setext-style blocks being ignored.
