### PR TITLE
Improve menu item performance

### DIFF
--- a/.changeset/200-menu-item-performance.md
+++ b/.changeset/200-menu-item-performance.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Improved performance of [`Menu`](https://ariakit.com/reference/menu) components with many [`MenuItem`](https://ariakit.com/reference/menu-item) components.

--- a/app/src/sandbox/menu-item-role/index.react.tsx
+++ b/app/src/sandbox/menu-item-role/index.react.tsx
@@ -1,0 +1,101 @@
+import * as Ariakit from "@ariakit/react";
+import { useMenuItem } from "@ariakit/react-components/menu/menu-item";
+import { useMenuList } from "@ariakit/react-components/menu/menu-list";
+import { useMergeRefs } from "@ariakit/react-utils";
+import { useLayoutEffect, useState } from "react";
+
+function HookMenu() {
+  const store = Ariakit.useMenuStore();
+  const item = useMenuItem({ store });
+
+  return (
+    <>
+      <Ariakit.MenuButton store={store}>Hook menu</Ariakit.MenuButton>
+      <Ariakit.Menu store={store} render={<div role="listbox" />}>
+        <Ariakit.Role {...item}>Hook item</Ariakit.Role>
+      </Ariakit.Menu>
+    </>
+  );
+}
+
+function LayoutEffectMenu() {
+  const [role, setRole] = useState<"tree" | undefined>("tree");
+
+  useLayoutEffect(() => {
+    setRole(undefined);
+  }, []);
+
+  return (
+    <Ariakit.MenuProvider>
+      <Ariakit.MenuList alwaysVisible render={<div role={role} />}>
+        <Ariakit.MenuItem>Layout item</Ariakit.MenuItem>
+      </Ariakit.MenuList>
+    </Ariakit.MenuProvider>
+  );
+}
+
+function MismatchedStoreMenu() {
+  const itemStore = Ariakit.useMenuStore();
+  const listStore = Ariakit.useMenuStore();
+
+  return (
+    <>
+      <Ariakit.MenuList
+        store={itemStore}
+        alwaysVisible
+        render={<div role="listbox" />}
+      />
+      <Ariakit.MenuList store={listStore} alwaysVisible>
+        <Ariakit.MenuItem store={itemStore}>Mismatched item</Ariakit.MenuItem>
+      </Ariakit.MenuList>
+    </>
+  );
+}
+
+function ReapplyRoleMenu() {
+  const store = Ariakit.useMenuStore();
+  const props = useMenuList({ store, alwaysVisible: true });
+  const ref = useMergeRefs(props.ref, (element: HTMLDivElement | null) => {
+    element?.setAttribute("role", "menu");
+  });
+
+  return (
+    <Ariakit.Role {...props} ref={ref}>
+      <Ariakit.MenuItem store={store}>Reapply item</Ariakit.MenuItem>
+    </Ariakit.Role>
+  );
+}
+
+export default function Example() {
+  const [role, setRole] = useState<"menu" | "listbox" | "tree" | undefined>(
+    "menu",
+  );
+
+  return (
+    <>
+      <Ariakit.MenuProvider>
+        <Ariakit.MenuButton>Actions</Ariakit.MenuButton>
+        <Ariakit.Menu
+          hideOnInteractOutside={false}
+          render={role === "tree" ? <ul role="tree" /> : <div role={role} />}
+        >
+          <Ariakit.MenuItem>Edit</Ariakit.MenuItem>
+          <Ariakit.MenuItem>Share</Ariakit.MenuItem>
+        </Ariakit.Menu>
+      </Ariakit.MenuProvider>
+      <Ariakit.Button onClick={() => setRole("listbox")}>
+        Use listbox role
+      </Ariakit.Button>
+      <Ariakit.Button onClick={() => setRole("tree")}>
+        Use tree role
+      </Ariakit.Button>
+      <Ariakit.Button onClick={() => setRole(undefined)}>
+        Remove role
+      </Ariakit.Button>
+      <HookMenu />
+      <LayoutEffectMenu />
+      <MismatchedStoreMenu />
+      <ReapplyRoleMenu />
+    </>
+  );
+}

--- a/app/src/sandbox/menu-item-role/test-browser.ts
+++ b/app/src/sandbox/menu-item-role/test-browser.ts
@@ -1,0 +1,32 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("updates item roles with the rendered menu", async ({ q }) => {
+    await test.expect(q.menuitem("Layout item")).toBeVisible();
+    await test.expect(q.treeitem("Layout item")).toHaveCount(0);
+    await test.expect(q.option("Mismatched item")).toBeVisible();
+    await test.expect(q.menuitem("Reapply item")).toBeVisible();
+
+    await q.button("Actions").click();
+    await test.expect(q.menuitem("Edit")).toBeVisible();
+
+    await q.button("Use listbox role").click();
+
+    await test.expect(q.option("Edit")).toBeVisible();
+    await test.expect(q.menuitem("Edit")).toHaveCount(0);
+
+    await q.button("Use tree role").click();
+
+    await test.expect(q.treeitem("Edit")).toBeVisible();
+    await test.expect(q.option("Edit")).toHaveCount(0);
+
+    await q.button("Remove role").click();
+
+    await test.expect(q.menuitem("Edit")).toBeVisible();
+    await test.expect(q.treeitem("Edit")).toHaveCount(0);
+
+    await q.button("Hook menu").click();
+
+    await test.expect(q.option("Hook item")).toBeVisible();
+  });
+});

--- a/app/src/sandbox/menu-item-role/test.ts
+++ b/app/src/sandbox/menu-item-role/test.ts
@@ -1,0 +1,31 @@
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+test("updates item roles with the rendered menu", async () => {
+  await expect.poll(q.menuitem.lazy("Layout item")).toBeVisible();
+  expect(q.treeitem("Layout item")).not.toBeInTheDocument();
+  await expect.poll(q.option.lazy("Mismatched item")).toBeVisible();
+  expect(q.menuitem("Reapply item")).toBeVisible();
+
+  await click(q.button("Actions"));
+  expect(q.menuitem("Edit")).toBeVisible();
+
+  await click(q.button("Use listbox role"));
+
+  await expect.poll(q.option.lazy("Edit")).toBeVisible();
+  expect(q.menuitem("Edit")).not.toBeInTheDocument();
+
+  await click(q.button("Use tree role"));
+
+  await expect.poll(q.treeitem.lazy("Edit")).toBeVisible();
+  expect(q.option("Edit")).not.toBeInTheDocument();
+
+  await click(q.button("Remove role"));
+
+  await expect.poll(q.menuitem.lazy("Edit")).toBeVisible();
+  expect(q.treeitem("Edit")).not.toBeInTheDocument();
+
+  await click(q.button("Hook menu"));
+
+  await expect.poll(q.option.lazy("Hook item")).toBeVisible();
+});

--- a/packages/ariakit-react-components/src/menu/menu-context.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-context.tsx
@@ -75,6 +75,15 @@ export const MenuItemCheckedContext = createContext<boolean | undefined>(
   undefined,
 );
 
+export interface MenuListRoleContextValue {
+  store: MenuStore;
+  role?: string;
+}
+
+export const MenuListRoleContext = createContext<
+  MenuListRoleContextValue | undefined
+>(undefined);
+
 /**
  * Whether the enclosing menu list is currently hidden (e.g. a closed menu
  * rendered without `unmountOnHide`). `MenuItem` uses it to skip registering

--- a/packages/ariakit-react-components/src/menu/menu-item.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-item.tsx
@@ -10,6 +10,7 @@ import {
 import type { Props } from "@ariakit/react-utils";
 import {
   getDocument,
+  getItemRoleByPopupRole,
   getPopupItemRole,
   isDownloading,
   isOpeningInNewTab,
@@ -27,6 +28,7 @@ import { useMenubarScopedContext } from "../menubar/menubar-context.tsx";
 import type { MenubarStore } from "../menubar/menubar-store.ts";
 import {
   MenuListHiddenContext,
+  MenuListRoleContext,
   useMenuScopedContext,
 } from "./menu-context.tsx";
 import type { MenuStore, MenuStoreState } from "./menu-store.ts";
@@ -111,15 +113,24 @@ export const useMenuItem = createHook<TagName, MenuItemOptions>(
       hideMenu();
     });
 
-    const contentElement = useStoreState(store, (state) =>
-      "contentElement" in state ? state.contentElement : null,
-    );
-
     // Whether the enclosing menu list is currently hidden (provided by
     // `MenuList`; see `MenuListHiddenContext`).
     const menuListHidden = useContext(MenuListHiddenContext);
+    const menuListRoleContext = useContext(MenuListRoleContext);
+    const hasMatchingMenuList = menuListRoleContext?.store === store;
+    // Hooks composed outside MenuList don't receive its context, so preserve
+    // store-based role resolution only for that path or an explicit mismatch.
+    const contentElement = useStoreState(
+      hasMatchingMenuList ? undefined : store,
+      (state): HTMLElement | null =>
+        state && "contentElement" in state
+          ? (state.contentElement as HTMLElement | null)
+          : null,
+    );
 
-    const role = getPopupItemRole(contentElement, "menuitem");
+    const role = hasMatchingMenuList
+      ? (getItemRoleByPopupRole(menuListRoleContext.role) ?? "menuitem")
+      : getPopupItemRole(contentElement, "menuitem");
 
     props = {
       role,

--- a/packages/ariakit-react-components/src/menu/menu-list.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-list.tsx
@@ -1,7 +1,9 @@
 import { useStoreState } from "@ariakit/react-store";
 import {
   useEvent,
+  useForceUpdate,
   useId,
+  useLiveRef,
   useMergeRefs,
   useWrapElement,
   createElement,
@@ -11,7 +13,7 @@ import {
 import type { Props } from "@ariakit/react-utils";
 import { invariant } from "@ariakit/utils";
 import type { ElementType, KeyboardEvent } from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { CompositeTypeaheadOptions } from "../composite/composite-typeahead.tsx";
 import { useCompositeTypeahead } from "../composite/composite-typeahead.tsx";
 import type { CompositeOptions } from "../composite/composite.tsx";
@@ -21,6 +23,7 @@ import { isHidden } from "../disclosure/disclosure-content.tsx";
 import { getBasePlacement } from "../popover/__utils.ts";
 import {
   MenuListHiddenContext,
+  MenuListRoleContext,
   MenuScopedContextProvider,
   useMenuProviderContext,
 } from "./menu-context.tsx";
@@ -81,7 +84,33 @@ export const useMenuList = createHook<TagName, MenuListOptions>(
     const parentMenu = store.parent;
     const parentMenubar = store.menubar;
     const hasParentMenu = !!parentMenu;
+    const hasCombobox = !!store.combobox;
+    composite = composite ?? !hasCombobox;
+
+    const [element, setElement] = useState<HTMLType | null>(null);
     const id = useId(props.id);
+    const defaultRole = props.role ?? (composite ? "menu" : undefined);
+    const [, forceRoleUpdate] = useForceUpdate();
+    const role = element
+      ? (element.getAttribute("role") ?? undefined)
+      : defaultRole;
+    const roleRef = useLiveRef(role);
+
+    useEffect(() => {
+      if (!element) return;
+      const updateRole = () => {
+        const nextRole = element.getAttribute("role") ?? undefined;
+        if (nextRole === roleRef.current) return;
+        roleRef.current = nextRole;
+        forceRoleUpdate();
+      };
+      const observer = new MutationObserver(updateRole);
+      observer.observe(element, { attributeFilter: ["role"] });
+      updateRole();
+      return () => observer.disconnect();
+    }, [element, forceRoleUpdate, roleRef]);
+
+    const roleContextValue = useMemo(() => ({ store, role }), [store, role]);
 
     const onKeyDownProp = props.onKeyDown;
     const dir = useStoreState(store, (state) =>
@@ -146,10 +175,12 @@ export const useMenuList = createHook<TagName, MenuListOptions>(
       props,
       (element) => (
         <MenuScopedContextProvider value={store}>
-          {element}
+          <MenuListRoleContext.Provider value={roleContextValue}>
+            {element}
+          </MenuListRoleContext.Provider>
         </MenuScopedContextProvider>
       ),
-      [store],
+      [store, roleContextValue],
     );
 
     const ariaLabelledBy = useAriaLabelledBy({ store, ...props });
@@ -176,13 +207,14 @@ export const useMenuList = createHook<TagName, MenuListOptions>(
       hidden,
       ...props,
       id,
-      ref: useMergeRefs(id ? store.setContentElement : null, props.ref),
+      ref: useMergeRefs(
+        id ? store.setContentElement : null,
+        setElement,
+        props.ref,
+      ),
       style,
       onKeyDown,
     };
-
-    const hasCombobox = !!store.combobox;
-    composite = composite ?? !hasCombobox;
 
     if (composite) {
       props = {


### PR DESCRIPTION
## Motivation

Each `MenuItem` subscribed to every `Menu` store update only to derive its role from the menu content element. In a 200-item menu, this duplicated callback work throughout keyboard navigation.

## Solution

Observe the resolved `MenuList` role once and share it with matching items through context. Keep the content-element fallback for hooks composed outside the list and items bound to an explicitly different store.

Track role mutations and host replacement while handling mount-time layout effects and redundant same-value writes. Add happy-dom and cross-browser regression coverage plus a patch changeset.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm build`
- 187 menu-related tests on React 19 and 187 on React 18
- `menu-item-role` browser test in Chrome, Firefox, and Safari
- Paired `menu-perf` benchmark: no statistically significant end-to-end change
- Instrumentation: 200 fewer all-state subscriptions and 79,600 fewer callbacks during a 199-step traversal of 200 items
