### PR TITLE
Improve dialog scrollbar-gutter changeset

### DIFF
--- a/.changeset/200-dialog-scrollbar-gutter.md
+++ b/.changeset/200-dialog-scrollbar-gutter.md
@@ -3,12 +3,25 @@
 "@ariakit/react": patch
 ---
 
-Modal dialogs reserve the scrollbar space with CSS `scrollbar-gutter`
+Modal scroll locks use `scrollbar-gutter`
 
-When [`preventBodyScroll`](https://ariakit.com/reference/dialog#preventbodyscroll) is enabled (the default for [`modal`](https://ariakit.com/reference/dialog#modal) dialogs), [`Dialog`](https://ariakit.com/reference/dialog) and components built on it, such as [`Popover`](https://ariakit.com/reference/popover), [`Menu`](https://ariakit.com/reference/menu), [`SelectPopover`](https://ariakit.com/reference/select-popover), and [`ComboboxPopover`](https://ariakit.com/reference/combobox-popover), now lock the page scroll by setting `scrollbar-gutter: stable` and hiding the overflow on the `html` element, instead of measuring the scrollbar and padding the `body` element.
+The [`Dialog`](https://ariakit.com/reference/dialog) component now locks page scroll in supporting browsers by setting `scrollbar-gutter: stable` and hiding overflow on the `html` element when [`preventBodyScroll`](https://ariakit.com/reference/dialog#preventbodyscroll) is enabled. This applies to [`modal`](https://ariakit.com/reference/dialog#modal) dialogs by default and to components built on [`Dialog`](https://ariakit.com/reference/dialog), including [`Popover`](https://ariakit.com/reference/popover), [`Hovercard`](https://ariakit.com/reference/hovercard), [`Tooltip`](https://ariakit.com/reference/tooltip), [`Menu`](https://ariakit.com/reference/menu), [`SelectPopover`](https://ariakit.com/reference/select-popover), and [`ComboboxPopover`](https://ariakit.com/reference/combobox-popover).
 
-The reserved gutter keeps the page layout stable without any width compensation, so `position: fixed` elements no longer shift when a modal dialog opens and no longer need the `--scrollbar-width` CSS variable to adjust their padding. This also makes opening modal dialogs slightly faster and plays well with pages that already set `scrollbar-gutter: stable` themselves, which previously caused a layout shift. Note that on browsers with classic scrollbars, the reserved gutter shows the page background while the dialog is open, and `position: fixed` elements such as backdrops don't extend over it, just like they don't extend under the scrollbar when it's visible.
+Pages that already set `scrollbar-gutter: stable` or `overflow-y: scroll` on `html` no longer shift when a modal opens, and Ariakit restores inline `html` overflow styles when it closes.
 
-This fixes the layout shift that occurred when the `html` element had `overflow-y: scroll` with an always-visible scrollbar. Scroll locking now also covers pages that scroll through the `html` element itself (any non-visible `html` overflow), where hiding the `body` overflow alone had no effect, and the lock restores inline overflow styles the page set on the `html` element exactly as they were.
+Fixed headers no longer need `--scrollbar-width` in browsers that support `scrollbar-gutter`:
 
-The `--scrollbar-width` CSS variable is now only defined when the scrollbar takes up space but `scrollbar-gutter` isn't supported (such as Safari before 18.2), where Ariakit falls back to the previous padding behavior. Styles that use the variable with a fallback value, like `padding-right: calc(16px + var(--scrollbar-width, 0px))`, keep working there and now resolve to the correct value in modern browsers as well. Note that a unitless `0` fallback is invalid inside `calc()`, so use `0px`.
+```css
+.header {
+  position: fixed;
+  padding-inline-end: 16px;
+}
+```
+
+The `--scrollbar-width` CSS variable is now only defined in the fallback path for browsers without `scrollbar-gutter` support. If you still target those browsers, keep a length fallback when using the variable inside `calc()`:
+
+```css
+.header {
+  padding-inline-end: calc(16px + var(--scrollbar-width, 0px));
+}
+```


### PR DESCRIPTION
## Motivation
The changeset for the dialog scroll-lock `scrollbar-gutter` update was too long and dense. It explained implementation details in prose, which made the release note harder to scan.

## Solution
Shorten `.changeset/200-dialog-scrollbar-gutter.md` to focus on user-facing behavior, keep representative linked APIs, and add CSS examples for the modern fixed-header case and the fallback-safe `--scrollbar-width` pattern.
