### PR TITLE
Fix Tab setSelectedId not updating the active tab in Select/Combobox popovers

### DIFF
--- a/.changeset/300-tab-select-active-id-sync.md
+++ b/.changeset/300-tab-select-active-id-sync.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/components": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Tab`](https://ariakit.com/reference/tab) not becoming the active item on the first [`setSelectedId`](https://ariakit.com/reference/use-tab-store#setselectedid-1) call after a [`SelectPopover`](https://ariakit.com/reference/select-popover) or [`ComboboxPopover`](https://ariakit.com/reference/combobox-popover) containing the tabs opens or toggles.

--- a/app/src/sandbox/tab-select-6346/index.react.tsx
+++ b/app/src/sandbox/tab-select-6346/index.react.tsx
@@ -3,14 +3,7 @@ import * as Ariakit from "@ariakit/react";
 function BrowseTabButton(props: { tabId: string; children: string }) {
   const tab = Ariakit.useTabContext();
   return (
-    <button
-      onClick={() => {
-        tab?.setSelectedId(props.tabId);
-        // TODO: Workaround for the swallowed setSelectedId -> activeId sync.
-        // Remove once https://github.com/ariakit/ariakit/issues/6346 is fixed.
-        tab?.setActiveId(props.tabId);
-      }}
-    >
+    <button onClick={() => tab?.setSelectedId(props.tabId)}>
       {props.children}
     </button>
   );

--- a/app/src/sandbox/tab-select-6346/index.react.tsx
+++ b/app/src/sandbox/tab-select-6346/index.react.tsx
@@ -3,7 +3,14 @@ import * as Ariakit from "@ariakit/react";
 function BrowseTabButton(props: { tabId: string; children: string }) {
   const tab = Ariakit.useTabContext();
   return (
-    <button onClick={() => tab?.setSelectedId(props.tabId)}>
+    <button
+      onClick={() => {
+        tab?.setSelectedId(props.tabId);
+        // TODO: Workaround for the swallowed setSelectedId -> activeId sync.
+        // Remove once https://github.com/ariakit/ariakit/issues/6346 is fixed.
+        tab?.setActiveId(props.tabId);
+      }}
+    >
       {props.children}
     </button>
   );

--- a/app/src/sandbox/tab-select-6346/index.react.tsx
+++ b/app/src/sandbox/tab-select-6346/index.react.tsx
@@ -1,0 +1,52 @@
+import * as Ariakit from "@ariakit/react";
+
+function BrowseTabButton(props: { tabId: string; children: string }) {
+  const tab = Ariakit.useTabContext();
+  return (
+    <button onClick={() => tab?.setSelectedId(props.tabId)}>
+      {props.children}
+    </button>
+  );
+}
+
+export default function Example() {
+  return (
+    <>
+      <style>{`[data-active-item] { outline: 2px solid red; }`}</style>
+      <Ariakit.SelectProvider defaultValue="Apple" virtualFocus={false}>
+        <Ariakit.SelectLabel>Grocery</Ariakit.SelectLabel>
+        <Ariakit.Select />
+        <Ariakit.SelectPopover
+          gutter={4}
+          sameWidth
+          style={{ background: "white", border: "1px solid gray", padding: 8 }}
+        >
+          <Ariakit.TabProvider defaultSelectedId="tab-fruits">
+            <Ariakit.TabList aria-label="Categories">
+              <Ariakit.Tab id="tab-fruits">Fruits</Ariakit.Tab>
+              <Ariakit.Tab id="tab-vegetables">Vegetables</Ariakit.Tab>
+            </Ariakit.TabList>
+            <Ariakit.TabPanel tabId="tab-fruits">
+              <Ariakit.SelectList>
+                <Ariakit.SelectItem value="Apple" />
+                <Ariakit.SelectItem value="Banana" />
+              </Ariakit.SelectList>
+              <BrowseTabButton tabId="tab-vegetables">
+                Browse vegetables
+              </BrowseTabButton>
+            </Ariakit.TabPanel>
+            <Ariakit.TabPanel tabId="tab-vegetables">
+              <Ariakit.SelectList>
+                <Ariakit.SelectItem value="Carrot" />
+                <Ariakit.SelectItem value="Potato" />
+              </Ariakit.SelectList>
+              <BrowseTabButton tabId="tab-fruits">
+                Browse fruits
+              </BrowseTabButton>
+            </Ariakit.TabPanel>
+          </Ariakit.TabProvider>
+        </Ariakit.SelectPopover>
+      </Ariakit.SelectProvider>
+    </>
+  );
+}

--- a/app/src/sandbox/tab-select-6346/test-browser.ts
+++ b/app/src/sandbox/tab-select-6346/test-browser.ts
@@ -14,13 +14,15 @@ withFramework(import.meta.dirname, async ({ test }) => {
       .expect(q.tab("Vegetables"))
       .toHaveAttribute("aria-selected", "true");
     await test.expect(q.tab("Vegetables")).toHaveAttribute("data-active-item");
-    await test.expect(q.tab("Vegetables")).toHaveAttribute("tabindex", "0");
+    await test
+      .expect(q.tab("Vegetables"))
+      .not.toHaveAttribute("tabindex", "-1");
 
     await q.button("Browse fruits").click();
 
     await test.expect(q.tab("Fruits")).toHaveAttribute("aria-selected", "true");
     await test.expect(q.tab("Fruits")).toHaveAttribute("data-active-item");
-    await test.expect(q.tab("Fruits")).toHaveAttribute("tabindex", "0");
+    await test.expect(q.tab("Fruits")).not.toHaveAttribute("tabindex", "-1");
   });
 
   test("activates the tab selected by setSelectedId after the popover toggles", async ({
@@ -48,12 +50,14 @@ withFramework(import.meta.dirname, async ({ test }) => {
       .expect(q.tab("Vegetables"))
       .toHaveAttribute("aria-selected", "true");
     await test.expect(q.tab("Vegetables")).toHaveAttribute("data-active-item");
-    await test.expect(q.tab("Vegetables")).toHaveAttribute("tabindex", "0");
+    await test
+      .expect(q.tab("Vegetables"))
+      .not.toHaveAttribute("tabindex", "-1");
 
     await q.button("Browse fruits").click();
 
     await test.expect(q.tab("Fruits")).toHaveAttribute("aria-selected", "true");
     await test.expect(q.tab("Fruits")).toHaveAttribute("data-active-item");
-    await test.expect(q.tab("Fruits")).toHaveAttribute("tabindex", "0");
+    await test.expect(q.tab("Fruits")).not.toHaveAttribute("tabindex", "-1");
   });
 });

--- a/app/src/sandbox/tab-select-6346/test-browser.ts
+++ b/app/src/sandbox/tab-select-6346/test-browser.ts
@@ -1,0 +1,59 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// See https://github.com/ariakit/ariakit/issues/6346
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("activates the tab selected by setSelectedId after the popover opens", async ({
+    q,
+  }) => {
+    await q.combobox("Grocery").click();
+    await test.expect(q.tab("Fruits")).toHaveAttribute("aria-selected", "true");
+
+    await q.button("Browse vegetables").click();
+
+    await test
+      .expect(q.tab("Vegetables"))
+      .toHaveAttribute("aria-selected", "true");
+    await test.expect(q.tab("Vegetables")).toHaveAttribute("data-active-item");
+    await test.expect(q.tab("Vegetables")).toHaveAttribute("tabindex", "0");
+
+    await q.button("Browse fruits").click();
+
+    await test.expect(q.tab("Fruits")).toHaveAttribute("aria-selected", "true");
+    await test.expect(q.tab("Fruits")).toHaveAttribute("data-active-item");
+    await test.expect(q.tab("Fruits")).toHaveAttribute("tabindex", "0");
+  });
+
+  test("activates the tab selected by setSelectedId after the popover toggles", async ({
+    q,
+  }) => {
+    await q.combobox("Grocery").click();
+    await test.expect(q.tab("Fruits")).toHaveAttribute("aria-selected", "true");
+
+    await q.button("Browse vegetables").click();
+    await test
+      .expect(q.tab("Vegetables"))
+      .toHaveAttribute("aria-selected", "true");
+
+    await q.combobox("Grocery").click();
+    await test
+      .expect(q.combobox("Grocery"))
+      .toHaveAttribute("aria-expanded", "false");
+
+    await q.combobox("Grocery").click();
+    await test.expect(q.tab("Fruits")).toHaveAttribute("aria-selected", "true");
+
+    await q.button("Browse vegetables").click();
+
+    await test
+      .expect(q.tab("Vegetables"))
+      .toHaveAttribute("aria-selected", "true");
+    await test.expect(q.tab("Vegetables")).toHaveAttribute("data-active-item");
+    await test.expect(q.tab("Vegetables")).toHaveAttribute("tabindex", "0");
+
+    await q.button("Browse fruits").click();
+
+    await test.expect(q.tab("Fruits")).toHaveAttribute("aria-selected", "true");
+    await test.expect(q.tab("Fruits")).toHaveAttribute("data-active-item");
+    await test.expect(q.tab("Fruits")).toHaveAttribute("tabindex", "0");
+  });
+});

--- a/app/src/sandbox/tab-select-6346/test.ts
+++ b/app/src/sandbox/tab-select-6346/test.ts
@@ -1,0 +1,49 @@
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// See https://github.com/ariakit/ariakit/issues/6346
+test("activates the tab selected by setSelectedId after the popover opens", async () => {
+  await click(q.combobox.ensure("Grocery"));
+  expect(q.tab.ensure("Fruits")).toHaveAttribute("aria-selected", "true");
+
+  await click(q.button.ensure("Browse vegetables"));
+
+  expect(q.tab.ensure("Vegetables")).toHaveAttribute("aria-selected", "true");
+  expect(q.tab.ensure("Vegetables")).toHaveAttribute("data-active-item");
+  expect(q.tab.ensure("Vegetables")).toHaveAttribute("tabindex", "0");
+
+  await click(q.button.ensure("Browse fruits"));
+
+  expect(q.tab.ensure("Fruits")).toHaveAttribute("aria-selected", "true");
+  expect(q.tab.ensure("Fruits")).toHaveAttribute("data-active-item");
+  expect(q.tab.ensure("Fruits")).toHaveAttribute("tabindex", "0");
+});
+
+test("activates the tab selected by setSelectedId after the popover toggles", async () => {
+  await click(q.combobox.ensure("Grocery"));
+  expect(q.tab.ensure("Fruits")).toHaveAttribute("aria-selected", "true");
+
+  await click(q.button.ensure("Browse vegetables"));
+  expect(q.tab.ensure("Vegetables")).toHaveAttribute("aria-selected", "true");
+
+  await click(q.combobox.ensure("Grocery"));
+  expect(q.combobox.ensure("Grocery")).toHaveAttribute(
+    "aria-expanded",
+    "false",
+  );
+
+  await click(q.combobox.ensure("Grocery"));
+  expect(q.tab.ensure("Fruits")).toHaveAttribute("aria-selected", "true");
+
+  await click(q.button.ensure("Browse vegetables"));
+
+  expect(q.tab.ensure("Vegetables")).toHaveAttribute("aria-selected", "true");
+  expect(q.tab.ensure("Vegetables")).toHaveAttribute("data-active-item");
+  expect(q.tab.ensure("Vegetables")).toHaveAttribute("tabindex", "0");
+
+  await click(q.button.ensure("Browse fruits"));
+
+  expect(q.tab.ensure("Fruits")).toHaveAttribute("aria-selected", "true");
+  expect(q.tab.ensure("Fruits")).toHaveAttribute("data-active-item");
+  expect(q.tab.ensure("Fruits")).toHaveAttribute("tabindex", "0");
+});

--- a/app/src/sandbox/tab-select-6346/test.ts
+++ b/app/src/sandbox/tab-select-6346/test.ts
@@ -10,13 +10,13 @@ test("activates the tab selected by setSelectedId after the popover opens", asyn
 
   expect(q.tab.ensure("Vegetables")).toHaveAttribute("aria-selected", "true");
   expect(q.tab.ensure("Vegetables")).toHaveAttribute("data-active-item");
-  expect(q.tab.ensure("Vegetables")).toHaveAttribute("tabindex", "0");
+  expect(q.tab.ensure("Vegetables")).not.toHaveAttribute("tabindex", "-1");
 
   await click(q.button.ensure("Browse fruits"));
 
   expect(q.tab.ensure("Fruits")).toHaveAttribute("aria-selected", "true");
   expect(q.tab.ensure("Fruits")).toHaveAttribute("data-active-item");
-  expect(q.tab.ensure("Fruits")).toHaveAttribute("tabindex", "0");
+  expect(q.tab.ensure("Fruits")).not.toHaveAttribute("tabindex", "-1");
 });
 
 test("activates the tab selected by setSelectedId after the popover toggles", async () => {
@@ -39,11 +39,11 @@ test("activates the tab selected by setSelectedId after the popover toggles", as
 
   expect(q.tab.ensure("Vegetables")).toHaveAttribute("aria-selected", "true");
   expect(q.tab.ensure("Vegetables")).toHaveAttribute("data-active-item");
-  expect(q.tab.ensure("Vegetables")).toHaveAttribute("tabindex", "0");
+  expect(q.tab.ensure("Vegetables")).not.toHaveAttribute("tabindex", "-1");
 
   await click(q.button.ensure("Browse fruits"));
 
   expect(q.tab.ensure("Fruits")).toHaveAttribute("aria-selected", "true");
   expect(q.tab.ensure("Fruits")).toHaveAttribute("data-active-item");
-  expect(q.tab.ensure("Fruits")).toHaveAttribute("tabindex", "0");
+  expect(q.tab.ensure("Fruits")).not.toHaveAttribute("tabindex", "-1");
 });

--- a/packages/ariakit-components/src/tab/tab-store.test.ts
+++ b/packages/ariakit-components/src/tab/tab-store.test.ts
@@ -1,5 +1,7 @@
 import { init } from "@ariakit/store";
 import { expect, test } from "vitest";
+import { createComboboxStore } from "../combobox/combobox-store.ts";
+import { createSelectStore } from "../select/select-store.ts";
 import { createTabStore } from "./tab-store.ts";
 
 function flushBatch() {
@@ -120,4 +122,125 @@ test("tracks explicit panel item state updates", () => {
   store.panels.setState("items", []);
 
   expect(store.panel("tab-1")).toBeNull();
+});
+
+test("syncs activeId on the first setSelectedId with a select parent", async () => {
+  const select = createSelectStore();
+  const store = createTabStore({
+    composite: select,
+    defaultSelectedId: "tab-1",
+  });
+  const stop = init(store);
+
+  try {
+    store.setSelectedId("tab-2");
+    await flushBatch();
+
+    expect(store.getState().selectedId).toBe("tab-2");
+    expect(store.getState().activeId).toBe("tab-2");
+  } finally {
+    stop();
+  }
+});
+
+test("syncs activeId on the first setSelectedId after a popover toggle", async () => {
+  const select = createSelectStore();
+  const store = createTabStore({
+    composite: select,
+    defaultSelectedId: "tab-1",
+  });
+  const stop = init(store);
+
+  try {
+    select.setOpen(true);
+    select.setOpen(false);
+    await flushBatch();
+
+    store.setSelectedId("tab-2");
+    await flushBatch();
+
+    expect(store.getState().activeId).toBe("tab-2");
+  } finally {
+    stop();
+  }
+});
+
+test("skips the activeId sync when restoring selectedId on popover toggle", async () => {
+  const select = createSelectStore();
+  const store = createTabStore({
+    composite: select,
+    defaultSelectedId: "tab-1",
+  });
+  const stop = init(store);
+
+  try {
+    store.setSelectedId("tab-2");
+    await flushBatch();
+
+    select.setOpen(true);
+    await flushBatch();
+
+    expect(store.getState().selectedId).toBe("tab-1");
+    expect(store.getState().activeId).toBe("tab-2");
+  } finally {
+    stop();
+  }
+});
+
+test("syncs activeId when a restore shares a flush with a later setSelectedId", async () => {
+  const select = createSelectStore();
+  const store = createTabStore({
+    composite: select,
+    defaultSelectedId: "tab-1",
+  });
+  const stop = init(store);
+
+  try {
+    store.setSelectedId("tab-2");
+    await flushBatch();
+
+    select.setOpen(true);
+    store.setSelectedId("tab-3");
+    await flushBatch();
+
+    expect(store.getState().selectedId).toBe("tab-3");
+    expect(store.getState().activeId).toBe("tab-3");
+  } finally {
+    stop();
+  }
+});
+
+test("does not leak a restore armed right before the store is destroyed", async () => {
+  const combobox = createComboboxStore({ defaultOpen: true });
+  const store = createTabStore({ combobox, defaultSelectedId: "tab-1" });
+  const stop = init(store);
+
+  try {
+    combobox.setState("selectedValue", "value");
+    store.setSelectedId("tab-2");
+    await flushBatch();
+
+    expect(store.getState().activeId).toBe("tab-2");
+
+    combobox.setOpen(false);
+    stop();
+    await flushBatch();
+  } finally {
+    stop();
+  }
+
+  const restart = init(store);
+
+  try {
+    await flushBatch();
+    expect(store.getState().selectedId).toBe("tab-1");
+
+    store.setSelectedId("tab-3");
+    await flushBatch();
+
+    expect(store.getState().selectedId).toBe("tab-3");
+    expect(store.getState().activeId).toBe("tab-3");
+  } finally {
+    restart();
+  }
 });

--- a/packages/ariakit-components/src/tab/tab-store.ts
+++ b/packages/ariakit-components/src/tab/tab-store.ts
@@ -145,17 +145,24 @@ export function createTabStore({
     }),
   );
 
-  let syncActiveId = true;
+  let pendingRestore = false;
+  let restoredSelectedId: TabStoreState["selectedId"];
 
   // Keep activeId in sync with selectedId.
-  setup(tab, () =>
-    batch(tab, ["selectedId"], (state, prev) => {
+  setup(tab, () => {
+    // A restore armed right before the store was destroyed (for example, when
+    // the popover unmounted) must not leak into this init. Reset before
+    // registering the listener below since it also runs on registration.
+    pendingRestore = false;
+    return batch(tab, ["selectedId"], (state, prev) => {
       // There are cases where we don't want to sync activeId with selectedId.
       // For example, restoring the selectedId from a select or combobox
-      // selected value. In those cases, we set syncActiveId to false.
-      if (!syncActiveId) {
-        syncActiveId = true;
-        return;
+      // selected value. Batch listeners are microtask-coalesced, so a restore
+      // may share a flush with a later legitimate change. In that case, the
+      // flushed value differs from the restored one and we must still sync.
+      if (pendingRestore) {
+        pendingRestore = false;
+        if (state.selectedId === restoredSelectedId) return;
       }
       // If there's a parent composite widget, we don't need to sync the
       // activeId state with the initial selectedId state. The parent composite
@@ -173,8 +180,8 @@ export function createTabStore({
         return;
       }
       tab.setState("activeId", state.selectedId);
-    }),
-  );
+    });
+  });
 
   // Automatically set selectedId if it's undefined.
   setup(tab, () =>
@@ -223,10 +230,16 @@ export function createTabStore({
       selectedIdFromSelectedValue = tab.getState().selectedId;
     };
     const restoreSelectedId = () => {
-      // We set syncActiveId to false to prevent the activeId state from being
-      // set to the selectedId state since this is just a restoration of the
-      // selectedId state from a select or combobox selected value.
-      syncActiveId = false;
+      // We suppress the activeId sync to prevent the activeId state from
+      // being set to the selectedId state since this is just a restoration of
+      // the selectedId state from a select or combobox selected value.
+      // setState early-returns on unchanged values and emits no batch event
+      // to consume the suppression, so only arm it when the restore will
+      // actually change the state.
+      const { selectedId } = tab.getState();
+      if (selectedId === selectedIdFromSelectedValue) return;
+      pendingRestore = true;
+      restoredSelectedId = selectedIdFromSelectedValue;
       tab.setState("selectedId", selectedIdFromSelectedValue);
     };
     if (parentComposite && "setSelectElement" in parentComposite) {


### PR DESCRIPTION
## Motivation

In the documented Select/Combobox + Tabs composition (see the [Select with Combobox and Tabs](https://ariakit.com/examples/select-combobox-tab) and [Combobox with Tabs](https://ariakit.com/examples/combobox-tabs) examples), the first `setSelectedId` call after the tab store initializes — and after every popover toggle in which `selectedId` didn't change — switches the selected tab and panel but silently skips the documented `activeId` sync: the newly selected tab never becomes the active composite item (no `data-active-item`, roving `tabindex` stays `-1`). A second identical call works, which is why click/arrow-key tab switching doesn't surface the bug.

```tsx
<Ariakit.SelectPopover>
  <Ariakit.TabProvider defaultSelectedId="tab-fruits">
    {/* tab.setSelectedId("tab-vegetables") selects the tab,
        but it never becomes the active item */}
  </Ariakit.TabProvider>
</Ariakit.SelectPopover>
```

The root cause is a leaked one-shot suppression flag in the tab store: `restoreSelectedId` armed `syncActiveId = false` unconditionally before restoring `selectedId` when the select/combobox popover toggles `mounted`, but `setState` early-returns when the value is unchanged, producing no batch event to consume the flag. Since `sync` invokes its listener immediately on registration, a guaranteed no-op restore ran at every store init, arming and leaking the flag. The next legitimate `selectedId` change was then swallowed by the suppression branch. A second failure mode: batch flushes are microtask-coalesced, so a real restore sharing a flush with a later legitimate change suppressed the legitimate change too.

Fixes #6346

## Solution

Replace the one-shot boolean with a `pendingRestore` flag paired with the restored value:

- `restoreSelectedId` arms the suppression only when the restore will actually change the state, since an unchanged `setState` emits no batch event to consume it. This removes the init-time and popover-toggle leaks.
- The batch listener, after consuming the flag, skips the `activeId` sync only when the flushed `selectedId` is the restored one, so a coalesced flush that also contains a later legitimate change still syncs.
- The flag resets at init, before the batch listener registers, so a restore armed right before the store is destroyed can't leak into the next init.

The sandbox workaround from the previous commit is reverted; the repro tests now pass against the library fix. Five store-level unit tests in `tab-store.test.ts` cover the restore paths directly (init leak, toggle leak, restore suppression, coalesced restore + change, and armed-restore across store destroy/re-init); all five fail against the previous implementation.

Verified with the full core/React/React 18/Solid suites, the repro sandbox in Chrome/Firefox/Safari, the neighboring tab sandboxes, and the select/combobox + tabs example browser tests.

### Known limitation

If a store with a just-armed restore is destroyed and re-initialized within the same microtask, the restore's still-queued batch flush lands in the new epoch after the flag reset and runs the `activeId` sync. Inside the batch listener, that cross-epoch flush is indistinguishable from the listener's registration-time invocation (both deliver an identical previous-state snapshot after the idle-registration refresh), so suppressing it would require event-origin tagging in `@ariakit/store`. The scenario is not reachable through React's lifecycle in practice, and the consequence is a transient `activeId` write while the popover is closed, which the parent select/combobox rewrites on open.

## Workaround

Until the fix is released, users can perform the swallowed `selectedId` → `activeId` sync manually by calling `setActiveId` alongside `setSelectedId`:

```tsx
function BrowseTabButton(props: { tabId: string; children: string }) {
  const tab = Ariakit.useTabContext();
  return (
    <button
      onClick={() => {
        tab?.setSelectedId(props.tabId);
        // TODO: Workaround for the swallowed setSelectedId -> activeId sync.
        // Remove once https://github.com/ariakit/ariakit/issues/6346 is fixed.
        tab?.setActiveId(props.tabId);
      }}
    >
      {props.children}
    </button>
  );
}
```

Alternatively, `tab.select(id)` also works when always moving DOM focus to the tab is acceptable.
