### PR TITLE
Make perf comparisons more reliable

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -408,7 +408,7 @@ jobs:
           done
           echo "Shard $PERF_SHARD_INDEX/$PERF_SHARD_TOTAL perf files: ${SHARD_FILES[*]:-<none>}"
 
-          run_perf_round() {
+          run_baseline_perf_round() {
             local i="$1"
 
             echo "::group::Round $i - baseline"
@@ -433,6 +433,10 @@ jobs:
               cp "${baseline_files[@]}" app/.perf-results/
             fi
             echo "::endgroup::"
+          }
+
+          run_current_perf_round() {
+            local i="$1"
 
             echo "::group::Round $i - current"
             PERF_RESULTS_FILE=current-$i-s$PERF_SHARD_INDEX.json \
@@ -445,6 +449,22 @@ jobs:
               exit 1
             fi
             echo "::endgroup::"
+          }
+
+          run_perf_round() {
+            local i="$1"
+
+            # Alternate sides first so same-runner drift cannot consistently
+            # favor the baseline or current run across every paired round.
+            if [ "$(( i % 2 ))" -eq 1 ]; then
+              echo "Round $i order: baseline -> current"
+              run_baseline_perf_round "$i"
+              run_current_perf_round "$i"
+            else
+              echo "Round $i order: current -> baseline"
+              run_current_perf_round "$i"
+              run_baseline_perf_round "$i"
+            fi
           }
 
           if [ ${#SHARD_FILES[@]} -eq 0 ]; then
@@ -557,7 +577,7 @@ jobs:
         run: |
           mkdir -p .perf-results
 
-          run_bench_round() {
+          run_baseline_bench_round() {
             local i="$1"
 
             echo "::group::Round $i - baseline"
@@ -578,6 +598,10 @@ jobs:
               printf '{"files":[]}\n' > ".perf-results/baseline-$i.json"
             fi
             echo "::endgroup::"
+          }
+
+          run_current_bench_round() {
+            local i="$1"
 
             echo "::group::Round $i - current"
             pnpm exec vitest bench \
@@ -588,6 +612,22 @@ jobs:
               exit 1
             fi
             echo "::endgroup::"
+          }
+
+          run_bench_round() {
+            local i="$1"
+
+            # Alternate sides first so same-runner drift cannot consistently
+            # favor the baseline or current run across every paired round.
+            if [ "$(( i % 2 ))" -eq 1 ]; then
+              echo "Round $i order: baseline -> current"
+              run_baseline_bench_round "$i"
+              run_current_bench_round "$i"
+            else
+              echo "Round $i order: current -> baseline"
+              run_current_bench_round "$i"
+              run_baseline_bench_round "$i"
+            fi
           }
 
           for i in $(seq 1 "$PERF_INITIAL_ROUNDS"); do

--- a/packages/ariakit-scripts/src/perf-compare.test.ts
+++ b/packages/ariakit-scripts/src/perf-compare.test.ts
@@ -397,6 +397,21 @@ test("does not flag empty Vitest benchmark metrics in node mode", () => {
   expect(markdown).not.toContain("+0 ops/sec :rocket:");
 });
 
+test("describes Node multi-round comparisons by round agreement", () => {
+  const dir = createTempDir();
+  for (const round of [1, 2]) {
+    writeJson(dir, `baseline-${round}.json`, createStoreBenchmarkReport(1000));
+    writeJson(dir, `current-${round}.json`, createStoreBenchmarkReport(500));
+  }
+
+  const markdown = runCompare(dir, ["--node"]);
+
+  expect(markdown).toContain(
+    "Aggregated across 2 interleaved rounds; a change is flagged only when the median exceeds the threshold, rounds agree on direction.",
+  );
+  expect(markdown).not.toContain("raw samples support it");
+});
+
 test("does not flag noisy rounds that disagree on direction", () => {
   const dir = createTempDir();
   for (let round = 1; round <= 5; round++) {
@@ -440,6 +455,19 @@ test("flags same-direction rounds with separated raw samples", () => {
   expect(markdown).toContain("100.0ms → 160.0ms (+60%) :warning:");
 });
 
+test("pools raw sample support across rounds", () => {
+  const dir = createTempDir();
+  writeRawRound(dir, "baseline", 1, [80, 100, 120, 140, 160]);
+  writeRawRound(dir, "current", 1, [100, 120, 140, 160, 180]);
+  writeRawRound(dir, "baseline", 2, [80, 90, 100, 110, 120]);
+  writeRawRound(dir, "current", 2, [140, 150, 160, 170, 180]);
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain(":warning:");
+  expect(markdown).toContain("110.0ms → 150.0ms (+36%) :warning:");
+});
+
 test("flags a consistent regression across rounds", () => {
   const dir = createTempDir();
   for (let round = 1; round <= 3; round++) {
@@ -469,6 +497,9 @@ test("aggregates displayed values from shared rounds", () => {
   expect(markdown).toContain("200.0ms → 160.0ms (-20%) :rocket:");
   expect(markdown).not.toContain("125.0ms");
   expect(markdown).toContain("Aggregated across 2 interleaved rounds");
+  expect(markdown).toContain(
+    "rounds agree on direction and raw samples support it",
+  );
 });
 
 test("merges sharded round files with shard-suffixed names", () => {

--- a/packages/ariakit-scripts/src/perf-compare.test.ts
+++ b/packages/ariakit-scripts/src/perf-compare.test.ts
@@ -81,6 +81,18 @@ function createMetrics(total: number): PerfMetrics {
   };
 }
 
+function medianValue(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  const midValue = sorted[mid];
+  if (midValue == null) return 0;
+  if (sorted.length % 2 !== 0) return midValue;
+  const prevValue = sorted[mid - 1];
+  if (prevValue == null) return midValue;
+  return (prevValue + midValue) / 2;
+}
+
 function createResult(total: number): PerfResult {
   const metrics = createMetrics(total);
   return {
@@ -89,6 +101,14 @@ function createResult(total: number): PerfResult {
     label: "sandbox/example/perf-chrome.ts > react > example",
     metrics,
     raw: [metrics],
+  };
+}
+
+function createResultWithRaw(label: string, totals: number[]): PerfResult {
+  const metrics = createMetrics(medianValue(totals));
+  return {
+    ...createResultWithMetrics(label, metrics),
+    raw: totals.map(createMetrics),
   };
 }
 
@@ -197,6 +217,17 @@ function writeRound(
   total: number,
 ) {
   writeJson(dir, `${prefix}-${round}-worker0.json`, [createResult(total)]);
+}
+
+function writeRawRound(
+  dir: string,
+  prefix: "baseline" | "current",
+  round: number,
+  totals: number[],
+) {
+  writeJson(dir, `${prefix}-${round}-worker0.json`, [
+    createResultWithRaw("raw samples", totals),
+  ]);
 }
 
 function runCompare(
@@ -380,6 +411,33 @@ test("does not flag noisy rounds that disagree on direction", () => {
   expect(markdown).toContain("No significant performance changes detected.");
   expect(markdown).not.toMatch(/% :warning:/);
   expect(markdown).toContain("Aggregated across 5 interleaved rounds");
+});
+
+test("does not flag same-direction rounds with overlapping raw samples", () => {
+  const dir = createTempDir();
+  for (const round of [1, 2]) {
+    writeRawRound(dir, "baseline", round, [80, 100, 120, 140, 160]);
+    writeRawRound(dir, "current", round, [100, 120, 140, 160, 180]);
+  }
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain("No significant performance changes detected.");
+  expect(markdown).toContain("120.0ms | 140.0ms | +20.0ms (+17%)");
+  expect(markdown).not.toMatch(/% :warning:/);
+});
+
+test("flags same-direction rounds with separated raw samples", () => {
+  const dir = createTempDir();
+  for (const round of [1, 2]) {
+    writeRawRound(dir, "baseline", round, [80, 90, 100, 110, 120]);
+    writeRawRound(dir, "current", round, [140, 150, 160, 170, 180]);
+  }
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain(":warning:");
+  expect(markdown).toContain("100.0ms → 160.0ms (+60%) :warning:");
 });
 
 test("flags a consistent regression across rounds", () => {
@@ -674,8 +732,9 @@ test("aggregates worker shards within the same round", () => {
 
   const markdown = runCompare(dir);
 
-  expect(markdown).toContain("100.0ms → 150.0ms (+50%) :warning:");
-  expect(markdown).toContain("100.0ms | 150.0ms | +50.0ms (+50%) :warning:");
+  expect(markdown).toContain("No significant performance changes detected.");
+  expect(markdown).toContain("100.0ms | 150.0ms | +50.0ms (+50%)");
+  expect(markdown).not.toMatch(/% :warning:/);
 });
 
 test("merges profiles across rounds", () => {

--- a/packages/ariakit-scripts/src/perf-compare.ts
+++ b/packages/ariakit-scripts/src/perf-compare.ts
@@ -25,8 +25,8 @@ const RESULTS_DIR = path.join(process.cwd(), ".perf-results");
 const PROFILE_LIMIT = 10;
 const THRESHOLD_PERCENT = 10;
 const MIN_SIGNIFICANT_DELTA_MS = 5;
-// Require at least 75% of pairwise raw-sample deltas to support the median
-// direction before a round contributes to significance.
+// Require at least 75% of pooled pairwise raw-sample deltas to support the
+// median direction before a browser comparison becomes significant.
 const RAW_SAMPLE_SUPPORT_QUANTILE = 0.25;
 
 type MetricKey = keyof PerfMetrics;
@@ -547,11 +547,17 @@ function computeSignificance({
 
   const delta = current - baseline;
   const direction = Math.sign(delta);
+  if (direction === 0) {
+    return { agreement: 0, significant: false };
+  }
+
   let agreement = 0;
+  const sampleDeltas: number[] = [];
   for (const comparison of roundComparisons) {
-    if (Math.sign(comparison.delta) !== direction) continue;
-    if (!samplesSupportDirection(comparison.sampleDeltas, direction)) continue;
-    agreement += 1;
+    sampleDeltas.push(...comparison.sampleDeltas);
+    if (Math.sign(comparison.delta) === direction) {
+      agreement += 1;
+    }
   }
 
   const percentOk = Math.abs(percent) > THRESHOLD_PERCENT;
@@ -560,10 +566,11 @@ function computeSignificance({
     baseline === 0 && current !== baseline && Math.abs(current) >= minDelta;
   const magnitudeOk = baseline === 0 ? zeroBaselineOk : percentOk && deltaOk;
   const agreementOk = agreement >= requiredAgreement(roundComparisons.length);
+  const sampleSupportOk = samplesSupportDirection(sampleDeltas, direction);
 
   return {
     agreement,
-    significant: primary && magnitudeOk && agreementOk,
+    significant: primary && magnitudeOk && agreementOk && sampleSupportOk,
   };
 }
 
@@ -1142,6 +1149,9 @@ function formatMarkdown(
     unpairedTests.length;
   const resultsName = getResultsName(options);
   const resultName = getResultName(options);
+  const supportClause = options.node
+    ? "rounds agree on direction"
+    : "rounds agree on direction and raw samples support it";
 
   const lines: string[] = [];
   lines.push("## Performance");
@@ -1279,12 +1289,12 @@ function formatMarkdown(
   if (pairedRoundsCount == null) {
     lines.push("");
     lines.push(
-      `Compared ${resultsName} used mixed interleaved round counts; a change is flagged only when the median exceeds the threshold and raw samples support the same direction.`,
+      `Compared ${resultsName} used mixed interleaved round counts; a change is flagged only when the median exceeds the threshold, ${supportClause}.`,
     );
   } else if (pairedRoundsCount > 1) {
     lines.push("");
     lines.push(
-      `Aggregated across ${pairedRoundsCount} interleaved rounds; a change is flagged only when the median exceeds the threshold and raw samples support the same direction.`,
+      `Aggregated across ${pairedRoundsCount} interleaved rounds; a change is flagged only when the median exceeds the threshold, ${supportClause}.`,
     );
   }
 

--- a/packages/ariakit-scripts/src/perf-compare.ts
+++ b/packages/ariakit-scripts/src/perf-compare.ts
@@ -25,6 +25,9 @@ const RESULTS_DIR = path.join(process.cwd(), ".perf-results");
 const PROFILE_LIMIT = 10;
 const THRESHOLD_PERCENT = 10;
 const MIN_SIGNIFICANT_DELTA_MS = 5;
+// Require at least 75% of pairwise raw-sample deltas to support the median
+// direction before a round contributes to significance.
+const RAW_SAMPLE_SUPPORT_QUANTILE = 0.25;
 
 type MetricKey = keyof PerfMetrics;
 
@@ -75,6 +78,13 @@ interface ProfileModeMismatch {
 interface RoundPerfResult {
   roundIndex: number;
   result: PerfResult;
+}
+
+interface RoundMetricComparison {
+  baseline: number;
+  current: number;
+  delta: number;
+  sampleDeltas: number[];
 }
 
 interface AggregatedPerfResult {
@@ -459,32 +469,89 @@ function requiredAgreement(roundsCount: number) {
   return roundsCount - 1;
 }
 
+function getMetricSamples(result: PerfResult, metric: MetricKey) {
+  const raw = Array.isArray(result.raw) ? result.raw : [];
+  const allMetrics = raw.length > 0 ? raw : [result.metrics];
+  const values: number[] = [];
+  for (const metrics of allMetrics) {
+    const value = metrics?.[metric];
+    if (Number.isFinite(value)) {
+      values.push(value);
+    }
+  }
+  if (values.length > 0) return values;
+  const fallback = result.metrics[metric];
+  return Number.isFinite(fallback) ? [fallback] : [0];
+}
+
+function getPairwiseDeltas(baseline: number[], current: number[]) {
+  const deltas: number[] = [];
+  for (const currentValue of current) {
+    for (const baselineValue of baseline) {
+      deltas.push(currentValue - baselineValue);
+    }
+  }
+  return deltas;
+}
+
+function getQuantile(values: number[], quantile: number) {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.floor((sorted.length - 1) * quantile);
+  return sorted[index] ?? 0;
+}
+
+function samplesSupportDirection(sampleDeltas: number[], direction: number) {
+  if (sampleDeltas.length === 0) return false;
+  if (direction > 0) {
+    return getQuantile(sampleDeltas, RAW_SAMPLE_SUPPORT_QUANTILE) > 0;
+  }
+  return getQuantile(sampleDeltas, 1 - RAW_SAMPLE_SUPPORT_QUANTILE) < 0;
+}
+
+function getRoundMetricComparison(
+  baseline: PerfResult,
+  current: PerfResult,
+  metric: MetricKey,
+): RoundMetricComparison {
+  const baselineSamples = getMetricSamples(baseline, metric);
+  const currentSamples = getMetricSamples(current, metric);
+  const baselineValue = median(baselineSamples);
+  const currentValue = median(currentSamples);
+  return {
+    baseline: baselineValue,
+    current: currentValue,
+    delta: currentValue - baselineValue,
+    sampleDeltas: getPairwiseDeltas(baselineSamples, currentSamples),
+  };
+}
+
 function computeSignificance({
   baseline,
   current,
   minDelta,
   primary,
   percent,
-  perRoundDeltas,
+  roundComparisons,
 }: {
   baseline: number;
   current: number;
   minDelta: number;
   primary: boolean;
   percent: number;
-  perRoundDeltas: number[];
+  roundComparisons: RoundMetricComparison[];
 }) {
-  if (perRoundDeltas.length === 0) {
+  if (roundComparisons.length === 0) {
     return { agreement: 0, significant: false };
   }
 
   const delta = current - baseline;
   const direction = Math.sign(delta);
   let agreement = 0;
-  for (const roundDelta of perRoundDeltas) {
-    if (Math.sign(roundDelta) === direction) {
-      agreement += 1;
-    }
+  for (const comparison of roundComparisons) {
+    if (Math.sign(comparison.delta) !== direction) continue;
+    if (!samplesSupportDirection(comparison.sampleDeltas, direction)) continue;
+    agreement += 1;
   }
 
   const percentOk = Math.abs(percent) > THRESHOLD_PERCENT;
@@ -492,7 +559,7 @@ function computeSignificance({
   const zeroBaselineOk =
     baseline === 0 && current !== baseline && Math.abs(current) >= minDelta;
   const magnitudeOk = baseline === 0 ? zeroBaselineOk : percentOk && deltaOk;
-  const agreementOk = agreement >= requiredAgreement(perRoundDeltas.length);
+  const agreementOk = agreement >= requiredAgreement(roundComparisons.length);
 
   return {
     agreement,
@@ -692,16 +759,19 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
     for (const metric of allMetrics) {
       const baselineValues: number[] = [];
       const currentValues: number[] = [];
-      const perRoundDeltas: number[] = [];
+      const roundComparisons: RoundMetricComparison[] = [];
       for (const roundIndex of sharedRoundIndices) {
         const baselineRound = base.byRound.get(roundIndex);
         const currentRound = cur.byRound.get(roundIndex);
         if (!baselineRound || !currentRound) continue;
-        const baselineValue = baselineRound.metrics[metric];
-        const currentValue = currentRound.metrics[metric];
-        baselineValues.push(baselineValue);
-        currentValues.push(currentValue);
-        perRoundDeltas.push(currentValue - baselineValue);
+        const comparison = getRoundMetricComparison(
+          baselineRound,
+          currentRound,
+          metric,
+        );
+        baselineValues.push(comparison.baseline);
+        currentValues.push(comparison.current);
+        roundComparisons.push(comparison);
       }
 
       const baseVal = median(baselineValues);
@@ -714,7 +784,7 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
         minDelta,
         primary: primary && primaryMetrics.includes(metric),
         percent,
-        perRoundDeltas,
+        roundComparisons,
       });
       rows.push({
         testFile: cur.result.testFile,
@@ -725,7 +795,7 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
         delta,
         percent,
         pairedRoundsCount: sharedRoundIndices.length,
-        perRoundDeltas,
+        perRoundDeltas: roundComparisons.map((comparison) => comparison.delta),
         agreement,
         significant,
         profileMode,
@@ -1209,12 +1279,12 @@ function formatMarkdown(
   if (pairedRoundsCount == null) {
     lines.push("");
     lines.push(
-      `Compared ${resultsName} used mixed interleaved round counts; a change is flagged only when the median exceeds the threshold and rounds agree on direction.`,
+      `Compared ${resultsName} used mixed interleaved round counts; a change is flagged only when the median exceeds the threshold and raw samples support the same direction.`,
     );
   } else if (pairedRoundsCount > 1) {
     lines.push("");
     lines.push(
-      `Aggregated across ${pairedRoundsCount} interleaved rounds; a change is flagged only when the median exceeds the threshold and rounds agree on direction.`,
+      `Aggregated across ${pairedRoundsCount} interleaved rounds; a change is flagged only when the median exceeds the threshold and raw samples support the same direction.`,
     );
   }
 


### PR DESCRIPTION
## Motivation

The perf workflow can report significant Chrome regressions for changes that do not affect the measured code. For example, ariakit/ariakit#6565 only updated `stripe`, but the perf comment reported unrelated `composite-perf` and `ariakit-tailwind` regressions.

Two things made those false positives easier to publish:

- Every paired CI round ran `baseline -> current`, so same-runner drift could consistently look like a current-side regression.
- `perf-compare` only checked median direction across rounds and ignored the raw iteration samples already persisted by Chrome perf tests.

## Solution

Run the existing paired rounds as a crossover comparison without adding more work:

```text
round 1: baseline -> current
round 2: current -> baseline
```

The same alternation applies to confirmation rounds and Node benchmarks, preserving the existing number of CI runs.

`perf-compare` now also requires each agreeing round to have raw-sample support in the aggregate direction. Displayed medians stay the same, but a warning icon is only added when the median exceeds the threshold and the raw samples support that direction. This keeps noisy overlapping samples visible in the detailed table without promoting them to top-level regressions.

## Verification

- `pnpm test packages/ariakit-scripts/src/perf-compare.test.ts`
- `pnpm lint-fix`
- `pnpm lint`
- `pnpm tsc`
- `git diff --check`
