### PR TITLE
Add visually hidden style helper

### DIFF
--- a/.changeset/200-visually-hidden-style-helper.md
+++ b/.changeset/200-visually-hidden-style-helper.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/react-components": patch
+---
+
+Added `getVisuallyHiddenStyle` to `@ariakit/react-components/visually-hidden/visually-hidden` for reusing the same styles as [`VisuallyHidden`](https://ariakit.com/reference/visually-hidden).

--- a/packages/ariakit-react-components/src/dialog/utils/prepend-hidden-dismiss.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/prepend-hidden-dismiss.ts
@@ -1,4 +1,5 @@
 import { getDocument } from "@ariakit/utils";
+import { getVisuallyHiddenStyle } from "../../visually-hidden/visually-hidden.tsx";
 
 export function prependHiddenDismiss(
   container: HTMLElement,
@@ -10,18 +11,7 @@ export function prependHiddenDismiss(
   button.tabIndex = -1;
   button.textContent = "Dismiss popup";
 
-  // Visually hidden styles
-  Object.assign(button.style, {
-    borderWidth: "0px",
-    clipPath: "inset(50%)",
-    height: "1px",
-    margin: "-1px",
-    overflow: "hidden",
-    padding: "0px",
-    position: "absolute",
-    whiteSpace: "nowrap",
-    width: "1px",
-  });
+  Object.assign(button.style, getVisuallyHiddenStyle());
 
   button.addEventListener("click", onClick);
   container.prepend(button);

--- a/packages/ariakit-react-components/src/select/select.tsx
+++ b/packages/ariakit-react-components/src/select/select.tsx
@@ -28,6 +28,7 @@ import { useCompositeTypeahead } from "../composite/composite-typeahead.tsx";
 import { getBasePlacement } from "../popover/__utils.ts";
 import type { PopoverDisclosureOptions } from "../popover/popover-disclosure.tsx";
 import { usePopoverDisclosure } from "../popover/popover-disclosure.tsx";
+import { getVisuallyHiddenStyle } from "../visually-hidden/visually-hidden.tsx";
 import { SelectArrow } from "./select-arrow.tsx";
 import {
   SelectScopedContextProvider,
@@ -190,17 +191,7 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
       return (
         <>
           <select
-            style={{
-              borderWidth: 0,
-              clipPath: "inset(50%)",
-              height: "1px",
-              margin: "-1px",
-              overflow: "hidden",
-              padding: 0,
-              position: "absolute",
-              whiteSpace: "nowrap",
-              width: "1px",
-            }}
+            style={getVisuallyHiddenStyle()}
             tabIndex={-1}
             aria-hidden
             aria-label={label}

--- a/packages/ariakit-react-components/src/visually-hidden/visually-hidden.tsx
+++ b/packages/ariakit-react-components/src/visually-hidden/visually-hidden.tsx
@@ -1,9 +1,28 @@
 import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
 import type { Options, Props } from "@ariakit/react-utils";
-import type { ElementType } from "react";
+import type { CSSProperties, ElementType } from "react";
 
 const TagName = "span" satisfies ElementType;
 type TagName = typeof TagName;
+
+/**
+ * Returns styles to visually hide an element while keeping it accessible to
+ * screen readers.
+ */
+export function getVisuallyHiddenStyle(style?: CSSProperties): CSSProperties {
+  return {
+    borderWidth: 0,
+    clipPath: "inset(50%)",
+    height: "1px",
+    margin: "-1px",
+    overflow: "hidden",
+    padding: 0,
+    position: "absolute",
+    whiteSpace: "nowrap",
+    width: "1px",
+    ...style,
+  };
+}
 
 /**
  * Returns props to create a `VisuallyHidden` component. When applying the props
@@ -22,18 +41,7 @@ export const useVisuallyHidden = createHook<TagName, VisuallyHiddenOptions>(
   function useVisuallyHidden(props) {
     props = {
       ...props,
-      style: {
-        borderWidth: 0,
-        clipPath: "inset(50%)",
-        height: "1px",
-        margin: "-1px",
-        overflow: "hidden",
-        padding: 0,
-        position: "absolute",
-        whiteSpace: "nowrap",
-        width: "1px",
-        ...props.style,
-      },
+      style: getVisuallyHiddenStyle(props.style),
     };
     return props;
   },


### PR DESCRIPTION
## Motivation

The visually hidden style object was duplicated in multiple React component internals. Keeping those values inline makes future updates easier to miss when `VisuallyHidden`, the Select native value mirror, and the Dialog hidden dismiss button should use the same hiding technique.

## Solution

Added `getVisuallyHiddenStyle` to `@ariakit/react-components/visually-hidden/visually-hidden` and updated `useVisuallyHidden`, `Select`, and the hidden Dialog dismiss button to use it. The helper preserves the existing style override behavior for `useVisuallyHidden` by spreading custom styles after the defaults.
