### PR TITLE
Make perf settle quiescence-based

### DIFF
--- a/packages/ariakit-scripts/src/perf.test.ts
+++ b/packages/ariakit-scripts/src/perf.test.ts
@@ -1,9 +1,11 @@
+import type { CDPSession, Page } from "@playwright/test";
 import { afterEach, expect, test } from "vitest";
 import {
   getIntegerEnv,
   getUniquePerfLabel,
   parseScriptProfile,
   resolveScriptProfileSourceMaps,
+  settleQuiescent,
 } from "./perf.ts";
 
 const envName = "PERF_ITERATIONS";
@@ -253,4 +255,83 @@ test("reuses source map cache across script profile resolutions", async () => {
   await resolveScriptProfileSourceMaps(profile, options);
 
   expect(loadCount).toBe(1);
+});
+
+/**
+ * Drives `settleQuiescent` with a scripted sequence of tracked-work values in
+ * ms. The value at index `i` is returned by the i-th metrics read; the last
+ * value repeats when polling outlasts the sequence.
+ */
+function createSettleHarness(
+  trackedWorkMs: number[],
+  metricName = "ScriptDuration",
+) {
+  let reads = 0;
+  let waits = 0;
+  const page = {
+    evaluate: async () => {},
+    waitForTimeout: async () => {
+      waits += 1;
+    },
+  } as unknown as Page;
+  const cdp = {
+    send: async () => {
+      const index = Math.min(reads, trackedWorkMs.length - 1);
+      reads += 1;
+      // Tracked metrics are reported by CDP in seconds.
+      return {
+        metrics: [
+          { name: metricName, value: (trackedWorkMs[index] ?? 0) / 1000 },
+        ],
+      };
+    },
+  } as unknown as CDPSession;
+  return {
+    page,
+    cdp,
+    getWaits: () => waits,
+  };
+}
+
+test("settle returns after consecutive quiet polls", async () => {
+  const harness = createSettleHarness([100, 100, 100, 100]);
+  await settleQuiescent(harness.page, harness.cdp);
+  expect(harness.getWaits()).toBe(3);
+});
+
+test("settle keeps polling while work grows and stops once it settles", async () => {
+  const harness = createSettleHarness([100, 300, 700, 700, 700, 700]);
+  await settleQuiescent(harness.page, harness.cdp);
+  expect(harness.getWaits()).toBe(5);
+});
+
+test("settle resets quiet detection when late work appears", async () => {
+  const harness = createSettleHarness([100, 100, 500, 500, 500, 500]);
+  await settleQuiescent(harness.page, harness.cdp);
+  expect(harness.getWaits()).toBe(5);
+});
+
+test("settle treats sub-epsilon increases as quiet", async () => {
+  const harness = createSettleHarness([100, 101, 101.5, 102]);
+  await settleQuiescent(harness.page, harness.cdp);
+  expect(harness.getWaits()).toBe(3);
+});
+
+test("settle counts non-script rendering work as activity", async () => {
+  const harness = createSettleHarness(
+    [100, 300, 700, 700, 700, 700],
+    "RecalcStyleDuration",
+  );
+  await settleQuiescent(harness.page, harness.cdp);
+  expect(harness.getWaits()).toBe(5);
+});
+
+test("settle stops at the max wait bound when work never settles", async () => {
+  const values = Array.from({ length: 20 }, (_, i) => i * 10);
+  const harness = createSettleHarness(values);
+  await settleQuiescent(harness.page, harness.cdp, {
+    pollInterval: 10,
+    maxWait: 50,
+  });
+  expect(harness.getWaits()).toBe(5);
 });

--- a/packages/ariakit-scripts/src/perf.ts
+++ b/packages/ariakit-scripts/src/perf.ts
@@ -880,8 +880,55 @@ async function gotoAndSettle(page: Page, url: string) {
     });
 }
 
-/** Lets paint and layout settle after an interaction. */
-async function settlePaint(page: Page) {
+export interface SettleQuiescentOptions {
+  /** Milliseconds between metric polls. */
+  pollInterval?: number;
+  /** Minimum tracked-work increase in ms between polls that counts as activity. */
+  epsilon?: number;
+  /** Consecutive quiet polls required before the page counts as settled. */
+  quietPolls?: number;
+  /**
+   * Cap in ms on the polling phase, so busy pages cannot stall runs. Polling
+   * runs in whole `pollInterval` steps, so a non-divisible cap is rounded up
+   * to the next whole poll.
+   */
+  maxWait?: number;
+}
+
+/**
+ * Main-thread work in ms tracked for settle quiescence. Painting is excluded
+ * on purpose: periodic repaints such as caret blinks would count as activity
+ * and defeat quiescence detection, while any deferred work that produces paint
+ * also shows up here first as script, style recalc, or layout time.
+ */
+function getTrackedWork(
+  metrics: Array<{ name: string; value: number }>,
+): number {
+  const scripting = getMetricValue(metrics, SCRIPT_DURATION);
+  const layout = getMetricValue(metrics, LAYOUT_DURATION);
+  const styleRecalc = getMetricValue(metrics, RECALC_STYLE_DURATION);
+  return (scripting + layout + styleRecalc) * 1000;
+}
+
+/**
+ * Lets the work triggered by an interaction settle before the closing metrics
+ * snapshot. A fixed post-paint wait undercounts deferred work that lands late
+ * on contended CI runners (such as a dialog inert-marking the page after it
+ * opens), which made per-iteration metrics bimodal. Instead, flush the pending
+ * frame, then poll CDP metrics until the tracked main-thread work stops
+ * increasing for `quietPolls` consecutive polls, within the `maxWait` cap.
+ */
+export async function settleQuiescent(
+  page: Page,
+  cdp: CDPSession,
+  options: SettleQuiescentOptions = {},
+) {
+  const {
+    pollInterval = 50,
+    epsilon = 2,
+    quietPolls = 3,
+    maxWait = 2000,
+  } = options;
   await page.evaluate(
     () =>
       new Promise<void>((resolve) => {
@@ -890,7 +937,24 @@ async function settlePaint(page: Page) {
         });
       }),
   );
-  await page.waitForTimeout(50);
+  const readTrackedWork = async () => {
+    const response: MetricsResponse = await cdp.send("Performance.getMetrics");
+    return getTrackedWork(response.metrics);
+  };
+  const maxPolls = Math.ceil(maxWait / pollInterval);
+  let previous = await readTrackedWork();
+  let quiet = 0;
+  for (let i = 0; i < maxPolls; i++) {
+    await page.waitForTimeout(pollInterval);
+    const current = await readTrackedWork();
+    if (current - previous < epsilon) {
+      quiet += 1;
+      if (quiet >= quietPolls) return;
+    } else {
+      quiet = 0;
+    }
+    previous = current;
+  }
 }
 
 /**
@@ -943,7 +1007,7 @@ async function measureOnce(
     }
 
     await interaction();
-    await settlePaint(page);
+    await settleQuiescent(page, cdp);
   } catch (error) {
     measureError = error;
   }
@@ -1117,7 +1181,7 @@ export async function createPerfMeasure(
         // Run the unmeasured setup and let its work settle so it doesn't leak
         // into the metrics snapshot taken right before the interaction.
         await setup();
-        await settlePaint(page);
+        await settleQuiescent(page, cdp);
       }
 
       const result = await measureOnce(page, cdp, interaction, {


### PR DESCRIPTION
## Motivation

Follow-up to the deferred settle suggestion in https://github.com/ariakit/ariakit/pull/6615#discussion_r3518220050.

Chrome perf measurements close their window a fixed double-rAF + 50ms after the interaction. Work that an interaction schedules asynchronously (such as a dialog inert-marking the page after it opens) can start after that window closes on contended CI runners, or still be running when it closes. The raw CI rounds from #6615 show the result: `open dialog` per-iteration scripting was bimodal (~185ms vs ~400-860ms), because the deferred chunk was randomly missed, sliced mid-run, or bled into the next iteration. Medians over 5 samples of a bimodal distribution produced threshold-sized unflagged diagnostics like "+38% scripting, raw 1/2".

A deterministic local testbed (a click handler that schedules a 400ms busy loop `gap` ms later) reproduces every one of those CI artifacts with the fixed settle:

| gap after frame | fixed 50ms settle, raw scripting per iteration |
|---|---|
| 0ms | 400, 400, 400, 400, 400 |
| 30ms | 36, 36, 36, 37, 38 (sliced mid-chunk) |
| 80ms | 0, 453, 0, 453, 0 (miss/bleed alternation) |
| 200ms | 400, 0, 14, 0, 0 |

## Solution

Make the settle quiescence-based. `settleQuiescent` flushes the pending frame (double rAF), then polls CDP `Performance.getMetrics` every 50ms until tracked main-thread work (`ScriptDuration` + `LayoutDuration` + `RecalcStyleDuration`) stops increasing (< 2ms) for 3 consecutive polls, bounded at 2s. Both the post-interaction settle and the unmeasured post-`setup` settle use it, so deferred work can neither escape the measured window nor leak into the next one at the opening edge.

Polling can never slice a running chunk (activity keeps the window open), and the capture tolerance for late-starting work grows from 50ms to 150ms of confirmed silence. Painting is excluded from the tracked sum so periodic repaints such as caret blinks cannot defeat quiescence. Waiting for the interaction's Event Timing entry was considered as an additional signal, but entry delivery only proves the interaction's frame presented (which the double-rAF flush already approximates), not that deferred timers ran, and page-load measurements have no interaction entry at all.

The same testbed with the quiescent settle:

| gap after frame | quiescent settle, raw scripting per iteration |
|---|---|
| 0ms | 400, 400, 400, 400, 400 |
| 30ms | 400, 400, 400, 400, 400 |
| 80ms | 400, 400, 400, 400, 400 |
| 200ms | 0, 800, 0, 800, 0 (documented limit: silent gaps > 150ms) |

Already-quiet pages pay 3 quiet polls (~150ms) instead of the fixed 50ms per iteration and report identical numbers: interleaved A/B runs of the real `dialog-perf` `open dialog` test (4x CPU throttle, 3 runs x 8 iterations per side, same dev server) measured pooled median scripting of 2566ms (old) vs 2511ms (new, -2.1%) with ~6-7% coefficient of variation on both sides and no wall-clock difference.

Unit tests cover the quiescence loop via an injected metrics sequence: consecutive-quiet exit, continued polling while work grows, quiet-count reset on late activity, sub-epsilon increases counting as quiet, and the max-wait bound.

## Expected perf report noise on this PR

The perf workflow's baseline side runs `main`'s `perf.ts`, so this PR's own Chrome report compares a fixed-settle baseline window against a quiescent-settle current window. Tests whose deferred work the old window undercounted (the dialog ones) will show inflated "regressions" that are measurement corrections, not app changes. After this merges, both sides of future PRs use the same settle.

## Testing

- `pnpm exec vitest run packages/ariakit-scripts/src/perf.test.ts packages/ariakit-scripts/src/perf-compare.test.ts`
- `pnpm exec oxlint --disable-nested-config packages/ariakit-scripts/src/perf.ts packages/ariakit-scripts/src/perf.test.ts`
- `pnpm exec oxfmt --check packages/ariakit-scripts/src/perf.ts packages/ariakit-scripts/src/perf.test.ts`
- `pnpm tsc`
- Deterministic gap testbed and interleaved throttled A/B runs described above (local, scratch harness not committed)
