### PR TITLE
Add Tab Chrome performance tests

### DIFF
--- a/app/src/sandbox/tab-perf/index.react.tsx
+++ b/app/src/sandbox/tab-perf/index.react.tsx
@@ -1,0 +1,42 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+import "./style.css";
+
+const tabCount = 200;
+const tabs = Array.from({ length: tabCount }, (_, index) => {
+  const number = index + 1;
+  return { id: `tab-${number}`, label: `Tab ${number}` };
+});
+
+function TabFixture() {
+  return (
+    <Ariakit.TabProvider defaultSelectedId="tab-1">
+      <Ariakit.TabList aria-label="Items" className="tab-list">
+        {tabs.map((tab) => (
+          <Ariakit.Tab key={tab.id} id={tab.id} className="tab">
+            {tab.label}
+          </Ariakit.Tab>
+        ))}
+      </Ariakit.TabList>
+      <div className="panels">
+        {tabs.map((tab) => (
+          <Ariakit.TabPanel key={tab.id} tabId={tab.id} className="panel">
+            Content for {tab.label}
+          </Ariakit.TabPanel>
+        ))}
+      </div>
+    </Ariakit.TabProvider>
+  );
+}
+
+export default function Example() {
+  const [mounted, setMounted] = useState(false);
+  return (
+    <div className="root">
+      <Ariakit.Button className="button" onClick={() => setMounted(true)}>
+        Mount tabs
+      </Ariakit.Button>
+      {mounted ? <TabFixture /> : null}
+    </div>
+  );
+}

--- a/app/src/sandbox/tab-perf/perf-chrome.ts
+++ b/app/src/sandbox/tab-perf/perf-chrome.ts
@@ -1,0 +1,75 @@
+import type { query } from "@ariakit/test/playwright";
+import { expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { withFramework } from "#app/test-utils/preview.ts";
+
+const tabCount = 200;
+type Query = ReturnType<typeof query>;
+
+async function mountTabs(q: Query) {
+  await q.button("Mount tabs").click();
+}
+
+async function verifyTabControlsPanel(q: Query, label: string) {
+  const panelId = await q.tabpanel(label).getAttribute("id");
+  if (!panelId) {
+    throw new Error(`${label} panel must have an id`);
+  }
+  await expect(q.tab(label)).toHaveAttribute("aria-controls", panelId);
+}
+
+async function verifyTabsMounted(q: Query) {
+  await expect(q.tab(`Tab ${tabCount}`)).toBeVisible();
+  await expect(q.tab("Tab 1")).toHaveAttribute("aria-selected", "true");
+  await expect(q.tabpanel("Tab 1")).toBeVisible();
+  await verifyTabControlsPanel(q, "Tab 1");
+}
+
+async function setupTabs(q: Query) {
+  await mountTabs(q);
+  await verifyTabsMounted(q);
+  const firstTab = q.tab("Tab 1");
+  await firstTab.focus();
+  await expect(firstTab).toBeFocused();
+}
+
+async function moveAcrossTabs(page: Page) {
+  for (let i = 1; i < tabCount; i++) {
+    await page.keyboard.press("ArrowRight");
+  }
+}
+
+async function verifyMovedAcrossTabs(q: Query) {
+  const lastTab = q.tab(`Tab ${tabCount}`);
+  await expect(lastTab).toBeFocused();
+  await expect(lastTab).toHaveAttribute("aria-selected", "true");
+  await expect(q.tabpanel(`Tab ${tabCount}`)).toBeVisible();
+  await verifyTabControlsPanel(q, `Tab ${tabCount}`);
+}
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("mount tabs", async ({ perf }) => {
+    await perf.measure(({ q }) => mountTabs(q), {
+      scriptProfile: true,
+      verify: ({ q }) => verifyTabsMounted(q),
+    });
+  });
+
+  test("move across tabs", async ({ perf }) => {
+    await perf.measure(({ page }) => moveAcrossTabs(page), {
+      setup: ({ q }) => setupTabs(q),
+      verify: ({ q }) => verifyMovedAcrossTabs(q),
+    });
+  });
+
+  // Keep the profiled traversal separate so its expensive diagnostic samples
+  // do not share a Playwright timeout with the timing samples above.
+  test("move across tabs (script profile)", async ({ perf }) => {
+    await perf.measure(({ page }) => moveAcrossTabs(page), {
+      scriptProfile: true,
+      profileLimit: 20,
+      setup: ({ q }) => setupTabs(q),
+      verify: ({ q }) => verifyMovedAcrossTabs(q),
+    });
+  });
+});

--- a/app/src/sandbox/tab-perf/perf-chrome.ts
+++ b/app/src/sandbox/tab-perf/perf-chrome.ts
@@ -57,17 +57,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
   test("move across tabs", async ({ perf }) => {
     await perf.measure(({ page }) => moveAcrossTabs(page), {
-      setup: ({ q }) => setupTabs(q),
-      verify: ({ q }) => verifyMovedAcrossTabs(q),
-    });
-  });
-
-  // Keep the profiled traversal separate so its expensive diagnostic samples
-  // do not share a Playwright timeout with the timing samples above.
-  test("move across tabs (script profile)", async ({ perf }) => {
-    await perf.measure(({ page }) => moveAcrossTabs(page), {
       scriptProfile: true,
-      profileLimit: 20,
       setup: ({ q }) => setupTabs(q),
       verify: ({ q }) => verifyMovedAcrossTabs(q),
     });

--- a/app/src/sandbox/tab-perf/style.css
+++ b/app/src/sandbox/tab-perf/style.css
@@ -1,0 +1,58 @@
+/* No transitions or animations: this sandbox is used by perf tests. */
+
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: flex-start;
+  padding: 1rem;
+}
+
+.button,
+.tab {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid hsl(204 10% 80%);
+  background: white;
+  color: hsl(204 10% 10%);
+  font: inherit;
+}
+
+.button {
+  border-radius: 0.5rem;
+  padding: 0.5rem 1rem;
+}
+
+.tab-list {
+  display: grid;
+  grid-template-columns: repeat(20, 3.5rem);
+  gap: 0.25rem;
+}
+
+.tab {
+  min-width: 0;
+  height: 2rem;
+  border-radius: 0.25rem;
+  padding: 0;
+}
+
+.tab[aria-selected="true"] {
+  background: hsl(204 100% 40%);
+  color: white;
+}
+
+.tab:focus-visible {
+  outline: 2px solid hsl(204 100% 40%);
+  outline-offset: 1px;
+}
+
+.panels {
+  width: 100%;
+}
+
+.panel {
+  border: 1px solid hsl(204 10% 80%);
+  border-radius: 0.5rem;
+  padding: 1rem;
+}


### PR DESCRIPTION
## Motivation

`Tab` and `TabPanel` combine composite navigation with panel registration, association, and disclosure state, but the Chrome performance workflow does not benchmark those costs directly at scale. Regressions in mounting a large tab set or repeatedly selecting panels with the keyboard are therefore difficult to catch.

## Solution

Add a `tab-perf` sandbox with 200 stable `Tab`/`TabPanel` pairs and animation-free, viewport-contained styling. The browser perf suite measures mounting all pairs and traversing from `Tab 1` to `Tab 200`:

```ts
for (let i = 1; i < tabCount; i++) {
  await page.keyboard.press("ArrowRight");
}
```

The tests verify public tab presence, focus, `aria-selected`, visible tabpanel state, and the `aria-controls` association produced by panel registration. Both timing rows request script profiling; the harness keeps their timing samples unprofiled and collects profile data in extra diagnostic iterations attached to each row.

## Verification

- `pnpm lint-fix`
- `pnpm lint-css`
- `pnpm tsc`
- `pnpm build-app-lite`
- `APP_PORT=4322 NEXTJS_PORT=4322 PERF_RESULTS_FILE=current-1.json PERF_ITERATIONS=5 PERF_WARMUP=1 pnpm -F app run test-perf --timeout=180000 src/sandbox/tab-perf/perf-chrome.ts`
