### PR TITLE
Remove invalid progress percentage values

### DIFF
--- a/app/src/lib/styles.test.ts
+++ b/app/src/lib/styles.test.ts
@@ -141,6 +141,36 @@ test("styleDefToCss renders ak-list-item-ol-border utility fully", () => {
   `);
 });
 
+test("progress value utilities do not advertise percentage values", () => {
+  const progress = getStyleDefinition("ak-progress-value-*", "utility");
+  expect(styleDefToCss(progress!)).toMatchInlineSnapshot(`
+    "@utility ak-progress-value-* {
+      --ak-progress-value: calc(--value(number) / 100);
+      --ak-progress-value: calc(--value(ratio));
+      --ak-progress-value: --value([*]);
+    }"
+  `);
+
+  const checkProgress = getStyleDefinition(
+    "ak-list-item-check-progress-*",
+    "utility",
+  );
+  expect(styleDefToCss(checkProgress!)).toMatchInlineSnapshot(`
+    "@utility ak-list-item-check-progress-* {
+      @apply before:ak-progress-circular-fill ak-progress-value-(--value);
+      --value: calc(--value(number) / 100);
+      --value: calc(--value(ratio));
+      --value: --value([*]);
+      @variant ak-list-ol {
+        @apply ak-progress-thickness-[0.15em];
+      }
+      @variant ak-list-ul {
+        @apply ak-progress-thickness-[calc(30%+0.25%*var(--contrast,0))];
+      }
+    }"
+  `);
+});
+
 test("findStyleDependency returns exact index matches only (no external)", () => {
   const util = findStyleDependency("ak-badge", "utility");
   expect(util).toEqual({ type: "utility", name: "ak-badge", module: "badge" });

--- a/app/src/styles/ak-list.css
+++ b/app/src/styles/ak-list.css
@@ -325,7 +325,7 @@
   @apply before:ak-progress-circular-fill ak-progress-value-(--value);
   --value: calc(--value(number) / 100);
   --value: calc(--value(ratio));
-  --value: --value(percentage, [*]);
+  --value: --value([*]);
   @variant ak-list-ol {
     @apply ak-progress-thickness-[0.15em];
   }

--- a/app/src/styles/ak-progress.css
+++ b/app/src/styles/ak-progress.css
@@ -16,7 +16,7 @@
 @utility ak-progress-value-* {
   --ak-progress-value: calc(--value(number) / 100);
   --ak-progress-value: calc(--value(ratio));
-  --ak-progress-value: --value(percentage, [*]);
+  --ak-progress-value: --value([*]);
 }
 
 @utility ak-progress-thickness-* {

--- a/app/src/styles/styles.json
+++ b/app/src/styles/styles.json
@@ -6602,7 +6602,7 @@
             },
             {
               "name": "--ak-progress-value",
-              "value": "--value(percentage, [*])"
+              "value": "--value([*])"
             }
           ],
           "dependencies": []
@@ -8117,7 +8117,7 @@
             },
             {
               "name": "--value",
-              "value": "--value(percentage, [*])"
+              "value": "--value([*])"
             },
             {
               "name": "@variant ak-list-ol",


### PR DESCRIPTION
## Motivation

`ak-progress-value-*` and `ak-list-item-check-progress-*` advertised bare percentage values such as `ak-progress-value-50%`.

Those values are assigned to `--ak-progress-value`, which is registered as a numeric custom property:

```css
@property --ak-progress-value {
  syntax: "<number>";
}
```

A percentage value does not match that syntax, so the custom property falls back to its initial `0` value and progress indicators render empty.

## Solution

Remove the bare `percentage` matcher from both progress value utilities while keeping the number, ratio, and arbitrary passthrough forms that already work:

```css
--ak-progress-value: calc(--value(number) / 100);
--ak-progress-value: calc(--value(ratio));
--ak-progress-value: --value([*]);
```

This keeps supported inputs like `ak-progress-value-50`, `ak-progress-value-1/2`, and `ak-progress-value-(--progress)` working, while no longer advertising the broken bare percentage form. The generated style metadata has been regenerated, and the style metadata tests now cover both progress utilities.

## Testing

- `pnpm -F app run build-styles --check`
- `pnpm exec stylelint app/src/styles/ak-progress.css app/src/styles/ak-list.css`
- `pnpm test app/src/lib/styles.test.ts`
- `pnpm lint`
- `pnpm tsc`
