### PR TITLE
Fix changesets action Renovate hint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         run: gh auth setup-git
 
       - name: Create PR or publish to npm
-        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           title: Publish
           commit: Publish


### PR DESCRIPTION
## Motivation

Renovate reports a package lookup warning for `changesets/action` because the pinned GitHub Action digest is annotated with `# v1`, but upstream exposes `v1` as a branch rather than a tag. Renovate's pinned-action helper resolves that hint through `github-tags` and cannot find `refs/tags/v1`.

## Solution

Keep the exact pinned commit for `changesets/action` and update the version hint comment to `# v1.9.0`. The peeled `v1.9.0` release tag resolves to the same commit, so workflow runtime behavior stays unchanged while Renovate can resolve the tag-backed version hint.