### PR TITLE
Update rolldown-plugin-dts to v0.27.3

### DIFF
--- a/packages/ariakit-scripts/package.json
+++ b/packages/ariakit-scripts/package.json
@@ -14,8 +14,9 @@
     "chokidar": "5.0.0",
     "commander": "15.0.0",
     "rolldown": "1.1.5",
-    "rolldown-plugin-dts": "0.27.1",
+    "rolldown-plugin-dts": "0.27.3",
     "ts-morph": "28.0.0",
+    "typescript": "npm:@typescript/typescript6@6.0.2",
     "vite-plugin-solid": "2.11.12"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -703,11 +703,14 @@ importers:
         specifier: 1.1.5
         version: 1.1.5
       rolldown-plugin-dts:
-        specifier: 0.27.1
-        version: 0.27.1(rolldown@1.1.5)(typescript@6.0.3)
+        specifier: 0.27.3
+        version: 0.27.3(@typescript/typescript6@6.0.2)(rolldown@1.1.5)
       ts-morph:
         specifier: 28.0.0
         version: 28.0.0
+      typescript:
+        specifier: npm:@typescript/typescript6@6.0.2
+        version: '@typescript/typescript6@6.0.2'
       vite-plugin-solid:
         specifier: 2.11.12
         version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.14)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(yaml@2.9.0))
@@ -9053,14 +9056,14 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
-  rolldown-plugin-dts@0.27.1:
-    resolution: {integrity: sha512-s1HLtZfsXcLsBrcqW6nmIcTqkBZd7Y9srgL9SMS2hNvl37US5jFl193d5ki2w9Ei5myP7ERLVlQX2o6ZTL/AQQ==}
+  rolldown-plugin-dts@0.27.3:
+    resolution: {integrity: sha512-J57nfkYu6dd6s/Pt4LwGHipbUcm969tyXbQ/kBz9+7m+oeVzD90AynO2u133I61LISwbCUh9l0bt0/tvhOdd7w==}
     engines: {node: ^22.18.0 || >=24.11.0}
     peerDependencies:
       '@ts-macro/tsc': ^0.3.6
       '@typescript/native-preview': '>=7.0.0-dev.20260325.1'
       rolldown: ^1.0.0
-      typescript: ^5.0.0 || ^6.0.0
+      typescript: ^5.0.0 || ^6.0.0 || ^7.0.0
       vue-tsc: ~3.2.0 || ~3.3.0
     peerDependenciesMeta:
       '@ts-macro/tsc':
@@ -9729,11 +9732,6 @@ packages:
 
   typescript@6.0.2:
     resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
-  typescript@6.0.3:
-    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -19505,7 +19503,7 @@ snapshots:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
 
-  rolldown-plugin-dts@0.27.1(rolldown@1.1.5)(typescript@6.0.3):
+  rolldown-plugin-dts@0.27.3(@typescript/typescript6@6.0.2)(rolldown@1.1.5):
     dependencies:
       dts-resolver: 3.0.0
       get-tsconfig: 5.0.0-beta.5
@@ -19515,7 +19513,7 @@ snapshots:
       yuku-codegen: 0.5.44
       yuku-parser: 0.5.44
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -20328,9 +20326,6 @@ snapshots:
       semver: 7.7.4
 
   typescript@6.0.2: {}
-
-  typescript@6.0.3:
-    optional: true
 
   typescript@7.0.2:
     optionalDependencies:


### PR DESCRIPTION
## Motivation

Update `rolldown-plugin-dts` while preserving Ariakit's declaration build.

Version 0.27.3 expands the plugin's TypeScript peer range to include TypeScript 7. With the repository's existing `typescript-7` alias, pnpm resolves the plugin against TypeScript 7 and the plugin automatically enables experimental `tsgo`. Ariakit builds declarations with project references:

```ts
dts({
  build: true,
  incremental: false,
})
```

The `tsgo` path cannot currently support this build mode, so package builds fail with:

```text
Error: tsgo did not generate dts file for packages/ariakit-utils/src/index.ts
```

This is an [upstream-known limitation](https://github.com/sxzz/rolldown-plugin-dts/issues/189): the plugin cannot redirect `tsgo --build` output and TypeScript 7 does not yet expose the API needed for an in-memory implementation.

## Solution

Upgrade `rolldown-plugin-dts` to 0.27.3 and explicitly declare Ariakit's stable TypeScript 6 alias in `@ariakit/scripts`:

```json
{
  "rolldown-plugin-dts": "0.27.3",
  "typescript": "npm:@typescript/typescript6@6.0.2"
}
```

This keeps the plugin on its supported `tsc` project-reference path without changing the repository-wide TypeScript 7 setup. The package-local dependency is narrower than a pnpm override and makes the compiler used by this build tool explicit.

The stable compiler declaration can be removed after `rolldown-plugin-dts` supports `build: true` through `tsgo`, or when Ariakit's declaration build no longer requires project references.

## Dependencies

| Package | Workspace | Old | New | Links |
| --- | --- | --- | --- | --- |
| `rolldown-plugin-dts` | `packages/ariakit-scripts` | 0.27.1 | 0.27.3 | [Source](https://github.com/sxzz/rolldown-plugin-dts) · [Changes](https://github.com/sxzz/rolldown-plugin-dts/compare/v0.27.1...v0.27.3) · [v0.27.3 release](https://github.com/sxzz/rolldown-plugin-dts/releases/tag/v0.27.3) |

The relevant upstream changes add TypeScript 7 peer support and automatically enable `tsgo` when TypeScript 7 is resolved. The 0.27.3 release also fixes option resolution ordering after Oxc resolution.
