### PR TITLE
Document the key prop recommendation for render element type changes

### DIFF
--- a/packages/ariakit-react-utils/readme.md
+++ b/packages/ariakit-react-utils/readme.md
@@ -580,7 +580,13 @@ interface Options {
    * original component props and gives back a React element with the props
    * merged.
    *
-   * Check out the [Composition](https://ariakit.com/guide/composition) guide
+   * Some Ariakit components detect the type of the underlying element when
+   * they mount. If the render element's type may change while the component
+   * is mounted, pass a
+   * [`key`](https://react.dev/learn/preserving-and-resetting-state) prop that
+   * changes with the element type so React remounts the component with the
+   * new element. Remounting resets uncontrolled state, so keep the relevant
+   // ... 11 more lines
    * for more details.
    */
   render?: RenderProp | React.ReactElement;

--- a/packages/ariakit-react-utils/src/types.ts
+++ b/packages/ariakit-react-utils/src/types.ts
@@ -32,6 +32,22 @@ export interface Options {
    * original component props and gives back a React element with the props
    * merged.
    *
+   * Some Ariakit components detect the type of the underlying element when
+   * they mount. If the render element's type may change while the component
+   * is mounted, pass a
+   * [`key`](https://react.dev/learn/preserving-and-resetting-state) prop that
+   * changes with the element type so React remounts the component with the
+   * new element. Remounting resets uncontrolled state, so keep the relevant
+   * state controlled:
+   * ```jsx
+   * <Checkbox
+   *   key={custom ? "custom" : "native"}
+   *   checked={checked}
+   *   onChange={() => setChecked(!checked)}
+   *   render={custom ? <div /> : <input />}
+   * />
+   * ```
+   *
    * Check out the [Composition](https://ariakit.com/guide/composition) guide
    * for more details.
    */


### PR DESCRIPTION
## Motivation

#6336 reported that components like [`Checkbox`](https://ariakit.com/reference/checkbox) keep props computed for the previous element when the [`render`](https://ariakit.com/guide/composition) prop swaps the element type at runtime (e.g. `render={custom ? <div /> : <input />}` losing `role="checkbox"` after the swap). The library fix in #6601 was closed as not planned: it added too much complexity to hot code paths for an edge case that is fully solved in userland by giving the component a new identity when the render element type changes.

That recommendation currently lives only in the issue thread, and the failure mode is silent (the element quietly drops out of the accessibility tree), so it deserves a place in the docs users actually see.

## Solution

Document the recommendation in the shared `render` prop JSDoc in `@ariakit/react-utils`, which every Ariakit React component inherits in IntelliSense and on the reference pages:

```jsx
<Checkbox
  key={custom ? "custom" : "native"}
  checked={checked}
  onChange={() => setChecked(!checked)}
  render={custom ? <div /> : <input />}
/>
```

The note explains that some Ariakit components detect the type of the underlying element when they mount, so a `key` that changes with the element type makes React remount the component with the new element, and that remounting resets uncontrolled state (hence the controlled example). It links to React's [Preserving and Resetting State](https://react.dev/learn/preserving-and-resetting-state) guide.

The `packages/ariakit-react-utils/readme.md` hunk is regenerated output of `ariakit docs --write`, keeping the docs freshness test green.

No changeset: this is a docs-only change with no effect on shipped runtime code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)