### PR TITLE
Add popup performance tests

### DIFF
--- a/app/src/sandbox/combobox-perf/index.react.tsx
+++ b/app/src/sandbox/combobox-perf/index.react.tsx
@@ -1,0 +1,43 @@
+import * as Ariakit from "@ariakit/react";
+import "./style.css";
+
+const pageItems = Array.from(
+  { length: 5000 },
+  (_, index) => `Element ${index + 1}`,
+);
+
+const items = Array.from({ length: 20 }, (_, index) => `Item ${index + 1}`);
+
+export default function Example() {
+  return (
+    <div className="root">
+      <Ariakit.ComboboxProvider>
+        <Ariakit.ComboboxLabel className="label">
+          Search items
+        </Ariakit.ComboboxLabel>
+        <Ariakit.Combobox className="combobox" placeholder="Search items" />
+        <Ariakit.ComboboxPopover
+          className="popover"
+          gutter={4}
+          sameWidth
+          unmountOnHide
+        >
+          {items.map((item) => (
+            <Ariakit.ComboboxItem
+              key={item}
+              className="popover-item"
+              value={item}
+            />
+          ))}
+        </Ariakit.ComboboxPopover>
+      </Ariakit.ComboboxProvider>
+      <div className="grid">
+        {pageItems.map((item) => (
+          <button key={item} className="card" type="button">
+            {item}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/src/sandbox/combobox-perf/index.react.tsx
+++ b/app/src/sandbox/combobox-perf/index.react.tsx
@@ -6,7 +6,7 @@ const pageItems = Array.from(
   (_, index) => `Element ${index + 1}`,
 );
 
-const items = Array.from({ length: 20 }, (_, index) => `Item ${index + 1}`);
+const items = Array.from({ length: 200 }, (_, index) => `Item ${index + 1}`);
 
 export default function Example() {
   return (

--- a/app/src/sandbox/combobox-perf/perf-chrome.ts
+++ b/app/src/sandbox/combobox-perf/perf-chrome.ts
@@ -3,7 +3,7 @@ import { expect } from "@playwright/test";
 import type { Page } from "@playwright/test";
 import { withFramework } from "#app/test-utils/preview.ts";
 
-const itemCount = 20;
+const itemCount = 200;
 type Query = ReturnType<typeof query>;
 
 async function openCombobox(q: Query) {

--- a/app/src/sandbox/combobox-perf/perf-chrome.ts
+++ b/app/src/sandbox/combobox-perf/perf-chrome.ts
@@ -1,0 +1,79 @@
+import type { query } from "@ariakit/test/playwright";
+import { expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { withFramework } from "#app/test-utils/preview.ts";
+
+const itemCount = 20;
+type Query = ReturnType<typeof query>;
+
+async function openCombobox(q: Query) {
+  await q.combobox("Search items").click();
+}
+
+async function verifyComboboxOpen(q: Query) {
+  await expect(q.listbox()).toBeVisible();
+}
+
+async function setupCombobox(q: Query) {
+  await openCombobox(q);
+  await verifyComboboxOpen(q);
+}
+
+async function closeCombobox(page: Page) {
+  await page.keyboard.press("Escape");
+}
+
+async function verifyComboboxClosed(q: Query) {
+  await expect(q.listbox()).not.toBeVisible();
+}
+
+async function setupComboboxMove(page: Page, q: Query) {
+  await setupCombobox(q);
+  await page.keyboard.press("ArrowDown");
+  await expect(q.option("Item 1")).toHaveAttribute("data-active-item");
+}
+
+async function moveAcrossItems(page: Page) {
+  for (let i = 1; i < itemCount; i++) {
+    await page.keyboard.press("ArrowDown");
+  }
+}
+
+async function verifyMovedAcrossItems(q: Query) {
+  await expect(q.option(`Item ${itemCount}`)).toHaveAttribute(
+    "data-active-item",
+  );
+}
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("open combobox", async ({ perf }) => {
+    await perf.measure(({ q }) => openCombobox(q), {
+      verify: ({ q }) => verifyComboboxOpen(q),
+    });
+  });
+
+  test("close combobox", async ({ perf }) => {
+    await perf.measure(({ page }) => closeCombobox(page), {
+      setup: ({ q }) => setupCombobox(q),
+      verify: ({ q }) => verifyComboboxClosed(q),
+    });
+  });
+
+  test("move across items", async ({ perf }) => {
+    await perf.measure(({ page }) => moveAcrossItems(page), {
+      setup: ({ page, q }) => setupComboboxMove(page, q),
+      verify: ({ q }) => verifyMovedAcrossItems(q),
+    });
+  });
+
+  // Same interaction as "open combobox", but with the script profiler enabled
+  // so the PR comment shows where the scripting time goes. Profiling adds
+  // overhead, so the unprofiled test above is the one to read for timings.
+  test("open combobox (script profile)", async ({ perf }) => {
+    await perf.measure(({ q }) => openCombobox(q), {
+      scriptProfile: true,
+      profileLimit: 20,
+      verify: ({ q }) => verifyComboboxOpen(q),
+    });
+  });
+});

--- a/app/src/sandbox/combobox-perf/style.css
+++ b/app/src/sandbox/combobox-perf/style.css
@@ -1,0 +1,72 @@
+/* No transitions or animations: this sandbox is used by perf tests. */
+
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: flex-start;
+  padding: 1rem;
+}
+
+.label {
+  font-weight: 500;
+}
+
+.combobox,
+.card,
+.popover-item {
+  border: 1px solid hsl(204 10% 80%);
+  background: white;
+  color: hsl(204 10% 10%);
+  font: inherit;
+}
+
+.combobox {
+  width: 16rem;
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.card {
+  overflow: hidden;
+  min-width: 0;
+  border-radius: 0.375rem;
+  padding: 0.5rem;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.popover {
+  position: relative;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  max-height: min(var(--popover-available-height, 20rem), 20rem);
+  border: 1px solid hsl(204 10% 80%);
+  border-radius: 0.5rem;
+  background: white;
+  padding: 0.25rem;
+  color: hsl(204 10% 10%);
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+
+.popover-item {
+  min-height: 2rem;
+  border: 0;
+  border-radius: 0.25rem;
+  padding: 0.375rem 0.5rem;
+}
+
+.popover-item[data-active-item] {
+  background: hsl(204 100% 40%);
+  color: white;
+}

--- a/app/src/sandbox/menu-perf/index.react.tsx
+++ b/app/src/sandbox/menu-perf/index.react.tsx
@@ -6,7 +6,7 @@ const pageItems = Array.from(
   (_, index) => `Element ${index + 1}`,
 );
 
-const items = Array.from({ length: 20 }, (_, index) => `Item ${index + 1}`);
+const items = Array.from({ length: 200 }, (_, index) => `Item ${index + 1}`);
 
 export default function Example() {
   return (

--- a/app/src/sandbox/menu-perf/index.react.tsx
+++ b/app/src/sandbox/menu-perf/index.react.tsx
@@ -1,0 +1,41 @@
+import * as Ariakit from "@ariakit/react";
+import "./style.css";
+
+const pageItems = Array.from(
+  { length: 5000 },
+  (_, index) => `Element ${index + 1}`,
+);
+
+const items = Array.from({ length: 20 }, (_, index) => `Item ${index + 1}`);
+
+export default function Example() {
+  return (
+    <div className="root">
+      <Ariakit.MenuProvider>
+        <Ariakit.MenuButton className="button">
+          Actions
+          <Ariakit.MenuButtonArrow />
+        </Ariakit.MenuButton>
+        <Ariakit.Menu
+          aria-label="Actions"
+          className="popover"
+          gutter={4}
+          unmountOnHide
+        >
+          {items.map((item) => (
+            <Ariakit.MenuItem key={item} className="popover-item">
+              {item}
+            </Ariakit.MenuItem>
+          ))}
+        </Ariakit.Menu>
+      </Ariakit.MenuProvider>
+      <div className="grid">
+        {pageItems.map((item) => (
+          <button key={item} className="card" type="button">
+            {item}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/src/sandbox/menu-perf/perf-chrome.ts
+++ b/app/src/sandbox/menu-perf/perf-chrome.ts
@@ -1,0 +1,79 @@
+import type { query } from "@ariakit/test/playwright";
+import { expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { withFramework } from "#app/test-utils/preview.ts";
+
+const itemCount = 20;
+type Query = ReturnType<typeof query>;
+
+async function openMenu(q: Query) {
+  await q.button("Actions").click();
+}
+
+async function verifyMenuOpen(q: Query) {
+  await expect(q.menu("Actions")).toBeVisible();
+}
+
+async function setupMenu(q: Query) {
+  await openMenu(q);
+  await verifyMenuOpen(q);
+}
+
+async function closeMenu(page: Page) {
+  await page.keyboard.press("Escape");
+}
+
+async function verifyMenuClosed(q: Query) {
+  await expect(q.menu("Actions")).not.toBeVisible();
+}
+
+async function setupMenuMove(page: Page, q: Query) {
+  await setupMenu(q);
+  await page.keyboard.press("Home");
+  await expect(q.menuitem("Item 1")).toHaveAttribute("data-active-item");
+}
+
+async function moveAcrossItems(page: Page) {
+  for (let i = 1; i < itemCount; i++) {
+    await page.keyboard.press("ArrowDown");
+  }
+}
+
+async function verifyMovedAcrossItems(q: Query) {
+  await expect(q.menuitem(`Item ${itemCount}`)).toHaveAttribute(
+    "data-active-item",
+  );
+}
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("open menu", async ({ perf }) => {
+    await perf.measure(({ q }) => openMenu(q), {
+      verify: ({ q }) => verifyMenuOpen(q),
+    });
+  });
+
+  test("close menu", async ({ perf }) => {
+    await perf.measure(({ page }) => closeMenu(page), {
+      setup: ({ q }) => setupMenu(q),
+      verify: ({ q }) => verifyMenuClosed(q),
+    });
+  });
+
+  test("move across items", async ({ perf }) => {
+    await perf.measure(({ page }) => moveAcrossItems(page), {
+      setup: ({ page, q }) => setupMenuMove(page, q),
+      verify: ({ q }) => verifyMovedAcrossItems(q),
+    });
+  });
+
+  // Same interaction as "open menu", but with the script profiler enabled
+  // so the PR comment shows where the scripting time goes. Profiling adds
+  // overhead, so the unprofiled test above is the one to read for timings.
+  test("open menu (script profile)", async ({ perf }) => {
+    await perf.measure(({ q }) => openMenu(q), {
+      scriptProfile: true,
+      profileLimit: 20,
+      verify: ({ q }) => verifyMenuOpen(q),
+    });
+  });
+});

--- a/app/src/sandbox/menu-perf/perf-chrome.ts
+++ b/app/src/sandbox/menu-perf/perf-chrome.ts
@@ -3,7 +3,7 @@ import { expect } from "@playwright/test";
 import type { Page } from "@playwright/test";
 import { withFramework } from "#app/test-utils/preview.ts";
 
-const itemCount = 20;
+const itemCount = 200;
 type Query = ReturnType<typeof query>;
 
 async function openMenu(q: Query) {

--- a/app/src/sandbox/menu-perf/style.css
+++ b/app/src/sandbox/menu-perf/style.css
@@ -1,0 +1,74 @@
+/* No transitions or animations: this sandbox is used by perf tests. */
+
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: flex-start;
+  padding: 1rem;
+}
+
+.button,
+.card,
+.popover-item {
+  border: 1px solid hsl(204 10% 80%);
+  background: white;
+  color: hsl(204 10% 10%);
+  font: inherit;
+}
+
+.button {
+  display: inline-flex;
+  gap: 0.25rem;
+  align-items: center;
+  justify-content: space-between;
+  min-width: 10rem;
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.card {
+  overflow: hidden;
+  min-width: 0;
+  border-radius: 0.375rem;
+  padding: 0.5rem;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.popover {
+  position: relative;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  min-width: 10rem;
+  max-height: min(var(--popover-available-height, 20rem), 20rem);
+  border: 1px solid hsl(204 10% 80%);
+  border-radius: 0.5rem;
+  background: white;
+  padding: 0.25rem;
+  color: hsl(204 10% 10%);
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+
+.popover-item {
+  min-height: 2rem;
+  border: 0;
+  border-radius: 0.25rem;
+  padding: 0.375rem 0.5rem;
+  text-align: left;
+}
+
+.popover-item[data-active-item] {
+  background: hsl(204 100% 40%);
+  color: white;
+}

--- a/app/src/sandbox/select-perf/index.react.tsx
+++ b/app/src/sandbox/select-perf/index.react.tsx
@@ -6,7 +6,7 @@ const pageItems = Array.from(
   (_, index) => `Element ${index + 1}`,
 );
 
-const items = Array.from({ length: 20 }, (_, index) => `Item ${index + 1}`);
+const items = Array.from({ length: 200 }, (_, index) => `Item ${index + 1}`);
 
 export default function Example() {
   return (

--- a/app/src/sandbox/select-perf/index.react.tsx
+++ b/app/src/sandbox/select-perf/index.react.tsx
@@ -1,0 +1,41 @@
+import * as Ariakit from "@ariakit/react";
+import "./style.css";
+
+const pageItems = Array.from(
+  { length: 5000 },
+  (_, index) => `Element ${index + 1}`,
+);
+
+const items = Array.from({ length: 20 }, (_, index) => `Item ${index + 1}`);
+
+export default function Example() {
+  return (
+    <div className="root">
+      <Ariakit.SelectProvider defaultValue={items[0]}>
+        <Ariakit.SelectLabel className="label">Choose item</Ariakit.SelectLabel>
+        <Ariakit.Select className="button" />
+        <Ariakit.SelectPopover
+          className="popover"
+          gutter={4}
+          sameWidth
+          unmountOnHide
+        >
+          {items.map((item) => (
+            <Ariakit.SelectItem
+              key={item}
+              className="popover-item"
+              value={item}
+            />
+          ))}
+        </Ariakit.SelectPopover>
+      </Ariakit.SelectProvider>
+      <div className="grid">
+        {pageItems.map((item) => (
+          <button key={item} className="card" type="button">
+            {item}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/src/sandbox/select-perf/perf-chrome.ts
+++ b/app/src/sandbox/select-perf/perf-chrome.ts
@@ -3,7 +3,7 @@ import { expect } from "@playwright/test";
 import type { Page } from "@playwright/test";
 import { withFramework } from "#app/test-utils/preview.ts";
 
-const itemCount = 20;
+const itemCount = 200;
 type Query = ReturnType<typeof query>;
 
 async function openSelect(q: Query) {

--- a/app/src/sandbox/select-perf/perf-chrome.ts
+++ b/app/src/sandbox/select-perf/perf-chrome.ts
@@ -1,0 +1,78 @@
+import type { query } from "@ariakit/test/playwright";
+import { expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { withFramework } from "#app/test-utils/preview.ts";
+
+const itemCount = 20;
+type Query = ReturnType<typeof query>;
+
+async function openSelect(q: Query) {
+  await q.combobox("Choose item").click();
+}
+
+async function verifySelectOpen(q: Query) {
+  await expect(q.listbox()).toBeVisible();
+}
+
+async function setupSelect(q: Query) {
+  await openSelect(q);
+  await verifySelectOpen(q);
+}
+
+async function closeSelect(page: Page) {
+  await page.keyboard.press("Escape");
+}
+
+async function verifySelectClosed(q: Query) {
+  await expect(q.listbox()).not.toBeVisible();
+}
+
+async function setupSelectMove(q: Query) {
+  await setupSelect(q);
+  await expect(q.option("Item 1")).toHaveAttribute("data-active-item");
+}
+
+async function moveAcrossItems(page: Page) {
+  for (let i = 1; i < itemCount; i++) {
+    await page.keyboard.press("ArrowDown");
+  }
+}
+
+async function verifyMovedAcrossItems(q: Query) {
+  await expect(q.option(`Item ${itemCount}`)).toHaveAttribute(
+    "data-active-item",
+  );
+}
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("open select", async ({ perf }) => {
+    await perf.measure(({ q }) => openSelect(q), {
+      verify: ({ q }) => verifySelectOpen(q),
+    });
+  });
+
+  test("close select", async ({ perf }) => {
+    await perf.measure(({ page }) => closeSelect(page), {
+      setup: ({ q }) => setupSelect(q),
+      verify: ({ q }) => verifySelectClosed(q),
+    });
+  });
+
+  test("move across items", async ({ perf }) => {
+    await perf.measure(({ page }) => moveAcrossItems(page), {
+      setup: ({ q }) => setupSelectMove(q),
+      verify: ({ q }) => verifyMovedAcrossItems(q),
+    });
+  });
+
+  // Same interaction as "open select", but with the script profiler enabled
+  // so the PR comment shows where the scripting time goes. Profiling adds
+  // overhead, so the unprofiled test above is the one to read for timings.
+  test("open select (script profile)", async ({ perf }) => {
+    await perf.measure(({ q }) => openSelect(q), {
+      scriptProfile: true,
+      profileLimit: 20,
+      verify: ({ q }) => verifySelectOpen(q),
+    });
+  });
+});

--- a/app/src/sandbox/select-perf/style.css
+++ b/app/src/sandbox/select-perf/style.css
@@ -1,0 +1,73 @@
+/* No transitions or animations: this sandbox is used by perf tests. */
+
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: flex-start;
+  padding: 1rem;
+}
+
+.label {
+  font-weight: 500;
+}
+
+.button,
+.card,
+.popover-item {
+  border: 1px solid hsl(204 10% 80%);
+  background: white;
+  color: hsl(204 10% 10%);
+  font: inherit;
+}
+
+.button {
+  width: 16rem;
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.card {
+  overflow: hidden;
+  min-width: 0;
+  border-radius: 0.375rem;
+  padding: 0.5rem;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.popover {
+  position: relative;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  max-height: min(var(--popover-available-height, 20rem), 20rem);
+  border: 1px solid hsl(204 10% 80%);
+  border-radius: 0.5rem;
+  background: white;
+  padding: 0.25rem;
+  color: hsl(204 10% 10%);
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+
+.popover-item {
+  min-height: 2rem;
+  border: 0;
+  border-radius: 0.25rem;
+  padding: 0.375rem 0.5rem;
+}
+
+.popover-item[data-active-item] {
+  background: hsl(204 100% 40%);
+  color: white;
+}


### PR DESCRIPTION
## Motivation

Combobox, select, and menu popup interactions need dedicated performance coverage with large surrounding DOMs, similar to the existing dialog performance sandbox. Without these benchmarks, regressions in opening popovers or moving through popup items are harder to catch.

## Solution

Add separate `combobox-perf`, `select-perf`, and `menu-perf` sandboxes. Each sandbox renders 5000 page buttons plus a 200-item popup, then measures:

- opening the popup
- closing it with `Escape`
- moving from the first item to the last with the keyboard
- opening with script profiling enabled

The popups use `unmountOnHide` and no CSS transitions so timings focus on popup work rather than animation overhead.
