### PR TITLE
Fix CompositeItem crash when aria-posinset or aria-setsize is NaN

### DIFF
--- a/.changeset/300-composite-item-nan-aria-posinset.md
+++ b/.changeset/300-composite-item-nan-aria-posinset.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/react-store": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`CompositeItem`](https://ariakit.com/reference/composite-item) and components built on it, such as [`Tab`](https://ariakit.com/reference/tab) and [`SelectItem`](https://ariakit.com/reference/select-item), crashing the app with a "Maximum update depth exceeded" error when a `NaN` value was passed to the `aria-posinset` or `aria-setsize` props. The `useStoreStateObject` hook now compares snapshot values with `Object.is`, so the fix also covers any direct consumer of that hook.

--- a/app/src/sandbox/composite-6335/index.react.tsx
+++ b/app/src/sandbox/composite-6335/index.react.tsx
@@ -48,13 +48,7 @@ export default function Example() {
             key={item}
             role="option"
             aria-setsize={TOTAL_ITEMS}
-            // TODO: Remove the NaN guard once
-            // https://github.com/ariakit/ariakit/issues/6335 is fixed
-            aria-posinset={
-              Number.isNaN(page)
-                ? undefined
-                : (page - 1) * PAGE_SIZE + index + 1
-            }
+            aria-posinset={(page - 1) * PAGE_SIZE + index + 1}
           >
             {item}
           </Ariakit.CompositeItem>

--- a/app/src/sandbox/composite-6335/index.react.tsx
+++ b/app/src/sandbox/composite-6335/index.react.tsx
@@ -48,7 +48,13 @@ export default function Example() {
             key={item}
             role="option"
             aria-setsize={TOTAL_ITEMS}
-            aria-posinset={(page - 1) * PAGE_SIZE + index + 1}
+            // TODO: Remove the NaN guard once
+            // https://github.com/ariakit/ariakit/issues/6335 is fixed
+            aria-posinset={
+              Number.isNaN(page)
+                ? undefined
+                : (page - 1) * PAGE_SIZE + index + 1
+            }
           >
             {item}
           </Ariakit.CompositeItem>

--- a/app/src/sandbox/composite-6335/index.react.tsx
+++ b/app/src/sandbox/composite-6335/index.react.tsx
@@ -1,0 +1,59 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+
+const PAGE_SIZE = 5;
+const TOTAL_ITEMS = 50;
+const PAGE_COUNT = TOTAL_ITEMS / PAGE_SIZE;
+
+const allItems = Array.from(
+  { length: TOTAL_ITEMS },
+  (_, index) => `Item ${index + 1}`,
+);
+
+function getPageItems(pageNumber: number) {
+  const start = (pageNumber - 1) * PAGE_SIZE;
+  return allItems.slice(start, start + PAGE_SIZE);
+}
+
+export default function Example() {
+  const composite = Ariakit.useCompositeStore();
+  const [pageInput, setPageInput] = useState("1");
+  const [items, setItems] = useState(() => getPageItems(1));
+  // NaN while the field is empty (a transient state when the user clears the
+  // field to type another page number)
+  const page = Number.parseInt(pageInput, 10);
+  return (
+    <div className="flex flex-col items-start gap-3">
+      <label className="flex items-center gap-2">
+        Page
+        <input
+          type="number"
+          min={1}
+          max={PAGE_COUNT}
+          value={pageInput}
+          className="w-16 rounded border border-gray-400 px-2 py-1"
+          onChange={(event) => {
+            const { value } = event.target;
+            setPageInput(value);
+            const nextPage = Number.parseInt(value, 10);
+            if (nextPage >= 1 && nextPage <= PAGE_COUNT) {
+              setItems(getPageItems(nextPage));
+            }
+          }}
+        />
+      </label>
+      <Ariakit.Composite store={composite} role="listbox" aria-label="Results">
+        {items.map((item, index) => (
+          <Ariakit.CompositeItem
+            key={item}
+            role="option"
+            aria-setsize={TOTAL_ITEMS}
+            aria-posinset={(page - 1) * PAGE_SIZE + index + 1}
+          >
+            {item}
+          </Ariakit.CompositeItem>
+        ))}
+      </Ariakit.Composite>
+    </div>
+  );
+}

--- a/app/src/sandbox/composite-6335/test-browser.ts
+++ b/app/src/sandbox/composite-6335/test-browser.ts
@@ -1,0 +1,20 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6335
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("clearing the page field does not crash the app", async ({ q }) => {
+    await test.expect(q.option("Item 1")).toBeVisible();
+    const input = q.spinbutton("Page");
+    await input.click();
+    // Clearing the field makes the page number NaN, a transient state while
+    // the user types another page number
+    await input.press("ControlOrMeta+a");
+    await input.press("Delete");
+    await test.expect(input).toHaveValue("");
+    await test.expect(q.option("Item 1")).toBeVisible();
+    await test.expect(q.listbox("Results")).toBeVisible();
+    // The app stays usable: typing a new page number renders that page
+    await input.pressSequentially("2");
+    await test.expect(q.option("Item 6")).toBeVisible();
+  });
+});

--- a/app/src/sandbox/composite-6335/test.ts
+++ b/app/src/sandbox/composite-6335/test.ts
@@ -1,0 +1,26 @@
+import { click, dispatch, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// Number inputs don't expose the text selection API that the type() utility
+// relies on, so fire the input events the browser produces while the user
+// edits the field.
+async function setValue(input: HTMLElement, value: string) {
+  const inputType = value ? "insertText" : "deleteContentBackward";
+  await dispatch.input(input, { target: { value }, inputType });
+}
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6335
+test("clearing the page field does not crash the app", async () => {
+  expect(q.option("Item 1")).toBeInTheDocument();
+  const input = q.spinbutton.ensure("Page");
+  await click(input);
+  // Clearing the field makes the page number NaN, a transient state while the
+  // user types another page number
+  await setValue(input, "");
+  expect(input).toHaveValue(null);
+  expect(q.option("Item 1")).toBeInTheDocument();
+  expect(q.listbox("Results")).toBeInTheDocument();
+  // The app stays usable: typing a new page number renders that page
+  await setValue(input, "2");
+  expect(q.option("Item 6")).toBeInTheDocument();
+});

--- a/packages/ariakit-react-store/src/index.tsx
+++ b/packages/ariakit-react-store/src/index.tsx
@@ -200,7 +200,12 @@ export function useStoreStateObject(
 
       if (typeof keyOrSelector === "function") {
         const value = keyOrSelector(state);
-        if (value !== obj[prop]) {
+        // Compare with Object.is, the same comparator useSyncExternalStore
+        // uses, so a NaN value doesn't invalidate the snapshot on every call,
+        // which would break the getSnapshot idempotency contract and make
+        // React loop until it throws "Maximum update depth exceeded". See
+        // https://github.com/ariakit/ariakit/issues/6335
+        if (!Object.is(value, obj[prop])) {
           obj[prop] = value;
           updated = true;
         }
@@ -210,7 +215,7 @@ export function useStoreStateObject(
         if (!state) continue;
         if (!hasOwnProperty(state, keyOrSelector)) continue;
         const value = state[keyOrSelector];
-        if (value !== obj[prop]) {
+        if (!Object.is(value, obj[prop])) {
           obj[prop] = value;
           updated = true;
         }


### PR DESCRIPTION
## Motivation

When a `NaN` value reaches a `CompositeItem`'s `aria-posinset` or `aria-setsize` prop — for example from `Number.parseInt("")` while the user is clearing a page number field — React throws "Maximum update depth exceeded" and unmounts the entire application tree, leaving a blank page:

```tsx
const page = Number.parseInt(pageInput, 10); // NaN while the field is empty

<Ariakit.CompositeItem
  role="option"
  aria-setsize={TOTAL_ITEMS}
  aria-posinset={(page - 1) * PAGE_SIZE + index + 1}
/>
```

A plain DOM element with the same `NaN` attribute just renders `aria-posinset="NaN"`, so the hard crash is specific to Ariakit.

The root cause is in `useStoreStateObject` (`@ariakit/react-store`): it builds its `useSyncExternalStore` snapshot by diffing each watched key/selector result with strict inequality (`!==`) and reallocating the snapshot object whenever anything "changed". Since `NaN !== NaN` is always `true`, a `NaN` entry produces a fresh snapshot identity on every `getSnapshot` call, breaking the `useSyncExternalStore` idempotency contract. React's post-commit consistency check then force-updates in a loop until the nested-update limit throws.

Every component built on `useCompositeItem` (combobox, select, and menu items, tabs, radios, toolbar items, etc.) and any direct consumer of `useStoreStateObject` is exposed.

Fixes #6335

## Solution

Compare snapshot entries with `Object.is` instead of `!==` in both branches of `useStoreStateObject`'s `getSnapshot`:

```diff
  const value = keyOrSelector(state);
- if (value !== obj[prop]) {
+ if (!Object.is(value, obj[prop])) {
    obj[prop] = value;
    updated = true;
  }
```

`Object.is` is reflexive (`Object.is(NaN, NaN)` is `true`), which is exactly the property the idempotency contract requires, and it is the same comparator `useSyncExternalStore` uses internally, so the hand-rolled diff can never disagree with React's own snapshot check. It behaves identically to `!==` for every value other than `NaN` and `±0`; a selector flipping between `0` and `-0` causes at most one extra re-render before the cached value stabilizes — it cannot loop.

With the fix, a transient `NaN` in an `aria-*` numeric prop at worst renders an invalid `aria-posinset="NaN"` attribute for a moment (matching plain React DOM behavior) and the app stays mounted and usable.

The repro sandbox at `app/src/sandbox/composite-6335` drives the user flow from the issue (clearing a page number field that feeds `aria-posinset`) with a cross-browser Playwright test and a happy-dom duplicate. Both failed with "Maximum update depth exceeded" before the fix (see the first commit's CI run) and pass with it.

## Workaround

Until the fix is released, make sure `NaN` never reaches `aria-setsize`/`aria-posinset` on composite items (or any `useStoreStateObject` selector result):

```tsx
<Ariakit.CompositeItem
  role="option"
  aria-setsize={TOTAL_ITEMS}
  // TODO: Remove the NaN guard once
  // https://github.com/ariakit/ariakit/issues/6335 is fixed
  aria-posinset={
    Number.isNaN(page) ? undefined : (page - 1) * PAGE_SIZE + index + 1
  }
/>
```
