### PR TITLE
Remove unused framework helpers

### DIFF
--- a/app/src/lib/frameworks.ts
+++ b/app/src/lib/frameworks.ts
@@ -114,17 +114,3 @@ export function removeFrameworkSuffix(path: string) {
     .replace(/\.react\.([tj]sx?)$/, ".$1")
     .replace(/\.solid\.([tj]sx?)$/, ".$1");
 }
-
-export function getIndexFile(framework: keyof typeof frameworks) {
-  const frameworkDetail = getFramework(framework);
-  if (!("indexFile" in frameworkDetail)) return null;
-  return frameworkDetail.indexFile;
-}
-
-export function isFrameworkDependency(
-  pkg: string,
-): pkg is keyof typeof frameworks {
-  return Object.values(frameworks).some((framework) =>
-    framework.dependencies.includes(pkg as never),
-  );
-}


### PR DESCRIPTION
## Motivation

`app/src/lib/frameworks.ts` exports two helpers that have no callers. One of them, `isFrameworkDependency`, checks dependency package names while narrowing the value to framework keys, so a value such as `react-dom` could pass the runtime check even though it is not a valid key for `frameworks`.

```ts
isFrameworkDependency("react-dom"); // true, but not a framework key
```

Keeping the unused export leaves a misleading type predicate available for future internal use.

## Solution

Remove `isFrameworkDependency` and the adjacent unused `getIndexFile` helper. The `app` package is private and only exports example library files, so `src/lib/frameworks.ts` is not part of an external API surface.