### PR TITLE
Document app PostCSS config shield

### DIFF
--- a/app/postcss.config.js
+++ b/app/postcss.config.js
@@ -7,4 +7,7 @@
  *
  * SPDX-License-Identifier: UNLICENSED
  */
+// Intentionally empty: prevents Vite's upward PostCSS config search from
+// picking up the legacy root postcss.config.cjs for website/.
+// The app uses Tailwind v4 through @tailwindcss/vite instead.
 export default {};


### PR DESCRIPTION
## Motivation

`app/postcss.config.js` only exports an empty object, so it looks like dead configuration. It is actually load-bearing because it prevents Vite's upward PostCSS config search from finding the root `postcss.config.cjs` used by the legacy `website/` workspace.

If this file is removed during cleanup, the app can inherit the root Tailwind v3 PostCSS pipeline even though the app uses Tailwind v4 through `@tailwindcss/vite`.

## Solution

Add a short WHY comment above the empty export explaining that the config is intentionally empty, stops the upward search, and keeps the app on its Tailwind v4 Vite integration.
