### PR TITLE
Load framework render helpers lazily in Vitest setup

### DIFF
--- a/packages/ariakit-test/src/mouse-down.test.ts
+++ b/packages/ariakit-test/src/mouse-down.test.ts
@@ -4,6 +4,7 @@ import { mouseDown } from "./mouse-down.ts";
 import { mouseUp } from "./mouse-up.ts";
 import { q } from "./query.ts";
 import { select } from "./select.ts";
+import "./shims.ts";
 
 const selectionText = "sample paragraph text";
 

--- a/packages/ariakit-test/src/query.test.ts
+++ b/packages/ariakit-test/src/query.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, expect, test } from "vitest";
 import { q } from "./query.ts";
+import "./shims.ts";
 
 afterEach(() => {
   document.body.innerHTML = "";

--- a/packages/ariakit-test/src/type.test.ts
+++ b/packages/ariakit-test/src/type.test.ts
@@ -2,6 +2,7 @@ import { afterEach, expect, test, vi } from "vitest";
 import { blur } from "./blur.ts";
 import { press } from "./press.ts";
 import { type } from "./type.ts";
+import "./shims.ts";
 
 afterEach(() => {
   document.body.innerHTML = "";

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,12 +1,6 @@
 import "@testing-library/jest-dom/vitest";
-import { render as renderReact } from "@ariakit/test/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { createElement, Suspense as ReactSuspense } from "react";
-import {
-  createComponent,
-  render as renderSolid,
-  Suspense as SolidSuspense,
-} from "solid-js/web";
 import { expect, beforeEach } from "vitest";
 import failOnConsole from "vitest-fail-on-console";
 import { getTestLoader, isAllowedTestLoader } from "./test-loader.ts";
@@ -53,6 +47,7 @@ async function tryImport(path: string) {
 }
 
 async function loadReact(dir: string) {
+  const { render } = await import("@ariakit/test/react");
   const { component, failedImport } = await tryImport(
     `./${dir}/index.react.tsx`,
   );
@@ -62,20 +57,21 @@ async function loadReact(dir: string) {
     // oxlint-disable-next-line react/no-children-prop -- createElement requires children prop
     children: createElement(component),
   });
-  const { unmount } = await renderReact(element, { strictMode: true });
+  const { unmount } = await render(element, { strictMode: true });
   return unmount;
 }
 
 async function loadSolid(dir: string) {
+  const { createComponent, render, Suspense } = await import("solid-js/web");
   const { component, failedImport } = await tryImport(
     `./${dir}/index.solid.tsx`,
   );
   if (failedImport) return false;
   const div = document.createElement("div");
   document.body.appendChild(div);
-  const dispose = renderSolid(
+  const dispose = render(
     () =>
-      createComponent(SolidSuspense, {
+      createComponent(Suspense, {
         fallback: null,
         get children() {
           return createComponent(component, {});


### PR DESCRIPTION
## Motivation

`vitest.setup.ts` imported the framework render helpers at module scope:

```ts
import { render as renderReact } from "@ariakit/test/react";
import {
  createComponent,
  render as renderSolid,
  Suspense as SolidSuspense,
} from "solid-js/web";
```

They are only used inside `loadReact`/`loadSolid`, which run exclusively for the framework example/sandbox suites (`test-react`, `test-react18`, `test-solid`). Because the imports were static, every suite — including the core no-loader `test` suite — eagerly pulled `@ariakit/test/react` (a `.tsx` JSX source) into its module graph.

That contradicts the documented design that the default root `test` script is the core, non-framework suite and should not run React/Solid render code. In the no-loader suite no framework Vite plugin is loaded, so `react.tsx`'s JSX is transformed only by Vite's built-in oxc transform, whose JSX mode is resolved per file from `tsconfig`. That is brittle — for example, running an individual core test from a git worktree nested inside the repo fails at collection:

```
vite:import-analysis: Failed to parse source ... content contains invalid JS syntax
  packages/ariakit-test/src/react.tsx
```

because the per-file `tsconfig` lookup walks out of the worktree into the parent repo and resolves a non-transforming JSX context.

## Solution

Import the framework render helpers lazily, inside the loaders that use them:

```ts
async function loadReact(dir: string) {
  const { render } = await import("@ariakit/test/react");
  // ...
}

async function loadSolid(dir: string) {
  const { createComponent, render, Suspense } = await import("solid-js/web");
  // ...
}
```

Now the core no-loader suite never loads framework render code, and `react.tsx` is only transformed when a framework loader is active (where `@vitejs/plugin-react` handles its JSX).

## Shims

The removed static import also transitively applied `@ariakit/test`'s browser shims (DOM-level normalizations the simulated interactions rely on, like focusability and `getClientRects` visibility) to every suite via `@ariakit/test/react` → `index.ts` → `import "./shims.ts"`. Most tests still get them by importing the `@ariakit/test` package entry (or `./index.ts`). The `@ariakit/test` tests that import the helper modules directly and therefore lose that side effect now import the shims themselves, matching the existing `shims.test.ts`:

```ts
import "./shims.ts";
```

This is added to `mouse-down.test.ts`, `query.test.ts`, and `type.test.ts` (which exercise DOM-simulation helpers — happy-dom natively returns an empty `getClientRects()`, so without the shims their focus/visibility flows would behave incorrectly). `__utils.test.ts` is intentionally left unchanged: it only tests `wrapAsync`'s act-environment nesting and has no shim dependency (`wrapAsync` applies no shims).

## Verification

- `pnpm test` (core no-loader) — 513 passing; `pnpm test-react` — 796 passing; `pnpm test-solid` — 9 passing; `pnpm tsc` clean.
- The previously-failing `pnpm test packages/ariakit-scripts/src/perf-compare.test.ts` (run from a nested worktree) now passes.
