### PR TITLE
Fix dialog backdrop exit transition when only the backdrop is animated

### DIFF
--- a/.changeset/300-dialog-backdrop-only-transition.md
+++ b/.changeset/300-dialog-backdrop-only-transition.md
@@ -3,4 +3,4 @@
 "@ariakit/react": patch
 ---
 
-Fixed [`Dialog`](https://ariakit.com/reference/dialog) and components built on it such as [`Popover`](https://ariakit.com/reference/popover) and [`Menu`](https://ariakit.com/reference/menu) hiding instantly on close when only the [`backdrop`](https://ariakit.com/reference/dialog#backdrop) element is animated, which skipped the backdrop's exit transition.
+Fixed [`Dialog`](https://ariakit.com/reference/dialog) and components built on it such as [`Popover`](https://ariakit.com/reference/popover) and [`Menu`](https://ariakit.com/reference/menu) hiding on close before the [`backdrop`](https://ariakit.com/reference/dialog#backdrop) element's exit transition ends: the backdrop's fade-out was skipped entirely when only the backdrop was animated, and cut short when its transition was longer than the panel's.

--- a/.changeset/300-dialog-backdrop-only-transition.md
+++ b/.changeset/300-dialog-backdrop-only-transition.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Dialog`](https://ariakit.com/reference/dialog) and components built on it such as [`Popover`](https://ariakit.com/reference/popover) and [`Menu`](https://ariakit.com/reference/menu) hiding instantly on close when only the [`backdrop`](https://ariakit.com/reference/dialog#backdrop) element is animated, which skipped the backdrop's exit transition.

--- a/app/src/sandbox/dialog-backdrop-6339/index.react.tsx
+++ b/app/src/sandbox/dialog-backdrop-6339/index.react.tsx
@@ -3,7 +3,7 @@ import * as Ariakit from "@ariakit/react";
 // See https://github.com/ariakit/ariakit/issues/6339
 //
 // Only the backdrop is animated: it should fade in when the dialog opens and
-// fade out when it closes. The dialog panel has no visible transition, so it
+// fade out when it closes. The dialog panel has no transition at all, so it
 // snaps in place while the backdrop fades. Before the fix, the enter fade
 // works, but on close the dialog hides instantly: the backdrop never receives
 // `data-leave` and the exit fade is skipped.
@@ -24,13 +24,6 @@ const css = `
     opacity: 1;
   }
   .dialog {
-    /* TODO: Workaround for https://github.com/ariakit/ariakit/issues/6339
-       Remove once the fix lands. A visually imperceptible transition matching
-       the backdrop's duration (the panel's opacity never changes) makes
-       Ariakit compute a non-zero animation timeout for the panel, keeping the
-       shared animation state alive so the backdrop can fade out on close. */
-    transition-property: opacity;
-    transition-duration: 500ms;
     position: fixed;
     inset: 0.75rem;
     z-index: 50;
@@ -62,7 +55,7 @@ export default function Example() {
         <Ariakit.DialogHeading>Success</Ariakit.DialogHeading>
         <p>
           Only the backdrop is animated: it should fade in when the dialog opens
-          and fade out when it closes. The panel has no visible transitions.
+          and fade out when it closes. The panel has no transitions.
         </p>
         <Ariakit.DialogDismiss>Close</Ariakit.DialogDismiss>
       </Ariakit.Dialog>

--- a/app/src/sandbox/dialog-backdrop-6339/index.react.tsx
+++ b/app/src/sandbox/dialog-backdrop-6339/index.react.tsx
@@ -1,0 +1,64 @@
+import * as Ariakit from "@ariakit/react";
+
+// See https://github.com/ariakit/ariakit/issues/6339
+//
+// Only the backdrop is animated: it should fade in when the dialog opens and
+// fade out when it closes. The dialog panel has no transition at all, so it
+// snaps in place while the backdrop fades. Before the fix, the enter fade
+// works, but on close the dialog hides instantly: the backdrop never receives
+// `data-leave` and the exit fade is skipped.
+//
+// The styles are inlined in a <style> tag (rather than a style.css import) on
+// purpose: CSS imports are only processed in vitest for the allowlist in the
+// root vitest.config.ts, which doesn't include this sandbox, so a style.css
+// refactor would strip the backdrop transition from the happy-dom test.
+const css = `
+  .backdrop {
+    background: rgb(0 0 0 / 0.4);
+    opacity: 0;
+    transition-property: opacity;
+    transition-duration: 500ms;
+    transition-timing-function: ease;
+  }
+  .backdrop[data-enter] {
+    opacity: 1;
+  }
+  .dialog {
+    position: fixed;
+    inset: 0.75rem;
+    z-index: 50;
+    margin: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    width: 24rem;
+    height: fit-content;
+    max-width: calc(100vw - 1.5rem);
+    border-radius: 1rem;
+    background: white;
+    color: black;
+    padding: 1.5rem;
+  }
+`;
+
+export default function Example() {
+  const dialog = Ariakit.useDialogStore();
+  return (
+    <>
+      <style>{css}</style>
+      <Ariakit.Button onClick={dialog.show}>Show dialog</Ariakit.Button>
+      <Ariakit.Dialog
+        store={dialog}
+        backdrop={<div className="backdrop" />}
+        className="dialog"
+      >
+        <Ariakit.DialogHeading>Success</Ariakit.DialogHeading>
+        <p>
+          Only the backdrop is animated: it should fade in when the dialog opens
+          and fade out when it closes. The panel has no transitions.
+        </p>
+        <Ariakit.DialogDismiss>Close</Ariakit.DialogDismiss>
+      </Ariakit.Dialog>
+    </>
+  );
+}

--- a/app/src/sandbox/dialog-backdrop-6339/index.react.tsx
+++ b/app/src/sandbox/dialog-backdrop-6339/index.react.tsx
@@ -3,7 +3,7 @@ import * as Ariakit from "@ariakit/react";
 // See https://github.com/ariakit/ariakit/issues/6339
 //
 // Only the backdrop is animated: it should fade in when the dialog opens and
-// fade out when it closes. The dialog panel has no transition at all, so it
+// fade out when it closes. The dialog panel has no visible transition, so it
 // snaps in place while the backdrop fades. Before the fix, the enter fade
 // works, but on close the dialog hides instantly: the backdrop never receives
 // `data-leave` and the exit fade is skipped.
@@ -24,6 +24,13 @@ const css = `
     opacity: 1;
   }
   .dialog {
+    /* TODO: Workaround for https://github.com/ariakit/ariakit/issues/6339
+       Remove once the fix lands. A visually imperceptible transition matching
+       the backdrop's duration (the panel's opacity never changes) makes
+       Ariakit compute a non-zero animation timeout for the panel, keeping the
+       shared animation state alive so the backdrop can fade out on close. */
+    transition-property: opacity;
+    transition-duration: 500ms;
     position: fixed;
     inset: 0.75rem;
     z-index: 50;
@@ -55,7 +62,7 @@ export default function Example() {
         <Ariakit.DialogHeading>Success</Ariakit.DialogHeading>
         <p>
           Only the backdrop is animated: it should fade in when the dialog opens
-          and fade out when it closes. The panel has no transitions.
+          and fade out when it closes. The panel has no visible transitions.
         </p>
         <Ariakit.DialogDismiss>Close</Ariakit.DialogDismiss>
       </Ariakit.Dialog>

--- a/app/src/sandbox/dialog-backdrop-6339/index.react.tsx
+++ b/app/src/sandbox/dialog-backdrop-6339/index.react.tsx
@@ -2,11 +2,16 @@ import * as Ariakit from "@ariakit/react";
 
 // See https://github.com/ariakit/ariakit/issues/6339
 //
-// Only the backdrop is animated: it should fade in when the dialog opens and
-// fade out when it closes. The dialog panel has no transition at all, so it
-// snaps in place while the backdrop fades. Before the fix, the enter fade
-// works, but on close the dialog hides instantly: the backdrop never receives
-// `data-leave` and the exit fade is skipped.
+// The backdrop has a 500ms opacity transition: it should fade in when the
+// dialog opens and fade out when it closes. There are two dialogs:
+//
+// - "Show dialog": the panel has no transition at all, so it snaps in place
+//   while the backdrop fades. Before the fix, the enter fade works, but on
+//   close the dialog hides instantly: the backdrop never receives
+//   `data-leave` and the exit fade is skipped.
+// - "Show fast dialog": the panel has a shorter 150ms transition. Before the
+//   fix, the panel's own timeout stopped the shared animation state early,
+//   hiding the backdrop at 150ms and cutting its 500ms exit fade short.
 //
 // The styles are inlined in a <style> tag (rather than a style.css import) on
 // purpose: CSS imports are only processed in vitest for the allowlist in the
@@ -39,14 +44,26 @@ const css = `
     color: black;
     padding: 1.5rem;
   }
+  .dialog-fast {
+    opacity: 0;
+    transition-property: opacity;
+    transition-duration: 150ms;
+  }
+  .dialog-fast[data-enter] {
+    opacity: 1;
+  }
 `;
 
 export default function Example() {
   const dialog = Ariakit.useDialogStore();
+  const fastDialog = Ariakit.useDialogStore();
   return (
     <>
       <style>{css}</style>
       <Ariakit.Button onClick={dialog.show}>Show dialog</Ariakit.Button>
+      <Ariakit.Button onClick={fastDialog.show}>
+        Show fast dialog
+      </Ariakit.Button>
       <Ariakit.Dialog
         store={dialog}
         backdrop={<div className="backdrop" />}
@@ -56,6 +73,18 @@ export default function Example() {
         <p>
           Only the backdrop is animated: it should fade in when the dialog opens
           and fade out when it closes. The panel has no transitions.
+        </p>
+        <Ariakit.DialogDismiss>Close</Ariakit.DialogDismiss>
+      </Ariakit.Dialog>
+      <Ariakit.Dialog
+        store={fastDialog}
+        backdrop={<div className="backdrop" />}
+        className="dialog dialog-fast"
+      >
+        <Ariakit.DialogHeading>Fast</Ariakit.DialogHeading>
+        <p>
+          The panel fades in over 150ms while the backdrop fades over 500ms. On
+          close, the backdrop should finish its longer fade out.
         </p>
         <Ariakit.DialogDismiss>Close</Ariakit.DialogDismiss>
       </Ariakit.Dialog>

--- a/app/src/sandbox/dialog-backdrop-6339/test-browser.ts
+++ b/app/src/sandbox/dialog-backdrop-6339/test-browser.ts
@@ -1,0 +1,24 @@
+// See https://github.com/ariakit/ariakit/issues/6339
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("backdrop fades out on close when only the backdrop is animated", async ({
+    q,
+  }) => {
+    await q.button("Show dialog").click();
+    const backdrop = q.presentation();
+    await test.expect(backdrop).toHaveAttribute("data-enter", "true");
+    await test.expect(q.button("Close")).toBeFocused();
+    await q.button("Close").click();
+    // Focus returns to the disclosure as soon as the dialog closes, so a
+    // failure below unambiguously points at the backdrop leave transition.
+    await test.expect(q.button("Show dialog")).toBeFocused();
+    // On close, the backdrop must receive data-leave and remain visible while
+    // its 500ms exit transition runs. Before the fix, the dialog hides
+    // instantly and data-leave is never applied.
+    await test.expect(backdrop).toHaveAttribute("data-leave", "true");
+    await test.expect(backdrop).toBeVisible();
+    // After the transition ends, the backdrop hides.
+    await test.expect(backdrop).toBeHidden();
+  });
+});

--- a/app/src/sandbox/dialog-backdrop-6339/test-browser.ts
+++ b/app/src/sandbox/dialog-backdrop-6339/test-browser.ts
@@ -21,4 +21,27 @@ withFramework(import.meta.dirname, async ({ test }) => {
     // After the transition ends, the backdrop hides.
     await test.expect(backdrop).toBeHidden();
   });
+
+  test("backdrop finishes its longer fade out when the panel has a shorter transition", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Show fast dialog").click();
+    const backdrop = q.presentation();
+    await test.expect(backdrop).toHaveAttribute("data-enter", "true");
+    await test.expect(q.button("Close")).toBeFocused();
+    await q.button("Close").click();
+    // Focus returns to the disclosure as soon as the dialog closes.
+    await test.expect(q.button("Show fast dialog")).toBeFocused();
+    await test.expect(backdrop).toHaveAttribute("data-leave", "true");
+    // Wait past the panel's 150ms transition. The backdrop must keep leaving
+    // until its own 500ms transition ends. Before the fix, the panel's shorter
+    // timeout stopped the shared animation state, hiding the backdrop at
+    // 150ms.
+    await page.waitForTimeout(250);
+    await test.expect(backdrop).toHaveAttribute("data-leave", "true");
+    await test.expect(backdrop).toBeVisible();
+    // After the backdrop's transition ends, it hides.
+    await test.expect(backdrop).toBeHidden();
+  });
 });

--- a/app/src/sandbox/dialog-backdrop-6339/test.ts
+++ b/app/src/sandbox/dialog-backdrop-6339/test.ts
@@ -1,0 +1,24 @@
+// See https://github.com/ariakit/ariakit/issues/6339
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+test("backdrop fades out on close when only the backdrop is animated", async () => {
+  await click(q.button.ensure("Show dialog"));
+  expect(q.dialog()).toBeVisible();
+  const backdrop = q.presentation.ensure();
+  // The enter state is applied after a couple of frames.
+  await expect.poll(() => backdrop.getAttribute("data-enter")).toBe("true");
+  // The Close button is auto-focused when the dialog opens.
+  expect(q.button("Close")).toHaveFocus();
+  await click(q.button("Close"));
+  // Focus returns to the disclosure as soon as the dialog closes, so a failure
+  // below unambiguously points at the backdrop leave transition.
+  expect(q.button("Show dialog")).toHaveFocus();
+  // On close, the backdrop must receive data-leave and remain visible while
+  // its 500ms exit transition runs. Before the fix, the dialog hides instantly
+  // and data-leave is never applied.
+  await expect.poll(() => backdrop.getAttribute("data-leave")).toBe("true");
+  expect(backdrop).not.toHaveStyle("display: none");
+  // After the transition ends, the backdrop hides.
+  await expect.poll(() => backdrop.style.display).toBe("none");
+});

--- a/app/src/sandbox/dialog-backdrop-6339/test.ts
+++ b/app/src/sandbox/dialog-backdrop-6339/test.ts
@@ -1,5 +1,5 @@
 // See https://github.com/ariakit/ariakit/issues/6339
-import { click, q } from "@ariakit/test";
+import { click, q, sleep } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 test("backdrop fades out on close when only the backdrop is animated", async () => {
@@ -20,5 +20,27 @@ test("backdrop fades out on close when only the backdrop is animated", async () 
   await expect.poll(() => backdrop.getAttribute("data-leave")).toBe("true");
   expect(backdrop).not.toHaveStyle("display: none");
   // After the transition ends, the backdrop hides.
+  await expect.poll(() => backdrop.style.display).toBe("none");
+});
+
+test("backdrop finishes its longer fade out when the panel has a shorter transition", async () => {
+  await click(q.button.ensure("Show fast dialog"));
+  expect(q.dialog()).toBeVisible();
+  const backdrop = q.presentation.ensure();
+  // The enter state is applied after a couple of frames.
+  await expect.poll(() => backdrop.getAttribute("data-enter")).toBe("true");
+  // The Close button is auto-focused when the dialog opens.
+  expect(q.button("Close")).toHaveFocus();
+  await click(q.button("Close"));
+  // Focus returns to the disclosure as soon as the dialog closes.
+  expect(q.button("Show fast dialog")).toHaveFocus();
+  await expect.poll(() => backdrop.getAttribute("data-leave")).toBe("true");
+  // Wait past the panel's 150ms transition. The backdrop must keep leaving
+  // until its own 500ms transition ends. Before the fix, the panel's shorter
+  // timeout stopped the shared animation state, hiding the backdrop at 150ms.
+  await sleep(250);
+  expect(backdrop).toHaveAttribute("data-leave", "true");
+  expect(backdrop).not.toHaveStyle("display: none");
+  // After the backdrop's transition ends, it hides.
   await expect.poll(() => backdrop.style.display).toBe("none");
 });

--- a/packages/ariakit-react-components/src/dialog/dialog-backdrop.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog-backdrop.tsx
@@ -1,6 +1,7 @@
 import { useStoreState } from "@ariakit/react-store";
-import { useSafeLayoutEffect } from "@ariakit/react-utils";
+import { useMergeRefs, useSafeLayoutEffect } from "@ariakit/react-utils";
 import { isValidElement, useRef } from "react";
+import type { RefObject } from "react";
 import { useDisclosureContent } from "../disclosure/disclosure-content.tsx";
 import { useDisclosureStore } from "../disclosure/disclosure-store.ts";
 import { Role } from "../role/role.tsx";
@@ -13,11 +14,13 @@ interface DialogBackdropProps extends Pick<
   "backdrop" | "alwaysVisible" | "hidden"
 > {
   store: DialogStore;
+  backdropRef?: RefObject<HTMLDivElement | null>;
 }
 
 export function DialogBackdrop({
   store,
   backdrop,
+  backdropRef,
   alwaysVisible,
   hidden,
 }: DialogBackdropProps) {
@@ -49,7 +52,7 @@ export function DialogBackdrop({
   }, [contentElement]);
 
   const props = useDisclosureContent({
-    ref,
+    ref: useMergeRefs(ref, backdropRef),
     store: disclosure,
     role: "presentation",
     "data-backdrop": contentElement?.id || "",

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -125,6 +125,7 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
 }) {
   const context = useDialogProviderContext();
   const ref = useRef<HTMLType>(null);
+  const backdropRef = useRef<HTMLDivElement>(null);
 
   const store = useDialogStore({
     store: storeProp || context,
@@ -551,6 +552,7 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
           <DialogBackdrop
             store={store}
             backdrop={backdrop}
+            backdropRef={backdropRef}
             hidden={hiddenProp}
             alwaysVisible={alwaysVisible}
           />
@@ -593,7 +595,11 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     ...props,
     autoFocusOnShow: autoFocusEnabled,
   });
-  props = useDisclosureContent({ store, ...props });
+  props = useDisclosureContent({
+    store,
+    ...props,
+    unstable_otherElementRef: backdropRef,
+  });
   props = useFocusable({ ...props, focusable });
   props = usePortal({ portal, ...props, portalRef, preserveTabOrder });
 

--- a/packages/ariakit-react-components/src/disclosure/disclosure-content.tsx
+++ b/packages/ariakit-react-components/src/disclosure/disclosure-content.tsx
@@ -9,7 +9,12 @@ import {
   forwardRef,
 } from "@ariakit/react-utils";
 import type { Options, Props } from "@ariakit/react-utils";
-import { afterPaint, invariant, removeUndefinedValues } from "@ariakit/utils";
+import {
+  afterPaint,
+  getDocument,
+  invariant,
+  removeUndefinedValues,
+} from "@ariakit/utils";
 import type { ElementType } from "react";
 import { useMemo, useRef, useState } from "react";
 import { flushSync } from "react-dom";
@@ -59,6 +64,27 @@ function getEndTime(names: string, delays: string, durations: string) {
     endTime = Math.max(endTime, delay + duration);
   }
   return endTime;
+}
+
+// Returns the time an element's transitions and animations end based on its
+// computed style. We compute each transition's and animation's end time
+// separately (pairing each item's own delay with its own duration) and take
+// the longest one. Combining them into a single max delay + max duration would
+// overestimate when, for example, the longest delay belongs to a transition
+// while the longest duration belongs to an animation.
+function getElementEndTime(element: Element) {
+  const {
+    transitionProperty,
+    transitionDuration,
+    transitionDelay,
+    animationName,
+    animationDuration,
+    animationDelay,
+  } = getComputedStyle(element);
+  return Math.max(
+    getEndTime(transitionProperty, transitionDelay, transitionDuration),
+    getEndTime(animationName, animationDelay, animationDuration),
+  );
 }
 
 export function isHidden(
@@ -183,38 +209,36 @@ export const useDisclosureContent = createHook<
     // first place, the events won't fire. Besides, there may be multiple
     // transitions or animations with different durations and delays, and we
     // need to consider the longest one.
-    const {
-      transitionProperty,
-      transitionDuration,
-      transitionDelay,
-      animationName,
-      animationDuration,
-      animationDelay,
-    } = getComputedStyle(contentElement);
+    const elements = [contentElement];
     // If we're rendering a dialog backdrop, otherElement will be the dialog
     // element itself. We need to consider both the backdrop and the dialog
     // animation/transition durations and delays because the dialog may be
     // animated while the backdrop is not.
-    const {
-      transitionProperty: transitionProperty2 = "",
-      transitionDuration: transitionDuration2 = "0",
-      transitionDelay: transitionDelay2 = "0",
-      animationName: animationName2 = "",
-      animationDuration: animationDuration2 = "0",
-      animationDelay: animationDelay2 = "0",
-    } = otherElement ? getComputedStyle(otherElement) : {};
-    // We compute each transition's and animation's end time separately (pairing
-    // each item's own delay with its own duration) and take the longest one,
-    // including the other element's. Combining them into a single max delay +
-    // max duration would overestimate when, for example, the longest delay
-    // belongs to a transition while the longest duration belongs to an
-    // animation.
-    const timeout = Math.max(
-      getEndTime(transitionProperty, transitionDelay, transitionDuration),
-      getEndTime(animationName, animationDelay, animationDuration),
-      getEndTime(transitionProperty2, transitionDelay2, transitionDuration2),
-      getEndTime(animationName2, animationDelay2, animationDuration2),
-    );
+    if (otherElement) {
+      elements.push(otherElement);
+    }
+    // Conversely, if we're rendering a dialog, its backdrop may be animated
+    // while the dialog itself is not. The backdrop element isn't tracked in
+    // the store, but it's rendered with a data-backdrop attribute set to the
+    // dialog id, so we can find it in the DOM. The data-dialog guard skips
+    // the document-wide query for content that can't have a backdrop, such
+    // as plain disclosures and the backdrop's own instance, and the id guard
+    // avoids matching an unrelated backdrop while it briefly renders with
+    // data-backdrop="".
+    const isDialog = contentElement.hasAttribute("data-dialog");
+    const backdropElement =
+      isDialog && contentElement.id
+        ? getDocument(contentElement).querySelector<HTMLElement>(
+            `[data-backdrop="${CSS.escape(contentElement.id)}"]`,
+          )
+        : null;
+    if (backdropElement) {
+      elements.push(backdropElement);
+    }
+    // The timeout is the longest end time among the content element and the
+    // related elements, so none of them gets hidden before its own transition
+    // or animation ends.
+    const timeout = Math.max(...elements.map(getElementEndTime));
     // If the timeout is zero, there's no animation or transition, either
     // because they weren't defined in the CSS or the duration was explicitly
     // set to zero. In this scenario, we can halt the animation right away

--- a/packages/ariakit-react-components/src/disclosure/disclosure-content.tsx
+++ b/packages/ariakit-react-components/src/disclosure/disclosure-content.tsx
@@ -9,13 +9,8 @@ import {
   forwardRef,
 } from "@ariakit/react-utils";
 import type { Options, Props } from "@ariakit/react-utils";
-import {
-  afterPaint,
-  getDocument,
-  invariant,
-  removeUndefinedValues,
-} from "@ariakit/utils";
-import type { ElementType } from "react";
+import { afterPaint, invariant, removeUndefinedValues } from "@ariakit/utils";
+import type { ElementType, RefObject } from "react";
 import { useMemo, useRef, useState } from "react";
 import { flushSync } from "react-dom";
 import { DialogScopedContextProvider } from "../dialog/dialog-context.tsx";
@@ -109,7 +104,12 @@ export function isHidden(
 export const useDisclosureContent = createHook<
   TagName,
   DisclosureContentOptions
->(function useDisclosureContent({ store, alwaysVisible, ...props }) {
+>(function useDisclosureContent({
+  store,
+  alwaysVisible,
+  unstable_otherElementRef: otherElementRef,
+  ...props
+}) {
   const context = useDisclosureProviderContext();
   store = store || context;
 
@@ -219,21 +219,10 @@ export const useDisclosureContent = createHook<
     }
     // Conversely, if we're rendering a dialog, its backdrop may be animated
     // while the dialog itself is not. The backdrop element isn't tracked in
-    // the store, but it's rendered with a data-backdrop attribute set to the
-    // dialog id, so we can find it in the DOM. The data-dialog guard skips
-    // the document-wide query for content that can't have a backdrop, such
-    // as plain disclosures and the backdrop's own instance, and the id guard
-    // avoids matching an unrelated backdrop while it briefly renders with
-    // data-backdrop="".
-    const isDialog = contentElement.hasAttribute("data-dialog");
-    const backdropElement =
-      isDialog && contentElement.id
-        ? getDocument(contentElement).querySelector<HTMLElement>(
-            `[data-backdrop="${CSS.escape(contentElement.id)}"]`,
-          )
-        : null;
-    if (backdropElement) {
-      elements.push(backdropElement);
+    // the store, so the dialog passes it in through otherElementRef.
+    const relatedElement = otherElementRef?.current;
+    if (relatedElement) {
+      elements.push(relatedElement);
     }
     // The timeout is the longest end time among the content element and the
     // related elements, so none of them gets hidden before its own transition
@@ -258,7 +247,15 @@ export const useDisclosureContent = createHook<
     const frameRate = 1000 / 60;
     const maxTimeout = Math.max(timeout - frameRate, 0);
     return afterTimeout(maxTimeout, stopAnimationSync);
-  }, [store, animated, contentElement, otherElement, open, transition]);
+  }, [
+    store,
+    animated,
+    contentElement,
+    otherElement,
+    otherElementRef,
+    open,
+    transition,
+  ]);
 
   props = useWrapElement(
     props,
@@ -337,6 +334,14 @@ export interface DisclosureContentOptions<
    * component's context will be used.
    */
   store?: DisclosureStore;
+  /**
+   * A ref to another element whose CSS transitions and animations should be
+   * taken into account when computing the animation timeout, such as the
+   * dialog's backdrop element, which may be animated while the dialog itself
+   * is not.
+   * @private
+   */
+  unstable_otherElementRef?: RefObject<HTMLElement | null>;
   /**
    * Determines whether the content element should remain visible even when the
    * [`open`](https://ariakit.com/reference/disclosure-provider#open) state is


### PR DESCRIPTION
Fixes #6339

## Motivation

When a [`Dialog`](https://ariakit.com/reference/dialog)'s [`backdrop`](https://ariakit.com/reference/dialog#backdrop) has a CSS transition but the dialog panel itself doesn't (an overlay that fades while the panel snaps in place), the backdrop's enter fade plays, but its exit fade is silently skipped: on close, the dialog hides instantly and `data-leave` is never applied to the backdrop.

```css
.backdrop {
  opacity: 0;
  transition: opacity 500ms ease;
}
.backdrop[data-enter] {
  opacity: 1;
}
/* .dialog has no transition */
```

The two `useDisclosureContent` instances (panel and backdrop) share one animation state, but they're asymmetric. The backdrop instance already unions the panel's computed transition/animation styles via `otherElement`, since "the dialog may be animated while the backdrop is not". The panel instance, however, knows nothing about the backdrop: with an unanimated panel it computes a zero animation timeout, and the zero-timeout branch sets the **shared** `animated` state to `false`. With `animated` false, closing never sets `animating`, so `mounted` flips to `false` immediately — the backdrop is hidden instantly and never receives `data-leave`.

## Solution

Give the panel's `useDisclosureContent` instance the reciprocal information the backdrop instance already has. `useDialog` now owns a `backdropRef` that `DialogBackdrop` merges into the backdrop element, and hands it to its own `useDisclosureContent` call through a private `unstable_otherElementRef` option — the reciprocal of how the backdrop instance already learns about the panel via `otherElement`. The timeout effect includes that element's computed transition/animation end times in the timeout computation, so the disclosure layer stays generic and no DOM query is needed.

With the panel computing a non-zero timeout, the zero-timeout branch no longer clears the shared `animated` state on enter, and on leave the panel waits for the backdrop's transition instead of stopping the animation synchronously. For non-dialog disclosure content and for the backdrop's own instance the ref is empty, so behavior is unchanged, and the fast-unmount path for fully unanimated dialogs is preserved. This also fixes the related case where both elements are animated but the backdrop's transition is longer than the panel's: the panel instance previously stopped the shared animation at its own shorter timeout, cutting the backdrop's fade short.

Both cases are covered by the `dialog-backdrop-6339` sandbox — a backdrop-only dialog and a "fast" dialog with a 150ms panel transition next to the 500ms backdrop — with Playwright browser tests and happy-dom duplicates that fail without the fix at the `data-leave` assertions.

## Workaround

Until the fix is released, add a visually imperceptible transition to the dialog panel matching the backdrop's duration. The panel's opacity never changes, so nothing is visible, but Ariakit then computes a non-zero animation timeout for the panel and keeps the shared animation state alive, letting the backdrop fade out on close:

```css
.dialog {
  /* TODO: Workaround for https://github.com/ariakit/ariakit/issues/6339
     Remove once the fix lands. Use the same duration as the backdrop's
     transition. */
  transition: opacity 500ms ease;
}
```
