### PR TITLE
Close nested hovercards on Escape when focus is outside

### DIFF
--- a/.changeset/300-hovercard-escape-outside-focus.md
+++ b/.changeset/300-hovercard-escape-outside-focus.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed nested [`Hovercard`](https://ariakit.com/reference/hovercard) components so pressing Escape closes the topmost card even when focus is on another element. This also applies to components built on [`Dialog`](https://ariakit.com/reference/dialog).

--- a/app/src/sandbox/hovercard-nested-listener/index.react.tsx
+++ b/app/src/sandbox/hovercard-nested-listener/index.react.tsx
@@ -39,6 +39,21 @@ function useMouseMoveListenerInstalls() {
 
 function NestedHovercard() {
   const [open, setOpen] = useState(false);
+  // Userland workaround: Dialog's Escape handler ignores events targeting
+  // elements outside the nested hovercard and its anchor.
+  // TODO: Remove once https://github.com/ariakit/ariakit/pull/6572 lands.
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      if (event.defaultPrevented) return;
+      setOpen(false);
+    };
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [open]);
   return (
     <>
       <button type="button" onClick={() => setOpen((value) => !value)}>

--- a/app/src/sandbox/hovercard-nested-listener/index.react.tsx
+++ b/app/src/sandbox/hovercard-nested-listener/index.react.tsx
@@ -45,7 +45,7 @@ function NestedHovercard() {
         Toggle nested
       </button>
       {open && (
-        <Ariakit.HovercardProvider open>
+        <Ariakit.HovercardProvider open={open} setOpen={setOpen}>
           <Ariakit.HovercardAnchor>Nested anchor</Ariakit.HovercardAnchor>
           <Ariakit.Hovercard
             portal
@@ -53,6 +53,9 @@ function NestedHovercard() {
             // listeners are unnecessary. Disabling them keeps the install
             // counter measuring only the parent hovercard's listener.
             hideOnHoverOutside={false}
+            // Keep outside focus from closing the nested hovercard before the
+            // Escape behavior can be exercised.
+            hideOnInteractOutside={false}
             aria-label="Nested hovercard"
           >
             Nested content
@@ -79,6 +82,10 @@ export default function Example() {
           <NestedHovercard />
         </Ariakit.Hovercard>
       </Ariakit.HovercardProvider>
+      <label>
+        Outside input
+        <input />
+      </label>
     </>
   );
 }

--- a/app/src/sandbox/hovercard-nested-listener/index.react.tsx
+++ b/app/src/sandbox/hovercard-nested-listener/index.react.tsx
@@ -39,21 +39,6 @@ function useMouseMoveListenerInstalls() {
 
 function NestedHovercard() {
   const [open, setOpen] = useState(false);
-  // Userland workaround: Dialog's Escape handler ignores events targeting
-  // elements outside the nested hovercard and its anchor.
-  // TODO: Remove once https://github.com/ariakit/ariakit/pull/6572 lands.
-  useEffect(() => {
-    if (!open) return;
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== "Escape") return;
-      if (event.defaultPrevented) return;
-      setOpen(false);
-    };
-    document.addEventListener("keydown", onKeyDown, true);
-    return () => {
-      document.removeEventListener("keydown", onKeyDown, true);
-    };
-  }, [open]);
   return (
     <>
       <button type="button" onClick={() => setOpen((value) => !value)}>

--- a/app/src/sandbox/hovercard-nested-listener/test-browser.ts
+++ b/app/src/sandbox/hovercard-nested-listener/test-browser.ts
@@ -19,4 +19,22 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.dialog("Nested hovercard")).not.toBeAttached();
     await test.expect(installs).toHaveText(initialInstalls);
   });
+
+  test("closes nested hovercard on Escape when focus is outside", async ({
+    page,
+    q,
+  }) => {
+    await test.expect(q.dialog("Parent hovercard")).toBeVisible();
+
+    await q.button("Toggle nested").click();
+    await test.expect(q.dialog("Nested hovercard")).toBeVisible();
+
+    await q.textbox("Outside input").click();
+    await test.expect(q.textbox("Outside input")).toBeFocused();
+    await test.expect(q.dialog("Nested hovercard")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await test.expect(q.dialog("Nested hovercard")).not.toBeAttached();
+    await test.expect(q.dialog("Parent hovercard")).toBeVisible();
+  });
 });

--- a/app/src/sandbox/hovercard-nested-listener/test.ts
+++ b/app/src/sandbox/hovercard-nested-listener/test.ts
@@ -1,4 +1,4 @@
-import { click, q } from "@ariakit/test";
+import { click, press, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 // See https://github.com/ariakit/ariakit/pull/6143
@@ -18,4 +18,19 @@ test("toggling a nested hovercard does not reinstall the parent mousemove listen
   await click(q.button("Toggle nested"));
   await expect.poll(q.dialog.lazy("Nested hovercard")).not.toBeInTheDocument();
   expect(installCount()).toBe(initialInstalls);
+});
+
+test("closes nested hovercard on Escape when focus is outside", async () => {
+  expect(q.dialog("Parent hovercard")).toBeVisible();
+
+  await click(q.button("Toggle nested"));
+  await expect.poll(q.dialog.lazy("Nested hovercard")).toBeVisible();
+
+  await click(q.textbox.ensure("Outside input"));
+  expect(q.textbox("Outside input")).toHaveFocus();
+  expect(q.dialog("Nested hovercard")).toBeVisible();
+
+  await press.Escape();
+  await expect.poll(q.dialog.lazy("Nested hovercard")).not.toBeInTheDocument();
+  expect(q.dialog("Parent hovercard")).toBeVisible();
 });

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -504,13 +504,17 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
       // keeps non-element nodes working with `contains`, as before.
       if (!isNode(target)) return;
       const { disclosureElement } = store.getState();
-      // This considers valid targets only the disclosure element or descendants
-      // of the dialog element.
+      // This considers valid targets the elements that belong to this dialog
+      // tree, including elements marked as outside by this dialog so Escape can
+      // close the topmost dialog even when focus is outside.
       const isValidTarget = () => {
         if (isElement(target) && target.tagName === "BODY") return true;
         if (contains(dialog, target)) return true;
         if (!disclosureElement) return true;
         if (contains(disclosureElement, target)) return true;
+        if (isElement(target) && isElementMarked(target, dialog.id)) {
+          return true;
+        }
         return false;
       };
       if (!isValidTarget()) return;


### PR DESCRIPTION
## Motivation

Pressing Escape should close the topmost nested Hovercard even when focus has moved to another control on the page. The current Dialog-level Escape handler listens on the document, but nested hovercards can ignore the event when its target is outside the nested card and its disclosure.

There is no public GitHub issue number for this report, so this PR has no auto-closing issue keyword. The repro was added to the existing nested hovercard sandbox because it already models portaled nested hovercards.

## Solution

Add a focused regression case to `app/src/sandbox/hovercard-nested-listener` that opens a nested hovercard, moves focus to an outside input, presses Escape, and expects only the nested hovercard to close while the parent remains open.

Update Dialog's Escape target check so elements marked as outside by the current dialog are still valid Escape targets for that dialog. Parent dialogs remain protected by the existing topmost-dialog guard, so Escape closes the nested card rather than the parent. The existing non-Node target guard remains before all `contains` and marker checks.

A patch changeset covers the behavior for `@ariakit/react-components` and `@ariakit/react`.

## Workaround

A userland workaround is to close the controlled nested hovercard from a document-level Escape listener. This bypasses the current Dialog target check that ignores Escape events when focus is outside the nested hovercard and its anchor.

```tsx
// Userland workaround: Dialog's Escape handler ignores events targeting
// elements outside the nested hovercard and its anchor.
// TODO: Remove once https://github.com/ariakit/ariakit/pull/6572 lands.
useEffect(() => {
  if (!open) return;
  const onKeyDown = (event: KeyboardEvent) => {
    if (event.key !== "Escape") return;
    if (event.defaultPrevented) return;
    setOpen(false);
  };
  document.addEventListener("keydown", onKeyDown, true);
  return () => {
    document.removeEventListener("keydown", onKeyDown, true);
  };
}, [open]);
```

With this workaround applied, the repro tests pass:

```sh
pnpm test-react app/src/sandbox/hovercard-nested-listener/test.ts
APP_PORT=4321 NEXTJS_PORT=3000 pnpm -F app run test app/src/sandbox/hovercard-nested-listener/
```
