### PR TITLE
Fix SubmitButton loading on admin pages

### DIFF
--- a/app/src/components/submit-button.astro
+++ b/app/src/components/submit-button.astro
@@ -30,7 +30,7 @@ interface Props extends HTMLAttributes<"button"> {}
     );
   }
 
-  document.addEventListener("astro:page-load", () => {
+  function init() {
     const buttons = document.querySelectorAll<HTMLButtonElement>(
       "[data-submit-button]"
     );
@@ -39,6 +39,8 @@ interface Props extends HTMLAttributes<"button"> {}
       const form = button.form;
       if (!form) continue;
 
+      // init() can run more than once; browsers ignore duplicate listener
+      // registrations with the same callback.
       form.addEventListener("submit", onSubmit);
 
       const hasBeenProcessed = button.hasAttribute("data-previous-disabled");
@@ -49,5 +51,14 @@ interface Props extends HTMLAttributes<"button"> {}
       button.removeAttribute("data-previous-disabled");
       button.removeAttribute("data-loading");
     }
+  }
+
+  // Layouts without <ClientRouter /> never fire astro:page-load, and bfcache
+  // restores do not rerun module scripts.
+  init();
+  document.addEventListener("astro:page-load", init);
+  window.addEventListener("pageshow", (event) => {
+    if (!event.persisted) return;
+    init();
   });
 </script>


### PR DESCRIPTION
## Motivation

`SubmitButton` is meant to disable the submitter and set `data-loading` while admin forms submit. Its setup only ran from `astro:page-load`, but the admin layout does not use `<ClientRouter />`, so that event never fires there.

As a result, Stripe sync, price, and promo admin forms can be submitted repeatedly and never show the loading state.

## Solution

Move the setup body into an idempotent `init()` function. Call it eagerly for normal MPA loads, keep the `astro:page-load` listener for possible ClientRouter usage, and run it on persisted `pageshow` events so bfcache restores can remove `data-loading` and restore the previous disabled state.

Duplicate `init()` calls reuse the same module-level submit listener, so browsers ignore duplicate listener registrations on the same form.

No changeset is included because this is a private app/admin component change, not a published package change.

## Testing

- `pnpm lint-fix`
- `pnpm -F app run check`

Manual follow-up coverage: verify an admin submit button disables and sets `data-loading` during submit, then verify browser Back after a submitted navigation restores the previous disabled state and clears `data-loading`/`data-previous-disabled`.
