### PR TITLE
Group Astro Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -44,6 +44,10 @@
       ]
     },
     {
+      "groupName": "astro",
+      "matchPackageNames": ["astro", "/^@astrojs\\//"]
+    },
+    {
       "groupName": "changesets",
       "matchPackageNames": ["/^@changesets\\//"]
     },


### PR DESCRIPTION
## Motivation

Renovate currently lets `@astrojs/markdown-remark` match the broad `unified` group through the `/remark/` package rule. That can produce separate markdown-remark updates instead of keeping it with the Astro packages, as happened in #6660 after the Astro monorepo update in #6659.

## Solution

Add an `astro` Renovate group that matches `astro` and all `@astrojs/*` packages. The rule is placed after `unified` so the more specific Astro group wins for `@astrojs/markdown-remark`, while non-Astro remark and unified packages stay in the existing group.
