### PR TITLE
Remove orchestrate non-null assertion

### DIFF
--- a/packages/ariakit-react-components/src/dialog/utils/orchestrate.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/orchestrate.ts
@@ -28,11 +28,12 @@ export function orchestrate(
   key: string,
   setup: () => () => void,
 ) {
-  if (!cleanups.has(element)) {
-    cleanups.set(element, new Map());
+  let elementCleanups = cleanups.get(element);
+  if (!elementCleanups) {
+    elementCleanups = new Map();
+    cleanups.set(element, elementCleanups);
   }
 
-  const elementCleanups = cleanups.get(element)!;
   const stack = elementCleanups.get(key) ?? [];
   const entry: CleanupEntry = { cleanup: setup(), disposed: false };
 


### PR DESCRIPTION
## Motivation

`orchestrate()` retrieves the per-element cleanup map with a `has`/`set`/`get` sequence followed by a non-null assertion:

```ts
if (!cleanups.has(element)) {
  cleanups.set(element, new Map());
}

const elementCleanups = cleanups.get(element)!;
```

The assertion is avoidable, and the extra WeakMap lookup makes a shared dialog utility slightly noisier than needed.

## Solution

Read the cleanup map first, initialize it on miss, and store that same map before using it:

```ts
let elementCleanups = cleanups.get(element);
if (!elementCleanups) {
  elementCleanups = new Map();
  cleanups.set(element, elementCleanups);
}
```

This lets TypeScript narrow the local variable through ordinary control flow while preserving the existing cleanup stack behavior.
