### PR TITLE
Fix docs object prop tokenization

### DIFF
--- a/app/src/lib/reference-tokenizer.test.ts
+++ b/app/src/lib/reference-tokenizer.test.ts
@@ -128,7 +128,12 @@ function refs(): CollectionEntry<"references">[] {
     "react/disclosure/store",
     createRefData("store", "useDisclosureStore", "disclosure", {
       state: [createProp("mounted")],
-      params: [createProp("props", { optional: true })],
+      params: [
+        createProp("props", {
+          optional: true,
+          props: [createProp("open"), createProp("setOpen")],
+        }),
+      ],
       returnProps: [
         createProp("getState"),
         createProp("open"),
@@ -660,6 +665,308 @@ const combobox = useComboboxStore({ setMounted: () => {} });
         "kind": "prop",
         "line": 2,
         "text": "setMounted",
+      },
+    ]
+  `);
+});
+
+test("tokenizes store object props without value-position identifiers", () => {
+  const code = `
+import { useComboboxStore } from "@ariakit/react";
+const setMounted = (mounted) => mounted;
+const combobox = useComboboxStore({
+  setMounted: (mounted) => setMounted(mounted),
+});
+`;
+  const perLine = findCodeReferenceAnchors({
+    code,
+    references: refs(),
+    framework: "react",
+  });
+  const ts = tokensAt(code, perLine);
+  expect(ts).toMatchInlineSnapshot(`
+    [
+      {
+        "kind": "store",
+        "line": 1,
+        "text": "useComboboxStore",
+      },
+      {
+        "kind": "store",
+        "line": 3,
+        "text": "useComboboxStore",
+      },
+      {
+        "kind": "prop",
+        "line": 4,
+        "text": "setMounted",
+      },
+    ]
+  `);
+});
+
+test("tokenizes shorthand store object props", () => {
+  const code = `
+import { useDisclosureStore } from "@ariakit/react";
+const open = true;
+const disclosure = useDisclosureStore({ open });
+`;
+  const perLine = findCodeReferenceAnchors({
+    code,
+    references: refs(),
+    framework: "react",
+  });
+  const ts = tokensAt(code, perLine);
+  expect(ts).toMatchInlineSnapshot(`
+    [
+      {
+        "kind": "store",
+        "line": 1,
+        "text": "useDisclosureStore",
+      },
+      {
+        "kind": "store",
+        "line": 3,
+        "text": "useDisclosureStore",
+      },
+      {
+        "kind": "prop",
+        "line": 3,
+        "text": "open",
+      },
+    ]
+  `);
+});
+
+test("tokenizes store object props after comments", () => {
+  const code = `
+import { useDisclosureStore } from "@ariakit/react";
+const disclosure = useDisclosureStore({
+  // Controlled state setter
+  setOpen: (open) => setOpen(open),
+});
+`;
+  const perLine = findCodeReferenceAnchors({
+    code,
+    references: refs(),
+    framework: "react",
+  });
+  const ts = tokensAt(code, perLine);
+  expect(ts).toMatchInlineSnapshot(`
+    [
+      {
+        "kind": "store",
+        "line": 1,
+        "text": "useDisclosureStore",
+      },
+      {
+        "kind": "store",
+        "line": 2,
+        "text": "useDisclosureStore",
+      },
+      {
+        "kind": "prop",
+        "line": 4,
+        "text": "setOpen",
+      },
+    ]
+  `);
+});
+
+test("tokenizes store object props after comments with braces", () => {
+  const code = `
+import { useDisclosureStore } from "@ariakit/react";
+const disclosure = useDisclosureStore({
+  // } closes nothing here
+  setOpen: (open) => setOpen(open),
+});
+`;
+  const perLine = findCodeReferenceAnchors({
+    code,
+    references: refs(),
+    framework: "react",
+  });
+  const ts = tokensAt(code, perLine);
+  expect(ts).toMatchInlineSnapshot(`
+    [
+      {
+        "kind": "store",
+        "line": 1,
+        "text": "useDisclosureStore",
+      },
+      {
+        "kind": "store",
+        "line": 2,
+        "text": "useDisclosureStore",
+      },
+      {
+        "kind": "prop",
+        "line": 4,
+        "text": "setOpen",
+      },
+    ]
+  `);
+});
+
+test("tokenizes store object props after comments before object", () => {
+  const code = `
+import { useDisclosureStore } from "@ariakit/react";
+const disclosure = useDisclosureStore(
+  // { closes nothing here
+  // ) closes nothing here
+  { setOpen: (open) => setOpen(open) },
+);
+`;
+  const perLine = findCodeReferenceAnchors({
+    code,
+    references: refs(),
+    framework: "react",
+  });
+  const ts = tokensAt(code, perLine);
+  expect(ts).toMatchInlineSnapshot(`
+    [
+      {
+        "kind": "store",
+        "line": 1,
+        "text": "useDisclosureStore",
+      },
+      {
+        "kind": "store",
+        "line": 2,
+        "text": "useDisclosureStore",
+      },
+      {
+        "kind": "prop",
+        "line": 5,
+        "text": "setOpen",
+      },
+    ]
+  `);
+});
+
+test("tokenizes store object props before delimiter comments", () => {
+  const code = `
+import { useDisclosureStore } from "@ariakit/react";
+const disclosure = useDisclosureStore({
+  setOpen /* setter */: (open) => setOpen(open),
+  open /* current */,
+});
+`;
+  const perLine = findCodeReferenceAnchors({
+    code,
+    references: refs(),
+    framework: "react",
+  });
+  const ts = tokensAt(code, perLine);
+  expect(ts).toMatchInlineSnapshot(`
+    [
+      {
+        "kind": "store",
+        "line": 1,
+        "text": "useDisclosureStore",
+      },
+      {
+        "kind": "store",
+        "line": 2,
+        "text": "useDisclosureStore",
+      },
+      {
+        "kind": "prop",
+        "line": 3,
+        "text": "setOpen",
+      },
+      {
+        "kind": "prop",
+        "line": 4,
+        "text": "open",
+      },
+    ]
+  `);
+});
+
+test("tokenizes method shorthand store object props", () => {
+  const code = `
+import { useDisclosureStore } from "@ariakit/react";
+const disclosure = useDisclosureStore({
+  setOpen(open) {
+    return open;
+  },
+});
+`;
+  const perLine = findCodeReferenceAnchors({
+    code,
+    references: refs(),
+    framework: "react",
+  });
+  const ts = tokensAt(code, perLine);
+  expect(ts).toMatchInlineSnapshot(`
+    [
+      {
+        "kind": "store",
+        "line": 1,
+        "text": "useDisclosureStore",
+      },
+      {
+        "kind": "store",
+        "line": 2,
+        "text": "useDisclosureStore",
+      },
+      {
+        "kind": "prop",
+        "line": 3,
+        "text": "setOpen",
+      },
+    ]
+  `);
+});
+
+test("tokenizes prefixed method store object props", () => {
+  const code = `
+import { useDisclosureStore } from "@ariakit/react";
+const disclosure = useDisclosureStore({
+  async setOpen(open) {
+    return open;
+  },
+  get open() {
+    return true;
+  },
+  *setOpen(open) {
+    return open;
+  },
+});
+`;
+  const perLine = findCodeReferenceAnchors({
+    code,
+    references: refs(),
+    framework: "react",
+  });
+  const ts = tokensAt(code, perLine);
+  expect(ts).toMatchInlineSnapshot(`
+    [
+      {
+        "kind": "store",
+        "line": 1,
+        "text": "useDisclosureStore",
+      },
+      {
+        "kind": "store",
+        "line": 2,
+        "text": "useDisclosureStore",
+      },
+      {
+        "kind": "prop",
+        "line": 3,
+        "text": "setOpen",
+      },
+      {
+        "kind": "prop",
+        "line": 6,
+        "text": "open",
+      },
+      {
+        "kind": "prop",
+        "line": 9,
+        "text": "setOpen",
       },
     ]
   `);

--- a/app/src/lib/reference-tokenizer.ts
+++ b/app/src/lib/reference-tokenizer.ts
@@ -53,6 +53,9 @@ interface TokenRange {
 /** Matches a valid JavaScript identifier */
 const IDENTIFIER_PATTERN = "[A-Za-z_$][\\w$]*";
 
+/** Matches the first character of a valid JavaScript identifier */
+const IDENTIFIER_START_CHAR_PATTERN = /[A-Za-z_$]/;
+
 /** Matches an identifier starting with uppercase (component-like) */
 const COMPONENT_NAME_PATTERN = "[A-Z][\\w$]*";
 
@@ -99,6 +102,45 @@ function skipStringLiteral(code: string, startIndex: number): number {
 }
 
 /**
+ * Skips over a line or block comment starting at the given index.
+ */
+function skipComment(code: string, startIndex: number): number | null {
+  if (code[startIndex] === "/" && code[startIndex + 1] === "/") {
+    const newlineIndex = code.indexOf("\n", startIndex);
+    return newlineIndex === -1 ? code.length : newlineIndex + 1;
+  }
+
+  if (code[startIndex] === "/" && code[startIndex + 1] === "*") {
+    const closeIndex = code.indexOf("*/", startIndex + 2);
+    return closeIndex === -1 ? code.length : closeIndex + 2;
+  }
+
+  return null;
+}
+
+/**
+ * Skips whitespace and comments starting at the given index.
+ */
+function skipWhitespaceAndComments(code: string, startIndex: number): number {
+  let index = startIndex;
+
+  while (index < code.length) {
+    const char = code[index] ?? "";
+    if (/\s/.test(char)) {
+      index++;
+      continue;
+    }
+
+    const commentEnd = skipComment(code, index);
+    if (commentEnd == null) break;
+
+    index = commentEnd;
+  }
+
+  return index;
+}
+
+/**
  * Finds the index of a closing bracket/brace/paren, respecting nesting and
  * string literals.
  */
@@ -115,6 +157,11 @@ function findMatchingClose(
     const char = code[index] ?? "";
     if (isQuoteChar(char)) {
       index = skipStringLiteral(code, index);
+      continue;
+    }
+    const commentEnd = skipComment(code, index);
+    if (commentEnd != null) {
+      index = commentEnd;
       continue;
     }
     if (char === openChar) {
@@ -419,6 +466,12 @@ function findObjectLiteralAtFirstArg(
       continue;
     }
 
+    const commentEnd = skipComment(code, index);
+    if (commentEnd != null) {
+      index = commentEnd;
+      continue;
+    }
+
     if (char === "(") depth++;
     if (char === ")") {
       if (depth === 0) break;
@@ -450,6 +503,9 @@ function findTopLevelObjectKeys(
   const keys: TokenRange[] = [];
   const text = code.slice(objStart, objEnd);
   let depth = 0;
+  let parenDepth = 0;
+  let bracketDepth = 0;
+  let lastSignificant = "";
   let index = 0;
   let inString: false | QuoteChar = false;
 
@@ -468,28 +524,71 @@ function findTopLevelObjectKeys(
 
     if (isQuoteChar(char)) {
       inString = char;
+      lastSignificant = char;
       index++;
+      continue;
+    }
+
+    const commentEnd = skipComment(text, index);
+    if (commentEnd != null) {
+      index = commentEnd;
       continue;
     }
 
     if (char === "{") depth++;
     if (char === "}") depth--;
+    if (char === "(") parenDepth++;
+    if (char === ")") parenDepth--;
+    if (char === "[") bracketDepth++;
+    if (char === "]") bracketDepth--;
 
-    // At top level inside the object, look for identifier keys
-    if (depth === 1) {
+    const inKeyPosition =
+      depth === 1 &&
+      parenDepth === 0 &&
+      bracketDepth === 0 &&
+      (lastSignificant === "{" || lastSignificant === ",");
+
+    if (inKeyPosition && char === "*") {
+      index++;
+      continue;
+    }
+
+    if (inKeyPosition) {
       const idRegex = new RegExp(`(${IDENTIFIER_PATTERN})`, "y");
       idRegex.lastIndex = index;
       const match = idRegex.exec(text);
       if (match) {
         const name = match[1] ?? "";
-        const start = objStart + match.index;
-        const end = start + name.length;
-        keys.push({ start, end, name });
+        const afterIndex = skipWhitespaceAndComments(
+          text,
+          match.index + name.length,
+        );
+        const nextChar = text[afterIndex] ?? "";
+        const isKey =
+          nextChar === ":" ||
+          nextChar === "," ||
+          nextChar === "}" ||
+          nextChar === "(";
+        const isKeyPrefix =
+          (name === "async" || name === "get" || name === "set") &&
+          (IDENTIFIER_START_CHAR_PATTERN.test(nextChar) || nextChar === "*");
+
+        if (isKey) {
+          const start = objStart + match.index;
+          const end = start + name.length;
+          keys.push({ start, end, name });
+        }
+        if (!isKeyPrefix) {
+          lastSignificant = name.slice(-1);
+        }
         index = match.index + name.length;
         continue;
       }
     }
 
+    if (!/\s/.test(char)) {
+      lastSignificant = char;
+    }
     index++;
   }
 


### PR DESCRIPTION
## Motivation

The docs code-block reference tokenizer links first-argument object keys for Ariakit calls, but `findTopLevelObjectKeys` previously collected any identifier at object brace depth 1. In controlled-state snippets like this, value-position identifiers could be exposed as prop hovercard anchors instead of only the actual object key:

```ts
useComboboxStore({ setMounted: (mounted) => setMounted(mounted) });
```

## Solution

Make the lightweight scanners comment-aware and key-position-aware. The object scanner now skips comments while finding the object span, tracks paren and bracket depth, only considers identifiers after `{` or `,`, and validates the next significant character so it keeps real keys while ignoring callback parameters, callees, and arguments.

The tests cover callback values, shorthand props, comments before keys, comments containing braces or parens, comments before delimiters, method shorthand, and prefixed method keys. No changeset is included because this only affects internal docs tokenizer behavior.

## Testing

- `pnpm lint-fix`
- `pnpm test app/src/lib/reference-tokenizer.test.ts`
- `pnpm tsc`
