### PR TITLE
Preserve single-paragraph admonition bodies

### DIFF
--- a/app/src/lib/rehype.test.ts
+++ b/app/src/lib/rehype.test.ts
@@ -7,10 +7,50 @@
  *
  * SPDX-License-Identifier: UNLICENSED
  */
-import type { Element, Root } from "hast";
+import type { Element, ElementContent, Root } from "hast";
 import { expect, test } from "vitest";
 import { decodeBase64 } from "./base64.ts";
-import { rehypePreviousCode } from "./rehype.ts";
+import { rehypeAdmonitions, rehypePreviousCode } from "./rehype.ts";
+
+function createParagraph(children: ElementContent[]): Element {
+  return {
+    type: "element",
+    tagName: "p",
+    properties: {},
+    children,
+  };
+}
+
+function createBlockquote(children: ElementContent[]): Element {
+  return {
+    type: "element",
+    tagName: "blockquote",
+    properties: {},
+    children,
+  };
+}
+
+function createText(value: string): ElementContent {
+  return { type: "text", value };
+}
+
+function createBreak(): Element {
+  return {
+    type: "element",
+    tagName: "br",
+    properties: {},
+    children: [],
+  };
+}
+
+function createInlineCode(value: string): Element {
+  return {
+    type: "element",
+    tagName: "code",
+    properties: {},
+    children: [createText(value)],
+  };
+}
 
 function createCodeBlock(code: string, metastring?: string): Element {
   return {
@@ -51,4 +91,127 @@ test("rehypePreviousCode encodes Unicode code blocks", () => {
   if (typeof encodedPreviousCode !== "string") return;
 
   expect(decodeBase64(encodedPreviousCode)).toBe(previousCode);
+});
+
+test("rehypeAdmonitions preserves canonical single-paragraph bodies", () => {
+  const blockquote = createBlockquote([
+    createParagraph([createText("[!NOTE]\nUseful information.")]),
+  ]);
+  const tree: Root = {
+    type: "root",
+    children: [blockquote],
+  };
+
+  rehypeAdmonitions()(tree);
+
+  expect(blockquote).toEqual({
+    type: "element",
+    tagName: "admonition",
+    properties: { type: "note" },
+    children: [createParagraph([createText("Useful information.")])],
+  });
+});
+
+test("rehypeAdmonitions preserves hard-break paragraph bodies", () => {
+  const blockquote = createBlockquote([
+    createParagraph([
+      createText("[!NOTE]"),
+      createBreak(),
+      createText("\nUseful information."),
+    ]),
+  ]);
+  const tree: Root = {
+    type: "root",
+    children: [blockquote],
+  };
+
+  rehypeAdmonitions()(tree);
+
+  expect(blockquote).toEqual({
+    type: "element",
+    tagName: "admonition",
+    properties: { type: "note" },
+    children: [createParagraph([createText("Useful information.")])],
+  });
+});
+
+test("rehypeAdmonitions preserves two-paragraph title behavior", () => {
+  const body = createParagraph([createText("Useful information.")]);
+  const blockquote = createBlockquote([
+    createParagraph([createText("[!TIP] A tip for you")]),
+    body,
+  ]);
+  const tree: Root = {
+    type: "root",
+    children: [blockquote],
+  };
+
+  rehypeAdmonitions()(tree);
+
+  expect(blockquote).toEqual({
+    type: "element",
+    tagName: "admonition",
+    properties: { type: "tip", title: "A tip for you" },
+    children: [body],
+  });
+});
+
+test("rehypeAdmonitions preserves two-paragraph titleless behavior", () => {
+  const body = createParagraph([createText("Useful information.")]);
+  const blockquote = createBlockquote([
+    createParagraph([createText("[!NOTE]")]),
+    body,
+  ]);
+  const tree: Root = {
+    type: "root",
+    children: [blockquote],
+  };
+
+  rehypeAdmonitions()(tree);
+
+  expect(blockquote).toEqual({
+    type: "element",
+    tagName: "admonition",
+    properties: { type: "note" },
+    children: [body],
+  });
+});
+
+test("rehypeAdmonitions reads inline code titles from the first line", () => {
+  const blockquote = createBlockquote([
+    createParagraph([
+      createText("[!WARNING] Do not use "),
+      createInlineCode("foo"),
+      createText(" selectors\nUse a class instead."),
+    ]),
+  ]);
+  const tree: Root = {
+    type: "root",
+    children: [blockquote],
+  };
+
+  rehypeAdmonitions()(tree);
+
+  expect(blockquote).toEqual({
+    type: "element",
+    tagName: "admonition",
+    properties: { type: "warning", title: "Do not use foo selectors" },
+    children: [createParagraph([createText("Use a class instead.")])],
+  });
+});
+
+test("rehypeAdmonitions leaves non-admonition blockquotes untouched", () => {
+  const paragraph = createParagraph([
+    createText("Not an admonition\nStill body"),
+  ]);
+  const blockquote = createBlockquote([paragraph]);
+  const expected = structuredClone(blockquote);
+  const tree: Root = {
+    type: "root",
+    children: [blockquote],
+  };
+
+  rehypeAdmonitions()(tree);
+
+  expect(blockquote).toEqual(expected);
 });

--- a/app/src/lib/rehype.ts
+++ b/app/src/lib/rehype.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: UNLICENSED
  */
-import type { Element, Root, RootContent, Text } from "hast";
+import type { Element, ElementContent, Root, RootContent, Text } from "hast";
 import { toText } from "hast-util-to-text";
 import { visit } from "unist-util-visit";
 import { encodeBase64 } from "./base64.ts";
@@ -148,6 +148,60 @@ export function rehypePreviousCode() {
   };
 }
 
+function removeLeadingTextWhitespace(children: ElementContent[]) {
+  while (children.length) {
+    const child = children[0];
+    if (!child) break;
+    if (child.type !== "text") break;
+
+    const value = child.value.replace(/^\s+/, "");
+    if (value) {
+      children[0] = { ...child, value };
+      break;
+    }
+    children.shift();
+  }
+}
+
+function splitParagraphAtFirstLineBreak(paragraph: Element) {
+  const firstLine: ElementContent[] = [];
+  const rest = [...paragraph.children];
+
+  while (rest.length) {
+    const child = rest[0];
+    if (!child) break;
+
+    if (child.type === "element" && child.tagName === "br") {
+      rest.shift();
+      removeLeadingTextWhitespace(rest);
+      break;
+    }
+
+    if (child.type === "text") {
+      const newlineIndex = child.value.indexOf("\n");
+      if (newlineIndex !== -1) {
+        const value = child.value.slice(newlineIndex + 1);
+        firstLine.push({
+          type: "text",
+          value: child.value.slice(0, newlineIndex),
+        });
+        if (value) {
+          rest[0] = { ...child, value };
+        } else {
+          rest.shift();
+        }
+        removeLeadingTextWhitespace(rest);
+        break;
+      }
+    }
+
+    firstLine.push(child);
+    rest.shift();
+  }
+
+  return { firstLine, rest };
+}
+
 /**
  * This plugin transforms GitHub-style admonition blockquotes. It adds
  * `data-admonition`, `data-type`, and an optional `data-title` attribute to the
@@ -168,12 +222,21 @@ export function rehypeAdmonitions() {
 
       if (!firstParagraph) return;
 
-      const text = toText(firstParagraph).trim();
-      const match = text.match(/^\[!(\w+)\]\s*(.*)?$/);
+      const { firstLine, rest } =
+        splitParagraphAtFirstLineBreak(firstParagraph);
+      const firstLineParagraph: Element = {
+        type: "element",
+        tagName: "p",
+        properties: {},
+        children: firstLine,
+      };
+      const text = toText(firstLineParagraph).trim();
+      const match = text.match(/^\[!(\w+)\]\s*(.*)$/);
 
       if (!match) return;
 
       const type = match[1]?.toLowerCase();
+      if (!type) return;
       const title = match[2]?.trim();
 
       node.properties.type = type;
@@ -181,10 +244,13 @@ export function rehypeAdmonitions() {
         node.properties.title = title;
       }
 
-      // Remove the paragraph with the admonition type and title
-      const pIndex = children.indexOf(firstParagraph);
-      if (pIndex > -1) {
-        children.splice(pIndex, 1);
+      if (rest.length) {
+        firstParagraph.children = rest;
+      } else {
+        const pIndex = children.indexOf(firstParagraph);
+        if (pIndex > -1) {
+          children.splice(pIndex, 1);
+        }
       }
       node.tagName = "admonition";
     });


### PR DESCRIPTION
## Motivation

GitHub-style admonitions can be written as a single blockquote paragraph, with the marker on the first quoted line and the body on following quoted lines:

```md
> [!NOTE]
> Useful information.
```

`rehypeAdmonitions` flattened the whole first paragraph before matching the marker. That collapsed the body into the optional title capture, then removed the paragraph, so canonical single-paragraph admonitions rendered the body text as the header and lost the body content.

## Solution

Split the first paragraph at the first line break before matching the marker. The marker and optional title are read only from the first line, while any remaining paragraph children stay in the admonition body.

The existing two-paragraph title and titleless forms continue to remove the marker paragraph as before, and tests now cover soft breaks, hard breaks, inline-code titles, two-paragraph forms, and non-admonition blockquotes.

## Verification

- `pnpm lint-fix`
- `pnpm test app/src/lib/rehype.test.ts`
- `pnpm tsc`
