### PR TITLE
Clean package builds directly in dev

### DIFF
--- a/packages/ariakit-scripts/src/build.test.ts
+++ b/packages/ariakit-scripts/src/build.test.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
 import {
+  access,
   mkdir,
   mkdtemp,
   readFile,
@@ -11,7 +12,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { TraceMap, originalPositionFor } from "@jridgewell/trace-mapping";
 import { expect, test } from "vitest";
-import { updateSourcePackageJson } from "./build.ts";
+import { cleanPackage, updateSourcePackageJson } from "./build.ts";
 
 const cliPath = join(import.meta.dirname, "index.ts");
 
@@ -80,6 +81,10 @@ async function createBuildFixture({
   }
 
   return rootPath;
+}
+
+async function expectPathMissing(path: string) {
+  await expect(access(path)).rejects.toMatchObject({ code: "ENOENT" });
 }
 
 interface SourceMappingExpectation {
@@ -154,6 +159,67 @@ test("omits npm ignored source files from package exports", async () => {
       ".": "./src/index.ts",
       "./button/button": "./src/button/button.ts",
       "./package.json": "./package.json",
+    });
+  } finally {
+    await rm(rootPath, { recursive: true, force: true });
+  }
+});
+
+test("clean removes current and legacy build output", async () => {
+  const rootPath = await createBuildFixture({
+    sources: {
+      "index.ts": "export {};\n",
+      "button.ts": "export {};\n",
+    },
+  });
+
+  try {
+    await writeFile(
+      join(rootPath, "package.json"),
+      `${JSON.stringify(
+        {
+          name: "test-package",
+          main: "cjs/index.cjs",
+          module: "esm/index.js",
+          types: "cjs/index.d.ts",
+          exports: {
+            ".": {
+              import: "./esm/index.js",
+              require: "./cjs/index.cjs",
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const outputFolders = ["dist", "cjs", "esm", "button"];
+
+    for (const folder of outputFolders) {
+      await mkdir(join(rootPath, folder), { recursive: true });
+      await writeFile(join(rootPath, folder, "index.js"), "export {};\n");
+    }
+
+    await cleanPackage(rootPath);
+
+    for (const folder of outputFolders) {
+      await expectPathMissing(join(rootPath, folder));
+    }
+
+    const packageJson = JSON.parse(
+      await readFile(join(rootPath, "package.json"), "utf-8"),
+    );
+
+    expect(packageJson).toMatchObject({
+      main: "src/index.ts",
+      module: "src/index.ts",
+      types: "src/index.ts",
+      exports: {
+        ".": "./src/index.ts",
+        "./button": "./src/button.ts",
+        "./package.json": "./package.json",
+      },
     });
   } finally {
     await rm(rootPath, { recursive: true, force: true });

--- a/packages/ariakit-scripts/src/build.ts
+++ b/packages/ariakit-scripts/src/build.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { build as rolldownBuild } from "rolldown";
 import { dts } from "rolldown-plugin-dts";
 import solidPlugin from "vite-plugin-solid";
+import { cleanLegacyBuild } from "./legacy-clean.ts";
 import { escapeRegExp } from "./regexp.ts";
 import { normalizePath, readPackageJson } from "./utils.ts";
 import type { PackageJson } from "./utils.ts";
@@ -257,6 +258,7 @@ export async function updateSourcePackageJson(
 ) {
   const publicFiles = await getPackagePublicFiles(rootPath, options);
   await updatePackageExports(rootPath, publicFiles, "source");
+  return publicFiles;
 }
 
 function getExternal(packageJson: PackageJson) {
@@ -386,6 +388,10 @@ export async function cleanPackage(
 ) {
   const packageJson = readPackageJson(rootPath);
   const isSolid = isSolidPackage(packageJson);
-  await updateSourcePackageJson(rootPath, options);
+  const publicFiles = await updateSourcePackageJson(rootPath, options);
   cleanOutput(rootPath, isSolid);
+  cleanLegacyBuild(
+    rootPath,
+    publicFiles.map((file) => file.name),
+  );
 }

--- a/packages/ariakit-scripts/src/dev.test.ts
+++ b/packages/ariakit-scripts/src/dev.test.ts
@@ -69,9 +69,14 @@ test("watches packages and cleans changed package entries", async () => {
 
   try {
     await mkdir(join(rootPath, "packages/foo/src"), { recursive: true });
+    await mkdir(join(rootPath, "packages/bar/src"), { recursive: true });
     await writeFile(
       join(rootPath, "packages/foo/package.json"),
       `${JSON.stringify({ scripts: { clean: "ariakit clean" } }, null, 2)}\n`,
+    );
+    await writeFile(
+      join(rootPath, "packages/bar/package.json"),
+      `${JSON.stringify({ scripts: { clean: "custom clean" } }, null, 2)}\n`,
     );
 
     vi.useFakeTimers();
@@ -101,10 +106,20 @@ test("watches packages and cleans changed package entries", async () => {
     expect(firstCall?.[0]).toEqual([
       {
         path: join(rootPath, "packages/foo"),
-        type: "ariakit",
       },
     ]);
     expect(cleanPackages).toHaveBeenCalledTimes(1);
+
+    watcher.emit("change", "packages/bar/src/index.ts");
+    await vi.advanceTimersByTimeAsync(100);
+
+    const secondCall = cleanPackages.mock.calls[1];
+    expect(secondCall?.[0]).toEqual([
+      {
+        path: join(rootPath, "packages/bar"),
+      },
+    ]);
+    expect(cleanPackages).toHaveBeenCalledTimes(2);
   } finally {
     await rm(rootPath, { recursive: true, force: true });
   }

--- a/packages/ariakit-scripts/src/dev.ts
+++ b/packages/ariakit-scripts/src/dev.ts
@@ -12,7 +12,6 @@ interface DevOptions {
 
 interface CleanPackage {
   path: string;
-  type: "ariakit" | "script";
 }
 
 interface PackageWatcher {
@@ -55,7 +54,6 @@ function getCleanPackage(rootPath: string): CleanPackage | undefined {
 
     return {
       path: rootPath,
-      type: cleanScript.startsWith("ariakit clean") ? "ariakit" : "script",
     };
   } catch {
     return;
@@ -95,30 +93,9 @@ function getPackagePath(filename: string) {
   return join(process.cwd(), "packages", packageName);
 }
 
-function runCleanScript(rootPath: string) {
-  return new Promise<void>((resolve, reject) => {
-    const child = spawn("pnpm", ["run", "clean"], {
-      cwd: rootPath,
-      stdio: "inherit",
-    });
-    child.on("error", reject);
-    child.on("exit", (code) => {
-      if (code) {
-        reject(new Error(`pnpm run clean failed with ${code}`));
-        return;
-      }
-      resolve();
-    });
-  });
-}
-
 async function cleanPackages(packages: CleanPackage[]) {
   for (const pkg of packages) {
-    if (pkg.type === "ariakit") {
-      await cleanPackage(pkg.path);
-      continue;
-    }
-    await runCleanScript(pkg.path);
+    await cleanPackage(pkg.path);
   }
 }
 

--- a/packages/ariakit-scripts/src/legacy-clean.test.ts
+++ b/packages/ariakit-scripts/src/legacy-clean.test.ts
@@ -1,0 +1,59 @@
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+import { cleanLegacyBuild } from "./legacy-clean.ts";
+
+async function expectPathMissing(path: string) {
+  await expect(access(path)).rejects.toMatchObject({ code: "ENOENT" });
+}
+
+test("removes legacy build output folders", async () => {
+  const rootPath = await mkdtemp(join(tmpdir(), "ariakit-legacy-clean-"));
+
+  try {
+    await writeFile(
+      join(rootPath, "package.json"),
+      `${JSON.stringify(
+        {
+          name: "test-package",
+          main: "cjs/index.cjs",
+          module: "esm/index.js",
+          types: "cjs/index.d.ts",
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const outputFolders = ["cjs", "esm", "button", "menu"];
+
+    for (const folder of outputFolders) {
+      await mkdir(join(rootPath, folder), { recursive: true });
+      await writeFile(join(rootPath, folder, "index.js"), "export {};\n");
+    }
+
+    cleanLegacyBuild(rootPath, ["index", "button", "menu/menu"]);
+
+    for (const folder of outputFolders) {
+      await expectPathMissing(join(rootPath, folder));
+    }
+
+    const packageJson = JSON.parse(
+      await readFile(join(rootPath, "package.json"), "utf-8"),
+    );
+
+    expect(packageJson.main).toBe("src/index.ts");
+    expect(packageJson.module).toBe("src/index.ts");
+    expect(packageJson.types).toBe("src/index.ts");
+  } finally {
+    await rm(rootPath, { recursive: true, force: true });
+  }
+});

--- a/packages/ariakit-scripts/src/legacy-clean.ts
+++ b/packages/ariakit-scripts/src/legacy-clean.ts
@@ -1,0 +1,54 @@
+import { readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { readPackageJson } from "./utils.ts";
+import type { PackageJson } from "./utils.ts";
+
+const sourceDir = "src";
+const cjsDir = "cjs";
+const esmDir = "esm";
+
+function writePackageJson(rootPath: string, packageJson: PackageJson) {
+  const packageJsonPath = join(rootPath, "package.json");
+  const currentContents = readFileSync(packageJsonPath, "utf-8");
+  const nextContents = `${JSON.stringify(packageJson, null, 2)}\n`;
+  const currentContentsMin = JSON.stringify(JSON.parse(currentContents));
+  const nextContentsMin = JSON.stringify(JSON.parse(nextContents));
+  if (currentContentsMin === nextContentsMin) return;
+  writeFileSync(packageJsonPath, nextContents);
+}
+
+function updateSourcePackageFields(rootPath: string) {
+  const packageJson = readPackageJson(rootPath);
+  const sourceIndex = `${sourceDir}/index.ts`;
+  if ("main" in packageJson) packageJson.main = sourceIndex;
+  if ("module" in packageJson) packageJson.module = sourceIndex;
+  if ("types" in packageJson) packageJson.types = sourceIndex;
+  writePackageJson(rootPath, packageJson);
+}
+
+function getProxyOutputFolders(publicFileNames: string[]) {
+  return Array.from(
+    new Set(
+      publicFileNames
+        .map((name) => name.replace(/\/index$/, ""))
+        .filter((name) => name !== "index")
+        .map((name) => name.split("/")[0])
+        .filter((name): name is string => !!name),
+    ),
+  );
+}
+
+function cleanLegacyOutput(rootPath: string, publicFileNames: string[]) {
+  const folders = [cjsDir, esmDir, ...getProxyOutputFolders(publicFileNames)];
+
+  for (const folder of folders) {
+    rmSync(join(rootPath, folder), { recursive: true, force: true });
+  }
+}
+
+// Keeps packages usable after the legacy CJS build runs. Delete this module
+// when packages no longer produce cjs/esm/proxy output.
+export function cleanLegacyBuild(rootPath: string, publicFileNames: string[]) {
+  updateSourcePackageFields(rootPath);
+  cleanLegacyOutput(rootPath, publicFileNames);
+}


### PR DESCRIPTION
## Motivation

`ariakit dev` currently reaches package cleanup through each package's `clean` script. That keeps the dev workflow coupled to script implementation details, including package clean scripts that still go through older build tooling. We want dev startup and package-change watching to clean build artifacts through `cleanPackage()` directly.

This also needs to handle the temporary state where `@ariakit/react` still uses a legacy CJS build. After `pnpm build && pnpm dev-app`, its CJS/ESM/proxy output must be cleaned so package resolution returns to source files.

## Solution

`dev.ts` now treats packages with a `clean` script as packages to clean through `cleanPackage()` and removes the fallback that spawned `pnpm run clean`.

`build.ts` keeps `cleanPackage()` responsible for the current `dist`/`solid` cleanup, and calls a new `cleanLegacyBuild()` helper with the package public file names. The legacy helper lives in `legacy-clean.ts`, with its own focused test file, so it can be removed cleanly when the legacy CJS build is removed.

The tests cover direct dev routing, the isolated legacy cleanup helper, and the `cleanPackage()` integration path that removes current and legacy output together.
