### PR TITLE
Fix collection store item() dropping items state metadata

### DIFF
--- a/app/src/sandbox/collection-6295/index.react.tsx
+++ b/app/src/sandbox/collection-6295/index.react.tsx
@@ -1,0 +1,75 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/6295
+//
+// The controlled `items` state is the source of truth for item metadata
+// (label), but `collection.item(id)` drops it: rendered items resolve to the
+// bare registration object, controlled updates are ignored, and items added
+// to the state without rendering aren't found at all.
+
+interface FruitItem {
+  id: string;
+  label: string;
+  hidden?: boolean;
+  element?: HTMLElement | null;
+}
+
+export default function Example() {
+  const [items, setItems] = useState<FruitItem[]>([
+    { id: "apple", label: "Apple" },
+    { id: "grape", label: "Grape" },
+    { id: "orange", label: "Orange" },
+  ]);
+  const [details, setDetails] = useState("");
+  const collection = Ariakit.useCollectionStore({ items, setItems });
+
+  function renameApple() {
+    setItems((prevItems) =>
+      prevItems.map((item) =>
+        item.id === "apple" ? { ...item, label: "Green Apple" } : item,
+      ),
+    );
+  }
+
+  function addKiwi() {
+    setItems((prevItems) => [
+      ...prevItems,
+      { id: "kiwi", label: "Kiwi", hidden: true },
+    ]);
+  }
+
+  function showDetails(id: string) {
+    const item = collection.item(id);
+    setDetails(item?.label ?? "Item not found");
+  }
+
+  return (
+    <div>
+      <Ariakit.Collection store={collection}>
+        {items
+          .filter((item) => !item.hidden)
+          .map((item) => (
+            <Ariakit.CollectionItem
+              key={item.id}
+              id={item.id}
+              render={<button type="button" />}
+              onClick={() => showDetails(item.id)}
+            >
+              {item.label}
+            </Ariakit.CollectionItem>
+          ))}
+      </Ariakit.Collection>
+      <button type="button" onClick={renameApple}>
+        Rename Apple
+      </button>
+      <button type="button" onClick={addKiwi}>
+        Add Kiwi
+      </button>
+      <button type="button" onClick={() => showDetails("kiwi")}>
+        Show Kiwi details
+      </button>
+      <output>{details}</output>
+    </div>
+  );
+}

--- a/app/src/sandbox/collection-6295/index.react.tsx
+++ b/app/src/sandbox/collection-6295/index.react.tsx
@@ -40,7 +40,13 @@ export default function Example() {
   }
 
   function showDetails(id: string) {
-    const item = collection.item(id);
+    // TODO: Remove this workaround once
+    // https://github.com/ariakit/ariakit/issues/6295 is fixed. The items state
+    // is the source of truth for item metadata, so look the item up there
+    // instead of using collection.item(id).
+    const item = collection
+      .getState()
+      .items.find((stateItem) => stateItem.id === id);
     setDetails(item?.label ?? "Item not found");
   }
 

--- a/app/src/sandbox/collection-6295/test-browser.ts
+++ b/app/src/sandbox/collection-6295/test-browser.ts
@@ -1,0 +1,26 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// https://github.com/ariakit/ariakit/issues/6295
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("item() returns the metadata listed in the items state", async ({
+    q,
+  }) => {
+    await q.button("Apple").click();
+    await test.expect(q.status()).toHaveText("Apple");
+  });
+
+  test("item() reflects controlled items updates", async ({ q }) => {
+    await q.button("Rename Apple").click();
+    await q.button("Green Apple").click();
+    await test.expect(q.status()).toHaveText("Green Apple");
+  });
+
+  test("item() finds items added to the items state without rendering", async ({
+    q,
+  }) => {
+    await q.button("Add Kiwi").click();
+    await test.expect(q.button("Kiwi")).not.toBeAttached();
+    await q.button("Show Kiwi details").click();
+    await test.expect(q.status()).toHaveText("Kiwi");
+  });
+});

--- a/app/src/sandbox/collection-6295/test.ts
+++ b/app/src/sandbox/collection-6295/test.ts
@@ -1,0 +1,21 @@
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// https://github.com/ariakit/ariakit/issues/6295
+test("item() returns the metadata listed in the items state", async () => {
+  await click(q.button("Apple"));
+  expect(q.status()).toHaveTextContent(/^Apple$/);
+});
+
+test("item() reflects controlled items updates", async () => {
+  await click(q.button("Rename Apple"));
+  await click(q.button("Green Apple"));
+  expect(q.status()).toHaveTextContent(/^Green Apple$/);
+});
+
+test("item() finds items added to the items state without rendering", async () => {
+  await click(q.button("Add Kiwi"));
+  expect(q.button("Kiwi")).not.toBeInTheDocument();
+  await click(q.button("Show Kiwi details"));
+  expect(q.status()).toHaveTextContent(/^Kiwi$/);
+});


### PR DESCRIPTION
## Motivation

`collection.item(id)` can disagree with the collection's own `items` state. With a collection whose items carry custom metadata — the pattern supported by the typed `useCollectionStore` overload that requires `items`/`defaultItems` — the lookup drops metadata that `getState().items` plainly lists:

- As soon as an item is rendered by `CollectionItem`, `item(id)` returns only the bare `{ id, element }` registration object, losing metadata provided through the `items` prop.
- Updating an item's metadata through the controlled `items`/`setItems` state is visible in the rendered list, but `item(id)` still returns the stale object.
- Items added purely through the `items` state (or `store.setState("items", ...)`) that never render aren't found at all.

```tsx
const collection = Ariakit.useCollectionStore({ items, setItems });
// items: [{ id: "apple", label: "Apple" }, ...]
collection.item("apple")?.label; // undefined — expected "Apple"
```

Fixes #6295.

## Solution

The sandbox in `app/src/sandbox/collection-6295` reproduces the user-visible flow from the issue: click a rendered collection item to look it up through `item()`, rename it through the controlled state and look it up again, and look up an item added to the `items` state that never renders. Coverage includes the cross-browser Playwright test and a happy-dom duplicate; all fail on `main`.

The library fix will follow in this PR; this description will be updated with the final approach.

## Workaround

Until the fix is released, don't use `item()` when item metadata lives in the `items` state — look the item up in the state directly:

```tsx
function showDetails(id: string) {
  // TODO: Remove this workaround once
  // https://github.com/ariakit/ariakit/issues/6295 is fixed.
  const item = collection
    .getState()
    .items.find((stateItem) => stateItem.id === id);
  setDetails(item?.label ?? "Item not found");
}
```

This covers all three legs above (rendered items, controlled updates, and state-only items that never render). Note that `getState().items` reflects the `items` state only: for items that just registered in the same tick, the state may not include the rendered `element` yet, so keep using `item(id)` when you only need the registration data (`id`/`element`).
