### PR TITLE
Fix TagListLabel option types

### DIFF
--- a/.changeset/300-tag-list-label-options.md
+++ b/.changeset/300-tag-list-label-options.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/react-components": patch
+---
+
+Fixed `TagListLabel` types so unsupported composite and focusable options are no longer accepted.

--- a/packages/ariakit-react-components/src/tag/tag-list-label.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-list-label.tsx
@@ -6,10 +6,9 @@ import {
   createHook,
   forwardRef,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Options, Props } from "@ariakit/react-utils";
 import { invariant } from "@ariakit/utils";
 import type { ElementType } from "react";
-import type { CompositeOptions } from "../composite/composite.tsx";
 import { useTagContext } from "./tag-context.tsx";
 import type { TagStore } from "./tag-store.ts";
 
@@ -84,8 +83,8 @@ export const TagListLabel = forwardRef(function TagListLabel(
 });
 
 export interface TagListLabelOptions<
-  T extends ElementType = TagName,
-> extends CompositeOptions<T> {
+  _T extends ElementType = TagName,
+> extends Options {
   /**
    * Object returned by the
    * [`useTagStore`](https://ariakit.com/reference/use-tag-store) hook. If not


### PR DESCRIPTION
## Motivation

`TagListLabelOptions` extended `CompositeOptions`, but `TagListLabel` does not implement composite or focusable behavior. This made TypeScript accept unsupported props such as `focusOnMove` or `onFocusVisible`, which passed through to the rendered `label` and could produce invalid DOM attributes or React development warnings.

## Solution

Changed `TagListLabelOptions` to extend the base `Options` type from `@ariakit/react-utils`, while preserving the existing generic parameter used by `TagListLabelProps<T>`. This removes the unused `CompositeOptions` import and keeps composition props like `render` and `wrapElement` available.

Added a patch changeset for `@ariakit/react-components`.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm build`
