### PR TITLE
Fix Combobox Korean IME composition with autoSelect

### DIFF
--- a/.changeset/300-combobox-korean-ime.md
+++ b/.changeset/300-combobox-korean-ime.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Combobox`](https://ariakit.com/reference/combobox) with [`autoSelect`](https://ariakit.com/reference/combobox#autoselect) moving focus between Korean IME composition steps.

--- a/app/src/examples/combobox-group/test.ts
+++ b/app/src/examples/combobox-group/test.ts
@@ -1,4 +1,4 @@
-import { click, dispatch, hover, press, q, type } from "@ariakit/test";
+import { click, dispatch, hover, press, q, sleep, type } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 function getSelectionValue(element: Element | HTMLInputElement | null) {
@@ -115,6 +115,7 @@ test("composition text", async () => {
   expect(q.option("John Smith")).not.toBeInTheDocument();
   await type("á", q.combobox(), { isComposing: true });
   await dispatch.compositionEnd(q.combobox());
+  await sleep();
   expect(q.combobox()).toHaveValue("ánnual_report.pdf");
   expect(getSelectionValue(q.combobox())).toBe("nnual_report.pdf");
   expect(q.option("annual_report.pdf")).toHaveFocus();

--- a/app/src/sandbox/combobox-ime-6663/index.react.tsx
+++ b/app/src/sandbox/combobox-ime-6663/index.react.tsx
@@ -15,6 +15,11 @@ export default function Example() {
         <Ariakit.ComboboxLabel>Fruit</Ariakit.ComboboxLabel>
         <Ariakit.Combobox
           autoSelect
+          onCompositionEnd={(event) => {
+            // TODO: Remove once https://github.com/ariakit/ariakit/issues/6663
+            // is fixed.
+            event.preventDefault();
+          }}
           placeholder="과일을 검색하세요"
           value={keyword}
           onChange={(event) => setKeyword(event.target.value)}

--- a/app/src/sandbox/combobox-ime-6663/index.react.tsx
+++ b/app/src/sandbox/combobox-ime-6663/index.react.tsx
@@ -1,0 +1,30 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+
+const fruits = ["사과", "바나나", "체리", "레몬", "오렌지"];
+
+export default function Example() {
+  const [keyword, setKeyword] = useState("");
+
+  return (
+    <>
+      <p>
+        Current keyword: <output>{keyword || "(empty)"}</output>
+      </p>
+      <Ariakit.ComboboxProvider>
+        <Ariakit.ComboboxLabel>Fruit</Ariakit.ComboboxLabel>
+        <Ariakit.Combobox
+          autoSelect
+          placeholder="과일을 검색하세요"
+          value={keyword}
+          onChange={(event) => setKeyword(event.target.value)}
+        />
+        <Ariakit.ComboboxPopover gutter={4} sameWidth>
+          {fruits.map((fruit) => (
+            <Ariakit.ComboboxItem key={fruit} value={fruit} />
+          ))}
+        </Ariakit.ComboboxPopover>
+      </Ariakit.ComboboxProvider>
+    </>
+  );
+}

--- a/app/src/sandbox/combobox-ime-6663/index.react.tsx
+++ b/app/src/sandbox/combobox-ime-6663/index.react.tsx
@@ -15,11 +15,6 @@ export default function Example() {
         <Ariakit.ComboboxLabel>Fruit</Ariakit.ComboboxLabel>
         <Ariakit.Combobox
           autoSelect
-          onCompositionEnd={(event) => {
-            // TODO: Remove once https://github.com/ariakit/ariakit/issues/6663
-            // is fixed.
-            event.preventDefault();
-          }}
           placeholder="과일을 검색하세요"
           value={keyword}
           onChange={(event) => setKeyword(event.target.value)}

--- a/app/src/sandbox/combobox-ime-6663/test-chrome.ts
+++ b/app/src/sandbox/combobox-ime-6663/test-chrome.ts
@@ -1,0 +1,94 @@
+import type { CDPSession, Page } from "@playwright/test";
+import { withFramework } from "#app/test-utils/preview.ts";
+
+interface ImeTraceEvent {
+  data?: string;
+  role?: string | null;
+  type: string;
+}
+
+declare global {
+  interface Window {
+    __comboboxImeEvents?: ImeTraceEvent[];
+  }
+}
+
+async function traceImeEvents(page: Page) {
+  await page.evaluate(() => {
+    const events: ImeTraceEvent[] = [];
+    window.__comboboxImeEvents = events;
+    for (const type of ["compositionstart", "compositionend", "focusin"]) {
+      document.addEventListener(
+        type,
+        (event) => {
+          const target = event.target as HTMLElement | null;
+          events.push({
+            type,
+            data: "data" in event ? event.data : undefined,
+            role: target?.getAttribute("role"),
+          });
+        },
+        true,
+      );
+    }
+  });
+}
+
+async function setComposition(cdp: CDPSession, text: string) {
+  await cdp.send("Input.imeSetComposition", {
+    text,
+    selectionStart: text.length,
+    selectionEnd: text.length,
+  });
+}
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6663
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("keeps DOM focus in the combobox between Korean IME syllables", async ({
+    page,
+    q,
+  }) => {
+    const combobox = q.combobox("Fruit");
+    const cdp = await page.context().newCDPSession(page);
+
+    await combobox.focus();
+    await traceImeEvents(page);
+
+    // This CDP sequence is derived from a real macOS Korean 2-set trace for
+    // typing t k r h k, which should produce 사과. CDP preserves the final
+    // value, but it still exposes the harmful focus move that makes the native
+    // macOS IME drop the composed 고 syllable and produce 사ㅏ.
+    await setComposition(cdp, "ㅅ");
+    await setComposition(cdp, "사");
+    await setComposition(cdp, "삭");
+    await setComposition(cdp, "사");
+    await cdp.send("Input.insertText", { text: "사" });
+    await setComposition(cdp, "고");
+
+    const focusMove = await page.evaluate(() => {
+      const events = window.__comboboxImeEvents ?? [];
+      const end = events.findIndex(
+        (event) => event.type === "compositionend" && event.data === "사",
+      );
+      const start = events.findIndex(
+        (event, index) => index > end && event.type === "compositionstart",
+      );
+      const movedToOption =
+        end >= 0 &&
+        start > end &&
+        events
+          .slice(end + 1, start)
+          .some((event) => event.type === "focusin" && event.role === "option");
+      return { end, events, movedToOption, start };
+    });
+    test.expect(focusMove.end).toBeGreaterThanOrEqual(0);
+    test.expect(focusMove.start).toBeGreaterThan(focusMove.end);
+    test.expect(focusMove.movedToOption).toBe(false);
+
+    await setComposition(cdp, "과");
+    await cdp.send("Input.insertText", { text: "과" });
+
+    await test.expect(combobox).toHaveValue("사과");
+    await test.expect(q.text("Current keyword: 사과")).toBeVisible();
+  });
+});

--- a/app/src/sandbox/combobox-ime-6663/test-chrome.ts
+++ b/app/src/sandbox/combobox-ime-6663/test-chrome.ts
@@ -22,9 +22,11 @@ async function traceImeEvents(page: Page) {
         type,
         (event) => {
           const target = event.target as HTMLElement | null;
+          const data =
+            event instanceof CompositionEvent ? event.data : undefined;
           events.push({
             type,
-            data: "data" in event ? event.data : undefined,
+            data,
             role: target?.getAttribute("role"),
           });
         },

--- a/app/src/sandbox/combobox-ime-6663/test-chrome.ts
+++ b/app/src/sandbox/combobox-ime-6663/test-chrome.ts
@@ -64,8 +64,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await setComposition(cdp, "사");
     await setComposition(cdp, "삭");
     await setComposition(cdp, "사");
-    await cdp.send("Input.insertText", { text: "사" });
-    await setComposition(cdp, "고");
+    const insertText = cdp.send("Input.insertText", { text: "사" });
+    const nextSyllable = setComposition(cdp, "고");
+    await Promise.all([insertText, nextSyllable]);
 
     const focusMove = await page.evaluate(() => {
       const events = window.__comboboxImeEvents ?? [];

--- a/app/src/sandbox/combobox-ime-6663/test.ts
+++ b/app/src/sandbox/combobox-ime-6663/test.ts
@@ -1,0 +1,27 @@
+import { dispatch, q, sleep, type } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6663
+test("keeps focus in the combobox between IME composition sessions", async () => {
+  const combobox = q.combobox.ensure("Fruit");
+
+  combobox.focus();
+  await type("사", combobox, { isComposing: true });
+  expect(combobox).toHaveFocus();
+
+  // A Korean IME commits the previous syllable and immediately starts
+  // composing the next one within a single keystroke, so no animation frames
+  // pass between compositionend and the next compositionstart.
+  await dispatch.compositionEnd(combobox);
+  await dispatch.compositionStart(combobox);
+  await sleep();
+
+  expect(q.option("사과")).not.toHaveFocus();
+  expect(combobox).toHaveFocus();
+
+  await type("고", combobox, { isComposing: true });
+  await dispatch.compositionEnd(combobox);
+  await sleep();
+
+  expect(q.option("사과")).toHaveFocus();
+});

--- a/examples/combobox-group/test.ts
+++ b/examples/combobox-group/test.ts
@@ -1,4 +1,4 @@
-import { click, dispatch, hover, press, q, type } from "@ariakit/test";
+import { click, dispatch, hover, press, q, sleep, type } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 function getSelectionValue(element: Element | HTMLInputElement | null) {
@@ -108,6 +108,7 @@ test("composition text", async () => {
   expect(q.option("Apple")).not.toBeInTheDocument();
   await type("á", q.combobox(), { isComposing: true });
   await dispatch.compositionEnd(q.combobox());
+  await sleep();
   expect(q.combobox()).toHaveValue("ápple");
   expect(getSelectionValue(q.combobox())).toBe("pple");
   expect(q.option("Apple")).toHaveFocus();

--- a/packages/ariakit-react-components/src/combobox/combobox.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox.tsx
@@ -148,6 +148,14 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
     const [valueUpdated, forceValueUpdate] = useForceUpdate();
     const canAutoSelectRef = useRef(false);
     const composingRef = useRef(false);
+    const compositionEndFrameRef = useRef<number | null>(null);
+
+    const cancelCompositionEndFrame = () => {
+      const frame = compositionEndFrameRef.current;
+      if (frame == null) return;
+      cancelAnimationFrame(frame);
+      compositionEndFrameRef.current = null;
+    };
 
     // We can only allow auto select when the combobox focus is handled via the
     // aria-activedescendant attribute. Othwerwise, the focus would move to the
@@ -383,6 +391,7 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       const canAutoSelect = canAutoSelectRef.current;
       if (!store) return;
       if (!open) return;
+      if (composingRef.current) return;
       if (!canAutoSelect && (!resetValueOnSelect || userScrolledRef.current))
         return;
       const { baseElement, contentElement, activeId } = store.getState();
@@ -555,6 +564,17 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       }
     });
 
+    useEffect(() => cancelCompositionEndFrame, []);
+
+    const onCompositionStartProp = props.onCompositionStart;
+
+    const onCompositionStart = useEvent((event: CompositionEvent<HTMLType>) => {
+      cancelCompositionEndFrame();
+      canAutoSelectRef.current = false;
+      composingRef.current = true;
+      onCompositionStartProp?.(event);
+    });
+
     const onCompositionEndProp = props.onCompositionEnd;
 
     // When dealing with composition text (for example, when the user is typing
@@ -568,7 +588,12 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       onCompositionEndProp?.(event);
       if (event.defaultPrevented) return;
       if (!autoSelect) return;
-      forceValueUpdate();
+      cancelCompositionEndFrame();
+      compositionEndFrameRef.current = requestAnimationFrame(() => {
+        compositionEndFrameRef.current = null;
+        if (composingRef.current) return;
+        forceValueUpdate();
+      });
     });
 
     const onMouseDownProp = props.onMouseDown;
@@ -668,6 +693,7 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       id,
       ref: useMergeRefs(ref, props.ref),
       onChange,
+      onCompositionStart,
       onCompositionEnd,
       onMouseDown,
       onKeyDown,


### PR DESCRIPTION
## Motivation

`Combobox` with `autoSelect` moves DOM focus to the auto-selected option between Korean IME composition steps. With macOS Korean 2-set, typing the physical keys `t k r h k` should produce `사과`, but the native input path can produce `사ㅏ`.

Playwright/CDP composition does not reproduce the final native macOS value loss, but it does expose the same inter-syllable focus move that causes the native IME to drop the composed `고` syllable. The same repro fails on `@ariakit/react@0.4.31` and the current `0.4.32` source, so this is not a `0.4.32`-only regression.

Fixes #6663

## Solution

The library now tracks composition start immediately, disables auto-select while composition is active, and defers the composition-end auto-select refresh to the next animation frame. If another composition starts before that frame runs, the pending refresh is canceled/skipped so DOM focus stays in the combobox between Korean IME syllables.

The sandbox regression test replays the observed Korean 2-set composition sequence and asserts that DOM focus does not move to an option between `compositionend("사")` and the next `compositionstart`. Existing composition behavior is still covered by the combobox-group tests, now waiting for the deferred composition-end refresh.

## Workaround

Until the library fix is released, prevent the composition-end auto-select refresh on the affected combobox:

```tsx
<Ariakit.Combobox
  autoSelect
  onCompositionEnd={(event) => {
    // TODO: Remove once https://github.com/ariakit/ariakit/issues/6663
    // is fixed.
    event.preventDefault();
  }}
/>
```

This keeps the input focused during the Korean IME boundary, but it also means `autoSelect` will not immediately re-run when a composition session ends. It will run again on the next normal value/update path.
