### PR TITLE
Group solid-js and solid-primitives in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -48,6 +48,14 @@
       "matchPackageNames": ["astro", "/^@astrojs\\//"]
     },
     {
+      "groupName": "solid",
+      "matchPackageNames": [
+        "solid-js",
+        "/^@solidjs\\//",
+        "/^@solid-primitives\\//"
+      ]
+    },
+    {
       "groupName": "changesets",
       "matchPackageNames": ["/^@changesets\\//"]
     },


### PR DESCRIPTION
## Motivation

Renovate already groups related dependencies (unified, astro, react, etc.) so their updates land in a single PR. The Solid dependencies (`solid-js` and `@solid-primitives/*`) were ungrouped, so each produced a separate update PR even though they are typically bumped together.

## Solution

Add a `solid` package rule grouping `solid-js`, `@solidjs/*`, and `@solid-primitives/*` together:

```json
{
  "groupName": "solid",
  "matchPackageNames": [
    "solid-js",
    "/^@solidjs\\//",
    "/^@solid-primitives\\//"
  ]
}
```
