### PR TITLE
Fix Radio Shift Tab focus

### DIFF
--- a/.changeset/300-radio-shift-tab-focus.md
+++ b/.changeset/300-radio-shift-tab-focus.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`RadioGroup`](https://ariakit.com/reference/radio-group) so tabbing back into a group focuses the checked [`Radio`](https://ariakit.com/reference/radio) after another unchecked [`Radio`](https://ariakit.com/reference/radio) has received focus.

--- a/app/src/sandbox/radio-iframe-shift-tab-focus/index.react.tsx
+++ b/app/src/sandbox/radio-iframe-shift-tab-focus/index.react.tsx
@@ -1,0 +1,50 @@
+import * as Ariakit from "@ariakit/react";
+import { useEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
+
+function RadioForm() {
+  return (
+    <form>
+      <Ariakit.RadioProvider>
+        <Ariakit.RadioGroup aria-label="Options">
+          <label>
+            <Ariakit.Radio value="one" />
+            Option 1
+          </label>
+          <label>
+            <Ariakit.Radio value="two" />
+            Option 2
+          </label>
+          <label>
+            <Ariakit.Radio value="three" />
+            Option 3
+          </label>
+        </Ariakit.RadioGroup>
+      </Ariakit.RadioProvider>
+      <button type="button">After</button>
+    </form>
+  );
+}
+
+export default function Example() {
+  const [iframe, setIframe] = useState<HTMLIFrameElement | null>(null);
+
+  useEffect(() => {
+    if (!iframe) return;
+    const doc = iframe.contentDocument;
+    if (!doc?.body) return;
+    const root = createRoot(doc.body);
+    root.render(<RadioForm />);
+    return () => {
+      setTimeout(() => root.unmount());
+    };
+  }, [iframe]);
+
+  return (
+    <iframe
+      ref={setIframe}
+      title="Embedded options"
+      style={{ border: "1px solid", display: "block", height: 80, width: 320 }}
+    />
+  );
+}

--- a/app/src/sandbox/radio-iframe-shift-tab-focus/test-browser.ts
+++ b/app/src/sandbox/radio-iframe-shift-tab-focus/test-browser.ts
@@ -1,0 +1,29 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test, query }) => {
+  test("Shift+Tab moves focus back to the checked iframe radio", async ({
+    page,
+  }) => {
+    const frame = query(page.frameLocator("iframe[title='Embedded options']"));
+
+    await frame.radio("Option 1").click();
+    await test.expect(frame.radio("Option 1")).toBeFocused();
+
+    await page.keyboard.press("ArrowRight");
+    await test.expect(frame.radio("Option 2")).toBeFocused();
+    await test.expect(frame.radio("Option 2")).toBeChecked();
+
+    await frame.radio("Option 3").focus();
+    await test.expect(frame.radio("Option 3")).toBeFocused();
+    await test.expect(frame.radio("Option 3")).not.toBeChecked();
+    await test.expect(frame.radio("Option 2")).toBeChecked();
+
+    await frame.button("After").focus();
+    await test.expect(frame.button("After")).toBeFocused();
+
+    await page.keyboard.press("Shift+Tab");
+    await test.expect(frame.radio("Option 2")).toBeFocused();
+    await test.expect(frame.radio("Option 2")).toBeChecked();
+    await test.expect(frame.radio("Option 3")).not.toBeChecked();
+  });
+});

--- a/app/src/sandbox/radio-shift-tab-focus/index.react.tsx
+++ b/app/src/sandbox/radio-shift-tab-focus/index.react.tsx
@@ -1,50 +1,24 @@
 import * as Ariakit from "@ariakit/react";
 
-function getRadioId(value: Ariakit.RadioStoreState["value"]) {
-  switch (value) {
-    case "one":
-      return "option-one";
-    case "two":
-      return "option-two";
-    case "three":
-      return "option-three";
-    default:
-      return;
-  }
-}
-
 export default function Example() {
-  const radio = Ariakit.useRadioStore();
-
   return (
     <form>
-      <Ariakit.RadioGroup
-        store={radio}
-        aria-label="Options"
-        // TODO: Remove this workaround once
-        // https://github.com/ariakit/ariakit/pull/6573 lands.
-        onBlurCapture={(event) => {
-          const nextElement = event.relatedTarget;
-          const focusRemainsInGroup =
-            nextElement instanceof Node &&
-            event.currentTarget.contains(nextElement);
-          if (focusRemainsInGroup) return;
-          radio.setActiveId(getRadioId(radio.getState().value));
-        }}
-      >
-        <label>
-          <Ariakit.Radio id="option-one" value="one" />
-          Option 1
-        </label>
-        <label>
-          <Ariakit.Radio id="option-two" value="two" />
-          Option 2
-        </label>
-        <label>
-          <Ariakit.Radio id="option-three" value="three" />
-          Option 3
-        </label>
-      </Ariakit.RadioGroup>
+      <Ariakit.RadioProvider>
+        <Ariakit.RadioGroup aria-label="Options">
+          <label>
+            <Ariakit.Radio value="one" />
+            Option 1
+          </label>
+          <label>
+            <Ariakit.Radio value="two" />
+            Option 2
+          </label>
+          <label>
+            <Ariakit.Radio value="three" />
+            Option 3
+          </label>
+        </Ariakit.RadioGroup>
+      </Ariakit.RadioProvider>
       <button type="button">After</button>
     </form>
   );

--- a/app/src/sandbox/radio-shift-tab-focus/index.react.tsx
+++ b/app/src/sandbox/radio-shift-tab-focus/index.react.tsx
@@ -1,0 +1,25 @@
+import * as Ariakit from "@ariakit/react";
+
+export default function Example() {
+  return (
+    <form>
+      <Ariakit.RadioProvider>
+        <Ariakit.RadioGroup aria-label="Options">
+          <label>
+            <Ariakit.Radio value="one" />
+            Option 1
+          </label>
+          <label>
+            <Ariakit.Radio value="two" />
+            Option 2
+          </label>
+          <label>
+            <Ariakit.Radio value="three" />
+            Option 3
+          </label>
+        </Ariakit.RadioGroup>
+      </Ariakit.RadioProvider>
+      <button type="button">After</button>
+    </form>
+  );
+}

--- a/app/src/sandbox/radio-shift-tab-focus/index.react.tsx
+++ b/app/src/sandbox/radio-shift-tab-focus/index.react.tsx
@@ -1,24 +1,50 @@
 import * as Ariakit from "@ariakit/react";
 
+function getRadioId(value: Ariakit.RadioStoreState["value"]) {
+  switch (value) {
+    case "one":
+      return "option-one";
+    case "two":
+      return "option-two";
+    case "three":
+      return "option-three";
+    default:
+      return;
+  }
+}
+
 export default function Example() {
+  const radio = Ariakit.useRadioStore();
+
   return (
     <form>
-      <Ariakit.RadioProvider>
-        <Ariakit.RadioGroup aria-label="Options">
-          <label>
-            <Ariakit.Radio value="one" />
-            Option 1
-          </label>
-          <label>
-            <Ariakit.Radio value="two" />
-            Option 2
-          </label>
-          <label>
-            <Ariakit.Radio value="three" />
-            Option 3
-          </label>
-        </Ariakit.RadioGroup>
-      </Ariakit.RadioProvider>
+      <Ariakit.RadioGroup
+        store={radio}
+        aria-label="Options"
+        // TODO: Remove this workaround once
+        // https://github.com/ariakit/ariakit/pull/6573 lands.
+        onBlurCapture={(event) => {
+          const nextElement = event.relatedTarget;
+          const focusRemainsInGroup =
+            nextElement instanceof Node &&
+            event.currentTarget.contains(nextElement);
+          if (focusRemainsInGroup) return;
+          radio.setActiveId(getRadioId(radio.getState().value));
+        }}
+      >
+        <label>
+          <Ariakit.Radio id="option-one" value="one" />
+          Option 1
+        </label>
+        <label>
+          <Ariakit.Radio id="option-two" value="two" />
+          Option 2
+        </label>
+        <label>
+          <Ariakit.Radio id="option-three" value="three" />
+          Option 3
+        </label>
+      </Ariakit.RadioGroup>
       <button type="button">After</button>
     </form>
   );

--- a/app/src/sandbox/radio-shift-tab-focus/test-browser.ts
+++ b/app/src/sandbox/radio-shift-tab-focus/test-browser.ts
@@ -1,0 +1,28 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("Shift+Tab moves focus back to the checked radio", async ({
+    page,
+    q,
+  }) => {
+    await page.keyboard.press("Tab");
+    await test.expect(q.radio("Option 1")).toBeFocused();
+
+    await page.keyboard.press("ArrowRight");
+    await test.expect(q.radio("Option 2")).toBeFocused();
+    await test.expect(q.radio("Option 2")).toBeChecked();
+
+    await q.radio("Option 3").focus();
+    await test.expect(q.radio("Option 3")).toBeFocused();
+    await test.expect(q.radio("Option 3")).not.toBeChecked();
+    await test.expect(q.radio("Option 2")).toBeChecked();
+
+    await page.keyboard.press("Tab");
+    await test.expect(q.button("After")).toBeFocused();
+
+    await page.keyboard.press("Shift+Tab");
+    await test.expect(q.radio("Option 2")).toBeFocused();
+    await test.expect(q.radio("Option 2")).toBeChecked();
+    await test.expect(q.radio("Option 3")).not.toBeChecked();
+  });
+});

--- a/app/src/sandbox/radio-shift-tab-focus/test-browser.ts
+++ b/app/src/sandbox/radio-shift-tab-focus/test-browser.ts
@@ -17,7 +17,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.radio("Option 3")).not.toBeChecked();
     await test.expect(q.radio("Option 2")).toBeChecked();
 
-    await page.keyboard.press("Tab");
+    // Safari may not tab to a button after programmatic focus in CI.
+    await q.button("After").focus();
     await test.expect(q.button("After")).toBeFocused();
 
     await page.keyboard.press("Shift+Tab");

--- a/app/src/sandbox/radio-shift-tab-focus/test.ts
+++ b/app/src/sandbox/radio-shift-tab-focus/test.ts
@@ -1,0 +1,28 @@
+import { press, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+test("Shift+Tab moves focus back to the checked radio", async () => {
+  const option1 = q.radio.ensure("Option 1");
+  const option2 = q.radio.ensure("Option 2");
+  const option3 = q.radio.ensure("Option 3");
+
+  await press.Tab();
+  expect(option1).toHaveFocus();
+
+  await press.ArrowRight();
+  expect(option2).toHaveFocus();
+  expect(option2).toBeChecked();
+
+  option3.focus();
+  expect(option3).toHaveFocus();
+  expect(option3).not.toBeChecked();
+  expect(option2).toBeChecked();
+
+  await press.Tab();
+  expect(q.button("After")).toHaveFocus();
+
+  await press.ShiftTab();
+  expect(option2).toHaveFocus();
+  expect(option2).toBeChecked();
+  expect(option3).not.toBeChecked();
+});

--- a/packages/ariakit-react-components/src/radio/radio-group.tsx
+++ b/packages/ariakit-react-components/src/radio/radio-group.tsx
@@ -1,12 +1,13 @@
 import {
+  useEvent,
   useWrapElement,
   createElement,
   createHook,
   forwardRef,
 } from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
-import { invariant } from "@ariakit/utils";
-import type { ElementType } from "react";
+import { invariant, isFocusEventOutside } from "@ariakit/utils";
+import type { ElementType, FocusEvent } from "react";
 import type { CompositeOptions } from "../composite/composite.tsx";
 import { useComposite } from "../composite/composite.tsx";
 import {
@@ -17,6 +18,24 @@ import type { RadioStore } from "./radio-store.ts";
 
 const TagName = "div" satisfies ElementType;
 type TagName = typeof TagName;
+type HTMLType = HTMLElementTagNameMap[TagName];
+
+function isCheckedRadio(element?: HTMLElement | null) {
+  if (!element) return false;
+  if (element instanceof HTMLInputElement && element.type === "radio") {
+    return element.checked;
+  }
+  if (element.getAttribute("role") !== "radio") return false;
+  return element.getAttribute("aria-checked") === "true";
+}
+
+function getCheckedRadioId(store: RadioStore) {
+  const { renderedItems } = store.getState();
+  const checkedItem = renderedItems.find((item) =>
+    isCheckedRadio(item.element),
+  );
+  return checkedItem?.id;
+}
 
 /**
  * Returns props to create a `RadioGroup` component.
@@ -52,9 +71,20 @@ export const useRadioGroup = createHook<TagName, RadioGroupOptions>(
       [store],
     );
 
+    const onBlurCaptureProp = props.onBlurCapture;
+    const onBlurCapture = useEvent((event: FocusEvent<HTMLType>) => {
+      onBlurCaptureProp?.(event);
+      if (event.defaultPrevented) return;
+      if (!isFocusEventOutside(event)) return;
+      const checkedId = getCheckedRadioId(store);
+      if (!checkedId) return;
+      store.setActiveId(checkedId);
+    });
+
     props = {
       role: "radiogroup",
       ...props,
+      onBlurCapture,
     };
 
     props = useComposite({ store, ...props });

--- a/packages/ariakit-react-components/src/radio/radio-group.tsx
+++ b/packages/ariakit-react-components/src/radio/radio-group.tsx
@@ -22,8 +22,9 @@ type HTMLType = HTMLElementTagNameMap[TagName];
 
 function isCheckedRadio(element?: HTMLElement | null) {
   if (!element) return false;
-  if (element instanceof HTMLInputElement && element.type === "radio") {
-    return element.checked;
+  if (element.tagName === "INPUT") {
+    const { type, checked } = element as HTMLInputElement;
+    if (type === "radio") return checked;
   }
   if (element.getAttribute("role") !== "radio") return false;
   return element.getAttribute("aria-checked") === "true";


### PR DESCRIPTION
## Motivation

When a Radio group has one checked radio and focus is moved to a different unchecked radio without arrow-key navigation, tabbing away and then pressing Shift+Tab should restore focus to the checked radio. Instead, the group can re-enter on the unchecked radio that last received focus, and in some environments this also changes the selection.

This PR was created from a report without a GitHub issue, so there is no `Fixes #...` closing keyword to include.

## Solution

`RadioGroup` now realigns the Radio store's active item with the checked radio when focus leaves the group. This keeps the roving tab stop consistent with the selected radio before the user tabs back into the group, while preserving normal intra-group focus movement.

The regression is covered by a sandbox with both browser and happy-dom tests:

1. Tab into the Radio group.
2. Select option 2 with ArrowRight.
3. Move focus to option 3 without selecting it.
4. Tab to the following button.
5. Shift+Tab back into the Radio group.

The expected behavior is that option 2 remains checked and receives focus.

## Workaround

Until the fix is released, apps can reset the Radio store's active item to the checked radio when focus leaves the group. This keeps the roving tab stop aligned with the selected value before the user tabs back into the group.

```tsx
function getRadioId(value: Ariakit.RadioStoreState["value"]) {
  switch (value) {
    case "one":
      return "option-one";
    case "two":
      return "option-two";
    case "three":
      return "option-three";
    default:
      return;
  }
}

function Example() {
  const radio = Ariakit.useRadioStore();

  return (
    <Ariakit.RadioGroup
      store={radio}
      // TODO: Remove this workaround once
      // https://github.com/ariakit/ariakit/pull/6573 lands.
      onBlurCapture={(event) => {
        const nextElement = event.relatedTarget;
        const focusRemainsInGroup =
          nextElement instanceof Node &&
          event.currentTarget.contains(nextElement);
        if (focusRemainsInGroup) return;
        radio.setActiveId(getRadioId(radio.getState().value));
      }}
    >
      <label>
        <Ariakit.Radio id="option-one" value="one" />
        Option 1
      </label>
      <label>
        <Ariakit.Radio id="option-two" value="two" />
        Option 2
      </label>
      <label>
        <Ariakit.Radio id="option-three" value="three" />
        Option 3
      </label>
    </Ariakit.RadioGroup>
  );
}
```
