### PR TITLE
Deduplicate legacy React build script

### DIFF
--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -78,38 +78,13 @@ const cjsInternalPackages = [
 ];
 
 /** @param {{ format: import("tsup").Format, outDir: string }} options */
-function buildStandard({ format, outDir }) {
-  if (isFramework) return;
+async function buildPackage({ format, outDir }) {
+  if (isFramework && !isReact) return;
   return build({
     entry,
     format,
     outDir,
     noExternal: format === "cjs" ? cjsInternalPackages : undefined,
-    // dts: true,
-    // tsconfig: "tsconfig.build.json",
-    splitting: true,
-    esbuildOptions(options) {
-      options.chunkNames = "__chunks/[hash]";
-      // TODO: this might not be necessary for anything other than react and react-components
-      if (format === "esm") {
-        options.banner = {
-          js: '"use client";',
-        };
-      }
-    },
-  });
-}
-
-/** @param {{ format: import("tsup").Format, outDir: string }} options */
-function buildReact({ format, outDir }) {
-  if (!isReact) return;
-  return build({
-    entry,
-    format,
-    outDir,
-    noExternal: format === "cjs" ? cjsInternalPackages : undefined,
-    // dts: true,
-    // tsconfig: "tsconfig.build.json",
     splitting: true,
     esbuildOptions(options) {
       options.chunkNames = "__chunks/[hash]";
@@ -122,4 +97,4 @@ function buildReact({ format, outDir }) {
   });
 }
 
-await Promise.all([...builds.map(buildStandard), ...builds.map(buildReact)]);
+await Promise.all(builds.map(buildPackage));


### PR DESCRIPTION
## Motivation

The legacy package build script still defines separate `buildStandard` and `buildReact` helpers with identical `tsup` options. The script is currently only used by `@ariakit/react`, so the standard helper is dead for real repository builds, and keeping two copies makes future build option changes easier to miss.

## Solution

Replace both helpers with a single `buildPackage` helper that preserves the original behavior: non-framework packages still build, React packages still build, and non-React framework packages still skip this legacy path. The refactor also removes stale commented-out declaration options and the dead-path TODO.

## Verification

- `pnpm lint-fix`
- `pnpm -F @ariakit/react run build`
