### PR TITLE
Cache table of contents heading thresholds

### DIFF
--- a/app/src/components/table-of-contents.astro
+++ b/app/src/components/table-of-contents.astro
@@ -246,6 +246,25 @@ const allHeadings = title
       }
 
       let timeout: number;
+      let headingThresholds: number[] = [];
+
+      // Scroll margins can change with responsive header size and font loading,
+      // but they do not need to be recomputed on every scroll frame.
+      const updateHeadingThresholds = () => {
+        headingThresholds = headings.map((heading) => {
+          const style = window.getComputedStyle(heading);
+          const scrollMargin = Number.parseFloat(style.scrollMarginBlockStart);
+          return (Number.isNaN(scrollMargin) ? 0 : scrollMargin) + topOffset;
+        });
+      };
+
+      updateHeadingThresholds();
+
+      let resizeObserver: ResizeObserver | null = null;
+      if ("ResizeObserver" in window) {
+        resizeObserver = new ResizeObserver(updateHeadingThresholds);
+        resizeObserver.observe(document.body);
+      }
 
       /**
        * This function is called on scroll. It determines which heading is
@@ -273,11 +292,10 @@ const allHeadings = title
         // last one whose top edge is above the viewport's "fold" (adjusted for
         // the sticky header).
         let currentActiveHeading: HTMLElement | null = null;
-        for (const heading of headings) {
-          const style = window.getComputedStyle(heading);
-          const scrollMargin = parseFloat(style.scrollMarginBlockStart);
-          const threshold =
-            (isNaN(scrollMargin) ? 0 : scrollMargin) + topOffset;
+        for (let index = 0; index < headings.length; index += 1) {
+          const heading = headings[index];
+          if (!heading) continue;
+          const threshold = headingThresholds[index] ?? topOffset;
           if (heading.getBoundingClientRect().top < threshold + 2) {
             currentActiveHeading = heading;
           }
@@ -303,6 +321,7 @@ const allHeadings = title
 
       const cleanup = () => {
         observer?.disconnect();
+        resizeObserver?.disconnect();
         window.removeEventListener("scroll", throttledScroll);
         if (timeout) window.cancelAnimationFrame(timeout);
         tocElement.removeAttribute("data-table-of-contents-initialized");


### PR DESCRIPTION
## Motivation

The docs table-of-contents scroll handler resolves computed styles and parses each heading's scroll margin while choosing the active heading on every scroll frame. Long docs and component reference pages can have many headings, so this repeats main-thread work during scrolling even though those thresholds are stable within ordinary scroll frames.

## Solution

Cache each heading's scroll-margin threshold when the TOC is initialized and use the cached threshold in the scroll loop. Refresh the cache with a body `ResizeObserver` so thresholds are updated when responsive layout or font changes resize the body, and disconnect that observer in the existing Astro teardown cleanup.

The scroll loop still scans all headings to preserve the existing last-matching-heading semantics, using an indexed loop to avoid extra iterator work in the hot path.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- Manual Playwright check on `http://localhost:4321/react/components/disclosure/`: active TOC link changed while scrolling; heading `getComputedStyle` calls stayed flat during scroll (`6 -> 6 -> 6`, `headingStyleCallsDuringScroll: 0`).
