### PR TITLE
Reduce menu initial focus rerenders

### DIFF
--- a/.changeset/300-menu-initial-focus-renders.md
+++ b/.changeset/300-menu-initial-focus-renders.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Reduced extra [`Menu`](https://ariakit.com/reference/menu) renders when menu items re-register without changing the initial focus target.

--- a/app/src/sandbox/menu-initial-focus-render/index.react.tsx
+++ b/app/src/sandbox/menu-initial-focus-render/index.react.tsx
@@ -1,0 +1,56 @@
+import * as Ariakit from "@ariakit/react";
+import { useMenu } from "@ariakit/react-components/menu/menu";
+import { useRef } from "react";
+
+interface MenuProps {
+  store: Ariakit.MenuStore;
+}
+
+function InstrumentedMenu({ store }: MenuProps) {
+  const renderCount = useRef(0);
+  renderCount.current += 1;
+
+  const props = useMenu({
+    store,
+    hideOnInteractOutside: false,
+  });
+
+  return (
+    <>
+      <Ariakit.Role {...props}>
+        <Ariakit.MenuItem>Edit</Ariakit.MenuItem>
+        <Ariakit.MenuItem>Share</Ariakit.MenuItem>
+        <Ariakit.MenuItem>Delete</Ariakit.MenuItem>
+      </Ariakit.Role>
+      <output aria-label="Menu renders">{renderCount.current}</output>
+    </>
+  );
+}
+
+function RenderedItemsRenders({ store }: MenuProps) {
+  const renderCount = useRef(0);
+  Ariakit.useStoreState(store, "renderedItems");
+  renderCount.current += 1;
+  return (
+    <output aria-label="Rendered items renders">{renderCount.current}</output>
+  );
+}
+
+export default function Example() {
+  const menu = Ariakit.useMenuStore();
+
+  return (
+    <div>
+      <Ariakit.MenuButton store={menu}>Actions</Ariakit.MenuButton>
+      <InstrumentedMenu store={menu} />
+      <RenderedItemsRenders store={menu} />
+      <Ariakit.Button
+        onClick={() => {
+          menu.setState("renderedItems", (items) => [...items]);
+        }}
+      >
+        Refresh rendered items
+      </Ariakit.Button>
+    </div>
+  );
+}

--- a/app/src/sandbox/menu-initial-focus-render/test-browser.ts
+++ b/app/src/sandbox/menu-initial-focus-render/test-browser.ts
@@ -1,0 +1,35 @@
+import { flushFrames, withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("does not re-render when rendered items keep the same focus element", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Actions").focus();
+    await page.keyboard.press("ArrowDown");
+    await test.expect(q.menu()).toBeVisible();
+    await test.expect(q.menuitem("Edit")).toBeVisible();
+
+    await flushFrames(page);
+
+    const menuRenders = q.status("Menu renders");
+    const renderedItemsRenders = q.status("Rendered items renders");
+    const previousMenuRenders = await menuRenders.textContent();
+    const previousRenderedItemsRenders =
+      await renderedItemsRenders.textContent();
+
+    if (previousMenuRenders == null) {
+      throw new Error("Menu render count was not found");
+    }
+    if (previousRenderedItemsRenders == null) {
+      throw new Error("Rendered items render count was not found");
+    }
+
+    await q.button("Refresh rendered items").click();
+
+    await test
+      .expect(renderedItemsRenders)
+      .not.toHaveText(previousRenderedItemsRenders);
+    await test.expect(menuRenders).toHaveText(previousMenuRenders);
+  });
+});

--- a/packages/ariakit-react-components/src/menu/menu.tsx
+++ b/packages/ariakit-react-components/src/menu/menu.tsx
@@ -87,10 +87,30 @@ export const useMenu = createHook<TagName, MenuOptions>(function useMenu({
   const [initialFocusRef, setInitialFocusRef] =
     useState<MutableRefObject<HTMLElement | null>>();
 
-  const autoFocusOnShowState = useStoreState(store, "autoFocusOnShow");
-  const initialFocus = useStoreState(store, "initialFocus");
-  const baseElement = useStoreState(store, "baseElement");
-  const items = useStoreState(store, "renderedItems");
+  // Resolve the initial focus element inside a selector so the component
+  // re-renders only when the resolved element changes, not whenever
+  // `renderedItems` gets a new array identity. Returning `undefined` means
+  // auto focus on show is disabled.
+  const initialFocusElement = useStoreState(store, (state) => {
+    if (!state.autoFocusOnShow) return;
+    const isEnabled = (item: (typeof state.renderedItems)[number]) =>
+      !item.disabled && !!item.element;
+    switch (state.initialFocus) {
+      case "first":
+        return state.renderedItems.find(isEnabled)?.element || null;
+      case "last":
+        for (let i = state.renderedItems.length - 1; i >= 0; i -= 1) {
+          const item = state.renderedItems[i];
+          if (!item) continue;
+          if (item.disabled) continue;
+          if (!item.element) continue;
+          return item.element;
+        }
+        return null;
+      default:
+        return state.baseElement;
+    }
+  });
 
   // Sets the initial focus ref.
   useEffect(() => {
@@ -100,34 +120,21 @@ export const useMenu = createHook<TagName, MenuOptions>(function useMenu({
       if (modal && prevInitialFocusRef?.current?.isConnected) {
         return prevInitialFocusRef;
       }
-      if (!autoFocusOnShowState) return;
-      let element: HTMLElement | null;
-      switch (initialFocus) {
-        // TODO: Refactor
-        case "first":
-          element =
-            items.find((item) => !item.disabled && item.element)?.element ||
-            null;
-          break;
-        case "last":
-          element =
-            [...items].reverse().find((item) => !item.disabled && item.element)
-              ?.element || null;
-          break;
-        default:
-          element = baseElement;
-      }
-      if (element && element === prevInitialFocusRef?.current) {
+      if (initialFocusElement === undefined) return;
+      if (
+        initialFocusElement &&
+        initialFocusElement === prevInitialFocusRef?.current
+      ) {
         return prevInitialFocusRef;
       }
       const ref = createRef() as MutableRefObject<HTMLElement | null>;
-      ref.current = element;
+      ref.current = initialFocusElement;
       return ref;
     });
     return () => {
       cleaning = true;
     };
-  }, [store, modal, autoFocusOnShowState, initialFocus, items, baseElement]);
+  }, [modal, initialFocusElement]);
 
   // When the `autoFocusOnShow` prop is set to `true` (default), we'll only
   // move focus to the menu when there's an initialFocusRef set or the menu is

--- a/packages/ariakit-react-components/src/menu/menu.tsx
+++ b/packages/ariakit-react-components/src/menu/menu.tsx
@@ -101,10 +101,9 @@ export const useMenu = createHook<TagName, MenuOptions>(function useMenu({
       case "last":
         for (let i = state.renderedItems.length - 1; i >= 0; i -= 1) {
           const item = state.renderedItems[i];
-          if (!item) continue;
-          if (item.disabled) continue;
-          if (!item.element) continue;
-          return item.element;
+          if (item && isEnabled(item)) {
+            return item.element;
+          }
         }
         return null;
       default:


### PR DESCRIPTION
## Motivation

`useMenu` subscribed directly to `autoFocusOnShow`, `initialFocus`, `baseElement`, and `renderedItems` only to resolve the initial focus element. When menu items re-register or `renderedItems` is re-sorted, that array can receive a fresh identity even if the resolved focus target stays the same, causing the full `Menu` hook chain to re-render unnecessarily.

## Solution

Resolve the initial focus element inside a single `useStoreState` selector. This keeps the snapshot stable when `renderedItems` changes identity but still points to the same DOM element, while preserving the disabled-auto-focus `undefined` state, unresolved-target `null` state, modal persistent-focus guard, and ref identity updates when the actual target changes.

The `"last"` focus path now scans the rendered items from the end without copying the array, so selector work stays allocation-free on store notifications.

## Testing

- `pnpm lint-fix`
- `pnpm tsc`
- `APP_PORT=4321 NEXTJS_PORT=3000 pnpm exec playwright test --project=chrome src/sandbox/menu-initial-focus-render/test-browser.ts`
- `APP_PORT=4321 NEXTJS_PORT=3000 pnpm exec playwright test --project=chrome src/sandbox/menu-4291/test-browser.ts`
- `pnpm build`