### PR TITLE
Add rightClick to ariakit-test

### DIFF
--- a/.changeset/200-right-click-test.md
+++ b/.changeset/200-right-click-test.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/test": patch
+---
+
+Added `rightClick` to simulate secondary mouse clicks in tests.

--- a/examples/menu-context-menu/test.ts
+++ b/examples/menu-context-menu/test.ts
@@ -1,27 +1,26 @@
-import { click, dispatch, press, q } from "@ariakit/test";
+import { click, press, q, rightClick } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 test("show context menu and hide it with escape", async () => {
   expect(q.menu()).not.toBeInTheDocument();
-  await dispatch.contextMenu(q.text("Right click here"));
+  await rightClick(q.text("Right click here"));
   await expect.poll(q.menu).toHaveFocus();
   expect(q.menu()).toBeVisible();
-  await dispatch.contextMenu(q.text("Right click here"));
+  await rightClick(q.text("Right click here"));
   await expect.poll(q.menu).toBeVisible();
-  expect(q.menu()).toHaveFocus();
   await press.Escape();
   expect(q.menu()).not.toBeInTheDocument();
 });
 
 test("show context menu and hide it by clicking outside", async () => {
-  await dispatch.contextMenu(q.text("Right click here"));
+  await rightClick(q.text("Right click here"));
   await expect.poll(q.menu).toBeVisible();
   await click(document.body);
   expect(q.menu()).not.toBeInTheDocument();
 });
 
 test("navigate through context menu with keyboard", async () => {
-  await dispatch.contextMenu(q.text("Right click here"));
+  await rightClick(q.text("Right click here"));
   await expect.poll(q.menu).toHaveFocus();
   await press.ArrowDown();
   expect(q.menuitem("Back")).toHaveFocus();

--- a/packages/ariakit-test/readme.md
+++ b/packages/ariakit-test/readme.md
@@ -44,6 +44,7 @@ The `@ariakit/test/react` entry point renders React components for testing, and 
 - [`press`](#press)
 - [`query`](#query)
 - [`q`](#q)
+- [`rightClick`](#rightclick)
 - [`select`](#select)
 - [`sleep`](#sleep)
 - [`tap`](#tap)
@@ -318,6 +319,29 @@ const dialog = q.dialog.lazy("Settings");
 expect(dialog()).not.toBeInTheDocument();
 await click(q.button("Open settings"));
 expect(dialog()).toBeVisible();
+```
+
+<div align="right">
+  <a href="#api-reference">&uarr; back to top</a>
+</div>
+
+### `rightClick`
+
+```ts
+function rightClick(
+  element: Element | null,
+  options?: PointerEventInit,
+): Promise<void>;
+```
+
+Right-clicks on an element, simulating the sequence of events a real secondary mouse click produces — hovering the target, then right-button `pointerdown`, `mousedown`, `focus`, `contextmenu`, `pointerup`, `mouseup`, and `auxclick`.
+
+Hidden elements are handled the same way a browser would, and no synthetic `click` event is fired. Pass `options` to set event properties such as modifier keys.
+
+Example:
+
+```ts
+await rightClick(q.text("Open menu"));
 ```
 
 <div align="right">

--- a/packages/ariakit-test/src/dispatch.ts
+++ b/packages/ariakit-test/src/dispatch.ts
@@ -224,6 +224,8 @@ const pointerEvents = [
   "mouseenter",
   "mouseout",
   "mouseleave",
+  "auxclick",
+  "contextmenu",
   "mousedown",
   "mouseup",
   "pointermove",

--- a/packages/ariakit-test/src/index.ts
+++ b/packages/ariakit-test/src/index.ts
@@ -9,6 +9,7 @@ export * from "./mouse-down.ts";
 export * from "./mouse-up.ts";
 export * from "./press.ts";
 export * from "./query.ts";
+export * from "./right-click.ts";
 export * from "./select.ts";
 export * from "./sleep.ts";
 export * from "./tap.ts";

--- a/packages/ariakit-test/src/right-click.test.ts
+++ b/packages/ariakit-test/src/right-click.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, expect, test } from "vitest";
+import { q, rightClick } from "./index.ts";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+test("rightClick dispatches a secondary click sequence", async () => {
+  document.body.innerHTML = `<button type="button">Open menu</button>`;
+
+  const button = q.button.ensure("Open menu");
+  const events: string[] = [];
+  const mouseEvents: Array<{
+    button: number;
+    buttons: number;
+    shiftKey: boolean;
+    type: string;
+  }> = [];
+
+  for (const type of [
+    "pointerdown",
+    "mousedown",
+    "focus",
+    "contextmenu",
+    "pointerup",
+    "mouseup",
+    "auxclick",
+    "click",
+  ]) {
+    button.addEventListener(type, (event) => {
+      events.push(event.type);
+      if (event instanceof MouseEvent) {
+        mouseEvents.push({
+          button: event.button,
+          buttons: event.buttons,
+          shiftKey: event.shiftKey,
+          type: event.type,
+        });
+      }
+    });
+  }
+
+  await rightClick(button, { shiftKey: true });
+
+  expect(events).toEqual([
+    "pointerdown",
+    "mousedown",
+    "focus",
+    "contextmenu",
+    "pointerup",
+    "mouseup",
+    "auxclick",
+  ]);
+  expect(mouseEvents).toEqual([
+    { type: "pointerdown", button: 2, buttons: 2, shiftKey: true },
+    { type: "mousedown", button: 2, buttons: 2, shiftKey: true },
+    { type: "contextmenu", button: 2, buttons: 2, shiftKey: true },
+    { type: "pointerup", button: 2, buttons: 0, shiftKey: true },
+    { type: "mouseup", button: 2, buttons: 0, shiftKey: true },
+    { type: "auxclick", button: 2, buttons: 0, shiftKey: true },
+  ]);
+});
+
+test("rightClick dispatches contextmenu and auxclick after prevented pointerdown", async () => {
+  document.body.innerHTML = `<button type="button">Open menu</button>`;
+
+  const button = q.button.ensure("Open menu");
+  const events: string[] = [];
+
+  for (const type of [
+    "pointerdown",
+    "mousedown",
+    "focus",
+    "contextmenu",
+    "pointerup",
+    "mouseup",
+    "auxclick",
+    "click",
+  ]) {
+    button.addEventListener(type, (event) => {
+      events.push(event.type);
+      if (event.type === "pointerdown") {
+        event.preventDefault();
+      }
+    });
+  }
+
+  await rightClick(button);
+
+  expect(events).toEqual([
+    "pointerdown",
+    "contextmenu",
+    "pointerup",
+    "auxclick",
+  ]);
+});
+
+test("rightClick retargets pointer events on pointer-events none", async () => {
+  document.body.innerHTML = `
+    <div data-testid="parent">
+      <button style="pointer-events: none" type="button">Open menu</button>
+    </div>
+  `;
+
+  const parent = document.querySelector("[data-testid='parent']");
+  const button = q.button.ensure("Open menu");
+  const events: string[] = [];
+
+  parent?.addEventListener("pointerdown", (event) => {
+    events.push(`parent ${event.type} ${(event.target as Element).tagName}`);
+  });
+  parent?.addEventListener("mousedown", (event) => {
+    events.push(`parent ${event.type} ${(event.target as Element).tagName}`);
+  });
+  parent?.addEventListener("contextmenu", (event) => {
+    events.push(`parent ${event.type} ${(event.target as Element).tagName}`);
+  });
+  parent?.addEventListener("pointerup", (event) => {
+    events.push(`parent ${event.type} ${(event.target as Element).tagName}`);
+  });
+  parent?.addEventListener("mouseup", (event) => {
+    events.push(`parent ${event.type} ${(event.target as Element).tagName}`);
+  });
+  parent?.addEventListener("auxclick", (event) => {
+    events.push(`parent ${event.type} ${(event.target as Element).tagName}`);
+  });
+
+  await rightClick(button);
+
+  expect(events).toEqual([
+    "parent pointerdown DIV",
+    "parent mousedown DIV",
+    "parent contextmenu DIV",
+    "parent pointerup DIV",
+    "parent mouseup DIV",
+    "parent auxclick DIV",
+  ]);
+});

--- a/packages/ariakit-test/src/right-click.ts
+++ b/packages/ariakit-test/src/right-click.ts
@@ -1,0 +1,74 @@
+import { isVisible, invariant } from "@ariakit/utils";
+import { settle, wrapAsync } from "./__utils.ts";
+import { dispatch } from "./dispatch.ts";
+import { hover } from "./hover.ts";
+import { mouseDown } from "./mouse-down.ts";
+import { mouseUp } from "./mouse-up.ts";
+import { sleep } from "./sleep.ts";
+
+function getHoverOptions(options?: PointerEventInit): PointerEventInit {
+  return { ...options, button: 0, buttons: 0 };
+}
+
+function getPressOptions(options?: PointerEventInit): PointerEventInit {
+  return { ...options, button: 2, buttons: 2 };
+}
+
+function getReleaseOptions(options?: PointerEventInit): PointerEventInit {
+  return { ...options, button: 2, buttons: 0 };
+}
+
+function createAuxClickEvent(element: Element, options: MouseEventInit) {
+  const { defaultView } = element.ownerDocument;
+  const MouseEventConstructor = defaultView?.MouseEvent ?? MouseEvent;
+  return new MouseEventConstructor("auxclick", {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    detail: 1,
+    ...options,
+  });
+}
+
+/**
+ * Right-clicks on an element, simulating the sequence of events a real secondary
+ * mouse click produces — hovering the target, then right-button `pointerdown`,
+ * `mousedown`, `focus`, `contextmenu`, `pointerup`, `mouseup`, and `auxclick`.
+ *
+ * Hidden elements are handled the same way a browser would, and no synthetic
+ * `click` event is fired. Pass `options` to set event properties such as
+ * modifier keys.
+ * @example
+ * ```ts
+ * await rightClick(q.text("Open menu"));
+ * ```
+ */
+export function rightClick(
+  element: Element | null,
+  options?: PointerEventInit,
+) {
+  return wrapAsync(async () => {
+    invariant(element, "Unable to rightClick on null element");
+    if (!isVisible(element)) return;
+
+    await hover(element, getHoverOptions(options));
+    const pressOptions = getPressOptions(options);
+    await mouseDown(element, pressOptions);
+
+    // The element may be hidden after hover/mouseDown, so we need to check again
+    // and find the first visible parent.
+    while (!isVisible(element)) {
+      if (!element.parentElement) return;
+      element = element.parentElement;
+    }
+
+    await dispatch.contextMenu(element, pressOptions);
+    await settle();
+
+    const releaseOptions = getReleaseOptions(options);
+
+    await mouseUp(element, releaseOptions);
+    await dispatch(element, createAuxClickEvent(element, releaseOptions));
+    await sleep();
+  });
+}


### PR DESCRIPTION
## Motivation

`@ariakit/test` had helpers for primary clicks and low-level event dispatching, but no user-level helper for secondary mouse clicks. Tests for the context menu example were using `dispatch.contextMenu(...)`, which opens the menu but skips the browser-like pointer and mouse sequence around a right click.

## Solution

Add `rightClick(element, options?)` to `@ariakit/test`. The helper hovers the target, presses the secondary pointer button, dispatches `contextmenu` while the button is still pressed, releases it, and dispatches `auxclick` without firing a synthetic primary `click`.

This also retargets `contextmenu` and `auxclick` through the same `pointer-events: none` path used by other pointer/mouse events, covers the new helper with package tests, documents it in the generated README, and migrates the context-menu example tests from `dispatch.contextMenu(...)` to `rightClick(...)`.
