### PR TITLE
Fix Dialog with getPersistentElements closing before the dialog is focused

### DIFF
--- a/.changeset/300-dialog-persistent-elements-before-focus.md
+++ b/.changeset/300-dialog-persistent-elements-before-focus.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Dialog`](https://ariakit.com/reference/dialog), including components built on it such as [`Popover`](https://ariakit.com/reference/popover) and [`Menu`](https://ariakit.com/reference/menu), so focusing, clicking, or right-clicking elements returned by [`getPersistentElements`](https://ariakit.com/reference/dialog#getpersistentelements) no longer closes the dialog before it has received focus, such as when it's rendered with [`autoFocusOnShow`](https://ariakit.com/reference/dialog#autofocusonshow) set to `false`.

--- a/app/src/sandbox/dialog-6344/index.react.tsx
+++ b/app/src/sandbox/dialog-6344/index.react.tsx
@@ -1,0 +1,82 @@
+import * as Ariakit from "@ariakit/react";
+import { useRef, useState } from "react";
+
+// Reproduces a non-modal dialog with getPersistentElements closing when the
+// user interacts with a persistent element before the dialog has been focused.
+// To see the bug:
+//   1. Click "Open dialog". The panel opens without taking focus
+//      (autoFocusOnShow={false}).
+//   2. Without clicking inside the dialog, click (or focus, or right-click) the
+//      "Notification field" input inside the persistent "Notifications" region.
+//   3. The dialog closes, even though the region is returned by
+//      getPersistentElements and should be treated as part of the dialog.
+// For contrast, focusing "Inside field" first makes the same interaction keep
+// the dialog open, as documented.
+export default function Example() {
+  const [open, setOpen] = useState(false);
+  const notificationsRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <div className="flex flex-col items-start gap-3">
+      <Ariakit.Button
+        className="rounded bg-blue-600 px-3 py-1 text-white"
+        onClick={() => setOpen(true)}
+      >
+        Open dialog
+      </Ariakit.Button>
+
+      <Ariakit.Dialog
+        open={open}
+        onClose={() => setOpen(false)}
+        modal={false}
+        autoFocusOnShow={false}
+        getPersistentElements={() => {
+          const notifications = notificationsRef.current;
+          return notifications ? [notifications] : [];
+        }}
+        className="flex w-72 flex-col items-start gap-3 rounded-lg border border-gray-300 bg-white p-4 shadow-lg"
+      >
+        <Ariakit.DialogHeading className="text-lg font-medium">
+          Dialog
+        </Ariakit.DialogHeading>
+        <input
+          aria-label="Inside field"
+          placeholder="Inside field"
+          className="rounded border border-gray-300 px-3 py-1"
+        />
+        <Ariakit.DialogDismiss className="rounded border border-gray-300 px-3 py-1">
+          Close dialog
+        </Ariakit.DialogDismiss>
+      </Ariakit.Dialog>
+
+      {/* Persistent notifications region, like the dialog-react-toastify
+          example. Interacting with it must never close the dialog. */}
+      <div
+        ref={notificationsRef}
+        role="region"
+        aria-label="Notifications"
+        className="flex flex-col items-start gap-3 rounded-lg border border-gray-300 p-4"
+      >
+        <input
+          aria-label="Notification field"
+          placeholder="Notification field"
+          className="rounded border border-gray-300 px-3 py-1"
+        />
+        <button
+          type="button"
+          className="rounded border border-gray-300 px-3 py-1"
+        >
+          Dismiss notification
+        </button>
+      </div>
+
+      {/* A regular outside element: interacting with it must still close the
+          dialog. */}
+      <input
+        aria-label="Outside field"
+        placeholder="Outside field"
+        className="rounded border border-gray-300 px-3 py-1"
+      />
+    </div>
+  );
+}

--- a/app/src/sandbox/dialog-6344/index.react.tsx
+++ b/app/src/sandbox/dialog-6344/index.react.tsx
@@ -34,15 +34,6 @@ export default function Example() {
           const notifications = notificationsRef.current;
           return notifications ? [notifications] : [];
         }}
-        // TODO: Workaround for https://github.com/ariakit/ariakit/issues/6344
-        // Remove once the fix lands: getPersistentElements alone should keep
-        // interactions with persistent elements from closing the dialog.
-        hideOnInteractOutside={(event) => {
-          const notifications = notificationsRef.current;
-          if (!notifications) return true;
-          if (!(event.target instanceof Node)) return true;
-          return !notifications.contains(event.target);
-        }}
         className="flex w-72 flex-col items-start gap-3 rounded-lg border border-gray-300 bg-white p-4 shadow-lg"
       >
         <Ariakit.DialogHeading className="text-lg font-medium">

--- a/app/src/sandbox/dialog-6344/index.react.tsx
+++ b/app/src/sandbox/dialog-6344/index.react.tsx
@@ -34,6 +34,15 @@ export default function Example() {
           const notifications = notificationsRef.current;
           return notifications ? [notifications] : [];
         }}
+        // TODO: Workaround for https://github.com/ariakit/ariakit/issues/6344
+        // Remove once the fix lands: getPersistentElements alone should keep
+        // interactions with persistent elements from closing the dialog.
+        hideOnInteractOutside={(event) => {
+          const notifications = notificationsRef.current;
+          if (!notifications) return true;
+          if (!(event.target instanceof Node)) return true;
+          return !notifications.contains(event.target);
+        }}
         className="flex w-72 flex-col items-start gap-3 rounded-lg border border-gray-300 bg-white p-4 shadow-lg"
       >
         <Ariakit.DialogHeading className="text-lg font-medium">

--- a/app/src/sandbox/dialog-6344/test-browser.ts
+++ b/app/src/sandbox/dialog-6344/test-browser.ts
@@ -1,0 +1,64 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6344
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("stays open when interacting with a persistent element before the dialog is focused", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Open dialog").click();
+    await test.expect(q.dialog("Dialog")).toBeVisible();
+
+    // The dialog hasn't been focused yet (autoFocusOnShow={false}). Clicking
+    // the persistent field must not close it. The bounded timeout guards
+    // against the assertion passing before the dialog processes the hide.
+    await q.textbox("Notification field").click();
+    await test.expect(q.textbox("Notification field")).toBeFocused();
+    await page.waitForTimeout(250);
+    await test.expect(q.dialog("Dialog")).toBeVisible();
+
+    // Other interactions with the persistent region must not close it either.
+    await q.button("Dismiss notification").click();
+    await page.waitForTimeout(250);
+    await test.expect(q.dialog("Dialog")).toBeVisible();
+  });
+
+  test("stays open on right-clicking a persistent element before the dialog is focused", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Open dialog").click();
+    await test.expect(q.dialog("Dialog")).toBeVisible();
+
+    await q.textbox("Notification field").click({ button: "right" });
+    await page.waitForTimeout(250);
+    await test.expect(q.dialog("Dialog")).toBeVisible();
+  });
+
+  test("keeps the documented behavior after the dialog has been focused", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Open dialog").click();
+    await test.expect(q.dialog("Dialog")).toBeVisible();
+
+    // Focusing inside the dialog first is the documented, working path.
+    await q.textbox("Inside field").click();
+    await test.expect(q.textbox("Inside field")).toBeFocused();
+
+    await q.textbox("Notification field").click();
+    await test.expect(q.textbox("Notification field")).toBeFocused();
+    await page.waitForTimeout(250);
+    await test.expect(q.dialog("Dialog")).toBeVisible();
+  });
+
+  test("still closes when interacting outside before the dialog is focused", async ({
+    q,
+  }) => {
+    await q.button("Open dialog").click();
+    await test.expect(q.dialog("Dialog")).toBeVisible();
+
+    await q.textbox("Outside field").click();
+    await test.expect(q.dialog("Dialog")).not.toBeVisible();
+  });
+});

--- a/app/src/sandbox/dialog-6344/test.ts
+++ b/app/src/sandbox/dialog-6344/test.ts
@@ -1,0 +1,47 @@
+import { click, q, rightClick } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6344
+test("stays open when interacting with a persistent element before the dialog is focused", async () => {
+  await click(q.button.ensure("Open dialog"));
+  expect(q.dialog("Dialog")).toBeVisible();
+
+  // The dialog hasn't been focused yet (autoFocusOnShow={false}). Clicking
+  // the persistent field must not close it.
+  await click(q.textbox.ensure("Notification field"));
+  expect(q.textbox("Notification field")).toHaveFocus();
+  expect(q.dialog("Dialog")).toBeVisible();
+
+  // Other interactions with the persistent region must not close it either.
+  await click(q.button.ensure("Dismiss notification"));
+  expect(q.dialog("Dialog")).toBeVisible();
+});
+
+test("stays open on right-clicking a persistent element before the dialog is focused", async () => {
+  await click(q.button.ensure("Open dialog"));
+  expect(q.dialog("Dialog")).toBeVisible();
+
+  await rightClick(q.textbox.ensure("Notification field"));
+  expect(q.dialog("Dialog")).toBeVisible();
+});
+
+test("keeps the documented behavior after the dialog has been focused", async () => {
+  await click(q.button.ensure("Open dialog"));
+  expect(q.dialog("Dialog")).toBeVisible();
+
+  // Focusing inside the dialog first is the documented, working path.
+  await click(q.textbox.ensure("Inside field"));
+  expect(q.textbox("Inside field")).toHaveFocus();
+
+  await click(q.textbox.ensure("Notification field"));
+  expect(q.textbox("Notification field")).toHaveFocus();
+  expect(q.dialog("Dialog")).toBeVisible();
+});
+
+test("still closes when interacting outside before the dialog is focused", async () => {
+  await click(q.button.ensure("Open dialog"));
+  expect(q.dialog("Dialog")).toBeVisible();
+
+  await click(q.textbox.ensure("Outside field"));
+  await expect.poll(q.dialog.hidden.lazy("Dialog")).not.toBeVisible();
+});

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -14,6 +14,7 @@ import {
 import type { Props } from "@ariakit/react-utils";
 import { sync } from "@ariakit/store";
 import {
+  chain,
   contains,
   getActiveElement,
   getDocument,
@@ -60,7 +61,11 @@ import {
   disableTree,
   markAndDisableTreeOutside,
 } from "./utils/disable-tree.ts";
-import { isElementMarked, markTreeOutside } from "./utils/mark-tree-outside.ts";
+import {
+  isElementMarked,
+  markTreeInside,
+  markTreeOutside,
+} from "./utils/mark-tree-outside.ts";
 import { prependHiddenDismiss } from "./utils/prepend-hidden-dismiss.ts";
 import { supportsInert } from "./utils/supports-inert.ts";
 import { useHideOnInteractOutside } from "./utils/use-hide-on-interact-outside.ts";
@@ -311,10 +316,23 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
       ...persistentElements,
       ...nestedDialogs.map((dialog) => dialog.getState().contentElement),
     ];
+    // Positively mark the elements the dialog knows about as "inside" so the
+    // outside event listeners can recognize them even before the dialog has
+    // been focused. The disclosure is excluded because it can change while
+    // the dialog is open (hovercards and tooltips set it to the focus
+    // source), so the listeners re-check it against the current state on
+    // every event instead. See https://github.com/ariakit/ariakit/issues/6344
+    const restoreInsideMarks = markTreeInside(id, allElements);
     if (modal) {
-      return markAndDisableTreeOutside(id, allElements);
+      return chain(
+        restoreInsideMarks,
+        markAndDisableTreeOutside(id, allElements),
+      );
     }
-    return markTreeOutside(id, [disclosureElement, ...allElements]);
+    return chain(
+      restoreInsideMarks,
+      markTreeOutside(id, [disclosureElement, ...allElements]),
+    );
   }, [
     id,
     store,

--- a/packages/ariakit-react-components/src/dialog/utils/mark-tree-outside.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/mark-tree-outside.ts
@@ -5,7 +5,13 @@ import {
 } from "./tree-cleanup.ts";
 import type { Elements } from "./tree-cleanup.ts";
 import { walkTreeOutside } from "./walk-tree-outside.ts";
-export { isElementMarked, markAncestor, markElement } from "./tree-cleanup.ts";
+export {
+  isElementInside,
+  isElementMarked,
+  markAncestor,
+  markElement,
+  markTreeInside,
+} from "./tree-cleanup.ts";
 
 export function markTreeOutside(id: string, elements: Elements) {
   const cleanups: Array<() => void> = [];

--- a/packages/ariakit-react-components/src/dialog/utils/orchestrate.test.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/orchestrate.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, expect, test } from "vitest";
 import { markAndDisableTreeOutside } from "./disable-tree.ts";
-import { isElementMarked, markTreeOutside } from "./mark-tree-outside.ts";
+import {
+  isElementInside,
+  isElementMarked,
+  markTreeInside,
+  markTreeOutside,
+} from "./mark-tree-outside.ts";
 import { assignStyle, setAttribute } from "./orchestrate.ts";
 import { supportsInert } from "./supports-inert.ts";
 import {
@@ -192,6 +197,42 @@ test("markTreeOutside skips backdrops and restores marks", () => {
   expect(isElementMarked(outside, "dialog")).toBe(false);
   expect(isElementMarked(outsideChild, "dialog")).toBe(false);
   expect(isElementMarked(backdrop, "dialog")).toBe(false);
+});
+
+test("markTreeInside marks the given elements and restores them", () => {
+  document.body.innerHTML = `
+    <div id="root">
+      <div id="dialog" data-dialog></div>
+      <section id="persistent">
+        <span id="persistent-child"></span>
+      </section>
+      <section id="outside"></section>
+    </div>
+  `;
+
+  const dialog = getElement("dialog");
+  const persistent = getElement("persistent");
+  const persistentChild = getElement("persistent-child");
+  const outside = getElement("outside");
+
+  const restoreInsideMarks = markTreeInside("dialog", [dialog, persistent]);
+  const restoreMarks = markTreeOutside("dialog", [dialog, persistent]);
+
+  expect(isElementInside(dialog, "dialog")).toBe(true);
+  expect(isElementInside(persistent, "dialog")).toBe(true);
+  // Descendants of inside elements are inside too, even when added after the
+  // dialog opens.
+  expect(isElementInside(persistentChild, "dialog")).toBe(true);
+  expect(isElementInside(outside, "dialog")).toBe(false);
+  expect(isElementMarked(persistent, "dialog")).toBe(false);
+  expect(isElementMarked(outside, "dialog")).toBe(true);
+
+  restoreMarks();
+  restoreInsideMarks();
+
+  expect(isElementInside(dialog, "dialog")).toBe(false);
+  expect(isElementInside(persistent, "dialog")).toBe(false);
+  expect(isElementInside(persistentChild, "dialog")).toBe(false);
 });
 
 test("markTreeOutside restores previous marks after nested cleanup", () => {

--- a/packages/ariakit-react-components/src/dialog/utils/tree-cleanup.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/tree-cleanup.ts
@@ -6,10 +6,10 @@ export type Elements = Array<Element | null>;
 export type Cleanups = Array<() => void>;
 export type Ids = Array<string | undefined>;
 
-function getPropertyName(id = "", ancestor = false) {
-  return `__ariakit-dialog-${ancestor ? "ancestor" : "outside"}${
-    id ? `-${id}` : ""
-  }` as keyof Element;
+type MarkKind = "outside" | "ancestor" | "inside";
+
+function getPropertyName(id = "", kind: MarkKind = "outside") {
+  return `__ariakit-dialog-${kind}${id ? `-${id}` : ""}` as keyof Element;
 }
 
 export function markElement(element: Element, id = "") {
@@ -21,13 +21,36 @@ export function markElement(element: Element, id = "") {
 
 export function markAncestor(element: Element, id = "") {
   return chain(
-    setProperty(element, getPropertyName("", true), true),
-    setProperty(element, getPropertyName(id, true), true),
+    setProperty(element, getPropertyName("", "ancestor"), true),
+    setProperty(element, getPropertyName(id, "ancestor"), true),
   );
 }
 
+// Marks elements the dialog knows about at open time (the dialog itself,
+// persistent elements, and nested dialogs), so the outside event listeners
+// can positively recognize them as "inside" regardless of whether the dialog
+// has been focused yet. See https://github.com/ariakit/ariakit/issues/6344
+export function markTreeInside(id: string, elements: Elements) {
+  return chain(
+    ...elements.map((element) => {
+      if (!element) return undefined;
+      return setProperty(element, getPropertyName(id, "inside"), true);
+    }),
+  );
+}
+
+export function isElementInside(element: Element, id: string) {
+  const propertyName = getPropertyName(id, "inside");
+  do {
+    if (element[propertyName]) return true;
+    if (!element.parentElement) return false;
+    element = element.parentElement;
+    // oxlint-disable-next-line no-constant-condition
+  } while (true);
+}
+
 export function isElementMarked(element: Element, id?: string) {
-  const ancestorProperty = getPropertyName(id, true);
+  const ancestorProperty = getPropertyName(id, "ancestor");
   if (element[ancestorProperty]) return true;
   const elementProperty = getPropertyName(id);
   do {

--- a/packages/ariakit-react-components/src/dialog/utils/use-hide-on-interact-outside.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/use-hide-on-interact-outside.ts
@@ -11,7 +11,7 @@ import type { MutableRefObject } from "react";
 import { useEffect, useRef } from "react";
 import type { DialogStore } from "../dialog-store.ts";
 import type { DialogOptions } from "../dialog.tsx";
-import { isElementMarked } from "./mark-tree-outside.ts";
+import { isElementInside, isElementMarked } from "./mark-tree-outside.ts";
 import { usePreviousMouseDownRef } from "./use-previous-mouse-down-ref.ts";
 
 interface EventOutsideOptions {
@@ -88,6 +88,12 @@ function useEventOutside({
       if (target.hasAttribute("data-focus-trap")) return;
       // Clicked on dialog's bounding box
       if (isMouseEventOnDialog(event, contentElement)) return;
+      // The dialog itself, persistent elements, and nested dialogs are marked
+      // as "inside" when the dialog opens. Events on them must never trigger
+      // the outside listeners, even before the dialog has been focused (for
+      // example, with autoFocusOnShow={false}). See
+      // https://github.com/ariakit/ariakit/issues/6344
+      if (isElementInside(target, contentElement.id)) return;
       // We need to check if the content element has been focused at least once
       // before checking if it's marked. This is so hovercards and tooltips
       // don't stay open when new nodes are added to the DOM and focused.


### PR DESCRIPTION
## Motivation

Elements returned by [`getPersistentElements`](https://ariakit.com/reference/dialog#getpersistentelements) are documented to be "considered as part of the dialog", so interacting with them should never close the dialog (this is the [Dialog with React-Toastify](https://ariakit.com/examples/dialog-react-toastify) pattern).

However, while the dialog hasn't been focused yet — which is the entire lifetime of a dialog rendered with [`autoFocusOnShow`](https://ariakit.com/reference/dialog#autofocusonshow)`={false}`, a common choice for non-modal panels that shouldn't steal focus — focusing, clicking, or right-clicking an element inside a persistent element closes the dialog:

```tsx
<Ariakit.Dialog
  modal={false}
  autoFocusOnShow={false}
  getPersistentElements={() => [notificationsRef.current]}
>
```

The persistent-element protection is purely negative: persistent elements are only *excluded* from the "outside" marking applied when the dialog opens, and the outside listeners in `useEventOutside` only consult that mark after something inside the dialog has been focused (`focusedRef.current`). While the dialog is unfocused, every other guard passes for a persistent element, so the `focusin` and `contextmenu` listeners call `store.hide()`. Once the dialog has been focused once, the identical interaction correctly keeps it open, so the failure is focus-history dependent.

The `focused` gate exists for hovercards and tooltips (#6198), so they close when brand-new DOM nodes appear and get focused — but persistent elements are the opposite case: the dialog explicitly knows about them at open time.

Fixes #6344

## Solution

Positively mark the elements the dialog knows about at open time — the dialog itself, persistent elements, and nested dialogs — with an id-scoped "inside" expando (`markTreeInside`, built on the same stacked, restorable `setProperty` mechanism as the existing outside marks). The outside event listeners now check this mark *before* the `focusedRef` gate, so events on those elements never reach the hide listeners, regardless of focus history.

This preserves the hovercard/tooltip behavior from #6198 exactly: genuinely new DOM nodes carry no inside mark, so they still close an unfocused dialog. Once the dialog has been focused, the new check is behaviorally redundant (inside elements were never marked outside, so the existing check already returned early).

The disclosure element is intentionally *not* marked inside: hovercards and tooltips update `disclosureElement` to the focus source while open (for example, a tooltip re-opening while its menu is open records the menu popup as its disclosure), so a persistent mark taken at open time would go stale and keep the tooltip open when the menu re-opens (caught by the `menu-tooltip-various` suite). The listeners keep re-checking the disclosure against the current store state on every event instead.

The first commit adds a repro sandbox (`dialog-6344`) with a cross-browser Playwright test and a happy-dom duplicate. The two "stays open … before the dialog is focused" tests fail on every browser without the fix, while the guard tests (documented behavior after focusing inside, and closing on genuinely-outside interactions) pass. The second commit demonstrated the userland workaround below in the sandbox (since reverted).

## Workaround

Until the fix is released, users can re-assert the persistent elements through [`hideOnInteractOutside`](https://ariakit.com/reference/dialog#hideoninteractoutside), which is consulted on every hide-on-interact-outside code path regardless of focus history:

```tsx
<Ariakit.Dialog
  modal={false}
  autoFocusOnShow={false}
  getPersistentElements={() => {
    const notifications = notificationsRef.current;
    return notifications ? [notifications] : [];
  }}
  // TODO: Workaround for https://github.com/ariakit/ariakit/issues/6344
  // Remove once the fix lands: getPersistentElements alone should keep
  // interactions with persistent elements from closing the dialog.
  hideOnInteractOutside={(event) => {
    const notifications = notificationsRef.current;
    if (!notifications) return true;
    if (!(event.target instanceof Node)) return true;
    return !notifications.contains(event.target);
  }}
>
```

Keeping `getPersistentElements` is still important: it also controls the accessibility tree and `inert` handling for modal dialogs.
