### PR TITLE
Add at-property type to style definitions

### DIFF
--- a/app/src/lib/build-styles.test.ts
+++ b/app/src/lib/build-styles.test.ts
@@ -68,24 +68,28 @@ test("resolveDependencies ignores tokens in inline comments", () => {
     atProperties: {
       "--ak-real-prop": {
         name: "--ak-real-prop",
+        type: "at-property",
         syntax: null,
         inherits: null,
         initialValue: null,
       },
       "--ak-comment-prop": {
         name: "--ak-comment-prop",
+        type: "at-property",
         syntax: null,
         inherits: null,
         initialValue: null,
       },
       "--ak-string-prop": {
         name: "--ak-string-prop",
+        type: "at-property",
         syntax: null,
         inherits: null,
         initialValue: null,
       },
       "--ak-joined-prop": {
         name: "--ak-joined-prop",
+        type: "at-property",
         syntax: null,
         inherits: null,
         initialValue: null,

--- a/app/src/lib/build-styles.ts
+++ b/app/src/lib/build-styles.ts
@@ -415,7 +415,7 @@ export function parsePropertyDecls(body: string): PropertyDecl[] {
  */
 export function parseAtPropertyBody(body: string) {
   const { declarations } = splitBody(body);
-  const def: Omit<AtPropertyDef, "name"> = {
+  const def: Omit<AtPropertyDef, "name" | "type"> = {
     syntax: null,
     inherits: null,
     initialValue: null,
@@ -450,7 +450,11 @@ async function parseStyleModule(modulePath: string): Promise<ModuleJson> {
   for (const block of blocks) {
     if (block.kind === "property") {
       const parsed = parseAtPropertyBody(block.body);
-      atProperties[block.name] = { name: block.name, ...parsed };
+      atProperties[block.name] = {
+        name: block.name,
+        type: "at-property",
+        ...parsed,
+      };
       continue;
     }
     if (block.kind === "utility") {

--- a/app/src/lib/stackblitz.ts
+++ b/app/src/lib/stackblitz.ts
@@ -223,8 +223,7 @@ function getStylesCss(styles?: StyleDependency[]) {
 
   const pushDef = (def: ReturnType<typeof getStyleDefinition>) => {
     if (!def) return;
-    const key =
-      "type" in def ? `${def.type}:${def.name}` : `at-property:${def.name}`;
+    const key = `${def.type}:${def.name}`;
     if (seen.has(key)) return;
     seen.add(key);
     chunks.push(styleDefToCss(def));

--- a/app/src/lib/styles-json-types.ts
+++ b/app/src/lib/styles-json-types.ts
@@ -26,6 +26,7 @@ export interface PropertyDecl {
 
 export interface AtPropertyDef {
   name: string;
+  type: "at-property";
   syntax: string | null;
   inherits: string | null;
   initialValue: string | null;

--- a/app/src/lib/styles.test.ts
+++ b/app/src/lib/styles.test.ts
@@ -68,7 +68,7 @@ test("scanAkTokensInFiles preserves colons inside arbitrary values", () => {
 
 test("styleDefToCss renders @property block", () => {
   const def = getStyleDefinition("--ak-tab-border-width", "at-property");
-  expect(def).toBeTruthy();
+  expect(def?.type).toBe("at-property");
   const css = styleDefToCss(def!);
   expect(css).toMatchInlineSnapshot(`
     "@property --ak-tab-border-width {
@@ -195,6 +195,7 @@ test("getStyleDefinition returns exact definitions and wildcard fallback within 
     "--ak-tab-border-width",
     "at-property",
   );
+  expect(atPropExact?.type).toBe("at-property");
   expect(atPropExact?.name).toBe("--ak-tab-border-width");
   const atPropWildcard = getStyleDefinition(
     "--ak-tab-border-width-extra",
@@ -248,6 +249,27 @@ test("getTransitiveDependencies returns BFS dependencies, excluding root and ded
   expect(deps.some((d) => d.name === root.name && d.type === root.type)).toBe(
     false,
   );
+});
+
+test("getTransitiveDependencies includes at-properties without expanding them", () => {
+  const root = {
+    type: "utility" as const,
+    name: "ak-command_active",
+    module: "command",
+  };
+
+  expect(getTransitiveDependencies(root)).toEqual([
+    {
+      type: "at-property",
+      name: "--ak-command-depth-x",
+      module: "command",
+    },
+    {
+      type: "at-property",
+      name: "--ak-command-depth-y",
+      module: "command",
+    },
+  ]);
 });
 
 test("resolveStyles aggregates base + transitive, deduped by identity", () => {

--- a/app/src/lib/styles.ts
+++ b/app/src/lib/styles.ts
@@ -245,7 +245,7 @@ export function getTransitiveDependencies(
   };
 
   const enqueueDeps = (def: StyleDef) => {
-    if (!("type" in def)) return;
+    if (def.type === "at-property") return;
     for (const dep of def.dependencies) {
       const didAdd = markDep(dep);
       if (!didAdd) continue;
@@ -381,37 +381,39 @@ function renderPropertyDecls(decls: PropertyDecl[], indentLevel = 0): string {
  * - @custom-variant for variants
  */
 export function styleDefToCss(def: StyleDef): string {
-  if ("type" in def) {
-    if (def.type === "utility") {
+  switch (def.type) {
+    case "at-property": {
+      const lines: string[] = [];
+      if (def.syntax != null) {
+        lines.push(`  syntax: ${def.syntax};`);
+      }
+      if (def.inherits != null) {
+        lines.push(`  inherits: ${def.inherits};`);
+      }
+      if (def.initialValue != null) {
+        lines.push(`  initial-value: ${def.initialValue};`);
+      }
+      const inner = lines.join("\n");
+      if (!inner) {
+        return `@property ${def.name} {}`;
+      }
+      return `@property ${def.name} {\n${inner}\n}`;
+    }
+    case "utility": {
       const body = renderPropertyDecls(def.properties, 1);
       if (!body) {
         return `@utility ${def.name} {}`;
       }
       return `@utility ${def.name} {\n${body}\n}`;
     }
-    // variant
-    const body = renderPropertyDecls(def.properties, 1);
-    if (!body) {
-      return `@custom-variant ${def.name} {}`;
+    case "variant": {
+      const body = renderPropertyDecls(def.properties, 1);
+      if (!body) {
+        return `@custom-variant ${def.name} {}`;
+      }
+      return `@custom-variant ${def.name} {\n${body}\n}`;
     }
-    return `@custom-variant ${def.name} {\n${body}\n}`;
   }
-  // @property
-  const lines: string[] = [];
-  if (def.syntax != null) {
-    lines.push(`  syntax: ${def.syntax};`);
-  }
-  if (def.inherits != null) {
-    lines.push(`  inherits: ${def.inherits};`);
-  }
-  if (def.initialValue != null) {
-    lines.push(`  initial-value: ${def.initialValue};`);
-  }
-  const inner = lines.join("\n");
-  if (!inner) {
-    return `@property ${def.name} {}`;
-  }
-  return `@property ${def.name} {\n${inner}\n}`;
 }
 
 export function styleDefsToCss(defs: StyleDef[]): string {

--- a/app/src/styles/styles.json
+++ b/app/src/styles/styles.json
@@ -340,12 +340,14 @@
       "atProperties": {
         "--ak-command-depth-x": {
           "name": "--ak-command-depth-x",
+          "type": "at-property",
           "syntax": "\"<number>\"",
           "inherits": "false",
           "initialValue": "0"
         },
         "--ak-command-depth-y": {
           "name": "--ak-command-depth-y",
+          "type": "at-property",
           "syntax": "\"<number>\"",
           "inherits": "false",
           "initialValue": "0"
@@ -2383,6 +2385,7 @@
       "atProperties": {
         "--ak-tab-border-width": {
           "name": "--ak-tab-border-width",
+          "type": "at-property",
           "syntax": "\"<length>\"",
           "inherits": "true",
           "initialValue": "0px"
@@ -6582,6 +6585,7 @@
       "atProperties": {
         "--ak-progress-value": {
           "name": "--ak-progress-value",
+          "type": "at-property",
           "syntax": "\"<number>\"",
           "inherits": "true",
           "initialValue": "0"


### PR DESCRIPTION
## Motivation

`StyleDef` was only partially discriminated because `AtPropertyDef` lacked the `type` field already present on utility and variant definitions. Consumers had to infer at-properties through field absence, for example:

```ts
if (!("type" in def)) return;
```

That made the style metadata harder to read and required StackBlitz CSS generation to reconstruct the missing `at-property` key by hand.

## Solution

Add `type: "at-property"` to `AtPropertyDef`, emit it from the style metadata generator, and regenerate `app/src/styles/styles.json` so the checked-in artifact matches the schema.

Consumers now branch on the discriminant directly:

```ts
if (def.type === "at-property") return;
```

`styleDefToCss` switches on `def.type`, and the StackBlitz dedupe key can use `${def.type}:${def.name}` for every style definition. Tests now assert the at-property discriminant and cover transitive dependencies that include at-properties without expanding them.

## Verification

- `pnpm -F app run build-styles --check`
- `pnpm test app/src/lib/styles.test.ts app/src/lib/build-styles.test.ts`
- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm test`
- `pnpm lint`
