### PR TITLE
Increase dialog perf fixture size

### DIFF
--- a/app/src/sandbox/dialog-perf/index.react.tsx
+++ b/app/src/sandbox/dialog-perf/index.react.tsx
@@ -2,7 +2,7 @@ import * as Ariakit from "@ariakit/react";
 import { useState } from "react";
 import "./style.css";
 
-const items = Array.from({ length: 200 }, (_, index) => ({
+const items = Array.from({ length: 1000 }, (_, index) => ({
   id: `item-${index + 1}`,
   title: `Item ${index + 1}`,
 }));

--- a/app/src/sandbox/dialog-perf/index.react.tsx
+++ b/app/src/sandbox/dialog-perf/index.react.tsx
@@ -2,7 +2,7 @@ import * as Ariakit from "@ariakit/react";
 import { useState } from "react";
 import "./style.css";
 
-const items = Array.from({ length: 1000 }, (_, index) => ({
+const items = Array.from({ length: 5000 }, (_, index) => ({
   id: `item-${index + 1}`,
   title: `Item ${index + 1}`,
 }));


### PR DESCRIPTION
## Motivation

The `dialog-perf` sandbox currently renders only 200 surrounding cards. That can make the dialog open/close measurements too small to serve as a robust performance signal.

## Solution

Increase the generated outside-card fixture from 200 to 5000 items so the dialog perf tests measure a much heavier page around the dialog without changing the tested interactions.

Because this PR intentionally changes the benchmark fixture, the first perf CI comparison may report large deltas against the old 200-item baseline. After this lands, future comparisons will use the heavier fixture on both sides.
