### PR TITLE
Preserve inline comments in style declarations

### DIFF
--- a/app/src/lib/build-styles.test.ts
+++ b/app/src/lib/build-styles.test.ts
@@ -7,11 +7,157 @@
  *
  * SPDX-License-Identifier: UNLICENSED
  */
+
 import { expect, test } from "vitest";
-import { findVarNamesInString } from "./build-styles.ts";
+import {
+  findVarNamesInString,
+  parseAtPropertyBody,
+  parsePropertyDecls,
+  resolveDependencies,
+} from "./build-styles.ts";
+import type { ModuleJson } from "./styles.ts";
 
 test("findVarNamesInString finds names in nested var fallbacks", () => {
   expect(
     findVarNamesInString("var(--ak-table-px, var(--ak-frame-padding, 0))"),
   ).toEqual(["--ak-table-px", "--ak-frame-padding"]);
+});
+
+test("parsePropertyDecls preserves mid-declaration comments", () => {
+  const decls = parsePropertyDecls(`
+    color: red /* note */;
+    width: calc(100% /* half */ - 2px);
+  `);
+
+  expect(decls).toEqual([
+    { name: "color", value: "red /* note */" },
+    { name: "width", value: "calc(100% /* half */ - 2px)" },
+  ]);
+});
+
+test("parsePropertyDecls preserves standalone comments before @apply", () => {
+  const decls = parsePropertyDecls(`
+    /* Base styles */
+    @apply ak-button;
+  `);
+
+  expect(decls).toEqual([
+    { name: "/* Base styles */", value: {} },
+    { name: "@apply ak-button", value: {} },
+  ]);
+});
+
+test("parseAtPropertyBody preserves mid-declaration comments", () => {
+  const def = parseAtPropertyBody(`
+    syntax: "<length>";
+    inherits: true;
+    initial-value: calc(1px /* c */ + 2px);
+  `);
+
+  expect(def).toEqual({
+    syntax: '"<length>"',
+    inherits: "true",
+    initialValue: "calc(1px /* c */ + 2px)",
+  });
+});
+
+test("resolveDependencies ignores tokens in inline comments", () => {
+  const styleModule: ModuleJson = {
+    id: "test",
+    path: "app/src/styles/ak-test.css",
+    atProperties: {
+      "--ak-real-prop": {
+        name: "--ak-real-prop",
+        syntax: null,
+        inherits: null,
+        initialValue: null,
+      },
+      "--ak-comment-prop": {
+        name: "--ak-comment-prop",
+        syntax: null,
+        inherits: null,
+        initialValue: null,
+      },
+      "--ak-string-prop": {
+        name: "--ak-string-prop",
+        syntax: null,
+        inherits: null,
+        initialValue: null,
+      },
+      "--ak-joined-prop": {
+        name: "--ak-joined-prop",
+        syntax: null,
+        inherits: null,
+        initialValue: null,
+      },
+    },
+    utilities: {
+      "ak-real-utility": {
+        name: "ak-real-utility",
+        type: "utility",
+        properties: [],
+        dependencies: [],
+      },
+      "ak-comment-utility": {
+        name: "ak-comment-utility",
+        type: "utility",
+        properties: [],
+        dependencies: [],
+      },
+      "ak-source": {
+        name: "ak-source",
+        type: "utility",
+        properties: [
+          {
+            name: "@apply ak-real-utility /* ak-comment-utility */",
+            value: {},
+          },
+          {
+            name: "color",
+            value:
+              "red var(--ak-real-prop) /* ak-comment-utility var(--ak-comment-prop) */",
+          },
+          {
+            name: "content",
+            value:
+              '"/*" var(--ak-string-prop) "*/" /* var(--ak-comment-prop) */',
+          },
+          {
+            name: "border-color",
+            value: "var(--ak-joined/* comment */-prop)",
+          },
+          {
+            name: "@variant ak-real-variant /* ak-comment-variant */",
+            value: [{ name: "@slot", value: {} }],
+          },
+        ],
+        dependencies: [],
+      },
+    },
+    variants: {
+      "ak-real-variant": {
+        name: "ak-real-variant",
+        type: "variant",
+        properties: [],
+        dependencies: [],
+      },
+      "ak-comment-variant": {
+        name: "ak-comment-variant",
+        type: "variant",
+        properties: [],
+        dependencies: [],
+      },
+    },
+  };
+
+  resolveDependencies([styleModule]);
+
+  const source = styleModule.utilities["ak-source"];
+
+  expect(source?.dependencies).toEqual([
+    { type: "utility", name: "ak-real-utility", module: "test" },
+    { type: "at-property", name: "--ak-real-prop", module: "test" },
+    { type: "at-property", name: "--ak-string-prop", module: "test" },
+    { type: "variant", name: "ak-real-variant", module: "test" },
+  ]);
 });

--- a/app/src/lib/build-styles.ts
+++ b/app/src/lib/build-styles.ts
@@ -277,14 +277,17 @@ function splitBody(content: string): SplitBodyResult {
       i++;
       continue;
     }
-    // capture comments at depth 0 as individual declarations
+    // capture standalone comments at depth 0 as individual declarations
     if (ch === "/" && next === "*" && depth === 0) {
-      const pending = content.slice(tokenStart, i).trim();
-      if (pending) {
-        declarations.push(pending);
-      }
       const end = content.indexOf("*/", i + 2);
       const commentEnd = end === -1 ? n - 2 : end;
+      const pending = content.slice(tokenStart, i).trim();
+      if (pending) {
+        // Mid-declaration comments are part of the CSS value; keep scanning
+        // until the real statement boundary.
+        i = commentEnd + 2;
+        continue;
+      }
       const comment = content.slice(i, commentEnd + 2);
       declarations.push(comment);
       items.push({ kind: "decl", content: comment });
@@ -345,7 +348,7 @@ function splitBody(content: string): SplitBodyResult {
 /**
  * Parse a block body into ordered PropertyDecl[] preserving declaration and block order.
  */
-function parsePropertyDecls(body: string): PropertyDecl[] {
+export function parsePropertyDecls(body: string): PropertyDecl[] {
   const { items } = splitBody(body);
   const decls: PropertyDecl[] = [];
   let pendingApplyComments: string[] = [];
@@ -410,7 +413,7 @@ function parsePropertyDecls(body: string): PropertyDecl[] {
 /**
  * Parse @property block body
  */
-function parseAtPropertyBody(body: string) {
+export function parseAtPropertyBody(body: string) {
   const { declarations } = splitBody(body);
   const def: Omit<AtPropertyDef, "name"> = {
     syntax: null,
@@ -698,14 +701,60 @@ function extractVariantNamesFromDeclName(name: string): string[] {
   if (!name.startsWith("@variant")) {
     return [];
   }
-  const raw = name.slice("@variant".length).trim();
+  const raw = getDependencyScanValue(name.slice("@variant".length)).trim();
   if (!raw) {
     return [];
   }
   return extractAkTokensFromApplyLine(raw);
 }
 
-function resolveDependencies(modules: ModuleJson[]): void {
+function getDependencyScanValue(value: string) {
+  // Comments remain in rendered CSS but should not create dependencies.
+  let output = "";
+  let i = 0;
+  let inStr: false | string = false;
+  while (i < value.length) {
+    const ch = value.charAt(i);
+    const next = value[i + 1];
+    if (inStr) {
+      output += ch;
+      if (ch === "\\") {
+        if (next != null) {
+          output += next;
+        }
+        i += 2;
+        continue;
+      }
+      if (ch === inStr) {
+        inStr = false;
+      }
+      i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      inStr = ch;
+      output += ch;
+      i++;
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      const end = value.indexOf("*/", i + 2);
+      if (end === -1) {
+        output += value.slice(i);
+        break;
+      }
+      const comment = value.slice(i, end + 2);
+      output += comment.replace(/[^\n]/g, " ");
+      i = end + 2;
+      continue;
+    }
+    output += ch;
+    i++;
+  }
+  return output;
+}
+
+export function resolveDependencies(modules: ModuleJson[]): void {
   const index = buildGlobalIndex(modules);
   const externalImport = "@ariakit/tailwind";
 
@@ -761,12 +810,13 @@ function resolveDependencies(modules: ModuleJson[]): void {
       for (const v of nestedValues) {
         // Any nested apply lines are stored as entire lines in val.apply;
         // others are declarations We still scan all strings for ak-* tokens
-        const akTokens = extractAkTokensFromApplyLine(v);
+        const scanValue = getDependencyScanValue(v);
+        const akTokens = extractAkTokensFromApplyLine(scanValue);
         for (const t of akTokens) {
           addAkTokenDep(deps, t);
         }
         // Also scan for var(--prop)
-        for (const varName of findVarNamesInString(v)) {
+        for (const varName of findVarNamesInString(scanValue)) {
           const propModule = index.atPropToModule.get(varName);
           if (propModule) {
             addDep(deps, {
@@ -806,11 +856,12 @@ function resolveDependencies(modules: ModuleJson[]): void {
       const deps: Dependency[] = [];
       const values = collectAllValuesFromPropertyDecls(variant.properties);
       for (const v of values) {
-        const akTokens = extractAkTokensFromApplyLine(v);
+        const scanValue = getDependencyScanValue(v);
+        const akTokens = extractAkTokensFromApplyLine(scanValue);
         for (const t of akTokens) {
           addAkTokenDep(deps, t);
         }
-        for (const varName of findVarNamesInString(v)) {
+        for (const varName of findVarNamesInString(scanValue)) {
           const propModule = index.atPropToModule.get(varName);
           if (propModule) {
             addDep(deps, {


### PR DESCRIPTION
## Motivation

`build-styles` parses the `ak-*.css` files into `styles.json`. Its `splitBody` helper treated every depth-0 block comment as a standalone declaration, even when the comment appeared in the middle of a declaration.

That caused `parsePropertyDecls` to lose the declaration text before inline comments:

```css
color: red /* note */;
width: calc(100% /* half */ - 2px);
```

The same split also made `parseAtPropertyBody` truncate values like `initial-value: calc(1px /* c */ + 2px);`.

## Solution

When `splitBody` sees a depth-0 comment after non-empty pending declaration text, it now skips over the comment without resetting `tokenStart`. The next semicolon or trailing tail emits the full declaration, preserving the inline comment as valid CSS text.

Standalone comments still become their own declaration items, so comments immediately before `@apply` keep the existing behavior. The parser helpers are exported for internal unit tests covering inline comments in declarations, comments inside `calc()`, `@property` initial values, and standalone comments before `@apply`.

Dependency resolution now strips inline comments only for token scanning, without removing comments from parsed/rendered CSS. That scanner is string-aware and preserves separators, so comment text cannot create fake `ak-*`/`var(--ak-*)` dependencies or accidentally join neighboring token fragments.

No changeset is included because this is an internal app generator/test change rather than a published package API change.

## Verification

- Confirmed the focused parser test fails against the old comment-splitting branch before restoring the fix.
- Confirmed the dependency regression fails with fake comment-derived dependencies before stripping comment text for dependency scanning.
- Confirmed the string-aware regression fails when regex comment stripping hides a real var dependency between quoted `"/*"` and `"*/"` delimiters.
- Confirmed the boundary regression fails when deleted comments join `var(--ak-joined/* comment */-prop)` into a fake dependency.
- `pnpm test app/src/lib/build-styles.test.ts`
- `pnpm tsc`
- `pnpm -F app run build-styles --check`
