### PR TITLE
Fix Radio onChange event on arrow-key selection

### DIFF
--- a/.changeset/300-radio-onchange-arrow-key.md
+++ b/.changeset/300-radio-onchange-arrow-key.md
@@ -1,0 +1,10 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Radio `onChange` event on arrow-key selection
+
+Selecting a native [`Radio`](https://ariakit.com/reference/radio) or [`FormRadio`](https://ariakit.com/reference/form-radio) with arrow keys now delivers a real `change` event with `event.target.checked` already set to `true`, matching pointer and Space selection. Previously, the handler received the focus event while `checked` was still `false`, which silently broke handlers gated on `event.target.checked`.
+
+Since arrow-key selection now replays the browser's native activation, `onClick` handlers also fire when a native radio is selected with arrow keys, matching native radio group behavior.

--- a/app/src/sandbox/radio-6345/index.react.tsx
+++ b/app/src/sandbox/radio-6345/index.react.tsx
@@ -5,13 +5,14 @@ import { useState } from "react";
 export default function Example() {
   const [fruit, setFruit] = useState("none");
 
-  // Standard React radio idiom: commit the value only when the radio that
-  // fired the event is checked. Arrow-key selection silently defeats this
-  // gate because the forwarded focus event still has checked === false.
+  // Commit the value unconditionally instead of gating on
+  // event.target.checked: arrow-key selection forwards a focus event where
+  // checked is still false, and Ariakit only calls onChange for the radio
+  // that is becoming checked anyway.
+  // TODO: Remove once https://github.com/ariakit/ariakit/issues/6345 is
+  // fixed and go back to the checked-gated handler.
   function onChange(event: ChangeEvent<HTMLInputElement>) {
-    if (event.target.checked) {
-      setFruit(event.target.value);
-    }
+    setFruit(event.target.value);
   }
 
   return (

--- a/app/src/sandbox/radio-6345/index.react.tsx
+++ b/app/src/sandbox/radio-6345/index.react.tsx
@@ -1,0 +1,35 @@
+import * as Ariakit from "@ariakit/react";
+import type { ChangeEvent } from "react";
+import { useState } from "react";
+
+export default function Example() {
+  const [fruit, setFruit] = useState("none");
+
+  // Standard React radio idiom: commit the value only when the radio that
+  // fired the event is checked. Arrow-key selection silently defeats this
+  // gate because the forwarded focus event still has checked === false.
+  function onChange(event: ChangeEvent<HTMLInputElement>) {
+    if (event.target.checked) {
+      setFruit(event.target.value);
+    }
+  }
+
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <Ariakit.RadioProvider>
+        <Ariakit.RadioGroup aria-label="Fruits">
+          <label>
+            <Ariakit.Radio value="apple" onChange={onChange} /> apple
+          </label>
+          <label>
+            <Ariakit.Radio value="orange" onChange={onChange} /> orange
+          </label>
+          <label>
+            <Ariakit.Radio value="watermelon" onChange={onChange} /> watermelon
+          </label>
+        </Ariakit.RadioGroup>
+      </Ariakit.RadioProvider>
+      <output>Selected fruit: {fruit}</output>
+    </div>
+  );
+}

--- a/app/src/sandbox/radio-6345/index.react.tsx
+++ b/app/src/sandbox/radio-6345/index.react.tsx
@@ -5,14 +5,14 @@ import { useState } from "react";
 export default function Example() {
   const [fruit, setFruit] = useState("none");
 
-  // Commit the value unconditionally instead of gating on
-  // event.target.checked: arrow-key selection forwards a focus event where
-  // checked is still false, and Ariakit only calls onChange for the radio
-  // that is becoming checked anyway.
-  // TODO: Remove once https://github.com/ariakit/ariakit/issues/6345 is
-  // fixed and go back to the checked-gated handler.
+  // Standard React radio idiom: commit the value only when the radio that
+  // fired the event is checked. Arrow-key selection used to silently defeat
+  // this gate because the forwarded focus event still had checked === false.
+  // See https://github.com/ariakit/ariakit/issues/6345
   function onChange(event: ChangeEvent<HTMLInputElement>) {
-    setFruit(event.target.value);
+    if (event.target.checked) {
+      setFruit(event.target.value);
+    }
   }
 
   return (

--- a/app/src/sandbox/radio-6345/test-browser.ts
+++ b/app/src/sandbox/radio-6345/test-browser.ts
@@ -1,0 +1,20 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6345
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("onChange commits the value on arrow-key selection", async ({ q }) => {
+    await q.radio("apple").click();
+    await test.expect(q.radio("apple")).toBeChecked();
+    await test.expect(q.text("Selected fruit: apple")).toBeVisible();
+
+    await q.radio("apple").press("ArrowDown");
+    await test.expect(q.radio("orange")).toBeFocused();
+    await test.expect(q.radio("orange")).toBeChecked();
+    await test.expect(q.text("Selected fruit: orange")).toBeVisible();
+
+    await q.radio("orange").press("ArrowUp");
+    await test.expect(q.radio("apple")).toBeFocused();
+    await test.expect(q.radio("apple")).toBeChecked();
+    await test.expect(q.text("Selected fruit: apple")).toBeVisible();
+  });
+});

--- a/app/src/sandbox/radio-6345/test.ts
+++ b/app/src/sandbox/radio-6345/test.ts
@@ -1,0 +1,22 @@
+import { click, press, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6345
+test("onChange commits the value on arrow-key selection", async () => {
+  const apple = q.radio.ensure("apple");
+  const orange = q.radio.ensure("orange");
+
+  await click(apple);
+  expect(apple).toBeChecked();
+  expect(q.text("Selected fruit: apple")).toBeInTheDocument();
+
+  await press.ArrowDown();
+  expect(orange).toHaveFocus();
+  expect(orange).toBeChecked();
+  expect(q.text("Selected fruit: orange")).toBeInTheDocument();
+
+  await press.ArrowUp();
+  expect(apple).toHaveFocus();
+  expect(apple).toBeChecked();
+  expect(q.text("Selected fruit: apple")).toBeInTheDocument();
+});

--- a/packages/ariakit-react-components/src/radio/radio.tsx
+++ b/packages/ariakit-react-components/src/radio/radio.tsx
@@ -146,11 +146,20 @@ export const useRadio = createHook<TagName, RadioOptions>(function useRadio({
     onFocusProp?.(event);
     if (event.defaultPrevented) return;
     if (!nativeRadio) return;
+    if (disabled) return;
     if (!store) return;
     const { moves, activeId } = store.getState();
     if (!moves) return;
     if (id && activeId !== id) return;
-    onChange(event);
+    // The composite keydown handler calls preventDefault() before moving
+    // focus, which suppresses the browser's native check-on-arrow-key
+    // behavior. Replay that activation with a real click so React delivers an
+    // actual change event with checked already set, going through its
+    // controlled input state restoration. The checked guard keeps no-op focus
+    // events, such as tabbing back to the checked radio, from dispatching
+    // spurious clicks. See https://github.com/ariakit/ariakit/issues/6345
+    if (event.currentTarget.checked) return;
+    event.currentTarget.click();
   });
 
   props = {


### PR DESCRIPTION
## Motivation

The [`Radio`](https://ariakit.com/reference/radio) component's `onChange` prop delivers inconsistent events depending on how the user selects the radio. Selecting with a mouse click (or <kbd>Space</kbd>) fires a real `change` event where the browser has already set `checked`. Selecting the same radio with **arrow keys** invokes the handler with `event.type === "focus"` and `event.target.checked === false`, so the standard React radio idiom silently fails for keyboard users:

```jsx
<Ariakit.Radio
  value="orange"
  onChange={(event) => {
    // Never runs on arrow-key selection: checked is still false there.
    if (event.target.checked) {
      setFruit(event.target.value);
    }
  }}
/>
```

The radio still becomes visually checked either way (the store updates), so the consumer's state silently goes stale on every keyboard-driven selection.

Ariakit implements selection-follows-focus: the composite keydown handler calls `event.preventDefault()` before moving focus, which suppresses the browser's native check-on-arrow-key behavior. To compensate, `useRadio`'s `onFocus` forwarded the focus event into its internal `onChange`, which normalizes `checked` only for non-native radios — on the native path it assumed the browser had already set it, which is true for clicks but false here since that native behavior was just prevented.

Fixes #6345

## Solution

Replay what the browser would have done if the composite keydown handler hadn't called `preventDefault()`: instead of forwarding the focus event to `onChange`, synthesize the suppressed native activation with `event.currentTarget.click()`. React synthesizes radio `onChange` from the native click, so the keyboard path now delivers an event identical to the pointer path (`type === "change"`, `checked === true`), and a genuine click goes through React's controlled-input state restoration, keeping `preventDefault()` in consumer handlers working for the whole radio group.

Two guards keep the replay safe:

- `disabled` prevents the replay from checking a focusable-but-disabled radio (`accessibleWhenDisabled`).
- The `checked` guard keeps no-op focus events (such as tabbing back to the checked radio) from dispatching spurious clicks, preserving the one-`onChange`-per-change semantics covered by the `radio-alert-on-change` browser test.

Since the replay is a real click, consumer `onClick` handlers now also fire on arrow-key selection of native radios — matching native browser behavior; the changeset calls this out.

The `app/src/sandbox/radio-6345/` sandbox reproduces the issue with a cross-browser Playwright test and a happy-dom duplicate. Both failed before the fix (commit 1) and pass with it, along with the full React and React 18 suites and the radio-related browser tests, including `radio-alert-on-change`.

## Workaround

Until the fix is released, don't gate on `event.target.checked`. Ariakit only invokes `onChange` for the radio that is becoming checked (it skips the call when the store value already matches), so the value can be committed unconditionally:

```jsx
// TODO: Remove once https://github.com/ariakit/ariakit/issues/6345 is fixed
// and go back to the checked-gated handler.
function onChange(event: ChangeEvent<HTMLInputElement>) {
  setFruit(event.target.value);
}
```

Alternatively, skip the event entirely and read the selected value from the store ([`useStoreState`](https://ariakit.com/reference/use-store-state) with a [`useRadioStore`](https://ariakit.com/reference/use-radio-store), or `RadioProvider`'s `setValue` prop).

Verified in the sandbox: with the unconditional commit, the previously failing happy-dom test and all three Playwright browser projects pass (commit 2).
