### PR TITLE
Improve public JSDocs

### DIFF
--- a/.changeset/300-form-jsdoc-examples.md
+++ b/.changeset/300-form-jsdoc-examples.md
@@ -1,6 +1,0 @@
----
-"@ariakit/react-components": patch
-"@ariakit/react": patch
----
-
-Fixed documentation comments and examples for [`FormError`](https://ariakit.com/reference/form-error), [`FormSubmit`](https://ariakit.com/reference/form-submit), [`FormLabel`](https://ariakit.com/reference/form-label), and [`FormProvider`](https://ariakit.com/reference/form-provider).

--- a/.changeset/300-improved-jsdocs.md
+++ b/.changeset/300-improved-jsdocs.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/components": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Improved public JSDoc comments for component and store options.

--- a/.changeset/300-select-move-on-key-down-default.md
+++ b/.changeset/300-select-move-on-key-down-default.md
@@ -1,6 +1,0 @@
----
-"@ariakit/react-components": patch
-"@ariakit/react": patch
----
-
-Fixed the documented [`Select`](https://ariakit.com/reference/select#moveonkeydown) `moveOnKeyDown` default to match the runtime behavior.

--- a/packages/ariakit-components/src/collection/collection-store.ts
+++ b/packages/ariakit-components/src/collection/collection-store.ts
@@ -283,7 +283,7 @@ export interface CollectionStoreOptions<
   T extends CollectionStoreItem = CollectionStoreItem,
 > extends StoreOptions<CollectionStoreState<T>, "items"> {
   /**
-   * The defaut value for the
+   * The default value for the
    * [`items`](https://ariakit.com/reference/collection-provider#items) state.
    * @default []
    */

--- a/packages/ariakit-components/src/combobox/combobox-store.ts
+++ b/packages/ariakit-components/src/combobox/combobox-store.ts
@@ -267,7 +267,9 @@ export interface ComboboxStoreState<
    * [`selectedValue`](https://ariakit.com/reference/combobox-provider#selectedvalue)
    * or
    * [`defaultSelectedValue`](https://ariakit.com/reference/combobox-provider#defaultselectedvalue)
-   * props are arrays.
+   * props are arrays. However, when the combobox is connected to a
+   * [`tag`](https://ariakit.com/reference/combobox-provider#tag) store, the
+   * default is `false` so the input value is kept when the popover closes.
    *
    * Live examples:
    * - [Multi-selectable

--- a/packages/ariakit-react-components/src/checkbox/checkbox-check.tsx
+++ b/packages/ariakit-react-components/src/checkbox/checkbox-check.tsx
@@ -92,7 +92,12 @@ export interface CheckboxCheckOptions<
   /**
    * Object returned by the
    * [`useCheckboxStore`](https://ariakit.com/reference/use-checkbox-store)
-   * hook.
+   * hook. This prop doesn't affect the checkmark. It's accepted for
+   * consistency with other Ariakit components and is not passed to the
+   * underlying element. The checked state is derived solely from the
+   * [`checked`](https://ariakit.com/reference/checkbox-check#checked) prop or,
+   * when it's not provided, from the closest
+   * [`Checkbox`](https://ariakit.com/reference/checkbox) component.
    */
   store?: CheckboxStore;
   /**

--- a/packages/ariakit-react-components/src/combobox/combobox-item-check.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item-check.tsx
@@ -72,7 +72,12 @@ export interface ComboboxItemCheckOptions<
   /**
    * Object returned by the
    * [`useComboboxStore`](https://ariakit.com/reference/use-combobox-store)
-   * hook.
+   * hook. This prop doesn't affect the checkmark. It's accepted for
+   * consistency with other Ariakit components and is not passed to the
+   * underlying element. The checked state is derived solely from the
+   * [`checked`](https://ariakit.com/reference/combobox-item-check#checked)
+   * prop or, when it's not provided, from the closest
+   * [`ComboboxItem`](https://ariakit.com/reference/combobox-item) component.
    */
   store?: ComboboxStore;
 }

--- a/packages/ariakit-react-components/src/dialog/dialog-description.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog-description.tsx
@@ -73,9 +73,12 @@ export interface DialogDescriptionOptions<
 > extends Options {
   /**
    * Object returned by the
-   * [`useDialogStore`](https://ariakit.com/reference/use-dialog-store) hook. If
-   * not provided, the closest [`Dialog`](https://ariakit.com/reference/dialog)
-   * component's context will be used.
+   * [`useDialogStore`](https://ariakit.com/reference/use-dialog-store) hook.
+   *
+   * **Note**: This prop has no effect on this component. The description is
+   * linked to the closest [`Dialog`](https://ariakit.com/reference/dialog)
+   * component through React context, so it must be rendered inside the dialog
+   * for the `aria-describedby` prop to be set on the dialog element.
    */
   store?: DialogStore;
 }

--- a/packages/ariakit-react-components/src/dialog/dialog-heading.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog-heading.tsx
@@ -75,9 +75,12 @@ export interface DialogHeadingOptions<
 > extends HeadingOptions<T> {
   /**
    * Object returned by the
-   * [`useDialogStore`](https://ariakit.com/reference/use-dialog-store) hook. If
-   * not provided, the closest [`Dialog`](https://ariakit.com/reference/dialog)
-   * component's context will be used.
+   * [`useDialogStore`](https://ariakit.com/reference/use-dialog-store) hook.
+   *
+   * **Note**: This prop has no effect on this component. The heading is
+   * linked to the closest [`Dialog`](https://ariakit.com/reference/dialog)
+   * component through React context, so it must be rendered inside the dialog
+   * for the `aria-labelledby` prop to be set on the dialog element.
    */
   store?: DialogStore;
 }

--- a/packages/ariakit-react-components/src/hovercard/hovercard-description.tsx
+++ b/packages/ariakit-react-components/src/hovercard/hovercard-description.tsx
@@ -55,10 +55,13 @@ export interface HovercardDescriptionOptions<
   /**
    * Object returned by the
    * [`useHovercardStore`](https://ariakit.com/reference/use-hovercard-store)
-   * hook. If not provided, the closest
-   * [`Hovercard`](https://ariakit.com/reference/hovercard) or
-   * [`HovercardProvider`](https://ariakit.com/reference/hovercard-provider)
-   * components' context will be used.
+   * hook.
+   *
+   * **Note**: This prop has no effect on this component. The description is
+   * linked to the closest
+   * [`Hovercard`](https://ariakit.com/reference/hovercard) component through
+   * React context, so it must be rendered inside the hovercard for the
+   * `aria-describedby` prop to be set on the hovercard element.
    */
   store?: HovercardStore;
 }

--- a/packages/ariakit-react-components/src/hovercard/hovercard-heading.tsx
+++ b/packages/ariakit-react-components/src/hovercard/hovercard-heading.tsx
@@ -54,10 +54,13 @@ export interface HovercardHeadingOptions<
   /**
    * Object returned by the
    * [`useHovercardStore`](https://ariakit.com/reference/use-hovercard-store)
-   * hook. If not provided, the closest
-   * [`Hovercard`](https://ariakit.com/reference/hovercard) or
-   * [`HovercardProvider`](https://ariakit.com/reference/hovercard-provider)
-   * components' context will be used.
+   * hook.
+   *
+   * **Note**: This prop has no effect on this component. The heading is
+   * linked to the closest
+   * [`Hovercard`](https://ariakit.com/reference/hovercard) component through
+   * React context, so it must be rendered inside the hovercard for the
+   * `aria-labelledby` prop to be set on the hovercard element.
    */
   store?: HovercardStore;
 }

--- a/packages/ariakit-react-components/src/menu/menu-item-check.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-item-check.tsx
@@ -68,7 +68,15 @@ export interface MenuItemCheckOptions<
 > extends Omit<CheckboxCheckOptions<T>, "store"> {
   /**
    * Object returned by the
-   * [`useMenuStore`](https://ariakit.com/reference/use-menu-store) hook.
+   * [`useMenuStore`](https://ariakit.com/reference/use-menu-store) hook. This
+   * prop doesn't affect the checkmark. It's accepted for consistency with
+   * other Ariakit components and is not passed to the underlying element. The
+   * checked state is derived solely from the
+   * [`checked`](https://ariakit.com/reference/menu-item-check#checked) prop or,
+   * when it's not provided, from the closest
+   * [`MenuItemCheckbox`](https://ariakit.com/reference/menu-item-checkbox) or
+   * [`MenuItemRadio`](https://ariakit.com/reference/menu-item-radio)
+   * component.
    */
   store?: MenuStore;
 }

--- a/packages/ariakit-react-components/src/menu/menu-item.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-item.tsx
@@ -79,6 +79,9 @@ export const useMenuItem = createHook<TagName, MenuItemOptions>(
     blurOnHoverEnd,
     ...props
   }) {
+    // Only use the scoped menu context here. The unscoped MenuProvider context
+    // is intentionally skipped so MenuItem can bind to the menubar store when
+    // it renders a MenuButton inside a Menubar.
     const menuContext = useMenuScopedContext(true);
     const menubarContext = useMenubarScopedContext();
     store = store || menuContext || (menubarContext as any);
@@ -214,7 +217,7 @@ export interface MenuItemOptions<T extends ElementType = TagName>
    * [`useMenubarStore`](https://ariakit.com/reference/use-menubar-store)
    * hooks. If not provided, the closest
    * [`Menu`](https://ariakit.com/reference/menu),
-   * [`MenuProvider`](https://ariakit.com/reference/menu-provider),
+   * [`MenuList`](https://ariakit.com/reference/menu-list),
    * [`Menubar`](https://ariakit.com/reference/menubar), or
    * [`MenubarProvider`](https://ariakit.com/reference/menubar-provider)
    * components' context will be used.

--- a/packages/ariakit-react-components/src/popover/popover-description.tsx
+++ b/packages/ariakit-react-components/src/popover/popover-description.tsx
@@ -55,10 +55,11 @@ export interface PopoverDescriptionOptions<
   /**
    * Object returned by the
    * [`usePopoverStore`](https://ariakit.com/reference/use-popover-store) hook.
-   * If not provided, the closest
-   * [`Popover`](https://ariakit.com/reference/popover) or
-   * [`PopoverProvider`](https://ariakit.com/reference/popover-provider)
-   * components' context will be used.
+   *
+   * **Note**: This prop has no effect on this component. The description is
+   * linked to the closest [`Popover`](https://ariakit.com/reference/popover)
+   * component through React context, so it must be rendered inside the popover
+   * for the `aria-describedby` prop to be set on the popover element.
    */
   store?: PopoverStore;
 }

--- a/packages/ariakit-react-components/src/popover/popover-heading.tsx
+++ b/packages/ariakit-react-components/src/popover/popover-heading.tsx
@@ -54,10 +54,11 @@ export interface PopoverHeadingOptions<
   /**
    * Object returned by the
    * [`usePopoverStore`](https://ariakit.com/reference/use-popover-store) hook.
-   * If not provided, the closest
-   * [`Popover`](https://ariakit.com/reference/popover) or
-   * [`PopoverProvider`](https://ariakit.com/reference/popover-provider)
-   * components' context will be used.
+   *
+   * **Note**: This prop has no effect on this component. The heading is
+   * linked to the closest [`Popover`](https://ariakit.com/reference/popover)
+   * component through React context, so it must be rendered inside the popover
+   * for the `aria-labelledby` prop to be set on the popover element.
    */
   store?: PopoverStore;
 }

--- a/packages/ariakit-react-components/src/select/select-heading.tsx
+++ b/packages/ariakit-react-components/src/select/select-heading.tsx
@@ -84,10 +84,12 @@ export interface SelectHeadingOptions<
   /**
    * Object returned by the
    * [`useSelectStore`](https://ariakit.com/reference/use-select-store) hook.
-   * If not provided, the closest
-   * [`Select`](https://ariakit.com/reference/select) or
-   * [`SelectProvider`](https://ariakit.com/reference/select-provider)
-   * components' context will be used.
+   *
+   * **Note**: This prop has no effect on this component. The heading is linked
+   * to the closest [`SelectList`](https://ariakit.com/reference/select-list)
+   * or [`SelectPopover`](https://ariakit.com/reference/select-popover)
+   * component through React context, so it must be rendered inside the list or
+   * popover for the `aria-labelledby` prop to be set on that element.
    */
   store?: SelectStore;
 }

--- a/packages/ariakit-react-components/src/select/select-item-check.tsx
+++ b/packages/ariakit-react-components/src/select/select-item-check.tsx
@@ -70,6 +70,12 @@ export interface SelectItemCheckOptions<
   /**
    * Object returned by the
    * [`useSelectStore`](https://ariakit.com/reference/use-select-store) hook.
+   * This prop doesn't affect the checkmark. It's accepted for consistency with
+   * other Ariakit components and is not passed to the underlying element. The
+   * checked state is derived solely from the
+   * [`checked`](https://ariakit.com/reference/select-item-check#checked) prop
+   * or, when it's not provided, from the closest
+   * [`SelectItem`](https://ariakit.com/reference/select-item) component.
    */
   store?: SelectStore;
 }

--- a/packages/ariakit-react-components/src/select/select-label.tsx
+++ b/packages/ariakit-react-components/src/select/select-label.tsx
@@ -20,8 +20,8 @@ type HTMLType = HTMLElementTagNameMap[TagName];
 /**
  * Returns props to create a `SelectLabel` component. Since it's not a native
  * select element, we can't use the native label element. The `SelectLabel`
- * component will move focus and click on the `Select` component when the user
- * clicks on the label.
+ * component will move focus to the `Select` component when the user clicks on
+ * the label.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx
@@ -49,9 +49,9 @@ export const useSelectLabel = createHook<TagName, SelectLabelOptions>(
     const onClick = useEvent((event: MouseEvent<HTMLType>) => {
       onClickProp?.(event);
       if (event.defaultPrevented) return;
-      // queueMicrotask will guarantee that the focus and click events will be
-      // triggered only after the current event queue is flushed (which includes
-      // this click event).
+      // queueMicrotask will guarantee that the focus event will be triggered
+      // only after the current event queue is flushed (which includes this
+      // click event).
       queueMicrotask(() => {
         const select = store?.getState().selectElement;
         select?.focus();
@@ -76,7 +76,7 @@ export const useSelectLabel = createHook<TagName, SelectLabelOptions>(
 /**
  * Renders a label for the [`Select`](https://ariakit.com/reference/select)
  * component. Since it's not a native select element, we can't use the native
- * label element. This component will move focus and click on the
+ * label element. This component will move focus to the
  * [`Select`](https://ariakit.com/reference/select) component when clicked.
  * @see https://ariakit.com/components/select
  * @example


### PR DESCRIPTION
## Motivation

Several public JSDoc comments that feed editor hovers and generated reference docs were stale or misleading. They described fallback contexts that are intentionally ignored, implied inert `store` props affect checkmark or heading state, documented a removed `SelectLabel` click behavior, and missed the tag-store exception for `resetValueOnHide`.

There were also multiple unreleased JSDoc-related changesets, which made the changelog noisier than the underlying docs cleanup needs to be.

## Solution

Update the affected JSDoc comments to match current behavior and add a short rationale comment for the scoped-only `MenuItem` lookup. The changes clarify inert `store` props across checkmark, dialog, popover, hovercard, and select heading components; fix the `defaultItems` typo; document the tag-store default for `resetValueOnHide`; and describe `SelectLabel` as focus-only.

Replace the existing JSDoc-specific changesets with a single generic `Improved public JSDoc comments for component and store options.` entry.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- Pre-commit review gate: native Codex reviewer and Cursor CLI reviewer both returned no findings.
