### PR TITLE
Remove select value non-null assertion

### DIFF
--- a/packages/ariakit-react-components/src/select/select.tsx
+++ b/packages/ariakit-react-components/src/select/select.tsx
@@ -176,7 +176,8 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
   });
   const values = useMemo(() => {
     // Filter out items without value and duplicate values.
-    return [...new Set(items?.map((i) => i.value!).filter((v) => v != null))];
+    const itemValues = items?.flatMap((item) => item.value ?? []);
+    return [...new Set(itemValues)];
   }, [items]);
 
   // Renders a native select element with the same value as the select so we


### PR DESCRIPTION
## Motivation

`useSelect` builds option values for the hidden native `<select>` used by browser autofill from select store items. `SelectStoreItem.value` is optional, but the memo used a non-null assertion before filtering out nullish values:

```tsx
items?.map((i) => i.value!).filter((v) => v != null)
```

That made the type less honest and could make the nullish filter look redundant to future refactors.

## Solution

Collect item values with `flatMap` instead:

```tsx
const itemValues = items?.flatMap((item) => item.value ?? []);
return [...new Set(itemValues)];
```

This drops only nullish values, keeps empty-string values, and preserves the existing `Set` deduplication behavior without a non-null assertion.

## Verification

- `pnpm lint-fix`
- `pnpm test-react examples/select-autofill/test.ts`
- `pnpm tsc` passed on rerun after an initial local Astro/Vite optimize-deps cache miss under `app/node_modules/.vite-check`
