### PR TITLE
Prevent lint-fix from breaking type checks

### DIFF
--- a/app/src/lib/styles.ts
+++ b/app/src/lib/styles.ts
@@ -26,6 +26,9 @@ import {
   toRegexFromWildcard,
 } from "./styles-shared.ts";
 
+// The JSON import keeps its generated literal type, but the resolver needs the
+// public schema shape shared with the build script.
+// oxlint-disable-next-line no-unnecessary-type-assertion
 const styles = stylesRaw as unknown as StylesJson;
 
 export type {

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  applyState,
   omit as _omit,
   pick as _pick,
   chain,
@@ -718,10 +719,7 @@ export function createStore<S extends State>(
     if (!hasOwnProperty(state, key)) return;
 
     const currentValue = state[key];
-    const nextValue =
-      typeof value === "function"
-        ? (value as (current: S[typeof key]) => S[typeof key])(currentValue)
-        : value;
+    const nextValue = applyState(value, () => currentValue);
 
     if (isSameValue(nextValue, currentValue)) return;
 

--- a/packages/ariakit-utils/src/focus.ts
+++ b/packages/ariakit-utils/src/focus.ts
@@ -57,14 +57,12 @@ export function isTabbable(
   // If we are in a radio group, we must check if the active element is part of
   // the same group, which would make all the other radio buttons in the group
   // non-tabbable.
-  const activeElement = getActiveElement(element) as
-    | HTMLElement
-    | HTMLInputElement
-    | null;
+  const activeElement = getActiveElement(element);
   if (!activeElement) return true;
   if (activeElement === element) return true;
   if (!("form" in activeElement)) return true;
   if (activeElement.form !== element.form) return true;
+  if (!("name" in activeElement)) return true;
   if (activeElement.name !== element.name) return true;
   return false;
 }


### PR DESCRIPTION
## Motivation

Running `pnpm lint-fix` currently removes a few type assertions that are still needed by TypeScript. If `pnpm tsc` runs after those autofixes, it fails in the styles resolver, store `setState` path, and focus tabbability helper.

Disabling `typescript/no-unnecessary-type-assertion` globally would avoid the immediate breakage, but it would also lose useful lint coverage for future genuinely unnecessary assertions.

## Solution

Keep the rule enabled and make the affected code explicit enough for both oxlint and TypeScript:

- Use the existing `applyState` helper in `createStore` so `setState` no longer needs a callable assertion.
- Replace the active-element assertion in `isTabbable` with a runtime `"name" in activeElement` guard.
- Keep the load-bearing generated JSON schema assertion in `styles.ts`, with a local `oxlint-disable-next-line no-unnecessary-type-assertion` comment explaining why the assertion stays.

No changeset is included because this is a tooling/type-checking maintenance fix with no intended runtime or public API behavior change.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm lint`
