### PR TITLE
Combine dialog perf script profile

### DIFF
--- a/app/src/sandbox/dialog-perf/index.react.tsx
+++ b/app/src/sandbox/dialog-perf/index.react.tsx
@@ -2,7 +2,7 @@ import * as Ariakit from "@ariakit/react";
 import { useState } from "react";
 import "./style.css";
 
-const items = Array.from({ length: 5000 }, (_, index) => ({
+const items = Array.from({ length: 3000 }, (_, index) => ({
   id: `item-${index + 1}`,
   title: `Item ${index + 1}`,
 }));

--- a/app/src/sandbox/dialog-perf/perf-chrome.ts
+++ b/app/src/sandbox/dialog-perf/perf-chrome.ts
@@ -4,6 +4,7 @@ import { withFramework } from "#app/test-utils/preview.ts";
 withFramework(import.meta.dirname, async ({ test }) => {
   test("open dialog", async ({ perf }) => {
     await perf.measure(({ q }) => q.button("Open dialog").click(), {
+      scriptProfile: true,
       verify: ({ q }) => expect(q.dialog("Settings")).toBeVisible(),
     });
   });
@@ -15,17 +16,6 @@ withFramework(import.meta.dirname, async ({ test }) => {
         await expect(q.dialog("Settings")).toBeVisible();
       },
       verify: ({ q }) => expect(q.dialog("Settings")).not.toBeVisible(),
-    });
-  });
-
-  // Same interaction as "open dialog", but with the script profiler enabled
-  // so the PR comment shows where the scripting time goes. Profiling adds
-  // overhead, so the unprofiled test above is the one to read for timings.
-  test("open dialog (script profile)", async ({ perf }) => {
-    await perf.measure(({ q }) => q.button("Open dialog").click(), {
-      scriptProfile: true,
-      profileLimit: 20,
-      verify: ({ q }) => expect(q.dialog("Settings")).toBeVisible(),
     });
   });
 });

--- a/packages/ariakit-scripts/src/perf-compare.test.ts
+++ b/packages/ariakit-scripts/src/perf-compare.test.ts
@@ -91,8 +91,8 @@ function createResult(total: number): PerfResult {
   const metrics = createMetrics(total);
   return {
     testFile: "sandbox/example/perf-chrome.ts",
-    testTitle: "sandbox/example/perf-chrome.ts > react > example",
-    label: "sandbox/example/perf-chrome.ts > react > example",
+    testTitle: "example > react > example",
+    label: "example > react > example",
     metrics,
     raw: [metrics],
   };
@@ -296,6 +296,27 @@ test("keeps single-run comparison behavior", () => {
 
   expect(markdown).toContain("100.0ms → 120.0ms (+20%) :warning:");
   expect(markdown).not.toContain("Aggregated across");
+});
+
+test("pairs legacy generated labels with normalized labels", () => {
+  const dir = createTempDir();
+  writeJson(dir, "baseline-worker0.json", [
+    createResultWithLabel(
+      "sandbox/example/perf-chrome.ts > react > example",
+      100,
+    ),
+  ]);
+  writeJson(dir, "current-worker0.json", [createResult(120)]);
+
+  const markdown = runCompare(dir);
+  const summary = readComparisonSummary(dir);
+
+  expect(markdown).toContain("100.0ms \u2192 120.0ms (+20%) :warning:");
+  expect(markdown).not.toContain("### New tests");
+  expect(markdown).not.toContain("### Removed tests");
+  expect(summary.rows[0]?.label).toBe("example > react > example");
+  expect(summary.newTests).toEqual([]);
+  expect(summary.removedTests).toEqual([]);
 });
 
 test("compares Vitest benchmark reports in node mode", () => {
@@ -905,9 +926,7 @@ test("reports tests with no paired rounds separately", () => {
     "No paired performance results available for comparison.",
   );
   expect(markdown).toContain("### Unpaired tests");
-  expect(markdown).toContain(
-    "| sandbox/example/perf-chrome.ts > react > example | 1 | 2 |",
-  );
+  expect(markdown).toContain("| example > react > example | 1 | 2 |");
   expect(markdown).not.toContain("0.0ms | 0.0ms");
 });
 
@@ -1143,7 +1162,7 @@ test("keeps node_modules script profile functions as unlinked code", () => {
   expect(markdown).not.toContain("react-dom-client.production.js");
 });
 
-test("omits metric tables for script profile comparisons", () => {
+test("renders script profiles below comparison tables", () => {
   const dir = createTempDir();
   const profiles: PerfProfiles = {
     script: [createScriptProfileEntry("profiledFn", 8)],
@@ -1156,16 +1175,18 @@ test("omits metric tables for script profile comparisons", () => {
   ]);
 
   const markdown = runCompare(dir);
+  const comparisonIndex = markdown.indexOf(
+    "| Total | 100.0ms | 130.0ms | +30.0ms (+30%) :warning: |",
+  );
+  const profileIndex = markdown.indexOf("#### Script profile");
 
-  expect(markdown).toContain("No significant performance changes detected.");
   expect(markdown).toContain("### profiled");
-  expect(markdown).toContain("#### Script profile");
+  expect(comparisonIndex).toBeGreaterThan(-1);
+  expect(profileIndex).toBeGreaterThan(comparisonIndex);
   expect(markdown).toContain("| `profiledFn` | 8.0ms | 8.0ms | 1 |");
-  expect(markdown).not.toContain("| Metric | Baseline | Current | Delta |");
-  expect(markdown).not.toContain("+30.0ms (+30%)");
 });
 
-test("omits new test metric rows for script profile results", () => {
+test("includes new test metric rows for script profile results", () => {
   const dir = createTempDir();
   const profiles: PerfProfiles = {
     script: [createScriptProfileEntry("profiledFn", 8)],
@@ -1180,15 +1201,15 @@ test("omits new test metric rows for script profile results", () => {
   expect(markdown).toContain("### New tests (no baseline)");
   expect(markdown).toContain("| Test | Scripting | Rendering | INP | Total |");
   expect(markdown).toContain("| regular | 100.0ms | 0.0ms | 0.0ms | 100.0ms |");
+  expect(markdown).toContain(
+    "| profiled | 130.0ms | 0.0ms | 0.0ms | 130.0ms |",
+  );
   expect(markdown).toContain("#### profiled");
   expect(markdown).toContain("#### Script profile");
   expect(markdown).toContain("| `profiledFn` | 8.0ms | 8.0ms | 1 |");
-  expect(markdown).not.toContain(
-    "| profiled | 130.0ms | 0.0ms | 0.0ms | 130.0ms |",
-  );
 });
 
-test("omits new test metric rows for selector profile results", () => {
+test("includes new test metric rows for selector profile results", () => {
   const dir = createTempDir();
   const profiles: PerfProfiles = {
     selectors: [createSelectorProfileEntry(".item")],
@@ -1210,12 +1231,12 @@ test("omits new test metric rows for selector profile results", () => {
   expect(markdown).toContain("### New tests (no baseline)");
   expect(markdown).toContain("| Test | Scripting | Rendering | INP | Total |");
   expect(markdown).toContain("| regular | 100.0ms | 0.0ms | 0.0ms | 100.0ms |");
+  expect(markdown).toContain(
+    "| selector-profiled | 130.0ms | 0.0ms | 0.0ms | 130.0ms |",
+  );
   expect(markdown).toContain("#### selector-profiled");
   expect(markdown).toContain("#### Selector profile");
   expect(markdown).toContain("| .item | 8.0ms | 10 | 2 | 20% |");
-  expect(markdown).not.toContain(
-    "| selector-profiled | 130.0ms | 0.0ms | 0.0ms | 130.0ms |",
-  );
 });
 
 test("warns when only one side has profile data for a test", () => {
@@ -1305,7 +1326,7 @@ test("omits metric tables when selector profile has no retained entries", () => 
   expect(markdown).not.toContain("+30.0ms (+30%)");
 });
 
-test("omits metric tables for selector profile comparisons", () => {
+test("renders selector profiles below comparison tables", () => {
   const dir = createTempDir();
   const profiles: PerfProfiles = {
     selectors: [createSelectorProfileEntry(".item")],
@@ -1332,11 +1353,13 @@ test("omits metric tables for selector profile comparisons", () => {
   ]);
 
   const markdown = runCompare(dir);
+  const comparisonIndex = markdown.indexOf(
+    "| Total | 100.0ms | 130.0ms | +30.0ms (+30%) :warning: |",
+  );
+  const profileIndex = markdown.indexOf("#### Selector profile");
 
-  expect(markdown).toContain("No significant performance changes detected.");
   expect(markdown).toContain("### selector-profiled");
-  expect(markdown).toContain("#### Selector profile");
+  expect(comparisonIndex).toBeGreaterThan(-1);
+  expect(profileIndex).toBeGreaterThan(comparisonIndex);
   expect(markdown).toContain("| .item | 8.0ms | 10 | 2 | 20% |");
-  expect(markdown).not.toContain("| Metric | Baseline | Current | Delta |");
-  expect(markdown).not.toContain("+30.0ms (+30%)");
 });

--- a/packages/ariakit-scripts/src/perf-compare.test.ts
+++ b/packages/ariakit-scripts/src/perf-compare.test.ts
@@ -51,6 +51,7 @@ interface PerfResult {
   label: string;
   metrics: PerfMetrics;
   raw: PerfMetrics[];
+  profileOnly?: boolean;
   scriptProfile?: boolean;
   selectorProfile?: boolean;
   profiles?: PerfProfiles;
@@ -317,6 +318,34 @@ test("pairs legacy generated labels with normalized labels", () => {
   expect(summary.rows[0]?.label).toBe("example > react > example");
   expect(summary.newTests).toEqual([]);
   expect(summary.removedTests).toEqual([]);
+});
+
+test("does not pair legacy dialog perf labels after the workload changes", () => {
+  const dir = createTempDir();
+  writeJson(dir, "baseline-worker0.json", [
+    createResultWithLabel(
+      "sandbox/dialog-perf/perf-chrome.ts > react > open dialog",
+      100,
+    ),
+  ]);
+  writeJson(dir, "current-worker0.json", [
+    createResultWithLabel("dialog-perf > react > open dialog", 120),
+  ]);
+
+  const markdown = runCompare(dir);
+  const summary = readComparisonSummary(dir);
+
+  expect(markdown).toContain("| dialog-perf > react > open dialog |");
+  expect(markdown).toContain(
+    "- sandbox/dialog-perf/perf-chrome.ts > react > open dialog",
+  );
+  expect(summary.rows).toEqual([]);
+  expect(summary.newTests).toMatchObject([
+    { label: "dialog-perf > react > open dialog" },
+  ]);
+  expect(summary.removedTests).toMatchObject([
+    { label: "sandbox/dialog-perf/perf-chrome.ts > react > open dialog" },
+  ]);
 });
 
 test("compares Vitest benchmark reports in node mode", () => {
@@ -1186,6 +1215,38 @@ test("renders script profiles below comparison tables", () => {
   expect(markdown).toContain("| `profiledFn` | 8.0ms | 8.0ms | 1 |");
 });
 
+test("merges script profile rows into base comparisons", () => {
+  const dir = createTempDir();
+  const profiles: PerfProfiles = {
+    script: [createScriptProfileEntry("profiledFn", 8)],
+  };
+  writeJson(dir, "baseline-worker0.json", [
+    createResultWithLabel("profiled", 100),
+  ]);
+  writeJson(dir, "current-worker0.json", [
+    createResultWithLabel("profiled", 130),
+    {
+      ...createResultWithMetrics(
+        "profiled (script profile)",
+        createMetrics(300),
+        profiles,
+      ),
+      scriptProfile: true,
+    },
+  ]);
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain("### profiled");
+  expect(markdown).toContain(
+    "| Total | 100.0ms | 130.0ms | +30.0ms (+30%) :warning: |",
+  );
+  expect(markdown).toContain("#### Script profile");
+  expect(markdown).toContain("| `profiledFn` | 8.0ms | 8.0ms | 1 |");
+  expect(markdown).not.toContain("### profiled (script profile)");
+  expect(markdown).not.toContain("300.0ms");
+});
+
 test("includes new test metric rows for script profile results", () => {
   const dir = createTempDir();
   const profiles: PerfProfiles = {
@@ -1209,7 +1270,7 @@ test("includes new test metric rows for script profile results", () => {
   expect(markdown).toContain("| `profiledFn` | 8.0ms | 8.0ms | 1 |");
 });
 
-test("includes new test metric rows for selector profile results", () => {
+test("omits new test metric rows for profile-only results", () => {
   const dir = createTempDir();
   const profiles: PerfProfiles = {
     selectors: [createSelectorProfileEntry(".item")],
@@ -1231,36 +1292,93 @@ test("includes new test metric rows for selector profile results", () => {
   expect(markdown).toContain("### New tests (no baseline)");
   expect(markdown).toContain("| Test | Scripting | Rendering | INP | Total |");
   expect(markdown).toContain("| regular | 100.0ms | 0.0ms | 0.0ms | 100.0ms |");
-  expect(markdown).toContain(
-    "| selector-profiled | 130.0ms | 0.0ms | 0.0ms | 130.0ms |",
-  );
   expect(markdown).toContain("#### selector-profiled");
   expect(markdown).toContain("#### Selector profile");
   expect(markdown).toContain("| .item | 8.0ms | 10 | 2 | 20% |");
+  expect(markdown).not.toContain(
+    "| selector-profiled | 130.0ms | 0.0ms | 0.0ms | 130.0ms |",
+  );
 });
 
-test("warns when only one side has profile data for a test", () => {
+test("omits new test metric rows for explicit profile-only results", () => {
   const dir = createTempDir();
-  writeJson(dir, "baseline-worker0.json", [
-    createResultWithMetrics("profile-mismatch", createMetrics(100), {
-      script: [createScriptProfileEntry("baselineProfile", 1)],
-    }),
-  ]);
+  const profiles: PerfProfiles = {
+    script: [createScriptProfileEntry("profiledFn", 8)],
+  };
   writeJson(dir, "current-worker0.json", [
-    createResultWithMetrics("profile-mismatch", createMetrics(130)),
+    {
+      ...createResultWithMetrics("profiled", createMetrics(130), profiles),
+      profileOnly: true,
+    },
   ]);
 
   const markdown = runCompare(dir);
 
-  expect(markdown).toContain("Profile mode differs between baseline");
-  expect(markdown).toContain("| profile-mismatch | script | yes | no |");
-  expect(markdown).toContain("No significant performance changes detected.");
-  expect(markdown).not.toContain("### profile-mismatch");
-  expect(markdown).not.toContain("| Metric | Baseline | Current | Delta |");
-  expect(markdown).not.toContain("+30.0ms (+30%)");
+  expect(markdown).toContain("### New tests (no baseline)");
+  expect(markdown).toContain("#### profiled");
+  expect(markdown).toContain("#### Script profile");
+  expect(markdown).toContain("| `profiledFn` | 8.0ms | 8.0ms | 1 |");
+  expect(markdown).not.toContain(
+    "| Test | Scripting | Rendering | INP | Total |",
+  );
+  expect(markdown).not.toContain(
+    "| profiled | 130.0ms | 0.0ms | 0.0ms | 130.0ms |",
+  );
 });
 
-test("omits metric tables when only current has script profile data", () => {
+test("ignores profile-only rounds in metric comparisons", () => {
+  const dir = createTempDir();
+  const profiles: PerfProfiles = {
+    script: [createScriptProfileEntry("profiledFn", 8)],
+  };
+  writeJson(dir, "baseline-1-worker0.json", [
+    createResultWithLabel("profiled", 100),
+  ]);
+  writeJson(dir, "current-1-worker0.json", [
+    createResultWithLabel("profiled", 130),
+  ]);
+  writeJson(dir, "baseline-2-worker0.json", [
+    createResultWithLabel("profiled", 100),
+  ]);
+  writeJson(dir, "current-2-worker0.json", [
+    {
+      ...createResultWithMetrics("profiled", createMetrics(300), profiles),
+      profileOnly: true,
+    },
+  ]);
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain(
+    "| Total | 100.0ms | 130.0ms | +30.0ms (+30%) :warning: |",
+  );
+  expect(markdown).toContain("#### Script profile");
+  expect(markdown).toContain("| `profiledFn` | 8.0ms | 8.0ms | 1 |");
+  expect(markdown).not.toContain("300.0ms");
+});
+
+test("compares metrics when only one side has attached profile data", () => {
+  const dir = createTempDir();
+  writeJson(dir, "baseline-worker0.json", [
+    createResultWithMetrics("profiled", createMetrics(100)),
+  ]);
+  writeJson(dir, "current-worker0.json", [
+    createResultWithMetrics("profiled", createMetrics(130), {
+      script: [createScriptProfileEntry("currentProfile", 8)],
+    }),
+  ]);
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain("### profiled");
+  expect(markdown).toContain(
+    "| Total | 100.0ms | 130.0ms | +30.0ms (+30%) :warning: |",
+  );
+  expect(markdown).toContain("| `currentProfile` | 8.0ms | 8.0ms | 1 |");
+  expect(markdown).not.toContain("Profile mode differs between baseline");
+});
+
+test("omits metric tables when only current has script profile mode", () => {
   const dir = createTempDir();
   const profiles: PerfProfiles = {
     script: [createScriptProfileEntry("currentProfile", 8)],
@@ -1269,7 +1387,14 @@ test("omits metric tables when only current has script profile data", () => {
     createResultWithMetrics("profile-mismatch", createMetrics(100)),
   ]);
   writeJson(dir, "current-worker0.json", [
-    createResultWithMetrics("profile-mismatch", createMetrics(130), profiles),
+    {
+      ...createResultWithMetrics(
+        "profile-mismatch",
+        createMetrics(130),
+        profiles,
+      ),
+      scriptProfile: true,
+    },
   ]);
 
   const markdown = runCompare(dir);
@@ -1326,7 +1451,7 @@ test("omits metric tables when selector profile has no retained entries", () => 
   expect(markdown).not.toContain("+30.0ms (+30%)");
 });
 
-test("renders selector profiles below comparison tables", () => {
+test("omits metric tables for profile-only comparisons", () => {
   const dir = createTempDir();
   const profiles: PerfProfiles = {
     selectors: [createSelectorProfileEntry(".item")],
@@ -1353,13 +1478,11 @@ test("renders selector profiles below comparison tables", () => {
   ]);
 
   const markdown = runCompare(dir);
-  const comparisonIndex = markdown.indexOf(
-    "| Total | 100.0ms | 130.0ms | +30.0ms (+30%) :warning: |",
-  );
-  const profileIndex = markdown.indexOf("#### Selector profile");
 
+  expect(markdown).toContain("No significant performance changes detected.");
   expect(markdown).toContain("### selector-profiled");
-  expect(comparisonIndex).toBeGreaterThan(-1);
-  expect(profileIndex).toBeGreaterThan(comparisonIndex);
+  expect(markdown).toContain("#### Selector profile");
   expect(markdown).toContain("| .item | 8.0ms | 10 | 2 | 20% |");
+  expect(markdown).not.toContain("| Metric | Baseline | Current | Delta |");
+  expect(markdown).not.toContain("+30.0ms (+30%)");
 });

--- a/packages/ariakit-scripts/src/perf-compare.test.ts
+++ b/packages/ariakit-scripts/src/perf-compare.test.ts
@@ -320,34 +320,6 @@ test("pairs legacy generated labels with normalized labels", () => {
   expect(summary.removedTests).toEqual([]);
 });
 
-test("does not pair legacy dialog perf labels after the workload changes", () => {
-  const dir = createTempDir();
-  writeJson(dir, "baseline-worker0.json", [
-    createResultWithLabel(
-      "sandbox/dialog-perf/perf-chrome.ts > react > open dialog",
-      100,
-    ),
-  ]);
-  writeJson(dir, "current-worker0.json", [
-    createResultWithLabel("dialog-perf > react > open dialog", 120),
-  ]);
-
-  const markdown = runCompare(dir);
-  const summary = readComparisonSummary(dir);
-
-  expect(markdown).toContain("| dialog-perf > react > open dialog |");
-  expect(markdown).toContain(
-    "- sandbox/dialog-perf/perf-chrome.ts > react > open dialog",
-  );
-  expect(summary.rows).toEqual([]);
-  expect(summary.newTests).toMatchObject([
-    { label: "dialog-perf > react > open dialog" },
-  ]);
-  expect(summary.removedTests).toMatchObject([
-    { label: "sandbox/dialog-perf/perf-chrome.ts > react > open dialog" },
-  ]);
-});
-
 test("compares Vitest benchmark reports in node mode", () => {
   const dir = createTempDir();
   writeJson(dir, "baseline-1.json", createStoreBenchmarkReport(1000));

--- a/packages/ariakit-scripts/src/perf-compare.test.ts
+++ b/packages/ariakit-scripts/src/perf-compare.test.ts
@@ -948,7 +948,7 @@ test("surfaces unpaired tests outside the details block", () => {
 
   expect(markdown).toContain("No significant performance changes detected.");
   expect(markdown).toContain(
-    ":warning: 1 test had no paired baseline/current rounds and was not compared.",
+    ":warning: 1 test had no comparable paired round and was not compared.",
   );
   expect(markdown.indexOf(":warning: 1 test")).toBeLessThan(
     markdown.indexOf("<details>"),
@@ -1327,6 +1327,51 @@ test("ignores profile-only rounds in metric comparisons", () => {
   expect(markdown).toContain("#### Script profile");
   expect(markdown).toContain("| `profiledFn` | 8.0ms | 8.0ms | 1 |");
   expect(markdown).not.toContain("300.0ms");
+});
+
+test("reports tests with no non-profile paired rounds as unpaired", () => {
+  const dir = createTempDir();
+  const profiles: PerfProfiles = {
+    script: [createScriptProfileEntry("profiledFn", 8)],
+  };
+  writeJson(dir, "baseline-1-worker0.json", [
+    createResultWithLabel("profiled", 100),
+  ]);
+  writeJson(dir, "current-1-worker0.json", [
+    {
+      ...createResultWithMetrics("profiled", createMetrics(300), profiles),
+      profileOnly: true,
+    },
+  ]);
+  writeJson(dir, "baseline-2-worker0.json", [
+    {
+      ...createResultWithMetrics("profiled", createMetrics(200), profiles),
+      profileOnly: true,
+    },
+  ]);
+  writeJson(dir, "current-2-worker0.json", [
+    createResultWithLabel("profiled", 130),
+  ]);
+
+  const markdown = runCompare(dir);
+  const summary = readComparisonSummary(dir);
+
+  expect(markdown).toContain(
+    "No paired performance results available for comparison.",
+  );
+  expect(markdown).toContain(
+    ":warning: 1 test had no comparable paired round and was not compared.",
+  );
+  expect(markdown).toContain("| profiled | 1, 2 | 1, 2 |");
+  expect(markdown).not.toContain("| Metric | Baseline | Current | Delta |");
+  expect(summary.rows).toEqual([]);
+  expect(summary.unpairedTests).toMatchObject([
+    {
+      label: "profiled",
+      baselineRounds: [1, 2],
+      currentRounds: [1, 2],
+    },
+  ]);
 });
 
 test("compares metrics when only one side has attached profile data", () => {

--- a/packages/ariakit-scripts/src/perf-compare.ts
+++ b/packages/ariakit-scripts/src/perf-compare.ts
@@ -9,6 +9,8 @@ import path from "node:path";
 import {
   computeMedianMetrics,
   formatPerfTitlePath,
+  getPerfProfileBaseLabel,
+  isPerfProfileLabel,
   median,
   mergeScriptProfiles,
   mergeSelectorProfiles,
@@ -57,6 +59,7 @@ interface ComparisonRow {
   threshold: boolean;
   significant: boolean;
   candidate: boolean;
+  profileMode: boolean;
   profileModeMismatch: boolean;
 }
 
@@ -362,14 +365,29 @@ function loadRounds(
 
 function normalizeGeneratedPerfLabel(label: string): string {
   if (!label.includes("perf-chrome.ts")) return label;
+  if (label.includes("sandbox/dialog-perf/perf-chrome.ts")) return label;
   return formatPerfTitlePath(label.split(" > "));
 }
 
 function normalizePerfResult(result: PerfResult): PerfResult {
-  const label = normalizeGeneratedPerfLabel(result.label);
-  const testTitle = normalizeGeneratedPerfLabel(result.testTitle);
-  if (label === result.label && testTitle === result.testTitle) return result;
-  return { ...result, label, testTitle };
+  const normalizedLabel = normalizeGeneratedPerfLabel(result.label);
+  const normalizedTitle = normalizeGeneratedPerfLabel(result.testTitle);
+  const label = getPerfProfileBaseLabel(normalizedLabel);
+  const testTitle = getPerfProfileBaseLabel(normalizedTitle);
+  const profileOnly =
+    result.profileOnly ||
+    result.scriptProfile ||
+    result.selectorProfile ||
+    isPerfProfileLabel(normalizedLabel) ||
+    isPerfProfileLabel(normalizedTitle);
+  if (
+    label === result.label &&
+    testTitle === result.testTitle &&
+    profileOnly === !!result.profileOnly
+  ) {
+    return result;
+  }
+  return { ...result, label, testTitle, profileOnly: profileOnly || undefined };
 }
 
 function mergeProfiles(results: PerfResult[]): PerfProfiles | undefined {
@@ -397,13 +415,19 @@ function mergeProfiles(results: PerfResult[]): PerfProfiles | undefined {
 function combineResults(results: PerfResult[]): PerfResult | undefined {
   const first = results[0];
   if (!first) return;
+  const metricResults = results.filter((result) => !result.profileOnly);
+  const metricsSource = metricResults.length > 0 ? metricResults : results;
+  const sourceFirst = metricsSource[0] ?? first;
   return {
-    ...first,
-    metrics: computeMedianMetrics(results.map((result) => result.metrics)),
-    raw: results.flatMap((result) => result.raw),
-    scriptProfile: results.some((result) => result.scriptProfile) || undefined,
+    ...sourceFirst,
+    metrics: computeMedianMetrics(
+      metricsSource.map((result) => result.metrics),
+    ),
+    raw: metricsSource.flatMap((result) => result.raw),
+    scriptProfile:
+      metricsSource.some((result) => result.scriptProfile) || undefined,
     selectorProfile:
-      results.some((result) => result.selectorProfile) || undefined,
+      metricsSource.some((result) => result.selectorProfile) || undefined,
     profiles: mergeProfiles(results),
   };
 }
@@ -732,21 +756,22 @@ function resultKey(result: PerfResult): string {
   return `${result.testFile}::${result.label}`;
 }
 
-function hasProfileData(
-  result: PerfResult | undefined,
-  profile: "script" | "selectors",
-): boolean {
-  return (result?.profiles?.[profile]?.length ?? 0) > 0;
-}
-
 function hasProfileMode(
   result: PerfResult | undefined,
   profile: "script" | "selectors",
 ): boolean {
   if (profile === "script") {
-    return !!result?.scriptProfile || hasProfileData(result, profile);
+    return !!result?.scriptProfile;
   }
-  return !!result?.selectorProfile || hasProfileData(result, profile);
+  return !!result?.selectorProfile;
+}
+
+function isProfileMode(result: PerfResult | undefined): boolean {
+  return (
+    !!result?.profileOnly ||
+    hasProfileMode(result, "script") ||
+    hasProfileMode(result, "selectors")
+  );
 }
 
 function isRegression(row: ComparisonRow, options: PerfCompareOptions) {
@@ -818,12 +843,22 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
       continue;
     }
 
+    const profileMode = isProfileMode(base.result) || isProfileMode(cur.result);
+    const comparisonRoundIndices = profileMode
+      ? sharedRoundIndices
+      : sharedRoundIndices.filter((roundIndex) => {
+          const baselineRound = base.byRound.get(roundIndex);
+          const currentRound = cur.byRound.get(roundIndex);
+          if (!baselineRound || !currentRound) return false;
+          return !isProfileMode(baselineRound) && !isProfileMode(currentRound);
+        });
+    if (comparisonRoundIndices.length === 0) continue;
     const profileModeMismatch = resultProfileModeMismatches.length > 0;
-    const primary = !profileModeMismatch;
+    const primary = !profileMode;
     for (const metric of primaryMetrics) {
       const baselineValues: number[] = [];
       const roundComparisons: RoundMetricComparison[] = [];
-      for (const roundIndex of sharedRoundIndices) {
+      for (const roundIndex of comparisonRoundIndices) {
         const baselineRound = base.byRound.get(roundIndex);
         const currentRound = cur.byRound.get(roundIndex);
         if (!baselineRound || !currentRound) continue;
@@ -859,9 +894,10 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
         current: curVal,
         delta,
         percent,
-        pairedRoundsCount: sharedRoundIndices.length,
+        pairedRoundsCount: comparisonRoundIndices.length,
         perRoundDeltas: roundComparisons.map((comparison) => comparison.delta),
         ...significance,
+        profileMode,
         profileModeMismatch,
       });
     }
@@ -1242,12 +1278,12 @@ function formatDetailedBreakdown({
     const testRows = rowsByKey.get(key) ?? [];
     const label = testRows[0]?.label ?? key;
     const currentResult = currentByKey.get(key)?.result;
-    const profileModeMismatch = testRows.some((row) => row.profileModeMismatch);
+    const profileMode = testRows.some((row) => row.profileMode);
     const profileLines = formatProfiles(currentResult);
-    if (profileModeMismatch && profileLines.length === 0) continue;
+    if (profileMode && profileLines.length === 0) continue;
     lines.push(`### ${label}`);
     lines.push("");
-    if (!profileModeMismatch) {
+    if (!profileMode) {
       lines.push("| Metric | Baseline | Current | Delta |");
       lines.push("|--------|----------|---------|-------|");
       for (const metric of primaryMetrics) {
@@ -1370,18 +1406,21 @@ function formatMarkdown(
 
   if (newTests.length > 0) {
     const primaryMetrics = getPrimaryMetrics(options);
+    const newTestsWithMetrics = newTests.filter(
+      ({ result }) => !isProfileMode(result),
+    );
     lines.push(`### New ${resultsName} (no baseline)`);
     lines.push("");
     if (options.node) {
-      lines.push(...formatNodeResultTables(newTests, options));
-    } else if (newTests.length > 0) {
+      lines.push(...formatNodeResultTables(newTestsWithMetrics, options));
+    } else if (newTestsWithMetrics.length > 0) {
       const headers = [
         resultName,
         ...primaryMetrics.map((metric) => getMetricLabel(metric, options)),
       ];
       lines.push(`| ${headers.join(" | ")} |`);
       lines.push(`| ${headers.map(() => "---").join(" | ")} |`);
-      for (const { result } of newTests) {
+      for (const { result } of newTestsWithMetrics) {
         const cells: string[] = [result.label];
         for (const metric of primaryMetrics) {
           cells.push(formatMetricValue(result.metrics[metric], options));

--- a/packages/ariakit-scripts/src/perf-compare.ts
+++ b/packages/ariakit-scripts/src/perf-compare.ts
@@ -8,6 +8,7 @@ import {
 import path from "node:path";
 import {
   computeMedianMetrics,
+  formatPerfTitlePath,
   median,
   mergeScriptProfiles,
   mergeSelectorProfiles,
@@ -56,7 +57,7 @@ interface ComparisonRow {
   threshold: boolean;
   significant: boolean;
   candidate: boolean;
-  profileMode: boolean;
+  profileModeMismatch: boolean;
 }
 
 interface ComparisonSummary {
@@ -350,10 +351,25 @@ function loadRounds(
       );
     }
     for (const result of data) {
-      rounds.push({ roundIndex, result: result as PerfResult });
+      rounds.push({
+        roundIndex,
+        result: normalizePerfResult(result as PerfResult),
+      });
     }
   }
   return rounds;
+}
+
+function normalizeGeneratedPerfLabel(label: string): string {
+  if (!label.includes("perf-chrome.ts")) return label;
+  return formatPerfTitlePath(label.split(" > "));
+}
+
+function normalizePerfResult(result: PerfResult): PerfResult {
+  const label = normalizeGeneratedPerfLabel(result.label);
+  const testTitle = normalizeGeneratedPerfLabel(result.testTitle);
+  if (label === result.label && testTitle === result.testTitle) return result;
+  return { ...result, label, testTitle };
 }
 
 function mergeProfiles(results: PerfResult[]): PerfProfiles | undefined {
@@ -733,12 +749,6 @@ function hasProfileMode(
   return !!result?.selectorProfile || hasProfileData(result, profile);
 }
 
-function isProfileMode(result: PerfResult | undefined): boolean {
-  return (
-    hasProfileMode(result, "script") || hasProfileMode(result, "selectors")
-  );
-}
-
 function isRegression(row: ComparisonRow, options: PerfCompareOptions) {
   return options.node ? row.delta < 0 : row.delta > 0;
 }
@@ -781,17 +791,20 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
       newTests.push(cur);
       continue;
     }
+    const resultProfileModeMismatches: ProfileModeMismatch[] = [];
     for (const profile of ["script", "selectors"] as const) {
       const baselineHasProfile = hasProfileMode(base.result, profile);
       const currentHasProfile = hasProfileMode(cur.result, profile);
       if (baselineHasProfile === currentHasProfile) continue;
-      profileModeMismatches.push({
+      const mismatch = {
         testFile: cur.result.testFile,
         label: cur.result.label,
         profile,
         baseline: baselineHasProfile,
         current: currentHasProfile,
-      });
+      };
+      profileModeMismatches.push(mismatch);
+      resultProfileModeMismatches.push(mismatch);
     }
 
     const sharedRoundIndices = getSharedRoundIndices(base, cur);
@@ -805,8 +818,8 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
       continue;
     }
 
-    const profileMode = isProfileMode(base.result) || isProfileMode(cur.result);
-    const primary = !profileMode;
+    const profileModeMismatch = resultProfileModeMismatches.length > 0;
+    const primary = !profileModeMismatch;
     for (const metric of primaryMetrics) {
       const baselineValues: number[] = [];
       const roundComparisons: RoundMetricComparison[] = [];
@@ -849,7 +862,7 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
         pairedRoundsCount: sharedRoundIndices.length,
         perRoundDeltas: roundComparisons.map((comparison) => comparison.delta),
         ...significance,
-        profileMode,
+        profileModeMismatch,
       });
     }
   }
@@ -1229,12 +1242,12 @@ function formatDetailedBreakdown({
     const testRows = rowsByKey.get(key) ?? [];
     const label = testRows[0]?.label ?? key;
     const currentResult = currentByKey.get(key)?.result;
-    const profileMode = testRows.some((row) => row.profileMode);
+    const profileModeMismatch = testRows.some((row) => row.profileModeMismatch);
     const profileLines = formatProfiles(currentResult);
-    if (profileMode && profileLines.length === 0) continue;
+    if (profileModeMismatch && profileLines.length === 0) continue;
     lines.push(`### ${label}`);
     lines.push("");
-    if (!profileMode) {
+    if (!profileModeMismatch) {
       lines.push("| Metric | Baseline | Current | Delta |");
       lines.push("|--------|----------|---------|-------|");
       for (const metric of primaryMetrics) {
@@ -1357,21 +1370,18 @@ function formatMarkdown(
 
   if (newTests.length > 0) {
     const primaryMetrics = getPrimaryMetrics(options);
-    const newTestsWithMetrics = newTests.filter(
-      ({ result }) => !isProfileMode(result),
-    );
     lines.push(`### New ${resultsName} (no baseline)`);
     lines.push("");
     if (options.node) {
-      lines.push(...formatNodeResultTables(newTestsWithMetrics, options));
-    } else if (newTestsWithMetrics.length > 0) {
+      lines.push(...formatNodeResultTables(newTests, options));
+    } else if (newTests.length > 0) {
       const headers = [
         resultName,
         ...primaryMetrics.map((metric) => getMetricLabel(metric, options)),
       ];
       lines.push(`| ${headers.join(" | ")} |`);
       lines.push(`| ${headers.map(() => "---").join(" | ")} |`);
-      for (const { result } of newTestsWithMetrics) {
+      for (const { result } of newTests) {
         const cells: string[] = [result.label];
         for (const metric of primaryMetrics) {
           cells.push(formatMetricValue(result.metrics[metric], options));

--- a/packages/ariakit-scripts/src/perf-compare.ts
+++ b/packages/ariakit-scripts/src/perf-compare.ts
@@ -60,7 +60,6 @@ interface ComparisonRow {
   significant: boolean;
   candidate: boolean;
   profileMode: boolean;
-  profileModeMismatch: boolean;
 }
 
 interface ComparisonSummary {
@@ -773,6 +772,22 @@ function isProfileMode(result: PerfResult | undefined): boolean {
   );
 }
 
+function getRoundIndices(result: AggregatedPerfResult): number[] {
+  return [...result.byRound.keys()].sort((a, b) => a - b);
+}
+
+function createUnpairedTest(
+  base: AggregatedPerfResult,
+  cur: AggregatedPerfResult,
+): UnpairedTest {
+  return {
+    testFile: cur.result.testFile,
+    label: cur.result.label,
+    baselineRounds: getRoundIndices(base),
+    currentRounds: getRoundIndices(cur),
+  };
+}
+
 function isRegression(row: ComparisonRow, options: PerfCompareOptions) {
   return options.node ? row.delta < 0 : row.delta > 0;
 }
@@ -815,30 +830,22 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
       newTests.push(cur);
       continue;
     }
-    const resultProfileModeMismatches: ProfileModeMismatch[] = [];
     for (const profile of ["script", "selectors"] as const) {
       const baselineHasProfile = hasProfileMode(base.result, profile);
       const currentHasProfile = hasProfileMode(cur.result, profile);
       if (baselineHasProfile === currentHasProfile) continue;
-      const mismatch = {
+      profileModeMismatches.push({
         testFile: cur.result.testFile,
         label: cur.result.label,
         profile,
         baseline: baselineHasProfile,
         current: currentHasProfile,
-      };
-      profileModeMismatches.push(mismatch);
-      resultProfileModeMismatches.push(mismatch);
+      });
     }
 
     const sharedRoundIndices = getSharedRoundIndices(base, cur);
     if (sharedRoundIndices.length === 0) {
-      unpairedTests.push({
-        testFile: cur.result.testFile,
-        label: cur.result.label,
-        baselineRounds: [...base.byRound.keys()].sort((a, b) => a - b),
-        currentRounds: [...cur.byRound.keys()].sort((a, b) => a - b),
-      });
+      unpairedTests.push(createUnpairedTest(base, cur));
       continue;
     }
 
@@ -851,8 +858,10 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
           if (!baselineRound || !currentRound) return false;
           return !isProfileMode(baselineRound) && !isProfileMode(currentRound);
         });
-    if (comparisonRoundIndices.length === 0) continue;
-    const profileModeMismatch = resultProfileModeMismatches.length > 0;
+    if (comparisonRoundIndices.length === 0) {
+      unpairedTests.push(createUnpairedTest(base, cur));
+      continue;
+    }
     const primary = !profileMode;
     for (const metric of primaryMetrics) {
       const baselineValues: number[] = [];
@@ -897,7 +906,6 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
         perRoundDeltas: roundComparisons.map((comparison) => comparison.delta),
         ...significance,
         profileMode,
-        profileModeMismatch,
       });
     }
   }
@@ -1377,7 +1385,7 @@ function formatMarkdown(
     const verb = unpairedTests.length === 1 ? "was" : "were";
     lines.push("");
     lines.push(
-      `:warning: ${unpairedTests.length} ${label} had no paired baseline/current rounds and ${verb} not compared.`,
+      `:warning: ${unpairedTests.length} ${label} had no comparable paired round and ${verb} not compared.`,
     );
     for (const result of visibleUnpairedTests) {
       lines.push(`- ${result.label}`);
@@ -1442,7 +1450,7 @@ function formatMarkdown(
     lines.push(`### Unpaired ${resultsName}`);
     lines.push("");
     lines.push(
-      `These ${resultsName} produced baseline and current results, but no shared round index.`,
+      `These ${resultsName} produced baseline and current results, but no comparable paired round.`,
     );
     lines.push("");
     lines.push(`| ${resultName} | Baseline rounds | Current rounds |`);

--- a/packages/ariakit-scripts/src/perf-compare.ts
+++ b/packages/ariakit-scripts/src/perf-compare.ts
@@ -365,7 +365,6 @@ function loadRounds(
 
 function normalizeGeneratedPerfLabel(label: string): string {
   if (!label.includes("perf-chrome.ts")) return label;
-  if (label.includes("sandbox/dialog-perf/perf-chrome.ts")) return label;
   return formatPerfTitlePath(label.split(" > "));
 }
 

--- a/packages/ariakit-scripts/src/perf.test.ts
+++ b/packages/ariakit-scripts/src/perf.test.ts
@@ -1,6 +1,7 @@
 import type { CDPSession, Page } from "@playwright/test";
 import { afterEach, beforeEach, expect, test } from "vitest";
 import {
+  formatPerfTitlePath,
   getIntegerEnv,
   getPerfSamplingOptions,
   getUniquePerfLabel,
@@ -123,6 +124,24 @@ test("resolves duplicate perf labels with exact label counts", () => {
   expect(getUniquePerfLabel(["foo #2"], "foo")).toBe("foo");
   expect(getUniquePerfLabel(["foo", "foo #2"], "foo")).toBe("foo #3");
   expect(getUniquePerfLabel(["foo", "foo #3"], "foo")).toBe("foo #2");
+});
+
+test("formats perf title paths", () => {
+  expect(
+    formatPerfTitlePath([
+      "sandbox/dialog-perf/perf-chrome.ts",
+      "react",
+      "open dialog",
+    ]),
+  ).toBe("dialog-perf > react > open dialog");
+  expect(
+    formatPerfTitlePath([
+      "app/src/sandbox/dialog-perf/perf-chrome.ts",
+      "react",
+      "open dialog",
+    ]),
+  ).toBe("dialog-perf > react > open dialog");
+  expect(formatPerfTitlePath(["example.ts", "a/b"])).toBe("example.ts > a/b");
 });
 
 test("does not double-count recursive script profile frames", () => {

--- a/packages/ariakit-scripts/src/perf.test.ts
+++ b/packages/ariakit-scripts/src/perf.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, expect, test } from "vitest";
 import {
   formatPerfTitlePath,
   getPerfProfileBaseLabel,
+  getPerfProfileMode,
   getIntegerEnv,
   getPerfSamplingOptions,
   getUniquePerfLabel,
@@ -16,8 +17,11 @@ const envName = "PERF_ITERATIONS";
 const envNames = [
   envName,
   "PERF_WARMUP",
+  "PERF_SCRIPT_PROFILE",
   "PERF_SCRIPT_PROFILE_ITERATIONS",
   "PERF_SCRIPT_PROFILE_WARMUP",
+  "PERF_SELECTOR_PROFILE",
+  "PERF_CSS_SELECTOR_PROFILE",
 ];
 const originalValues = new Map(
   envNames.map((name) => [name, process.env[name]]),
@@ -156,6 +160,75 @@ test("detects profile-only labels", () => {
   expect(getPerfProfileBaseLabel("open dialog")).toBe("open dialog");
   expect(isPerfProfileLabel("open dialog (script profile)")).toBe(true);
   expect(isPerfProfileLabel("open dialog")).toBe(false);
+});
+
+test("resolves explicit profile options as diagnostic iterations", () => {
+  expect(
+    getPerfProfileMode({ label: "open dialog", scriptProfile: true }),
+  ).toMatchObject({
+    profileOnly: false,
+    scriptProfile: true,
+    timingScriptProfile: false,
+    diagnosticScriptProfile: true,
+  });
+  expect(
+    getPerfProfileMode({
+      label: "open dialog",
+      selectorProfile: true,
+    }),
+  ).toMatchObject({
+    profileOnly: false,
+    selectorProfile: true,
+    timingSelectorProfile: false,
+    diagnosticSelectorProfile: true,
+  });
+});
+
+test("resolves env profile options as measured iterations", () => {
+  process.env.PERF_SCRIPT_PROFILE = "1";
+  process.env.PERF_SELECTOR_PROFILE = "1";
+
+  expect(getPerfProfileMode({ label: "open dialog" })).toMatchObject({
+    profileOnly: false,
+    scriptProfile: true,
+    selectorProfile: true,
+    timingScriptProfile: true,
+    timingSelectorProfile: true,
+    diagnosticScriptProfile: false,
+    diagnosticSelectorProfile: false,
+  });
+  expect(
+    getPerfProfileMode({ label: "open dialog", scriptProfile: false }),
+  ).toMatchObject({
+    scriptProfile: false,
+    selectorProfile: true,
+    timingScriptProfile: false,
+    timingSelectorProfile: true,
+  });
+
+  delete process.env.PERF_SELECTOR_PROFILE;
+  process.env.PERF_CSS_SELECTOR_PROFILE = "true";
+  expect(
+    getPerfProfileMode({ label: "open dialog", scriptProfile: false }),
+  ).toMatchObject({
+    scriptProfile: false,
+    selectorProfile: true,
+    timingSelectorProfile: true,
+  });
+});
+
+test("resolves profile-only labels as measured profile iterations", () => {
+  expect(
+    getPerfProfileMode({
+      label: "open dialog (script profile)",
+      scriptProfile: true,
+    }),
+  ).toMatchObject({
+    profileOnly: true,
+    scriptProfile: true,
+    timingScriptProfile: true,
+    diagnosticScriptProfile: false,
+  });
 });
 
 test("does not double-count recursive script profile frames", () => {

--- a/packages/ariakit-scripts/src/perf.test.ts
+++ b/packages/ariakit-scripts/src/perf.test.ts
@@ -2,9 +2,11 @@ import type { CDPSession, Page } from "@playwright/test";
 import { afterEach, beforeEach, expect, test } from "vitest";
 import {
   formatPerfTitlePath,
+  getPerfProfileBaseLabel,
   getIntegerEnv,
   getPerfSamplingOptions,
   getUniquePerfLabel,
+  isPerfProfileLabel,
   parseScriptProfile,
   resolveScriptProfileSourceMaps,
   settleQuiescent,
@@ -142,6 +144,18 @@ test("formats perf title paths", () => {
     ]),
   ).toBe("dialog-perf > react > open dialog");
   expect(formatPerfTitlePath(["example.ts", "a/b"])).toBe("example.ts > a/b");
+});
+
+test("detects profile-only labels", () => {
+  expect(getPerfProfileBaseLabel("open dialog (script profile)")).toBe(
+    "open dialog",
+  );
+  expect(getPerfProfileBaseLabel("open dialog (selector profile)")).toBe(
+    "open dialog",
+  );
+  expect(getPerfProfileBaseLabel("open dialog")).toBe("open dialog");
+  expect(isPerfProfileLabel("open dialog (script profile)")).toBe(true);
+  expect(isPerfProfileLabel("open dialog")).toBe(false);
 });
 
 test("does not double-count recursive script profile frames", () => {

--- a/packages/ariakit-scripts/src/perf.ts
+++ b/packages/ariakit-scripts/src/perf.ts
@@ -122,9 +122,19 @@ export interface PerfMeasureOptions {
   verify?: PerfMeasureCallback;
   /** Override the auto-generated label for this measurement. */
   label?: string;
-  /** Collect expensive JS functions. Adds overhead to measured metrics. */
+  /**
+   * Collect expensive JS functions. Explicit options on regular labels keep
+   * measured metrics unprofiled by collecting profiles in extra diagnostic
+   * iterations. Profile-only labels and env-driven profiling collect during
+   * measured iterations and add overhead to those metrics.
+   */
   scriptProfile?: boolean;
-  /** Collect expensive CSS selectors. Adds overhead to measured metrics. */
+  /**
+   * Collect expensive CSS selectors. Explicit options on regular labels keep
+   * measured metrics unprofiled by collecting profiles in extra diagnostic
+   * iterations. Profile-only labels and env-driven profiling collect during
+   * measured iterations and add overhead to those metrics.
+   */
   selectorProfile?: boolean;
   /** Maximum number of profile entries stored per profile type. */
   profileLimit?: number;
@@ -148,6 +158,22 @@ interface PerfSamplingOptions {
 interface PerfSamplingResult {
   iterations: number;
   warmup: number;
+}
+
+interface PerfProfileModeOptions {
+  label: string;
+  scriptProfile?: boolean;
+  selectorProfile?: boolean;
+}
+
+interface PerfProfileModeResult {
+  profileOnly: boolean;
+  scriptProfile: boolean;
+  selectorProfile: boolean;
+  timingScriptProfile: boolean;
+  timingSelectorProfile: boolean;
+  diagnosticScriptProfile: boolean;
+  diagnosticSelectorProfile: boolean;
 }
 
 export interface PerfResult {
@@ -363,7 +389,6 @@ export function formatPerfTitlePath(titlePath: string[]): string {
       sandboxIndex >= 0 ? pathParts.slice(sandboxIndex + 1) : pathParts;
     for (const part of visibleParts) {
       if (!part) continue;
-      if (part === "sandbox") continue;
       if (part === "perf-chrome.ts") continue;
       titleParts.push(part);
     }
@@ -373,6 +398,11 @@ export function formatPerfTitlePath(titlePath: string[]): string {
 
 const PROFILE_LABEL_SUFFIXES = [" (script profile)", " (selector profile)"];
 
+/**
+ * Removes suffixes that mark dedicated profile-only measurements. These legacy
+ * labels run with profiler overhead, use profile sampling defaults, and are
+ * merged into their base label without contributing metrics to comparisons.
+ */
 export function getPerfProfileBaseLabel(label: string): string {
   for (const suffix of PROFILE_LABEL_SUFFIXES) {
     if (label.endsWith(suffix)) {
@@ -382,8 +412,48 @@ export function getPerfProfileBaseLabel(label: string): string {
   return label;
 }
 
+/**
+ * Detects labels that opt into profile-only behavior through their suffix. A
+ * profile-only measurement runs with profiler overhead and is excluded from
+ * timing comparisons.
+ */
 export function isPerfProfileLabel(label: string): boolean {
   return getPerfProfileBaseLabel(label) !== label;
+}
+
+/**
+ * Resolves whether profiling runs in the measured iteration or in separate
+ * diagnostic iterations. Env-driven profiling keeps the old quick measured
+ * path with profiler overhead; explicit profiling options on regular labels
+ * keep timing metrics unprofiled.
+ */
+export function getPerfProfileMode({
+  label,
+  scriptProfile: scriptProfileOption,
+  selectorProfile: selectorProfileOption,
+}: PerfProfileModeOptions): PerfProfileModeResult {
+  const envScriptProfile =
+    scriptProfileOption == null && isTruthyEnv("PERF_SCRIPT_PROFILE");
+  const envSelectorProfile =
+    selectorProfileOption == null &&
+    (isTruthyEnv("PERF_SELECTOR_PROFILE") ||
+      isTruthyEnv("PERF_CSS_SELECTOR_PROFILE"));
+  const scriptProfile = scriptProfileOption ?? envScriptProfile;
+  const selectorProfile = selectorProfileOption ?? envSelectorProfile;
+  const profileOnly = isPerfProfileLabel(label);
+  const timingScriptProfile =
+    scriptProfile && (profileOnly || envScriptProfile);
+  const timingSelectorProfile =
+    selectorProfile && (profileOnly || envSelectorProfile);
+  return {
+    profileOnly,
+    scriptProfile,
+    selectorProfile,
+    timingScriptProfile,
+    timingSelectorProfile,
+    diagnosticScriptProfile: scriptProfile && !timingScriptProfile,
+    diagnosticSelectorProfile: selectorProfile && !timingSelectorProfile,
+  };
 }
 
 function normalizeProfileUrl(url: string): string {
@@ -1338,17 +1408,19 @@ export async function createPerfMeasure(
     label,
     profileLimit = DEFAULT_PROFILE_LIMIT,
   } = options;
-  const scriptProfile =
-    options.scriptProfile ?? isTruthyEnv("PERF_SCRIPT_PROFILE");
-  const selectorProfile =
-    options.selectorProfile ??
-    (isTruthyEnv("PERF_SELECTOR_PROFILE") ||
-      isTruthyEnv("PERF_CSS_SELECTOR_PROFILE"));
   const testTitle = formatPerfTitlePath(testInfo.titlePath);
   const baseLabel = label ?? testTitle;
-  const profileOnly = isPerfProfileLabel(baseLabel);
-  const timingScriptProfile = profileOnly && scriptProfile;
-  const timingSelectorProfile = profileOnly && selectorProfile;
+  const {
+    profileOnly,
+    timingScriptProfile,
+    timingSelectorProfile,
+    diagnosticScriptProfile,
+    diagnosticSelectorProfile,
+  } = getPerfProfileMode({
+    label: baseLabel,
+    scriptProfile: options.scriptProfile,
+    selectorProfile: options.selectorProfile,
+  });
   const { iterations, warmup } = getPerfSamplingOptions({
     iterations: options.iterations,
     warmup: options.warmup,
@@ -1436,13 +1508,13 @@ export async function createPerfMeasure(
     collectMetrics: true,
   });
 
-  if (!profileOnly && (scriptProfile || selectorProfile)) {
+  if (diagnosticScriptProfile || diagnosticSelectorProfile) {
     const profileSampling = getPerfSamplingOptions({ scriptProfile: true });
     await runIterations({
       iterationCount: profileSampling.iterations,
       warmupCount: profileSampling.warmup,
-      scriptProfile,
-      selectorProfile,
+      scriptProfile: diagnosticScriptProfile,
+      selectorProfile: diagnosticSelectorProfile,
       collectMetrics: false,
     });
   }

--- a/packages/ariakit-scripts/src/perf.ts
+++ b/packages/ariakit-scripts/src/perf.ts
@@ -352,6 +352,24 @@ export function getPerfSamplingOptions({
   };
 }
 
+export function formatPerfTitlePath(titlePath: string[]): string {
+  const titleParts: string[] = [];
+  for (const title of titlePath) {
+    if (!title) continue;
+    const pathParts = /\.tsx?$/.test(title) ? title.split(/[\\/]/) : [title];
+    const sandboxIndex = pathParts.lastIndexOf("sandbox");
+    const visibleParts =
+      sandboxIndex >= 0 ? pathParts.slice(sandboxIndex + 1) : pathParts;
+    for (const part of visibleParts) {
+      if (!part) continue;
+      if (part === "sandbox") continue;
+      if (part === "perf-chrome.ts") continue;
+      titleParts.push(part);
+    }
+  }
+  return titleParts.join(" > ");
+}
+
 function normalizeProfileUrl(url: string): string {
   try {
     const parsedUrl = new URL(url);
@@ -1375,7 +1393,7 @@ export async function createPerfMeasure(
 
   const medianMetrics = computeMedianMetrics(allMetrics);
 
-  const testTitle = testInfo.titlePath.filter(Boolean).join(" > ");
+  const testTitle = formatPerfTitlePath(testInfo.titlePath);
   const baseLabel = label ?? testTitle;
   const resolvedLabel = getUniquePerfLabel(
     results.map((result) => result.label),

--- a/packages/ariakit-scripts/src/perf.ts
+++ b/packages/ariakit-scripts/src/perf.ts
@@ -156,6 +156,7 @@ export interface PerfResult {
   label: string;
   metrics: PerfMetrics;
   raw: PerfMetrics[];
+  profileOnly?: boolean;
   scriptProfile?: boolean;
   selectorProfile?: boolean;
   profiles?: PerfProfiles;
@@ -368,6 +369,21 @@ export function formatPerfTitlePath(titlePath: string[]): string {
     }
   }
   return titleParts.join(" > ");
+}
+
+const PROFILE_LABEL_SUFFIXES = [" (script profile)", " (selector profile)"];
+
+export function getPerfProfileBaseLabel(label: string): string {
+  for (const suffix of PROFILE_LABEL_SUFFIXES) {
+    if (label.endsWith(suffix)) {
+      return label.slice(0, -suffix.length);
+    }
+  }
+  return label;
+}
+
+export function isPerfProfileLabel(label: string): boolean {
+  return getPerfProfileBaseLabel(label) !== label;
 }
 
 function normalizeProfileUrl(url: string): string {
@@ -1328,10 +1344,15 @@ export async function createPerfMeasure(
     options.selectorProfile ??
     (isTruthyEnv("PERF_SELECTOR_PROFILE") ||
       isTruthyEnv("PERF_CSS_SELECTOR_PROFILE"));
+  const testTitle = formatPerfTitlePath(testInfo.titlePath);
+  const baseLabel = label ?? testTitle;
+  const profileOnly = isPerfProfileLabel(baseLabel);
+  const timingScriptProfile = profileOnly && scriptProfile;
+  const timingSelectorProfile = profileOnly && selectorProfile;
   const { iterations, warmup } = getPerfSamplingOptions({
     iterations: options.iterations,
     warmup: options.warmup,
-    scriptProfile,
+    scriptProfile: timingScriptProfile,
   });
 
   if (!Number.isInteger(iterations) || iterations <= 0) {
@@ -1365,36 +1386,69 @@ export async function createPerfMeasure(
     traceMapCache: new Map(),
   };
 
-  for (let i = 0; i < warmup + iterations; i++) {
-    const result = await measureIteration({
-      browser,
-      contextOptions,
-      testInfo,
-      url,
-      loadPage,
-      interaction,
-      setup,
-      verify,
+  const runIterations = async ({
+    iterationCount,
+    warmupCount,
+    scriptProfile,
+    selectorProfile,
+    collectMetrics,
+  }: {
+    iterationCount: number;
+    warmupCount: number;
+    scriptProfile: boolean;
+    selectorProfile: boolean;
+    collectMetrics: boolean;
+  }) => {
+    for (let i = 0; i < warmupCount + iterationCount; i++) {
+      const result = await measureIteration({
+        browser,
+        contextOptions,
+        testInfo,
+        url,
+        loadPage,
+        interaction,
+        setup,
+        verify,
+        scriptProfile,
+        selectorProfile,
+        scriptSourceMapResolver,
+      });
+
+      // Only keep measured (non-warmup) iterations.
+      if (i < warmupCount) continue;
+      if (collectMetrics) {
+        allMetrics.push(result.metrics);
+      }
+      if (result.profiles?.script && result.profiles.script.length > 0) {
+        scriptProfiles.push(result.profiles.script);
+      }
+      if (result.profiles?.selectors && result.profiles.selectors.length > 0) {
+        selectorProfiles.push(result.profiles.selectors);
+      }
+    }
+  };
+
+  await runIterations({
+    iterationCount: iterations,
+    warmupCount: warmup,
+    scriptProfile: timingScriptProfile,
+    selectorProfile: timingSelectorProfile,
+    collectMetrics: true,
+  });
+
+  if (!profileOnly && (scriptProfile || selectorProfile)) {
+    const profileSampling = getPerfSamplingOptions({ scriptProfile: true });
+    await runIterations({
+      iterationCount: profileSampling.iterations,
+      warmupCount: profileSampling.warmup,
       scriptProfile,
       selectorProfile,
-      scriptSourceMapResolver,
+      collectMetrics: false,
     });
-
-    // Only keep measured (non-warmup) iterations.
-    if (i < warmup) continue;
-    allMetrics.push(result.metrics);
-    if (result.profiles?.script && result.profiles.script.length > 0) {
-      scriptProfiles.push(result.profiles.script);
-    }
-    if (result.profiles?.selectors && result.profiles.selectors.length > 0) {
-      selectorProfiles.push(result.profiles.selectors);
-    }
   }
 
   const medianMetrics = computeMedianMetrics(allMetrics);
 
-  const testTitle = formatPerfTitlePath(testInfo.titlePath);
-  const baseLabel = label ?? testTitle;
   const resolvedLabel = getUniquePerfLabel(
     results.map((result) => result.label),
     baseLabel,
@@ -1406,8 +1460,9 @@ export async function createPerfMeasure(
     label: resolvedLabel,
     metrics: medianMetrics,
     raw: allMetrics,
-    scriptProfile: scriptProfile || undefined,
-    selectorProfile: selectorProfile || undefined,
+    profileOnly: profileOnly || undefined,
+    scriptProfile: timingScriptProfile || undefined,
+    selectorProfile: timingSelectorProfile || undefined,
     profiles: createProfiles(scriptProfiles, selectorProfiles, profileLimit),
   });
 


### PR DESCRIPTION
## Motivation

The dialog perf sandbox has a separate `open dialog (script profile)` test only to collect scripting details for the same interaction covered by `open dialog`. That creates an extra perf row instead of attaching the diagnostic profile to the primary interaction.

The generated perf labels also include implementation path segments like:

```text
sandbox/dialog-perf/perf-chrome.ts > react > open dialog
```

Those labels are noisy in PR comments.

## Solution

Move `scriptProfile: true` onto the existing `open dialog` measurement and remove the dedicated dialog script-profile test. The timing samples for that row remain unprofiled; the runner collects script profiles in separate diagnostic iterations and attaches the resulting `Script profile` table to the same row.

The dialog perf sandbox now renders 3000 items instead of 5000.

Perf result labels now omit the generated `sandbox` and `perf-chrome.ts` path segments, so this:

```text
sandbox/dialog-perf/perf-chrome.ts > react > open dialog
```

becomes:

```text
dialog-perf > react > open dialog
```

Generated labels are normalized consistently during comparison, including `dialog-perf`, so main and PR results still pair when sandbox code changes.

The comparison formatter treats profile data as an add-on to normal comparisons when it is attached to a timing row, rendering the `Script profile` table directly below the metric comparison table. Existing dedicated `(... script profile)` rows are still collected as profile-only diagnostics, but `perf-compare` merges them under their base labels and excludes their profiler-inflated metrics from timing comparisons and new-test metric rows.

If every shared round for a test is filtered out because one side only has profile-mode data, the comparison now reports the test as unpaired instead of silently dropping it.

Explicit `scriptProfile`/`selectorProfile` options on regular labels collect profiles in separate diagnostic iterations. Env-driven profiling through `PERF_SCRIPT_PROFILE`, `PERF_SELECTOR_PROFILE`, or `PERF_CSS_SELECTOR_PROFILE` keeps the old quick measured-profile path for local diagnostics.

The removed dialog profile test used `profileLimit: 20`; the combined test intentionally uses the default profile limit because the measure call only needs `{ scriptProfile: true }`.

## Verification

- `pnpm exec oxlint --disable-nested-config --fix packages/ariakit-scripts/src/perf.ts packages/ariakit-scripts/src/perf-compare.ts packages/ariakit-scripts/src/perf.test.ts packages/ariakit-scripts/src/perf-compare.test.ts`
- `pnpm exec oxfmt packages/ariakit-scripts/src/perf.ts packages/ariakit-scripts/src/perf-compare.ts packages/ariakit-scripts/src/perf.test.ts packages/ariakit-scripts/src/perf-compare.test.ts`
- `pnpm lint-fix`
- `pnpm vitest packages/ariakit-scripts/src/perf.test.ts packages/ariakit-scripts/src/perf-compare.test.ts`
- `pnpm vitest packages/ariakit-scripts/src/perf-compare.test.ts`
- `pnpm tsc`
- `APP_PORT=4322 NEXTJS_PORT=3001 pnpm -F app run test-perf src/sandbox/dialog-perf/perf-chrome.ts`
- Temporarily reverted the new env-profile and unpaired-round implementation paths and confirmed the new regression tests fail.
