### PR TITLE
Improve dialog performance

### DIFF
--- a/.changeset/200-dialog-focus-performance.md
+++ b/.changeset/200-dialog-focus-performance.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Improved [`Dialog`](https://ariakit.com/reference/dialog) performance by avoiding extra renders when tracking focus restoration. Focus is no longer moved back to the disclosure after the dialog has already reopened or been replaced. This also benefits components built on it, such as [`Popover`](https://ariakit.com/reference/popover) and [`Menu`](https://ariakit.com/reference/menu).

--- a/.changeset/200-negative-tabindex-performance.md
+++ b/.changeset/200-negative-tabindex-performance.md
@@ -1,0 +1,9 @@
+---
+"@ariakit/utils": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+"@ariakit/solid-components": patch
+"@ariakit/solid": patch
+---
+
+Improved `isTabbable` performance for elements with a negative `tabindex`.

--- a/app/src/sandbox/dialog-focus-on-hide/index.react.tsx
+++ b/app/src/sandbox/dialog-focus-on-hide/index.react.tsx
@@ -1,0 +1,215 @@
+import * as Ariakit from "@ariakit/react";
+import * as React from "react";
+
+type ActivityMode = "hidden" | "visible";
+
+interface ActivityBoundaryProps {
+  children: React.ReactNode;
+  mode: ActivityMode;
+}
+
+function ActivityBoundary({ children, mode }: ActivityBoundaryProps) {
+  if (!("Activity" in React)) {
+    return children;
+  }
+  return <React.Activity mode={mode}>{children}</React.Activity>;
+}
+
+function ExampleContent() {
+  const [open, setOpen] = React.useState(false);
+  const [activityMode, setActivityMode] =
+    React.useState<ActivityMode>("visible");
+  const [dialogKey, setDialogKey] = React.useState(0);
+  const [closeWhileHidden, setCloseWhileHidden] = React.useState(false);
+  const [autoFocusEnabled, setAutoFocusEnabled] = React.useState(true);
+  const [finalFocusDisabled, setFinalFocusDisabled] = React.useState(false);
+  const [reopenAfterClose, setReopenAfterClose] = React.useState(false);
+  const [replaceOnReopen, setReplaceOnReopen] = React.useState(false);
+  const [closeAfterReopen, setCloseAfterReopen] = React.useState(false);
+  const [portal, setPortal] = React.useState(false);
+  const [restoreFocus, setRestoreFocus] = React.useState(true);
+  const [useFinalFocus, setUseFinalFocus] = React.useState(true);
+  const [callbackName, setCallbackName] = React.useState<"first" | "second">(
+    "first",
+  );
+  const [callbackLog, setCallbackLog] = React.useState("none");
+  const finalFocusRef = React.useRef<HTMLButtonElement>(null);
+
+  const autoFocusOnHide = React.useCallback(() => {
+    setCallbackLog((log) =>
+      log === "none" ? callbackName : `${log}, ${callbackName}`,
+    );
+    return restoreFocus;
+  }, [callbackName, restoreFocus]);
+
+  React.useEffect(() => {
+    if (!closeWhileHidden) return;
+    if (activityMode !== "hidden") return;
+    if (callbackLog === "none") return;
+    setOpen(false);
+    setActivityMode("visible");
+    setCloseWhileHidden(false);
+  }, [activityMode, callbackLog, closeWhileHidden]);
+
+  React.useLayoutEffect(() => {
+    if (!reopenAfterClose) return;
+    if (open) return;
+    setFinalFocusDisabled(false);
+    if (replaceOnReopen) {
+      setDialogKey((key) => key + 1);
+      setReplaceOnReopen(false);
+    }
+    setOpen(true);
+    setReopenAfterClose(false);
+  }, [open, reopenAfterClose, replaceOnReopen]);
+
+  React.useLayoutEffect(() => {
+    if (!closeAfterReopen) return;
+    if (!open) return;
+    if (reopenAfterClose) return;
+    setOpen(false);
+    setCloseAfterReopen(false);
+  }, [closeAfterReopen, open, reopenAfterClose]);
+
+  return (
+    <div className="flex flex-col items-start gap-3">
+      <Ariakit.Button
+        ref={finalFocusRef}
+        disabled={finalFocusDisabled}
+        className="rounded bg-blue-600 px-3 py-1 text-white"
+        onClick={() => {
+          setActivityMode("visible");
+          setPortal(false);
+          setUseFinalFocus(true);
+          setOpen(true);
+        }}
+      >
+        Open dialog
+      </Ariakit.Button>
+      <Ariakit.Button
+        className="rounded border border-gray-300 px-3 py-1"
+        onClick={() => {
+          setActivityMode("visible");
+          setPortal(false);
+          setUseFinalFocus(false);
+          setOpen(true);
+        }}
+      >
+        Open dialog without final focus
+      </Ariakit.Button>
+      <Ariakit.Button
+        className="rounded border border-gray-300 px-3 py-1"
+        onClick={() => {
+          setActivityMode("visible");
+          setPortal(true);
+          setUseFinalFocus(false);
+          setOpen(true);
+        }}
+      >
+        Open portaled dialog without final focus
+      </Ariakit.Button>
+      <ActivityBoundary mode={activityMode}>
+        <Ariakit.Dialog
+          key={dialogKey}
+          open={open}
+          onClose={() => setOpen(false)}
+          modal={false}
+          portal={portal}
+          autoFocusOnShow={false}
+          hideOnInteractOutside={false}
+          finalFocus={useFinalFocus ? finalFocusRef : undefined}
+          autoFocusOnHide={autoFocusEnabled ? autoFocusOnHide : false}
+          className="flex w-72 flex-col items-start gap-3 rounded-lg border border-gray-300 bg-white p-4 shadow-lg"
+        >
+          <Ariakit.DialogHeading className="text-lg font-medium">
+            Dialog
+          </Ariakit.DialogHeading>
+          <button
+            type="button"
+            className="rounded border border-gray-300 px-3 py-1"
+            onClick={() => setCallbackName("second")}
+          >
+            Use second callback
+          </button>
+          <button
+            type="button"
+            className="rounded border border-gray-300 px-3 py-1"
+            onClick={() => setRestoreFocus(false)}
+          >
+            Prevent focus restoration
+          </button>
+          <button
+            type="button"
+            className="rounded border border-gray-300 px-3 py-1"
+            onClick={() => setAutoFocusEnabled(false)}
+          >
+            Disable focus restoration
+          </button>
+          <button
+            type="button"
+            className="rounded border border-gray-300 px-3 py-1"
+            onClick={() => setDialogKey((key) => key + 1)}
+          >
+            Remount dialog
+          </button>
+          <button
+            type="button"
+            className="rounded border border-gray-300 px-3 py-1"
+            onClick={() => {
+              setFinalFocusDisabled(true);
+              setReopenAfterClose(true);
+              setOpen(false);
+            }}
+          >
+            Close and reopen dialog
+          </button>
+          <button
+            type="button"
+            className="rounded border border-gray-300 px-3 py-1"
+            onClick={() => {
+              setFinalFocusDisabled(true);
+              setReopenAfterClose(true);
+              setReplaceOnReopen(true);
+              setCloseAfterReopen(true);
+              setOpen(false);
+            }}
+          >
+            Close replacement before retry
+          </button>
+          <Ariakit.DialogDismiss className="rounded border border-gray-300 px-3 py-1">
+            Close dialog
+          </Ariakit.DialogDismiss>
+          <button
+            type="button"
+            className="rounded border border-gray-300 px-3 py-1"
+            onClick={() => setActivityMode("hidden")}
+          >
+            Hide activity
+          </button>
+          <button
+            type="button"
+            className="rounded border border-gray-300 px-3 py-1"
+            onClick={() => {
+              setCloseWhileHidden(true);
+              setActivityMode("hidden");
+            }}
+          >
+            Hide, close, and show activity
+          </button>
+        </Ariakit.Dialog>
+      </ActivityBoundary>
+      <output aria-label="Focus callbacks">{callbackLog}</output>
+      <output aria-label="Dialog state">
+        {activityMode}, {open ? "open" : "closed"}
+      </output>
+    </div>
+  );
+}
+
+export default function Example() {
+  return (
+    <React.StrictMode>
+      <ExampleContent />
+    </React.StrictMode>
+  );
+}

--- a/app/src/sandbox/dialog-focus-on-hide/test-browser.ts
+++ b/app/src/sandbox/dialog-focus-on-hide/test-browser.ts
@@ -1,0 +1,95 @@
+import { flushFrames, withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("restores focus once with the latest callback", async ({ q }) => {
+    await test.expect(q.status("Focus callbacks")).toHaveText("none");
+
+    await q.button("Open dialog").click();
+    await test.expect(q.dialog("Dialog")).toBeVisible();
+    await test.expect(q.status("Focus callbacks")).toHaveText("none");
+
+    await q.button("Use second callback").click();
+    await test.expect(q.status("Focus callbacks")).toHaveText("none");
+
+    await q.button("Close dialog").click();
+
+    await test.expect(q.status("Focus callbacks")).toHaveText("second");
+    await test.expect(q.button("Open dialog")).toBeFocused();
+  });
+
+  test("restores focus when Activity hides the dialog", async ({ q }) => {
+    await q.button("Open dialog").click();
+    await test.expect(q.dialog("Dialog")).toBeVisible();
+    await test.expect(q.status("Focus callbacks")).toHaveText("none");
+
+    await q.button("Hide activity").click();
+
+    const dialog = q.dialog("Dialog", { includeHidden: true });
+    await test.expect(dialog).not.toBeVisible();
+    await test.expect(q.status("Focus callbacks")).toHaveText("first");
+    await test.expect(q.button("Open dialog")).toBeFocused();
+  });
+
+  test("does not restore focus from a replaced dialog", async ({ q }) => {
+    await q.button("Open dialog without final focus").click();
+    await q.button("Remount dialog").click();
+
+    await test.expect(q.dialog("Dialog")).toBeVisible();
+    await test.expect(q.status("Focus callbacks")).toHaveText("none");
+  });
+
+  test("does not restore focus from a replaced portaled dialog", async ({
+    q,
+  }) => {
+    await q.button("Open portaled dialog without final focus").click();
+    await q.button("Remount dialog").click();
+
+    await test.expect(q.dialog("Dialog")).toBeVisible();
+    await test.expect(q.status("Focus callbacks")).toHaveText("none");
+  });
+
+  test("does not restore focus when disabled", async ({ q }) => {
+    await q.button("Open dialog").click();
+    await q.button("Disable focus restoration").click();
+    await q.button("Close dialog").click();
+
+    await test.expect(q.status("Focus callbacks")).toHaveText("none");
+  });
+
+  test("does not restore focus after reopening before a retry", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Open dialog").click();
+    await q.button("Close and reopen dialog").click();
+    await flushFrames(page);
+
+    await test.expect(q.dialog("Dialog")).toBeVisible();
+    await test.expect(q.status("Focus callbacks")).toHaveText("none");
+  });
+
+  test("does not run a superseded retry after the replacement closes", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Open dialog").click();
+    await q.button("Close replacement before retry").click();
+    await flushFrames(page);
+
+    await test.expect(q.dialog("Dialog")).not.toBeVisible();
+    await test.expect(q.status("Focus callbacks")).toHaveText("first");
+  });
+
+  test("does not restore focus again after closing while hidden", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Open dialog").click();
+    await q.button("Prevent focus restoration").click();
+    await q.button("Hide, close, and show activity").click();
+
+    await test.expect(q.status("Dialog state")).toHaveText("visible, closed");
+    await flushFrames(page);
+    await test.expect(q.status("Focus callbacks")).toHaveText("first");
+  });
+});

--- a/app/src/sandbox/dialog-focus-on-hide/test.ts
+++ b/app/src/sandbox/dialog-focus-on-hide/test.ts
@@ -1,0 +1,91 @@
+import { click, q, sleep } from "@ariakit/test";
+import * as React from "react";
+import { expect, test } from "vitest";
+
+test("restores focus once with the latest callback", async () => {
+  expect(q.status("Focus callbacks")).toHaveTextContent(/^none$/);
+
+  await click(q.button("Open dialog"));
+  expect(q.dialog("Dialog")).toBeVisible();
+  expect(q.status("Focus callbacks")).toHaveTextContent(/^none$/);
+
+  await click(q.button("Use second callback"));
+  expect(q.status("Focus callbacks")).toHaveTextContent(/^none$/);
+
+  await click(q.button("Close dialog"));
+
+  expect(q.status("Focus callbacks")).toHaveTextContent(/^second$/);
+  expect(q.button("Open dialog")).toHaveFocus();
+});
+
+const activityTest = "Activity" in React ? test : test.skip;
+
+activityTest("restores focus when Activity hides the dialog", async () => {
+  await click(q.button("Open dialog"));
+  expect(q.dialog("Dialog")).toBeVisible();
+  expect(q.status("Focus callbacks")).toHaveTextContent(/^none$/);
+
+  await click(q.button("Hide activity"));
+
+  expect(q.dialog("Dialog")).not.toBeInTheDocument();
+  expect(q.status("Focus callbacks")).toHaveTextContent(/^first$/);
+  expect(q.button("Open dialog")).toHaveFocus();
+});
+
+test("does not restore focus from a replaced dialog", async () => {
+  await click(q.button("Open dialog without final focus"));
+  await click(q.button("Remount dialog"));
+
+  expect(q.dialog("Dialog")).toBeVisible();
+  expect(q.status("Focus callbacks")).toHaveTextContent(/^none$/);
+});
+
+test("does not restore focus from a replaced portaled dialog", async () => {
+  await click(q.button("Open portaled dialog without final focus"));
+  await click(q.button("Remount dialog"));
+
+  expect(q.dialog("Dialog")).toBeVisible();
+  expect(q.status("Focus callbacks")).toHaveTextContent(/^none$/);
+});
+
+test("does not restore focus when disabled", async () => {
+  await click(q.button("Open dialog"));
+  await click(q.button("Disable focus restoration"));
+  await click(q.button("Close dialog"));
+  await sleep();
+
+  expect(q.status("Focus callbacks")).toHaveTextContent(/^none$/);
+});
+
+test("does not restore focus after reopening before a retry", async () => {
+  await click(q.button("Open dialog"));
+  await click(q.button("Close and reopen dialog"));
+  await sleep();
+
+  expect(q.dialog("Dialog")).toBeVisible();
+  expect(q.status("Focus callbacks")).toHaveTextContent(/^none$/);
+});
+
+test("does not run a superseded retry after the replacement closes", async () => {
+  await click(q.button("Open dialog"));
+  await click(q.button("Close replacement before retry"));
+  await sleep();
+
+  expect(q.dialog("Dialog")).not.toBeInTheDocument();
+  expect(q.status("Focus callbacks")).toHaveTextContent(/^first$/);
+});
+
+activityTest(
+  "does not restore focus again after closing while hidden",
+  async () => {
+    await click(q.button("Open dialog"));
+    await click(q.button("Prevent focus restoration"));
+    await click(q.button("Hide, close, and show activity"));
+
+    await expect
+      .poll(() => q.status.ensure("Dialog state").textContent)
+      .toBe("visible, closed");
+    await sleep();
+    expect(q.status("Focus callbacks")).toHaveTextContent(/^first$/);
+  },
+);

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -36,7 +36,7 @@ import type {
   RefObject,
   SyntheticEvent,
 } from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { DisclosureContentOptions } from "../disclosure/disclosure-content.tsx";
 import {
   isHidden,
@@ -96,6 +96,131 @@ function getElementFromProp(
   if (!element) return null;
   if (focusable) return isFocusable(element) ? element : null;
   return element;
+}
+
+interface FocusOnHideSession {
+  captureBatch: () => FocusOnHideBatch;
+  finish: (batch: FocusOnHideBatch) => boolean;
+  finishRetry: () => void;
+  isCurrent: () => boolean;
+  waitForRetry: () => void;
+}
+
+interface FocusOnHideBatch {
+  sessions: Set<object>;
+}
+
+interface FocusOnHideSessionState {
+  superseded: boolean;
+}
+
+interface FocusOnHideDocumentState {
+  batch?: FocusOnHideBatch;
+  pending: Set<FocusOnHideSessionState>;
+}
+
+const focusOnHideSessions = new WeakMap<object, Set<object>>();
+const focusOnHideDocumentStates = new WeakMap<
+  Document,
+  FocusOnHideDocumentState
+>();
+
+function getFocusOnHideDocumentState(document: Document) {
+  let state = focusOnHideDocumentStates.get(document);
+  if (!state) {
+    state = { pending: new Set() };
+    focusOnHideDocumentStates.set(document, state);
+  }
+  return state;
+}
+
+// React may replace a dialog or replay its effects without logically closing
+// it. Sessions created in the same task are grouped so the obsolete cleanup
+// doesn't restore focus. The batch is document-scoped to support DOM realms.
+function getFocusOnHideBatch(
+  document: Document,
+  documentState = getFocusOnHideDocumentState(document),
+) {
+  if (documentState.batch) return documentState.batch;
+  const batch: FocusOnHideBatch = { sessions: new Set() };
+  documentState.batch = batch;
+  queueMicrotask(() => {
+    if (documentState.batch !== batch) return;
+    documentState.batch = undefined;
+  });
+  return batch;
+}
+
+function createFocusOnHideSession(
+  document: Document,
+  keys: Iterable<object>,
+): FocusOnHideSession {
+  const token = {};
+  const uniqueKeys = new Set(keys);
+  const documentState = getFocusOnHideDocumentState(document);
+  // A newly opened dialog takes precedence over focus restoration that
+  // another dialog deferred until the next animation frame.
+  for (const pendingSession of documentState.pending) {
+    pendingSession.superseded = true;
+  }
+  documentState.pending.clear();
+  getFocusOnHideBatch(document, documentState).sessions.add(token);
+  for (const key of uniqueKeys) {
+    let sessions = focusOnHideSessions.get(key);
+    if (!sessions) {
+      sessions = new Set();
+      focusOnHideSessions.set(key, sessions);
+    }
+    sessions.add(token);
+  }
+  let finished = false;
+  const sessionState: FocusOnHideSessionState = { superseded: false };
+  return {
+    captureBatch() {
+      return getFocusOnHideBatch(document, documentState);
+    },
+    finish(batch) {
+      if (finished) return false;
+      finished = true;
+      let isLast = true;
+      for (const key of uniqueKeys) {
+        const sessions = focusOnHideSessions.get(key);
+        if (!sessions) continue;
+        sessions.delete(token);
+        if (sessions.size) {
+          isLast = false;
+          continue;
+        }
+        focusOnHideSessions.delete(key);
+      }
+      if (isLast) {
+        for (const session of batch.sessions) {
+          if (session === token) continue;
+          isLast = false;
+          break;
+        }
+      }
+      sessionState.superseded = !isLast;
+      return isLast;
+    },
+    finishRetry() {
+      documentState.pending.delete(sessionState);
+    },
+    isCurrent() {
+      if (sessionState.superseded) return false;
+      for (const key of uniqueKeys) {
+        const sessions = focusOnHideSessions.get(key);
+        if (!sessions) continue;
+        if (sessions.size !== 1) return false;
+        if (!sessions.has(token)) return false;
+      }
+      return true;
+    },
+    waitForRetry() {
+      if (sessionState.superseded) return;
+      documentState.pending.add(sessionState);
+    },
+  };
 }
 
 /**
@@ -412,18 +537,26 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
   const mayAutoFocusOnHide = !!autoFocusOnHide;
   const autoFocusOnHideProp = useBooleanEvent(autoFocusOnHide);
 
-  // Sets a `hasOpened` flag on an effect so we only auto focus on hide if the
-  // dialog was open before.
-  const [hasOpened, setHasOpened] = useState(false);
+  const focusedOnHideRef = useRef(false);
+  const focusOnHideGenerationRef = useRef(0);
+  const focusOnHideSessionRef = useRef<FocusOnHideSession | null>(null);
+  const wasOpenRef = useRef(false);
+  const focusOnHideOpen = openProp ?? open;
 
-  useSafeLayoutEffect(() => {
-    if (!open) return;
-    setHasOpened(true);
-    return () => setHasOpened(false);
-  }, [open]);
+  const getFocusOnHideSessionKeys = useEvent(() => {
+    const { disclosureElement } = store.getState();
+    const focusTarget = finalFocus || disclosureElement;
+    return focusTarget ? [store, focusTarget] : [store];
+  });
 
-  const focusOnHide = useCallback(
-    (dialog: HTMLElement | null, retry = true) => {
+  const focusOnHide = useEvent(
+    (
+      dialog: HTMLElement | null,
+      retry = true,
+      generation = focusOnHideGenerationRef.current,
+      session = focusOnHideSessionRef.current,
+    ) => {
+      if (!autoFocusOnHide) return;
       // Hide was triggered by clicking or right-clicking outside the dialog.
       // Native HTML dialogs and popovers don't restore focus to the trigger
       // in this case, so we skip focus restoration entirely.
@@ -465,43 +598,78 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
         // again on the next frame. This is sometimes necessary because there
         // may be nested dialogs that still need a tick to remove the inert
         // attribute from elements outside.
-        requestAnimationFrame(() => focusOnHide(dialog, false));
+        session?.waitForRetry();
+        requestAnimationFrame(() => {
+          session?.finishRetry();
+          if (generation !== focusOnHideGenerationRef.current) return;
+          if (session && !session.isCurrent()) return;
+          focusOnHide(dialog, false, generation, session);
+        });
         return;
       }
       if (!autoFocusOnHideProp(isElementFocusable ? element : null)) return;
       if (!isElementFocusable) return;
       element?.focus();
     },
-    [store, finalFocus, autoFocusOnHideProp],
   );
-
-  const focusedOnHideRef = useRef(false);
 
   // Auto focus on hide with an always rendered dialog.
   useSafeLayoutEffect(() => {
-    if (open) return;
-    if (!hasOpened) return;
+    const wasOpen = wasOpenRef.current;
+    wasOpenRef.current = focusOnHideOpen;
+    if (focusOnHideOpen) {
+      if (!wasOpen) {
+        focusOnHideGenerationRef.current += 1;
+      }
+      return;
+    }
+    if (!wasOpen) return;
     if (!mayAutoFocusOnHide) return;
     const dialog = ref.current;
     // We don't want to focus on hide twice if the dialog is not unmounted, so
     // we set this flag here that will be checked in the cleanup effect below.
     focusedOnHideRef.current = true;
     focusOnHide(dialog);
-  }, [open, hasOpened, domReady, mayAutoFocusOnHide, focusOnHide]);
+  }, [focusOnHideOpen, domReady, mayAutoFocusOnHide, focusOnHide]);
 
   // Auto focus on hide with a dialog that gets unmounted when hidden.
   useEffect(() => {
-    if (!hasOpened) return;
+    if (!open) return;
+    if (!focusOnHideOpen) return;
     if (!mayAutoFocusOnHide) return;
+    const generation = focusOnHideGenerationRef.current;
     const dialog = ref.current;
+    const session = createFocusOnHideSession(
+      getDocument(dialog),
+      getFocusOnHideSessionKeys(),
+    );
+    focusOnHideSessionRef.current = session;
+    focusedOnHideRef.current = false;
     return () => {
-      if (focusedOnHideRef.current) {
-        focusedOnHideRef.current = false;
-        return;
-      }
-      focusOnHide(dialog);
+      const batch = session.captureBatch();
+      queueMicrotask(() => {
+        if (focusOnHideSessionRef.current === session) {
+          focusOnHideSessionRef.current = null;
+        }
+        // React may replay effects in Strict Mode. A replacement dialog or a
+        // dialog that reopens before this cleanup runs creates another session.
+        if (!session.finish(batch)) return;
+        if (generation !== focusOnHideGenerationRef.current) return;
+        if (focusedOnHideRef.current) {
+          focusedOnHideRef.current = false;
+          return;
+        }
+        wasOpenRef.current = false;
+        focusOnHide(dialog, true, generation, session);
+      });
     };
-  }, [hasOpened, mayAutoFocusOnHide, focusOnHide]);
+  }, [
+    open,
+    focusOnHideOpen,
+    mayAutoFocusOnHide,
+    focusOnHide,
+    getFocusOnHideSessionKeys,
+  ]);
 
   const hideOnEscapeProp = useBooleanEvent(hideOnEscape);
 

--- a/packages/ariakit-utils/src/focus.test.ts
+++ b/packages/ariakit-utils/src/focus.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, expect, test } from "vitest";
+import { afterEach, expect, test, vi } from "vitest";
 import {
   getAllTabbableIn,
   getClosestFocusable,
@@ -73,6 +73,20 @@ test("keeps radios outside a form tabbable", () => {
   document.body.append(radio);
 
   expect(isTabbable(radio)).toBe(true);
+});
+
+test("skips visibility checks for elements with a negative tab index", () => {
+  const button = document.createElement("button");
+  button.tabIndex = -1;
+  const checkVisibility = vi.fn(() => true);
+  Object.defineProperty(button, "checkVisibility", {
+    configurable: true,
+    value: checkVisibility,
+  });
+  document.body.append(button);
+
+  expect(isTabbable(button)).toBe(false);
+  expect(checkVisibility).not.toHaveBeenCalled();
 });
 
 test("getFirstTabbableIn returns the first tabbable element in order", () => {

--- a/packages/ariakit-utils/src/focus.ts
+++ b/packages/ariakit-utils/src/focus.ts
@@ -42,8 +42,8 @@ export function isFocusable(element: Element) {
 export function isTabbable(
   element: Element | HTMLElement | HTMLInputElement,
 ): element is HTMLElement {
-  if (!isFocusable(element)) return false;
   if (hasNegativeTabIndex(element)) return false;
+  if (!isFocusable(element)) return false;
   // If the element is a radio button in a form, we must take roving tabindex
   // into account.
   if (!("form" in element)) return true;


### PR DESCRIPTION
## Motivation

`Dialog` used React state solely to remember whether it had opened. Updating that state added commits to every open/close cycle, including components built on Dialog such as Popover and Menu.

```tsx
const [hasOpened, setHasOpened] = useState(false);
```

Focus restoration still has to behave correctly when React replays effects, hides content with Activity, replaces a keyed dialog, or reopens before a deferred focus retry. Separately, `isTabbable` performed a visibility check before rejecting elements with a negative `tabindex`.

## Solution

Track the Dialog open lifecycle with refs instead of render-triggering state. Document-scoped focus sessions coordinate effect replay and keyed replacements, while generation checks and pending-session invalidation prevent stale animation-frame retries from moving focus after a dialog reopens or is superseded.

The behavior matrix lives in an app sandbox, including React 19 Activity, StrictMode, non-portaled and portaled replacement, disabled restoration, and deferred-retry cases. No React tests were added to `ariakit-react-components`.

`isTabbable` now checks negative `tabindex` before the visibility-dependent focusability path:

```ts
if (hasNegativeTabIndex(element)) return false;
if (!isFocusable(element)) return false;
```

## Performance

Ten samples against the same-runner `origin/main` baseline:

| Interaction | Scripting | Total |
| --- | --- | --- |
| Open dialog | 71ms → 66.8ms (-6%) | 114ms → 109.2ms (-4%) |
| Close dialog | 128.8ms → 121ms (-6%) | 169.1ms → 160.4ms (-5%) |

No significant regression was detected.

## Verification

- `pnpm lint`
- `pnpm tsc`
- `pnpm build`
- `pnpm test` — 564 tests
- Focused React 19 tests — 51 passed
- Focused React 18 tests — 49 passed, 2 Activity tests skipped
- Chrome, Firefox, and Safari sandbox tests — 24 passed
