### PR TITLE
Compact perf report breakdown

### DIFF
--- a/packages/ariakit-scripts/src/perf-compare.test.ts
+++ b/packages/ariakit-scripts/src/perf-compare.test.ts
@@ -128,6 +128,18 @@ function createResultWithMetrics(
   };
 }
 
+function createResultWithTitle(
+  label: string,
+  testTitle: string,
+  metrics: PerfMetrics,
+  profiles?: PerfProfiles,
+): PerfResult {
+  return {
+    ...createResultWithMetrics(label, metrics, profiles),
+    testTitle,
+  };
+}
+
 function createScriptProfileEntry(
   functionName: string,
   selfTime: number,
@@ -302,7 +314,7 @@ test("keeps single-run comparison behavior", () => {
 
   const markdown = runCompare(dir);
 
-  expect(markdown).toContain("100.0ms → 120.0ms (+20%) :warning:");
+  expect(markdown).toContain("100ms → 120ms (+20%) :warning:");
   expect(markdown).not.toContain("Aggregated across");
 });
 
@@ -319,7 +331,7 @@ test("pairs legacy generated labels with normalized labels", () => {
   const markdown = runCompare(dir);
   const summary = readComparisonSummary(dir);
 
-  expect(markdown).toContain("100.0ms \u2192 120.0ms (+20%) :warning:");
+  expect(markdown).toContain("100ms \u2192 120ms (+20%) :warning:");
   expect(markdown).not.toContain("### New tests");
   expect(markdown).not.toContain("### Removed tests");
   expect(summary.rows[0]?.label).toBe("example > react > example");
@@ -515,9 +527,9 @@ test("reports overlapping same-direction rounds as unconfirmed candidates", () =
     markdown.indexOf("<details>"),
   );
   expect(markdown).toContain(
-    "| raw samples | Scripting | 120.0ms | 140.0ms | +20.0ms (+17%) | low | rounds 2/2, raw 0/2, pairs 60% |",
+    "| raw samples | Scripting | 120ms | 140ms | +20ms (+17%) | low | rounds 2/2, raw 0/2, pairs 60% |",
   );
-  expect(markdown).toContain("120.0ms | 140.0ms | +20.0ms (+17%)");
+  expect(markdown).toContain("120ms | 140ms | +20ms (+17%)");
   // Candidates are reported in the unconfirmed changes section, not repeated
   // in the detailed breakdown diagnostics.
   expect(markdown).not.toContain("Unflagged threshold-sized changes");
@@ -539,7 +551,7 @@ test("grades candidates by their displayed pairs percent", () => {
   const markdown = runCompare(dir);
 
   expect(markdown).toContain(
-    "| raw samples | Scripting | 55.0ms | 85.0ms | +30.0ms (+55%) | medium | rounds 2/2, raw 0/2, pairs 70% |",
+    "| raw samples | Scripting | 55ms | 85ms | +30ms (+55%) | medium | rounds 2/2, raw 0/2, pairs 70% |",
   );
 });
 
@@ -553,7 +565,7 @@ test("flags same-direction rounds with separated raw samples", () => {
   const markdown = runCompare(dir);
 
   expect(markdown).toContain(":warning:");
-  expect(markdown).toContain("100.0ms → 160.0ms (+60%) :warning:");
+  expect(markdown).toContain("100ms → 160ms (+60%) :warning:");
   expect(markdown).not.toContain("Unconfirmed changes");
 });
 
@@ -567,9 +579,9 @@ test("requires raw sample support in each required round", () => {
   const markdown = runCompare(dir);
 
   expect(markdown).toContain("No confirmed performance changes detected.");
-  expect(markdown).toContain("110.0ms | 150.0ms | +40.0ms (+36%)");
+  expect(markdown).toContain("110ms | 150ms | +40ms (+36%)");
   expect(markdown).toContain(
-    "| raw samples | Scripting | 110.0ms | 150.0ms | +40.0ms (+36%) | medium | rounds 2/2, raw 1/2, pairs 80% |",
+    "| raw samples | Scripting | 110ms | 150ms | +40ms (+36%) | medium | rounds 2/2, raw 1/2, pairs 80% |",
   );
   expect(markdown).not.toMatch(/% :warning:/);
 });
@@ -628,7 +640,7 @@ test("keeps zero-baseline candidates visible under the cap", () => {
   // Zero-baseline rows have no percent, so they must rank ahead of
   // percent-sorted rows instead of falling behind them and off the cap.
   expect(markdown).toContain(
-    "| from zero | Scripting | 0.0ms | 200.0ms | +200.0ms | low | rounds 2/2, raw 0/2, pairs 60% |",
+    "| from zero | Scripting | 0ms | 200ms | +200ms | low | rounds 2/2, raw 0/2, pairs 60% |",
   );
   expect(markdown.indexOf("| from zero | Scripting |")).toBeLessThan(
     markdown.indexOf("| c1 | Scripting |"),
@@ -649,7 +661,7 @@ test("reports INP-only changes as unconfirmed candidates", () => {
 
   expect(markdown).toContain("No confirmed performance changes detected.");
   expect(markdown).toContain(
-    "| inp test | INP | 650.0ms | 400.0ms | -250.0ms (-38%) | low | rounds 2/2, raw 0/2, pairs 60% |",
+    "| inp test | INP | 650ms | 400ms | -250ms (-38%) | low | rounds 2/2, raw 0/2, pairs 60% |",
   );
   expect(markdown).not.toMatch(/% :rocket:/);
 });
@@ -664,7 +676,7 @@ test("flags confirmed INP regressions", () => {
   const markdown = runCompare(dir);
 
   expect(markdown).toContain("| Test | Scripting | Rendering | INP | Total |");
-  expect(markdown).toContain("110.0ms → 220.0ms (+100%) :warning:");
+  expect(markdown).toContain("110ms → 220ms (+100%) :warning:");
   expect(markdown).not.toContain("Unconfirmed changes");
 });
 
@@ -677,7 +689,7 @@ test("flags confirmed INP improvements", () => {
 
   const markdown = runCompare(dir);
 
-  expect(markdown).toContain("220.0ms → 110.0ms (-50%) :rocket:");
+  expect(markdown).toContain("220ms → 110ms (-50%) :rocket:");
   expect(markdown).not.toContain("Unconfirmed changes");
 });
 
@@ -736,10 +748,10 @@ test("lists confirmation files for significant and candidate changes", () => {
   );
   // Significant and unconfirmed changes are reported side by side, without
   // icons on the unconfirmed rows.
-  expect(markdown).toContain("100.0ms → 160.0ms (+60%) :warning:");
+  expect(markdown).toContain("100ms → 160ms (+60%) :warning:");
   expect(markdown).toContain("#### Unconfirmed changes");
   expect(markdown).toContain(
-    "| candidate | Scripting | 120.0ms | 140.0ms | +20.0ms (+17%) | low | rounds 2/2, raw 0/2, pairs 60% |",
+    "| candidate | Scripting | 120ms | 140ms | +20ms (+17%) | low | rounds 2/2, raw 0/2, pairs 60% |",
   );
 });
 
@@ -769,8 +781,8 @@ test("aggregates displayed values from shared rounds", () => {
 
   const markdown = runCompare(dir);
 
-  expect(markdown).toContain("200.0ms → 160.0ms (-20%) :rocket:");
-  expect(markdown).not.toContain("125.0ms");
+  expect(markdown).toContain("200ms → 160ms (-20%) :rocket:");
+  expect(markdown).not.toContain("125ms");
   expect(markdown).toContain("Aggregated across 2 interleaved rounds");
   expect(markdown).toContain(
     "paired median delta exceeds the threshold, rounds agree on direction and raw samples support it",
@@ -804,7 +816,7 @@ test("merges sharded round files with shard-suffixed names", () => {
   expect(markdown).toContain("Aggregated across 2 interleaved rounds");
   expect(markdown).toContain("shard one test");
   expect(markdown).toContain("shard two test");
-  expect(markdown).toContain("100.0ms → 130.0ms (+30%) :warning:");
+  expect(markdown).toContain("100ms → 130ms (+30%) :warning:");
 });
 
 test("does not overstate mixed paired round counts", () => {
@@ -848,7 +860,7 @@ test("requires both rounds to agree in two-round comparisons", () => {
   const markdown = runCompare(dir);
 
   expect(markdown).toContain("No significant performance changes detected.");
-  expect(markdown).toContain("100.0ms | 115.0ms | +15.0ms (+15%)");
+  expect(markdown).toContain("100ms → 115ms (+15%)");
   expect(markdown).not.toMatch(/% :warning:/);
 });
 
@@ -877,7 +889,7 @@ test("keeps zero-baseline paired rounds in the agreement count", () => {
   const markdown = runCompare(dir);
 
   expect(markdown).toContain("No significant performance changes detected.");
-  expect(markdown).toContain("50.0ms | 65.0ms | +15.0ms (+30%)");
+  expect(markdown).toContain("50ms → 65ms (+30%)");
   expect(markdown).not.toMatch(/% :warning:/);
 });
 
@@ -946,7 +958,7 @@ test("reports tests with no paired rounds separately", () => {
   );
   expect(markdown).toContain("### Unpaired tests");
   expect(markdown).toContain("| example > react > example | 1 | 2 |");
-  expect(markdown).not.toContain("0.0ms | 0.0ms");
+  expect(markdown).not.toContain("0ms | 0ms");
 });
 
 test("surfaces unpaired tests outside the details block", () => {
@@ -1002,7 +1014,7 @@ test("does not flag percentage-only changes below the absolute floor", () => {
   const markdown = runCompare(dir);
 
   expect(markdown).toContain("No significant performance changes detected.");
-  expect(markdown).toContain("20.0ms | 24.0ms | +4.0ms (+20%)");
+  expect(markdown).toContain("20ms → 24ms (+20%)");
   expect(markdown).not.toMatch(/% :warning:/);
 });
 
@@ -1038,7 +1050,7 @@ test("ignores legacy rendering sub-metrics in older baselines", () => {
   const markdown = runCompare(dir);
 
   expect(markdown).toContain("No significant performance changes detected.");
-  expect(markdown).toContain("| Rendering | 20.0ms | 20.0ms | +0.0ms (+0%) |");
+  expect(markdown).toContain("20ms → 20ms (+0%)");
   expect(markdown).not.toContain("Style recalc");
   expect(markdown).not.toContain("Painting");
 });
@@ -1053,7 +1065,7 @@ test("aggregates worker shards within the same round", () => {
   const markdown = runCompare(dir);
 
   expect(markdown).toContain("No confirmed performance changes detected.");
-  expect(markdown).toContain("100.0ms | 150.0ms | +50.0ms (+50%)");
+  expect(markdown).toContain("100ms | 150ms | +50ms (+50%)");
   expect(markdown).toContain("rounds 1/1, raw 0/1, pairs 50%");
   expect(markdown).not.toMatch(/% :warning:/);
 });
@@ -1142,7 +1154,7 @@ test("renders script profile function names as linked code", () => {
     "[`Escaped`](https://github.com/ariakit/ariakit/blob/abc123/app/src/sandbox/dialog%5C%5Bperf%5D%7Ccase.tsx#L56)",
   );
   expect(markdown).toContain(
-    "| [`Dialog`](https://github.com/ariakit/ariakit/blob/abc123/packages/ariakit-react-components/src/dialog/dialog.tsx#L12) | 8.0ms | 9.0ms | 2 |",
+    "| [`Dialog`](https://github.com/ariakit/ariakit/blob/abc123/packages/ariakit-react-components/src/dialog/dialog.tsx#L12) | 8ms | 9ms | 2 |",
   );
   expect(markdown).not.toContain("| Function | Self | Total | Hits | Source |");
   expect(markdown).not.toContain("dialog.tsx:12:3");
@@ -1175,34 +1187,40 @@ test("keeps node_modules script profile functions as unlinked code", () => {
     GITHUB_SHA: "abc123",
   });
 
-  expect(markdown).toContain(
-    "| `updateWorkInProgressHook` | 8.0ms | 9.0ms | 2 |",
-  );
+  expect(markdown).toContain("| `updateWorkInProgressHook` | 8ms | 9ms | 2 |");
   expect(markdown).not.toContain("react-dom-client.production.js");
 });
 
 test("renders script profiles below comparison tables", () => {
   const dir = createTempDir();
+  const label = "custom label";
+  const testTitle = "ariakit-tailwind > react > page load";
   const profiles: PerfProfiles = {
     script: [createScriptProfileEntry("profiledFn", 8)],
   };
   writeJson(dir, "baseline-worker0.json", [
-    createResultWithMetrics("profiled", createMetrics(100), profiles),
+    createResultWithTitle(label, testTitle, createMetrics(100), profiles),
   ]);
   writeJson(dir, "current-worker0.json", [
-    createResultWithMetrics("profiled", createMetrics(130), profiles),
+    createResultWithTitle(label, testTitle, createMetrics(130), profiles),
   ]);
 
   const markdown = runCompare(dir);
   const comparisonIndex = markdown.indexOf(
-    "| Total | 100.0ms | 130.0ms | +30.0ms (+30%) :warning: |",
+    "| [ariakit-tailwind > react > page load](#script-profile-ariakit-tailwind-react-page-load) | 100ms → 130ms (+30%) :warning:",
   );
-  const profileIndex = markdown.indexOf("#### Script profile");
+  const profileIndex = markdown.indexOf(
+    "#### ariakit-tailwind > react > page load",
+  );
 
-  expect(markdown).toContain("### profiled");
+  expect(markdown).toContain(
+    `<a id="script-profile-ariakit-tailwind-react-page-load"></a>`,
+  );
   expect(comparisonIndex).toBeGreaterThan(-1);
   expect(profileIndex).toBeGreaterThan(comparisonIndex);
-  expect(markdown).toContain("| `profiledFn` | 8.0ms | 8.0ms | 1 |");
+  expect(markdown).toContain("| `profiledFn` | 8ms | 8ms | 1 |");
+  expect(markdown).not.toContain("#### custom label");
+  expect(markdown).not.toContain("#### Script profile");
 });
 
 test("merges script profile rows into base comparisons", () => {
@@ -1227,14 +1245,61 @@ test("merges script profile rows into base comparisons", () => {
 
   const markdown = runCompare(dir);
 
-  expect(markdown).toContain("### profiled");
   expect(markdown).toContain(
-    "| Total | 100.0ms | 130.0ms | +30.0ms (+30%) :warning: |",
+    "| [profiled](#script-profile-profiled) | 100ms → 130ms (+30%) :warning:",
   );
-  expect(markdown).toContain("#### Script profile");
-  expect(markdown).toContain("| `profiledFn` | 8.0ms | 8.0ms | 1 |");
+  expect(markdown).toContain(`<a id="script-profile-profiled"></a>`);
+  expect(markdown).toContain("#### profiled");
+  expect(markdown).toContain("| `profiledFn` | 8ms | 8ms | 1 |");
   expect(markdown).not.toContain("### profiled (script profile)");
-  expect(markdown).not.toContain("300.0ms");
+  expect(markdown).not.toContain("#### Script profile");
+  expect(markdown).not.toContain("300ms");
+});
+
+test("escapes and disambiguates script profile anchors", () => {
+  const dir = createTempDir();
+  const profiles: PerfProfiles = {
+    script: [createScriptProfileEntry("profiledFn", 8)],
+  };
+  writeJson(dir, "baseline-worker0.json", [
+    createResultWithTitle(
+      "first custom label",
+      "same [title] | test",
+      createMetrics(100),
+      profiles,
+    ),
+    createResultWithTitle(
+      "second custom label",
+      "same title test",
+      createMetrics(100),
+      profiles,
+    ),
+  ]);
+  writeJson(dir, "current-worker0.json", [
+    createResultWithTitle(
+      "first custom label",
+      "same [title] | test",
+      createMetrics(130),
+      profiles,
+    ),
+    createResultWithTitle(
+      "second custom label",
+      "same title test",
+      createMetrics(130),
+      profiles,
+    ),
+  ]);
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain(
+    "| [same \\[title\\] \\| test](#script-profile-same-title-test) |",
+  );
+  expect(markdown).toContain(
+    "| [same title test](#script-profile-same-title-test-2) |",
+  );
+  expect(markdown).toContain(`<a id="script-profile-same-title-test"></a>`);
+  expect(markdown).toContain(`<a id="script-profile-same-title-test-2"></a>`);
 });
 
 test("includes new test metric rows for script profile results", () => {
@@ -1244,20 +1309,27 @@ test("includes new test metric rows for script profile results", () => {
   };
   writeJson(dir, "current-worker0.json", [
     createResultWithLabel("regular", 100),
-    createResultWithMetrics("profiled", createMetrics(130), profiles),
+    createResultWithTitle(
+      "profiled label",
+      "profiled title",
+      createMetrics(130),
+      profiles,
+    ),
   ]);
 
   const markdown = runCompare(dir);
 
   expect(markdown).toContain("### New tests (no baseline)");
   expect(markdown).toContain("| Test | Scripting | Rendering | INP | Total |");
-  expect(markdown).toContain("| regular | 100.0ms | 0.0ms | 0.0ms | 100.0ms |");
+  expect(markdown).toContain("| regular | 100ms | 0ms | 0ms | 100ms |");
   expect(markdown).toContain(
-    "| profiled | 130.0ms | 0.0ms | 0.0ms | 130.0ms |",
+    "| [profiled title](#script-profile-profiled-title) | 130ms | 0ms | 0ms | 130ms |",
   );
-  expect(markdown).toContain("#### profiled");
-  expect(markdown).toContain("#### Script profile");
-  expect(markdown).toContain("| `profiledFn` | 8.0ms | 8.0ms | 1 |");
+  expect(markdown).toContain(`<a id="script-profile-profiled-title"></a>`);
+  expect(markdown).toContain("#### profiled title");
+  expect(markdown).not.toContain("#### profiled label");
+  expect(markdown).not.toContain("#### Script profile");
+  expect(markdown).toContain("| `profiledFn` | 8ms | 8ms | 1 |");
 });
 
 test("omits new test metric rows for profile-only results", () => {
@@ -1281,12 +1353,12 @@ test("omits new test metric rows for profile-only results", () => {
 
   expect(markdown).toContain("### New tests (no baseline)");
   expect(markdown).toContain("| Test | Scripting | Rendering | INP | Total |");
-  expect(markdown).toContain("| regular | 100.0ms | 0.0ms | 0.0ms | 100.0ms |");
-  expect(markdown).toContain("#### selector-profiled");
-  expect(markdown).toContain("#### Selector profile");
-  expect(markdown).toContain("| .item | 8.0ms | 10 | 2 | 20% |");
+  expect(markdown).toContain("| regular | 100ms | 0ms | 0ms | 100ms |");
+  expect(markdown).toMatch(/^#### selector-profiled$/m);
+  expect(markdown).toMatch(/^##### Selector profile$/m);
+  expect(markdown).toContain("| .item | 8ms | 10 | 2 | 20% |");
   expect(markdown).not.toContain(
-    "| selector-profiled | 130.0ms | 0.0ms | 0.0ms | 130.0ms |",
+    "| selector-profiled | 130ms | 0ms | 0ms | 130ms |",
   );
 });
 
@@ -1306,14 +1378,12 @@ test("omits new test metric rows for explicit profile-only results", () => {
 
   expect(markdown).toContain("### New tests (no baseline)");
   expect(markdown).toContain("#### profiled");
-  expect(markdown).toContain("#### Script profile");
-  expect(markdown).toContain("| `profiledFn` | 8.0ms | 8.0ms | 1 |");
+  expect(markdown).not.toContain("#### Script profile");
+  expect(markdown).toContain("| `profiledFn` | 8ms | 8ms | 1 |");
   expect(markdown).not.toContain(
     "| Test | Scripting | Rendering | INP | Total |",
   );
-  expect(markdown).not.toContain(
-    "| profiled | 130.0ms | 0.0ms | 0.0ms | 130.0ms |",
-  );
+  expect(markdown).not.toContain("| profiled | 130ms | 0ms | 0ms | 130ms |");
 });
 
 test("ignores profile-only rounds in metric comparisons", () => {
@@ -1340,11 +1410,12 @@ test("ignores profile-only rounds in metric comparisons", () => {
   const markdown = runCompare(dir);
 
   expect(markdown).toContain(
-    "| Total | 100.0ms | 130.0ms | +30.0ms (+30%) :warning: |",
+    "| [profiled](#script-profile-profiled) | 100ms → 130ms (+30%) :warning:",
   );
-  expect(markdown).toContain("#### Script profile");
-  expect(markdown).toContain("| `profiledFn` | 8.0ms | 8.0ms | 1 |");
-  expect(markdown).not.toContain("300.0ms");
+  expect(markdown).toContain("#### profiled");
+  expect(markdown).not.toContain("#### Script profile");
+  expect(markdown).toContain("| `profiledFn` | 8ms | 8ms | 1 |");
+  expect(markdown).not.toContain("300ms");
 });
 
 test("reports tests with no non-profile paired rounds as unpaired", () => {
@@ -1405,11 +1476,11 @@ test("compares metrics when only one side has attached profile data", () => {
 
   const markdown = runCompare(dir);
 
-  expect(markdown).toContain("### profiled");
   expect(markdown).toContain(
-    "| Total | 100.0ms | 130.0ms | +30.0ms (+30%) :warning: |",
+    "| [profiled](#script-profile-profiled) | 100ms → 130ms (+30%) :warning:",
   );
-  expect(markdown).toContain("| `currentProfile` | 8.0ms | 8.0ms | 1 |");
+  expect(markdown).toContain("#### profiled");
+  expect(markdown).toContain("| `currentProfile` | 8ms | 8ms | 1 |");
   expect(markdown).not.toContain("Profile mode differs between baseline");
 });
 
@@ -1437,9 +1508,9 @@ test("omits metric tables when only current has script profile mode", () => {
   expect(markdown).toContain("Profile mode differs between baseline");
   expect(markdown).toContain("| profile-mismatch | script | no | yes |");
   expect(markdown).toContain("No significant performance changes detected.");
-  expect(markdown).toContain("| `currentProfile` | 8.0ms | 8.0ms | 1 |");
+  expect(markdown).toContain("| `currentProfile` | 8ms | 8ms | 1 |");
   expect(markdown).not.toContain("| Metric | Baseline | Current | Delta |");
-  expect(markdown).not.toContain("+30.0ms (+30%)");
+  expect(markdown).not.toContain("+30ms (+30%)");
 });
 
 test("omits metric tables when script profile has no retained entries", () => {
@@ -1461,7 +1532,7 @@ test("omits metric tables when script profile has no retained entries", () => {
   expect(markdown).toContain("No significant performance changes detected.");
   expect(markdown).not.toContain("### profile-mismatch");
   expect(markdown).not.toContain("| Metric | Baseline | Current | Delta |");
-  expect(markdown).not.toContain("+30.0ms (+30%)");
+  expect(markdown).not.toContain("+30ms (+30%)");
 });
 
 test("omits metric tables when selector profile has no retained entries", () => {
@@ -1483,7 +1554,7 @@ test("omits metric tables when selector profile has no retained entries", () => 
   expect(markdown).toContain("No significant performance changes detected.");
   expect(markdown).not.toContain("### profile-mismatch");
   expect(markdown).not.toContain("| Metric | Baseline | Current | Delta |");
-  expect(markdown).not.toContain("+30.0ms (+30%)");
+  expect(markdown).not.toContain("+30ms (+30%)");
 });
 
 test("omits metric tables for profile-only comparisons", () => {
@@ -1515,9 +1586,9 @@ test("omits metric tables for profile-only comparisons", () => {
   const markdown = runCompare(dir);
 
   expect(markdown).toContain("No significant performance changes detected.");
-  expect(markdown).toContain("### selector-profiled");
-  expect(markdown).toContain("#### Selector profile");
-  expect(markdown).toContain("| .item | 8.0ms | 10 | 2 | 20% |");
+  expect(markdown).toMatch(/^#### selector-profiled$/m);
+  expect(markdown).toMatch(/^##### Selector profile$/m);
+  expect(markdown).toContain("| .item | 8ms | 10 | 2 | 20% |");
   expect(markdown).not.toContain("| Metric | Baseline | Current | Delta |");
-  expect(markdown).not.toContain("+30.0ms (+30%)");
+  expect(markdown).not.toContain("+30ms (+30%)");
 });

--- a/packages/ariakit-scripts/src/perf-compare.test.ts
+++ b/packages/ariakit-scripts/src/perf-compare.test.ts
@@ -140,6 +140,19 @@ function createResultWithTitle(
   };
 }
 
+function createFileResultWithTitle(
+  testFile: string,
+  label: string,
+  testTitle: string,
+  metrics: PerfMetrics,
+  profiles?: PerfProfiles,
+): PerfResult {
+  return {
+    ...createResultWithTitle(label, testTitle, metrics, profiles),
+    testFile,
+  };
+}
+
 function createScriptProfileEntry(
   functionName: string,
   selfTime: number,
@@ -1196,16 +1209,15 @@ test("keeps node_modules script profile functions as unlinked code", () => {
 
 test("renders script profiles below comparison tables", () => {
   const dir = createTempDir();
-  const label = "custom label";
   const testTitle = "ariakit-tailwind > react > page load";
   const profiles: PerfProfiles = {
     script: [createScriptProfileEntry("profiledFn", 8)],
   };
   writeJson(dir, "baseline-worker0.json", [
-    createResultWithTitle(label, testTitle, createMetrics(100), profiles),
+    createResultWithTitle(testTitle, testTitle, createMetrics(100), profiles),
   ]);
   writeJson(dir, "current-worker0.json", [
-    createResultWithTitle(label, testTitle, createMetrics(130), profiles),
+    createResultWithTitle(testTitle, testTitle, createMetrics(130), profiles),
   ]);
 
   const markdown = runCompare(dir);
@@ -1222,8 +1234,59 @@ test("renders script profiles below comparison tables", () => {
   expect(comparisonIndex).toBeGreaterThan(-1);
   expect(profileIndex).toBeGreaterThan(comparisonIndex);
   expect(markdown).toContain("| `profiledFn` | 8ms | 8ms | 1 |");
-  expect(markdown).not.toContain("#### custom label");
   expect(markdown).not.toContain("#### Script profile");
+});
+
+test("includes custom labels when test titles are shared", () => {
+  const dir = createTempDir();
+  const testTitle = "combobox-perf > react > open combobox";
+  const profiles: PerfProfiles = {
+    script: [createScriptProfileEntry("profiledFn", 8)],
+  };
+  writeJson(dir, "baseline-worker0.json", [
+    createResultWithTitle(
+      "open with mouse",
+      testTitle,
+      createMetrics(100),
+      profiles,
+    ),
+    createResultWithTitle(
+      "open with keyboard",
+      testTitle,
+      createMetrics(100),
+      profiles,
+    ),
+  ]);
+  writeJson(dir, "current-worker0.json", [
+    createResultWithTitle(
+      "open with mouse",
+      testTitle,
+      createMetrics(130),
+      profiles,
+    ),
+    createResultWithTitle(
+      "open with keyboard",
+      testTitle,
+      createMetrics(120),
+      profiles,
+    ),
+  ]);
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain(
+    "| [combobox-perf > react > open combobox > open with mouse](#user-content-script-profile-combobox-perf-react-open-combobox-open-with-mouse) | 100ms → 130ms (+30%) :warning:",
+  );
+  expect(markdown).toContain(
+    "| [combobox-perf > react > open combobox > open with keyboard](#user-content-script-profile-combobox-perf-react-open-combobox-open-with-keyboard) | 100ms → 120ms (+20%) :warning:",
+  );
+  expect(markdown).toContain(
+    "#### combobox-perf > react > open combobox > open with mouse",
+  );
+  expect(markdown).toContain(
+    "#### combobox-perf > react > open combobox > open with keyboard",
+  );
+  expect(markdown).not.toContain("| [combobox-perf > react > open combobox](#");
 });
 
 test("merges script profile rows into base comparisons", () => {
@@ -1265,40 +1328,46 @@ test("escapes and disambiguates script profile anchors", () => {
     script: [createScriptProfileEntry("profiledFn", 8)],
   };
   writeJson(dir, "baseline-worker0.json", [
-    createResultWithTitle(
-      "first custom label",
+    createFileResultWithTitle(
+      "sandbox/first/perf-chrome.ts",
+      "same [title] | test",
       "same [title] | test",
       createMetrics(100),
       profiles,
     ),
-    createResultWithTitle(
-      "second custom label",
+    createFileResultWithTitle(
+      "sandbox/second/perf-chrome.ts",
+      "same title test",
       "same title test",
       createMetrics(100),
       profiles,
     ),
-    createResultWithTitle(
-      "third custom label",
+    createFileResultWithTitle(
+      "sandbox/third/perf-chrome.ts",
+      "same title test 2",
       "same title test 2",
       createMetrics(100),
       profiles,
     ),
   ]);
   writeJson(dir, "current-worker0.json", [
-    createResultWithTitle(
-      "first custom label",
+    createFileResultWithTitle(
+      "sandbox/first/perf-chrome.ts",
+      "same [title] | test",
       "same [title] | test",
       createMetrics(130),
       profiles,
     ),
-    createResultWithTitle(
-      "second custom label",
+    createFileResultWithTitle(
+      "sandbox/second/perf-chrome.ts",
+      "same title test",
       "same title test",
       createMetrics(130),
       profiles,
     ),
-    createResultWithTitle(
-      "third custom label",
+    createFileResultWithTitle(
+      "sandbox/third/perf-chrome.ts",
+      "same title test 2",
       "same title test 2",
       createMetrics(130),
       profiles,
@@ -1342,11 +1411,12 @@ test("includes new test metric rows for script profile results", () => {
   expect(markdown).toContain("| Test | Scripting | Rendering | INP | Total |");
   expect(markdown).toContain("| regular | 100ms | 0ms | 0ms | 100ms |");
   expect(markdown).toContain(
-    "| [profiled title](#user-content-script-profile-profiled-title) | 130ms | 0ms | 0ms | 130ms |",
+    "| [profiled title > profiled label](#user-content-script-profile-profiled-title-profiled-label) | 130ms | 0ms | 0ms | 130ms |",
   );
-  expect(markdown).toContain(`<a id="script-profile-profiled-title"></a>`);
-  expect(markdown).toContain("#### profiled title");
-  expect(markdown).not.toContain("#### profiled label");
+  expect(markdown).toContain(
+    `<a id="script-profile-profiled-title-profiled-label"></a>`,
+  );
+  expect(markdown).toContain("#### profiled title > profiled label");
   expect(markdown).not.toContain("#### Script profile");
   expect(markdown).toContain("| `profiledFn` | 8ms | 8ms | 1 |");
 });

--- a/packages/ariakit-scripts/src/perf-compare.test.ts
+++ b/packages/ariakit-scripts/src/perf-compare.test.ts
@@ -1226,53 +1226,6 @@ test("renders script profiles below comparison tables", () => {
   expect(markdown).not.toContain("#### Script profile");
 });
 
-test("groups detailed comparison rows by shared title prefix", () => {
-  const dir = createTempDir();
-  const profiles: PerfProfiles = {
-    script: [createScriptProfileEntry("profiledFn", 8)],
-  };
-  writeJson(dir, "baseline-worker0.json", [
-    createResultWithTitle(
-      "mount label",
-      "composite-perf > react > mount composite",
-      createMetrics(100),
-      profiles,
-    ),
-    createResultWithTitle(
-      "move label",
-      "composite-perf > react > move across items",
-      createMetrics(100),
-    ),
-  ]);
-  writeJson(dir, "current-worker0.json", [
-    createResultWithTitle(
-      "mount label",
-      "composite-perf > react > mount composite",
-      createMetrics(130),
-      profiles,
-    ),
-    createResultWithTitle(
-      "move label",
-      "composite-perf > react > move across items",
-      createMetrics(120),
-    ),
-  ]);
-
-  const markdown = runCompare(dir);
-
-  expect(markdown).toContain("| **composite-perf > react** |  |  |  |  |");
-  expect(markdown).toContain(
-    "| [mount composite](#user-content-script-profile-composite-perf-react-mount-composite) | 100ms → 130ms (+30%) :warning:",
-  );
-  expect(markdown).toContain(
-    "| move across items | 100ms → 120ms (+20%) :warning:",
-  );
-  expect(markdown).toContain("#### composite-perf > react > mount composite");
-  expect(markdown).not.toContain(
-    "| composite-perf > react > move across items |",
-  );
-});
-
 test("merges script profile rows into base comparisons", () => {
   const dir = createTempDir();
   const profiles: PerfProfiles = {

--- a/packages/ariakit-scripts/src/perf-compare.test.ts
+++ b/packages/ariakit-scripts/src/perf-compare.test.ts
@@ -107,6 +107,18 @@ function createResultWithRaw(label: string, totals: number[]): PerfResult {
   };
 }
 
+function createResultWithTitleRaw(
+  label: string,
+  testTitle: string,
+  totals: number[],
+): PerfResult {
+  const metrics = createMetrics(medianValue(totals));
+  return {
+    ...createResultWithTitle(label, testTitle, metrics),
+    raw: totals.map(createMetrics),
+  };
+}
+
 function createResultWithLabel(label: string, total: number): PerfResult {
   return {
     ...createResult(total),
@@ -548,6 +560,34 @@ test("reports overlapping same-direction rounds as unconfirmed candidates", () =
   expect(markdown).not.toContain("Unflagged threshold-sized changes");
   expect(markdown).not.toMatch(/% :warning:/);
   expect(markdown).not.toMatch(/% :rocket:/);
+});
+
+test("includes custom labels in unconfirmed candidate rows", () => {
+  const dir = createTempDir();
+  const testTitle = "combobox-perf > react > open combobox";
+  for (const round of [1, 2]) {
+    writeJson(dir, `baseline-${round}-worker0.json`, [
+      createResultWithTitleRaw(
+        "open with mouse",
+        testTitle,
+        [80, 100, 120, 140, 160],
+      ),
+    ]);
+    writeJson(dir, `current-${round}-worker0.json`, [
+      createResultWithTitleRaw(
+        "open with mouse",
+        testTitle,
+        [100, 120, 140, 160, 180],
+      ),
+    ]);
+  }
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain(
+    "| combobox-perf > react > open combobox > open with mouse | Scripting | 120ms | 140ms | +20ms (+17%) | low | rounds 2/2, raw 0/2, pairs 60% |",
+  );
+  expect(markdown).not.toContain("| open with mouse | Scripting |");
 });
 
 test("grades candidates by their displayed pairs percent", () => {
@@ -1275,6 +1315,12 @@ test("includes custom labels when test titles are shared", () => {
   const markdown = runCompare(dir);
 
   expect(markdown).toContain(
+    "| combobox-perf > react > open combobox > open with mouse | 100ms → 130ms (+30%) :warning:",
+  );
+  expect(markdown).toContain(
+    "| combobox-perf > react > open combobox > open with keyboard | 100ms → 120ms (+20%) :warning:",
+  );
+  expect(markdown).toContain(
     "| [combobox-perf > react > open combobox > open with mouse](#user-content-script-profile-combobox-perf-react-open-combobox-open-with-mouse) | 100ms → 130ms (+30%) :warning:",
   );
   expect(markdown).toContain(
@@ -1286,6 +1332,8 @@ test("includes custom labels when test titles are shared", () => {
   expect(markdown).toContain(
     "#### combobox-perf > react > open combobox > open with keyboard",
   );
+  expect(markdown).not.toContain("| open with mouse |");
+  expect(markdown).not.toContain("| open with keyboard |");
   expect(markdown).not.toContain("| [combobox-perf > react > open combobox](#");
 });
 

--- a/packages/ariakit-scripts/src/perf-compare.test.ts
+++ b/packages/ariakit-scripts/src/perf-compare.test.ts
@@ -1210,7 +1210,7 @@ test("renders script profiles below comparison tables", () => {
 
   const markdown = runCompare(dir);
   const comparisonIndex = markdown.indexOf(
-    "| [ariakit-tailwind > react > page load](#script-profile-ariakit-tailwind-react-page-load) | 100ms → 130ms (+30%) :warning:",
+    "| [ariakit-tailwind > react > page load](#user-content-script-profile-ariakit-tailwind-react-page-load) | 100ms → 130ms (+30%) :warning:",
   );
   const profileIndex = markdown.indexOf(
     "#### ariakit-tailwind > react > page load",
@@ -1224,6 +1224,53 @@ test("renders script profiles below comparison tables", () => {
   expect(markdown).toContain("| `profiledFn` | 8ms | 8ms | 1 |");
   expect(markdown).not.toContain("#### custom label");
   expect(markdown).not.toContain("#### Script profile");
+});
+
+test("groups detailed comparison rows by shared title prefix", () => {
+  const dir = createTempDir();
+  const profiles: PerfProfiles = {
+    script: [createScriptProfileEntry("profiledFn", 8)],
+  };
+  writeJson(dir, "baseline-worker0.json", [
+    createResultWithTitle(
+      "mount label",
+      "composite-perf > react > mount composite",
+      createMetrics(100),
+      profiles,
+    ),
+    createResultWithTitle(
+      "move label",
+      "composite-perf > react > move across items",
+      createMetrics(100),
+    ),
+  ]);
+  writeJson(dir, "current-worker0.json", [
+    createResultWithTitle(
+      "mount label",
+      "composite-perf > react > mount composite",
+      createMetrics(130),
+      profiles,
+    ),
+    createResultWithTitle(
+      "move label",
+      "composite-perf > react > move across items",
+      createMetrics(120),
+    ),
+  ]);
+
+  const markdown = runCompare(dir);
+
+  expect(markdown).toContain("| **composite-perf > react** |  |  |  |  |");
+  expect(markdown).toContain(
+    "| [mount composite](#user-content-script-profile-composite-perf-react-mount-composite) | 100ms → 130ms (+30%) :warning:",
+  );
+  expect(markdown).toContain(
+    "| move across items | 100ms → 120ms (+20%) :warning:",
+  );
+  expect(markdown).toContain("#### composite-perf > react > mount composite");
+  expect(markdown).not.toContain(
+    "| composite-perf > react > move across items |",
+  );
 });
 
 test("merges script profile rows into base comparisons", () => {
@@ -1249,7 +1296,7 @@ test("merges script profile rows into base comparisons", () => {
   const markdown = runCompare(dir);
 
   expect(markdown).toContain(
-    "| [profiled](#script-profile-profiled) | 100ms → 130ms (+30%) :warning:",
+    "| [profiled](#user-content-script-profile-profiled) | 100ms → 130ms (+30%) :warning:",
   );
   expect(markdown).toContain(`<a id="script-profile-profiled"></a>`);
   expect(markdown).toContain("#### profiled");
@@ -1308,13 +1355,13 @@ test("escapes and disambiguates script profile anchors", () => {
   const markdown = runCompare(dir);
 
   expect(markdown).toContain(
-    "| [same \\[title\\] \\| test](#script-profile-same-title-test) |",
+    "| [same \\[title\\] \\| test](#user-content-script-profile-same-title-test) |",
   );
   expect(markdown).toContain(
-    "| [same title test](#script-profile-same-title-test-2) |",
+    "| [same title test](#user-content-script-profile-same-title-test-2) |",
   );
   expect(markdown).toContain(
-    "| [same title test 2](#script-profile-same-title-test-2-2) |",
+    "| [same title test 2](#user-content-script-profile-same-title-test-2-2) |",
   );
   expect(markdown).toContain(`<a id="script-profile-same-title-test"></a>`);
   expect(markdown).toContain(`<a id="script-profile-same-title-test-2"></a>`);
@@ -1342,7 +1389,7 @@ test("includes new test metric rows for script profile results", () => {
   expect(markdown).toContain("| Test | Scripting | Rendering | INP | Total |");
   expect(markdown).toContain("| regular | 100ms | 0ms | 0ms | 100ms |");
   expect(markdown).toContain(
-    "| [profiled title](#script-profile-profiled-title) | 130ms | 0ms | 0ms | 130ms |",
+    "| [profiled title](#user-content-script-profile-profiled-title) | 130ms | 0ms | 0ms | 130ms |",
   );
   expect(markdown).toContain(`<a id="script-profile-profiled-title"></a>`);
   expect(markdown).toContain("#### profiled title");
@@ -1429,7 +1476,7 @@ test("ignores profile-only rounds in metric comparisons", () => {
   const markdown = runCompare(dir);
 
   expect(markdown).toContain(
-    "| [profiled](#script-profile-profiled) | 100ms → 130ms (+30%) :warning:",
+    "| [profiled](#user-content-script-profile-profiled) | 100ms → 130ms (+30%) :warning:",
   );
   expect(markdown).toContain("#### profiled");
   expect(markdown).not.toContain("#### Script profile");
@@ -1496,7 +1543,7 @@ test("compares metrics when only one side has attached profile data", () => {
   const markdown = runCompare(dir);
 
   expect(markdown).toContain(
-    "| [profiled](#script-profile-profiled) | 100ms → 130ms (+30%) :warning:",
+    "| [profiled](#user-content-script-profile-profiled) | 100ms → 130ms (+30%) :warning:",
   );
   expect(markdown).toContain("#### profiled");
   expect(markdown).toContain("| `currentProfile` | 8ms | 8ms | 1 |");

--- a/packages/ariakit-scripts/src/perf-compare.test.ts
+++ b/packages/ariakit-scripts/src/perf-compare.test.ts
@@ -861,6 +861,9 @@ test("requires both rounds to agree in two-round comparisons", () => {
 
   expect(markdown).toContain("No significant performance changes detected.");
   expect(markdown).toContain("100ms → 115ms (+15%)");
+  expect(markdown).toContain(
+    "Unflagged threshold-sized changes for example &gt; react &gt; example:",
+  );
   expect(markdown).not.toMatch(/% :warning:/);
 });
 
@@ -1274,6 +1277,12 @@ test("escapes and disambiguates script profile anchors", () => {
       createMetrics(100),
       profiles,
     ),
+    createResultWithTitle(
+      "third custom label",
+      "same title test 2",
+      createMetrics(100),
+      profiles,
+    ),
   ]);
   writeJson(dir, "current-worker0.json", [
     createResultWithTitle(
@@ -1288,6 +1297,12 @@ test("escapes and disambiguates script profile anchors", () => {
       createMetrics(130),
       profiles,
     ),
+    createResultWithTitle(
+      "third custom label",
+      "same title test 2",
+      createMetrics(130),
+      profiles,
+    ),
   ]);
 
   const markdown = runCompare(dir);
@@ -1298,8 +1313,12 @@ test("escapes and disambiguates script profile anchors", () => {
   expect(markdown).toContain(
     "| [same title test](#script-profile-same-title-test-2) |",
   );
+  expect(markdown).toContain(
+    "| [same title test 2](#script-profile-same-title-test-2-2) |",
+  );
   expect(markdown).toContain(`<a id="script-profile-same-title-test"></a>`);
   expect(markdown).toContain(`<a id="script-profile-same-title-test-2"></a>`);
+  expect(markdown).toContain(`<a id="script-profile-same-title-test-2-2"></a>`);
 });
 
 test("includes new test metric rows for script profile results", () => {

--- a/packages/ariakit-scripts/src/perf-compare.ts
+++ b/packages/ariakit-scripts/src/perf-compare.ts
@@ -1334,8 +1334,17 @@ function formatProfileAnchorSlug(value: string) {
   return slug || "profile";
 }
 
+function getResultDisplayTitle({
+  label,
+  testTitle,
+}: Pick<PerfResult, "label" | "testTitle">) {
+  if (!testTitle) return label;
+  if (!label || label === testTitle) return testTitle;
+  return `${testTitle} > ${label}`;
+}
+
 function getProfileHeading(result: PerfResult) {
-  return result.testTitle || result.label;
+  return getResultDisplayTitle(result);
 }
 
 function createScriptProfileAnchor(heading: string, usedAnchors: Set<string>) {
@@ -1391,7 +1400,7 @@ function formatDetailedComparisonTable({
     if (testRows.length === 0) continue;
     if (testRows.some((row) => row.profileMode)) continue;
 
-    const label = testRows[0]?.testTitle ?? testRows[0]?.label ?? key;
+    const label = testRows[0] ? getResultDisplayTitle(testRows[0]) : key;
     const cells = [
       formatDetailedTestCell(label, scriptProfileAnchors.get(key)),
     ];

--- a/packages/ariakit-scripts/src/perf-compare.ts
+++ b/packages/ariakit-scripts/src/perf-compare.ts
@@ -45,6 +45,7 @@ type MetricKey = keyof PerfMetrics;
 
 interface ComparisonRow {
   testFile: string;
+  testTitle: string;
   label: string;
   metric: MetricKey;
   baseline: number;
@@ -646,7 +647,9 @@ function computeSignificance({
 }
 
 function formatMs(value: number): string {
-  return `${value.toFixed(1)}ms`;
+  const rounded = value.toFixed(1);
+  const normalized = rounded === "-0.0" ? "0.0" : rounded;
+  return `${normalized.replace(/\.0$/, "")}ms`;
 }
 
 function formatOpsPerSecond(value: number) {
@@ -680,6 +683,21 @@ function formatDelta(
   return `${formatMetricValue(delta, options, true)} (${sign}${percent.toFixed(0)}%)`;
 }
 
+function formatComparisonCell(row: ComparisonRow, options: PerfCompareOptions) {
+  let cell = `${formatMetricValue(row.baseline, options)} \u2192 ${formatMetricValue(
+    row.current,
+    options,
+  )}`;
+  cell +=
+    row.baseline === 0
+      ? " (n/a)"
+      : ` (${row.delta >= 0 ? "+" : ""}${row.percent.toFixed(0)}%)`;
+  if (row.significant) {
+    cell += getSignificanceIcon(row, options);
+  }
+  return cell;
+}
+
 function formatPercent(value: number): string {
   return `${value.toFixed(0)}%`;
 }
@@ -690,6 +708,25 @@ function escapeTableCell(value: string): string {
     .replace(/\|/g, "\\|")
     .replace(/[\r\n\t]/g, " ")
     .trim();
+}
+
+function escapeMarkdownLinkText(value: string): string {
+  return escapeTableCell(value).replace(/([[\]])/g, "\\$1");
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function escapeHtmlText(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }
 
 function getGitHubSourceBaseUrl(): string | undefined {
@@ -899,6 +936,7 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
       });
       rows.push({
         testFile: cur.result.testFile,
+        testTitle: cur.result.testTitle,
         label: cur.result.label,
         metric,
         baseline: baseVal,
@@ -1080,18 +1118,7 @@ function formatSummaryTable(
         cells.push("--");
         continue;
       }
-      let cell = `${formatMetricValue(row.baseline, options)} \u2192 ${formatMetricValue(
-        row.current,
-        options,
-      )}`;
-      cell +=
-        row.baseline === 0
-          ? " (n/a)"
-          : ` (${row.delta >= 0 ? "+" : ""}${row.percent.toFixed(0)}%)`;
-      if (row.significant) {
-        cell += getSignificanceIcon(row, options);
-      }
-      cells.push(cell);
+      cells.push(formatComparisonCell(row, options));
     }
     lines.push(`| ${cells.join(" | ")} |`);
   }
@@ -1177,6 +1204,7 @@ function formatCandidateChanges(
 function formatUnflaggedDiagnostics(
   rows: ComparisonRow[],
   options: PerfCompareOptions,
+  label?: string,
 ): string[] {
   const diagnostics = rows.filter((row) => {
     if (row.significant) return false;
@@ -1190,20 +1218,23 @@ function formatUnflaggedDiagnostics(
     const metric = getMetricLabel(row.metric, options);
     return `${metric} (${formatSupport(row, options)})`;
   });
+  const labelPart = label ? ` for ${escapeHtmlText(label)}` : "";
   return [
-    `<sub>Unflagged threshold-sized changes: ${details.join("; ")}.</sub>`,
+    `<sub>Unflagged threshold-sized changes${labelPart}: ${details.join("; ")}.</sub>`,
     "",
   ];
 }
 
-function formatScriptProfile(result: PerfResult): string[] {
+function hasScriptProfile(result: PerfResult | undefined): boolean {
+  return !!result?.profiles?.script?.length;
+}
+
+function formatScriptProfileTable(result: PerfResult): string[] {
   const profile = result.profiles?.script;
   if (!profile) return [];
   if (profile.length === 0) return [];
 
   const lines: string[] = [];
-  lines.push("#### Script profile");
-  lines.push("");
   lines.push("| Function | Self | Total | Hits |");
   lines.push("|----------|------|-------|------|");
 
@@ -1217,14 +1248,12 @@ function formatScriptProfile(result: PerfResult): string[] {
   return lines;
 }
 
-function formatSelectorProfile(result: PerfResult): string[] {
+function formatSelectorProfileTable(result: PerfResult): string[] {
   const profile = result.profiles?.selectors;
   if (!profile) return [];
   if (profile.length === 0) return [];
 
   const lines: string[] = [];
-  lines.push("#### Selector profile");
-  lines.push("");
   lines.push(
     "| Selector | Elapsed | Attempts | Matches | Slow non-match | Stylesheet |",
   );
@@ -1242,9 +1271,30 @@ function formatSelectorProfile(result: PerfResult): string[] {
   return lines;
 }
 
-function formatProfiles(result?: PerfResult): string[] {
+function formatProfileSection(
+  result: PerfResult | undefined,
+  heading: string,
+  anchor?: string,
+): string[] {
   if (!result) return [];
-  return [...formatScriptProfile(result), ...formatSelectorProfile(result)];
+  const scriptProfile = formatScriptProfileTable(result);
+  const selectorProfile = formatSelectorProfileTable(result);
+  if (scriptProfile.length === 0 && selectorProfile.length === 0) return [];
+
+  const lines: string[] = [];
+  if (anchor) {
+    lines.push(`<a id="${escapeHtmlAttribute(anchor)}"></a>`);
+    lines.push("");
+  }
+  lines.push(`#### ${heading}`);
+  lines.push("");
+  lines.push(...scriptProfile);
+  if (selectorProfile.length > 0) {
+    lines.push("##### Selector profile");
+    lines.push("");
+    lines.push(...selectorProfile);
+  }
+  return lines;
 }
 
 function formatProfileModeWarning(mismatches: ProfileModeMismatch[]): string[] {
@@ -1270,49 +1320,151 @@ interface FormatDetailedBreakdownParams {
   rowsByKey: Map<string, ComparisonRow[]>;
   keys: string[];
   currentByKey: Map<string, AggregatedPerfResult>;
+  scriptProfileAnchors: Map<string, string>;
   options: PerfCompareOptions;
+}
+
+interface FormatDetailedComparisonTableParams {
+  rowsByKey: Map<string, ComparisonRow[]>;
+  keys: string[];
+  scriptProfileAnchors: Map<string, string>;
+  options: PerfCompareOptions;
+}
+
+function formatProfileAnchorSlug(value: string) {
+  const slug = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "profile";
+}
+
+function getProfileHeading(result: PerfResult) {
+  return result.testTitle || result.label;
+}
+
+function createScriptProfileAnchor(
+  heading: string,
+  usedAnchors: Map<string, number>,
+) {
+  const baseAnchor = `script-profile-${formatProfileAnchorSlug(heading)}`;
+  const count = usedAnchors.get(baseAnchor) ?? 0;
+  usedAnchors.set(baseAnchor, count + 1);
+  return count === 0 ? baseAnchor : `${baseAnchor}-${count + 1}`;
+}
+
+function createScriptProfileAnchors(
+  keys: string[],
+  currentByKey: Map<string, AggregatedPerfResult>,
+  usedAnchors: Map<string, number>,
+) {
+  const anchors = new Map<string, string>();
+  for (const key of keys) {
+    const result = currentByKey.get(key)?.result;
+    if (!result) continue;
+    if (!hasScriptProfile(result)) continue;
+    anchors.set(
+      key,
+      createScriptProfileAnchor(getProfileHeading(result), usedAnchors),
+    );
+  }
+  return anchors;
+}
+
+function createResultScriptProfileAnchors(
+  results: AggregatedPerfResult[],
+  usedAnchors: Map<string, number>,
+) {
+  const anchors = new Map<string, string>();
+  for (const { key, result } of results) {
+    if (!hasScriptProfile(result)) continue;
+    anchors.set(
+      key,
+      createScriptProfileAnchor(getProfileHeading(result), usedAnchors),
+    );
+  }
+  return anchors;
+}
+
+function formatDetailedTestCell(label: string, anchor?: string) {
+  if (!anchor) return escapeTableCell(label);
+  return `[${escapeMarkdownLinkText(label)}](#${anchor})`;
+}
+
+function formatDetailedComparisonTable({
+  rowsByKey,
+  keys,
+  scriptProfileAnchors,
+  options,
+}: FormatDetailedComparisonTableParams): string[] {
+  const primaryMetrics = getPrimaryMetrics(options);
+  const headers = [
+    getResultName(options),
+    ...primaryMetrics.map((metric) => getMetricLabel(metric, options)),
+  ];
+  const tableRows: string[] = [];
+  const diagnostics: string[] = [];
+
+  for (const key of keys) {
+    const testRows = rowsByKey.get(key) ?? [];
+    if (testRows.length === 0) continue;
+    if (testRows.some((row) => row.profileMode)) continue;
+
+    const label = testRows[0]?.testTitle ?? testRows[0]?.label ?? key;
+    const cells = [
+      formatDetailedTestCell(label, scriptProfileAnchors.get(key)),
+    ];
+    for (const metric of primaryMetrics) {
+      const row = testRows.find((r) => r.metric === metric);
+      cells.push(row ? formatComparisonCell(row, options) : "--");
+    }
+    tableRows.push(`| ${cells.join(" | ")} |`);
+    diagnostics.push(...formatUnflaggedDiagnostics(testRows, options, label));
+  }
+
+  if (tableRows.length === 0) return [];
+
+  const lines: string[] = [];
+  lines.push(`| ${headers.join(" | ")} |`);
+  lines.push(`| ${headers.map(() => "---").join(" | ")} |`);
+  lines.push(...tableRows);
+  lines.push("");
+  lines.push(...diagnostics);
+  return lines;
 }
 
 function formatDetailedBreakdown({
   rowsByKey,
   keys,
   currentByKey,
+  scriptProfileAnchors,
   options,
 }: FormatDetailedBreakdownParams): string[] {
   if (options.node) {
     return formatNodeComparisonTables(rowsByKey, keys, options);
   }
   const lines: string[] = [];
-  const primaryMetrics = getPrimaryMetrics(options);
+  lines.push(
+    ...formatDetailedComparisonTable({
+      rowsByKey,
+      keys,
+      scriptProfileAnchors,
+      options,
+    }),
+  );
   for (const key of keys) {
     const testRows = rowsByKey.get(key) ?? [];
-    const label = testRows[0]?.label ?? key;
     const currentResult = currentByKey.get(key)?.result;
-    const profileMode = testRows.some((row) => row.profileMode);
-    const profileLines = formatProfiles(currentResult);
-    if (profileMode && profileLines.length === 0) continue;
-    lines.push(`### ${label}`);
-    lines.push("");
-    if (!profileMode) {
-      lines.push("| Metric | Baseline | Current | Delta |");
-      lines.push("|--------|----------|---------|-------|");
-      for (const metric of primaryMetrics) {
-        const row = testRows.find((r) => r.metric === metric);
-        if (!row) continue;
-        const deltaStr = formatDelta(
-          row.delta,
-          row.percent,
-          row.baseline,
-          options,
-        );
-        const icon = getSignificanceIcon(row, options);
-        lines.push(
-          `| ${getMetricLabel(metric, options)} | ${formatMetricValue(row.baseline, options)} | ${formatMetricValue(row.current, options)} | ${deltaStr}${icon} |`,
-        );
-      }
-      lines.push("");
-      lines.push(...formatUnflaggedDiagnostics(testRows, options));
-    }
+    const label =
+      currentResult != null
+        ? getProfileHeading(currentResult)
+        : (testRows[0]?.testTitle ?? testRows[0]?.label ?? key);
+    const profileLines = formatProfileSection(
+      currentResult,
+      label,
+      scriptProfileAnchors.get(key),
+    );
+    if (profileLines.length === 0) continue;
     lines.push(...profileLines);
   }
   return lines;
@@ -1344,6 +1496,16 @@ function formatMarkdown(
     const testRows = rowsByKey.get(key);
     return testRows?.some((row) => row.significant) ?? false;
   });
+  const usedScriptProfileAnchors = new Map<string, number>();
+  const scriptProfileAnchors = createScriptProfileAnchors(
+    allKeys,
+    currentByKey,
+    usedScriptProfileAnchors,
+  );
+  const newTestScriptProfileAnchors = createResultScriptProfileAnchors(
+    newTests,
+    usedScriptProfileAnchors,
+  );
 
   const totalTests =
     allKeys.length +
@@ -1410,6 +1572,7 @@ function formatMarkdown(
       rowsByKey,
       keys: allKeys,
       currentByKey,
+      scriptProfileAnchors,
       options,
     }),
   );
@@ -1430,8 +1593,14 @@ function formatMarkdown(
       ];
       lines.push(`| ${headers.join(" | ")} |`);
       lines.push(`| ${headers.map(() => "---").join(" | ")} |`);
-      for (const { result } of newTestsWithMetrics) {
-        const cells: string[] = [result.label];
+      for (const entry of newTestsWithMetrics) {
+        const { result } = entry;
+        const cells: string[] = [
+          formatDetailedTestCell(
+            getProfileHeading(result),
+            newTestScriptProfileAnchors.get(entry.key),
+          ),
+        ];
         for (const metric of primaryMetrics) {
           cells.push(formatMetricValue(result.metrics[metric], options));
         }
@@ -1440,11 +1609,14 @@ function formatMarkdown(
       lines.push("");
     }
 
-    for (const { result } of newTests) {
-      const profileLines = formatProfiles(result);
+    for (const entry of newTests) {
+      const { result } = entry;
+      const profileLines = formatProfileSection(
+        result,
+        getProfileHeading(result),
+        newTestScriptProfileAnchors.get(entry.key),
+      );
       if (profileLines.length === 0) continue;
-      lines.push(`#### ${result.label}`);
-      lines.push("");
       lines.push(...profileLines);
     }
   }

--- a/packages/ariakit-scripts/src/perf-compare.ts
+++ b/packages/ariakit-scripts/src/perf-compare.ts
@@ -1363,9 +1363,57 @@ function createResultScriptProfileAnchors(
   return anchors;
 }
 
+function getGitHubAnchorHref(anchor: string) {
+  return `#user-content-${anchor}`;
+}
+
 function formatDetailedTestCell(label: string, anchor?: string) {
   if (!anchor) return escapeTableCell(label);
-  return `[${escapeLinkText(label)}](#${anchor})`;
+  return `[${escapeLinkText(label)}](${getGitHubAnchorHref(anchor)})`;
+}
+
+interface DetailedTestTitle {
+  group?: string;
+  title: string;
+}
+
+function splitDetailedTestTitle(title: string): DetailedTestTitle {
+  const separator = " > ";
+  const separatorIndex = title.lastIndexOf(separator);
+  if (separatorIndex <= 0) return { title };
+
+  const group = title.slice(0, separatorIndex);
+  const shortTitle = title.slice(separatorIndex + separator.length);
+  if (!group || !shortTitle) return { title };
+  return { group, title: shortTitle };
+}
+
+function getDetailedComparisonLabel(
+  key: string,
+  rows: ComparisonRow[],
+): string {
+  return rows[0]?.testTitle ?? rows[0]?.label ?? key;
+}
+
+function getDetailedComparisonGroups(
+  rowsByKey: Map<string, ComparisonRow[]>,
+  keys: string[],
+) {
+  const counts = new Map<string, number>();
+  for (const key of keys) {
+    const rows = rowsByKey.get(key) ?? [];
+    if (rows.length === 0) continue;
+    if (rows.some((row) => row.profileMode)) continue;
+
+    const label = getDetailedComparisonLabel(key, rows);
+    const { group } = splitDetailedTestTitle(label);
+    if (!group) continue;
+
+    counts.set(group, (counts.get(group) ?? 0) + 1);
+  }
+  return new Set(
+    [...counts].filter(([, count]) => count > 1).map(([group]) => group),
+  );
 }
 
 function formatDetailedComparisonTable({
@@ -1381,15 +1429,36 @@ function formatDetailedComparisonTable({
   ];
   const tableRows: string[] = [];
   const diagnostics: string[] = [];
+  const groupedTitles = getDetailedComparisonGroups(rowsByKey, keys);
+  let currentGroup: string | undefined;
 
   for (const key of keys) {
     const testRows = rowsByKey.get(key) ?? [];
     if (testRows.length === 0) continue;
     if (testRows.some((row) => row.profileMode)) continue;
 
-    const label = testRows[0]?.testTitle ?? testRows[0]?.label ?? key;
+    const label = getDetailedComparisonLabel(key, testRows);
+    const title = splitDetailedTestTitle(label);
+    const group =
+      title.group && groupedTitles.has(title.group) ? title.group : undefined;
+    if (group) {
+      if (group !== currentGroup) {
+        const cells = [
+          `**${escapeTableCell(group)}**`,
+          ...primaryMetrics.map(() => ""),
+        ];
+        tableRows.push(`| ${cells.join(" | ")} |`);
+        currentGroup = group;
+      }
+    } else {
+      currentGroup = undefined;
+    }
+
     const cells = [
-      formatDetailedTestCell(label, scriptProfileAnchors.get(key)),
+      formatDetailedTestCell(
+        group ? title.title : label,
+        scriptProfileAnchors.get(key),
+      ),
     ];
     for (const metric of primaryMetrics) {
       const row = testRows.find((r) => r.metric === metric);

--- a/packages/ariakit-scripts/src/perf-compare.ts
+++ b/packages/ariakit-scripts/src/perf-compare.ts
@@ -710,10 +710,6 @@ function escapeTableCell(value: string): string {
     .trim();
 }
 
-function escapeMarkdownLinkText(value: string): string {
-  return escapeTableCell(value).replace(/([[\]])/g, "\\$1");
-}
-
 function escapeHtmlAttribute(value: string): string {
   return value
     .replace(/&/g, "&amp;")
@@ -1273,7 +1269,6 @@ function formatSelectorProfileTable(result: PerfResult): string[] {
 
 function formatProfileSection(
   result: PerfResult | undefined,
-  heading: string,
   anchor?: string,
 ): string[] {
   if (!result) return [];
@@ -1286,7 +1281,7 @@ function formatProfileSection(
     lines.push(`<a id="${escapeHtmlAttribute(anchor)}"></a>`);
     lines.push("");
   }
-  lines.push(`#### ${heading}`);
+  lines.push(`#### ${getProfileHeading(result)}`);
   lines.push("");
   lines.push(...scriptProfile);
   if (selectorProfile.length > 0) {
@@ -1343,37 +1338,19 @@ function getProfileHeading(result: PerfResult) {
   return result.testTitle || result.label;
 }
 
-function createScriptProfileAnchor(
-  heading: string,
-  usedAnchors: Map<string, number>,
-) {
+function createScriptProfileAnchor(heading: string, usedAnchors: Set<string>) {
   const baseAnchor = `script-profile-${formatProfileAnchorSlug(heading)}`;
-  const count = usedAnchors.get(baseAnchor) ?? 0;
-  usedAnchors.set(baseAnchor, count + 1);
-  return count === 0 ? baseAnchor : `${baseAnchor}-${count + 1}`;
-}
-
-function createScriptProfileAnchors(
-  keys: string[],
-  currentByKey: Map<string, AggregatedPerfResult>,
-  usedAnchors: Map<string, number>,
-) {
-  const anchors = new Map<string, string>();
-  for (const key of keys) {
-    const result = currentByKey.get(key)?.result;
-    if (!result) continue;
-    if (!hasScriptProfile(result)) continue;
-    anchors.set(
-      key,
-      createScriptProfileAnchor(getProfileHeading(result), usedAnchors),
-    );
+  let anchor = baseAnchor;
+  for (let index = 2; usedAnchors.has(anchor); index += 1) {
+    anchor = `${baseAnchor}-${index}`;
   }
-  return anchors;
+  usedAnchors.add(anchor);
+  return anchor;
 }
 
 function createResultScriptProfileAnchors(
   results: AggregatedPerfResult[],
-  usedAnchors: Map<string, number>,
+  usedAnchors: Set<string>,
 ) {
   const anchors = new Map<string, string>();
   for (const { key, result } of results) {
@@ -1388,7 +1365,7 @@ function createResultScriptProfileAnchors(
 
 function formatDetailedTestCell(label: string, anchor?: string) {
   if (!anchor) return escapeTableCell(label);
-  return `[${escapeMarkdownLinkText(label)}](#${anchor})`;
+  return `[${escapeLinkText(label)}](#${anchor})`;
 }
 
 function formatDetailedComparisonTable({
@@ -1453,15 +1430,8 @@ function formatDetailedBreakdown({
     }),
   );
   for (const key of keys) {
-    const testRows = rowsByKey.get(key) ?? [];
-    const currentResult = currentByKey.get(key)?.result;
-    const label =
-      currentResult != null
-        ? getProfileHeading(currentResult)
-        : (testRows[0]?.testTitle ?? testRows[0]?.label ?? key);
     const profileLines = formatProfileSection(
-      currentResult,
-      label,
+      currentByKey.get(key)?.result,
       scriptProfileAnchors.get(key),
     );
     if (profileLines.length === 0) continue;
@@ -1496,10 +1466,12 @@ function formatMarkdown(
     const testRows = rowsByKey.get(key);
     return testRows?.some((row) => row.significant) ?? false;
   });
-  const usedScriptProfileAnchors = new Map<string, number>();
-  const scriptProfileAnchors = createScriptProfileAnchors(
-    allKeys,
-    currentByKey,
+  const usedScriptProfileAnchors = new Set<string>();
+  const scriptProfileAnchors = createResultScriptProfileAnchors(
+    allKeys.flatMap((key) => {
+      const result = currentByKey.get(key);
+      return result ? [result] : [];
+    }),
     usedScriptProfileAnchors,
   );
   const newTestScriptProfileAnchors = createResultScriptProfileAnchors(
@@ -1613,7 +1585,6 @@ function formatMarkdown(
       const { result } = entry;
       const profileLines = formatProfileSection(
         result,
-        getProfileHeading(result),
         newTestScriptProfileAnchors.get(entry.key),
       );
       if (profileLines.length === 0) continue;

--- a/packages/ariakit-scripts/src/perf-compare.ts
+++ b/packages/ariakit-scripts/src/perf-compare.ts
@@ -1372,50 +1372,6 @@ function formatDetailedTestCell(label: string, anchor?: string) {
   return `[${escapeLinkText(label)}](${getGitHubAnchorHref(anchor)})`;
 }
 
-interface DetailedTestTitle {
-  group?: string;
-  title: string;
-}
-
-function splitDetailedTestTitle(title: string): DetailedTestTitle {
-  const separator = " > ";
-  const separatorIndex = title.lastIndexOf(separator);
-  if (separatorIndex <= 0) return { title };
-
-  const group = title.slice(0, separatorIndex);
-  const shortTitle = title.slice(separatorIndex + separator.length);
-  if (!group || !shortTitle) return { title };
-  return { group, title: shortTitle };
-}
-
-function getDetailedComparisonLabel(
-  key: string,
-  rows: ComparisonRow[],
-): string {
-  return rows[0]?.testTitle ?? rows[0]?.label ?? key;
-}
-
-function getDetailedComparisonGroups(
-  rowsByKey: Map<string, ComparisonRow[]>,
-  keys: string[],
-) {
-  const counts = new Map<string, number>();
-  for (const key of keys) {
-    const rows = rowsByKey.get(key) ?? [];
-    if (rows.length === 0) continue;
-    if (rows.some((row) => row.profileMode)) continue;
-
-    const label = getDetailedComparisonLabel(key, rows);
-    const { group } = splitDetailedTestTitle(label);
-    if (!group) continue;
-
-    counts.set(group, (counts.get(group) ?? 0) + 1);
-  }
-  return new Set(
-    [...counts].filter(([, count]) => count > 1).map(([group]) => group),
-  );
-}
-
 function formatDetailedComparisonTable({
   rowsByKey,
   keys,
@@ -1429,36 +1385,15 @@ function formatDetailedComparisonTable({
   ];
   const tableRows: string[] = [];
   const diagnostics: string[] = [];
-  const groupedTitles = getDetailedComparisonGroups(rowsByKey, keys);
-  let currentGroup: string | undefined;
 
   for (const key of keys) {
     const testRows = rowsByKey.get(key) ?? [];
     if (testRows.length === 0) continue;
     if (testRows.some((row) => row.profileMode)) continue;
 
-    const label = getDetailedComparisonLabel(key, testRows);
-    const title = splitDetailedTestTitle(label);
-    const group =
-      title.group && groupedTitles.has(title.group) ? title.group : undefined;
-    if (group) {
-      if (group !== currentGroup) {
-        const cells = [
-          `**${escapeTableCell(group)}**`,
-          ...primaryMetrics.map(() => ""),
-        ];
-        tableRows.push(`| ${cells.join(" | ")} |`);
-        currentGroup = group;
-      }
-    } else {
-      currentGroup = undefined;
-    }
-
+    const label = testRows[0]?.testTitle ?? testRows[0]?.label ?? key;
     const cells = [
-      formatDetailedTestCell(
-        group ? title.title : label,
-        scriptProfileAnchors.get(key),
-      ),
+      formatDetailedTestCell(label, scriptProfileAnchors.get(key)),
     ];
     for (const metric of primaryMetrics) {
       const row = testRows.find((r) => r.metric === metric);

--- a/packages/ariakit-scripts/src/perf-compare.ts
+++ b/packages/ariakit-scripts/src/perf-compare.ts
@@ -1106,8 +1106,8 @@ function formatSummaryTable(
 
   for (const key of keys) {
     const testRows = rowsByKey.get(key) ?? [];
-    const label = testRows[0]?.label ?? key;
-    const cells: string[] = [label];
+    const label = testRows[0] ? getResultDisplayTitle(testRows[0]) : key;
+    const cells: string[] = [escapeTableCell(label)];
     for (const metric of primaryMetrics) {
       const row = testRows.find((r) => r.metric === metric);
       if (!row) {
@@ -1177,7 +1177,7 @@ function formatCandidateChanges(
   const visibleRows = candidateRows.slice(0, MAX_VISIBLE_CANDIDATE_ROWS);
   for (const row of visibleRows) {
     const cells = [
-      escapeTableCell(row.label),
+      escapeTableCell(getResultDisplayTitle(row)),
       getMetricLabel(row.metric, options),
       formatMetricValue(row.baseline, options),
       formatMetricValue(row.current, options),


### PR DESCRIPTION
## Motivation

The perf report full breakdown currently spends vertical space on one metric table per test, followed by generic `Script profile` headings. Large perf runs become harder to scan because the same four metric headings are repeated for every test.

The compact table also needs links that work in GitHub PR comments. GitHub rewrites custom HTML anchors such as `<a id="script-profile-foo"></a>` to `user-content-*` IDs when rendering comments, so table links must target that rendered fragment.

## Solution

Render the non-node full breakdown as one comparison table, with linked test cells when a script profile exists. Script profile sections now use the same display title as the table row and expose stable generated anchors, while selector profiles remain nested under the test heading.

```md
| Test | Scripting | Rendering | INP | Total |
| --- | --- | --- | --- | --- |
| [composite-perf > react > mount composite](#user-content-script-profile-composite-perf-react-mount-composite) | 100ms → 105ms (+5%) | ... |
| composite-perf > react > move across items | 420ms → 404ms (-4%) | ... |
```

If a performance result has a custom `perf.measure({ label })` that differs from the Playwright test title, the compact breakdown includes both as `testTitle > label` so multiple measurements from one test remain distinguishable. The significant-change summary table and unconfirmed-candidate table use the same display title so prominent regression rows also keep their test context.

GitHub-flavored Markdown tables do not render single-cell group rows as colspan headings in PR comments; they render a first-column cell plus empty cells for the remaining columns. Because of that, this keeps full test titles in the table instead of simulating groups.

This also trims unnecessary `.0` from millisecond values throughout the perf markdown output, so `10.0ms` becomes `10ms` while non-integer values keep their decimal precision.

Additional tests cover title-based profile headings, GitHub-compatible profile links, custom-label disambiguation across compact breakdown, summary, and candidate rows, new-test profile anchors, duplicate anchor disambiguation, markdown-sensitive link text, and the updated compact millisecond formatting.

## Verification

- `pnpm test packages/ariakit-scripts/src/perf-compare.test.ts`
- `pnpm exec oxlint --disable-nested-config packages/ariakit-scripts/src/perf-compare.ts packages/ariakit-scripts/src/perf-compare.test.ts`
- `pnpm exec oxfmt --check packages/ariakit-scripts/src/perf-compare.ts packages/ariakit-scripts/src/perf-compare.test.ts`
- `pnpm tsc`
- Red check: temporarily removed the summary/candidate display-title source fix and confirmed the focused perf comparison test failed on the new assertions, then restored the fix and reran the suite successfully.