### PR TITLE
Create changeset overviews

### DIFF
--- a/.changeset/200-overview-react-components.md
+++ b/.changeset/200-overview-react-components.md
@@ -1,0 +1,9 @@
+---
+"@ariakit/react-components": minor
+---
+
+Overview
+
+This version removes an internal dialog tree helper that was exposed through a deep import path, and improves form handling and composite separator behavior in React components.
+
+Please review the brief notes following the **BREAKING** labels on each update to determine if any changes are needed in your code.

--- a/.changeset/300-overview-components.md
+++ b/.changeset/300-overview-components.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/components": patch
+---
+
+Overview
+
+This version improves form store behavior by making generated field name paths more resilient to symbol probes and keeping form submission and validation from stalling in background tabs.

--- a/.changeset/300-overview-react.md
+++ b/.changeset/300-overview-react.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/react": patch
+---
+
+Overview
+
+This version improves React form behavior and composite separators, including safer generated field name paths, form submission and validation that continue in background tabs, and explicit separator orientation handling.


### PR DESCRIPTION
## Motivation

The current release queue includes several multi-paragraph changesets for the same public packages. Without overview changesets, the generated changelog jumps directly into detailed entries without a short package-level introduction.

## Solution

Add overview changesets for the packages that qualify under the changeset guidelines:

- `@ariakit/react-components`, including the breaking deep-import removal note.
- `@ariakit/components`, summarizing the form store fixes.
- `@ariakit/react`, summarizing the React form and composite separator fixes.

Packages with fewer than two multi-paragraph changesets were left without overview entries.
