### PR TITLE
Improve perf reporting reliability

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -387,6 +387,7 @@ jobs:
           mkdir -p app/.perf-results
           shopt -s nullglob
           SHARD_FILES=()
+          ROUND_FILES=()
           manifest_status=failed
           manifest_message="Chrome shard exited before completing."
           manifest_failed=0
@@ -395,10 +396,14 @@ jobs:
             PERF_SHARD_STATUS="$manifest_status" \
             PERF_SHARD_MESSAGE="$manifest_message" \
             PERF_SHARD_FILES="$(printf '%s\n' "${SHARD_FILES[@]}")" \
+            PERF_SHARD_ROUND_FILES="$(printf '%s\n' "${ROUND_FILES[@]}")" \
             node --input-type=module <<'NODE'
           import { writeFileSync } from "node:fs";
 
           const files = (process.env.PERF_SHARD_FILES ?? "")
+            .split("\n")
+            .filter(Boolean);
+          const roundFiles = (process.env.PERF_SHARD_ROUND_FILES ?? "")
             .split("\n")
             .filter(Boolean);
           const manifest = {
@@ -407,12 +412,18 @@ jobs:
             status: process.env.PERF_SHARD_STATUS,
             message: process.env.PERF_SHARD_MESSAGE,
             files,
+            roundFiles,
           };
           writeFileSync(
             `app/.perf-results/shard-${process.env.PERF_SHARD_INDEX}-manifest.json`,
             `${JSON.stringify(manifest)}\n`,
           );
           NODE
+          }
+
+          add_round_file() {
+            local file="$1"
+            ROUND_FILES+=("$(basename "$file")")
           }
 
           trap write_chrome_manifest EXIT
@@ -460,13 +471,15 @@ jobs:
             if [ "$baseline_failed" -eq 1 ] || [ ${#baseline_files[@]} -eq 0 ]; then
               if [ "$baseline_failed" -eq 0 ]; then
                 echo "::warning::No baseline perf results for round $i; writing an empty baseline."
-                manifest_failed=1
-                manifest_status=failed
-                manifest_message="No baseline perf results for round $i."
               fi
-              printf '[]\n' > app/.perf-results/baseline-"$i"-s"$PERF_SHARD_INDEX"-worker0.json
+              local empty_baseline_file=app/.perf-results/baseline-"$i"-s"$PERF_SHARD_INDEX"-worker0.json
+              printf '[]\n' > "$empty_baseline_file"
+              add_round_file "$empty_baseline_file"
             else
-              cp "${baseline_files[@]}" app/.perf-results/
+              for file in "${baseline_files[@]}"; do
+                cp "$file" app/.perf-results/
+                add_round_file "$file"
+              done
             fi
             echo "::endgroup::"
           }
@@ -494,6 +507,9 @@ jobs:
               manifest_message="No current perf results for round $i."
               exit 1
             fi
+            for file in "${current_files[@]}"; do
+              add_round_file "$file"
+            done
             echo "::endgroup::"
           }
 
@@ -826,10 +842,14 @@ jobs:
           manifests=("$RUNNER_TEMP"/perf-chrome-rounds/shard-*-manifest.json)
           if ! validation_message="$(
             node --input-type=module - "${manifests[@]}" <<'NODE'
-          import { readFileSync } from "node:fs";
+          import { existsSync, readFileSync } from "node:fs";
+          import path from "node:path";
 
           const manifests = process.argv.slice(2).map((file) => {
-            return JSON.parse(readFileSync(file, "utf-8"));
+            return {
+              file,
+              data: JSON.parse(readFileSync(file, "utf-8")),
+            };
           });
           if (manifests.length === 0) {
             console.log("no shard manifests found.");
@@ -837,7 +857,7 @@ jobs:
           }
           const issues = [];
           const byShard = new Map();
-          for (const manifest of manifests) {
+          for (const { data: manifest, file } of manifests) {
             if (byShard.has(manifest.shard)) {
               issues.push(`duplicate shard manifest: ${manifest.shard}`);
             }
@@ -846,8 +866,41 @@ jobs:
               const message = manifest.message ? ` (${manifest.message})` : "";
               issues.push(`failed shard: ${manifest.shard}${message}`);
             }
+            if (manifest.status === "success") {
+              const roundFiles = Array.isArray(manifest.roundFiles)
+                ? manifest.roundFiles
+                : [];
+              if (roundFiles.length === 0) {
+                issues.push(
+                  `missing round file list for shard: ${manifest.shard}`,
+                );
+              }
+              const seenRoundFiles = new Set();
+              for (const roundFile of roundFiles) {
+                if (typeof roundFile !== "string" || roundFile.includes("/")) {
+                  issues.push(
+                    `invalid round file for shard ${manifest.shard}: ${roundFile}`,
+                  );
+                  continue;
+                }
+                if (seenRoundFiles.has(roundFile)) {
+                  issues.push(
+                    `duplicate round file for shard ${manifest.shard}: ${roundFile}`,
+                  );
+                }
+                seenRoundFiles.add(roundFile);
+                const roundPath = path.join(path.dirname(file), roundFile);
+                if (!existsSync(roundPath)) {
+                  issues.push(
+                    `missing round file for shard ${manifest.shard}: ${roundFile}`,
+                  );
+                }
+              }
+            }
           }
-          const totals = new Set(manifests.map((manifest) => manifest.total));
+          const totals = new Set(
+            manifests.map(({ data: manifest }) => manifest.total),
+          );
           if (totals.size > 1) {
             const sortedTotals = [...totals].sort((a, b) => a - b);
             issues.push(

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -290,9 +290,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       # Let all shards finish even if one fails, so each shard's logs and
-      # uploaded rounds stay available for debugging. The post job compares
-      # whatever rounds the succeeding shards produced (partial results are
-      # fine; a failed shard stays visibly red in CI).
+      # uploaded rounds stay available for debugging. The post job marks
+      # Chrome inconclusive when any shard fails.
       fail-fast: false
       matrix:
         # `shard` is the only matrix dimension, so the job count equals the
@@ -387,6 +386,36 @@ jobs:
           rm -rf app/.perf-results "$BASELINE_DIR/app/.perf-results"
           mkdir -p app/.perf-results
           shopt -s nullglob
+          SHARD_FILES=()
+          manifest_status=failed
+          manifest_message="Chrome shard exited before completing."
+          manifest_failed=0
+
+          write_chrome_manifest() {
+            PERF_SHARD_STATUS="$manifest_status" \
+            PERF_SHARD_MESSAGE="$manifest_message" \
+            PERF_SHARD_FILES="$(printf '%s\n' "${SHARD_FILES[@]}")" \
+            node --input-type=module <<'NODE'
+          import { writeFileSync } from "node:fs";
+
+          const files = (process.env.PERF_SHARD_FILES ?? "")
+            .split("\n")
+            .filter(Boolean);
+          const manifest = {
+            shard: Number(process.env.PERF_SHARD_INDEX),
+            total: Number(process.env.PERF_SHARD_TOTAL),
+            status: process.env.PERF_SHARD_STATUS,
+            message: process.env.PERF_SHARD_MESSAGE,
+            files,
+          };
+          writeFileSync(
+            `app/.perf-results/shard-${process.env.PERF_SHARD_INDEX}-manifest.json`,
+            `${JSON.stringify(manifest)}\n`,
+          );
+          NODE
+          }
+
+          trap write_chrome_manifest EXIT
 
           # Partition the perf test files across shards. The list is computed
           # from the current checkout and the SAME slice is passed to both the
@@ -400,7 +429,6 @@ jobs:
               \( -path '*perf*-chrome.ts' -o -path '*perf*-chrome.tsx' \) \
               | sort
           )
-          SHARD_FILES=()
           for idx in "${!ALL_PERF_FILES[@]}"; do
             if [ "$(( idx % PERF_SHARD_TOTAL ))" -eq "$(( PERF_SHARD_INDEX - 1 ))" ]; then
               SHARD_FILES+=("${ALL_PERF_FILES[$idx]}")
@@ -424,11 +452,17 @@ jobs:
             ); then
               echo "::warning::Baseline perf run failed for round $i; writing an empty baseline."
               baseline_failed=1
+              manifest_failed=1
+              manifest_status=failed
+              manifest_message="Baseline perf run failed for round $i."
             fi
             local baseline_files=("$BASELINE_DIR"/app/.perf-results/baseline-"$i"*.json)
             if [ "$baseline_failed" -eq 1 ] || [ ${#baseline_files[@]} -eq 0 ]; then
               if [ "$baseline_failed" -eq 0 ]; then
                 echo "::warning::No baseline perf results for round $i; writing an empty baseline."
+                manifest_failed=1
+                manifest_status=failed
+                manifest_message="No baseline perf results for round $i."
               fi
               printf '[]\n' > app/.perf-results/baseline-"$i"-s"$PERF_SHARD_INDEX"-worker0.json
             else
@@ -443,13 +477,21 @@ jobs:
             local perf_files=("$@")
 
             echo "::group::Round $i - current"
-            PERF_RESULTS_FILE=current-$i-s$PERF_SHARD_INDEX.json \
-            PERF_ITERATIONS="$PERF_ITERATIONS" \
-            PERF_WARMUP="$PERF_WARMUP" \
-            xvfb-run -a pnpm -F app run test-perf --pass-with-no-tests "${perf_files[@]}"
+            if ! (
+              PERF_RESULTS_FILE=current-$i-s$PERF_SHARD_INDEX.json \
+              PERF_ITERATIONS="$PERF_ITERATIONS" \
+              PERF_WARMUP="$PERF_WARMUP" \
+              xvfb-run -a pnpm -F app run test-perf --pass-with-no-tests "${perf_files[@]}"
+            ); then
+              manifest_status=failed
+              manifest_message="Current perf run failed for round $i."
+              exit 1
+            fi
             local current_files=(app/.perf-results/current-"$i"*.json)
             if [ ${#current_files[@]} -eq 0 ]; then
               echo "Missing current perf results for round $i" >&2
+              manifest_status=failed
+              manifest_message="No current perf results for round $i."
               exit 1
             fi
             echo "::endgroup::"
@@ -475,6 +517,8 @@ jobs:
 
           if [ ${#SHARD_FILES[@]} -eq 0 ]; then
             echo "No perf files assigned to this shard; nothing to benchmark."
+            manifest_status=skipped
+            manifest_message="No perf files assigned to this shard."
             exit 0
           fi
 
@@ -531,12 +575,18 @@ jobs:
             echo "No significant changes detected; skipping confirmation rounds."
           fi
 
+          if [ "$manifest_failed" -eq 0 ]; then
+            manifest_status=success
+            manifest_message=""
+          fi
+
       - name: Upload shard round results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: perf-chrome-rounds-${{ matrix.shard }}
           path: |
+            app/.perf-results/shard-*-manifest.json
             app/.perf-results/baseline-*.json
             app/.perf-results/current-*.json
           if-no-files-found: ignore
@@ -748,27 +798,107 @@ jobs:
 
       - name: Compare Chrome perf results
         # Never let a Chrome comparison failure abort the job before the Node
-        # section is posted; on failure the Chrome section is simply absent.
+        # section is posted; on failure the Chrome section is marked
+        # inconclusive instead.
         continue-on-error: true
         env:
+          PERF_CHROME_RESULT: ${{ needs.chrome.result }}
           PERF_RESULTS_DIR: ${{ runner.temp }}/perf-results
           PERF_SOURCE_BASE_URL: ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.event.pull_request.head.sha }}
         run: |
           shopt -s nullglob
-          rounds=("$RUNNER_TEMP"/perf-chrome-rounds/*.json)
-          if [ ${#rounds[@]} -eq 0 ]; then
-            echo "::warning::No Chrome shard rounds found; skipping Chrome comparison."
+          output_dir="$PERF_RESULTS_DIR/perf-results-chrome"
+          write_chrome_inconclusive() {
+            mkdir -p "$output_dir"
+            {
+              echo "## Performance"
+              echo ""
+              echo ":warning: Chrome perf inconclusive: $1"
+            } > "$output_dir/comparison.md"
+            printf 'Chrome\n' > "$output_dir/title.txt"
+          }
+
+          if [ "$PERF_CHROME_RESULT" != "success" ]; then
+            write_chrome_inconclusive "Chrome shard job result was $PERF_CHROME_RESULT."
             exit 0
           fi
-          # Partial results are fine: compare whatever rounds the succeeding
-          # shards produced. Any failed shard stays visibly red in CI.
+
+          manifests=("$RUNNER_TEMP"/perf-chrome-rounds/shard-*-manifest.json)
+          if ! validation_message="$(
+            node --input-type=module - "${manifests[@]}" <<'NODE'
+          import { readFileSync } from "node:fs";
+
+          const manifests = process.argv.slice(2).map((file) => {
+            return JSON.parse(readFileSync(file, "utf-8"));
+          });
+          if (manifests.length === 0) {
+            console.log("no shard manifests found.");
+            process.exit(0);
+          }
+          const issues = [];
+          const byShard = new Map();
+          for (const manifest of manifests) {
+            if (byShard.has(manifest.shard)) {
+              issues.push(`duplicate shard manifest: ${manifest.shard}`);
+            }
+            byShard.set(manifest.shard, manifest);
+            if (manifest.status !== "success" && manifest.status !== "skipped") {
+              const message = manifest.message ? ` (${manifest.message})` : "";
+              issues.push(`failed shard: ${manifest.shard}${message}`);
+            }
+          }
+          const totals = new Set(manifests.map((manifest) => manifest.total));
+          if (totals.size > 1) {
+            const sortedTotals = [...totals].sort((a, b) => a - b);
+            issues.push(
+              `inconsistent shard totals: ${sortedTotals.join(", ")}`,
+            );
+          }
+          const total = [...totals][0];
+          if (!Number.isInteger(total) || total < 1) {
+            issues.push(`invalid shard total: ${total}`);
+          } else {
+            const missing = [];
+            for (let shard = 1; shard <= total; shard += 1) {
+              if (!byShard.has(shard)) {
+                missing.push(shard);
+              }
+            }
+            if (missing.length > 0) {
+              issues.push(`missing shard manifest(s): ${missing.join(", ")}`);
+            }
+          }
+          if (issues.length > 0) {
+            console.log(issues.join("; "));
+          }
+          NODE
+          )"; then
+            write_chrome_inconclusive "shard manifest validation failed."
+            exit 0
+          fi
+          if [ -n "$validation_message" ]; then
+            write_chrome_inconclusive "$validation_message"
+            exit 0
+          fi
+
+          rounds=(
+            "$RUNNER_TEMP"/perf-chrome-rounds/baseline-*.json
+            "$RUNNER_TEMP"/perf-chrome-rounds/current-*.json
+          )
+          if [ ${#rounds[@]} -eq 0 ]; then
+            write_chrome_inconclusive "no Chrome shard rounds found."
+            exit 0
+          fi
           rm -rf app/.perf-results
           mkdir -p app/.perf-results
           cp "${rounds[@]}" app/.perf-results/
-          pnpm -F app run perf-compare
-          mkdir -p "$PERF_RESULTS_DIR/perf-results-chrome"
-          cp app/.perf-results/comparison.md "$PERF_RESULTS_DIR/perf-results-chrome/"
-          printf 'Chrome\n' > "$PERF_RESULTS_DIR/perf-results-chrome/title.txt"
+          if ! pnpm -F app run perf-compare; then
+            write_chrome_inconclusive "comparison failed."
+            exit 0
+          fi
+          mkdir -p "$output_dir"
+          cp app/.perf-results/comparison.md "$output_dir/"
+          printf 'Chrome\n' > "$output_dir/title.txt"
 
       - name: Create GitHub App token
         id: app-token

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -390,7 +390,6 @@ jobs:
           ROUND_FILES=()
           manifest_status=failed
           manifest_message="Chrome shard exited before completing."
-          manifest_failed=0
 
           write_chrome_manifest() {
             PERF_SHARD_STATUS="$manifest_status" \
@@ -453,7 +452,6 @@ jobs:
             local perf_files=("$@")
 
             echo "::group::Round $i - baseline"
-            local baseline_failed=0
             if ! (
               cd "$BASELINE_DIR" || exit 1
               PERF_RESULTS_FILE=baseline-$i-s$PERF_SHARD_INDEX.json \
@@ -461,17 +459,19 @@ jobs:
               PERF_WARMUP="$PERF_WARMUP" \
               xvfb-run -a pnpm -F app run test-perf --pass-with-no-tests "${perf_files[@]}"
             ); then
-              echo "::warning::Baseline perf run failed for round $i; writing an empty baseline."
-              baseline_failed=1
-              manifest_failed=1
+              # The post job discards every shard's rounds when any shard
+              # fails, so fail fast instead of benchmarking output that is
+              # guaranteed to be thrown away.
               manifest_status=failed
               manifest_message="Baseline perf run failed for round $i."
+              exit 1
             fi
             local baseline_files=("$BASELINE_DIR"/app/.perf-results/baseline-"$i"*.json)
-            if [ "$baseline_failed" -eq 1 ] || [ ${#baseline_files[@]} -eq 0 ]; then
-              if [ "$baseline_failed" -eq 0 ]; then
-                echo "::warning::No baseline perf results for round $i; writing an empty baseline."
-              fi
+            if [ ${#baseline_files[@]} -eq 0 ]; then
+              # A clean run with no matching tests (new or renamed perf files
+              # absent from the base worktree) stays comparable so
+              # perf-compare can report them as new tests with no baseline.
+              echo "::warning::No baseline perf results for round $i; writing an empty baseline."
               local empty_baseline_file=app/.perf-results/baseline-"$i"-s"$PERF_SHARD_INDEX"-worker0.json
               printf '[]\n' > "$empty_baseline_file"
               add_round_file "$empty_baseline_file"
@@ -591,10 +591,8 @@ jobs:
             echo "No significant changes detected; skipping confirmation rounds."
           fi
 
-          if [ "$manifest_failed" -eq 0 ]; then
-            manifest_status=success
-            manifest_message=""
-          fi
+          manifest_status=success
+          manifest_message=""
 
       - name: Upload shard round results
         if: always()

--- a/app/src/sandbox/ariakit-tailwind/perf-chrome.ts
+++ b/app/src/sandbox/ariakit-tailwind/perf-chrome.ts
@@ -6,8 +6,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
   });
 
   test("toggle layer and text classes", async ({ page, perf }) => {
-    await perf.measure(async () => {
-      await page.evaluate(() => {
+    await perf.measure(() =>
+      page.evaluate(() => {
         const sections = document.querySelectorAll<HTMLElement>(
           "section[aria-labelledby]",
         );
@@ -24,7 +24,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
           section.classList.toggle("*:ak-text-red-600");
           section.classList.toggle("ak-frame-p-4");
         }
-      });
-    });
+      }),
+    );
   });
 });

--- a/app/src/sandbox/composite-perf/perf-chrome.ts
+++ b/app/src/sandbox/composite-perf/perf-chrome.ts
@@ -65,39 +65,29 @@ withFramework(import.meta.dirname, async ({ test }) => {
   test("move across items", async ({ q, page, perf }) => {
     const firstItem = q.button("Item 1");
 
-    await perf.measure(
-      async () => {
-        await moveAcrossItems(page);
+    await perf.measure(() => moveAcrossItems(page), {
+      setup: async () => {
+        await setupComposite(q);
+        await firstItem.focus();
+        await expect(firstItem).toBeFocused();
       },
-      {
-        setup: async () => {
-          await setupComposite(q);
-          await firstItem.focus();
-          await expect(firstItem).toBeFocused();
-        },
-        verify: () => verifyMovedAcrossItems(q),
-      },
-    );
+      verify: () => verifyMovedAcrossItems(q),
+    });
   });
 
   test("move across items (script profile)", async ({ q, page, perf }) => {
     const firstItem = q.button("Item 1");
 
-    await perf.measure(
-      async () => {
-        await moveAcrossItems(page);
+    await perf.measure(() => moveAcrossItems(page), {
+      scriptProfile: true,
+      profileLimit: 20,
+      setup: async () => {
+        await setupComposite(q);
+        await firstItem.focus();
+        await expect(firstItem).toBeFocused();
       },
-      {
-        scriptProfile: true,
-        profileLimit: 20,
-        setup: async () => {
-          await setupComposite(q);
-          await firstItem.focus();
-          await expect(firstItem).toBeFocused();
-        },
-        verify: () => verifyMovedAcrossItems(q),
-      },
-    );
+      verify: () => verifyMovedAcrossItems(q),
+    });
   });
 
   test("mount controlled composite", async ({ q, perf }) => {

--- a/app/src/sandbox/composite-perf/perf-chrome.ts
+++ b/app/src/sandbox/composite-perf/perf-chrome.ts
@@ -9,10 +9,11 @@ type Query = ReturnType<typeof query>;
 
 async function mountComposite(q: Query) {
   const mountButton = q.button("Mount composite");
-  const lastItem = q.button(`Item ${itemCount}`);
-
   await mountButton.click();
-  await expect(lastItem).toBeVisible();
+}
+
+async function verifyCompositeMounted(q: Query) {
+  await expect(q.button(`Item ${itemCount}`)).toBeVisible();
 }
 
 async function setupComposite(q: Query) {
@@ -20,12 +21,14 @@ async function setupComposite(q: Query) {
   await expect(q.button("Item 1")).toBeVisible();
 }
 
-async function moveAcrossItems(q: Query, page: Page) {
-  const lastItem = q.button(`Item ${itemCount}`);
+async function moveAcrossItems(page: Page) {
   for (let i = 1; i < itemCount; i++) {
     await page.keyboard.press("ArrowRight");
   }
-  await expect(lastItem).toBeFocused();
+}
+
+async function verifyMovedAcrossItems(q: Query) {
+  await expect(q.button(`Item ${itemCount}`)).toBeFocused();
 }
 
 async function setupControlledComposite(q: Query) {
@@ -38,26 +41,25 @@ async function updateControlledItems(q: Query) {
   for (let i = 0; i < updateCount; i++) {
     await updateButton.click();
   }
+}
+
+async function verifyControlledItemsUpdated(q: Query) {
   await expect(q.status("Updates")).toHaveText(String(updateCount));
 }
 
 withFramework(import.meta.dirname, async ({ test }) => {
   test("mount composite", async ({ q, perf }) => {
-    await perf.measure(async () => {
-      await mountComposite(q);
+    await perf.measure(() => mountComposite(q), {
+      verify: () => verifyCompositeMounted(q),
     });
   });
 
   test("mount composite (script profile)", async ({ q, perf }) => {
-    await perf.measure(
-      async () => {
-        await mountComposite(q);
-      },
-      {
-        scriptProfile: true,
-        profileLimit: 20,
-      },
-    );
+    await perf.measure(() => mountComposite(q), {
+      scriptProfile: true,
+      profileLimit: 20,
+      verify: () => verifyCompositeMounted(q),
+    });
   });
 
   test("move across items", async ({ q, page, perf }) => {
@@ -65,7 +67,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
     await perf.measure(
       async () => {
-        await moveAcrossItems(q, page);
+        await moveAcrossItems(page);
       },
       {
         setup: async () => {
@@ -73,6 +75,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
           await firstItem.focus();
           await expect(firstItem).toBeFocused();
         },
+        verify: () => verifyMovedAcrossItems(q),
       },
     );
   });
@@ -82,7 +85,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
     await perf.measure(
       async () => {
-        await moveAcrossItems(q, page);
+        await moveAcrossItems(page);
       },
       {
         scriptProfile: true,
@@ -92,23 +95,22 @@ withFramework(import.meta.dirname, async ({ test }) => {
           await firstItem.focus();
           await expect(firstItem).toBeFocused();
         },
+        verify: () => verifyMovedAcrossItems(q),
       },
     );
   });
 
   test("mount controlled composite", async ({ q, perf }) => {
     const mountButton = q.button("Mount controlled composite");
-    const lastItem = q.button(`Item ${itemCount}`);
-
-    await perf.measure(async () => {
-      await mountButton.click();
-      await expect(lastItem).toBeVisible();
+    await perf.measure(() => mountButton.click(), {
+      verify: () => verifyCompositeMounted(q),
     });
   });
 
   test("update controlled items", async ({ q, perf }) => {
     await perf.measure(() => updateControlledItems(q), {
       setup: () => setupControlledComposite(q),
+      verify: () => verifyControlledItemsUpdated(q),
     });
   });
 });

--- a/app/src/sandbox/dialog-perf/perf-chrome.ts
+++ b/app/src/sandbox/dialog-perf/perf-chrome.ts
@@ -3,22 +3,30 @@ import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
   test("open dialog", async ({ q, perf }) => {
-    await perf.measure(async () => {
-      await q.button("Open dialog").click();
-      await expect(q.dialog("Settings")).toBeVisible();
-    });
+    await perf.measure(
+      async () => {
+        await q.button("Open dialog").click();
+      },
+      {
+        verify: async () => {
+          await expect(q.dialog("Settings")).toBeVisible();
+        },
+      },
+    );
   });
 
   test("close dialog", async ({ q, perf }) => {
     await perf.measure(
       async () => {
         await q.button("Cancel").click();
-        await expect(q.dialog("Settings")).not.toBeVisible();
       },
       {
         setup: async () => {
           await q.button("Open dialog").click();
           await expect(q.dialog("Settings")).toBeVisible();
+        },
+        verify: async () => {
+          await expect(q.dialog("Settings")).not.toBeVisible();
         },
       },
     );
@@ -31,11 +39,13 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await perf.measure(
       async () => {
         await q.button("Open dialog").click();
-        await expect(q.dialog("Settings")).toBeVisible();
       },
       {
         scriptProfile: true,
         profileLimit: 20,
+        verify: async () => {
+          await expect(q.dialog("Settings")).toBeVisible();
+        },
       },
     );
   });

--- a/app/src/sandbox/dialog-perf/perf-chrome.ts
+++ b/app/src/sandbox/dialog-perf/perf-chrome.ts
@@ -3,50 +3,29 @@ import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
   test("open dialog", async ({ q, perf }) => {
-    await perf.measure(
-      async () => {
-        await q.button("Open dialog").click();
-      },
-      {
-        verify: async () => {
-          await expect(q.dialog("Settings")).toBeVisible();
-        },
-      },
-    );
+    await perf.measure(() => q.button("Open dialog").click(), {
+      verify: () => expect(q.dialog("Settings")).toBeVisible(),
+    });
   });
 
   test("close dialog", async ({ q, perf }) => {
-    await perf.measure(
-      async () => {
-        await q.button("Cancel").click();
+    await perf.measure(() => q.button("Cancel").click(), {
+      setup: async () => {
+        await q.button("Open dialog").click();
+        await expect(q.dialog("Settings")).toBeVisible();
       },
-      {
-        setup: async () => {
-          await q.button("Open dialog").click();
-          await expect(q.dialog("Settings")).toBeVisible();
-        },
-        verify: async () => {
-          await expect(q.dialog("Settings")).not.toBeVisible();
-        },
-      },
-    );
+      verify: () => expect(q.dialog("Settings")).not.toBeVisible(),
+    });
   });
 
   // Same interaction as "open dialog", but with the script profiler enabled
   // so the PR comment shows where the scripting time goes. Profiling adds
   // overhead, so the unprofiled test above is the one to read for timings.
   test("open dialog (script profile)", async ({ q, perf }) => {
-    await perf.measure(
-      async () => {
-        await q.button("Open dialog").click();
-      },
-      {
-        scriptProfile: true,
-        profileLimit: 20,
-        verify: async () => {
-          await expect(q.dialog("Settings")).toBeVisible();
-        },
-      },
-    );
+    await perf.measure(() => q.button("Open dialog").click(), {
+      scriptProfile: true,
+      profileLimit: 20,
+      verify: () => expect(q.dialog("Settings")).toBeVisible(),
+    });
   });
 });

--- a/packages/ariakit-scripts/src/perf-compare.test.ts
+++ b/packages/ariakit-scripts/src/perf-compare.test.ts
@@ -407,7 +407,7 @@ test("describes Node multi-round comparisons by round agreement", () => {
   const markdown = runCompare(dir, ["--node"]);
 
   expect(markdown).toContain(
-    "Aggregated across 2 interleaved rounds; a change is flagged only when the median exceeds the threshold, rounds agree on direction.",
+    "Aggregated across 2 interleaved rounds; a change is flagged only when the paired median delta exceeds the threshold, rounds agree on direction.",
   );
   expect(markdown).not.toContain("raw samples support it");
 });
@@ -455,7 +455,7 @@ test("flags same-direction rounds with separated raw samples", () => {
   expect(markdown).toContain("100.0ms → 160.0ms (+60%) :warning:");
 });
 
-test("pools raw sample support across rounds", () => {
+test("requires raw sample support in each required round", () => {
   const dir = createTempDir();
   writeRawRound(dir, "baseline", 1, [80, 100, 120, 140, 160]);
   writeRawRound(dir, "current", 1, [100, 120, 140, 160, 180]);
@@ -464,8 +464,10 @@ test("pools raw sample support across rounds", () => {
 
   const markdown = runCompare(dir);
 
-  expect(markdown).toContain(":warning:");
-  expect(markdown).toContain("110.0ms → 150.0ms (+36%) :warning:");
+  expect(markdown).toContain("No significant performance changes detected.");
+  expect(markdown).toContain("110.0ms | 150.0ms | +40.0ms (+36%)");
+  expect(markdown).toContain("raw 1/2");
+  expect(markdown).not.toMatch(/% :warning:/);
 });
 
 test("flags a consistent regression across rounds", () => {
@@ -498,7 +500,7 @@ test("aggregates displayed values from shared rounds", () => {
   expect(markdown).not.toContain("125.0ms");
   expect(markdown).toContain("Aggregated across 2 interleaved rounds");
   expect(markdown).toContain(
-    "rounds agree on direction and raw samples support it",
+    "paired median delta exceeds the threshold, rounds agree on direction and raw samples support it",
   );
 });
 

--- a/packages/ariakit-scripts/src/perf-compare.ts
+++ b/packages/ariakit-scripts/src/perf-compare.ts
@@ -25,8 +25,9 @@ const RESULTS_DIR = path.join(process.cwd(), ".perf-results");
 const PROFILE_LIMIT = 10;
 const THRESHOLD_PERCENT = 10;
 const MIN_SIGNIFICANT_DELTA_MS = 5;
-// Require at least 75% of pooled pairwise raw-sample deltas to support the
-// median direction before a browser comparison becomes significant.
+// Require at least 75% of each required round's pairwise raw-sample deltas to
+// support the paired median direction before a browser comparison becomes
+// significant.
 const RAW_SAMPLE_SUPPORT_QUANTILE = 0.25;
 
 type MetricKey = keyof PerfMetrics;
@@ -42,6 +43,8 @@ interface ComparisonRow {
   pairedRoundsCount: number;
   perRoundDeltas: number[];
   agreement: number;
+  sampleSupport: number;
+  threshold: boolean;
   significant: boolean;
   profileMode: boolean;
 }
@@ -518,10 +521,11 @@ function getRoundMetricComparison(
   const currentSamples = getMetricSamples(current, metric);
   const baselineValue = median(baselineSamples);
   const currentValue = median(currentSamples);
+  const delta = currentValue - baselineValue;
   return {
     baseline: baselineValue,
     current: currentValue,
-    delta: currentValue - baselineValue,
+    delta,
     sampleDeltas: getPairwiseDeltas(baselineSamples, currentSamples),
   };
 }
@@ -532,6 +536,7 @@ function computeSignificance({
   minDelta,
   primary,
   percent,
+  requireSampleSupport,
   roundComparisons,
 }: {
   baseline: number;
@@ -539,24 +544,37 @@ function computeSignificance({
   minDelta: number;
   primary: boolean;
   percent: number;
+  requireSampleSupport: boolean;
   roundComparisons: RoundMetricComparison[];
 }) {
   if (roundComparisons.length === 0) {
-    return { agreement: 0, significant: false };
+    return {
+      agreement: 0,
+      sampleSupport: 0,
+      threshold: false,
+      significant: false,
+    };
   }
 
   const delta = current - baseline;
   const direction = Math.sign(delta);
   if (direction === 0) {
-    return { agreement: 0, significant: false };
+    return {
+      agreement: 0,
+      sampleSupport: 0,
+      threshold: false,
+      significant: false,
+    };
   }
 
   let agreement = 0;
-  const sampleDeltas: number[] = [];
+  let sampleSupport = 0;
   for (const comparison of roundComparisons) {
-    sampleDeltas.push(...comparison.sampleDeltas);
     if (Math.sign(comparison.delta) === direction) {
       agreement += 1;
+    }
+    if (samplesSupportDirection(comparison.sampleDeltas, direction)) {
+      sampleSupport += 1;
     }
   }
 
@@ -565,11 +583,14 @@ function computeSignificance({
   const zeroBaselineOk =
     baseline === 0 && current !== baseline && Math.abs(current) >= minDelta;
   const magnitudeOk = baseline === 0 ? zeroBaselineOk : percentOk && deltaOk;
-  const agreementOk = agreement >= requiredAgreement(roundComparisons.length);
-  const sampleSupportOk = samplesSupportDirection(sampleDeltas, direction);
+  const required = requiredAgreement(roundComparisons.length);
+  const agreementOk = agreement >= required;
+  const sampleSupportOk = !requireSampleSupport || sampleSupport >= required;
 
   return {
     agreement,
+    sampleSupport,
+    threshold: magnitudeOk,
     significant: primary && magnitudeOk && agreementOk && sampleSupportOk,
   };
 }
@@ -765,7 +786,6 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
     const primary = !profileMode;
     for (const metric of allMetrics) {
       const baselineValues: number[] = [];
-      const currentValues: number[] = [];
       const roundComparisons: RoundMetricComparison[] = [];
       for (const roundIndex of sharedRoundIndices) {
         const baselineRound = base.byRound.get(roundIndex);
@@ -777,22 +797,25 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
           metric,
         );
         baselineValues.push(comparison.baseline);
-        currentValues.push(comparison.current);
         roundComparisons.push(comparison);
       }
 
       const baseVal = median(baselineValues);
-      const curVal = median(currentValues);
-      const delta = curVal - baseVal;
+      const delta = median(
+        roundComparisons.map((comparison) => comparison.delta),
+      );
+      const curVal = baseVal + delta;
       const percent = baseVal > 0 ? (delta / baseVal) * 100 : 0;
-      const { agreement, significant } = computeSignificance({
-        baseline: baseVal,
-        current: curVal,
-        minDelta,
-        primary: primary && primaryMetrics.includes(metric),
-        percent,
-        roundComparisons,
-      });
+      const { agreement, sampleSupport, threshold, significant } =
+        computeSignificance({
+          baseline: baseVal,
+          current: curVal,
+          minDelta,
+          primary: primary && primaryMetrics.includes(metric),
+          percent,
+          requireSampleSupport: !options.node,
+          roundComparisons,
+        });
       rows.push({
         testFile: cur.result.testFile,
         label: cur.result.label,
@@ -804,6 +827,8 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
         pairedRoundsCount: sharedRoundIndices.length,
         perRoundDeltas: roundComparisons.map((comparison) => comparison.delta),
         agreement,
+        sampleSupport,
+        threshold,
         significant,
         profileMode,
       });
@@ -993,6 +1018,34 @@ function formatSummaryTable(
   return lines;
 }
 
+function formatSupport(row: ComparisonRow, options: PerfCompareOptions) {
+  const rounds = `${row.agreement}/${row.pairedRoundsCount} rounds`;
+  if (options.node) return rounds;
+  return `${rounds}, raw ${row.sampleSupport}/${row.pairedRoundsCount}`;
+}
+
+function formatUnflaggedDiagnostics(
+  rows: ComparisonRow[],
+  options: PerfCompareOptions,
+): string[] {
+  const primaryMetrics = getPrimaryMetrics(options);
+  const diagnostics = rows.filter((row) => {
+    if (row.significant) return false;
+    if (!row.threshold) return false;
+    return primaryMetrics.includes(row.metric);
+  });
+  if (diagnostics.length === 0) return [];
+
+  const details = diagnostics.map((row) => {
+    const metric = getMetricLabel(row.metric, options);
+    return `${metric} (${formatSupport(row, options)})`;
+  });
+  return [
+    `<sub>Unflagged threshold-sized changes: ${details.join("; ")}.</sub>`,
+    "",
+  ];
+}
+
 function formatScriptProfile(result: PerfResult): string[] {
   const profile = result.profiles?.script;
   if (!profile) return [];
@@ -1110,6 +1163,7 @@ function formatDetailedBreakdown({
         );
       }
       lines.push("");
+      lines.push(...formatUnflaggedDiagnostics(testRows, options));
     }
     lines.push(...profileLines);
   }
@@ -1289,12 +1343,12 @@ function formatMarkdown(
   if (pairedRoundsCount == null) {
     lines.push("");
     lines.push(
-      `Compared ${resultsName} used mixed interleaved round counts; a change is flagged only when the median exceeds the threshold, ${supportClause}.`,
+      `Compared ${resultsName} used mixed interleaved round counts; a change is flagged only when the paired median delta exceeds the threshold, ${supportClause}.`,
     );
   } else if (pairedRoundsCount > 1) {
     lines.push("");
     lines.push(
-      `Aggregated across ${pairedRoundsCount} interleaved rounds; a change is flagged only when the median exceeds the threshold, ${supportClause}.`,
+      `Aggregated across ${pairedRoundsCount} interleaved rounds; a change is flagged only when the paired median delta exceeds the threshold, ${supportClause}.`,
     );
   }
 

--- a/packages/ariakit-scripts/src/perf.ts
+++ b/packages/ariakit-scripts/src/perf.ts
@@ -98,6 +98,12 @@ export interface PerfMeasureOptions {
    * close it.
    */
   setup?: () => Promise<void> | void;
+  /**
+   * Unmeasured verification callback run after the metrics snapshot for each
+   * iteration. Use this for assertions so Playwright polling is not counted as
+   * application work.
+   */
+  verify?: () => Promise<void> | void;
   /** Override the auto-generated label for this measurement. */
   label?: string;
   /** Collect expensive JS functions. Adds overhead to measured metrics. */
@@ -842,6 +848,11 @@ async function collectInpValues(page: Page): Promise<number[]> {
   return page.evaluate(() => {
     const w = window as any;
     if (w.__perfObserver) {
+      for (const entry of w.__perfObserver.takeRecords()) {
+        if (entry.interactionId) {
+          w.__perfInpEntries.push(entry.duration);
+        }
+      }
       w.__perfObserver.disconnect();
     }
     return w.__perfInpEntries ?? [];
@@ -1037,6 +1048,7 @@ export async function createPerfMeasure(
     warmup = getIntegerEnv("PERF_WARMUP", 1, { min: 0 }),
     resetPage = true,
     setup,
+    verify,
     label,
     profileLimit = DEFAULT_PROFILE_LIMIT,
   } = options;
@@ -1115,6 +1127,10 @@ export async function createPerfMeasure(
         styleSheetUrls,
         scriptSourceMapUrls,
       });
+
+      if (verify) {
+        await verify();
+      }
 
       // Only keep measured (non-warmup) iterations.
       if (i >= warmup) {

--- a/packages/ariakit-scripts/src/perf.ts
+++ b/packages/ariakit-scripts/src/perf.ts
@@ -1189,9 +1189,7 @@ export async function createPerfPageLoadMeasure(
   const url = page.url();
   return createPerfMeasure(
     page,
-    async () => {
-      await gotoAndSettle(page, url);
-    },
+    () => gotoAndSettle(page, url),
     results,
     testInfo,
     {


### PR DESCRIPTION
## Motivation

Perf reports can be confusing when the reported numbers include Playwright assertion polling, when pending Event Timing entries are missed, or when a Chrome shard failure leaves the PR comment comparing only the surviving shard output.

The comparison logic also made some browser results look stronger than they were by pooling raw sample support across rounds and by displaying independently aggregated medians instead of the paired round delta that decides the comparison.

## Solution

Add an unmeasured `verify` hook to `perf.measure` and move dialog/composite perf assertions into it, so validation still runs without being counted as measured app work. Drain pending Event Timing observer records before disconnecting to avoid losing late INP entries.

Update browser comparison reporting to use paired median deltas, require raw sample support per required round, and show diagnostics for threshold-sized changes that are not flagged. Chrome perf shards now upload manifests, and the post job marks Chrome inconclusive instead of publishing partial comparisons when shards fail, reports are missing, or artifact download is incomplete.

## Testing

- `pnpm exec vitest run packages/ariakit-scripts/src/perf-compare.test.ts packages/ariakit-scripts/src/perf.test.ts`
- `pnpm exec oxlint --disable-nested-config .github/workflows/perf.yml app/src/sandbox/dialog-perf/perf-chrome.ts app/src/sandbox/composite-perf/perf-chrome.ts packages/ariakit-scripts/src/perf.ts packages/ariakit-scripts/src/perf-compare.ts packages/ariakit-scripts/src/perf-compare.test.ts`
- `pnpm exec oxfmt --check packages/ariakit-scripts/src/perf.ts packages/ariakit-scripts/src/perf-compare.ts packages/ariakit-scripts/src/perf-compare.test.ts app/src/sandbox/dialog-perf/perf-chrome.ts app/src/sandbox/composite-perf/perf-chrome.ts`
- `pnpm tsc`
- `git diff --check`
