### PR TITLE
Fix Plus checkout submit selector

### DIFF
--- a/website/tests/ariakit-plus.ts
+++ b/website/tests/ariakit-plus.ts
@@ -281,7 +281,7 @@ for (const plan of ["month", "year"] as const) {
     expect(checkoutPrice).toBe(nextPrice);
 
     await fillCheckout(page, email);
-    await fq.button("Pay").click();
+    await fq.button(/^Pay$/).click();
     await expect(q.text("Purchased")).toBeVisible({ timeout: 10000 });
 
     const stripe = getStripeClient();
@@ -334,7 +334,7 @@ test("purchase Plus from /plus, sign out, sign in again, and access the billing 
   const frame = await fillCheckout(page, email);
   const fq = query(frame);
 
-  await fq.button("Pay").click();
+  await fq.button(/^Pay$/).click();
   await expect(q.text("Purchased")).toBeVisible({ timeout: 10000 });
 
   await page.goto("/", { waitUntil: "networkidle" });
@@ -383,7 +383,7 @@ test("purchase Plus from /components, sign out, sign in again, and access the bi
   const frame = await fillCheckout(page, email);
   const fq = query(frame);
 
-  await fq.button("Pay").click();
+  await fq.button(/^Pay$/).click();
   await expect(q.text("Purchased")).toBeVisible({ timeout: 10000 });
 
   await expect(async () => {


### PR DESCRIPTION
## Motivation

Stripe's embedded checkout now exposes additional payment method controls whose accessible names include `Pay`, such as `Pay with card` and `Pay with Bank`. The Plus Playwright tests use `getByRole("button", { name: "Pay" })` through the local query helper, so Playwright strict mode now sees multiple matching buttons before the checkout submit button can be clicked.

## Solution

Update the three Plus checkout submit clicks to use an exact regex, `/^Pay$/`, so the tests continue to target the real submit button while allowing Stripe to display additional `Pay`-prefixed payment method controls.
