### PR TITLE
Fix React package sourcemaps

### DIFF
--- a/.changeset/300-react-sourcemap-banner.md
+++ b/.changeset/300-react-sourcemap-banner.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react-store": patch
+"@ariakit/react-utils": patch
+---
+
+Fixed React package sourcemaps so generated mappings account for the `"use client"` directive.

--- a/packages/ariakit-scripts/src/build.test.ts
+++ b/packages/ariakit-scripts/src/build.test.ts
@@ -1,32 +1,149 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { TraceMap, originalPositionFor } from "@jridgewell/trace-mapping";
 import { expect, test } from "vitest";
 import { updateSourcePackageJson } from "./build.ts";
 
-test("omits npm ignored source files from package exports", async () => {
+const cliPath = join(import.meta.dirname, "index.ts");
+
+function runBuild(rootPath: string, ...args: string[]) {
+  const result = spawnSync(process.execPath, [cliPath, "build", ...args], {
+    cwd: rootPath,
+    encoding: "utf-8",
+  });
+
+  if (result.status === 0) {
+    return result;
+  }
+
+  throw new Error(result.stderr || result.stdout);
+}
+
+function expectNoBrokenSourcemapWarning(result: ReturnType<typeof runBuild>) {
+  expect(result.stderr).not.toContain("SOURCEMAP_BROKEN");
+  expect(result.stdout).not.toContain("SOURCEMAP_BROKEN");
+}
+
+async function writeTsConfig(rootPath: string) {
+  await writeFile(
+    join(rootPath, "tsconfig.json"),
+    `${JSON.stringify(
+      {
+        compilerOptions: {
+          target: "es2018",
+          module: "nodenext",
+          moduleResolution: "nodenext",
+          allowImportingTsExtensions: true,
+          strict: true,
+          skipLibCheck: true,
+        },
+        include: ["src"],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+interface BuildFixtureOptions {
+  name?: string;
+  sources: Record<string, string>;
+}
+
+async function createBuildFixture({
+  name = "test-package",
+  sources,
+}: BuildFixtureOptions) {
   const rootPath = await mkdtemp(join(tmpdir(), "ariakit-build-"));
+  const sourceRootPath = join(rootPath, "src");
+
+  await mkdir(sourceRootPath, { recursive: true });
+  await writeFile(
+    join(rootPath, "package.json"),
+    `${JSON.stringify({ name }, null, 2)}\n`,
+  );
+  await writeTsConfig(rootPath);
+
+  for (const [filename, source] of Object.entries(sources)) {
+    const sourcePath = join(sourceRootPath, filename);
+    await mkdir(dirname(sourcePath), { recursive: true });
+    await writeFile(sourcePath, source);
+  }
+
+  return rootPath;
+}
+
+interface SourceMappingExpectation {
+  jsPath: string;
+  generatedText: string;
+  sourceName: string;
+  sourceLine: number;
+  sourceColumn: number;
+}
+
+async function expectGeneratedLineToMapToSource({
+  jsPath,
+  generatedText,
+  sourceName,
+  sourceLine,
+  sourceColumn,
+}: SourceMappingExpectation) {
+  const code = await readFile(jsPath, "utf-8");
+  const sourceMap = JSON.parse(await readFile(`${jsPath}.map`, "utf-8"));
+  const traceMap = new TraceMap(sourceMap);
+  const generatedLines = code.split("\n");
+  let generatedLineIndex = -1;
+  let generatedColumn = -1;
+  let matchCount = 0;
+
+  for (const [index, line] of generatedLines.entries()) {
+    const lineMatchCount = line.split(generatedText).length - 1;
+    if (!lineMatchCount) continue;
+    matchCount += lineMatchCount;
+    generatedLineIndex = index;
+    generatedColumn = line.indexOf(generatedText);
+  }
+
+  if (matchCount === 0) {
+    throw new Error(`Missing ${generatedText} in generated output`);
+  }
+  if (matchCount > 1) {
+    throw new Error(`Expected one ${generatedText} in generated output`);
+  }
+
+  const original = originalPositionFor(traceMap, {
+    line: generatedLineIndex + 1,
+    column: generatedColumn,
+  });
+
+  expect(original.source).toContain(sourceName);
+  expect(original.line).toBe(sourceLine);
+  expect(original.column).toBe(sourceColumn);
+}
+
+test("omits npm ignored source files from package exports", async () => {
+  const rootPath = await createBuildFixture({
+    sources: {
+      "index.ts": "export {};\n",
+      "widget.test.ts": "export {};\n",
+      "button/button.ts": "export {};\n",
+      "button/button.test.ts": "export {};\n",
+      "button/__tests__/button.ts": "export {};\n",
+      "button.config.ts": "export {};\n",
+      "test.ts": "export {};\n",
+    },
+  });
 
   try {
-    await mkdir(join(rootPath, "src/button/__tests__"), { recursive: true });
-    await writeFile(
-      join(rootPath, "package.json"),
-      `${JSON.stringify({ name: "test-package" }, null, 2)}\n`,
-    );
-    await writeFile(join(rootPath, "src/index.ts"), "export {};\n");
-    await writeFile(join(rootPath, "src/widget.test.ts"), "export {};\n");
-    await writeFile(join(rootPath, "src/button/button.ts"), "export {};\n");
-    await writeFile(
-      join(rootPath, "src/button/button.test.ts"),
-      "export {};\n",
-    );
-    await writeFile(
-      join(rootPath, "src/button/__tests__/button.ts"),
-      "export {};\n",
-    );
-    await writeFile(join(rootPath, "src/button.config.ts"), "export {};\n");
-    await writeFile(join(rootPath, "src/test.ts"), "export {};\n");
-
     await updateSourcePackageJson(rootPath);
 
     const packageJson = JSON.parse(
@@ -37,6 +154,139 @@ test("omits npm ignored source files from package exports", async () => {
       ".": "./src/index.ts",
       "./button/button": "./src/button/button.ts",
       "./package.json": "./package.json",
+    });
+  } finally {
+    await rm(rootPath, { recursive: true, force: true });
+  }
+});
+
+test("uses a sourcemap-aware banner for React packages", async () => {
+  const rootPath = await createBuildFixture({
+    name: "@ariakit/react-test",
+    sources: {
+      "index.ts": [
+        'import { sharedValue } from "./__shared.ts";',
+        "",
+        "export function indexValue() {",
+        "  return sharedValue();",
+        "}",
+        "",
+      ].join("\n"),
+      "button.ts": [
+        'import { sharedValue } from "./__shared.ts";',
+        "",
+        "export function buttonValue() {",
+        "  return sharedValue();",
+        "}",
+        "",
+      ].join("\n"),
+      "__shared.ts": "export function sharedValue() {\n  return 1;\n}\n",
+    },
+  });
+
+  try {
+    const result = runBuild(rootPath);
+
+    expectNoBrokenSourcemapWarning(result);
+
+    const indexPath = join(rootPath, "dist/index.js");
+    const buttonPath = join(rootPath, "dist/button.js");
+    const indexCode = await readFile(indexPath, "utf-8");
+    const buttonCode = await readFile(buttonPath, "utf-8");
+    const chunkNames = (await readdir(join(rootPath, "dist/__chunks"))).filter(
+      (name) => name.endsWith(".js"),
+    );
+    const chunkName = chunkNames[0];
+
+    expect(indexCode.startsWith('"use client";\n')).toBe(true);
+    expect(buttonCode.startsWith('"use client";\n')).toBe(true);
+    expect(chunkNames).toHaveLength(1);
+    if (!chunkName) {
+      throw new Error("Missing shared chunk");
+    }
+
+    const chunkPath = join(rootPath, "dist/__chunks", chunkName);
+    const chunkCode = await readFile(chunkPath, "utf-8");
+
+    expect(chunkCode.startsWith('"use client";\n')).toBe(true);
+
+    await expectGeneratedLineToMapToSource({
+      jsPath: indexPath,
+      generatedText: "return sharedValue()",
+      sourceName: "index.ts",
+      sourceLine: 4,
+      sourceColumn: 2,
+    });
+    await expectGeneratedLineToMapToSource({
+      jsPath: buttonPath,
+      generatedText: "return sharedValue()",
+      sourceName: "button.ts",
+      sourceLine: 4,
+      sourceColumn: 2,
+    });
+    await expectGeneratedLineToMapToSource({
+      jsPath: chunkPath,
+      generatedText: "return 1",
+      sourceName: "__shared.ts",
+      sourceLine: 2,
+      sourceColumn: 2,
+    });
+  } finally {
+    await rm(rootPath, { recursive: true, force: true });
+  }
+});
+
+test("uses a sourcemap-aware banner for index-only React packages", async () => {
+  const rootPath = await createBuildFixture({
+    name: "@ariakit/react-test",
+    sources: {
+      "index.ts": "export function value() {\n  return 1;\n}\n",
+    },
+  });
+
+  try {
+    const result = runBuild(rootPath, "--index-only");
+
+    expectNoBrokenSourcemapWarning(result);
+
+    const indexPath = join(rootPath, "dist/index.js");
+    const indexCode = await readFile(indexPath, "utf-8");
+
+    expect(indexCode.startsWith('"use client";\n')).toBe(true);
+    await expectGeneratedLineToMapToSource({
+      jsPath: indexPath,
+      generatedText: "return 1",
+      sourceName: "index.ts",
+      sourceLine: 2,
+      sourceColumn: 2,
+    });
+  } finally {
+    await rm(rootPath, { recursive: true, force: true });
+  }
+});
+
+test("omits the use client banner for non-React packages", async () => {
+  const rootPath = await createBuildFixture({
+    sources: {
+      "index.ts": "export function value() {\n  return 1;\n}\n",
+    },
+  });
+
+  try {
+    const result = runBuild(rootPath);
+
+    expectNoBrokenSourcemapWarning(result);
+
+    const indexPath = join(rootPath, "dist/index.js");
+    const indexCode = await readFile(indexPath, "utf-8");
+
+    expect(indexCode.startsWith('"use client";\n')).toBe(false);
+    await expectGeneratedLineToMapToSource({
+      jsPath: indexPath,
+      generatedText: "return 1",
+      sourceName: "index.ts",
+      sourceLine: 2,
+      sourceColumn: 2,
     });
   } finally {
     await rm(rootPath, { recursive: true, force: true });

--- a/packages/ariakit-scripts/src/build.ts
+++ b/packages/ariakit-scripts/src/build.ts
@@ -2,7 +2,6 @@ import { lstatSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { build as rolldownBuild } from "rolldown";
-import type { Plugin } from "rolldown";
 import { dts } from "rolldown-plugin-dts";
 import solidPlugin from "vite-plugin-solid";
 import { escapeRegExp } from "./regexp.ts";
@@ -275,18 +274,6 @@ function getInput(publicFiles: PublicFile[]) {
   return Object.fromEntries(publicFiles.map((file) => [file.name, file.path]));
 }
 
-function getUseClientPlugin(enabled: boolean): Plugin[] {
-  if (!enabled) return [];
-  return [
-    {
-      name: "ariakit-use-client",
-      renderChunk(code) {
-        return `"use client";\n${code}`;
-      },
-    },
-  ];
-}
-
 function cleanOutput(rootPath: string, isSolid: boolean) {
   const folders = [distDir, ...(isSolid ? [solidDir] : [])];
   for (const folder of folders) {
@@ -363,9 +350,9 @@ async function buildDist(rootPath: string, publicFiles: PublicFile[]) {
       entryFileNames: "[name].js",
       chunkFileNames: "__chunks/[hash].js",
       sourcemap: true,
+      ...(isReactPackage && { banner: '"use client";' }),
     },
     plugins: [
-      ...getUseClientPlugin(isReactPackage),
       ...(isSolid ? [solidPlugin({ solid: { generate: "dom" } })] : []),
     ],
   });


### PR DESCRIPTION
## Motivation

React packages built with `@ariakit/scripts` prepend `"use client"` through a custom Rolldown `renderChunk` plugin while emitting sourcemaps. Because the plugin returns transformed code without a sourcemap, Rolldown warns that sourcemaps are likely incorrect and generated mappings can point one line early in the published output.

```ts
renderChunk(code) {
  return `"use client";\n${code}`;
}
```

## Solution

Move the directive to Rolldown's `output.banner` option for React package builds. This keeps the generated JavaScript banner on entries and shared chunks while letting Rolldown account for the inserted directive when producing sourcemaps.

```ts
output: {
  sourcemap: true,
  ...(isReactPackage && { banner: '"use client";' }),
}
```

The regression tests now build temporary packages through the real `ariakit build` CLI and verify:

- React entry files, secondary entries, and shared chunks receive the banner.
- React entry and chunk sourcemaps map back to the expected source line and column.
- `--index-only` React builds keep correct banner-aware sourcemaps.
- Non-React builds do not receive the banner and keep healthy sourcemaps.
- The previous `SOURCEMAP_BROKEN` warning does not appear on stdout or stderr.
