### PR TITLE
Fix div-based Focusable server-rendering without tabindex and with an invalid disabled attribute

### DIFF
--- a/.changeset/300-focusable-ssr-tabindex.md
+++ b/.changeset/300-focusable-ssr-tabindex.md
@@ -1,0 +1,12 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Server-rendered `Focusable` keyboard accessibility
+
+[`Focusable`](https://ariakit.com/reference/focusable)-based components that render a non-native tag — such as the default `div` of [`Focusable`](https://ariakit.com/reference/focusable) itself, a virtual focus [`Composite`](https://ariakit.com/reference/composite) container, or [`TooltipAnchor`](https://ariakit.com/reference/tooltip-anchor) — now server-render with the `tabindex="0"` fallback, so keyboard users can reach them before hydration completes or when JavaScript is disabled.
+
+Disabled non-native components — including div-based items such as [`MenuItem`](https://ariakit.com/reference/menu-item), [`SelectItem`](https://ariakit.com/reference/select-item), and [`ComboboxItem`](https://ariakit.com/reference/combobox-item) — no longer server-render an invalid `disabled` attribute, which is silently removed on hydration but could match `[disabled]` CSS selectors until then. Native controls such as [`Button`](https://ariakit.com/reference/button) and [`Checkbox`](https://ariakit.com/reference/checkbox) keep their native `disabled` attribute in the server-rendered HTML.
+
+In both cases, the server now renders the same attributes the client computes on its first render, keeping hydration consistent.

--- a/app/src/sandbox/focusable-6341/index.react.tsx
+++ b/app/src/sandbox/focusable-6341/index.react.tsx
@@ -9,14 +9,23 @@ export default function Example() {
   return (
     <>
       <Ariakit.Button>Before</Ariakit.Button>
-      <Ariakit.Focusable>Focusable card</Ariakit.Focusable>
-      <Ariakit.Focusable disabled>Disabled focusable card</Ariakit.Focusable>
+      {/* TODO: Remove the explicit tabIndex and accessibleWhenDisabled props
+          from the elements below once
+          https://github.com/ariakit/ariakit/issues/6341 is fixed. Note that
+          accessibleWhenDisabled changes behavior: the disabled element remains
+          focusable (with aria-disabled) after hydration. */}
+      <Ariakit.Focusable tabIndex={0}>Focusable card</Ariakit.Focusable>
+      <Ariakit.Focusable disabled accessibleWhenDisabled>
+        Disabled focusable card
+      </Ariakit.Focusable>
       <Ariakit.TooltipProvider>
-        <Ariakit.TooltipAnchor>Tooltip anchor</Ariakit.TooltipAnchor>
+        <Ariakit.TooltipAnchor tabIndex={0}>
+          Tooltip anchor
+        </Ariakit.TooltipAnchor>
         <Ariakit.Tooltip>Tooltip content</Ariakit.Tooltip>
       </Ariakit.TooltipProvider>
       <Ariakit.CompositeProvider virtualFocus>
-        <Ariakit.Composite role="toolbar" aria-label="Composite">
+        <Ariakit.Composite role="toolbar" aria-label="Composite" tabIndex={0}>
           <Ariakit.CompositeItem render={<div />}>Item 1</Ariakit.CompositeItem>
           <Ariakit.CompositeItem render={<div />}>Item 2</Ariakit.CompositeItem>
         </Ariakit.Composite>

--- a/app/src/sandbox/focusable-6341/index.react.tsx
+++ b/app/src/sandbox/focusable-6341/index.react.tsx
@@ -1,0 +1,28 @@
+import * as Ariakit from "@ariakit/react";
+
+// See https://github.com/ariakit/ariakit/issues/6341
+// Div-based Focusable elements must be part of the server-rendered HTML's tab
+// order (tabindex="0") so keyboard users can reach them before hydration, and
+// a disabled non-native Focusable must not server-render an invalid `disabled`
+// attribute.
+export default function Example() {
+  return (
+    <>
+      <Ariakit.Button>Before</Ariakit.Button>
+      <Ariakit.Focusable>Focusable card</Ariakit.Focusable>
+      <Ariakit.Focusable disabled>Disabled focusable card</Ariakit.Focusable>
+      <Ariakit.TooltipProvider>
+        <Ariakit.TooltipAnchor>Tooltip anchor</Ariakit.TooltipAnchor>
+        <Ariakit.Tooltip>Tooltip content</Ariakit.Tooltip>
+      </Ariakit.TooltipProvider>
+      <Ariakit.CompositeProvider virtualFocus>
+        <Ariakit.Composite role="toolbar" aria-label="Composite">
+          <Ariakit.CompositeItem render={<div />}>Item 1</Ariakit.CompositeItem>
+          <Ariakit.CompositeItem render={<div />}>Item 2</Ariakit.CompositeItem>
+        </Ariakit.Composite>
+      </Ariakit.CompositeProvider>
+      <Ariakit.Button disabled>Disabled button</Ariakit.Button>
+      <Ariakit.Button>After</Ariakit.Button>
+    </>
+  );
+}

--- a/app/src/sandbox/focusable-6341/index.react.tsx
+++ b/app/src/sandbox/focusable-6341/index.react.tsx
@@ -9,27 +9,28 @@ export default function Example() {
   return (
     <>
       <Ariakit.Button>Before</Ariakit.Button>
-      {/* TODO: Remove the explicit tabIndex and accessibleWhenDisabled props
-          from the elements below once
-          https://github.com/ariakit/ariakit/issues/6341 is fixed. Note that
-          accessibleWhenDisabled changes behavior: the disabled element remains
-          focusable (with aria-disabled) after hydration. */}
-      <Ariakit.Focusable tabIndex={0}>Focusable card</Ariakit.Focusable>
-      <Ariakit.Focusable disabled accessibleWhenDisabled>
-        Disabled focusable card
-      </Ariakit.Focusable>
+      <Ariakit.Focusable>Focusable card</Ariakit.Focusable>
+      <Ariakit.Focusable disabled>Disabled focusable card</Ariakit.Focusable>
       <Ariakit.TooltipProvider>
-        <Ariakit.TooltipAnchor tabIndex={0}>
-          Tooltip anchor
-        </Ariakit.TooltipAnchor>
+        <Ariakit.TooltipAnchor>Tooltip anchor</Ariakit.TooltipAnchor>
         <Ariakit.Tooltip>Tooltip content</Ariakit.Tooltip>
       </Ariakit.TooltipProvider>
       <Ariakit.CompositeProvider virtualFocus>
-        <Ariakit.Composite role="toolbar" aria-label="Composite" tabIndex={0}>
+        <Ariakit.Composite role="toolbar" aria-label="Composite">
           <Ariakit.CompositeItem render={<div />}>Item 1</Ariakit.CompositeItem>
           <Ariakit.CompositeItem render={<div />}>Item 2</Ariakit.CompositeItem>
         </Ariakit.Composite>
       </Ariakit.CompositeProvider>
+      <Ariakit.MenuProvider defaultOpen>
+        <Ariakit.MenuButton>Menu button</Ariakit.MenuButton>
+        <Ariakit.Menu portal={false} autoFocusOnShow={false}>
+          <Ariakit.MenuItem>Menu item</Ariakit.MenuItem>
+          <Ariakit.MenuItem disabled>Disabled menu item</Ariakit.MenuItem>
+          <Ariakit.MenuProvider>
+            <Ariakit.MenuButton>Submenu button</Ariakit.MenuButton>
+          </Ariakit.MenuProvider>
+        </Ariakit.Menu>
+      </Ariakit.MenuProvider>
       <Ariakit.Button disabled>Disabled button</Ariakit.Button>
       <Ariakit.Button>After</Ariakit.Button>
     </>

--- a/app/src/sandbox/focusable-6341/test-browser.ts
+++ b/app/src/sandbox/focusable-6341/test-browser.ts
@@ -31,6 +31,26 @@ withFramework(import.meta.dirname, async ({ test }) => {
       await test.expect(disabledCard).not.toHaveAttribute("tabindex");
     });
 
+    // The submenu button covers the MenuButton case, which renders as a div
+    // when nested in another menu.
+    test("div-based menu items server-render in the tab order", async ({
+      q,
+    }) => {
+      await test.expect(q.text("Menu item")).toHaveAttribute("tabindex", "0");
+      await test
+        .expect(q.text("Submenu button"))
+        .toHaveAttribute("tabindex", "0");
+    });
+
+    test("disabled menu item doesn't server-render a disabled attribute", async ({
+      q,
+    }) => {
+      const disabledItem = q.text("Disabled menu item");
+      await test.expect(disabledItem).toHaveAttribute("aria-disabled", "true");
+      await test.expect(disabledItem).not.toHaveAttribute("disabled");
+      await test.expect(disabledItem).not.toHaveAttribute("tabindex");
+    });
+
     test("native buttons keep their server-rendered semantics", async ({
       q,
     }) => {
@@ -64,11 +84,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
       .toHaveAttribute("tabindex", "0");
     const disabledCard = q.text("Disabled focusable card");
     await test.expect(disabledCard).toHaveAttribute("aria-disabled", "true");
-    // No tabindex absence check here: the userland workaround
-    // (accessibleWhenDisabled) legitimately keeps the disabled card focusable
-    // after hydration, so this guard only asserts the contract shared by the
-    // workaround and the library fix.
     await test.expect(disabledCard).not.toHaveAttribute("disabled");
+    await test.expect(disabledCard).not.toHaveAttribute("tabindex");
     await test
       .expect(q.text("Tooltip anchor"))
       .toHaveAttribute("tabindex", "0");

--- a/app/src/sandbox/focusable-6341/test-browser.ts
+++ b/app/src/sandbox/focusable-6341/test-browser.ts
@@ -64,8 +64,11 @@ withFramework(import.meta.dirname, async ({ test }) => {
       .toHaveAttribute("tabindex", "0");
     const disabledCard = q.text("Disabled focusable card");
     await test.expect(disabledCard).toHaveAttribute("aria-disabled", "true");
+    // No tabindex absence check here: the userland workaround
+    // (accessibleWhenDisabled) legitimately keeps the disabled card focusable
+    // after hydration, so this guard only asserts the contract shared by the
+    // workaround and the library fix.
     await test.expect(disabledCard).not.toHaveAttribute("disabled");
-    await test.expect(disabledCard).not.toHaveAttribute("tabindex");
     await test
       .expect(q.text("Tooltip anchor"))
       .toHaveAttribute("tabindex", "0");

--- a/app/src/sandbox/focusable-6341/test-browser.ts
+++ b/app/src/sandbox/focusable-6341/test-browser.ts
@@ -1,0 +1,77 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// See https://github.com/ariakit/ariakit/issues/6341
+// With JavaScript disabled, the browser only gets the server-rendered HTML, so
+// these tests assert what keyboard users experience before hydration completes
+// or while JavaScript is unavailable.
+withFramework(import.meta.dirname, async ({ test }) => {
+  test.describe("javascript disabled", () => {
+    test.use({ javaScriptEnabled: false });
+
+    test("server HTML keeps div-based focusables keyboard accessible", async ({
+      q,
+    }) => {
+      await test
+        .expect(q.text("Focusable card"))
+        .toHaveAttribute("tabindex", "0");
+      await test
+        .expect(q.text("Tooltip anchor"))
+        .toHaveAttribute("tabindex", "0");
+      await test
+        .expect(q.toolbar("Composite"))
+        .toHaveAttribute("tabindex", "0");
+    });
+
+    test("disabled Focusable doesn't server-render an invalid disabled attribute", async ({
+      q,
+    }) => {
+      const disabledCard = q.text("Disabled focusable card");
+      await test.expect(disabledCard).toHaveAttribute("aria-disabled", "true");
+      await test.expect(disabledCard).not.toHaveAttribute("disabled");
+      await test.expect(disabledCard).not.toHaveAttribute("tabindex");
+    });
+
+    test("native buttons keep their server-rendered semantics", async ({
+      q,
+    }) => {
+      await test.expect(q.button("Before")).not.toHaveAttribute("tabindex");
+      await test.expect(q.button("After")).not.toHaveAttribute("tabindex");
+      const disabledButton = q.button("Disabled button");
+      await test.expect(disabledButton).toHaveAttribute("disabled");
+      await test.expect(disabledButton).not.toHaveAttribute("tabindex");
+    });
+
+    test("tab reaches div-based focusables before hydration", async ({
+      page,
+      q,
+    }) => {
+      await q.button("Before").focus();
+      await page.keyboard.press("Tab");
+      await test.expect(q.text("Focusable card")).toBeFocused();
+      // The disabled focusable card is skipped.
+      await page.keyboard.press("Tab");
+      await test.expect(q.text("Tooltip anchor")).toBeFocused();
+      await page.keyboard.press("Tab");
+      await test.expect(q.toolbar("Composite")).toBeFocused();
+    });
+  });
+
+  test("hydrated markup matches the server-rendered attributes", async ({
+    q,
+  }) => {
+    await test
+      .expect(q.text("Focusable card"))
+      .toHaveAttribute("tabindex", "0");
+    const disabledCard = q.text("Disabled focusable card");
+    await test.expect(disabledCard).toHaveAttribute("aria-disabled", "true");
+    await test.expect(disabledCard).not.toHaveAttribute("disabled");
+    await test.expect(disabledCard).not.toHaveAttribute("tabindex");
+    await test
+      .expect(q.text("Tooltip anchor"))
+      .toHaveAttribute("tabindex", "0");
+    await test.expect(q.toolbar("Composite")).toHaveAttribute("tabindex", "0");
+    const disabledButton = q.button("Disabled button");
+    await test.expect(disabledButton).toHaveAttribute("disabled");
+    await test.expect(disabledButton).not.toHaveAttribute("tabindex");
+  });
+});

--- a/app/src/sandbox/focusable-6341/test.ts
+++ b/app/src/sandbox/focusable-6341/test.ts
@@ -1,8 +1,30 @@
 import { q } from "@ariakit/test";
 import { createElement } from "react";
 import { renderToString } from "react-dom/server";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import Example from "./index.react.tsx";
+
+// React 18's renderToString warns that useLayoutEffect does nothing on the
+// server when it runs in a DOM test environment like this one. Real servers
+// don't have a DOM, so useSafeLayoutEffect resolves to useEffect there and the
+// warning doesn't apply. Silence only that warning so failOnConsole keeps
+// catching everything else.
+function renderToStringSilencingLayoutEffectWarning() {
+  const originalError = console.error;
+  const spy = vi.spyOn(console, "error").mockImplementation((...args) => {
+    if (
+      String(args[0]).includes("useLayoutEffect does nothing on the server")
+    ) {
+      return;
+    }
+    originalError(...args);
+  });
+  try {
+    return renderToString(createElement(Example));
+  } finally {
+    spy.mockRestore();
+  }
+}
 
 // See https://github.com/ariakit/ariakit/issues/6341
 // renderToString produces the exact HTML a server framework (Next.js, Remix,
@@ -13,7 +35,7 @@ import Example from "./index.react.tsx";
 // holding only the server markup.
 function renderServerMarkup() {
   const container = document.createElement("div");
-  container.innerHTML = renderToString(createElement(Example));
+  container.innerHTML = renderToStringSilencingLayoutEffectWarning();
   return q.within(container);
 }
 
@@ -38,6 +60,22 @@ test("div-based TooltipAnchor server-renders in the tab order", () => {
 test("virtual focus composite container server-renders in the tab order", () => {
   const server = renderServerMarkup();
   expect(server.toolbar("Composite")).toHaveAttribute("tabindex", "0");
+});
+
+// The submenu button covers the MenuButton case, which renders as a div when
+// nested in another menu.
+test("div-based menu items server-render in the tab order", () => {
+  const server = renderServerMarkup();
+  expect(server.text.ensure("Menu item")).toHaveAttribute("tabindex", "0");
+  expect(server.text.ensure("Submenu button")).toHaveAttribute("tabindex", "0");
+});
+
+test("disabled menu item doesn't server-render a disabled attribute", () => {
+  const server = renderServerMarkup();
+  const disabledItem = server.text.ensure("Disabled menu item");
+  expect(disabledItem).toHaveAttribute("aria-disabled", "true");
+  expect(disabledItem).not.toHaveAttribute("disabled");
+  expect(disabledItem).not.toHaveAttribute("tabindex");
 });
 
 test("native buttons keep their server-rendered semantics", () => {

--- a/app/src/sandbox/focusable-6341/test.ts
+++ b/app/src/sandbox/focusable-6341/test.ts
@@ -1,0 +1,50 @@
+import { q } from "@ariakit/test";
+import { createElement } from "react";
+import { renderToString } from "react-dom/server";
+import { expect, test } from "vitest";
+import Example from "./index.react.tsx";
+
+// See https://github.com/ariakit/ariakit/issues/6341
+// renderToString produces the exact HTML a server framework (Next.js, Remix,
+// etc.) sends to the browser, so these tests assert what keyboard users get
+// before hydration completes or while JavaScript is disabled. The test harness
+// also client-renders this sandbox into the document, but that hydrated copy
+// doesn't exhibit the bug, so the queries are scoped to a detached container
+// holding only the server markup.
+function renderServerMarkup() {
+  const container = document.createElement("div");
+  container.innerHTML = renderToString(createElement(Example));
+  return q.within(container);
+}
+
+test("div-based Focusable server-renders in the tab order", () => {
+  const server = renderServerMarkup();
+  expect(server.text.ensure("Focusable card")).toHaveAttribute("tabindex", "0");
+});
+
+test("disabled Focusable doesn't server-render an invalid disabled attribute", () => {
+  const server = renderServerMarkup();
+  const disabledCard = server.text.ensure("Disabled focusable card");
+  expect(disabledCard).toHaveAttribute("aria-disabled", "true");
+  expect(disabledCard).not.toHaveAttribute("disabled");
+  expect(disabledCard).not.toHaveAttribute("tabindex");
+});
+
+test("div-based TooltipAnchor server-renders in the tab order", () => {
+  const server = renderServerMarkup();
+  expect(server.text.ensure("Tooltip anchor")).toHaveAttribute("tabindex", "0");
+});
+
+test("virtual focus composite container server-renders in the tab order", () => {
+  const server = renderServerMarkup();
+  expect(server.toolbar("Composite")).toHaveAttribute("tabindex", "0");
+});
+
+test("native buttons keep their server-rendered semantics", () => {
+  const server = renderServerMarkup();
+  expect(server.button("Before")).not.toHaveAttribute("tabindex");
+  expect(server.button("After")).not.toHaveAttribute("tabindex");
+  const disabledButton = server.text.ensure("Disabled button");
+  expect(disabledButton).toHaveAttribute("disabled");
+  expect(disabledButton).not.toHaveAttribute("tabindex");
+});

--- a/packages/ariakit-react-components/src/combobox/combobox-item.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item.tsx
@@ -214,6 +214,7 @@ export const useComboboxItem = createHook<TagName, ComboboxItemOptions>(
 
     props = useCompositeItem<TagName>({
       store,
+      unstable_defaultTagName: TagName,
       ...props,
       getItem,
       // Dispatch a custom event on the combobox input when moving to an item

--- a/packages/ariakit-react-components/src/combobox/combobox.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox.tsx
@@ -677,6 +677,7 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
     props = useComposite<TagName>({
       store,
       focusable,
+      unstable_defaultTagName: TagName,
       ...props,
       // Enable inline autocomplete when the user moves from the combobox input
       // to an item.

--- a/packages/ariakit-react-components/src/command/command.tsx
+++ b/packages/ariakit-react-components/src/command/command.tsx
@@ -184,7 +184,10 @@ export const useCommand = createHook<TagName, CommandOptions>(
       onKeyUp,
     };
 
-    props = useFocusable<TagName>(props);
+    props = useFocusable<TagName>({
+      unstable_defaultTagName: TagName,
+      ...props,
+    });
 
     return props;
   },

--- a/packages/ariakit-react-components/src/composite/composite-item.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-item.tsx
@@ -21,6 +21,7 @@ import {
   isPortalEvent,
   isSelfTarget,
   disabledFromProps,
+  hasFocus,
   removeUndefinedValues,
   isSafari,
 } from "@ariakit/utils";
@@ -272,7 +273,25 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
       // We need to verify if the base element is connected to the DOM to avoid
       // a scroll jump on Safari. This is necessary when the base element is
       // removed from the DOM just before triggering this focus event.
-      if (!baseElement?.isConnected) return;
+      if (!baseElement?.isConnected) {
+        // The composite element may not have been registered in the store yet:
+        // that registration happens in a layout effect on a render triggered
+        // by its ref, while a pending move can focus the item from an effect
+        // that runs before that render (for example, a select popover that
+        // mounts on show and moves to the selected item). Redirect focus to
+        // the composite element once the registration has been committed, as
+        // long as the item still has focus.
+        const itemElement = event.currentTarget;
+        const itemStore = store;
+        queueMicrotask(() => {
+          const { baseElement } = itemStore.getState();
+          if (!baseElement?.isConnected) return;
+          if (!hasFocus(itemElement)) return;
+          hasFocusedComposite.current = true;
+          baseElement.focus();
+        });
+        return;
+      }
       // Safari doesn't scroll the element into view when another element is
       // immediately focused. So we have to do it manually here.
       if (isSafari() && event.currentTarget.hasAttribute("data-autofocus")) {

--- a/packages/ariakit-react-components/src/focusable/focusable.tsx
+++ b/packages/ariakit-react-components/src/focusable/focusable.tsx
@@ -29,7 +29,14 @@ import type {
   KeyboardEvent as ReactKeyboardEvent,
   SyntheticEvent,
 } from "react";
-import { useContext, useEffect, useMemo, useRef, useState } from "react";
+import {
+  isValidElement,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { FocusableContext } from "./focusable-context.tsx";
 
 const TagName = "div" satisfies ElementType;
@@ -70,6 +77,12 @@ function isAlwaysFocusVisible(element: HTMLElement) {
     return true;
   }
   return false;
+}
+
+function getRenderTagName(render?: FocusableProps["render"]) {
+  if (!isValidElement(render)) return;
+  if (typeof render.type !== "string") return;
+  return render.type;
 }
 
 function isNativeTabbable(tagName?: string) {
@@ -196,6 +209,7 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
     accessibleWhenDisabled,
     autoFocus,
     onFocusVisible,
+    unstable_defaultTagName: defaultTagName = TagName,
     ...props
   }) {
     const ref = useRef<HTMLType>(null);
@@ -390,7 +404,16 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
       });
     });
 
-    const tagName = useTagName(ref);
+    // The ref is only populated after mounting, so during server rendering and
+    // the first client render the tag name falls back to a deterministic
+    // guess: the intrinsic tag from a string render prop, or the default tag
+    // of the underlying component. Both the server and the client first render
+    // compute the same value, so this can't cause hydration mismatches, and
+    // the actual DOM tag still takes over once the layout effect runs.
+    const tagName = useTagName(
+      ref,
+      getRenderTagName(props.render) ?? defaultTagName,
+    );
     const nativeTabbable = focusable && isNativeTabbable(tagName);
     const supportsDisabled = focusable && supportsDisabledAttribute(tagName);
 
@@ -579,6 +602,10 @@ export interface FocusableOptions<
   onFocusVisible?: BivariantCallback<
     (event: SyntheticEvent<HTMLElement>) => void
   >;
+  /**
+   * @private
+   */
+  unstable_defaultTagName?: keyof HTMLElementTagNameMap;
 }
 
 export type FocusableProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/form/form-input.tsx
+++ b/packages/ariakit-react-components/src/form/form-input.tsx
@@ -55,7 +55,10 @@ export const useFormInput = createHook<TagName, FormInputOptions>(
       onChange,
     };
 
-    props = useFocusable<TagName>(props);
+    props = useFocusable<TagName>({
+      unstable_defaultTagName: TagName,
+      ...props,
+    });
     props = useFormControl({ store: form, name, ...props });
 
     return props;

--- a/packages/ariakit-react-components/src/hovercard/hovercard-anchor.tsx
+++ b/packages/ariakit-react-components/src/hovercard/hovercard-anchor.tsx
@@ -140,7 +140,10 @@ export const useHovercardAnchor = createHook<TagName, HovercardAnchorOptions>(
       onClick,
     };
 
-    props = useFocusable<TagName>(props);
+    props = useFocusable<TagName>({
+      unstable_defaultTagName: TagName,
+      ...props,
+    });
 
     return props;
   },

--- a/packages/ariakit-react-components/src/menu/menu-button.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-button.tsx
@@ -199,6 +199,10 @@ export const useMenuButton = createHook<TagName, MenuButtonOptions>(
       };
     }
 
+    // Submenu buttons render as a div through the Role.div element above, so
+    // the tag name guess for server rendering must be a div as well.
+    const defaultTagName = hasParentMenu ? "div" : TagName;
+
     // We'll use this id to render the aria-labelledby attribute on the menu.
     const id = useId(props.id);
 
@@ -241,6 +245,7 @@ export const useMenuButton = createHook<TagName, MenuButtonOptions>(
       store,
       focusable,
       accessibleWhenDisabled,
+      unstable_defaultTagName: defaultTagName,
       ...props,
       showOnHover: (event) => {
         const getShowOnHover = () => {
@@ -270,6 +275,7 @@ export const useMenuButton = createHook<TagName, MenuButtonOptions>(
       toggleOnClick: !hasParentMenu,
       focusable,
       accessibleWhenDisabled,
+      unstable_defaultTagName: defaultTagName,
       ...props,
     });
 

--- a/packages/ariakit-react-components/src/menu/menu-item-checkbox.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-item-checkbox.tsx
@@ -122,6 +122,7 @@ export const useMenuItemCheckbox = createHook<TagName, MenuItemCheckboxOptions>(
       name,
       value,
       checked,
+      unstable_defaultTagName: TagName,
       ...props,
     });
     props = useMenuItem({ store, hideOnClick, ...props });

--- a/packages/ariakit-react-components/src/menu/menu-item-radio.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-item-radio.tsx
@@ -106,6 +106,7 @@ export const useMenuItemRadio = createHook<TagName, MenuItemRadioOptions>(
       name,
       value,
       checked: isChecked,
+      unstable_defaultTagName: TagName,
       onChange(event) {
         onChangeProp?.(event);
         if (event.defaultPrevented) return;

--- a/packages/ariakit-react-components/src/menu/menu-item.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-item.tsx
@@ -130,6 +130,7 @@ export const useMenuItem = createHook<TagName, MenuItemOptions>(
     props = useCompositeItem<TagName>({
       store,
       preventScrollOnKeyDown,
+      unstable_defaultTagName: TagName,
       ...props,
       // Skip registering items while the menu list is hidden. Unlike a Select,
       // a Menu doesn't interact with its items while hidden, so registering

--- a/packages/ariakit-react-components/src/select/select-item.tsx
+++ b/packages/ariakit-react-components/src/select/select-item.tsx
@@ -175,6 +175,7 @@ export const useSelectItem = createHook<TagName, SelectItemOptions>(
       store,
       getItem,
       preventScrollOnKeyDown,
+      unstable_defaultTagName: TagName,
       ...props,
     });
 

--- a/packages/ariakit-react-components/src/tag/tag.tsx
+++ b/packages/ariakit-react-components/src/tag/tag.tsx
@@ -126,6 +126,7 @@ export const useTag = createHook<TagName, TagOptions>(function useTag({
 
   props = useCompositeItem<TagName>({
     store,
+    unstable_defaultTagName: TagName,
     ...props,
     getItem,
   });

--- a/packages/ariakit-react-components/src/toolbar/toolbar-container.tsx
+++ b/packages/ariakit-react-components/src/toolbar/toolbar-container.tsx
@@ -34,7 +34,11 @@ export const useToolbarContainer = createHook<TagName, ToolbarContainerOptions>(
     const context = useToolbarContext();
     store = store || context;
     props = useCompositeContainer({ store, ...props });
-    props = useToolbarItem<TagName>({ store, ...props });
+    props = useToolbarItem<TagName>({
+      store,
+      unstable_defaultTagName: TagName,
+      ...props,
+    });
     return props;
   },
 );

--- a/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
+++ b/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
@@ -164,6 +164,7 @@ export const useTooltipAnchor = createHook<TagName, TooltipAnchorOptions>(
 
     props = useHovercardAnchor<TagName>({
       store,
+      unstable_defaultTagName: TagName,
       showOnHover(event) {
         if (!canShowOnHoverRef.current) return false;
         if (isFalsyBooleanCallback(showOnHover, event)) return false;


### PR DESCRIPTION
## Motivation

Fixes #6341

When a [`Focusable`](https://ariakit.com/reference/focusable)-based component renders a non-native tag (the default for `Focusable` is a `div`), the server-rendered HTML is missing the `tabIndex={0}` fallback the component relies on to be focusable. Until hydration completes — or indefinitely for users browsing with JavaScript disabled — the element is absent from the tab order:

```html
<!-- <Focusable>Focusable card</Focusable> server-renders as: -->
<div>Focusable card</div>

<!-- client steady state after hydration: -->
<div tabindex="0">Focusable card</div>
```

A disabled `Focusable` additionally server-renders a literal `disabled` attribute on the `div`, which is invalid HTML and matches `[disabled]` CSS selectors until hydration silently removes it:

```html
<!-- <Focusable disabled>…</Focusable> server-renders as: -->
<div aria-disabled="true" disabled="" style="pointer-events:none">…</div>
```

`useFocusable` computes `tabIndex` and `disabled` from the element's tag name, read from the DOM via `useTagName(ref)` with no fallback type. The tag name is only learned inside a layout effect, which never runs during server rendering, so both predicates default to "assume a native control": no `tabIndex` fallback is emitted and the stray `disabled` attribute is.

Every div-rendered descendant of `useFocusable` inherits this: a virtual-focus [`Composite`](https://ariakit.com/reference/composite) container (the widget's only tabbable element) SSRs with no `tabindex`, and [`TooltipAnchor`](https://ariakit.com/reference/tooltip-anchor) SSRs as a bare `<div>`.

## Solution

Give `useFocusable` a deterministic tag name during server rendering and the first client render instead of `undefined`:

1. When the [`render`](https://ariakit.com/guide/composition) prop is an element with an intrinsic (string) type, that tag is used — e.g. `render={<button />}` computes as `button`.
2. Otherwise, a private `unstable_defaultTagName` option threaded by derived components is used: `Command` passes `"button"` (covering `Button`, `Disclosure`, `CompositeItem`, and everything else built on it), `Combobox` and `FormInput` pass `"input"`, `HovercardAnchor` passes `"a"`, `MenuButton` passes `"button"` — or `"div"` when nested in another menu, since submenu buttons render through a `Role.div` element — and the div-based components (`TooltipAnchor`, `ToolbarContainer`, `MenuItem`, `MenuItemCheckbox`, `MenuItemRadio`, `SelectItem`, `ComboboxItem`, `Tag`) pass `"div"`.
3. Otherwise, `Focusable`'s own default `"div"` applies.

Since the server and the client first render compute identical props, this cannot introduce hydration mismatches, and the actual DOM tag still takes over once `useTagName`'s layout effect runs. Components whose arriving guess differs only within the same predicate class (e.g. `Checkbox`'s `input` vs `Command`'s `button`, both native and `disabled`-capable) don't need to thread anything, because the tag name only feeds `isNativeTabbable` and `supportsDisabledAttribute`.

Known limitation: when the `render` prop is a custom component (e.g. `render={<RouterLink />}`), the rendered tag can't be known statically, so the threaded default is used as the guess and the real tag is picked up after mounting — the same transient correction that already existed before this fix. Common compositions like `render={<MenuItem />}` still produce correct server markup because the inner Ariakit component computes its own attributes.

### Composite focus race unmasked by the fix

Previously, `useTagName`'s `undefined → "div"` state correction forced an extra render after mount, which happened to flush the composite base element registration (a layout effect on a ref-triggered second render) before the composite focus-on-move effect focused the active item. With the guess now matching the real tag, that accidental re-render is gone, and in flows like `select-items-unmount` (a popover that mounts on show with a pending move) the selected item could receive DOM focus while `store.baseElement` was still unregistered, so the virtual focus redirect in `CompositeItem` bailed and left DOM focus on the item.

`CompositeItem`'s `onFocus` now handles that case: when the redirect bails only because the base element isn't registered yet, it queues a microtask that redirects focus to the composite element once the registration has been committed, as long as the item still has focus. (Deferring the focus-on-move effect itself was tried and rejected: it broke multi-store items, such as select-with-combobox tabs, where another store's redirect handles the focus synchronously.)

## Tests

The `focusable-6341` sandbox asserts the server-rendered markup both with JavaScript disabled in a real browser (`test-browser.ts`: attributes plus real Tab-key navigation) and via `renderToString` in happy-dom (`test.ts`).

Two tests pass by design at every stage and act as regression guards:

- "native buttons keep their server-rendered semantics" ensures the fix doesn't strip the native `disabled` attribute or add a stray `tabindex` to native controls (which would happen if the undefined-tag defaults in `isNativeTabbable`/`supportsDisabledAttribute` were naively flipped).
- "hydrated markup matches the server-rendered attributes" documents that post-hydration output is the contract the server markup must match.

## Workaround

Until the fix is released, pass the fallback `tabIndex` explicitly so it lands in the server HTML, and use [`accessibleWhenDisabled`](https://ariakit.com/reference/focusable#accessiblewhendisabled) on disabled non-native Focusables to avoid the stray `disabled` attribute:

```tsx
// TODO: Remove the explicit tabIndex and accessibleWhenDisabled props once
// https://github.com/ariakit/ariakit/issues/6341 is fixed.
<Ariakit.Focusable tabIndex={0}>Focusable card</Ariakit.Focusable>
<Ariakit.Focusable disabled accessibleWhenDisabled>
  Disabled focusable card
</Ariakit.Focusable>
```

The same explicit `tabIndex={0}` applies to other div-rendered Focusable-based elements, such as a virtual-focus `Composite` container or a `TooltipAnchor`.

Caveat: `accessibleWhenDisabled` is a documented option but changes behavior — the disabled element remains focusable (with `aria-disabled`) after hydration. There is no consumer-side way to keep the exact default disabled semantics and avoid the server-rendered `disabled` attribute, because `aria-disabled` is treated the same way as the `disabled` prop.
