### PR TITLE
Fix stale render element detection when the render prop swaps the element type

### DIFF
--- a/.changeset/300-render-element-swap.md
+++ b/.changeset/300-render-element-swap.md
@@ -1,0 +1,18 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Components re-detect the element when the `render` prop swaps its type
+
+Components that adapt to their underlying HTML element — such as [`Checkbox`](https://ariakit.com/reference/checkbox), [`Radio`](https://ariakit.com/reference/radio), [`Button`](https://ariakit.com/reference/button), [`Command`](https://ariakit.com/reference/command), [`Focusable`](https://ariakit.com/reference/focusable), [`Form`](https://ariakit.com/reference/form), [`Heading`](https://ariakit.com/reference/heading), [`ComboboxList`](https://ariakit.com/reference/combobox-list), and everything built on them — used to detect the element only once on mount. Swapping the element type through [composition](https://ariakit.com/guide/composition) while the component stayed mounted kept props computed for the previous element. For example, a [`Checkbox`](https://ariakit.com/reference/checkbox) swapped from `<input />` to `<div />` would lose its `role="checkbox"`, keep a stale `type` attribute, and stop toggling on click:
+
+```tsx
+<Checkbox
+  checked={checked}
+  onChange={() => setChecked(!checked)}
+  render={custom ? <div /> : <input />}
+/>
+```
+
+The element is now re-detected whenever it changes, so the components above apply the correct role, attributes, tab index, and event behavior after the swap.

--- a/.changeset/300-tag-name-attribute-re-detection.md
+++ b/.changeset/300-tag-name-attribute-re-detection.md
@@ -2,4 +2,4 @@
 "@ariakit/react-utils": patch
 ---
 
-Fixed `useTagName` and `useAttribute` to re-detect the element when it changes, instead of reading it only on mount. `useTagName` also accepts the component's `render` prop as an optional third argument, so a host element render prop resolves the tag name during render, before the element is committed to the DOM.
+Fixed `useTagName` and `useAttribute` to re-detect the element when it changes, instead of reading it only on mount. `useTagName` accepts the component's `render` prop as an optional third argument: it keys the re-detection and, when it's a host element, resolves the tag name during render, before the element is committed to the DOM.

--- a/.changeset/300-tag-name-attribute-re-detection.md
+++ b/.changeset/300-tag-name-attribute-re-detection.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/react-utils": patch
+---
+
+Fixed `useTagName` and `useAttribute` to re-detect the element when it changes, instead of reading it only on mount. `useTagName` also accepts the component's `render` prop as an optional third argument, so a host element render prop resolves the tag name during render, before the element is committed to the DOM.

--- a/app/src/sandbox/checkbox-button-combobox-6336/index.react.tsx
+++ b/app/src/sandbox/checkbox-button-combobox-6336/index.react.tsx
@@ -9,7 +9,12 @@ function CheckboxExample() {
       <button onClick={() => setCustom(!custom)}>
         {custom ? "Use native checkbox" : "Use custom checkbox"}
       </button>
+      {/* TODO: Remove the key workaround when
+      https://github.com/ariakit/ariakit/issues/6336 is fixed. It forces a
+      remount when the render element type changes, re-running the one-shot
+      tag detection. */}
       <Ariakit.Checkbox
+        key={custom ? "custom" : "native"}
         aria-label="Accept terms"
         checked={checked}
         onChange={() => setChecked(!checked)}
@@ -47,7 +52,10 @@ function ButtonExample({ label, defaultCustom = false }: ButtonExampleProps) {
       <button onClick={() => setCustom(!custom)}>
         {custom ? `Use native ${name}` : `Use custom ${name}`}
       </button>
+      {/* TODO: Remove the key workaround when
+      https://github.com/ariakit/ariakit/issues/6336 is fixed. */}
       <Ariakit.Button
+        key={custom ? "custom" : "native"}
         onClick={() => setClicks((count) => count + 1)}
         render={custom ? <div /> : <button />}
       >
@@ -69,7 +77,10 @@ function ComboboxExample() {
       </button>
       <Ariakit.ComboboxProvider defaultSelectedValue={["Apple"]}>
         <Ariakit.Combobox aria-label="Fruit" />
+        {/* TODO: Remove the key workaround when
+        https://github.com/ariakit/ariakit/issues/6336 is fixed. */}
         <Ariakit.ComboboxList
+          key={custom ? "custom" : "native"}
           aria-label="Fruits"
           alwaysVisible
           render={custom ? <section role="dialog" /> : undefined}

--- a/app/src/sandbox/checkbox-button-combobox-6336/index.react.tsx
+++ b/app/src/sandbox/checkbox-button-combobox-6336/index.react.tsx
@@ -9,12 +9,7 @@ function CheckboxExample() {
       <button onClick={() => setCustom(!custom)}>
         {custom ? "Use native checkbox" : "Use custom checkbox"}
       </button>
-      {/* TODO: Remove the key workaround when
-      https://github.com/ariakit/ariakit/issues/6336 is fixed. It forces a
-      remount when the render element type changes, re-running the one-shot
-      tag detection. */}
       <Ariakit.Checkbox
-        key={custom ? "custom" : "native"}
         aria-label="Accept terms"
         checked={checked}
         onChange={() => setChecked(!checked)}
@@ -38,6 +33,45 @@ function CheckboxExample() {
   );
 }
 
+function RadioExample() {
+  const [custom, setCustom] = useState(false);
+  const [fruit, setFruit] = useState("apple");
+  return (
+    <div>
+      <button onClick={() => setCustom(!custom)}>
+        {custom ? "Use native radio" : "Use custom radio"}
+      </button>
+      <Ariakit.RadioProvider
+        value={fruit}
+        setValue={(value) => setFruit(String(value))}
+      >
+        <Ariakit.RadioGroup aria-label="Fruit">
+          <Ariakit.Radio aria-label="apple" value="apple" />
+          <Ariakit.Radio
+            aria-label="orange"
+            value="orange"
+            render={
+              custom ? (
+                <div
+                  style={{
+                    width: 20,
+                    height: 20,
+                    border: "1px solid black",
+                    background: fruit === "orange" ? "black" : "white",
+                  }}
+                />
+              ) : (
+                <input />
+              )
+            }
+          />
+        </Ariakit.RadioGroup>
+      </Ariakit.RadioProvider>
+      <output>fruit: {fruit}</output>
+    </div>
+  );
+}
+
 interface ButtonExampleProps {
   label: string;
   defaultCustom?: boolean;
@@ -52,10 +86,7 @@ function ButtonExample({ label, defaultCustom = false }: ButtonExampleProps) {
       <button onClick={() => setCustom(!custom)}>
         {custom ? `Use native ${name}` : `Use custom ${name}`}
       </button>
-      {/* TODO: Remove the key workaround when
-      https://github.com/ariakit/ariakit/issues/6336 is fixed. */}
       <Ariakit.Button
-        key={custom ? "custom" : "native"}
         onClick={() => setClicks((count) => count + 1)}
         render={custom ? <div /> : <button />}
       >
@@ -77,10 +108,7 @@ function ComboboxExample() {
       </button>
       <Ariakit.ComboboxProvider defaultSelectedValue={["Apple"]}>
         <Ariakit.Combobox aria-label="Fruit" />
-        {/* TODO: Remove the key workaround when
-        https://github.com/ariakit/ariakit/issues/6336 is fixed. */}
         <Ariakit.ComboboxList
-          key={custom ? "custom" : "native"}
           aria-label="Fruits"
           alwaysVisible
           render={custom ? <section role="dialog" /> : undefined}
@@ -96,6 +124,7 @@ export default function Example() {
   return (
     <>
       <CheckboxExample />
+      <RadioExample />
       <ButtonExample label="Submit" />
       <ButtonExample label="Save" defaultCustom />
       <ComboboxExample />

--- a/app/src/sandbox/checkbox-button-combobox-6336/index.react.tsx
+++ b/app/src/sandbox/checkbox-button-combobox-6336/index.react.tsx
@@ -1,0 +1,93 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+
+function CheckboxExample() {
+  const [custom, setCustom] = useState(false);
+  const [checked, setChecked] = useState(false);
+  return (
+    <div>
+      <button onClick={() => setCustom(!custom)}>
+        {custom ? "Use native checkbox" : "Use custom checkbox"}
+      </button>
+      <Ariakit.Checkbox
+        aria-label="Accept terms"
+        checked={checked}
+        onChange={() => setChecked(!checked)}
+        render={
+          custom ? (
+            <div
+              style={{
+                width: 20,
+                height: 20,
+                border: "1px solid black",
+                background: checked ? "black" : "white",
+              }}
+            />
+          ) : (
+            <input />
+          )
+        }
+      />
+      <output>checked: {String(checked)}</output>
+    </div>
+  );
+}
+
+interface ButtonExampleProps {
+  label: string;
+  defaultCustom?: boolean;
+}
+
+function ButtonExample({ label, defaultCustom = false }: ButtonExampleProps) {
+  const [custom, setCustom] = useState(defaultCustom);
+  const [clicks, setClicks] = useState(0);
+  const name = label.toLowerCase();
+  return (
+    <div>
+      <button onClick={() => setCustom(!custom)}>
+        {custom ? `Use native ${name}` : `Use custom ${name}`}
+      </button>
+      <Ariakit.Button
+        onClick={() => setClicks((count) => count + 1)}
+        render={custom ? <div /> : <button />}
+      >
+        {label}
+      </Ariakit.Button>
+      <output>
+        {name} clicks: {clicks}
+      </output>
+    </div>
+  );
+}
+
+function ComboboxExample() {
+  const [custom, setCustom] = useState(false);
+  return (
+    <div>
+      <button onClick={() => setCustom(!custom)}>
+        {custom ? "Use listbox list" : "Use dialog list"}
+      </button>
+      <Ariakit.ComboboxProvider defaultSelectedValue={["Apple"]}>
+        <Ariakit.Combobox aria-label="Fruit" />
+        <Ariakit.ComboboxList
+          aria-label="Fruits"
+          alwaysVisible
+          render={custom ? <section role="dialog" /> : undefined}
+        >
+          <Ariakit.ComboboxItem value="Apple" />
+        </Ariakit.ComboboxList>
+      </Ariakit.ComboboxProvider>
+    </div>
+  );
+}
+
+export default function Example() {
+  return (
+    <>
+      <CheckboxExample />
+      <ButtonExample label="Submit" />
+      <ButtonExample label="Save" defaultCustom />
+      <ComboboxExample />
+    </>
+  );
+}

--- a/app/src/sandbox/checkbox-button-combobox-6336/test-browser.ts
+++ b/app/src/sandbox/checkbox-button-combobox-6336/test-browser.ts
@@ -1,0 +1,104 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/6336
+  test("checkbox keeps role and toggling after swapping the render element", async ({
+    q,
+  }) => {
+    const checkbox = q.checkbox("Accept terms");
+
+    await checkbox.click();
+    await test.expect(q.text("checked: true")).toBeVisible();
+
+    await q.button("Use custom checkbox").click();
+
+    await test.expect(checkbox).toBeVisible();
+    await test.expect(checkbox).not.toHaveAttribute("type");
+    await test.expect(checkbox).toHaveAttribute("tabindex", "0");
+
+    await checkbox.click();
+    await test.expect(q.text("checked: false")).toBeVisible();
+
+    await checkbox.press(" ");
+    await test.expect(q.text("checked: true")).toBeVisible();
+
+    await q.button("Use native checkbox").click();
+
+    await test.expect(checkbox).toHaveAttribute("type", "checkbox");
+
+    await checkbox.click();
+    await test.expect(q.text("checked: false")).toBeVisible();
+  });
+
+  // https://github.com/ariakit/ariakit/issues/6336
+  test("button keeps role and keyboard activation after swapping the render element", async ({
+    q,
+  }) => {
+    const button = q.button("Submit");
+
+    await button.click();
+    await test.expect(q.text("submit clicks: 1")).toBeVisible();
+
+    await q.button("Use custom submit").click();
+
+    await test.expect(button).toBeVisible();
+    await test.expect(button).not.toHaveAttribute("type");
+    await test.expect(button).toHaveAttribute("tabindex", "0");
+
+    await button.click();
+    await test.expect(q.text("submit clicks: 2")).toBeVisible();
+
+    await button.press("Enter");
+    await test.expect(q.text("submit clicks: 3")).toBeVisible();
+
+    await button.press(" ");
+    await test.expect(q.text("submit clicks: 4")).toBeVisible();
+
+    await q.button("Use native submit").click();
+
+    await test.expect(button).toHaveAttribute("type", "button");
+
+    await button.click();
+    await test.expect(q.text("submit clicks: 5")).toBeVisible();
+  });
+
+  // https://github.com/ariakit/ariakit/issues/6336
+  test("button regains native button props after swapping from a custom element", async ({
+    q,
+  }) => {
+    const button = q.button("Save");
+
+    await button.click();
+    await test.expect(q.text("save clicks: 1")).toBeVisible();
+
+    await q.button("Use native save").click();
+
+    await test.expect(button).toHaveAttribute("type", "button");
+    await test.expect(button).not.toHaveAttribute("role");
+
+    await button.click();
+    await test.expect(q.text("save clicks: 2")).toBeVisible();
+  });
+
+  // https://github.com/ariakit/ariakit/issues/6336
+  test("combobox list updates aria-multiselectable after swapping the render element", async ({
+    q,
+  }) => {
+    await test
+      .expect(q.listbox("Fruits"))
+      .toHaveAttribute("aria-multiselectable", "true");
+
+    await q.button("Use dialog list").click();
+
+    await test.expect(q.dialog("Fruits")).toBeVisible();
+    await test
+      .expect(q.dialog("Fruits"))
+      .not.toHaveAttribute("aria-multiselectable");
+
+    await q.button("Use listbox list").click();
+
+    await test
+      .expect(q.listbox("Fruits"))
+      .toHaveAttribute("aria-multiselectable", "true");
+  });
+});

--- a/app/src/sandbox/checkbox-button-combobox-6336/test-browser.ts
+++ b/app/src/sandbox/checkbox-button-combobox-6336/test-browser.ts
@@ -31,6 +31,38 @@ withFramework(import.meta.dirname, async ({ test }) => {
   });
 
   // https://github.com/ariakit/ariakit/issues/6336
+  test("radio keeps role and toggling after swapping the render element", async ({
+    q,
+  }) => {
+    const radio = q.radio("orange");
+
+    await radio.click();
+    await test.expect(q.text("fruit: orange")).toBeVisible();
+
+    await q.radio("apple").click();
+    await test.expect(q.text("fruit: apple")).toBeVisible();
+
+    await q.button("Use custom radio").click();
+
+    await test.expect(radio).toBeVisible();
+    await test.expect(radio).not.toHaveAttribute("type");
+
+    await radio.click();
+    await test.expect(q.text("fruit: orange")).toBeVisible();
+    await test.expect(radio).toHaveAttribute("aria-checked", "true");
+
+    // Swap back to the native input while the radio is checked so the swapped
+    // element mounts as a controlled checked radio right away.
+    await q.button("Use native radio").click();
+
+    await test.expect(radio).toHaveAttribute("type", "radio");
+    await test.expect(radio).toHaveAttribute("aria-checked", "true");
+
+    await q.radio("apple").click();
+    await test.expect(q.text("fruit: apple")).toBeVisible();
+  });
+
+  // https://github.com/ariakit/ariakit/issues/6336
   test("button keeps role and keyboard activation after swapping the render element", async ({
     q,
   }) => {

--- a/app/src/sandbox/checkbox-button-combobox-6336/test-safari.ts
+++ b/app/src/sandbox/checkbox-button-combobox-6336/test-safari.ts
@@ -1,0 +1,20 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // On Safari, Focusable adds an explicit tabindex="0" to native buttons and
+  // button-like inputs so they receive focus on mousedown. The detection reads
+  // the DOM element, so it must re-run when the render prop swaps the element
+  // type. https://github.com/ariakit/ariakit/issues/6336
+  test("native button keeps the Safari tabindex after swapping from a custom element", async ({
+    q,
+  }) => {
+    const button = q.button("Save");
+
+    await test.expect(button).toBeVisible();
+
+    await q.button("Use native save").click();
+
+    await test.expect(button).toHaveAttribute("type", "button");
+    await test.expect(button).toHaveAttribute("tabindex", "0");
+  });
+});

--- a/app/src/sandbox/checkbox-button-combobox-6336/test.ts
+++ b/app/src/sandbox/checkbox-button-combobox-6336/test.ts
@@ -28,6 +28,35 @@ test("checkbox keeps role and toggling after swapping the render element", async
 });
 
 // https://github.com/ariakit/ariakit/issues/6336
+test("radio keeps role and toggling after swapping the render element", async () => {
+  await click(q.radio.ensure("orange"));
+  expect(q.text("fruit: orange")).toBeInTheDocument();
+
+  await click(q.radio.ensure("apple"));
+  expect(q.text("fruit: apple")).toBeInTheDocument();
+
+  await click(q.button.ensure("Use custom radio"));
+
+  const radio = q.radio.ensure("orange");
+  expect(radio).not.toHaveAttribute("type");
+
+  await click(radio);
+  expect(q.text("fruit: orange")).toBeInTheDocument();
+  expect(radio).toHaveAttribute("aria-checked", "true");
+
+  // Swap back to the native input while the radio is checked so the swapped
+  // element mounts as a controlled checked radio right away.
+  await click(q.button.ensure("Use native radio"));
+
+  const nativeRadio = q.radio.ensure("orange");
+  expect(nativeRadio).toHaveAttribute("type", "radio");
+  expect(nativeRadio).toHaveAttribute("aria-checked", "true");
+
+  await click(q.radio.ensure("apple"));
+  expect(q.text("fruit: apple")).toBeInTheDocument();
+});
+
+// https://github.com/ariakit/ariakit/issues/6336
 test("button keeps role and keyboard activation after swapping the render element", async () => {
   await click(q.button.ensure("Submit"));
   expect(q.text("submit clicks: 1")).toBeInTheDocument();

--- a/app/src/sandbox/checkbox-button-combobox-6336/test.ts
+++ b/app/src/sandbox/checkbox-button-combobox-6336/test.ts
@@ -1,0 +1,91 @@
+import { click, press, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// https://github.com/ariakit/ariakit/issues/6336
+test("checkbox keeps role and toggling after swapping the render element", async () => {
+  await click(q.checkbox.ensure("Accept terms"));
+  expect(q.text("checked: true")).toBeInTheDocument();
+
+  await click(q.button.ensure("Use custom checkbox"));
+
+  const checkbox = q.checkbox.ensure("Accept terms");
+  expect(checkbox).not.toHaveAttribute("type");
+  expect(checkbox).toHaveAttribute("tabindex", "0");
+
+  await click(checkbox);
+  expect(q.text("checked: false")).toBeInTheDocument();
+
+  await press.Space(checkbox);
+  expect(q.text("checked: true")).toBeInTheDocument();
+
+  await click(q.button.ensure("Use native checkbox"));
+
+  const nativeCheckbox = q.checkbox.ensure("Accept terms");
+  expect(nativeCheckbox).toHaveAttribute("type", "checkbox");
+
+  await click(nativeCheckbox);
+  expect(q.text("checked: false")).toBeInTheDocument();
+});
+
+// https://github.com/ariakit/ariakit/issues/6336
+test("button keeps role and keyboard activation after swapping the render element", async () => {
+  await click(q.button.ensure("Submit"));
+  expect(q.text("submit clicks: 1")).toBeInTheDocument();
+
+  await click(q.button.ensure("Use custom submit"));
+
+  const button = q.button.ensure("Submit");
+  expect(button).not.toHaveAttribute("type");
+  expect(button).toHaveAttribute("tabindex", "0");
+
+  await click(button);
+  expect(q.text("submit clicks: 2")).toBeInTheDocument();
+
+  await press.Enter(button);
+  expect(q.text("submit clicks: 3")).toBeInTheDocument();
+
+  await press.Space(button);
+  expect(q.text("submit clicks: 4")).toBeInTheDocument();
+
+  await click(q.button.ensure("Use native submit"));
+
+  const nativeButton = q.button.ensure("Submit");
+  expect(nativeButton).toHaveAttribute("type", "button");
+
+  await click(nativeButton);
+  expect(q.text("submit clicks: 5")).toBeInTheDocument();
+});
+
+// https://github.com/ariakit/ariakit/issues/6336
+test("button regains native button props after swapping from a custom element", async () => {
+  await click(q.button.ensure("Save"));
+  expect(q.text("save clicks: 1")).toBeInTheDocument();
+
+  await click(q.button.ensure("Use native save"));
+
+  const button = q.button.ensure("Save");
+  expect(button).toHaveAttribute("type", "button");
+  expect(button).not.toHaveAttribute("role");
+
+  await click(button);
+  expect(q.text("save clicks: 2")).toBeInTheDocument();
+});
+
+// https://github.com/ariakit/ariakit/issues/6336
+test("combobox list updates aria-multiselectable after swapping the render element", async () => {
+  expect(q.listbox.ensure("Fruits")).toHaveAttribute(
+    "aria-multiselectable",
+    "true",
+  );
+
+  await click(q.button.ensure("Use dialog list"));
+
+  expect(q.dialog.ensure("Fruits")).not.toHaveAttribute("aria-multiselectable");
+
+  await click(q.button.ensure("Use listbox list"));
+
+  expect(q.listbox.ensure("Fruits")).toHaveAttribute(
+    "aria-multiselectable",
+    "true",
+  );
+});

--- a/packages/ariakit-react-components/src/button/button.tsx
+++ b/packages/ariakit-react-components/src/button/button.tsx
@@ -29,15 +29,30 @@ type HTMLType = HTMLElementTagNameMap[TagName];
 export const useButton = createHook<TagName, ButtonOptions>(
   function useButton(props) {
     const ref = useRef<HTMLType>(null);
-    const tagName = useTagName(ref, TagName);
+    // Pass the render hint so host element swaps resolve the tag name in the
+    // same render. For Button, this makes the anchor check below immediate on
+    // swaps to render={<a />}, and seeds the isNativeButton initial state
+    // correctly on the first render (including SSR) when the render prop is a
+    // non-button host element. See
+    // https://github.com/ariakit/ariakit/issues/6336
+    const tagName = useTagName(ref, TagName, props.render);
     const [isNativeButton, setIsNativeButton] = useState(
       () => !!tagName && isButton({ tagName, type: props.type }),
     );
 
+    // No dependency array so the check re-runs on every render: the render
+    // prop can swap the underlying DOM node without remounting the component.
+    // The equality guard skips the state update entirely in the steady state —
+    // scheduling even a bailed-out update on every commit trips React 18's
+    // synchronous work loop. See
+    // https://github.com/ariakit/ariakit/issues/6336
+    // oxlint-disable-next-line exhaustive-deps
     useEffect(() => {
       if (!ref.current) return;
-      setIsNativeButton(isButton(ref.current));
-    }, []);
+      const nextIsNativeButton = isButton(ref.current);
+      if (nextIsNativeButton === isNativeButton) return;
+      setIsNativeButton(nextIsNativeButton);
+    });
 
     props = {
       role: !isNativeButton && tagName !== "a" ? "button" : undefined,

--- a/packages/ariakit-react-components/src/button/button.tsx
+++ b/packages/ariakit-react-components/src/button/button.tsx
@@ -1,5 +1,6 @@
 import {
   useMergeRefs,
+  useSafeLayoutEffect,
   useTagName,
   createElement,
   createHook,
@@ -8,7 +9,7 @@ import {
 import type { Props } from "@ariakit/react-utils";
 import { isButton } from "@ariakit/utils";
 import type { ElementType } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import type { CommandOptions } from "../command/command.tsx";
 import { useCommand } from "../command/command.tsx";
 
@@ -40,19 +41,20 @@ export const useButton = createHook<TagName, ButtonOptions>(
       () => !!tagName && isButton({ tagName, type: props.type }),
     );
 
-    // No dependency array so the check re-runs on every render: the render
-    // prop can swap the underlying DOM node without remounting the component.
-    // The equality guard skips the state update entirely in the steady state —
-    // scheduling even a bailed-out update on every commit trips React 18's
-    // synchronous work loop. See
+    // Re-check the element whenever the render prop changes: it can swap the
+    // underlying DOM node without remounting the component, and depending on
+    // the render prop keeps the effect mount-only for components without one.
+    // Layout timing keeps the role prop correct before paint, and the
+    // equality guard skips the state update entirely while the result is
+    // unchanged — scheduling even a bailed-out update on every commit trips
+    // React 18's synchronous work loop. See
     // https://github.com/ariakit/ariakit/issues/6336
-    // oxlint-disable-next-line exhaustive-deps
-    useEffect(() => {
+    useSafeLayoutEffect(() => {
       if (!ref.current) return;
       const nextIsNativeButton = isButton(ref.current);
       if (nextIsNativeButton === isNativeButton) return;
       setIsNativeButton(nextIsNativeButton);
-    });
+    }, [props.render, props.type, isNativeButton]);
 
     props = {
       role: !isNativeButton && tagName !== "a" ? "button" : undefined,

--- a/packages/ariakit-react-components/src/checkbox/checkbox.tsx
+++ b/packages/ariakit-react-components/src/checkbox/checkbox.tsx
@@ -82,7 +82,11 @@ export const useCheckbox = createHook<TagName, CheckboxOptions>(
     });
 
     const ref = useRef<HTMLType>(null);
-    const tagName = useTagName(ref, TagName);
+    // Pass the render prop so host element swaps (render={<div />} to
+    // render={<input />}) resolve the tag name in the same render, keeping
+    // the type/checked props consistent from the swapped element's first
+    // commit. See https://github.com/ariakit/ariakit/issues/6336
+    const tagName = useTagName(ref, TagName, props.render);
     const nativeCheckbox = isNativeCheckbox(tagName, props.type);
     const mixed = checked ? checked === "mixed" : undefined;
     const isChecked = checked === "mixed" ? false : checked;

--- a/packages/ariakit-react-components/src/command/command.tsx
+++ b/packages/ariakit-react-components/src/command/command.tsx
@@ -66,10 +66,19 @@ export const useCommand = createHook<TagName, CommandOptions>(
     const ref = useRef<HTMLType>(null);
     const [isNativeButton, setIsNativeButton] = useState(false);
 
+    // No dependency array so the check re-runs on every render: the render
+    // prop can swap the underlying DOM node without remounting the component.
+    // The equality guard skips the state update entirely in the steady state —
+    // scheduling even a bailed-out update on every commit trips React 18's
+    // synchronous work loop. See
+    // https://github.com/ariakit/ariakit/issues/6336
+    // oxlint-disable-next-line exhaustive-deps
     useEffect(() => {
       if (!ref.current) return;
-      setIsNativeButton(isButton(ref.current));
-    }, []);
+      const nextIsNativeButton = isButton(ref.current);
+      if (nextIsNativeButton === isNativeButton) return;
+      setIsNativeButton(nextIsNativeButton);
+    });
 
     const [active, setActive] = useState(false);
     const activeRef = useRef(false);

--- a/packages/ariakit-react-components/src/command/command.tsx
+++ b/packages/ariakit-react-components/src/command/command.tsx
@@ -18,7 +18,7 @@ import {
   isFirefox,
 } from "@ariakit/utils";
 import type { ElementType, KeyboardEvent } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import type { FocusableOptions } from "../focusable/focusable.tsx";
 import { useFocusable } from "../focusable/focusable.tsx";
 
@@ -66,19 +66,20 @@ export const useCommand = createHook<TagName, CommandOptions>(
     const ref = useRef<HTMLType>(null);
     const [isNativeButton, setIsNativeButton] = useState(false);
 
-    // No dependency array so the check re-runs on every render: the render
-    // prop can swap the underlying DOM node without remounting the component.
-    // The equality guard skips the state update entirely in the steady state —
-    // scheduling even a bailed-out update on every commit trips React 18's
-    // synchronous work loop. See
+    // Re-check the element whenever the render prop changes: it can swap the
+    // underlying DOM node without remounting the component, and depending on
+    // the render prop keeps the effect mount-only for components without one.
+    // Layout timing keeps the type prop correct before paint, and the
+    // equality guard skips the state update entirely while the result is
+    // unchanged — scheduling even a bailed-out update on every commit trips
+    // React 18's synchronous work loop. See
     // https://github.com/ariakit/ariakit/issues/6336
-    // oxlint-disable-next-line exhaustive-deps
-    useEffect(() => {
+    useSafeLayoutEffect(() => {
       if (!ref.current) return;
       const nextIsNativeButton = isButton(ref.current);
       if (nextIsNativeButton === isNativeButton) return;
       setIsNativeButton(nextIsNativeButton);
-    });
+    }, [props.render, props.type, isNativeButton]);
 
     const [active, setActive] = useState(false);
     const activeRef = useRef(false);

--- a/packages/ariakit-react-components/src/focusable/focusable.tsx
+++ b/packages/ariakit-react-components/src/focusable/focusable.tsx
@@ -400,6 +400,13 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
     const [safariTabIndex, setSafariTabIndex] = useState(false);
 
     if (isSafariBrowser) {
+      // No dependency array so the check re-runs on every render: the render
+      // prop can swap the underlying DOM node without remounting the
+      // component. The equality guard skips the state update entirely in the
+      // steady state — scheduling even a bailed-out update on every commit
+      // trips React 18's synchronous work loop. See
+      // https://github.com/ariakit/ariakit/issues/6336
+      // oxlint-disable-next-line exhaustive-deps
       useEffect(() => {
         if (!focusable) return;
         const element = ref.current;
@@ -408,8 +415,10 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
         const isNativeCheckboxOrRadio =
           element.tagName === "INPUT" &&
           (type === "checkbox" || type === "radio");
-        setSafariTabIndex(isButton(element) || isNativeCheckboxOrRadio);
-      }, [focusable]);
+        const nextSafariTabIndex = isButton(element) || isNativeCheckboxOrRadio;
+        if (nextSafariTabIndex === safariTabIndex) return;
+        setSafariTabIndex(nextSafariTabIndex);
+      });
     }
 
     const styleProp = props.style;

--- a/packages/ariakit-react-components/src/focusable/focusable.tsx
+++ b/packages/ariakit-react-components/src/focusable/focusable.tsx
@@ -2,6 +2,7 @@ import {
   useEvent,
   useMergeRefs,
   useMetadataProps,
+  useSafeLayoutEffect,
   useTagName,
   createElement,
   createHook,
@@ -390,7 +391,11 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
       });
     });
 
-    const tagName = useTagName(ref);
+    // Pass the render prop so the tag name stays in sync when the render prop
+    // swaps the underlying element, keeping the native tabbable and disabled
+    // support checks below correct. See
+    // https://github.com/ariakit/ariakit/issues/6336
+    const tagName = useTagName(ref, undefined, props.render);
     const nativeTabbable = focusable && isNativeTabbable(tagName);
     const supportsDisabled = focusable && supportsDisabledAttribute(tagName);
 
@@ -400,14 +405,14 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
     const [safariTabIndex, setSafariTabIndex] = useState(false);
 
     if (isSafariBrowser) {
-      // No dependency array so the check re-runs on every render: the render
-      // prop can swap the underlying DOM node without remounting the
-      // component. The equality guard skips the state update entirely in the
-      // steady state — scheduling even a bailed-out update on every commit
-      // trips React 18's synchronous work loop. See
+      // Re-check the element whenever the render prop changes: it can swap
+      // the underlying DOM node without remounting the component, and
+      // depending on the render prop keeps the effect mount-only for
+      // components without one. The equality guard skips the state update
+      // entirely while the result is unchanged — scheduling even a bailed-out
+      // update on every commit trips React 18's synchronous work loop. See
       // https://github.com/ariakit/ariakit/issues/6336
-      // oxlint-disable-next-line exhaustive-deps
-      useEffect(() => {
+      useSafeLayoutEffect(() => {
         if (!focusable) return;
         const element = ref.current;
         if (!element) return;
@@ -418,7 +423,7 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
         const nextSafariTabIndex = isButton(element) || isNativeCheckboxOrRadio;
         if (nextSafariTabIndex === safariTabIndex) return;
         setSafariTabIndex(nextSafariTabIndex);
-      });
+      }, [focusable, props.render, safariTabIndex]);
     }
 
     const styleProp = props.style;

--- a/packages/ariakit-react-components/src/form/form.tsx
+++ b/packages/ariakit-react-components/src/form/form.tsx
@@ -156,7 +156,11 @@ export const useForm = createHook<TagName, FormOptions>(function useForm({
     [store],
   );
 
-  const tagName = useTagName(ref, TagName);
+  // Pass the render prop so host element swaps (render={<div />} to
+  // render={<form />}) resolve the tag name in the same render, keeping the
+  // role fallback correct from the element's first commit. See
+  // https://github.com/ariakit/ariakit/issues/6336
+  const tagName = useTagName(ref, TagName, props.render);
 
   props = {
     role: tagName !== "form" ? "form" : undefined,

--- a/packages/ariakit-react-components/src/heading/heading.tsx
+++ b/packages/ariakit-react-components/src/heading/heading.tsx
@@ -32,7 +32,11 @@ export const useHeading = createHook<TagName, HeadingOptions>(
     const ref = useRef<HTMLType>(null);
     const level: HeadingLevels = useContext(HeadingContext) || 1;
     const Element = `h${level}` as const;
-    const tagName = useTagName(ref, Element);
+    // Pass the render prop so host element swaps (render={<div />} to a
+    // native heading) resolve the tag name in the same render, keeping the
+    // role and aria-level fallbacks correct from the element's first commit.
+    // See https://github.com/ariakit/ariakit/issues/6336
+    const tagName = useTagName(ref, Element, props.render);
     const isNativeHeading = !!tagName && /^h\d$/.test(tagName);
 
     props = {

--- a/packages/ariakit-react-components/src/radio/radio.tsx
+++ b/packages/ariakit-react-components/src/radio/radio.tsx
@@ -88,7 +88,11 @@ export const useRadio = createHook<TagName, RadioOptions>(function useRadio({
   }, [store, isChecked, id]);
 
   const onChangeProp = props.onChange;
-  const tagName = useTagName(ref, TagName);
+  // Pass the render prop so host element swaps (render={<div />} to
+  // render={<input />}) resolve the tag name in the same render, keeping
+  // the type/checked props consistent from the swapped element's first
+  // commit. See https://github.com/ariakit/ariakit/issues/6336
+  const tagName = useTagName(ref, TagName, props.render);
   const nativeRadio = isNativeRadio(tagName, props.type);
   const disabled = disabledFromProps(props);
   // When the checked property is programmatically set on the change event, we

--- a/packages/ariakit-react-utils/readme.md
+++ b/packages/ariakit-react-utils/readme.md
@@ -212,6 +212,7 @@ Uses React's useDeferredValue if available.
 function useTagName(
   refOrElement?: RefObject<HTMLElement | null> | HTMLElement | null,
   type?: string | ComponentType,
+  render?: unknown,
 ): string | undefined;
 ```
 

--- a/packages/ariakit-react-utils/src/hooks.ts
+++ b/packages/ariakit-react-utils/src/hooks.ts
@@ -203,14 +203,15 @@ export function useDeferredValue<T>(value: T): T {
  * Returns the tag name by parsing an element ref.
  * @param refOrElement The element or a ref pointing to it.
  * @param type The fallback tag name used until the element is available.
- * @param render An optional `render` prop. When it's a host element (for
- * example, `<div />`), its tag name is returned right away, so consumers get
- * the correct tag name during render, even before the element is committed to
- * the DOM or when the render prop swaps the underlying element. A nullish
- * render prop provides no hint: hooks like `useCheckbox` can be composed by
- * components that render a different default element (for example,
- * `MenuItemCheckbox` renders a `div`), so only an explicit host element is
- * authoritative at this layer.
+ * @param render The component's `render` prop, which keeps the tag name in
+ * sync when the render prop swaps the underlying element. When it's a host
+ * element (for example, `<div />`), its tag name is also returned right away,
+ * so consumers get the correct tag name during render, even before the
+ * element is committed to the DOM. A nullish render prop provides no
+ * render-time hint: hooks like `useCheckbox` can be composed by components
+ * that render a different default element (for example, `MenuItemCheckbox`
+ * renders a `div`), so only an explicit host element is authoritative at this
+ * layer.
  * @example
  * function Component(props) {
  *   const ref = React.useRef();
@@ -230,13 +231,19 @@ export function useTagName(
 
   const [tagName, setTagName] = useState(() => stringOrUndefined(type));
 
-  // The effect has no dependency array so it re-reads the committed element
-  // on every render: the composition API can swap the underlying DOM node
-  // without remounting the component (and without changing the ref object's
-  // identity), so a mount-only read would go stale. The equality guard skips
-  // the state update entirely in the steady state — scheduling even a
-  // bailed-out update on every commit trips React 18's synchronous work loop.
-  // See https://github.com/ariakit/ariakit/issues/6336
+  // Re-read the committed element whenever the render prop changes: the
+  // composition API can swap the underlying DOM node without remounting the
+  // component (and without changing the ref object's identity), so a
+  // mount-only read would go stale, and any such swap comes from a render
+  // that received a different render prop value (inline render elements and
+  // functions change identity every render; the one exception is a hoisted
+  // stable-identity render function whose output tag depends on outer state).
+  // Depending on the render prop (rather than omitting the dependency array)
+  // keeps this effect mount-only for components without a render prop, so
+  // large collections don't pay a per-commit cost. The equality guard skips
+  // the state update entirely while the tag name is unchanged — scheduling
+  // even a bailed-out update on every commit trips React 18's synchronous
+  // work loop. See https://github.com/ariakit/ariakit/issues/6336
   useSafeLayoutEffect(() => {
     const element =
       refOrElement && "current" in refOrElement
@@ -246,7 +253,7 @@ export function useTagName(
       element?.tagName.toLowerCase() || stringOrUndefined(type);
     if (nextTagName === tagName) return;
     setTagName(nextTagName);
-  });
+  }, [refOrElement, type, render, tagName]);
 
   // Prefer the render prop's host element type when available: it reflects
   // the element that will be committed by the current render, whereas the

--- a/packages/ariakit-react-utils/src/hooks.ts
+++ b/packages/ariakit-react-utils/src/hooks.ts
@@ -18,6 +18,7 @@ import type {
 } from "react";
 import * as React from "react";
 import {
+  isValidElement,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -200,6 +201,16 @@ export function useDeferredValue<T>(value: T): T {
 
 /**
  * Returns the tag name by parsing an element ref.
+ * @param refOrElement The element or a ref pointing to it.
+ * @param type The fallback tag name used until the element is available.
+ * @param render An optional `render` prop. When it's a host element (for
+ * example, `<div />`), its tag name is returned right away, so consumers get
+ * the correct tag name during render, even before the element is committed to
+ * the DOM or when the render prop swaps the underlying element. A nullish
+ * render prop provides no hint: hooks like `useCheckbox` can be composed by
+ * components that render a different default element (for example,
+ * `MenuItemCheckbox` renders a `div`), so only an explicit host element is
+ * authoritative at this layer.
  * @example
  * function Component(props) {
  *   const ref = React.useRef();
@@ -210,6 +221,7 @@ export function useDeferredValue<T>(value: T): T {
 export function useTagName(
   refOrElement?: RefObject<HTMLElement | null> | HTMLElement | null,
   type?: string | ComponentType,
+  render?: unknown,
 ) {
   const stringOrUndefined = (type?: string | ComponentType) => {
     if (typeof type !== "string") return;
@@ -218,13 +230,33 @@ export function useTagName(
 
   const [tagName, setTagName] = useState(() => stringOrUndefined(type));
 
+  // The effect has no dependency array so it re-reads the committed element
+  // on every render: the composition API can swap the underlying DOM node
+  // without remounting the component (and without changing the ref object's
+  // identity), so a mount-only read would go stale. The equality guard skips
+  // the state update entirely in the steady state — scheduling even a
+  // bailed-out update on every commit trips React 18's synchronous work loop.
+  // See https://github.com/ariakit/ariakit/issues/6336
   useSafeLayoutEffect(() => {
     const element =
       refOrElement && "current" in refOrElement
         ? refOrElement.current
         : refOrElement;
-    setTagName(element?.tagName.toLowerCase() || stringOrUndefined(type));
-  }, [refOrElement, type]);
+    const nextTagName =
+      element?.tagName.toLowerCase() || stringOrUndefined(type);
+    if (nextTagName === tagName) return;
+    setTagName(nextTagName);
+  });
+
+  // Prefer the render prop's host element type when available: it reflects
+  // the element that will be committed by the current render, whereas the
+  // state above lags one commit behind on swaps. This lets consumers compute
+  // element-dependent props (such as a checkbox's type and checked props) in
+  // the same render that swaps the element, avoiding React's
+  // uncontrolled-to-controlled input warning.
+  if (isValidElement(render) && typeof render.type === "string") {
+    return render.type.toLowerCase();
+  }
 
   return tagName;
 }
@@ -245,12 +277,26 @@ export function useAttribute(
 ) {
   const initialValue = useInitialValue(defaultValue);
   const [attribute, setAttribute] = useState(initialValue);
+  const [element, setElement] = useState<HTMLElement | null>(null);
 
-  useEffect(() => {
-    const element =
+  // Snapshot the committed element into state on every render so the observer
+  // effect below is keyed on the actual DOM node rather than the stable ref
+  // object: the composition API can swap the underlying element without
+  // remounting the component, and the observer must detach from the old node
+  // and re-attach to the new one. The equality guard skips the state update
+  // entirely in the steady state — scheduling even a bailed-out update on
+  // every commit trips React 18's synchronous work loop. See
+  // https://github.com/ariakit/ariakit/issues/6336
+  useSafeLayoutEffect(() => {
+    const nextElement =
       refOrElement && "current" in refOrElement
         ? refOrElement.current
         : refOrElement;
+    if (nextElement === element) return;
+    setElement(nextElement);
+  });
+
+  useEffect(() => {
     if (!element) return;
 
     const callback = () => {
@@ -264,7 +310,7 @@ export function useAttribute(
     callback();
 
     return () => observer.disconnect();
-  }, [refOrElement, attributeName, initialValue]);
+  }, [element, attributeName, initialValue]);
 
   return attribute;
 }


### PR DESCRIPTION
## Motivation

Fixes #6336.

When the element passed to the `render` prop changes type while the component stays mounted, Ariakit components keep the props computed for the previous element:

```tsx
<Ariakit.Checkbox
  checked={checked}
  onChange={() => setChecked(!checked)}
  render={custom ? <div /> : <input />}
/>
```

After swapping from `<input />` to `<div />`, the `<div>` has no `role="checkbox"` (it disappears from the accessibility tree), no `tabindex`, a stale `type="checkbox"` attribute, and clicking it no longer toggles the checked state.

The root cause is in `useTagName` and `useAttribute` in `@ariakit/react-utils`: they read `ref.current` inside effects whose dependency arrays only contain the ref object's identity. A `useRef` object is stable for the component's lifetime, so those effects run once after mount and never again — but the composition API attaches a brand-new DOM node to the same ref object when the render element's type changes, without remounting the component.

The same stale pattern affects `Radio` (`nativeRadio`), `Form` (`role="form"` fallback), `Button` and `Command` (`isNativeButton`, set in separate mount-only effects), `Focusable` (`nativeTabbable`/`supportsDisabled` and the Safari `tabindex` workaround), and `ComboboxList` (whose `MutationObserver` keeps watching the detached node, freezing the observed `role` and therefore `aria-multiselectable`).

## Solution

Two complementary changes in `@ariakit/react-utils`, plus the same treatment for the standalone mount-only effects in `@ariakit/react-components`:

- **`useTagName`** re-reads the committed element whenever the `render` prop changes (the effect depends on the `render` prop value instead of only the stable ref object). Any element swap comes from a render that received a different `render` prop value — inline render elements change identity every render — so the layout effect always sees the current node, while components without a `render` prop keep a mount-only effect and pay no per-commit cost (an earlier deps-less variant regressed the composite mount bench by ~10% scripting). An equality guard skips the `setState` call entirely while the value is unchanged: relying on React's internal bailout is not enough, because scheduling an update from a layout effect on every commit trips React 18's synchronous work loop ("Should not already be working" crashes in the React 18 suite; React 19 is unaffected). The same deps-plus-guard pattern applies to every re-detection effect in this PR.
- **`useTagName` also accepts the `render` prop as an optional hint.** When `render` is a plain host element (e.g. `<input />`), its tag name is returned during render — one commit earlier than the DOM read. `Checkbox`, `Radio`, `Button`, `Form`, `Heading`, and `Focusable` pass `props.render`. For `Checkbox`/`Radio` this is load-bearing: they compute controlled-input props (`type`/`checked`) from the tag name, and without the render-time hint, an element swapped back to `render={<input />}` would mount as a typeless input for one commit and then flip to `type="checkbox"`/`type="radio"`, triggering React's "changing an uncontrolled input to be controlled" dev warning (React's controlled check is `type`-dependent). The happy-dom tests enforce this via `vitest-fail-on-console`. For `Button`, the hint makes the anchor check immediate and seeds the `isNativeButton` initial state correctly on the first render (including SSR) for custom-first buttons. For `Form` and `Heading`, it makes the `role` (and `aria-level`) fallbacks correct from the element's first commit when rendering custom host elements. Only an explicit host element is authoritative: a nullish `render` prop deliberately provides no hint, because hooks like `useCheckbox` are composed by components that render a different default element (`MenuItemCheckbox` renders a `div`) — an earlier `props.render ?? TagName` variant broke exactly those (21 suite failures across `menu-item-checkbox`, `menu-item-radio`, `menu-values`, and `menu-nested-combobox` tests).
- **`useAttribute`** snapshots the committed element into state via a deps-less layout effect and keys the `MutationObserver` effect on that element, so the observer detaches from the swapped-out node and re-attaches to the new one (fixes frozen `role`/`aria-multiselectable` in `ComboboxList`).
- **`Button`, `Command`, and `Focusable` (Safari `tabindex` path)** get the same render-prop-keyed, equality-guarded treatment for their previously mount-only element-detection effects (`isNativeButton`, `safariTabIndex`), now on layout timing so the derived `role`/`type`/`tabindex` props are correct before paint.

The repro sandbox at `app/src/sandbox/checkbox-button-combobox-6336/` covers `Checkbox`, `Radio`, `Button` (both swap directions), and `ComboboxList` with Playwright browser tests and a faster happy-dom duplicate, asserting restored `role`, removed stale `type`, `tabindex`, click/keyboard toggling, and updated `aria-multiselectable`.

## Test coverage notes

- The first repro commit shows the original four scenarios failing in CI (4 happy-dom tests, 12 Playwright tests across chrome/firefox/safari), each at the assertion documenting the stale behavior.
- The `Radio` scenario was added with the fix commit. Verified red without the fix (fails at the `role="radio"` query, like the checkbox), and red with a deps-only fix that lacks the `Radio` render-time hint (fails via the uncontrolled-to-controlled console error on swap-back while checked).
- `test-safari.ts` pins the `Focusable` Safari `tabindex` re-detection. It cannot be red before any fix — with everything stale, the non-native `tagName` path forces `tabindex="0"` anyway, masking the Safari path — so its red state was verified against a partial fix (hooks/button/command fixed, `Focusable` Safari effect still mount-only): it fails at the `tabindex` assertion there and passes with the full fix.
- The checkbox/button swap-back legs pass even without the fix once the swap-forward assertions are fixed (state frozen at initial-native values); the reversed `Save` scenario provides the genuinely-red custom-to-native coverage.

## Known limitation

Swapping from a host render element back to **no `render` prop at all** (`render={custom ? <div /> : undefined}`) still logs the one-commit "changing an uncontrolled input to be controlled" dev warning for `Checkbox`/`Radio` while checked. When `render` is nullish, the upcoming element type is unknowable inside the shared hook — the same `useCheckbox` is rendered as an `input` by `Checkbox` but as a `div` by `MenuItemCheckbox` — so no render-time default can be assumed (a `props.render ?? TagName` attempt broke the menu item components). The deps-less effect still corrects all props one commit later, so behavior and accessibility recover; only the transient dev warning remains for that specific swap form. Swapping between two explicit render elements (as in the issue's repro) is warning-free.

Because re-detection is keyed on the `render` prop value, a hoisted render function with stable identity whose output element type changes based on outer state (rather than on the props it receives) will not trigger re-detection. Inline render functions and render elements — the overwhelmingly common forms — change identity on every render and are always caught.

## Workaround

Until the fix is released, key the component by its rendering mode so React remounts it when the render element type changes, which re-runs the one-shot tag detection:

```tsx
// TODO: Remove the key workaround when
// https://github.com/ariakit/ariakit/issues/6336 is fixed.
<Ariakit.Checkbox
  key={custom ? "custom" : "native"}
  checked={checked}
  onChange={() => setChecked(!checked)}
  render={custom ? <div /> : <input />}
/>
```

The same `key` technique applies to the other affected components (`Button`, `Radio`, `Form`, `ComboboxList`, and anything composed from `Focusable`). Note the tradeoff of the remount: uncontrolled internal state and DOM focus on the remounted element are reset, so keep the relevant state controlled in a parent (as above, where `checked` lives in the parent) or in a provider so it survives the swap.
