### PR TITLE
Remove iframe focus listener on cleanup

### DIFF
--- a/app/src/components/code-block.react.tsx
+++ b/app/src/components/code-block.react.tsx
@@ -468,6 +468,10 @@ export function CodeBlockPreviewIframe({
       cancelAnimationFrame(raf);
       cancelAnimationFrame(scrollRaf);
       iframe.removeEventListener("load", onLoad);
+      iframe.contentDocument?.body?.removeEventListener(
+        "focusin",
+        setDataFocus,
+      );
       iframe.contentWindow?.removeEventListener("focus", setDataFocus);
       iframe.contentWindow?.removeEventListener("blur", setDataFocus);
       iframe.contentWindow?.removeEventListener(


### PR DESCRIPTION
## Motivation

`CodeBlockPreviewIframe` adds a `focusin` listener to the preview iframe body when the iframe loads, but its effect cleanup only removed the iframe `load` listener and the window-level listeners. If the effect re-runs while the same iframe document is already loaded, the old body listener can stay attached and a new `setDataFocus` closure can be registered.

## Solution

Remove the iframe body `focusin` listener during the effect cleanup, using `iframe.contentDocument?.body` to target the same document body while safely handling teardown states where the document or body is unavailable.

No changeset is needed because this only affects the private docs app component.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
