### PR TITLE
Fix Command stuck active state when focus moves away mid-press

### DIFF
--- a/.changeset/300-command-blur-active-state.md
+++ b/.changeset/300-command-blur-active-state.md
@@ -1,0 +1,10 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed `Command` stuck pressed state when losing focus mid-press
+
+When rendering a non-native element (such as `render={<div />}`), the [`Command`](https://ariakit.com/reference/command) component — and components built on it, such as [`Button`](https://ariakit.com/reference/button), [`Checkbox`](https://ariakit.com/reference/checkbox), [`CompositeItem`](https://ariakit.com/reference/composite-item), and their derivatives — now clears its pressed state (`data-active`) when the element loses focus while <kbd>Space</kbd> is held, mirroring how native buttons cancel the Space activation when they lose focus before the keyup.
+
+Additionally, a Space keyup bubbling up from a focused child no longer dispatches a synthetic click on the element, and calling `event.preventDefault()` in a custom `onKeyUp` handler no longer leaves the element stuck looking pressed.

--- a/app/src/sandbox/command-6340/index.react.tsx
+++ b/app/src/sandbox/command-6340/index.react.tsx
@@ -1,18 +1,35 @@
 import * as Ariakit from "@ariakit/react";
+import type { FocusEvent } from "react";
 import { useState } from "react";
 import "./style.css";
+
+// TODO: Remove this workaround once the fix for
+// https://github.com/ariakit/ariakit/issues/6340 lands. Command clears its
+// in-flight pressed state on a Space keyup, and its metaKey guard prevents the
+// synthetic click from firing, so dispatching this synthetic keyup on blur
+// cancels an in-flight press when focus moves away while Space is held.
+function cancelSpacePressOnBlur(event: FocusEvent<HTMLElement>) {
+  event.currentTarget.dispatchEvent(
+    new KeyboardEvent("keyup", { key: " ", metaKey: true, bubbles: true }),
+  );
+}
 
 export default function Example() {
   const [cardClicks, setCardClicks] = useState(0);
   const [pins, setPins] = useState(0);
   return (
     <div>
-      <Ariakit.Command className="button" render={<div />}>
+      <Ariakit.Command
+        className="button"
+        render={<div />}
+        onBlur={cancelSpacePressOnBlur}
+      >
         Save
       </Ariakit.Command>
       <Ariakit.Command
         className="button"
         render={<div />}
+        onBlur={cancelSpacePressOnBlur}
         onClick={() => setCardClicks((count) => count + 1)}
       >
         Open article{" "}

--- a/app/src/sandbox/command-6340/index.react.tsx
+++ b/app/src/sandbox/command-6340/index.react.tsx
@@ -1,35 +1,18 @@
 import * as Ariakit from "@ariakit/react";
-import type { FocusEvent } from "react";
 import { useState } from "react";
 import "./style.css";
-
-// TODO: Remove this workaround once the fix for
-// https://github.com/ariakit/ariakit/issues/6340 lands. Command clears its
-// in-flight pressed state on a Space keyup, and its metaKey guard prevents the
-// synthetic click from firing, so dispatching this synthetic keyup on blur
-// cancels an in-flight press when focus moves away while Space is held.
-function cancelSpacePressOnBlur(event: FocusEvent<HTMLElement>) {
-  event.currentTarget.dispatchEvent(
-    new KeyboardEvent("keyup", { key: " ", metaKey: true, bubbles: true }),
-  );
-}
 
 export default function Example() {
   const [cardClicks, setCardClicks] = useState(0);
   const [pins, setPins] = useState(0);
   return (
     <div>
-      <Ariakit.Command
-        className="button"
-        render={<div />}
-        onBlur={cancelSpacePressOnBlur}
-      >
+      <Ariakit.Command className="button" render={<div />}>
         Save
       </Ariakit.Command>
       <Ariakit.Command
         className="button"
         render={<div />}
-        onBlur={cancelSpacePressOnBlur}
         onClick={() => setCardClicks((count) => count + 1)}
       >
         Open article{" "}
@@ -42,6 +25,18 @@ export default function Example() {
         >
           Pin
         </button>
+      </Ariakit.Command>
+      <Ariakit.Command
+        className="button"
+        render={<div />}
+        onKeyUp={(event) => {
+          // Suppresses the click on release, a way to opt out of the default
+          // keyup behavior. It must not leave the element stuck looking
+          // pressed.
+          event.preventDefault();
+        }}
+      >
+        Bookmark
       </Ariakit.Command>
       <p>Outside text</p>
       <output>

--- a/app/src/sandbox/command-6340/index.react.tsx
+++ b/app/src/sandbox/command-6340/index.react.tsx
@@ -1,0 +1,35 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+import "./style.css";
+
+export default function Example() {
+  const [cardClicks, setCardClicks] = useState(0);
+  const [pins, setPins] = useState(0);
+  return (
+    <div>
+      <Ariakit.Command className="button" render={<div />}>
+        Save
+      </Ariakit.Command>
+      <Ariakit.Command
+        className="button"
+        render={<div />}
+        onClick={() => setCardClicks((count) => count + 1)}
+      >
+        Open article{" "}
+        <button
+          onClick={(event) => {
+            // The nested action shouldn't trigger the card click.
+            event.stopPropagation();
+            setPins((count) => count + 1);
+          }}
+        >
+          Pin
+        </button>
+      </Ariakit.Command>
+      <p>Outside text</p>
+      <output>
+        card clicks: {cardClicks}, pins: {pins}
+      </output>
+    </div>
+  );
+}

--- a/app/src/sandbox/command-6340/style.css
+++ b/app/src/sandbox/command-6340/style.css
@@ -1,0 +1,11 @@
+.button {
+  display: inline-flex;
+  cursor: pointer;
+  padding: 8px 16px;
+  border-radius: 6px;
+  background-color: #ddd;
+}
+
+.button[data-active] {
+  background-color: #aaa;
+}

--- a/app/src/sandbox/command-6340/test-browser.ts
+++ b/app/src/sandbox/command-6340/test-browser.ts
@@ -62,4 +62,22 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.status()).toHaveText("card clicks: 0, pins: 0");
     await test.expect(card).not.toHaveAttribute("data-active");
   });
+
+  test("data-active is cleared when a consumer onKeyUp prevents the default", async ({
+    page,
+    q,
+  }) => {
+    const command = q.text("Bookmark");
+    await command.focus();
+
+    // Pressing Space sets the active state on the focused command.
+    await page.keyboard.down("Space");
+    await test.expect(command).toHaveAttribute("data-active");
+
+    // The example's own onKeyUp calls preventDefault to suppress the click on
+    // release. That must only suppress the click, not skip the state clearing,
+    // otherwise the element stays stuck looking pressed.
+    await page.keyboard.up("Space");
+    await test.expect(command).not.toHaveAttribute("data-active");
+  });
 });

--- a/app/src/sandbox/command-6340/test-browser.ts
+++ b/app/src/sandbox/command-6340/test-browser.ts
@@ -50,11 +50,14 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await page.keyboard.down("Space");
     await test.expect(card).toHaveAttribute("data-active");
 
-    // Tab moves focus into the nested button while Space is still held, so the
+    // Move focus into the nested button while Space is still held, so the
     // keyup fires on the button and bubbles through the card. The press never
     // finished on the card, so it must not dispatch a synthetic click on
-    // itself, and losing focus must clear the pressed state.
-    await page.keyboard.press("Tab");
+    // itself, and losing focus must clear the pressed state. The move is
+    // scripted rather than pressing Tab because WebKit skips native buttons
+    // when tabbing under the default macOS keyboard settings; mid-press focus
+    // moves from a script are one of the reported triggers anyway.
+    await q.button("Pin").focus();
     await test.expect(q.button("Pin")).toBeFocused();
     await test.expect(card).not.toHaveAttribute("data-active");
 

--- a/app/src/sandbox/command-6340/test-browser.ts
+++ b/app/src/sandbox/command-6340/test-browser.ts
@@ -1,0 +1,65 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/6340
+  //
+  // A non-native `Command` (rendered as a div) sets a `data-active` ("pressed")
+  // state on the Space keydown and clears it in its own keyup handler. If focus
+  // moves away while Space is still held, the keyup is delivered to the new
+  // focus target, so that handler never runs. Native buttons cancel Space
+  // activation when they lose focus before the keyup, and the non-native
+  // emulation must do the same. These tests cover the two legs of that bug:
+  // the element staying stuck looking pressed after focus leaves, and a keyup
+  // bubbling from a focused child dispatching a synthetic click on the element
+  // even though the press never finished on it.
+
+  test("data-active is cleared when focus leaves while Space is held", async ({
+    page,
+    q,
+  }) => {
+    const command = q.text("Save");
+    await command.focus();
+
+    // Pressing Space sets the active state on the focused command.
+    await page.keyboard.down("Space");
+    await test.expect(command).toHaveAttribute("data-active");
+
+    // Clicking elsewhere while Space is still held moves focus away, so the
+    // keyup lands on the new focus target (the body) and never reaches the
+    // command. Losing focus mid-press must cancel the press, like a native
+    // button, instead of leaving the element stuck looking pressed.
+    await q.text("Outside text").click();
+    await test.expect(command).not.toBeFocused();
+    await test.expect(command).not.toHaveAttribute("data-active");
+
+    await page.keyboard.up("Space");
+    await test.expect(command).not.toHaveAttribute("data-active");
+  });
+
+  test("Space keyup bubbling from a child does not click the command", async ({
+    page,
+    q,
+  }) => {
+    // Playwright text queries match the element's full text content (which
+    // here includes the nested button's label), so exact matching must be
+    // turned off to find the card by its own text.
+    const card = q.text("Open article", { exact: false });
+    await card.focus();
+
+    // Pressing Space sets the active state on the focused card.
+    await page.keyboard.down("Space");
+    await test.expect(card).toHaveAttribute("data-active");
+
+    // Tab moves focus into the nested button while Space is still held, so the
+    // keyup fires on the button and bubbles through the card. The press never
+    // finished on the card, so it must not dispatch a synthetic click on
+    // itself, and losing focus must clear the pressed state.
+    await page.keyboard.press("Tab");
+    await test.expect(q.button("Pin")).toBeFocused();
+    await test.expect(card).not.toHaveAttribute("data-active");
+
+    await page.keyboard.up("Space");
+    await test.expect(q.status()).toHaveText("card clicks: 0, pins: 0");
+    await test.expect(card).not.toHaveAttribute("data-active");
+  });
+});

--- a/app/src/sandbox/command-6340/test.ts
+++ b/app/src/sandbox/command-6340/test.ts
@@ -48,3 +48,19 @@ test("Space keyup bubbling from a child does not click the command", async () =>
   expect(q.status.ensure()).toHaveTextContent("card clicks: 0");
   expect(card).not.toHaveAttribute("data-active");
 });
+
+test("data-active is cleared when a consumer onKeyUp prevents the default", async () => {
+  const command = q.text.ensure("Bookmark");
+  await focus(command);
+  expect(command).toHaveFocus();
+
+  // Pressing Space sets the active state on the focused command.
+  await press.down.Space();
+  expect(command).toHaveAttribute("data-active");
+
+  // The example's own onKeyUp calls preventDefault to suppress the click on
+  // release. That must only suppress the click, not skip the state clearing,
+  // otherwise the element stays stuck looking pressed.
+  await press.up.Space();
+  expect(command).not.toHaveAttribute("data-active");
+});

--- a/app/src/sandbox/command-6340/test.ts
+++ b/app/src/sandbox/command-6340/test.ts
@@ -1,0 +1,50 @@
+import { click, focus, press, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// See https://github.com/ariakit/ariakit/issues/6340
+
+test("data-active is cleared when focus leaves while Space is held", async () => {
+  const command = q.text.ensure("Save");
+  await focus(command);
+  expect(command).toHaveFocus();
+
+  // Pressing Space sets the active ("pressed") state on a non-native command.
+  await press.down.Space();
+  expect(command).toHaveAttribute("data-active");
+
+  // Clicking elsewhere while Space is still held moves focus to the body, so
+  // the keyup lands there and never reaches the command. Losing focus
+  // mid-press must cancel the press, like a native button, instead of leaving
+  // the element stuck looking pressed.
+  await click(q.text.ensure("Outside text"));
+  expect(command).not.toHaveFocus();
+  expect(command).not.toHaveAttribute("data-active");
+
+  await press.up.Space();
+  expect(command).not.toHaveAttribute("data-active");
+});
+
+test("Space keyup bubbling from a child does not click the command", async () => {
+  const card = q.text.ensure("Open article");
+  await focus(card);
+  expect(card).toHaveFocus();
+
+  // Pressing Space sets the active state on the focused card.
+  await press.down.Space();
+  expect(card).toHaveAttribute("data-active");
+
+  // Tab moves focus into the nested button while Space is still held, so the
+  // keyup fires on the button and bubbles through the card. The press never
+  // finished on the card, so it must not dispatch a synthetic click on itself,
+  // and losing focus must clear the pressed state.
+  await press.Tab();
+  expect(q.button.ensure("Pin")).toHaveFocus();
+  expect(card).not.toHaveAttribute("data-active");
+
+  await press.up.Space();
+  // Unlike a real browser, the `press.up` emulation synthesizes a click on any
+  // focused native button regardless of where the keydown happened, so the pin
+  // count is asserted only in `test-browser.ts`.
+  expect(q.status.ensure()).toHaveTextContent("card clicks: 0");
+  expect(card).not.toHaveAttribute("data-active");
+});

--- a/packages/ariakit-react-components/src/command/command.tsx
+++ b/packages/ariakit-react-components/src/command/command.tsx
@@ -17,7 +17,7 @@ import {
   disabledFromProps,
   isFirefox,
 } from "@ariakit/utils";
-import type { ElementType, KeyboardEvent } from "react";
+import type { ElementType, FocusEvent, KeyboardEvent } from "react";
 import { useEffect, useRef, useState } from "react";
 import type { FocusableOptions } from "../focusable/focusable.tsx";
 import { useFocusable } from "../focusable/focusable.tsx";
@@ -146,7 +146,6 @@ export const useCommand = createHook<TagName, CommandOptions>(
     const onKeyUp = useEvent((event: KeyboardEvent<HTMLType>) => {
       onKeyUpProp?.(event);
 
-      if (event.defaultPrevented) return;
       if (isDuplicate) return;
 
       const isSpace = clickOnSpace && event.key === " ";
@@ -154,16 +153,22 @@ export const useCommand = createHook<TagName, CommandOptions>(
 
       const nativeClick = isNativeClick(event);
 
-      // Clear the active state as soon as Space is released, before the
-      // `disabled` and `metaKey` guards below, so a short-circuited keyup (Meta
-      // still held on release, or the element becoming disabled between keydown
-      // and keyup) can't leave the element stuck in a visually "pressed" state.
+      // Clear the active state as soon as Space is released, before all the
+      // guards below (defaultPrevented, self-target, disabled, metaKey), so a
+      // short-circuited keyup (a consumer calling preventDefault, Meta still
+      // held on release, or the element becoming disabled between keydown and
+      // keyup) can't leave the element stuck in a visually "pressed" state.
       // Firing the synthetic click is still gated by those guards.
       activeRef.current = false;
       if (!nativeClick) {
         setActive(false);
       }
 
+      if (event.defaultPrevented) return;
+      // The keydown only sets the pressed state when self-targeted, so a keyup
+      // bubbling from a child (focus moved into the child mid-press) must not
+      // dispatch a synthetic click on this element.
+      if (!isSelfTarget(event)) return;
       if (disabled) return;
       if (event.metaKey) return;
       if (nativeClick) return;
@@ -174,6 +179,21 @@ export const useCommand = createHook<TagName, CommandOptions>(
       queueMicrotask(() => fireClickEvent(element, eventInit));
     });
 
+    const onBlurProp = props.onBlur;
+
+    // If focus moves away while Space is held, the keyup is delivered to the
+    // new focus target and `onKeyUp` above never runs. Clear the pressed state
+    // so the element doesn't stay stuck looking pressed, mirroring how native
+    // buttons cancel the Space activation when they lose focus before the
+    // keyup. Focus moving into a descendant also cancels the press, so a keyup
+    // bubbling up from a child can't reinstate it.
+    const onBlur = useEvent((event: FocusEvent<HTMLType>) => {
+      onBlurProp?.(event);
+      if (!activeRef.current) return;
+      activeRef.current = false;
+      setActive(false);
+    });
+
     props = {
       "data-active": active || undefined,
       type: isNativeButton ? "button" : undefined,
@@ -182,6 +202,7 @@ export const useCommand = createHook<TagName, CommandOptions>(
       ref: useMergeRefs(ref, props.ref),
       onKeyDown,
       onKeyUp,
+      onBlur,
     };
 
     props = useFocusable<TagName>(props);


### PR DESCRIPTION
## Motivation

When [`Command`](https://ariakit.com/reference/command) renders a non-native element (e.g. `render={<div />}`), pressing <kbd>Space</kbd> marks it as pressed via the `data-active` attribute. The only paths that cleared that state were the element's own `onKeyUp` handler and a layout effect for the element becoming `disabled` mid-press. Nothing cleared it on blur, which diverges from native `<button>` semantics in two user-visible ways (reported in #6340):

1. **Stuck pressed state.** If focus moves away while <kbd>Space</kbd> is still held (mouse click elsewhere, a handler moving focus, <kbd>Tab</kbd>…), the keyup is delivered to the new focus target, the Command's `onKeyUp` never runs, and the element keeps `data-active` indefinitely. Native buttons cancel Space activation when they lose focus before the keyup.
2. **Click fired from a child's keyup.** If focus moves into a focusable child mid-press (e.g. a clickable card with a nested action button), the Space keyup bubbles up from the child and fires a synthetic click on the Command itself — activating it even though the press never finished there. The keydown requires `isSelfTarget`, but the keyup did not.

There was also a third, related short-circuit: the state-clearing in `onKeyUp` sat below the `event.defaultPrevented` bail-out, so a consumer calling `preventDefault()` in their own `onKeyUp` (to suppress the click on release) also left the element stuck pressed.

## Solution

Three coordinated changes in `command.tsx`, affecting `Command` and every component built on it (`Button`, `Checkbox`, `CompositeItem`, and their derivatives):

1. **Clear the pressed state on blur.** A new chained `onBlur` (bubble phase, composed before `useFocusable` consumes the props) resets the internal pressed flag and `data-active` when focus leaves mid-press. It deliberately doesn't check `isFocusEventOutside`: focus moving into a descendant also cancels the press, matching native buttons. For native buttons the handler only resets the internal flag (the visual state is never set for native clicks), so native Space handling is untouched. The bubble phase composes with composite virtual focus: `CompositeItem`'s `onBlurCapture` stops propagation of intermediate silent-focus blurs, while a genuine `move()` dispatches a bubbling `focusout` that does reach the handler.
2. **Hoist the state-clearing in `onKeyUp` above the `defaultPrevented` bail-out**, so a consumer `preventDefault()` only suppresses the click without leaving the element stuck pressed (the same treatment #6221 and #6271 gave the `metaKey` and `disabled` short-circuits).
3. **Guard the synthetic click with `isSelfTarget`**, mirroring the keydown. With change 1 this is defense-in-depth: focusing a child always blurs the element first, so the bubbled keyup already finds the pressed flag cleared — which is also why no test can isolate this guard through user-level interaction.

The repro sandbox `app/src/sandbox/command-6340/` covers all three legs with a Playwright `test-browser.ts` (Chrome, Firefox, and Safari) and a happy-dom `test.ts` duplicate, all verified failing before the fix and passing with it. Full `test-react` (805/805), `test-react18` (797 passed, 8 pre-existing skips), the `command-6217` regression sandbox, and `tsc` all pass.

Out of scope: virtual-focus composite items changing via arrow keys while <kbd>Space</kbd> is held are unaffected by this change (with virtual focus the item is never DOM-focused, so the pressed state is never set on it in the first place — the keydown's `isSelfTarget` guard already prevents it).

## Workaround

Until the fix is released, consumers can cancel the in-flight press from their own `onBlur` by dispatching a synthetic <kbd>Space</kbd> keyup with the Meta modifier held. `Command` clears its in-flight pressed state on a Space keyup, and its `metaKey` guard prevents the synthetic click from firing. This also covers the child-keyup leg, because the blur fires (and clears the internal pressed flag) before the real keyup bubbles up from the child.

```tsx
// TODO: Remove this workaround once the fix for
// https://github.com/ariakit/ariakit/issues/6340 lands.
function cancelSpacePressOnBlur(event: React.FocusEvent<HTMLElement>) {
  event.currentTarget.dispatchEvent(
    new KeyboardEvent("keyup", { key: " ", metaKey: true, bubbles: true }),
  );
}

<Ariakit.Command render={<div />} onBlur={cancelSpacePressOnBlur}>
  Save
</Ariakit.Command>
```

Fixes #6340

