### PR TITLE
Support provider components in store props and store hooks

### DIFF
--- a/.changeset/200-provider-component-store.md
+++ b/.changeset/200-provider-component-store.md
@@ -15,6 +15,8 @@ For example, [`CompositeItem`](https://ariakit.com/reference/composite-item) can
 <CompositeItem store={ComboboxProvider} />
 ```
 
+If no matching provider context exists above the component, the store resolves to `undefined` rather than falling back to a closer compatible context. Note that components composed from multiple layers may still bind lower-level behavior to their own contexts in that case.
+
 The [`useStoreState`](https://ariakit.com/reference/use-store-state) and `useStoreStateObject` hooks accept provider components as well:
 
 ```tsx

--- a/.changeset/200-provider-component-store.md
+++ b/.changeset/200-provider-component-store.md
@@ -7,7 +7,7 @@
 
 Support provider components in store props and store hooks
 
-Component `store` props now accept a provider component (for example, [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)) in place of a store object. The store is read from the closest matching provider through context, which lets you explicitly bind a component to a specific provider even when a different compatible provider is nested closer.
+Component `store` props now accept a provider component (for example, [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)) in place of a store object. The store is read from that provider's context, which lets you explicitly bind a component to a specific provider kind even when a different compatible provider is nested closer.
 
 For example, [`CompositeItem`](https://ariakit.com/reference/composite-item) can read from the closest [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider) even when a [`ToolbarProvider`](https://ariakit.com/reference/toolbar-provider) or [`CompositeProvider`](https://ariakit.com/reference/composite-provider) is nested closer to it:
 
@@ -19,4 +19,21 @@ The [`useStoreState`](https://ariakit.com/reference/use-store-state) and `useSto
 
 ```tsx
 const value = useStoreState(ComboboxProvider, "value");
+```
+
+The new `ProviderComponent` type is exported from `@ariakit/react` and `@ariakit/react-store` so you can reference the widened props in your own types:
+
+```tsx
+interface Props {
+  store?: ComboboxStore | ProviderComponent<ComboboxStore>;
+}
+```
+
+Note that this is a type-level change to the `store` props: passing store objects keeps working as before, but code that reads a widened `store` prop type and passes its value to an API that expects a store object (for example, [`useFormValidate`](https://ariakit.com/reference/use-form-validate)) must now re-narrow the prop:
+
+```tsx
+interface FormProps extends Ariakit.FormProps {
+  // Accept only store objects so the prop can be passed to useFormValidate.
+  store?: Ariakit.FormStore;
+}
 ```

--- a/.changeset/200-provider-component-store.md
+++ b/.changeset/200-provider-component-store.md
@@ -5,7 +5,7 @@
 "@ariakit/react": patch
 ---
 
-Support provider components in store props and store hooks
+Store props and store hooks accept provider components
 
 Component `store` props now accept a provider component (for example, [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)) in place of a store object. The store is read from that provider's context, which lets you explicitly bind a component to a specific provider kind even when a different compatible provider is nested closer.
 

--- a/.changeset/200-provider-component-store.md
+++ b/.changeset/200-provider-component-store.md
@@ -1,0 +1,22 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react-store": patch
+"@ariakit/react-utils": patch
+"@ariakit/react": patch
+---
+
+Support provider components in store props and store hooks
+
+Component `store` props now accept a provider component (for example, [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)) in place of a store object. The store is read from the closest matching provider through context, which lets you explicitly bind a component to a specific provider even when a different compatible provider is nested closer.
+
+For example, [`CompositeItem`](https://ariakit.com/reference/composite-item) can read from the closest [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider) even when a [`ToolbarProvider`](https://ariakit.com/reference/toolbar-provider) or [`CompositeProvider`](https://ariakit.com/reference/composite-provider) is nested closer to it:
+
+```tsx
+<CompositeItem store={ComboboxProvider} />
+```
+
+The [`useStoreState`](https://ariakit.com/reference/use-store-state) and `useStoreStateObject` hooks accept provider components as well:
+
+```tsx
+const value = useStoreState(ComboboxProvider, "value");
+```

--- a/.changeset/300-composite-input-context-store.md
+++ b/.changeset/300-composite-input-context-store.md
@@ -1,0 +1,9 @@
+---
+"@ariakit/react-components": patch
+---
+
+`CompositeInput` reads the store from context
+
+The deprecated `CompositeInput` component now reads the store from the closest [`Composite`](https://ariakit.com/reference/composite) or [`CompositeProvider`](https://ariakit.com/reference/composite-provider) context when the `store` prop is not provided, as its documentation already stated.
+
+As a result, while the caret moves within the text field, `CompositeInput` now only stops the propagation of arrow keys along the composite widget's [`orientation`](https://ariakit.com/reference/use-composite-store#orientation). Arrow keys on the other axis, which the composite widget doesn't handle, are no longer stopped.

--- a/.changeset/300-composite-input-context-store.md
+++ b/.changeset/300-composite-input-context-store.md
@@ -2,7 +2,7 @@
 "@ariakit/react-components": patch
 ---
 
-`CompositeInput` reads the store from context
+`CompositeInput` now reads the store from context
 
 The deprecated `CompositeInput` component now reads the store from the closest [`Composite`](https://ariakit.com/reference/composite) or [`CompositeProvider`](https://ariakit.com/reference/composite-provider) context when the `store` prop is not provided, as its documentation already stated.
 

--- a/app/src/sandbox/composite-item-provider-store/index.react.tsx
+++ b/app/src/sandbox/composite-item-provider-store/index.react.tsx
@@ -1,0 +1,69 @@
+import * as Ariakit from "@ariakit/react";
+import "./style.css";
+
+// Reads state directly from provider components instead of store objects.
+// `useStoreState` resolves each provider component to the closest matching
+// provider through context, so this works without threading stores as props.
+function StoreStatus() {
+  const comboboxValue = Ariakit.useStoreState(
+    Ariakit.ComboboxProvider,
+    "value",
+  );
+  const comboboxItemCount = Ariakit.useStoreState(
+    Ariakit.ComboboxProvider,
+    (state) => state?.renderedItems.length ?? 0,
+  );
+  const toolbarItemCount = Ariakit.useStoreState(
+    Ariakit.ToolbarProvider,
+    (state) => state?.renderedItems.length ?? 0,
+  );
+  return (
+    <div className="status">
+      <output aria-label="Combobox value">{comboboxValue}</output>
+      <output aria-label="Combobox items">{comboboxItemCount}</output>
+      <output aria-label="Toolbar items">{toolbarItemCount}</output>
+    </div>
+  );
+}
+
+// Rendered outside any ComboboxProvider. Because a provider component is an
+// explicit reference with no fallback, `useStoreState` resolves to `undefined`
+// here even though a ComboboxProvider exists elsewhere in the tree.
+function OutsideStatus() {
+  const value = Ariakit.useStoreState(Ariakit.ComboboxProvider, "value");
+  return <output aria-label="Outside combobox value">{value ?? "none"}</output>;
+}
+
+export default function Example() {
+  return (
+    <>
+      <OutsideStatus />
+      <ComboboxWithToolbar />
+    </>
+  );
+}
+
+function ComboboxWithToolbar() {
+  return (
+    <Ariakit.ComboboxProvider defaultValue="Apple">
+      <Ariakit.ComboboxLabel>Fruit</Ariakit.ComboboxLabel>
+      <Ariakit.Combobox className="combobox" />
+      <Ariakit.ToolbarProvider>
+        <Ariakit.Toolbar className="toolbar" aria-label="Fruit actions">
+          {/* Binds to the nearest Toolbar, its closest composite context. */}
+          <Ariakit.ToolbarItem className="button">Clear</Ariakit.ToolbarItem>
+          {/* Explicitly binds to the Combobox by passing the provider
+              component, even though the Toolbar is the closer composite
+              context. It becomes a combobox item, not a toolbar item. */}
+          <Ariakit.CompositeItem
+            store={Ariakit.ComboboxProvider}
+            className="button"
+          >
+            Focus first option
+          </Ariakit.CompositeItem>
+        </Ariakit.Toolbar>
+        <StoreStatus />
+      </Ariakit.ToolbarProvider>
+    </Ariakit.ComboboxProvider>
+  );
+}

--- a/app/src/sandbox/composite-item-provider-store/index.react.tsx
+++ b/app/src/sandbox/composite-item-provider-store/index.react.tsx
@@ -1,17 +1,18 @@
 import * as Ariakit from "@ariakit/react";
+import { useStoreStateObject } from "@ariakit/react-components/store";
 import "./style.css";
 
 // Reads state directly from provider components instead of store objects.
-// `useStoreState` resolves each provider component to the closest matching
-// provider through context, so this works without threading stores as props.
+// `useStoreState` and `useStoreStateObject` resolve each provider component
+// through that provider's context, so this works without threading stores as
+// props.
 function StoreStatus() {
-  const comboboxValue = Ariakit.useStoreState(
+  const { comboboxValue, comboboxItemCount } = useStoreStateObject(
     Ariakit.ComboboxProvider,
-    "value",
-  );
-  const comboboxItemCount = Ariakit.useStoreState(
-    Ariakit.ComboboxProvider,
-    (state) => state?.renderedItems.length ?? 0,
+    {
+      comboboxValue: "value",
+      comboboxItemCount: (state) => state?.renderedItems.length ?? 0,
+    },
   );
   const toolbarItemCount = Ariakit.useStoreState(
     Ariakit.ToolbarProvider,
@@ -39,6 +40,7 @@ export default function Example() {
     <>
       <OutsideStatus />
       <ComboboxWithToolbar />
+      <OutsideCollection />
     </>
   );
 }
@@ -59,11 +61,45 @@ function ComboboxWithToolbar() {
             store={Ariakit.ComboboxProvider}
             className="button"
           >
-            Focus first option
+            Combobox item
           </Ariakit.CompositeItem>
         </Ariakit.Toolbar>
         <StoreStatus />
       </Ariakit.ToolbarProvider>
     </Ariakit.ComboboxProvider>
+  );
+}
+
+// Rendered outside any ComboboxProvider. The second CollectionItem explicitly
+// targets ComboboxProvider, and provider components have no fallback, so it
+// must not register with the closer collection even though that compatible
+// context is right above it.
+function OutsideCollection() {
+  return (
+    <Ariakit.CollectionProvider>
+      <Ariakit.Collection className="collection">
+        <Ariakit.CollectionItem className="button" render={<button />}>
+          Plain item
+        </Ariakit.CollectionItem>
+        <Ariakit.CollectionItem
+          className="button"
+          render={<button />}
+          store={Ariakit.ComboboxProvider}
+        >
+          Outside combobox item
+        </Ariakit.CollectionItem>
+      </Ariakit.Collection>
+      <OutsideCollectionStatus />
+    </Ariakit.CollectionProvider>
+  );
+}
+
+function OutsideCollectionStatus() {
+  const collectionItemCount = Ariakit.useStoreState(
+    Ariakit.CollectionProvider,
+    (state) => state?.renderedItems.length ?? 0,
+  );
+  return (
+    <output aria-label="Outside collection items">{collectionItemCount}</output>
   );
 }

--- a/app/src/sandbox/composite-item-provider-store/style.css
+++ b/app/src/sandbox/composite-item-provider-store/style.css
@@ -3,7 +3,8 @@
   padding: 0 0.5rem;
 }
 
-.toolbar {
+.toolbar,
+.collection {
   display: flex;
   gap: 0.5rem;
   margin-top: 0.5rem;

--- a/app/src/sandbox/composite-item-provider-store/style.css
+++ b/app/src/sandbox/composite-item-provider-store/style.css
@@ -1,0 +1,22 @@
+.combobox {
+  height: 2.5rem;
+  padding: 0 0.5rem;
+}
+
+.toolbar {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.button {
+  height: 2.5rem;
+  padding: 0 0.75rem;
+}
+
+.status {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-top: 1rem;
+}

--- a/app/src/sandbox/composite-item-provider-store/test-browser.ts
+++ b/app/src/sandbox/composite-item-provider-store/test-browser.ts
@@ -1,14 +1,14 @@
 import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
-  test("useStoreState reads state through a provider component", async ({
+  test("useStoreStateObject reads state through a provider component", async ({
     page,
     q,
   }) => {
     await test.expect(q.status("Combobox value")).toHaveText("Apple");
 
     // Typing updates the combobox store, and the readout reflects it live
-    // through the provider component passed to `useStoreState`.
+    // through the provider component passed to `useStoreStateObject`.
     await q.combobox("Fruit").click();
     await page.keyboard.type("s");
 
@@ -18,13 +18,13 @@ withFramework(import.meta.dirname, async ({ test }) => {
   test("CompositeItem store={ComboboxProvider} binds to the combobox, not the closer toolbar", async ({
     q,
   }) => {
-    // The `Focus first option` item is nested inside the Toolbar but explicitly
+    // The `Combobox item` item is nested inside the Toolbar but explicitly
     // targets the ComboboxProvider, so it registers with the combobox instead
     // of the toolbar.
     await test.expect(q.status("Combobox items")).toHaveText("1");
     await test.expect(q.status("Toolbar items")).toHaveText("1");
     await test.expect(q.button("Clear")).toBeVisible();
-    await test.expect(q.button("Focus first option")).toBeVisible();
+    await test.expect(q.button("Combobox item")).toBeVisible();
   });
 
   test("provider components have no fallback: useStoreState is undefined outside a matching provider", async ({
@@ -33,5 +33,17 @@ withFramework(import.meta.dirname, async ({ test }) => {
     // `OutsideStatus` reads useStoreState(ComboboxProvider) while rendered
     // outside every ComboboxProvider, so it resolves to undefined ("none").
     await test.expect(q.status("Outside combobox value")).toHaveText("none");
+  });
+
+  test("provider components have no fallback: CollectionItem store={ComboboxProvider} skips the closer collection outside a matching provider", async ({
+    q,
+  }) => {
+    // The outside collection renders one plain CollectionItem plus a
+    // CollectionItem that targets ComboboxProvider. No ComboboxProvider wraps
+    // that region, and provider components have no fallback, so the second
+    // item must not register with the closer collection: the count stays at
+    // the plain item.
+    await test.expect(q.status("Outside collection items")).toHaveText("1");
+    await test.expect(q.button("Outside combobox item")).toBeVisible();
   });
 });

--- a/app/src/sandbox/composite-item-provider-store/test-browser.ts
+++ b/app/src/sandbox/composite-item-provider-store/test-browser.ts
@@ -1,0 +1,37 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("useStoreState reads state through a provider component", async ({
+    page,
+    q,
+  }) => {
+    await test.expect(q.status("Combobox value")).toHaveText("Apple");
+
+    // Typing updates the combobox store, and the readout reflects it live
+    // through the provider component passed to `useStoreState`.
+    await q.combobox("Fruit").click();
+    await page.keyboard.type("s");
+
+    await test.expect(q.status("Combobox value")).toHaveText("Apples");
+  });
+
+  test("CompositeItem store={ComboboxProvider} binds to the combobox, not the closer toolbar", async ({
+    q,
+  }) => {
+    // The `Focus first option` item is nested inside the Toolbar but explicitly
+    // targets the ComboboxProvider, so it registers with the combobox instead
+    // of the toolbar.
+    await test.expect(q.status("Combobox items")).toHaveText("1");
+    await test.expect(q.status("Toolbar items")).toHaveText("1");
+    await test.expect(q.button("Clear")).toBeVisible();
+    await test.expect(q.button("Focus first option")).toBeVisible();
+  });
+
+  test("provider components have no fallback: useStoreState is undefined outside a matching provider", async ({
+    q,
+  }) => {
+    // `OutsideStatus` reads useStoreState(ComboboxProvider) while rendered
+    // outside every ComboboxProvider, so it resolves to undefined ("none").
+    await test.expect(q.status("Outside combobox value")).toHaveText("none");
+  });
+});

--- a/app/src/sandbox/composite-item-provider-store/test.ts
+++ b/app/src/sandbox/composite-item-provider-store/test.ts
@@ -1,13 +1,13 @@
 import { q, type } from "@ariakit/test";
 import { expect, test } from "vitest";
 
-test("useStoreState reads state through a provider component", async () => {
+test("useStoreStateObject reads state through a provider component", async () => {
   await expect
     .poll(() => q.status.ensure("Combobox value").textContent)
     .toBe("Apple");
 
   // Typing updates the combobox store, and the readout reflects it live
-  // through the provider component passed to `useStoreState`.
+  // through the provider component passed to `useStoreStateObject`.
   await type("s", q.combobox.ensure("Fruit"));
 
   await expect
@@ -25,7 +25,7 @@ test("provider components have no fallback: useStoreState is undefined outside a
 });
 
 test("CompositeItem store={ComboboxProvider} binds to the combobox, not the closer toolbar", async () => {
-  // The `Focus first option` item is nested inside the Toolbar (its closest
+  // The `Combobox item` item is nested inside the Toolbar (its closest
   // composite context) but explicitly targets the ComboboxProvider, so it
   // registers with the combobox instead of the toolbar.
   await expect
@@ -37,5 +37,17 @@ test("CompositeItem store={ComboboxProvider} binds to the combobox, not the clos
 
   // Both items render as buttons regardless of which store they belong to.
   expect(q.button("Clear")).toBeInTheDocument();
-  expect(q.button("Focus first option")).toBeInTheDocument();
+  expect(q.button("Combobox item")).toBeInTheDocument();
+});
+
+test("provider components have no fallback: CollectionItem store={ComboboxProvider} skips the closer collection outside a matching provider", async () => {
+  // The outside collection renders one plain CollectionItem plus a
+  // CollectionItem that targets ComboboxProvider. No ComboboxProvider wraps
+  // that region, and provider components have no fallback, so the second item
+  // must not register with the closer collection: the count stays at the
+  // plain item.
+  await expect
+    .poll(() => q.status.ensure("Outside collection items").textContent)
+    .toBe("1");
+  expect(q.button("Outside combobox item")).toBeInTheDocument();
 });

--- a/app/src/sandbox/composite-item-provider-store/test.ts
+++ b/app/src/sandbox/composite-item-provider-store/test.ts
@@ -1,0 +1,41 @@
+import { q, type } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+test("useStoreState reads state through a provider component", async () => {
+  await expect
+    .poll(() => q.status.ensure("Combobox value").textContent)
+    .toBe("Apple");
+
+  // Typing updates the combobox store, and the readout reflects it live
+  // through the provider component passed to `useStoreState`.
+  await type("s", q.combobox.ensure("Fruit"));
+
+  await expect
+    .poll(() => q.status.ensure("Combobox value").textContent)
+    .toBe("Apples");
+});
+
+test("provider components have no fallback: useStoreState is undefined outside a matching provider", async () => {
+  // `OutsideStatus` reads `useStoreState(ComboboxProvider, "value")` while
+  // rendered outside every ComboboxProvider, so it must resolve to undefined
+  // (shown as "none") even though a ComboboxProvider exists elsewhere.
+  await expect
+    .poll(() => q.status.ensure("Outside combobox value").textContent)
+    .toBe("none");
+});
+
+test("CompositeItem store={ComboboxProvider} binds to the combobox, not the closer toolbar", async () => {
+  // The `Focus first option` item is nested inside the Toolbar (its closest
+  // composite context) but explicitly targets the ComboboxProvider, so it
+  // registers with the combobox instead of the toolbar.
+  await expect
+    .poll(() => q.status.ensure("Combobox items").textContent)
+    .toBe("1");
+  await expect
+    .poll(() => q.status.ensure("Toolbar items").textContent)
+    .toBe("1");
+
+  // Both items render as buttons regardless of which store they belong to.
+  expect(q.button("Clear")).toBeInTheDocument();
+  expect(q.button("Focus first option")).toBeInTheDocument();
+});

--- a/examples/form-callback-queue/index.react.tsx
+++ b/examples/form-callback-queue/index.react.tsx
@@ -33,6 +33,7 @@ function RequiredField({ store, label, name, ...props }: NameFieldProps) {
 }
 
 interface FormProps extends Ariakit.FormProps {
+  store?: Ariakit.FormStore;
   requiredNames: Array<NameFieldProps["name"]>;
 }
 

--- a/packages/ariakit-react-components/src/checkbox/checkbox-check.tsx
+++ b/packages/ariakit-react-components/src/checkbox/checkbox-check.tsx
@@ -1,5 +1,5 @@
 import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Options, Props } from "@ariakit/react-utils";
+import type { Options, Props, ProviderComponent } from "@ariakit/react-utils";
 import { removeUndefinedValues } from "@ariakit/utils";
 import type { ElementType } from "react";
 import { useContext } from "react";
@@ -99,7 +99,7 @@ export interface CheckboxCheckOptions<
    * when it's not provided, from the closest
    * [`Checkbox`](https://ariakit.com/reference/checkbox) component.
    */
-  store?: CheckboxStore;
+  store?: CheckboxStore | ProviderComponent<CheckboxStore>;
   /**
    * Determines if the checkmark should be rendered. This value is automatically
    * derived from the context when it exists. Manually setting this prop will

--- a/packages/ariakit-react-components/src/checkbox/checkbox-context.tsx
+++ b/packages/ariakit-react-components/src/checkbox/checkbox-context.tsx
@@ -25,3 +25,5 @@ export const useCheckboxProviderContext = ctx.useProviderContext;
 export const CheckboxContextProvider = ctx.ContextProvider;
 
 export const CheckboxScopedContextProvider = ctx.ScopedContextProvider;
+
+export const createCheckboxProvider = ctx.createProviderComponent;

--- a/packages/ariakit-react-components/src/checkbox/checkbox-provider.tsx
+++ b/packages/ariakit-react-components/src/checkbox/checkbox-provider.tsx
@@ -1,13 +1,25 @@
+import type { ProviderComponent } from "@ariakit/react-utils";
 import type { PickRequired } from "@ariakit/utils";
 import type { ReactElement, ReactNode } from "react";
-import { CheckboxContextProvider } from "./checkbox-context.tsx";
+import {
+  CheckboxContextProvider,
+  createCheckboxProvider,
+} from "./checkbox-context.tsx";
 import type {
+  CheckboxStore,
   CheckboxStoreProps,
   CheckboxStoreValue,
 } from "./checkbox-store.ts";
 import { useCheckboxStore } from "./checkbox-store.ts";
 
 type Value = CheckboxStoreValue;
+
+export interface CheckboxProviderComponent extends ProviderComponent<CheckboxStore> {
+  <T extends Value = Value>(
+    props: PickRequired<CheckboxProviderProps<T>, "value" | "defaultValue">,
+  ): ReactElement;
+  (props?: CheckboxProviderProps): ReactElement;
+}
 
 /**
  * Provides a checkbox store for its descendants. This comes in handy when
@@ -30,21 +42,17 @@ type Value = CheckboxStoreValue;
  * </CheckboxProvider>
  * ```
  */
-
-export function CheckboxProvider<T extends Value = Value>(
-  props: PickRequired<CheckboxProviderProps<T>, "value" | "defaultValue">,
-): ReactElement;
-
-export function CheckboxProvider(props?: CheckboxProviderProps): ReactElement;
-
-export function CheckboxProvider(props: CheckboxProviderProps = {}) {
-  const store = useCheckboxStore(props);
-  return (
-    <CheckboxContextProvider value={store}>
-      {props.children}
-    </CheckboxContextProvider>
-  );
-}
+export const CheckboxProvider: CheckboxProviderComponent =
+  createCheckboxProvider(function CheckboxProvider(
+    props: CheckboxProviderProps = {},
+  ) {
+    const store = useCheckboxStore(props);
+    return (
+      <CheckboxContextProvider value={store}>
+        {props.children}
+      </CheckboxContextProvider>
+    );
+  });
 
 export interface CheckboxProviderProps<
   T extends Value = Value,

--- a/packages/ariakit-react-components/src/checkbox/checkbox.tsx
+++ b/packages/ariakit-react-components/src/checkbox/checkbox.tsx
@@ -8,8 +8,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { disabledFromProps, removeUndefinedValues } from "@ariakit/utils";
 import type {
   ChangeEvent,
@@ -62,7 +63,7 @@ export const useCheckbox = createHook<TagName, CheckboxOptions>(
     ...props
   }) {
     const context = useCheckboxContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     const [_checked, setChecked] = useState(defaultChecked ?? false);
 
@@ -213,8 +214,13 @@ export interface CheckboxOptions<
    *
    * Live examples:
    * - [Checkbox as button](https://ariakit.com/examples/checkbox-as-button)
+   *
+   * You can also pass a provider component (for example,
+   * [`CheckboxProvider`](https://ariakit.com/reference/checkbox-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: CheckboxStore;
+  store?: CheckboxStore | ProviderComponent<CheckboxStore>;
   /**
    * The native `name` attribute.
    *

--- a/packages/ariakit-react-components/src/checkbox/checkbox.tsx
+++ b/packages/ariakit-react-components/src/checkbox/checkbox.tsx
@@ -217,8 +217,9 @@ export interface CheckboxOptions<
    *
    * You can also pass a provider component (for example,
    * [`CheckboxProvider`](https://ariakit.com/reference/checkbox-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: CheckboxStore | ProviderComponent<CheckboxStore>;
   /**

--- a/packages/ariakit-react-components/src/collection/collection-context.tsx
+++ b/packages/ariakit-react-components/src/collection/collection-context.tsx
@@ -25,3 +25,5 @@ export const useCollectionProviderContext = ctx.useProviderContext;
 export const CollectionContextProvider = ctx.ContextProvider;
 
 export const CollectionScopedContextProvider = ctx.ScopedContextProvider;
+
+export const createCollectionProvider = ctx.createProviderComponent;

--- a/packages/ariakit-react-components/src/collection/collection-item.tsx
+++ b/packages/ariakit-react-components/src/collection/collection-item.tsx
@@ -102,8 +102,9 @@ export interface CollectionItemOptions<
    *
    * You can also pass a provider component (for example,
    * [`CollectionProvider`](https://ariakit.com/reference/collection-provider)).
-   * In that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * In that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: CollectionStore | ProviderComponent<CollectionStore>;
   /**

--- a/packages/ariakit-react-components/src/collection/collection-item.tsx
+++ b/packages/ariakit-react-components/src/collection/collection-item.tsx
@@ -5,8 +5,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Options, Props } from "@ariakit/react-utils";
+import type { Options, Props, ProviderComponent } from "@ariakit/react-utils";
 import { identity, removeUndefinedValues } from "@ariakit/utils";
 import type { ElementType } from "react";
 import { useEffect, useRef } from "react";
@@ -40,7 +41,7 @@ export const useCollectionItem = createHook<TagName, CollectionItemOptions>(
     ...props
   }) {
     const context = useCollectionContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     const id = useId(props.id);
     const ref = useRef<HTMLType>(element);
@@ -98,8 +99,13 @@ export interface CollectionItemOptions<
    *
    * Live examples:
    * - [Navigation Menubar](https://ariakit.com/examples/menubar-navigation)
+   *
+   * You can also pass a provider component (for example,
+   * [`CollectionProvider`](https://ariakit.com/reference/collection-provider)).
+   * In that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: CollectionStore;
+  store?: CollectionStore | ProviderComponent<CollectionStore>;
   /**
    * The unique ID of the item. This will be used to register the item in the
    * store and for the element's `id` attribute. If not provided, a unique ID

--- a/packages/ariakit-react-components/src/collection/collection-provider.tsx
+++ b/packages/ariakit-react-components/src/collection/collection-provider.tsx
@@ -1,11 +1,23 @@
+import type { ProviderComponent } from "@ariakit/react-utils";
 import type { PickRequired } from "@ariakit/utils";
 import type { ReactElement, ReactNode } from "react";
-import { CollectionContextProvider } from "./collection-context.tsx";
+import {
+  CollectionContextProvider,
+  createCollectionProvider,
+} from "./collection-context.tsx";
 import type {
+  CollectionStore,
   CollectionStoreItem,
   CollectionStoreProps,
 } from "./collection-store.ts";
 import { useCollectionStore } from "./collection-store.ts";
+
+export interface CollectionProviderComponent extends ProviderComponent<CollectionStore> {
+  <T extends CollectionStoreItem = CollectionStoreItem>(
+    props: PickRequired<CollectionProviderProps<T>, "items" | "defaultItems">,
+  ): ReactElement;
+  (props?: CollectionProviderProps): ReactElement;
+}
 
 /**
  * Provides a collection store to
@@ -20,25 +32,17 @@ import { useCollectionStore } from "./collection-store.ts";
  * </CollectionProvider>
  * ```
  */
-
-export function CollectionProvider<
-  T extends CollectionStoreItem = CollectionStoreItem,
->(
-  props: PickRequired<CollectionProviderProps<T>, "items" | "defaultItems">,
-): ReactElement;
-
-export function CollectionProvider(
-  props?: CollectionProviderProps,
-): ReactElement;
-
-export function CollectionProvider(props: CollectionProviderProps = {}) {
-  const store = useCollectionStore(props);
-  return (
-    <CollectionContextProvider value={store}>
-      {props.children}
-    </CollectionContextProvider>
-  );
-}
+export const CollectionProvider: CollectionProviderComponent =
+  createCollectionProvider(function CollectionProvider(
+    props: CollectionProviderProps = {},
+  ) {
+    const store = useCollectionStore(props);
+    return (
+      <CollectionContextProvider value={store}>
+        {props.children}
+      </CollectionContextProvider>
+    );
+  });
 
 export interface CollectionProviderProps<
   T extends CollectionStoreItem = CollectionStoreItem,

--- a/packages/ariakit-react-components/src/collection/collection-renderer.tsx
+++ b/packages/ariakit-react-components/src/collection/collection-renderer.tsx
@@ -5,11 +5,12 @@ import {
   useForceUpdate,
   useId,
   useMergeRefs,
+  useStoreProp,
   useWrapElement,
   createElement,
   forwardRef,
 } from "@ariakit/react-utils";
-import type { Options, Props } from "@ariakit/react-utils";
+import type { Options, ProviderComponent, Props } from "@ariakit/react-utils";
 import {
   getScrollingElement,
   getWindow,
@@ -445,7 +446,7 @@ export function useCollectionRenderer<T extends Item = any>({
   ...props
 }: CollectionRendererProps<T>) {
   const context = useCollectionContext();
-  const store = storeProp || (context as typeof storeProp);
+  const store = useStoreProp(storeProp, context);
 
   const items = useStoreState(
     store,
@@ -913,10 +914,17 @@ export interface CollectionRendererOptions<
    * will be used to render the items if the
    * [`items`](https://ariakit.com/reference/collection-items#items) prop is not
    * provided.
+   *
+   * You can also pass a provider component (for example,
+   * [`CollectionProvider`](https://ariakit.com/reference/collection-provider)).
+   * In that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: CollectionStore<
-    T extends CollectionStoreItem ? T : CollectionStoreItem
-  >;
+  store?:
+    | CollectionStore<T extends CollectionStoreItem ? T : CollectionStoreItem>
+    | ProviderComponent<
+        CollectionStore<T extends CollectionStoreItem ? T : CollectionStoreItem>
+      >;
   /**
    * All items to be rendered. This prop can be either a memoized array of items
    * or a number representing the total number of items to be rendered.

--- a/packages/ariakit-react-components/src/collection/collection-renderer.tsx
+++ b/packages/ariakit-react-components/src/collection/collection-renderer.tsx
@@ -116,7 +116,9 @@ type Data = Map<
 >;
 
 interface CollectionRendererContextValue {
-  store: CollectionRendererOptions["store"];
+  // The context value is built from the resolved store (the `useStoreProp`
+  // result), so the `ProviderComponent` arm of the option never occurs here.
+  store: Exclude<CollectionRendererOptions["store"], ProviderComponent>;
   orientation: CollectionRendererOptions["orientation"];
   overscan: CollectionRendererOptions["overscan"];
   childrenData: Map<string, Data>;
@@ -917,14 +919,16 @@ export interface CollectionRendererOptions<
    *
    * You can also pass a provider component (for example,
    * [`CollectionProvider`](https://ariakit.com/reference/collection-provider)).
-   * In that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * In that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?:
     | CollectionStore<T extends CollectionStoreItem ? T : CollectionStoreItem>
-    | ProviderComponent<
-        CollectionStore<T extends CollectionStoreItem ? T : CollectionStoreItem>
-      >;
+    // The provider brand never carries the item type and runtime resolution
+    // doesn't depend on `T`, so the provider arm uses the base store to keep
+    // `T` inference and explicit generic arguments working.
+    | ProviderComponent<CollectionStore>;
   /**
    * All items to be rendered. This prop can be either a memoized array of items
    * or a number representing the total number of items to be rendered.

--- a/packages/ariakit-react-components/src/collection/collection.tsx
+++ b/packages/ariakit-react-components/src/collection/collection.tsx
@@ -87,8 +87,9 @@ export interface CollectionOptions<
    *
    * You can also pass a provider component (for example,
    * [`CollectionProvider`](https://ariakit.com/reference/collection-provider)).
-   * In that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * In that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: CollectionStore | ProviderComponent<CollectionStore>;
 }

--- a/packages/ariakit-react-components/src/collection/collection.tsx
+++ b/packages/ariakit-react-components/src/collection/collection.tsx
@@ -3,8 +3,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Options, Props } from "@ariakit/react-utils";
+import type { Options, Props, ProviderComponent } from "@ariakit/react-utils";
 import { removeUndefinedValues } from "@ariakit/utils";
 import type { ElementType } from "react";
 import {
@@ -35,7 +36,7 @@ type TagName = typeof TagName;
 export const useCollection = createHook<TagName, CollectionOptions>(
   function useCollection({ store, ...props }) {
     const context = useCollectionProviderContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     props = useWrapElement(
       props,
@@ -83,8 +84,13 @@ export interface CollectionOptions<
    * hook. If not provided, the closest
    * [`CollectionProvider`](https://ariakit.com/reference/collection-provider)
    * component's context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`CollectionProvider`](https://ariakit.com/reference/collection-provider)).
+   * In that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: CollectionStore;
+  store?: CollectionStore | ProviderComponent<CollectionStore>;
 }
 
 export type CollectionProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/combobox/combobox-cancel.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-cancel.tsx
@@ -5,8 +5,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { invariant } from "@ariakit/utils";
 import type { ElementType, MouseEvent } from "react";
 import { Fragment } from "react";
@@ -53,7 +54,7 @@ const children = (
 export const useComboboxCancel = createHook<TagName, ComboboxCancelOptions>(
   function useComboboxCancel({ store, hideWhenEmpty, ...props }) {
     const context = useComboboxProviderContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -134,8 +135,13 @@ export interface ComboboxCancelOptions<
    * hook. If not provided, the closest
    * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)
    * component's context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: ComboboxStore;
+  store?: ComboboxStore | ProviderComponent<ComboboxStore>;
   /**
    * When enabled, the button won't be rendered when the combobox input value is
    * empty.

--- a/packages/ariakit-react-components/src/combobox/combobox-cancel.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-cancel.tsx
@@ -138,8 +138,9 @@ export interface ComboboxCancelOptions<
    *
    * You can also pass a provider component (for example,
    * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: ComboboxStore | ProviderComponent<ComboboxStore>;
   /**

--- a/packages/ariakit-react-components/src/combobox/combobox-context.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-context.tsx
@@ -42,6 +42,8 @@ export const ComboboxContextProvider = ctx.ContextProvider;
 
 export const ComboboxScopedContextProvider = ctx.ScopedContextProvider;
 
+export const createComboboxProvider = ctx.createProviderComponent;
+
 export const ComboboxItemValueContext = createContext<string | undefined>(
   undefined,
 );

--- a/packages/ariakit-react-components/src/combobox/combobox-disclosure.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-disclosure.tsx
@@ -5,8 +5,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { invariant } from "@ariakit/utils";
 import type { ElementType, MouseEvent } from "react";
 import type { DialogDisclosureOptions } from "../dialog/dialog-disclosure.tsx";
@@ -58,7 +59,7 @@ export const useComboboxDisclosure = createHook<
   ComboboxDisclosureOptions
 >(function useComboboxDisclosure({ store, ...props }) {
   const context = useComboboxProviderContext();
-  store = store || context;
+  store = useStoreProp(store, context);
 
   invariant(
     store,
@@ -153,8 +154,13 @@ export interface ComboboxDisclosureOptions<
    * hook. If not provided, the closest
    * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)
    * component's context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: ComboboxStore;
+  store?: ComboboxStore | ProviderComponent<ComboboxStore>;
 }
 
 export type ComboboxDisclosureProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/combobox/combobox-disclosure.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-disclosure.tsx
@@ -157,8 +157,9 @@ export interface ComboboxDisclosureOptions<
    *
    * You can also pass a provider component (for example,
    * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: ComboboxStore | ProviderComponent<ComboboxStore>;
 }

--- a/packages/ariakit-react-components/src/combobox/combobox-group-label.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-group-label.tsx
@@ -1,5 +1,5 @@
 import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { CompositeGroupLabelOptions } from "../composite/composite-group-label.tsx";
 import { useCompositeGroupLabel } from "../composite/composite-group-label.tsx";
@@ -65,7 +65,7 @@ export interface ComboboxGroupLabelOptions<
    * [`ComboboxPopover`](https://ariakit.com/reference/combobox-popover)
    * components' context will be used.
    */
-  store?: ComboboxStore;
+  store?: ComboboxStore | ProviderComponent<ComboboxStore>;
 }
 
 export type ComboboxGroupLabelProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/combobox/combobox-group.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-group.tsx
@@ -1,6 +1,11 @@
 import { useStoreState } from "@ariakit/react-store";
-import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import {
+  createElement,
+  createHook,
+  forwardRef,
+  useStoreProp,
+} from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { getPopupRole, invariant } from "@ariakit/utils";
 import type { ElementType } from "react";
 import type { CompositeGroupOptions } from "../composite/composite-group.tsx";
@@ -31,7 +36,7 @@ type TagName = typeof TagName;
 export const useComboboxGroup = createHook<TagName, ComboboxGroupOptions>(
   function useComboboxGroup({ store, ...props }) {
     const context = useComboboxScopedContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -90,8 +95,13 @@ export interface ComboboxGroupOptions<
    * [`ComboboxList`](https://ariakit.com/reference/combobox-list) or
    * [`ComboboxPopover`](https://ariakit.com/reference/combobox-popover)
    * components' context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: ComboboxStore;
+  store?: ComboboxStore | ProviderComponent<ComboboxStore>;
 }
 
 export type ComboboxGroupProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/combobox/combobox-group.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-group.tsx
@@ -98,8 +98,9 @@ export interface ComboboxGroupOptions<
    *
    * You can also pass a provider component (for example,
    * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: ComboboxStore | ProviderComponent<ComboboxStore>;
 }

--- a/packages/ariakit-react-components/src/combobox/combobox-item-check.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item-check.tsx
@@ -1,5 +1,5 @@
 import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import { useContext } from "react";
 import type { CheckboxCheckOptions } from "../checkbox/checkbox-check.tsx";
@@ -79,7 +79,7 @@ export interface ComboboxItemCheckOptions<
    * prop or, when it's not provided, from the closest
    * [`ComboboxItem`](https://ariakit.com/reference/combobox-item) component.
    */
-  store?: ComboboxStore;
+  store?: ComboboxStore | ProviderComponent<ComboboxStore>;
 }
 
 export type ComboboxItemCheckProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/combobox/combobox-item-offscreen.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item-offscreen.tsx
@@ -1,4 +1,4 @@
-import { useMergeRefs, forwardRef } from "@ariakit/react-utils";
+import { useMergeRefs, forwardRef, useStoreProp } from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import { useContext } from "react";
@@ -20,7 +20,7 @@ export function useComboboxItemOffscreen<
   P extends ComboboxItemProps<T>,
 >({ store, value, ...props }: P) {
   const context = useComboboxScopedContext();
-  store = store || context;
+  store = useStoreProp(store, context);
 
   const offscreenProps = useCompositeItemOffscreen({ store, value, ...props });
   const popupRole = useContext(ComboboxListRoleContext);

--- a/packages/ariakit-react-components/src/combobox/combobox-item-value.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item-value.tsx
@@ -1,6 +1,11 @@
 import { useStoreState } from "@ariakit/react-store";
-import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Options, Props } from "@ariakit/react-utils";
+import {
+  createElement,
+  createHook,
+  forwardRef,
+  useStoreProp,
+} from "@ariakit/react-utils";
+import type { Options, Props, ProviderComponent } from "@ariakit/react-utils";
 import {
   toArray,
   normalizeString,
@@ -198,7 +203,7 @@ export const useComboboxItemValue = createHook<
   ComboboxItemValueOptions
 >(function useComboboxItemValue({ store, value, userValue, ...props }) {
   const context = useComboboxScopedContext();
-  store = store || context;
+  store = useStoreProp(store, context);
 
   const itemContext = useContext(ComboboxItemValueContext);
   const itemValue = value ?? itemContext;
@@ -275,8 +280,13 @@ export interface ComboboxItemValueOptions<
    * [`ComboboxList`](https://ariakit.com/reference/combobox-list) or
    * [`ComboboxPopover`](https://ariakit.com/reference/combobox-popover)
    * components' context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: ComboboxStore;
+  store?: ComboboxStore | ProviderComponent<ComboboxStore>;
   /**
    * The current combobox item value. If not provided, the parent
    * [`ComboboxItem`](https://ariakit.com/reference/combobox-item) component's

--- a/packages/ariakit-react-components/src/combobox/combobox-item-value.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item-value.tsx
@@ -283,8 +283,9 @@ export interface ComboboxItemValueOptions<
    *
    * You can also pass a provider component (for example,
    * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: ComboboxStore | ProviderComponent<ComboboxStore>;
   /**

--- a/packages/ariakit-react-components/src/combobox/combobox-item.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item.tsx
@@ -278,8 +278,9 @@ export interface ComboboxItemOptions<T extends ElementType = TagName>
    *
    * You can also pass a provider component (for example,
    * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: ComboboxStore | ProviderComponent<ComboboxStore>;
   /**

--- a/packages/ariakit-react-components/src/combobox/combobox-item.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item.tsx
@@ -7,8 +7,9 @@ import {
   createHook,
   forwardRef,
   memo,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import {
   getItemRoleByPopupRole,
   hasFocus,
@@ -80,7 +81,7 @@ export const useComboboxItem = createHook<TagName, ComboboxItemOptions>(
     ...props
   }) {
     const context = useComboboxScopedContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -274,8 +275,13 @@ export interface ComboboxItemOptions<T extends ElementType = TagName>
    *
    * Live examples:
    * - [Navigation Menubar](https://ariakit.com/examples/menubar-navigation)
+   *
+   * You can also pass a provider component (for example,
+   * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: ComboboxStore;
+  store?: ComboboxStore | ProviderComponent<ComboboxStore>;
   /**
    * The value of the item. This will be rendered as the children by default.
    * - If

--- a/packages/ariakit-react-components/src/combobox/combobox-label.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-label.tsx
@@ -83,8 +83,9 @@ export interface ComboboxLabelOptions<
    *
    * You can also pass a provider component (for example,
    * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: ComboboxStore | ProviderComponent<ComboboxStore>;
 }

--- a/packages/ariakit-react-components/src/combobox/combobox-label.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-label.tsx
@@ -4,8 +4,9 @@ import {
   createHook,
   forwardRef,
   memo,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Options, Props } from "@ariakit/react-utils";
+import type { Options, Props, ProviderComponent } from "@ariakit/react-utils";
 import { invariant, removeUndefinedValues } from "@ariakit/utils";
 import type { ElementType } from "react";
 import { useComboboxProviderContext } from "./combobox-context.tsx";
@@ -28,7 +29,7 @@ type TagName = typeof TagName;
 export const useComboboxLabel = createHook<TagName, ComboboxLabelOptions>(
   function useComboboxLabel({ store, ...props }) {
     const context = useComboboxProviderContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -79,8 +80,13 @@ export interface ComboboxLabelOptions<
    * hook. If not provided, the closest
    * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)
    * component's context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: ComboboxStore;
+  store?: ComboboxStore | ProviderComponent<ComboboxStore>;
 }
 
 export type ComboboxLabelProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/combobox/combobox-list.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-list.tsx
@@ -8,8 +8,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Options, Props } from "@ariakit/react-utils";
+import type { Options, Props, ProviderComponent } from "@ariakit/react-utils";
 import { invariant, removeUndefinedValues } from "@ariakit/utils";
 import type { ElementType } from "react";
 import { useRef, useState } from "react";
@@ -45,7 +46,7 @@ export const useComboboxList = createHook<TagName, ComboboxListOptions>(
   function useComboboxList({ store, alwaysVisible, ...props }) {
     const scopedContext = useComboboxScopedContext(true);
     const context = useComboboxContext();
-    store = store || context;
+    store = useStoreProp(store, context);
     const scopedContextSameStore = !!store && store === scopedContext;
 
     invariant(
@@ -166,8 +167,13 @@ export interface ComboboxListOptions<T extends ElementType = TagName>
    * hook. If not provided, the closest
    * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)
    * component's context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: ComboboxStore;
+  store?: ComboboxStore | ProviderComponent<ComboboxStore>;
 }
 
 export type ComboboxListProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/combobox/combobox-list.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-list.tsx
@@ -170,8 +170,9 @@ export interface ComboboxListOptions<T extends ElementType = TagName>
    *
    * You can also pass a provider component (for example,
    * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: ComboboxStore | ProviderComponent<ComboboxStore>;
 }

--- a/packages/ariakit-react-components/src/combobox/combobox-popover.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-popover.tsx
@@ -1,5 +1,10 @@
 import { useStoreState } from "@ariakit/react-store";
-import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
+import {
+  createElement,
+  createHook,
+  forwardRef,
+  useStoreProp,
+} from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
 import { getDocument, invariant, isFalsyBooleanCallback } from "@ariakit/utils";
 import type { ElementType } from "react";
@@ -55,7 +60,7 @@ export const useComboboxPopover = createHook<TagName, ComboboxPopoverOptions>(
     ...props
   }) {
     const context = useComboboxProviderContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,

--- a/packages/ariakit-react-components/src/combobox/combobox-provider.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-provider.tsx
@@ -1,13 +1,28 @@
+import type { ProviderComponent } from "@ariakit/react-utils";
 import type { PickRequired } from "@ariakit/utils";
 import type { ReactElement, ReactNode } from "react";
-import { ComboboxContextProvider } from "./combobox-context.tsx";
+import {
+  ComboboxContextProvider,
+  createComboboxProvider,
+} from "./combobox-context.tsx";
 import type {
+  ComboboxStore,
   ComboboxStoreProps,
   ComboboxStoreSelectedValue,
 } from "./combobox-store.ts";
 import { useComboboxStore } from "./combobox-store.ts";
 
 type Value = ComboboxStoreSelectedValue;
+
+export interface ComboboxProviderComponent extends ProviderComponent<ComboboxStore> {
+  <T extends Value = Value>(
+    props: PickRequired<
+      ComboboxProviderProps<T>,
+      "selectedValue" | "defaultSelectedValue"
+    >,
+  ): ReactElement;
+  (props?: ComboboxProviderProps): ReactElement;
+}
 
 /**
  * Provides a combobox store that controls the state of
@@ -25,23 +40,17 @@ type Value = ComboboxStoreSelectedValue;
  * </ComboboxProvider>
  * ```
  */
-export function ComboboxProvider<T extends Value = Value>(
-  props: PickRequired<
-    ComboboxProviderProps<T>,
-    "selectedValue" | "defaultSelectedValue"
-  >,
-): ReactElement;
-
-export function ComboboxProvider(props?: ComboboxProviderProps): ReactElement;
-
-export function ComboboxProvider(props: ComboboxProviderProps = {}) {
-  const store = useComboboxStore(props);
-  return (
-    <ComboboxContextProvider value={store}>
-      {props.children}
-    </ComboboxContextProvider>
-  );
-}
+export const ComboboxProvider: ComboboxProviderComponent =
+  createComboboxProvider(function ComboboxProvider(
+    props: ComboboxProviderProps = {},
+  ) {
+    const store = useComboboxStore(props);
+    return (
+      <ComboboxContextProvider value={store}>
+        {props.children}
+      </ComboboxContextProvider>
+    );
+  });
 
 export interface ComboboxProviderProps<
   T extends Value = Value,

--- a/packages/ariakit-react-components/src/combobox/combobox-row.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-row.tsx
@@ -1,6 +1,11 @@
 import { useStoreState } from "@ariakit/react-store";
-import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import {
+  createElement,
+  createHook,
+  forwardRef,
+  useStoreProp,
+} from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { getPopupRole, invariant } from "@ariakit/utils";
 import type { ElementType } from "react";
 import type { CompositeRowOptions } from "../composite/composite-row.tsx";
@@ -30,7 +35,7 @@ type TagName = typeof TagName;
 export const useComboboxRow = createHook<TagName, ComboboxRowOptions>(
   function useComboboxRow({ store, ...props }) {
     const context = useComboboxScopedContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -92,8 +97,13 @@ export interface ComboboxRowOptions<
    * [`ComboboxList`](https://ariakit.com/reference/combobox-list) or
    * [`ComboboxPopover`](https://ariakit.com/reference/combobox-popover)
    * components' context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: ComboboxStore;
+  store?: ComboboxStore | ProviderComponent<ComboboxStore>;
 }
 
 export type ComboboxRowProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/combobox/combobox-row.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-row.tsx
@@ -100,8 +100,9 @@ export interface ComboboxRowOptions<
    *
    * You can also pass a provider component (for example,
    * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: ComboboxStore | ProviderComponent<ComboboxStore>;
 }

--- a/packages/ariakit-react-components/src/combobox/combobox-separator.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-separator.tsx
@@ -1,5 +1,10 @@
-import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import {
+  createElement,
+  createHook,
+  forwardRef,
+  useStoreProp,
+} from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { invariant } from "@ariakit/utils";
 import type { ElementType } from "react";
 import type { CompositeSeparatorOptions } from "../composite/composite-separator.tsx";
@@ -31,7 +36,7 @@ export const useComboboxSeparator = createHook<
   ComboboxSeparatorOptions
 >(function useComboboxSeparator({ store, ...props }) {
   const context = useComboboxScopedContext();
-  store = store || context;
+  store = useStoreProp(store, context);
 
   invariant(
     store,
@@ -80,8 +85,13 @@ export interface ComboboxSeparatorOptions<
    * [`ComboboxList`](https://ariakit.com/reference/combobox-list) or
    * [`ComboboxPopover`](https://ariakit.com/reference/combobox-popover)
    * components' context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: ComboboxStore;
+  store?: ComboboxStore | ProviderComponent<ComboboxStore>;
 }
 
 export type ComboboxSeparatorProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/combobox/combobox-separator.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-separator.tsx
@@ -88,8 +88,9 @@ export interface ComboboxSeparatorOptions<
    *
    * You can also pass a provider component (for example,
    * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: ComboboxStore | ProviderComponent<ComboboxStore>;
 }

--- a/packages/ariakit-react-components/src/combobox/combobox-value.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-value.tsx
@@ -1,4 +1,6 @@
 import { useStoreState } from "@ariakit/react-store";
+import { useStoreProp } from "@ariakit/react-utils";
+import type { ProviderComponent } from "@ariakit/react-utils";
 import { invariant } from "@ariakit/utils";
 import type { ReactNode } from "react";
 import { useComboboxContext } from "./combobox-context.tsx";
@@ -29,7 +31,7 @@ import type { ComboboxStore, ComboboxStoreState } from "./combobox-store.ts";
  */
 export function ComboboxValue({ store, children }: ComboboxValueProps = {}) {
   const context = useComboboxContext();
-  store = store || context;
+  store = useStoreProp(store, context);
 
   invariant(
     store,
@@ -53,8 +55,13 @@ export interface ComboboxValueProps {
    * hook. If not provided, the closest
    * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)
    * component's context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: ComboboxStore;
+  store?: ComboboxStore | ProviderComponent<ComboboxStore>;
   /**
    * A function that gets called with the current value as an argument. It can
    * be used to render the combobox value in a custom way.

--- a/packages/ariakit-react-components/src/combobox/combobox-value.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-value.tsx
@@ -58,8 +58,9 @@ export interface ComboboxValueProps {
    *
    * You can also pass a provider component (for example,
    * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: ComboboxStore | ProviderComponent<ComboboxStore>;
   /**

--- a/packages/ariakit-react-components/src/combobox/combobox.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox.tsx
@@ -11,8 +11,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { sync } from "@ariakit/store";
 import {
   getPopupRole,
@@ -136,7 +137,7 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
     ...props
   }) {
     const context = useComboboxProviderContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -747,8 +748,13 @@ export interface ComboboxOptions<T extends ElementType = TagName>
    * hook. If not provided, the closest
    * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)
    * component's context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: ComboboxStore;
+  store?: ComboboxStore | ProviderComponent<ComboboxStore>;
   /**
    * Determines if the first enabled item will be automatically focused when the
    * combobox input value changes. If set to `true` or `"always"`, the exact

--- a/packages/ariakit-react-components/src/combobox/combobox.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox.tsx
@@ -751,8 +751,9 @@ export interface ComboboxOptions<T extends ElementType = TagName>
    *
    * You can also pass a provider component (for example,
    * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: ComboboxStore | ProviderComponent<ComboboxStore>;
   /**

--- a/packages/ariakit-react-components/src/composite/composite-container.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-container.tsx
@@ -6,8 +6,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Options, Props } from "@ariakit/react-utils";
+import type { Options, Props, ProviderComponent } from "@ariakit/react-utils";
 import {
   isButton,
   isTextField,
@@ -57,7 +58,7 @@ export const useCompositeContainer = createHook<
   CompositeContainerOptions
 >(function useCompositeContainer({ store, ...props }) {
   const context = useCompositeScopedContext();
-  store = store || context;
+  store = useStoreProp(store, context);
 
   const ref = useRef<HTMLType>(null);
   const isOpenRef = useRef(false);
@@ -288,8 +289,13 @@ export interface CompositeContainerOptions<
    * [`Composite`](https://ariakit.com/reference/composite) or
    * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)
    * components' context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: CompositeStore;
+  store?: CompositeStore | ProviderComponent<CompositeStore>;
 }
 
 export type CompositeContainerProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/composite/composite-container.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-container.tsx
@@ -291,9 +291,10 @@ export interface CompositeContainerOptions<
    * components' context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)).
+   * In that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: CompositeStore | ProviderComponent<CompositeStore>;
 }

--- a/packages/ariakit-react-components/src/composite/composite-context.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-context.tsx
@@ -34,6 +34,8 @@ export const CompositeContextProvider = ctx.ContextProvider;
 
 export const CompositeScopedContextProvider = ctx.ScopedContextProvider;
 
+export const createCompositeProvider = ctx.createProviderComponent;
+
 interface ItemContext {
   baseElement?: HTMLElement;
   id?: string;

--- a/packages/ariakit-react-components/src/composite/composite-group-label.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-group-label.tsx
@@ -1,5 +1,5 @@
 import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { GroupLabelOptions } from "../group/group-label.tsx";
 import { useGroupLabel } from "../group/group-label.tsx";
@@ -64,7 +64,7 @@ export interface CompositeGroupLabelOptions<
    * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)
    * components' context will be used.
    */
-  store?: CompositeStore;
+  store?: CompositeStore | ProviderComponent<CompositeStore>;
 }
 
 export type CompositeGroupLabelProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/composite/composite-group.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-group.tsx
@@ -1,5 +1,5 @@
 import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { ProviderComponent, Props } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { GroupOptions } from "../group/group.tsx";
 import { useGroup } from "../group/group.tsx";
@@ -68,7 +68,7 @@ export interface CompositeGroupOptions<
    * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)
    * components' context will be used.
    */
-  store?: CompositeStore;
+  store?: CompositeStore | ProviderComponent<CompositeStore>;
 }
 
 export type CompositeGroupProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/composite/composite-hover.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-hover.tsx
@@ -7,8 +7,9 @@ import {
   createHook,
   forwardRef,
   memo,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Options, Props } from "@ariakit/react-utils";
+import type { Options, Props, ProviderComponent } from "@ariakit/react-utils";
 import {
   contains,
   hasFocus,
@@ -70,7 +71,7 @@ export const useCompositeHover = createHook<TagName, CompositeHoverOptions>(
     ...props
   }) {
     const context = useCompositeScopedContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -173,8 +174,13 @@ export interface CompositeHoverOptions<
    * [`Composite`](https://ariakit.com/reference/composite) or
    * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)
    * components' context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: CompositeStore;
+  store?: CompositeStore | ProviderComponent<CompositeStore>;
   /**
    * Determines if the composite item should be _focused_ when hovered over.
    *

--- a/packages/ariakit-react-components/src/composite/composite-hover.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-hover.tsx
@@ -176,9 +176,10 @@ export interface CompositeHoverOptions<
    * components' context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)).
+   * In that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: CompositeStore | ProviderComponent<CompositeStore>;
   /**

--- a/packages/ariakit-react-components/src/composite/composite-input.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-input.tsx
@@ -1,11 +1,12 @@
 import {
   useEvent,
+  useStoreProp,
   createElement,
   createHook,
   forwardRef,
   memo,
 } from "@ariakit/react-utils";
-import type { Options, Props } from "@ariakit/react-utils";
+import type { Options, Props, ProviderComponent } from "@ariakit/react-utils";
 import {
   getDocument,
   getTextboxSelection,
@@ -14,6 +15,7 @@ import {
 } from "@ariakit/utils";
 import type { ElementType, FocusEvent, KeyboardEvent } from "react";
 import { useEffect } from "react";
+import { useCompositeScopedContext } from "./composite-context.tsx";
 import type { CompositeStore } from "./composite-store.ts";
 import { selectTextField } from "./utils.ts";
 
@@ -49,6 +51,8 @@ function getValueLength(element: HTMLElement) {
  */
 export const useCompositeInput = createHook<TagName, CompositeInputOptions>(
   function useCompositeInput({ store, ...props }) {
+    const context = useCompositeScopedContext();
+    store = useStoreProp(store, context);
     const onKeyDownCaptureProp = props.onKeyDownCapture;
 
     if (process.env.NODE_ENV !== "production") {
@@ -137,8 +141,13 @@ export interface CompositeInputOptions<
    * [`Composite`](https://ariakit.com/reference/composite) or
    * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)
    * components' context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: CompositeStore;
+  store?: CompositeStore | ProviderComponent<CompositeStore>;
 }
 
 export type CompositeInputProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/composite/composite-input.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-input.tsx
@@ -143,9 +143,10 @@ export interface CompositeInputOptions<
    * components' context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)).
+   * In that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: CompositeStore | ProviderComponent<CompositeStore>;
 }

--- a/packages/ariakit-react-components/src/composite/composite-item-offscreen.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-item-offscreen.tsx
@@ -1,5 +1,10 @@
 import { useStoreStateObject } from "@ariakit/react-store";
-import { useId, useMergeRefs, forwardRef } from "@ariakit/react-utils";
+import {
+  useId,
+  useMergeRefs,
+  useStoreProp,
+  forwardRef,
+} from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
 import { disabledFromProps, getPopupItemRole } from "@ariakit/utils";
 import type { ElementType } from "react";
@@ -27,7 +32,7 @@ export function useCompositeItemOffscreen<
   ...props
 }: P) {
   const context = useCompositeScopedContext();
-  store = store || context;
+  store = useStoreProp(store, context);
 
   const id = useId(props.id);
 

--- a/packages/ariakit-react-components/src/composite/composite-item.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-item.tsx
@@ -556,8 +556,9 @@ export interface CompositeItemOptions<T extends ElementType = TagName>
    *
    * You can also pass a provider component (for example,
    * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)).
-   * In that case, the store is read from the closest matching provider, even
-   * if another compatible store context is closer.
+   * In that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: CompositeStore | ProviderComponent<CompositeStore>;
   /**

--- a/packages/ariakit-react-components/src/composite/composite-item.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-item.tsx
@@ -4,13 +4,14 @@ import {
   useEvent,
   useId,
   useMergeRefs,
+  useStoreProp,
   useWrapElement,
   createElement,
   createHook,
   forwardRef,
   memo,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { ProviderComponent, Props } from "@ariakit/react-utils";
 import { subscribe } from "@ariakit/store";
 import {
   getActiveElement,
@@ -158,7 +159,7 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
     ...props
   }) {
     const context = useCompositeScopedContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     const id = useId(props.id);
     const ref = useRef<HTMLType>(null);
@@ -552,8 +553,13 @@ export interface CompositeItemOptions<T extends ElementType = TagName>
    * [`Composite`](https://ariakit.com/reference/composite) or
    * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)
    * components' context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)).
+   * In that case, the store is read from the closest matching provider, even
+   * if another compatible store context is closer.
    */
-  store?: CompositeStore;
+  store?: CompositeStore | ProviderComponent<CompositeStore>;
   /**
    * Determines if the item should be registered as part of the collection. If
    * this is set to `false`, the item won't be accessible via arrow keys.

--- a/packages/ariakit-react-components/src/composite/composite-provider.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-provider.tsx
@@ -1,11 +1,23 @@
+import type { ProviderComponent } from "@ariakit/react-utils";
 import type { PickRequired } from "@ariakit/utils";
 import type { ReactElement, ReactNode } from "react";
-import { CompositeContextProvider } from "./composite-context.tsx";
+import {
+  CompositeContextProvider,
+  createCompositeProvider,
+} from "./composite-context.tsx";
 import type {
+  CompositeStore,
   CompositeStoreItem,
   CompositeStoreProps,
 } from "./composite-store.ts";
 import { useCompositeStore } from "./composite-store.ts";
+
+export interface CompositeProviderComponent extends ProviderComponent<CompositeStore> {
+  <T extends CompositeStoreItem = CompositeStoreItem>(
+    props: PickRequired<CompositeProviderProps<T>, "items" | "defaultItems">,
+  ): ReactElement;
+  (props?: CompositeProviderProps): ReactElement;
+}
 
 /**
  * Provides a composite store to
@@ -22,23 +34,17 @@ import { useCompositeStore } from "./composite-store.ts";
  * </CompositeProvider>
  * ```
  */
-
-export function CompositeProvider<
-  T extends CompositeStoreItem = CompositeStoreItem,
->(
-  props: PickRequired<CompositeProviderProps<T>, "items" | "defaultItems">,
-): ReactElement;
-
-export function CompositeProvider(props?: CompositeProviderProps): ReactElement;
-
-export function CompositeProvider(props: CompositeProviderProps = {}) {
-  const store = useCompositeStore(props);
-  return (
-    <CompositeContextProvider value={store}>
-      {props.children}
-    </CompositeContextProvider>
-  );
-}
+export const CompositeProvider: CompositeProviderComponent =
+  createCompositeProvider(function CompositeProvider(
+    props: CompositeProviderProps = {},
+  ) {
+    const store = useCompositeStore(props);
+    return (
+      <CompositeContextProvider value={store}>
+        {props.children}
+      </CompositeContextProvider>
+    );
+  });
 
 export interface CompositeProviderProps<
   T extends CompositeStoreItem = CompositeStoreItem,

--- a/packages/ariakit-react-components/src/composite/composite-renderer.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-renderer.tsx
@@ -261,14 +261,16 @@ export interface CompositeRendererOptions<T extends Item = any> extends Omit<
    *
    * You can also pass a provider component (for example,
    * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)).
-   * In that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * In that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?:
     | CompositeStore<T extends CollectionStoreItem ? T : CompositeStoreItem>
-    | ProviderComponent<
-        CompositeStore<T extends CollectionStoreItem ? T : CompositeStoreItem>
-      >;
+    // The provider brand never carries the item type and runtime resolution
+    // doesn't depend on `T`, so the provider arm uses the base store to keep
+    // `T` inference and explicit generic arguments working.
+    | ProviderComponent<CompositeStore>;
   /**
    * The `children` should be a function that receives item props and returns a
    * React element. The item props should be spread onto the element that

--- a/packages/ariakit-react-components/src/composite/composite-renderer.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-renderer.tsx
@@ -1,6 +1,11 @@
 import { useStoreState } from "@ariakit/react-store";
-import { useId, createElement, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import {
+  useId,
+  useStoreProp,
+  createElement,
+  forwardRef,
+} from "@ariakit/react-utils";
+import type { ProviderComponent, Props } from "@ariakit/react-utils";
 import type { ElementType, ReactNode } from "react";
 import { useMemo } from "react";
 import type {
@@ -142,7 +147,7 @@ export function useCompositeRenderer<T extends Item = any>({
   ...props
 }: CompositeRendererProps<T>) {
   const context = useCompositeScopedContext();
-  store = store || (context as typeof store);
+  store = useStoreProp(store, context);
 
   const orientation = useStoreState(
     store,
@@ -253,10 +258,17 @@ export interface CompositeRendererOptions<T extends Item = any> extends Omit<
    * will be used to render the items if the
    * [`items`](https://ariakit.com/reference/composite-items#items) prop is not
    * provided.
+   *
+   * You can also pass a provider component (for example,
+   * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)).
+   * In that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: CompositeStore<
-    T extends CollectionStoreItem ? T : CompositeStoreItem
-  >;
+  store?:
+    | CompositeStore<T extends CollectionStoreItem ? T : CompositeStoreItem>
+    | ProviderComponent<
+        CompositeStore<T extends CollectionStoreItem ? T : CompositeStoreItem>
+      >;
   /**
    * The `children` should be a function that receives item props and returns a
    * React element. The item props should be spread onto the element that

--- a/packages/ariakit-react-components/src/composite/composite-row.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-row.tsx
@@ -5,8 +5,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Options, Props } from "@ariakit/react-utils";
+import type { Options, Props, ProviderComponent } from "@ariakit/react-utils";
 import { invariant, removeUndefinedValues } from "@ariakit/utils";
 import type { ElementType } from "react";
 import { useMemo } from "react";
@@ -45,7 +46,7 @@ export const useCompositeRow = createHook<TagName, CompositeRowOptions>(
     ...props
   }) {
     const context = useCompositeScopedContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -123,8 +124,13 @@ export interface CompositeRowOptions<
    * [`Composite`](https://ariakit.com/reference/composite) or
    * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)
    * components' context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: CompositeStore;
+  store?: CompositeStore | ProviderComponent<CompositeStore>;
 }
 
 export type CompositeRowProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/composite/composite-row.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-row.tsx
@@ -126,9 +126,10 @@ export interface CompositeRowOptions<
    * components' context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)).
+   * In that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: CompositeStore | ProviderComponent<CompositeStore>;
 }

--- a/packages/ariakit-react-components/src/composite/composite-separator.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-separator.tsx
@@ -93,9 +93,10 @@ export interface CompositeSeparatorOptions<
    * components' context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)).
+   * In that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: CompositeStore | ProviderComponent<CompositeStore>;
   /**

--- a/packages/ariakit-react-components/src/composite/composite-separator.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-separator.tsx
@@ -1,6 +1,11 @@
 import { useStoreState } from "@ariakit/react-store";
-import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import {
+  createElement,
+  createHook,
+  forwardRef,
+  useStoreProp,
+} from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { invariant } from "@ariakit/utils";
 import type { ElementType } from "react";
 import type { SeparatorOptions } from "../separator/separator.tsx";
@@ -34,7 +39,7 @@ export const useCompositeSeparator = createHook<
   ...props
 }) {
   const context = useCompositeScopedContext();
-  store = store || context;
+  store = useStoreProp(store, context);
 
   invariant(
     store,
@@ -86,8 +91,13 @@ export interface CompositeSeparatorOptions<
    * [`Composite`](https://ariakit.com/reference/composite) or
    * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)
    * components' context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: CompositeStore;
+  store?: CompositeStore | ProviderComponent<CompositeStore>;
   /**
    * The orientation of the separator. By default, this is the opposite of the
    * [`orientation`](https://ariakit.com/reference/composite-provider#orientation)

--- a/packages/ariakit-react-components/src/composite/composite-typeahead.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-typeahead.tsx
@@ -266,9 +266,10 @@ export interface CompositeTypeaheadOptions<
    * components' context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)).
+   * In that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: CompositeStore | ProviderComponent<CompositeStore>;
   /**

--- a/packages/ariakit-react-components/src/composite/composite-typeahead.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-typeahead.tsx
@@ -3,8 +3,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Options, Props } from "@ariakit/react-utils";
+import type { Options, Props, ProviderComponent } from "@ariakit/react-utils";
 import {
   getDocument,
   isTextField,
@@ -138,7 +139,7 @@ export const useCompositeTypeahead = createHook<
   CompositeTypeaheadOptions
 >(function useCompositeTypeahead({ store, typeahead = true, ...props }) {
   const context = useCompositeScopedContext();
-  store = store || context;
+  store = useStoreProp(store, context);
 
   invariant(
     store,
@@ -263,8 +264,13 @@ export interface CompositeTypeaheadOptions<
    * [`Composite`](https://ariakit.com/reference/composite) or
    * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)
    * components' context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: CompositeStore;
+  store?: CompositeStore | ProviderComponent<CompositeStore>;
   /**
    * When enabled, pressing printable character keys will move focus to the next
    * composite item that starts with the entered characters.

--- a/packages/ariakit-react-components/src/composite/composite.tsx
+++ b/packages/ariakit-react-components/src/composite/composite.tsx
@@ -10,8 +10,9 @@ import {
   createHook,
   forwardRef,
   memo,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import {
   flatten2DArray,
   reverseArray,
@@ -240,7 +241,7 @@ export const useComposite = createHook<TagName, CompositeOptions>(
     ...props
   }) {
     const context = useCompositeProviderContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -553,8 +554,13 @@ export interface CompositeOptions<
    * hook. If not provided, the closest
    * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)
    * component's context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: CompositeStore;
+  store?: CompositeStore | ProviderComponent<CompositeStore>;
   /**
    * Determines if the component should act as a composite widget. This prop
    * needs to be set to `false` when merging various composite widgets where

--- a/packages/ariakit-react-components/src/composite/composite.tsx
+++ b/packages/ariakit-react-components/src/composite/composite.tsx
@@ -556,9 +556,10 @@ export interface CompositeOptions<
    * component's context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * [`CompositeProvider`](https://ariakit.com/reference/composite-provider)).
+   * In that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: CompositeStore | ProviderComponent<CompositeStore>;
   /**

--- a/packages/ariakit-react-components/src/dialog/dialog-context.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog-context.tsx
@@ -35,6 +35,8 @@ export const DialogContextProvider = ctx.ContextProvider;
 
 export const DialogScopedContextProvider = ctx.ScopedContextProvider;
 
+export const createDialogProvider = ctx.createProviderComponent;
+
 export const DialogHeadingContext = createContext<
   SetState<string | undefined> | undefined
 >(undefined);

--- a/packages/ariakit-react-components/src/dialog/dialog-description.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog-description.tsx
@@ -5,7 +5,7 @@ import {
   createHook,
   forwardRef,
 } from "@ariakit/react-utils";
-import type { Options, Props } from "@ariakit/react-utils";
+import type { Options, Props, ProviderComponent } from "@ariakit/react-utils";
 import { removeUndefinedValues } from "@ariakit/utils";
 import type { ElementType } from "react";
 import { useContext } from "react";
@@ -80,7 +80,7 @@ export interface DialogDescriptionOptions<
    * component through React context, so it must be rendered inside the dialog
    * for the `aria-describedby` prop to be set on the dialog element.
    */
-  store?: DialogStore;
+  store?: DialogStore | ProviderComponent<DialogStore>;
 }
 
 export type DialogDescriptionProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/dialog/dialog-disclosure.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog-disclosure.tsx
@@ -82,8 +82,9 @@ export interface DialogDisclosureOptions<
    *
    * You can also pass a provider component (for example,
    * [`DialogProvider`](https://ariakit.com/reference/dialog-provider)). In that
-   * case, the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: DialogStore | ProviderComponent<DialogStore>;
 }

--- a/packages/ariakit-react-components/src/dialog/dialog-disclosure.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog-disclosure.tsx
@@ -1,6 +1,11 @@
 import { useStoreState } from "@ariakit/react-store";
-import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import {
+  createElement,
+  createHook,
+  forwardRef,
+  useStoreProp,
+} from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { getPopupRole, invariant } from "@ariakit/utils";
 import type { ElementType } from "react";
 import type { DisclosureOptions } from "../disclosure/disclosure.tsx";
@@ -25,7 +30,7 @@ type TagName = typeof TagName;
 export const useDialogDisclosure = createHook<TagName, DialogDisclosureOptions>(
   function useDialogDisclosure({ store, ...props }) {
     const context = useDialogProviderContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -74,8 +79,13 @@ export interface DialogDisclosureOptions<
    * not provided, the closest
    * [`DialogProvider`](https://ariakit.com/reference/dialog-provider)
    * component's context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`DialogProvider`](https://ariakit.com/reference/dialog-provider)). In that
+   * case, the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: DialogStore;
+  store?: DialogStore | ProviderComponent<DialogStore>;
 }
 
 export type DialogDisclosureProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/dialog/dialog-dismiss.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog-dismiss.tsx
@@ -3,8 +3,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType, MouseEvent } from "react";
 import { useMemo } from "react";
 import type { ButtonOptions } from "../button/button.tsx";
@@ -31,7 +32,7 @@ type HTMLType = HTMLElementTagNameMap[TagName];
 export const useDialogDismiss = createHook<TagName, DialogDismissOptions>(
   function useDialogDismiss({ store, ...props }) {
     const context = useDialogScopedContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     const onClickProp = props.onClick;
 
@@ -103,8 +104,13 @@ export interface DialogDismissOptions<
    * [`useDialogStore`](https://ariakit.com/reference/use-dialog-store) hook. If
    * not provided, the closest [`Dialog`](https://ariakit.com/reference/dialog)
    * component's context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`DialogProvider`](https://ariakit.com/reference/dialog-provider)). In that
+   * case, the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: DialogStore;
+  store?: DialogStore | ProviderComponent<DialogStore>;
 }
 
 export type DialogDismissProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/dialog/dialog-dismiss.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog-dismiss.tsx
@@ -107,8 +107,9 @@ export interface DialogDismissOptions<
    *
    * You can also pass a provider component (for example,
    * [`DialogProvider`](https://ariakit.com/reference/dialog-provider)). In that
-   * case, the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: DialogStore | ProviderComponent<DialogStore>;
 }

--- a/packages/ariakit-react-components/src/dialog/dialog-heading.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog-heading.tsx
@@ -5,7 +5,7 @@ import {
   createHook,
   forwardRef,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import { useContext } from "react";
 import type { HeadingOptions } from "../heading/heading.tsx";
@@ -82,7 +82,7 @@ export interface DialogHeadingOptions<
    * component through React context, so it must be rendered inside the dialog
    * for the `aria-labelledby` prop to be set on the dialog element.
    */
-  store?: DialogStore;
+  store?: DialogStore | ProviderComponent<DialogStore>;
 }
 
 export type DialogHeadingProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/dialog/dialog-provider.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog-provider.tsx
@@ -1,5 +1,8 @@
 import type { ReactNode } from "react";
-import { DialogContextProvider } from "./dialog-context.tsx";
+import {
+  createDialogProvider,
+  DialogContextProvider,
+} from "./dialog-context.tsx";
 import type { DialogStoreProps } from "./dialog-store.ts";
 import { useDialogStore } from "./dialog-store.ts";
 
@@ -14,14 +17,16 @@ import { useDialogStore } from "./dialog-store.ts";
  * </DialogProvider>
  * ```
  */
-export function DialogProvider(props: DialogProviderProps = {}) {
+export const DialogProvider = createDialogProvider(function DialogProvider(
+  props: DialogProviderProps = {},
+) {
   const store = useDialogStore(props);
   return (
     <DialogContextProvider value={store}>
       {props.children}
     </DialogContextProvider>
   );
-}
+});
 
 export interface DialogProviderProps extends DialogStoreProps {
   children?: ReactNode;

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -699,9 +699,10 @@ export interface DialogOptions<T extends ElementType = TagName>
    * created.
    *
    * You can also pass a provider component (for example,
-   * [`DialogProvider`](https://ariakit.com/reference/dialog-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * [`DialogProvider`](https://ariakit.com/reference/dialog-provider)). In that
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: DialogStore | ProviderComponent<DialogStore>;
   /**

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -6,12 +6,13 @@ import {
   useMergeRefs,
   usePortalRef,
   useSafeLayoutEffect,
+  useStoreProp,
   useWrapElement,
   createElement,
   createHook,
   forwardRef,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { sync } from "@ariakit/store";
 import {
   chain,
@@ -129,11 +130,12 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
   ...props
 }) {
   const context = useDialogProviderContext();
+  storeProp = useStoreProp(storeProp, context);
   const ref = useRef<HTMLType>(null);
   const backdropRef = useRef<HTMLDivElement>(null);
 
   const store = useDialogStore({
-    store: storeProp || context,
+    store: storeProp,
     open: openProp,
     setOpen(open) {
       if (open) return;
@@ -630,7 +632,7 @@ export function createDialogComponent<T extends DialogOptions>(
 ) {
   return forwardRef(function DialogComponent(props: T) {
     const context = useProviderContext();
-    const store = props.store || context;
+    const store = useStoreProp(props.store, context);
     const mounted = useStoreState(
       store,
       (state) => !props.unmountOnHide || state?.mounted || !!props.open,
@@ -695,8 +697,13 @@ export interface DialogOptions<T extends ElementType = TagName>
    * [`DialogProvider`](https://ariakit.com/reference/dialog-provider)
    * component's context will be used. Otherwise, an internal store will be
    * created.
+   *
+   * You can also pass a provider component (for example,
+   * [`DialogProvider`](https://ariakit.com/reference/dialog-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: DialogStore;
+  store?: DialogStore | ProviderComponent<DialogStore>;
   /**
    * Controls the open state of the dialog. This is similar to the
    * [`open`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/open)

--- a/packages/ariakit-react-components/src/disclosure/disclosure-content.tsx
+++ b/packages/ariakit-react-components/src/disclosure/disclosure-content.tsx
@@ -336,8 +336,9 @@ export interface DisclosureContentOptions<
    *
    * You can also pass a provider component (for example,
    * [`DisclosureProvider`](https://ariakit.com/reference/disclosure-provider)).
-   * In that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * In that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: DisclosureStore | ProviderComponent<DisclosureStore>;
   /**

--- a/packages/ariakit-react-components/src/disclosure/disclosure-content.tsx
+++ b/packages/ariakit-react-components/src/disclosure/disclosure-content.tsx
@@ -3,12 +3,13 @@ import {
   useId,
   useMergeRefs,
   useSafeLayoutEffect,
+  useStoreProp,
   useWrapElement,
   createElement,
   createHook,
   forwardRef,
 } from "@ariakit/react-utils";
-import type { Options, Props } from "@ariakit/react-utils";
+import type { Options, ProviderComponent, Props } from "@ariakit/react-utils";
 import { afterPaint, invariant, removeUndefinedValues } from "@ariakit/utils";
 import type { ElementType, RefObject } from "react";
 import { useMemo, useRef, useState } from "react";
@@ -111,7 +112,7 @@ export const useDisclosureContent = createHook<
   ...props
 }) {
   const context = useDisclosureProviderContext();
-  store = store || context;
+  store = useStoreProp(store, context);
 
   invariant(
     store,
@@ -314,7 +315,7 @@ export const DisclosureContent = forwardRef(function DisclosureContent({
   ...props
 }: DisclosureContentProps) {
   const context = useDisclosureProviderContext();
-  const store = props.store || context;
+  const store = useStoreProp(props.store, context);
   const mounted = useStoreState(
     store,
     (state) => !unmountOnHide || state?.mounted,
@@ -332,8 +333,13 @@ export interface DisclosureContentOptions<
    * hook. If not provided, the closest
    * [`DisclosureProvider`](https://ariakit.com/reference/disclosure-provider)
    * component's context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`DisclosureProvider`](https://ariakit.com/reference/disclosure-provider)).
+   * In that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: DisclosureStore;
+  store?: DisclosureStore | ProviderComponent<DisclosureStore>;
   /**
    * A ref to another element whose CSS transitions and animations should be
    * taken into account when computing the animation timeout, such as the

--- a/packages/ariakit-react-components/src/disclosure/disclosure-context.tsx
+++ b/packages/ariakit-react-components/src/disclosure/disclosure-context.tsx
@@ -25,3 +25,5 @@ export const useDisclosureProviderContext = ctx.useProviderContext;
 export const DisclosureContextProvider = ctx.ContextProvider;
 
 export const DisclosureScopedContextProvider = ctx.ScopedContextProvider;
+
+export const createDisclosureProvider = ctx.createProviderComponent;

--- a/packages/ariakit-react-components/src/disclosure/disclosure-provider.tsx
+++ b/packages/ariakit-react-components/src/disclosure/disclosure-provider.tsx
@@ -1,5 +1,8 @@
 import type { ReactNode } from "react";
-import { DisclosureContextProvider } from "./disclosure-context.tsx";
+import {
+  createDisclosureProvider,
+  DisclosureContextProvider,
+} from "./disclosure-context.tsx";
 import type { DisclosureStoreProps } from "./disclosure-store.ts";
 import { useDisclosureStore } from "./disclosure-store.ts";
 
@@ -15,14 +18,16 @@ import { useDisclosureStore } from "./disclosure-store.ts";
  * </DisclosureProvider>
  * ```
  */
-export function DisclosureProvider(props: DisclosureProviderProps = {}) {
-  const store = useDisclosureStore(props);
-  return (
-    <DisclosureContextProvider value={store}>
-      {props.children}
-    </DisclosureContextProvider>
-  );
-}
+export const DisclosureProvider = createDisclosureProvider(
+  function DisclosureProvider(props: DisclosureProviderProps = {}) {
+    const store = useDisclosureStore(props);
+    return (
+      <DisclosureContextProvider value={store}>
+        {props.children}
+      </DisclosureContextProvider>
+    );
+  },
+);
 
 export interface DisclosureProviderProps extends DisclosureStoreProps {
   children?: ReactNode;

--- a/packages/ariakit-react-components/src/disclosure/disclosure.tsx
+++ b/packages/ariakit-react-components/src/disclosure/disclosure.tsx
@@ -127,8 +127,9 @@ export interface DisclosureOptions<
    *
    * You can also pass a provider component (for example,
    * [`DisclosureProvider`](https://ariakit.com/reference/disclosure-provider)).
-   * In that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * In that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: DisclosureStore | ProviderComponent<DisclosureStore>;
   /**

--- a/packages/ariakit-react-components/src/disclosure/disclosure.tsx
+++ b/packages/ariakit-react-components/src/disclosure/disclosure.tsx
@@ -7,8 +7,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { invariant } from "@ariakit/utils";
 import type { BooleanOrCallback } from "@ariakit/utils";
 import type { ElementType, MouseEvent } from "react";
@@ -38,7 +39,7 @@ const symbol = Symbol("disclosure");
 export const useDisclosure = createHook<TagName, DisclosureOptions>(
   function useDisclosure({ store, toggleOnClick = true, ...props }) {
     const context = useDisclosureProviderContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -123,8 +124,13 @@ export interface DisclosureOptions<
    * hook. If not provided, the closest
    * [`DisclosureProvider`](https://ariakit.com/reference/disclosure-provider)
    * component's context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`DisclosureProvider`](https://ariakit.com/reference/disclosure-provider)).
+   * In that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: DisclosureStore;
+  store?: DisclosureStore | ProviderComponent<DisclosureStore>;
   /**
    * Determines whether
    * [`toggle`](https://ariakit.com/reference/use-disclosure-store#toggle) will

--- a/packages/ariakit-react-components/src/form/form-context.tsx
+++ b/packages/ariakit-react-components/src/form/form-context.tsx
@@ -1,5 +1,6 @@
 import type { StringLike } from "@ariakit/components/form/types";
-import { createStoreContext, useId } from "@ariakit/react-utils";
+import type { ProviderComponent } from "@ariakit/react-utils";
+import { createStoreContext, useId, useStoreProp } from "@ariakit/react-utils";
 import { invariant } from "@ariakit/utils";
 import { useCallback, useRef } from "react";
 import {
@@ -13,7 +14,7 @@ type FormItemType = FormStoreItem["type"];
 type FormItemGetItem = NonNullable<CollectionItemOptions["getItem"]>;
 
 interface FormItemContextOptions {
-  store?: FormStore;
+  store?: FormStore | ProviderComponent<FormStore>;
   name: StringLike;
   component: string;
 }
@@ -44,7 +45,7 @@ export function useFormItemContext({
   component,
 }: FormItemContextOptions) {
   const context = useFormContext();
-  const form = store || context;
+  const form = useStoreProp(store, context);
 
   invariant(
     form,
@@ -94,3 +95,5 @@ export const useFormProviderContext = ctx.useProviderContext;
 export const FormContextProvider = ctx.ContextProvider;
 
 export const FormScopedContextProvider = ctx.ScopedContextProvider;
+
+export const createFormProvider = ctx.createProviderComponent;

--- a/packages/ariakit-react-components/src/form/form-control.tsx
+++ b/packages/ariakit-react-components/src/form/form-control.tsx
@@ -236,9 +236,10 @@ export interface FormControlOptions<
    * context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`FormProvider`](https://ariakit.com/reference/form-provider)). In that case,
-   * the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * [`FormProvider`](https://ariakit.com/reference/form-provider)). In that
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: FormStore | ProviderComponent<FormStore>;
   /**

--- a/packages/ariakit-react-components/src/form/form-control.tsx
+++ b/packages/ariakit-react-components/src/form/form-control.tsx
@@ -9,7 +9,7 @@ import {
   forwardRef,
   memo,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { getDocument, cx } from "@ariakit/utils";
 import type { BooleanOrCallback } from "@ariakit/utils";
 import type { ElementType, FocusEvent, RefObject } from "react";
@@ -234,8 +234,13 @@ export interface FormControlOptions<
    * provided, the closest [`Form`](https://ariakit.com/reference/form) or
    * [`FormProvider`](https://ariakit.com/reference/form-provider) components'
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`FormProvider`](https://ariakit.com/reference/form-provider)). In that case,
+   * the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: FormStore;
+  store?: FormStore | ProviderComponent<FormStore>;
   /**
    * Field name. This can either be a string corresponding to an existing
    * property name in the

--- a/packages/ariakit-react-components/src/form/form-description.tsx
+++ b/packages/ariakit-react-components/src/form/form-description.tsx
@@ -103,9 +103,10 @@ export interface FormDescriptionOptions<
    * context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`FormProvider`](https://ariakit.com/reference/form-provider)). In that case,
-   * the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * [`FormProvider`](https://ariakit.com/reference/form-provider)). In that
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: FormStore | ProviderComponent<FormStore>;
   /**

--- a/packages/ariakit-react-components/src/form/form-description.tsx
+++ b/packages/ariakit-react-components/src/form/form-description.tsx
@@ -6,7 +6,7 @@ import {
   forwardRef,
   memo,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { CollectionItemOptions } from "../collection/collection-item.tsx";
 import { useCollectionItem } from "../collection/collection-item.tsx";
@@ -101,8 +101,13 @@ export interface FormDescriptionOptions<
    * provided, the closest [`Form`](https://ariakit.com/reference/form) or
    * [`FormProvider`](https://ariakit.com/reference/form-provider) components'
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`FormProvider`](https://ariakit.com/reference/form-provider)). In that case,
+   * the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: FormStore;
+  store?: FormStore | ProviderComponent<FormStore>;
   /**
    * Name of the field described by this element. This can either be a string or
    * a reference to a field name from the

--- a/packages/ariakit-react-components/src/form/form-error.tsx
+++ b/packages/ariakit-react-components/src/form/form-error.tsx
@@ -7,7 +7,7 @@ import {
   forwardRef,
   memo,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { CollectionItemOptions } from "../collection/collection-item.tsx";
 import { useCollectionItem } from "../collection/collection-item.tsx";
@@ -123,8 +123,13 @@ export interface FormErrorOptions<
    * provided, the closest [`Form`](https://ariakit.com/reference/form) or
    * [`FormProvider`](https://ariakit.com/reference/form-provider) components'
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`FormProvider`](https://ariakit.com/reference/form-provider)). In that case,
+   * the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: FormStore;
+  store?: FormStore | ProviderComponent<FormStore>;
   /**
    * Name of the field associated with this error. This can either be a string
    * or a reference to a field name from the

--- a/packages/ariakit-react-components/src/form/form-error.tsx
+++ b/packages/ariakit-react-components/src/form/form-error.tsx
@@ -125,9 +125,10 @@ export interface FormErrorOptions<
    * context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`FormProvider`](https://ariakit.com/reference/form-provider)). In that case,
-   * the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * [`FormProvider`](https://ariakit.com/reference/form-provider)). In that
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: FormStore | ProviderComponent<FormStore>;
   /**

--- a/packages/ariakit-react-components/src/form/form-group-label.tsx
+++ b/packages/ariakit-react-components/src/form/form-group-label.tsx
@@ -1,5 +1,5 @@
 import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { GroupLabelOptions } from "../group/group-label.tsx";
 import { useGroupLabel } from "../group/group-label.tsx";
@@ -70,7 +70,7 @@ export interface FormGroupLabelOptions<
    * [`FormProvider`](https://ariakit.com/reference/form-provider) components'
    * context will be used.
    */
-  store?: FormStore;
+  store?: FormStore | ProviderComponent<FormStore>;
 }
 
 export type FormGroupLabelProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/form/form-group.tsx
+++ b/packages/ariakit-react-components/src/form/form-group.tsx
@@ -1,5 +1,5 @@
 import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { GroupOptions } from "../group/group.tsx";
 import { useGroup } from "../group/group.tsx";
@@ -70,7 +70,7 @@ export interface FormGroupOptions<
    * [`FormProvider`](https://ariakit.com/reference/form-provider) components'
    * context will be used.
    */
-  store?: FormStore;
+  store?: FormStore | ProviderComponent<FormStore>;
 }
 
 export type FormGroupProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/form/form-label.tsx
+++ b/packages/ariakit-react-components/src/form/form-label.tsx
@@ -9,7 +9,7 @@ import {
   forwardRef,
   memo,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { getFirstTabbableIn } from "@ariakit/utils";
 import type { ElementType, MouseEvent } from "react";
 import type { CollectionItemOptions } from "../collection/collection-item.tsx";
@@ -160,8 +160,13 @@ export interface FormLabelOptions<
    * provided, the closest [`Form`](https://ariakit.com/reference/form) or
    * [`FormProvider`](https://ariakit.com/reference/form-provider) components'
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`FormProvider`](https://ariakit.com/reference/form-provider)). In that case,
+   * the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: FormStore;
+  store?: FormStore | ProviderComponent<FormStore>;
   /**
    * Name of the field labeled by this element. This can either be a string or a
    * reference to a field name from the

--- a/packages/ariakit-react-components/src/form/form-label.tsx
+++ b/packages/ariakit-react-components/src/form/form-label.tsx
@@ -162,9 +162,10 @@ export interface FormLabelOptions<
    * context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`FormProvider`](https://ariakit.com/reference/form-provider)). In that case,
-   * the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * [`FormProvider`](https://ariakit.com/reference/form-provider)). In that
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: FormStore | ProviderComponent<FormStore>;
   /**

--- a/packages/ariakit-react-components/src/form/form-provider.tsx
+++ b/packages/ariakit-react-components/src/form/form-provider.tsx
@@ -1,11 +1,27 @@
 import type { FormStoreValues } from "@ariakit/components/form/form-store";
+import type { ProviderComponent } from "@ariakit/react-utils";
 import type { PickRequired } from "@ariakit/utils";
 import type { ReactElement, ReactNode } from "react";
-import { FormContextProvider } from "./form-context.tsx";
-import type { FormStoreProps } from "./form-store.ts";
+import { createFormProvider, FormContextProvider } from "./form-context.tsx";
+import type { FormStore, FormStoreProps } from "./form-store.ts";
 import { useFormStore } from "./form-store.ts";
 
 type Values = FormStoreValues;
+
+export interface FormProviderComponent extends ProviderComponent<FormStore> {
+  <T extends Values = Values>(
+    props: PickRequired<
+      FormProviderProps<T>,
+      | "values"
+      | "defaultValues"
+      | "errors"
+      | "defaultErrors"
+      | "touched"
+      | "defaultTouched"
+    >,
+  ): ReactElement;
+  (props: FormProviderProps): ReactElement;
+}
 
 /**
  * Provides a form store to [Form](https://ariakit.com/components/form)
@@ -20,27 +36,14 @@ type Values = FormStoreValues;
  * </FormProvider>
  * ```
  */
-
-export function FormProvider<T extends Values = Values>(
-  props: PickRequired<
-    FormProviderProps<T>,
-    | "values"
-    | "defaultValues"
-    | "errors"
-    | "defaultErrors"
-    | "touched"
-    | "defaultTouched"
-  >,
-): ReactElement;
-
-export function FormProvider(props: FormProviderProps): ReactElement;
-
-export function FormProvider(props: FormProviderProps = {}) {
-  const store = useFormStore(props);
-  return (
-    <FormContextProvider value={store}>{props.children}</FormContextProvider>
-  );
-}
+export const FormProvider: FormProviderComponent = createFormProvider(
+  function FormProvider(props: FormProviderProps = {}) {
+    const store = useFormStore(props);
+    return (
+      <FormContextProvider value={store}>{props.children}</FormContextProvider>
+    );
+  },
+);
 
 export interface FormProviderProps<
   T extends Values = Values,

--- a/packages/ariakit-react-components/src/form/form-push.tsx
+++ b/packages/ariakit-react-components/src/form/form-push.tsx
@@ -6,7 +6,7 @@ import {
   createHook,
   forwardRef,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType, MouseEvent } from "react";
 import { useCallback, useEffect, useState } from "react";
 import type { ButtonOptions } from "../button/button.tsx";
@@ -166,8 +166,13 @@ export interface FormPushOptions<T extends ElementType = TagName>
    * provided, the closest [`Form`](https://ariakit.com/reference/form) or
    * [`FormProvider`](https://ariakit.com/reference/form-provider) components'
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`FormProvider`](https://ariakit.com/reference/form-provider)). In that case,
+   * the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: FormStore;
+  store?: FormStore | ProviderComponent<FormStore>;
   /**
    * Name of the array field. This can either be a string or a reference to a
    * field name from the

--- a/packages/ariakit-react-components/src/form/form-push.tsx
+++ b/packages/ariakit-react-components/src/form/form-push.tsx
@@ -168,9 +168,10 @@ export interface FormPushOptions<T extends ElementType = TagName>
    * context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`FormProvider`](https://ariakit.com/reference/form-provider)). In that case,
-   * the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * [`FormProvider`](https://ariakit.com/reference/form-provider)). In that
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: FormStore | ProviderComponent<FormStore>;
   /**

--- a/packages/ariakit-react-components/src/form/form-remove.tsx
+++ b/packages/ariakit-react-components/src/form/form-remove.tsx
@@ -169,9 +169,10 @@ export interface FormRemoveOptions<
    * context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`FormProvider`](https://ariakit.com/reference/form-provider)). In that case,
-   * the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * [`FormProvider`](https://ariakit.com/reference/form-provider)). In that
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: FormStore | ProviderComponent<FormStore>;
   /**

--- a/packages/ariakit-react-components/src/form/form-remove.tsx
+++ b/packages/ariakit-react-components/src/form/form-remove.tsx
@@ -5,7 +5,7 @@ import {
   createHook,
   forwardRef,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { isTextField } from "@ariakit/utils";
 import type { ElementType, MouseEvent } from "react";
 import type { ButtonOptions } from "../button/button.tsx";
@@ -167,8 +167,13 @@ export interface FormRemoveOptions<
    * provided, the closest [`Form`](https://ariakit.com/reference/form) or
    * [`FormProvider`](https://ariakit.com/reference/form-provider) components'
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`FormProvider`](https://ariakit.com/reference/form-provider)). In that case,
+   * the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: FormStore;
+  store?: FormStore | ProviderComponent<FormStore>;
   /**
    * Name of the array field. This can either be a string or a reference to a
    * field name from the

--- a/packages/ariakit-react-components/src/form/form-reset.tsx
+++ b/packages/ariakit-react-components/src/form/form-reset.tsx
@@ -82,9 +82,10 @@ export interface FormResetOptions<
    * context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`FormProvider`](https://ariakit.com/reference/form-provider)). In that case,
-   * the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * [`FormProvider`](https://ariakit.com/reference/form-provider)). In that
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: FormStore | ProviderComponent<FormStore>;
 }

--- a/packages/ariakit-react-components/src/form/form-reset.tsx
+++ b/packages/ariakit-react-components/src/form/form-reset.tsx
@@ -1,6 +1,11 @@
 import { useStoreState } from "@ariakit/react-store";
-import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import {
+  createElement,
+  createHook,
+  forwardRef,
+  useStoreProp,
+} from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { invariant } from "@ariakit/utils";
 import type { ElementType } from "react";
 import type { ButtonOptions } from "../button/button.tsx";
@@ -26,7 +31,7 @@ type TagName = typeof TagName;
 export const useFormReset = createHook<TagName, FormResetOptions>(
   function useFormReset({ store, ...props }) {
     const context = useFormContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -75,8 +80,13 @@ export interface FormResetOptions<
    * provided, the closest [`Form`](https://ariakit.com/reference/form) or
    * [`FormProvider`](https://ariakit.com/reference/form-provider) components'
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`FormProvider`](https://ariakit.com/reference/form-provider)). In that case,
+   * the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: FormStore;
+  store?: FormStore | ProviderComponent<FormStore>;
 }
 
 export type FormResetProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/form/form-submit.tsx
+++ b/packages/ariakit-react-components/src/form/form-submit.tsx
@@ -86,9 +86,10 @@ export interface FormSubmitOptions<
    * context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`FormProvider`](https://ariakit.com/reference/form-provider)). In that case,
-   * the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * [`FormProvider`](https://ariakit.com/reference/form-provider)). In that
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: FormStore | ProviderComponent<FormStore>;
   /**

--- a/packages/ariakit-react-components/src/form/form-submit.tsx
+++ b/packages/ariakit-react-components/src/form/form-submit.tsx
@@ -1,6 +1,11 @@
 import { useStoreState } from "@ariakit/react-store";
-import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import {
+  createElement,
+  createHook,
+  forwardRef,
+  useStoreProp,
+} from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { invariant } from "@ariakit/utils";
 import type { ElementType } from "react";
 import type { ButtonOptions } from "../button/button.tsx";
@@ -26,7 +31,7 @@ type TagName = typeof TagName;
 export const useFormSubmit = createHook<TagName, FormSubmitOptions>(
   function useFormSubmit({ store, accessibleWhenDisabled = true, ...props }) {
     const context = useFormContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -79,8 +84,13 @@ export interface FormSubmitOptions<
    * provided, the closest [`Form`](https://ariakit.com/reference/form) or
    * [`FormProvider`](https://ariakit.com/reference/form-provider) components'
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`FormProvider`](https://ariakit.com/reference/form-provider)). In that case,
+   * the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: FormStore;
+  store?: FormStore | ProviderComponent<FormStore>;
   /**
    * @default true
    */

--- a/packages/ariakit-react-components/src/form/form.tsx
+++ b/packages/ariakit-react-components/src/form/form.tsx
@@ -9,8 +9,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Options, Props } from "@ariakit/react-utils";
+import type { Options, Props, ProviderComponent } from "@ariakit/react-utils";
 import { isTextField, invariant, sortBasedOnDOMPosition } from "@ariakit/utils";
 import type { ElementType, FocusEvent, FormEvent } from "react";
 import { useEffect, useRef, useState } from "react";
@@ -56,7 +57,7 @@ export const useForm = createHook<TagName, FormOptions>(function useForm({
   ...props
 }) {
   const context = useFormContext();
-  store = store || context;
+  store = useStoreProp(store, context);
 
   invariant(
     store,
@@ -213,8 +214,13 @@ export interface FormOptions<_T extends ElementType = TagName> extends Options {
    * provided, the closest
    * [`FormProvider`](https://ariakit.com/reference/form-provider) component's
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`FormProvider`](https://ariakit.com/reference/form-provider)). In that case,
+   * the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: FormStore;
+  store?: FormStore | ProviderComponent<FormStore>;
   /**
    * Determines if the form should invoke the validation callbacks registered
    * with

--- a/packages/ariakit-react-components/src/form/form.tsx
+++ b/packages/ariakit-react-components/src/form/form.tsx
@@ -216,9 +216,10 @@ export interface FormOptions<_T extends ElementType = TagName> extends Options {
    * context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`FormProvider`](https://ariakit.com/reference/form-provider)). In that case,
-   * the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * [`FormProvider`](https://ariakit.com/reference/form-provider)). In that
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: FormStore | ProviderComponent<FormStore>;
   /**

--- a/packages/ariakit-react-components/src/hovercard/hovercard-anchor.tsx
+++ b/packages/ariakit-react-components/src/hovercard/hovercard-anchor.tsx
@@ -6,8 +6,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import {
   addGlobalEventListener,
   disabledFromProps,
@@ -39,7 +40,7 @@ type HTMLType = HTMLElementTagNameMap[TagName];
 export const useHovercardAnchor = createHook<TagName, HovercardAnchorOptions>(
   function useHovercardAnchor({ store, showOnHover = true, ...props }) {
     const context = useHovercardProviderContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -174,8 +175,13 @@ export interface HovercardAnchorOptions<
    * hook. If not provided, the closest
    * [`HovercardProvider`](https://ariakit.com/reference/hovercard-provider)
    * component's context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`HovercardProvider`](https://ariakit.com/reference/hovercard-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: HovercardStore;
+  store?: HovercardStore | ProviderComponent<HovercardStore>;
   /**
    * Shows the content element based on the user's _hover intent_ over the
    * anchor element. This behavior purposely ignores mobile touch and

--- a/packages/ariakit-react-components/src/hovercard/hovercard-anchor.tsx
+++ b/packages/ariakit-react-components/src/hovercard/hovercard-anchor.tsx
@@ -177,9 +177,10 @@ export interface HovercardAnchorOptions<
    * component's context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`HovercardProvider`](https://ariakit.com/reference/hovercard-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * [`HovercardProvider`](https://ariakit.com/reference/hovercard-provider)).
+   * In that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: HovercardStore | ProviderComponent<HovercardStore>;
   /**

--- a/packages/ariakit-react-components/src/hovercard/hovercard-arrow.tsx
+++ b/packages/ariakit-react-components/src/hovercard/hovercard-arrow.tsx
@@ -1,5 +1,10 @@
-import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import {
+  createElement,
+  createHook,
+  forwardRef,
+  useStoreProp,
+} from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { PopoverArrowOptions } from "../popover/popover-arrow.tsx";
 import { usePopoverArrow } from "../popover/popover-arrow.tsx";
@@ -25,7 +30,7 @@ type TagName = typeof TagName;
 export const useHovercardArrow = createHook<TagName, HovercardArrowOptions>(
   function useHovercardArrow({ store, ...props }) {
     const context = useHovercardContext();
-    store = store || context;
+    store = useStoreProp(store, context);
     props = usePopoverArrow({ store, ...props });
     return props;
   },
@@ -64,8 +69,13 @@ export interface HovercardArrowOptions<
    * [`Hovercard`](https://ariakit.com/reference/hovercard) or
    * [`HovercardProvider`](https://ariakit.com/reference/hovercard-provider)
    * components' context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`HovercardProvider`](https://ariakit.com/reference/hovercard-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: HovercardStore;
+  store?: HovercardStore | ProviderComponent<HovercardStore>;
 }
 
 export type HovercardArrowProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/hovercard/hovercard-arrow.tsx
+++ b/packages/ariakit-react-components/src/hovercard/hovercard-arrow.tsx
@@ -71,9 +71,10 @@ export interface HovercardArrowOptions<
    * components' context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`HovercardProvider`](https://ariakit.com/reference/hovercard-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * [`HovercardProvider`](https://ariakit.com/reference/hovercard-provider)).
+   * In that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: HovercardStore | ProviderComponent<HovercardStore>;
 }

--- a/packages/ariakit-react-components/src/hovercard/hovercard-context.tsx
+++ b/packages/ariakit-react-components/src/hovercard/hovercard-context.tsx
@@ -32,3 +32,5 @@ export const useHovercardProviderContext = ctx.useProviderContext;
 export const HovercardContextProvider = ctx.ContextProvider;
 
 export const HovercardScopedContextProvider = ctx.ScopedContextProvider;
+
+export const createHovercardProvider = ctx.createProviderComponent;

--- a/packages/ariakit-react-components/src/hovercard/hovercard-description.tsx
+++ b/packages/ariakit-react-components/src/hovercard/hovercard-description.tsx
@@ -1,5 +1,5 @@
 import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { PopoverDescriptionOptions } from "../popover/popover-description.tsx";
 import { usePopoverDescription } from "../popover/popover-description.tsx";
@@ -63,7 +63,7 @@ export interface HovercardDescriptionOptions<
    * React context, so it must be rendered inside the hovercard for the
    * `aria-describedby` prop to be set on the hovercard element.
    */
-  store?: HovercardStore;
+  store?: HovercardStore | ProviderComponent<HovercardStore>;
 }
 
 export type HovercardDescriptionProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/hovercard/hovercard-disclosure.tsx
+++ b/packages/ariakit-react-components/src/hovercard/hovercard-disclosure.tsx
@@ -4,8 +4,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { sync } from "@ariakit/store";
 import {
   contains,
@@ -47,7 +48,7 @@ export const useHovercardDisclosure = createHook<
   HovercardDisclosureOptions
 >(function useHovercardDisclosure({ store, ...props }) {
   const context = useHovercardProviderContext();
-  store = store || context;
+  store = useStoreProp(store, context);
 
   invariant(
     store,
@@ -200,8 +201,13 @@ export interface HovercardDisclosureOptions<
    * hook. If not provided, the closest
    * [`HovercardProvider`](https://ariakit.com/reference/hovercard-provider)
    * component's context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`HovercardProvider`](https://ariakit.com/reference/hovercard-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: HovercardStore;
+  store?: HovercardStore | ProviderComponent<HovercardStore>;
 }
 
 export type HovercardDisclosureProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/hovercard/hovercard-disclosure.tsx
+++ b/packages/ariakit-react-components/src/hovercard/hovercard-disclosure.tsx
@@ -203,9 +203,10 @@ export interface HovercardDisclosureOptions<
    * component's context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`HovercardProvider`](https://ariakit.com/reference/hovercard-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * [`HovercardProvider`](https://ariakit.com/reference/hovercard-provider)).
+   * In that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: HovercardStore | ProviderComponent<HovercardStore>;
 }

--- a/packages/ariakit-react-components/src/hovercard/hovercard-dismiss.tsx
+++ b/packages/ariakit-react-components/src/hovercard/hovercard-dismiss.tsx
@@ -1,5 +1,10 @@
-import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import {
+  createElement,
+  createHook,
+  forwardRef,
+  useStoreProp,
+} from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { PopoverDismissOptions } from "../popover/popover-dismiss.tsx";
 import { usePopoverDismiss } from "../popover/popover-dismiss.tsx";
@@ -24,7 +29,7 @@ type TagName = typeof TagName;
 export const useHovercardDismiss = createHook<TagName, HovercardDismissOptions>(
   function useHovercardDismiss({ store, ...props }) {
     const context = useHovercardScopedContext();
-    store = store || context;
+    store = useStoreProp(store, context);
     props = usePopoverDismiss({ store, ...props });
     return props;
   },
@@ -60,8 +65,13 @@ export interface HovercardDismissOptions<
    * [`Hovercard`](https://ariakit.com/reference/hovercard) or
    * [`HovercardProvider`](https://ariakit.com/reference/hovercard-provider)
    * components' context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`HovercardProvider`](https://ariakit.com/reference/hovercard-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: HovercardStore;
+  store?: HovercardStore | ProviderComponent<HovercardStore>;
 }
 
 export type HovercardDismissProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/hovercard/hovercard-dismiss.tsx
+++ b/packages/ariakit-react-components/src/hovercard/hovercard-dismiss.tsx
@@ -67,9 +67,10 @@ export interface HovercardDismissOptions<
    * components' context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`HovercardProvider`](https://ariakit.com/reference/hovercard-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * [`HovercardProvider`](https://ariakit.com/reference/hovercard-provider)).
+   * In that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: HovercardStore | ProviderComponent<HovercardStore>;
 }

--- a/packages/ariakit-react-components/src/hovercard/hovercard-heading.tsx
+++ b/packages/ariakit-react-components/src/hovercard/hovercard-heading.tsx
@@ -1,5 +1,5 @@
 import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { PopoverHeadingOptions } from "../popover/popover-heading.tsx";
 import { usePopoverHeading } from "../popover/popover-heading.tsx";
@@ -62,7 +62,7 @@ export interface HovercardHeadingOptions<
    * React context, so it must be rendered inside the hovercard for the
    * `aria-labelledby` prop to be set on the hovercard element.
    */
-  store?: HovercardStore;
+  store?: HovercardStore | ProviderComponent<HovercardStore>;
 }
 
 export type HovercardHeadingProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/hovercard/hovercard-provider.tsx
+++ b/packages/ariakit-react-components/src/hovercard/hovercard-provider.tsx
@@ -1,5 +1,8 @@
 import type { ReactNode } from "react";
-import { HovercardContextProvider } from "./hovercard-context.tsx";
+import {
+  createHovercardProvider,
+  HovercardContextProvider,
+} from "./hovercard-context.tsx";
 import type { HovercardStoreProps } from "./hovercard-store.ts";
 import { useHovercardStore } from "./hovercard-store.ts";
 
@@ -15,14 +18,16 @@ import { useHovercardStore } from "./hovercard-store.ts";
  * </HovercardProvider>
  * ```
  */
-export function HovercardProvider(props: HovercardProviderProps = {}) {
-  const store = useHovercardStore(props);
-  return (
-    <HovercardContextProvider value={store}>
-      {props.children}
-    </HovercardContextProvider>
-  );
-}
+export const HovercardProvider = createHovercardProvider(
+  function HovercardProvider(props: HovercardProviderProps = {}) {
+    const store = useHovercardStore(props);
+    return (
+      <HovercardContextProvider value={store}>
+        {props.children}
+      </HovercardContextProvider>
+    );
+  },
+);
 
 export interface HovercardProviderProps extends HovercardStoreProps {
   children?: ReactNode;

--- a/packages/ariakit-react-components/src/hovercard/hovercard.tsx
+++ b/packages/ariakit-react-components/src/hovercard/hovercard.tsx
@@ -11,8 +11,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { sync } from "@ariakit/store";
 import {
   addGlobalEventListener,
@@ -174,7 +175,7 @@ export const useHovercard = createHook<TagName, HovercardOptions>(
     ...props
   }) {
     const context = useHovercardProviderContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -441,8 +442,13 @@ export interface HovercardOptions<
    * hook. If not provided, the closest
    * [`HovercardProvider`](https://ariakit.com/reference/hovercard-provider)
    * component's context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`HovercardProvider`](https://ariakit.com/reference/hovercard-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: HovercardStore;
+  store?: HovercardStore | ProviderComponent<HovercardStore>;
   /**
    * Determines whether the popover should hide when the mouse leaves the
    * popover or the anchor element and there's no _hover intent_, meaning, the

--- a/packages/ariakit-react-components/src/hovercard/hovercard.tsx
+++ b/packages/ariakit-react-components/src/hovercard/hovercard.tsx
@@ -444,9 +444,10 @@ export interface HovercardOptions<
    * component's context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`HovercardProvider`](https://ariakit.com/reference/hovercard-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * [`HovercardProvider`](https://ariakit.com/reference/hovercard-provider)).
+   * In that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: HovercardStore | ProviderComponent<HovercardStore>;
   /**

--- a/packages/ariakit-react-components/src/menu/menu-arrow.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-arrow.tsx
@@ -1,5 +1,10 @@
-import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import {
+  createElement,
+  createHook,
+  forwardRef,
+  useStoreProp,
+} from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { PopoverArrowOptions } from "../popover/popover-arrow.tsx";
 import { usePopoverArrow } from "../popover/popover-arrow.tsx";
@@ -25,7 +30,7 @@ type TagName = typeof TagName;
 export const useMenuArrow = createHook<TagName, MenuArrowOptions>(
   function useMenuArrow({ store, ...props }) {
     const context = useMenuContext();
-    store = store || context;
+    store = useStoreProp(store, context);
     return usePopoverArrow({ store, ...props });
   },
 );
@@ -59,8 +64,13 @@ export interface MenuArrowOptions<
    * provided, the closest [`Menu`](https://ariakit.com/reference/menu) or
    * [`MenuProvider`](https://ariakit.com/reference/menu-provider) components'
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`MenuProvider`](https://ariakit.com/reference/menu-provider)). In that case,
+   * the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: MenuStore;
+  store?: MenuStore | ProviderComponent<MenuStore>;
 }
 
 export type MenuArrowProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/menu/menu-arrow.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-arrow.tsx
@@ -66,9 +66,10 @@ export interface MenuArrowOptions<
    * context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`MenuProvider`](https://ariakit.com/reference/menu-provider)). In that case,
-   * the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * [`MenuProvider`](https://ariakit.com/reference/menu-provider)). In that
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: MenuStore | ProviderComponent<MenuStore>;
 }

--- a/packages/ariakit-react-components/src/menu/menu-bar-provider.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-bar-provider.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { createMenubarProvider } from "../menubar/menubar-context.tsx";
 import type { MenubarProviderProps } from "../menubar/menubar-provider.tsx";
 import { MenubarProvider } from "../menubar/menubar-provider.tsx";
 
@@ -29,7 +30,9 @@ import { MenubarProvider } from "../menubar/menubar-provider.tsx";
  * </MenuBarProvider>
  * ```
  */
-export function MenuBarProvider(props: MenuBarProviderProps = {}) {
+export const MenuBarProvider = createMenubarProvider(function MenuBarProvider(
+  props: MenuBarProviderProps = {},
+) {
   useEffect(() => {
     if (process.env.NODE_ENV !== "production") {
       console.warn(
@@ -39,6 +42,6 @@ export function MenuBarProvider(props: MenuBarProviderProps = {}) {
     }
   }, []);
   return <MenubarProvider {...props} />;
-}
+});
 
 export interface MenuBarProviderProps extends MenubarProviderProps {}

--- a/packages/ariakit-react-components/src/menu/menu-button-arrow.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-button-arrow.tsx
@@ -82,9 +82,10 @@ export interface MenuButtonArrowOptions<
    * context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`MenuProvider`](https://ariakit.com/reference/menu-provider)). In that case,
-   * the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * [`MenuProvider`](https://ariakit.com/reference/menu-provider)). In that
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: MenuStore | ProviderComponent<MenuStore>;
 }

--- a/packages/ariakit-react-components/src/menu/menu-button-arrow.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-button-arrow.tsx
@@ -1,5 +1,10 @@
-import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import {
+  createElement,
+  createHook,
+  forwardRef,
+  useStoreProp,
+} from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { PopoverDisclosureArrowOptions } from "../popover/popover-disclosure-arrow.tsx";
 import { usePopoverDisclosureArrow } from "../popover/popover-disclosure-arrow.tsx";
@@ -29,7 +34,7 @@ type TagName = typeof TagName;
 export const useMenuButtonArrow = createHook<TagName, MenuButtonArrowOptions>(
   function useMenuButtonArrow({ store, ...props }) {
     const context = useMenuContext();
-    store = store || context;
+    store = useStoreProp(store, context);
     props = usePopoverDisclosureArrow({ store, ...props });
     return props;
   },
@@ -75,8 +80,13 @@ export interface MenuButtonArrowOptions<
    * [`MenuButton`](https://ariakit.com/reference/menu-button) or
    * [`MenuProvider`](https://ariakit.com/reference/menu-provider) components'
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`MenuProvider`](https://ariakit.com/reference/menu-provider)). In that case,
+   * the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: MenuStore;
+  store?: MenuStore | ProviderComponent<MenuStore>;
 }
 
 export type MenuButtonArrowProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/menu/menu-button.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-button.tsx
@@ -320,9 +320,10 @@ export interface MenuButtonOptions<T extends ElementType = TagName>
    * context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`MenuProvider`](https://ariakit.com/reference/menu-provider)). In that case,
-   * the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * [`MenuProvider`](https://ariakit.com/reference/menu-provider)). In that
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: MenuStore | ProviderComponent<MenuStore>;
   /**

--- a/packages/ariakit-react-components/src/menu/menu-button.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-button.tsx
@@ -7,8 +7,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import {
   getPopupItemRole,
   getPopupRole,
@@ -81,7 +82,7 @@ export const useMenuButton = createHook<TagName, MenuButtonOptions>(
     ...props
   }) {
     const context = useMenuProviderContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -317,8 +318,13 @@ export interface MenuButtonOptions<T extends ElementType = TagName>
    * provided, the closest
    * [`MenuProvider`](https://ariakit.com/reference/menu-provider) component's
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`MenuProvider`](https://ariakit.com/reference/menu-provider)). In that case,
+   * the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: MenuStore;
+  store?: MenuStore | ProviderComponent<MenuStore>;
   /**
    * Determines whether pressing a character key while focusing on the
    * [`MenuButton`](https://ariakit.com/reference/menu-button) should move focus

--- a/packages/ariakit-react-components/src/menu/menu-context.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-context.tsx
@@ -45,6 +45,8 @@ export const MenuContextProvider = menu.ContextProvider;
 
 export const MenuScopedContextProvider = menu.ScopedContextProvider;
 
+export const createMenuProvider = menu.createProviderComponent;
+
 /**
  * Returns the menuBar store from the nearest menuBar container.
  * @deprecated

--- a/packages/ariakit-react-components/src/menu/menu-description.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-description.tsx
@@ -1,5 +1,5 @@
 import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { HovercardDescriptionOptions } from "../hovercard/hovercard-description.tsx";
 import { useHovercardDescription } from "../hovercard/hovercard-description.tsx";
@@ -58,7 +58,7 @@ export interface MenuDescriptionOptions<
    * [`MenuProvider`](https://ariakit.com/reference/menu-provider) components'
    * context will be used.
    */
-  store?: MenuStore;
+  store?: MenuStore | ProviderComponent<MenuStore>;
 }
 
 export type MenuDescriptionProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/menu/menu-dismiss.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-dismiss.tsx
@@ -66,9 +66,10 @@ export interface MenuDismissOptions<
    * context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`MenuProvider`](https://ariakit.com/reference/menu-provider)). In that case,
-   * the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * [`MenuProvider`](https://ariakit.com/reference/menu-provider)). In that
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: MenuStore | ProviderComponent<MenuStore>;
 }

--- a/packages/ariakit-react-components/src/menu/menu-dismiss.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-dismiss.tsx
@@ -1,5 +1,10 @@
-import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import {
+  createElement,
+  createHook,
+  forwardRef,
+  useStoreProp,
+} from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { HovercardDismissOptions } from "../hovercard/hovercard-dismiss.tsx";
 import { useHovercardDismiss } from "../hovercard/hovercard-dismiss.tsx";
@@ -24,7 +29,7 @@ type TagName = typeof TagName;
 export const useMenuDismiss = createHook<TagName, MenuDismissOptions>(
   function useMenuDismiss({ store, ...props }) {
     const context = useMenuScopedContext();
-    store = store || context;
+    store = useStoreProp(store, context);
     props = useHovercardDismiss({ store, ...props });
     return props;
   },
@@ -59,8 +64,13 @@ export interface MenuDismissOptions<
    * provided, the closest [`Menu`](https://ariakit.com/reference/menu) or
    * [`MenuProvider`](https://ariakit.com/reference/menu-provider) components'
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`MenuProvider`](https://ariakit.com/reference/menu-provider)). In that case,
+   * the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: MenuStore;
+  store?: MenuStore | ProviderComponent<MenuStore>;
 }
 
 export type MenuDismissProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/menu/menu-group-label.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-group-label.tsx
@@ -1,5 +1,5 @@
 import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { CompositeGroupLabelOptions } from "../composite/composite-group-label.tsx";
 import { useCompositeGroupLabel } from "../composite/composite-group-label.tsx";
@@ -63,7 +63,7 @@ export interface MenuGroupLabelOptions<
    * [`MenuProvider`](https://ariakit.com/reference/menu-provider) components'
    * context will be used.
    */
-  store?: MenuStore;
+  store?: MenuStore | ProviderComponent<MenuStore>;
 }
 
 export type MenuGroupLabelProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/menu/menu-group.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-group.tsx
@@ -1,5 +1,5 @@
 import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { CompositeGroupOptions } from "../composite/composite-group.tsx";
 import { useCompositeGroup } from "../composite/composite-group.tsx";
@@ -67,7 +67,7 @@ export interface MenuGroupOptions<
    * [`MenuProvider`](https://ariakit.com/reference/menu-provider) components'
    * context will be used.
    */
-  store?: MenuStore;
+  store?: MenuStore | ProviderComponent<MenuStore>;
 }
 
 export type MenuGroupProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/menu/menu-heading.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-heading.tsx
@@ -1,5 +1,5 @@
 import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { HovercardHeadingOptions } from "../hovercard/hovercard-heading.tsx";
 import { useHovercardHeading } from "../hovercard/hovercard-heading.tsx";
@@ -58,7 +58,7 @@ export interface MenuHeadingOptions<
    * [`MenuProvider`](https://ariakit.com/reference/menu-provider) components'
    * context will be used.
    */
-  store?: MenuStore;
+  store?: MenuStore | ProviderComponent<MenuStore>;
 }
 
 export type MenuHeadingProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/menu/menu-item-check.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-item-check.tsx
@@ -1,5 +1,5 @@
 import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import { useContext } from "react";
 import type { CheckboxCheckOptions } from "../checkbox/checkbox-check.tsx";
@@ -78,7 +78,7 @@ export interface MenuItemCheckOptions<
    * [`MenuItemRadio`](https://ariakit.com/reference/menu-item-radio)
    * component.
    */
-  store?: MenuStore;
+  store?: MenuStore | ProviderComponent<MenuStore>;
 }
 
 export type MenuItemCheckProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/menu/menu-item-checkbox.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-item-checkbox.tsx
@@ -190,9 +190,10 @@ export interface MenuItemCheckboxOptions<T extends ElementType = TagName>
    * context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`MenuProvider`](https://ariakit.com/reference/menu-provider)). In that case,
-   * the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * [`MenuProvider`](https://ariakit.com/reference/menu-provider)). In that
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: MenuStore | ProviderComponent<MenuStore>;
   /**

--- a/packages/ariakit-react-components/src/menu/menu-item-checkbox.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-item-checkbox.tsx
@@ -5,8 +5,9 @@ import {
   createHook,
   forwardRef,
   memo,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { invariant, shallowEqual } from "@ariakit/utils";
 import type { ElementType } from "react";
 import { useEffect } from "react";
@@ -72,7 +73,7 @@ export const useMenuItemCheckbox = createHook<TagName, MenuItemCheckboxOptions>(
     ...props
   }) {
     const context = useMenuScopedContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -187,8 +188,13 @@ export interface MenuItemCheckboxOptions<T extends ElementType = TagName>
    * provided, the closest [`Menu`](https://ariakit.com/reference/menu) or
    * [`MenuProvider`](https://ariakit.com/reference/menu-provider) components'
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`MenuProvider`](https://ariakit.com/reference/menu-provider)). In that case,
+   * the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: MenuStore;
+  store?: MenuStore | ProviderComponent<MenuStore>;
   /**
    * The name of the field in the
    * [`values`](https://ariakit.com/reference/menu-provider#values) state.

--- a/packages/ariakit-react-components/src/menu/menu-item-radio.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-item-radio.tsx
@@ -168,9 +168,10 @@ export interface MenuItemRadioOptions<T extends ElementType = TagName>
    * context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`MenuProvider`](https://ariakit.com/reference/menu-provider)). In that case,
-   * the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * [`MenuProvider`](https://ariakit.com/reference/menu-provider)). In that
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: MenuStore | ProviderComponent<MenuStore>;
   /**

--- a/packages/ariakit-react-components/src/menu/menu-item-radio.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-item-radio.tsx
@@ -6,8 +6,9 @@ import {
   createHook,
   forwardRef,
   memo,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { invariant } from "@ariakit/utils";
 import type { ElementType } from "react";
 import { useEffect } from "react";
@@ -57,7 +58,7 @@ export const useMenuItemRadio = createHook<TagName, MenuItemRadioOptions>(
     ...props
   }) {
     const context = useMenuScopedContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -165,8 +166,13 @@ export interface MenuItemRadioOptions<T extends ElementType = TagName>
    * provided, the closest [`Menu`](https://ariakit.com/reference/menu) or
    * [`MenuProvider`](https://ariakit.com/reference/menu-provider) components'
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`MenuProvider`](https://ariakit.com/reference/menu-provider)). In that case,
+   * the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: MenuStore;
+  store?: MenuStore | ProviderComponent<MenuStore>;
   /**
    * The name of the field in the
    * [`values`](https://ariakit.com/reference/menu-provider#values) state.

--- a/packages/ariakit-react-components/src/menu/menu-item.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-item.tsx
@@ -226,8 +226,9 @@ export interface MenuItemOptions<T extends ElementType = TagName>
    * You can also pass a provider component (for example,
    * [`MenuProvider`](https://ariakit.com/reference/menu-provider) or
    * [`MenubarProvider`](https://ariakit.com/reference/menubar-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?:
     | MenubarStore

--- a/packages/ariakit-react-components/src/menu/menu-item.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-item.tsx
@@ -2,12 +2,13 @@ import { useStoreState } from "@ariakit/react-store";
 import {
   useBooleanEvent,
   useEvent,
+  useStoreProp,
   createElement,
   createHook,
   forwardRef,
   memo,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import {
   getDocument,
   getPopupItemRole,
@@ -84,7 +85,7 @@ export const useMenuItem = createHook<TagName, MenuItemOptions>(
     // it renders a MenuButton inside a Menubar.
     const menuContext = useMenuScopedContext(true);
     const menubarContext = useMenubarScopedContext();
-    store = store || menuContext || (menubarContext as any);
+    store = useStoreProp(store, menuContext, menubarContext);
 
     invariant(
       store,
@@ -221,8 +222,17 @@ export interface MenuItemOptions<T extends ElementType = TagName>
    * [`Menubar`](https://ariakit.com/reference/menubar), or
    * [`MenubarProvider`](https://ariakit.com/reference/menubar-provider)
    * components' context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`MenuProvider`](https://ariakit.com/reference/menu-provider) or
+   * [`MenubarProvider`](https://ariakit.com/reference/menubar-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: MenubarStore | MenuStore;
+  store?:
+    | MenubarStore
+    | MenuStore
+    | ProviderComponent<MenubarStore | MenuStore>;
   /**
    * Determines if the menu should hide when this item is clicked.
    *

--- a/packages/ariakit-react-components/src/menu/menu-list.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-list.tsx
@@ -237,9 +237,10 @@ export interface MenuListOptions<T extends ElementType = TagName>
    * context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`MenuProvider`](https://ariakit.com/reference/menu-provider)). In that case,
-   * the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * [`MenuProvider`](https://ariakit.com/reference/menu-provider)). In that
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: MenuStore | ProviderComponent<MenuStore>;
 }

--- a/packages/ariakit-react-components/src/menu/menu-list.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-list.tsx
@@ -7,8 +7,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { invariant } from "@ariakit/utils";
 import type { ElementType, KeyboardEvent } from "react";
 import { useEffect, useState } from "react";
@@ -70,7 +71,7 @@ function useAriaLabelledBy({ store, ...props }: MenuListProps) {
 export const useMenuList = createHook<TagName, MenuListOptions>(
   function useMenuList({ store, alwaysVisible, composite, ...props }) {
     const context = useMenuProviderContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -234,8 +235,13 @@ export interface MenuListOptions<T extends ElementType = TagName>
    * provided, the closest
    * [`MenuProvider`](https://ariakit.com/reference/menu-provider) component's
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`MenuProvider`](https://ariakit.com/reference/menu-provider)). In that case,
+   * the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: MenuStore;
+  store?: MenuStore | ProviderComponent<MenuStore>;
 }
 
 export type MenuListProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/menu/menu-provider.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-provider.tsx
@@ -1,10 +1,22 @@
+import type { ProviderComponent } from "@ariakit/react-utils";
 import type { PickRequired } from "@ariakit/utils";
 import type { ReactElement, ReactNode } from "react";
-import { MenuContextProvider } from "./menu-context.tsx";
-import type { MenuStoreProps, MenuStoreValues } from "./menu-store.ts";
+import { createMenuProvider, MenuContextProvider } from "./menu-context.tsx";
+import type {
+  MenuStore,
+  MenuStoreProps,
+  MenuStoreValues,
+} from "./menu-store.ts";
 import { useMenuStore } from "./menu-store.ts";
 
 type Values = MenuStoreValues;
+
+export interface MenuProviderComponent extends ProviderComponent<MenuStore> {
+  <T extends Values = Values>(
+    props: PickRequired<MenuProviderProps<T>, "values" | "defaultValues">,
+  ): ReactElement;
+  (props?: MenuProviderProps): ReactElement;
+}
 
 /**
  * Provides a menu store to [Menu](https://ariakit.com/components/menu)
@@ -21,19 +33,14 @@ type Values = MenuStoreValues;
  * </MenuProvider>
  * ```
  */
-
-export function MenuProvider<T extends Values = Values>(
-  props: PickRequired<MenuProviderProps<T>, "values" | "defaultValues">,
-): ReactElement;
-
-export function MenuProvider(props?: MenuProviderProps): ReactElement;
-
-export function MenuProvider(props: MenuProviderProps = {}) {
-  const store = useMenuStore(props);
-  return (
-    <MenuContextProvider value={store}>{props.children}</MenuContextProvider>
-  );
-}
+export const MenuProvider: MenuProviderComponent = createMenuProvider(
+  function MenuProvider(props: MenuProviderProps = {}) {
+    const store = useMenuStore(props);
+    return (
+      <MenuContextProvider value={store}>{props.children}</MenuContextProvider>
+    );
+  },
+);
 
 export interface MenuProviderProps<
   T extends Values = Values,

--- a/packages/ariakit-react-components/src/menu/menu-separator.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-separator.tsx
@@ -76,9 +76,10 @@ export interface MenuSeparatorOptions<
    * context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`MenuProvider`](https://ariakit.com/reference/menu-provider)). In that case,
-   * the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * [`MenuProvider`](https://ariakit.com/reference/menu-provider)). In that
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: MenuStore | ProviderComponent<MenuStore>;
 }

--- a/packages/ariakit-react-components/src/menu/menu-separator.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-separator.tsx
@@ -1,5 +1,10 @@
-import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import {
+  createElement,
+  createHook,
+  forwardRef,
+  useStoreProp,
+} from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { CompositeSeparatorOptions } from "../composite/composite-separator.tsx";
 import { useCompositeSeparator } from "../composite/composite-separator.tsx";
@@ -28,7 +33,7 @@ type TagName = typeof TagName;
 export const useMenuSeparator = createHook<TagName, MenuSeparatorOptions>(
   function useMenuSeparator({ store, ...props }) {
     const context = useMenuContext();
-    store = store || context;
+    store = useStoreProp(store, context);
     props = useCompositeSeparator({ store, ...props });
     return props;
   },
@@ -69,8 +74,13 @@ export interface MenuSeparatorOptions<
    * provided, the closest [`Menu`](https://ariakit.com/reference/menu) or
    * [`MenuProvider`](https://ariakit.com/reference/menu-provider) components'
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`MenuProvider`](https://ariakit.com/reference/menu-provider)). In that case,
+   * the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: MenuStore;
+  store?: MenuStore | ProviderComponent<MenuStore>;
 }
 
 export type MenuSeparatorProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/menu/menu.tsx
+++ b/packages/ariakit-react-components/src/menu/menu.tsx
@@ -4,6 +4,7 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
 import {
@@ -50,7 +51,7 @@ export const useMenu = createHook<TagName, MenuOptions>(function useMenu({
   ...props
 }) {
   const context = useMenuProviderContext();
-  store = store || context;
+  store = useStoreProp(store, context);
 
   invariant(
     store,

--- a/packages/ariakit-react-components/src/menubar/menubar-context.tsx
+++ b/packages/ariakit-react-components/src/menubar/menubar-context.tsx
@@ -32,3 +32,5 @@ export const useMenubarProviderContext = menubar.useProviderContext;
 export const MenubarContextProvider = menubar.ContextProvider;
 
 export const MenubarScopedContextProvider = menubar.ScopedContextProvider;
+
+export const createMenubarProvider = menubar.createProviderComponent;

--- a/packages/ariakit-react-components/src/menubar/menubar-provider.tsx
+++ b/packages/ariakit-react-components/src/menubar/menubar-provider.tsx
@@ -1,5 +1,8 @@
 import type { ReactNode } from "react";
-import { MenubarContextProvider } from "./menubar-context.tsx";
+import {
+  createMenubarProvider,
+  MenubarContextProvider,
+} from "./menubar-context.tsx";
 import type { MenubarStoreProps } from "./menubar-store.ts";
 import { useMenubarStore } from "./menubar-store.ts";
 
@@ -29,14 +32,16 @@ import { useMenubarStore } from "./menubar-store.ts";
  * </MenubarProvider>
  * ```
  */
-export function MenubarProvider(props: MenubarProviderProps = {}) {
+export const MenubarProvider = createMenubarProvider(function MenubarProvider(
+  props: MenubarProviderProps = {},
+) {
   const store = useMenubarStore(props);
   return (
     <MenubarContextProvider value={store}>
       {props.children}
     </MenubarContextProvider>
   );
-}
+});
 
 export interface MenubarProviderProps extends MenubarStoreProps {
   children?: ReactNode;

--- a/packages/ariakit-react-components/src/menubar/menubar.tsx
+++ b/packages/ariakit-react-components/src/menubar/menubar.tsx
@@ -1,11 +1,12 @@
 import { useStoreState } from "@ariakit/react-store";
 import {
+  useStoreProp,
   useWrapElement,
   createElement,
   createHook,
   forwardRef,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { CompositeOptions } from "../composite/composite.tsx";
 import { useComposite } from "../composite/composite.tsx";
@@ -50,7 +51,7 @@ export const useMenubar = createHook<TagName, MenubarOptions>(
     ...props
   }) {
     const context = useMenubarProviderContext();
-    storeProp = storeProp || context;
+    storeProp = useStoreProp(storeProp, context);
 
     const store = useMenubarStore({
       store: storeProp,
@@ -135,8 +136,13 @@ export interface MenubarOptions<T extends ElementType = TagName>
    * component context will be used. If the component is not wrapped in a
    * [`MenubarProvider`](https://ariakit.com/reference/menubar-provider)
    * component, an internal store will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`MenubarProvider`](https://ariakit.com/reference/menubar-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: MenubarStore;
+  store?: MenubarStore | ProviderComponent<MenubarStore>;
 }
 
 export type MenubarProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/menubar/menubar.tsx
+++ b/packages/ariakit-react-components/src/menubar/menubar.tsx
@@ -139,8 +139,9 @@ export interface MenubarOptions<T extends ElementType = TagName>
    *
    * You can also pass a provider component (for example,
    * [`MenubarProvider`](https://ariakit.com/reference/menubar-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: MenubarStore | ProviderComponent<MenubarStore>;
 }

--- a/packages/ariakit-react-components/src/popover/popover-anchor.tsx
+++ b/packages/ariakit-react-components/src/popover/popover-anchor.tsx
@@ -3,8 +3,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Options, Props } from "@ariakit/react-utils";
+import type { Options, Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import { usePopoverProviderContext } from "./popover-context.tsx";
 import type { PopoverStore } from "./popover-store.ts";
@@ -26,7 +27,7 @@ type TagName = typeof TagName;
 export const usePopoverAnchor = createHook<TagName, PopoverAnchorOptions>(
   function usePopoverAnchor({ store, ...props }) {
     const context = usePopoverProviderContext();
-    store = store || context;
+    store = useStoreProp(store, context);
     props = {
       ...props,
       ref: useMergeRefs(store?.setAnchorElement, props.ref),
@@ -64,8 +65,13 @@ export interface PopoverAnchorOptions<
    * If not provided, the closest
    * [`PopoverProvider`](https://ariakit.com/reference/popover-provider)
    * component's context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`PopoverProvider`](https://ariakit.com/reference/popover-provider)). In that
+   * case, the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: PopoverStore;
+  store?: PopoverStore | ProviderComponent<PopoverStore>;
 }
 
 export type PopoverAnchorProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/popover/popover-anchor.tsx
+++ b/packages/ariakit-react-components/src/popover/popover-anchor.tsx
@@ -67,9 +67,10 @@ export interface PopoverAnchorOptions<
    * component's context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`PopoverProvider`](https://ariakit.com/reference/popover-provider)). In that
-   * case, the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * [`PopoverProvider`](https://ariakit.com/reference/popover-provider)). In
+   * that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: PopoverStore | ProviderComponent<PopoverStore>;
 }

--- a/packages/ariakit-react-components/src/popover/popover-arrow.tsx
+++ b/packages/ariakit-react-components/src/popover/popover-arrow.tsx
@@ -288,9 +288,10 @@ export interface PopoverArrowOptions<
    * components' context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`PopoverProvider`](https://ariakit.com/reference/popover-provider)). In that
-   * case, the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * [`PopoverProvider`](https://ariakit.com/reference/popover-provider)). In
+   * that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: PopoverStore | ProviderComponent<PopoverStore>;
   /**

--- a/packages/ariakit-react-components/src/popover/popover-arrow.tsx
+++ b/packages/ariakit-react-components/src/popover/popover-arrow.tsx
@@ -7,8 +7,9 @@ import {
   createHook,
   forwardRef,
   memo,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Options, Props } from "@ariakit/react-utils";
+import type { Options, Props, ProviderComponent } from "@ariakit/react-utils";
 import { getWindow, invariant, removeUndefinedValues } from "@ariakit/utils";
 import type { ElementType } from "react";
 import { useMemo, useState } from "react";
@@ -147,7 +148,7 @@ export const usePopoverArrow = createHook<TagName, PopoverArrowOptions>(
     ...props
   }) {
     const context = usePopoverContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -285,8 +286,13 @@ export interface PopoverArrowOptions<
    * [`Popover`](https://ariakit.com/reference/popover) or
    * [`PopoverProvider`](https://ariakit.com/reference/popover-provider)
    * components' context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`PopoverProvider`](https://ariakit.com/reference/popover-provider)). In that
+   * case, the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: PopoverStore;
+  store?: PopoverStore | ProviderComponent<PopoverStore>;
   /**
    * The size of the arrow.
    *

--- a/packages/ariakit-react-components/src/popover/popover-context.tsx
+++ b/packages/ariakit-react-components/src/popover/popover-context.tsx
@@ -32,3 +32,5 @@ export const usePopoverProviderContext = ctx.useProviderContext;
 export const PopoverContextProvider = ctx.ContextProvider;
 
 export const PopoverScopedContextProvider = ctx.ScopedContextProvider;
+
+export const createPopoverProvider = ctx.createProviderComponent;

--- a/packages/ariakit-react-components/src/popover/popover-description.tsx
+++ b/packages/ariakit-react-components/src/popover/popover-description.tsx
@@ -1,5 +1,5 @@
 import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { DialogDescriptionOptions } from "../dialog/dialog-description.tsx";
 import { useDialogDescription } from "../dialog/dialog-description.tsx";
@@ -61,7 +61,7 @@ export interface PopoverDescriptionOptions<
    * component through React context, so it must be rendered inside the popover
    * for the `aria-describedby` prop to be set on the popover element.
    */
-  store?: PopoverStore;
+  store?: PopoverStore | ProviderComponent<PopoverStore>;
 }
 
 export type PopoverDescriptionProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/popover/popover-disclosure-arrow.tsx
+++ b/packages/ariakit-react-components/src/popover/popover-disclosure-arrow.tsx
@@ -126,9 +126,10 @@ export interface PopoverDisclosureArrowOptions<
    * components' context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`PopoverProvider`](https://ariakit.com/reference/popover-provider)). In that
-   * case, the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * [`PopoverProvider`](https://ariakit.com/reference/popover-provider)). In
+   * that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: PopoverStore | ProviderComponent<PopoverStore>;
   /**

--- a/packages/ariakit-react-components/src/popover/popover-disclosure-arrow.tsx
+++ b/packages/ariakit-react-components/src/popover/popover-disclosure-arrow.tsx
@@ -1,6 +1,11 @@
 import { useStoreState } from "@ariakit/react-store";
-import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Options, Props } from "@ariakit/react-utils";
+import {
+  createElement,
+  createHook,
+  forwardRef,
+  useStoreProp,
+} from "@ariakit/react-utils";
+import type { Options, Props, ProviderComponent } from "@ariakit/react-utils";
 import { invariant, removeUndefinedValues } from "@ariakit/utils";
 import type { ElementType } from "react";
 import { useMemo } from "react";
@@ -36,7 +41,7 @@ export const usePopoverDisclosureArrow = createHook<
   PopoverDisclosureArrowOptions
 >(function usePopoverDisclosureArrow({ store, placement, ...props }) {
   const context = usePopoverContext();
-  store = store || context;
+  store = useStoreProp(store, context);
 
   invariant(
     store,
@@ -119,8 +124,13 @@ export interface PopoverDisclosureArrowOptions<
    * [`PopoverDisclosure`](https://ariakit.com/reference/popover-disclosure) or
    * [`PopoverProvider`](https://ariakit.com/reference/popover-provider)
    * components' context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`PopoverProvider`](https://ariakit.com/reference/popover-provider)). In that
+   * case, the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: PopoverStore;
+  store?: PopoverStore | ProviderComponent<PopoverStore>;
   /**
    * Arrow's placement direction. If not provided, it will be inferred from the
    * context.

--- a/packages/ariakit-react-components/src/popover/popover-disclosure.tsx
+++ b/packages/ariakit-react-components/src/popover/popover-disclosure.tsx
@@ -4,6 +4,7 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
 import { invariant } from "@ariakit/utils";
@@ -37,7 +38,7 @@ export const usePopoverDisclosure = createHook<
   PopoverDisclosureOptions
 >(function usePopoverDisclosure({ store, ...props }) {
   const context = usePopoverProviderContext();
-  store = store || context;
+  store = useStoreProp(store, context);
 
   invariant(
     store,

--- a/packages/ariakit-react-components/src/popover/popover-dismiss.tsx
+++ b/packages/ariakit-react-components/src/popover/popover-dismiss.tsx
@@ -1,5 +1,10 @@
-import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import {
+  createElement,
+  createHook,
+  forwardRef,
+  useStoreProp,
+} from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { DialogDismissOptions } from "../dialog/dialog-dismiss.tsx";
 import { useDialogDismiss } from "../dialog/dialog-dismiss.tsx";
@@ -24,7 +29,7 @@ type TagName = typeof TagName;
 export const usePopoverDismiss = createHook<TagName, PopoverDismissOptions>(
   function usePopoverDismiss({ store, ...props }) {
     const context = usePopoverScopedContext();
-    store = store || context;
+    store = useStoreProp(store, context);
     props = useDialogDismiss({ store, ...props });
     return props;
   },
@@ -60,8 +65,13 @@ export interface PopoverDismissOptions<
    * [`Popover`](https://ariakit.com/reference/popover) or
    * [`PopoverProvider`](https://ariakit.com/reference/popover-provider)
    * components' context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`PopoverProvider`](https://ariakit.com/reference/popover-provider)). In that
+   * case, the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: PopoverStore;
+  store?: PopoverStore | ProviderComponent<PopoverStore>;
 }
 
 export type PopoverDismissProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/popover/popover-dismiss.tsx
+++ b/packages/ariakit-react-components/src/popover/popover-dismiss.tsx
@@ -67,9 +67,10 @@ export interface PopoverDismissOptions<
    * components' context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`PopoverProvider`](https://ariakit.com/reference/popover-provider)). In that
-   * case, the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * [`PopoverProvider`](https://ariakit.com/reference/popover-provider)). In
+   * that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: PopoverStore | ProviderComponent<PopoverStore>;
 }

--- a/packages/ariakit-react-components/src/popover/popover-heading.tsx
+++ b/packages/ariakit-react-components/src/popover/popover-heading.tsx
@@ -1,5 +1,5 @@
 import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { DialogHeadingOptions } from "../dialog/dialog-heading.tsx";
 import { useDialogHeading } from "../dialog/dialog-heading.tsx";
@@ -60,7 +60,7 @@ export interface PopoverHeadingOptions<
    * component through React context, so it must be rendered inside the popover
    * for the `aria-labelledby` prop to be set on the popover element.
    */
-  store?: PopoverStore;
+  store?: PopoverStore | ProviderComponent<PopoverStore>;
 }
 
 export type PopoverHeadingProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/popover/popover-provider.tsx
+++ b/packages/ariakit-react-components/src/popover/popover-provider.tsx
@@ -1,5 +1,8 @@
 import type { ReactNode } from "react";
-import { PopoverContextProvider } from "./popover-context.tsx";
+import {
+  createPopoverProvider,
+  PopoverContextProvider,
+} from "./popover-context.tsx";
 import type { PopoverStoreProps } from "./popover-store.ts";
 import { usePopoverStore } from "./popover-store.ts";
 
@@ -15,14 +18,16 @@ import { usePopoverStore } from "./popover-store.ts";
  * </PopoverProvider>
  * ```
  */
-export function PopoverProvider(props: PopoverProviderProps = {}) {
+export const PopoverProvider = createPopoverProvider(function PopoverProvider(
+  props: PopoverProviderProps = {},
+) {
   const store = usePopoverStore(props);
   return (
     <PopoverContextProvider value={store}>
       {props.children}
     </PopoverContextProvider>
   );
-}
+});
 
 export interface PopoverProviderProps extends PopoverStoreProps {
   children?: ReactNode;

--- a/packages/ariakit-react-components/src/popover/popover.tsx
+++ b/packages/ariakit-react-components/src/popover/popover.tsx
@@ -7,8 +7,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { invariant } from "@ariakit/utils";
 import {
   arrow,
@@ -242,7 +243,7 @@ export const usePopover = createHook<TagName, PopoverOptions>(
     ...props
   }) {
     const context = usePopoverProviderContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -542,8 +543,13 @@ export interface PopoverOptions<
    * If not provided, the closest
    * [`PopoverProvider`](https://ariakit.com/reference/popover-provider)
    * component's context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`PopoverProvider`](https://ariakit.com/reference/popover-provider)). In that
+   * case, the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: PopoverStore;
+  store?: PopoverStore | ProviderComponent<PopoverStore>;
   /**
    * Props that will be passed to the popover wrapper element. This element will
    * be used to position the popover.

--- a/packages/ariakit-react-components/src/popover/popover.tsx
+++ b/packages/ariakit-react-components/src/popover/popover.tsx
@@ -545,9 +545,10 @@ export interface PopoverOptions<
    * component's context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`PopoverProvider`](https://ariakit.com/reference/popover-provider)). In that
-   * case, the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * [`PopoverProvider`](https://ariakit.com/reference/popover-provider)). In
+   * that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: PopoverStore | ProviderComponent<PopoverStore>;
   /**

--- a/packages/ariakit-react-components/src/provider-component.test.tsx
+++ b/packages/ariakit-react-components/src/provider-component.test.tsx
@@ -1,0 +1,60 @@
+import { expect, test } from "vitest";
+import { CollectionProvider } from "./collection/collection-provider.tsx";
+import { CollectionRenderer } from "./collection/collection-renderer.tsx";
+import { CompositeProvider } from "./composite/composite-provider.tsx";
+import { CompositeRenderer } from "./composite/composite-renderer.tsx";
+import { SelectProvider } from "./select/select-provider.tsx";
+import { SelectValue } from "./select/select-value.tsx";
+
+interface MyItem {
+  id: string;
+  label: string;
+}
+
+const myItems: MyItem[] = [{ id: "a", label: "A" }];
+
+// These JSX expressions are type-level regression coverage: they must keep
+// compiling, which `pnpm tsc` enforces. Branding provider components with base
+// stores previously poisoned the renderers' item type inference (`item.label`
+// errored) and rejected explicit generic arguments when the provider arm of
+// the `store` option was parameterized over `T`.
+test("store props accept provider components without poisoning generics", () => {
+  const cases = [
+    // Item type inference must not degrade to the base store item type.
+    <CollectionRenderer
+      key="collection"
+      items={myItems}
+      store={CollectionProvider}
+    >
+      {(item) => <div key={item.id}>{item.label}</div>}
+    </CollectionRenderer>,
+    <CompositeRenderer
+      key="composite"
+      items={myItems}
+      store={CompositeProvider}
+    >
+      {(item) => <div key={item.id}>{item.label}</div>}
+    </CompositeRenderer>,
+    // Explicit generic arguments must accept provider components.
+    <CollectionRenderer<MyItem>
+      key="collection-explicit"
+      items={myItems}
+      store={CollectionProvider}
+    >
+      {(item) => <div key={item.id}>{item.label}</div>}
+    </CollectionRenderer>,
+    <CompositeRenderer<MyItem>
+      key="composite-explicit"
+      items={myItems}
+      store={CompositeProvider}
+    >
+      {(item) => <div key={item.id}>{item.label}</div>}
+    </CompositeRenderer>,
+    <SelectValue<"a" | "b">
+      key="select-value"
+      store={SelectProvider}
+      fallback="a"
+    />,
+  ];
+  expect(cases).toHaveLength(5);
+});

--- a/packages/ariakit-react-components/src/radio/radio-context.tsx
+++ b/packages/ariakit-react-components/src/radio/radio-context.tsx
@@ -32,3 +32,5 @@ export const useRadioProviderContext = ctx.useProviderContext;
 export const RadioContextProvider = ctx.ContextProvider;
 
 export const RadioScopedContextProvider = ctx.ScopedContextProvider;
+
+export const createRadioProvider = ctx.createProviderComponent;

--- a/packages/ariakit-react-components/src/radio/radio-group.tsx
+++ b/packages/ariakit-react-components/src/radio/radio-group.tsx
@@ -128,8 +128,9 @@ export interface RadioGroupOptions<
    *
    * You can also pass a provider component (for example,
    * [`RadioProvider`](https://ariakit.com/reference/radio-provider)). In that
-   * case, the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: RadioStore | ProviderComponent<RadioStore>;
 }

--- a/packages/ariakit-react-components/src/radio/radio-group.tsx
+++ b/packages/ariakit-react-components/src/radio/radio-group.tsx
@@ -4,8 +4,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { invariant, isFocusEventOutside } from "@ariakit/utils";
 import type { ElementType, FocusEvent } from "react";
 import type { CompositeOptions } from "../composite/composite.tsx";
@@ -54,7 +55,7 @@ function getCheckedRadioId(store: RadioStore) {
 export const useRadioGroup = createHook<TagName, RadioGroupOptions>(
   function useRadioGroup({ store, ...props }) {
     const context = useRadioProviderContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -124,8 +125,13 @@ export interface RadioGroupOptions<
    * not provided, the closest
    * [`RadioProvider`](https://ariakit.com/reference/radio-provider) component's
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`RadioProvider`](https://ariakit.com/reference/radio-provider)). In that
+   * case, the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: RadioStore;
+  store?: RadioStore | ProviderComponent<RadioStore>;
 }
 
 export type RadioGroupProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/radio/radio-provider.tsx
+++ b/packages/ariakit-react-components/src/radio/radio-provider.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { RadioContextProvider } from "./radio-context.tsx";
+import { createRadioProvider, RadioContextProvider } from "./radio-context.tsx";
 import type { RadioStoreProps } from "./radio-store.ts";
 import { useRadioStore } from "./radio-store.ts";
 
@@ -17,12 +17,14 @@ import { useRadioStore } from "./radio-store.ts";
  * </RadioProvider>
  * ```
  */
-export function RadioProvider(props: RadioProviderProps = {}) {
+export const RadioProvider = createRadioProvider(function RadioProvider(
+  props: RadioProviderProps = {},
+) {
   const store = useRadioStore(props);
   return (
     <RadioContextProvider value={store}>{props.children}</RadioContextProvider>
   );
-}
+});
 
 export interface RadioProviderProps extends RadioStoreProps {
   children?: ReactNode;

--- a/packages/ariakit-react-components/src/radio/radio.tsx
+++ b/packages/ariakit-react-components/src/radio/radio.tsx
@@ -223,8 +223,9 @@ export interface RadioOptions<
    *
    * You can also pass a provider component (for example,
    * [`RadioProvider`](https://ariakit.com/reference/radio-provider)). In that
-   * case, the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: RadioStore | ProviderComponent<RadioStore>;
   /**

--- a/packages/ariakit-react-components/src/radio/radio.tsx
+++ b/packages/ariakit-react-components/src/radio/radio.tsx
@@ -9,8 +9,9 @@ import {
   createHook,
   forwardRef,
   memo,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { disabledFromProps, removeUndefinedValues } from "@ariakit/utils";
 import type { BivariantCallback } from "@ariakit/utils";
 import type { ChangeEvent, ElementType, FocusEvent, MouseEvent } from "react";
@@ -60,7 +61,7 @@ export const useRadio = createHook<TagName, RadioOptions>(function useRadio({
   ...props
 }) {
   const context = useRadioContext();
-  store = store || context;
+  store = useStoreProp(store, context);
 
   const id = useId(props.id);
 
@@ -219,8 +220,13 @@ export interface RadioOptions<
    * [`RadioGroup`](https://ariakit.com/reference/radio-group) or
    * [`RadioProvider`](https://ariakit.com/reference/radio-provider) components'
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`RadioProvider`](https://ariakit.com/reference/radio-provider)). In that
+   * case, the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: RadioStore;
+  store?: RadioStore | ProviderComponent<RadioStore>;
   /**
    * The value of the radio button.
    *

--- a/packages/ariakit-react-components/src/select/select-arrow.tsx
+++ b/packages/ariakit-react-components/src/select/select-arrow.tsx
@@ -1,5 +1,10 @@
-import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import {
+  createElement,
+  createHook,
+  forwardRef,
+  useStoreProp,
+} from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { PopoverDisclosureArrowOptions } from "../popover/popover-disclosure-arrow.tsx";
 import { usePopoverDisclosureArrow } from "../popover/popover-disclosure-arrow.tsx";
@@ -29,7 +34,7 @@ type TagName = typeof TagName;
 export const useSelectArrow = createHook<TagName, SelectArrowOptions>(
   function useSelectArrow({ store, ...props }) {
     const context = useSelectContext();
-    store = store || context;
+    store = useStoreProp(store, context);
     props = usePopoverDisclosureArrow({ store, ...props });
     return props;
   },
@@ -70,8 +75,13 @@ export interface SelectArrowOptions<
    * not provided, the closest [`Select`](https://ariakit.com/reference/select)
    * or [`SelectProvider`](https://ariakit.com/reference/select-provider)
    * components' context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`SelectProvider`](https://ariakit.com/reference/select-provider)). In that
+   * case, the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: SelectStore;
+  store?: SelectStore | ProviderComponent<SelectStore>;
 }
 
 export type SelectArrowProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/select/select-arrow.tsx
+++ b/packages/ariakit-react-components/src/select/select-arrow.tsx
@@ -78,8 +78,9 @@ export interface SelectArrowOptions<
    *
    * You can also pass a provider component (for example,
    * [`SelectProvider`](https://ariakit.com/reference/select-provider)). In that
-   * case, the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: SelectStore | ProviderComponent<SelectStore>;
 }

--- a/packages/ariakit-react-components/src/select/select-context.tsx
+++ b/packages/ariakit-react-components/src/select/select-context.tsx
@@ -39,6 +39,8 @@ export const SelectContextProvider = ctx.ContextProvider;
 
 export const SelectScopedContextProvider = ctx.ScopedContextProvider;
 
+export const createSelectProvider = ctx.createProviderComponent;
+
 export const SelectItemCheckedContext = createContext(false);
 
 export const SelectHeadingContext = createContext<

--- a/packages/ariakit-react-components/src/select/select-dismiss.tsx
+++ b/packages/ariakit-react-components/src/select/select-dismiss.tsx
@@ -1,5 +1,10 @@
-import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import {
+  createElement,
+  createHook,
+  forwardRef,
+  useStoreProp,
+} from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { PopoverDismissOptions } from "../popover/popover-dismiss.tsx";
 import { usePopoverDismiss } from "../popover/popover-dismiss.tsx";
@@ -21,7 +26,7 @@ type TagName = typeof TagName;
 export const useSelectDismiss = createHook<TagName, SelectDismissOptions>(
   function useSelectDismiss({ store, ...props }) {
     const context = useSelectScopedContext();
-    store = store || context;
+    store = useStoreProp(store, context);
     props = usePopoverDismiss({ store, ...props });
     return props;
   },
@@ -69,8 +74,13 @@ export interface SelectDismissOptions<
    * [`Select`](https://ariakit.com/reference/select) or
    * [`SelectProvider`](https://ariakit.com/reference/select-provider)
    * components' context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`SelectProvider`](https://ariakit.com/reference/select-provider)). In that
+   * case, the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: SelectStore;
+  store?: SelectStore | ProviderComponent<SelectStore>;
 }
 
 export type SelectDismissProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/select/select-dismiss.tsx
+++ b/packages/ariakit-react-components/src/select/select-dismiss.tsx
@@ -77,8 +77,9 @@ export interface SelectDismissOptions<
    *
    * You can also pass a provider component (for example,
    * [`SelectProvider`](https://ariakit.com/reference/select-provider)). In that
-   * case, the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: SelectStore | ProviderComponent<SelectStore>;
 }

--- a/packages/ariakit-react-components/src/select/select-group-label.tsx
+++ b/packages/ariakit-react-components/src/select/select-group-label.tsx
@@ -1,5 +1,5 @@
 import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { CompositeGroupLabelOptions } from "../composite/composite-group-label.tsx";
 import { useCompositeGroupLabel } from "../composite/composite-group-label.tsx";
@@ -69,7 +69,7 @@ export interface SelectGroupLabelOptions<
    * [`SelectPopover`](https://ariakit.com/reference/select-popover) components'
    * context will be used.
    */
-  store?: SelectStore;
+  store?: SelectStore | ProviderComponent<SelectStore>;
 }
 
 export type SelectGroupLabelProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/select/select-group.tsx
+++ b/packages/ariakit-react-components/src/select/select-group.tsx
@@ -1,5 +1,5 @@
 import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { CompositeGroupOptions } from "../composite/composite-group.tsx";
 import { useCompositeGroup } from "../composite/composite-group.tsx";
@@ -70,7 +70,7 @@ export interface SelectGroupOptions<
    * [`SelectPopover`](https://ariakit.com/reference/select-popover) components'
    * context will be used.
    */
-  store?: SelectStore;
+  store?: SelectStore | ProviderComponent<SelectStore>;
 }
 
 export type SelectGroupProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/select/select-heading.tsx
+++ b/packages/ariakit-react-components/src/select/select-heading.tsx
@@ -5,7 +5,7 @@ import {
   createHook,
   forwardRef,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import { useContext } from "react";
 import type { PopoverHeadingOptions } from "../popover/popover-heading.tsx";
@@ -91,7 +91,7 @@ export interface SelectHeadingOptions<
    * component through React context, so it must be rendered inside the list or
    * popover for the `aria-labelledby` prop to be set on that element.
    */
-  store?: SelectStore;
+  store?: SelectStore | ProviderComponent<SelectStore>;
 }
 
 export type SelectHeadingProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/select/select-item-check.tsx
+++ b/packages/ariakit-react-components/src/select/select-item-check.tsx
@@ -1,5 +1,5 @@
 import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import { useContext } from "react";
 import type { CheckboxCheckOptions } from "../checkbox/checkbox-check.tsx";
@@ -77,7 +77,7 @@ export interface SelectItemCheckOptions<
    * or, when it's not provided, from the closest
    * [`SelectItem`](https://ariakit.com/reference/select-item) component.
    */
-  store?: SelectStore;
+  store?: SelectStore | ProviderComponent<SelectStore>;
 }
 
 export type SelectItemCheckProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/select/select-item-offscreen.tsx
+++ b/packages/ariakit-react-components/src/select/select-item-offscreen.tsx
@@ -1,4 +1,4 @@
-import { useMergeRefs, forwardRef } from "@ariakit/react-utils";
+import { useMergeRefs, forwardRef, useStoreProp } from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { CompositeItemOptions } from "../composite/composite-item-offscreen.tsx";
@@ -16,7 +16,7 @@ export function useSelectItemOffscreen<
   P extends SelectItemProps<T>,
 >({ store, value, ...props }: P) {
   const context = useSelectScopedContext();
-  store = store || context;
+  store = useStoreProp(store, context);
   return useCompositeItemOffscreen({ store, value, ...props });
 }
 

--- a/packages/ariakit-react-components/src/select/select-item.tsx
+++ b/packages/ariakit-react-components/src/select/select-item.tsx
@@ -8,8 +8,9 @@ import {
   createHook,
   forwardRef,
   memo,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import {
   getPopupItemRole,
   isDownloading,
@@ -68,7 +69,7 @@ export const useSelectItem = createHook<TagName, SelectItemOptions>(
     ...props
   }) {
     const context = useSelectScopedContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -239,8 +240,13 @@ export interface SelectItemOptions<T extends ElementType = TagName>
    * [`SelectList`](https://ariakit.com/reference/select-list) or
    * [`SelectPopover`](https://ariakit.com/reference/select-popover) components'
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`SelectProvider`](https://ariakit.com/reference/select-provider)). In that
+   * case, the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: SelectStore;
+  store?: SelectStore | ProviderComponent<SelectStore>;
   /**
    * The value of the item. This will be rendered as the children by default.
    * - If

--- a/packages/ariakit-react-components/src/select/select-item.tsx
+++ b/packages/ariakit-react-components/src/select/select-item.tsx
@@ -243,8 +243,9 @@ export interface SelectItemOptions<T extends ElementType = TagName>
    *
    * You can also pass a provider component (for example,
    * [`SelectProvider`](https://ariakit.com/reference/select-provider)). In that
-   * case, the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: SelectStore | ProviderComponent<SelectStore>;
   /**

--- a/packages/ariakit-react-components/src/select/select-label.tsx
+++ b/packages/ariakit-react-components/src/select/select-label.tsx
@@ -6,8 +6,9 @@ import {
   createHook,
   forwardRef,
   memo,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Options, Props } from "@ariakit/react-utils";
+import type { Options, Props, ProviderComponent } from "@ariakit/react-utils";
 import { invariant, removeUndefinedValues } from "@ariakit/utils";
 import type { ElementType, MouseEvent } from "react";
 import { useSelectProviderContext } from "./select-context.tsx";
@@ -34,7 +35,7 @@ type HTMLType = HTMLElementTagNameMap[TagName];
 export const useSelectLabel = createHook<TagName, SelectLabelOptions>(
   function useSelectLabel({ store, ...props }) {
     const context = useSelectProviderContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -107,8 +108,13 @@ export interface SelectLabelOptions<
    * not provided, the closest
    * [`SelectProvider`](https://ariakit.com/reference/select-provider)
    * component's context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`SelectProvider`](https://ariakit.com/reference/select-provider)). In that
+   * case, the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: SelectStore;
+  store?: SelectStore | ProviderComponent<SelectStore>;
 }
 
 export type SelectLabelProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/select/select-label.tsx
+++ b/packages/ariakit-react-components/src/select/select-label.tsx
@@ -111,8 +111,9 @@ export interface SelectLabelOptions<
    *
    * You can also pass a provider component (for example,
    * [`SelectProvider`](https://ariakit.com/reference/select-provider)). In that
-   * case, the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: SelectStore | ProviderComponent<SelectStore>;
 }

--- a/packages/ariakit-react-components/src/select/select-list.tsx
+++ b/packages/ariakit-react-components/src/select/select-list.tsx
@@ -218,8 +218,9 @@ export interface SelectListOptions<T extends ElementType = TagName>
    *
    * You can also pass a provider component (for example,
    * [`SelectProvider`](https://ariakit.com/reference/select-provider)). In that
-   * case, the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: SelectStore | ProviderComponent<SelectStore>;
   /**

--- a/packages/ariakit-react-components/src/select/select-list.tsx
+++ b/packages/ariakit-react-components/src/select/select-list.tsx
@@ -9,8 +9,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { isSelfTarget, invariant } from "@ariakit/utils";
 import type { BooleanOrCallback } from "@ariakit/utils";
 import type { ElementType, KeyboardEvent } from "react";
@@ -59,7 +60,7 @@ export const useSelectList = createHook<TagName, SelectListOptions>(
     ...props
   }) {
     const context = useSelectContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -214,8 +215,13 @@ export interface SelectListOptions<T extends ElementType = TagName>
    * not provided, the closest
    * [`SelectProvider`](https://ariakit.com/reference/select-provider)
    * component's context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`SelectProvider`](https://ariakit.com/reference/select-provider)). In that
+   * case, the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: SelectStore;
+  store?: SelectStore | ProviderComponent<SelectStore>;
   /**
    * Whether the select value should be reset to the value before the list got
    * shown when Escape is pressed. This has effect only when

--- a/packages/ariakit-react-components/src/select/select-popover.tsx
+++ b/packages/ariakit-react-components/src/select/select-popover.tsx
@@ -1,4 +1,9 @@
-import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
+import {
+  createElement,
+  createHook,
+  forwardRef,
+  useStoreProp,
+} from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import { createDialogComponent } from "../dialog/dialog.tsx";
@@ -27,7 +32,7 @@ type TagName = typeof TagName;
 export const useSelectPopover = createHook<TagName, SelectPopoverOptions>(
   function useSelectPopover({ store, alwaysVisible, ...props }) {
     const context = useSelectProviderContext();
-    store = store || context;
+    store = useStoreProp(store, context);
     props = useSelectList({ store, alwaysVisible, ...props });
     props = usePopover({ store, alwaysVisible, ...props });
     return props;

--- a/packages/ariakit-react-components/src/select/select-provider.tsx
+++ b/packages/ariakit-react-components/src/select/select-provider.tsx
@@ -1,10 +1,25 @@
+import type { ProviderComponent } from "@ariakit/react-utils";
 import type { PickRequired } from "@ariakit/utils";
 import type { ReactElement, ReactNode } from "react";
-import { SelectContextProvider } from "./select-context.tsx";
-import type { SelectStoreProps, SelectStoreValue } from "./select-store.ts";
+import {
+  createSelectProvider,
+  SelectContextProvider,
+} from "./select-context.tsx";
+import type {
+  SelectStore,
+  SelectStoreProps,
+  SelectStoreValue,
+} from "./select-store.ts";
 import { useSelectStore } from "./select-store.ts";
 
 type Value = SelectStoreValue;
+
+export interface SelectProviderComponent extends ProviderComponent<SelectStore> {
+  <T extends Value = Value>(
+    props: PickRequired<SelectProviderProps<T>, "value" | "defaultValue">,
+  ): ReactElement;
+  (props?: SelectProviderProps): ReactElement;
+}
 
 /**
  * Provides a select store to [Select](https://ariakit.com/components/select)
@@ -22,21 +37,16 @@ type Value = SelectStoreValue;
  * </SelectProvider>
  * ```
  */
-
-export function SelectProvider<T extends Value = Value>(
-  props: PickRequired<SelectProviderProps<T>, "value" | "defaultValue">,
-): ReactElement;
-
-export function SelectProvider(props?: SelectProviderProps): ReactElement;
-
-export function SelectProvider(props: SelectProviderProps = {}) {
-  const store = useSelectStore(props);
-  return (
-    <SelectContextProvider value={store}>
-      {props.children}
-    </SelectContextProvider>
-  );
-}
+export const SelectProvider: SelectProviderComponent = createSelectProvider(
+  function SelectProvider(props: SelectProviderProps = {}) {
+    const store = useSelectStore(props);
+    return (
+      <SelectContextProvider value={store}>
+        {props.children}
+      </SelectContextProvider>
+    );
+  },
+);
 
 export interface SelectProviderProps<
   T extends Value = Value,

--- a/packages/ariakit-react-components/src/select/select-renderer.tsx
+++ b/packages/ariakit-react-components/src/select/select-renderer.tsx
@@ -145,8 +145,9 @@ export interface SelectRendererOptions<T extends Item = any> extends Omit<
    *
    * You can also pass a provider component (for example,
    * [`SelectProvider`](https://ariakit.com/reference/select-provider)). In that
-   * case, the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: SelectStore | ProviderComponent<SelectStore>;
   /**

--- a/packages/ariakit-react-components/src/select/select-renderer.tsx
+++ b/packages/ariakit-react-components/src/select/select-renderer.tsx
@@ -1,6 +1,6 @@
 import { useStoreState } from "@ariakit/react-store";
-import { createElement, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import { createElement, forwardRef, useStoreProp } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { toArray } from "@ariakit/utils";
 import type { ElementType } from "react";
 import { useMemo } from "react";
@@ -75,7 +75,7 @@ function useSelectRenderer<T extends Item = any>({
   ...props
 }: SelectRendererProps<T>) {
   const context = useSelectContext();
-  store = store || context;
+  store = useStoreProp(store, context);
 
   const items = useStoreState(store, (state) => {
     if (!state) return itemsProp;
@@ -142,8 +142,13 @@ export interface SelectRendererOptions<T extends Item = any> extends Omit<
    * state will be used to render the items if the
    * [`items`](https://ariakit.com/reference/select-items#items) prop is not
    * provided.
+   *
+   * You can also pass a provider component (for example,
+   * [`SelectProvider`](https://ariakit.com/reference/select-provider)). In that
+   * case, the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: SelectStore;
+  store?: SelectStore | ProviderComponent<SelectStore>;
   /**
    * The current value of the select. This will ensure the item with the given
    * value is rendered even if it's not in the viewport, so it can be

--- a/packages/ariakit-react-components/src/select/select-row.tsx
+++ b/packages/ariakit-react-components/src/select/select-row.tsx
@@ -1,6 +1,11 @@
 import { useStoreState } from "@ariakit/react-store";
-import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import {
+  createElement,
+  createHook,
+  forwardRef,
+  useStoreProp,
+} from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { getPopupRole, invariant } from "@ariakit/utils";
 import type { ElementType } from "react";
 import type { CompositeRowOptions } from "../composite/composite-row.tsx";
@@ -29,7 +34,7 @@ type TagName = typeof TagName;
 export const useSelectRow = createHook<TagName, SelectRowOptions>(
   function useSelectRow({ store, ...props }) {
     const context = useSelectContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -87,8 +92,13 @@ export interface SelectRowOptions<
    * [`SelectList`](https://ariakit.com/reference/select-list) or
    * [`SelectPopover`](https://ariakit.com/reference/select-popover) components'
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`SelectProvider`](https://ariakit.com/reference/select-provider)). In that
+   * case, the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: SelectStore;
+  store?: SelectStore | ProviderComponent<SelectStore>;
 }
 
 export type SelectRowProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/select/select-row.tsx
+++ b/packages/ariakit-react-components/src/select/select-row.tsx
@@ -95,8 +95,9 @@ export interface SelectRowOptions<
    *
    * You can also pass a provider component (for example,
    * [`SelectProvider`](https://ariakit.com/reference/select-provider)). In that
-   * case, the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: SelectStore | ProviderComponent<SelectStore>;
 }

--- a/packages/ariakit-react-components/src/select/select-separator.tsx
+++ b/packages/ariakit-react-components/src/select/select-separator.tsx
@@ -1,5 +1,10 @@
-import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import {
+  createElement,
+  createHook,
+  forwardRef,
+  useStoreProp,
+} from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { CompositeSeparatorOptions } from "../composite/composite-separator.tsx";
 import { useCompositeSeparator } from "../composite/composite-separator.tsx";
@@ -28,7 +33,7 @@ type TagName = typeof TagName;
 export const useSelectSeparator = createHook<TagName, SelectSeparatorOptions>(
   function useSelectSeparator({ store, ...props }) {
     const context = useSelectContext();
-    store = store || context;
+    store = useStoreProp(store, context);
     props = useCompositeSeparator({ store, ...props });
     return props;
   },
@@ -70,8 +75,13 @@ export interface SelectSeparatorOptions<
    * [`SelectList`](https://ariakit.com/reference/select-list) or
    * [`SelectPopover`](https://ariakit.com/reference/select-popover) components'
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`SelectProvider`](https://ariakit.com/reference/select-provider)). In that
+   * case, the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: SelectStore;
+  store?: SelectStore | ProviderComponent<SelectStore>;
 }
 
 export type SelectSeparatorProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/select/select-separator.tsx
+++ b/packages/ariakit-react-components/src/select/select-separator.tsx
@@ -78,8 +78,9 @@ export interface SelectSeparatorOptions<
    *
    * You can also pass a provider component (for example,
    * [`SelectProvider`](https://ariakit.com/reference/select-provider)). In that
-   * case, the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: SelectStore | ProviderComponent<SelectStore>;
 }

--- a/packages/ariakit-react-components/src/select/select-value.tsx
+++ b/packages/ariakit-react-components/src/select/select-value.tsx
@@ -96,10 +96,16 @@ export interface SelectValueProps<T extends Value = Value> {
    *
    * You can also pass a provider component (for example,
    * [`SelectProvider`](https://ariakit.com/reference/select-provider)). In that
-   * case, the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
-  store?: SelectStore<T> | ProviderComponent<SelectStore<T>>;
+  store?:
+    | SelectStore<T>
+    // The provider brand never carries the value type and runtime resolution
+    // doesn't depend on `T`, so the provider arm uses the base store to keep
+    // `T` inference and explicit generic arguments working.
+    | ProviderComponent<SelectStore>;
   /**
    * The value to use as a default if the store's
    * [`value`](https://ariakit.com/reference/use-select-store#value) is

--- a/packages/ariakit-react-components/src/select/select-value.tsx
+++ b/packages/ariakit-react-components/src/select/select-value.tsx
@@ -1,4 +1,6 @@
 import { useStoreState } from "@ariakit/react-store";
+import { useStoreProp } from "@ariakit/react-utils";
+import type { ProviderComponent } from "@ariakit/react-utils";
 import type { PickRequired, ToPrimitive } from "@ariakit/utils";
 import type { ReactNode } from "react";
 import { useSelectContext } from "./select-context.tsx";
@@ -69,7 +71,7 @@ export function SelectValue({
   children,
 }: SelectValueProps = {}) {
   const context = useSelectContext();
-  store = store || context;
+  store = useStoreProp(store, context);
 
   const value = useStoreState(store, (state) => {
     if (!state?.value.length) return fallback;
@@ -91,8 +93,13 @@ export interface SelectValueProps<T extends Value = Value> {
    * [`SelectList`](https://ariakit.com/reference/select-list) or
    * [`SelectPopover`](https://ariakit.com/reference/select-popover) components'
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`SelectProvider`](https://ariakit.com/reference/select-provider)). In that
+   * case, the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: SelectStore<T>;
+  store?: SelectStore<T> | ProviderComponent<SelectStore<T>>;
   /**
    * The value to use as a default if the store's
    * [`value`](https://ariakit.com/reference/use-select-store#value) is

--- a/packages/ariakit-react-components/src/select/select.tsx
+++ b/packages/ariakit-react-components/src/select/select.tsx
@@ -7,8 +7,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import {
   toArray,
   getPopupRole,
@@ -91,7 +92,7 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
   ...props
 }) {
   const context = useSelectProviderContext();
-  store = store || context;
+  store = useStoreProp(store, context);
 
   invariant(
     store,
@@ -325,8 +326,13 @@ export interface SelectOptions<T extends ElementType = TagName>
    * not provided, the closest
    * [`SelectProvider`](https://ariakit.com/reference/select-provider)
    * component's context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`SelectProvider`](https://ariakit.com/reference/select-provider)). In that
+   * case, the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: SelectStore;
+  store?: SelectStore | ProviderComponent<SelectStore>;
   /**
    * Determines if the
    * [`SelectList`](https://ariakit.com/reference/select-list) or

--- a/packages/ariakit-react-components/src/select/select.tsx
+++ b/packages/ariakit-react-components/src/select/select.tsx
@@ -329,8 +329,9 @@ export interface SelectOptions<T extends ElementType = TagName>
    *
    * You can also pass a provider component (for example,
    * [`SelectProvider`](https://ariakit.com/reference/select-provider)). In that
-   * case, the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * case, the store is read from the closest context of that provider's kind
+   * (set by that provider, an extending provider, or a compatible container
+   * component), skipping less specific store contexts.
    */
   store?: SelectStore | ProviderComponent<SelectStore>;
   /**

--- a/packages/ariakit-react-components/src/tab/tab-context.tsx
+++ b/packages/ariakit-react-components/src/tab/tab-context.tsx
@@ -32,3 +32,5 @@ export const useTabProviderContext = ctx.useProviderContext;
 export const TabContextProvider = ctx.ContextProvider;
 
 export const TabScopedContextProvider = ctx.ScopedContextProvider;
+
+export const createTabProvider = ctx.createProviderComponent;

--- a/packages/ariakit-react-components/src/tab/tab-list.tsx
+++ b/packages/ariakit-react-components/src/tab/tab-list.tsx
@@ -114,8 +114,9 @@ export interface TabListOptions<
    *
    * You can also pass a provider component (for example,
    * [`TabProvider`](https://ariakit.com/reference/tab-provider)). In that case,
-   * the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * the store is read from the closest context of that provider's kind (set by
+   * that provider, an extending provider, or a compatible container component),
+   * skipping less specific store contexts.
    */
   store?: TabStore | ProviderComponent<TabStore>;
 }

--- a/packages/ariakit-react-components/src/tab/tab-list.tsx
+++ b/packages/ariakit-react-components/src/tab/tab-list.tsx
@@ -4,8 +4,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { invariant } from "@ariakit/utils";
 import type { ElementType } from "react";
 import type { CompositeOptions } from "../composite/composite.tsx";
@@ -37,7 +38,7 @@ type TagName = typeof TagName;
 export const useTabList = createHook<TagName, TabListOptions>(
   function useTabList({ store, ...props }) {
     const context = useTabProviderContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -110,8 +111,13 @@ export interface TabListOptions<
    * provided, the closest
    * [`TabProvider`](https://ariakit.com/reference/tab-provider) component's
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`TabProvider`](https://ariakit.com/reference/tab-provider)). In that case,
+   * the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: TabStore;
+  store?: TabStore | ProviderComponent<TabStore>;
 }
 
 export type TabListProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/tab/tab-panel.tsx
+++ b/packages/ariakit-react-components/src/tab/tab-panel.tsx
@@ -247,8 +247,9 @@ export interface TabPanelOptions<T extends ElementType = TagName>
    *
    * You can also pass a provider component (for example,
    * [`TabProvider`](https://ariakit.com/reference/tab-provider)). In that case,
-   * the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * the store is read from the closest context of that provider's kind (set by
+   * that provider, an extending provider, or a compatible container component),
+   * skipping less specific store contexts.
    */
   store?: TabStore | ProviderComponent<TabStore>;
   /**

--- a/packages/ariakit-react-components/src/tab/tab-panel.tsx
+++ b/packages/ariakit-react-components/src/tab/tab-panel.tsx
@@ -8,8 +8,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { getFirstTabbableIn, invariant } from "@ariakit/utils";
 import type { ElementType, KeyboardEvent, RefObject } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -54,7 +55,7 @@ export const useTabPanel = createHook<TagName, TabPanelOptions>(
     ...props
   }) {
     const context = useTabProviderContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -243,8 +244,13 @@ export interface TabPanelOptions<T extends ElementType = TagName>
    * provided, the closest
    * [`TabProvider`](https://ariakit.com/reference/tab-provider) component's
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`TabProvider`](https://ariakit.com/reference/tab-provider)). In that case,
+   * the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: TabStore;
+  store?: TabStore | ProviderComponent<TabStore>;
   /**
    * The [`id`](https://ariakit.com/reference/tab#id) of the tab controlling
    * this panel. This connection is used to assign the `aria-labelledby`

--- a/packages/ariakit-react-components/src/tab/tab-provider.tsx
+++ b/packages/ariakit-react-components/src/tab/tab-provider.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { TabContextProvider } from "./tab-context.tsx";
+import { createTabProvider, TabContextProvider } from "./tab-context.tsx";
 import type { TabStoreProps } from "./tab-store.ts";
 import { useTabStore } from "./tab-store.ts";
 
@@ -18,12 +18,14 @@ import { useTabStore } from "./tab-store.ts";
  * </TabProvider>
  * ```
  */
-export function TabProvider(props: TabProviderProps = {}) {
+export const TabProvider = createTabProvider(function TabProvider(
+  props: TabProviderProps = {},
+) {
   const store = useTabStore(props);
   return (
     <TabContextProvider value={store}>{props.children}</TabContextProvider>
   );
-}
+});
 
 export interface TabProviderProps extends TabStoreProps {
   children?: ReactNode;

--- a/packages/ariakit-react-components/src/tab/tab.tsx
+++ b/packages/ariakit-react-components/src/tab/tab.tsx
@@ -198,8 +198,9 @@ export interface TabOptions<
    *
    * You can also pass a provider component (for example,
    * [`TabProvider`](https://ariakit.com/reference/tab-provider)). In that case,
-   * the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * the store is read from the closest context of that provider's kind (set by
+   * that provider, an extending provider, or a compatible container component),
+   * skipping less specific store contexts.
    */
   store?: TabStore | ProviderComponent<TabStore>;
   /**

--- a/packages/ariakit-react-components/src/tab/tab.tsx
+++ b/packages/ariakit-react-components/src/tab/tab.tsx
@@ -6,8 +6,9 @@ import {
   createHook,
   forwardRef,
   memo,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { disabledFromProps, invariant } from "@ariakit/utils";
 import type { ElementType, MouseEvent } from "react";
 import { useCallback } from "react";
@@ -42,7 +43,7 @@ export const useTab = createHook<TagName, TabOptions>(function useTab({
   ...props
 }) {
   const context = useTabScopedContext();
-  store = store || context;
+  store = useStoreProp(store, context);
 
   invariant(
     store,
@@ -194,8 +195,13 @@ export interface TabOptions<
    * [`useTabStore`](https://ariakit.com/reference/use-tab-store) hook. If not
    * provided, the closest [`TabList`](https://ariakit.com/reference/tab-list)
    * component's context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`TabProvider`](https://ariakit.com/reference/tab-provider)). In that case,
+   * the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: TabStore;
+  store?: TabStore | ProviderComponent<TabStore>;
   /**
    * @default true
    */

--- a/packages/ariakit-react-components/src/tag/tag-context.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-context.tsx
@@ -38,3 +38,5 @@ export const useTagProviderContext = ctx.useProviderContext;
 export const TagContextProvider = ctx.ContextProvider;
 
 export const TagScopedContextProvider = ctx.ScopedContextProvider;
+
+export const createTagProvider = ctx.createProviderComponent;

--- a/packages/ariakit-react-components/src/tag/tag-input.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-input.tsx
@@ -231,8 +231,9 @@ export interface TagInputOptions<
    *
    * You can also pass a provider component (for example,
    * [`TagProvider`](https://ariakit.com/reference/tag-provider)). In that case,
-   * the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * the store is read from the closest context of that provider's kind (set by
+   * that provider, an extending provider, or a compatible container component),
+   * skipping less specific store contexts.
    */
   store?: TagStore | ProviderComponent<TagStore>;
   /**

--- a/packages/ariakit-react-components/src/tag/tag-input.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-input.tsx
@@ -6,8 +6,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import {
   getTextboxSelection,
   setSelectionRange,
@@ -59,7 +60,7 @@ export const useTagInput = createHook<TagName, TagInputOptions>(
     ...props
   }) {
     const context = useTagContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -227,8 +228,13 @@ export interface TagInputOptions<
    * provided, the closest
    * [`TagProvider`](https://ariakit.com/reference/tag-provider) component's
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`TagProvider`](https://ariakit.com/reference/tag-provider)). In that case,
+   * the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: TagStore;
+  store?: TagStore | ProviderComponent<TagStore>;
   /**
    * The string or pattern employed to break the input value into multiple tags.
    * This could be a string, a regular expression, an array of strings and

--- a/packages/ariakit-react-components/src/tag/tag-list-label.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-list-label.tsx
@@ -95,8 +95,9 @@ export interface TagListLabelOptions<
    *
    * You can also pass a provider component (for example,
    * [`TagProvider`](https://ariakit.com/reference/tag-provider)). In that case,
-   * the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * the store is read from the closest context of that provider's kind (set by
+   * that provider, an extending provider, or a compatible container component),
+   * skipping less specific store contexts.
    */
   store?: TagStore | ProviderComponent<TagStore>;
 }

--- a/packages/ariakit-react-components/src/tag/tag-list-label.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-list-label.tsx
@@ -5,8 +5,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Options, Props } from "@ariakit/react-utils";
+import type { Options, Props, ProviderComponent } from "@ariakit/react-utils";
 import { invariant } from "@ariakit/utils";
 import type { ElementType } from "react";
 import { useTagContext } from "./tag-context.tsx";
@@ -27,7 +28,7 @@ type TagName = typeof TagName;
 export const useTagListLabel = createHook<TagName, TagListLabelOptions>(
   function useTagListLabel({ store, ...props }) {
     const context = useTagContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -91,8 +92,13 @@ export interface TagListLabelOptions<
    * provided, the closest
    * [`TagProvider`](https://ariakit.com/reference/tag-provider) component's
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`TagProvider`](https://ariakit.com/reference/tag-provider)). In that case,
+   * the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: TagStore;
+  store?: TagStore | ProviderComponent<TagStore>;
 }
 
 export type TagListLabelProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/tag/tag-list.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-list.tsx
@@ -5,8 +5,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import {
   queueBeforeEvent,
   getClosestFocusable,
@@ -40,7 +41,7 @@ type HTMLType = HTMLElementTagNameMap[TagName];
 export const useTagList = createHook<TagName, TagListOptions>(
   function useTagList({ store, ...props }) {
     const context = useTagProviderContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -200,8 +201,13 @@ export interface TagListOptions<
    * provided, the closest
    * [`TagProvider`](https://ariakit.com/reference/tag-provider) component's
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`TagProvider`](https://ariakit.com/reference/tag-provider)). In that case,
+   * the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: TagStore;
+  store?: TagStore | ProviderComponent<TagStore>;
 }
 
 export type TagListProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/tag/tag-list.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-list.tsx
@@ -204,8 +204,9 @@ export interface TagListOptions<
    *
    * You can also pass a provider component (for example,
    * [`TagProvider`](https://ariakit.com/reference/tag-provider)). In that case,
-   * the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * the store is read from the closest context of that provider's kind (set by
+   * that provider, an extending provider, or a compatible container component),
+   * skipping less specific store contexts.
    */
   store?: TagStore | ProviderComponent<TagStore>;
 }

--- a/packages/ariakit-react-components/src/tag/tag-provider.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-provider.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { TagContextProvider } from "./tag-context.tsx";
+import { createTagProvider, TagContextProvider } from "./tag-context.tsx";
 import type { TagStoreProps } from "./tag-store.ts";
 import { useTagStore } from "./tag-store.ts";
 
@@ -26,12 +26,14 @@ import { useTagStore } from "./tag-store.ts";
  * </TagProvider>
  * ```
  */
-export function TagProvider(props: TagProviderProps = {}) {
+export const TagProvider = createTagProvider(function TagProvider(
+  props: TagProviderProps = {},
+) {
   const store = useTagStore(props);
   return (
     <TagContextProvider value={store}>{props.children}</TagContextProvider>
   );
-}
+});
 
 export interface TagProviderProps extends TagStoreProps {
   children?: ReactNode;

--- a/packages/ariakit-react-components/src/tag/tag-remove.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-remove.tsx
@@ -5,8 +5,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Options, Props } from "@ariakit/react-utils";
+import type { Options, Props, ProviderComponent } from "@ariakit/react-utils";
 import { invariant } from "@ariakit/utils";
 import type { BooleanOrCallback } from "@ariakit/utils";
 import type { ElementType, MouseEvent } from "react";
@@ -41,7 +42,7 @@ export const useTagRemove = createHook<TagName, TagRemoveOptions>(
     ...props
   }) {
     const context = useTagContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -153,8 +154,13 @@ export interface TagRemoveOptions<
    * provided, the closest
    * [`TagProvider`](https://ariakit.com/reference/tag-provider) component's
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`TagProvider`](https://ariakit.com/reference/tag-provider)). In that case,
+   * the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: TagStore;
+  store?: TagStore | ProviderComponent<TagStore>;
   /**
    * The value of the tag to remove. If not provided, the value will be inferred
    * from the parent [`Tag`](https://ariakit.com/reference/tag) component.

--- a/packages/ariakit-react-components/src/tag/tag-remove.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-remove.tsx
@@ -157,8 +157,9 @@ export interface TagRemoveOptions<
    *
    * You can also pass a provider component (for example,
    * [`TagProvider`](https://ariakit.com/reference/tag-provider)). In that case,
-   * the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * the store is read from the closest context of that provider's kind (set by
+   * that provider, an extending provider, or a compatible container component),
+   * skipping less specific store contexts.
    */
   store?: TagStore | ProviderComponent<TagStore>;
   /**

--- a/packages/ariakit-react-components/src/tag/tag-value.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-value.tsx
@@ -1,4 +1,6 @@
 import { useStoreState } from "@ariakit/react-store";
+import { useStoreProp } from "@ariakit/react-utils";
+import type { ProviderComponent } from "@ariakit/react-utils";
 import { invariant } from "@ariakit/utils";
 import type { ReactNode } from "react";
 import { useTagContext } from "./tag-context.tsx";
@@ -29,7 +31,7 @@ import type { TagStore, TagStoreState } from "./tag-store.ts";
  */
 export function TagValue({ store, children }: TagValueProps = {}) {
   const context = useTagContext();
-  store = store || context;
+  store = useStoreProp(store, context);
 
   invariant(
     store,
@@ -53,8 +55,13 @@ export interface TagValueProps {
    * hook. If not provided, the closest
    * [`TagProvider`](https://ariakit.com/reference/tag-provider)
    * component's context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`TagProvider`](https://ariakit.com/reference/tag-provider)). In that case,
+   * the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: TagStore;
+  store?: TagStore | ProviderComponent<TagStore>;
   /**
    * A function that gets called with the current value as an argument. It can
    * be used to render the tag value in a custom way.

--- a/packages/ariakit-react-components/src/tag/tag-value.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-value.tsx
@@ -58,8 +58,9 @@ export interface TagValueProps {
    *
    * You can also pass a provider component (for example,
    * [`TagProvider`](https://ariakit.com/reference/tag-provider)). In that case,
-   * the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * the store is read from the closest context of that provider's kind (set by
+   * that provider, an extending provider, or a compatible container component),
+   * skipping less specific store contexts.
    */
   store?: TagStore | ProviderComponent<TagStore>;
   /**

--- a/packages/ariakit-react-components/src/tag/tag-values.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-values.tsx
@@ -1,4 +1,6 @@
 import { useStoreState } from "@ariakit/react-store";
+import { useStoreProp } from "@ariakit/react-utils";
+import type { ProviderComponent } from "@ariakit/react-utils";
 import { invariant } from "@ariakit/utils";
 import type { ReactNode } from "react";
 import { useTagContext } from "./tag-context.tsx";
@@ -39,7 +41,7 @@ import type { TagStore, TagStoreState } from "./tag-store.ts";
  */
 export function TagValues({ store, children }: TagValuesProps = {}) {
   const context = useTagContext();
-  store = store || context;
+  store = useStoreProp(store, context);
 
   invariant(
     store,
@@ -63,8 +65,13 @@ export interface TagValuesProps {
    * provided, the closest
    * [`TagProvider`](https://ariakit.com/reference/tag-provider) component's
    * context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`TagProvider`](https://ariakit.com/reference/tag-provider)). In that case,
+   * the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: TagStore;
+  store?: TagStore | ProviderComponent<TagStore>;
   /**
    * A function that gets called with the current values as an argument. This
    * can be used as an uncontrolled API to render

--- a/packages/ariakit-react-components/src/tag/tag-values.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-values.tsx
@@ -68,8 +68,9 @@ export interface TagValuesProps {
    *
    * You can also pass a provider component (for example,
    * [`TagProvider`](https://ariakit.com/reference/tag-provider)). In that case,
-   * the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * the store is read from the closest context of that provider's kind (set by
+   * that provider, an extending provider, or a compatible container component),
+   * skipping less specific store contexts.
    */
   store?: TagStore | ProviderComponent<TagStore>;
   /**

--- a/packages/ariakit-react-components/src/tag/tag.tsx
+++ b/packages/ariakit-react-components/src/tag/tag.tsx
@@ -7,8 +7,9 @@ import {
   createHook,
   forwardRef,
   memo,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { invariant, isApple } from "@ariakit/utils";
 import type { BooleanOrCallback } from "@ariakit/utils";
 import type { ElementType, KeyboardEvent } from "react";
@@ -44,7 +45,7 @@ export const useTag = createHook<TagName, TagOptions>(function useTag({
   ...props
 }) {
   const context = useTagContext();
-  store = store || context;
+  store = useStoreProp(store, context);
 
   invariant(
     store,
@@ -180,8 +181,13 @@ export interface TagOptions<
    * [`useTagStore`](https://ariakit.com/reference/use-tag-store) hook. If not
    * provided, the closest [`TagList`](https://ariakit.com/reference/tag-list)
    * component's context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`TagProvider`](https://ariakit.com/reference/tag-provider)). In that case,
+   * the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: TagStore;
+  store?: TagStore | ProviderComponent<TagStore>;
   /**
    * The unique value of the tag. This is automatically rendered as the tag's
    * content if no children are provided.

--- a/packages/ariakit-react-components/src/tag/tag.tsx
+++ b/packages/ariakit-react-components/src/tag/tag.tsx
@@ -184,8 +184,9 @@ export interface TagOptions<
    *
    * You can also pass a provider component (for example,
    * [`TagProvider`](https://ariakit.com/reference/tag-provider)). In that case,
-   * the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * the store is read from the closest context of that provider's kind (set by
+   * that provider, an extending provider, or a compatible container component),
+   * skipping less specific store contexts.
    */
   store?: TagStore | ProviderComponent<TagStore>;
   /**

--- a/packages/ariakit-react-components/src/toolbar/toolbar-container.tsx
+++ b/packages/ariakit-react-components/src/toolbar/toolbar-container.tsx
@@ -3,6 +3,7 @@ import {
   createHook,
   forwardRef,
   memo,
+  useStoreProp,
 } from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
 import type { ElementType } from "react";
@@ -32,7 +33,7 @@ type TagName = typeof TagName;
 export const useToolbarContainer = createHook<TagName, ToolbarContainerOptions>(
   function useToolbarContainer({ store, ...props }) {
     const context = useToolbarContext();
-    store = store || context;
+    store = useStoreProp(store, context);
     props = useCompositeContainer({ store, ...props });
     props = useToolbarItem<TagName>({ store, ...props });
     return props;

--- a/packages/ariakit-react-components/src/toolbar/toolbar-context.tsx
+++ b/packages/ariakit-react-components/src/toolbar/toolbar-context.tsx
@@ -32,3 +32,5 @@ export const useToolbarProviderContext = ctx.useProviderContext;
 export const ToolbarContextProvider = ctx.ContextProvider;
 
 export const ToolbarScopedContextProvider = ctx.ScopedContextProvider;
+
+export const createToolbarProvider = ctx.createProviderComponent;

--- a/packages/ariakit-react-components/src/toolbar/toolbar-input.tsx
+++ b/packages/ariakit-react-components/src/toolbar/toolbar-input.tsx
@@ -3,6 +3,7 @@ import {
   createHook,
   forwardRef,
   memo,
+  useStoreProp,
 } from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
 import type { ElementType } from "react";
@@ -29,7 +30,7 @@ type TagName = typeof TagName;
 export const useToolbarInput = createHook<TagName, ToolbarInputOptions>(
   function useToolbarInput({ store, ...props }) {
     const context = useToolbarContext();
-    store = store || context;
+    store = useStoreProp(store, context);
     props = useToolbarItem<TagName>({ store, ...props });
     return props;
   },

--- a/packages/ariakit-react-components/src/toolbar/toolbar-item.tsx
+++ b/packages/ariakit-react-components/src/toolbar/toolbar-item.tsx
@@ -65,9 +65,10 @@ export interface ToolbarItemOptions<
    * be used.
    *
    * You can also pass a provider component (for example,
-   * [`ToolbarProvider`](https://ariakit.com/reference/toolbar-provider)). In that
-   * case, the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * [`ToolbarProvider`](https://ariakit.com/reference/toolbar-provider)). In
+   * that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: ToolbarStore | ProviderComponent<ToolbarStore>;
 }

--- a/packages/ariakit-react-components/src/toolbar/toolbar-item.tsx
+++ b/packages/ariakit-react-components/src/toolbar/toolbar-item.tsx
@@ -3,8 +3,9 @@ import {
   createHook,
   forwardRef,
   memo,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { CompositeItemOptions } from "../composite/composite-item.tsx";
 import { useCompositeItem } from "../composite/composite-item.tsx";
@@ -29,7 +30,7 @@ type TagName = typeof TagName;
 export const useToolbarItem = createHook<TagName, ToolbarItemOptions>(
   function useToolbarItem({ store, ...props }) {
     const context = useToolbarContext();
-    store = store || context;
+    store = useStoreProp(store, context);
     props = useCompositeItem({ store, ...props });
     return props;
   },
@@ -62,8 +63,13 @@ export interface ToolbarItemOptions<
    * If not provided, the closest
    * [`Toolbar`](https://ariakit.com/reference/toolbar) component's context will
    * be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`ToolbarProvider`](https://ariakit.com/reference/toolbar-provider)). In that
+   * case, the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: ToolbarStore;
+  store?: ToolbarStore | ProviderComponent<ToolbarStore>;
 }
 
 export type ToolbarItemProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/toolbar/toolbar-provider.tsx
+++ b/packages/ariakit-react-components/src/toolbar/toolbar-provider.tsx
@@ -1,5 +1,8 @@
 import type { ReactNode } from "react";
-import { ToolbarContextProvider } from "./toolbar-context.tsx";
+import {
+  createToolbarProvider,
+  ToolbarContextProvider,
+} from "./toolbar-context.tsx";
 import type { ToolbarStoreProps } from "./toolbar-store.ts";
 import { useToolbarStore } from "./toolbar-store.ts";
 
@@ -18,14 +21,16 @@ import { useToolbarStore } from "./toolbar-store.ts";
  * </ToolbarProvider>
  * ```
  */
-export function ToolbarProvider(props: ToolbarProviderProps = {}) {
+export const ToolbarProvider = createToolbarProvider(function ToolbarProvider(
+  props: ToolbarProviderProps = {},
+) {
   const store = useToolbarStore(props);
   return (
     <ToolbarContextProvider value={store}>
       {props.children}
     </ToolbarContextProvider>
   );
-}
+});
 
 export interface ToolbarProviderProps extends ToolbarStoreProps {
   children?: ReactNode;

--- a/packages/ariakit-react-components/src/toolbar/toolbar-separator.tsx
+++ b/packages/ariakit-react-components/src/toolbar/toolbar-separator.tsx
@@ -1,5 +1,10 @@
-import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import {
+  createElement,
+  createHook,
+  forwardRef,
+  useStoreProp,
+} from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { CompositeSeparatorOptions } from "../composite/composite-separator.tsx";
 import { useCompositeSeparator } from "../composite/composite-separator.tsx";
@@ -26,7 +31,7 @@ type TagName = typeof TagName;
 export const useToolbarSeparator = createHook<TagName, ToolbarSeparatorOptions>(
   function useToolbarSeparator({ store, ...props }) {
     const context = useToolbarContext();
-    store = store || context;
+    store = useStoreProp(store, context);
     props = useCompositeSeparator({ store, ...props });
     return props;
   },
@@ -61,8 +66,13 @@ export interface ToolbarSeparatorOptions<
    * If not provided, the closest
    * [`Toolbar`](https://ariakit.com/reference/toolbar) component's context will
    * be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`ToolbarProvider`](https://ariakit.com/reference/toolbar-provider)). In that
+   * case, the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: ToolbarStore;
+  store?: ToolbarStore | ProviderComponent<ToolbarStore>;
 }
 
 export type ToolbarSeparatorProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/toolbar/toolbar-separator.tsx
+++ b/packages/ariakit-react-components/src/toolbar/toolbar-separator.tsx
@@ -68,9 +68,10 @@ export interface ToolbarSeparatorOptions<
    * be used.
    *
    * You can also pass a provider component (for example,
-   * [`ToolbarProvider`](https://ariakit.com/reference/toolbar-provider)). In that
-   * case, the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * [`ToolbarProvider`](https://ariakit.com/reference/toolbar-provider)). In
+   * that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: ToolbarStore | ProviderComponent<ToolbarStore>;
 }

--- a/packages/ariakit-react-components/src/toolbar/toolbar.tsx
+++ b/packages/ariakit-react-components/src/toolbar/toolbar.tsx
@@ -113,8 +113,9 @@ export interface ToolbarOptions<T extends ElementType = TagName>
    *
    * You can also pass a provider component (for example,
    * [`ToolbarProvider`](https://ariakit.com/reference/toolbar-provider)). In
-   * that case, the store is read from the closest matching provider, even if
-   * another compatible store context is closer.
+   * that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: ToolbarStore | ProviderComponent<ToolbarStore>;
 }

--- a/packages/ariakit-react-components/src/toolbar/toolbar.tsx
+++ b/packages/ariakit-react-components/src/toolbar/toolbar.tsx
@@ -1,11 +1,12 @@
 import { useStoreState } from "@ariakit/react-store";
 import {
+  useStoreProp,
   useWrapElement,
   createElement,
   createHook,
   forwardRef,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import type { ElementType } from "react";
 import type { CompositeOptions } from "../composite/composite.tsx";
 import { useComposite } from "../composite/composite.tsx";
@@ -42,7 +43,7 @@ export const useToolbar = createHook<TagName, ToolbarOptions>(
     ...props
   }) {
     const context = useToolbarProviderContext();
-    storeProp = storeProp || context;
+    storeProp = useStoreProp(storeProp, context);
 
     const store = useToolbarStore({
       store: storeProp,
@@ -109,8 +110,13 @@ export interface ToolbarOptions<T extends ElementType = TagName>
    * component context will be used. If the component is not wrapped in a
    * [`ToolbarProvider`](https://ariakit.com/reference/toolbar-provider)
    * component, an internal store will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`ToolbarProvider`](https://ariakit.com/reference/toolbar-provider)). In
+   * that case, the store is read from the closest matching provider, even if
+   * another compatible store context is closer.
    */
-  store?: ToolbarStore;
+  store?: ToolbarStore | ProviderComponent<ToolbarStore>;
 }
 
 export type ToolbarProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
+++ b/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
@@ -218,9 +218,10 @@ export interface TooltipAnchorOptions<
    * component's context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`TooltipProvider`](https://ariakit.com/reference/tooltip-provider)). In that
-   * case, the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * [`TooltipProvider`](https://ariakit.com/reference/tooltip-provider)). In
+   * that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: TooltipStore | ProviderComponent<TooltipStore>;
 }

--- a/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
+++ b/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
@@ -4,8 +4,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { createStore, sync } from "@ariakit/store";
 import { chain, invariant, isFalsyBooleanCallback } from "@ariakit/utils";
 import type { ElementType, FocusEvent, MouseEvent } from "react";
@@ -58,7 +59,7 @@ function hideStore(store: TooltipStore | null) {
 export const useTooltipAnchor = createHook<TagName, TooltipAnchorOptions>(
   function useTooltipAnchor({ store, showOnHover = true, ...props }) {
     const context = useTooltipProviderContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -215,8 +216,13 @@ export interface TooltipAnchorOptions<
    * If not provided, the closest
    * [`TooltipProvider`](https://ariakit.com/reference/tooltip-provider)
    * component's context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`TooltipProvider`](https://ariakit.com/reference/tooltip-provider)). In that
+   * case, the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: TooltipStore;
+  store?: TooltipStore | ProviderComponent<TooltipStore>;
 }
 
 export type TooltipAnchorProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/tooltip/tooltip-arrow.tsx
+++ b/packages/ariakit-react-components/src/tooltip/tooltip-arrow.tsx
@@ -1,5 +1,10 @@
-import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import {
+  createElement,
+  createHook,
+  forwardRef,
+  useStoreProp,
+} from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { invariant } from "@ariakit/utils";
 import type { ElementType } from "react";
 import type { PopoverArrowOptions } from "../popover/popover-arrow.tsx";
@@ -29,7 +34,7 @@ export const useTooltipArrow = createHook<TagName, TooltipArrowOptions>(
     // We need to get the tooltip store here because Tooltip is not using the
     // Popover component, so PopoverArrow can't access the popover context.
     const context = useTooltipContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -74,8 +79,13 @@ export interface TooltipArrowOptions<
    * [`Tooltip`](https://ariakit.com/reference/tooltip) or
    * [`TooltipProvider`](https://ariakit.com/reference/tooltip-provider)
    * components' context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`TooltipProvider`](https://ariakit.com/reference/tooltip-provider)). In that
+   * case, the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: TooltipStore;
+  store?: TooltipStore | ProviderComponent<TooltipStore>;
 }
 
 export type TooltipArrowProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/tooltip/tooltip-arrow.tsx
+++ b/packages/ariakit-react-components/src/tooltip/tooltip-arrow.tsx
@@ -81,9 +81,10 @@ export interface TooltipArrowOptions<
    * components' context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`TooltipProvider`](https://ariakit.com/reference/tooltip-provider)). In that
-   * case, the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * [`TooltipProvider`](https://ariakit.com/reference/tooltip-provider)). In
+   * that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: TooltipStore | ProviderComponent<TooltipStore>;
 }

--- a/packages/ariakit-react-components/src/tooltip/tooltip-context.tsx
+++ b/packages/ariakit-react-components/src/tooltip/tooltip-context.tsx
@@ -32,3 +32,5 @@ export const useTooltipProviderContext = ctx.useProviderContext;
 export const TooltipContextProvider = ctx.ContextProvider;
 
 export const TooltipScopedContextProvider = ctx.ScopedContextProvider;
+
+export const createTooltipProvider = ctx.createProviderComponent;

--- a/packages/ariakit-react-components/src/tooltip/tooltip-provider.tsx
+++ b/packages/ariakit-react-components/src/tooltip/tooltip-provider.tsx
@@ -1,5 +1,8 @@
 import type { ReactNode } from "react";
-import { TooltipContextProvider } from "./tooltip-context.tsx";
+import {
+  createTooltipProvider,
+  TooltipContextProvider,
+} from "./tooltip-context.tsx";
 import type { TooltipStoreProps } from "./tooltip-store.ts";
 import { useTooltipStore } from "./tooltip-store.ts";
 
@@ -15,14 +18,16 @@ import { useTooltipStore } from "./tooltip-store.ts";
  * </TooltipProvider>
  * ```
  */
-export function TooltipProvider(props: TooltipProviderProps = {}) {
+export const TooltipProvider = createTooltipProvider(function TooltipProvider(
+  props: TooltipProviderProps = {},
+) {
   const store = useTooltipStore(props);
   return (
     <TooltipContextProvider value={store}>
       {props.children}
     </TooltipContextProvider>
   );
-}
+});
 
 export interface TooltipProviderProps extends TooltipStoreProps {
   children?: ReactNode;

--- a/packages/ariakit-react-components/src/tooltip/tooltip.tsx
+++ b/packages/ariakit-react-components/src/tooltip/tooltip.tsx
@@ -4,8 +4,9 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useStoreProp,
 } from "@ariakit/react-utils";
-import type { Props } from "@ariakit/react-utils";
+import type { Props, ProviderComponent } from "@ariakit/react-utils";
 import { contains, invariant, isFalsyBooleanCallback } from "@ariakit/utils";
 import type { ElementType } from "react";
 import { createDialogComponent } from "../dialog/dialog.tsx";
@@ -42,7 +43,7 @@ export const useTooltip = createHook<TagName, TooltipOptions>(
     ...props
   }) {
     const context = useTooltipProviderContext();
-    store = store || context;
+    store = useStoreProp(store, context);
 
     invariant(
       store,
@@ -135,8 +136,13 @@ export interface TooltipOptions<
    * If not provided, the closest
    * [`TooltipProvider`](https://ariakit.com/reference/tooltip-provider)
    * component's context will be used.
+   *
+   * You can also pass a provider component (for example,
+   * [`TooltipProvider`](https://ariakit.com/reference/tooltip-provider)). In that
+   * case, the store is read from the closest matching provider, even if another
+   * compatible store context is closer.
    */
-  store?: TooltipStore;
+  store?: TooltipStore | ProviderComponent<TooltipStore>;
   /**
    * @default true
    */

--- a/packages/ariakit-react-components/src/tooltip/tooltip.tsx
+++ b/packages/ariakit-react-components/src/tooltip/tooltip.tsx
@@ -138,9 +138,10 @@ export interface TooltipOptions<
    * component's context will be used.
    *
    * You can also pass a provider component (for example,
-   * [`TooltipProvider`](https://ariakit.com/reference/tooltip-provider)). In that
-   * case, the store is read from the closest matching provider, even if another
-   * compatible store context is closer.
+   * [`TooltipProvider`](https://ariakit.com/reference/tooltip-provider)). In
+   * that case, the store is read from the closest context of that provider's
+   * kind (set by that provider, an extending provider, or a compatible
+   * container component), skipping less specific store contexts.
    */
   store?: TooltipStore | ProviderComponent<TooltipStore>;
   /**

--- a/packages/ariakit-react-store/readme.md
+++ b/packages/ariakit-react-store/readme.md
@@ -99,7 +99,7 @@ function useStoreState<T extends CoreStore, V>(
 ): V;
 ```
 
-Receives an Ariakit store object (which can be `null` or `undefined`) or a provider component (for example, `ComboboxProvider`) and returns the current state. When a provider component is passed, the store is read from the closest matching provider via context. If a key is provided as the second argument, it returns the value of that key. If a selector function is provided, the state is passed to it, and its return value is used.
+Receives an Ariakit store object (which can be `null` or `undefined`) or a provider component (for example, `ComboboxProvider`) and returns the current state. When a provider component is passed, the store is read from the closest context of that provider's kind (set by that provider, an extending provider, or a compatible container component), skipping less specific store contexts. If a key is provided as the second argument, it returns the value of that key. If a selector function is provided, the state is passed to it, and its return value is used.
 
 The component using this hook will re-render when the returned value changes.
 
@@ -143,7 +143,7 @@ const value = Ariakit.useStoreState(combobox, "value");
 Example:
 
 Passing a provider component instead of a store object, in which case the
-store is read from the closest matching provider:
+store is read from the closest context of that provider's kind:
 
 ```js
 const value = Ariakit.useStoreState(Ariakit.ComboboxProvider, "value");
@@ -192,7 +192,7 @@ function useStoreStateObject<
 ): StoreStateObjectResult<T, StoreState<T> | undefined, O>;
 ```
 
-Receives an Ariakit store object (which can be `null` or `undefined`) or a provider component (for example, `ComboboxProvider`) and returns the current state. Unlike `useStoreState`, this hook receives an object with keys that map to store keys or selector functions. When a provider component is passed, the store is read from the closest matching provider via context.
+Receives an Ariakit store object (which can be `null` or `undefined`) or a provider component (for example, `ComboboxProvider`) and returns the current state. Unlike `useStoreState`, this hook receives an object with keys that map to store keys or selector functions. When a provider component is passed, the store is read from the closest context of that provider's kind (set by that provider, an extending provider, or a compatible container component), skipping less specific store contexts.
 
 <div align="right">
   <a href="#api-reference">&uarr; back to top</a>
@@ -271,7 +271,7 @@ interface ProviderComponent<T extends Store = Store> {
 }
 ```
 
-A provider component (for example, `ComboboxProvider`) that can be passed to store props and [`useStoreState`](https://ariakit.com/reference/use-store-state) in place of a store object. The store is then read from the closest matching provider via context.
+A provider component (for example, `ComboboxProvider`) that can be passed to store props and [`useStoreState`](https://ariakit.com/reference/use-store-state) in place of a store object. The store is then read from the closest context of that provider's kind (set by that provider, an extending provider, or a compatible container component), skipping less specific store contexts.
 
 <div align="right">
   <a href="#api-reference">&uarr; back to top</a>

--- a/packages/ariakit-react-store/readme.md
+++ b/packages/ariakit-react-store/readme.md
@@ -273,6 +273,8 @@ interface ProviderComponent<T extends Store = Store> {
 
 A provider component (for example, `ComboboxProvider`) that can be passed to store props and [`useStoreState`](https://ariakit.com/reference/use-store-state) in place of a store object. The store is then read from the closest context of that provider's kind (set by that provider, an extending provider, or a compatible container component), skipping less specific store contexts.
 
+If no such context is found, the store resolves to `undefined`. Components composed from multiple layers may still bind lower-level behavior to their own contexts in that case.
+
 <div align="right">
   <a href="#api-reference">&uarr; back to top</a>
 </div>

--- a/packages/ariakit-react-store/readme.md
+++ b/packages/ariakit-react-store/readme.md
@@ -30,14 +30,19 @@ This package is ESM-only and exposes a single public entrypoint.
 
 ## API reference
 
-- [`UseState`](#usestate)
-- [`useStoreState`](#usestorestate)
-- [`useStoreStateObject`](#usestorestateobject)
-- [`useStoreProps`](#usestoreprops)
-- [`useStore`](#usestore)
-- [`Store`](#store)
+- [Other exports](#other-exports)
+  - [`UseState`](#usestate)
+  - [`useStoreState`](#usestorestate)
+  - [`useStoreStateObject`](#usestorestateobject)
+  - [`useStoreProps`](#usestoreprops)
+  - [`useStore`](#usestore)
+  - [`Store`](#store)
+- [System utilities](#system-utilities)
+  - [`ProviderComponent`](#providercomponent)
 
-### `UseState`
+### Other exports
+
+#### `UseState`
 
 ```ts
 interface UseState<S> {
@@ -65,7 +70,7 @@ interface UseState<S> {
   <a href="#api-reference">&uarr; back to top</a>
 </div>
 
-### `useStoreState`
+#### `useStoreState`
 
 ```ts
 type StateStore<T = CoreStore> = T | null | undefined;
@@ -74,14 +79,14 @@ type StateKey<T = CoreStore> = keyof StoreState<T>;
 
 function useStoreState<T extends CoreStore>(store: T): StoreState<T>;
 function useStoreState<T extends CoreStore>(
-  store: StateStore<T>,
+  store: StateStore<T> | ProviderComponent<T>,
 ): StoreState<T> | undefined;
 function useStoreState<T extends CoreStore, K extends StateKey<T>>(
   store: T,
   key: K,
 ): StoreState<T>[K];
 function useStoreState<T extends CoreStore, K extends StateKey<T>>(
-  store: StateStore<T>,
+  store: StateStore<T> | ProviderComponent<T>,
   key: K,
 ): StoreState<T>[K] | undefined;
 function useStoreState<T extends CoreStore, V>(
@@ -89,12 +94,12 @@ function useStoreState<T extends CoreStore, V>(
   selector: (state: StoreState<T>) => V,
 ): V;
 function useStoreState<T extends CoreStore, V>(
-  store: StateStore<T>,
+  store: StateStore<T> | ProviderComponent<T>,
   selector: (state?: StoreState<T>) => V,
 ): V;
 ```
 
-Receives an Ariakit store object (which can be `null` or `undefined`) and returns the current state. If a key is provided as the second argument, it returns the value of that key. If a selector function is provided, the state is passed to it, and its return value is used.
+Receives an Ariakit store object (which can be `null` or `undefined`) or a provider component (for example, `ComboboxProvider`) and returns the current state. When a provider component is passed, the store is read from the closest matching provider via context. If a key is provided as the second argument, it returns the value of that key. If a selector function is provided, the state is passed to it, and its return value is used.
 
 The component using this hook will re-render when the returned value changes.
 
@@ -135,11 +140,20 @@ const combobox = Ariakit.useComboboxContext();
 const value = Ariakit.useStoreState(combobox, "value");
 ```
 
+Example:
+
+Passing a provider component instead of a store object, in which case the
+store is read from the closest matching provider:
+
+```js
+const value = Ariakit.useStoreState(Ariakit.ComboboxProvider, "value");
+```
+
 <div align="right">
   <a href="#api-reference">&uarr; back to top</a>
 </div>
 
-### `useStoreStateObject`
+#### `useStoreStateObject`
 
 ```ts
 type StateStore<T = CoreStore> = T | null | undefined;
@@ -170,18 +184,21 @@ function useStoreStateObject<
   O extends StoreStateObject<T, StoreState<T>>,
 >(store: T, object: O): StoreStateObjectResult<T, StoreState<T>, O>;
 function useStoreStateObject<
-  T extends StateStore,
+  T extends CoreStore,
   O extends StoreStateObject<T, StoreState<T> | undefined>,
->(store: T, object: O): StoreStateObjectResult<T, StoreState<T> | undefined, O>;
+>(
+  store: StateStore<T> | ProviderComponent<T>,
+  object: O,
+): StoreStateObjectResult<T, StoreState<T> | undefined, O>;
 ```
 
-Receives an Ariakit store object (which can be `null` or `undefined`) and returns the current state. Unlike `useStoreState`, this hook receives an object with keys that map to store keys or selector functions.
+Receives an Ariakit store object (which can be `null` or `undefined`) or a provider component (for example, `ComboboxProvider`) and returns the current state. Unlike `useStoreState`, this hook receives an object with keys that map to store keys or selector functions. When a provider component is passed, the store is read from the closest matching provider via context.
 
 <div align="right">
   <a href="#api-reference">&uarr; back to top</a>
 </div>
 
-### `useStoreProps`
+#### `useStoreProps`
 
 ```ts
 function useStoreProps<
@@ -198,7 +215,7 @@ Synchronizes the store with the props, including parent store props.
   <a href="#api-reference">&uarr; back to top</a>
 </div>
 
-### `useStore`
+#### `useStore`
 
 ```ts
 function useStore<T extends CoreStore, P>(
@@ -213,7 +230,7 @@ Creates a React store from a core store object and returns a tuple with the stor
   <a href="#api-reference">&uarr; back to top</a>
 </div>
 
-### `Store`
+#### `Store`
 
 ```ts
 type Store<T extends CoreStore = CoreStore> = T & {
@@ -226,6 +243,35 @@ type Store<T extends CoreStore = CoreStore> = T & {
   useState: UseState<StoreState<T>>;
 };
 ```
+
+<div align="right">
+  <a href="#api-reference">&uarr; back to top</a>
+</div>
+
+### System utilities
+
+Helpers for creating and composing Ariakit React components.
+
+#### `ProviderComponent`
+
+```ts
+interface ProviderComponentBrand<T extends Store = Store> {
+  /**
+   * Phantom property that carries the provider's store type. It makes provider
+   * components assignable to `ProviderComponent` types of base stores (for
+   * example, `ComboboxProvider` to `ProviderComponent<CompositeStore>`), which
+   * wouldn't be possible if the store type only appeared in the invariant
+   * `React.Context` position. Never set at runtime.
+   */
+  store?: T;
+}
+
+interface ProviderComponent<T extends Store = Store> {
+  readonly [providerComponentSymbol]: ProviderComponentBrand<T>;
+}
+```
+
+A provider component (for example, `ComboboxProvider`) that can be passed to store props and [`useStoreState`](https://ariakit.com/reference/use-store-state) in place of a store object. The store is then read from the closest matching provider via context.
 
 <div align="right">
   <a href="#api-reference">&uarr; back to top</a>

--- a/packages/ariakit-react-store/src/index.tsx
+++ b/packages/ariakit-react-store/src/index.tsx
@@ -2,8 +2,12 @@ import {
   useEvent,
   useLiveRef,
   useSafeLayoutEffect,
+  useStoreProp,
 } from "@ariakit/react-utils";
+import type { ProviderComponent } from "@ariakit/react-utils";
 import { batch, init, subscribe, sync } from "@ariakit/store";
+
+export type { ProviderComponent } from "@ariakit/react-utils";
 import type { Store as CoreStore, State, StoreState } from "@ariakit/store";
 import { hasOwnProperty, identity } from "@ariakit/utils";
 import type {
@@ -55,10 +59,12 @@ type StateKey<T = CoreStore> = keyof StoreState<T>;
 const noopSubscribe = () => () => {};
 
 /**
- * Receives an Ariakit store object (which can be `null` or `undefined`) and
- * returns the current state. If a key is provided as the second argument, it
- * returns the value of that key. If a selector function is provided, the state
- * is passed to it, and its return value is used.
+ * Receives an Ariakit store object (which can be `null` or `undefined`) or a
+ * provider component (for example, `ComboboxProvider`) and returns the current
+ * state. When a provider component is passed, the store is read from the
+ * closest matching provider via context. If a key is provided as the second
+ * argument, it returns the value of that key. If a selector function is
+ * provided, the state is passed to it, and its return value is used.
  *
  * The component using this hook will re-render when the returned value changes.
  * @example
@@ -86,12 +92,18 @@ const noopSubscribe = () => () => {};
  * const combobox = Ariakit.useComboboxContext();
  * const value = Ariakit.useStoreState(combobox, "value");
  * ```
+ * @example
+ * Passing a provider component instead of a store object, in which case the
+ * store is read from the closest matching provider:
+ * ```js
+ * const value = Ariakit.useStoreState(Ariakit.ComboboxProvider, "value");
+ * ```
  */
 
 export function useStoreState<T extends CoreStore>(store: T): StoreState<T>;
 
 export function useStoreState<T extends CoreStore>(
-  store: StateStore<T>,
+  store: StateStore<T> | ProviderComponent<T>,
 ): StoreState<T> | undefined;
 
 export function useStoreState<T extends CoreStore, K extends StateKey<T>>(
@@ -100,7 +112,7 @@ export function useStoreState<T extends CoreStore, K extends StateKey<T>>(
 ): StoreState<T>[K];
 
 export function useStoreState<T extends CoreStore, K extends StateKey<T>>(
-  store: StateStore<T>,
+  store: StateStore<T> | ProviderComponent<T>,
   key: K,
 ): StoreState<T>[K] | undefined;
 
@@ -110,14 +122,15 @@ export function useStoreState<T extends CoreStore, V>(
 ): V;
 
 export function useStoreState<T extends CoreStore, V>(
-  store: StateStore<T>,
+  store: StateStore<T> | ProviderComponent<T>,
   selector: (state?: StoreState<T>) => V,
 ): V;
 
 export function useStoreState(
-  store: StateStore,
+  storeOrProvider: StateStore | ProviderComponent,
   keyOrSelector: StateKey | ((state?: AnyObject) => any) = identity,
 ) {
+  const store = useStoreProp(storeOrProvider);
   const storeSubscribe = React.useCallback(
     (callback: () => void) => {
       if (!store) return noopSubscribe();
@@ -160,9 +173,11 @@ type StoreStateObjectResult<
 };
 
 /**
- * Receives an Ariakit store object (which can be `null` or `undefined`) and
- * returns the current state. Unlike `useStoreState`, this hook receives an
- * object with keys that map to store keys or selector functions.
+ * Receives an Ariakit store object (which can be `null` or `undefined`) or a
+ * provider component (for example, `ComboboxProvider`) and returns the current
+ * state. Unlike `useStoreState`, this hook receives an object with keys that
+ * map to store keys or selector functions. When a provider component is
+ * passed, the store is read from the closest matching provider via context.
  */
 export function useStoreStateObject<
   T extends CoreStore,
@@ -170,14 +185,18 @@ export function useStoreStateObject<
 >(store: T, object: O): StoreStateObjectResult<T, StoreState<T>, O>;
 
 export function useStoreStateObject<
-  T extends StateStore,
+  T extends CoreStore,
   O extends StoreStateObject<T, StoreState<T> | undefined>,
->(store: T, object: O): StoreStateObjectResult<T, StoreState<T> | undefined, O>;
+>(
+  store: StateStore<T> | ProviderComponent<T>,
+  object: O,
+): StoreStateObjectResult<T, StoreState<T> | undefined, O>;
 
 export function useStoreStateObject(
-  store: StateStore,
+  storeOrProvider: StateStore | ProviderComponent,
   object: StoreStateObject<StateStore, State | undefined>,
 ) {
+  const store = useStoreProp(storeOrProvider);
   const objRef = React.useRef(
     {} as StoreStateObjectResult<StateStore, State, any>,
   );

--- a/packages/ariakit-react-store/src/index.tsx
+++ b/packages/ariakit-react-store/src/index.tsx
@@ -6,8 +6,6 @@ import {
 } from "@ariakit/react-utils";
 import type { ProviderComponent } from "@ariakit/react-utils";
 import { batch, init, subscribe, sync } from "@ariakit/store";
-
-export type { ProviderComponent } from "@ariakit/react-utils";
 import type { Store as CoreStore, State, StoreState } from "@ariakit/store";
 import { hasOwnProperty, identity } from "@ariakit/utils";
 import type {
@@ -18,6 +16,8 @@ import type {
 } from "@ariakit/utils";
 import * as React from "react";
 import { useSyncExternalStore } from "use-sync-external-store/shim";
+
+export type { ProviderComponent } from "@ariakit/react-utils";
 
 export interface UseState<S> {
   /**
@@ -62,9 +62,11 @@ const noopSubscribe = () => () => {};
  * Receives an Ariakit store object (which can be `null` or `undefined`) or a
  * provider component (for example, `ComboboxProvider`) and returns the current
  * state. When a provider component is passed, the store is read from the
- * closest matching provider via context. If a key is provided as the second
- * argument, it returns the value of that key. If a selector function is
- * provided, the state is passed to it, and its return value is used.
+ * closest context of that provider's kind (set by that provider, an extending
+ * provider, or a compatible container component), skipping less specific store
+ * contexts. If a key is provided as the second argument, it returns the value
+ * of that key. If a selector function is provided, the state is passed to it,
+ * and its return value is used.
  *
  * The component using this hook will re-render when the returned value changes.
  * @example
@@ -94,7 +96,7 @@ const noopSubscribe = () => () => {};
  * ```
  * @example
  * Passing a provider component instead of a store object, in which case the
- * store is read from the closest matching provider:
+ * store is read from the closest context of that provider's kind:
  * ```js
  * const value = Ariakit.useStoreState(Ariakit.ComboboxProvider, "value");
  * ```
@@ -177,7 +179,9 @@ type StoreStateObjectResult<
  * provider component (for example, `ComboboxProvider`) and returns the current
  * state. Unlike `useStoreState`, this hook receives an object with keys that
  * map to store keys or selector functions. When a provider component is
- * passed, the store is read from the closest matching provider via context.
+ * passed, the store is read from the closest context of that provider's kind
+ * (set by that provider, an extending provider, or a compatible container
+ * component), skipping less specific store contexts.
  */
 export function useStoreStateObject<
   T extends CoreStore,

--- a/packages/ariakit-react-utils/package.json
+++ b/packages/ariakit-react-utils/package.json
@@ -32,7 +32,10 @@
   },
   "devDependencies": {
     "@ariakit/scripts": "workspace:*",
-    "react": "19.2.7"
+    "@ariakit/test": "workspace:*",
+    "@testing-library/react": "16.3.2",
+    "react": "19.2.7",
+    "react-dom": "19.2.7"
   },
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/packages/ariakit-react-utils/readme.md
+++ b/packages/ariakit-react-utils/readme.md
@@ -59,6 +59,10 @@ This package is ESM-only and exposes a single public entrypoint.
   - [`memo`](#memo)
   - [`createElement`](#createelement)
   - [`createHook`](#createhook)
+  - [`providerComponentSymbol`](#providercomponentsymbol)
+  - [`ProviderComponent`](#providercomponent)
+  - [`isProviderComponent`](#isprovidercomponent)
+  - [`useStoreProp`](#usestoreprop)
   - [`createStoreContext`](#createstorecontext)
 - [Type utilities](#type-utilities)
   - [`RenderProp`](#renderprop)
@@ -501,6 +505,75 @@ Creates a component hook that accepts props and returns props so they can be pas
   <a href="#api-reference">&uarr; back to top</a>
 </div>
 
+#### `providerComponentSymbol`
+
+```ts
+const providerComponentSymbol: typeof providerComponentSymbol;
+```
+
+Key used to brand provider components created by `createStoreContext` so store props and `useStoreState` can resolve them to their store context. `Symbol.for` is used so different copies of this module still recognize each other's provider components.
+
+<div align="right">
+  <a href="#api-reference">&uarr; back to top</a>
+</div>
+
+#### `ProviderComponent`
+
+```ts
+interface ProviderComponentBrand<T extends Store = Store> {
+  /**
+   * Phantom property that carries the provider's store type. It makes provider
+   * components assignable to `ProviderComponent` types of base stores (for
+   * example, `ComboboxProvider` to `ProviderComponent<CompositeStore>`), which
+   * wouldn't be possible if the store type only appeared in the invariant
+   * `React.Context` position. Never set at runtime.
+   */
+  store?: T;
+}
+
+interface ProviderComponent<T extends Store = Store> {
+  readonly [providerComponentSymbol]: ProviderComponentBrand<T>;
+}
+```
+
+A provider component (for example, `ComboboxProvider`) that can be passed to store props and [`useStoreState`](https://ariakit.com/reference/use-store-state) in place of a store object. The store is then read from the closest matching provider via context.
+
+<div align="right">
+  <a href="#api-reference">&uarr; back to top</a>
+</div>
+
+#### `isProviderComponent`
+
+```ts
+function isProviderComponent<T extends Store>(
+  value: T | ProviderComponent<T> | null | undefined,
+): value is ProviderComponent<T>;
+function isProviderComponent(value: unknown): value is ProviderComponent;
+```
+
+Checks whether the value is a provider component created by `createStoreContext` (for example, `ComboboxProvider`).
+
+<div align="right">
+  <a href="#api-reference">&uarr; back to top</a>
+</div>
+
+#### `useStoreProp`
+
+```ts
+function useStoreProp<T extends Store>(
+  store: T | ProviderComponent<T> | null | undefined,
+  ...fallbacks: Array<Store | null | undefined>
+): T | undefined;
+```
+
+Resolves the value of a `store` prop that may receive either a store object or a provider component. When a provider component is passed, it's an explicit reference to that specific provider: the store is read only from the closest matching provider's context, without falling back to the given fallback stores, so it may be `undefined` if no matching provider is found. Otherwise, the store prop itself is returned, falling back to the given fallback stores (typically the component's own context) when it's not provided.
+
+The store type is inferred only from the `store` prop; the fallback stores are loosely typed so they never widen or poison that inference.
+
+<div align="right">
+  <a href="#api-reference">&uarr; back to top</a>
+</div>
+
 #### `createStoreContext`
 
 ```ts
@@ -524,6 +597,9 @@ function createStoreContext<T extends Store>(
   ScopedContextProvider: (
     props: React.ComponentPropsWithoutRef<React.Provider<T | undefined>>,
   ) => React.JSX.Element;
+  createProviderComponent: <C extends AnyFunction>(
+    component: C,
+  ) => C & ProviderComponent<T>;
 };
 ```
 

--- a/packages/ariakit-react-utils/readme.md
+++ b/packages/ariakit-react-utils/readme.md
@@ -538,6 +538,8 @@ interface ProviderComponent<T extends Store = Store> {
 
 A provider component (for example, `ComboboxProvider`) that can be passed to store props and [`useStoreState`](https://ariakit.com/reference/use-store-state) in place of a store object. The store is then read from the closest context of that provider's kind (set by that provider, an extending provider, or a compatible container component), skipping less specific store contexts.
 
+If no such context is found, the store resolves to `undefined`. Components composed from multiple layers may still bind lower-level behavior to their own contexts in that case.
+
 <div align="right">
   <a href="#api-reference">&uarr; back to top</a>
 </div>

--- a/packages/ariakit-react-utils/readme.md
+++ b/packages/ariakit-react-utils/readme.md
@@ -536,7 +536,7 @@ interface ProviderComponent<T extends Store = Store> {
 }
 ```
 
-A provider component (for example, `ComboboxProvider`) that can be passed to store props and [`useStoreState`](https://ariakit.com/reference/use-store-state) in place of a store object. The store is then read from the closest matching provider via context.
+A provider component (for example, `ComboboxProvider`) that can be passed to store props and [`useStoreState`](https://ariakit.com/reference/use-store-state) in place of a store object. The store is then read from the closest context of that provider's kind (set by that provider, an extending provider, or a compatible container component), skipping less specific store contexts.
 
 <div align="right">
   <a href="#api-reference">&uarr; back to top</a>
@@ -561,14 +561,14 @@ Checks whether the value is a provider component created by `createStoreContext`
 
 ```ts
 function useStoreProp<T extends Store>(
-  store: T | ProviderComponent<T> | null | undefined,
+  store: T | ProviderComponent | null | undefined,
   ...fallbacks: Array<Store | null | undefined>
 ): T | undefined;
 ```
 
-Resolves the value of a `store` prop that may receive either a store object or a provider component. When a provider component is passed, it's an explicit reference to that specific provider: the store is read only from the closest matching provider's context, without falling back to the given fallback stores, so it may be `undefined` if no matching provider is found. Otherwise, the store prop itself is returned, falling back to the given fallback stores (typically the component's own context) when it's not provided.
+Resolves the value of a `store` prop that may receive either a store object or a provider component. When a provider component is passed, it's an explicit reference to that provider's context kind: the store is read only from the closest context of that kind (set by that provider, an extending provider, or a compatible container component), without falling back to the given fallback stores, so it may be `undefined` if no such context value is found. Otherwise, the store prop itself is returned, falling back to the given fallback stores (typically the component's own context) when it's not provided.
 
-The store type is inferred only from the `store` prop; the fallback stores are loosely typed so they never widen or poison that inference.
+The store type is inferred only from the store object arm of the `store` prop; the provider component arm and the fallback stores are loosely typed so they never widen or poison that inference. This matters for generic options (for example, renderers), whose provider arm is branded with the base store type.
 
 <div align="right">
   <a href="#api-reference">&uarr; back to top</a>

--- a/packages/ariakit-react-utils/src/system.test.tsx
+++ b/packages/ariakit-react-utils/src/system.test.tsx
@@ -1,0 +1,157 @@
+import { createStore } from "@ariakit/store";
+import type { Store } from "@ariakit/store";
+import { render } from "@ariakit/test/react";
+import type { ReactNode } from "react";
+import { expect, test } from "vitest";
+import {
+  createStoreContext,
+  isProviderComponent,
+  useStoreProp,
+} from "./system.tsx";
+import type { ProviderComponent } from "./system.tsx";
+
+interface ProbeProps {
+  store?: Store | ProviderComponent | null;
+  fallbacks?: Array<Store | null | undefined>;
+  onResolve: (store: Store | undefined) => void;
+}
+
+function Probe({ store, fallbacks = [], onResolve }: ProbeProps) {
+  onResolve(useStoreProp(store, ...fallbacks));
+  return null;
+}
+
+test("isProviderComponent matches only branded provider components", () => {
+  const { createProviderComponent } = createStoreContext();
+  const Provider = createProviderComponent(function Provider() {
+    return null;
+  });
+  const PlainComponent = () => null;
+
+  expect(isProviderComponent(Provider)).toBe(true);
+  expect(isProviderComponent(PlainComponent)).toBe(false);
+  expect(isProviderComponent(createStore({}))).toBe(false);
+  expect(isProviderComponent(null)).toBe(false);
+  expect(isProviderComponent(undefined)).toBe(false);
+});
+
+test("useStoreProp returns the store prop without reading fallbacks", async () => {
+  const store = createStore({});
+  const fallbackStore = createStore({});
+  const resolved: Array<Store | undefined> = [];
+
+  await render(
+    <Probe
+      store={store}
+      fallbacks={[fallbackStore]}
+      onResolve={(value) => resolved.push(value)}
+    />,
+  );
+
+  expect(resolved.at(-1)).toBe(store);
+});
+
+test("useStoreProp falls back to the first truthy fallback in order", async () => {
+  const firstStore = createStore({});
+  const secondStore = createStore({});
+  const resolved: Array<Store | undefined> = [];
+
+  await render(
+    <Probe
+      fallbacks={[null, undefined, firstStore, secondStore]}
+      onResolve={(value) => resolved.push(value)}
+    />,
+  );
+
+  expect(resolved.at(-1)).toBe(firstStore);
+});
+
+test("useStoreProp resolves a provider component from its own context, ignoring fallbacks", async () => {
+  const { ContextProvider, createProviderComponent } = createStoreContext();
+
+  interface ProviderProps {
+    store: Store;
+    children?: ReactNode;
+  }
+
+  const Provider = createProviderComponent(function Provider({
+    store,
+    children,
+  }: ProviderProps) {
+    return <ContextProvider value={store}>{children}</ContextProvider>;
+  });
+
+  const providerStore = createStore({});
+  const fallbackStore = createStore({});
+  const resolved: Array<Store | undefined> = [];
+
+  await render(
+    <Provider store={providerStore}>
+      <Probe
+        store={Provider}
+        fallbacks={[fallbackStore]}
+        onResolve={(value) => resolved.push(value)}
+      />
+    </Provider>,
+  );
+
+  expect(resolved.at(-1)).toBe(providerStore);
+});
+
+test("useStoreProp resolves a provider component from an extending provider's context", async () => {
+  const base = createStoreContext();
+  const extending = createStoreContext([base.ContextProvider]);
+
+  const BaseProvider = base.createProviderComponent(function BaseProvider() {
+    return null;
+  });
+
+  interface ExtendingProviderProps {
+    store: Store;
+    children?: ReactNode;
+  }
+
+  // Mirrors how extending providers work (for example, PopoverProvider also
+  // sets the dialog context): the extending ContextProvider composes the base
+  // ContextProvider with the same store value.
+  const ExtendingProvider = extending.createProviderComponent(
+    function ExtendingProvider({ store, children }: ExtendingProviderProps) {
+      return (
+        <extending.ContextProvider value={store}>
+          {children}
+        </extending.ContextProvider>
+      );
+    },
+  );
+
+  const extendingStore = createStore({});
+  const resolved: Array<Store | undefined> = [];
+
+  await render(
+    <ExtendingProvider store={extendingStore}>
+      <Probe store={BaseProvider} onResolve={(value) => resolved.push(value)} />
+    </ExtendingProvider>,
+  );
+
+  expect(resolved.at(-1)).toBe(extendingStore);
+});
+
+test("useStoreProp does not fall back when a provider component has no matching provider", async () => {
+  const { createProviderComponent } = createStoreContext();
+  const Provider = createProviderComponent(function Provider() {
+    return null;
+  });
+
+  const fallbackStore = createStore({});
+  const resolved: Array<Store | undefined> = [];
+
+  await render(
+    <Probe
+      store={Provider}
+      fallbacks={[fallbackStore]}
+      onResolve={(value) => resolved.push(value)}
+    />,
+  );
+
+  expect(resolved.at(-1)).toBeUndefined();
+});

--- a/packages/ariakit-react-utils/src/system.tsx
+++ b/packages/ariakit-react-utils/src/system.tsx
@@ -121,6 +121,10 @@ interface ProviderComponentValue<
  * in place of a store object. The store is then read from the closest context
  * of that provider's kind (set by that provider, an extending provider, or a
  * compatible container component), skipping less specific store contexts.
+ *
+ * If no such context is found, the store resolves to `undefined`. Components
+ * composed from multiple layers may still bind lower-level behavior to their
+ * own contexts in that case.
  */
 export interface ProviderComponent<T extends Store = Store> {
   readonly [providerComponentSymbol]: ProviderComponentBrand<T>;

--- a/packages/ariakit-react-utils/src/system.tsx
+++ b/packages/ariakit-react-utils/src/system.tsx
@@ -118,8 +118,9 @@ interface ProviderComponentValue<
 /**
  * A provider component (for example, `ComboboxProvider`) that can be passed to
  * store props and [`useStoreState`](https://ariakit.com/reference/use-store-state)
- * in place of a store object. The store is then read from the closest matching
- * provider via context.
+ * in place of a store object. The store is then read from the closest context
+ * of that provider's kind (set by that provider, an extending provider, or a
+ * compatible container component), skipping less specific store contexts.
  */
 export interface ProviderComponent<T extends Store = Store> {
   readonly [providerComponentSymbol]: ProviderComponentBrand<T>;
@@ -156,18 +157,22 @@ const emptyStoreContext = React.createContext<Store | undefined>(undefined);
 /**
  * Resolves the value of a `store` prop that may receive either a store object
  * or a provider component. When a provider component is passed, it's an
- * explicit reference to that specific provider: the store is read only from
- * the closest matching provider's context, without falling back to the given
- * fallback stores, so it may be `undefined` if no matching provider is found.
- * Otherwise, the store prop itself is returned, falling back to the given
- * fallback stores (typically the component's own context) when it's not
+ * explicit reference to that provider's context kind: the store is read only
+ * from the closest context of that kind (set by that provider, an extending
+ * provider, or a compatible container component), without falling back to the
+ * given fallback stores, so it may be `undefined` if no such context value is
+ * found. Otherwise, the store prop itself is returned, falling back to the
+ * given fallback stores (typically the component's own context) when it's not
  * provided.
  *
- * The store type is inferred only from the `store` prop; the fallback stores
- * are loosely typed so they never widen or poison that inference.
+ * The store type is inferred only from the store object arm of the `store`
+ * prop; the provider component arm and the fallback stores are loosely typed
+ * so they never widen or poison that inference. This matters for generic
+ * options (for example, renderers), whose provider arm is branded with the
+ * base store type.
  */
 export function useStoreProp<T extends Store>(
-  store: T | ProviderComponent<T> | null | undefined,
+  store: T | ProviderComponent | null | undefined,
   ...fallbacks: Array<Store | null | undefined>
 ): T | undefined;
 

--- a/packages/ariakit-react-utils/src/system.tsx
+++ b/packages/ariakit-react-utils/src/system.tsx
@@ -4,7 +4,7 @@
  */
 
 import type { Store } from "@ariakit/store";
-import type { AnyObject, EmptyObject } from "@ariakit/utils";
+import type { AnyFunction, AnyObject, EmptyObject } from "@ariakit/utils";
 import * as React from "react";
 import { useMergeRefs } from "./hooks.ts";
 import { getRefProperty, mergeProps } from "./misc.ts";
@@ -89,6 +89,109 @@ type StoreProvider<T extends Store> = React.ComponentType<{
 }>;
 
 /**
+ * Key used to brand provider components created by `createStoreContext` so
+ * store props and `useStoreState` can resolve them to their store context.
+ * `Symbol.for` is used so different copies of this module still recognize each
+ * other's provider components.
+ */
+export const providerComponentSymbol: unique symbol = Symbol.for(
+  "ariakit.provider-component",
+);
+
+interface ProviderComponentBrand<T extends Store = Store> {
+  /**
+   * Phantom property that carries the provider's store type. It makes provider
+   * components assignable to `ProviderComponent` types of base stores (for
+   * example, `ComboboxProvider` to `ProviderComponent<CompositeStore>`), which
+   * wouldn't be possible if the store type only appeared in the invariant
+   * `React.Context` position. Never set at runtime.
+   */
+  store?: T;
+}
+
+interface ProviderComponentValue<
+  T extends Store = Store,
+> extends ProviderComponentBrand<T> {
+  context: React.Context<T | undefined>;
+}
+
+/**
+ * A provider component (for example, `ComboboxProvider`) that can be passed to
+ * store props and [`useStoreState`](https://ariakit.com/reference/use-store-state)
+ * in place of a store object. The store is then read from the closest matching
+ * provider via context.
+ */
+export interface ProviderComponent<T extends Store = Store> {
+  readonly [providerComponentSymbol]: ProviderComponentBrand<T>;
+}
+
+/**
+ * Checks whether the value is a provider component created by
+ * `createStoreContext` (for example, `ComboboxProvider`).
+ */
+export function isProviderComponent<T extends Store>(
+  value: T | ProviderComponent<T> | null | undefined,
+): value is ProviderComponent<T>;
+
+export function isProviderComponent(value: unknown): value is ProviderComponent;
+
+export function isProviderComponent(
+  value: unknown,
+): value is ProviderComponent {
+  if (typeof value !== "function") return false;
+  return providerComponentSymbol in value;
+}
+
+function getProviderComponentContext<T extends Store>(
+  provider: ProviderComponent<T>,
+) {
+  // The brand slot is always created by createStoreContext with the context
+  // attached, so it can be safely narrowed to its full runtime shape.
+  const value = provider[providerComponentSymbol] as ProviderComponentValue<T>;
+  return value.context;
+}
+
+const emptyStoreContext = React.createContext<Store | undefined>(undefined);
+
+/**
+ * Resolves the value of a `store` prop that may receive either a store object
+ * or a provider component. When a provider component is passed, it's an
+ * explicit reference to that specific provider: the store is read only from
+ * the closest matching provider's context, without falling back to the given
+ * fallback stores, so it may be `undefined` if no matching provider is found.
+ * Otherwise, the store prop itself is returned, falling back to the given
+ * fallback stores (typically the component's own context) when it's not
+ * provided.
+ *
+ * The store type is inferred only from the `store` prop; the fallback stores
+ * are loosely typed so they never widen or poison that inference.
+ */
+export function useStoreProp<T extends Store>(
+  store: T | ProviderComponent<T> | null | undefined,
+  ...fallbacks: Array<Store | null | undefined>
+): T | undefined;
+
+export function useStoreProp(
+  store: Store | ProviderComponent | null | undefined,
+  ...fallbacks: Array<Store | null | undefined>
+): Store | undefined {
+  const isProvider = isProviderComponent(store);
+  // Hooks must be called unconditionally, so always read a context: the
+  // provider component's own context when the store is a provider component, or
+  // an always empty context otherwise (its value is always undefined).
+  const providerContext = isProvider
+    ? getProviderComponentContext(store)
+    : emptyStoreContext;
+  const contextStore = React.useContext(providerContext);
+  if (isProvider) return contextStore;
+  if (store) return store;
+  for (const fallback of fallbacks) {
+    if (fallback) return fallback;
+  }
+  return;
+}
+
+/**
  * Creates an Ariakit store context with hooks and provider components.
  */
 export function createStoreContext<T extends Store>(
@@ -138,6 +241,13 @@ export function createStoreContext<T extends Store>(
     );
   };
 
+  const createProviderComponent = <C extends AnyFunction>(
+    component: C,
+  ): C & ProviderComponent<T> => {
+    const value: ProviderComponentValue<T> = { context };
+    return Object.assign(component, { [providerComponentSymbol]: value });
+  };
+
   return {
     context,
     scopedContext,
@@ -146,5 +256,6 @@ export function createStoreContext<T extends Store>(
     useProviderContext,
     ContextProvider,
     ScopedContextProvider,
+    createProviderComponent,
   };
 }

--- a/packages/ariakit-react/src/store.ts
+++ b/packages/ariakit-react/src/store.ts
@@ -1,1 +1,2 @@
+export type { ProviderComponent } from "@ariakit/react-components/store";
 export { useStoreState } from "@ariakit/react-components/store";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,7 +145,7 @@ importers:
         version: 16.2.10(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       open-cli:
         specifier: 9.0.0
-        version: 9.0.0
+        version: 9.0.0(supports-color@8.1.1)
       oxfmt:
         specifier: 0.57.0
         version: 0.57.0
@@ -184,10 +184,10 @@ importers:
         version: 1.9.14
       stylelint:
         specifier: 17.14.0
-        version: 17.14.0(typescript@6.0.3)
+        version: 17.14.0(supports-color@8.1.1)(typescript@6.0.3)
       stylelint-config-standard:
         specifier: 40.0.0
-        version: 40.0.0(stylelint@17.14.0(typescript@6.0.3))
+        version: 40.0.0(stylelint@17.14.0(supports-color@8.1.1)(typescript@6.0.3))
       tailwindcss:
         specifier: 3.4.18
         version: 3.4.18(yaml@2.9.0)
@@ -196,7 +196,7 @@ importers:
         version: 1.0.7(tailwindcss@3.4.18(yaml@2.9.0))
       tsup:
         specifier: 8.5.1
-        version: 8.5.1(jiti@1.21.7)(postcss@8.5.8)(typescript@6.0.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.8)(supports-color@8.1.1)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -479,7 +479,7 @@ importers:
         version: 2.3.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@wordpress/components':
         specifier: 36.1.0
-        version: 36.1.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react@19.2.17)(esbuild@0.27.4)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(stylelint@17.14.0(typescript@6.0.3))(vite@8.1.3(@types/node@24.13.2)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(yaml@2.9.0))
+        version: 36.1.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react@19.2.17)(esbuild@0.27.4)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(stylelint@17.14.0(supports-color@8.1.1)(typescript@6.0.3))(vite@8.1.3(@types/node@24.13.2)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(yaml@2.9.0))
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -561,7 +561,7 @@ importers:
     devDependencies:
       '@opennextjs/cloudflare':
         specifier: 1.20.1
-        version: 1.20.1(encoding@0.1.13)(next@16.2.10(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(wrangler@4.107.0)
+        version: 1.20.1(encoding@0.1.13)(next@16.2.10(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(supports-color@8.1.1)(wrangler@4.107.0)
       '@tailwindcss/postcss':
         specifier: 4.3.2
         version: 4.3.2
@@ -678,9 +678,18 @@ importers:
       '@ariakit/scripts':
         specifier: workspace:*
         version: link:../ariakit-scripts
+      '@ariakit/test':
+        specifier: workspace:*
+        version: link:../ariakit-test
+      '@testing-library/react':
+        specifier: 16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: 19.2.7
         version: 19.2.7
+      react-dom:
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
 
   packages/ariakit-scripts:
     dependencies:
@@ -913,7 +922,7 @@ importers:
         version: 7.29.2
       '@babel/preset-env':
         specifier: 7.29.2
-        version: 7.29.2(@babel/core@7.29.0)
+        version: 7.29.2(@babel/core@7.29.0)(supports-color@8.1.1)
       '@babel/preset-react':
         specifier: 7.28.5
         version: 7.28.5(@babel/core@7.29.0)
@@ -1048,7 +1057,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       react-markdown:
         specifier: 8.0.7
-        version: 8.0.7(@types/react@18.3.28)(react@18.3.1)
+        version: 8.0.7(@types/react@18.3.28)(react@18.3.1)(supports-color@8.1.1)
       read-package-up:
         specifier: 12.0.0
         version: 12.0.0
@@ -11273,7 +11282,7 @@ snapshots:
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.0)':
+  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.28.6
@@ -11823,7 +11832,7 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/preset-env@7.29.2(@babel/core@7.29.0)':
+  '@babel/preset-env@7.29.2(@babel/core@7.29.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/compat-data': 7.29.0
       '@babel/core': 7.29.0
@@ -11891,7 +11900,7 @@ snapshots:
       '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.29.0)
       '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.0)
-      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.0)
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.0)(supports-color@8.1.1)
       babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.0)
       babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.0)
       core-js-compat: 3.49.0
@@ -13095,7 +13104,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@opennextjs/aws@4.0.2(next@16.2.10(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@opennextjs/aws@4.0.2(next@16.2.10(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(supports-color@8.1.1)':
     dependencies:
       '@ast-grep/napi': 0.40.5
       '@aws-sdk/client-cloudfront': 3.984.0
@@ -13110,7 +13119,7 @@ snapshots:
       chalk: 5.6.2
       cookie: 1.1.1
       esbuild: 0.25.4
-      express: 5.2.1
+      express: 5.2.1(supports-color@8.1.1)
       next: 16.2.10(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       path-to-regexp: 6.3.0
       urlpattern-polyfill: 10.1.0
@@ -13119,11 +13128,11 @@ snapshots:
       - aws-crt
       - supports-color
 
-  '@opennextjs/cloudflare@1.20.1(encoding@0.1.13)(next@16.2.10(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(wrangler@4.107.0)':
+  '@opennextjs/cloudflare@1.20.1(encoding@0.1.13)(next@16.2.10(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(supports-color@8.1.1)(wrangler@4.107.0)':
     dependencies:
       '@ast-grep/napi': 0.40.5
       '@dotenvx/dotenvx': 1.31.0
-      '@opennextjs/aws': 4.0.2(next@16.2.10(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@opennextjs/aws': 4.0.2(next@16.2.10(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(supports-color@8.1.1)
       ci-info: 4.4.0
       cloudflare: 4.5.0(encoding@0.1.13)
       comment-json: 4.6.2
@@ -14300,7 +14309,7 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@tokenizer/inflate@0.4.1':
+  '@tokenizer/inflate@0.4.1(supports-color@8.1.1)':
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       token-types: 6.1.2
@@ -14808,7 +14817,7 @@ snapshots:
 
   '@wordpress/base-styles@10.2.0': {}
 
-  '@wordpress/components@36.1.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react@19.2.17)(esbuild@0.27.4)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(stylelint@17.14.0(typescript@6.0.3))(vite@8.1.3(@types/node@24.13.2)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(yaml@2.9.0))':
+  '@wordpress/components@36.1.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react@19.2.17)(esbuild@0.27.4)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(stylelint@17.14.0(supports-color@8.1.1)(typescript@6.0.3))(vite@8.1.3(@types/node@24.13.2)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(yaml@2.9.0))':
     dependencies:
       '@ariakit/react': link:packages/ariakit-react
       '@date-fns/utc': 2.1.1
@@ -14840,7 +14849,7 @@ snapshots:
       '@wordpress/private-apis': 1.50.0
       '@wordpress/rich-text': 7.50.0(@types/react@19.2.17)(react@19.2.7)
       '@wordpress/style-runtime': 0.6.0
-      '@wordpress/ui': 0.17.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.4.0)(esbuild@0.27.4)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(stylelint@17.14.0(typescript@6.0.3))(vite@8.1.3(@types/node@24.13.2)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(yaml@2.9.0))
+      '@wordpress/ui': 0.17.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.4.0)(esbuild@0.27.4)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(stylelint@17.14.0(supports-color@8.1.1)(typescript@6.0.3))(vite@8.1.3(@types/node@24.13.2)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(yaml@2.9.0))
       '@wordpress/warning': 3.50.0
       change-case: 4.1.2
       clsx: 2.1.1
@@ -15012,7 +15021,7 @@ snapshots:
 
   '@wordpress/style-runtime@0.6.0': {}
 
-  '@wordpress/theme@0.17.0(@types/react@19.2.17)(esbuild@0.27.4)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(stylelint@17.14.0(typescript@6.0.3))(vite@8.1.3(@types/node@24.13.2)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(yaml@2.9.0))':
+  '@wordpress/theme@0.17.0(@types/react@19.2.17)(esbuild@0.27.4)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(stylelint@17.14.0(supports-color@8.1.1)(typescript@6.0.3))(vite@8.1.3(@types/node@24.13.2)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(yaml@2.9.0))':
     dependencies:
       '@wordpress/compose': 8.3.0(@types/react@19.2.17)(react@19.2.7)
       '@wordpress/deprecated': 4.50.0
@@ -15027,10 +15036,10 @@ snapshots:
       '@types/react': 19.2.17
       esbuild: 0.27.4
       postcss: 8.5.16
-      stylelint: 17.14.0(typescript@6.0.3)
+      stylelint: 17.14.0(supports-color@8.1.1)(typescript@6.0.3)
       vite: 8.1.3(@types/node@24.13.2)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(yaml@2.9.0)
 
-  '@wordpress/ui@0.17.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.4.0)(esbuild@0.27.4)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(stylelint@17.14.0(typescript@6.0.3))(vite@8.1.3(@types/node@24.13.2)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(yaml@2.9.0))':
+  '@wordpress/ui@0.17.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.4.0)(esbuild@0.27.4)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(stylelint@17.14.0(supports-color@8.1.1)(typescript@6.0.3))(vite@8.1.3(@types/node@24.13.2)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(yaml@2.9.0))':
     dependencies:
       '@base-ui/react': 1.5.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@wordpress/a11y': 4.50.0
@@ -15042,7 +15051,7 @@ snapshots:
       '@wordpress/primitives': 4.50.0(@types/react@19.2.17)(react@19.2.7)
       '@wordpress/private-apis': 1.50.0
       '@wordpress/style-runtime': 0.6.0
-      '@wordpress/theme': 0.17.0(@types/react@19.2.17)(esbuild@0.27.4)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(stylelint@17.14.0(typescript@6.0.3))(vite@8.1.3(@types/node@24.13.2)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(yaml@2.9.0))
+      '@wordpress/theme': 0.17.0(@types/react@19.2.17)(esbuild@0.27.4)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(stylelint@17.14.0(supports-color@8.1.1)(typescript@6.0.3))(vite@8.1.3(@types/node@24.13.2)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(yaml@2.9.0))
       clsx: 2.1.1
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -15346,11 +15355,11 @@ snapshots:
       cosmiconfig: 7.1.0
       resolve: 1.22.11
 
-  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0):
+  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0)(supports-color@8.1.1):
     dependencies:
       '@babel/compat-data': 7.29.0
       '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -15358,7 +15367,7 @@ snapshots:
   babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.0):
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)(supports-color@8.1.1)
       core-js-compat: 3.49.0
     transitivePeerDependencies:
       - supports-color
@@ -15366,7 +15375,7 @@ snapshots:
   babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.0):
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -15421,7 +15430,7 @@ snapshots:
 
   blake3-wasm@2.1.5: {}
 
-  body-parser@2.2.2:
+  body-parser@2.2.2(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
@@ -16164,10 +16173,10 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express@5.2.1:
+  express@5.2.1(supports-color@8.1.1):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2
+      body-parser: 2.2.2(supports-color@8.1.1)
       content-disposition: 1.0.1
       content-type: 1.0.5
       cookie: 0.7.2
@@ -16177,7 +16186,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@8.1.1)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -16188,8 +16197,8 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.0
       range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.1
+      router: 2.2.0(supports-color@8.1.1)
+      send: 1.2.1(supports-color@8.1.1)
       serve-static: 2.2.1
       statuses: 2.0.2
       type-is: 2.0.1
@@ -16259,9 +16268,9 @@ snapshots:
     dependencies:
       flat-cache: 6.1.22
 
-  file-type@21.3.4:
+  file-type@21.3.4(supports-color@8.1.1):
     dependencies:
-      '@tokenizer/inflate': 0.4.1
+      '@tokenizer/inflate': 0.4.1(supports-color@8.1.1)
       strtok3: 10.3.5
       token-types: 6.1.2
       uint8array-extras: 1.5.0
@@ -16272,7 +16281,7 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
@@ -17269,13 +17278,13 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  mdast-util-from-markdown@1.3.1:
+  mdast-util-from-markdown@1.3.1(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 3.0.15
       '@types/unist': 2.0.11
       decode-named-character-reference: 1.3.0
       mdast-util-to-string: 3.2.0
-      micromark: 3.2.0
+      micromark: 3.2.0(supports-color@8.1.1)
       micromark-util-decode-numeric-character-reference: 1.1.0
       micromark-util-decode-string: 1.1.0
       micromark-util-normalize-identifier: 1.1.0
@@ -17351,7 +17360,7 @@ snapshots:
     dependencies:
       '@types/mdast': 3.0.15
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 1.3.1
+      mdast-util-from-markdown: 1.3.1(supports-color@8.1.1)
       mdast-util-to-markdown: 1.5.0
     transitivePeerDependencies:
       - supports-color
@@ -17382,7 +17391,7 @@ snapshots:
 
   mdast-util-gfm@2.0.2:
     dependencies:
-      mdast-util-from-markdown: 1.3.1
+      mdast-util-from-markdown: 1.3.1(supports-color@8.1.1)
       mdast-util-gfm-autolink-literal: 1.0.3
       mdast-util-gfm-footnote: 1.0.2
       mdast-util-gfm-strikethrough: 1.0.3
@@ -17948,7 +17957,7 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@3.2.0:
+  micromark@3.2.0(supports-color@8.1.1):
     dependencies:
       '@types/debug': 4.1.12
       debug: 4.4.3(supports-color@8.1.1)
@@ -18268,9 +18277,9 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  open-cli@9.0.0:
+  open-cli@9.0.0(supports-color@8.1.1):
     dependencies:
-      file-type: 21.3.4
+      file-type: 21.3.4(supports-color@8.1.1)
       meow: 14.1.0
       open: 11.0.0
       tempy: 3.2.0
@@ -18756,7 +18765,7 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-markdown@8.0.7(@types/react@18.3.28)(react@18.3.1):
+  react-markdown@8.0.7(@types/react@18.3.28)(react@18.3.1)(supports-color@8.1.1):
     dependencies:
       '@types/hast': 2.3.10
       '@types/prop-types': 15.7.15
@@ -18768,7 +18777,7 @@ snapshots:
       property-information: 6.5.0
       react: 18.3.1
       react-is: 18.3.1
-      remark-parse: 10.0.2
+      remark-parse: 10.0.2(supports-color@8.1.1)
       remark-rehype: 10.1.0
       space-separated-tokens: 2.0.2
       style-to-object: 0.4.4
@@ -19052,10 +19061,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  remark-parse@10.0.2:
+  remark-parse@10.0.2(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 3.0.15
-      mdast-util-from-markdown: 1.3.1
+      mdast-util-from-markdown: 1.3.1(supports-color@8.1.1)
       unified: 10.1.2
     transitivePeerDependencies:
       - supports-color
@@ -19232,7 +19241,7 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
-  router@2.2.0:
+  router@2.2.0(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
@@ -19310,7 +19319,7 @@ snapshots:
 
   semver@7.7.4: {}
 
-  send@1.2.1:
+  send@1.2.1(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
@@ -19343,7 +19352,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -19643,16 +19652,16 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.0
 
-  stylelint-config-recommended@18.0.0(stylelint@17.14.0(typescript@6.0.3)):
+  stylelint-config-recommended@18.0.0(stylelint@17.14.0(supports-color@8.1.1)(typescript@6.0.3)):
     dependencies:
-      stylelint: 17.14.0(typescript@6.0.3)
+      stylelint: 17.14.0(supports-color@8.1.1)(typescript@6.0.3)
 
-  stylelint-config-standard@40.0.0(stylelint@17.14.0(typescript@6.0.3)):
+  stylelint-config-standard@40.0.0(stylelint@17.14.0(supports-color@8.1.1)(typescript@6.0.3)):
     dependencies:
-      stylelint: 17.14.0(typescript@6.0.3)
-      stylelint-config-recommended: 18.0.0(stylelint@17.14.0(typescript@6.0.3))
+      stylelint: 17.14.0(supports-color@8.1.1)(typescript@6.0.3)
+      stylelint-config-recommended: 18.0.0(stylelint@17.14.0(supports-color@8.1.1)(typescript@6.0.3))
 
-  stylelint@17.14.0(typescript@6.0.3):
+  stylelint@17.14.0(supports-color@8.1.1)(typescript@6.0.3):
     dependencies:
       '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
@@ -19934,7 +19943,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@1.21.7)(postcss@8.5.8)(typescript@6.0.3)(yaml@2.9.0):
+  tsup@8.5.1(jiti@1.21.7)(postcss@8.5.8)(supports-color@8.1.1)(typescript@6.0.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.4)
       cac: 6.7.14

--- a/website/build-pages/reference-utils.js
+++ b/website/build-pages/reference-utils.js
@@ -32,7 +32,14 @@ export function getReferences(filename) {
     const decl = decls.at(0);
     if (!decl) continue;
     if (Node.isVariableDeclaration(decl)) {
-      const options = exportedDecls.get(`${name}Options`)?.at(0);
+      // Prefer the `${name}Options` type, falling back to `${name}Props`. The
+      // latter matters for provider components, which expose a `${name}Props`
+      // type and are exported as `const X = createXProvider(function X() {})`.
+      // The function-parameter fallback can't reach the wrapped function
+      // expression, so the props must come from the type here.
+      const options =
+        exportedDecls.get(`${name}Options`)?.at(0) ??
+        exportedDecls.get(`${name}Props`)?.at(0);
       references.push(getReference(filename, decl, options));
     } else if (Node.isFunctionDeclaration(decl)) {
       references.push(getReference(filename, decl));

--- a/website/build-pages/reference-utils.test.ts
+++ b/website/build-pages/reference-utils.test.ts
@@ -53,3 +53,16 @@ test("uses typed destructured props parameters as reference props", () => {
   expect(comboboxProps).toContain("children");
   expect(headingProps).toContain("level");
 });
+
+test("uses the props type for branded provider const exports", () => {
+  // Provider components are exported as `const X = createXProvider(function
+  // X() {})` and expose a `XProviderProps` type instead of `XProviderOptions`.
+  // Their props must still be resolved from that type.
+  const props = getReference(comboboxFilename, "ComboboxProvider").props.map(
+    (prop) => {
+      return prop.name;
+    },
+  );
+
+  expect(props).toContain("virtualFocus");
+});


### PR DESCRIPTION
## Motivation

Ariakit components resolve their store from the closest compatible context when a `store` prop isn't passed. Because many stores extend one another (for example, `ToolbarProvider` implements a composite store), a component like `CompositeItem` implicitly binds to whatever compatible provider happens to be nearest, with no way to say "use _this_ provider instead".

```tsx
<ComboboxProvider>
  <ToolbarProvider>
    {/* Implicitly binds to the closer ToolbarProvider. There was no way to
        target the outer ComboboxProvider without passing a store object. */}
    <CompositeItem />
  </ToolbarProvider>
</ComboboxProvider>
```

We want to let people be explicit about which provider a component reads from, and eventually stop relying on the implicit "read the nearest extending provider" behavior.

## Solution

Store props and the store-state hooks now accept a **provider component** (for example, `ComboboxProvider`) in place of a store object. When a provider component is passed, the store is read from the closest matching provider through that provider's own context, and nothing else: there is no fallback to other compatible contexts, so the reference is unambiguous.

```tsx
<ComboboxProvider>
  <ToolbarProvider>
    {/* Explicitly reads from the closest ComboboxProvider, even though the
        ToolbarProvider is closer. */}
    <CompositeItem store={ComboboxProvider} />
  </ToolbarProvider>
</ComboboxProvider>
```

The same works with [`useStoreState`](https://ariakit.com/reference/use-store-state) and `useStoreStateObject`:

```tsx
const value = useStoreState(ComboboxProvider, "value");
```

### Changes

- Provider components are now branded with their store context (`createStoreContext` gains a `createProviderComponent` helper). A new `useStoreProp` hook resolves a `store` prop that may be either a store object or a provider component, and an exported `ProviderComponent` type and `isProviderComponent` guard back the machinery.
- Every component `store` prop is widened to `Store | ProviderComponent<Store>` and resolves provider components. Some presentational components declare a `store` prop by convention without consuming it yet; those props are widened for consistency (and to stay non-breaking if wired up later) but are not documented as resolving a provider.
- `useStoreState` and `useStoreStateObject` accept provider components and resolve them via context.
- When a provider component is passed but no matching provider is found, the store resolves to `undefined`, so the existing "must be wrapped in a provider" invariants still fire.

This is an additive change: passing a store object or omitting the prop behaves exactly as before.
