### PR TITLE
Deduplicate composite store navigation options

### DIFF
--- a/packages/ariakit-components/src/composite/composite-store.test.ts
+++ b/packages/ariakit-components/src/composite/composite-store.test.ts
@@ -21,6 +21,30 @@ test("moves through enabled items in one-dimensional composites", () => {
   expect(store.previous({ activeId: "one" })).toBeUndefined();
 });
 
+test("supports the deprecated skip number overload", () => {
+  const store = createComposite([
+    { id: "a1", rowId: "a" },
+    { id: "a2", rowId: "a" },
+    { id: "a3", rowId: "a" },
+    { id: "b1", rowId: "b" },
+    { id: "b2", rowId: "b" },
+    { id: "b3", rowId: "b" },
+    { id: "c1", rowId: "c" },
+    { id: "c2", rowId: "c" },
+    { id: "c3", rowId: "c" },
+  ]);
+
+  store.setActiveId("a1");
+  expect(store.next(1)).toBe("a3");
+  expect(store.down(1)).toBe("c1");
+
+  store.setActiveId("a3");
+  expect(store.previous(1)).toBe("a1");
+
+  store.setActiveId("c1");
+  expect(store.up(1)).toBe("a1");
+});
+
 test("loops through items and the base element", () => {
   const store = createComposite([{ id: "one" }, { id: "two" }]);
 

--- a/packages/ariakit-components/src/composite/composite-store.ts
+++ b/packages/ariakit-components/src/composite/composite-store.ts
@@ -11,6 +11,7 @@ import type {
 import { createCollectionStore } from "../collection/collection-store.ts";
 
 type Orientation = "horizontal" | "vertical" | "both";
+type CompositeStoreDirection = "next" | "previous" | "up" | "down";
 
 interface NextOptions extends Pick<
   Partial<CompositeStoreState>,
@@ -219,7 +220,7 @@ export function createCompositeStore<
   );
 
   const getNextId = (
-    direction: "next" | "previous" | "up" | "down" = "next",
+    direction: CompositeStoreDirection = "next",
     options: NextOptions = {},
   ): string | null | undefined => {
     const defaultState = composite.getState();
@@ -334,6 +335,17 @@ export function createCompositeStore<
     return nextItem?.id;
   };
 
+  const getNextIdFromOptions = (
+    direction: CompositeStoreDirection,
+    options?: NextOptions | number,
+  ) => {
+    // Support the deprecated number overloads such as next(skip).
+    if (typeof options === "number") {
+      return getNextId(direction, { skip: options });
+    }
+    return getNextId(direction, options);
+  };
+
   return {
     ...collection,
     ...composite,
@@ -353,33 +365,10 @@ export function createCompositeStore<
       findFirstEnabledItem(reverseArray(composite.getState().renderedItems))
         ?.id,
 
-    next: (options) => {
-      if (options !== undefined && typeof options === "number") {
-        options = { skip: options };
-      }
-      return getNextId("next", options);
-    },
-
-    previous: (options) => {
-      if (options !== undefined && typeof options === "number") {
-        options = { skip: options };
-      }
-      return getNextId("previous", options);
-    },
-
-    down: (options) => {
-      if (options !== undefined && typeof options === "number") {
-        options = { skip: options };
-      }
-      return getNextId("down", options);
-    },
-
-    up: (options) => {
-      if (options !== undefined && typeof options === "number") {
-        options = { skip: options };
-      }
-      return getNextId("up", options);
-    },
+    next: (options) => getNextIdFromOptions("next", options),
+    previous: (options) => getNextIdFromOptions("previous", options),
+    down: (options) => getNextIdFromOptions("down", options),
+    up: (options) => getNextIdFromOptions("up", options),
   };
 }
 


### PR DESCRIPTION
## Motivation

The composite store still supports deprecated numeric skip overloads such as:

```ts
store.next(2);
```

Before this change, `next`, `previous`, `down`, and `up` each normalized that overload with the same inline block before calling the shared navigation helper. Those copies also included an unnecessary `options !== undefined` check even though `typeof options === "number"` already excludes `undefined`.

## Solution

Centralize the navigation direction type and route all four methods through a single helper that preserves the deprecated number overload:

```ts
next: (options) => getNextIdFromOptions("next", options);
```

The helper maps numeric arguments to `{ skip }` and passes object or undefined options through to `getNextId`, so the core navigation logic remains unchanged. This also adds focused coverage for the deprecated numeric overload across `next`, `previous`, `down`, and `up`.

## Testing

- `pnpm lint-fix`
- `pnpm test packages/ariakit-components/src/composite/composite-store.test.ts`
- `pnpm tsc`
- `pnpm build`
