### PR TITLE
Type preview source kinds

### DIFF
--- a/app/src/content.config.ts
+++ b/app/src/content.config.ts
@@ -14,7 +14,7 @@ import { z } from "astro/zod";
 import { defineCollection, reference } from "astro:content";
 import { jsdoc } from "./lib/jsdoc-loader.ts";
 import { componentLoader, exampleLoader } from "./lib/mdx-loader.ts";
-import { previewConfig } from "./lib/preview-config.ts";
+import { PreviewKindSchema, previewConfig } from "./lib/preview-config.ts";
 import { previewLoader } from "./lib/preview-discovery.ts";
 import { TagSchema } from "./lib/schemas.ts";
 
@@ -85,7 +85,7 @@ const galleries = defineCollection({
 
 const previews = defineCollection({
   loader: previewLoader(previewConfig),
-  schema: previewLoader.schema,
+  schema: previewLoader.schema.extend({ source: PreviewKindSchema }),
 });
 
 const references = defineCollection({

--- a/app/src/lib/preview-config.ts
+++ b/app/src/lib/preview-config.ts
@@ -7,19 +7,43 @@
  *
  * SPDX-License-Identifier: UNLICENSED
  */
-import type { PreviewDiscoveryOptions } from "./preview-discovery.ts";
+import { z } from "astro/zod";
+import type {
+  PreviewDiscoveryOptions,
+  PreviewRootOptions,
+} from "./preview-discovery.ts";
+
+export const EXAMPLES_PREVIEW_KIND = "examples";
+export const SANDBOX_PREVIEW_KIND = "sandbox";
+
+export const PREVIEW_KINDS = [
+  EXAMPLES_PREVIEW_KIND,
+  SANDBOX_PREVIEW_KIND,
+] as const;
+
+export const PreviewKindSchema = z.enum(PREVIEW_KINDS);
+
+export type PreviewKind = z.infer<typeof PreviewKindSchema>;
+
+interface PreviewConfigRoot extends PreviewRootOptions {
+  kind: PreviewKind;
+}
+
+interface PreviewConfig extends PreviewDiscoveryOptions {
+  roots: PreviewConfigRoot[];
+}
 
 export const previewConfig = {
   roots: [
     {
-      kind: "examples",
+      kind: EXAMPLES_PREVIEW_KIND,
       dir: "examples",
       metadataRequired: true,
     },
     {
-      kind: "sandbox",
+      kind: SANDBOX_PREVIEW_KIND,
       dir: "sandbox",
       metadataRequired: false,
     },
   ],
-} satisfies PreviewDiscoveryOptions;
+} satisfies PreviewConfig;

--- a/app/src/lib/preview-index.test.ts
+++ b/app/src/lib/preview-index.test.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2025-present Ariakit FZ-LLC. All Rights Reserved.
+ *
+ * This software is proprietary. See the license.md file in the root of this
+ * package for licensing terms.
+ *
+ * SPDX-License-Identifier: UNLICENSED
+ */
+import { expect, test } from "vitest";
+import {
+  EXAMPLES_PREVIEW_KIND,
+  SANDBOX_PREVIEW_KIND,
+} from "./preview-config.ts";
+import { getPreviewIndexPaths } from "./preview-index.ts";
+
+test("excludes sandbox previews from the preview index", () => {
+  const paths = getPreviewIndexPaths([
+    {
+      id: "menu",
+      data: {
+        frameworks: ["react", "solid"],
+        source: EXAMPLES_PREVIEW_KIND,
+      },
+    },
+    {
+      id: "dialog-1234",
+      data: {
+        frameworks: ["react"],
+        source: SANDBOX_PREVIEW_KIND,
+      },
+    },
+  ]);
+
+  expect(paths).toEqual(["/react/previews/menu", "/solid/previews/menu"]);
+});

--- a/app/src/lib/preview-index.ts
+++ b/app/src/lib/preview-index.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2025-present Ariakit FZ-LLC. All Rights Reserved.
+ *
+ * This software is proprietary. See the license.md file in the root of this
+ * package for licensing terms.
+ *
+ * SPDX-License-Identifier: UNLICENSED
+ */
+import type { PreviewKind } from "./preview-config.ts";
+import { SANDBOX_PREVIEW_KIND } from "./preview-config.ts";
+import type { Framework } from "./schemas.ts";
+
+interface PreviewIndexEntry {
+  id: string;
+  data: {
+    frameworks: Framework[];
+    source: PreviewKind;
+  };
+}
+
+export function getPreviewIndexPaths(entries: PreviewIndexEntry[]) {
+  return entries
+    .filter((entry) => entry.data.source !== SANDBOX_PREVIEW_KIND)
+    .flatMap((entry) =>
+      entry.data.frameworks.map(
+        (framework) => `/${framework}/previews/${entry.id}`,
+      ),
+    );
+}

--- a/app/src/pages/previews.ts
+++ b/app/src/pages/previews.ts
@@ -1,14 +1,9 @@
 import type { APIRoute } from "astro";
 import { getCollection } from "astro:content";
+import { getPreviewIndexPaths } from "../lib/preview-index.ts";
 
 export const GET: APIRoute = async () => {
   const entries = await getCollection("previews");
-  const paths = entries
-    .filter((entry) => entry.data.source !== "sandbox")
-    .flatMap((entry) =>
-      entry.data.frameworks.map(
-        (framework) => `/${framework}/previews/${entry.id}`,
-      ),
-    );
+  const paths = getPreviewIndexPaths(entries);
   return Response.json(paths);
 };


### PR DESCRIPTION
## Motivation

Preview discovery roots are configured with inline source kinds such as `examples` and `sandbox`, while the `/previews` endpoint excludes sandbox entries by source. Because preview collection `source` data was typed as `string`, future drift between those values could compile and cause sandbox fixtures to appear in the preview index.

## Solution

Define the app preview source kinds once in `preview-config.ts`, constrain `previewConfig` roots to that union, and extend the app previews collection schema so `source` is parsed as the same enum. The generic preview discovery schema remains string-based so the reusable loader can still support arbitrary roots.

The `/previews` path generation now uses a small helper that filters against the shared sandbox kind, with a focused unit test covering that sandbox previews stay out of the index paths.
