### PR TITLE
Remove redundant menubar store wrapper

### DIFF
--- a/.changeset/300-menubar-store-wrapper.md
+++ b/.changeset/300-menubar-store-wrapper.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/components": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed menubar and menu bar stores to reflect navigation updates immediately before initialization.

--- a/packages/ariakit-components/src/menubar/menubar-store.test.ts
+++ b/packages/ariakit-components/src/menubar/menubar-store.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "vitest";
+import { createMenubarStore } from "./menubar-store.ts";
+
+test("reflects navigation state updates before initialization", () => {
+  const store = createMenubarStore();
+
+  store.setActiveId("file");
+  expect(store.getState().activeId).toBe("file");
+
+  store.move("edit");
+  expect(store.getState().activeId).toBe("edit");
+  expect(store.getState().moves).toBe(1);
+});

--- a/packages/ariakit-components/src/menubar/menubar-store.ts
+++ b/packages/ariakit-components/src/menubar/menubar-store.ts
@@ -1,4 +1,3 @@
-import { createStore } from "@ariakit/store";
 import type { Store, StoreProps } from "@ariakit/store";
 import { defaultValue } from "@ariakit/utils";
 import type {
@@ -16,7 +15,7 @@ export function createMenubarStore(
 ): MenubarStore {
   const syncState = props.store?.getState();
 
-  const composite = createCompositeStore({
+  return createCompositeStore({
     ...props,
     orientation: defaultValue(
       props.orientation,
@@ -25,17 +24,6 @@ export function createMenubarStore(
     ),
     focusLoop: defaultValue(props.focusLoop, syncState?.focusLoop, true),
   });
-
-  const initialState: MenubarStoreState = {
-    ...composite.getState(),
-  };
-
-  const menubar = createStore(initialState, composite, props.store);
-
-  return {
-    ...composite,
-    ...menubar,
-  };
 }
 
 export interface MenubarStoreState extends CompositeStoreState {}


### PR DESCRIPTION
## Motivation

`createMenubarStore` builds a composite store and then wraps it in a second store that adds no state or functions. This duplicates store sync wiring and can make pre-initialization navigation updates inconsistent: methods like `setActiveId` and `move` update the inner composite store while `getState` reads from the outer wrapper snapshot.

## Solution

Return the composite store directly, matching the existing `createToolbarStore` pattern. `createCompositeStore` already handles `props.store` syncing, and the menubar store interfaces add no extra state or functions beyond the composite store surface.

This also adds a regression test that verifies `setActiveId` and `move` are reflected by `getState` before store initialization, and includes a patch changeset for menubar and menu bar stores.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm exec vitest run packages/ariakit-components/src/menubar/menubar-store.test.ts`
- `pnpm test`
- `pnpm test-react examples/menubar/test.ts`
- `pnpm build`
