### PR TITLE
Deduplicate style and preview path helpers

### DIFF
--- a/app/src/lib/build-styles.ts
+++ b/app/src/lib/build-styles.ts
@@ -10,6 +10,11 @@
 
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import {
+  isWildcard,
+  splitVariantSegments,
+  toRegexFromWildcard,
+} from "./styles-shared.ts";
 import type {
   AtPropertyDef,
   ModuleJson,
@@ -507,47 +512,6 @@ interface GlobalIndex {
   variantToModule: Map<string, string>;
   variantWildcards: Array<{ name: string; module: string; re: RegExp }>;
   atPropToModule: Map<string, string>;
-}
-
-function isWildcard(name: string): boolean {
-  return name.includes("*");
-}
-
-function escapeRegexSpecialChars(input: string) {
-  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function toRegexFromWildcard(pattern: string) {
-  let regexBody = "";
-  for (let i = 0; i < pattern.length; i++) {
-    const char = pattern.charAt(i);
-    regexBody += char === "*" ? ".*" : escapeRegexSpecialChars(char);
-  }
-  return new RegExp(`^${regexBody}$`);
-}
-
-function splitVariantSegments(token: string) {
-  const segments: string[] = [];
-  let start = 0;
-  let bracketDepth = 0;
-  let parenDepth = 0;
-  for (let i = 0; i < token.length; i++) {
-    const char = token.charAt(i);
-    if (char === "[") {
-      bracketDepth++;
-    } else if (char === "]") {
-      bracketDepth = Math.max(0, bracketDepth - 1);
-    } else if (char === "(") {
-      parenDepth++;
-    } else if (char === ")") {
-      parenDepth = Math.max(0, parenDepth - 1);
-    } else if (char === ":" && bracketDepth === 0 && parenDepth === 0) {
-      segments.push(token.slice(start, i));
-      start = i + 1;
-    }
-  }
-  segments.push(token.slice(start));
-  return segments;
 }
 
 function buildGlobalIndex(modules: ModuleJson[]): GlobalIndex {

--- a/app/src/lib/mdx-loader.ts
+++ b/app/src/lib/mdx-loader.ts
@@ -7,15 +7,14 @@
  *
  * SPDX-License-Identifier: UNLICENSED
  */
-import { basename, dirname, isAbsolute, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { basename, dirname } from "node:path";
 import { invariant } from "@ariakit/utils";
 import { glob } from "astro/loaders";
 import type { Loader, LoaderContext } from "astro/loaders";
 import type { z } from "astro/zod";
+import { isInDirectory, toFilePath } from "./paths.ts";
 import {
   getPreviewFrameworks,
-  isInDirectory,
   isPreviewEntryFile,
 } from "./preview-discovery.ts";
 import { FrameworkSchema } from "./schemas.ts";
@@ -40,22 +39,6 @@ interface WatchFrameworkEntryFilesParams {
   context: LoaderContext;
   loader: Loader;
   parseData: LoaderContext["parseData"];
-}
-
-function toFilePath(path: string | URL, base?: string | URL): string {
-  if (path instanceof URL) {
-    return fileURLToPath(path);
-  }
-  if (path.startsWith("file:")) {
-    return fileURLToPath(path);
-  }
-  if (isAbsolute(path)) {
-    return path;
-  }
-  if (base) {
-    return resolve(toFilePath(base), path);
-  }
-  return resolve(path);
 }
 
 function getErrorMessage(error: unknown) {

--- a/app/src/lib/paths.ts
+++ b/app/src/lib/paths.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2025-present Ariakit FZ-LLC. All Rights Reserved.
+ *
+ * This software is proprietary. See the license.md file in the root of this
+ * package for licensing terms.
+ *
+ * SPDX-License-Identifier: UNLICENSED
+ */
+import { isAbsolute, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export type PathInput = string | URL;
+
+/**
+ * Normalizes path separators to posix style.
+ */
+export function toPosixPath(path: string) {
+  return path.replace(/\\/g, "/");
+}
+
+/**
+ * Converts a string path or file URL to an absolute file path.
+ */
+export function toFilePath(path: PathInput, base?: PathInput): string {
+  if (path instanceof URL) {
+    return fileURLToPath(path);
+  }
+  if (path.startsWith("file:")) {
+    return fileURLToPath(path);
+  }
+  if (isAbsolute(path)) {
+    return path;
+  }
+  if (base) {
+    return resolve(toFilePath(base), path);
+  }
+  return resolve(path);
+}
+
+/**
+ * Returns whether a path matches a directory or lives inside it.
+ */
+export function isInDirectory(file: string, dir: string) {
+  const relativePath = relative(dir, file);
+  return (
+    relativePath === "" ||
+    (!!relativePath &&
+      !relativePath.startsWith("..") &&
+      !isAbsolute(relativePath))
+  );
+}

--- a/app/src/lib/preview-codegen.ts
+++ b/app/src/lib/preview-codegen.ts
@@ -8,15 +8,14 @@
  * SPDX-License-Identifier: UNLICENSED
  */
 import fs from "node:fs/promises";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { dirname, join, relative } from "node:path";
 import { invariant } from "@ariakit/utils";
+import { isInDirectory, toFilePath, toPosixPath } from "./paths.ts";
+import type { PathInput } from "./paths.ts";
 import type { DiscoveredPreview } from "./preview-discovery.ts";
 import type { Framework } from "./schemas.ts";
 
 const INTEGRATION_NAME = "ariakit-previews";
-
-type PathInput = string | URL;
 
 interface PreviewCodegenParams {
   codegenDir: string;
@@ -28,20 +27,6 @@ interface PreviewCodegenResult {
 }
 
 const previewCodegenDirs = new Map<string, string>();
-
-export function toPosixPath(path: string) {
-  return path.replace(/\\/g, "/");
-}
-
-function toFilePath(path: PathInput): string {
-  if (path instanceof URL) {
-    return fileURLToPath(path);
-  }
-  if (path.startsWith("file:")) {
-    return fileURLToPath(path);
-  }
-  return resolve(path);
-}
 
 export function setPreviewCodegenDir(root: PathInput, codegenDir: string) {
   previewCodegenDirs.set(toFilePath(root), codegenDir);
@@ -162,16 +147,6 @@ async function getGeneratedPreviewFiles(dir: string) {
     }
   }
   return files;
-}
-
-function isInDirectory(file: string, dir: string) {
-  const relativePath = relative(dir, file);
-  return (
-    relativePath === "" ||
-    (!!relativePath &&
-      !relativePath.startsWith("..") &&
-      !isAbsolute(relativePath))
-  );
 }
 
 async function removeFileAndEmptyParents(file: string, root: string) {

--- a/app/src/lib/preview-discovery.ts
+++ b/app/src/lib/preview-discovery.ts
@@ -10,13 +10,15 @@
 import { readdirSync } from "node:fs";
 import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
-import { basename, isAbsolute, join, relative, resolve } from "node:path";
+import { basename, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { invariant } from "@ariakit/utils";
 import type { Loader } from "astro/loaders";
 import type { LoaderContext } from "astro/loaders";
 import { z } from "astro/zod";
 import { getFrameworkByFilename, isFramework } from "./frameworks.ts";
+import { isInDirectory, toFilePath, toPosixPath } from "./paths.ts";
+import type { PathInput } from "./paths.ts";
 import {
   getPreviewCodegenDir,
   getPreviewContentFile,
@@ -24,8 +26,6 @@ import {
 } from "./preview-codegen.ts";
 import { FRAMEWORKS, FrameworkSchema } from "./schemas.ts";
 import type { Framework } from "./schemas.ts";
-
-type PathInput = string | URL;
 
 export interface PreviewRootOptions {
   kind: string;
@@ -77,26 +77,6 @@ export const PreviewDataSchema = z.object({
 interface DiscoverRootContext {
   root: ResolvedPreviewRoot;
   previews: Map<string, DiscoveredPreview>;
-}
-
-function toPosixPath(path: string) {
-  return path.replace(/\\/g, "/");
-}
-
-function toFilePath(path: PathInput, base?: PathInput): string {
-  if (path instanceof URL) {
-    return fileURLToPath(path);
-  }
-  if (path.startsWith("file:")) {
-    return fileURLToPath(path);
-  }
-  if (isAbsolute(path)) {
-    return path;
-  }
-  if (base) {
-    return resolve(toFilePath(base), path);
-  }
-  return resolve(path);
 }
 
 function getDefaultSrcDir(options: PreviewDiscoveryOptions) {
@@ -184,16 +164,6 @@ async function readPreviewMetadata(file: string, id: string) {
 function isDirectoryIgnored(name: string) {
   if (name.startsWith(".")) return true;
   return name === "node_modules";
-}
-
-export function isInDirectory(file: string, dir: string) {
-  const relativePath = relative(dir, file);
-  return (
-    relativePath === "" ||
-    (!!relativePath &&
-      !relativePath.startsWith("..") &&
-      !isAbsolute(relativePath))
-  );
 }
 
 export function isPreviewEntryFile(filename: string) {

--- a/app/src/lib/preview-integration.ts
+++ b/app/src/lib/preview-integration.ts
@@ -11,15 +11,14 @@ import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AstroConfig, AstroIntegration } from "astro";
 import type { Plugin } from "vite";
+import { isInDirectory, toPosixPath } from "./paths.ts";
 import {
   getPreviewFile,
   setPreviewCodegenDir,
-  toPosixPath,
   writePreviewCodegen,
 } from "./preview-codegen.ts";
 import {
   discoverPreviews,
-  isInDirectory,
   resolvePreviewRoots,
   shouldRegeneratePreview,
 } from "./preview-discovery.ts";

--- a/app/src/lib/source-plugin.ts
+++ b/app/src/lib/source-plugin.ts
@@ -27,6 +27,7 @@ import {
   findSiblingConventionFiles,
   isNextjsConventionFile,
 } from "./nextjs.ts";
+import { toPosixPath } from "./paths.ts";
 import type { Source, SourceFile } from "./source.ts";
 import { getImportPaths, mergeFiles, replaceImportPaths } from "./source.ts";
 import { resolveStyles } from "./styles.ts";
@@ -112,13 +113,6 @@ function isLibPath(path: string) {
     path.startsWith(APP_LIB_PATH) ||
     path.startsWith(NEXTJS_LIB_PATH)
   );
-}
-
-/**
- * Normalize path separators to posix style.
- */
-function toPosixPath(filePath: string) {
-  return filePath.replace(/\\/g, "/");
 }
 
 /**

--- a/app/src/lib/styles-shared.ts
+++ b/app/src/lib/styles-shared.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2025-present Ariakit FZ-LLC. All Rights Reserved.
+ *
+ * This software is proprietary. See the license.md file in the root of this
+ * package for licensing terms.
+ *
+ * SPDX-License-Identifier: UNLICENSED
+ */
+
+/**
+ * Style token helpers shared by the runtime resolver and styles.json builder.
+ *
+ * This module must not import styles.json, directly or indirectly. The builder
+ * generates that file and should not load its own output.
+ */
+
+export function isWildcard(name: string): boolean {
+  return name.includes("*");
+}
+
+function escapeRegexSpecialChars(input: string) {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Builds a regular expression from a wildcard pattern.
+ */
+export function toRegexFromWildcard(pattern: string) {
+  let regexBody = "";
+  for (let i = 0; i < pattern.length; i++) {
+    const char = pattern.charAt(i);
+    regexBody += char === "*" ? ".*" : escapeRegexSpecialChars(char);
+  }
+  return new RegExp(`^${regexBody}$`);
+}
+
+/**
+ * Splits a class token on top-level colon separators.
+ */
+export function splitVariantSegments(token: string) {
+  const segments: string[] = [];
+  let start = 0;
+  let bracketDepth = 0;
+  let parenDepth = 0;
+  for (let i = 0; i < token.length; i++) {
+    const char = token.charAt(i);
+    if (char === "[") {
+      bracketDepth++;
+    } else if (char === "]") {
+      bracketDepth = Math.max(0, bracketDepth - 1);
+    } else if (char === "(") {
+      parenDepth++;
+    } else if (char === ")") {
+      parenDepth = Math.max(0, parenDepth - 1);
+    } else if (char === ":" && bracketDepth === 0 && parenDepth === 0) {
+      segments.push(token.slice(start, i));
+      start = i + 1;
+    }
+  }
+  segments.push(token.slice(start));
+  return segments;
+}

--- a/app/src/lib/styles.ts
+++ b/app/src/lib/styles.ts
@@ -20,6 +20,11 @@ import type {
   UtilityDef,
   VariantDef,
 } from "./styles-json-types.ts";
+import {
+  isWildcard,
+  splitVariantSegments,
+  toRegexFromWildcard,
+} from "./styles-shared.ts";
 
 const styles = stylesRaw as unknown as StylesJson;
 
@@ -68,52 +73,6 @@ function dedupeDependencies(deps: StyleDependency[]): StyleDependency[] {
     unique.push(dep);
   }
   return unique;
-}
-
-function isWildcard(name: string): boolean {
-  return name.includes("*");
-}
-
-function escapeRegexSpecialChars(input: string): string {
-  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function toRegexFromWildcard(pattern: string): RegExp {
-  // Build regex by escaping each char except '*' which becomes '.*'
-  let regexBody = "";
-  for (let i = 0; i < pattern.length; i++) {
-    const ch = pattern.charAt(i);
-    if (ch === "*") {
-      regexBody += ".*";
-    } else {
-      regexBody += escapeRegexSpecialChars(ch);
-    }
-  }
-  return new RegExp(`^${regexBody}$`);
-}
-
-function splitVariantSegments(token: string) {
-  const segments: string[] = [];
-  let start = 0;
-  let bracketDepth = 0;
-  let parenDepth = 0;
-  for (let i = 0; i < token.length; i++) {
-    const char = token.charAt(i);
-    if (char === "[") {
-      bracketDepth++;
-    } else if (char === "]") {
-      bracketDepth = Math.max(0, bracketDepth - 1);
-    } else if (char === "(") {
-      parenDepth++;
-    } else if (char === ")") {
-      parenDepth = Math.max(0, parenDepth - 1);
-    } else if (char === ":" && bracketDepth === 0 && parenDepth === 0) {
-      segments.push(token.slice(start, i));
-      start = i + 1;
-    }
-  }
-  segments.push(token.slice(start));
-  return segments;
 }
 
 type IndexMap = Record<string, { module: string }>;

--- a/app/src/test-utils/preview.ts
+++ b/app/src/test-utils/preview.ts
@@ -1,7 +1,8 @@
-import { isAbsolute, relative, resolve } from "node:path";
+import { relative, resolve } from "node:path";
 import { query } from "@ariakit/test/playwright";
 import { errors } from "@playwright/test";
 import type { Page } from "@playwright/test";
+import { isInDirectory, toPosixPath } from "#app/lib/paths.ts";
 import { previewConfig } from "#app/lib/preview-config.ts";
 import {
   getPreviewFrameworksSync,
@@ -33,20 +34,6 @@ export async function gotoAndSettle(page: Page, url: string) {
 
 const SRC_DIR = resolve(import.meta.dirname, "..");
 const previewRoots = resolvePreviewRoots({ ...previewConfig, srcDir: SRC_DIR });
-
-function toPosixPath(path: string) {
-  return path.replace(/\\/g, "/");
-}
-
-function isInDirectory(file: string, dir: string) {
-  const relativePath = relative(dir, file);
-  return (
-    relativePath === "" ||
-    (!!relativePath &&
-      !relativePath.startsWith("..") &&
-      !isAbsolute(relativePath))
-  );
-}
 
 function getPreviewId(dirname: string) {
   const dir = resolve(dirname);


### PR DESCRIPTION
## Motivation

The style runtime resolver and `styles.json` builder duplicated the same wildcard matching and variant segment parsing logic. If those copies drift, runtime style resolution can disagree with the generated dependency graph.

Preview tooling had the same maintenance problem across path helpers such as `toPosixPath`, `toFilePath`, and `isInDirectory`, with copies spread across codegen, discovery, MDX loading, browser test utilities, and source flattening.

## Solution

Added `app/src/lib/styles-shared.ts` for the shared style token helpers and imported it from both `styles.ts` and `build-styles.ts`. The new module intentionally avoids importing `styles.json` or `styles.ts`, so the style generator still does not load its own output.

Added `app/src/lib/paths.ts` for Node-side path helpers, then updated preview codegen, discovery, integration, MDX loading, preview tests, and source plugin code to import from that module. This keeps `preview-codegen.ts` from importing `preview-discovery.ts`, avoiding a runtime cycle.

The shared `toFilePath` keeps absolute paths as-is, while the old codegen-only helper passed them through `resolve()`. The codegen map callers use Astro URL roots and both set/get paths now go through the same shared helper, so the keying behavior remains consistent.

No changeset is included because this is an internal app-tooling refactor with no user-facing package behavior change.

## Testing

- `pnpm lint-fix`
- `pnpm -F app run build-styles --check`
- `pnpm test app/src/lib/styles.test.ts app/src/lib/preview-discovery.test.ts app/src/lib/preview-integration.test.ts`
- `pnpm test app/src/lib/source-plugin.test.ts app/src/lib/mdx-loader.test.ts`
- `pnpm tsc`
