### PR TITLE
Separate Chrome perf CI into 3 shards

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -289,7 +289,7 @@ jobs:
     needs: [build, build-nextjs, chrome-baseline]
     runs-on: ubuntu-latest
     strategy:
-      # Let both shards finish even if one fails, so each shard's logs and
+      # Let all shards finish even if one fails, so each shard's logs and
       # uploaded rounds stay available for debugging. The post job compares
       # whatever rounds the succeeding shards produced (partial results are
       # fine; a failed shard stays visibly red in CI).
@@ -298,7 +298,7 @@ jobs:
         # `shard` is the only matrix dimension, so the job count equals the
         # shard count; PERF_SHARD_TOTAL below derives from strategy.job-total.
         # Raise this list as the number of perf-chrome test files grows.
-        shard: [1, 2]
+        shard: [1, 2, 3]
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
## Motivation

The Chrome performance CI job currently splits perf browser tests across two shards. As the perf Chrome suite grows, it needs another shard to reduce per-run load while preserving the existing per-shard paired baseline/current measurement flow.

## Solution

Increase the perf workflow's Chrome shard matrix from two entries to three. The existing workflow already derives `PERF_SHARD_TOTAL` from `strategy.job-total`, so adding the third shard automatically updates file partitioning, job names, artifact naming, and the final comparison download pattern.