### PR TITLE
Reuse style dependency traversal

### DIFF
--- a/app/src/lib/styles.ts
+++ b/app/src/lib/styles.ts
@@ -254,38 +254,13 @@ export function getStyleDefinition(
 export function getTransitiveStyleDefinitions(
   input: StyleDependency,
 ): StyleDef[] {
-  const out: StyleDef[] = [];
-  const queue: StyleDependency[] = [];
-  const visited = new Set<string>();
-
-  const rootDef = getStyleDefinition(input.name, input.type);
-  if (!rootDef) return out;
-  const enqueueDeps = (def: StyleDef) => {
-    if (!("type" in def)) return;
-    for (const dep of def.dependencies) {
-      const modId = dep.module ?? "";
-      const k = `${dep.type}:${modId}:${dep.name}`;
-      if (visited.has(k)) continue;
-      const depDef = getStyleDefinition(dep.name, dep.type);
-      if (!depDef) {
-        visited.add(k);
-        continue;
-      }
-      visited.add(k);
-      out.push(depDef);
-      queue.push(dep);
-    }
-  };
-
-  enqueueDeps(rootDef);
-  while (queue.length > 0) {
-    const current = queue.shift();
-    if (!current) break;
-    const def = getStyleDefinition(current.name, current.type);
-    if (!def) continue;
-    enqueueDeps(def);
+  const definitions: StyleDef[] = [];
+  for (const dependency of getTransitiveDependencies(input)) {
+    const definition = getStyleDefinition(dependency.name, dependency.type);
+    if (!definition) continue;
+    definitions.push(definition);
   }
-  return out;
+  return definitions;
 }
 
 /**


### PR DESCRIPTION
## Motivation

`getTransitiveStyleDefinitions` duplicated the breadth-first dependency traversal already implemented by `getTransitiveDependencies`. The two copies had drifted in how they tracked visited dependencies, which made future traversal fixes easier to apply inconsistently.

## Solution

Make `getTransitiveStyleDefinitions` call `getTransitiveDependencies`, then resolve each returned dependency with `getStyleDefinition` and skip unresolved external dependencies. This leaves one traversal implementation while preserving the existing definition output and order for StackBlitz CSS generation.

## Verification

- `pnpm lint-fix`
- `pnpm test run app/src/lib/styles.test.ts app/src/lib/stackblitz.test.ts`
- `pnpm tsc`
