### PR TITLE
Remove unneeded ensure queries from sandbox tests

### DIFF
--- a/app/src/sandbox/combobox-6297/test.ts
+++ b/app/src/sandbox/combobox-6297/test.ts
@@ -13,32 +13,32 @@ function isApplePlatform(platform: string) {
 // See https://github.com/ariakit/ariakit/issues/6297
 for (const shortcut of shortcuts) {
   test(`${shortcut.name} on a focused item does not commit inline autocomplete`, async () => {
-    const combobox = q.combobox.ensure("Fruit");
+    const combobox = q.combobox("Fruit");
 
     await click(combobox);
     await type("b");
-    expect(q.status.ensure()).toHaveTextContent("b");
+    expect(q.status()).toHaveTextContent("b");
 
     await press.ArrowDown();
-    const apple = q.option.ensure("Apple");
+    const apple = q.option("Apple");
     expect(apple).toHaveFocus();
     expect(combobox).toHaveValue("Apple");
 
     await press("c", null, shortcut.options);
     expect(apple).toHaveFocus();
-    expect(q.status.ensure()).toHaveTextContent("b");
+    expect(q.status()).toHaveTextContent("b");
   });
 }
 
 test("paste shortcut on a focused item moves focus to the input", async () => {
-  const combobox = q.combobox.ensure("Fruit");
+  const combobox = q.combobox("Fruit");
   const applePlatform = isApplePlatform(navigator.platform);
   const options = applePlatform ? { metaKey: true } : { ctrlKey: true };
 
   await click(combobox);
   await type("b");
   await press.ArrowDown();
-  const apple = q.option.ensure("Apple");
+  const apple = q.option("Apple");
   expect(apple).toHaveFocus();
 
   await press("v", null, options);

--- a/app/src/sandbox/combobox-6315/test.ts
+++ b/app/src/sandbox/combobox-6315/test.ts
@@ -64,5 +64,5 @@ test("completes unaccented input against accented items", async () => {
   expect(getInputValue(combobox)).toBe("cafe au lait");
 
   await click(q.button("Save"));
-  expect(q.status.ensure()).toHaveTextContent("cafe au lait");
+  expect(q.status()).toHaveTextContent("cafe au lait");
 });

--- a/app/src/sandbox/combobox-disclosure-6296/test.ts
+++ b/app/src/sandbox/combobox-disclosure-6296/test.ts
@@ -3,10 +3,10 @@ import { expect, test } from "vitest";
 
 // Reproduces https://github.com/ariakit/ariakit/issues/6296
 test("honors prevented mousedown on disclosure", async () => {
-  await click(q.textbox.ensure("Notes"));
+  await click(q.textbox("Notes"));
   expect(q.textbox("Notes")).toHaveFocus();
 
-  await click(q.button.ensure("Show popup"));
+  await click(q.button("Show popup"));
 
   expect(q.listbox()).toBeVisible();
   expect(q.textbox("Notes")).toHaveFocus();

--- a/app/src/sandbox/combobox-item-value-6298/test.ts
+++ b/app/src/sandbox/combobox-item-value-6298/test.ts
@@ -3,7 +3,7 @@ import { expect, test } from "vitest";
 
 // Reproduces https://github.com/ariakit/ariakit/issues/6298
 test("renders overlapping matches without duplicated text", async () => {
-  await type("ana", q.combobox.ensure("Your favorite fruit"));
+  await type("ana", q.combobox("Your favorite fruit"));
 
   const option = q.option.ensure("Banana");
   expect(option).toHaveTextContent("Banana");

--- a/app/src/sandbox/combobox-item-value-6298/test.ts
+++ b/app/src/sandbox/combobox-item-value-6298/test.ts
@@ -3,7 +3,7 @@ import { expect, test } from "vitest";
 
 // Reproduces https://github.com/ariakit/ariakit/issues/6298
 test("renders overlapping matches without duplicated text", async () => {
-  await type("ana", q.combobox("Your favorite fruit"));
+  await type("ana", q.combobox.ensure("Your favorite fruit"));
 
   const option = q.option.ensure("Banana");
   expect(option).toHaveTextContent("Banana");

--- a/app/src/sandbox/combobox-item-value-6329/test.ts
+++ b/app/src/sandbox/combobox-item-value-6329/test.ts
@@ -14,7 +14,7 @@ function getPartTexts(element: HTMLElement, selector: string) {
 
 // Reproduces https://github.com/ariakit/ariakit/issues/6329
 test("highlights only the typed syllable in Hangul item values", async () => {
-  await type("사", q.combobox("Search files"));
+  await type("사", q.combobox.ensure("Search files"));
 
   const option = q.option.ensure("사과.txt");
   expect(option.textContent).toBe("사과.txt");
@@ -23,7 +23,7 @@ test("highlights only the typed syllable in Hangul item values", async () => {
 });
 
 test("highlights only the typed kana in item values with dakuten", async () => {
-  await type("ガ", q.combobox("Search files"));
+  await type("ガ", q.combobox.ensure("Search files"));
 
   const option = q.option.ensure("ガラス.txt");
   expect(option.textContent).toBe("ガラス.txt");
@@ -34,7 +34,7 @@ test("highlights only the typed kana in item values with dakuten", async () => {
 });
 
 test("keeps combining marks attached in decomposed item values", async () => {
-  await type("sum", q.combobox("Search files"));
+  await type("sum", q.combobox.ensure("Search files"));
 
   const option = q.option.ensure(decomposedResume);
   expect(option.textContent).toBe(decomposedResume);
@@ -48,7 +48,7 @@ test("keeps combining marks attached in decomposed item values", async () => {
 test("renders a single autocomplete span for normalized-empty input", async () => {
   // A lone combining mark normalizes to an empty string, which must not
   // produce highlights but must keep the autocomplete span structure.
-  await type("\u0301", q.combobox("Search files"));
+  await type("\u0301", q.combobox.ensure("Search files"));
 
   const option = q.option.ensure("notes.txt");
   expect(option.textContent).toBe("notes.txt");
@@ -61,7 +61,7 @@ test("renders a single autocomplete span for normalized-empty input", async () =
 test("does not highlight characters the input only partially matches", async () => {
   // A lone medial jamo matches only a fragment of the decomposed 사 syllable,
   // which must not highlight the whole character.
-  await type("\u1161", q.combobox("Search files"));
+  await type("\u1161", q.combobox.ensure("Search files"));
 
   const option = q.option.ensure("사과.txt");
   expect(option.textContent).toBe("사과.txt");
@@ -89,7 +89,7 @@ test("highlights a character fully covered by overlapping partial matches", asyn
 });
 
 test("highlights diacritic-insensitive matches in decomposed item values", async () => {
-  await type("resume", q.combobox("Search files"));
+  await type("resume", q.combobox.ensure("Search files"));
 
   const option = q.option.ensure(decomposedResume);
   expect(option.textContent).toBe(decomposedResume);

--- a/app/src/sandbox/combobox-item-value-6329/test.ts
+++ b/app/src/sandbox/combobox-item-value-6329/test.ts
@@ -14,7 +14,7 @@ function getPartTexts(element: HTMLElement, selector: string) {
 
 // Reproduces https://github.com/ariakit/ariakit/issues/6329
 test("highlights only the typed syllable in Hangul item values", async () => {
-  await type("사", q.combobox.ensure("Search files"));
+  await type("사", q.combobox("Search files"));
 
   const option = q.option.ensure("사과.txt");
   expect(option.textContent).toBe("사과.txt");
@@ -23,7 +23,7 @@ test("highlights only the typed syllable in Hangul item values", async () => {
 });
 
 test("highlights only the typed kana in item values with dakuten", async () => {
-  await type("ガ", q.combobox.ensure("Search files"));
+  await type("ガ", q.combobox("Search files"));
 
   const option = q.option.ensure("ガラス.txt");
   expect(option.textContent).toBe("ガラス.txt");
@@ -34,7 +34,7 @@ test("highlights only the typed kana in item values with dakuten", async () => {
 });
 
 test("keeps combining marks attached in decomposed item values", async () => {
-  await type("sum", q.combobox.ensure("Search files"));
+  await type("sum", q.combobox("Search files"));
 
   const option = q.option.ensure(decomposedResume);
   expect(option.textContent).toBe(decomposedResume);
@@ -48,7 +48,7 @@ test("keeps combining marks attached in decomposed item values", async () => {
 test("renders a single autocomplete span for normalized-empty input", async () => {
   // A lone combining mark normalizes to an empty string, which must not
   // produce highlights but must keep the autocomplete span structure.
-  await type("\u0301", q.combobox.ensure("Search files"));
+  await type("\u0301", q.combobox("Search files"));
 
   const option = q.option.ensure("notes.txt");
   expect(option.textContent).toBe("notes.txt");
@@ -61,7 +61,7 @@ test("renders a single autocomplete span for normalized-empty input", async () =
 test("does not highlight characters the input only partially matches", async () => {
   // A lone medial jamo matches only a fragment of the decomposed 사 syllable,
   // which must not highlight the whole character.
-  await type("\u1161", q.combobox.ensure("Search files"));
+  await type("\u1161", q.combobox("Search files"));
 
   const option = q.option.ensure("사과.txt");
   expect(option.textContent).toBe("사과.txt");
@@ -89,7 +89,7 @@ test("highlights a character fully covered by overlapping partial matches", asyn
 });
 
 test("highlights diacritic-insensitive matches in decomposed item values", async () => {
-  await type("resume", q.combobox.ensure("Search files"));
+  await type("resume", q.combobox("Search files"));
 
   const option = q.option.ensure(decomposedResume);
   expect(option.textContent).toBe(decomposedResume);

--- a/app/src/sandbox/command-6217/test.ts
+++ b/app/src/sandbox/command-6217/test.ts
@@ -4,7 +4,7 @@ import { expect, test } from "vitest";
 // See https://github.com/ariakit/ariakit/issues/6217
 
 test("releasing Space with Meta held clears data-active", async () => {
-  const command = q.text.ensure("Meta release");
+  const command = q.text("Meta release");
   await focus(command);
   expect(command).toHaveFocus();
 
@@ -21,7 +21,7 @@ test("releasing Space with Meta held clears data-active", async () => {
 });
 
 test("releasing Space clears data-active when the element becomes disabled mid-press", async () => {
-  const command = q.text.ensure("Disable on press");
+  const command = q.text("Disable on press");
   await focus(command);
   expect(command).toHaveFocus();
 

--- a/app/src/sandbox/command-6340/test.ts
+++ b/app/src/sandbox/command-6340/test.ts
@@ -4,7 +4,7 @@ import { expect, test } from "vitest";
 // See https://github.com/ariakit/ariakit/issues/6340
 
 test("data-active is cleared when focus leaves while Space is held", async () => {
-  const command = q.text.ensure("Save");
+  const command = q.text("Save");
   await focus(command);
   expect(command).toHaveFocus();
 
@@ -16,7 +16,7 @@ test("data-active is cleared when focus leaves while Space is held", async () =>
   // the keyup lands there and never reaches the command. Losing focus
   // mid-press must cancel the press, like a native button, instead of leaving
   // the element stuck looking pressed.
-  await click(q.text.ensure("Outside text"));
+  await click(q.text("Outside text"));
   expect(command).not.toHaveFocus();
   expect(command).not.toHaveAttribute("data-active");
 
@@ -25,7 +25,7 @@ test("data-active is cleared when focus leaves while Space is held", async () =>
 });
 
 test("Space keyup bubbling from a child does not click the command", async () => {
-  const card = q.text.ensure("Open article");
+  const card = q.text("Open article");
   await focus(card);
   expect(card).toHaveFocus();
 
@@ -38,19 +38,19 @@ test("Space keyup bubbling from a child does not click the command", async () =>
   // finished on the card, so it must not dispatch a synthetic click on itself,
   // and losing focus must clear the pressed state.
   await press.Tab();
-  expect(q.button.ensure("Pin")).toHaveFocus();
+  expect(q.button("Pin")).toHaveFocus();
   expect(card).not.toHaveAttribute("data-active");
 
   await press.up.Space();
   // Unlike a real browser, the `press.up` emulation synthesizes a click on any
   // focused native button regardless of where the keydown happened, so the pin
   // count is asserted only in `test-browser.ts`.
-  expect(q.status.ensure()).toHaveTextContent("card clicks: 0");
+  expect(q.status()).toHaveTextContent("card clicks: 0");
   expect(card).not.toHaveAttribute("data-active");
 });
 
 test("data-active is cleared when a consumer onKeyUp prevents the default", async () => {
-  const command = q.text.ensure("Bookmark");
+  const command = q.text("Bookmark");
   await focus(command);
   expect(command).toHaveFocus();
 

--- a/app/src/sandbox/composite-offscreen-props/test.ts
+++ b/app/src/sandbox/composite-offscreen-props/test.ts
@@ -10,7 +10,7 @@ const leakedAttributes = [
 ] as const;
 
 test("omits composite option props from the offscreen placeholder", () => {
-  const item = q.button.ensure("Archive");
+  const item = q.button("Archive");
 
   expect(item).toHaveAttribute("data-offscreen");
   expect(item).toHaveAttribute("aria-disabled", "true");

--- a/app/src/sandbox/composite-renderer-active-ancestor/test.ts
+++ b/app/src/sandbox/composite-renderer-active-ancestor/test.ts
@@ -25,7 +25,7 @@ const cases = [
 ] as const;
 
 function getRenderedIndices(label: string) {
-  const region = q.region.ensure(label);
+  const region = q.region(label);
   const items = q.within(region).button.all();
   return items.map((element) => element.getAttribute("data-index"));
 }

--- a/app/src/sandbox/composite-row-6334/test.ts
+++ b/app/src/sandbox/composite-row-6334/test.ts
@@ -9,7 +9,7 @@ test("cells compute their position from row-level aria-posinset", async () => {
     await expect
       .poll(q.gridcell.lazy(`Cell ${position}`))
       .toHaveAttribute("aria-posinset", `${position}`);
-    expect(q.gridcell.ensure(`Cell ${position}`)).toHaveAttribute(
+    expect(q.gridcell(`Cell ${position}`)).toHaveAttribute(
       "aria-setsize",
       "100",
     );

--- a/app/src/sandbox/create-ref-6349/test.ts
+++ b/app/src/sandbox/create-ref-6349/test.ts
@@ -5,14 +5,14 @@ import { expect, test } from "vitest";
 test("resets a function-typed ref to its initial value", async () => {
   expect(q.text("Stored value type: function")).toBeVisible();
 
-  await click(q.button.ensure("Use email handler"));
-  await click(q.button.ensure("Focus field"));
+  await click(q.button("Use email handler"));
+  await click(q.button("Focus field"));
   expect(q.textbox("Email")).toHaveFocus();
 
-  await click(q.button.ensure("Restore default"));
+  await click(q.button("Restore default"));
   expect(q.textbox("Name")).not.toHaveFocus();
   expect(q.text("Stored value type: function")).toBeVisible();
 
-  await click(q.button.ensure("Focus field"));
+  await click(q.button("Focus field"));
   expect(q.textbox("Name")).toHaveFocus();
 });

--- a/app/src/sandbox/dialog-6344/test.ts
+++ b/app/src/sandbox/dialog-6344/test.ts
@@ -3,45 +3,45 @@ import { expect, test } from "vitest";
 
 // Reproduces https://github.com/ariakit/ariakit/issues/6344
 test("stays open when interacting with a persistent element before the dialog is focused", async () => {
-  await click(q.button.ensure("Open dialog"));
+  await click(q.button("Open dialog"));
   expect(q.dialog("Dialog")).toBeVisible();
 
   // The dialog hasn't been focused yet (autoFocusOnShow={false}). Clicking
   // the persistent field must not close it.
-  await click(q.textbox.ensure("Notification field"));
+  await click(q.textbox("Notification field"));
   expect(q.textbox("Notification field")).toHaveFocus();
   expect(q.dialog("Dialog")).toBeVisible();
 
   // Other interactions with the persistent region must not close it either.
-  await click(q.button.ensure("Dismiss notification"));
+  await click(q.button("Dismiss notification"));
   expect(q.dialog("Dialog")).toBeVisible();
 });
 
 test("stays open on right-clicking a persistent element before the dialog is focused", async () => {
-  await click(q.button.ensure("Open dialog"));
+  await click(q.button("Open dialog"));
   expect(q.dialog("Dialog")).toBeVisible();
 
-  await rightClick(q.textbox.ensure("Notification field"));
+  await rightClick(q.textbox("Notification field"));
   expect(q.dialog("Dialog")).toBeVisible();
 });
 
 test("keeps the documented behavior after the dialog has been focused", async () => {
-  await click(q.button.ensure("Open dialog"));
+  await click(q.button("Open dialog"));
   expect(q.dialog("Dialog")).toBeVisible();
 
   // Focusing inside the dialog first is the documented, working path.
-  await click(q.textbox.ensure("Inside field"));
+  await click(q.textbox("Inside field"));
   expect(q.textbox("Inside field")).toHaveFocus();
 
-  await click(q.textbox.ensure("Notification field"));
+  await click(q.textbox("Notification field"));
   expect(q.textbox("Notification field")).toHaveFocus();
   expect(q.dialog("Dialog")).toBeVisible();
 });
 
 test("still closes when interacting outside before the dialog is focused", async () => {
-  await click(q.button.ensure("Open dialog"));
+  await click(q.button("Open dialog"));
   expect(q.dialog("Dialog")).toBeVisible();
 
-  await click(q.textbox.ensure("Outside field"));
+  await click(q.textbox("Outside field"));
   await expect.poll(q.dialog.hidden.lazy("Dialog")).not.toBeVisible();
 });

--- a/app/src/sandbox/dialog-backdrop-6339/test.ts
+++ b/app/src/sandbox/dialog-backdrop-6339/test.ts
@@ -3,7 +3,7 @@ import { click, q, sleep } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 test("backdrop fades out on close when only the backdrop is animated", async () => {
-  await click(q.button.ensure("Show dialog"));
+  await click(q.button("Show dialog"));
   expect(q.dialog()).toBeVisible();
   const backdrop = q.presentation.ensure();
   // The enter state is applied after a couple of frames.
@@ -24,7 +24,7 @@ test("backdrop fades out on close when only the backdrop is animated", async () 
 });
 
 test("backdrop finishes its longer fade out when the panel has a shorter transition", async () => {
-  await click(q.button.ensure("Show fast dialog"));
+  await click(q.button("Show fast dialog"));
   expect(q.dialog()).toBeVisible();
   const backdrop = q.presentation.ensure();
   // The enter state is applied after a couple of frames.

--- a/app/src/sandbox/dialog-reopen-focus-state/test.ts
+++ b/app/src/sandbox/dialog-reopen-focus-state/test.ts
@@ -2,23 +2,23 @@ import { click, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 test("resets outside-interaction focus tracking when reopened", async () => {
-  await click(q.button.ensure("Open dialog"));
+  await click(q.button("Open dialog"));
   expect(q.dialog("Dialog")).toBeVisible();
 
   // Mark the dialog as interacted-with by focusing a field inside it, then
   // close and reopen it.
-  await click(q.textbox.ensure("Inside field"));
+  await click(q.textbox("Inside field"));
   expect(q.textbox("Inside field")).toHaveFocus();
-  await click(q.button.ensure("Close dialog"));
+  await click(q.button("Close dialog"));
   await expect.poll(q.dialog.hidden.lazy("Dialog")).not.toBeVisible();
 
-  await click(q.button.ensure("Open dialog"));
+  await click(q.button("Open dialog"));
   expect(q.dialog("Dialog")).toBeVisible();
 
   // Revealing the outside field moves focus to a brand-new node outside the
   // dialog. Because reopening reset the "was focused inside" flag, this counts
   // as interacting outside and closes the dialog.
-  await click(q.button.ensure("Reveal outside field"));
+  await click(q.button("Reveal outside field"));
   expect(q.textbox("Dynamic outside field")).toHaveFocus();
   await expect.poll(q.dialog.hidden.lazy("Dialog")).not.toBeVisible();
 });

--- a/app/src/sandbox/form-6307/test.ts
+++ b/app/src/sandbox/form-6307/test.ts
@@ -4,7 +4,7 @@ import { expect, test } from "vitest";
 // Reproduces https://github.com/ariakit/ariakit/issues/6307
 
 test("a successful submit does not steal focus on later items changes", async () => {
-  const email = q.textbox.ensure("Email");
+  const email = q.textbox("Email");
 
   // 1. Submit with the email empty: the submission fails and the invalid email
   //    field is focused (correct autoFocusOnSubmit behavior).

--- a/app/src/sandbox/form-6307/test.ts
+++ b/app/src/sandbox/form-6307/test.ts
@@ -4,7 +4,7 @@ import { expect, test } from "vitest";
 // Reproduces https://github.com/ariakit/ariakit/issues/6307
 
 test("a successful submit does not steal focus on later items changes", async () => {
-  const email = q.textbox("Email");
+  const email = q.textbox.ensure("Email");
 
   // 1. Submit with the email empty: the submission fails and the invalid email
   //    field is focused (correct autoFocusOnSubmit behavior).

--- a/app/src/sandbox/form-names-6308/test.ts
+++ b/app/src/sandbox/form-names-6308/test.ts
@@ -13,5 +13,5 @@ test("inspecting a form.names.* value resolves to an object tag instead of throw
   // throwing "Cannot convert a Symbol value to a string" (the fix yields
   // "[object Object]", a coercing workaround "[object String]").
   await click(q.button("Inspect field name"));
-  expect(q.status.ensure()).toHaveTextContent(/^\[object \w+\]$/);
+  expect(q.status()).toHaveTextContent(/^\[object \w+\]$/);
 });

--- a/app/src/sandbox/group-6327/test.ts
+++ b/app/src/sandbox/group-6327/test.ts
@@ -3,13 +3,13 @@ import { expect, test } from "vitest";
 
 // See https://github.com/ariakit/ariakit/issues/6327
 test("uses aria-label instead of GroupLabel for the group name", () => {
-  const group = q.group.ensure("Audio playback settings");
+  const group = q.group("Audio playback settings");
   expect(group).toHaveAttribute("aria-label", "Audio playback settings");
   expect(group).not.toHaveAttribute("aria-labelledby");
 });
 
 test("preserves explicit aria-labelledby when aria-label is passed", () => {
-  const group = q.group.ensure("Explicit playback settings");
+  const group = q.group("Explicit playback settings");
   expect(group).toHaveAttribute("aria-label", "Audio playback settings");
   expect(group).toHaveAttribute("aria-labelledby", "explicit-group-label");
 });

--- a/app/src/sandbox/hovercard-nested-listener/test.ts
+++ b/app/src/sandbox/hovercard-nested-listener/test.ts
@@ -26,7 +26,7 @@ test("closes nested hovercard on Escape when focus is outside", async () => {
   await click(q.button("Toggle nested"));
   await expect.poll(q.dialog.lazy("Nested hovercard")).toBeVisible();
 
-  await click(q.textbox.ensure("Outside input"));
+  await click(q.textbox("Outside input"));
   expect(q.textbox("Outside input")).toHaveFocus();
   expect(q.dialog("Nested hovercard")).toBeVisible();
 

--- a/app/src/sandbox/menu-item-checkbox-6318/test.ts
+++ b/app/src/sandbox/menu-item-checkbox-6318/test.ts
@@ -2,7 +2,7 @@ import { click, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 test("syncs boolean item checked state with menu values", async () => {
-  await click(q.button.ensure("View"));
+  await click(q.button("View"));
 
   expect(q.menuitemcheckbox("Show sidebar")).toHaveAttribute(
     "aria-checked",

--- a/app/src/sandbox/menu-radio-default-checked/test.ts
+++ b/app/src/sandbox/menu-radio-default-checked/test.ts
@@ -2,7 +2,7 @@ import { q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 test("does not leak defaultChecked to the rendered menu item", () => {
-  const item = q.menuitemradio.ensure("Compact");
+  const item = q.menuitemradio("Compact");
   expect(item).toHaveAttribute("aria-checked", "true");
   expect(item).not.toHaveAttribute("data-default-checked-prop");
 });

--- a/app/src/sandbox/popover-6310/test.ts
+++ b/app/src/sandbox/popover-6310/test.ts
@@ -5,7 +5,7 @@ import { expect, test } from "vitest";
 test("reopened portaled popover focuses the first focusable element when a hidden element comes first", async () => {
   // First open: focus lands on the visible button, skipping the hidden file
   // input that comes before it in the DOM.
-  await click(q.button.ensure("Attachments"));
+  await click(q.button("Attachments"));
   expect(q.dialog("Attachments")).toBeVisible();
   expect(q.button("Choose file")).toHaveFocus();
 
@@ -13,7 +13,7 @@ test("reopened portaled popover focuses the first focusable element when a hidde
   // focus inside it and leaves "Choose file" with tabindex="-1". The click
   // helper's dwell between mousedown and mouseup lets the disable run while the
   // popover is still visible, like a real click's gap.
-  await click(q.button.ensure("Attachments"));
+  await click(q.button("Attachments"));
   // Wait for the close to settle: focus returns to the disclosure once the
   // popover hides.
   await expect.poll(q.button.lazy("Attachments")).toHaveFocus();
@@ -24,7 +24,7 @@ test("reopened portaled popover focuses the first focusable element when a hidde
   // Reopening must move focus to the visible button again. Before the fix, focus
   // stayed on the disclosure because the focusable fallback resolved to the
   // hidden file input and focusing it is a no-op.
-  await click(q.button.ensure("Attachments"));
+  await click(q.button("Attachments"));
   expect(q.dialog("Attachments")).toBeVisible();
   expect(q.button("Choose file")).toHaveFocus();
 });

--- a/app/src/sandbox/popover-6320/test.ts
+++ b/app/src/sandbox/popover-6320/test.ts
@@ -3,7 +3,7 @@ import { click, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 test("clears the arrow's stale static-side inset after a placement change", async () => {
-  await click(q.button.ensure("Accept invite"));
+  await click(q.button("Accept invite"));
   const dialog = q.dialog.ensure("Team meeting");
   const arrow = dialog.querySelector<HTMLElement>(".arrow");
   expect(arrow).toBeInTheDocument();
@@ -16,7 +16,7 @@ test("clears the arrow's stale static-side inset after a placement change", asyn
   await expect.poll(() => arrow.style.right).toBe("100%");
 
   // Changing the placement to `top` repositions the arrow with `top: 100%`.
-  await click(q.button.ensure("Show above"));
+  await click(q.button("Show above"));
   await expect.poll(() => arrow.style.top).toBe("100%");
 
   // The previous placement's `right: 100%` must be cleared. When it lingers,

--- a/app/src/sandbox/popover-arrow-6321/test.ts
+++ b/app/src/sandbox/popover-arrow-6321/test.ts
@@ -33,7 +33,7 @@ const cases = [
 
 for (const { label, strokeWidth, stroke } of cases) {
   test(`arrow stroke matches the ${label.toLowerCase()} box-shadow`, async () => {
-    await click(q.button.ensure(label));
+    await click(q.button(label));
     const dialog = q.dialog.ensure(label);
     // The arrow SVG paths inherit the stroke and stroke-width set on the
     // arrow element, so the values on the arrow are what the user sees drawn

--- a/app/src/sandbox/portal-dialog-6322/test.ts
+++ b/app/src/sandbox/portal-dialog-6322/test.ts
@@ -3,10 +3,10 @@ import { click, q, type } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 test("typing into a dialog with an inline portalRef keeps focus and value", async () => {
-  await click(q.button.ensure("Open dialog"));
+  await click(q.button("Open dialog"));
   expect(q.dialog("Profile")).toBeVisible();
 
-  await click(q.textbox.ensure("Name"));
+  await click(q.textbox("Name"));
   await type("hello");
 
   // Before the fix, the first keystroke re-renders the parent, the new inline
@@ -17,7 +17,7 @@ test("typing into a dialog with an inline portalRef keeps focus and value", asyn
 });
 
 test("typing into a portal with an inline portalRef keeps focus and value", async () => {
-  await click(q.textbox.ensure("Notes"));
+  await click(q.textbox("Notes"));
   await type("hello");
 
   // Before the fix, the portal node is recreated on every keystroke and focus

--- a/app/src/sandbox/portal-toggle-ref-cleanup/test.ts
+++ b/app/src/sandbox/portal-toggle-ref-cleanup/test.ts
@@ -4,7 +4,7 @@ import { expect, test } from "vitest";
 test("detaches portalRef before removing the node when the portal prop is toggled off", async () => {
   expect(q.text("Portal content")).toBeVisible();
 
-  await click(q.button.ensure("Disable portal"));
+  await click(q.button("Disable portal"));
   // The content is rendered in place once the portal is disabled, and the
   // portalRef cleanup must have run while the node was still in the DOM.
   expect(q.text("Portal content")).toBeVisible();
@@ -15,7 +15,7 @@ test("does not attach an inline portalRef to the removed node when the portal pr
   expect(q.text("Inline portal content")).toBeVisible();
   expect(q.text("Inline portal attach connected: yes")).toBeVisible();
 
-  await click(q.button.ensure("Disable inline portal"));
+  await click(q.button("Disable inline portal"));
   // The content is rendered in place once the portal is disabled, and the
   // new inline portalRef must not have fired against the removed node.
   expect(q.text("Inline portal content")).toBeVisible();

--- a/app/src/sandbox/queue-before-event-6350/test.ts
+++ b/app/src/sandbox/queue-before-event-6350/test.ts
@@ -4,14 +4,14 @@ import { expect, test } from "vitest";
 // See https://github.com/ariakit/ariakit/issues/6350
 
 test("canceling a queued callback keeps it from running on the next event", async () => {
-  await click(q.button.ensure("Show shortcuts"));
-  const hint = q.region.ensure("Keyboard shortcuts");
+  await click(q.button("Show shortcuts"));
+  const hint = q.region("Keyboard shortcuts");
   expect(hint).toBeVisible();
 
   await hover(hint);
   expect(q.text("Status: pinned")).toBeVisible();
 
-  await click(q.button.ensure("New document"));
+  await click(q.button("New document"));
   expect(q.region("Keyboard shortcuts")).toBeVisible();
   expect(q.text("Status: pinned")).toBeVisible();
 });

--- a/app/src/sandbox/radio-6345/test.ts
+++ b/app/src/sandbox/radio-6345/test.ts
@@ -3,8 +3,8 @@ import { expect, test } from "vitest";
 
 // Reproduces https://github.com/ariakit/ariakit/issues/6345
 test("onChange commits the value on arrow-key selection", async () => {
-  const apple = q.radio.ensure("apple");
-  const orange = q.radio.ensure("orange");
+  const apple = q.radio("apple");
+  const orange = q.radio("orange");
 
   await click(apple);
   expect(apple).toBeChecked();

--- a/app/src/sandbox/radio-shift-tab-focus/test.ts
+++ b/app/src/sandbox/radio-shift-tab-focus/test.ts
@@ -2,8 +2,8 @@ import { press, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 test("Shift+Tab moves focus back to the checked radio", async () => {
-  const option1 = q.radio.ensure("Option 1");
-  const option2 = q.radio.ensure("Option 2");
+  const option1 = q.radio("Option 1");
+  const option2 = q.radio("Option 2");
   const option3 = q.radio.ensure("Option 3");
 
   await press.Tab();

--- a/app/src/sandbox/select-6319/test.ts
+++ b/app/src/sandbox/select-6319/test.ts
@@ -6,9 +6,9 @@ import { expect, test } from "vitest";
 // by the browser test: on the buggy code, the keydown handler loops forever
 // synchronously, which would hang the happy-dom worker instead of failing.
 test("arrow keys on the closed select skip the trailing item without value", async () => {
-  const combobox = q.combobox.ensure("Favorite color");
+  const combobox = q.combobox("Favorite color");
   await click(combobox);
-  expect(q.option.ensure("Green")).toBeVisible();
+  expect(q.option("Green")).toBeVisible();
   await press.Escape();
   expect(combobox).toHaveFocus();
   expect(combobox).toHaveTextContent("Green");
@@ -22,9 +22,9 @@ test("arrow keys on the closed select skip the trailing item without value", asy
 });
 
 test("arrow keys on the closed select with focusLoop wrap past the item without value", async () => {
-  const combobox = q.combobox.ensure("Favorite shape");
+  const combobox = q.combobox("Favorite shape");
   await click(combobox);
-  expect(q.option.ensure("Triangle")).toBeVisible();
+  expect(q.option("Triangle")).toBeVisible();
   await press.Escape();
   expect(combobox).toHaveFocus();
   expect(combobox).toHaveTextContent("Triangle");

--- a/app/src/sandbox/select-6324/test.ts
+++ b/app/src/sandbox/select-6324/test.ts
@@ -4,10 +4,10 @@ import { expect, test } from "vitest";
 // https://github.com/ariakit/ariakit/issues/6324
 test("focusOnMove={false} keeps focus while arrow keys move the active item", async () => {
   await click(q.combobox("Fruit"));
-  expect(q.option.ensure("Apple")).toHaveFocus();
+  expect(q.option("Apple")).toHaveFocus();
 
   await press.ArrowDown();
 
-  expect(q.option.ensure("Banana")).toHaveAttribute("data-active-item");
-  expect(q.option.ensure("Apple")).toHaveFocus();
+  expect(q.option("Banana")).toHaveAttribute("data-active-item");
+  expect(q.option("Apple")).toHaveFocus();
 });

--- a/app/src/sandbox/select-6347/test.ts
+++ b/app/src/sandbox/select-6347/test.ts
@@ -4,32 +4,32 @@ import { expect, test } from "vitest";
 // https://github.com/ariakit/ariakit/issues/6347
 test("typeahead skips disabled offscreen select items", async () => {
   await click(q.combobox("Fruit"));
-  expect(q.option.ensure("Apple")).toHaveAttribute("data-active-item");
-  expect(q.option.ensure("Papaya")).toHaveAttribute("data-offscreen");
+  expect(q.option("Apple")).toHaveAttribute("data-active-item");
+  expect(q.option("Papaya")).toHaveAttribute("data-offscreen");
 
   await press("p");
 
-  expect(q.option.ensure("Papaya")).not.toHaveAttribute("data-active-item");
-  expect(q.option.ensure("Peach")).toHaveAttribute("data-active-item");
+  expect(q.option("Papaya")).not.toHaveAttribute("data-active-item");
+  expect(q.option("Peach")).toHaveAttribute("data-active-item");
 });
 
 test("typeahead includes accessible disabled offscreen select items", async () => {
   await click(q.combobox("Accessible fruit"));
-  expect(q.option.ensure("Pawpaw")).toHaveAttribute("data-offscreen");
-  expect(q.option.ensure("Pawpaw")).toHaveAttribute("aria-disabled", "true");
+  expect(q.option("Pawpaw")).toHaveAttribute("data-offscreen");
+  expect(q.option("Pawpaw")).toHaveAttribute("aria-disabled", "true");
 
   await press("p");
 
-  expect(q.option.ensure("Pawpaw")).toHaveAttribute("data-active-item");
+  expect(q.option("Pawpaw")).toHaveAttribute("data-active-item");
 });
 
 test("typeahead skips aria-disabled offscreen select items", async () => {
   await click(q.combobox("ARIA disabled fruit"));
-  expect(q.option.ensure("Papaw")).toHaveAttribute("data-offscreen");
-  expect(q.option.ensure("Papaw")).toHaveAttribute("aria-disabled", "true");
+  expect(q.option("Papaw")).toHaveAttribute("data-offscreen");
+  expect(q.option("Papaw")).toHaveAttribute("aria-disabled", "true");
 
   await press("p");
 
-  expect(q.option.ensure("Papaw")).not.toHaveAttribute("data-active-item");
-  expect(q.option.ensure("Peach")).toHaveAttribute("data-active-item");
+  expect(q.option("Papaw")).not.toHaveAttribute("data-active-item");
+  expect(q.option("Peach")).toHaveAttribute("data-active-item");
 });

--- a/app/src/sandbox/select-combobox-6313/test.ts
+++ b/app/src/sandbox/select-combobox-6313/test.ts
@@ -3,6 +3,6 @@ import { expect, test } from "vitest";
 
 // See https://github.com/ariakit/ariakit/issues/6313
 test("keeps hoisted and provider select values in sync after init", () => {
-  expect(q.combobox.ensure("Favorite fruit")).toHaveTextContent("Banana");
-  expect(q.status.ensure()).toHaveTextContent("Banana");
+  expect(q.combobox("Favorite fruit")).toHaveTextContent("Banana");
+  expect(q.status()).toHaveTextContent("Banana");
 });

--- a/app/src/sandbox/select-renderer-6301/test.ts
+++ b/app/src/sandbox/select-renderer-6301/test.ts
@@ -8,7 +8,7 @@ test("sets sequential option positions across groups and leaves", async () => {
   await click(q.combobox("Fruit"));
 
   for (const [index, name] of options.entries()) {
-    const option = q.option.ensure(name);
+    const option = q.option(name);
     expect(option).toHaveAttribute("aria-setsize", "5");
     expect(option).toHaveAttribute("aria-posinset", `${index + 1}`);
   }

--- a/app/src/sandbox/select-renderer-orientation/test.ts
+++ b/app/src/sandbox/select-renderer-orientation/test.ts
@@ -9,5 +9,5 @@ test("SelectRenderer forwards horizontal orientation to the item layout", async 
   // keeps the check robust because it stays rendered as a persistent index even
   // when virtualization trims middle items. Before the fix, the dropped
   // `orientation` prop fell back to vertical, offsetting by `top` instead.
-  expect(q.option.ensure("Cherry")).toHaveStyle({ left: "192px", top: "0px" });
+  expect(q.option("Cherry")).toHaveStyle({ left: "192px", top: "0px" });
 });

--- a/app/src/sandbox/store-6317/test.ts
+++ b/app/src/sandbox/store-6317/test.ts
@@ -5,7 +5,7 @@ import { expect, test } from "vitest";
 test("notifies an all-keys listener subscribed during a keyed dispatch", async () => {
   expect(q.text("No activity yet")).toBeVisible();
 
-  await click(q.button.ensure("Like (0)"));
+  await click(q.button("Like (0)"));
 
   expect(q.button("Like (1)")).toBeVisible();
   expect(q.text("0 -> 1")).toBeVisible();

--- a/app/src/sandbox/store-6331/test.ts
+++ b/app/src/sandbox/store-6331/test.ts
@@ -3,13 +3,13 @@ import { expect, test } from "vitest";
 
 // Reproduces https://github.com/ariakit/ariakit/issues/6331
 test("keeps parent stores in sync when a parent clamps the child value", async () => {
-  await click(q.button.ensure("Add 3"));
-  expect(q.status.ensure("Selected")).toHaveTextContent("3");
-  expect(q.status.ensure("Cart")).toHaveTextContent("3");
-  expect(q.status.ensure("Order summary")).toHaveTextContent("3");
+  await click(q.button("Add 3"));
+  expect(q.status("Selected")).toHaveTextContent("3");
+  expect(q.status("Cart")).toHaveTextContent("3");
+  expect(q.status("Order summary")).toHaveTextContent("3");
 
-  await click(q.button.ensure("Add 3"));
-  expect(q.status.ensure("Selected")).toHaveTextContent("5");
-  expect(q.status.ensure("Cart")).toHaveTextContent("5");
-  expect(q.status.ensure("Order summary")).toHaveTextContent("5");
+  await click(q.button("Add 3"));
+  expect(q.status("Selected")).toHaveTextContent("5");
+  expect(q.status("Cart")).toHaveTextContent("5");
+  expect(q.status("Order summary")).toHaveTextContent("5");
 });

--- a/app/src/sandbox/store-init-6314/test.ts
+++ b/app/src/sandbox/store-init-6314/test.ts
@@ -8,7 +8,7 @@ test("keeps sibling setup teardowns active after a stale init disposer runs", as
   expect(q.text("A count: 1")).toBeVisible();
   expect(q.text("B count: 1")).toBeVisible();
 
-  await click(q.button.ensure("Stop hotkey A"));
+  await click(q.button("Stop hotkey A"));
   expect(q.text("A active: no")).toBeVisible();
 
   await press("a");
@@ -17,7 +17,7 @@ test("keeps sibling setup teardowns active after a stale init disposer runs", as
   await press("b");
   expect(q.text("B count: 2")).toBeVisible();
 
-  await click(q.button.ensure("Hide panel A"));
+  await click(q.button("Hide panel A"));
   expect(q.text("A count:")).not.toBeInTheDocument();
 
   await press("b");

--- a/app/src/sandbox/tab-panel-6332/test.ts
+++ b/app/src/sandbox/tab-panel-6332/test.ts
@@ -3,19 +3,19 @@ import { expect, test } from "vitest";
 
 // See https://github.com/ariakit/ariakit/issues/6332
 test("panel gains tabindex when switching to a tab without tabbable content", async () => {
-  const section = q.within(q.region.ensure("Link first"));
-  expect(section.tabpanel.ensure("Link")).not.toHaveAttribute("tabindex");
-  await click(section.tab.ensure("Text"));
-  expect(section.tabpanel.ensure("Text")).toHaveAttribute("tabindex", "0");
+  const section = q.within(q.region("Link first"));
+  expect(section.tabpanel("Link")).not.toHaveAttribute("tabindex");
+  await click(section.tab("Text"));
+  expect(section.tabpanel("Text")).toHaveAttribute("tabindex", "0");
   await press.Tab();
-  expect(section.tabpanel.ensure("Text")).toHaveFocus();
+  expect(section.tabpanel("Text")).toHaveFocus();
 });
 
 test("panel drops tabindex when switching to a tab with tabbable content", async () => {
-  const section = q.within(q.region.ensure("Text first"));
-  expect(section.tabpanel.ensure("Text")).toHaveAttribute("tabindex", "0");
-  await click(section.tab.ensure("Link"));
-  expect(section.tabpanel.ensure("Link")).not.toHaveAttribute("tabindex");
+  const section = q.within(q.region("Text first"));
+  expect(section.tabpanel("Text")).toHaveAttribute("tabindex", "0");
+  await click(section.tab("Link"));
+  expect(section.tabpanel("Link")).not.toHaveAttribute("tabindex");
   await press.Tab();
-  expect(section.link.ensure("Read the documentation")).toHaveFocus();
+  expect(section.link("Read the documentation")).toHaveFocus();
 });

--- a/app/src/sandbox/tab-select-6346/test.ts
+++ b/app/src/sandbox/tab-select-6346/test.ts
@@ -3,47 +3,44 @@ import { expect, test } from "vitest";
 
 // See https://github.com/ariakit/ariakit/issues/6346
 test("activates the tab selected by setSelectedId after the popover opens", async () => {
-  await click(q.combobox.ensure("Grocery"));
-  expect(q.tab.ensure("Fruits")).toHaveAttribute("aria-selected", "true");
+  await click(q.combobox("Grocery"));
+  expect(q.tab("Fruits")).toHaveAttribute("aria-selected", "true");
 
-  await click(q.button.ensure("Browse vegetables"));
+  await click(q.button("Browse vegetables"));
 
-  expect(q.tab.ensure("Vegetables")).toHaveAttribute("aria-selected", "true");
-  expect(q.tab.ensure("Vegetables")).toHaveAttribute("data-active-item");
-  expect(q.tab.ensure("Vegetables")).not.toHaveAttribute("tabindex", "-1");
+  expect(q.tab("Vegetables")).toHaveAttribute("aria-selected", "true");
+  expect(q.tab("Vegetables")).toHaveAttribute("data-active-item");
+  expect(q.tab("Vegetables")).not.toHaveAttribute("tabindex", "-1");
 
-  await click(q.button.ensure("Browse fruits"));
+  await click(q.button("Browse fruits"));
 
-  expect(q.tab.ensure("Fruits")).toHaveAttribute("aria-selected", "true");
-  expect(q.tab.ensure("Fruits")).toHaveAttribute("data-active-item");
-  expect(q.tab.ensure("Fruits")).not.toHaveAttribute("tabindex", "-1");
+  expect(q.tab("Fruits")).toHaveAttribute("aria-selected", "true");
+  expect(q.tab("Fruits")).toHaveAttribute("data-active-item");
+  expect(q.tab("Fruits")).not.toHaveAttribute("tabindex", "-1");
 });
 
 test("activates the tab selected by setSelectedId after the popover toggles", async () => {
-  await click(q.combobox.ensure("Grocery"));
-  expect(q.tab.ensure("Fruits")).toHaveAttribute("aria-selected", "true");
+  await click(q.combobox("Grocery"));
+  expect(q.tab("Fruits")).toHaveAttribute("aria-selected", "true");
 
-  await click(q.button.ensure("Browse vegetables"));
-  expect(q.tab.ensure("Vegetables")).toHaveAttribute("aria-selected", "true");
+  await click(q.button("Browse vegetables"));
+  expect(q.tab("Vegetables")).toHaveAttribute("aria-selected", "true");
 
-  await click(q.combobox.ensure("Grocery"));
-  expect(q.combobox.ensure("Grocery")).toHaveAttribute(
-    "aria-expanded",
-    "false",
-  );
+  await click(q.combobox("Grocery"));
+  expect(q.combobox("Grocery")).toHaveAttribute("aria-expanded", "false");
 
-  await click(q.combobox.ensure("Grocery"));
-  expect(q.tab.ensure("Fruits")).toHaveAttribute("aria-selected", "true");
+  await click(q.combobox("Grocery"));
+  expect(q.tab("Fruits")).toHaveAttribute("aria-selected", "true");
 
-  await click(q.button.ensure("Browse vegetables"));
+  await click(q.button("Browse vegetables"));
 
-  expect(q.tab.ensure("Vegetables")).toHaveAttribute("aria-selected", "true");
-  expect(q.tab.ensure("Vegetables")).toHaveAttribute("data-active-item");
-  expect(q.tab.ensure("Vegetables")).not.toHaveAttribute("tabindex", "-1");
+  expect(q.tab("Vegetables")).toHaveAttribute("aria-selected", "true");
+  expect(q.tab("Vegetables")).toHaveAttribute("data-active-item");
+  expect(q.tab("Vegetables")).not.toHaveAttribute("tabindex", "-1");
 
-  await click(q.button.ensure("Browse fruits"));
+  await click(q.button("Browse fruits"));
 
-  expect(q.tab.ensure("Fruits")).toHaveAttribute("aria-selected", "true");
-  expect(q.tab.ensure("Fruits")).toHaveAttribute("data-active-item");
-  expect(q.tab.ensure("Fruits")).not.toHaveAttribute("tabindex", "-1");
+  expect(q.tab("Fruits")).toHaveAttribute("aria-selected", "true");
+  expect(q.tab("Fruits")).toHaveAttribute("data-active-item");
+  expect(q.tab("Fruits")).not.toHaveAttribute("tabindex", "-1");
 });

--- a/app/src/sandbox/tag-input-6333/test.ts
+++ b/app/src/sandbox/tag-input-6333/test.ts
@@ -3,16 +3,16 @@ import { expect, test } from "vitest";
 
 // Reproduces https://github.com/ariakit/ariakit/issues/6333
 test("splits string delimiters with regex metacharacters literally", async () => {
-  await type("one.two.", q.textbox("Dot tags"));
+  await type("one.two.", q.textbox.ensure("Dot tags"));
   expect(q.text("Dot tags values: one, two")).toBeVisible();
 });
 
 test("does not throw on string delimiters that are invalid regex patterns", async () => {
-  await type("one+two+", q.textbox("Plus tags"));
+  await type("one+two+", q.textbox.ensure("Plus tags"));
   expect(q.text("Plus tags values: one, two")).toBeVisible();
 });
 
 test("does not freeze on string delimiters that match empty regexes", async () => {
-  await type("one|two|", q.textbox("Pipe tags"));
+  await type("one|two|", q.textbox.ensure("Pipe tags"));
   expect(q.text("Pipe tags values: one, two")).toBeVisible();
 });

--- a/app/src/sandbox/tag-input-6333/test.ts
+++ b/app/src/sandbox/tag-input-6333/test.ts
@@ -3,16 +3,16 @@ import { expect, test } from "vitest";
 
 // Reproduces https://github.com/ariakit/ariakit/issues/6333
 test("splits string delimiters with regex metacharacters literally", async () => {
-  await type("one.two.", q.textbox.ensure("Dot tags"));
+  await type("one.two.", q.textbox("Dot tags"));
   expect(q.text("Dot tags values: one, two")).toBeVisible();
 });
 
 test("does not throw on string delimiters that are invalid regex patterns", async () => {
-  await type("one+two+", q.textbox.ensure("Plus tags"));
+  await type("one+two+", q.textbox("Plus tags"));
   expect(q.text("Plus tags values: one, two")).toBeVisible();
 });
 
 test("does not freeze on string delimiters that match empty regexes", async () => {
-  await type("one|two|", q.textbox.ensure("Pipe tags"));
+  await type("one|two|", q.textbox("Pipe tags"));
   expect(q.text("Pipe tags values: one, two")).toBeVisible();
 });

--- a/app/src/sandbox/tag-remove-6330/test.ts
+++ b/app/src/sandbox/tag-remove-6330/test.ts
@@ -3,7 +3,7 @@ import { expect, test } from "vitest";
 
 // Reproduces https://github.com/ariakit/ariakit/issues/6330
 test("exposes standalone TagRemove with visible text as a named button", () => {
-  const removeButton = q.button.ensure("Remove React filter");
+  const removeButton = q.button("Remove React filter");
   expect(removeButton).not.toHaveAttribute("aria-hidden", "true");
   expect(removeButton).not.toHaveAttribute("aria-label");
   const tagRemove = document.querySelector(
@@ -15,7 +15,7 @@ test("exposes standalone TagRemove with visible text as a named button", () => {
 });
 
 test("exposes standalone TagRemove with an aria-label", () => {
-  const removeButton = q.button.ensure("Remove Vue filter");
+  const removeButton = q.button("Remove Vue filter");
   expect(removeButton).not.toHaveAttribute("aria-hidden", "true");
   expect(removeButton).toHaveAttribute("aria-label", "Remove Vue filter");
   expect(removeButton).toHaveTextContent("x");
@@ -30,14 +30,14 @@ test("does not render a default icon outside a Tag", () => {
 });
 
 test("preserves a standalone render element name", () => {
-  const removeButton = q.button.ensure("Remove Svelte filter");
+  const removeButton = q.button("Remove Svelte filter");
   expect(removeButton).not.toHaveAttribute("aria-hidden", "true");
   expect(removeButton).not.toHaveAttribute("aria-label");
   expect(q.button("Remove Svelte")).not.toBeInTheDocument();
 });
 
 test("preserves a standalone root labelledby name", () => {
-  const removeButton = q.button.ensure("Remove Solid filter");
+  const removeButton = q.button("Remove Solid filter");
   expect(removeButton).not.toHaveAttribute("aria-hidden", "true");
   expect(removeButton).not.toHaveAttribute("aria-label");
   expect(removeButton).toHaveAttribute("aria-labelledby", "solid-label");

--- a/app/src/sandbox/toolbar-separator-6302/test.ts
+++ b/app/src/sandbox/toolbar-separator-6302/test.ts
@@ -3,17 +3,17 @@ import { expect, test } from "vitest";
 
 // https://github.com/ariakit/ariakit/issues/6302
 test("honors explicit toolbar separator orientation", () => {
-  expect(q.separator.ensure("Column divider")).toHaveAttribute(
+  expect(q.separator("Column divider")).toHaveAttribute(
     "aria-orientation",
     "vertical",
   );
 
-  expect(q.separator.ensure("Row divider")).toHaveAttribute(
+  expect(q.separator("Row divider")).toHaveAttribute(
     "aria-orientation",
     "horizontal",
   );
 
-  expect(q.separator.ensure("Plain divider")).toHaveAttribute(
+  expect(q.separator("Plain divider")).toHaveAttribute(
     "aria-orientation",
     "vertical",
   );

--- a/app/src/sandbox/tooltip-6585/test.ts
+++ b/app/src/sandbox/tooltip-6585/test.ts
@@ -8,7 +8,7 @@ test("does not leak duplicate tooltip portal containers in StrictMode", async ()
     "Portal containers: 0",
   );
 
-  await hover(q.button.ensure("Hover target"));
+  await hover(q.button("Hover target"));
   expect(q.tooltip("Tooltip content")).toBeVisible();
   expect(q.status("Portal containers")).toHaveTextContent(
     "Portal containers: 1",

--- a/app/src/sandbox/visually-hidden-focus-trap-role-6304/test.ts
+++ b/app/src/sandbox/visually-hidden-focus-trap-role-6304/test.ts
@@ -3,10 +3,10 @@ import { expect, test } from "vitest";
 
 // https://github.com/ariakit/ariakit/issues/6304
 test("documented zero-argument Solid hooks return usable props", () => {
-  expect(q.link.ensure(/Learn more\s+about the Solar System/)).toBeVisible();
-  expect(q.region.ensure("Focus trap region")).toBeVisible();
-  expect(q.text.ensure("Role rendered")).toBeVisible();
-  expect(q.text.ensure(/about the Solar System/)).toHaveStyle({
+  expect(q.link(/Learn more\s+about the Solar System/)).toBeVisible();
+  expect(q.region("Focus trap region")).toBeVisible();
+  expect(q.text("Role rendered")).toBeVisible();
+  expect(q.text(/about the Solar System/)).toHaveStyle({
     position: "absolute",
   });
 });


### PR DESCRIPTION
## Motivation

Sandbox tests under `app/src/sandbox/**/test.ts` were using the throwing `.ensure(...)` query variant pervasively, even where the result is only passed to APIs that already handle `null` with a clear failure:

- The `@ariakit/test` interaction utilities (`click`, `hover`, `focus`, `rightClick`) throw an explicit invariant on a null element.
- jest-dom matchers (`toHaveAttribute`, `toBeVisible`, `toHaveFocus`, …) throw on a null received value, including under `.not`.
- `q.within(...)` throws its own invariant on null.

The established convention in `examples/**/test.ts` reserves `.ensure` for the cases where the element is dereferenced directly, so the pervasive usage in sandboxes was inconsistent noise:

```ts
// Before
await click(q.button.ensure("Open dialog"));
expect(q.tab.ensure("Fruits")).toHaveAttribute("aria-selected", "true");

// After — same failure behavior when the element is missing
await click(q.button("Open dialog"));
expect(q.tab("Fruits")).toHaveAttribute("aria-selected", "true");
```

## Solution

Remove `.ensure` wherever the query result only feeds a null-safe sink (interaction utilities, `expect` matchers, `q.within`), and keep it in two cases:

1. The element is dereferenced — property or method access such as `.textContent`, `.querySelector()`, `.focus()`, `.style`, or an argument to a local helper typed with a non-null `HTMLElement` parameter:

   ```ts
   // .ensure stays: the element is dereferenced directly
   const backdrop = q.presentation.ensure();
   await expect.poll(() => backdrop.getAttribute("data-enter")).toBe("true");
   ```

2. The element is an explicit `type()` or `press()` target (from review feedback): unlike the other interaction utilities, `type`/`press` treat a null element as "use the active element" and silently no-op when it isn't focusable, so a missing target would not fail at the call site:

   ```ts
   // .ensure stays: type() falls back to the active element on null
   await type("ana", q.combobox.ensure("Your favorite fruit"));
   ```

This removes 146 redundant call sites across 40 files. The diff is a pure `.ensure` token removal (every removed line equals its added line after deleting `.ensure`), plus an oxfmt rewrap of now-shorter lines in `app/src/sandbox/tab-select-6346/test.ts`.

Verified with `pnpm test-react app/src/sandbox` (48 files / 97 tests), `pnpm test-solid app/src/sandbox` (3 files / 4 tests), `pnpm tsc`, and `pnpm lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)