### PR TITLE
Improve style recalculation when opening a modal dialog

### DIFF
--- a/.changeset/200-dialog-open-style-recalc.md
+++ b/.changeset/200-dialog-open-style-recalc.md
@@ -1,0 +1,10 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Improved style recalculation when opening a modal `Dialog`
+
+Opening a modal [`Dialog`](https://ariakit.com/reference/dialog), or a dialog-based component such as [`Popover`](https://ariakit.com/reference/popover) or [`Menu`](https://ariakit.com/reference/menu) with the [`modal`](https://ariakit.com/reference/popover#modal) prop, no longer recalculates the dialog subtree styles twice before the browser paints. The `--dialog-viewport-height` variable is now written while the subtree styles are already invalidated by the dialog's own mount, and repeated writes of the same height are skipped when the viewport resizes.
+
+The style invalidation caused by disabling the tree outside the dialog is also flushed right where it originates. Performance profiles now attribute that cost to the tree disabling code instead of whichever style read happened to run first, such as the viewport height measurement.

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -239,7 +239,15 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
   // Sets --dialog-viewport-height CSS variable to the height of the visual
   // viewport. This allows the dialog to be positioned correctly when the
   // viewport height changes (e.g., when the keyboard is shown on mobile).
-  useEffect(() => {
+  // The initial write must run in the layout phase, before the effect below
+  // that disables the tree outside modal dialogs: the dialog subtree is
+  // still dirty from its own mount there, so the write gets absorbed by the
+  // style flush that disabling forces. As a passive effect, the write
+  // re-dirtied the dialog subtree right after that flush, forcing the next
+  // style read (the backdrop z-index sync or the auto focus tabbable scan)
+  // to recalc the dialog subtree a second time before the browser could
+  // paint.
+  useSafeLayoutEffect(() => {
     if (!mounted) return;
     if (!domReady) return;
     const dialog = ref.current;
@@ -247,8 +255,13 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     const win = getWindow(dialog);
     const viewport = win.visualViewport || win;
     const setViewportHeight = () => {
-      const height = win.visualViewport?.height ?? win.innerHeight;
-      dialog.style.setProperty("--dialog-viewport-height", `${height}px`);
+      const height = `${win.visualViewport?.height ?? win.innerHeight}px`;
+      // Resizes that keep the height (horizontal-only window resizes) would
+      // still invalidate the dialog subtree's styles if the same value was
+      // written again.
+      const property = "--dialog-viewport-height";
+      if (dialog.style.getPropertyValue(property) === height) return;
+      dialog.style.setProperty(property, height);
     };
     setViewportHeight();
     viewport.addEventListener("resize", setViewportHeight);

--- a/packages/ariakit-react-components/src/dialog/utils/disable-tree.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/disable-tree.ts
@@ -1,4 +1,10 @@
-import { contains, getAllTabbableIn, chain, noop } from "@ariakit/utils";
+import {
+  contains,
+  getAllTabbableIn,
+  getDocument,
+  chain,
+  noop,
+} from "@ariakit/utils";
 import { hideElementFromAccessibilityTree } from "./disable-accessibility-tree-outside.ts";
 import { isBackdrop } from "./is-backdrop.ts";
 import { isFocusTrap } from "./is-focus-trap.ts";
@@ -103,6 +109,28 @@ export function markAndDisableTreeOutside(id: string, elements: Elements) {
       addRoleNoneCleanup(cleanups, ancestor, elements);
     },
   );
+
+  // The writes above (inert on modern browsers, tabindex and inline styles
+  // on the legacy path) invalidate the computed styles of the entire outside
+  // tree, which can span the whole page. Something always reads styles
+  // before the browser paints the open dialog (the backdrop z-index sync,
+  // the auto focus tabbable scan, or focus itself), so that read would force
+  // this same recalc anyway, misattributing the cost to whichever read
+  // happens to run first. Flush it here instead, right after the writes, so
+  // the cost is paid where it originates and the later reads run on a clean
+  // tree. The walk above visits each connected element's own document, so
+  // elements living in other same-origin frames get their documents flushed
+  // too. The restore path must not flush: it runs among other cleanups and
+  // commit mutations, so the tree gets dirtied again before the next paint
+  // and the flush would be pure waste.
+  const documents = new Set<Document>();
+  for (const element of elements) {
+    if (!element?.isConnected) continue;
+    documents.add(getDocument(element));
+  }
+  for (const doc of documents) {
+    void doc.documentElement.offsetHeight;
+  }
 
   const restoreTreeOutside = () => {
     restoreCleanups(cleanups);


### PR DESCRIPTION
## Motivation

The dialog-perf "open dialog (script profile)" CI report showed `setViewportHeight` as by far the most expensive function during the opening interaction (666ms self time, 6x the next entry), suggesting the `--dialog-viewport-height` measurement was the dialog's biggest cost.

Chrome traces and CDP counters tell a different story. When a modal dialog opens, the tree snapshot effect marks the entire outside tree `inert`, and Blink propagates inertness through computed styles, invalidating the whole outside subtree (on the dialog-perf page, ~45k elements, ~68ms of style recalculation). `setViewportHeight` ran in a passive effect and read `visualViewport.height`, which forces a style and layout flush. Being the first forced read after the `inert` writes, it paid the entire bill, and the V8 profiler attributed that wall time to it.

The cost itself is unavoidable: something always reads styles before the browser paints the open dialog (the backdrop z-index sync, the auto focus tabbable scan, or focus itself), so removing or deferring the viewport height measurement just moves the same bill to the next reader. An interleaved A/B benchmark run (20 samples per side) confirms scripting, rendering, INP, and total are all unchanged when the measurement is removed entirely.

The measurement did add one piece of real waste: it wrote the `--dialog-viewport-height` inline custom property after the big flush, re-dirtying the dialog subtree, so the next pre-paint style read had to recalculate the dialog subtree a second time.

## Solution

Two ordering changes, both count-neutral by construction and verified count-neutral with CDP `RecalcStyleCount`/`RecalcStyleDuration` deltas:

- The viewport height effect now runs in the layout phase (`useSafeLayoutEffect`), before the tree snapshot effect. The initial `--dialog-viewport-height` write lands while the dialog subtree is still dirty from its own mount, so it gets absorbed by the flush that disabling the outside tree forces, instead of re-dirtying the subtree after that flush. The resize handler also skips writes when the height hasn't changed, so horizontal-only window resizes no longer invalidate the dialog subtree.
- `markAndDisableTreeOutside` now deliberately flushes style and layout (an `offsetHeight` read on each walked document, since persistent elements can live in other same-origin frames) right after its `inert`/marking writes. The recalculation cost of disabling the outside tree is paid once, where it originates, and every later pre-paint read (backdrop z-index sync, tabbable scan, focus) runs on a clean tree. The restore path intentionally doesn't flush: it runs among other cleanups and commit mutations that dirty the tree again, so a flush there would be wasted work.

After this change, the script profile attributes the cost honestly:

Before (dev, dialog-perf open):

```
194.4ms  setViewportHeight        <- wearing the inert bill
131.2ms  exports.jsxDEV
```

After:

```
196.3ms  markAndDisableTreeOutside  <- the actual owner of the bill
150.4ms  exports.jsxDEV
```

`setViewportHeight` disappears from the profile entirely (0.47ms forced recalc, down from 68.6ms), and the interleaved A/B benchmark shows all metrics flat (scripting -0.0%, rendering -0.0%, INP -0.6%, total -0.0%), as expected for an attribution and ordering fix.

## Verification

- Chrome trace: exactly one big recalc per open, attributed to `markAndDisableTreeOutside`; later readers pay ~0.1ms; `RecalcStyleCount` unchanged (8 vs 8).
- Interleaved perf A/B (2 rounds per side, 20 samples each): all metrics within noise.
- `pnpm test-react dialog` (150/150), `pnpm test-react18 dialog` (145 passed, 5 pre-existing skips), `orchestrate` unit tests (12/12), app Chrome dialog browser tests (23/23), `pnpm tsc`, `pnpm lint`.
