### PR TITLE
Improve composite store navigation performance

### DIFF
--- a/.changeset/200-composite-store-next-perf.md
+++ b/.changeset/200-composite-store-next-perf.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/components": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Improved the performance of the composite store's [`next`](https://ariakit.com/reference/use-composite-store#next), [`previous`](https://ariakit.com/reference/use-composite-store#previous), [`up`](https://ariakit.com/reference/use-composite-store#up), and [`down`](https://ariakit.com/reference/use-composite-store#down) functions, which now scan the rendered items without copying arrays in the most common cases.

--- a/packages/ariakit-components/src/composite/composite-store.test.ts
+++ b/packages/ariakit-components/src/composite/composite-store.test.ts
@@ -145,3 +145,29 @@ test("loops past disabled items in one-dimensional composites", () => {
   // Wraps backward to the last enabled item.
   expect(store.previous({ activeId: "one", focusLoop: true })).toBe("two");
 });
+
+test("moves vertically in one-dimensional composites", () => {
+  const store = createComposite([
+    { id: "one" },
+    { id: "two", disabled: true },
+    { id: "three" },
+  ]);
+
+  // Skips the disabled item just like horizontal movement.
+  expect(store.down({ activeId: "one" })).toBe("three");
+  // Vertical loops wrap around just like horizontal ones.
+  expect(store.down({ activeId: "three", focusLoop: true })).toBe("one");
+  expect(store.up({ activeId: "one", focusLoop: true })).toBe("three");
+});
+
+test("handles falsy item ids and row ids", () => {
+  // An item with an empty string id must not return itself when looping.
+  const single = createComposite([{ id: "" }]);
+  expect(single.next({ activeId: "", focusLoop: true })).toBeUndefined();
+
+  // Empty string row ids behave like undefined row ids when moving
+  // vertically.
+  const store = createComposite([{ id: "b", rowId: "" }, { id: "a" }]);
+  expect(store.down({ activeId: "b" })).toBe("a");
+  expect(store.up({ activeId: "a" })).toBe("b");
+});

--- a/packages/ariakit-components/src/composite/composite-store.ts
+++ b/packages/ariakit-components/src/composite/composite-store.ts
@@ -59,6 +59,33 @@ function getItemsInRow(items: CompositeStoreItem[], rowId?: string) {
   return items.filter((item) => item.rowId === rowId);
 }
 
+interface FindEnabledItemIdParams {
+  items: CompositeStoreItem[];
+  fromIndex: number;
+  /** 1 to scan forward, -1 to scan backward. */
+  step: 1 | -1;
+  rowId?: string;
+  excludeId?: string;
+}
+
+function findEnabledItemId({
+  items,
+  fromIndex,
+  step,
+  rowId,
+  excludeId,
+}: FindEnabledItemIdParams) {
+  for (let i = fromIndex; i >= 0 && i < items.length; i += step) {
+    const item = items[i];
+    if (!item) continue;
+    if (item.rowId !== rowId) continue;
+    if (item.disabled) continue;
+    if (excludeId != null && item.id === excludeId) continue;
+    return item.id;
+  }
+  return undefined;
+}
+
 /**
  * Moves all the items before the passed `id` to the end of the array. This is
  * useful when we want to loop through the items in the same row or column as
@@ -243,6 +270,50 @@ export function createCompositeStore<
       : !rtl || isVerticalDirection;
 
     const canShift = focusShift && !skip;
+
+    // Fast path for the most common cases: moving from an active item on
+    // one-dimensional composites or within the same row on two-dimensional
+    // composites, without wrapping, shifting, or skipping. The generic logic
+    // below copies the rendered items array multiple times, which is wasteful
+    // when this function runs on every keyboard navigation event.
+    if (!skip && !focusWrap && !includesBaseElement && activeId != null) {
+      const canFastScan = !isVerticalDirection
+        ? true
+        : !canShift && !renderedItems.some((item) => item.rowId != null);
+      if (canFastScan) {
+        const activeIndex = renderedItems.findIndex(
+          (item) => item.id === activeId,
+        );
+        const activeItem = renderedItems[activeIndex];
+        if (activeItem) {
+          const step: 1 | -1 = canReverse ? -1 : 1;
+          const nextId = findEnabledItemId({
+            items: renderedItems,
+            fromIndex: activeIndex + step,
+            step,
+            rowId: activeItem.rowId,
+            excludeId: activeId,
+          });
+          if (nextId !== undefined) return nextId;
+          const canLoop =
+            focusLoop &&
+            (isVerticalDirection
+              ? focusLoop !== "horizontal"
+              : focusLoop !== "vertical");
+          if (!canLoop) return undefined;
+          // Wrap around to the beginning (or end, when scanning backward) of
+          // the same row, matching the flipItems behavior in the generic
+          // logic below.
+          return findEnabledItemId({
+            items: renderedItems,
+            fromIndex: step === 1 ? 0 : renderedItems.length - 1,
+            step,
+            rowId: activeItem.rowId,
+            excludeId: activeId,
+          });
+        }
+      }
+    }
 
     let items = !isVerticalDirection
       ? renderedItems


### PR DESCRIPTION
## Motivation

Every arrow-key movement in a composite widget calls the store's [`next`](https://ariakit.com/reference/use-composite-store#next), [`previous`](https://ariakit.com/reference/use-composite-store#previous), [`up`](https://ariakit.com/reference/use-composite-store#up), or [`down`](https://ariakit.com/reference/use-composite-store#down) function, and the shared `getNextId` logic copies the rendered items array several times per call (`find`/`indexOf`/`slice`/`filter`/`reverse` chains, plus row grouping and flattening for vertical movement). With hundreds of items, these allocations run on every keystroke. Measured as part of #6616, the copy-free scan contributed to a 17–20% reduction in scripting time in the move-across-400-items benchmark.

## Solution

Add a fast path to `getNextId` for the most common cases — moving from an active item in a one-dimensional composite or within the same row on grids, without `skip`, `focusWrap`, or `includesBaseElement`, and only for non-grids without `focusShift` when moving vertically. The new `findEnabledItemId` helper performs a single indexed scan over `renderedItems` (±1 step, scoped to the active row, skipping disabled items). `focusLoop` is handled by restarting the scan from the opposite end of the array, matching the generic `flipItems` behavior. All other cases (grids moving vertically, wrapping, shifting, base-element handling) keep the generic logic.

Two degenerate-value divergences found during review are fixed and pinned by tests: an item with an empty string id no longer returns itself on loop wrap, and empty string row ids fall back to the generic vertical logic, matching how the generic path normalizes them.

## Tests

The navigation tests added in #6621 were written to pin exactly this fast path's edge cases: row boundaries in both directions, row-scoped looping, and disabled-item skips during scans and loop wraps. This PR adds two more tests — vertical movement in one-dimensional composites (including loops) and the falsy id/row id cases above, the latter verified to fail against the unfixed fast path. A side-by-side comparison script running this branch's store against main's confirmed identical outputs for all probed cases.

Extracted from #6616.

🤖 Generated with [Claude Code](https://claude.com/claude-code)