### PR TITLE
Extract base placement helper

### DIFF
--- a/packages/ariakit-react-components/src/menu/menu-button.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-button.tsx
@@ -22,6 +22,8 @@ import type { CompositeTypeaheadOptions } from "../composite/composite-typeahead
 import { useCompositeTypeahead } from "../composite/composite-typeahead.tsx";
 import type { HovercardAnchorOptions } from "../hovercard/hovercard-anchor.tsx";
 import { useHovercardAnchor } from "../hovercard/hovercard-anchor.tsx";
+import type { BasePlacement } from "../popover/__utils.ts";
+import { getBasePlacement } from "../popover/__utils.ts";
 import type { PopoverDisclosureOptions } from "../popover/popover-disclosure.tsx";
 import { usePopoverDisclosure } from "../popover/popover-disclosure.tsx";
 import { Role } from "../role/role.tsx";
@@ -34,7 +36,6 @@ import type { MenuStore, MenuStoreState } from "./menu-store.ts";
 const TagName = "button" satisfies ElementType;
 type TagName = typeof TagName | "div";
 type HTMLType = HTMLElementTagNameMap[TagName];
-type BasePlacement = "top" | "bottom" | "left" | "right";
 
 function getInitialFocus(event: KeyboardEvent, dir: BasePlacement) {
   const keyMap = {
@@ -129,9 +130,8 @@ export const useMenuButton = createHook<TagName, MenuButtonOptions>(
       }
     });
 
-    const dir = useStoreState(
-      store,
-      (state) => state.placement.split("-")[0] as BasePlacement,
+    const dir = useStoreState(store, (state) =>
+      getBasePlacement(state.placement),
     );
 
     const onKeyDownProp = props.onKeyDown;

--- a/packages/ariakit-react-components/src/menu/menu-list.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-list.tsx
@@ -18,6 +18,7 @@ import type { CompositeOptions } from "../composite/composite.tsx";
 import { useComposite } from "../composite/composite.tsx";
 import type { DisclosureContentOptions } from "../disclosure/disclosure-content.tsx";
 import { isHidden } from "../disclosure/disclosure-content.tsx";
+import { getBasePlacement } from "../popover/__utils.ts";
 import {
   MenuListHiddenContext,
   MenuScopedContextProvider,
@@ -28,7 +29,6 @@ import type { MenuStore } from "./menu-store.ts";
 const TagName = "div" satisfies ElementType;
 type TagName = typeof TagName;
 type HTMLType = HTMLElementTagNameMap[TagName];
-type BasePlacement = "top" | "bottom" | "left" | "right";
 
 function useAriaLabelledBy({ store, ...props }: MenuListProps) {
   const [id, setId] = useState<string | undefined>(undefined);
@@ -84,9 +84,8 @@ export const useMenuList = createHook<TagName, MenuListOptions>(
     const id = useId(props.id);
 
     const onKeyDownProp = props.onKeyDown;
-    const dir = useStoreState(
-      store,
-      (state) => state.placement.split("-")[0] as BasePlacement,
+    const dir = useStoreState(store, (state) =>
+      getBasePlacement(state.placement),
     );
     const orientation = useStoreState(store, (state) =>
       state.orientation === "both" ? undefined : state.orientation,

--- a/packages/ariakit-react-components/src/popover/__utils.ts
+++ b/packages/ariakit-react-components/src/popover/__utils.ts
@@ -1,0 +1,14 @@
+import type { PopoverStoreState } from "./popover-store.ts";
+
+export type Placement = PopoverStoreState["placement"];
+
+type BasePlacementOf<T extends string> = T extends `${infer Base}-${string}`
+  ? Base
+  : T;
+
+export type BasePlacement = BasePlacementOf<Placement>;
+
+export function getBasePlacement(placement: Placement) {
+  // Every Placement union member starts with its base side.
+  return placement.split("-")[0] as BasePlacement;
+}

--- a/packages/ariakit-react-components/src/popover/popover-arrow.tsx
+++ b/packages/ariakit-react-components/src/popover/popover-arrow.tsx
@@ -12,13 +12,14 @@ import type { Options, Props } from "@ariakit/react-utils";
 import { getWindow, invariant, removeUndefinedValues } from "@ariakit/utils";
 import type { ElementType } from "react";
 import { useMemo, useState } from "react";
+import type { BasePlacement } from "./__utils.ts";
+import { getBasePlacement } from "./__utils.ts";
 import { POPOVER_ARROW_PATH } from "./popover-arrow-path.ts";
 import { usePopoverContext } from "./popover-context.tsx";
 import type { PopoverStore } from "./popover-store.ts";
 
 const TagName = "div" satisfies ElementType;
 type TagName = typeof TagName;
-type BasePlacement = "top" | "bottom" | "left" | "right";
 
 const defaultSize = 30;
 const halfDefaultSize = defaultSize / 2;
@@ -90,9 +91,8 @@ export const usePopoverArrow = createHook<TagName, PopoverArrowOptions>(
         "PopoverArrow must be wrapped in a Popover component.",
     );
 
-    const dir = useStoreState(
-      store,
-      (state) => state.currentPlacement.split("-")[0] as BasePlacement,
+    const dir = useStoreState(store, (state) =>
+      getBasePlacement(state.currentPlacement),
     );
 
     const maskId = useId();

--- a/packages/ariakit-react-components/src/popover/popover-disclosure-arrow.tsx
+++ b/packages/ariakit-react-components/src/popover/popover-disclosure-arrow.tsx
@@ -4,12 +4,12 @@ import type { Options, Props } from "@ariakit/react-utils";
 import { invariant, removeUndefinedValues } from "@ariakit/utils";
 import type { ElementType } from "react";
 import { useMemo } from "react";
+import { getBasePlacement } from "./__utils.ts";
 import { usePopoverContext } from "./popover-context.tsx";
 import type { PopoverStore, PopoverStoreState } from "./popover-store.ts";
 
 const TagName = "span" satisfies ElementType;
 type TagName = typeof TagName;
-type BasePlacement = "top" | "bottom" | "left" | "right";
 
 const pointsMap = {
   top: "4,10 8,6 12,10",
@@ -48,7 +48,7 @@ export const usePopoverDisclosureArrow = createHook<
     store,
     (state) => placement || state.placement,
   );
-  const dir = position.split("-")[0] as BasePlacement;
+  const dir = getBasePlacement(position);
   const points = pointsMap[dir];
 
   const children = useMemo(

--- a/packages/ariakit-react-components/src/popover/popover.tsx
+++ b/packages/ariakit-react-components/src/popover/popover.tsx
@@ -24,6 +24,8 @@ import type { ElementType, HTMLAttributes } from "react";
 import { useRef, useState } from "react";
 import type { DialogOptions } from "../dialog/dialog.tsx";
 import { createDialogComponent, useDialog } from "../dialog/dialog.tsx";
+import type { Placement } from "./__utils.ts";
+import { getBasePlacement } from "./__utils.ts";
 import {
   PopoverScopedContextProvider,
   usePopoverProviderContext,
@@ -32,12 +34,6 @@ import type { PopoverStore } from "./popover-store.ts";
 
 const TagName = "div" satisfies ElementType;
 type TagName = typeof TagName;
-type BasePlacement = "top" | "bottom" | "left" | "right";
-
-type Placement =
-  | BasePlacement
-  | `${BasePlacement}-start`
-  | `${BasePlacement}-end`;
 
 interface AnchorRect {
   x?: number;
@@ -350,7 +346,7 @@ export const usePopover = createHook<TagName, PopoverOptions>(
         if (arrow && pos.middlewareData.arrow) {
           const { x: arrowX, y: arrowY } = pos.middlewareData.arrow;
 
-          const side = pos.placement.split("-")[0] as BasePlacement;
+          const side = getBasePlacement(pos.placement);
 
           const centerX = arrow.clientWidth / 2;
           const centerY = arrow.clientHeight / 2;

--- a/packages/ariakit-react-components/src/select/select.tsx
+++ b/packages/ariakit-react-components/src/select/select.tsx
@@ -25,6 +25,7 @@ import type {
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { CompositeTypeaheadOptions } from "../composite/composite-typeahead.tsx";
 import { useCompositeTypeahead } from "../composite/composite-typeahead.tsx";
+import { getBasePlacement } from "../popover/__utils.ts";
 import type { PopoverDisclosureOptions } from "../popover/popover-disclosure.tsx";
 import { usePopoverDisclosure } from "../popover/popover-disclosure.tsx";
 import { SelectArrow } from "./select-arrow.tsx";
@@ -37,7 +38,6 @@ import type { SelectStore } from "./select-store.ts";
 const TagName = "button" satisfies ElementType;
 type TagName = typeof TagName;
 type HTMLType = HTMLElementTagNameMap[TagName];
-type BasePlacement = "top" | "bottom" | "left" | "right";
 
 function getSelectedValues(select: HTMLSelectElement) {
   return Array.from(select.selectedOptions).map((option) => option.value);
@@ -97,7 +97,7 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
   const showOnKeyDownProp = useBooleanEvent(showOnKeyDown);
   const moveOnKeyDownProp = useBooleanEvent(moveOnKeyDown);
   const placement = useStoreState(store, "placement");
-  const dir = placement.split("-")[0] as BasePlacement;
+  const dir = getBasePlacement(placement);
   const value = useStoreState(store, "value");
   const multiSelectable = Array.isArray(value);
 


### PR DESCRIPTION
## Motivation
Several `@ariakit/react-components` menu, popover, and select files duplicate the same `BasePlacement` alias and placement parsing assertion:

```ts
placement.split("-")[0] as BasePlacement
```

The assertion is currently sound, but spreading it across the popover family makes the placement parsing rule harder to maintain and repeat correctly.

## Solution
Add a private popover helper module that derives `BasePlacement` from `PopoverStoreState["placement"]` and centralizes the single placement parsing assertion in `getBasePlacement`.

The menu, popover, and select call sites now use that helper instead of re-declaring the alias and repeating the cast. The helper lives in `popover/__utils.ts`, which keeps it out of the generated package exports, so this remains an internal behavior-preserving refactor with no changeset.
