### PR TITLE
Fix Portal StrictMode duplicate containers

### DIFF
--- a/.changeset/300-portal-fullscreen-strictmode.md
+++ b/.changeset/300-portal-fullscreen-strictmode.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Portal`](https://ariakit.com/reference/portal), including components built on it such as [`Tooltip`](https://ariakit.com/reference/tooltip) and [`Popover`](https://ariakit.com/reference/popover), to avoid leaking duplicate portal containers in React development StrictMode when syncing with fullscreen elements.

--- a/.changeset/300-portal-fullscreen-strictmode.md
+++ b/.changeset/300-portal-fullscreen-strictmode.md
@@ -3,4 +3,4 @@
 "@ariakit/react": patch
 ---
 
-Fixed [`Portal`](https://ariakit.com/reference/portal), including components built on it such as [`Tooltip`](https://ariakit.com/reference/tooltip) and [`Popover`](https://ariakit.com/reference/popover), to avoid leaking duplicate portal containers in React development StrictMode when syncing with fullscreen elements.
+Fixed [`Portal`](https://ariakit.com/reference/portal), including components built on it such as [`Tooltip`](https://ariakit.com/reference/tooltip) and [`Popover`](https://ariakit.com/reference/popover), to avoid leaking duplicate portal containers in React development StrictMode.

--- a/app/src/sandbox/tooltip-6585/index.react.tsx
+++ b/app/src/sandbox/tooltip-6585/index.react.tsx
@@ -1,11 +1,5 @@
 import * as Ariakit from "@ariakit/react";
-import {
-  StrictMode,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react";
+import { StrictMode, useEffect, useRef, useState } from "react";
 
 const tooltipId = "tooltip-repro";
 const portalSelector = `[id="portal/${tooltipId}"]`;
@@ -28,58 +22,12 @@ function usePortalCount() {
   return count;
 }
 
-function getFullscreenRoot(element: HTMLElement) {
-  const doc = element.ownerDocument;
-  const { fullscreenElement } = doc;
-  const HTMLElement = doc.defaultView?.HTMLElement;
-  if (HTMLElement && fullscreenElement instanceof HTMLElement) {
-    return fullscreenElement;
-  }
-  return doc.body;
-}
-
-function useFullscreenPortalElement() {
-  const elementRef = useRef<HTMLElement | null>(null);
-  const [portalElement, setPortalElement] = useState<HTMLElement | null>(null);
-
-  useLayoutEffect(() => {
-    const element = elementRef.current || document.createElement("div");
-    elementRef.current = element;
-    setPortalElement(element);
-  }, []);
-
-  useLayoutEffect(() => {
-    if (!portalElement) return;
-    const sync = () => {
-      if (!portalElement.isConnected) return;
-      const rootElement = getFullscreenRoot(portalElement);
-      if (portalElement.parentElement !== rootElement) {
-        rootElement.appendChild(portalElement);
-      }
-    };
-    const doc = portalElement.ownerDocument;
-    let frame = 0;
-    const onFullscreenChange = () => {
-      cancelAnimationFrame(frame);
-      frame = requestAnimationFrame(sync);
-    };
-    doc.addEventListener("fullscreenchange", onFullscreenChange);
-    return () => {
-      cancelAnimationFrame(frame);
-      doc.removeEventListener("fullscreenchange", onFullscreenChange);
-    };
-  }, [portalElement]);
-
-  return portalElement;
-}
-
 function Repro() {
   const containerRef = useRef<HTMLDivElement>(null);
   const [mounted, setMounted] = useState(true);
   const [open, setOpen] = useState(false);
   const [pinnedOpen, setPinnedOpen] = useState(false);
   const portalCount = usePortalCount();
-  const portalElement = useFullscreenPortalElement();
   const tooltipOpen = open || pinnedOpen;
 
   const enterFullscreen = () => {
@@ -135,15 +83,9 @@ function Repro() {
           <Ariakit.TooltipAnchor render={<button type="button" />}>
             Hover target
           </Ariakit.TooltipAnchor>
-          {portalElement && (
-            <Ariakit.Tooltip
-              id={tooltipId}
-              portalElement={portalElement}
-              unmountOnHide
-            >
-              Tooltip content
-            </Ariakit.Tooltip>
-          )}
+          <Ariakit.Tooltip id={tooltipId} unmountOnHide>
+            Tooltip content
+          </Ariakit.Tooltip>
         </Ariakit.TooltipProvider>
       )}
     </section>

--- a/app/src/sandbox/tooltip-6585/index.react.tsx
+++ b/app/src/sandbox/tooltip-6585/index.react.tsx
@@ -25,7 +25,10 @@ function usePortalCount() {
 function Repro() {
   const containerRef = useRef<HTMLDivElement>(null);
   const [mounted, setMounted] = useState(true);
+  const [open, setOpen] = useState(false);
+  const [pinnedOpen, setPinnedOpen] = useState(false);
   const portalCount = usePortalCount();
+  const tooltipOpen = open || pinnedOpen;
 
   const enterFullscreen = () => {
     void containerRef.current?.requestFullscreen();
@@ -58,6 +61,9 @@ function Repro() {
         <button type="button" onClick={exitFullscreen}>
           Exit fullscreen
         </button>
+        <button type="button" onClick={() => setPinnedOpen(true)}>
+          Pin tooltip
+        </button>
         <button type="button" onClick={() => setMounted(false)}>
           Unmount tooltip
         </button>
@@ -69,7 +75,11 @@ function Repro() {
         Portal containers: {portalCount}
       </div>
       {mounted && (
-        <Ariakit.TooltipProvider timeout={0}>
+        <Ariakit.TooltipProvider
+          open={tooltipOpen}
+          setOpen={setOpen}
+          timeout={0}
+        >
           <Ariakit.TooltipAnchor render={<button type="button" />}>
             Hover target
           </Ariakit.TooltipAnchor>

--- a/app/src/sandbox/tooltip-6585/index.react.tsx
+++ b/app/src/sandbox/tooltip-6585/index.react.tsx
@@ -1,0 +1,91 @@
+import * as Ariakit from "@ariakit/react";
+import { StrictMode, useEffect, useRef, useState } from "react";
+
+const tooltipId = "tooltip-repro";
+const portalSelector = `[id="portal/${tooltipId}"]`;
+
+function getPortalCount() {
+  return document.querySelectorAll(portalSelector).length;
+}
+
+function usePortalCount() {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    const update = () => setCount(getPortalCount());
+    update();
+    const observer = new MutationObserver(update);
+    observer.observe(document.body, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, []);
+
+  return count;
+}
+
+function Repro() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [mounted, setMounted] = useState(true);
+  const portalCount = usePortalCount();
+
+  const enterFullscreen = () => {
+    void containerRef.current?.requestFullscreen();
+  };
+
+  const exitFullscreen = () => {
+    if (!document.fullscreenElement) return;
+    void document.exitFullscreen();
+  };
+
+  return (
+    <section
+      aria-label="Portal leak repro"
+      ref={containerRef}
+      style={{
+        alignItems: "flex-start",
+        background: "white",
+        color: "black",
+        display: "flex",
+        flexDirection: "column",
+        gap: 16,
+        minHeight: 240,
+        padding: 24,
+      }}
+    >
+      <div style={{ display: "flex", gap: 8 }}>
+        <button type="button" onClick={enterFullscreen}>
+          Enter fullscreen
+        </button>
+        <button type="button" onClick={exitFullscreen}>
+          Exit fullscreen
+        </button>
+        <button type="button" onClick={() => setMounted(false)}>
+          Unmount tooltip
+        </button>
+        <button type="button" onClick={() => setMounted(true)}>
+          Mount tooltip
+        </button>
+      </div>
+      <div role="status" aria-label="Portal containers">
+        Portal containers: {portalCount}
+      </div>
+      {mounted && (
+        <Ariakit.TooltipProvider timeout={0}>
+          <Ariakit.TooltipAnchor render={<button type="button" />}>
+            Hover target
+          </Ariakit.TooltipAnchor>
+          <Ariakit.Tooltip id={tooltipId} unmountOnHide>
+            Tooltip content
+          </Ariakit.Tooltip>
+        </Ariakit.TooltipProvider>
+      )}
+    </section>
+  );
+}
+
+export default function Example() {
+  return (
+    <StrictMode>
+      <Repro />
+    </StrictMode>
+  );
+}

--- a/app/src/sandbox/tooltip-6585/index.react.tsx
+++ b/app/src/sandbox/tooltip-6585/index.react.tsx
@@ -23,7 +23,8 @@ function usePortalCount() {
 }
 
 function Repro() {
-  const containerRef = useRef<HTMLDivElement>(null);
+  const fullscreenHostRef = useRef<HTMLDivElement>(null);
+  const [fullscreenHostMounted, setFullscreenHostMounted] = useState(true);
   const [mounted, setMounted] = useState(true);
   const [open, setOpen] = useState(false);
   const [pinnedOpen, setPinnedOpen] = useState(false);
@@ -31,7 +32,7 @@ function Repro() {
   const tooltipOpen = open || pinnedOpen;
 
   const enterFullscreen = () => {
-    void containerRef.current?.requestFullscreen();
+    void fullscreenHostRef.current?.requestFullscreen();
   };
 
   const exitFullscreen = () => {
@@ -42,7 +43,6 @@ function Repro() {
   return (
     <section
       aria-label="Portal leak repro"
-      ref={containerRef}
       style={{
         alignItems: "flex-start",
         background: "white",
@@ -54,26 +54,47 @@ function Repro() {
         padding: 24,
       }}
     >
-      <div style={{ display: "flex", gap: 8 }}>
-        <button type="button" onClick={enterFullscreen}>
-          Enter fullscreen
-        </button>
-        <button type="button" onClick={exitFullscreen}>
-          Exit fullscreen
-        </button>
-        <button type="button" onClick={() => setPinnedOpen(true)}>
-          Pin tooltip
-        </button>
-        <button type="button" onClick={() => setMounted(false)}>
-          Unmount tooltip
-        </button>
-        <button type="button" onClick={() => setMounted(true)}>
-          Mount tooltip
-        </button>
-      </div>
-      <div role="status" aria-label="Portal containers">
-        Portal containers: {portalCount}
-      </div>
+      {fullscreenHostMounted && (
+        <div
+          ref={fullscreenHostRef}
+          style={{
+            alignItems: "flex-start",
+            background: "white",
+            color: "black",
+            display: "flex",
+            flexDirection: "column",
+            gap: 16,
+            padding: 24,
+          }}
+        >
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+            <button type="button" onClick={enterFullscreen}>
+              Enter fullscreen
+            </button>
+            <button type="button" onClick={exitFullscreen}>
+              Exit fullscreen
+            </button>
+            <button type="button" onClick={() => setPinnedOpen(true)}>
+              Pin tooltip
+            </button>
+            <button type="button" onClick={() => setMounted(false)}>
+              Unmount tooltip
+            </button>
+            <button type="button" onClick={() => setMounted(true)}>
+              Mount tooltip
+            </button>
+            <button
+              type="button"
+              onClick={() => setFullscreenHostMounted(false)}
+            >
+              Unmount fullscreen host
+            </button>
+          </div>
+          <div role="status" aria-label="Portal containers">
+            Portal containers: {portalCount}
+          </div>
+        </div>
+      )}
       {mounted && (
         <Ariakit.TooltipProvider
           open={tooltipOpen}

--- a/app/src/sandbox/tooltip-6585/index.react.tsx
+++ b/app/src/sandbox/tooltip-6585/index.react.tsx
@@ -1,5 +1,11 @@
 import * as Ariakit from "@ariakit/react";
-import { StrictMode, useEffect, useRef, useState } from "react";
+import {
+  StrictMode,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 
 const tooltipId = "tooltip-repro";
 const portalSelector = `[id="portal/${tooltipId}"]`;
@@ -22,12 +28,58 @@ function usePortalCount() {
   return count;
 }
 
+function getFullscreenRoot(element: HTMLElement) {
+  const doc = element.ownerDocument;
+  const { fullscreenElement } = doc;
+  const HTMLElement = doc.defaultView?.HTMLElement;
+  if (HTMLElement && fullscreenElement instanceof HTMLElement) {
+    return fullscreenElement;
+  }
+  return doc.body;
+}
+
+function useFullscreenPortalElement() {
+  const elementRef = useRef<HTMLElement | null>(null);
+  const [portalElement, setPortalElement] = useState<HTMLElement | null>(null);
+
+  useLayoutEffect(() => {
+    const element = elementRef.current || document.createElement("div");
+    elementRef.current = element;
+    setPortalElement(element);
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!portalElement) return;
+    const sync = () => {
+      if (!portalElement.isConnected) return;
+      const rootElement = getFullscreenRoot(portalElement);
+      if (portalElement.parentElement !== rootElement) {
+        rootElement.appendChild(portalElement);
+      }
+    };
+    const doc = portalElement.ownerDocument;
+    let frame = 0;
+    const onFullscreenChange = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(sync);
+    };
+    doc.addEventListener("fullscreenchange", onFullscreenChange);
+    return () => {
+      cancelAnimationFrame(frame);
+      doc.removeEventListener("fullscreenchange", onFullscreenChange);
+    };
+  }, [portalElement]);
+
+  return portalElement;
+}
+
 function Repro() {
   const containerRef = useRef<HTMLDivElement>(null);
   const [mounted, setMounted] = useState(true);
   const [open, setOpen] = useState(false);
   const [pinnedOpen, setPinnedOpen] = useState(false);
   const portalCount = usePortalCount();
+  const portalElement = useFullscreenPortalElement();
   const tooltipOpen = open || pinnedOpen;
 
   const enterFullscreen = () => {
@@ -83,9 +135,15 @@ function Repro() {
           <Ariakit.TooltipAnchor render={<button type="button" />}>
             Hover target
           </Ariakit.TooltipAnchor>
-          <Ariakit.Tooltip id={tooltipId} unmountOnHide>
-            Tooltip content
-          </Ariakit.Tooltip>
+          {portalElement && (
+            <Ariakit.Tooltip
+              id={tooltipId}
+              portalElement={portalElement}
+              unmountOnHide
+            >
+              Tooltip content
+            </Ariakit.Tooltip>
+          )}
         </Ariakit.TooltipProvider>
       )}
     </section>

--- a/app/src/sandbox/tooltip-6585/test-browser.ts
+++ b/app/src/sandbox/tooltip-6585/test-browser.ts
@@ -1,3 +1,4 @@
+import type { Page } from "@playwright/test";
 import { withFramework } from "#app/test-utils/preview.ts";
 
 // See https://github.com/ariakit/ariakit/issues/6585
@@ -5,9 +6,7 @@ import { withFramework } from "#app/test-utils/preview.ts";
 // `pnpm react18 dev-app`. CI's React 18 signal comes from test.ts.
 const portalId = "portal/tooltip-repro";
 
-async function getPortalState(page: {
-  evaluate: <T>(fn: (id: string) => T, arg: string) => Promise<T>;
-}) {
+async function getPortalState(page: Page) {
   return page.evaluate((id) => {
     const nodes = Array.from(document.querySelectorAll(`#${CSS.escape(id)}`));
     const node = nodes[0];

--- a/app/src/sandbox/tooltip-6585/test-browser.ts
+++ b/app/src/sandbox/tooltip-6585/test-browser.ts
@@ -99,4 +99,36 @@ withFramework(import.meta.dirname, async ({ test }) => {
     const state = await getPortalState(page);
     test.expect(state.count).toBe(0);
   });
+
+  test("moves the portal to body when the fullscreen host is removed", async ({
+    page,
+    q,
+  }) => {
+    await test
+      .expect(q.status("Portal containers"))
+      .toHaveText("Portal containers: 0");
+
+    await q.button("Pin tooltip").click();
+    await q.button("Enter fullscreen").click();
+    await page.waitForFunction(() => document.fullscreenElement != null);
+
+    await test.expect(q.tooltip("Tooltip content")).toBeVisible();
+    await test.expect
+      .poll(() => getPortalState(page))
+      .toMatchObject({
+        count: 1,
+        parentIsFullscreen: true,
+      });
+
+    await q.button("Unmount fullscreen host").click();
+    await page.waitForFunction(() => document.fullscreenElement == null);
+
+    await test.expect(q.tooltip("Tooltip content")).toBeVisible();
+    await test.expect
+      .poll(() => getPortalState(page))
+      .toMatchObject({
+        count: 1,
+        parentIsBody: true,
+      });
+  });
 });

--- a/app/src/sandbox/tooltip-6585/test-browser.ts
+++ b/app/src/sandbox/tooltip-6585/test-browser.ts
@@ -51,47 +51,50 @@ withFramework(import.meta.dirname, async ({ test }) => {
     page,
     q,
   }) => {
-    await q.button("Enter fullscreen").click();
-    await page.waitForFunction(() => document.fullscreenElement != null);
-
-    await q.button("Hover target").hover();
-    await test.expect(q.tooltip("Tooltip content")).toBeVisible();
+    await q.button("Unmount tooltip").click();
     await test
       .expect(q.status("Portal containers"))
-      .toHaveText("Portal containers: 1");
+      .toHaveText("Portal containers: 0");
 
-    let state = await getPortalState(page);
-    test.expect(state).toMatchObject({
-      count: 1,
-      parentIsFullscreen: true,
-    });
+    await q.button("Pin tooltip").click();
+    await q.button("Enter fullscreen").click();
+    await page.waitForFunction(() => document.fullscreenElement != null);
+    await q.button("Mount tooltip").click();
+    await test.expect(q.tooltip("Tooltip content")).toBeVisible();
+
+    await test.expect
+      .poll(() => getPortalState(page))
+      .toMatchObject({
+        count: 1,
+        parentIsFullscreen: true,
+      });
 
     await q.button("Exit fullscreen").click();
     await page.waitForFunction(() => document.fullscreenElement == null);
-    await q.button("Hover target").hover();
-    await test.expect(q.tooltip("Tooltip content")).toBeVisible();
 
-    state = await getPortalState(page);
-    test.expect(state).toMatchObject({
-      count: 1,
-      parentIsBody: true,
-    });
+    await test.expect
+      .poll(() => getPortalState(page))
+      .toMatchObject({
+        count: 1,
+        parentIsBody: true,
+      });
 
     await q.button("Enter fullscreen").click();
     await page.waitForFunction(() => document.fullscreenElement != null);
 
-    state = await getPortalState(page);
-    test.expect(state).toMatchObject({
-      count: 1,
-      parentIsFullscreen: true,
-    });
+    await test.expect
+      .poll(() => getPortalState(page))
+      .toMatchObject({
+        count: 1,
+        parentIsFullscreen: true,
+      });
 
     await q.button("Unmount tooltip").click();
     await test
       .expect(q.status("Portal containers"))
       .toHaveText("Portal containers: 0");
 
-    state = await getPortalState(page);
+    const state = await getPortalState(page);
     test.expect(state.count).toBe(0);
   });
 });

--- a/app/src/sandbox/tooltip-6585/test-browser.ts
+++ b/app/src/sandbox/tooltip-6585/test-browser.ts
@@ -51,6 +51,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
     page,
     q,
   }) => {
+    await test
+      .expect(q.status("Portal containers"))
+      .toHaveText("Portal containers: 0");
     await q.button("Unmount tooltip").click();
     await test
       .expect(q.status("Portal containers"))

--- a/app/src/sandbox/tooltip-6585/test-browser.ts
+++ b/app/src/sandbox/tooltip-6585/test-browser.ts
@@ -1,0 +1,97 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// See https://github.com/ariakit/ariakit/issues/6585
+// To reproduce the React 18 StrictMode failure in a browser, serve the app with
+// `pnpm react18 dev-app`. CI's React 18 signal comes from test.ts.
+const portalId = "portal/tooltip-repro";
+
+async function getPortalState(page: {
+  evaluate: <T>(fn: (id: string) => T, arg: string) => Promise<T>;
+}) {
+  return page.evaluate((id) => {
+    const nodes = Array.from(document.querySelectorAll(`#${CSS.escape(id)}`));
+    const node = nodes[0];
+    const fullscreenElement = document.fullscreenElement;
+
+    return {
+      count: nodes.length,
+      parentIsBody: node?.parentElement === document.body,
+      parentIsFullscreen:
+        !!fullscreenElement && node?.parentElement === fullscreenElement,
+    };
+  }, portalId);
+}
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("does not leak duplicate tooltip portal containers", async ({
+    page,
+    q,
+  }) => {
+    await test
+      .expect(q.status("Portal containers"))
+      .toHaveText("Portal containers: 0");
+
+    await q.button("Hover target").hover();
+    await test.expect(q.tooltip("Tooltip content")).toBeVisible();
+    await test
+      .expect(q.status("Portal containers"))
+      .toHaveText("Portal containers: 1");
+
+    await q.button("Unmount tooltip").click();
+    await test.expect(q.tooltip("Tooltip content")).not.toBeVisible();
+    await test
+      .expect(q.status("Portal containers"))
+      .toHaveText("Portal containers: 0");
+
+    const state = await getPortalState(page);
+    test.expect(state.count).toBe(0);
+  });
+
+  test("keeps one portal container while moving in and out of fullscreen", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Enter fullscreen").click();
+    await page.waitForFunction(() => document.fullscreenElement != null);
+
+    await q.button("Hover target").hover();
+    await test.expect(q.tooltip("Tooltip content")).toBeVisible();
+    await test
+      .expect(q.status("Portal containers"))
+      .toHaveText("Portal containers: 1");
+
+    let state = await getPortalState(page);
+    test.expect(state).toMatchObject({
+      count: 1,
+      parentIsFullscreen: true,
+    });
+
+    await q.button("Exit fullscreen").click();
+    await page.waitForFunction(() => document.fullscreenElement == null);
+    await q.button("Hover target").hover();
+    await test.expect(q.tooltip("Tooltip content")).toBeVisible();
+
+    state = await getPortalState(page);
+    test.expect(state).toMatchObject({
+      count: 1,
+      parentIsBody: true,
+    });
+
+    await q.button("Enter fullscreen").click();
+    await page.waitForFunction(() => document.fullscreenElement != null);
+
+    state = await getPortalState(page);
+    test.expect(state).toMatchObject({
+      count: 1,
+      parentIsFullscreen: true,
+    });
+
+    await q.button("Unmount tooltip").click();
+    await test
+      .expect(q.status("Portal containers"))
+      .toHaveText("Portal containers: 0");
+
+    state = await getPortalState(page);
+    test.expect(state.count).toBe(0);
+  });
+});

--- a/app/src/sandbox/tooltip-6585/test.ts
+++ b/app/src/sandbox/tooltip-6585/test.ts
@@ -1,0 +1,22 @@
+import { click, hover, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// See https://github.com/ariakit/ariakit/issues/6585
+// This regression reproduces in React 18 development StrictMode.
+test("does not leak duplicate tooltip portal containers in StrictMode", async () => {
+  expect(q.status("Portal containers")).toHaveTextContent(
+    "Portal containers: 0",
+  );
+
+  await hover(q.button.ensure("Hover target"));
+  expect(q.tooltip("Tooltip content")).toBeVisible();
+  expect(q.status("Portal containers")).toHaveTextContent(
+    "Portal containers: 1",
+  );
+
+  await click(q.button("Unmount tooltip"));
+  expect(q.tooltip("Tooltip content")).not.toBeInTheDocument();
+  expect(q.status("Portal containers")).toHaveTextContent(
+    "Portal containers: 0",
+  );
+});

--- a/packages/ariakit-react-components/src/portal/portal.tsx
+++ b/packages/ariakit-react-components/src/portal/portal.tsx
@@ -32,7 +32,8 @@ type HTMLType = HTMLElementTagNameMap[TagName];
 function getRootElement(element?: Element | null) {
   const doc = getDocument(element);
   const { fullscreenElement } = doc;
-  if (fullscreenElement instanceof HTMLElement) {
+  const HTMLElementClass = doc.defaultView?.HTMLElement;
+  if (HTMLElementClass && fullscreenElement instanceof HTMLElementClass) {
     return fullscreenElement;
   }
   return doc.body;
@@ -141,6 +142,7 @@ export const usePortal = createHook<TagName, PortalOptions>(function usePortal({
     if (portalElement) return;
     const doc = getDocument(portalNode);
     const onFullscreenChange = () => {
+      if (!portalNode.isConnected) return;
       const rootElement = getRootElement(portalNode);
       if (portalNode.parentElement !== rootElement) {
         rootElement.appendChild(portalNode);

--- a/packages/ariakit-react-components/src/portal/portal.tsx
+++ b/packages/ariakit-react-components/src/portal/portal.tsx
@@ -142,7 +142,6 @@ export const usePortal = createHook<TagName, PortalOptions>(function usePortal({
     if (portalElement) return;
     const doc = getDocument(portalNode);
     const onFullscreenChange = () => {
-      if (!portalNode.isConnected) return;
       const rootElement = getRootElement(portalNode);
       if (portalNode.parentElement !== rootElement) {
         rootElement.appendChild(portalNode);
@@ -150,8 +149,12 @@ export const usePortal = createHook<TagName, PortalOptions>(function usePortal({
     };
     // Sync immediately in case fullscreen was entered before this effect
     // ran, which can happen if the portal mounts while already in
-    // fullscreen mode.
-    onFullscreenChange();
+    // fullscreen mode. Skip when the captured node is already disconnected,
+    // which happens for a StrictMode cleanup node whose layout cleanup
+    // already removed it.
+    if (portalNode.isConnected) {
+      onFullscreenChange();
+    }
     doc.addEventListener("fullscreenchange", onFullscreenChange);
     return () => {
       doc.removeEventListener("fullscreenchange", onFullscreenChange);


### PR DESCRIPTION
## Motivation

Fixes #6585.

`Portal` can leave duplicate portal containers in React 18 development `StrictMode`. The fullscreen sync effect runs immediately after a portal node is stored, and in StrictMode that can happen after the layout cleanup has already removed a stale portal node. Since the stale node has no parent, the immediate sync can append it back to the document and leave two connected nodes with the same `portal/...` id.

This affected components built on [`Portal`](https://ariakit.com/reference/portal), including tooltips.

## Solution

Added a focused sandbox regression at `app/src/sandbox/tooltip-6585` that counts connected portal containers while showing and unmounting a tooltip in `StrictMode`. The browser coverage also exercises fullscreen movement, including mounting the tooltip while already fullscreen and removing the fullscreen host while the tooltip stays mounted.

The library fix keeps the fullscreen behavior from #5742, including the immediate sync for portals mounted while already fullscreen, but skips that immediate sync when the captured portal node is no longer connected:

```ts
if (portalNode.isConnected) {
  onFullscreenChange();
}
```

That prevents a StrictMode cleanup node from being reattached. Real `fullscreenchange` events still run the reparenting logic, so an active portal can move back to `document.body` if the fullscreen element containing it is removed.

The fullscreen root check now also uses the portal node document's `defaultView.HTMLElement`, which avoids relying on the parent window's `HTMLElement` constructor for iframe/cross-realm documents.

## Workaround

Before this fix, a userland workaround was to pass a stable custom `portalElement` to the tooltip and move that element on `fullscreenchange`. Supplying `portalElement` avoided the internal auto-created portal node path that could be duplicated by the fullscreen sync effect.
