### PR TITLE
Remove unused app vfile dependency

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -106,7 +106,6 @@
     "unified": "11.0.5",
     "unist-util-visit": "5.1.0",
     "use-local-storage-state": "19.5.0",
-    "vfile": "6.0.3",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,9 +389,6 @@ importers:
       use-local-storage-state:
         specifier: 19.5.0
         version: 19.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      vfile:
-        specifier: 6.0.3
-        version: 6.0.3
       zod:
         specifier: 4.4.3
         version: 4.4.3


### PR DESCRIPTION
## Motivation

The private `app` workspace declares `vfile` as a direct dependency, but the app does not import or reference it directly. Keeping the unused direct dependency makes the manifest noisier and leaves Renovate with a package to update even though no app code path depends on it.

## Solution

Remove `vfile` from `app/package.json` and remove the matching `app` importer entry from `pnpm-lock.yaml`. The lockfile still keeps `vfile` transitively for packages that declare it themselves, including `unified` and `@astrojs/markdown-remark`.

No changeset is needed because this only cleans up a private workspace manifest.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm lint-fix`
- `pnpm -F app run check`
- `pnpm -F app run build`
