### PR TITLE
Improve Tailwind layer rendering performance

### DIFF
--- a/.changeset/200-tailwind-layer-contrast-performance.md
+++ b/.changeset/200-tailwind-layer-contrast-performance.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/tailwind": patch
+---
+
+Improved layer rendering performance by only calculating parent-relative contrast for elements using the `ak-layer-contrast` utility.

--- a/app/src/sandbox/ariakit-tailwind-layer-contrast-fallback/index.react.tsx
+++ b/app/src/sandbox/ariakit-tailwind-layer-contrast-fallback/index.react.tsx
@@ -1,0 +1,43 @@
+import "./style.css";
+
+export default function Example() {
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <div className="[--_ak-ll:transparent] flex gap-4">
+        <section
+          aria-label="Layer without contrast"
+          className="ak-layer ak-layer-gray-950 p-4"
+        />
+        <section
+          aria-label="Layer with unmatched contrast"
+          className="ak-layer ak-layer-gray-950 ak-layer-contrast p-4"
+        />
+        <section
+          aria-label="Pushed layer without contrast"
+          className="ak-layer ak-layer-gray-950 ak-layer-push-50 p-4"
+        />
+        <section
+          aria-label="Pushed layer with unmatched contrast"
+          className="ak-layer ak-layer-gray-950 ak-layer-push-50 ak-layer-contrast p-4"
+        />
+      </div>
+      <section className="ak-layer ak-layer-l-0 flex gap-4 p-4">
+        <section className="ak-layer ak-layer-gray-950 p-4">
+          <section
+            aria-label="Nested pushed layer control"
+            className="ak-layer ak-layer-gray-950 ak-layer-push-50 p-4"
+          />
+        </section>
+        <section
+          aria-label="Matched contrast parent"
+          className="ak-layer ak-layer-gray-950 ak-layer-contrast p-4"
+        >
+          <section
+            aria-label="Nested pushed layer under contrast"
+            className="ak-layer ak-layer-gray-950 ak-layer-push-50 p-4"
+          />
+        </section>
+      </section>
+    </div>
+  );
+}

--- a/app/src/sandbox/ariakit-tailwind-layer-contrast-fallback/style.css
+++ b/app/src/sandbox/ariakit-tailwind-layer-contrast-fallback/style.css
@@ -1,0 +1,23 @@
+@import "tailwindcss" source(none);
+@import "@ariakit/tailwind";
+
+@source "./index.react.tsx";
+
+@theme {
+  --spacing: 0.25rem;
+  --spacing-px: 1px;
+  --radius: 0.25rem;
+}
+
+@theme inline {
+  --radius-none: 0;
+  --radius-xs: calc(var(--radius) * 0.5);
+  --radius-sm: calc(var(--radius) * 1);
+  --radius-md: calc(var(--radius) * 1.5);
+  --radius-lg: calc(var(--radius) * 2);
+  --radius-xl: calc(var(--radius) * 3);
+  --radius-2xl: calc(var(--radius) * 4);
+  --radius-3xl: calc(var(--radius) * 6);
+  --radius-4xl: calc(var(--radius) * 8);
+  --radius-full: calc(var(--radius) * infinity);
+}

--- a/app/src/sandbox/ariakit-tailwind-layer-contrast-fallback/test-chrome.ts
+++ b/app/src/sandbox/ariakit-tailwind-layer-contrast-fallback/test-chrome.ts
@@ -1,0 +1,51 @@
+import { expect } from "@playwright/test";
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("preserves contrast bias without quantized parent lightness", async ({
+    page,
+    q,
+  }) => {
+    await page.emulateMedia({ contrast: "more" });
+
+    const control = q.region("Layer without contrast");
+    const contrast = q.region("Layer with unmatched contrast");
+    const getBackgroundColor = (element: HTMLElement) =>
+      getComputedStyle(element).backgroundColor;
+
+    await expect(contrast).toHaveCSS("--_ak-lcd", "0");
+    expect(await contrast.evaluate(getBackgroundColor)).toBe(
+      await control.evaluate(getBackgroundColor),
+    );
+    expect(
+      await q
+        .region("Pushed layer with unmatched contrast")
+        .evaluate(getBackgroundColor),
+    ).toBe(
+      await q
+        .region("Pushed layer without contrast")
+        .evaluate(getBackgroundColor),
+    );
+  });
+
+  test("does not inherit contrast direction into nested pushed layers", async ({
+    page,
+    q,
+  }) => {
+    await page.emulateMedia({ contrast: "more" });
+
+    const contrastParent = q.region("Matched contrast parent");
+    const control = q.region("Nested pushed layer control");
+    const nested = q.region("Nested pushed layer under contrast");
+    const getCustomProperty = (element: HTMLElement) =>
+      getComputedStyle(element).getPropertyValue("--_ak-lcd").trim();
+    const getBackgroundColor = (element: HTMLElement) =>
+      getComputedStyle(element).backgroundColor;
+
+    expect(await contrastParent.evaluate(getCustomProperty)).not.toBe("0");
+    await expect(nested).toHaveCSS("--_ak-lcd", "0");
+    expect(await nested.evaluate(getBackgroundColor)).toBe(
+      await control.evaluate(getBackgroundColor),
+    );
+  });
+});

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -609,8 +609,14 @@ const layerColorVars = {
 };
 
 const layerContrastMathVars = {
+  // This value is also read by layer push utilities and must not inherit from
+  // contrast ancestors.
   layerContrastDirection: _ak.prop.zero("lcd"),
-  layerContrastParentL: _ak.prop.zero("lcpl"),
+  // This scratch value is reset and consumed only by ak-layer-contrast.
+  layerContrastParentL: _ak.var("lcpl", 0),
+  // Keep the resolved value non-inherited so ordinary nested layers use the
+  // cheaper fallback instead of their parent's contrast calculation.
+  layerContrastL: _ak.prop("lcl"),
 };
 
 const outlineMathVars = {
@@ -1127,25 +1133,26 @@ const layerIdleOffset = fn.oklch(layerIdleMixed, {
 });
 
 /**
- * Computes parent-relative contrast lightness. When `ak-layer-contrast` is
- * active (layerContrastDirection !== 0), derives the target lightness from the
- * parent layer's lightness rather than the current color's lightness. Falls
- * back to the self-relative `selfRelativeL` when inactive.
+ * Computes parent-relative lightness for `ak-layer-contrast`.
  */
-function getContrastL(selfRelativeL: Value, contrastValue: Value) {
+function getParentContrastL(contrastValue: Value) {
   const direction = vars.layerContrastDirection;
-  // Use the contrast value as the shift magnitude, pushed in the parent-
-  // relative direction (positive = lighter, negative = darker).
   const parentShift = fn.mul(contrastValue, direction);
   const parentTargetL = fn.clamp01(
     fn.add(vars.layerContrastParentL, parentShift),
   );
-  const parentDirectedL = getDirectionalLightness(l, parentTargetL, direction);
-  // When ak-layer-contrast is active, direction is ±1 so |direction|=1.
-  // When inactive, direction=0. Use this as a blend mask.
+  return getDirectionalLightness(l, parentTargetL, direction);
+}
+
+/**
+ * Uses parent-relative contrast when a quantized parent lightness matches,
+ * otherwise preserves the ordinary layer lightness.
+ */
+function getContrastL(selfRelativeL: Value, contrastValue: Value) {
+  const direction = vars.layerContrastDirection;
   const isActive = fn.mul(direction, direction);
   return fn.add(
-    fn.mul(parentDirectedL, isActive),
+    fn.mul(getParentContrastL(contrastValue), isActive),
     fn.mul(selfRelativeL, fn.sub(1, isActive)),
   );
 }
@@ -1158,12 +1165,13 @@ const layerIdleContrastBias = fn.mul(
   vars.layerContrastBias,
   layerContrastInactive,
 );
+const layerIdleFallbackL = fn.add(
+  l,
+  fn.mul(vars.layerContrastBias, fn.sub(1, vars.layerIdlePushEnabled)),
+);
 
 const layerIdle = fn.oklch(vars.layerIdleOffset, {
-  l: fn.add(
-    getContrastL(l, getPushValue(inputs.layerIdleContrastL)),
-    fn.mul(layerIdleContrastBias, fn.sub(1, vars.layerIdlePushEnabled)),
-  ),
+  l: fn.var(vars.layerContrastL, layerIdleFallbackL),
 });
 
 const layerState = fn.oklch(fn.oklch(vars.layerIdle, stateLayerChannels), {
@@ -1493,6 +1501,11 @@ utility(
 utility(
   "layer-contrast",
   set(inputs.layerIdleContrastL, 0.25),
+  set(vars.layerContrastParentL, 0),
+  set(
+    vars.layerContrastL,
+    getContrastL(layerIdleFallbackL, getPushValue(inputs.layerIdleContrastL)),
+  ),
   mapLayerLightnessSteps((parentL, isDark) => [
     set(vars.layerContrastDirection, isDark ? 1 : -1),
     set(vars.layerContrastParentL, parentL),

--- a/packages/ariakit-tailwind/src/output.css
+++ b/packages/ariakit-tailwind/src/output.css
@@ -134,7 +134,7 @@
   --_ak-ecv: calc(var(--_ak-ct) * 0.3334);
   --_ak-lib: oklch(from var(--_ak-layer-color, var(--ak-layer-parent, canvas)) var(--_ak-layer-lightness, calc(l + var(--_ak-layer-idle-relative-lightness) + (clamp(0, (var(--_ak-layer-idle-relative-lightness) * 1000000), 1) * var(--_ak-llfb)))) var(--_ak-layer-chroma, calc(c + var(--_ak-layer-idle-relative-chroma))) var(--_ak-layer-hue, calc(h + var(--_ak-layer-idle-relative-hue))));
   --_ak-lio: oklch(from var(--_ak-layer-mix, var(--_ak-lib)) var(--_ak-liprl, var(--_ak-layer-idle-lightness-offset-resolved, clamp(var(--_ak-layer-lightness-min), (l + var(--_ak-layer-idle-lightness-offset) + (clamp(0, (var(--_ak-layer-idle-lightness-offset) * 1000000), 1) * var(--_ak-llfb))), var(--_ak-layer-lightness-max)))) c h);
-  --_ak-li: oklch(from var(--_ak-lio) calc((((l + (var(--_ak-lcd) * max(0, ((clamp(0, (var(--_ak-lcpl) + ((var(--_ak-layer-idle-contrast-lightness) * var(--_ak-cps)) * var(--_ak-lcd))), 1) - l) * var(--_ak-lcd))))) * (var(--_ak-lcd) * var(--_ak-lcd))) + (l * (1 - (var(--_ak-lcd) * var(--_ak-lcd))))) + ((var(--_ak-lcb) * (1 - (var(--_ak-lcd) * var(--_ak-lcd)))) * (1 - var(--_ak-lipe)))) c h);
+  --_ak-li: oklch(from var(--_ak-lio) var(--_ak-lcl, calc(l + (var(--_ak-lcb) * (1 - var(--_ak-lipe))))) c h);
   --_ak-lb: oklch(from oklch(from var(--_ak-li) calc(l + var(--_ak-layer-relative-lightness) + (clamp(0, (var(--_ak-layer-relative-lightness) * 1000000), 1) * var(--_ak-llfb))) calc(c + var(--_ak-layer-relative-chroma)) calc(h + var(--_ak-layer-relative-hue))) calc(l + (clamp(0, (min((l - var(--_ak-fla)), (var(--_ak-flb) - l)) * 1000000), 1) * ((var(--_ak-fla) + (clamp(0, ((l - ((var(--_ak-fla) + var(--_ak-flb)) / 2)) * 1000000), 1) * (var(--_ak-flb) - var(--_ak-fla)))) - l))) c h);
   --_ak-lo: oklch(from var(--_ak-lb) var(--_ak-layer-lightness-offset-resolved, calc(l + var(--_ak-layer-lightness-offset) + (clamp(0, (var(--_ak-layer-lightness-offset) * 1000000), 1) * var(--_ak-llfb)))) c h);
   @variant ak-light {
@@ -253,6 +253,8 @@
 
 @utility ak-layer-contrast {
   --_ak-layer-idle-contrast-lightness: 0.25;
+  --_ak-lcpl: 0;
+  --_ak-lcl: calc(((l + (var(--_ak-lcd) * max(0, ((clamp(0, (var(--_ak-lcpl, 0) + ((var(--_ak-layer-idle-contrast-lightness) * var(--_ak-cps)) * var(--_ak-lcd))), 1) - l) * var(--_ak-lcd))))) * (var(--_ak-lcd) * var(--_ak-lcd))) + ((l + (var(--_ak-lcb) * (1 - var(--_ak-lipe)))) * (1 - (var(--_ak-lcd) * var(--_ak-lcd)))));
   @container style(--_ak-ll: oklch(0 0 0)) {
     --_ak-lcd: 1;
     --_ak-lcpl: 0;
@@ -1578,10 +1580,9 @@
   initial-value: 0;
 }
 
-@property --_ak-lcpl {
-  syntax: "<number>";
+@property --_ak-lcl {
+  syntax: "*";
   inherits: false;
-  initial-value: 0;
 }
 
 @property --_ak-opd {


### PR DESCRIPTION
## Motivation

Every element using `ak-layer` currently evaluates the parent-relative
`ak-layer-contrast` lightness path, even though only elements with the contrast
utility consume it.

## Solution

Move the parent-relative lightness calculation and its scratch values into the
static `ak-layer-contrast` utility. Ordinary layers now use a short,
non-inherited resolved-lightness fallback, while contrast layers preserve the
existing active and inactive calculations.

Add focused browser coverage for unmatched parent lightness and ordinary pushed
layers nested under a contrast ancestor. Regenerate the distributed CSS and add
a patch changeset.

## Performance

Fresh unprofiled 10-sample baseline/current comparison:

- Page load: 3480.8 ms → 3339.7 ms (-4%)
- Toggle layer and text classes: 1752.6 ms → 1661.7 ms (-5%)

These directional improvements are below the repository's 10% publication
threshold, so `perf-compare` correctly reports no significant change.

## Testing

- `pnpm lint-fix`
- `pnpm -F @ariakit/tailwind build`
- `APP_PORT=4322 NEXTJS_PORT=4322 pnpm -F app test-chrome ariakit-tailwind`
- `pnpm build`
- `pnpm tsc`
