### PR TITLE
Use pnpm pack for release previews

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -59,9 +59,32 @@ jobs:
         env:
           AFFECTED_PACKAGES: ${{ steps.compute-affected-packages.outputs.affected-packages }}
         run: |
-          packages=$(echo $AFFECTED_PACKAGES | jq -r '.[]' | tr '\n' ' ')
+          set -euo pipefail
+
+          packages=$(echo "$AFFECTED_PACKAGES" | jq -r '.[]' | tr '\n' ' ')
           if [ -n "$packages" ]; then
-            pnpm dlx pkg-pr-new publish --compact --template './templates/*' $packages
+            tmp=$(mktemp -d)
+            trap 'rm -rf "$tmp"' EXIT
+            for package in $packages; do
+              tarball=$(pnpm --dir "$package" pack --json --pack-destination "$tmp" | jq -r '.filename')
+              manifest=$(tar -xOf "$tarball" package/package.json)
+              if jq -e '
+                [
+                  .dependencies,
+                  .optionalDependencies,
+                  .peerDependencies
+                ]
+                | map(. // {})
+                | add
+                | to_entries
+                | map(select(.value | startswith("workspace:")))
+                | length > 0
+              ' <<< "$manifest" > /dev/null; then
+                echo "$package still has workspace: runtime dependencies after pnpm pack"
+                exit 1
+              fi
+            done
+            pnpm exec pkg-pr-new publish --pnpm --compact --template './templates/*' $packages
           else
             echo "No affected packages to publish"
           fi

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -59,31 +59,8 @@ jobs:
         env:
           AFFECTED_PACKAGES: ${{ steps.compute-affected-packages.outputs.affected-packages }}
         run: |
-          set -euo pipefail
-
           packages=$(echo "$AFFECTED_PACKAGES" | jq -r '.[]' | tr '\n' ' ')
           if [ -n "$packages" ]; then
-            tmp=$(mktemp -d)
-            trap 'rm -rf "$tmp"' EXIT
-            for package in $packages; do
-              tarball=$(pnpm --dir "$package" pack --json --pack-destination "$tmp" | jq -r '.filename')
-              manifest=$(tar -xOf "$tarball" package/package.json)
-              if jq -e '
-                [
-                  .dependencies,
-                  .optionalDependencies,
-                  .peerDependencies
-                ]
-                | map(. // {})
-                | add
-                | to_entries
-                | map(select(.value | startswith("workspace:")))
-                | length > 0
-              ' <<< "$manifest" > /dev/null; then
-                echo "$package still has workspace: runtime dependencies after pnpm pack"
-                exit 1
-              fi
-            done
             pnpm exec pkg-pr-new publish --pnpm --compact --template './templates/*' $packages
           else
             echo "No affected packages to publish"

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "oxfmt": "0.56.0",
     "oxlint": "1.71.0",
     "oxlint-tsgolint": "0.23.0",
+    "pkg-pr-new": "0.0.75",
     "postcss": "8.5.8",
     "postcss-import": "16.1.1",
     "prettier": "3.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       oxlint-tsgolint:
         specifier: 0.23.0
         version: 0.23.0
+      pkg-pr-new:
+        specifier: 0.0.75
+        version: 0.0.75
       postcss:
         specifier: 8.5.8
         version: 8.5.8
@@ -8207,6 +8210,10 @@ packages:
 
   pixelmatch@7.2.0:
     resolution: {integrity: sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg==}
+    hasBin: true
+
+  pkg-pr-new@0.0.75:
+    resolution: {integrity: sha512-u9mdErTewKSMsr+ceCt8VcNuNP0ro5AXiPXhUVApuEyqr2Zlvt+DdCFBcm+yGWN8mhOdZJ27meIDbnoZgfzpOw==}
     hasBin: true
 
   pkg-types@1.3.1:
@@ -18500,6 +18507,8 @@ snapshots:
   pixelmatch@7.2.0:
     dependencies:
       pngjs: 7.0.0
+
+  pkg-pr-new@0.0.75: {}
 
   pkg-types@1.3.1:
     dependencies:


### PR DESCRIPTION
## Motivation

The release-preview workflow publishes only the packages selected by the PR changesets. That keeps preview comments small, but it exposed a packaging problem: pkg.pr.new defaults to `npm pack`, and `npm pack` does not rewrite pnpm workspace protocol dependencies in packed manifests.

For example, a PR that previews `@ariakit/react-components` without also preview-publishing `@ariakit/components` can produce a package manifest with a runtime dependency like this:

```json
{
  "dependencies": {
    "@ariakit/components": "workspace:*"
  }
}
```

That manifest is not installable from the StackBlitz/pkg.pr.new template because `@ariakit/components` is not present as a local workspace package there.

## Solution

Install `pkg-pr-new` as a pinned root dev dependency and run it through `pnpm exec` instead of `pnpm dlx`, following pkg.pr.new's CI guidance to use the lockfile-resolved CLI.

The publish command now passes `--pnpm`, so pkg.pr.new packs preview packages with `pnpm pack`. pnpm rewrites workspace protocol dependencies to the current workspace versions during packing, so unpublished internal runtime dependencies resolve to installable versions.

## Verification

- `corepack pnpm lint`
- `corepack pnpm exec pkg-pr-new publish --help`
- Direct `pnpm pack --json` manifest inspection for `packages/ariakit-react-components`, confirming packed runtime dependencies include concrete versions such as `@ariakit/components: "0.1.4"`
- `git diff --check`
