### PR TITLE
Sync StackBlitz scaffold versions

### DIFF
--- a/app/src/lib/stackblitz.test.ts
+++ b/app/src/lib/stackblitz.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, expect, test, vi } from "vitest";
+import nextPkg from "../../../nextjs/package.json" with { type: "json" };
+import templatePkg from "../../../templates/react/package.json" with { type: "json" };
 import type {
   AppStackblitzFramework,
   AppStackblitzProps,
@@ -34,6 +36,21 @@ const stackblitzFrameworks: AppStackblitzFramework[] = [
   "react-nextjs",
   "solid-vite",
 ];
+
+interface GeneratedPackageJson {
+  dependencies: Record<string, string>;
+  devDependencies: Record<string, string>;
+}
+
+function getGeneratedPackageJson(
+  project: ReturnType<typeof getProject>["project"],
+) {
+  const pkgJson = project.files["package.json"];
+  if (typeof pkgJson !== "string") {
+    throw new Error("Expected package.json to be generated");
+  }
+  return JSON.parse(pkgJson) as GeneratedPackageJson;
+}
 
 test.each(stackblitzFrameworks)(
   "%s project uses bundler module resolution",
@@ -133,6 +150,19 @@ test("react-vite project includes tailwind v4 setup", () => {
   const props: AppStackblitzProps = {
     id: "accordion-basic",
     framework: "react-vite",
+    dependencies: {
+      react: "0.0.0",
+      "react-dom": "0.0.0",
+    },
+    devDependencies: {
+      vite: "0.0.0",
+      "@vitejs/plugin-react": "0.0.0",
+      "@tailwindcss/vite": "0.0.0",
+      "@types/react": "0.0.0",
+      "@types/react-dom": "0.0.0",
+      tailwindcss: "0.0.0",
+      typescript: "0.0.0",
+    },
     files: {
       "index.tsx":
         "export default function Example() { return <div>Example</div>; }\n",
@@ -147,7 +177,7 @@ test("react-vite project includes tailwind v4 setup", () => {
 
     @theme {
       --color-canvas: oklch(99.33% 0.0011 197.14);
-      --color-primary: oklch(56.7% 0.154556 248.5156);
+      --color-primary: oklch(56.7% 0.1546 248.5156);
       --color-secondary: oklch(65.59% 0.2118 354.31);
 
       --radius-container: var(--radius-xl);
@@ -204,35 +234,99 @@ test("react-vite project includes tailwind v4 setup", () => {
     }
     "
   `);
-  expect(project.files["package.json"]).toMatchInlineSnapshot(`
-    "{
-      "name": "@ariakit/accordion-basic",
-      "description": "accordion-basic",
-      "private": true,
-      "version": "0.0.0",
-      "type": "module",
-      "license": "MIT",
-      "repository": "https://github.com/ariakit/ariakit.git",
-      "scripts": {
-        "dev": "vite",
-        "build": "tsc && vite build",
-        "preview": "vite preview"
-      },
-      "dependencies": {
-        "react": "latest",
-        "react-dom": "latest",
-        "@ariakit/tailwind": "latest"
-      },
-      "devDependencies": {
-        "vite": "latest",
-        "@vitejs/plugin-react": "latest",
-        "@tailwindcss/vite": "^4.0.0",
-        "tailwindcss": "^4.0.0",
-        "typescript": "5.4.4"
-      }
-    }"
-  `);
+  const pkg = getGeneratedPackageJson(project);
+  expect(pkg.dependencies["@ariakit/tailwind"]).toBe("latest");
+  expect(pkg.dependencies.react).toBe(templatePkg.dependencies.react);
+  expect(pkg.dependencies["react-dom"]).toBe(
+    templatePkg.dependencies["react-dom"],
+  );
+  expect(pkg.devDependencies.vite).toBe(templatePkg.devDependencies.vite);
+  expect(pkg.devDependencies["@vitejs/plugin-react"]).toBe(
+    templatePkg.devDependencies["@vitejs/plugin-react"],
+  );
+  expect(pkg.devDependencies["@tailwindcss/vite"]).toBe(
+    templatePkg.devDependencies["@tailwindcss/vite"],
+  );
+  expect(pkg.devDependencies["@types/react"]).toBe(
+    templatePkg.devDependencies["@types/react"],
+  );
+  expect(pkg.devDependencies["@types/react-dom"]).toBe(
+    templatePkg.devDependencies["@types/react-dom"],
+  );
+  expect(pkg.devDependencies.tailwindcss).toBe(
+    templatePkg.devDependencies.tailwindcss,
+  );
+  expect(pkg.devDependencies.typescript).toBe(
+    templatePkg.devDependencies.typescript,
+  );
   expect(sourceFiles["accordion-basic/index.tsx"]).toBeDefined();
+});
+
+test("solid-vite project syncs shared template dev versions", () => {
+  const props: AppStackblitzProps = {
+    id: "separator-solid",
+    framework: "solid-vite",
+    devDependencies: {
+      "@tailwindcss/vite": "0.0.0",
+      tailwindcss: "0.0.0",
+      typescript: "0.0.0",
+    },
+    files: {
+      "index.tsx":
+        'export default function Example() { return <div class="ak-badge-primary">Solid</div>; }\n',
+    },
+  };
+
+  const { project } = getProject(props);
+  const pkg = getGeneratedPackageJson(project);
+
+  expect(pkg.dependencies["@ariakit/tailwind"]).toBe("latest");
+  expect(pkg.dependencies["solid-js"]).toBe("latest");
+  expect(pkg.devDependencies.vite).toBe("latest");
+  expect(pkg.devDependencies["vite-plugin-solid"]).toBe("latest");
+  expect(pkg.devDependencies["@tailwindcss/vite"]).toBe(
+    templatePkg.devDependencies["@tailwindcss/vite"],
+  );
+  expect(pkg.devDependencies.tailwindcss).toBe(
+    templatePkg.devDependencies.tailwindcss,
+  );
+  expect(pkg.devDependencies.typescript).toBe(
+    templatePkg.devDependencies.typescript,
+  );
+});
+
+test("react-nextjs project syncs shared template and Next dev versions", () => {
+  const props: AppStackblitzProps = {
+    id: "dialog-nextjs",
+    framework: "react-nextjs",
+    devDependencies: {
+      "@tailwindcss/postcss": "0.0.0",
+      tailwindcss: "0.0.0",
+      typescript: "0.0.0",
+    },
+    files: {
+      "index.tsx":
+        "export default function Example() { return <div>Example</div>; }\n",
+    },
+  };
+
+  const { project } = getProject(props);
+  const pkg = getGeneratedPackageJson(project);
+
+  expect(pkg.dependencies.next).toBe("latest");
+  expect(pkg.dependencies.react).toBe("latest");
+  expect(pkg.dependencies["react-dom"]).toBe("latest");
+  expect(pkg.dependencies["@ariakit/tailwind"]).toBe("latest");
+  expect(pkg.devDependencies["@types/node"]).toBe("latest");
+  expect(pkg.devDependencies["@tailwindcss/postcss"]).toBe(
+    nextPkg.devDependencies["@tailwindcss/postcss"],
+  );
+  expect(pkg.devDependencies.tailwindcss).toBe(
+    nextPkg.devDependencies.tailwindcss,
+  );
+  expect(pkg.devDependencies.typescript).toBe(
+    nextPkg.devDependencies.typescript,
+  );
 });
 
 test("react-nextjs project generates styles and query provider", () => {
@@ -312,7 +406,7 @@ test("solid-vite project emits generated utilities", () => {
 
     @theme {
       --color-canvas: oklch(99.33% 0.0011 197.14);
-      --color-primary: oklch(56.7% 0.154556 248.5156);
+      --color-primary: oklch(56.7% 0.1546 248.5156);
       --color-secondary: oklch(65.59% 0.2118 354.31);
 
       --radius-container: var(--radius-xl);

--- a/app/src/lib/stackblitz.ts
+++ b/app/src/lib/stackblitz.ts
@@ -1,6 +1,8 @@
 import { hasOwnProperty, invariant } from "@ariakit/utils";
 import type { Project, ProjectFiles } from "@stackblitz/sdk";
 import _sdk from "@stackblitz/sdk";
+import nextPkg from "../../../nextjs/package.json" with { type: "json" };
+import templatePkg from "../../../templates/react/package.json" with { type: "json" };
 import type { StyleDependency } from "./styles.ts";
 import {
   getStyleDefinition,
@@ -55,6 +57,33 @@ function normalizeDeps(deps: Record<string, string> = {}) {
     },
     {},
   );
+}
+
+const templateVersions: Record<string, string | undefined> = {
+  ...templatePkg.dependencies,
+  ...templatePkg.devDependencies,
+};
+
+const nextVersions: Record<string, string | undefined> = {
+  ...nextPkg.dependencies,
+  ...nextPkg.devDependencies,
+};
+
+function getVersion(
+  versions: Record<string, string | undefined>,
+  name: string,
+) {
+  const version = versions[name];
+  invariant(version, `Missing package version for ${name}`);
+  return version;
+}
+
+function getTemplateVersion(name: string) {
+  return getVersion(templateVersions, name);
+}
+
+function getNextVersion(name: string) {
+  return getVersion(nextVersions, name);
 }
 
 function normalizeProps(props: AppStackblitzProps): NormalizedProps {
@@ -128,7 +157,7 @@ function getBaseCss() {
 
 @theme {
   --color-canvas: oklch(99.33% 0.0011 197.14);
-  --color-primary: oklch(56.7% 0.154556 248.5156);
+  --color-primary: oklch(56.7% 0.1546 248.5156);
   --color-secondary: oklch(65.59% 0.2118 354.31);
 
   --radius-container: var(--radius-xl);
@@ -239,12 +268,12 @@ function getPackageJson({
   templateDevDependencies,
 }: GetPackageJsonParams) {
   const dependencies = {
-    ...normalizeDeps(templateDependencies),
     ...props.dependencies,
+    ...normalizeDeps(templateDependencies),
   };
   const devDependencies = {
-    ...normalizeDeps(templateDevDependencies),
     ...props.devDependencies,
+    ...normalizeDeps(templateDevDependencies),
   };
   return JSON.stringify(
     {
@@ -297,16 +326,18 @@ function getViteProject(props: NormalizedProps): ProjectResult {
       preview: "vite preview",
     },
     templateDependencies: {
-      react: "latest",
-      "react-dom": "latest",
+      react: getTemplateVersion("react"),
+      "react-dom": getTemplateVersion("react-dom"),
       "@ariakit/tailwind": "latest",
     },
     templateDevDependencies: {
-      vite: "latest",
-      "@vitejs/plugin-react": "latest",
-      "@tailwindcss/vite": "^4.0.0",
-      tailwindcss: "^4.0.0",
-      typescript: "5.4.4",
+      vite: getTemplateVersion("vite"),
+      "@vitejs/plugin-react": getTemplateVersion("@vitejs/plugin-react"),
+      "@tailwindcss/vite": getTemplateVersion("@tailwindcss/vite"),
+      "@types/react": getTemplateVersion("@types/react"),
+      "@types/react-dom": getTemplateVersion("@types/react-dom"),
+      tailwindcss: getTemplateVersion("tailwindcss"),
+      typescript: getTemplateVersion("typescript"),
     },
   });
 
@@ -387,9 +418,9 @@ function getSolidProject(props: NormalizedProps): ProjectResult {
     templateDevDependencies: {
       vite: "latest",
       "vite-plugin-solid": "latest",
-      "@tailwindcss/vite": "^4.0.0",
-      tailwindcss: "^4.0.0",
-      typescript: "5.4.4",
+      "@tailwindcss/vite": getTemplateVersion("@tailwindcss/vite"),
+      tailwindcss: getTemplateVersion("tailwindcss"),
+      typescript: getTemplateVersion("typescript"),
     },
   });
 
@@ -460,9 +491,9 @@ function getNextProject(props: NormalizedProps): ProjectResult {
     },
     templateDevDependencies: {
       "@types/node": "latest",
-      "@tailwindcss/postcss": "^4.0.0",
-      tailwindcss: "^4.0.0",
-      typescript: "5.4.4",
+      "@tailwindcss/postcss": getNextVersion("@tailwindcss/postcss"),
+      tailwindcss: getNextVersion("tailwindcss"),
+      typescript: getNextVersion("typescript"),
     },
   });
 

--- a/templates/react/vite.config.ts
+++ b/templates/react/vite.config.ts
@@ -2,6 +2,9 @@ import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
+// The StackBlitz generators import this template's package.json and reuse its
+// shared version pins. Keep dependency renames/removals in sync with
+// app/src/lib/stackblitz.ts.
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [tailwindcss(), react()],


### PR DESCRIPTION
## Motivation

Docs examples generate StackBlitz projects from package maps embedded in `app/src/lib/stackblitz.ts`. Those maps can drift from the maintained scaffolds that Renovate updates, so generated React Vite, Solid Vite, and React Next.js projects could keep stale Tailwind and TypeScript pins even when `templates/react` and `nextjs` had already moved forward.

The real docs path also passes source-collected dependencies into the generator. Without an explicit override, those source versions can win over the curated scaffold pins and keep the generated project on the older dependency set.

## Solution

The StackBlitz generator now imports `templates/react/package.json` and `nextjs/package.json` and reuses their maintained version pins for the packages each generated project should track.

React Vite projects use `templates/react` for React, Vite, Tailwind, TypeScript, and React type packages. Solid Vite projects keep Solid-specific packages floating on `latest`, but share Tailwind and TypeScript pins from `templates/react` because there is no maintained Solid template scaffold. React Next.js projects keep runtime framework packages on `latest`, but use `nextjs/package.json` for Next-specific dev tooling such as `@tailwindcss/postcss`, `tailwindcss`, and `typescript`.

Generated package merging now lets those curated scaffold pins override stale source-collected versions while preserving extra example-only dependencies. The StackBlitz tests parse generated `package.json` files and compare against the source scaffold metadata, including stale `0.0.0` inputs to prove the override behavior. The shared primary color literal is also aligned with `templates/react`, and the React template Vite config notes the StackBlitz coupling.

## Verification

- `pnpm lint-fix`
- `pnpm test app/src/lib/stackblitz.test.ts`
- `pnpm tsc`
- `pnpm build-app-lite`
