### PR TITLE
Use form item context in form hooks

### DIFF
--- a/packages/ariakit-react-components/src/form/form-checkbox.tsx
+++ b/packages/ariakit-react-components/src/form/form-checkbox.tsx
@@ -5,12 +5,11 @@ import {
   memo,
 } from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
-import { invariant } from "@ariakit/utils";
 import type { ElementType } from "react";
 import { useCheckboxStore } from "../checkbox/checkbox-store.ts";
 import type { CheckboxOptions } from "../checkbox/checkbox.tsx";
 import { useCheckbox } from "../checkbox/checkbox.tsx";
-import { useFormContext } from "./form-context.tsx";
+import { useFormItemContext } from "./form-context.tsx";
 import type { FormControlOptions } from "./form-control.tsx";
 import { useFormControl } from "./form-control.tsx";
 
@@ -41,26 +40,21 @@ export const useFormCheckbox = createHook<TagName, FormCheckboxOptions>(
     defaultChecked,
     ...props
   }) {
-    const context = useFormContext();
-    store = store || context;
-
-    invariant(
+    const { store: form, name } = useFormItemContext({
       store,
-      process.env.NODE_ENV !== "production" &&
-        "FormCheckbox must be wrapped in a Form component.",
-    );
-
-    const name = String(nameProp);
+      name: nameProp,
+      component: "FormCheckbox",
+    });
 
     const checkboxStore = useCheckboxStore({
-      value: store.useValue(name),
-      setValue: (value) => store?.setValue(name, value),
+      value: form.useValue(name),
+      setValue: (value) => form.setValue(name, value),
     });
 
     props = useCheckbox({ store: checkboxStore, value, checked, ...props });
 
     props = useFormControl({
-      store,
+      store: form,
       name,
       "aria-labelledby": undefined,
       ...props,

--- a/packages/ariakit-react-components/src/form/form-push.tsx
+++ b/packages/ariakit-react-components/src/form/form-push.tsx
@@ -7,14 +7,13 @@ import {
   forwardRef,
 } from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
-import { invariant } from "@ariakit/utils";
 import type { ElementType, MouseEvent } from "react";
 import { useCallback, useEffect, useState } from "react";
 import type { ButtonOptions } from "../button/button.tsx";
 import { useButton } from "../button/button.tsx";
 import type { CollectionItemOptions } from "../collection/collection-item.tsx";
 import { useCollectionItem } from "../collection/collection-item.tsx";
-import { useFormContext } from "./form-context.tsx";
+import { useFormItemContext } from "./form-context.tsx";
 import type { FormStore, FormStoreState } from "./form-store.ts";
 import { getArrayFieldIndex } from "./utils.ts";
 
@@ -67,17 +66,12 @@ export const useFormPush = createHook<TagName, FormPushOptions>(
     autoFocusOnClick = true,
     ...props
   }) {
-    const context = useFormContext();
-    store = store || context;
-
-    invariant(
+    const { store: form, name } = useFormItemContext({
       store,
-      process.env.NODE_ENV !== "production" &&
-        "FormPush must be wrapped in a Form component.",
-    );
-
-    const name = String(nameProp);
-    const items = useStoreState(store, "items");
+      name: nameProp,
+      component: "FormPush",
+    });
+    const items = useStoreState(form, "items");
     const [focusIndex, setFocusIndex] = useState<number | null>(null);
 
     useEffect(() => {
@@ -107,8 +101,8 @@ export const useFormPush = createHook<TagName, FormPushOptions>(
     const onClick = useEvent((event: MouseEvent<HTMLType>) => {
       onClickProp?.(event);
       if (event.defaultPrevented) return;
-      const length = store?.getValue<unknown[]>(name)?.length ?? 0;
-      store?.pushValue(name, value);
+      const length = form.getValue<unknown[]>(name)?.length ?? 0;
+      form.pushValue(name, value);
       if (!autoFocusOnClick) return;
       setFocusIndex(length);
     });
@@ -119,7 +113,7 @@ export const useFormPush = createHook<TagName, FormPushOptions>(
     };
 
     props = useButton(props);
-    props = useCollectionItem<TagName>({ store, ...props, getItem });
+    props = useCollectionItem<TagName>({ store: form, ...props, getItem });
 
     return props;
   },

--- a/packages/ariakit-react-components/src/form/form-radio.tsx
+++ b/packages/ariakit-react-components/src/form/form-radio.tsx
@@ -7,11 +7,10 @@ import {
   memo,
 } from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
-import { invariant } from "@ariakit/utils";
 import type { ChangeEvent, ElementType } from "react";
 import type { RadioOptions } from "../radio/radio.tsx";
 import { useRadio } from "../radio/radio.tsx";
-import { useFormContext } from "./form-context.tsx";
+import { useFormItemContext } from "./form-context.tsx";
 import type { FormControlOptions } from "./form-control.tsx";
 import { useFormControl } from "./form-control.tsx";
 
@@ -39,28 +38,23 @@ type TagName = typeof TagName;
  */
 export const useFormRadio = createHook<TagName, FormRadioOptions>(
   function useFormRadio({ store, name: nameProp, value, ...props }) {
-    const context = useFormContext();
-    store = store || context;
-
-    invariant(
+    const { store: form, name } = useFormItemContext({
       store,
-      process.env.NODE_ENV !== "production" &&
-        "FormRadio must be wrapped in a Form component.",
-    );
-
-    const name = String(nameProp);
+      name: nameProp,
+      component: "FormRadio",
+    });
     const onChangeProp = props.onChange;
 
     const onChange = useEvent((event: ChangeEvent<HTMLInputElement>) => {
       onChangeProp?.(event);
       if (event.defaultPrevented) return;
-      store?.setValue(name, value);
+      form.setValue(name, value);
     });
 
     const checkedProp = props.checked;
     const checked = useStoreState(
-      store,
-      () => checkedProp ?? store?.getValue(name) === value,
+      form,
+      () => checkedProp ?? form.getValue(name) === value,
     );
 
     props = {
@@ -72,7 +66,7 @@ export const useFormRadio = createHook<TagName, FormRadioOptions>(
     props = useRadio({ name, value, ...props });
 
     props = useFormControl({
-      store,
+      store: form,
       name,
       "aria-labelledby": undefined,
       ...props,

--- a/packages/ariakit-react-components/src/form/form-remove.tsx
+++ b/packages/ariakit-react-components/src/form/form-remove.tsx
@@ -6,11 +6,11 @@ import {
   forwardRef,
 } from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
-import { isTextField, invariant } from "@ariakit/utils";
+import { isTextField } from "@ariakit/utils";
 import type { ElementType, MouseEvent } from "react";
 import type { ButtonOptions } from "../button/button.tsx";
 import { useButton } from "../button/button.tsx";
-import { useFormContext } from "./form-context.tsx";
+import { useFormItemContext } from "./form-context.tsx";
 import type { FormStore, FormStoreState } from "./form-store.ts";
 import { getArrayFieldIndex, isArrayFieldName } from "./utils.ts";
 
@@ -76,25 +76,19 @@ export const useFormRemove = createHook<TagName, FormRemoveOptions>(
     autoFocusOnClick = true,
     ...props
   }) {
-    const context = useFormContext();
-    store = store || context;
-
-    invariant(
+    const { store: form, name } = useFormItemContext({
       store,
-      process.env.NODE_ENV !== "production" &&
-        "FormRemove must be wrapped in a Form component.",
-    );
-
-    const name = String(nameProp);
+      name: nameProp,
+      component: "FormRemove",
+    });
     const onClickProp = props.onClick;
 
     const onClick = useEvent((event: MouseEvent<HTMLType>) => {
       onClickProp?.(event);
       if (event.defaultPrevented) return;
-      if (!store) return;
-      store.removeValue(name, index);
+      form.removeValue(name, index);
       if (!autoFocusOnClick) return;
-      const { items } = store.getState();
+      const { items } = form.getState();
       const item = findNextOrPreviousField(items, name, index);
       const element = item?.element;
       if (element) {


### PR DESCRIPTION
## Motivation

`useFormItemContext` centralizes the store/context fallback, form invariant, and name stringification that named form items need. `FormCheckbox`, `FormRadio`, `FormPush`, and `FormRemove` still repeated that setup inline:

```tsx
const context = useFormContext();
store = store || context;
const name = String(nameProp);
```

That also left dead nullable guards like `store?.setValue(...)` and `if (!store) return` after the invariant had already asserted the store exists.

## Solution

Migrate those four hooks to `useFormItemContext`, matching the existing `FormInput` pattern:

```tsx
const { store: form, name } = useFormItemContext({
  store,
  name: nameProp,
  component: "FormInput",
});
```

The hooks now use the returned non-null `form` binding for checkbox, radio, collection, and array operations, so the redundant optional chains and early return can be removed. This preserves hook order and keeps the same component-specific invariant messages.

No changeset is included because this is an internal refactor with no public API or behavior change.

## Testing

- `corepack pnpm lint-fix`
- `corepack pnpm tsc`
- `corepack pnpm test-react examples/form-radio/test.ts examples/form-checkbox-integer-like-name/test.ts app/src/sandbox/form-push-6293/test.ts app/src/sandbox/form-push-remove-6219/test.ts`
- `corepack pnpm -F @ariakit/react-components run build`
- `git diff --check`
