### PR TITLE
Add composite store navigation tests

### DIFF
--- a/packages/ariakit-components/src/composite/composite-store.test.ts
+++ b/packages/ariakit-components/src/composite/composite-store.test.ts
@@ -96,3 +96,52 @@ test("moves vertically in grids and shifts across uneven rows", () => {
   expect(store.down({ activeId: "a3" })).toBeUndefined();
   expect(store.down({ activeId: "a3", focusShift: true })).toBe("b1");
 });
+
+test("scans within the active item's row on grids", () => {
+  const store = createComposite([
+    { id: "a1", rowId: "a" },
+    { id: "a2", rowId: "a", disabled: true },
+    { id: "a3", rowId: "a" },
+    { id: "b1", rowId: "b" },
+  ]);
+
+  // Skips the disabled item in the same row.
+  expect(store.next({ activeId: "a1" })).toBe("a3");
+  // Stops at the end of the row without moving into the next row.
+  expect(store.next({ activeId: "a3" })).toBeUndefined();
+  // Moves backward within the row.
+  expect(store.previous({ activeId: "a3" })).toBe("a1");
+  // Stops at the start of the row without moving into the previous row.
+  expect(store.previous({ activeId: "b1" })).toBeUndefined();
+});
+
+test("loops within the active item's row on grids", () => {
+  const store = createComposite([
+    { id: "a1", rowId: "a" },
+    { id: "a2", rowId: "a" },
+    { id: "a3", rowId: "a", disabled: true },
+    { id: "b1", rowId: "b" },
+    { id: "b2", rowId: "b" },
+  ]);
+
+  // Forward loop skips the disabled item and wraps to the first item in the
+  // same row, not the next row.
+  expect(store.next({ activeId: "a2", focusLoop: true })).toBe("a1");
+  // Backward loop wraps to the last item in the same row.
+  expect(store.previous({ activeId: "b1", focusLoop: true })).toBe("b2");
+  // Backward loop also skips the disabled item when wrapping.
+  expect(store.previous({ activeId: "a1", focusLoop: true })).toBe("a2");
+});
+
+test("loops past disabled items in one-dimensional composites", () => {
+  const store = createComposite([
+    { id: "one" },
+    { id: "two" },
+    { id: "three", disabled: true },
+  ]);
+
+  // Wraps around to the first enabled item, skipping the disabled last item.
+  expect(store.next({ activeId: "two", focusLoop: true })).toBe("one");
+  // Wraps backward to the last enabled item.
+  expect(store.previous({ activeId: "one", focusLoop: true })).toBe("two");
+});


### PR DESCRIPTION
## Motivation

The composite store's `next` and `previous` functions have edge cases that the existing unit tests in `composite-store.test.ts` don't cover: staying within the active row on grids (skipping disabled items and stopping at row boundaries in both directions instead of moving into an adjacent row), `focusLoop` wrapping within the active row (including past disabled items in both directions) rather than into adjacent rows, and `focusLoop` wrapping past disabled items in one-dimensional composites.

For example, none of the existing tests would catch a regression where `previous` crosses from the first item of a row into the previous row:

```ts
// Stops at the start of the row without moving into the previous row.
expect(store.previous({ activeId: "b1" })).toBeUndefined();
```

Pinning these behaviors down protects upcoming refactors of the navigation logic, such as the performance work in #6616, against regressions.

## Solution

Add three unit tests to `composite-store.test.ts` covering grid row-scoped scanning with disabled items and row boundaries in both directions, grid row-scoped looping that skips disabled items in both directions, and one-dimensional looping past disabled items. All tests pass against the current implementation.

These extend the test additions from #6616 with extra boundary and disabled-item assertions, so that branch can adopt this version of the file when it rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)