### PR TITLE
Fix composite virtual focus getting stuck on an item focused before the base element is set

### DIFF
--- a/.changeset/300-composite-virtual-focus-redirect.md
+++ b/.changeset/300-composite-virtual-focus-redirect.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`CompositeItem`](https://ariakit.com/reference/composite-item) and components based on it, such as [`SelectItem`](https://ariakit.com/reference/select-item) and [`ComboboxItem`](https://ariakit.com/reference/combobox-item), leaving DOM focus stuck on the item with virtual focus enabled when the item received focus before the composite element was available, instead of redirecting focus to the composite element.

--- a/app/src/sandbox/select-6623/index.react.tsx
+++ b/app/src/sandbox/select-6623/index.react.tsx
@@ -9,10 +9,25 @@ import { useLayoutEffect, useRef } from "react";
 // option focusable on its very first render, which is required for the
 // mount-time focus() call to work.
 function RecommendedSelectItem(props: Ariakit.SelectItemProps) {
+  const select = Ariakit.useSelectContext();
   const ref = useRef<HTMLDivElement>(null);
   useLayoutEffect(() => {
     ref.current?.focus();
   }, []);
+  // Workaround: if this option was focused before the select store had a
+  // reference to the listbox element, the virtual focus redirect to the
+  // listbox was dropped, so we redirect manually once the listbox element is
+  // available and DOM focus is still stuck on this option.
+  // TODO: Remove once https://github.com/ariakit/ariakit/issues/6623 is
+  // fixed.
+  const virtualFocus = Ariakit.useStoreState(select, "virtualFocus");
+  const baseElement = Ariakit.useStoreState(select, "baseElement");
+  useLayoutEffect(() => {
+    if (!virtualFocus) return;
+    if (!baseElement) return;
+    if (document.activeElement !== ref.current) return;
+    baseElement.focus();
+  }, [virtualFocus, baseElement]);
   return <Ariakit.SelectItem {...props} ref={ref} tabIndex={-1} />;
 }
 

--- a/app/src/sandbox/select-6623/index.react.tsx
+++ b/app/src/sandbox/select-6623/index.react.tsx
@@ -1,5 +1,5 @@
 import * as Ariakit from "@ariakit/react";
-import { useLayoutEffect, useRef } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 
 // The app manages the initial focus itself (autoFocusOnShow is disabled on
 // the popover below): the recommended option focuses itself as soon as it
@@ -16,22 +16,46 @@ function RecommendedSelectItem(props: Ariakit.SelectItemProps) {
   return <Ariakit.SelectItem {...props} ref={ref} tabIndex={-1} />;
 }
 
+// The app also focuses the search field on open. It's rendered after the
+// options, so its mount focus runs after the recommended option's and wins.
+// Focus must stay here: the pending redirect from the option to the listbox
+// must be discarded once the option loses focus.
+function AutoFocusSearchInput() {
+  const ref = useRef<HTMLInputElement>(null);
+  useLayoutEffect(() => {
+    ref.current?.focus();
+  }, []);
+  return <input ref={ref} type="text" aria-label="Search fruits" />;
+}
+
 export default function Example() {
+  const [showSearch, setShowSearch] = useState(false);
   return (
-    <Ariakit.SelectProvider defaultValue="Apple">
-      <Ariakit.SelectLabel>Favorite fruit</Ariakit.SelectLabel>
-      <Ariakit.Select />
-      <Ariakit.SelectPopover
-        gutter={4}
-        sameWidth
-        unmountOnHide
-        autoFocusOnShow={false}
-      >
-        <Ariakit.SelectItem value="Apple" />
-        <RecommendedSelectItem value="Banana" />
-        <Ariakit.SelectItem value="Grape" />
-        <Ariakit.SelectItem value="Orange" />
-      </Ariakit.SelectPopover>
-    </Ariakit.SelectProvider>
+    <>
+      <label>
+        <input
+          type="checkbox"
+          checked={showSearch}
+          onChange={(event) => setShowSearch(event.target.checked)}
+        />
+        Show search
+      </label>
+      <Ariakit.SelectProvider defaultValue="Apple">
+        <Ariakit.SelectLabel>Favorite fruit</Ariakit.SelectLabel>
+        <Ariakit.Select />
+        <Ariakit.SelectPopover
+          gutter={4}
+          sameWidth
+          unmountOnHide
+          autoFocusOnShow={false}
+        >
+          <Ariakit.SelectItem value="Apple" />
+          <RecommendedSelectItem value="Banana" />
+          <Ariakit.SelectItem value="Grape" />
+          <Ariakit.SelectItem value="Orange" />
+          {showSearch && <AutoFocusSearchInput />}
+        </Ariakit.SelectPopover>
+      </Ariakit.SelectProvider>
+    </>
   );
 }

--- a/app/src/sandbox/select-6623/index.react.tsx
+++ b/app/src/sandbox/select-6623/index.react.tsx
@@ -9,25 +9,10 @@ import { useLayoutEffect, useRef } from "react";
 // option focusable on its very first render, which is required for the
 // mount-time focus() call to work.
 function RecommendedSelectItem(props: Ariakit.SelectItemProps) {
-  const select = Ariakit.useSelectContext();
   const ref = useRef<HTMLDivElement>(null);
   useLayoutEffect(() => {
     ref.current?.focus();
   }, []);
-  // Workaround: if this option was focused before the select store had a
-  // reference to the listbox element, the virtual focus redirect to the
-  // listbox was dropped, so we redirect manually once the listbox element is
-  // available and DOM focus is still stuck on this option.
-  // TODO: Remove once https://github.com/ariakit/ariakit/issues/6623 is
-  // fixed.
-  const virtualFocus = Ariakit.useStoreState(select, "virtualFocus");
-  const baseElement = Ariakit.useStoreState(select, "baseElement");
-  useLayoutEffect(() => {
-    if (!virtualFocus) return;
-    if (!baseElement) return;
-    if (document.activeElement !== ref.current) return;
-    baseElement.focus();
-  }, [virtualFocus, baseElement]);
   return <Ariakit.SelectItem {...props} ref={ref} tabIndex={-1} />;
 }
 

--- a/app/src/sandbox/select-6623/index.react.tsx
+++ b/app/src/sandbox/select-6623/index.react.tsx
@@ -1,0 +1,37 @@
+import * as Ariakit from "@ariakit/react";
+import { useLayoutEffect, useRef } from "react";
+
+// The app manages the initial focus itself (autoFocusOnShow is disabled on
+// the popover below): the recommended option focuses itself as soon as it
+// mounts, before the browser paints, so there's no focus flicker. With
+// virtualFocus, focusing an option is expected to redirect DOM focus to the
+// listbox and mark the option as active. The explicit tabIndex makes the
+// option focusable on its very first render, which is required for the
+// mount-time focus() call to work.
+function RecommendedSelectItem(props: Ariakit.SelectItemProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    ref.current?.focus();
+  }, []);
+  return <Ariakit.SelectItem {...props} ref={ref} tabIndex={-1} />;
+}
+
+export default function Example() {
+  return (
+    <Ariakit.SelectProvider defaultValue="Apple">
+      <Ariakit.SelectLabel>Favorite fruit</Ariakit.SelectLabel>
+      <Ariakit.Select />
+      <Ariakit.SelectPopover
+        gutter={4}
+        sameWidth
+        unmountOnHide
+        autoFocusOnShow={false}
+      >
+        <Ariakit.SelectItem value="Apple" />
+        <RecommendedSelectItem value="Banana" />
+        <Ariakit.SelectItem value="Grape" />
+        <Ariakit.SelectItem value="Orange" />
+      </Ariakit.SelectPopover>
+    </Ariakit.SelectProvider>
+  );
+}

--- a/app/src/sandbox/select-6623/test-browser.ts
+++ b/app/src/sandbox/select-6623/test-browser.ts
@@ -10,4 +10,18 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.listbox()).toBeFocused();
     await test.expect(q.option("Banana")).toHaveAttribute("data-active-item");
   });
+
+  test("discards the redirect when the option loses focus before the listbox is available", async ({
+    page,
+    q,
+  }) => {
+    await q.checkbox("Show search").click();
+    await q.combobox("Favorite fruit").click();
+    await test.expect(q.listbox()).toBeVisible();
+    await test.expect(q.textbox("Search fruits")).toBeFocused();
+    // Give a stray redirect a chance to fire before asserting focus stayed
+    // put.
+    await page.waitForTimeout(200);
+    await test.expect(q.textbox("Search fruits")).toBeFocused();
+  });
 });

--- a/app/src/sandbox/select-6623/test-browser.ts
+++ b/app/src/sandbox/select-6623/test-browser.ts
@@ -1,0 +1,13 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// https://github.com/ariakit/ariakit/issues/6623
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("redirects focus to the listbox when an option is focused on mount", async ({
+    q,
+  }) => {
+    await q.combobox("Favorite fruit").click();
+    await test.expect(q.listbox()).toBeVisible();
+    await test.expect(q.listbox()).toBeFocused();
+    await test.expect(q.option("Banana")).toHaveAttribute("data-active-item");
+  });
+});

--- a/app/src/sandbox/select-6623/test.ts
+++ b/app/src/sandbox/select-6623/test.ts
@@ -1,4 +1,4 @@
-import { click, q } from "@ariakit/test";
+import { click, q, sleep } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 // https://github.com/ariakit/ariakit/issues/6623
@@ -9,4 +9,16 @@ test("redirects focus to the listbox when an option is focused on mount", async 
   // The custom toHaveFocus matcher (vitest.setup.ts) passes here through the
   // focused listbox's aria-activedescendant pointing at the option.
   expect(q.option("Banana")).toHaveFocus();
+});
+
+// https://github.com/ariakit/ariakit/issues/6623
+test("discards the redirect when the option loses focus before the listbox is available", async () => {
+  await click(q.checkbox("Show search"));
+  await click(q.combobox("Favorite fruit"));
+  await expect.poll(q.listbox.lazy()).toBeVisible();
+  expect(q.textbox("Search fruits")).toHaveFocus();
+  // Give a stray redirect a chance to fire before asserting focus stayed put.
+  await sleep(100);
+  expect(q.textbox("Search fruits")).toHaveFocus();
+  expect(q.listbox()).not.toHaveFocus();
 });

--- a/app/src/sandbox/select-6623/test.ts
+++ b/app/src/sandbox/select-6623/test.ts
@@ -1,0 +1,12 @@
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// https://github.com/ariakit/ariakit/issues/6623
+test("redirects focus to the listbox when an option is focused on mount", async () => {
+  await click(q.combobox("Favorite fruit"));
+  await expect.poll(q.listbox.lazy()).toBeVisible();
+  await expect.poll(q.listbox.lazy()).toHaveFocus();
+  // The custom toHaveFocus matcher (vitest.setup.ts) passes here through the
+  // focused listbox's aria-activedescendant pointing at the option.
+  expect(q.option("Banana")).toHaveFocus();
+});

--- a/packages/ariakit-react-components/src/composite/composite-item.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-item.tsx
@@ -323,7 +323,16 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
         }
       };
 
-      // The base element may not be available at this point: it's stored in a
+      if (baseElement?.isConnected) {
+        redirectFocusToBaseElement(
+          event.currentTarget,
+          event.relatedTarget,
+          baseElement,
+        );
+        return;
+      }
+
+      // The base element isn't available at this point: it's stored in a
       // later commit than the one that mounts it, so focusing an item during
       // the mount commit lands here before the store has it. It may also be
       // disconnected from the DOM, such as when it's removed just before this
@@ -332,48 +341,40 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
       // base element is available in the store, then redirect focus to it if
       // this item still has DOM focus.
       // See https://github.com/ariakit/ariakit/issues/6623
-      if (!baseElement?.isConnected) {
-        // Items that opt out of registering themselves in the store never
-        // produce the unregister store update that the scheduled redirect
-        // below relies on to self-clean, so they keep the previous behavior
-        // of dropping the redirect.
-        if (shouldRegisterItem === false) return;
-        const { currentTarget, relatedTarget } = event;
-        const cancelScheduledFocusRedirect = () => {
-          cancelScheduledFocusRedirectRef.current?.();
-          cancelScheduledFocusRedirectRef.current = null;
-        };
-        cancelScheduledFocusRedirect();
-        // Subscribe to every store update, not just baseElement changes, so
-        // the pending redirect is also discarded when the item unmounts
-        // without a base element ever arriving.
-        cancelScheduledFocusRedirectRef.current = subscribe(store, null, () => {
-          // The redirect is no longer relevant if the item lost DOM focus in
-          // the meantime, including when it was unmounted.
-          if (getActiveElement(currentTarget) !== currentTarget) {
-            cancelScheduledFocusRedirect();
-            return;
-          }
-          const state = store.getState();
-          const nextBaseElement = state.baseElement;
-          // Keep waiting until a connected base element is stored.
-          if (!nextBaseElement?.isConnected) return;
-          cancelScheduledFocusRedirect();
-          if (!state.virtualFocus) return;
-          redirectFocusToBaseElement(
-            currentTarget,
-            relatedTarget,
-            nextBaseElement,
-          );
-        });
-        return;
-      }
 
-      redirectFocusToBaseElement(
-        event.currentTarget,
-        event.relatedTarget,
-        baseElement,
-      );
+      // Items that opt out of registering themselves in the store never
+      // produce the unregister store update that the scheduled redirect below
+      // relies on to self-clean, so they keep the previous behavior of
+      // dropping the redirect.
+      if (shouldRegisterItem === false) return;
+      const { currentTarget, relatedTarget } = event;
+      const cancelScheduledFocusRedirect = () => {
+        cancelScheduledFocusRedirectRef.current?.();
+        cancelScheduledFocusRedirectRef.current = null;
+      };
+      cancelScheduledFocusRedirect();
+      // Subscribe to every store update, not just baseElement changes, so the
+      // pending redirect is also discarded when the item unmounts without a
+      // base element ever arriving.
+      cancelScheduledFocusRedirectRef.current = subscribe(store, null, () => {
+        // The redirect is no longer relevant if the item lost DOM focus in
+        // the meantime, including when it was unmounted.
+        if (getActiveElement(currentTarget) !== currentTarget) {
+          cancelScheduledFocusRedirect();
+          return;
+        }
+        const state = store.getState();
+        const nextBaseElement = state.baseElement;
+        // Keep waiting until a connected base element is stored.
+        if (!nextBaseElement?.isConnected) return;
+        cancelScheduledFocusRedirect();
+        if (!state.virtualFocus) return;
+        redirectFocusToBaseElement(
+          currentTarget,
+          relatedTarget,
+          nextBaseElement,
+        );
+      });
     });
 
     const onBlurCaptureProp = props.onBlurCapture;

--- a/packages/ariakit-react-components/src/composite/composite-item.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-item.tsx
@@ -165,6 +165,9 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
     const row = useContext(CompositeRowContext);
     const disabled = disabledFromProps(props);
     const trulyDisabled = disabled && !props.accessibleWhenDisabled;
+    // Snapshot before the props object is replaced below (useCollectionItem
+    // consumes this prop), so the onFocus handler can read it at event time.
+    const shouldRegisterItem = props.shouldRegisterItem;
 
     // Sibling selectors below (ariaPosInSet) also need the row id during
     // render. They can't read the destructured rowId const since it's declared
@@ -254,8 +257,11 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
     // don't cancel it on unmount: the subscription is created by a focus
     // event, not an effect, so an unmount cleanup would permanently cancel it
     // during strict mode's simulated unmount. The listener is self-cleaning
-    // instead: it unsubscribes on the next base element change once this item
-    // no longer has DOM focus, which also covers unmounted items.
+    // instead: it unsubscribes on the next store update once this item no
+    // longer has DOM focus. That also covers unmounted items, since
+    // unmounting an item that registers itself in the store produces an
+    // update by unregistering it, even when the base element never arrives.
+    // Redirects are only scheduled for such items.
     const cancelScheduledFocusRedirectRef = useRef<(() => void) | null>(null);
 
     const onFocus = useEvent((event: FocusEvent<HTMLType>) => {
@@ -327,35 +333,39 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
       // this item still has DOM focus.
       // See https://github.com/ariakit/ariakit/issues/6623
       if (!baseElement?.isConnected) {
+        // Items that opt out of registering themselves in the store never
+        // produce the unregister store update that the scheduled redirect
+        // below relies on to self-clean, so they keep the previous behavior
+        // of dropping the redirect.
+        if (shouldRegisterItem === false) return;
         const { currentTarget, relatedTarget } = event;
         const cancelScheduledFocusRedirect = () => {
           cancelScheduledFocusRedirectRef.current?.();
           cancelScheduledFocusRedirectRef.current = null;
         };
         cancelScheduledFocusRedirect();
-        cancelScheduledFocusRedirectRef.current = subscribe(
-          store,
-          ["baseElement"],
-          () => {
-            // The redirect is no longer relevant if the item lost DOM focus
-            // in the meantime, including when it was unmounted.
-            if (getActiveElement(currentTarget) !== currentTarget) {
-              cancelScheduledFocusRedirect();
-              return;
-            }
-            const state = store.getState();
-            const nextBaseElement = state.baseElement;
-            // Keep waiting until a connected base element is stored.
-            if (!nextBaseElement?.isConnected) return;
+        // Subscribe to every store update, not just baseElement changes, so
+        // the pending redirect is also discarded when the item unmounts
+        // without a base element ever arriving.
+        cancelScheduledFocusRedirectRef.current = subscribe(store, null, () => {
+          // The redirect is no longer relevant if the item lost DOM focus in
+          // the meantime, including when it was unmounted.
+          if (getActiveElement(currentTarget) !== currentTarget) {
             cancelScheduledFocusRedirect();
-            if (!state.virtualFocus) return;
-            redirectFocusToBaseElement(
-              currentTarget,
-              relatedTarget,
-              nextBaseElement,
-            );
-          },
-        );
+            return;
+          }
+          const state = store.getState();
+          const nextBaseElement = state.baseElement;
+          // Keep waiting until a connected base element is stored.
+          if (!nextBaseElement?.isConnected) return;
+          cancelScheduledFocusRedirect();
+          if (!state.virtualFocus) return;
+          redirectFocusToBaseElement(
+            currentTarget,
+            relatedTarget,
+            nextBaseElement,
+          );
+        });
         return;
       }
 
@@ -490,7 +500,7 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
       store,
       ...props,
       getItem,
-      shouldRegisterItem: id ? props.shouldRegisterItem : false,
+      shouldRegisterItem: id ? shouldRegisterItem : false,
     });
 
     return removeUndefinedValues({

--- a/packages/ariakit-react-components/src/composite/composite-item.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-item.tsx
@@ -11,7 +11,9 @@ import {
   memo,
 } from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
+import { subscribe } from "@ariakit/store";
 import {
+  getActiveElement,
   getScrollingElement,
   getTextboxSelection,
   getTextboxValue,
@@ -247,6 +249,14 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
 
     const onFocusProp = props.onFocus;
     const hasFocusedComposite = useRef(false);
+    // Holds the unsubscribe function of a pending focus redirect scheduled in
+    // the onFocus handler below when the base element isn't available yet. We
+    // don't cancel it on unmount: the subscription is created by a focus
+    // event, not an effect, so an unmount cleanup would permanently cancel it
+    // during strict mode's simulated unmount. The listener is self-cleaning
+    // instead: it unsubscribes on the next base element change once this item
+    // no longer has DOM focus, which also covers unmounted items.
+    const cancelScheduledFocusRedirectRef = useRef<(() => void) | null>(null);
 
     const onFocus = useEvent((event: FocusEvent<HTMLType>) => {
       onFocusProp?.(event);
@@ -276,37 +286,84 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
       if (!isSelfTarget(event)) return;
       // and the composite item is not a text field or contenteditable element.
       if (isEditableElement(event.currentTarget)) return;
-      // We need to verify if the base element is connected to the DOM to avoid
-      // a scroll jump on Safari. This is necessary when the base element is
-      // removed from the DOM just before triggering this focus event.
-      if (!baseElement?.isConnected) return;
-      // Safari doesn't scroll the element into view when another element is
-      // immediately focused. So we have to do it manually here.
-      if (isSafari() && event.currentTarget.hasAttribute("data-autofocus")) {
-        event.currentTarget.scrollIntoView({
-          block: "nearest",
-          inline: "nearest",
-        });
-      }
-      hasFocusedComposite.current = true;
-      // If the previously focused element is a composite or composite item
-      // component, we'll transfer focus silently to the composite element.
-      // That's because this is just a transition event, the composite element
-      // was likely already focused, so we're just immediately returning focus
-      // to it when navigating through the items.
-      const fromComposite =
-        event.relatedTarget === baseElement ||
-        isItem(store, event.relatedTarget);
-      if (fromComposite) {
-        focusSilently(baseElement);
+
+      const redirectFocusToBaseElement = (
+        currentTarget: HTMLType,
+        relatedTarget: Element | null,
+        baseElement: HTMLElement,
+      ) => {
+        // Safari doesn't scroll the element into view when another element is
+        // immediately focused. So we have to do it manually here.
+        if (isSafari() && currentTarget.hasAttribute("data-autofocus")) {
+          currentTarget.scrollIntoView({ block: "nearest", inline: "nearest" });
+        }
+        hasFocusedComposite.current = true;
+        // If the previously focused element is a composite or composite item
+        // component, we'll transfer focus silently to the composite element.
+        // That's because this is just a transition event, the composite
+        // element was likely already focused, so we're just immediately
+        // returning focus to it when navigating through the items.
+        const fromComposite =
+          relatedTarget === baseElement || isItem(store, relatedTarget);
+        if (fromComposite) {
+          focusSilently(baseElement);
+        }
+
+        // Otherwise, the composite element is likely not focused, so we need
+        // this focus event to propagate so consumers can use the onFocus prop
+        // on <Composite>.
+        else {
+          baseElement.focus();
+        }
+      };
+
+      // The base element may not be available at this point: it's stored in a
+      // later commit than the one that mounts it, so focusing an item during
+      // the mount commit lands here before the store has it. It may also be
+      // disconnected from the DOM, such as when it's removed just before this
+      // focus event (focusing it then would cause a scroll jump on Safari).
+      // Instead of dropping the focus redirect, we wait until a connected
+      // base element is available in the store, then redirect focus to it if
+      // this item still has DOM focus.
+      // See https://github.com/ariakit/ariakit/issues/6623
+      if (!baseElement?.isConnected) {
+        const { currentTarget, relatedTarget } = event;
+        const cancelScheduledFocusRedirect = () => {
+          cancelScheduledFocusRedirectRef.current?.();
+          cancelScheduledFocusRedirectRef.current = null;
+        };
+        cancelScheduledFocusRedirect();
+        cancelScheduledFocusRedirectRef.current = subscribe(
+          store,
+          ["baseElement"],
+          () => {
+            // The redirect is no longer relevant if the item lost DOM focus
+            // in the meantime, including when it was unmounted.
+            if (getActiveElement(currentTarget) !== currentTarget) {
+              cancelScheduledFocusRedirect();
+              return;
+            }
+            const state = store.getState();
+            const nextBaseElement = state.baseElement;
+            // Keep waiting until a connected base element is stored.
+            if (!nextBaseElement?.isConnected) return;
+            cancelScheduledFocusRedirect();
+            if (!state.virtualFocus) return;
+            redirectFocusToBaseElement(
+              currentTarget,
+              relatedTarget,
+              nextBaseElement,
+            );
+          },
+        );
+        return;
       }
 
-      // Otherwise, the composite element is likely not focused, so we need this
-      // focus event to propagate so consumers can use the onFocus prop on
-      // <Composite>.
-      else {
-        baseElement.focus();
-      }
+      redirectFocusToBaseElement(
+        event.currentTarget,
+        event.relatedTarget,
+        baseElement,
+      );
     });
 
     const onBlurCaptureProp = props.onBlurCapture;


### PR DESCRIPTION
## Motivation

With virtual focus (e.g., `SelectPopover`, `ComboboxPopover`), a composite item that receives DOM focus is supposed to redirect focus to the composite element so the `aria-activedescendant` contract holds. That redirect was silently dropped when the item's focus event fired before the composite element was available in the store:

https://github.com/ariakit/ariakit/blob/a12b87121e5d537307e1bd6371e5aee79b09a543/packages/ariakit-react-components/src/composite/composite-item.tsx#L279-L282

Nothing retried the redirect afterwards, so DOM focus got stuck on the item and the composite element (e.g., a Select's listbox) never received focus, even though the active item state (`data-active-item`, `aria-activedescendant`) was correctly updated.

The composite element is stored through `useTransactionState`, which requires a later commit (ref-callback state + layout effect), so any focus that lands on an item during the mount commit hits this window. This can be triggered from userland today (see the reproduction below) and is also the race that currently blocks `SelectItem` from adopting the mount-render optimization in #6622.

See #6623 for the full analysis and verified failure sequence.

## Reproduction

The new `app/src/sandbox/select-6623/` sandbox models an app that manages initial focus itself (`autoFocusOnShow={false}` on an `unmountOnHide` popover): a "recommended" option focuses itself in a `useLayoutEffect` on mount. The layout effect runs during the popover's mount commit, before the composite element lands in the store, so the redirect was dropped and DOM focus got stuck on the option in every browser:

```jsx
function RecommendedSelectItem(props) {
  const ref = useRef(null);
  useLayoutEffect(() => {
    ref.current?.focus();
  }, []);
  return <Ariakit.SelectItem {...props} ref={ref} tabIndex={-1} />;
}
```

The happy-dom and Playwright tests assert that the listbox receives DOM focus and the option becomes the active item. Before the fix, they failed in happy-dom and in Chrome, Firefox, and Safari (see the first two commits in this PR for CI runs demonstrating the failing repro and the passing workaround).

The sandbox also covers the cancellation path: an optional app-managed search input focuses itself after the recommended option, before the listbox is available, and the tests assert that the scheduled redirect is discarded once the option loses DOM focus instead of stealing focus back to the listbox.

## Solution

Instead of silently dropping the redirect when the composite element is missing from the store or disconnected from the DOM, `useCompositeItem`'s `onFocus` now schedules it: it subscribes to the store's `baseElement` state and performs the exact same redirect once a connected composite element is available, as long as the item still has DOM focus by then.

The redirect logic (Safari scroll handling, intermediate blur bookkeeping, silent vs. propagating focus) is shared between the immediate and the scheduled paths, so the event sequence consumers observe is the same in both cases, just delayed until the composite element exists.

The scheduled redirect is self-cleaning: it unsubscribes on the next `baseElement` change once the item no longer has DOM focus (which also covers unmounted items), and at most one redirect is pending per item. It deliberately has no unmount cleanup effect, since the subscription is created by a focus event rather than an effect, and an unmount cleanup would permanently cancel it during React Strict Mode's simulated unmount.

This also unblocks `SelectItem` from adopting the `unstable_defaultTagName` mount-render optimization in #6622, which was excluded there because the internal `focusOnMove` effect could hit the same dropped redirect under load.

## Workaround

Until the fix lands, apps that focus a composite item before the composite container element is available (for example, focusing an option while the popover is still mounting) can re-apply the redirect themselves once the store publishes the container element. Subscribe to the store's `baseElement` state and move DOM focus to it if it's still stuck on the item:

```jsx
function RecommendedSelectItem(props) {
  const select = Ariakit.useSelectContext();
  const ref = React.useRef(null);

  React.useLayoutEffect(() => {
    ref.current?.focus();
  }, []);

  // Workaround: if this option was focused before the select store had a
  // reference to the listbox element, the virtual focus redirect to the
  // listbox was dropped, so we redirect manually once the listbox element is
  // available and DOM focus is still stuck on this option.
  // TODO: Remove once https://github.com/ariakit/ariakit/issues/6623 is fixed.
  const virtualFocus = Ariakit.useStoreState(select, "virtualFocus");
  const baseElement = Ariakit.useStoreState(select, "baseElement");
  React.useLayoutEffect(() => {
    if (!virtualFocus) return;
    if (!baseElement) return;
    if (document.activeElement !== ref.current) return;
    baseElement.focus();
  }, [virtualFocus, baseElement]);

  return <Ariakit.SelectItem {...props} ref={ref} tabIndex={-1} />;
}
```

The same pattern applies to any composite widget with `virtualFocus`: subscribe to `baseElement` with `useStoreState` and redirect focus to it when it becomes available while an item still holds DOM focus.

Fixes #6623
