### PR TITLE
Fix nested CSS variable dependency scanning

### DIFF
--- a/app/src/lib/build-styles.test.ts
+++ b/app/src/lib/build-styles.test.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2025-present Ariakit FZ-LLC. All Rights Reserved.
+ *
+ * This software is proprietary. See the license.md file in the root of this
+ * package for licensing terms.
+ *
+ * SPDX-License-Identifier: UNLICENSED
+ */
+import { expect, test } from "vitest";
+import { findVarNamesInString } from "./build-styles.ts";
+
+test("findVarNamesInString finds names in nested var fallbacks", () => {
+  expect(
+    findVarNamesInString("var(--ak-table-px, var(--ak-frame-padding, 0))"),
+  ).toEqual(["--ak-table-px", "--ak-frame-padding"]);
+});

--- a/app/src/lib/build-styles.ts
+++ b/app/src/lib/build-styles.ts
@@ -654,9 +654,9 @@ function extractAkTokensFromApplyLine(line: string) {
   return uniqPreserveOrder(akTokens);
 }
 
-function findVarNamesInString(value: string) {
+export function findVarNamesInString(value: string) {
   const out: string[] = [];
-  const re = /var\(\s*(--[A-Za-z0-9_-]+)\b[^)]*\)/g;
+  const re = /var\(\s*(--[A-Za-z0-9_-]+)/g;
   let match: RegExpExecArray | null;
   while (true) {
     match = re.exec(value);


### PR DESCRIPTION
## Motivation

The docs app serializes the `ak-*` CSS modules into `styles.json` and records `var(--name)` references so registered `@property` rules can be included as dependencies. The existing regex matched a whole `var(...)` call through the first closing parenthesis, so nested fallbacks skipped the inner variable name.

For example, this value only captured `--ak-table-px`:

```css
var(--ak-table-px, var(--ak-frame-padding, 0))
```

If a registered `@property` were referenced only from an inner fallback, generated StackBlitz styles could miss the corresponding `@property` rule.

## Solution

Match only the `var(` prefix and the custom property name instead of consuming the closing parenthesis. That lets the global regex keep scanning nested fallback calls:

```ts
/var\(\s*(--[A-Za-z0-9_-]+)/g
```

The helper is exported for focused coverage, and a regression test now verifies the table padding fallback captures both `--ak-table-px` and `--ak-frame-padding`. Regenerating `styles.json` stays byte-identical with the current CSS, because the newly found inner fallbacks are not registered `@property` dependencies today.

## Verification

- Temporarily restored the old regex and confirmed `pnpm test app/src/lib/build-styles.test.ts` fails for the new regression test.
- `pnpm lint-fix`
- `pnpm test app/src/lib/build-styles.test.ts`
- `pnpm -F app run build-styles` followed by an empty `git diff app/src/styles/styles.json`
- `pnpm tsc`

No changeset is included because this only changes the private `app` workspace, which is ignored by Changesets.
