### PR TITLE
Use lighter defaults for script perf profiles

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -310,6 +310,12 @@ jobs:
       # enough signal for noisy results.
       PERF_ITERATIONS: 5
       PERF_WARMUP: 1
+      # Script profiles are diagnostic and significantly slower. These values
+      # are also passed through the legacy PERF_ITERATIONS/PERF_WARMUP names
+      # for the baseline checkout, which may not support script-specific env
+      # vars yet.
+      PERF_SCRIPT_PROFILE_ITERATIONS: 3
+      PERF_SCRIPT_PROFILE_WARMUP: 0
       PERF_SOURCE_BASE_URL: ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.event.pull_request.head.sha }}
       # Each shard benchmarks a disjoint subset of the perf test files and runs
       # its own interleaved baseline-vs-current rounds on this one runner, so the
@@ -425,6 +431,31 @@ jobs:
             ROUND_FILES+=("$(basename "$file")")
           }
 
+          has_matching_tests() {
+            local workspace="$1"
+            local grep_flag="$2"
+            shift
+            shift
+            local output
+            if ! output="$(
+              cd "$workspace" || exit 1
+              pnpm -F app run test-perf \
+                --pass-with-no-tests \
+                --list \
+                "$grep_flag" "script profile" \
+              "$@"
+            )"; then
+              printf '%s\n' "$output"
+              manifest_status=failed
+              manifest_message="Failed to list matching perf tests."
+              exit 1
+            fi
+            if grep -Eq "Total: [1-9][0-9]* tests? in" <<< "$output"; then
+              return 0
+            fi
+            return 1
+          }
+
           trap write_chrome_manifest EXIT
 
           # Partition the perf test files across shards. The list is computed
@@ -448,16 +479,20 @@ jobs:
 
           run_baseline_perf_round() {
             local i="$1"
-            shift
-            local perf_files=("$@")
+            local group="$2"
+            local iterations="$3"
+            local warmup="$4"
+            shift 4
+            local perf_args=("$@")
+            local result_prefix=baseline-"$i"-s"$PERF_SHARD_INDEX"-"$group"
 
-            echo "::group::Round $i - baseline"
+            echo "::group::Round $i - baseline ($group)"
             if ! (
               cd "$BASELINE_DIR" || exit 1
-              PERF_RESULTS_FILE=baseline-$i-s$PERF_SHARD_INDEX.json \
-              PERF_ITERATIONS="$PERF_ITERATIONS" \
-              PERF_WARMUP="$PERF_WARMUP" \
-              xvfb-run -a pnpm -F app run test-perf --pass-with-no-tests "${perf_files[@]}"
+              PERF_RESULTS_FILE="$result_prefix.json" \
+              PERF_ITERATIONS="$iterations" \
+              PERF_WARMUP="$warmup" \
+              xvfb-run -a pnpm -F app run test-perf --pass-with-no-tests "${perf_args[@]}"
             ); then
               # The post job discards every shard's rounds when any shard
               # fails, so fail fast instead of benchmarking output that is
@@ -466,13 +501,13 @@ jobs:
               manifest_message="Baseline perf run failed for round $i."
               exit 1
             fi
-            local baseline_files=("$BASELINE_DIR"/app/.perf-results/baseline-"$i"*.json)
+            local baseline_files=("$BASELINE_DIR"/app/.perf-results/"$result_prefix"*.json)
             if [ ${#baseline_files[@]} -eq 0 ]; then
               # A clean run with no matching tests (new or renamed perf files
               # absent from the base worktree) stays comparable so
               # perf-compare can report them as new tests with no baseline.
-              echo "::warning::No baseline perf results for round $i; writing an empty baseline."
-              local empty_baseline_file=app/.perf-results/baseline-"$i"-s"$PERF_SHARD_INDEX"-worker0.json
+              echo "::warning::No baseline perf results for round $i ($group); writing an empty baseline."
+              local empty_baseline_file=app/.perf-results/"$result_prefix"-worker0.json
               printf '[]\n' > "$empty_baseline_file"
               add_round_file "$empty_baseline_file"
             else
@@ -486,26 +521,39 @@ jobs:
 
           run_current_perf_round() {
             local i="$1"
-            shift
-            local perf_files=("$@")
+            local group="$2"
+            local iterations="$3"
+            local warmup="$4"
+            local allow_empty="$5"
+            shift 5
+            local perf_args=("$@")
+            local result_prefix=current-"$i"-s"$PERF_SHARD_INDEX"-"$group"
 
-            echo "::group::Round $i - current"
+            echo "::group::Round $i - current ($group)"
             if ! (
-              PERF_RESULTS_FILE=current-$i-s$PERF_SHARD_INDEX.json \
-              PERF_ITERATIONS="$PERF_ITERATIONS" \
-              PERF_WARMUP="$PERF_WARMUP" \
-              xvfb-run -a pnpm -F app run test-perf --pass-with-no-tests "${perf_files[@]}"
+              PERF_RESULTS_FILE="$result_prefix.json" \
+              PERF_ITERATIONS="$iterations" \
+              PERF_WARMUP="$warmup" \
+              xvfb-run -a pnpm -F app run test-perf --pass-with-no-tests "${perf_args[@]}"
             ); then
               manifest_status=failed
               manifest_message="Current perf run failed for round $i."
               exit 1
             fi
-            local current_files=(app/.perf-results/current-"$i"*.json)
+            local current_files=(app/.perf-results/"$result_prefix"*.json)
             if [ ${#current_files[@]} -eq 0 ]; then
-              echo "Missing current perf results for round $i" >&2
-              manifest_status=failed
-              manifest_message="No current perf results for round $i."
-              exit 1
+              if [ "$allow_empty" -ne 1 ]; then
+                echo "Missing current perf results for round $i ($group)" >&2
+                manifest_status=failed
+                manifest_message="No current perf results for round $i ($group)."
+                exit 1
+              fi
+              echo "::warning::No current perf results for round $i ($group); writing an empty current result."
+              local empty_current_file=app/.perf-results/"$result_prefix"-worker0.json
+              printf '[]\n' > "$empty_current_file"
+              add_round_file "$empty_current_file"
+              echo "::endgroup::"
+              return
             fi
             for file in "${current_files[@]}"; do
               add_round_file "$file"
@@ -515,19 +563,61 @@ jobs:
 
           run_perf_round() {
             local i="$1"
-            shift
-            local perf_files=("$@")
+            local group="$2"
+            local iterations="$3"
+            local warmup="$4"
+            local allow_empty="$5"
+            shift 5
+            local perf_args=("$@")
 
             # Alternate sides first so same-runner drift cannot consistently
             # favor the baseline or current run across every paired round.
             if [ "$(( i % 2 ))" -eq 1 ]; then
-              echo "Round $i order: baseline -> current"
-              run_baseline_perf_round "$i" "${perf_files[@]}"
-              run_current_perf_round "$i" "${perf_files[@]}"
+              echo "Round $i ($group) order: baseline -> current"
+              run_baseline_perf_round "$i" "$group" "$iterations" "$warmup" "${perf_args[@]}"
+              run_current_perf_round "$i" "$group" "$iterations" "$warmup" "$allow_empty" "${perf_args[@]}"
             else
-              echo "Round $i order: current -> baseline"
-              run_current_perf_round "$i" "${perf_files[@]}"
-              run_baseline_perf_round "$i" "${perf_files[@]}"
+              echo "Round $i ($group) order: current -> baseline"
+              run_current_perf_round "$i" "$group" "$iterations" "$warmup" "$allow_empty" "${perf_args[@]}"
+              run_baseline_perf_round "$i" "$group" "$iterations" "$warmup" "${perf_args[@]}"
+            fi
+          }
+
+          run_perf_rounds() {
+            local i="$1"
+            shift
+            local perf_files=("$@")
+            local current_has_timing=0
+            local current_has_script_profile=0
+            local baseline_has_script_profile=0
+            if has_matching_tests "." --grep-invert "${perf_files[@]}"; then
+              current_has_timing=1
+            fi
+            if has_matching_tests "." --grep "${perf_files[@]}"; then
+              current_has_script_profile=1
+            fi
+            if has_matching_tests "$BASELINE_DIR" --grep "${perf_files[@]}"; then
+              baseline_has_script_profile=1
+            fi
+
+            run_perf_round \
+              "$i" \
+              timing \
+              "$PERF_ITERATIONS" \
+              "$PERF_WARMUP" \
+              "$(( 1 - current_has_timing ))" \
+              --grep-invert "script profile" \
+              "${perf_files[@]}"
+
+            if [ "$current_has_script_profile" -eq 1 ] || [ "$baseline_has_script_profile" -eq 1 ]; then
+              run_perf_round \
+                "$i" \
+                script-profile \
+                "$PERF_SCRIPT_PROFILE_ITERATIONS" \
+                "$PERF_SCRIPT_PROFILE_WARMUP" \
+                "$(( 1 - current_has_script_profile ))" \
+                --grep "script profile" \
+                "${perf_files[@]}"
             fi
           }
 
@@ -539,7 +629,7 @@ jobs:
           fi
 
           for i in $(seq 1 "$PERF_INITIAL_ROUNDS"); do
-            run_perf_round "$i" "${SHARD_FILES[@]}"
+            run_perf_rounds "$i" "${SHARD_FILES[@]}"
           done
 
           # This per-shard comparison only decides whether THIS shard needs
@@ -585,7 +675,7 @@ jobs:
             start_round=$((PERF_INITIAL_ROUNDS + 1))
             end_round=$((PERF_INITIAL_ROUNDS + PERF_CONFIRMATION_ROUNDS))
             for i in $(seq "$start_round" "$end_round"); do
-              run_perf_round "$i" "${CONFIRMATION_FILES[@]}"
+              run_perf_rounds "$i" "${CONFIRMATION_FILES[@]}"
             done
           else
             echo "No significant changes detected; skipping confirmation rounds."

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -310,12 +310,6 @@ jobs:
       # enough signal for noisy results.
       PERF_ITERATIONS: 5
       PERF_WARMUP: 1
-      # Script profiles are diagnostic and significantly slower. These values
-      # are also passed through the legacy PERF_ITERATIONS/PERF_WARMUP names
-      # for the baseline checkout, which may not support script-specific env
-      # vars yet.
-      PERF_SCRIPT_PROFILE_ITERATIONS: 3
-      PERF_SCRIPT_PROFILE_WARMUP: 0
       PERF_SOURCE_BASE_URL: ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.event.pull_request.head.sha }}
       # Each shard benchmarks a disjoint subset of the perf test files and runs
       # its own interleaved baseline-vs-current rounds on this one runner, so the
@@ -431,31 +425,6 @@ jobs:
             ROUND_FILES+=("$(basename "$file")")
           }
 
-          has_matching_tests() {
-            local workspace="$1"
-            local grep_flag="$2"
-            shift
-            shift
-            local output
-            if ! output="$(
-              cd "$workspace" || exit 1
-              pnpm -F app run test-perf \
-                --pass-with-no-tests \
-                --list \
-                "$grep_flag" "script profile" \
-              "$@"
-            )"; then
-              printf '%s\n' "$output"
-              manifest_status=failed
-              manifest_message="Failed to list matching perf tests."
-              exit 1
-            fi
-            if grep -Eq "Total: [1-9][0-9]* tests? in" <<< "$output"; then
-              return 0
-            fi
-            return 1
-          }
-
           trap write_chrome_manifest EXIT
 
           # Partition the perf test files across shards. The list is computed
@@ -479,20 +448,16 @@ jobs:
 
           run_baseline_perf_round() {
             local i="$1"
-            local group="$2"
-            local iterations="$3"
-            local warmup="$4"
-            shift 4
-            local perf_args=("$@")
-            local result_prefix=baseline-"$i"-s"$PERF_SHARD_INDEX"-"$group"
+            shift
+            local perf_files=("$@")
 
-            echo "::group::Round $i - baseline ($group)"
+            echo "::group::Round $i - baseline"
             if ! (
               cd "$BASELINE_DIR" || exit 1
-              PERF_RESULTS_FILE="$result_prefix.json" \
-              PERF_ITERATIONS="$iterations" \
-              PERF_WARMUP="$warmup" \
-              xvfb-run -a pnpm -F app run test-perf --pass-with-no-tests "${perf_args[@]}"
+              PERF_RESULTS_FILE=baseline-$i-s$PERF_SHARD_INDEX.json \
+              PERF_ITERATIONS="$PERF_ITERATIONS" \
+              PERF_WARMUP="$PERF_WARMUP" \
+              xvfb-run -a pnpm -F app run test-perf --pass-with-no-tests "${perf_files[@]}"
             ); then
               # The post job discards every shard's rounds when any shard
               # fails, so fail fast instead of benchmarking output that is
@@ -501,13 +466,13 @@ jobs:
               manifest_message="Baseline perf run failed for round $i."
               exit 1
             fi
-            local baseline_files=("$BASELINE_DIR"/app/.perf-results/"$result_prefix"*.json)
+            local baseline_files=("$BASELINE_DIR"/app/.perf-results/baseline-"$i"*.json)
             if [ ${#baseline_files[@]} -eq 0 ]; then
               # A clean run with no matching tests (new or renamed perf files
               # absent from the base worktree) stays comparable so
               # perf-compare can report them as new tests with no baseline.
-              echo "::warning::No baseline perf results for round $i ($group); writing an empty baseline."
-              local empty_baseline_file=app/.perf-results/"$result_prefix"-worker0.json
+              echo "::warning::No baseline perf results for round $i; writing an empty baseline."
+              local empty_baseline_file=app/.perf-results/baseline-"$i"-s"$PERF_SHARD_INDEX"-worker0.json
               printf '[]\n' > "$empty_baseline_file"
               add_round_file "$empty_baseline_file"
             else
@@ -521,39 +486,26 @@ jobs:
 
           run_current_perf_round() {
             local i="$1"
-            local group="$2"
-            local iterations="$3"
-            local warmup="$4"
-            local allow_empty="$5"
-            shift 5
-            local perf_args=("$@")
-            local result_prefix=current-"$i"-s"$PERF_SHARD_INDEX"-"$group"
+            shift
+            local perf_files=("$@")
 
-            echo "::group::Round $i - current ($group)"
+            echo "::group::Round $i - current"
             if ! (
-              PERF_RESULTS_FILE="$result_prefix.json" \
-              PERF_ITERATIONS="$iterations" \
-              PERF_WARMUP="$warmup" \
-              xvfb-run -a pnpm -F app run test-perf --pass-with-no-tests "${perf_args[@]}"
+              PERF_RESULTS_FILE=current-$i-s$PERF_SHARD_INDEX.json \
+              PERF_ITERATIONS="$PERF_ITERATIONS" \
+              PERF_WARMUP="$PERF_WARMUP" \
+              xvfb-run -a pnpm -F app run test-perf --pass-with-no-tests "${perf_files[@]}"
             ); then
               manifest_status=failed
               manifest_message="Current perf run failed for round $i."
               exit 1
             fi
-            local current_files=(app/.perf-results/"$result_prefix"*.json)
+            local current_files=(app/.perf-results/current-"$i"*.json)
             if [ ${#current_files[@]} -eq 0 ]; then
-              if [ "$allow_empty" -ne 1 ]; then
-                echo "Missing current perf results for round $i ($group)" >&2
-                manifest_status=failed
-                manifest_message="No current perf results for round $i ($group)."
-                exit 1
-              fi
-              echo "::warning::No current perf results for round $i ($group); writing an empty current result."
-              local empty_current_file=app/.perf-results/"$result_prefix"-worker0.json
-              printf '[]\n' > "$empty_current_file"
-              add_round_file "$empty_current_file"
-              echo "::endgroup::"
-              return
+              echo "Missing current perf results for round $i" >&2
+              manifest_status=failed
+              manifest_message="No current perf results for round $i."
+              exit 1
             fi
             for file in "${current_files[@]}"; do
               add_round_file "$file"
@@ -563,61 +515,19 @@ jobs:
 
           run_perf_round() {
             local i="$1"
-            local group="$2"
-            local iterations="$3"
-            local warmup="$4"
-            local allow_empty="$5"
-            shift 5
-            local perf_args=("$@")
+            shift
+            local perf_files=("$@")
 
             # Alternate sides first so same-runner drift cannot consistently
             # favor the baseline or current run across every paired round.
             if [ "$(( i % 2 ))" -eq 1 ]; then
-              echo "Round $i ($group) order: baseline -> current"
-              run_baseline_perf_round "$i" "$group" "$iterations" "$warmup" "${perf_args[@]}"
-              run_current_perf_round "$i" "$group" "$iterations" "$warmup" "$allow_empty" "${perf_args[@]}"
+              echo "Round $i order: baseline -> current"
+              run_baseline_perf_round "$i" "${perf_files[@]}"
+              run_current_perf_round "$i" "${perf_files[@]}"
             else
-              echo "Round $i ($group) order: current -> baseline"
-              run_current_perf_round "$i" "$group" "$iterations" "$warmup" "$allow_empty" "${perf_args[@]}"
-              run_baseline_perf_round "$i" "$group" "$iterations" "$warmup" "${perf_args[@]}"
-            fi
-          }
-
-          run_perf_rounds() {
-            local i="$1"
-            shift
-            local perf_files=("$@")
-            local current_has_timing=0
-            local current_has_script_profile=0
-            local baseline_has_script_profile=0
-            if has_matching_tests "." --grep-invert "${perf_files[@]}"; then
-              current_has_timing=1
-            fi
-            if has_matching_tests "." --grep "${perf_files[@]}"; then
-              current_has_script_profile=1
-            fi
-            if has_matching_tests "$BASELINE_DIR" --grep "${perf_files[@]}"; then
-              baseline_has_script_profile=1
-            fi
-
-            run_perf_round \
-              "$i" \
-              timing \
-              "$PERF_ITERATIONS" \
-              "$PERF_WARMUP" \
-              "$(( 1 - current_has_timing ))" \
-              --grep-invert "script profile" \
-              "${perf_files[@]}"
-
-            if [ "$current_has_script_profile" -eq 1 ] || [ "$baseline_has_script_profile" -eq 1 ]; then
-              run_perf_round \
-                "$i" \
-                script-profile \
-                "$PERF_SCRIPT_PROFILE_ITERATIONS" \
-                "$PERF_SCRIPT_PROFILE_WARMUP" \
-                "$(( 1 - current_has_script_profile ))" \
-                --grep "script profile" \
-                "${perf_files[@]}"
+              echo "Round $i order: current -> baseline"
+              run_current_perf_round "$i" "${perf_files[@]}"
+              run_baseline_perf_round "$i" "${perf_files[@]}"
             fi
           }
 
@@ -629,7 +539,7 @@ jobs:
           fi
 
           for i in $(seq 1 "$PERF_INITIAL_ROUNDS"); do
-            run_perf_rounds "$i" "${SHARD_FILES[@]}"
+            run_perf_round "$i" "${SHARD_FILES[@]}"
           done
 
           # This per-shard comparison only decides whether THIS shard needs
@@ -675,7 +585,7 @@ jobs:
             start_round=$((PERF_INITIAL_ROUNDS + 1))
             end_round=$((PERF_INITIAL_ROUNDS + PERF_CONFIRMATION_ROUNDS))
             for i in $(seq "$start_round" "$end_round"); do
-              run_perf_rounds "$i" "${CONFIRMATION_FILES[@]}"
+              run_perf_round "$i" "${CONFIRMATION_FILES[@]}"
             done
           else
             echo "No significant changes detected; skipping confirmation rounds."

--- a/packages/ariakit-scripts/src/perf.test.ts
+++ b/packages/ariakit-scripts/src/perf.test.ts
@@ -1,7 +1,8 @@
 import type { CDPSession, Page } from "@playwright/test";
-import { afterEach, expect, test } from "vitest";
+import { afterEach, beforeEach, expect, test } from "vitest";
 import {
   getIntegerEnv,
+  getPerfSamplingOptions,
   getUniquePerfLabel,
   parseScriptProfile,
   resolveScriptProfileSourceMaps,
@@ -9,14 +10,35 @@ import {
 } from "./perf.ts";
 
 const envName = "PERF_ITERATIONS";
-const originalValue = process.env[envName];
+const envNames = [
+  envName,
+  "PERF_WARMUP",
+  "PERF_SCRIPT_PROFILE_ITERATIONS",
+  "PERF_SCRIPT_PROFILE_WARMUP",
+];
+const originalValues = new Map(
+  envNames.map((name) => [name, process.env[name]]),
+);
+
+function clearPerfEnv() {
+  for (const name of envNames) {
+    delete process.env[name];
+  }
+}
+
+beforeEach(() => {
+  clearPerfEnv();
+});
 
 afterEach(() => {
-  if (originalValue == null) {
-    delete process.env[envName];
-    return;
+  for (const name of envNames) {
+    const originalValue = originalValues.get(name);
+    if (originalValue == null) {
+      delete process.env[name];
+    } else {
+      process.env[name] = originalValue;
+    }
   }
-  process.env[envName] = originalValue;
 });
 
 test("gets integer env values with range validation", () => {
@@ -30,6 +52,71 @@ test("gets integer env values with range validation", () => {
 
   process.env[envName] = "0";
   expect(getIntegerEnv(envName, 1, { min: 0 })).toBe(0);
+});
+
+test("gets built-in perf sampling defaults", () => {
+  expect(getPerfSamplingOptions()).toEqual({
+    iterations: 10,
+    warmup: 1,
+  });
+  expect(getPerfSamplingOptions({ scriptProfile: true })).toEqual({
+    iterations: 3,
+    warmup: 0,
+  });
+});
+
+test("gets env perf sampling options", () => {
+  process.env.PERF_ITERATIONS = "5";
+  process.env.PERF_WARMUP = "2";
+
+  expect(getPerfSamplingOptions()).toEqual({
+    iterations: 5,
+    warmup: 2,
+  });
+  expect(getPerfSamplingOptions({ scriptProfile: true })).toEqual({
+    iterations: 3,
+    warmup: 0,
+  });
+});
+
+test("overrides script profile perf sampling options", () => {
+  process.env.PERF_ITERATIONS = "5";
+  process.env.PERF_WARMUP = "1";
+  process.env.PERF_SCRIPT_PROFILE_ITERATIONS = "4";
+  process.env.PERF_SCRIPT_PROFILE_WARMUP = "1";
+
+  expect(getPerfSamplingOptions({ scriptProfile: true })).toEqual({
+    iterations: 4,
+    warmup: 1,
+  });
+  expect(getPerfSamplingOptions({ iterations: 2, warmup: 2 })).toEqual({
+    iterations: 2,
+    warmup: 2,
+  });
+  expect(
+    getPerfSamplingOptions({
+      iterations: 2,
+      warmup: 2,
+      scriptProfile: true,
+    }),
+  ).toEqual({
+    iterations: 2,
+    warmup: 2,
+  });
+});
+
+test("preserves explicit invalid perf sampling options", () => {
+  expect(
+    getPerfSamplingOptions({
+      // @ts-expect-error Preserve runtime validation for invalid callers.
+      iterations: null,
+      // @ts-expect-error Preserve runtime validation for invalid callers.
+      warmup: null,
+    }),
+  ).toEqual({
+    iterations: null,
+    warmup: null,
+  });
 });
 
 test("resolves duplicate perf labels with exact label counts", () => {

--- a/packages/ariakit-scripts/src/perf.ts
+++ b/packages/ariakit-scripts/src/perf.ts
@@ -13,6 +13,10 @@ import type { CDPSession, Page, TestInfo } from "@playwright/test";
 
 const RESULTS_DIR = path.join(process.cwd(), ".perf-results");
 const DEFAULT_PROFILE_LIMIT = 10;
+const DEFAULT_PERF_ITERATIONS = 10;
+const DEFAULT_PERF_WARMUP = 1;
+const DEFAULT_SCRIPT_PROFILE_ITERATIONS = 3;
+const DEFAULT_SCRIPT_PROFILE_WARMUP = 0;
 const initializedResultFiles = new Set<string>();
 
 // CDP metric names (values are in seconds).
@@ -117,6 +121,17 @@ export interface PerfMeasureOptions {
 interface CreatePerfMeasureOptions extends PerfMeasureOptions {
   /** Re-navigate to the current page URL before each measured interaction. */
   resetPage?: boolean;
+}
+
+interface PerfSamplingOptions {
+  iterations?: number;
+  warmup?: number;
+  scriptProfile?: boolean;
+}
+
+interface PerfSamplingResult {
+  iterations: number;
+  warmup: number;
 }
 
 export interface PerfResult {
@@ -294,6 +309,34 @@ export function getIntegerEnv(
   if (!Number.isInteger(parsed)) return fallback;
   if (options.min != null && parsed < options.min) return fallback;
   return parsed;
+}
+
+export function getPerfSamplingOptions({
+  iterations,
+  warmup,
+  scriptProfile,
+}: PerfSamplingOptions = {}): PerfSamplingResult {
+  // Script profiles are diagnostic and much more expensive than the unprofiled
+  // timing run, so keep their default sample count lower.
+  const defaultIterations = scriptProfile
+    ? getIntegerEnv(
+        "PERF_SCRIPT_PROFILE_ITERATIONS",
+        DEFAULT_SCRIPT_PROFILE_ITERATIONS,
+        { min: 1 },
+      )
+    : getIntegerEnv("PERF_ITERATIONS", DEFAULT_PERF_ITERATIONS, { min: 1 });
+  const defaultWarmup = scriptProfile
+    ? getIntegerEnv(
+        "PERF_SCRIPT_PROFILE_WARMUP",
+        DEFAULT_SCRIPT_PROFILE_WARMUP,
+        { min: 0 },
+      )
+    : getIntegerEnv("PERF_WARMUP", DEFAULT_PERF_WARMUP, { min: 0 });
+
+  return {
+    iterations: iterations === undefined ? defaultIterations : iterations,
+    warmup: warmup === undefined ? defaultWarmup : warmup,
+  };
 }
 
 function normalizeProfileUrl(url: string): string {
@@ -1108,8 +1151,6 @@ export async function createPerfMeasure(
   options: CreatePerfMeasureOptions = {},
 ): Promise<PerfMetrics> {
   const {
-    iterations = getIntegerEnv("PERF_ITERATIONS", 10, { min: 1 }),
-    warmup = getIntegerEnv("PERF_WARMUP", 1, { min: 0 }),
     resetPage = true,
     setup,
     verify,
@@ -1122,6 +1163,11 @@ export async function createPerfMeasure(
     options.selectorProfile ??
     (isTruthyEnv("PERF_SELECTOR_PROFILE") ||
       isTruthyEnv("PERF_CSS_SELECTOR_PROFILE"));
+  const { iterations, warmup } = getPerfSamplingOptions({
+    iterations: options.iterations,
+    warmup: options.warmup,
+    scriptProfile,
+  });
 
   if (!Number.isInteger(iterations) || iterations <= 0) {
     throw new Error(`Invalid perf iterations: ${iterations}`);


### PR DESCRIPTION
## Motivation

Chrome perf jobs currently run script-profile measurements with the same sample count as normal timing measurements. Profiling is diagnostic and much more expensive, and a profiler-only dialog perf test recently hit Playwright's per-test timeout on the baseline side of CI.

## Solution

Add script-profile-specific sampling defaults in `@ariakit/scripts/perf`: script profiles default to 3 measured iterations and 0 warmup, while normal measurements still use `PERF_ITERATIONS`/`PERF_WARMUP`. Add optional `PERF_SCRIPT_PROFILE_ITERATIONS` and `PERF_SCRIPT_PROFILE_WARMUP` env overrides plus unit tests for default, env, explicit per-call behavior, and invalid explicit runtime values.
