### PR TITLE
Prevent form store prototype path corruption

### DIFF
--- a/.changeset/300-form-store-prototype-keys.md
+++ b/.changeset/300-form-store-prototype-keys.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/components": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`useFormStore`](https://ariakit.com/reference/use-form-store) to ignore `__proto__` and `constructor` path segments in field names, preventing form state objects from being corrupted through prototype replacement.

--- a/packages/ariakit-components/src/form/form-store.test.ts
+++ b/packages/ariakit-components/src/form/form-store.test.ts
@@ -29,6 +29,20 @@ test("supports numeric array path segments at runtime", () => {
   });
 });
 
+test("normalizes runtime array path segments", () => {
+  const store = createFormStore({});
+  const path = [new String("__proto__"), "polluted"];
+
+  Reflect.apply(store.setValue, store, [path, true]);
+
+  const { values } = store.getState();
+
+  expect(Object.getPrototypeOf(values)).toBe(Object.prototype);
+  expect("polluted" in values).toBe(false);
+  expect(values).toEqual({});
+  expect(Reflect.apply(store.getValue, store, [path])).toBeUndefined();
+});
+
 test("uses object paths for non-array index segments", () => {
   const store = createFormStore({});
 
@@ -48,6 +62,23 @@ test("uses object paths for non-array index segments", () => {
   });
 });
 
+test("ignores prototype path segments", () => {
+  const store = createFormStore({});
+
+  store.setValue("__proto__.polluted", true);
+  store.setValue("user.__proto__.polluted", true);
+  store.setValue("constructor.prototype.polluted", true);
+
+  const { values } = store.getState();
+
+  expect(Object.getPrototypeOf(values)).toBe(Object.prototype);
+  expect("polluted" in values).toBe(false);
+  expect(values).toEqual({});
+  expect(store.getValue("__proto__.polluted")).toBeUndefined();
+  expect(store.getValue("user.__proto__.polluted")).toBeUndefined();
+  expect(store.getValue("constructor.prototype.polluted")).toBeUndefined();
+});
+
 test("replaces an existing array container for non-array index segments", () => {
   const store = createFormStore({});
 
@@ -58,6 +89,14 @@ test("replaces an existing array container for non-array index segments", () => 
   expect(store.getState().values).toEqual({
     users: { "0": { name: "Ada" }, "-1": { name: "Grace" } },
   });
+});
+
+test("preserves values when ignoring prototype path segments", () => {
+  const store = createFormStore({ defaultValues: { user: "Ada" } });
+
+  store.setValue("user.__proto__.polluted", true);
+
+  expect(store.getState().values).toEqual({ user: "Ada" });
 });
 
 test("updates nested values with setter functions", () => {
@@ -117,4 +156,44 @@ test("marks nested values as touched on submit", async () => {
     user: { name: true },
     items: [{ name: true }, { name: true }],
   });
+});
+
+test("ignores prototype keys when marking values as touched", async () => {
+  const defaultValues = JSON.parse('{"__proto__":{"polluted":true},"name":""}');
+  const store = createFormStore({ defaultValues });
+
+  await store.submit();
+
+  const { touched } = store.getState();
+
+  expect(Object.getPrototypeOf(touched)).toBe(Object.prototype);
+  expect("polluted" in touched).toBe(false);
+  expect(touched).toEqual({ name: true });
+});
+
+test("ignores prototype keys when updating values", () => {
+  const defaultValues = JSON.parse('{"__proto__":{"polluted":true},"name":""}');
+  const store = createFormStore({ defaultValues });
+
+  store.setValue("name", "Ada");
+
+  const { values } = store.getState();
+
+  expect(Object.getPrototypeOf(values)).toBe(Object.prototype);
+  expect("polluted" in values).toBe(false);
+  expect(Object.hasOwn(values, "__proto__")).toBe(false);
+  expect(values).toEqual({ name: "Ada" });
+});
+
+test("ignores prototype error keys when validating messages", () => {
+  const defaultErrors = JSON.parse('{"__proto__":{"message":"Invalid"}}');
+  const store = createFormStore({ defaultErrors });
+
+  expect(store.getState().valid).toBe(true);
+  expect(store.getError("__proto__.message")).toBeUndefined();
+
+  store.setErrors(JSON.parse('{"constructor":{"message":"Invalid"}}'));
+
+  expect(store.getState().valid).toBe(true);
+  expect(store.getError("constructor.message")).toBeUndefined();
 });

--- a/packages/ariakit-components/src/form/form-store.ts
+++ b/packages/ariakit-components/src/form/form-store.ts
@@ -42,13 +42,6 @@ function isPrototypePathSegment(key: PathSegment) {
   return false;
 }
 
-function hasPrototypePathSegment(path: readonly PathSegment[]) {
-  for (const key of path) {
-    if (isPrototypePathSegment(key)) return true;
-  }
-  return false;
-}
-
 function nextFrame() {
   return new Promise<void>((resolve) => {
     // Browsers pause `requestAnimationFrame` in hidden documents, which would
@@ -92,10 +85,9 @@ function getPathValue<T>(
   defaultValue?: T,
 ): T {
   const [key, ...rest] = path;
-  if (key == null || !values) {
+  if (key == null || !values || isPrototypePathSegment(key)) {
     return defaultValue as T;
   }
-  if (isPrototypePathSegment(key)) return defaultValue as T;
   if (!rest.length) {
     return values[key] ?? defaultValue;
   }
@@ -146,7 +138,7 @@ function set<T extends FormStoreValues | unknown[]>(
   value: unknown,
 ): T {
   const pathKeys = getPath(path);
-  if (hasPrototypePathSegment(pathKeys)) return values;
+  if (pathKeys.some(isPrototypePathSegment)) return values;
   return setPath(values, pathKeys, value);
 }
 

--- a/packages/ariakit-components/src/form/form-store.ts
+++ b/packages/ariakit-components/src/form/form-store.ts
@@ -23,7 +23,31 @@ import { createCollectionStore } from "../collection/collection-store.ts";
 import type { DeepMap, DeepPartial, Names, StringLike } from "./types.ts";
 
 type ErrorMessage = string | undefined | null;
+type PathSegment = string | number;
 const maxArrayIndex = 2 ** 32 - 2;
+
+function getPath(path: StringLike | unknown[]) {
+  if (!Array.isArray(path)) {
+    return String(path).split(".");
+  }
+  return path.map((key) => {
+    if (typeof key === "number") return key;
+    return String(key);
+  });
+}
+
+function isPrototypePathSegment(key: PathSegment) {
+  if (key === "__proto__") return true;
+  if (key === "constructor") return true;
+  return false;
+}
+
+function hasPrototypePathSegment(path: readonly PathSegment[]) {
+  for (const key of path) {
+    if (isPrototypePathSegment(key)) return true;
+  }
+  return false;
+}
 
 function nextFrame() {
   return new Promise<void>((resolve) => {
@@ -41,30 +65,44 @@ function nextFrame() {
 }
 
 export function hasMessages(object: FormStoreValues): boolean {
-  return Object.keys(object).some((key) => {
+  const keys = Object.keys(object);
+  for (const key of keys) {
+    if (isPrototypePathSegment(key)) continue;
     if (isObject(object[key])) {
-      return hasMessages(object[key]);
+      if (hasMessages(object[key])) return true;
+      continue;
     }
-    return !!object[key];
-  });
+    if (object[key]) return true;
+  }
+  return false;
 }
 
 export function get<T>(
   values: FormStoreValues,
-  path: StringLike | string[],
+  path: StringLike | Array<string | number>,
   defaultValue?: T,
 ): T {
-  const [key, ...rest] = Array.isArray(path) ? path : String(path).split(".");
+  const pathKeys = getPath(path);
+  return getPathValue(values, pathKeys, defaultValue);
+}
+
+function getPathValue<T>(
+  values: FormStoreValues,
+  path: PathSegment[],
+  defaultValue?: T,
+): T {
+  const [key, ...rest] = path;
   if (key == null || !values) {
     return defaultValue as T;
   }
+  if (isPrototypePathSegment(key)) return defaultValue as T;
   if (!rest.length) {
     return values[key] ?? defaultValue;
   }
-  return get(values[key], rest, defaultValue);
+  return getPathValue(values[key], rest, defaultValue);
 }
 
-function isArrayIndex(key: string | number) {
+function isArrayIndex(key: PathSegment) {
   if (typeof key !== "string" && typeof key !== "number") return false;
   const stringKey = String(key);
   const index = Number(stringKey);
@@ -78,11 +116,28 @@ function isArrayIndex(key: string | number) {
 
 // Returns the existing nested value if it is an array or object, otherwise
 // creates a new container based on whether the next key is an array index.
-function getOrCreateNested(nestedValues: unknown, nextKey: string | number) {
+function getOrCreateNested(nestedValues: unknown, nextKey: PathSegment) {
   if (Array.isArray(nestedValues) || isObject(nestedValues)) {
     return nestedValues;
   }
   return isArrayIndex(nextKey) ? [] : {};
+}
+
+function setObjectValue<T extends FormStoreValues | unknown[]>(
+  values: T,
+  key: keyof T,
+  value: unknown,
+) {
+  const result = {} as T;
+  if (values) {
+    const keys = Object.keys(values);
+    for (const propertyKey of keys) {
+      if (isPrototypePathSegment(propertyKey)) continue;
+      result[propertyKey as keyof T] = values[propertyKey as keyof T];
+    }
+  }
+  result[key] = value as T[keyof T];
+  return result;
 }
 
 function set<T extends FormStoreValues | unknown[]>(
@@ -90,7 +145,17 @@ function set<T extends FormStoreValues | unknown[]>(
   path: StringLike | Array<string | number>,
   value: unknown,
 ): T {
-  const [k, ...rest] = Array.isArray(path) ? path : String(path).split(".");
+  const pathKeys = getPath(path);
+  if (hasPrototypePathSegment(pathKeys)) return values;
+  return setPath(values, pathKeys, value);
+}
+
+function setPath<T extends FormStoreValues | unknown[]>(
+  values: T,
+  path: PathSegment[],
+  value: unknown,
+): T {
+  const [k, ...rest] = path;
   if (k == null) return values;
   const key = k as keyof T;
   const isArrayIndexKey = isArrayIndex(k);
@@ -99,7 +164,7 @@ function set<T extends FormStoreValues | unknown[]>(
   const nextKey = rest[0];
   const result =
     rest.length && nextKey != null
-      ? set(getOrCreateNested(nestedValues, nextKey), rest, value)
+      ? setPath(getOrCreateNested(nestedValues, nextKey), rest, value)
       : value;
   if (isArrayIndexKey) {
     const index = Number(key);
@@ -112,13 +177,14 @@ function set<T extends FormStoreValues | unknown[]>(
     nextValues[index as keyof T] = result as T[keyof T];
     return nextValues;
   }
-  return Object.assign({}, values, { [key]: result });
+  return setObjectValue(values, key, result);
 }
 
 function setAll<T extends FormStoreValues, V>(values: T, value: V) {
   const result = {} as FormStoreValues;
   const keys = Object.keys(values);
   for (const key of keys) {
+    if (isPrototypePathSegment(key)) continue;
     const currentValue = values[key];
     if (Array.isArray(currentValue)) {
       result[key] = currentValue.map((v) => {


### PR DESCRIPTION
## Motivation

The form store accepts field names as dot-delimited paths and uses each segment as an object key for values, errors, and touched state. A `__proto__` or `constructor` segment could previously flow into reads and writes: object copies could replace the returned state object's prototype, inherited properties could be resolved, and protected keys from JSON-defined form data could affect derived state even though field APIs could not address them.

This mostly affects dynamic or server-driven forms where field names or form state can come from external data.

## Solution

Normalize runtime array path segments before processing them, then treat `__proto__` and `constructor` as protected path segments. Reads return the default value, writes no-op before creating nested containers, and state-copy helpers skip protected own keys so they cannot replace object prototypes.

The same protected-key rule now applies when deriving touched state and when scanning errors for validation messages, keeping `valid` consistent with what `getError` and `setError` can read or clear.

## Verification

- `corepack pnpm exec vitest packages/ariakit-components/src/form/form-store.test.ts --run`
- `corepack pnpm tsc`
- `corepack pnpm lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form field path handling to ignore unsafe keys like `__proto__` and `constructor`, helping prevent corrupted form state.
  * Fixed updates, touched state, and validation/message handling so protected keys are skipped consistently.
  * Added safeguards for array-style field paths and nested values to keep form data stable and secure.
  * Updated the form-store getter/setter behavior to normalize path segments and avoid prototype-related corruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->