### PR TITLE
Fix docs theme toggle after navigation

### DIFF
--- a/app/src/pages/_layout.astro
+++ b/app/src/pages/_layout.astro
@@ -146,34 +146,46 @@ const { title, headerBorder = false } = Astro.props;
 </style>
 
 <script>
-  const themeToggle = document.getElementById("theme-toggle");
-  const themeSidebar = document.getElementById("theme-sidebar");
+  function getThemeSidebar() {
+    return document.getElementById("theme-sidebar");
+  }
 
-  const toggleSidebar = () => {
+  function toggleSidebar() {
+    const themeSidebar = getThemeSidebar();
     if (!themeSidebar) return;
     themeSidebar.dataset.state =
       themeSidebar.dataset.state !== "open" ? "open" : "closed";
-  };
+  }
 
-  themeToggle?.addEventListener("click", toggleSidebar);
+  function isEditableTarget(target: EventTarget | null) {
+    if (!(target instanceof HTMLElement)) return false;
+    if (target.closest("input, textarea, select")) return true;
+    return target.isContentEditable;
+  }
 
-  document.addEventListener("keydown", (e) => {
-    if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
-    if (e.key === "t" || e.key === "T") {
-      toggleSidebar();
+  document.addEventListener("astro:page-load", () => {
+    const themeToggle = document.getElementById("theme-toggle");
+    themeToggle?.addEventListener("click", toggleSidebar);
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (event.defaultPrevented) return;
+    if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
+      return;
     }
+    if (event.key !== "t" && event.key !== "T") return;
+    if (isEditableTarget(event.target)) return;
+    toggleSidebar();
   });
 
   // Mark the sidebar as transitioning during view transitions
   document.addEventListener("astro:before-preparation", () => {
-    if (!themeSidebar) return;
-    themeSidebar.setAttribute("data-view-transitioning", "true");
+    getThemeSidebar()?.setAttribute("data-view-transitioning", "true");
   });
 
   document.addEventListener("astro:after-swap", () => {
     requestAnimationFrame(() => {
-      if (!themeSidebar) return;
-      themeSidebar.removeAttribute("data-view-transitioning");
+      getThemeSidebar()?.removeAttribute("data-view-transitioning");
     });
   });
 </script>

--- a/app/src/tests/theme-browser.ts
+++ b/app/src/tests/theme-browser.ts
@@ -1,0 +1,42 @@
+import { test } from "#app/test-utils/fixtures.ts";
+import { gotoAndSettle } from "#app/test-utils/preview.ts";
+
+test("theme button works after client-side navigation", async ({ page }) => {
+  await gotoAndSettle(page, "/");
+
+  const themeSidebar = page.locator("#theme-sidebar");
+  const pageLoad = page.evaluate(() => {
+    return new Promise<void>((resolve) => {
+      document.addEventListener("astro:page-load", () => resolve(), {
+        once: true,
+      });
+    });
+  });
+
+  await test.expect(themeSidebar).toHaveAttribute("data-state", "closed");
+  await Promise.all([
+    page.waitForURL("**/plus/"),
+    pageLoad,
+    page.getByRole("link", { name: "Plus" }).click(),
+  ]);
+  await page.getByRole("button", { name: /Theme/ }).click();
+
+  await test.expect(themeSidebar).toHaveAttribute("data-state", "open");
+});
+
+test("theme shortcut ignores editable targets", async ({ page }) => {
+  await gotoAndSettle(page, "/react/examples/checkbox-card/");
+
+  const themeSidebar = page.locator("#theme-sidebar");
+  const nameField = page.getByRole("textbox", { name: "Name" });
+
+  await test.expect(themeSidebar).toHaveAttribute("data-state", "closed");
+  await nameField.click();
+  await page.keyboard.press("t");
+
+  await test.expect(nameField).toHaveValue("t");
+  await test.expect(themeSidebar).toHaveAttribute("data-state", "closed");
+  await nameField.evaluate((element) => element.blur());
+  await page.keyboard.press("t");
+  await test.expect(themeSidebar).toHaveAttribute("data-state", "open");
+});


### PR DESCRIPTION
## Motivation

The new docs app layout uses Astro's `ClientRouter`, so client-side navigation swaps the header DOM. The theme button listener was attached to the original `#theme-toggle` element once, leaving the replacement button inert after navigation.

The document-level `t`/`T` shortcut also fired while users typed in editable controls inside inline examples, such as the checkbox-card form.

## Solution

Look up `#theme-sidebar` lazily, bind the theme button on `astro:page-load` so each swapped header button receives the listener, and ignore the shortcut when the event target is an `input`, `textarea`, `select`, or editable element.

Added a focused app browser regression test that verifies the Theme button works after client-side navigation and that typing `t` in the inline checkbox-card form does not open the sidebar while the shortcut still works after focus leaves the field.

## Testing

- `pnpm lint-fix`
- `pnpm tsc`
- `APP_PORT=4321 NEXTJS_PORT=3000 pnpm -F app run test --project=chrome --project=firefox --project=safari src/tests/theme-browser.ts`
