### PR TITLE
Stabilize Chrome perf measurements with isolated iterations

### DIFF
--- a/app/src/sandbox/ariakit-tailwind/perf-chrome.ts
+++ b/app/src/sandbox/ariakit-tailwind/perf-chrome.ts
@@ -5,8 +5,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await perf.measurePageLoad();
   });
 
-  test("toggle layer and text classes", async ({ page, perf }) => {
-    await perf.measure(() =>
+  test("toggle layer and text classes", async ({ perf }) => {
+    await perf.measure(({ page }) =>
       page.evaluate(() => {
         const sections = document.querySelectorAll<HTMLElement>(
           "section[aria-labelledby]",

--- a/app/src/sandbox/composite-perf/perf-chrome.ts
+++ b/app/src/sandbox/composite-perf/perf-chrome.ts
@@ -18,7 +18,10 @@ async function verifyCompositeMounted(q: Query) {
 
 async function setupComposite(q: Query) {
   await q.button("Mount composite").click();
-  await expect(q.button("Item 1")).toBeVisible();
+  const firstItem = q.button("Item 1");
+  await expect(firstItem).toBeVisible();
+  await firstItem.focus();
+  await expect(firstItem).toBeFocused();
 }
 
 async function moveAcrossItems(page: Page) {
@@ -48,59 +51,49 @@ async function verifyControlledItemsUpdated(q: Query) {
 }
 
 withFramework(import.meta.dirname, async ({ test }) => {
-  test("mount composite", async ({ q, perf }) => {
-    await perf.measure(() => mountComposite(q), {
-      verify: () => verifyCompositeMounted(q),
+  test("mount composite", async ({ perf }) => {
+    await perf.measure(({ q }) => mountComposite(q), {
+      verify: ({ q }) => verifyCompositeMounted(q),
     });
   });
 
-  test("mount composite (script profile)", async ({ q, perf }) => {
-    await perf.measure(() => mountComposite(q), {
+  test("mount composite (script profile)", async ({ perf }) => {
+    await perf.measure(({ q }) => mountComposite(q), {
       scriptProfile: true,
       profileLimit: 20,
-      verify: () => verifyCompositeMounted(q),
+      verify: ({ q }) => verifyCompositeMounted(q),
     });
   });
 
-  test("move across items", async ({ q, page, perf }) => {
-    const firstItem = q.button("Item 1");
-
-    await perf.measure(() => moveAcrossItems(page), {
-      setup: async () => {
-        await setupComposite(q);
-        await firstItem.focus();
-        await expect(firstItem).toBeFocused();
-      },
-      verify: () => verifyMovedAcrossItems(q),
+  test("move across items", async ({ perf }) => {
+    await perf.measure(({ page }) => moveAcrossItems(page), {
+      setup: ({ q }) => setupComposite(q),
+      verify: ({ q }) => verifyMovedAcrossItems(q),
     });
   });
 
-  test("move across items (script profile)", async ({ q, page, perf }) => {
-    const firstItem = q.button("Item 1");
-
-    await perf.measure(() => moveAcrossItems(page), {
+  test("move across items (script profile)", async ({ perf }) => {
+    await perf.measure(({ page }) => moveAcrossItems(page), {
       scriptProfile: true,
       profileLimit: 20,
-      setup: async () => {
-        await setupComposite(q);
-        await firstItem.focus();
-        await expect(firstItem).toBeFocused();
+      setup: ({ q }) => setupComposite(q),
+      verify: ({ q }) => verifyMovedAcrossItems(q),
+    });
+  });
+
+  test("mount controlled composite", async ({ perf }) => {
+    await perf.measure(
+      ({ q }) => q.button("Mount controlled composite").click(),
+      {
+        verify: ({ q }) => verifyCompositeMounted(q),
       },
-      verify: () => verifyMovedAcrossItems(q),
-    });
+    );
   });
 
-  test("mount controlled composite", async ({ q, perf }) => {
-    const mountButton = q.button("Mount controlled composite");
-    await perf.measure(() => mountButton.click(), {
-      verify: () => verifyCompositeMounted(q),
-    });
-  });
-
-  test("update controlled items", async ({ q, perf }) => {
-    await perf.measure(() => updateControlledItems(q), {
-      setup: () => setupControlledComposite(q),
-      verify: () => verifyControlledItemsUpdated(q),
+  test("update controlled items", async ({ perf }) => {
+    await perf.measure(({ q }) => updateControlledItems(q), {
+      setup: ({ q }) => setupControlledComposite(q),
+      verify: ({ q }) => verifyControlledItemsUpdated(q),
     });
   });
 });

--- a/app/src/sandbox/dialog-perf/perf-chrome.ts
+++ b/app/src/sandbox/dialog-perf/perf-chrome.ts
@@ -2,30 +2,30 @@ import { expect } from "@playwright/test";
 import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
-  test("open dialog", async ({ q, perf }) => {
-    await perf.measure(() => q.button("Open dialog").click(), {
-      verify: () => expect(q.dialog("Settings")).toBeVisible(),
+  test("open dialog", async ({ perf }) => {
+    await perf.measure(({ q }) => q.button("Open dialog").click(), {
+      verify: ({ q }) => expect(q.dialog("Settings")).toBeVisible(),
     });
   });
 
-  test("close dialog", async ({ q, perf }) => {
-    await perf.measure(() => q.button("Cancel").click(), {
-      setup: async () => {
+  test("close dialog", async ({ perf }) => {
+    await perf.measure(({ q }) => q.button("Cancel").click(), {
+      setup: async ({ q }) => {
         await q.button("Open dialog").click();
         await expect(q.dialog("Settings")).toBeVisible();
       },
-      verify: () => expect(q.dialog("Settings")).not.toBeVisible(),
+      verify: ({ q }) => expect(q.dialog("Settings")).not.toBeVisible(),
     });
   });
 
   // Same interaction as "open dialog", but with the script profiler enabled
   // so the PR comment shows where the scripting time goes. Profiling adds
   // overhead, so the unprofiled test above is the one to read for timings.
-  test("open dialog (script profile)", async ({ q, perf }) => {
-    await perf.measure(() => q.button("Open dialog").click(), {
+  test("open dialog (script profile)", async ({ perf }) => {
+    await perf.measure(({ q }) => q.button("Open dialog").click(), {
       scriptProfile: true,
       profileLimit: 20,
-      verify: () => expect(q.dialog("Settings")).toBeVisible(),
+      verify: ({ q }) => expect(q.dialog("Settings")).toBeVisible(),
     });
   });
 });

--- a/app/src/test-utils/fixtures.ts
+++ b/app/src/test-utils/fixtures.ts
@@ -10,17 +10,60 @@ import type {
 } from "@ariakit/scripts/perf";
 import { query } from "@ariakit/test/playwright";
 import { test as base } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { visual } from "./visual.ts";
 import type { ScreenshotOptions } from "./visual.ts";
+
+export interface PerfHelpers {
+  page: Page;
+  q: ReturnType<typeof query>;
+}
+
+/**
+ * Callback invoked with the iteration's page and a query bound to it. Each
+ * perf iteration runs in a fresh browser context, so callbacks must use the
+ * helpers they receive instead of closing over the test's fixture `page` or
+ * `q`.
+ */
+export type PerfCallback = (helpers: PerfHelpers) => Promise<void> | void;
+
+export interface PerfOptions extends Omit<
+  PerfMeasureOptions,
+  "setup" | "verify"
+> {
+  setup?: PerfCallback;
+  verify?: PerfCallback;
+}
+
+function toPageCallback(callback: PerfCallback) {
+  // A zero-argument callback cannot be using the iteration helpers, so it is
+  // almost certainly closing over the test's fixture `page` or `q` and would
+  // drive a page other than the one being measured.
+  if (callback.length === 0) {
+    throw new Error(
+      "Perf callbacks must accept the iteration helpers, such as ({ q }) => q.button().click()",
+    );
+  }
+  return (page: Page) => callback({ page, q: query(page) });
+}
+
+function toPerfMeasureOptions(options: PerfOptions = {}): PerfMeasureOptions {
+  const { setup, verify, ...rest } = options;
+  return {
+    ...rest,
+    setup: setup && toPageCallback(setup),
+    verify: verify && toPageCallback(verify),
+  };
+}
 
 export const test = base.extend<{
   visual: (options?: ScreenshotOptions) => Promise<void>;
   perf: {
     measure: (
-      interaction: () => Promise<void>,
-      options?: PerfMeasureOptions,
+      interaction: PerfCallback,
+      options?: PerfOptions,
     ) => Promise<PerfMetrics>;
-    measurePageLoad: (options?: PerfMeasureOptions) => Promise<PerfMetrics>;
+    measurePageLoad: (options?: PerfOptions) => Promise<PerfMetrics>;
   };
   q: ReturnType<typeof query>;
 }>({
@@ -29,15 +72,26 @@ export const test = base.extend<{
     await use((options) => visual(page, options, testInfo));
   },
 
-  // Lazy fixture: no CDP session is opened until measure() is called, so
-  // existing visual tests pay zero overhead.
+  // Lazy fixture: no browser contexts or CDP sessions are created until
+  // measure() is called, so existing visual tests pay zero overhead.
   perf: async ({ page }, use, testInfo) => {
     const results: PerfResult[] = [];
     await use({
       measure: (interaction, options) =>
-        createPerfMeasure(page, interaction, results, testInfo, options),
+        createPerfMeasure(
+          page,
+          toPageCallback(interaction),
+          results,
+          testInfo,
+          toPerfMeasureOptions(options),
+        ),
       measurePageLoad: (options) =>
-        createPerfPageLoadMeasure(page, results, testInfo, options),
+        createPerfPageLoadMeasure(
+          page,
+          results,
+          testInfo,
+          toPerfMeasureOptions(options),
+        ),
     });
     if (results.length > 0) {
       appendResults(results, testInfo);

--- a/packages/ariakit-scripts/src/perf-compare.test.ts
+++ b/packages/ariakit-scripts/src/perf-compare.test.ts
@@ -14,9 +14,6 @@ import { afterEach, expect, test } from "vitest";
 
 interface PerfMetrics {
   scripting: number;
-  layout: number;
-  styleRecalc: number;
-  painting: number;
   rendering: number;
   inp: number;
   total: number;
@@ -72,9 +69,6 @@ function createTempDir() {
 function createMetrics(total: number): PerfMetrics {
   return {
     scripting: total,
-    layout: 0,
-    styleRecalc: 0,
-    painting: 0,
     rendering: 0,
     inp: 0,
     total,
@@ -974,9 +968,11 @@ test("does not flag percentage-only changes below the absolute floor", () => {
   expect(markdown).not.toMatch(/% :warning:/);
 });
 
-test("does not flag rendering sub-metric noise", () => {
+test("ignores legacy rendering sub-metrics in older baselines", () => {
   const dir = createTempDir();
-  const baselineMetrics: PerfMetrics = {
+  // Baselines produced by an older harness carry the retired layout, style
+  // recalc, and painting keys alongside the current metrics.
+  const legacyMetrics = {
     scripting: 100,
     layout: 16,
     styleRecalc: 4,
@@ -985,30 +981,28 @@ test("does not flag rendering sub-metric noise", () => {
     inp: 0,
     total: 120,
   };
-  const currentMetrics: PerfMetrics = {
-    scripting: 100,
-    layout: 11,
-    styleRecalc: 9,
-    painting: 0,
-    rendering: 20,
-    inp: 0,
-    total: 120,
-  };
   writeJson(dir, "baseline-worker0.json", [
-    createResultWithMetrics("sub-metrics", baselineMetrics),
+    {
+      ...createResultWithLabel("legacy sub-metrics", legacyMetrics.total),
+      metrics: legacyMetrics,
+      raw: [legacyMetrics],
+    },
   ]);
   writeJson(dir, "current-worker0.json", [
-    createResultWithMetrics("sub-metrics", currentMetrics),
+    createResultWithMetrics("legacy sub-metrics", {
+      scripting: 100,
+      rendering: 20,
+      inp: 0,
+      total: 120,
+    }),
   ]);
 
   const markdown = runCompare(dir);
 
   expect(markdown).toContain("No significant performance changes detected.");
-  expect(markdown).toContain(
-    "| - Style recalc | 4.0ms | 9.0ms | +5.0ms (+125%) |",
-  );
-  expect(markdown).not.toContain("+5.0ms (+125%) :warning:");
-  expect(markdown).not.toContain("-5.0ms (-31%) :rocket:");
+  expect(markdown).toContain("| Rendering | 20.0ms | 20.0ms | +0.0ms (+0%) |");
+  expect(markdown).not.toContain("Style recalc");
+  expect(markdown).not.toContain("Painting");
 });
 
 test("aggregates worker shards within the same round", () => {

--- a/packages/ariakit-scripts/src/perf-compare.ts
+++ b/packages/ariakit-scripts/src/perf-compare.ts
@@ -151,45 +151,19 @@ export interface PerfCompareRunResult {
   markdown: string;
 }
 
-// Primary metrics eligible for top-level reporting: they form the summary
-// table columns and are the only metrics that can be flagged as significant
-// or reported as unconfirmed candidates.
+// Metrics shown in the summary table and detailed breakdown. All of them can
+// be flagged as significant or reported as unconfirmed candidates.
 const PRIMARY_METRICS: MetricKey[] = ["scripting", "rendering", "inp", "total"];
-
-// All metrics shown in the detailed breakdown.
-const ALL_METRICS: MetricKey[] = [
-  "scripting",
-  "rendering",
-  "layout",
-  "styleRecalc",
-  "painting",
-  "inp",
-  "total",
-];
 
 const METRIC_LABELS: Record<MetricKey, string> = {
   scripting: "Scripting",
-  layout: "Layout",
-  styleRecalc: "Style recalc",
-  painting: "Painting",
   rendering: "Rendering",
   inp: "INP",
   total: "Total",
 };
 
-// Rendering sub-metrics are indented in the detailed breakdown.
-const RENDERING_SUB_METRICS = new Set<MetricKey>([
-  "layout",
-  "styleRecalc",
-  "painting",
-]);
-
 function getPrimaryMetrics(options: PerfCompareOptions): MetricKey[] {
   return options.node ? ["total"] : PRIMARY_METRICS;
-}
-
-function getAllMetrics(options: PerfCompareOptions): MetricKey[] {
-  return options.node ? ["total"] : ALL_METRICS;
 }
 
 function getResultName(options: PerfCompareOptions) {
@@ -280,9 +254,6 @@ function createNodeMetrics({ hz, mean }: { hz: number; mean: number }) {
   const total = hz > 0 ? hz : mean > 0 ? 1000 / mean : 0;
   return {
     scripting: 0,
-    layout: 0,
-    styleRecalc: 0,
-    painting: 0,
     rendering: 0,
     inp: 0,
     total,
@@ -796,7 +767,6 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
   const baseline = aggregateByKey(loadRounds("baseline", options));
   const current = aggregateByKey(loadRounds("current", options));
   const primaryMetrics = getPrimaryMetrics(options);
-  const allMetrics = getAllMetrics(options);
   const minDelta = getMinSignificantDelta(options);
 
   const rows: ComparisonRow[] = [];
@@ -837,7 +807,7 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
 
     const profileMode = isProfileMode(base.result) || isProfileMode(cur.result);
     const primary = !profileMode;
-    for (const metric of allMetrics) {
+    for (const metric of primaryMetrics) {
       const baselineValues: number[] = [];
       const roundComparisons: RoundMetricComparison[] = [];
       for (const roundIndex of sharedRoundIndices) {
@@ -863,7 +833,7 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
         baseline: baseVal,
         current: curVal,
         minDelta,
-        primary: primary && primaryMetrics.includes(metric),
+        primary,
         percent,
         requireSampleSupport: !options.node,
         roundComparisons,
@@ -1149,13 +1119,11 @@ function formatUnflaggedDiagnostics(
   rows: ComparisonRow[],
   options: PerfCompareOptions,
 ): string[] {
-  const primaryMetrics = getPrimaryMetrics(options);
   const diagnostics = rows.filter((row) => {
     if (row.significant) return false;
     // Candidates are already reported in the unconfirmed changes section.
     if (row.candidate) return false;
-    if (!row.threshold) return false;
-    return primaryMetrics.includes(row.metric);
+    return row.threshold;
   });
   if (diagnostics.length === 0) return [];
 
@@ -1256,7 +1224,7 @@ function formatDetailedBreakdown({
     return formatNodeComparisonTables(rowsByKey, keys, options);
   }
   const lines: string[] = [];
-  const allMetrics = getAllMetrics(options);
+  const primaryMetrics = getPrimaryMetrics(options);
   for (const key of keys) {
     const testRows = rowsByKey.get(key) ?? [];
     const label = testRows[0]?.label ?? key;
@@ -1269,11 +1237,9 @@ function formatDetailedBreakdown({
     if (!profileMode) {
       lines.push("| Metric | Baseline | Current | Delta |");
       lines.push("|--------|----------|---------|-------|");
-      for (const metric of allMetrics) {
+      for (const metric of primaryMetrics) {
         const row = testRows.find((r) => r.metric === metric);
         if (!row) continue;
-        const prefix = RENDERING_SUB_METRICS.has(metric) ? "- " : "";
-        const metricLabel = `${prefix}${getMetricLabel(metric, options)}`;
         const deltaStr = formatDelta(
           row.delta,
           row.percent,
@@ -1282,7 +1248,7 @@ function formatDetailedBreakdown({
         );
         const icon = getSignificanceIcon(row, options);
         lines.push(
-          `| ${metricLabel} | ${formatMetricValue(row.baseline, options)} | ${formatMetricValue(row.current, options)} | ${deltaStr}${icon} |`,
+          `| ${getMetricLabel(metric, options)} | ${formatMetricValue(row.baseline, options)} | ${formatMetricValue(row.current, options)} | ${deltaStr}${icon} |`,
         );
       }
       lines.push("");

--- a/packages/ariakit-scripts/src/perf.ts
+++ b/packages/ariakit-scripts/src/perf.ts
@@ -9,7 +9,13 @@ import {
 } from "@jridgewell/trace-mapping";
 import type { SourceMapInput } from "@jridgewell/trace-mapping";
 import { errors } from "@playwright/test";
-import type { CDPSession, Page, TestInfo } from "@playwright/test";
+import type {
+  Browser,
+  BrowserContextOptions,
+  CDPSession,
+  Page,
+  TestInfo,
+} from "@playwright/test";
 
 const RESULTS_DIR = path.join(process.cwd(), ".perf-results");
 const DEFAULT_PROFILE_LIMIT = 10;
@@ -23,7 +29,6 @@ const initializedResultFiles = new Set<string>();
 const SCRIPT_DURATION = "ScriptDuration";
 const LAYOUT_DURATION = "LayoutDuration";
 const RECALC_STYLE_DURATION = "RecalcStyleDuration";
-const PAINTING_DURATION = "PaintingDuration";
 
 const SELECTOR_TRACE_CATEGORIES = [
   "-*",
@@ -42,9 +47,7 @@ const INTERNAL_SCRIPT_FUNCTIONS = new Set([
 
 export interface PerfMetrics {
   scripting: number;
-  layout: number;
-  styleRecalc: number;
-  painting: number;
+  /** Layout plus style recalc time. */
   rendering: number;
   inp: number;
   total: number;
@@ -90,24 +93,33 @@ export interface PerfProfiles {
   selectors?: PerfSelectorProfileEntry[];
 }
 
+/**
+ * Callback invoked with the iteration's page. Each iteration runs in a fresh
+ * browser context, so callbacks must use the page they receive instead of
+ * closing over the test's fixture page.
+ */
+export type PerfMeasureCallback = (page: Page) => Promise<void> | void;
+
 export interface PerfMeasureOptions {
   /** Number of measured iterations (warmup runs are additional). */
   iterations?: number;
   /** Number of discarded warm-up runs before measurement begins. */
   warmup?: number;
   /**
-   * Unmeasured setup callback run before every iteration, after the page
-   * reset. Useful for getting the page into the state the measured interaction
-   * expects, such as opening a dialog before measuring how long it takes to
-   * close it.
+   * Unmeasured setup callback run before every iteration's measured
+   * interaction. For interaction measurements it runs after the iteration
+   * page loads; for page-load measurements it runs on the blank page before
+   * the measured navigation. Useful for getting the page into the state the
+   * measured interaction expects, such as opening a dialog before measuring
+   * how long it takes to close it.
    */
-  setup?: () => Promise<void> | void;
+  setup?: PerfMeasureCallback;
   /**
    * Unmeasured verification callback run after the metrics snapshot for each
    * iteration. Use this for assertions so Playwright polling is not counted as
    * application work.
    */
-  verify?: () => Promise<void> | void;
+  verify?: PerfMeasureCallback;
   /** Override the auto-generated label for this measurement. */
   label?: string;
   /** Collect expensive JS functions. Adds overhead to measured metrics. */
@@ -119,8 +131,12 @@ export interface PerfMeasureOptions {
 }
 
 interface CreatePerfMeasureOptions extends PerfMeasureOptions {
-  /** Re-navigate to the current page URL before each measured interaction. */
-  resetPage?: boolean;
+  /**
+   * Navigate each iteration page to the measured URL before the interaction.
+   * Page-load measurements disable this and navigate inside the measured
+   * interaction instead.
+   */
+  loadPage?: boolean;
 }
 
 interface PerfSamplingOptions {
@@ -265,9 +281,6 @@ export function median(values: number[]): number {
 export function computeMedianMetrics(all: PerfMetrics[]): PerfMetrics {
   return {
     scripting: median(all.map((m) => m.scripting)),
-    layout: median(all.map((m) => m.layout)),
-    styleRecalc: median(all.map((m) => m.styleRecalc)),
-    painting: median(all.map((m) => m.painting)),
     rendering: median(all.map((m) => m.rendering)),
     inp: median(all.map((m) => m.inp)),
     total: median(all.map((m) => m.total)),
@@ -939,10 +952,9 @@ export interface SettleQuiescentOptions {
 }
 
 /**
- * Main-thread work in ms tracked for settle quiescence. Painting is excluded
- * on purpose: periodic repaints such as caret blinks would count as activity
- * and defeat quiescence detection, while any deferred work that produces paint
- * also shows up here first as script, style recalc, or layout time.
+ * Main-thread work in ms tracked for settle quiescence. Any deferred work that
+ * produces paint also shows up here first as script, style recalc, or layout
+ * time, so paint work needs no tracking of its own.
  */
 function getTrackedWork(
   metrics: Array<{ name: string; value: number }>,
@@ -1110,23 +1122,17 @@ async function measureOnce(
   const layoutAfter = getMetricValue(after.metrics, LAYOUT_DURATION);
   const styleBefore = getMetricValue(before.metrics, RECALC_STYLE_DURATION);
   const styleAfter = getMetricValue(after.metrics, RECALC_STYLE_DURATION);
-  const paintBefore = getMetricValue(before.metrics, PAINTING_DURATION);
-  const paintAfter = getMetricValue(after.metrics, PAINTING_DURATION);
 
   // CDP values are in seconds; convert to milliseconds.
   const scripting = (scriptAfter - scriptBefore) * 1000;
   const layout = (layoutAfter - layoutBefore) * 1000;
   const styleRecalc = (styleAfter - styleBefore) * 1000;
-  const painting = (paintAfter - paintBefore) * 1000;
-  const rendering = layout + styleRecalc + painting;
+  const rendering = layout + styleRecalc;
   const inp = inpValues.length > 0 ? Math.max(...inpValues) : 0;
   const total = scripting + rendering;
 
   const metrics = {
     scripting,
-    layout,
-    styleRecalc,
-    painting,
     rendering,
     inp,
     total,
@@ -1139,19 +1145,160 @@ async function measureOnce(
 }
 
 /**
+ * Context options mirrored from the test project configuration so iteration
+ * contexts match the fixture page environment. `browser.newContext` starts
+ * from Playwright's built-in defaults rather than the project's `use` block,
+ * so the context-relevant options are forwarded explicitly. Only project-level
+ * options are visible here: a per-file `test.use()` override would apply to
+ * the fixture page but not to iteration contexts.
+ */
+function getContextOptions(testInfo: TestInfo): BrowserContextOptions {
+  const use = testInfo.project.use;
+  return {
+    baseURL: use.baseURL,
+    colorScheme: use.colorScheme,
+    deviceScaleFactor: use.deviceScaleFactor,
+    hasTouch: use.hasTouch,
+    isMobile: use.isMobile,
+    // The test runner defaults the fixture page's locale to en-US, while raw
+    // contexts default to the system locale; pin it so they match.
+    locale: use.locale ?? "en-US",
+    timezoneId: use.timezoneId,
+    userAgent: use.userAgent,
+    viewport: use.viewport,
+  };
+}
+
+interface MeasureIterationParams {
+  browser: Browser;
+  contextOptions: BrowserContextOptions;
+  testInfo: TestInfo;
+  url: string;
+  loadPage: boolean;
+  interaction: PerfMeasureCallback;
+  setup?: PerfMeasureCallback;
+  verify?: PerfMeasureCallback;
+  scriptProfile: boolean;
+  selectorProfile: boolean;
+  scriptSourceMapResolver: SourceMapResolverOptions;
+}
+
+/**
+ * The runner's `screenshot: "only-on-failure"` captures the fixture page,
+ * which never receives the interaction; attach the iteration page so failures
+ * show the page that was actually measured. Best-effort: the original error
+ * matters more than a failed screenshot.
+ */
+async function attachFailureScreenshot(testInfo: TestInfo, page: Page) {
+  try {
+    // Bound the screenshot so a hung renderer cannot delay the rethrow of
+    // the original, more informative error.
+    const body = await page.screenshot({ timeout: 5000 });
+    await testInfo.attach("perf-iteration-failure", {
+      body,
+      contentType: "image/png",
+    });
+  } catch {}
+}
+
+/**
+ * Runs one measurement iteration in a dedicated browser context. A fresh
+ * context gets a fresh renderer process, so no browser state accumulated by
+ * previous iterations leaks into this measurement. Re-navigating the same tab
+ * is not enough: renderer state accumulated across same-URL navigations makes
+ * some interactions cost over 2x more scripting time from roughly the fourth
+ * navigation onward, which made per-iteration metrics bimodal.
+ */
+async function measureIteration(
+  params: MeasureIterationParams,
+): Promise<MeasureOnceResult> {
+  const context = await params.browser.newContext(params.contextOptions);
+  try {
+    const page = await context.newPage();
+    const cdp = await context.newCDPSession(page);
+    const styleSheetUrls = new Map<string, string>();
+    const scriptSourceMapUrls = new Map<string, string>();
+    const onStyleSheetAdded = (event: CssStyleSheetAddedEvent) => {
+      const { styleSheetId, sourceURL = "" } = event.header;
+      styleSheetUrls.set(styleSheetId, sourceURL);
+    };
+    const onScriptParsed = (event: DebuggerScriptParsedEvent) => {
+      const { scriptId, sourceMapURL = "" } = event;
+      if (sourceMapURL) {
+        scriptSourceMapUrls.set(scriptId, sourceMapURL);
+      }
+    };
+
+    // Track durations in thread CPU time instead of wall-clock time so time
+    // the renderer main thread spends preempted by other processes on a
+    // contended runner is not counted. The time domain must be set when the
+    // domain is enabled.
+    await cdp.send("Performance.enable", { timeDomain: "threadTicks" });
+    if (params.scriptProfile) {
+      cdp.on("Debugger.scriptParsed", onScriptParsed);
+      await cdp.send("Debugger.enable");
+      await cdp.send("Profiler.enable");
+    }
+    if (params.selectorProfile) {
+      cdp.on("CSS.styleSheetAdded", onStyleSheetAdded);
+      await cdp.send("DOM.enable");
+      await cdp.send("CSS.enable");
+    }
+
+    if (params.loadPage) {
+      await gotoAndSettle(page, params.url);
+    }
+
+    if (params.setup) {
+      // Run the unmeasured setup and let its work settle so it doesn't leak
+      // into the metrics snapshot taken right before the interaction.
+      await params.setup(page);
+      await settleQuiescent(page, cdp);
+    }
+
+    const interaction = async () => {
+      await params.interaction(page);
+    };
+    const result = await measureOnce(page, cdp, interaction, {
+      scriptProfile: params.scriptProfile,
+      selectorProfile: params.selectorProfile,
+      scriptSourceMapResolver: params.scriptSourceMapResolver,
+      styleSheetUrls,
+      scriptSourceMapUrls,
+    });
+
+    if (params.verify) {
+      await params.verify(page);
+    }
+
+    return result;
+  } catch (error) {
+    const page = context.pages()[0];
+    if (page) {
+      await attachFailureScreenshot(params.testInfo, page);
+    }
+    throw error;
+  } finally {
+    // Swallow close failures: by this point the result is already computed or
+    // a more informative error is in flight.
+    await context.close().catch(() => {});
+  }
+}
+
+/**
  * Runs the interaction multiple times, discards warm-up runs, and returns the
- * median metrics. By default, each iteration re-navigates to the page URL for
- * a clean state.
+ * median metrics. Each iteration runs in a fresh browser context so the
+ * samples are independent; see `measureIteration`.
  */
 export async function createPerfMeasure(
   page: Page,
-  interaction: () => Promise<void>,
+  interaction: PerfMeasureCallback,
   results: PerfResult[],
   testInfo: TestInfo,
   options: CreatePerfMeasureOptions = {},
 ): Promise<PerfMetrics> {
   const {
-    resetPage = true,
+    loadPage = true,
     setup,
     verify,
     label,
@@ -1179,92 +1326,51 @@ export async function createPerfMeasure(
     throw new Error(`Invalid perf profile limit: ${profileLimit}`);
   }
 
-  const cdp = await page.context().newCDPSession(page);
-  await cdp.send("Performance.enable");
+  const browser = page.context().browser();
+  if (!browser) {
+    throw new Error("Perf measurements require a browser-launched page.");
+  }
+
+  const contextOptions = getContextOptions(testInfo);
+  // The test navigated the fixture page to the measured URL; each iteration
+  // page visits the same URL in its own context.
+  const url = page.url();
 
   const allMetrics: PerfMetrics[] = [];
   const scriptProfiles: PerfScriptProfileEntry[][] = [];
   const selectorProfiles: PerfSelectorProfileEntry[][] = [];
-  const styleSheetUrls = new Map<string, string>();
-  const onStyleSheetAdded = (event: CssStyleSheetAddedEvent) => {
-    const { styleSheetId, sourceURL = "" } = event.header;
-    styleSheetUrls.set(styleSheetId, sourceURL);
-  };
-  const scriptSourceMapUrls = new Map<string, string>();
+  // Source map fetches are cached across iterations; the URLs are stable
+  // because every iteration loads the same build output.
   const scriptSourceMapResolver: SourceMapResolverOptions = {
     loadScript: createCachedLoader(defaultLoadText),
     loadSourceMap: createCachedLoader(defaultLoadSourceMap),
     traceMapCache: new Map(),
   };
-  const onScriptParsed = (event: DebuggerScriptParsedEvent) => {
-    const { scriptId, sourceMapURL = "" } = event;
-    if (sourceMapURL) {
-      scriptSourceMapUrls.set(scriptId, sourceMapURL);
+
+  for (let i = 0; i < warmup + iterations; i++) {
+    const result = await measureIteration({
+      browser,
+      contextOptions,
+      testInfo,
+      url,
+      loadPage,
+      interaction,
+      setup,
+      verify,
+      scriptProfile,
+      selectorProfile,
+      scriptSourceMapResolver,
+    });
+
+    // Only keep measured (non-warmup) iterations.
+    if (i < warmup) continue;
+    allMetrics.push(result.metrics);
+    if (result.profiles?.script && result.profiles.script.length > 0) {
+      scriptProfiles.push(result.profiles.script);
     }
-  };
-
-  try {
-    if (scriptProfile) {
-      cdp.on("Debugger.scriptParsed", onScriptParsed);
-      await cdp.send("Debugger.enable");
-      await cdp.send("Profiler.enable");
+    if (result.profiles?.selectors && result.profiles.selectors.length > 0) {
+      selectorProfiles.push(result.profiles.selectors);
     }
-    if (selectorProfile) {
-      cdp.on("CSS.styleSheetAdded", onStyleSheetAdded);
-      await cdp.send("DOM.enable");
-      await cdp.send("CSS.enable");
-    }
-
-    const url = page.url();
-
-    for (let i = 0; i < warmup + iterations; i++) {
-      if (resetPage) {
-        // Re-navigate for a clean state on every iteration.
-        await gotoAndSettle(page, url);
-      }
-
-      if (setup) {
-        // Run the unmeasured setup and let its work settle so it doesn't leak
-        // into the metrics snapshot taken right before the interaction.
-        await setup();
-        await settleQuiescent(page, cdp);
-      }
-
-      const result = await measureOnce(page, cdp, interaction, {
-        scriptProfile,
-        selectorProfile,
-        scriptSourceMapResolver,
-        styleSheetUrls,
-        scriptSourceMapUrls,
-      });
-
-      if (verify) {
-        await verify();
-      }
-
-      // Only keep measured (non-warmup) iterations.
-      if (i >= warmup) {
-        allMetrics.push(result.metrics);
-        if (result.profiles?.script && result.profiles.script.length > 0) {
-          scriptProfiles.push(result.profiles.script);
-        }
-        if (
-          result.profiles?.selectors &&
-          result.profiles.selectors.length > 0
-        ) {
-          selectorProfiles.push(result.profiles.selectors);
-        }
-      }
-    }
-  } finally {
-    cdp.off("Debugger.scriptParsed", onScriptParsed);
-    cdp.off("CSS.styleSheetAdded", onStyleSheetAdded);
-    await cdp.send("Profiler.disable").catch(() => {});
-    await cdp.send("Debugger.disable").catch(() => {});
-    await cdp.send("CSS.disable").catch(() => {});
-    await cdp.send("DOM.disable").catch(() => {});
-    await cdp.send("Performance.disable").catch(() => {});
-    await cdp.detach().catch(() => {});
   }
 
   const medianMetrics = computeMedianMetrics(allMetrics);
@@ -1299,12 +1405,12 @@ export async function createPerfPageLoadMeasure(
   const url = page.url();
   return createPerfMeasure(
     page,
-    () => gotoAndSettle(page, url),
+    (iterationPage) => gotoAndSettle(iterationPage, url),
     results,
     testInfo,
     {
       ...options,
-      resetPage: false,
+      loadPage: false,
     },
   );
 }


### PR DESCRIPTION
## Motivation

`sandbox/dialog-perf/perf-chrome.ts > react > open dialog` has been flip-flopping between ~300ms and ~550ms totals across CI rounds — on the `@clerk/astro` bump (#6637), the perf comment showed scripting going from 199ms to 449ms (+126%) even though the PR could not affect dialog performance.

The raw round artifacts show this is not runner noise. Per-iteration samples are bimodal and the slow mode is positional: iterations at positions 1–2 of a round are always fast, and slow iterations only appear from position 3 onward (the 4th same-tab navigation, counting warmup) — in 20/20 rounds inspected. Only `open dialog` is affected; `close dialog` (which opens the dialog in unmeasured setup) and every other perf test are clean.

Root cause: the harness re-navigated a single tab for every iteration, and renderer-process state accumulated across same-URL navigations makes the dialog-open interaction cost over 2x more scripting from roughly the fourth navigation onward. Locally the effect reproduces deterministically (scripting `68, 60, 82, 145, 136, 156, …` across 12 re-navigated iterations) and survives forced major GC, `Page.clearCompilationCache`, and `Network.setCacheDisabled` — only a fresh renderer process avoids it. With 5 iterations per round, the median lands on whichever mode has 3+ samples, which is exactly the observed flip-flop.

Two more measurement-layer issues surfaced while investigating:

- CDP `Performance.getMetrics` durations are wall-clock by default, so time the renderer main thread spends preempted by other processes on a shared runner inflates the metrics.
- `PaintingDuration` no longer exists in the CDP Performance domain, so the reported painting metric silently always read 0 (visible in every perf comment).

## Solution

1. **Fresh browser context per iteration.** Each measured iteration runs in its own context (hence its own renderer process), so no state accumulated by earlier iterations leaks into the sample. Locally this takes `open dialog` scripting from a 68→164ms within-round drift to 61–69ms across 10 iterations, at the same wall-clock cost per iteration. Callbacks now receive the iteration page instead of closing over the fixture page:

    ```ts
    // Before: callbacks closed over the fixture-bound `q`
    test("open dialog", async ({ q, perf }) => {
      await perf.measure(() => q.button("Open dialog").click(), {
        verify: () => expect(q.dialog("Settings")).toBeVisible(),
      });
    });

    // After: callbacks receive the iteration's `{ page, q }`
    test("open dialog", async ({ perf }) => {
      await perf.measure(({ q }) => q.button("Open dialog").click(), {
        verify: ({ q }) => expect(q.dialog("Settings")).toBeVisible(),
      });
    });
    ```

    The fixture adapter throws on zero-argument callbacks, since those can only be closing over the fixture page. Iteration contexts mirror the perf project's context options (viewport, device emulation, locale pinned to the runner's `en-US` default), and failures attach a screenshot of the iteration page since the runner's `screenshot: "only-on-failure"` only captures the idle fixture page.

2. **Thread CPU time instead of wall-clock time.** The Performance domain is enabled with `timeDomain: "threadTicks"`, so ScriptDuration/LayoutDuration/RecalcStyleDuration deltas no longer count time the main thread spends descheduled — removing noisy-neighbor preemption on `ubuntu-latest` from the metrics themselves. INP intentionally stays wall-clock.

3. **Collapse reported metrics to Scripting / Rendering / INP / Total.** Layout and style recalc fold into a single rendering value, and the phantom painting metric is gone. perf-compare still reads old-format baseline files (extra keys are simply ignored; `rendering` is numerically identical in both formats since painting always read 0), covered by a new test.

## Expected re-baselining on this PR

The perf comment on this PR compares incompatible measurement methodologies: baseline rounds run the base branch's harness (wall-clock, same-tab re-navigation) while current rounds use thread CPU time in fresh contexts. Every flagged change is the methodology shift, not a library change — this PR touches no library code. The observed pattern, verified against the raw round artifacts:

- **`open dialog` −48%**: the baseline was contaminated by the renderer-state slow mode. Every baseline round in this run shows the signature (e.g. raw totals `269, 268, 550, 554, 462` — two fast iterations, then slow ones), while the new harness's 25 samples sit flat at 223–249ms.
- **Mount-type tests +15–33%** (`mount composite`, `mount controlled composite`, and unconfirmed `close dialog`): these never had the slow mode, so their baselines were *warm-renderer* wall times — earlier same-process page loads had already warmed V8 for the measured code path. The new harness measures a genuinely cold renderer every iteration, so the first-run compile/interpreter cost is now included. Raw distributions are tight on both sides; it's a consistent level shift, and the cold number is the more representative one (a real user's first interaction on a freshly loaded page).
- **`page load` +12%**: now a true cold load (fresh HTTP cache per iteration, so staggered CSS/font arrival adds recalc passes). The raw spread tightened from ~550ms to ~130ms.
- **Steady-state tests ±0–4%** (`move across items`, `update controlled items`, tailwind toggle): cold-start amortizes away over long interactions.
- **Rendering columns barely move** (`open dialog` rendering: 88.4ms → 88.4ms): deterministic style/layout work measures identically under both harnesses.

Absolute values before and after this PR are not comparable, and the first post-merge perf comments should be read with that in mind.

## Notes

- Only private packages change (`@ariakit/scripts`, `app`), so no changeset.
- Verified: `tsc -b --force` clean at root, `pnpm test run perf` 63/63, and all three perf sandbox suites pass end-to-end against a production build served by `preview-lite`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
