### PR TITLE
Remove dead combobox code

### DIFF
--- a/packages/ariakit-react-components/src/combobox/combobox.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox.tsx
@@ -292,7 +292,6 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       storeValue,
     ]);
 
-    const scrollingElementRef = useRef<Element | null>(null);
     const getAutoSelectIdProp = useEvent(getAutoSelectId);
     const autoSelectIdRef = useRef<string | null | undefined>(null);
     // Tracks the item (id and value) the autoSelect behavior last moved focus
@@ -316,7 +315,6 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       if (!contentElement) return;
       const scrollingElement = getScrollingElement(contentElement);
       if (!scrollingElement) return;
-      scrollingElementRef.current = scrollingElement;
       const onUserScroll = () => {
         // A wheel event is always initiated by the user, so we can disable the
         // autoSelect behavior without any additional checks.
@@ -642,7 +640,6 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       // cleared. See combobox-cancel tests.
       canAutoSelectRef.current = false;
       onBlurProp?.(event);
-      if (event.defaultPrevented) return;
     });
 
     // This is necessary so other components like ComboboxCancel can reference


### PR DESCRIPTION
## Motivation

`useCombobox` still had two leftovers from previous refactors:

```tsx
const scrollingElementRef = useRef<Element | null>(null);
```

This ref was only assigned inside the scroll listener effect and was never read. The same hook also ended its `onBlur` handler with a `defaultPrevented` guard even though there was no Ariakit logic after the guard to skip.

Both lines were behavior-neutral, but they made this already subtle auto-select/scroll code harder to read by suggesting state and preventable blur behavior that no longer existed.

## Solution

Remove the write-only `scrollingElementRef` declaration and assignment. The effect already keeps using its local `scrollingElement` variable for listener setup and cleanup.

Also remove the trailing no-op `event.defaultPrevented` guard from `onBlur` while keeping the wrapper and the unconditional `canAutoSelectRef` reset intact.

No changeset is needed because this is dead-code cleanup with no public API or behavior change.
