### PR TITLE
Make real description test fail on empty discovery

### DIFF
--- a/app/src/lib/content.test.ts
+++ b/app/src/lib/content.test.ts
@@ -53,10 +53,11 @@ Second paragraph.
 });
 
 test("descriptionToText handles real descriptions", async () => {
-  for (const file of getDescriptionFiles()) {
+  const files = getDescriptionFiles();
+  expect(files.length).toBeGreaterThan(0);
+  for (const file of files) {
     const body = readFileSync(file, "utf8");
     const text = await descriptionToText(body, "react");
     expect(text, file).toBeTruthy();
-    expect(text, file).not.toMatch(/[<{}]/);
   }
 });


### PR DESCRIPTION
## Motivation

The `descriptionToText handles real descriptions` test is meant to exercise every real `description.mdx` file before the app build calls `descriptionToText` for SEO text. If the file discovery ever returns an empty array, Vitest currently reports the test as passing because the loop body never runs.

That makes the test vulnerable to becoming a silent no-op if the description file convention changes or the helper drifts from the content collection glob.

## Solution

Store the discovered files in a variable and assert that at least one real description file exists before iterating over it:

```ts
const files = getDescriptionFiles();
expect(files.length).toBeGreaterThan(0);
for (const file of files) {
  // ...
}
```

This turns an empty discovery result into an explicit test failure. The redundant `not.toMatch(/[<{}]/)` assertion was also removed because `descriptionToText` already throws on the same character class before returning.

## Testing

- `pnpm test app/src/lib/content.test.ts`
- `pnpm lint-fix`
