### PR TITLE
Share checkbox primitive value helper

### DIFF
--- a/packages/ariakit-react-components/src/checkbox/__utils.ts
+++ b/packages/ariakit-react-components/src/checkbox/__utils.ts
@@ -1,0 +1,6 @@
+export function getPrimitiveValue<T>(value: T) {
+  if (Array.isArray(value)) {
+    return value.toString();
+  }
+  return value as Exclude<T, readonly any[]>;
+}

--- a/packages/ariakit-react-components/src/checkbox/checkbox.tsx
+++ b/packages/ariakit-react-components/src/checkbox/checkbox.tsx
@@ -20,6 +20,7 @@ import type {
 import { useEffect, useRef, useState } from "react";
 import type { CommandOptions } from "../command/command.tsx";
 import { useCommand } from "../command/command.tsx";
+import { getPrimitiveValue } from "./__utils.ts";
 import { CheckboxCheckedContext } from "./checkbox-checked-context.tsx";
 import { useCheckboxContext } from "./checkbox-context.tsx";
 import type { CheckboxStore } from "./checkbox-store.ts";
@@ -38,13 +39,6 @@ function setMixed(element: HTMLType, mixed?: boolean) {
 
 function isNativeCheckbox(tagName?: string, type?: string) {
   return tagName === "input" && (!type || type === "checkbox");
-}
-
-function getPrimitiveValue<T>(value: T) {
-  if (Array.isArray(value)) {
-    return value.toString();
-  }
-  return value as Exclude<T, readonly any[]>;
 }
 
 /**

--- a/packages/ariakit-react-components/src/menu/menu-item-checkbox.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-item-checkbox.tsx
@@ -10,6 +10,7 @@ import type { Props } from "@ariakit/react-utils";
 import { invariant, shallowEqual } from "@ariakit/utils";
 import type { ElementType } from "react";
 import { useEffect } from "react";
+import { getPrimitiveValue } from "../checkbox/__utils.ts";
 import { useCheckboxStore } from "../checkbox/checkbox-store.ts";
 import type { CheckboxOptions } from "../checkbox/checkbox.tsx";
 import { useCheckbox } from "../checkbox/checkbox.tsx";
@@ -21,13 +22,6 @@ import type { MenuStore, MenuStoreValues } from "./menu-store.ts";
 const TagName = "div" satisfies ElementType;
 type TagName = typeof TagName;
 type ValueState = MenuStoreValues[string];
-
-function getPrimitiveValue<T>(value: T) {
-  if (Array.isArray(value)) {
-    return value.toString();
-  }
-  return value as Exclude<T, readonly any[]>;
-}
 
 function getValue(
   storeValue: ValueState,


### PR DESCRIPTION
## Motivation

`Checkbox` and `MenuItemCheckbox` both normalized checkbox `value` props with duplicated `getPrimitiveValue` logic. These paths can read from and write to the same array-backed value state, so keeping two private copies makes future normalization changes easy to apply to one path but not the other.

## Solution

Move `getPrimitiveValue` into an internal checkbox helper module and import it from both `checkbox.tsx` and `menu-item-checkbox.tsx`. The helper uses the `__utils.ts` naming convention so generated package exports keep it private, and the distinct scalar and no-value updater branches stay local to each component.

No changeset is included because this is an internal refactor with no behavior or public API change.

## Testing

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm test-react examples/checkbox-group/test.ts examples/menu-item-checkbox/test.ts`
