### PR TITLE
Share popup item role helper

### DIFF
--- a/.changeset/200-popup-item-role-helper.md
+++ b/.changeset/200-popup-item-role-helper.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/utils": patch
+---
+
+Added `getItemRoleByPopupRole` to `@ariakit/utils` for resolving item roles from popup role strings.

--- a/packages/ariakit-react-components/src/combobox/combobox-item.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item.tsx
@@ -10,8 +10,8 @@ import {
 } from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
 import {
+  getItemRoleByPopupRole,
   hasFocus,
-  hasOwnProperty,
   isTextField,
   isDownloading,
   isOpeningInNewTab,
@@ -37,12 +37,6 @@ const TagName = "div" satisfies ElementType;
 type TagName = typeof TagName;
 type HTMLType = HTMLElementTagNameMap[TagName];
 
-const itemRoleByPopupRole = {
-  menu: "menuitem",
-  listbox: "option",
-  tree: "treeitem",
-};
-
 function isSelected(
   storeValue?: string | readonly string[],
   itemValue?: string,
@@ -59,9 +53,7 @@ function isSelected(
  * Returns the role for a combobox item based on the popup role.
  */
 export function getItemRole(popupRole?: string) {
-  if (popupRole == null) return "option";
-  if (!hasOwnProperty(itemRoleByPopupRole, popupRole)) return "option";
-  return itemRoleByPopupRole[popupRole];
+  return getItemRoleByPopupRole(popupRole) ?? "option";
 }
 
 /**

--- a/packages/ariakit-utils/readme.md
+++ b/packages/ariakit-utils/readme.md
@@ -51,6 +51,7 @@ This package is ESM-only and exposes a single public entrypoint.
   - [`getTextboxValue`](#gettextboxvalue)
   - [`getTextboxSelection`](#gettextboxselection)
   - [`getPopupRole`](#getpopuprole)
+  - [`getItemRoleByPopupRole`](#getitemrolebypopuprole)
   - [`getPopupItemRole`](#getpopupitemrole)
   - [`scrollIntoViewIfNeeded`](#scrollintoviewifneeded)
   - [`getScrollingElement`](#getscrollingelement)
@@ -474,6 +475,18 @@ function getPopupRole(
 ```
 
 Returns the popup role from the element's role attribute, if it has one.
+
+<div align="right">
+  <a href="#api-reference">&uarr; back to top</a>
+</div>
+
+#### `getItemRoleByPopupRole`
+
+```ts
+function getItemRoleByPopupRole(popupRole?: string | null): string | undefined;
+```
+
+Returns the item role based on the popup role.
 
 <div align="right">
   <a href="#api-reference">&uarr; back to top</a>

--- a/packages/ariakit-utils/src/dom.test.ts
+++ b/packages/ariakit-utils/src/dom.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, expect, test } from "vitest";
 import {
+  getItemRoleByPopupRole,
   getScrollingElement,
   getTextboxSelection,
   getTextboxValue,
@@ -22,6 +23,14 @@ test("detects text fields without throwing for unsupported inputs", () => {
   expect(isTextField(text)).toBe(true);
   expect(isTextField(checkbox)).toBe(false);
   expect(isTextField(textarea)).toBe(true);
+});
+
+test("gets item roles by popup role", () => {
+  expect(getItemRoleByPopupRole("menu")).toBe("menuitem");
+  expect(getItemRoleByPopupRole("listbox")).toBe("option");
+  expect(getItemRoleByPopupRole("tree")).toBe("treeitem");
+  expect(getItemRoleByPopupRole("dialog")).toBeUndefined();
+  expect(getItemRoleByPopupRole("toString")).toBeUndefined();
 });
 
 test("reads selection offsets from text fields", () => {

--- a/packages/ariakit-utils/src/dom.ts
+++ b/packages/ariakit-utils/src/dom.ts
@@ -3,6 +3,7 @@
  * @module DOM utilities
  */
 
+import { hasOwnProperty } from "./misc.ts";
 import type { AriaHasPopup, AriaRole } from "./types.ts";
 
 /**
@@ -279,6 +280,15 @@ export function getPopupRole(
 }
 
 /**
+ * Returns the item role based on the popup role.
+ */
+export function getItemRoleByPopupRole(popupRole?: string | null) {
+  if (popupRole == null) return;
+  if (!hasOwnProperty(itemRoleByPopupRole, popupRole)) return;
+  return itemRoleByPopupRole[popupRole];
+}
+
+/**
  * Returns the item role attribute based on the popup's role.
  */
 export function getPopupItemRole(
@@ -286,9 +296,8 @@ export function getPopupItemRole(
   fallback?: AriaRole,
 ) {
   const popupRole = getPopupRole(element);
-  if (!popupRole) return fallback;
-  const key = popupRole as keyof typeof itemRoleByPopupRole;
-  return itemRoleByPopupRole[key] ?? fallback;
+  if (typeof popupRole !== "string") return fallback;
+  return getItemRoleByPopupRole(popupRole) ?? fallback;
 }
 
 /**


### PR DESCRIPTION
## Motivation

`ComboboxItem` kept its own popup-role-to-item-role map even though `@ariakit/utils` already owns the same mapping for `getPopupItemRole`. Keeping both copies in separate packages makes future role changes easier to miss, and the Combobox path still needs an own-property guard because it receives raw role strings.

```ts
getItemRoleByPopupRole("menu"); // "menuitem"
getItemRoleByPopupRole("toString"); // undefined
```

## Solution

Add `getItemRoleByPopupRole` to `@ariakit/utils` as the shared guarded string lookup. `getPopupItemRole` delegates to it after narrowing the DOM-derived popup role, and Combobox's exported `getItemRole` wrapper delegates to the same helper while preserving its `"option"` fallback.

The PR also adds focused coverage for mapped roles and inherited prototype keys, updates the generated `@ariakit/utils` README entry, and includes a changeset for the new utils export.

## Verification

- `pnpm lint-fix`
- `pnpm test packages/ariakit-utils/src/dom.test.ts`
- `pnpm tsc`
- `pnpm build`
- `pnpm -F @ariakit/utils run docs`
