### PR TITLE
Deprecate form store hook methods

### DIFF
--- a/.changeset/200-form-store-hooks.md
+++ b/.changeset/200-form-store-hooks.md
@@ -1,0 +1,16 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Added `useFormValue`, `useFormValidate`, and `useFormSubmit`
+
+The new `useFormValue`, `useFormValidate`, and `useFormSubmit` hooks replace the matching [`useFormStore`](https://ariakit.com/reference/use-form-store) methods with top-level hook calls that are compatible with the React Compiler:
+
+```tsx
+const value = useFormValue(form, form.names.email);
+
+useFormSubmit(form, async (state) => {
+  // ...
+});
+```

--- a/.changeset/200-form-store-hooks.md
+++ b/.changeset/200-form-store-hooks.md
@@ -5,7 +5,7 @@
 
 Added `useFormValue`, `useFormValidate`, and `useFormSubmit`
 
-The new `useFormValue`, `useFormValidate`, and `useFormSubmit` hooks replace the matching [`useFormStore`](https://ariakit.com/reference/use-form-store) methods with top-level hook calls that are compatible with the React Compiler:
+The new [`useFormValue`](https://ariakit.com/reference/use-form-value), [`useFormValidate`](https://ariakit.com/reference/use-form-validate), and [`useFormSubmit`](https://ariakit.com/reference/use-form-submit) hooks replace the matching [`useFormStore`](https://ariakit.com/reference/use-form-store) methods with top-level hook calls that are compatible with the React Compiler:
 
 ```tsx
 const value = useFormValue(form, form.names.email);

--- a/.changeset/290-form-store-hooks.md
+++ b/.changeset/290-form-store-hooks.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Added `useFormValue`, `useFormValidate`, and `useFormSubmit`, and deprecated their matching [`useFormStore`](https://ariakit.com/reference/use-form-store) methods.

--- a/.changeset/290-form-store-hooks.md
+++ b/.changeset/290-form-store-hooks.md
@@ -3,4 +3,4 @@
 "@ariakit/react": patch
 ---
 
-Added `useFormValue`, `useFormValidate`, and `useFormSubmit`, and deprecated their matching [`useFormStore`](https://ariakit.com/reference/use-form-store) methods.
+Deprecated the [`useValue`](https://ariakit.com/reference/use-form-store#usevalue), [`useValidate`](https://ariakit.com/reference/use-form-store#usevalidate), and [`useSubmit`](https://ariakit.com/reference/use-form-store#usesubmit) methods of [`useFormStore`](https://ariakit.com/reference/use-form-store) in favor of the new top-level form hooks.

--- a/app/src/sandbox/form-3607/index.react.tsx
+++ b/app/src/sandbox/form-3607/index.react.tsx
@@ -12,7 +12,7 @@ export default function Example() {
     },
   });
 
-  form.useValidate(() => {
+  ak.useFormValidate(form, () => {
     const items = form.getValue(form.names.items);
     for (const [i, item] of items.entries()) {
       const name = form.names.items[i]?.name;
@@ -23,7 +23,7 @@ export default function Example() {
     }
   });
 
-  form.useSubmit(async (state) => {
+  ak.useFormSubmit(form, async (state) => {
     alert(JSON.stringify(state.values));
   });
 

--- a/app/src/sandbox/form-6307/index.react.tsx
+++ b/app/src/sandbox/form-6307/index.react.tsx
@@ -13,11 +13,11 @@ export default function Example() {
     defaultValues: { email: "", nickname: "" },
   });
 
-  // The email is required. Validation runs through the standard `useValidate`
-  // API so the invalid state is deterministic across environments. `validate()`
-  // resets the errors before running this callback, so it only needs to set the
-  // current violation.
-  form.useValidate(() => {
+  // The email is required. Validation runs through the standard
+  // `useFormValidate` API so the invalid state is deterministic across
+  // environments. `validate()` resets the errors before running this callback,
+  // so it only needs to set the current violation.
+  ak.useFormValidate(form, () => {
     if (!form.getValue(form.names.email)) {
       form.setError(form.names.email, "Email is required");
     }

--- a/app/src/sandbox/form-6309/index.react.tsx
+++ b/app/src/sandbox/form-6309/index.react.tsx
@@ -10,7 +10,7 @@ export default function Example() {
   const form = ak.useFormStore({ defaultValues: { draft: "" } });
   const [saveState, setSaveState] = useState("Idle");
 
-  form.useSubmit(async () => {
+  ak.useFormSubmit(form, async () => {
     // Simulate a quick network request that saves the draft. Timers keep
     // running while the tab is hidden, so this resolves regardless of
     // visibility.

--- a/app/src/sandbox/form-radio-3833/index.react.tsx
+++ b/app/src/sandbox/form-radio-3833/index.react.tsx
@@ -3,13 +3,13 @@ import * as ak from "@ariakit/react";
 export default function Example() {
   const form = ak.useFormStore({ defaultValues: { color: "" } });
 
-  form.useValidate(() => {
+  ak.useFormValidate(form, () => {
     if (!form.getValue(form.names.color)) {
       form.setError(form.names.color, "Please select a color.");
     }
   });
 
-  form.useSubmit(async (state) => {
+  ak.useFormSubmit(form, async (state) => {
     alert(JSON.stringify(state.values));
   });
 

--- a/components/form.md
+++ b/components/form.md
@@ -21,6 +21,9 @@ Submit information with accessible interactive controls in React. Take advantage
 ```jsx
 useFormStore()
 useFormContext()
+useFormValue()
+useFormValidate()
+useFormSubmit()
 
 <FormProvider>
   <Form>
@@ -46,14 +49,14 @@ useFormContext()
 
 ## Submitting the form
 
-The [`useFormStore`](/reference/use-form-store) function returns a [`useSubmit`](/reference/use-form-store#usesubmit) hook that can be used to register a submit handler on the form store. All registered handlers run when the user submits the form or the program calls the [`submit`](/reference/use-form-store#submit) function.
+The [`useFormSubmit`](/reference/use-form-submit) function can be used to register a submit handler on the form store. All registered handlers run when the user submits the form or the program calls the [`submit`](/reference/use-form-store#submit) function.
 
 Submit handlers may return a promise and interact with the form store. This means we can access the form [`values`](/reference/use-form-store#values) and call methods such as [`setErrors`](/reference/use-form-store#seterrors) to display errors when the form is submitted:
 
 ```js
 const form = useFormStore();
 
-form.useSubmit(async (state) => {
+useFormSubmit(form, async (state) => {
   const response = await fetch("https://jsonplaceholder.typicode.com/posts", {
     method: "POST",
     body: JSON.stringify(state.values),
@@ -79,13 +82,13 @@ Thankfully, JavaScript allows us to hook into this validation process using the 
 
 ### Custom validation
 
-Similar to [Submitting the form](#submitting-the-form), the [`useFormStore`](/reference/use-form-store) function also returns a [`useValidate`](/reference/use-form-store#usevalidate) hook that can be used to register a validation handler on the form store.
+Similar to [Submitting the form](#submitting-the-form), the [`useFormValidate`](/reference/use-form-validate) function can be used to register a validation handler on the form store.
 
 We can pass this hook to other components as a prop to create field-level validations:
 
 ```jsx
 function MyForm() {
-  const form = useFormStore({ defaultValue: { name: "" } });
+  const form = useFormStore({ defaultValues: { name: "" } });
   return (
     <Form store={form}>
       <NameInput store={form} name={form.names.name} />
@@ -94,7 +97,7 @@ function MyForm() {
 }
 
 function NameInput({ store, name, ...props }) {
-  store.useValidate(() => {
+  useFormValidate(store, () => {
     const value = store.getValue(name);
     if (value.length < 3) {
       store.setError(name, "Name must be at least 3 characters long");

--- a/examples/form-callback-queue/index.react.tsx
+++ b/examples/form-callback-queue/index.react.tsx
@@ -9,17 +9,17 @@ interface NameFieldProps extends Ariakit.FormInputProps {
 }
 
 function RequiredField({ store, label, name, ...props }: NameFieldProps) {
-  store.useValidate(() => {
+  Ariakit.useFormValidate(store, () => {
     if (!store.getValue(name)) {
       store.setError(name, `${store.getError(name)} - Field 1`);
     }
   });
-  store.useValidate(() => {
+  Ariakit.useFormValidate(store, () => {
     if (!store.getValue(name)) {
       store.setError(name, `${store.getError(name)} - Field 2`);
     }
   });
-  store.useSubmit(async () => {
+  Ariakit.useFormSubmit(store, async () => {
     await Promise.resolve();
     store.setError(name, "Field");
   });
@@ -39,19 +39,19 @@ interface FormProps extends Ariakit.FormProps {
 function RequiredForm({ store, requiredNames, ...props }: FormProps) {
   invariant(store);
 
-  store.useValidate(() => {
+  Ariakit.useFormValidate(store, () => {
     for (const name of requiredNames) {
       if (!store.getValue(name)) {
         store.setError(name, `${store.getError(name)} - Abstract Form`);
       }
     }
   });
-  store.useSubmit(() => {
+  Ariakit.useFormSubmit(store, () => {
     for (const name of requiredNames) {
       store.setError(name, `${store.getError(name)} - Abstract Form 1`);
     }
   });
-  store.useSubmit(() => {
+  Ariakit.useFormSubmit(store, () => {
     for (const name of requiredNames) {
       store.setError(name, `${store.getError(name)} - Abstract Form 2`);
     }
@@ -64,7 +64,7 @@ export default function Example() {
   const form = Ariakit.useFormStore({ defaultValues: { name: "", email: "" } });
   const requiredNames = [form.names.name, form.names.email];
 
-  form.useValidate(() => {
+  Ariakit.useFormValidate(form, () => {
     for (const name of requiredNames) {
       if (!form.getValue(name)) {
         form.setError(name, `${form.getError(name)} - Form`);
@@ -72,13 +72,13 @@ export default function Example() {
     }
   });
 
-  form.useSubmit(() => {
+  Ariakit.useFormSubmit(form, () => {
     for (const name of requiredNames) {
       form.setError(name, `${form.getError(name)} - Form 1`);
     }
   });
 
-  form.useSubmit(() => {
+  Ariakit.useFormSubmit(form, () => {
     for (const name of requiredNames) {
       form.setError(name, `${form.getError(name)} - Form 2`);
     }

--- a/examples/form-radio/index.react.tsx
+++ b/examples/form-radio/index.react.tsx
@@ -6,13 +6,13 @@ export default function Example() {
   const id = useId();
   const form = Ariakit.useFormStore({ defaultValues: { color: "" } });
 
-  form.useValidate(() => {
+  Ariakit.useFormValidate(form, () => {
     if (!form.getValue(form.names.color)) {
       form.setError(form.names.color, "Please select a color.");
     }
   });
 
-  form.useSubmit(async (state) => {
+  Ariakit.useFormSubmit(form, async (state) => {
     alert(JSON.stringify(state.values));
   });
 

--- a/examples/form-select/form.tsx
+++ b/examples/form-select/form.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import type { SelectProps } from "./select.tsx";
 import { Select } from "./select.tsx";
 
-export { useFormStore } from "@ariakit/react";
+export { useFormStore, useFormSubmit } from "@ariakit/react";
 
 export interface FormProps extends Ariakit.FormProps {}
 
@@ -75,7 +75,7 @@ export const FormSelect = React.forwardRef<HTMLButtonElement, FormSelectProps>(
     const form = Ariakit.useFormContext();
     if (!form) throw new Error("FormSelect must be used within a Form");
 
-    const value = form.useValue(name);
+    const value = Ariakit.useFormValue(form, name);
 
     const select = (
       <Select

--- a/examples/form-select/index.react.tsx
+++ b/examples/form-select/index.react.tsx
@@ -4,6 +4,7 @@ import {
   FormInput,
   FormSelect,
   FormSubmit,
+  useFormSubmit,
   useFormStore,
 } from "./form.tsx";
 import { SelectItem } from "./select.tsx";
@@ -13,7 +14,7 @@ export default function Example() {
   const form = useFormStore({ defaultValues: { name: "", fruit: "" } });
   const $ = form.names;
 
-  form.useSubmit(() => {
+  useFormSubmit(form, () => {
     alert(JSON.stringify(form.getState().values));
   });
 

--- a/examples/form/index.react.tsx
+++ b/examples/form/index.react.tsx
@@ -4,7 +4,7 @@ import "./style.css";
 export default function Example() {
   const form = Ariakit.useFormStore({ defaultValues: { name: "", email: "" } });
 
-  form.useSubmit(async (state) => {
+  Ariakit.useFormSubmit(form, async (state) => {
     alert(JSON.stringify(state.values));
   });
 

--- a/examples/menu-dialog-animated/index.react.tsx
+++ b/examples/menu-dialog-animated/index.react.tsx
@@ -37,7 +37,7 @@ export default function Example() {
 
   const form = Ariakit.useFormStore({ defaultValues: { list: "" } });
 
-  form.useSubmit((state) => {
+  Ariakit.useFormSubmit(form, (state) => {
     setLists((prevLists) => [...prevLists, state.values.list]);
     setValues((prevValues) => ({
       ...prevValues,

--- a/guide/400-component-stores/readme.md
+++ b/guide/400-component-stores/readme.md
@@ -199,7 +199,7 @@ dialog.toggle(); // dialog.setOpen((open) => !open)
 When you need to access the store in child components, passing it as a prop is usually the most straightforward approach. However, if the component is deeply nested within the component tree or if you're unable to pass the store as a prop for some reason, you can leverage React Context instead:
 
 ```jsx "useFormContext"
-import { useFormContext, FormInput } from "@ariakit/react";
+import { useFormContext, useFormValidate, FormInput } from "@ariakit/react";
 
 function RequiredInput(props) {
   const form = useFormContext();
@@ -208,7 +208,7 @@ function RequiredInput(props) {
     throw new Error("RequiredInput must be used within a Form component");
   }
 
-  form.useValidate(() => {
+  useFormValidate(form, () => {
     if (!form.getValue(props.name)) {
       form.setError(props.name, "This field is required");
     }

--- a/packages/ariakit-react-components/src/form/form-checkbox.tsx
+++ b/packages/ariakit-react-components/src/form/form-checkbox.tsx
@@ -12,6 +12,7 @@ import { useCheckbox } from "../checkbox/checkbox.tsx";
 import { useFormItemContext } from "./form-context.tsx";
 import type { FormControlOptions } from "./form-control.tsx";
 import { useFormControl } from "./form-control.tsx";
+import { useFormValue } from "./form-store.ts";
 
 const TagName = "input" satisfies ElementType;
 type TagName = typeof TagName;
@@ -47,7 +48,7 @@ export const useFormCheckbox = createHook<TagName, FormCheckboxOptions>(
     });
 
     const checkboxStore = useCheckboxStore({
-      value: form.useValue(name),
+      value: useFormValue(form, name),
       setValue: (value) => form.setValue(name, value),
     });
 

--- a/packages/ariakit-react-components/src/form/form-control.tsx
+++ b/packages/ariakit-react-components/src/form/form-control.tsx
@@ -17,6 +17,7 @@ import { useMemo } from "react";
 import type { CollectionItemOptions } from "../collection/collection-item.tsx";
 import { useCollectionItem } from "../collection/collection-item.tsx";
 import { useFormItem } from "./form-context.tsx";
+import { useFormValidate } from "./form-store.ts";
 import type { FormStore, FormStoreState } from "./form-store.ts";
 
 const TagName = "input" satisfies ElementType;
@@ -102,7 +103,7 @@ function useControlState(form: FormStore, name: string) {
  * ```jsx
  * const store = useFormStore({ defaultValues: { content: "" } });
  * const props = useFormControl({ store, name: store.names.content });
- * const value = store.useValue(store.names.content);
+ * const value = useFormValue(store, store.names.content);
  *
  * <Form store={store}>
  *   <FormLabel name={store.names.content}>Content</FormLabel>
@@ -138,7 +139,7 @@ export const useFormControl = createHook<TagName, FormControlOptions>(
       component: "FormControl",
     });
 
-    form.useValidate(async () => {
+    useFormValidate(form, async () => {
       const element = getNamedElement(ref, name);
       if (!element) return;
       // Flush microtasks to make sure the validity state is up to date
@@ -201,7 +202,7 @@ export const useFormControl = createHook<TagName, FormControlOptions>(
  *   },
  * });
  *
- * const value = form.useValue(form.names.content);
+ * const value = useFormValue(form, form.names.content);
  *
  * <Form store={form}>
  *   <FormLabel name={form.names.content}>Content</FormLabel>

--- a/packages/ariakit-react-components/src/form/form-error.tsx
+++ b/packages/ariakit-react-components/src/form/form-error.tsx
@@ -26,7 +26,7 @@ type HTMLType = HTMLElementTagNameMap[TagName];
  * const store = useFormStore({ defaultValues: { email: "" } });
  * const props = useFormError({ store, name: store.names.email });
  *
- * store.useValidate(() => {
+ * useFormValidate(store, () => {
  *   if (!store.getValue(store.names.email)) {
  *     store.setError(store.names.email, "Email is required!");
  *   }
@@ -94,8 +94,8 @@ export const useFormError = createHook<TagName, FormErrorOptions>(
  *   },
  * });
  *
- * form.useValidate(() => {
- *   if (!form.values.email) {
+ * useFormValidate(form, () => {
+ *   if (!form.getValue(form.names.email)) {
  *     form.setError(form.names.email, "Email is required!");
  *   }
  * });

--- a/packages/ariakit-react-components/src/form/form-field.tsx
+++ b/packages/ariakit-react-components/src/form/form-field.tsx
@@ -23,7 +23,7 @@ type TagName = typeof TagName;
  * ```jsx
  * const store = useFormStore({ defaultValues: { content: "" } });
  * const props = useFormField({ store, name: store.names.content });
- * const value = store.useValue(store.names.content);
+ * const value = useFormValue(store, store.names.content);
  *
  * <Form store={store}>
  *   <FormLabel name={store.names.content}>Content</FormLabel>
@@ -61,7 +61,7 @@ export const useFormField = createHook<TagName, FormFieldOptions>(
  *   },
  * });
  *
- * const value = form.useValue(form.names.content);
+ * const value = useFormValue(form, form.names.content);
  *
  * <Form store={form}>
  *   <FormLabel name={form.names.content}>Content</FormLabel>

--- a/packages/ariakit-react-components/src/form/form-input.tsx
+++ b/packages/ariakit-react-components/src/form/form-input.tsx
@@ -12,6 +12,7 @@ import { useFocusable } from "../focusable/focusable.tsx";
 import { useFormItemContext } from "./form-context.tsx";
 import type { FormControlOptions } from "./form-control.tsx";
 import { useFormControl } from "./form-control.tsx";
+import { useFormValue } from "./form-store.ts";
 
 const TagName = "input" satisfies ElementType;
 type TagName = typeof TagName;
@@ -47,7 +48,7 @@ export const useFormInput = createHook<TagName, FormInputOptions>(
       form.setValue(name, event.target.value);
     });
 
-    const value = form.useValue(name);
+    const value = useFormValue(form, name);
 
     props = {
       value,

--- a/packages/ariakit-react-components/src/form/form-store.ts
+++ b/packages/ariakit-react-components/src/form/form-store.ts
@@ -12,9 +12,89 @@ import type {
 } from "../collection/collection-store.ts";
 import { useCollectionStoreProps } from "../collection/collection-store.ts";
 
-export function useFormStoreProps<
-  T extends Omit<FormStore, "useValue" | "useValidate" | "useSubmit">,
->(store: T, update: () => void, props: FormStoreProps) {
+type FormStoreHookStore<T extends FormStoreValues = FormStoreValues> = Omit<
+  FormStore<T>,
+  "useValue" | "useValidate" | "useSubmit"
+>;
+
+/**
+ * Re-renders the component when the value of the given field changes and
+ * returns the current value.
+ *
+ * Live examples:
+ * - [Form with Select](https://ariakit.com/examples/form-select)
+ * @example
+ * const form = useFormStore({
+ *   defaultValues: { email: "" },
+ * });
+ * const emailValue = useFormValue(form, form.names.email);
+ */
+// oxlint-disable-next-line no-unnecessary-type-parameters
+export function useFormValue<T = any>(
+  store: FormStoreHookStore,
+  name: StringLike,
+): T {
+  return useStoreState(store, () => store.getValue<T>(name));
+}
+
+/**
+ * Registers a callback that will be used to validate the form when
+ * [`validate`](https://ariakit.com/reference/use-form-store#validate) is
+ * called, typically when a form field is touched or when the form is submitted.
+ *
+ * Live examples:
+ * - [FormRadio](https://ariakit.com/examples/form-radio)
+ * @example
+ * useFormValidate(form, async (state) => {
+ *   const errors = await api.validate(state.values);
+ *   if (errors) {
+ *     form.setErrors(errors);
+ *   }
+ * });
+ */
+export function useFormValidate<T extends FormStoreValues = FormStoreValues>(
+  store: FormStoreHookStore<T>,
+  callback: Core.FormStoreCallback<FormStoreState<T>>,
+) {
+  callback = useEvent(callback);
+  // Whenever the items change (for example, when form fields are lazily
+  // rendered), we need to reset the callbacks so they always run in a
+  // consistent order.
+  const items = useStoreState(store, "items");
+  useEffect(() => store.onValidate(callback), [store, items, callback]);
+}
+
+/**
+ * Registers a callback that will be used to submit the form when
+ * [`submit`](https://ariakit.com/reference/use-form-store#submit) is called.
+ *
+ * Live examples:
+ * - [FormRadio](https://ariakit.com/examples/form-radio)
+ * - [Form with Select](https://ariakit.com/examples/form-select)
+ * @example
+ * useFormSubmit(form, async (state) => {
+ *   try {
+ *     await api.submit(state.values);
+ *   } catch (errors) {
+ *     form.setErrors(errors);
+ *   }
+ * });
+ */
+export function useFormSubmit<T extends FormStoreValues = FormStoreValues>(
+  store: FormStoreHookStore<T>,
+  callback: Core.FormStoreCallback<FormStoreState<T>>,
+) {
+  callback = useEvent(callback);
+  // Same logic as useFormValidate.
+  const items = useStoreState(store, "items");
+  useEffect(() => store.onSubmit(callback), [store, items, callback]);
+}
+
+export function useFormStoreProps<T extends FormStoreHookStore>(
+  store: T,
+  update: () => void,
+  props: FormStoreProps,
+) {
   store = useCollectionStoreProps(store, update, props);
 
   useStoreProps(store, props, "values", "setValues");
@@ -22,28 +102,20 @@ export function useFormStoreProps<
   useStoreProps(store, props, "touched", "setTouched");
 
   const useValue = useCallback<FormStore["useValue"]>(
-    (name) => useStoreState(store, () => store.getValue(name)),
+    (name) => useFormValue(store, name),
     [store],
   );
 
   const useValidate = useCallback<FormStore["useValidate"]>(
     (callback) => {
-      callback = useEvent(callback);
-      // Whenever the items change (for example, when form fields are lazily
-      // rendered), we need to reset the callbacks so they always run in a
-      // consistent order.
-      const items = useStoreState(store, "items");
-      useEffect(() => store.onValidate(callback), [items, callback]);
+      useFormValidate(store, callback);
     },
     [store],
   );
 
   const useSubmit = useCallback<FormStore["useSubmit"]>(
     (callback) => {
-      callback = useEvent(callback);
-      // Same logic as useValidate.
-      const items = useStoreState(store, "items");
-      useEffect(() => store.onSubmit(callback), [items, callback]);
+      useFormSubmit(store, callback);
     },
     [store],
   );
@@ -115,9 +187,11 @@ export interface FormStoreFunctions<T extends FormStoreValues = FormStoreValues>
    * Live examples:
    * - [Form with Select](https://ariakit.com/examples/form-select)
    * @example
-   * const nameValue = store.useValue("name");
+   * const nameValue = useFormValue(store, "name");
    * // Can also use store.names for type safety.
-   * const emailValue = store.useValue(store.names.email);
+   * const emailValue = useFormValue(store, store.names.email);
+   * @deprecated Use
+   * [`useFormValue`](https://ariakit.com/reference/use-form-value) instead.
    */
   // oxlint-disable-next-line no-unnecessary-type-parameters
   useValue: <T = any>(name: StringLike) => T;
@@ -130,12 +204,15 @@ export interface FormStoreFunctions<T extends FormStoreValues = FormStoreValues>
    * Live examples:
    * - [FormRadio](https://ariakit.com/examples/form-radio)
    * @example
-   * store.useValidate(async (state) => {
+   * useFormValidate(store, async (state) => {
    *   const errors = await api.validate(state.values);
    *   if (errors) {
    *     store.setErrors(errors);
    *   }
    * });
+   * @deprecated Use
+   * [`useFormValidate`](https://ariakit.com/reference/use-form-validate)
+   * instead.
    */
   useValidate: (callback: Core.FormStoreCallback<FormStoreState<T>>) => void;
   /**
@@ -147,13 +224,15 @@ export interface FormStoreFunctions<T extends FormStoreValues = FormStoreValues>
    * - [FormRadio](https://ariakit.com/examples/form-radio)
    * - [Form with Select](https://ariakit.com/examples/form-select)
    * @example
-   * store.useSubmit(async (state) => {
+   * useFormSubmit(store, async (state) => {
    *   try {
    *     await api.submit(state.values);
    *   } catch (errors) {
    *     store.setErrors(errors);
    *   }
    * });
+   * @deprecated Use
+   * [`useFormSubmit`](https://ariakit.com/reference/use-form-submit) instead.
    */
   useSubmit: (callback: Core.FormStoreCallback<FormStoreState<T>>) => void;
 }

--- a/packages/ariakit-react-components/src/form/form.tsx
+++ b/packages/ariakit-react-components/src/form/form.tsx
@@ -218,7 +218,7 @@ export interface FormOptions<_T extends ElementType = TagName> extends Options {
   /**
    * Determines if the form should invoke the validation callbacks registered
    * with
-   * [`useValidate`](https://ariakit.com/reference/use-form-store#usevalidate)
+   * [`useFormValidate`](https://ariakit.com/reference/use-form-validate)
    * when the [`values`](https://ariakit.com/reference/use-form-store#values)
    * change.
    * @default true
@@ -227,7 +227,7 @@ export interface FormOptions<_T extends ElementType = TagName> extends Options {
   /**
    * Determines if the form should invoke the validation callbacks registered
    * with
-   * [`useValidate`](https://ariakit.com/reference/use-form-store#usevalidate)
+   * [`useFormValidate`](https://ariakit.com/reference/use-form-validate)
    * when a field loses focus.
    * @default true
    */

--- a/packages/ariakit-react/src/form.ts
+++ b/packages/ariakit-react/src/form.ts
@@ -82,7 +82,12 @@ export type {
   FormStoreProps,
   FormStoreState,
 } from "@ariakit/react-components/form/form-store";
-export { useFormStore } from "@ariakit/react-components/form/form-store";
+export {
+  useFormStore,
+  useFormSubmit,
+  useFormValidate,
+  useFormValue,
+} from "@ariakit/react-components/form/form-store";
 export type {
   FormSubmitOptions,
   FormSubmitProps,

--- a/website/build-pages/get-page-content.js
+++ b/website/build-pages/get-page-content.js
@@ -61,6 +61,7 @@ export function createReferencePageContent(reference) {
 
   const requiredProps = props.filter((prop) => !prop.optional).sort(sortProp);
   const optionalProps = props.filter((prop) => prop.optional).sort(sortProp);
+  const sortedReturnProps = returnProps?.slice().sort(sortProp);
 
   /** @param {string | boolean} [deprecated] */
   const renderDeprecated = (deprecated, warn = false) => {
@@ -159,12 +160,12 @@ ${optionalProps.map(renderProp).join("\n\n---\n\n")}\n`
     : ""
 }
 ${
-  returnProps && returnProps.length > 0
+  sortedReturnProps && sortedReturnProps.length > 0
     ? `## Return Props
 
 ---
 
-${returnProps.map(renderProp).join("\n\n---\n\n")}\n`
+${sortedReturnProps.map(renderProp).join("\n\n---\n\n")}\n`
     : ""
 }
 `;

--- a/website/build-pages/get-page-content.test.ts
+++ b/website/build-pages/get-page-content.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "vitest";
+import { createReferencePageContent } from "./get-page-content.js";
+import type { Reference, ReferenceProp } from "./types.ts";
+
+function createProp(name: string, deprecated: boolean): ReferenceProp {
+  return {
+    name,
+    type: "unknown",
+    description: `${name} description.`,
+    optional: false,
+    defaultValue: null,
+    deprecated,
+    examples: [],
+  };
+}
+
+function getHeadingIndex(content: string, heading: string) {
+  const index = content.indexOf(heading);
+  expect(index).toBeGreaterThanOrEqual(0);
+  return index;
+}
+
+test("sorts deprecated return props after active return props", () => {
+  const reference: Reference = {
+    filename: "form.ts",
+    name: "useFormStore",
+    description: "Creates a form store.",
+    deprecated: false,
+    examples: [],
+    props: [],
+    returnProps: [
+      createProp("useValue", true),
+      createProp("validate", false),
+      createProp("useState", true),
+      createProp("submit", false),
+    ],
+  };
+
+  const content = createReferencePageContent(reference);
+  const returnProps = content.slice(
+    getHeadingIndex(content, "## Return Props"),
+  );
+
+  const submitIndex = getHeadingIndex(returnProps, "### `submit`");
+  const validateIndex = getHeadingIndex(returnProps, "### `validate`");
+  const useStateIndex = getHeadingIndex(returnProps, "### ~`useState`~");
+  const useValueIndex = getHeadingIndex(returnProps, "### ~`useValue`~");
+
+  expect(submitIndex).toBeLessThan(validateIndex);
+  expect(validateIndex).toBeLessThan(useStateIndex);
+  expect(useStateIndex).toBeLessThan(useValueIndex);
+});

--- a/website/build-pages/reference-utils.js
+++ b/website/build-pages/reference-utils.js
@@ -1,13 +1,13 @@
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import invariant from "tiny-invariant";
 import { Node, Project, ts } from "ts-morph";
 import { getPageName } from "./get-page-name.js";
 
+const cwd = process.cwd();
+const root = basename(cwd) === "website" ? join(cwd, "..") : cwd;
+
 const project = new Project({
-  tsConfigFilePath: join(
-    process.cwd(),
-    "../packages/ariakit-react/tsconfig.json",
-  ),
+  tsConfigFilePath: join(root, "packages/ariakit-react/tsconfig.json"),
 });
 
 /**
@@ -182,7 +182,6 @@ function getExamples(node) {
     const text = tag.text?.toString();
     if (!text) continue;
     const match = text.match(
-      // @ts-expect-error
       /^(?<description>(.|\n)*)```(?<language>[^\n]+)\n(?<code>(.|\n)+)\n```$/m,
     );
     examples.push({
@@ -236,6 +235,22 @@ function getFunction(node) {
 
 /**
  * @param {Node} node
+ * @param {string} name
+ */
+function getPropsParameter(node, name) {
+  const param = getFunction(node)?.getParameters()?.at(0);
+  if (!param) return;
+  const nameNode = param.getNameNode();
+  if (Node.isIdentifier(nameNode) && nameNode.getText() === "props") {
+    return param;
+  }
+  const type = param.getTypeNode()?.getText();
+  if (type !== `${name}Props` && type !== `${name}Options`) return;
+  return param;
+}
+
+/**
+ * @param {Node} node
  */
 function getNodeName(node) {
   if (Node.isVariableStatement(node)) {
@@ -261,7 +276,7 @@ function getReference(filename, node, props, returnedProps) {
 
   const hasProps = getPageName(filename) !== "store";
   if (hasProps) {
-    props = props || getFunction(node)?.getParameters()?.at(0);
+    props = props || getPropsParameter(node, name);
   }
 
   returnedProps =

--- a/website/build-pages/reference-utils.test.ts
+++ b/website/build-pages/reference-utils.test.ts
@@ -1,0 +1,55 @@
+import { join } from "node:path";
+import { expect, test } from "vitest";
+import { getReferences } from "./reference-utils.js";
+import type { Reference } from "./types.ts";
+
+const formFilename = join(process.cwd(), "packages/ariakit-react/src/form.ts");
+const comboboxFilename = join(
+  process.cwd(),
+  "packages/ariakit-react/src/combobox.ts",
+);
+const headingFilename = join(
+  process.cwd(),
+  "packages/ariakit-react/src/heading.ts",
+);
+
+function getReference(filename: string, name: string) {
+  const reference = getReferences(filename).find((reference) => {
+    return reference.name === name;
+  });
+  if (!reference) {
+    throw new Error(`Missing ${name} reference`);
+  }
+  return reference as Reference;
+}
+
+test("does not use non-props function parameters as reference props", () => {
+  expect(getReference(formFilename, "useFormValue").props).toEqual([]);
+  expect(getReference(formFilename, "useFormValidate").props).toEqual([]);
+  expect(getReference(formFilename, "useFormSubmit").props).toEqual([]);
+});
+
+test("uses props parameters as reference props", () => {
+  const props = getReference(formFilename, "useFormStore").props.map((prop) => {
+    return prop.name;
+  });
+
+  expect(props).toContain("defaultValues");
+});
+
+test("uses typed destructured props parameters as reference props", () => {
+  const comboboxProps = getReference(
+    comboboxFilename,
+    "ComboboxValue",
+  ).props.map((prop) => {
+    return prop.name;
+  });
+  const headingProps = getReference(headingFilename, "HeadingLevel").props.map(
+    (prop) => {
+      return prop.name;
+    },
+  );
+
+  expect(comboboxProps).toContain("children");
+  expect(headingProps).toContain("level");
+});


### PR DESCRIPTION
## Motivation

React Compiler-compatible hooks need to be called as top-level hook functions. Form stores still expose hook-like methods such as `form.useValue`, `form.useValidate`, and `form.useSubmit`, which encourage member-call hook usage.

The legacy reference website also needs to present the new hooks and soft-deprecated store methods correctly: deprecated return props should appear at the end of the `useFormStore` Return Props list, and standalone function pages such as `useFormValidate` should not derive unrelated Required Props from their `store` parameter.

## Solution

Added top-level form store hooks and soft-deprecated the store methods:

```tsx
const value = useFormValue(form, form.names.email);

useFormValidate(form, (state) => {
  // ...
});

useFormSubmit(form, async (state) => {
  // ...
});
```

The existing store methods remain functional and now delegate to the new hooks, with `@deprecated` JSDoc pointing to the replacement APIs. The public `@ariakit/react` form entry exports the new hooks, while `@ariakit/react-components` keeps component hook name conflicts isolated to separate subpath files.

Docs, root examples, app sandboxes, and internal form component usage were migrated to the new top-level hooks. A changeset documents the soft deprecation for `@ariakit/react-components` and `@ariakit/react`.

The legacy website reference generator now sorts Return Props with the same deprecated-last ordering used by Required and Optional Props, and it only treats a function's first parameter as a prop table when it is actually a `props`/`Options`/`Props` parameter. Focused tests cover the new form hook pages, store props, typed destructured props, and deprecated return-prop ordering.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm test-react examples/form/test.ts examples/form-radio/test.ts examples/form-select/test.ts examples/form-callback-queue/test.ts app/src/sandbox/form-6307/test.ts`
- `pnpm test website/build-pages/get-page-content.test.ts website/build-pages/reference-utils.test.ts`
- `pnpm build`
- `pnpm build-website-lite`
- `pnpm lint`
- `git diff --check`
