### PR TITLE
Share sandbox frame flushing helper

### DIFF
--- a/app/src/sandbox/button-ref-cleanup/test-browser.ts
+++ b/app/src/sandbox/button-ref-cleanup/test-browser.ts
@@ -1,4 +1,4 @@
-import { withFramework } from "#app/test-utils/preview.ts";
+import { flushFrames, withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
   test("preserves React ref cleanup", async ({ page, q }) => {
@@ -8,14 +8,6 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test
       .expect(q.text("Plain button object ref attached: yes"))
       .toBeVisible();
-    const waitForPaint = async () => {
-      await page.evaluate(
-        () =>
-          new Promise<void>((resolve) => {
-            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
-          }),
-      );
-    };
 
     await page.keyboard.press("b");
     await test.expect(q.text("Button shortcut count: 1")).toBeVisible();
@@ -28,7 +20,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.text("Button object ref detached: yes")).toBeVisible();
     await page.keyboard.press("b");
     await page.keyboard.press("b");
-    await waitForPaint();
+    await flushFrames(page);
     await test.expect(q.text("Button shortcut count: 2")).toBeVisible();
     await test.expect(q.text("Button shortcut count: 3")).toBeHidden();
 
@@ -48,7 +40,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.text("Portal cleanup connected: yes")).toBeVisible();
     await page.keyboard.press("p");
     await page.keyboard.press("p");
-    await waitForPaint();
+    await flushFrames(page);
     await test.expect(q.text("Portal shortcut count: 2")).toBeVisible();
     await test.expect(q.text("Portal shortcut count: 3")).toBeHidden();
 
@@ -65,7 +57,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.text("Connected portal root")).toBeVisible();
     await page.keyboard.press("c");
     await page.keyboard.press("c");
-    await waitForPaint();
+    await flushFrames(page);
     await test
       .expect(q.text("Connected portal shortcut count: 2"))
       .toBeVisible();

--- a/app/src/sandbox/composite-renderer-6215/test-browser.ts
+++ b/app/src/sandbox/composite-renderer-6215/test-browser.ts
@@ -1,4 +1,4 @@
-import { withFramework } from "#app/test-utils/preview.ts";
+import { flushFrames, withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
   // https://github.com/ariakit/ariakit/issues/6215
@@ -18,15 +18,6 @@ withFramework(import.meta.dirname, async ({ test }) => {
     const scroller = page.locator(".scroller");
     const detachedCount = q.status();
 
-    // Let the virtualizer's scroll handler and effects settle across two frames.
-    const settle = () =>
-      page.evaluate(
-        () =>
-          new Promise<void>((resolve) =>
-            requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
-          ),
-      );
-
     // The list renders and measures items to begin with. Anchor the pattern so
     // it doesn't also match the "Refresh items" control.
     await test.expect(q.button(/^item /).first()).toBeVisible();
@@ -39,28 +30,28 @@ withFramework(import.meta.dirname, async ({ test }) => {
       await scroller.evaluate((element, y) => {
         element.scrollTop = y;
       }, top);
-      await settle();
+      await flushFrames(page);
     }
     await scroller.evaluate((element) => {
       element.scrollTop = element.scrollHeight;
     });
-    await settle();
+    await flushFrames(page);
     await scroller.evaluate((element) => {
       element.scrollTop = 0;
     });
-    await settle();
+    await flushFrames(page);
 
     // Scrolled-out items must have been unobserved — no detached node retained.
     await test.expect(detachedCount).toHaveText("0");
 
     // Re-rendering items to new nodes (same id) must unobserve the old nodes.
     await q.button("Refresh items").click();
-    await settle();
+    await flushFrames(page);
     await test.expect(detachedCount).toHaveText("0");
 
     // Unmounting the list must disconnect the observer — still nothing retained.
     await q.button("Unmount the list").click();
-    await settle();
+    await flushFrames(page);
     await test.expect(detachedCount).toHaveText("0");
   });
 });

--- a/app/src/sandbox/select-combobox-3837/test-browser.ts
+++ b/app/src/sandbox/select-combobox-3837/test-browser.ts
@@ -1,4 +1,4 @@
-import { withFramework } from "#app/test-utils/preview.ts";
+import { flushFrames, withFramework } from "#app/test-utils/preview.ts";
 
 declare global {
   interface Window {
@@ -42,22 +42,11 @@ withFramework(import.meta.dirname, async ({ test }) => {
     test.expect(renderedBefore).toBeGreaterThan(2);
     test.expect(renderedBefore).toBeLessThan(50);
 
-    const flushFrames = (frames: number) =>
-      page.evaluate(
-        (n) =>
-          new Promise<void>((resolve) => {
-            const tick = () =>
-              n-- > 0 ? requestAnimationFrame(tick) : resolve();
-            tick();
-          }),
-        frames,
-      );
-
     // The virtualizer's ResizeObserver ignores its very first callback, so flush
     // a couple of frames to make sure that first callback has already fired.
     // Otherwise a fast run could have our resize below swallowed as the ignored
     // one, and the bug would not reproduce.
-    await flushFrames(2);
+    await flushFrames(page, 2);
 
     // From now on, count any focus event that lands on an option element.
     await page.evaluate(() => {
@@ -89,7 +78,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect
       .poll(() => popover.evaluate((el) => el.clientHeight))
       .toBeLessThan(heightBefore);
-    await flushFrames(5);
+    await flushFrames(page, 5);
 
     // The auto-selected item is still active, but focus must have stayed on the
     // input the whole time — the resize must not move focus to the option.

--- a/app/src/test-utils/preview.ts
+++ b/app/src/test-utils/preview.ts
@@ -32,6 +32,24 @@ export async function gotoAndSettle(page: Page, url: string) {
     });
 }
 
+/** Waits for animation frames in the page so effects can settle. */
+export function flushFrames(page: Page, frames = 2) {
+  return page.evaluate(
+    (frameCount) =>
+      new Promise<void>((resolve) => {
+        const tick = () => {
+          if (frameCount-- <= 0) {
+            resolve();
+            return;
+          }
+          requestAnimationFrame(tick);
+        };
+        tick();
+      }),
+    frames,
+  );
+}
+
 const SRC_DIR = resolve(import.meta.dirname, "..");
 const previewRoots = resolvePreviewRoots({ ...previewConfig, srcDir: SRC_DIR });
 


### PR DESCRIPTION
## Motivation

Several sandbox browser tests duplicate small `page.evaluate` helpers that wait for animation frames before making assertions. The copies use different local names and shapes, and one test already needed a generalized frame count, so future tests are likely to keep reimplementing the same settling logic.

## Solution

Export a shared `flushFrames(page, frames = 2)` helper from `app/src/test-utils/preview.ts`, next to `gotoAndSettle`, and update the affected sandbox tests to import it. Existing two-frame waits use the default, and `select-combobox-3837` keeps its explicit two- and five-frame waits.

No changeset is included because this only changes test infrastructure.

## Testing

- `pnpm lint-fix`
- `pnpm tsc` (passed after clearing a stale local `app/node_modules/.vite-check` cache from the first run)
- `APP_PORT=4322 NEXTJS_PORT=3001 pnpm -F app run test app/src/sandbox/button-ref-cleanup/test-browser.ts app/src/sandbox/composite-renderer-6215/test-browser.ts app/src/sandbox/select-combobox-3837/test-browser.ts`
