### PR TITLE
Harden Chrome perf CI against infra flakes

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -509,25 +509,53 @@ jobs:
           fi
           echo "Chrome perf file: ${PERF_FILES[*]:-<none>}"
 
+          # Pass the per-test timeout on the CLI (it takes precedence over the
+          # config file) so the baseline worktree, which runs the base
+          # branch's Playwright config, gets the same headroom as the current
+          # side: script-profile tests can legitimately exceed the old 120s
+          # config default on slow runners. Playwright test retries are NOT
+          # passed here on purpose: the base worktree may predate the
+          # retry-safety guards (pass-only result recording and stale-attempt
+          # pruning), and a failed baseline invocation is retried whole below
+          # with its partial results removed.
+          PLAYWRIGHT_TEST_TIMEOUT=180000
+
+          baseline_perf_attempt() {
+            local i="$1"
+            shift
+            (
+              cd "$BASELINE_DIR" || exit 1
+              PERF_RESULTS_FILE=baseline-$i-j$PERF_JOB_INDEX.json \
+              PERF_ITERATIONS="$PERF_ITERATIONS" \
+              PERF_WARMUP="$PERF_WARMUP" \
+              xvfb-run -a pnpm -F app run test-perf --pass-with-no-tests \
+                --timeout="$PLAYWRIGHT_TEST_TIMEOUT" "$@"
+            )
+          }
+
           run_baseline_perf_round() {
             local i="$1"
             shift
             local perf_files=("$@")
 
             echo "::group::Round $i - baseline"
-            if ! (
-              cd "$BASELINE_DIR" || exit 1
-              PERF_RESULTS_FILE=baseline-$i-j$PERF_JOB_INDEX.json \
-              PERF_ITERATIONS="$PERF_ITERATIONS" \
-              PERF_WARMUP="$PERF_WARMUP" \
-              xvfb-run -a pnpm -F app run test-perf --pass-with-no-tests "${perf_files[@]}"
-            ); then
-              # The post job discards every job's rounds when any job fails,
-              # so fail fast instead of benchmarking output that is
-              # guaranteed to be thrown away.
-              manifest_status=failed
-              manifest_message="Baseline perf run failed for round $i."
-              exit 1
+            # A perf invocation can fail for infra reasons unrelated to the
+            # code under test, such as a browser that wedges mid-run or a
+            # workerd port bind race at web server startup. Retry the
+            # invocation once with fresh servers and browsers, removing the
+            # failed attempt's partial result files first so the retry cannot
+            # double-count.
+            if ! baseline_perf_attempt "$i" "${perf_files[@]}"; then
+              echo "::warning::Baseline perf run failed for round $i; retrying once."
+              rm -f "$BASELINE_DIR"/app/.perf-results/baseline-"$i"*.json
+              if ! baseline_perf_attempt "$i" "${perf_files[@]}"; then
+                # The post job discards every job's rounds when any job fails,
+                # so fail fast instead of benchmarking output that is
+                # guaranteed to be thrown away.
+                manifest_status=failed
+                manifest_message="Baseline perf run failed for round $i."
+                exit 1
+              fi
             fi
             local baseline_files=("$BASELINE_DIR"/app/.perf-results/baseline-"$i"*.json)
             if [ ${#baseline_files[@]} -eq 0 ]; then
@@ -547,21 +575,32 @@ jobs:
             echo "::endgroup::"
           }
 
+          current_perf_attempt() {
+            local i="$1"
+            shift
+            PERF_RESULTS_FILE=current-$i-j$PERF_JOB_INDEX.json \
+            PERF_ITERATIONS="$PERF_ITERATIONS" \
+            PERF_WARMUP="$PERF_WARMUP" \
+            xvfb-run -a pnpm -F app run test-perf --pass-with-no-tests \
+              --timeout="$PLAYWRIGHT_TEST_TIMEOUT" "$@"
+          }
+
           run_current_perf_round() {
             local i="$1"
             shift
             local perf_files=("$@")
 
             echo "::group::Round $i - current"
-            if ! (
-              PERF_RESULTS_FILE=current-$i-j$PERF_JOB_INDEX.json \
-              PERF_ITERATIONS="$PERF_ITERATIONS" \
-              PERF_WARMUP="$PERF_WARMUP" \
-              xvfb-run -a pnpm -F app run test-perf --pass-with-no-tests "${perf_files[@]}"
-            ); then
-              manifest_status=failed
-              manifest_message="Current perf run failed for round $i."
-              exit 1
+            # See run_baseline_perf_round for why failed invocations get one
+            # retry with fresh servers and browsers.
+            if ! current_perf_attempt "$i" "${perf_files[@]}"; then
+              echo "::warning::Current perf run failed for round $i; retrying once."
+              rm -f app/.perf-results/current-"$i"*.json
+              if ! current_perf_attempt "$i" "${perf_files[@]}"; then
+                manifest_status=failed
+                manifest_message="Current perf run failed for round $i."
+                exit 1
+              fi
             fi
             local current_files=(app/.perf-results/current-"$i"*.json)
             if [ ${#current_files[@]} -eq 0 ]; then

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -9,6 +9,22 @@ const HEADED = process.env.PWHEADED === "true";
 const PERF = process.env.PERF_TEST === "true";
 const port = Number(process.env.APP_PORT) || 4321;
 const nextjsPort = Number(process.env.NEXTJS_PORT) || 3000;
+// Pin the wrangler dev inspector ports outside the OS ephemeral range in CI.
+// When unset, wrangler preselects a random free high port and workerd binds
+// it later, so another process (such as a browser connection claiming it as
+// an outbound source port) can take it in between, which kills the server
+// with a fatal "Address already in use" on startup. Only pin by default in
+// CI, where each job owns the runner: fixed local defaults would make
+// concurrent sessions (such as per-worktree servers on overridden app ports)
+// collide deterministically. Zero means "let wrangler pick".
+const inspectorPort = Number(process.env.APP_INSPECTOR_PORT) || (CI ? 9339 : 0);
+const nextjsInspectorPort =
+  Number(process.env.NEXTJS_INSPECTOR_PORT) || (CI ? 9340 : 0);
+
+function inspectorPortArg(port: number) {
+  if (!port) return "";
+  return ` --inspector-port ${port}`;
+}
 
 function testMatchersFor(...kinds: string[]): RegExp[] {
   return kinds.flatMap((kind) => [
@@ -28,13 +44,13 @@ export default defineConfig({
   snapshotPathTemplate: "{testDir}/{testFileDir}/__snapshots__/{arg}{ext}",
   webServer: [
     {
-      command: `pnpm run preview-lite --log-level warn --port ${port} --var NEXTJS_PORT:${nextjsPort}`,
+      command: `pnpm run preview-lite --log-level warn --port ${port}${inspectorPortArg(inspectorPort)} --var NEXTJS_PORT:${nextjsPort}`,
       reuseExistingServer: !CI,
       stdout: CI ? "pipe" : "ignore",
       port,
     },
     {
-      command: `pnpm -F nextjs exec opennextjs-cloudflare preview --port ${nextjsPort}`,
+      command: `pnpm -F nextjs exec opennextjs-cloudflare preview --port ${nextjsPort}${inspectorPortArg(nextjsInspectorPort)}`,
       reuseExistingServer: !CI,
       stdout: CI ? "pipe" : "ignore",
       port: nextjsPort,
@@ -65,9 +81,29 @@ export default defineConfig({
             launchOptions: {
               args: ["--enable-precise-memory-info"],
             },
+            // Fail a wedged navigation fast instead of letting it consume
+            // the whole test budget; healthy CI page loads finish in a few
+            // seconds. Iteration contexts bound their navigations the same
+            // way in ariakit-scripts perf.ts.
+            navigationTimeout: 30_000,
+            // Tracing a retried attempt would add overhead to the retried
+            // measurement and distort its metrics.
+            trace: "off",
           },
-          retries: 0,
-          timeout: 120_000,
+          // Failed attempts record no results (the perf fixture only
+          // appends results for passing attempts) and results land in
+          // per-worker files, so retrying in a fresh worker (new browser)
+          // cannot double-count. It recovers the run when the previous
+          // worker's browser wedged mid-file. Same value as the root
+          // retries, but kept explicit: perf previously opted out and the
+          // retry safety argument lives here.
+          retries: 1,
+          // Script-profile tests do over 100s of real work on slow runners.
+          // This is headroom over observed durations, not a hang allowance:
+          // navigations are bounded above. CI perf runs pass the same value
+          // via --timeout in perf.yml (PLAYWRIGHT_TEST_TIMEOUT), which takes
+          // precedence, so keep the two in sync.
+          timeout: 180_000,
         },
       ]
     : [

--- a/app/src/test-utils/fixtures.ts
+++ b/app/src/test-utils/fixtures.ts
@@ -93,7 +93,12 @@ export const test = base.extend<{
           toPerfMeasureOptions(options),
         ),
     });
-    if (results.length > 0) {
+    // Only record results for passing attempts. A failed attempt is retried
+    // in a fresh worker, so appending its partial results (measures that
+    // succeeded before the failure in a multi-measure test) would count them
+    // again when the retry passes and records the full set.
+    const passed = testInfo.status === testInfo.expectedStatus;
+    if (passed && results.length > 0) {
       appendResults(results, testInfo);
     }
   },

--- a/packages/ariakit-scripts/src/perf.test.ts
+++ b/packages/ariakit-scripts/src/perf.test.ts
@@ -1,17 +1,24 @@
-import type { CDPSession, Page } from "@playwright/test";
-import { afterEach, beforeEach, expect, test } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { errors } from "@playwright/test";
+import type { CDPSession, Page, TestInfo } from "@playwright/test";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import {
+  appendResults,
   formatPerfTitlePath,
   getPerfProfileBaseLabel,
   getPerfProfileMode,
   getIntegerEnv,
   getPerfSamplingOptions,
   getUniquePerfLabel,
+  isNavigationTimeoutError,
   isPerfProfileLabel,
   parseScriptProfile,
   resolveScriptProfileSourceMaps,
   settleQuiescent,
 } from "./perf.ts";
+import type { PerfResult } from "./perf.ts";
 
 const envName = "PERF_ITERATIONS";
 const envNames = [
@@ -46,6 +53,84 @@ afterEach(() => {
       process.env[name] = originalValue;
     }
   }
+});
+
+test("prunes an earlier attempt's results when a retried test records", () => {
+  const makeResult = (testTitle: string): PerfResult => ({
+    testFile: "src/sandbox/select-perf/perf-chrome.ts",
+    testTitle,
+    label: testTitle,
+    metrics: { scripting: 1, rendering: 1, inp: 0, total: 2 },
+    raw: [],
+  });
+  // The worker index is the only TestInfo field appendResults reads.
+  const workerInfo = (workerIndex: number) =>
+    ({ workerIndex }) as unknown as TestInfo;
+  const workDir = mkdtempSync(path.join(tmpdir(), "perf-results-"));
+  const resultsDir = path.join(workDir, ".perf-results");
+  const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(workDir);
+  const originalResultsFile = process.env.PERF_RESULTS_FILE;
+  process.env.PERF_RESULTS_FILE = "current-1-j0.json";
+  const readTitles = (workerIndex: number) => {
+    const filePath = path.join(
+      resultsDir,
+      `current-1-j0-worker${workerIndex}.json`,
+    );
+    if (!existsSync(filePath)) return null;
+    const entries: PerfResult[] = JSON.parse(readFileSync(filePath, "utf-8"));
+    return entries.map((entry) => entry.testTitle);
+  };
+  try {
+    // Worker 0: an attempt records two tests, then one of them is retried in
+    // worker 1 (a pass whose later fixture teardown failed still appends).
+    appendResults([makeResult("mount"), makeResult("open")], workerInfo(0));
+    appendResults([makeResult("open")], workerInfo(1));
+    expect(readTitles(0)).toEqual(["mount"]);
+    expect(readTitles(1)).toEqual(["open"]);
+
+    // A retry that supersedes every entry removes the stale file entirely.
+    appendResults([makeResult("mount")], workerInfo(2));
+    expect(readTitles(0)).toBeNull();
+    expect(readTitles(1)).toEqual(["open"]);
+    expect(readTitles(2)).toEqual(["mount"]);
+  } finally {
+    cwdSpy.mockRestore();
+    if (originalResultsFile == null) {
+      delete process.env.PERF_RESULTS_FILE;
+    } else {
+      process.env.PERF_RESULTS_FILE = originalResultsFile;
+    }
+    rmSync(workDir, { recursive: true, force: true });
+  }
+});
+
+test("detects navigation timeouts by class and message", () => {
+  // Real navigation timeout message format, verified against Playwright:
+  // bounded goto on a hanging server throws errors.TimeoutError with a
+  // "page.goto:"-prefixed message.
+  const navigationTimeout = new errors.TimeoutError(
+    "page.goto: Timeout 30000ms exceeded.\nCall log:\n  - navigating to ...",
+  );
+  expect(isNavigationTimeoutError(navigationTimeout)).toBe(true);
+
+  // Same message on a plain Error must not match: only Playwright timeouts
+  // are transient navigation stalls.
+  const plainError = new Error("page.goto: Timeout 30000ms exceeded.");
+  expect(isNavigationTimeoutError(plainError)).toBe(false);
+
+  // Non-navigation Playwright timeouts (interactions, verify steps) must not
+  // be retried; they can reflect real behavior of the measured code.
+  const clickTimeout = new errors.TimeoutError(
+    'locator.click: Timeout 5000ms exceeded.\nCall log:\n  - waiting for locator("#nope")',
+  );
+  expect(isNavigationTimeoutError(clickTimeout)).toBe(false);
+  const loadStateTimeout = new errors.TimeoutError(
+    "page.waitForLoadState: Timeout 5000ms exceeded.",
+  );
+  expect(isNavigationTimeoutError(loadStateTimeout)).toBe(false);
+
+  expect(isNavigationTimeoutError(undefined)).toBe(false);
+  expect(isNavigationTimeoutError("page.goto: timeout")).toBe(false);
 });
 
 test("gets integer env values with range validation", () => {

--- a/packages/ariakit-scripts/src/perf.ts
+++ b/packages/ariakit-scripts/src/perf.ts
@@ -1,5 +1,12 @@
 import { Buffer } from "node:buffer";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -17,12 +24,20 @@ import type {
   TestInfo,
 } from "@playwright/test";
 
-const RESULTS_DIR = path.join(process.cwd(), ".perf-results");
 const DEFAULT_PROFILE_LIMIT = 10;
 const DEFAULT_PERF_ITERATIONS = 10;
 const DEFAULT_PERF_WARMUP = 1;
 const DEFAULT_SCRIPT_PROFILE_ITERATIONS = 3;
 const DEFAULT_SCRIPT_PROFILE_WARMUP = 0;
+// Upper bound for a single iteration navigation. Healthy CI page loads finish
+// in a few seconds even on contended runners; a navigation that runs this
+// long means the browser wedged (the server keeps serving a fresh browser
+// right away), so fail it fast and retry in a new context instead of letting
+// the pending navigation consume the remaining test budget.
+const ITERATION_NAVIGATION_TIMEOUT = 30_000;
+// Upper bound for closing an iteration context on a wedged browser; see the
+// close handling in measureIteration.
+const CONTEXT_CLOSE_TIMEOUT = 10_000;
 const initializedResultFiles = new Set<string>();
 
 // CDP metric names (values are in seconds).
@@ -1317,6 +1332,9 @@ async function measureIteration(
   params: MeasureIterationParams,
 ): Promise<MeasureOnceResult> {
   const context = await params.browser.newContext(params.contextOptions);
+  // Raw contexts do not inherit the test runner's navigationTimeout, so bound
+  // navigations here; see ITERATION_NAVIGATION_TIMEOUT.
+  context.setDefaultNavigationTimeout(ITERATION_NAVIGATION_TIMEOUT);
   try {
     const page = await context.newPage();
     const cdp = await context.newCDPSession(page);
@@ -1384,8 +1402,64 @@ async function measureIteration(
     throw error;
   } finally {
     // Swallow close failures: by this point the result is already computed or
-    // a more informative error is in flight.
-    await context.close().catch(() => {});
+    // a more informative error is in flight. Still log them: a context that
+    // fails to close stays open in the shared browser, and accumulated leaks
+    // precede wedged navigations in later iterations. `close()` has no
+    // timeout of its own and can also hang on a wedged browser, which would
+    // eat the budget the bounded navigation just saved, so give it a bounded
+    // window and abandon it otherwise.
+    const closed = context.close().then(
+      () => true,
+      (error) => {
+        console.warn(
+          `Failed to close perf iteration context: ${String(error)}`,
+        );
+        return true;
+      },
+    );
+    const closeTimer = new Promise<boolean>((resolve) => {
+      setTimeout(() => resolve(false), CONTEXT_CLOSE_TIMEOUT).unref?.();
+    });
+    const didClose = await Promise.race([closed, closeTimer]);
+    if (!didClose) {
+      console.warn("Perf iteration context close timed out; abandoning it.");
+    }
+  }
+}
+
+/**
+ * Whether `error` is a Playwright timeout thrown by a navigation. Only
+ * navigations are retried: other timeouts, such as interaction or verify
+ * steps, can reflect real behavior of the code under measurement. Page-load
+ * measures are the one case where the measured interaction is itself a
+ * navigation, so a page load that legitimately exceeds the navigation bound
+ * is retried too; that stays safe because the failed attempt records nothing
+ * and the retry fails the same way.
+ */
+export function isNavigationTimeoutError(error: unknown) {
+  if (!(error instanceof errors.TimeoutError)) return false;
+  return error.message.includes("page.goto");
+}
+
+/**
+ * Runs `measureIteration`, retrying once in a brand-new context when the
+ * iteration's navigation times out. A browser under repeated context churn
+ * occasionally wedges so that a new context's navigation never resolves even
+ * though the server stays healthy (a replacement browser passes against the
+ * same server immediately). The failed attempt recorded nothing, so the
+ * retried iteration is an independent, equally valid sample.
+ */
+async function measureIterationWithRetry(
+  params: MeasureIterationParams,
+): Promise<MeasureOnceResult> {
+  try {
+    return await measureIteration(params);
+  } catch (error) {
+    if (!isNavigationTimeoutError(error)) throw error;
+    console.warn(
+      "Perf iteration navigation timed out; retrying in a new context.",
+    );
+    return measureIteration(params);
   }
 }
 
@@ -1472,7 +1546,7 @@ export async function createPerfMeasure(
     collectMetrics: boolean;
   }) => {
     for (let i = 0; i < warmupCount + iterationCount; i++) {
-      const result = await measureIteration({
+      const result = await measureIterationWithRetry({
         browser,
         contextOptions,
         testInfo,
@@ -1560,17 +1634,74 @@ export async function createPerfPageLoadMeasure(
   );
 }
 
+interface RemoveStaleAttemptResultsParams {
+  resultsDir: string;
+  prefix: string;
+  fileName: string;
+  results: PerfResult[];
+}
+
+/**
+ * Drops the tests in `results` from the run's other worker files. A test can
+ * only appear in two worker files of one run when an earlier attempt recorded
+ * results and the test was retried anyway (for example a pass whose later
+ * fixture teardown failed, flipping the attempt's final status after the perf
+ * fixture already appended). Keeping both attempts would double-count the
+ * test in the run's collected results.
+ */
+function removeStaleAttemptResults({
+  resultsDir,
+  prefix,
+  fileName,
+  results,
+}: RemoveStaleAttemptResultsParams) {
+  const testKey = (result: PerfResult) =>
+    `${result.testFile}\n${result.testTitle}`;
+  const appendedKeys = new Set(results.map(testKey));
+  if (!appendedKeys.size) return;
+  for (const siblingName of readdirSync(resultsDir)) {
+    if (siblingName === fileName) continue;
+    if (!siblingName.startsWith(`${prefix}-worker`)) continue;
+    if (!siblingName.endsWith(".json")) continue;
+    const siblingPath = path.join(resultsDir, siblingName);
+    try {
+      const entries: PerfResult[] = JSON.parse(
+        readFileSync(siblingPath, "utf-8"),
+      );
+      const kept = entries.filter((entry) => !appendedKeys.has(testKey(entry)));
+      if (kept.length === entries.length) continue;
+      if (kept.length) {
+        writeFileSync(siblingPath, JSON.stringify(kept, null, 2));
+      } else {
+        rmSync(siblingPath);
+      }
+    } catch (error) {
+      // A malformed sibling file should not fail the passing attempt that is
+      // recording its results.
+      console.warn(
+        `Failed to prune stale perf results in ${siblingName}: ${String(error)}`,
+      );
+    }
+  }
+}
+
 /**
  * Appends collected results to a worker-specific JSON file inside the results
  * directory. Using per-worker files avoids write conflicts when Playwright runs
- * tests in parallel.
+ * tests in parallel. A retried test runs in a fresh worker with a new worker
+ * index, so any results an earlier attempt left in another worker file are
+ * pruned first; see `removeStaleAttemptResults`.
  */
 export function appendResults(results: PerfResult[], testInfo: TestInfo) {
-  mkdirSync(RESULTS_DIR, { recursive: true });
+  // Resolved at call time (not module load) so tests can point it at a
+  // temporary working directory.
+  const resultsDir = path.join(process.cwd(), ".perf-results");
+  mkdirSync(resultsDir, { recursive: true });
   const prefix =
     process.env.PERF_RESULTS_FILE?.replace(/\.json$/, "") ?? "current";
   const fileName = `${prefix}-worker${testInfo.workerIndex}.json`;
-  const filePath = path.join(RESULTS_DIR, fileName);
+  const filePath = path.join(resultsDir, fileName);
+  removeStaleAttemptResults({ resultsDir, prefix, fileName, results });
   let existing: PerfResult[] = [];
   if (initializedResultFiles.has(filePath) && existsSync(filePath)) {
     existing = JSON.parse(readFileSync(filePath, "utf-8"));


### PR DESCRIPTION
## Motivation

Chrome perf jobs have been timing out often enough to disrupt unrelated PRs: 13 failed `perf.yml` runs between July 2 and July 4, with the per-run failure rate climbing (~2.5% → ~7% → ~13%) as the Chrome job count grew from 1 to 3 shards (#6612) to a per-file matrix (#6641). The logs and round artifacts show three distinct infra failure modes, none caused by the code under test (baseline rounds fail the same way):

1. **Real 120s budget blowouts.** Script-profile tests do the most work per test and started brushing against the fixed 120s perf timeout right after the dialog fixture grew in #6610. #6632 and #6647 reduced profile cost, but select/composite profiles still ride close to the cap on slow runners ([example](https://github.com/ariakit/ariakit/actions/runs/28632604249)).
2. **A wedged browser instance.** Since #6640 every iteration runs in a fresh browser context. Occasionally the shared browser wedges after this context churn and one iteration's `page.goto` never resolves, consuming the rest of the test budget. The round artifacts prove the server is innocent: in [this run](https://github.com/ariakit/ariakit/actions/runs/28717041629/job/85160369403), worker 0's browser wedged mid-file while the replacement worker's fresh browser immediately passed the heaviest test against the same server. The failure screenshots also show several pages still open at timeout even though every iteration closes its context in a `finally`, meaning close failures were being silently swallowed.
3. **A workerd port bind race at webServer startup.** With no `--inspector-port`, wrangler preselects a random free high port and workerd binds it later, so another process can take it in between ([example](https://github.com/ariakit/ariakit/actions/runs/28716462434/job/85158898882)):

   ```
   *** Fatal uncaught kj::Exception: … Address already in use; toString() = 127.0.0.1:36315
   ERROR: Process from config.webServer was not able to start.
   ```

Each Chrome matrix job runs up to 10 sequential Playwright invocations (baseline/current × rounds) and any single flake fails the whole run, so the exposure multiplied with every matrix split.

## Solution

Defense in four layers, from the inside out:

1. **Bound and retry iteration navigations** (`packages/ariakit-scripts/src/perf.ts`). Iteration contexts set a 30s navigation timeout, and an iteration whose navigation times out is retried once in a brand-new context — the failed attempt records nothing, so the retried iteration is an independent, equally valid sample. Context close is also bounded (10s) and close failures are logged instead of silently swallowed, since leaked contexts precede wedged navigations.
2. **Perf project hardening** (`app/playwright.config.ts`). `navigationTimeout: 30s` for the fixture page's `beforeEach` navigation, `retries: 1` so a failed perf test reruns in a fresh worker whose new browser recovers a wedged one, `trace: "off"` so tracing cannot distort a retried measurement, and `timeout: 180s` for script-profile headroom (navigations are bounded, so the larger budget no longer extends hangs). Retries cannot double-count results: the perf fixture now appends results only for passing attempts, and `appendResults` prunes an earlier attempt's entries from sibling worker files when a retried test records — a test can only appear in two worker files of one run via a retry.
3. **Pinned wrangler inspector ports** (`app/playwright.config.ts`). In CI both webServers pass explicit `--inspector-port`s (9339/9340, overridable via `APP_INSPECTOR_PORT`/`NEXTJS_INSPECTOR_PORT`) outside the ephemeral range, eliminating the random-port bind race. Local runs keep wrangler's random ports so concurrent sessions (such as per-worktree servers) cannot collide on fixed defaults. Verified end-to-end that both `wrangler dev` and `opennextjs-cloudflare preview` forward the flag and that workerd binds the pinned ports.
4. **One retry per failed invocation** (`.github/workflows/perf.yml`). Each round side retries its Playwright invocation once with fresh servers and browsers, deleting the failed attempt's partial result files first. The per-test timeout is also passed as `--timeout=180000` on the CLI, which takes precedence over the config file, so the baseline worktree — which runs the base branch's Playwright config — gets the same headroom; Playwright-level retries are deliberately not passed on the CLI because the base worktree may predate the retry-safety guards.

## Verification

- `pnpm tsc`, `pnpm lint-fix`, and the ariakit-scripts unit suite (75 tests, including two new ones) pass. Both new tests were red-checked: temporarily breaking the code under test made each fail on the expected assertion.
- The navigation-timeout detection was validated against real Playwright errors: a hanging server under `setDefaultNavigationTimeout` throws `errors.TimeoutError` with a `page.goto:`-prefixed message, while a click timeout does not match.
- CLI-over-config timeout precedence was verified empirically: `--timeout=1000` against the 180s project config produced `Test timeout of 1000ms exceeded` (and a `retry1` attempt, confirming retries are active).
- The workflow's retry logic was simulated with a stubbed runner: fail-once-then-pass cleans partials and collects the retry's files on both sides, a double failure exits 1 with the failed manifest, and a first-attempt success never retries; `bash -n` passes on the extracted script.
- Full local E2E of `select-perf/perf-chrome.ts` against the built app: 4/4 passed, both workerd processes bound the pinned inspector ports, results recorded per worker, servers torn down cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)