### PR TITLE
Use shared afterPaint utility

### DIFF
--- a/packages/ariakit-react-components/src/disclosure/disclosure-content.tsx
+++ b/packages/ariakit-react-components/src/disclosure/disclosure-content.tsx
@@ -9,7 +9,7 @@ import {
   forwardRef,
 } from "@ariakit/react-utils";
 import type { Options, Props } from "@ariakit/react-utils";
-import { invariant, removeUndefinedValues } from "@ariakit/utils";
+import { afterPaint, invariant, removeUndefinedValues } from "@ariakit/utils";
 import type { ElementType } from "react";
 import { useMemo, useRef, useState } from "react";
 import { flushSync } from "react-dom";
@@ -25,13 +25,6 @@ type TransitionState = "enter" | "leave" | null;
 function afterTimeout(timeoutMs: number, cb: () => void) {
   const timeoutId = setTimeout(cb, timeoutMs);
   return () => clearTimeout(timeoutId);
-}
-
-function afterPaint(cb: () => void) {
-  let raf = requestAnimationFrame(() => {
-    raf = requestAnimationFrame(cb);
-  });
-  return () => cancelAnimationFrame(raf);
 }
 
 function parseCSSTime(time: string | undefined) {


### PR DESCRIPTION
## Motivation

Disclosure content currently defines a private `afterPaint` helper that duplicates the shared `@ariakit/utils` implementation. Keeping the copy creates a second source of truth for the double-`requestAnimationFrame` timing used to start disclosure animations.

## Solution

Import `afterPaint` from `@ariakit/utils` and delete the local helper. The call site still passes an explicit callback, and the shared implementation is behaviorally identical to the removed helper.
