### PR TITLE
Remove unused React utility hooks

### DIFF
--- a/.changeset/100-remove-unused-react-utils-hooks.md
+++ b/.changeset/100-remove-unused-react-utils-hooks.md
@@ -1,0 +1,32 @@
+---
+"@ariakit/react-utils": minor
+---
+
+Removed unused React utility hooks
+
+**BREAKING** if you import `useLazyValue` or `usePreviousValue` from `@ariakit/react-utils`.
+
+These hooks were not used by Ariakit packages and have been removed. Replace `useLazyValue` with `useInitialValue`, which accepts a lazy initializer. Inline the previous-value state pattern if you still need `usePreviousValue`.
+
+Before:
+
+```ts
+import { useLazyValue, usePreviousValue } from "@ariakit/react-utils";
+
+const set = useLazyValue(() => new Set());
+const previous = usePreviousValue(value);
+```
+
+After:
+
+```ts
+import { useInitialValue } from "@ariakit/react-utils";
+import { useState } from "react";
+
+const set = useInitialValue(() => new Set());
+
+const [previous, setPrevious] = useState(value);
+if (value !== previous) {
+  setPrevious(value);
+}
+```

--- a/packages/ariakit-react-utils/readme.md
+++ b/packages/ariakit-react-utils/readme.md
@@ -33,9 +33,7 @@ This package is ESM-only and exposes a single public entrypoint.
 - [Hooks](#hooks)
   - [`useSafeLayoutEffect`](#usesafelayouteffect)
   - [`useInitialValue`](#useinitialvalue)
-  - [`useLazyValue`](#uselazyvalue)
   - [`useLiveRef`](#useliveref)
-  - [`usePreviousValue`](#usepreviousvalue)
   - [`useEvent`](#useevent)
   - [`useTransactionState`](#usetransactionstate)
   - [`useMergeRefs`](#usemergerefs)
@@ -106,26 +104,6 @@ function Component({ prop }) {
   <a href="#api-reference">&uarr; back to top</a>
 </div>
 
-#### `useLazyValue`
-
-```ts
-function useLazyValue<T>(init: () => T): T;
-```
-
-Returns a value that is lazily initiated and never changes.
-
-Example:
-
-```ts
-function Component() {
-  const set = useLazyValue(() => new Set());
-}
-```
-
-<div align="right">
-  <a href="#api-reference">&uarr; back to top</a>
-</div>
-
 #### `useLiveRef`
 
 ```ts
@@ -141,18 +119,6 @@ function Component({ prop }) {
   const propRef = useLiveRef(prop);
 }
 ```
-
-<div align="right">
-  <a href="#api-reference">&uarr; back to top</a>
-</div>
-
-#### `usePreviousValue`
-
-```ts
-function usePreviousValue<T>(value: T): T;
-```
-
-Keeps the reference of the previous value to be used in the render phase.
 
 <div align="right">
   <a href="#api-reference">&uarr; back to top</a>

--- a/packages/ariakit-react-utils/src/hooks.ts
+++ b/packages/ariakit-react-utils/src/hooks.ts
@@ -58,21 +58,6 @@ export function useInitialValue<T>(value: T | (() => T)) {
 }
 
 /**
- * Returns a value that is lazily initiated and never changes.
- * @example
- * function Component() {
- *   const set = useLazyValue(() => new Set());
- * }
- */
-export function useLazyValue<T>(init: () => T) {
-  const ref = useRef<T>(undefined);
-  if (ref.current === undefined) {
-    ref.current = init();
-  }
-  return ref.current;
-}
-
-/**
  * Creates a `React.RefObject` that is constantly updated with the incoming
  * value.
  * @example
@@ -86,17 +71,6 @@ export function useLiveRef<T>(value: T) {
     ref.current = value;
   });
   return ref;
-}
-
-/**
- * Keeps the reference of the previous value to be used in the render phase.
- */
-export function usePreviousValue<T>(value: T) {
-  const [previousValue, setPreviousValue] = useState(value);
-  if (value !== previousValue) {
-    setPreviousValue(value);
-  }
-  return previousValue;
 }
 
 /**


### PR DESCRIPTION
## Motivation

`@ariakit/react-utils` exports `useLazyValue` and `usePreviousValue`, but they had no call sites in the repository. Since the package API reference is generated from exported APIs, these dead hooks looked like maintained utilities and widened the internal package surface.

Before this change, direct package consumers could import hooks that Ariakit itself no longer used:

```ts
import { useLazyValue, usePreviousValue } from "@ariakit/react-utils";
```

## Solution

Remove both hook implementations from `packages/ariakit-react-utils/src/hooks.ts`, regenerate `packages/ariakit-react-utils/readme.md`, and add a breaking changeset for `@ariakit/react-utils` with migration notes.

Consumers importing `useLazyValue` can use `useInitialValue` with the same lazy initializer shape:

```ts
import { useInitialValue } from "@ariakit/react-utils";

const set = useInitialValue(() => new Set());
```

`usePreviousValue` did not have an Ariakit call site; the changeset documents the equivalent inline state pattern for any direct `@ariakit/react-utils` importer.

## Testing

- `pnpm -F @ariakit/react-utils run docs`
- `pnpm lint-fix`
- `pnpm test-react packages/ariakit-react-utils/src/misc.test.ts`
- `pnpm tsc`
- `pnpm build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the `useLazyValue` and `usePreviousValue` hooks from the React utilities package.
  * Existing apps using these hooks will need to switch to alternative patterns before upgrading.

* **Documentation**
  * Updated the React utilities docs to remove references, examples, and API entries for the removed hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->