### PR TITLE
Report unconfirmed candidate changes and INP in perf comparisons

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -302,10 +302,16 @@ jobs:
       actions: read
       contents: read
     env:
-      # Clean runs stop after two paired rounds. Significant deltas get one
-      # extra confirmation round before the PR comment is published.
+      # Clean runs stop after two paired rounds. Significant deltas and
+      # unconfirmed candidates get three extra confirmation rounds (five
+      # paired rounds total) before the PR comment is published. Five rounds
+      # matter: agreement and raw support are then required in n-1 = 4 rounds,
+      # so a near-miss candidate (raw 1/2) still has a path to confirmation,
+      # while fewer confirmation rounds could only ever demote candidates
+      # (with <= 4 rounds every round must pass, and a candidate has already
+      # failed raw support in an immutable initial round).
       PERF_INITIAL_ROUNDS: 2
-      PERF_CONFIRMATION_ROUNDS: 1
+      PERF_CONFIRMATION_ROUNDS: 3
       # Keep per-round samples modest; paired rounds and confirmation preserve
       # enough signal for noisy results.
       PERF_ITERATIONS: 5
@@ -544,12 +550,12 @@ jobs:
 
           # This per-shard comparison only decides whether THIS shard needs
           # confirmation rounds for its own files. When only a subset of this
-          # shard has significant deltas, rerun just those files for
-          # confirmation. The published comparison is produced once by the post
-          # job over every shard's raw round files.
+          # shard has significant deltas or unconfirmed candidates, rerun just
+          # those files for confirmation. The published comparison is produced
+          # once by the post job over every shard's raw round files.
           echo "::group::Preliminary comparison (shard $PERF_SHARD_INDEX)"
           pnpm -F app run perf-compare
-          significant_files="$(
+          confirmation_files="$(
             node --input-type=module <<'NODE'
           import { readFileSync } from "node:fs";
 
@@ -557,38 +563,30 @@ jobs:
             readFileSync("app/.perf-results/comparison.json", "utf-8"),
           );
 
-          if (!Array.isArray(summary.rows)) {
-            throw new Error("Missing comparison rows.");
+          if (!Array.isArray(summary.confirmationFiles)) {
+            throw new Error("Missing confirmation files in comparison summary.");
           }
 
-          const files = new Set();
-          for (const row of summary.rows) {
-            if (!row?.significant) continue;
-            if (!row.testFile) {
-              throw new Error("Missing test file for significant comparison row.");
-            }
-            files.add(row.testFile);
-          }
-          for (const file of [...files].sort()) {
+          for (const file of summary.confirmationFiles) {
             console.log(file);
           }
           NODE
           )"
           CONFIRMATION_FILES=()
-          if [ -n "$significant_files" ]; then
-            mapfile -t CONFIRMATION_FILES <<< "$significant_files"
+          if [ -n "$confirmation_files" ]; then
+            mapfile -t CONFIRMATION_FILES <<< "$confirmation_files"
           fi
           echo "::endgroup::"
 
           if [ ${#CONFIRMATION_FILES[@]} -gt 0 ]; then
-            echo "Significant changes detected; running confirmation rounds for: ${CONFIRMATION_FILES[*]}"
+            echo "Significant or candidate changes detected; running confirmation rounds for: ${CONFIRMATION_FILES[*]}"
             start_round=$((PERF_INITIAL_ROUNDS + 1))
             end_round=$((PERF_INITIAL_ROUNDS + PERF_CONFIRMATION_ROUNDS))
             for i in $(seq "$start_round" "$end_round"); do
               run_perf_round "$i" "${CONFIRMATION_FILES[@]}"
             done
           else
-            echo "No significant changes detected; skipping confirmation rounds."
+            echo "No significant or candidate changes detected; skipping confirmation rounds."
           fi
 
           manifest_status=success
@@ -723,7 +721,7 @@ jobs:
 
           echo "::group::Preliminary comparison"
           pnpm exec ariakit perf-compare --node
-          has_significant_changes=$(
+          needs_confirmation=$(
             node --input-type=module <<'NODE'
           import { readFileSync } from "node:fs";
 
@@ -731,12 +729,16 @@ jobs:
             readFileSync(".perf-results/comparison.json", "utf-8"),
           );
 
-          console.log(summary.hasSignificantChanges ? "true" : "false");
+          if (!Array.isArray(summary.confirmationFiles)) {
+            throw new Error("Missing confirmation files in comparison summary.");
+          }
+
+          console.log(summary.confirmationFiles.length > 0 ? "true" : "false");
           NODE
           )
           echo "::endgroup::"
 
-          if [ "$has_significant_changes" = "true" ]; then
+          if [ "$needs_confirmation" = "true" ]; then
             echo "Significant benchmark changes detected; running confirmation rounds."
             start_round=$((PERF_INITIAL_ROUNDS + 1))
             end_round=$((PERF_INITIAL_ROUNDS + PERF_CONFIRMATION_ROUNDS))

--- a/packages/ariakit-scripts/src/perf-compare.test.ts
+++ b/packages/ariakit-scripts/src/perf-compare.test.ts
@@ -230,6 +230,39 @@ function writeRawRound(
   ]);
 }
 
+function createResultWithInpRaw(label: string, inps: number[]): PerfResult {
+  return {
+    ...createResultWithLabel(label, 100),
+    metrics: { ...createMetrics(100), inp: medianValue(inps) },
+    raw: inps.map((inp) => ({ ...createMetrics(100), inp })),
+  };
+}
+
+function writeInpRawRound(
+  dir: string,
+  prefix: "baseline" | "current",
+  round: number,
+  inps: number[],
+) {
+  writeJson(dir, `${prefix}-${round}-worker0.json`, [
+    createResultWithInpRaw("inp test", inps),
+  ]);
+}
+
+function createFileResultWithRaw(
+  testFile: string,
+  label: string,
+  totals: number[],
+): PerfResult {
+  return { ...createResultWithRaw(label, totals), testFile };
+}
+
+function readComparisonSummary(dir: string) {
+  return JSON.parse(
+    readFileSync(path.join(dir, resultsDir, "comparison.json"), "utf-8"),
+  );
+}
+
 function runCompare(
   dir: string,
   args: string[] = [],
@@ -405,11 +438,20 @@ test("describes Node multi-round comparisons by round agreement", () => {
   }
 
   const markdown = runCompare(dir, ["--node"]);
+  const summary = readComparisonSummary(dir);
 
   expect(markdown).toContain(
     "Aggregated across 2 interleaved rounds; a change is flagged only when the paired median delta exceeds the threshold, rounds agree on direction.",
   );
   expect(markdown).not.toContain("raw samples support it");
+  // Node mode does not require raw sample support, so rows that pass the
+  // magnitude and agreement gates are significant, never candidates.
+  expect(markdown).not.toContain("Unconfirmed changes");
+  expect(summary.hasCandidateChanges).toBe(false);
+  expect(summary.rows.every((row: any) => !row.candidate)).toBe(true);
+  expect(summary.confirmationFiles).toEqual([
+    "packages/ariakit-store/benchmark/store.bench.ts",
+  ]);
 });
 
 test("does not flag noisy rounds that disagree on direction", () => {
@@ -424,11 +466,12 @@ test("does not flag noisy rounds that disagree on direction", () => {
   const markdown = runCompare(dir);
 
   expect(markdown).toContain("No significant performance changes detected.");
+  expect(markdown).not.toContain("Unconfirmed changes");
   expect(markdown).not.toMatch(/% :warning:/);
   expect(markdown).toContain("Aggregated across 5 interleaved rounds");
 });
 
-test("does not flag same-direction rounds with overlapping raw samples", () => {
+test("reports overlapping same-direction rounds as unconfirmed candidates", () => {
   const dir = createTempDir();
   for (const round of [1, 2]) {
     writeRawRound(dir, "baseline", round, [80, 100, 120, 140, 160]);
@@ -437,9 +480,38 @@ test("does not flag same-direction rounds with overlapping raw samples", () => {
 
   const markdown = runCompare(dir);
 
-  expect(markdown).toContain("No significant performance changes detected.");
+  expect(markdown).toContain("No confirmed performance changes detected.");
+  expect(markdown).toContain("#### Unconfirmed changes");
+  expect(markdown.indexOf("#### Unconfirmed changes")).toBeLessThan(
+    markdown.indexOf("<details>"),
+  );
+  expect(markdown).toContain(
+    "| raw samples | Scripting | 120.0ms | 140.0ms | +20.0ms (+17%) | low | rounds 2/2, raw 0/2, pairs 60% |",
+  );
   expect(markdown).toContain("120.0ms | 140.0ms | +20.0ms (+17%)");
+  // Candidates are reported in the unconfirmed changes section, not repeated
+  // in the detailed breakdown diagnostics.
+  expect(markdown).not.toContain("Unflagged threshold-sized changes");
   expect(markdown).not.toMatch(/% :warning:/);
+  expect(markdown).not.toMatch(/% :rocket:/);
+});
+
+test("grades candidates by their displayed pairs percent", () => {
+  const dir = createTempDir();
+  const baseline = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+  // 70 of 100 pairwise deltas support round 1 and 69 of 100 support round 2,
+  // pooling to 139/200 = 69.5%, which displays as "pairs 70%". The medium
+  // grade must match the displayed percent, not the raw 69.5 value.
+  writeRawRound(dir, "baseline", 1, baseline);
+  writeRawRound(dir, "current", 1, [35, 45, 75, 85, 85, 85, 85, 85, 85, 85]);
+  writeRawRound(dir, "baseline", 2, baseline);
+  writeRawRound(dir, "current", 2, [35, 35, 75, 85, 85, 85, 85, 85, 85, 85]);
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain(
+    "| raw samples | Scripting | 55.0ms | 85.0ms | +30.0ms (+55%) | medium | rounds 2/2, raw 0/2, pairs 70% |",
+  );
 });
 
 test("flags same-direction rounds with separated raw samples", () => {
@@ -453,6 +525,7 @@ test("flags same-direction rounds with separated raw samples", () => {
 
   expect(markdown).toContain(":warning:");
   expect(markdown).toContain("100.0ms → 160.0ms (+60%) :warning:");
+  expect(markdown).not.toContain("Unconfirmed changes");
 });
 
 test("requires raw sample support in each required round", () => {
@@ -464,10 +537,176 @@ test("requires raw sample support in each required round", () => {
 
   const markdown = runCompare(dir);
 
-  expect(markdown).toContain("No significant performance changes detected.");
+  expect(markdown).toContain("No confirmed performance changes detected.");
   expect(markdown).toContain("110.0ms | 150.0ms | +40.0ms (+36%)");
-  expect(markdown).toContain("raw 1/2");
+  expect(markdown).toContain(
+    "| raw samples | Scripting | 110.0ms | 150.0ms | +40.0ms (+36%) | medium | rounds 2/2, raw 1/2, pairs 80% |",
+  );
   expect(markdown).not.toMatch(/% :warning:/);
+});
+
+test("caps the unconfirmed changes table", () => {
+  const dir = createTempDir();
+  const labels = ["c1", "c2", "c3", "c4", "c5", "c6"];
+  for (const round of [1, 2]) {
+    writeJson(
+      dir,
+      `baseline-${round}-worker0.json`,
+      labels.map((label) =>
+        createResultWithRaw(label, [80, 100, 120, 140, 160]),
+      ),
+    );
+    writeJson(
+      dir,
+      `current-${round}-worker0.json`,
+      labels.map((label) =>
+        createResultWithRaw(label, [100, 120, 140, 160, 180]),
+      ),
+    );
+  }
+
+  const markdown = runCompare(dir);
+
+  // Each candidate test contributes a Scripting and a Total row, so six tests
+  // exceed the ten-row cap by two rows.
+  expect(markdown).toContain("| c5 | Total |");
+  expect(markdown).not.toContain("| c6 | Scripting |");
+  expect(markdown).toContain(
+    "...and 2 more unconfirmed changes in the full breakdown.",
+  );
+});
+
+test("keeps zero-baseline candidates visible under the cap", () => {
+  const dir = createTempDir();
+  const labels = ["c1", "c2", "c3", "c4", "c5", "c6"];
+  for (const round of [1, 2]) {
+    writeJson(dir, `baseline-${round}-worker0.json`, [
+      ...labels.map((label) =>
+        createResultWithRaw(label, [80, 100, 120, 140, 160]),
+      ),
+      createResultWithRaw("from zero", [0, 0, 0, 0, 0]),
+    ]);
+    writeJson(dir, `current-${round}-worker0.json`, [
+      ...labels.map((label) =>
+        createResultWithRaw(label, [100, 120, 140, 160, 180]),
+      ),
+      createResultWithRaw("from zero", [0, 0, 200, 250, 300]),
+    ]);
+  }
+
+  const markdown = runCompare(dir);
+
+  // Zero-baseline rows have no percent, so they must rank ahead of
+  // percent-sorted rows instead of falling behind them and off the cap.
+  expect(markdown).toContain(
+    "| from zero | Scripting | 0.0ms | 200.0ms | +200.0ms | low | rounds 2/2, raw 0/2, pairs 60% |",
+  );
+  expect(markdown.indexOf("| from zero | Scripting |")).toBeLessThan(
+    markdown.indexOf("| c1 | Scripting |"),
+  );
+  expect(markdown).toContain(
+    "...and 4 more unconfirmed changes in the full breakdown.",
+  );
+});
+
+test("reports INP-only changes as unconfirmed candidates", () => {
+  const dir = createTempDir();
+  for (const round of [1, 2]) {
+    writeInpRawRound(dir, "baseline", round, [600, 620, 650, 700, 710]);
+    writeInpRawRound(dir, "current", round, [380, 390, 400, 790, 800]);
+  }
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain("No confirmed performance changes detected.");
+  expect(markdown).toContain(
+    "| inp test | INP | 650.0ms | 400.0ms | -250.0ms (-38%) | low | rounds 2/2, raw 0/2, pairs 60% |",
+  );
+  expect(markdown).not.toMatch(/% :rocket:/);
+});
+
+test("flags confirmed INP regressions", () => {
+  const dir = createTempDir();
+  for (const round of [1, 2]) {
+    writeInpRawRound(dir, "baseline", round, [100, 105, 110, 115, 120]);
+    writeInpRawRound(dir, "current", round, [200, 210, 220, 230, 240]);
+  }
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain("| Test | Scripting | Rendering | INP | Total |");
+  expect(markdown).toContain("110.0ms → 220.0ms (+100%) :warning:");
+  expect(markdown).not.toContain("Unconfirmed changes");
+});
+
+test("flags confirmed INP improvements", () => {
+  const dir = createTempDir();
+  for (const round of [1, 2]) {
+    writeInpRawRound(dir, "baseline", round, [200, 210, 220, 230, 240]);
+    writeInpRawRound(dir, "current", round, [100, 105, 110, 115, 120]);
+  }
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain("220.0ms → 110.0ms (-50%) :rocket:");
+  expect(markdown).not.toContain("Unconfirmed changes");
+});
+
+test("lists confirmation files for significant and candidate changes", () => {
+  const dir = createTempDir();
+  for (const round of [1, 2]) {
+    writeJson(dir, `baseline-${round}-worker0.json`, [
+      createFileResultWithRaw(
+        "sandbox/a/perf-chrome.ts",
+        "significant",
+        [80, 90, 100, 110, 120],
+      ),
+      createFileResultWithRaw(
+        "sandbox/b/perf-chrome.ts",
+        "candidate",
+        [80, 100, 120, 140, 160],
+      ),
+      createFileResultWithRaw(
+        "sandbox/c/perf-chrome.ts",
+        "stable",
+        [100, 100, 100, 100, 100],
+      ),
+    ]);
+    writeJson(dir, `current-${round}-worker0.json`, [
+      createFileResultWithRaw(
+        "sandbox/a/perf-chrome.ts",
+        "significant",
+        [140, 150, 160, 170, 180],
+      ),
+      createFileResultWithRaw(
+        "sandbox/b/perf-chrome.ts",
+        "candidate",
+        [100, 120, 140, 160, 180],
+      ),
+      createFileResultWithRaw(
+        "sandbox/c/perf-chrome.ts",
+        "stable",
+        [100, 100, 100, 100, 100],
+      ),
+    ]);
+  }
+
+  const markdown = runCompare(dir);
+  const summary = readComparisonSummary(dir);
+
+  expect(summary.hasSignificantChanges).toBe(true);
+  expect(summary.hasCandidateChanges).toBe(true);
+  expect(summary.confirmationFiles).toEqual([
+    "sandbox/a/perf-chrome.ts",
+    "sandbox/b/perf-chrome.ts",
+  ]);
+  // Significant and unconfirmed changes are reported side by side, without
+  // icons on the unconfirmed rows.
+  expect(markdown).toContain("100.0ms → 160.0ms (+60%) :warning:");
+  expect(markdown).toContain("#### Unconfirmed changes");
+  expect(markdown).toContain(
+    "| candidate | Scripting | 120.0ms | 140.0ms | +20.0ms (+17%) | low | rounds 2/2, raw 0/2, pairs 60% |",
+  );
 });
 
 test("flags a consistent regression across rounds", () => {
@@ -606,6 +845,22 @@ test("keeps zero-baseline paired rounds in the agreement count", () => {
   expect(markdown).toContain("No significant performance changes detected.");
   expect(markdown).toContain("50.0ms | 65.0ms | +15.0ms (+30%)");
   expect(markdown).not.toMatch(/% :warning:/);
+});
+
+test("fails when a flagged row has no test file", () => {
+  const dir = createTempDir();
+  for (const round of [1, 2]) {
+    writeJson(dir, `baseline-${round}-worker0.json`, [
+      createFileResultWithRaw("", "no file", [80, 90, 100, 110, 120]),
+    ]);
+    writeJson(dir, `current-${round}-worker0.json`, [
+      createFileResultWithRaw("", "no file", [140, 150, 160, 170, 180]),
+    ]);
+  }
+
+  const stderr = runCompareFailure(dir);
+
+  expect(stderr).toContain("Missing test file for comparison row: no file");
 });
 
 test("fails on malformed perf result files", () => {
@@ -765,8 +1020,9 @@ test("aggregates worker shards within the same round", () => {
 
   const markdown = runCompare(dir);
 
-  expect(markdown).toContain("No significant performance changes detected.");
+  expect(markdown).toContain("No confirmed performance changes detected.");
   expect(markdown).toContain("100.0ms | 150.0ms | +50.0ms (+50%)");
+  expect(markdown).toContain("rounds 1/1, raw 0/1, pairs 50%");
   expect(markdown).not.toMatch(/% :warning:/);
 });
 
@@ -928,12 +1184,14 @@ test("omits new test metric rows for script profile results", () => {
   const markdown = runCompare(dir);
 
   expect(markdown).toContain("### New tests (no baseline)");
-  expect(markdown).toContain("| Test | Scripting | Rendering | Total |");
-  expect(markdown).toContain("| regular | 100.0ms | 0.0ms | 100.0ms |");
+  expect(markdown).toContain("| Test | Scripting | Rendering | INP | Total |");
+  expect(markdown).toContain("| regular | 100.0ms | 0.0ms | 0.0ms | 100.0ms |");
   expect(markdown).toContain("#### profiled");
   expect(markdown).toContain("#### Script profile");
   expect(markdown).toContain("| `profiledFn` | 8.0ms | 8.0ms | 1 |");
-  expect(markdown).not.toContain("| profiled | 130.0ms | 0.0ms | 130.0ms |");
+  expect(markdown).not.toContain(
+    "| profiled | 130.0ms | 0.0ms | 0.0ms | 130.0ms |",
+  );
 });
 
 test("omits new test metric rows for selector profile results", () => {
@@ -956,13 +1214,13 @@ test("omits new test metric rows for selector profile results", () => {
   const markdown = runCompare(dir);
 
   expect(markdown).toContain("### New tests (no baseline)");
-  expect(markdown).toContain("| Test | Scripting | Rendering | Total |");
-  expect(markdown).toContain("| regular | 100.0ms | 0.0ms | 100.0ms |");
+  expect(markdown).toContain("| Test | Scripting | Rendering | INP | Total |");
+  expect(markdown).toContain("| regular | 100.0ms | 0.0ms | 0.0ms | 100.0ms |");
   expect(markdown).toContain("#### selector-profiled");
   expect(markdown).toContain("#### Selector profile");
   expect(markdown).toContain("| .item | 8.0ms | 10 | 2 | 20% |");
   expect(markdown).not.toContain(
-    "| selector-profiled | 130.0ms | 0.0ms | 130.0ms |",
+    "| selector-profiled | 130.0ms | 0.0ms | 0.0ms | 130.0ms |",
   );
 });
 

--- a/packages/ariakit-scripts/src/perf-compare.ts
+++ b/packages/ariakit-scripts/src/perf-compare.ts
@@ -27,8 +27,16 @@ const THRESHOLD_PERCENT = 10;
 const MIN_SIGNIFICANT_DELTA_MS = 5;
 // Require at least 75% of each required round's pairwise raw-sample deltas to
 // support the paired median direction before a browser comparison becomes
-// significant.
+// significant. Threshold-sized changes whose rounds agree on direction but
+// fail this gate are reported as unconfirmed candidates instead.
 const RAW_SAMPLE_SUPPORT_QUANTILE = 0.25;
+// Cap the unconfirmed candidate table so a noisy run cannot flood the PR
+// comment; the detailed breakdown still lists every metric.
+const MAX_VISIBLE_CANDIDATE_ROWS = 10;
+// Pooled pairwise raw-sample agreement at or above this percent grades an
+// unconfirmed candidate as medium confidence: close to the 75% per-round
+// raw support gate without meeting it in every round.
+const MEDIUM_CONFIDENCE_PAIRWISE_PERCENT = 70;
 
 type MetricKey = keyof PerfMetrics;
 
@@ -44,14 +52,18 @@ interface ComparisonRow {
   perRoundDeltas: number[];
   agreement: number;
   sampleSupport: number;
+  pairwiseSupportPercent: number;
   threshold: boolean;
   significant: boolean;
+  candidate: boolean;
   profileMode: boolean;
 }
 
 interface ComparisonSummary {
   rows: ComparisonRow[];
   hasSignificantChanges: boolean;
+  hasCandidateChanges: boolean;
+  confirmationFiles: string[];
   currentResults: AggregatedPerfResult[];
   profileModeMismatches: ProfileModeMismatch[];
   newTests: AggregatedPerfResult[];
@@ -63,6 +75,8 @@ interface ComparisonSummary {
 interface PersistedComparisonSummary {
   rows: ComparisonRow[];
   hasSignificantChanges: boolean;
+  hasCandidateChanges: boolean;
+  confirmationFiles: string[];
   profileModeMismatches: ProfileModeMismatch[];
   newTests: PerfResult[];
   removedTests: PerfResult[];
@@ -137,8 +151,10 @@ export interface PerfCompareRunResult {
   markdown: string;
 }
 
-// Primary metrics shown in the summary table.
-const PRIMARY_METRICS: MetricKey[] = ["scripting", "rendering", "total"];
+// Primary metrics eligible for top-level reporting: they form the summary
+// table columns and are the only metrics that can be flagged as significant
+// or reported as unconfirmed candidates.
+const PRIMARY_METRICS: MetricKey[] = ["scripting", "rendering", "inp", "total"];
 
 // All metrics shown in the detailed breakdown.
 const ALL_METRICS: MetricKey[] = [
@@ -512,6 +528,15 @@ function samplesSupportDirection(sampleDeltas: number[], direction: number) {
   return getQuantile(sampleDeltas, 1 - RAW_SAMPLE_SUPPORT_QUANTILE) < 0;
 }
 
+const EMPTY_SIGNIFICANCE = {
+  agreement: 0,
+  sampleSupport: 0,
+  pairwiseSupportPercent: 0,
+  threshold: false,
+  significant: false,
+  candidate: false,
+};
+
 function getRoundMetricComparison(
   baseline: PerfResult,
   current: PerfResult,
@@ -548,27 +573,19 @@ function computeSignificance({
   roundComparisons: RoundMetricComparison[];
 }) {
   if (roundComparisons.length === 0) {
-    return {
-      agreement: 0,
-      sampleSupport: 0,
-      threshold: false,
-      significant: false,
-    };
+    return EMPTY_SIGNIFICANCE;
   }
 
   const delta = current - baseline;
   const direction = Math.sign(delta);
   if (direction === 0) {
-    return {
-      agreement: 0,
-      sampleSupport: 0,
-      threshold: false,
-      significant: false,
-    };
+    return EMPTY_SIGNIFICANCE;
   }
 
   let agreement = 0;
   let sampleSupport = 0;
+  let pairwiseCount = 0;
+  let pairwiseSupportCount = 0;
   for (const comparison of roundComparisons) {
     if (Math.sign(comparison.delta) === direction) {
       agreement += 1;
@@ -576,7 +593,19 @@ function computeSignificance({
     if (samplesSupportDirection(comparison.sampleDeltas, direction)) {
       sampleSupport += 1;
     }
+    pairwiseCount += comparison.sampleDeltas.length;
+    for (const sampleDelta of comparison.sampleDeltas) {
+      if (Math.sign(sampleDelta) === direction) {
+        pairwiseSupportCount += 1;
+      }
+    }
   }
+
+  // Share of all raw sample pairs (baseline x current, pooled across rounds)
+  // that move in the median's direction. 50% means the raw distributions
+  // fully overlap; the per-round raw support gate needs 75%.
+  const pairwiseSupportPercent =
+    pairwiseCount > 0 ? (pairwiseSupportCount / pairwiseCount) * 100 : 0;
 
   const percentOk = Math.abs(percent) > THRESHOLD_PERCENT;
   const deltaOk = Math.abs(delta) >= minDelta;
@@ -586,12 +615,21 @@ function computeSignificance({
   const required = requiredAgreement(roundComparisons.length);
   const agreementOk = agreement >= required;
   const sampleSupportOk = !requireSampleSupport || sampleSupport >= required;
+  const significant = primary && magnitudeOk && agreementOk && sampleSupportOk;
 
   return {
     agreement,
     sampleSupport,
+    pairwiseSupportPercent,
     threshold: magnitudeOk,
-    significant: primary && magnitudeOk && agreementOk && sampleSupportOk,
+    significant,
+    // A candidate clears the magnitude threshold and rounds agree on
+    // direction, but the raw samples fail to support it. It is reported as an
+    // unconfirmed change and triggers confirmation rounds like significant
+    // rows do; the extra rounds can demote it (direction flips), promote it
+    // (enough rounds gain raw support under the n-1 rule), or leave it
+    // unconfirmed with more data behind its diagnostics.
+    candidate: primary && magnitudeOk && agreementOk && !significant,
   };
 }
 
@@ -739,6 +777,21 @@ function getSignificanceIcon(row: ComparisonRow, options: PerfCompareOptions) {
   return isRegression(row, options) ? " :warning:" : " :rocket:";
 }
 
+// Test files whose rows warrant extra confirmation rounds. Candidates are
+// included so a change that only fails raw sample support gets more data
+// before the final comparison is published.
+function getConfirmationFiles(rows: ComparisonRow[]): string[] {
+  const files = new Set<string>();
+  for (const row of rows) {
+    if (!row.significant && !row.candidate) continue;
+    if (!row.testFile) {
+      throw new Error(`Missing test file for comparison row: ${row.label}`);
+    }
+    files.add(row.testFile);
+  }
+  return [...files].sort();
+}
+
 function compare(options: PerfCompareOptions): ComparisonSummary {
   const baseline = aggregateByKey(loadRounds("baseline", options));
   const current = aggregateByKey(loadRounds("current", options));
@@ -806,16 +859,15 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
       );
       const curVal = baseVal + delta;
       const percent = baseVal > 0 ? (delta / baseVal) * 100 : 0;
-      const { agreement, sampleSupport, threshold, significant } =
-        computeSignificance({
-          baseline: baseVal,
-          current: curVal,
-          minDelta,
-          primary: primary && primaryMetrics.includes(metric),
-          percent,
-          requireSampleSupport: !options.node,
-          roundComparisons,
-        });
+      const significance = computeSignificance({
+        baseline: baseVal,
+        current: curVal,
+        minDelta,
+        primary: primary && primaryMetrics.includes(metric),
+        percent,
+        requireSampleSupport: !options.node,
+        roundComparisons,
+      });
       rows.push({
         testFile: cur.result.testFile,
         label: cur.result.label,
@@ -826,10 +878,7 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
         percent,
         pairedRoundsCount: sharedRoundIndices.length,
         perRoundDeltas: roundComparisons.map((comparison) => comparison.delta),
-        agreement,
-        sampleSupport,
-        threshold,
-        significant,
+        ...significance,
         profileMode,
       });
     }
@@ -846,6 +895,8 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
   return {
     rows,
     hasSignificantChanges: rows.some((r) => r.significant),
+    hasCandidateChanges: rows.some((r) => r.candidate),
+    confirmationFiles: getConfirmationFiles(rows),
     currentResults: [...current.values()],
     profileModeMismatches,
     newTests,
@@ -1019,9 +1070,79 @@ function formatSummaryTable(
 }
 
 function formatSupport(row: ComparisonRow, options: PerfCompareOptions) {
-  const rounds = `${row.agreement}/${row.pairedRoundsCount} rounds`;
+  const rounds = `rounds ${row.agreement}/${row.pairedRoundsCount}`;
   if (options.node) return rounds;
-  return `${rounds}, raw ${row.sampleSupport}/${row.pairedRoundsCount}`;
+  const raw = `raw ${row.sampleSupport}/${row.pairedRoundsCount}`;
+  const pairs = `pairs ${formatPercent(row.pairwiseSupportPercent)}`;
+  return `${rounds}, ${raw}, ${pairs}`;
+}
+
+// Candidate confidence comes from the pooled pairwise raw-sample agreement:
+// how many baseline x current sample pairs move in the median's direction.
+// Grade on the rounded value shown in the support diagnostics so a row can
+// never display a percent at the grade boundary with the lower grade.
+function getCandidateConfidence(row: ComparisonRow) {
+  const percent = Math.round(row.pairwiseSupportPercent);
+  if (percent >= MEDIUM_CONFIDENCE_PAIRWISE_PERCENT) {
+    return "medium";
+  }
+  return "low";
+}
+
+// Order by relative change size so the row cap keeps the most notable
+// candidates. Zero-baseline rows have no percent (an unbounded relative
+// change), so they rank first; ties fall back to the absolute delta.
+function compareCandidateRows(a: ComparisonRow, b: ComparisonRow) {
+  const aPercent = a.baseline === 0 ? Infinity : Math.abs(a.percent);
+  const bPercent = b.baseline === 0 ? Infinity : Math.abs(b.percent);
+  return bPercent - aPercent || Math.abs(b.delta) - Math.abs(a.delta);
+}
+
+// Candidate rows are shown outside the collapsed details, but without
+// significance icons: their uncertainty must stay explicit.
+function formatCandidateChanges(
+  rows: ComparisonRow[],
+  options: PerfCompareOptions,
+): string[] {
+  const candidateRows = rows
+    .filter((row) => row.candidate)
+    .sort(compareCandidateRows);
+  if (candidateRows.length === 0) return [];
+
+  const lines: string[] = [];
+  lines.push("#### Unconfirmed changes");
+  lines.push("");
+  lines.push(
+    "These changes pass the size threshold and rounds agree on direction, but the raw samples overlap too much to confirm them. Treat them as possible changes, not confirmed ones. Confidence reflects how many raw sample pairs move in the same direction as the median; low can mean the raw samples carry little to no directional evidence.",
+  );
+  lines.push("");
+  lines.push(
+    `| ${getResultName(options)} | Metric | Baseline | Current | Change | Confidence | Support |`,
+  );
+  lines.push(
+    "|------|--------|----------|---------|--------|------------|---------|",
+  );
+  const visibleRows = candidateRows.slice(0, MAX_VISIBLE_CANDIDATE_ROWS);
+  for (const row of visibleRows) {
+    const cells = [
+      escapeTableCell(row.label),
+      getMetricLabel(row.metric, options),
+      formatMetricValue(row.baseline, options),
+      formatMetricValue(row.current, options),
+      formatDelta(row.delta, row.percent, row.baseline, options),
+      getCandidateConfidence(row),
+      formatSupport(row, options),
+    ];
+    lines.push(`| ${cells.join(" | ")} |`);
+  }
+  const hiddenRows = candidateRows.length - visibleRows.length;
+  if (hiddenRows > 0) {
+    lines.push("");
+    lines.push(
+      `...and ${hiddenRows} more unconfirmed ${hiddenRows === 1 ? "change" : "changes"} in the full breakdown.`,
+    );
+  }
+  return lines;
 }
 
 function formatUnflaggedDiagnostics(
@@ -1031,6 +1152,8 @@ function formatUnflaggedDiagnostics(
   const primaryMetrics = getPrimaryMetrics(options);
   const diagnostics = rows.filter((row) => {
     if (row.significant) return false;
+    // Candidates are already reported in the unconfirmed changes section.
+    if (row.candidate) return false;
     if (!row.threshold) return false;
     return primaryMetrics.includes(row.metric);
   });
@@ -1177,6 +1300,7 @@ function formatMarkdown(
   const {
     rows,
     hasSignificantChanges,
+    hasCandidateChanges,
     currentResults,
     profileModeMismatches,
     newTests,
@@ -1219,8 +1343,15 @@ function formatMarkdown(
     lines.push("No paired performance results available for comparison.");
   } else if (rows.length === 0 && newTests.length === 0) {
     lines.push("No performance results found.");
+  } else if (hasCandidateChanges) {
+    lines.push("No confirmed performance changes detected.");
   } else {
     lines.push("No significant performance changes detected.");
+  }
+
+  if (hasCandidateChanges) {
+    lines.push("");
+    lines.push(...formatCandidateChanges(rows, options));
   }
 
   if (unpairedTests.length > 0) {
@@ -1361,6 +1492,8 @@ function toPersistedSummary(
   return {
     rows: summary.rows,
     hasSignificantChanges: summary.hasSignificantChanges,
+    hasCandidateChanges: summary.hasCandidateChanges,
+    confirmationFiles: summary.confirmationFiles,
     profileModeMismatches: summary.profileModeMismatches,
     newTests: summary.newTests.map((entry) => entry.result),
     removedTests: summary.removedTests.map((entry) => entry.result),


### PR DESCRIPTION
## Motivation

The perf PR comment can hide plausible, real performance changes. In [this Chrome perf run](https://github.com/ariakit/ariakit/actions/runs/28680625607/job/85063390912?pr=6622), `dialog-perf > open dialog` showed large median improvements:

- Scripting: `531.8ms → 362.5ms (-32%)`
- INP: `664ms → 388ms (-42%)`

Yet the comment led with "No significant performance changes detected", because significance requires per-round raw sample support (~19/25 pairwise deltas in the median's direction) and this change only reached `15/25` and `13/25`. The raw-support gate is the right guard against noisy false positives, but a threshold-sized change that fails only that gate was demoted to a `<sub>` diagnostics line inside the collapsed `<details>` block, where nobody sees it.

Two related gaps made this worse:

- Confirmation rounds only ran for `row.significant`, so a near-miss change never got the extra data that could confirm or refute it.
- INP only existed in the detailed breakdown (`ALL_METRICS`), so even a fully supported INP change could never be summarized or flagged with :rocket:/:warning:.

## Solution

Introduce an explicit **unconfirmed candidate** state between "significant" and "noise":

- **Significant** (unchanged): magnitude threshold (>10% and ≥5ms), round agreement, and per-round raw sample support. Only these rows get :rocket:/:warning:.
- **Candidate** (new): passes magnitude threshold and round agreement but fails raw sample support. Reported outside `<details>` in a new "Unconfirmed changes" section with explicitly uncertain wording, a confidence grade, and support diagnostics — never with :rocket:/:warning:.

For the reference run above, the comment now leads with:

> No confirmed performance changes detected.
>
> #### Unconfirmed changes
>
> | Test | Metric | Baseline | Current | Change | Confidence | Support |
> |------|--------|----------|---------|--------|------------|---------|
> | dialog-perf > open dialog | Scripting | 531.8ms | 362.6ms | -169.2ms (-32%) | low | rounds 2/2, raw 0/2, pairs 56% |
> | dialog-perf > open dialog | INP | 664.0ms | 390.0ms | -274.0ms (-41%) | low | rounds 2/2, raw 0/2, pairs 60% |

The **Confidence** grade comes from a new pooled `pairwiseSupportPercent` diagnostic: the share of all baseline×current raw sample pairs (across rounds) that move in the median's direction. 50% means fully overlapping distributions; the per-round gate needs 75%. Candidates at ≥70% pooled read as `medium`, below that `low` (graded on the rounded value shown in the table, so a displayed `pairs 70%` can never sit next to `low`). The same `pairs N%` figure is added to the support diagnostics, so a reader can tell a barely-overlapping 74% miss from a coin-flip 52%. Candidate rows are sorted by relative change size (zero-baseline rows first, since their relative change is unbounded; ties by absolute delta) and capped at 10 with an "...and N more" line so a noisy run cannot flood the comment, and rows already shown as candidates are no longer repeated in the in-details "Unflagged threshold-sized changes" diagnostics.

### INP joins the primary metrics

Browser `PRIMARY_METRICS` is now `["scripting", "rendering", "inp", "total"]` rather than a separate "reportable metrics" concept: any metric eligible for confirmed :rocket:/:warning: flags must also appear in the summary table, so one list keeping columns and eligibility in sync is clearer than two lists that could drift. INP now participates in the summary table, significance flags, candidate reporting, and the unflagged-diagnostics line. Node mode still only reports `total` (ops/sec).

### Confirmation rounds for candidates

Selection of files needing confirmation rounds moved out of the workflow's inline script into `perf-compare` itself, which now persists `confirmationFiles` (test files with significant *or* candidate rows, throwing loudly if such a row has no test file) plus `hasCandidateChanges` in `comparison.json`. The Chrome shard and Node job scripts in `perf.yml` just read that array, so the selection logic is unit-tested. (Node mode cannot produce candidates — it does not require raw support, so threshold + agreement is already significant — and a test locks that invariant.)

Chrome `PERF_CONFIRMATION_ROUNDS` goes from 1 to 3 (matching the Node job). This is not just more data: with 2 initial + 1 confirmation rounds, the 3-round comparison required agreement and raw support in **all** 3 rounds, and a candidate has by definition already failed raw support in an immutable initial round — so the confirmation round could only ever demote a candidate, never confirm it. With 5 paired rounds the `n-1` rule applies (4/5 required), giving a near-miss candidate (`raw 1/2`) a real path to either confirmation or demotion. The cost stays bounded: confirmation rounds only run when something was detected, and only for the affected files within the shard.

## Tests

- Existing significant regression/improvement flows remain covered (single-run, multi-round, sharded, node mode).
- Overlapping same-direction rounds and partial raw support (`raw 1/2`) now assert candidate reporting outside `<details>` with confidence/support diagnostics, no icons, and no duplicated in-details diagnostics.
- INP: candidate reporting, confirmed :warning: regression, confirmed :rocket: improvement.
- Confidence grading boundary: a pooled 69.5% candidate displays `pairs 70%` and grades `medium` (red-checked: fails against the unrounded comparison).
- `confirmationFiles` selection: significant + candidate files listed, stable files excluded, node-mode population, a loud failure when a flagged row has no test file (red-checked), and a run where confirmed and unconfirmed sections coexist.
- Candidate table cap: 12 candidate rows render 10 plus an "...and 2 more" line, and zero-baseline candidates stay visible under the cap (red-checked).
