### PR TITLE
Paint modal dialogs before disabling the outside tree

### DIFF
--- a/.changeset/200-dialog-open-paint.md
+++ b/.changeset/200-dialog-open-paint.md
@@ -1,0 +1,10 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Faster modal `Dialog` opening
+
+Opening a modal [`Dialog`](https://ariakit.com/reference/dialog), or a component built on it such as [`Popover`](https://ariakit.com/reference/popover) or [`Menu`](https://ariakit.com/reference/menu) with the [`modal`](https://ariakit.com/reference/popover#modal) prop, no longer waits for the page behind it to be disabled before painting.
+
+Previously, making the element tree outside the dialog inert invalidated the styles of the entire page before the dialog's first paint, delaying the open in proportion to the page size. Now the inert step runs right after the dialog is first painted, so the page outside stays interactive and exposed to assistive technology for about one frame longer. The outside-click and Escape logic is unaffected: it relies on element marks that still apply synchronously. On browsers without CSS `scrollbar-gutter` support, when the scroll lock must remove a visible scrollbar, everything still applies before the first paint, matching the previous behavior.

--- a/examples/dialog-nested-various/test.ts
+++ b/examples/dialog-nested-various/test.ts
@@ -1,4 +1,4 @@
-import { click, press, q } from "@ariakit/test";
+import { click, dispatch, press, q, sleep } from "@ariakit/test";
 import { expect, test, vi } from "vitest";
 
 function getBackdrop(name: string) {
@@ -270,6 +270,95 @@ test.each(["nested", "sibling"])(
     expectModalStyle(false);
   },
 );
+
+test("disables the outside tree before paint without scrollbar-gutter support", async () => {
+  // happy-dom's window.CSS getter returns a fresh object on every access, so
+  // the getter itself must be mocked rather than a single instance's method.
+  const unsupportedCSS: Pick<typeof CSS, "supports"> = {
+    supports: () => false,
+  };
+  using _supports = vi
+    .spyOn(window, "CSS", "get")
+    .mockReturnValue(unsupportedCSS as typeof CSS);
+  // Without scrollbar-gutter support, the scroll lock is about to write the
+  // --scrollbar-width property that invalidates the whole document before
+  // paint, so the dialog disables the outside tree synchronously to share
+  // that pass instead of deferring it. dispatch.click fires a single event
+  // without settling, so no animation frames have run when we assert.
+  await dispatch.click(q.button("Open dialog"));
+  expect(q.dialog("Dialog")).toBeVisible();
+  expect(document.querySelector("[inert]")).not.toBeNull();
+  await press.Escape();
+  expect(q.dialog("Dialog")).not.toBeInTheDocument();
+  expect(document.querySelector("[inert]")).toBeNull();
+});
+
+test("closing before the deferred disable leaves no inert behind", async () => {
+  // dispatch.click fires a single event without settling, so no animation
+  // frames run between the open and close below: the close happens while the
+  // outside-tree disabling is still scheduled for the frame after the open
+  // paint.
+  await dispatch.click(q.button("Open dialog"));
+  expect(q.dialog("Dialog")).toBeVisible();
+  // The deferred path applies: the outside tree is not inert yet.
+  expect(document.querySelector("[inert]")).toBeNull();
+  await dispatch.click(q.button("Close"));
+  expect(q.dialog("Dialog")).not.toBeInTheDocument();
+  // Let the frames the dialog canceled elapse: the deferred disable must not
+  // fire after the dialog closed.
+  await sleep(50);
+  expect(document.querySelector("[inert]")).toBeNull();
+});
+
+test("outside tree stays disabled when a sibling dialog takes over", async () => {
+  // happy-dom reports scrollbar-gutter support, so the sync fallback probe
+  // doesn't apply and the dialog takes the deferred path where the inert
+  // writes land right after the open frame paints, exercising the
+  // synchronous re-apply handoff below.
+  await click(q.button("Open dialog"));
+  const inertRoot = document.querySelector("[inert]");
+  expect(inertRoot).not.toBeNull();
+  if (!inertRoot) return;
+  // The closing dialog restores the outside tree synchronously, and the
+  // opening sibling must re-disable it in the same task. We record the inert
+  // state at every mutation delivery (a microtask checkpoint) to catch a
+  // handoff that leaves the tree enabled until a later frame.
+  const inertValues: boolean[] = [];
+  const observer = new MutationObserver(() => {
+    inertValues.push(inertRoot.hasAttribute("inert"));
+  });
+  observer.observe(inertRoot, {
+    attributes: true,
+    attributeFilter: ["inert"],
+  });
+  await click(q.button("sibling dismiss unmount"));
+  observer.disconnect();
+  expect(q.dialog("sibling dismiss unmount")).toBeVisible();
+  expect(inertRoot.hasAttribute("inert")).toBe(true);
+  expect(inertValues.every((inert) => inert)).toBe(true);
+});
+
+test("scroll stays locked when a sibling dialog takes over", async () => {
+  await click(q.button("Open dialog"));
+  expectModalStyle(true);
+  // The closing dialog defers its scroll unlock to a microtask while the
+  // opening dialog locks synchronously, so we watch every style change on the
+  // html element during the handoff to catch a transient unlock between the
+  // two.
+  const overflowValues: string[] = [];
+  const observer = new MutationObserver(() => {
+    overflowValues.push(document.documentElement.style.overflowY);
+  });
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["style"],
+  });
+  await click(q.button("sibling dismiss unmount"));
+  observer.disconnect();
+  expect(q.dialog("sibling dismiss unmount")).toBeVisible();
+  expectModalStyle(true);
+  expect(overflowValues.every((overflow) => overflow === "hidden")).toBe(true);
+});
 
 test.each(["sibling"])(
   "show %s dismiss unmount dialog and hide with escape",

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -70,7 +70,10 @@ import { prependHiddenDismiss } from "./utils/prepend-hidden-dismiss.ts";
 import { supportsInert } from "./utils/supports-inert.ts";
 import { useHideOnInteractOutside } from "./utils/use-hide-on-interact-outside.ts";
 import { useNestedDialogs } from "./utils/use-nested-dialogs.tsx";
-import { usePreventBodyScroll } from "./utils/use-prevent-body-scroll.ts";
+import {
+  supportsScrollbarGutter,
+  usePreventBodyScroll,
+} from "./utils/use-prevent-body-scroll.ts";
 import { createWalkTreeSnapshot } from "./utils/walk-tree-outside.ts";
 
 const TagName = "div" satisfies ElementType;
@@ -78,6 +81,13 @@ type TagName = typeof TagName;
 type HTMLType = HTMLElementTagNameMap[TagName];
 
 const isSafariBrowser = isSafari();
+
+// Set when a dialog's active outside-tree disabling is restored, and consumed
+// by the next disabling in the same task so it re-applies synchronously
+// instead of deferring past the next paint. Module-level rather than
+// per-instance so it also covers handoffs between different dialogs, such as
+// a dialog closing while a sibling opens in the same commit.
+let redisableTreeOutsideSync = false;
 
 function isAlreadyFocusingAnotherElement(dialog?: HTMLElement | null) {
   const activeElement = getActiveElement(dialog);
@@ -165,8 +175,6 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
   const mounted = useStoreState(store, "mounted");
   const contentElement = useStoreState(store, "contentElement");
   const hidden = isHidden(mounted, props.hidden, props.alwaysVisible);
-
-  usePreventBodyScroll(contentElement, id, preventBodyScroll && !hidden);
 
   // Tracks whether the dialog was hidden by an outside click or context menu.
   // When true, focusOnHide skips focus restoration to match native HTML
@@ -325,9 +333,71 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     // every event instead. See https://github.com/ariakit/ariakit/issues/6344
     const restoreInsideMarks = markTreeInside(id, allElements);
     if (modal) {
+      const { disableTreeOutside, restoreTreeOutside } =
+        markAndDisableTreeOutside(id, allElements);
+      let disabled = false;
+      const applyDisableTreeOutside = () => {
+        disableTreeOutside();
+        disabled = true;
+      };
+      const win = getWindow(dialog);
+      const { documentElement } = getDocument(dialog);
+      // Whether the scroll lock below is about to write the --scrollbar-width
+      // fallback (browsers without scrollbar-gutter support removing a
+      // visible scrollbar). Custom properties are inherited, so that write
+      // invalidates the styles of the whole document before the open frame
+      // paints. Deferring the inert writes below then wouldn't save any paint
+      // latency — it would only add a second full-document recalc one frame
+      // later — so the tree is disabled synchronously to share the same
+      // pre-paint pass. The scrollbar-gutter lock and the zero-width lock
+      // only touch the html and body elements' own styles, so they don't
+      // force that pass and the deferral below stays worthwhile.
+      const lockWritesScrollbarWidth =
+        preventBodyScroll &&
+        !hidden &&
+        !supportsScrollbarGutter(win) &&
+        win.innerWidth - documentElement.clientWidth > 0;
+      let raf = 0;
+      if (redisableTreeOutsideSync || lockWritesScrollbarWidth) {
+        // Disable synchronously when the scroll lock is about to force the
+        // pre-paint full-document pass this run should share (see
+        // lockWritesScrollbarWidth above), or when this run replaces a
+        // disabling that was active until a cleanup in this same task
+        // restored it: the same dialog re-running (e.g., a nested dialog
+        // opened), or another dialog closing while this one opens. That
+        // restore already invalidated the outside tree, so re-applying
+        // synchronously merges into the same style recalc and avoids a frame
+        // where the tree between the two modal states is interactive again.
+        applyDisableTreeOutside();
+      } else {
+        // Disabling the outside tree sets inert on the top-level elements
+        // around the dialog, which invalidates the styles of everything
+        // inside them. The resulting style recalc scales with the page size
+        // and matches what the browser charges for a native showModal() call,
+        // but paying it before the open frame delays the dialog's first paint
+        // (see issue 4075). Defer it to right after that frame paints: the
+        // marks above (JavaScript properties with no style impact) already
+        // let the outside listeners and the Escape logic treat the tree as
+        // outside in the meantime, and no user interaction can land within
+        // that frame.
+        raf = win.requestAnimationFrame(() => {
+          raf = win.requestAnimationFrame(applyDisableTreeOutside);
+        });
+      }
       return chain(
         restoreInsideMarks,
-        markAndDisableTreeOutside(id, allElements),
+        () => win.cancelAnimationFrame(raf),
+        restoreTreeOutside,
+        () => {
+          if (!disabled) return;
+          // Let the next disabling, if it happens in this same task, know
+          // it's replacing an active one. The microtask clears the flag right
+          // after, so a later open still defers.
+          redisableTreeOutsideSync = true;
+          queueMicrotask(() => {
+            redisableTreeOutsideSync = false;
+          });
+        },
       );
     }
     return chain(
@@ -341,8 +411,18 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     getPersistentElementsProp,
     nestedDialogs,
     modal,
+    preventBodyScroll,
+    hidden,
     unstable_treeSnapshotKey,
   ]);
+
+  // This hook is called after the tree-disabling effect above on purpose:
+  // that effect probes the scrollbar dimensions to decide whether to defer
+  // the inert writes, and the scroll lock in this hook removes the scrollbar.
+  // With always-rendered dialogs, both effects re-run in the same commit when
+  // the dialog opens, so the lock must be registered later or the probe would
+  // measure an already-removed scrollbar.
+  usePreventBodyScroll(contentElement, id, preventBodyScroll && !hidden);
 
   const mayAutoFocusOnShow = !!autoFocusOnShow;
   const autoFocusOnShowProp = useBooleanEvent(autoFocusOnShow);

--- a/packages/ariakit-react-components/src/dialog/utils/disable-tree.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/disable-tree.ts
@@ -84,11 +84,16 @@ function addRoleNoneCleanup(
   cleanups.push(setAttribute(ancestor, "role", "none"));
 }
 
-// Marks and disables the element tree outside the dialog in a single walk.
-// Modal dialogs always need both marking and disabling outside elements, so
-// this combines their callbacks to avoid walking the tree twice on open.
+// Marks the element tree outside the dialog in a single walk and collects the
+// disabling work into a separate function. Marking only sets JavaScript
+// properties, so it's cheap and must run synchronously: the outside event
+// listeners rely on the marks from the moment the dialog opens. Disabling
+// writes inert and role attributes, which invalidates the styles of the
+// entire outside tree, so the dialog usually defers it until after the open
+// frame paints.
 export function markAndDisableTreeOutside(id: string, elements: Elements) {
   const cleanups: Array<() => void> = [];
+  const disableCallbacks: Array<() => void> = [];
   const ids = elements.map((el) => el?.id);
 
   walkTreeOutside(
@@ -96,17 +101,29 @@ export function markAndDisableTreeOutside(id: string, elements: Elements) {
     elements,
     (element) => {
       addElementMarkCleanup({ cleanups, element, id, ids });
-      addDisabledElementCleanup({ cleanups, element, elements, ids });
+      disableCallbacks.push(() => {
+        addDisabledElementCleanup({ cleanups, element, elements, ids });
+      });
     },
     (ancestor, element) => {
       addAncestorMarkCleanup({ cleanups, ancestor, element, id });
-      addRoleNoneCleanup(cleanups, ancestor, elements);
+      disableCallbacks.push(() => {
+        addRoleNoneCleanup(cleanups, ancestor, elements);
+      });
     },
   );
 
+  const disableTreeOutside = () => {
+    for (const disable of disableCallbacks) {
+      disable();
+    }
+  };
+
+  // Restores both the marks and, if disableTreeOutside has run, the disabled
+  // elements, since their cleanups accumulate in the same list.
   const restoreTreeOutside = () => {
     restoreCleanups(cleanups);
   };
 
-  return restoreTreeOutside;
+  return { disableTreeOutside, restoreTreeOutside };
 }

--- a/packages/ariakit-react-components/src/dialog/utils/orchestrate.test.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/orchestrate.test.ts
@@ -294,11 +294,21 @@ test("markAndDisableTreeOutside skips focus traps and restores disabled elements
   const focusTrap = getElement("focus-trap");
   const outside = getElement("outside");
 
-  const restoreTree = markAndDisableTreeOutside("dialog", [dialog]);
+  const { disableTreeOutside, restoreTreeOutside } = markAndDisableTreeOutside(
+    "dialog",
+    [dialog],
+  );
 
   expect(isElementMarked(outside, "dialog")).toBe(true);
   // Focus traps are marked as outside the dialog, but not disabled.
   expect(isElementMarked(focusTrap, "dialog")).toBe(true);
+
+  // Marking is synchronous, but disabling is a separate step the dialog
+  // usually defers until after the open frame paints.
+  expect(outside.inert).toBe(false);
+  expect(outside.hasAttribute("aria-hidden")).toBe(false);
+
+  disableTreeOutside();
 
   if (supportsInert()) {
     expect(outside.inert).toBe(true);
@@ -310,7 +320,7 @@ test("markAndDisableTreeOutside skips focus traps and restores disabled elements
     expect(focusTrap.style.pointerEvents).toBe("");
   }
 
-  restoreTree();
+  restoreTreeOutside();
 
   expect(isElementMarked(outside, "dialog")).toBe(false);
   expect(isElementMarked(focusTrap, "dialog")).toBe(false);

--- a/packages/ariakit-react-components/src/dialog/utils/use-prevent-body-scroll.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/use-prevent-body-scroll.ts
@@ -14,7 +14,7 @@ interface WindowWithCSS extends Window {
   CSS?: Pick<typeof CSS, "supports">;
 }
 
-function supportsScrollbarGutter(win: Window) {
+export function supportsScrollbarGutter(win: Window) {
   const { CSS } = win as WindowWithCSS;
   return !!CSS?.supports("scrollbar-gutter", "stable");
 }


### PR DESCRIPTION
## Motivation

Opening a modal `Dialog` is slow on pages with a lot of content (#4075). Chrome traces on the dialog-perf sandbox (5000 cards) show why: when the dialog opens, `markAndDisableTreeOutside` sets `inert` on the top-level elements around it, and the browser propagates inertness through computed styles, invalidating the entire outside tree. The resulting ~68ms style recalculation runs before the dialog's first paint, so the open interaction blocks on work whose only purpose is to disable content the user can no longer see uncovered. This is also what made `setViewportHeight` top the perf-report script profiles: its `visualViewport.height` read was the first forced style flush after the `inert` writes, so the profiler attributed the whole bill to it.

This revives the direction of #6609 (closed), adapted to how `main` has evolved since:

- The scroll-lock half of #6609 is already shipped: the `scrollbar-gutter` lock (#6634) removed the `--scrollbar-width` full-document invalidation on every browser that supports the property, and skips all width compensation when there is no scrollbar width to compensate.
- That also changes #6609's "share the pre-paint pass" gating: with the gutter lock, removing a visible classic scrollbar no longer forces a full-document pass, so deferring the inert writes pays off on classic-scrollbar systems too (e.g. Windows). Only the no-gutter-support fallback (Safari < 18.2) still writes the inherited `--scrollbar-width` property that forces a pre-paint full-document recalc.

## Solution

Keep the semantics; move the cost off the input → paint critical path:

- `markAndDisableTreeOutside` now marks synchronously and returns the disabling work separately (`{ disableTreeOutside, restoreTreeOutside }`). Marks are plain JavaScript properties with no style impact, and they're what the outside-click and Escape logic runs on, so that logic is unaffected.
- The dialog defers `disableTreeOutside` to right after the open frame paints (double `requestAnimationFrame` through the element's owner window, canceled if the dialog closes first). The ~68ms recalculation still happens — it's the platform price of inertness, same as native `showModal()` — but no longer blocks the first paint.
- **Sync exception 1 — replacements never leave gaps.** When a disabling replaces one that was active until a cleanup in the same task restored it (the same dialog re-running because a nested dialog opened, or a sibling dialog taking over), it re-applies synchronously: the restore already invalidated the outside tree, so the sync re-apply merges into the same recalc instead of leaving the tree interactive for a frame. Tracked by a module-level flag cleared in a microtask, covered by a MutationObserver regression test that asserts the outside tree is inert at every mutation checkpoint during a sibling takeover.
- **Sync exception 2 — legacy scrollbar fallback.** On browsers without `scrollbar-gutter` support that are about to remove a visible scrollbar, the scroll lock's `--scrollbar-width` write already forces a pre-paint full-document recalc, so the inert writes apply synchronously to share that pass instead of adding a second one a frame later (this is #6609's probe, narrowed by a `supportsScrollbarGutter` check so modern browsers with classic scrollbars still get the deferral). The `usePreventBodyScroll` call moved below the tree-disabling effect so the probe measures the scrollbar before the lock removes it.
- The close path is unchanged: restores stay synchronous because focus-on-hide needs the outside tree re-enabled to move focus back to the disclosure.

## Measured (dialog-perf, 5000 cards, dev server)

Chrome trace of the open interaction:

| | main | this PR |
|---|---|---|
| click task duration | 246ms | 186ms |
| first paint after click | ~268ms | ~197ms |
| pre-paint forced style recalc | 68.6ms (whole outside tree) | 0.9ms |
| the inert recalc | pre-paint, blamed on `setViewportHeight` | post-paint, unforced, in the frame pipeline |

Interleaved A/B benchmark (2 rounds per side, 20 samples each, medians) of the "open dialog" perf test:

| Metric | main | this PR |
|---|---|---|
| INP | 688ms | 616ms (−10.5%) |
| Scripting | 549ms | 547ms (−0.5%) |
| Rendering | 127ms | 126ms (−1.2%) |
| Total | 677ms | 673ms (−0.6%) |

The INP drop matches the deferred recalculation time; total work stays the same because the recalc moves past the paint, it doesn't disappear (RecalcStyleCount goes from 8 to 9 since the deferred pass no longer merges with the open-frame flush).

## Tradeoffs

- The outside tree becomes inert one frame (~16ms) after the dialog appears when the deferred path applies. No real user interaction can land in that window, the backdrop already covers the page, and the outside-click/Escape logic runs off the synchronous marks. Native `showModal()` applies inertness synchronously; this intentionally trades that for paint latency (same tradeoff #6609 chose).
- If the dialog closes before the deferred frame fires, the callback is canceled and the restore only undoes the marks.
- `markAndDisableTreeOutside` (reachable via the `@ariakit/react-components/dialog/utils/disable-tree` sub-path, not re-exported by `@ariakit/react`, undocumented) changes its return type from a restore function to `{ disableTreeOutside, restoreTreeOutside }`. Treated as an internal util.

## Verification

- happy-dom reports `scrollbar-gutter` support, so the entire integration suite exercises the deferred path by default (matching what all modern browsers do); the existing `CSS.supports`-mocked fallback test exercises the sync path.
- New tests: sibling-takeover inert continuity (MutationObserver at every checkpoint) and sibling-takeover scroll-lock continuity; `markAndDisableTreeOutside` unit test updated for the split API.
- Full `test-react` suite 848/848 (twice), `test-react18` 840 passed + 8 pre-existing skips, app Chrome dialog browser tests 23/23, `pnpm tsc`, `pnpm lint`.
