### PR TITLE
Encode reference code block HTML

### DIFF
--- a/app/src/components/reference-content.astro
+++ b/app/src/components/reference-content.astro
@@ -23,6 +23,7 @@ import {
 } from "#app/components/reference-label.react.tsx";
 import TableOfContents from "#app/components/table-of-contents.astro";
 import {
+  getReferenceCodeBlockHtml,
   getReferenceItemId,
   getReferenceItemKind,
   getReferenceSections,
@@ -31,7 +32,6 @@ import type { ReferenceSection } from "#app/lib/reference.ts";
 import type { Reference } from "#app/lib/schemas.ts";
 import { getReferencePath } from "#app/lib/url.ts";
 import type { CollectionEntry } from "astro:content";
-import { encode } from "html-entities";
 
 interface Props {
   reference: CollectionEntry<"references">;
@@ -49,7 +49,11 @@ interface ReferenceSectionContent extends ReferenceSection {
 function formatExamplesToHtml(examples: typeof data.examples = []) {
   return examples.map((example) => ({
     ...example,
-    codeHtml: `<code class="language-${example.language}"${example.meta ? ` metastring="${encode(example.meta)}"` : ""}>${encode(example.code)}</code>`,
+    codeHtml: getReferenceCodeBlockHtml({
+      code: example.code,
+      language: example.language,
+      meta: example.meta,
+    }),
   }));
 }
 
@@ -57,7 +61,10 @@ function getSectionsFromData(data: Reference) {
   const sections = getReferenceSections(data).map((section) => ({
     ...section,
     typeHtml: section.type
-      ? `<code class=\"language-typescript\">${section.type}</code>`
+      ? getReferenceCodeBlockHtml({
+          code: section.type,
+          language: "typescript",
+        })
       : undefined,
   }));
   return sections;

--- a/app/src/components/reference-item.astro
+++ b/app/src/components/reference-item.astro
@@ -8,12 +8,14 @@
  *
  * SPDX-License-Identifier: UNLICENSED
  */
-import type { ReferenceItem as ReferenceSectionItem } from "#app/lib/reference.ts";
+import {
+  getReferenceCodeBlockHtml,
+  type ReferenceItem as ReferenceSectionItem,
+} from "#app/lib/reference.ts";
 import { getReferencePath } from "#app/lib/url.ts";
 import type { ComponentProps } from "astro/types";
 import { getEntry } from "astro:content";
 import type { CollectionEntry } from "astro:content";
-import { encode } from "html-entities";
 import pluralize from "pluralize";
 import ContentAdmonition from "./content-admonition.astro";
 import ContentCodeBlock from "./content-code-block.astro";
@@ -48,7 +50,11 @@ const {
 const path = getReferencePath({ reference, item: id });
 
 function getCodeBlockCode(example: ReferenceSectionItem["examples"][number]) {
-  return `<code class="language-${example.language}"${example.meta ? ` metastring="${encode(example.meta)}"` : ""}>${example.code}</code>`;
+  return getReferenceCodeBlockHtml({
+    code: example.code,
+    language: example.language,
+    meta: example.meta,
+  });
 }
 
 const ex = await getEntry("examples", "checkbox-card");

--- a/app/src/lib/reference.test.ts
+++ b/app/src/lib/reference.test.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2025-present Ariakit FZ-LLC. All Rights Reserved.
+ *
+ * This software is proprietary. See the license.md file in the root of this
+ * package for licensing terms.
+ *
+ * SPDX-License-Identifier: UNLICENSED
+ */
+
+import { decode } from "html-entities";
+import { expect, test } from "vitest";
+import { getReferenceCodeBlockHtml } from "./reference.ts";
+
+function getCodeContent(html: string) {
+  const match = html.match(/^<code[^>]*>([\s\S]*?)<\/code>$/);
+  if (!match) {
+    throw new Error(`Invalid code block HTML: ${html}`);
+  }
+  return match[1] ?? "";
+}
+
+test("getReferenceCodeBlockHtml preserves entity-like code text", () => {
+  const code = [
+    'fetch("/api?page=1&copy=2")',
+    "<span>5 &times; 3</span>",
+    "a &amp;&amp; b",
+  ].join("\n");
+  const html = getReferenceCodeBlockHtml({ code, language: "jsx" });
+
+  expect(html).toContain('<code class="language-jsx">');
+  expect(decode(getCodeContent(html))).toBe(code);
+});

--- a/app/src/lib/reference.ts
+++ b/app/src/lib/reference.ts
@@ -9,6 +9,7 @@
  */
 
 import type { CollectionEntry } from "astro:content";
+import { encode } from "html-entities";
 import type { Reference, ReferenceProp } from "./schemas.ts";
 import { slugify } from "./string.ts";
 
@@ -49,6 +50,20 @@ export interface ReferenceSection {
 
 export interface ReferenceContent extends Reference {
   sections: ReferenceSection[];
+}
+
+interface GetReferenceCodeBlockHtmlParams {
+  code: string;
+  language: string;
+  meta?: string;
+}
+
+export function getReferenceCodeBlockHtml({
+  code,
+  language,
+  meta,
+}: GetReferenceCodeBlockHtmlParams) {
+  return `<code class="language-${language}"${meta ? ` metastring="${encode(meta)}"` : ""}>${encode(code)}</code>`;
 }
 
 export function getPropsParam(data: Reference) {


### PR DESCRIPTION
## Motivation

`ContentCodeBlock` parses `<code>` HTML and decodes the code text before syntax highlighting. Reference docs build some of that HTML from JSDoc example code and TypeScript return type text, so raw entity-like sequences can be rewritten when the block is parsed.

For example, code text like this should render exactly as written:

```ts
fetch("/api?page=1&copy=2");
```

Without encoding before interpolation, `&copy;` is decoded as an HTML entity instead of staying part of the code sample.

## Solution

Add a shared `getReferenceCodeBlockHtml` helper for reference code-block HTML. The helper encodes code text before it is passed to `ContentCodeBlock`, preserving the existing encode/decode contract and keeping all reference producers consistent.

This updates:

- top-level reference examples
- reference item examples
- return-value type snippets

It also adds a focused regression test that fails when the helper interpolates raw code text and passes when entity-like code text round-trips through `html-entities` decoding unchanged.

## Verification

- `pnpm lint-fix`
- `pnpm test app/src/lib/reference.test.ts`
- `pnpm tsc`
- `pnpm build-app-lite`
