### PR TITLE
Update @opennextjs/cloudflare to v1.20.0

### DIFF
--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -24,7 +24,7 @@
     "react-dom": "19.2.7"
   },
   "devDependencies": {
-    "@opennextjs/cloudflare": "1.19.11",
+    "@opennextjs/cloudflare": "1.20.0",
     "@tailwindcss/postcss": "4.3.1",
     "@types/node": "24.13.2",
     "@types/react": "19.2.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -557,8 +557,8 @@ importers:
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@opennextjs/cloudflare':
-        specifier: 1.19.11
-        version: 1.19.11(encoding@0.1.13)(next@16.2.9(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(supports-color@8.1.1)(wrangler@4.105.0)
+        specifier: 1.20.0
+        version: 1.20.0(encoding@0.1.13)(next@16.2.9(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(supports-color@8.1.1)(wrangler@4.105.0)
       '@tailwindcss/postcss':
         specifier: 4.3.1
         version: 4.3.1
@@ -3386,12 +3386,16 @@ packages:
     peerDependencies:
       next: '>=15.5.18 <16 || >=16.2.6'
 
-  '@opennextjs/cloudflare@1.19.11':
-    resolution: {integrity: sha512-spZ7YsZZW9q/OJStaZlJhuklYKei5e2tNQ7PMi3DDSJ7x7167m7EYYHQZfVN5gwJBDkMR2jUDW88oHjnGz4YYw==}
+  '@opennextjs/cloudflare@1.20.0':
+    resolution: {integrity: sha512-gbCIRNv4DYU5HgPQEsmyP/v+5zGZkMSGN2bYb04XfSibxiGjwNoTmtRxj/j0yOB70DLe3Xkh5f0eouXshXZtkw==}
     hasBin: true
     peerDependencies:
       next: '>=15.5.18 <16 || >=16.2.6'
+      rclone.js: ^0.6.6
       wrangler: ^4.86.0
+    peerDependenciesMeta:
+      rclone.js:
+        optional: true
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
@@ -12887,7 +12891,7 @@ snapshots:
       - aws-crt
       - supports-color
 
-  '@opennextjs/cloudflare@1.19.11(encoding@0.1.13)(next@16.2.9(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(supports-color@8.1.1)(wrangler@4.105.0)':
+  '@opennextjs/cloudflare@1.20.0(encoding@0.1.13)(next@16.2.9(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(supports-color@8.1.1)(wrangler@4.105.0)':
     dependencies:
       '@ast-grep/napi': 0.40.5
       '@dotenvx/dotenvx': 1.31.0


### PR DESCRIPTION
## Motivation

Keep the Next.js Cloudflare build tooling current by updating `@opennextjs/cloudflare` in the `nextjs` workspace from `1.19.11` to `1.20.0`.

## Solution

Updated the `nextjs` workspace dev dependency and regenerated `pnpm-lock.yaml` with the repository package manager. No application code changes were needed because the new `rclone` deploy path is opt-in and the current scripts use `opennextjs-cloudflare build` and `opennextjs-cloudflare preview` without `--rclone`.

## Dependencies

| Package | From | To | Links |
| --- | --- | --- | --- |
| `@opennextjs/cloudflare` | `1.19.11` | `1.20.0` | [release](https://github.com/opennextjs/opennextjs-cloudflare/releases/tag/%40opennextjs/cloudflare%401.20.0) · [compare](https://github.com/opennextjs/opennextjs-cloudflare/compare/@opennextjs/cloudflare@1.19.11...@opennextjs/cloudflare@1.20.0) · [repo](https://github.com/opennextjs/opennextjs-cloudflare) |

### `@opennextjs/cloudflare` 1.19.11 → 1.20.0

Relevant changes for this repo:

- Adds an optional `--rclone` deploy path for faster R2 cache population. This introduces `rclone.js` as an optional peer dependency, but it is only loaded when the new flag is used.
- Fixes tag purge handling in the R2 bucket cache alarm by passing SQLite bindings in the expected variadic form.
- Fixes R2 cache bucket provisioning by disabling response compression for the Cloudflare API call.

[Full release notes](https://github.com/opennextjs/opennextjs-cloudflare/releases/tag/%40opennextjs/cloudflare%401.20.0)
