### PR TITLE
Explain Ariakit Tailwind mental model

### DIFF
--- a/.changeset/200-tailwind-mental-model.md
+++ b/.changeset/200-tailwind-mental-model.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/tailwind": patch
+---
+
+Expanded the README with a material mental model and practical examples for composing layers, interactive states, frames, and contextual colors, and corrected the v0.2 contrast migration guidance.

--- a/packages/ariakit-tailwind/migrating-to-v02.md
+++ b/packages/ariakit-tailwind/migrating-to-v02.md
@@ -83,11 +83,20 @@ When the element already has `ak-layer`, only `hover:ak-state-6` needs to be add
 
 Compound contrast layer utilities are decomposed into color + parent-relative contrast.
 
-In v0.1, `ak-layer-contrast-<color>` adjusted the color's lightness to contrast against the **parent** layer. In v0.2, this is handled by `ak-layer-contrast` (base) + optionally `ak-layer-contrast-N` (amount). The base utility uses container queries to derive contrast direction from the parent layer's lightness and includes a default contrast amount of 25, matching the old numerical default. This is a parent-directed lightness amount, not a guaranteed contrast ratio.
+In v0.1, `ak-layer-contrast-<color>` adjusted the color's lightness to contrast against the **parent** layer. A trailing number set the selected color's lightness level before automatic parent contrast. The `0` level kept the theme color unchanged, but it did not set or disable contrast.
+
+In v0.2, this is handled by `ak-layer-contrast` (base) + optionally `ak-layer-contrast-N` (amount). The base utility uses container queries to derive contrast direction from the parent layer's lightness and includes a default contrast amount of 25, matching the old numerical default. This is a parent-directed lightness amount, not a guaranteed contrast ratio.
 
 ```diff
 - ak-layer-contrast-primary
 + ak-layer ak-layer-primary ak-layer-contrast
+```
+
+The v0.1 trailing `0` can be omitted while preserving parent contrast:
+
+```diff
+- ak-layer-contrast-secondary-0
++ ak-layer ak-layer-secondary ak-layer-contrast
 ```
 
 `ak-layer-contrast-N` overrides the default contrast amount. Higher values set a target farther from the parent's lightness. A value of `0` targets the parent's own lightness and may still move a color to the parent-selected side. To migrate a color without parent-directed contrast, omit both contrast utilities:

--- a/packages/ariakit-tailwind/migrating-to-v02.md
+++ b/packages/ariakit-tailwind/migrating-to-v02.md
@@ -83,19 +83,19 @@ When the element already has `ak-layer`, only `hover:ak-state-6` needs to be add
 
 Compound contrast layer utilities are decomposed into color + parent-relative contrast.
 
-In v0.1, `ak-layer-contrast-<color>` adjusted the color's lightness to contrast against the **parent** layer. In v0.2, this is handled by `ak-layer-contrast` (base) + optionally `ak-layer-contrast-N` (amount). The base utility uses container queries to derive contrast direction from the parent layer's lightness and includes a default contrast amount of 25 (matching the old default of ~3:1).
+In v0.1, `ak-layer-contrast-<color>` adjusted the color's lightness to contrast against the **parent** layer. In v0.2, this is handled by `ak-layer-contrast` (base) + optionally `ak-layer-contrast-N` (amount). The base utility uses container queries to derive contrast direction from the parent layer's lightness and includes a default contrast amount of 25, matching the old numerical default. This is a parent-directed lightness amount, not a guaranteed contrast ratio.
 
 ```diff
 - ak-layer-contrast-primary
 + ak-layer ak-layer-primary ak-layer-contrast
 ```
 
-`ak-layer-contrast-N` overrides the default contrast amount. Higher values push the color further from the parent's lightness; `ak-layer-contrast-0` disables the push entirely (useful when you want the raw color without any contrast adjustment):
+`ak-layer-contrast-N` overrides the default contrast amount. Higher values set a target farther from the parent's lightness. A value of `0` targets the parent's own lightness and may still move a color to the parent-selected side. To migrate a color without parent-directed contrast, omit both contrast utilities:
 
 ```diff
-  <!-- Keep the color as-is, no automatic contrast -->
+  <!-- Keep the color without parent-directed contrast -->
 - ak-layer-secondary
-+ ak-layer ak-layer-secondary ak-layer-contrast ak-layer-contrast-0
++ ak-layer ak-layer-secondary
 ```
 
 ### `ak-layer-canvas` → `ak-layer ak-layer-canvas`

--- a/packages/ariakit-tailwind/readme.md
+++ b/packages/ariakit-tailwind/readme.md
@@ -10,6 +10,7 @@ Ariakit Tailwind is framework and library agnostic. It works with any frontend f
 
 - [Installation](#installation)
 - [How it works](#how-it-works)
+- [Mental model](#mental-model)
 - [Theming](#theming)
 - [`ak-layer`](#ak-layer) — background, text, border colors for a surface
 - [`ak-ink`](#ak-ink) — text opacity inside a layer
@@ -38,39 +39,294 @@ Ariakit Tailwind is framework and library agnostic. It works with any frontend f
    @import "@ariakit/tailwind";
    ```
 
-4. Apply the base layer to a container element (must **not** be `html` or `:root`):
+4. Define the application canvas and starter component tokens:
+
+   ```css
+   @theme {
+     --color-canvas: #f5f8f7;
+     --color-primary: #2563eb;
+     --color-warning: #d97706;
+
+     --radius-card: var(--radius-2xl);
+     --spacing-card: --spacing(4);
+
+     --radius-field: var(--radius-xl);
+     --spacing-field: --spacing(2);
+
+     --radius-badge: calc(infinity * 1px);
+     --spacing-badge: --spacing(1.5);
+   }
+
+   :root {
+     color-scheme: light;
+
+     @variant dark {
+       --color-canvas: #0b1110;
+       color-scheme: dark;
+     }
+   }
+   ```
+
+   This follows Tailwind's `dark` variant. For a manual theme toggle, configure that variant to match your root selector or override `--color-canvas` and `color-scheme` on the selector directly.
+
+5. Apply the base layer to a container element (must **not** be `html` or `:root`):
 
    <!-- prettier-ignore -->
    ```html
-   <body class="ak-layer ak-layer-white dark:ak-layer-gray-950">
+   <body class="ak-layer ak-layer-canvas">
    ```
 
    Or via `@apply`:
 
    ```css
    body {
-     @apply ak-layer ak-layer-white dark:ak-layer-gray-950;
+     @apply ak-layer ak-layer-canvas;
    }
    ```
+
+   Choose descendant surfaces deliberately, as described in the [mental model](#mental-model).
 
 ## How it works
 
 Ariakit Tailwind revolves around a few families of utilities:
 
-- **[`ak-layer`](#ak-layer)** turns any element into a _layer_ — a surface with its own background, text, and edge colors. Layers can nest, and lightness modifiers such as `ak-layer-lighten-*`, `ak-layer-darken-*`, and numeric `ak-layer-*` modifiers shift nested surfaces relative to their parent so stacked surfaces read correctly in both light and dark modes.
+- **[`ak-layer`](#ak-layer)** turns an element into a _layer_, a surface with its own background, text, and edge colors. Directional modifiers such as `ak-layer-lighten-*` and `ak-layer-darken-*` express raised and recessed surfaces, while numeric `ak-layer-*` modifiers provide appearance-aware separation without assigning a fixed depth direction.
 - **[`ak-ink`](#ak-ink)** sets the text opacity for the layer's own text. Safe to apply on the same element as `ak-layer` or on a descendant.
 - **[`ak-text`](#ak-text)** colors inline text _inside_ a layer with automatic WCAG contrast. Must go on a descendant, not on the `ak-layer` element itself.
 - **[`ak-edge`](#ak-edge)** colors borders and rings, adapting opacity and contrast to the element's own layer. `ak-edge-*` utilities require the static `ak-layer` class on the same element.
 - **[`ak-outline`](#ak-outline)** colors outlines in the same adaptive way.
 - **[`ak-frame`](#ak-frame)** handles radius, padding, margin, borders, and concentric-radius layout.
 
-Color channel utilities are authored in [OKLCH](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/oklch), so modifiers like `ak-layer-warm-40` or `ak-text-saturate-50` behave predictably across hues. Text contrast is converted to LCH at the final contrast step, and layer mixing can use any supported CSS `color-mix()` interpolation method. Because every value is computed relatively, changing a single theme token ripples through every layer, text, edge, and frame that depends on it — so users can reskin the whole system without breaking contrast, depth, or shape relationships.
+Static utilities activate their context, while modifiers configure it. Pair `ak-layer-*`, `ak-state-*`, and `ak-edge-*` with `ak-layer` on the same element; pair `ak-text-*` with `ak-text` on the same descendant; pair `ak-frame-*` with `ak-frame`; and pair `ak-outline-*` with `ak-outline`. `ak-ink-*` is self-contained.
+
+Color channel utilities are authored in [OKLCH](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/oklch), so modifiers like `ak-layer-warm-40` or `ak-text-saturate-50` behave predictably across hues. Text contrast is converted to LCH at the final contrast step, and layer mixing can use any supported CSS `color-mix()` interpolation method. Because every value is computed relatively, changing a single theme token ripples through every layer, text, edge, and frame that depends on it, so users can reskin the whole system without breaking contrast, depth, or shape relationships.
 
 ### Value scales
 
 Bare numeric modifiers use Ariakit's documented authoring scales. For example, lightness and alpha values use `0`–`100`, chroma values use `0`–`40`, and mix amounts use `0`–`100`.
 
 Arbitrary values and custom properties are raw CSS values. That means percent-style modifiers use normalized `0`–`1` values in arbitrary/custom-property form, even when their bare numeric forms use Ariakit's `0`–`100` or `0`–`40` authoring scales. Use normalized OKLCH channel values like `ak-layer-l-[0.8]`, normalized percent-style values like `ak-layer-warm-[0.4]` or `ak-text-saturate-[0.25]`, raw deltas like `ak-layer-[calc(l+0.1)]`, percentages where CSS expects percentages like `ak-layer-mix-amount-[35%]`, and custom properties that already contain those raw values.
+
+## Mental model
+
+Think in materials, not elements. Ariakit Tailwind models a small tree of intentional surfaces and the content, boundaries, and shapes that belong to them. This material tree is usually much smaller than the DOM tree.
+
+This does not imply skeuomorphic decoration. A flat interface still needs a coherent answer to what lies on the same plane, what sits above it, what is recessed into it, and what has a different material or semantic finish. Tone, containment, edges, and shape communicate those relationships even when there are no realistic textures or shadows.
+
+### Think about the whole scene
+
+Start with one canvas for the application. Then add a layer only when an element represents a visible surface with a purpose. Layout containers, headers, rows, text wrappers, and spacing elements should usually inherit the nearest surface.
+
+Every `ak-layer` paints a background and establishes the text, edge, and contrast context inherited by its descendants. Adding one at every level turns DOM nesting into a tonal staircase:
+
+```html
+<!-- Avoid: none of these nested layers has a distinct material purpose. -->
+<article class="ak-layer ak-layer-3">
+  <header class="ak-layer ak-layer-3">
+    <h2 class="ak-layer ak-layer-3">Deployment</h2>
+  </header>
+</article>
+```
+
+A more intentional scene uses one raised card, keeps its ordinary content on the card, and creates a new layer only for the recessed well:
+
+```html
+<body class="ak-layer ak-layer-canvas">
+  <main class="p-6">
+    <article
+      class="ak-layer ak-layer-lighten-6 ak-frame ak-frame-card/card ak-frame-bordering grid gap-4"
+    >
+      <header class="grid gap-1">
+        <h2>Deployment</h2>
+        <p class="ak-ink-70">Updated two minutes ago</p>
+      </header>
+
+      <section
+        class="ak-layer ak-layer-darken-3 ak-frame ak-frame-field/field ak-frame-bordering"
+      >
+        Recessed deployment details
+      </section>
+    </article>
+  </main>
+</body>
+```
+
+The `body`, card, and well are materials. The `main`, `header`, heading, and paragraph are structure or content on those materials, so they do not need layers.
+
+### Give every surface a spatial role
+
+In ordinary lighting, an exposed surface catches more light while a cutout or well receives less. Ariakit expresses that directional relationship directly, and the same intent holds on light and dark canvases:
+
+| Intent                      | Visual role                                                                          | Utilities                                                                                 |
+| --------------------------- | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
+| Same plane                  | Content or layout that belongs to the current material                               | No new `ak-layer`                                                                         |
+| Raised or exposed           | Card, popover, floating toolbar, or control above its support                        | `ak-layer ak-layer-lighten-*`                                                             |
+| Recessed                    | Well, track, code area, media bed, input bed, or pressed region                      | `ak-layer ak-layer-darken-*`                                                              |
+| Appearance-aware separation | Selected row, adjacent pane, or neutral control that should contrast in either theme | `ak-layer ak-layer-*`                                                                     |
+| New material or pigment     | Canvas, primary action, warning, brand region, or another intentional color boundary | `ak-layer ak-layer-<color>`, optionally with `ak-layer-mix-*`                             |
+| Interactive response        | The same material responding to hover, press, focus, selection, or disabled state    | Variant-prefixed `ak-state-*`, `ak-ink-*`, `ak-outline-*`, and other contextual modifiers |
+| Parent-directed contrast    | A surface whose lightness must move against its supporting layer                     | `ak-layer-contrast`                                                                       |
+| Self-relative tonal push    | A surface that needs a minimum tonal move and must skip the ambiguous midrange       | `ak-layer-push-*`                                                                         |
+
+Numeric `ak-layer-<number>` modifiers are not elevation values. They request appearance-aware separation from the selected source, which defaults to the parent layer. They normally move light sources darker and dark sources lighter, but the contrast-safe lightness pipeline may clamp the target or move it past an ambiguous midrange. Use them to separate a surface without declaring that it is above or below, and use `ak-layer-lighten-*` or `ak-layer-darken-*` when spatial direction matters.
+
+Relative adjustments accumulate. Repeating them through wrappers creates competing boxes and can exhaust the useful tonal range. A practical test for every layer is: "Why is this a different material?" If the answer is only "because this element is nested," remove it.
+
+Interactive states usually change the existing material instead of creating another nested surface:
+
+```html
+<button
+  class="ak-layer ak-layer-lighten-6 hover:ak-state-lighten-2 active:ak-state-darken-3 ak-frame ak-frame-field/field focus-visible:ak-outline focus-visible:ak-outline-primary focus-visible:outline-2"
+>
+  Save
+</button>
+```
+
+The button starts raised, becomes slightly more exposed on hover, and darkens when pressed. Its focus outline is an external signal, not another material.
+
+### Treat color as a material finish
+
+Lightness usually communicates spatial relationship. Hue, chroma, warmth, and mixing describe the material's pigment, atmosphere, or semantic identity. Changing hue at every nesting level does not create meaningful depth.
+
+Use an absolute `ak-layer-<color>` at a deliberate boundary such as the canvas, a primary action, or a warning surface. Use `ak-layer-mix-*` when that pigment should feel tinted by its surrounding material:
+
+```html
+<aside
+  class="ak-layer ak-layer-warning ak-layer-mix-15 ak-frame ak-frame-card/card ak-frame-bordering"
+>
+  <strong>Pending review</strong>
+</aside>
+```
+
+Mixing creates a contextual solid color, not transparency and not another depth level. Hue and chroma adjustments similarly change the finish of the current material.
+
+Custom gradients, patterns, and textures are also surface paint. Derive them from the resolved layer variables so the visible pixels stay related to the contrast context:
+
+```html
+<div
+  class="surface-pattern ak-layer ak-layer-lighten-6 ak-frame ak-frame-card/card"
+>
+  ...
+</div>
+```
+
+```css
+.surface-pattern {
+  --pattern-color: color-mix(
+    in oklab,
+    var(--ak-layer),
+    var(--ak-layer-parent) 35%
+  );
+  background-image: linear-gradient(
+    135deg,
+    var(--pattern-color) 1px,
+    transparent 1px
+  );
+  background-size: 0.75rem 0.75rem;
+}
+```
+
+A custom image or multistop gradient can still vary independently across the surface, so inspect text contrast against its actual pixels.
+
+### Put content and boundaries on the material
+
+The other utility families describe what belongs to a surface rather than creating more surfaces:
+
+| Feature        | Material role                                                                       |
+| -------------- | ----------------------------------------------------------------------------------- |
+| Normal text    | Inherits the layer's default ink                                                    |
+| `ak-ink-*`     | Changes the strength of neutral writing while preserving a readable contrast floor  |
+| `ak-text-*`    | Applies adaptive colored pigment to a descendant inside a layer                     |
+| `ak-edge-*`    | Configures the seam between the current material and its surroundings               |
+| `ak-outline-*` | Draws an external focus or attention signal                                         |
+| `ak-frame-*`   | Defines the material's silhouette, inset, border thickness, and concentric geometry |
+| `ak-state-*`   | Changes the current material temporarily in response to interaction                 |
+
+Normal text needs no utility. Use `ak-ink-*` for hierarchy and `ak-text` on a descendant when text needs its own adaptive color:
+
+```html
+<article class="ak-layer ak-layer-lighten-6 ak-frame ak-frame-card/card">
+  <h2>Build complete</h2>
+  <p class="ak-ink-70">Finished three minutes ago</p>
+  <a class="ak-text ak-text-primary" href="/builds/1284">View build 1284</a>
+</article>
+```
+
+A neutral badge can use a semantic edge and adaptive colored text without turning either mark into another layer:
+
+```html
+<span
+  class="ak-layer ak-layer-6 ak-edge-warning ak-edge-35 ak-frame ak-frame-badge/badge ak-frame-bordering"
+>
+  <span class="ak-text ak-text-warning ak-text-25">Pending review</span>
+</span>
+```
+
+Do not put `ak-text` on the `ak-layer` element itself. It makes its own background transparent so the ancestor layer can show through.
+
+Use edges where materials meet closely or a control needs a clearer affordance. Avoid outlining every surface. Tonal separation, spacing, and shape should carry most of the hierarchy. `ak-frame-bordering` is a useful adaptive seam because it chooses a border or ring from the parent appearance and the layer's explicit lighten or darken relationship.
+
+### Give isolated components their own shape
+
+Every isolated card, control, popover, dialog, and badge should declare a non-zero radius by default. An isolated `ak-frame` has a zero declared radius until a radius modifier is applied, while a nested frame may derive an effective concentric radius from its parent. Component recipes should still select a semantic radius and usually its padding:
+
+```css
+@theme {
+  --radius-card: var(--radius-2xl);
+  --spacing-card: --spacing(4);
+
+  --radius-field: var(--radius-xl);
+  --spacing-field: --spacing(2);
+
+  --radius-dialog: var(--radius-3xl);
+  --spacing-dialog: --spacing(6);
+
+  --radius-badge: calc(infinity * 1px);
+  --spacing-badge: --spacing(1.5);
+}
+```
+
+```html
+<article class="ak-layer ak-layer-lighten-6 ak-frame ak-frame-card/card">
+  ...
+</article>
+<button class="ak-layer ak-layer-6 ak-frame ak-frame-field/field">...</button>
+<div class="ak-layer ak-layer-lighten-6 ak-frame ak-frame-dialog/dialog">
+  Dialog
+</div>
+<span class="ak-layer ak-layer-6 ak-frame ak-frame-badge/badge">Badge</span>
+```
+
+These recipes own their shapes even when rendered without a parent frame. When frames are nested, Ariakit reconciles their effective radii with the parent's radius, padding, and border plus the child's frame margin so nearby corners remain concentric.
+
+A square visual language is a theme decision. Override the shared radius tokens once instead of putting `ak-frame-rounded-none` in every component recipe:
+
+```css
+:root[data-shape="square"] {
+  --radius-card: 0px;
+  --radius-field: 0px;
+  --radius-dialog: 0px;
+  --radius-badge: 0px;
+}
+```
+
+Local square corners are still appropriate when geometry is intentionally attached or flush, such as a viewport sidebar or an internal segment of a composite control. Use `ak-frame ak-frame-force ak-frame-rounded-none` when that local shape must be exactly square. Let `ak-frame-cover`, `ak-frame-start`, and `ak-frame-end` compute any corners that meet the parent's outer silhouette.
+
+Frame padding and borders participate in concentric geometry. Use `ak-frame-p-*`, the combined `ak-frame-<radius>/<padding>` form, and `ak-frame-border`, `ak-frame-ring`, or `ak-frame-bordering` for component chrome. Do not override frame padding with `p-*`, `px-*`, or `py-*` on the same element. Put asymmetric layout spacing on an inner wrapper instead.
+
+### Judge the whole scene
+
+Accessibility math protects contrast, not taste. Before shipping, inspect the complete scene and ask:
+
+- Can every layer be described as the canvas, raised, recessed, appearance-aware separation, semantic material, or interactive material?
+- Does removing any layer make the hierarchy clearer?
+- Do raised and recessed relationships remain coherent when only the canvas changes between light and dark?
+- Do hover, active, selected, focus, and disabled states change the existing material with a clear purpose?
+- Do isolated component recipes remain intentionally rounded, and can a square theme be achieved by changing shared tokens only?
+- Do nested corners and adaptive edges describe the intended material boundaries?
+- Does the composition remain coherent in [`contrast-more`](#accessibility), inside another semantic layer, and across supported browsers?
+
+Package contributors should use the existing light, dark, and high-contrast computed-style snapshot matrix. That sandbox deliberately exercises many utilities at once and is a behavior test, not an aesthetic example.
 
 ## Theming
 
@@ -80,8 +336,8 @@ Ariakit Tailwind integrates directly with Tailwind's theming system. Every `--co
 @theme {
   /* Any --color-* token can be used in ak-layer, ak-text, ak-edge, ak-outline */
   --color-canvas: #f1f1f1;
-  --color-primary: #007acc;
-  --color-secondary: #ec4899;
+  --color-primary: #2563eb;
+  --color-warning: #d97706;
 
   /* Any --radius-* / --spacing-* token can be used in ak-frame.
    * Sharing names lets you reference both sides with a single modifier:
@@ -89,14 +345,14 @@ Ariakit Tailwind integrates directly with Tailwind's theming system. Every `--co
   --radius-field: var(--radius-xl);
   --spacing-field: --spacing(2);
 
-  --radius-container: var(--radius-xl);
-  --spacing-container: --spacing(1);
+  --radius-card: var(--radius-2xl);
+  --spacing-card: --spacing(4);
 }
 
 /* Theme overrides per variant */
 :root {
   @variant dark {
-    --color-canvas: #0e0e11;
+    --color-canvas: #0b1110;
   }
 }
 ```
@@ -135,12 +391,19 @@ Override any of these in your own `@theme` block:
 
 ## `ak-layer`
 
-Layers are the foundation of Ariakit Styles. Every element with `ak-layer` is a surface with its own background, text, and edge colors. Add lightness modifiers to nested layers so stacked cards read progressively lighter in light mode and progressively darker-to-lighter in dark mode.
+Layers are the foundation of Ariakit Styles. Every element with `ak-layer` is a surface with its own background, text, and edge colors, so only use it when the element represents an intentional material. Use `ak-layer-lighten-*` for raised surfaces, `ak-layer-darken-*` for recessed surfaces, and numeric `ak-layer-*` modifiers for appearance-aware separation that does not imply a fixed depth direction.
 
 ```html
 <body class="ak-layer ak-layer-canvas">
-  <div class="ak-layer ak-layer-lighten-5">Subtly lighter surface</div>
-  <div class="ak-layer ak-layer-primary">Brand-colored surface</div>
+  <article class="ak-layer ak-layer-lighten-6 ak-frame ak-frame-card/card">
+    Raised card
+  </article>
+  <div class="ak-layer ak-layer-darken-3 ak-frame ak-frame-field/field">
+    Recessed well
+  </div>
+  <button class="ak-layer ak-layer-6 ak-frame ak-frame-field/field">
+    Appearance-aware control
+  </button>
 </body>
 ```
 
@@ -153,24 +416,26 @@ A layer automatically sets border and ring colors through the shared `--ak-edge`
 
 Use [`ak-edge`](#ak-edge) to fine-tune border and ring colors without touching the layer background.
 
+Custom backgrounds can read the resolved `--ak-layer` and `--ak-layer-parent` colors. See [Treat color as a material finish](#treat-color-as-a-material-finish) for patterns that stay related to their contrast context.
+
 ### Setting the layer color
 
-| Utility                   | Description                                                                                                                                                                                         |
-| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ak-layer`                | Required base class. Sets background, text, border, and ring colors.                                                                                                                                |
-| `ak-layer-<color>`        | Sets the layer to a specific color. Accepts any theme color (e.g. `ak-layer-primary`, `ak-layer-blue-500`) or arbitrary value (`ak-layer-[#131418]`).                                               |
-| `ak-layer-color-<color>`  | Explicit color-only alias. Useful for custom properties without a typed arbitrary value hint (`ak-layer-color-(--surface)`).                                                                        |
-| `ak-layer-<number>`       | Shifts lightness relative to parent layer (`0`–`100`). Bare `ak-layer` doesn't shift lightness on its own. Arbitrary values are raw, e.g. `ak-layer-[calc(l+0.1)]`.                                 |
-| `ak-layer-offset-<value>` | Explicit lightness-offset alias for `ak-layer-<number>`. Useful for custom properties without a typed arbitrary value hint (`ak-layer-offset-(--depth)`). Arbitrary/custom-property values are raw. |
-| `ak-layer-<chroma>`       | Sets chroma from a named preset, e.g. `ak-layer-vivid`, `ak-layer-muted`. See `--chroma-*` tokens.                                                                                                  |
-| `ak-layer-<hue>`          | Sets hue from a named preset, e.g. `ak-layer-red`, `ak-layer-blue`. See `--hue-*` tokens.                                                                                                           |
+| Utility                   | Description                                                                                                                                                                                                                                                                                      |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ak-layer`                | Required base class. Sets background, text, border, and ring colors.                                                                                                                                                                                                                             |
+| `ak-layer-<color>`        | Sets the layer to a specific color. Accepts any theme color (e.g. `ak-layer-primary`, `ak-layer-blue-500`) or arbitrary value (`ak-layer-[#131418]`).                                                                                                                                            |
+| `ak-layer-color-<color>`  | Explicit color-only alias. Useful for custom properties without a typed arbitrary value hint (`ak-layer-color-(--surface)`).                                                                                                                                                                     |
+| `ak-layer-<number>`       | Applies an appearance-aware lightness offset relative to the selected source, which defaults to the parent layer (`0`–`100`). This provides separation rather than fixed elevation. Bare `ak-layer` doesn't shift lightness on its own. Arbitrary values are raw, e.g. `ak-layer-[calc(l+0.1)]`. |
+| `ak-layer-offset-<value>` | Explicit lightness-offset alias for `ak-layer-<number>`. Useful for custom properties without a typed arbitrary value hint (`ak-layer-offset-(--depth)`). Arbitrary/custom-property values are raw.                                                                                              |
+| `ak-layer-<chroma>`       | Sets chroma from a named preset, e.g. `ak-layer-vivid`, `ak-layer-muted`. See `--chroma-*` tokens.                                                                                                                                                                                               |
+| `ak-layer-<hue>`          | Sets hue from a named preset, e.g. `ak-layer-red`, `ak-layer-blue`. See `--hue-*` tokens.                                                                                                                                                                                                        |
 
 ### Lightness adjustments
 
 | Utility                      | Description                                                                                                                                                            |
 | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ak-layer-lighten-<number>`  | Lightens the layer by `<number>`%. Arbitrary values are raw (`ak-layer-lighten-[0.05]`).                                                                               |
-| `ak-layer-darken-<number>`   | Darkens the layer by `<number>`%. Arbitrary values are raw (`ak-layer-darken-[0.05]`).                                                                                 |
+| `ak-layer-lighten-<number>`  | Lightens the layer by `<number>`%, useful for intentionally raised or exposed surfaces. Arbitrary values are raw (`ak-layer-lighten-[0.05]`).                          |
+| `ak-layer-darken-<number>`   | Darkens the layer by `<number>`%, useful for intentionally recessed or pressed surfaces. Arbitrary values are raw (`ak-layer-darken-[0.05]`).                          |
 | `ak-layer-push-<number>`     | Minimum lightness shift (self-relative), jumping the forbidden mid-luminance range where contrast math becomes unreliable.                                             |
 | `ak-layer-contrast`          | Adapts the layer to contrast against its parent (preset `25`).                                                                                                         |
 | `ak-layer-contrast-<number>` | Custom contrast amount (`0`–`100`, default `25`).                                                                                                                      |
@@ -207,12 +472,12 @@ Use [`ak-edge`](#ak-edge) to fine-tune border and ring colors without touching t
 | `ak-layer-mix`                 | Enables mixing. By default, mixes with the parent layer at `50%` using the `oklab` interpolation method.                                                           |
 | `ak-layer-mix-<color>`         | Enables mixing with a color, e.g. `ak-layer-mix-primary` or `ak-layer-mix-[#000]`.                                                                                 |
 | `ak-layer-mix-color-<color>`   | Sets the mix color for `ak-layer-mix`. Useful for custom properties (`ak-layer-mix-color-(--mix-color)`).                                                          |
-| `ak-layer-mix-<number>`        | Sets the mix amount (`0`–`100`).                                                                                                                                   |
+| `ak-layer-mix-<number>`        | Enables mixing and sets the mix amount (`0`–`100`).                                                                                                                |
 | `ak-layer-mix-amount-<value>`  | Sets the amount for `ak-layer-mix`. Useful for custom properties (`ak-layer-mix-amount-(--mix-amount)`). Arbitrary/custom-property values are raw CSS percentages. |
 | `ak-layer-mix-<method>`        | Sets the interpolation method, e.g. `ak-layer-mix-oklch`, `ak-layer-mix-oklch-shorter-hue`, `ak-layer-mix-srgb`. See the `--mix-*` tokens.                         |
 | `ak-layer-mix-method-<method>` | Sets the interpolation method for `ak-layer-mix`. Useful for custom properties (`ak-layer-mix-method-(--mix-method)`).                                             |
 
-Combine freely — `ak-layer ak-layer-primary ak-layer-mix ak-layer-mix-30 ak-layer-mix-oklch` mixes the primary color 30% into the parent layer using OKLCH.
+Combine freely: `ak-layer ak-layer-primary ak-layer-mix-30 ak-layer-mix-oklch` mixes the primary color 30% into the parent layer using OKLCH.
 
 The explicit `ak-layer-mix-*` longhands configure the mix color, amount, and method, but don't enable mixing by themselves. Pair them with `ak-layer-mix` when setting any of these values independently.
 
@@ -223,7 +488,9 @@ The explicit `ak-layer-mix-*` longhands configure the mix color, amount, and met
 The static `ak-layer` class must be applied to the same element as `ak-state-*`. Keep `ak-layer` unprefixed, then add state utilities with variants such as `hover:` or `active:`.
 
 ```html
-<button class="ak-layer ak-layer-primary hover:ak-state-10 active:ak-state-20">
+<button
+  class="ak-layer ak-layer-primary hover:ak-state-lighten-2 active:ak-state-darken-3 ak-frame ak-frame-field/field"
+>
   Primary action
 </button>
 ```
@@ -260,6 +527,8 @@ Controls the opacity of text inside a layer — useful for secondary text, capti
 
 > **Apply `ak-text` to a descendant, not to the layer element itself.** It forces `background-color: transparent` to let the layer show through, which would erase the surface if placed on the `ak-layer` element. For styling the layer's own text color, use [`ak-ink`](#ak-ink) instead.
 
+Normal text should inherit the layer's text color without an extra utility. Use `ak-ink-*` for secondary or translucent text. Use `ak-text` on a descendant when the text needs its own adaptive color or additional contrast, and add `ak-text-<color>` when it needs a specific hue.
+
 ```html
 <div class="ak-layer ak-layer-canvas">
   <span class="ak-text ak-text-primary">Primary text</span>
@@ -292,18 +561,18 @@ Controls the opacity of text inside a layer — useful for secondary text, capti
 
 ### Channels and bounds
 
-| Utility                     | Description                                                                                                           |
-| --------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `ak-text-l-<value>`         | Absolute lightness (`0`–`100` for bare numbers, raw `0`–`1` for arbitrary/custom-property values).                    |
-| `ak-text-c-<value>`         | Absolute chroma (`0`–`40` for bare numbers, raw OKLCH chroma for arbitrary/custom-property values) or a named preset. |
-| `ak-text-h-<value>`         | Absolute hue. Accepts named hues or degrees, including custom properties.                                             |
-| `ak-text-h-rotate-<number>` | Rotates hue by degrees.                                                                                               |
-| `ak-text-max-<value>`       | Caps lightness, or caps chroma when given a named chroma preset.                                                      |
-| `ak-text-min-<value>`       | Floors lightness or chroma, same form.                                                                                |
-| `ak-text-max-l-<value>`     | Caps lightness specifically. Arbitrary/custom-property values are raw.                                                |
-| `ak-text-min-l-<value>`     | Floors lightness specifically. Arbitrary/custom-property values are raw.                                              |
-| `ak-text-max-c-<value>`     | Caps chroma specifically. Arbitrary/custom-property values are raw.                                                   |
-| `ak-text-min-c-<value>`     | Floors chroma specifically. Arbitrary/custom-property values are raw.                                                 |
+| Utility                     | Description                                                                                                                                                                 |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ak-text-l-<value>`         | Sets the candidate absolute lightness (`0`–`100` for bare numbers, raw `0`–`1` for arbitrary/custom-property values). Automatic contrast may adjust the rendered lightness. |
+| `ak-text-c-<value>`         | Absolute chroma (`0`–`40` for bare numbers, raw OKLCH chroma for arbitrary/custom-property values) or a named preset.                                                       |
+| `ak-text-h-<value>`         | Absolute hue. Accepts named hues or degrees, including custom properties.                                                                                                   |
+| `ak-text-h-rotate-<number>` | Rotates hue by degrees.                                                                                                                                                     |
+| `ak-text-max-<value>`       | Caps lightness, or caps chroma when given a named chroma preset.                                                                                                            |
+| `ak-text-min-<value>`       | Floors lightness or chroma, same form.                                                                                                                                      |
+| `ak-text-max-l-<value>`     | Caps lightness specifically. Arbitrary/custom-property values are raw.                                                                                                      |
+| `ak-text-min-l-<value>`     | Floors lightness specifically. Arbitrary/custom-property values are raw.                                                                                                    |
+| `ak-text-max-c-<value>`     | Caps chroma specifically. Arbitrary/custom-property values are raw.                                                                                                         |
+| `ak-text-min-c-<value>`     | Floors chroma specifically. Arbitrary/custom-property values are raw.                                                                                                       |
 
 ## `ak-edge`
 
@@ -364,7 +633,7 @@ Controls the opacity of text inside a layer — useful for secondary text, capti
 
 ```html
 <button
-  class="ak-layer ak-outline ak-outline-primary outline-2 focus-visible:outline"
+  class="ak-layer ak-frame ak-frame-field/field ak-outline ak-outline-primary outline-2 focus-visible:outline"
 >
   Outlined button
 </button>
@@ -412,6 +681,10 @@ Controls the opacity of text inside a layer — useful for secondary text, capti
 
 `ak-frame` defines border radius, padding, margin, borders, and layout flow **relative to the parent frame**. Nested frames automatically compute concentric radii that look correct regardless of the outermost container's size. When no parent frame exists, values are treated as absolute.
 
+See [Give isolated components their own shape](#give-isolated-components-their-own-shape) for choosing semantic radii, preserving default roundness, and implementing a square theme.
+
+Use `ak-frame-p-*` or the combined `ak-frame-<radius>/<padding>` form when padding belongs to component chrome. This keeps padding, borders, and nested radii in the same geometry model.
+
 ```html
 <!-- radius 2xl, padding 1 -->
 <div class="ak-frame ak-frame-2xl/1">
@@ -433,10 +706,10 @@ Controls the opacity of text inside a layer — useful for secondary text, capti
 
 ### Setup
 
-| Utility          | Description                                                                        |
-| ---------------- | ---------------------------------------------------------------------------------- |
-| `ak-frame`       | Required base class. Sets up the frame context for radius and padding inheritance. |
-| `ak-frame-force` | Uses the declared radius exactly, ignoring parent-frame context.                   |
+| Utility          | Description                                                                                                                                                                                                        |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ak-frame`       | Required base class. Sets up the frame context for radius and padding inheritance. An isolated frame declares zero radius until a radius modifier is applied, while a nested frame may derive a concentric radius. |
+| `ak-frame-force` | Uses the declared radius exactly, ignoring parent-frame context.                                                                                                                                                   |
 
 ### Radius and padding
 
@@ -447,30 +720,19 @@ The shortcut form `ak-frame-<radius>/<padding>` sets both values at once. The pa
 <!-- rounded-xl, p-4 -->
 <div class="ak-frame ak-frame-[1rem]/2"></div>
 <!-- r 1rem, p-2 -->
-<div class="ak-frame ak-frame-container/container"></div>
-<!-- --radius-container, --spacing-container -->
+<div class="ak-frame ak-frame-card/card"></div>
+<!-- --radius-card, --spacing-card -->
 ```
 
-Frame presets make paired radius/spacing tokens ergonomic:
+Sharing a name between radius and spacing tokens lets one modifier set both values.
 
-```css
-@theme {
-  --radius-card: var(--radius-xl);
-  --spacing-card: --spacing(6);
-}
-```
-
-```html
-<div class="ak-frame ak-frame-card/card">Card</div>
-```
-
-| Utility                       | Description                                                                                                                                           |
-| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ak-frame-<radius>`           | Sets border radius only. Accepts any `--radius-*` token (e.g. `ak-frame-xl`, `ak-frame-2xl`, `ak-frame-full`) or arbitrary value (`ak-frame-[1rem]`). |
-| `ak-frame-<radius>/<padding>` | Sets radius **and** padding. Padding accepts `--spacing-*` tokens or numeric values (`/4`).                                                           |
-| `ak-frame-rounded-<radius>`   | Alias for radius-only.                                                                                                                                |
-| `ak-frame-rounded-none`       | Sets radius to `0px`.                                                                                                                                 |
-| `ak-frame-p-<spacing>`        | Padding only. Accepts `--spacing-*` tokens, numeric values, or arbitrary values.                                                                      |
+| Utility                       | Description                                                                                                                                                                |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ak-frame-<radius>`           | Sets border radius only. Accepts any defined `--radius-*` token (e.g. `ak-frame-xl`, `ak-frame-2xl`, or a custom `ak-frame-badge`) or arbitrary value (`ak-frame-[1rem]`). |
+| `ak-frame-<radius>/<padding>` | Sets radius **and** padding. Padding accepts `--spacing-*` tokens or numeric values (`/4`).                                                                                |
+| `ak-frame-rounded-<radius>`   | Alias for radius-only.                                                                                                                                                     |
+| `ak-frame-rounded-none`       | Sets the declared radius to `0px`. Add `ak-frame-force` when a nested frame must remain exactly square.                                                                    |
+| `ak-frame-p-<spacing>`        | Padding only. Accepts `--spacing-*` tokens, numeric values, or arbitrary values.                                                                                           |
 
 ### Margin
 
@@ -483,12 +745,12 @@ Frame presets make paired radius/spacing tokens ergonomic:
 
 All three utilities accept no argument (defaults to `1px`), named widths (`0`, `1`, `2`, `4`, `8`), or arbitrary values (`[3px]`).
 
-| Utility                                             | Description                                                                                                                                                                |
-| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ak-frame-border` / `ak-frame-border-<width>`       | Applies a border whose width is factored into nested-frame radius calculations.                                                                                            |
-| `ak-frame-ring` / `ak-frame-ring-<width>`           | Applies a ring with the same treatment. Rings draw outside the border-box without shifting layout.                                                                         |
-| `ak-frame-bordering` / `ak-frame-bordering-<width>` | Adaptive edge: chooses border or ring based on parent layer appearance and whether the layer is lightening or darkening, keeping surfaces visually separated across modes. |
-| `ak-frame-bordering-inherit`                        | Inherits the nearest ancestor frame border, ring, or bordering width, skipping intermediate frames that do not explicitly set one; falls back to `0px`.                    |
+| Utility                                             | Description                                                                                                                                                                         |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ak-frame-border` / `ak-frame-border-<width>`       | Applies a border whose width is factored into nested-frame radius calculations.                                                                                                     |
+| `ak-frame-ring` / `ak-frame-ring-<width>`           | Applies a ring with the same treatment. Rings draw outside the border-box without shifting layout.                                                                                  |
+| `ak-frame-bordering` / `ak-frame-bordering-<width>` | Adaptive edge: chooses a border or ring based on parent layer appearance and the layer's explicit lighten or darken relationship, keeping surfaces visually separated across modes. |
+| `ak-frame-bordering-inherit`                        | Inherits the nearest ancestor frame border, ring, or bordering width, skipping intermediate frames that do not explicitly set one; falls back to `0px`.                             |
 
 ### Cover and flow
 
@@ -513,7 +775,7 @@ All three utilities accept no argument (defaults to `1px`), named widths (`0`, `
 
 ## Variants
 
-Variants apply utilities conditionally based on the parent layer or user preference. Use them like any Tailwind variant: `ak-dark:ak-layer-darken-6`.
+Variants apply utilities conditionally based on the parent layer or user preference. Use them like any Tailwind variant: `ak-dark:ak-ink-80`.
 
 ### Layer appearance
 
@@ -533,17 +795,19 @@ Each layer appearance variant also has a `not-*` counterpart, such as
 
 ```html
 <div class="ak-layer ak-layer-canvas">
-  <div class="ak-layer ak-dark:ak-layer-darken-6 ak-light:ak-layer-lighten-6">
-    Adapts to its parent layer's appearance.
-  </div>
+  <p class="ak-dark:ak-ink-80 ak-light:ak-ink-70">
+    Appearance-adjusted secondary text.
+  </p>
 
-  <div class="ak-layer ak-dark-high:ak-edge-20 ak-light-high:ak-edge-10">
+  <div
+    class="ak-layer ak-frame ak-frame-field/field ak-frame-border ak-dark-high:ak-edge-20 ak-light-high:ak-edge-10"
+  >
     Stronger edges on the darkest surfaces.
   </div>
 
-  <div class="ak-layer not-ak-dark:ak-layer-lighten-6">
-    Applies inside this layer when the current layer is not dark.
-  </div>
+  <p class="not-ak-dark:ak-ink-60">
+    Subdued when the current layer is not dark.
+  </p>
 </div>
 ```
 
@@ -558,7 +822,9 @@ Each layer appearance variant also has a `not-*` counterpart, such as
 You can opt extra utilities into high-contrast mode with `contrast-more:`:
 
 ```html
-<button class="ak-layer ak-frame ak-frame-ring contrast-more:ak-frame-border-2">
+<button
+  class="ak-layer ak-frame ak-frame-field/field ak-frame-ring contrast-more:ak-frame-border-2"
+>
   Extra border weight in high-contrast mode.
 </button>
 ```

--- a/packages/ariakit-tailwind/readme.md
+++ b/packages/ariakit-tailwind/readme.md
@@ -2,27 +2,26 @@
 
 **Important:** This package is experimental and does not follow semantic versioning, meaning breaking changes may occur in patch and minor versions.
 
-Ariakit Tailwind is a Tailwind CSS v4 plugin that brings Ariakit Styles to your projects. It enables developers to build accessible design systems with **relative colors and radii** instead of fixed values, giving end users full freedom to customize the theme without sacrificing visual consistency. Swap any token — a brand color, a radius, a spacing scale — and every derived surface, text, and border rebalances itself automatically.
+Ariakit Tailwind is a Tailwind CSS v4 plugin that brings Ariakit Styles to your projects. It enables developers to build accessible design systems with **relative colors and radii** instead of fixed values, giving end users full freedom to customize the theme without sacrificing visual consistency. Swap a brand color, radius, or spacing scale, and every derived surface, text, and border rebalances itself automatically.
 
 Ariakit Tailwind is framework and library agnostic. It works with any frontend framework (React, Vue, Svelte, Astro, …) and any component library (Ariakit React, Radix UI, React Aria, …).
 
 ## Contents
 
-- [Installation](#installation)
-- [How it works](#how-it-works)
-- [Mental model](#mental-model)
+- [Quick start](#quick-start)
 - [Theming](#theming)
-- [`ak-layer`](#ak-layer) — background, text, border colors for a surface
-- [`ak-ink`](#ak-ink) — text opacity inside a layer
-- [`ak-text`](#ak-text) — colored text with automatic contrast
-- [`ak-edge`](#ak-edge) — border and ring colors
-- [`ak-outline`](#ak-outline) — outline colors
-- [`ak-frame`](#ak-frame) — radius, padding, margin, borders, layout
-- [`ak-state-*`](#ak-state) — interactive state adjustments
+- [Mental model](#mental-model)
+- [`ak-layer`](#ak-layer): background, text, and border colors for a surface
+- [`ak-state-*`](#ak-state): interactive state adjustments
+- [`ak-ink`](#ak-ink): text opacity inside a layer
+- [`ak-text`](#ak-text): colored text with automatic contrast
+- [`ak-edge`](#ak-edge): border and ring colors
+- [`ak-outline`](#ak-outline): outline colors
+- [`ak-frame`](#ak-frame): radius, padding, margin, borders, and layout
 - [Variants](#variants)
 - [Migrating to v0.2](#migrating-to-v02)
 
-## Installation
+## Quick start
 
 1. [Install Tailwind v4](https://tailwindcss.com/docs/installation/using-vite).
 
@@ -39,73 +38,91 @@ Ariakit Tailwind is framework and library agnostic. It works with any frontend f
    @import "@ariakit/tailwind";
    ```
 
-4. Define the application canvas and starter component tokens:
-
-   ```css
-   @theme {
-     --color-canvas: #f5f8f7;
-     --color-primary: #2563eb;
-     --color-warning: #d97706;
-
-     --radius-card: var(--radius-2xl);
-     --spacing-card: --spacing(4);
-
-     --radius-field: var(--radius-xl);
-     --spacing-field: --spacing(2);
-
-     --radius-badge: calc(infinity * 1px);
-     --spacing-badge: --spacing(1.5);
-   }
-
-   :root {
-     color-scheme: light;
-
-     @variant dark {
-       --color-canvas: #0b1110;
-       color-scheme: dark;
-     }
-   }
-   ```
-
-   This follows Tailwind's `dark` variant. For a manual theme toggle, configure that variant to match your root selector or override `--color-canvas` and `color-scheme` on the selector directly.
-
-5. Apply the base layer to a container element (must **not** be `html` or `:root`):
+4. Apply the base layer to a container element (must **not** be `html` or `:root`):
 
    <!-- prettier-ignore -->
    ```html
-   <body class="ak-layer ak-layer-canvas">
+   <body class="ak-layer ak-layer-white dark:ak-layer-gray-950">
    ```
 
    Or via `@apply`:
 
    ```css
    body {
-     @apply ak-layer ak-layer-canvas;
+     @apply ak-layer ak-layer-white dark:ak-layer-gray-950;
    }
    ```
 
-   Choose descendant surfaces deliberately, as described in the [mental model](#mental-model).
+   These root colors establish one application canvas. The [theming](#theming) section replaces them with a semantic canvas token, and the [mental model](#mental-model) explains how to choose descendant surfaces.
 
-## How it works
+## Theming
 
-Ariakit Tailwind revolves around a few families of utilities:
+Ariakit Tailwind integrates directly with Tailwind's theming system. Every `--color-*`, `--radius-*`, and `--spacing-*` token in your `@theme` block becomes available to the matching Ariakit utilities.
 
-- **[`ak-layer`](#ak-layer)** turns an element into a _layer_, a surface with its own background, text, and edge colors. Directional modifiers such as `ak-layer-lighten-*` and `ak-layer-darken-*` express raised and recessed surfaces, while numeric `ak-layer-*` modifiers provide appearance-aware separation without assigning a fixed depth direction.
-- **[`ak-ink`](#ak-ink)** sets the text opacity for the layer's own text. Safe to apply on the same element as `ak-layer` or on a descendant.
-- **[`ak-text`](#ak-text)** colors inline text _inside_ a layer with automatic WCAG contrast. Must go on a descendant, not on the `ak-layer` element itself.
-- **[`ak-edge`](#ak-edge)** colors borders and rings, adapting opacity and contrast to the element's own layer. `ak-edge-*` utilities require the static `ak-layer` class on the same element.
-- **[`ak-outline`](#ak-outline)** colors outlines in the same adaptive way.
-- **[`ak-frame`](#ak-frame)** handles radius, padding, margin, borders, and concentric-radius layout.
+```css
+@theme {
+  --spacing-px: 1px;
 
-Static utilities activate their context, while modifiers configure it. Pair `ak-layer-*`, `ak-state-*`, and `ak-edge-*` with `ak-layer` on the same element; pair `ak-text-*` with `ak-text` on the same descendant; pair `ak-frame-*` with `ak-frame`; and pair `ak-outline-*` with `ak-outline`. `ak-ink-*` is self-contained.
+  --color-canvas: #f5f8f7;
+  --color-primary: #2563eb;
+  --color-warning: #d97706;
 
-Color channel utilities are authored in [OKLCH](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/oklch), so modifiers like `ak-layer-warm-40` or `ak-text-saturate-50` behave predictably across hues. Text contrast is converted to LCH at the final contrast step, and layer mixing can use any supported CSS `color-mix()` interpolation method. Because every value is computed relatively, changing a single theme token ripples through every layer, text, edge, and frame that depends on it, so users can reskin the whole system without breaking contrast, depth, or shape relationships.
+  --radius-card: var(--radius-2xl);
+  --spacing-card: --spacing(4);
 
-### Value scales
+  --radius-field: var(--radius-xl);
+  --spacing-field: --spacing(2);
 
-Bare numeric modifiers use Ariakit's documented authoring scales. For example, lightness and alpha values use `0`–`100`, chroma values use `0`–`40`, and mix amounts use `0`–`100`.
+  --radius-dialog: var(--radius-3xl);
+  --spacing-dialog: --spacing(6);
 
-Arbitrary values and custom properties are raw CSS values. That means percent-style modifiers use normalized `0`–`1` values in arbitrary/custom-property form, even when their bare numeric forms use Ariakit's `0`–`100` or `0`–`40` authoring scales. Use normalized OKLCH channel values like `ak-layer-l-[0.8]`, normalized percent-style values like `ak-layer-warm-[0.4]` or `ak-text-saturate-[0.25]`, raw deltas like `ak-layer-[calc(l+0.1)]`, percentages where CSS expects percentages like `ak-layer-mix-amount-[35%]`, and custom properties that already contain those raw values.
+  --radius-badge: calc(infinity * 1px);
+  --spacing-badge: --spacing(1.5);
+}
+
+:root {
+  color-scheme: light;
+
+  @variant dark {
+    --color-canvas: #0b1110;
+    color-scheme: dark;
+  }
+}
+```
+
+Matching radius and spacing names produce semantic frame shortcuts. For example, `ak-frame-card/card` uses `--radius-card` and `--spacing-card`. The `--spacing-px` token enables compact frame padding such as `ak-frame-field/px`.
+
+This setup follows Tailwind's `dark` variant. For a manual theme toggle, configure that variant to match your root selector or override `--color-canvas` and `color-scheme` on the selector directly.
+
+Use the custom canvas instead of repeating absolute colors:
+
+<!-- prettier-ignore -->
+```diff
+- <body class="ak-layer ak-layer-white dark:ak-layer-gray-950">
++ <body class="ak-layer ak-layer-canvas">
+```
+
+### Advanced theme tokens
+
+Ariakit Tailwind exposes additional tokens beyond `--color-*`, `--radius-*`, and `--spacing-*`:
+
+| Token family | Purpose                                                                                                                                                                                                    | Defaults                                                                                                                                                                                                                                                                                                                                            |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--contrast` | Global contrast preference (`0`–`100`). Utilities like `ak-text` push lightness farther from the layer as `--contrast` grows. Automatically set to `100` by the [`contrast-more`](#accessibility) variant. | `0`                                                                                                                                                                                                                                                                                                                                                 |
+| `--chroma-*` | Named chroma presets for `ak-layer-*`, `ak-text-*`, `ak-edge-*`, `ak-outline-*`, and all `-c-*` / `-max-c-*` / `-min-c-*` utilities.                                                                       | `grayscale` (0), `muted` (0.05), `balanced` (0.15), `vivid` (0.22), `neon` (0.32)                                                                                                                                                                                                                                                                   |
+| `--hue-*`    | Named hue presets (OKLCH degrees) for `-<hue>` / `-h-*` utilities.                                                                                                                                         | Absolute: `red`, `orange`, `yellow`, `green`, `cyan`, `blue`, `magenta`. Relational (relative to current hue): `complementary`, `split1`/`split2`, `analogous1`/`analogous2`, `triadic1`/`triadic2`, `tetradic1`/`tetradic2`/`tetradic3`, `square1`/`square2`/`square3`. `--hue-warm` and `--hue-cool` are used by `-warm-*` / `-cool-*` utilities. |
+| `--mix-*`    | Named `color-mix()` interpolation methods used by `ak-layer-mix-*`.                                                                                                                                        | Every CSS color-mix method, e.g. `oklab`, `oklch`, `lab`, `lch`, `hsl`, `hwb`, `srgb`, `srgb-linear`, `display-p3`, `rec2020`, etc. Hyphen-separated forms like `oklch-shorter-hue` are available via `ak-layer-mix-oklch-shorter-hue`.                                                                                                             |
+
+Override any of these in your own `@theme` block:
+
+```css
+@theme {
+  --contrast: 50;
+  --chroma-balanced: 0.18;
+  --hue-brand: 250;
+  --hue-warm: var(--hue-orange);
+}
+```
 
 ## Mental model
 
@@ -186,19 +203,27 @@ The button starts raised, becomes slightly more exposed on hover, and darkens wh
 
 ### Treat color as a material finish
 
-Lightness usually communicates spatial relationship. Hue, chroma, warmth, and mixing describe the material's pigment, atmosphere, or semantic identity. Changing hue at every nesting level does not create meaningful depth.
+Lightness usually communicates spatial relationship. Hue, chroma, warmth, and mixing describe the material's pigment, atmosphere, or semantic identity. Changing hue at every nesting level does not create meaningful depth, but keeping every material neutral can hide meaning that should be recognizable at a glance.
 
-Use an absolute `ak-layer-<color>` at a deliberate boundary such as the canvas, a primary action, or a warning surface. Use `ak-layer-mix-*` when that pigment should feel tinted by its surrounding material:
+Treat hue as information. Keep most of the scene in one family, then spend stronger colors where identity, status, or priority should survive scanning before someone reads the label. A primary action can carry a concentrated brand color, while a status badge can use a lighter tint of its semantic color so it still belongs to the surrounding scene:
 
 ```html
-<aside
-  class="ak-layer ak-layer-warning ak-layer-mix-15 ak-frame ak-frame-card/card ak-frame-bordering"
->
-  <strong>Pending review</strong>
-</aside>
+<div class="flex items-center gap-2">
+  <button
+    class="ak-layer ak-layer-primary hover:ak-state-lighten-2 active:ak-state-darken-3 ak-frame ak-frame-field/field focus-visible:ak-outline focus-visible:ak-outline-primary focus-visible:outline-2"
+  >
+    Deploy now
+  </button>
+
+  <span
+    class="ak-layer ak-layer-warning ak-layer-mix-15 ak-frame ak-frame-badge/badge"
+  >
+    <span class="ak-text ak-text-warning ak-text-25">Needs review</span>
+  </span>
+</div>
 ```
 
-Mixing creates a contextual solid color, not transparency and not another depth level. Hue and chroma adjustments similarly change the finish of the current material.
+These materials do not need borders because pigment, tone, and shape already separate them from the canvas. Mixing creates a contextual solid color, not transparency and not another depth level. Hue and chroma adjustments similarly change the finish of the current material.
 
 Custom gradients, patterns, and textures are also surface paint. Derive them from the resolved layer variables so the visible pixels stay related to the contrast context:
 
@@ -215,7 +240,7 @@ Custom gradients, patterns, and textures are also surface paint. Derive them fro
   --pattern-color: color-mix(
     in oklab,
     var(--ak-layer),
-    var(--ak-layer-parent) 35%
+    var(--ak-layer-parent, canvas) 35%
   );
   background-image: linear-gradient(
     135deg,
@@ -226,21 +251,27 @@ Custom gradients, patterns, and textures are also surface paint. Derive them fro
 }
 ```
 
+A top-level layer has no resolved parent custom property, so the `canvas` fallback keeps its pattern valid. Nested layers still mix with their actual parent.
+
 A custom image or multistop gradient can still vary independently across the surface, so inspect text contrast against its actual pixels.
 
 ### Put content and boundaries on the material
 
 The other utility families describe what belongs to a surface rather than creating more surfaces:
 
-| Feature        | Material role                                                                       |
-| -------------- | ----------------------------------------------------------------------------------- |
-| Normal text    | Inherits the layer's default ink                                                    |
-| `ak-ink-*`     | Changes the strength of neutral writing while preserving a readable contrast floor  |
-| `ak-text-*`    | Applies adaptive colored pigment to a descendant inside a layer                     |
-| `ak-edge-*`    | Configures the seam between the current material and its surroundings               |
-| `ak-outline-*` | Draws an external focus or attention signal                                         |
-| `ak-frame-*`   | Defines the material's silhouette, inset, border thickness, and concentric geometry |
-| `ak-state-*`   | Changes the current material temporarily in response to interaction                 |
+| Feature                       | Material role                                                                       |
+| ----------------------------- | ----------------------------------------------------------------------------------- |
+| Normal text                   | Inherits the layer's default ink                                                    |
+| [`ak-ink-*`](#ak-ink)         | Changes the strength of neutral writing while preserving a readable contrast floor  |
+| [`ak-text-*`](#ak-text)       | Applies adaptive colored pigment to a descendant inside a layer                     |
+| [`ak-edge-*`](#ak-edge)       | Configures the seam between the current material and its surroundings               |
+| [`ak-outline-*`](#ak-outline) | Draws an external focus or attention signal                                         |
+| [`ak-frame-*`](#ak-frame)     | Defines the material's silhouette, inset, border thickness, and concentric geometry |
+| [`ak-state-*`](#ak-state)     | Changes the current material temporarily in response to interaction                 |
+
+Static utilities activate their context, while modifiers configure it. Pair `ak-layer-*`, `ak-state-*`, and `ak-edge-*` with `ak-layer` on the same element; pair `ak-text-*` with `ak-text` on the same descendant; pair `ak-frame-*` with `ak-frame`; and pair `ak-outline-*` with `ak-outline`. `ak-ink-*` is self-contained.
+
+Color channel utilities are authored in [OKLCH](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/oklch), so modifiers like `ak-layer-warm-40` or `ak-text-saturate-50` behave predictably across hues. Text contrast is converted to LCH at the final contrast step, and layer mixing can use any supported CSS `color-mix()` interpolation method. Because values are computed relatively, changing one theme token ripples through every material role that depends on it.
 
 Normal text needs no utility. Use `ak-ink-*` for hierarchy and `ak-text` on a descendant when text needs its own adaptive color:
 
@@ -252,49 +283,94 @@ Normal text needs no utility. Use `ak-ink-*` for hierarchy and `ak-text` on a de
 </article>
 ```
 
-A neutral badge can use a semantic edge and adaptive colored text without turning either mark into another layer:
-
-```html
-<span
-  class="ak-layer ak-layer-6 ak-edge-warning ak-edge-35 ak-frame ak-frame-badge/badge ak-frame-bordering"
->
-  <span class="ak-text ak-text-warning ak-text-25">Pending review</span>
-</span>
-```
-
 Do not put `ak-text` on the `ak-layer` element itself. It makes its own background transparent so the ancestor layer can show through.
 
-Use edges where materials meet closely or a control needs a clearer affordance. Avoid outlining every surface. Tonal separation, spacing, and shape should carry most of the hierarchy. `ak-frame-bordering` is a useful adaptive seam because it chooses a border or ring from the parent appearance and the layer's explicit lighten or darken relationship.
+### Let groups share a material
+
+An edge is a seam between materials, not decoration for every control. Add one when an isolated control needs a clearer affordance or two neighboring materials would otherwise merge. When a toolbar reads as one instrument, let the group own the surface and seam while its buttons share that material:
+
+```html
+<div
+  role="toolbar"
+  aria-label="Formatting"
+  class="ak-layer ak-layer-lighten-6 ak-frame ak-frame-field/0.5 ak-frame-bordering inline-flex gap-0.5"
+>
+  <button
+    type="button"
+    class="ak-frame ak-frame-field/0.5 border-0 bg-transparent ak-ink-70 hover:ak-ink-100"
+  >
+    <span class="block px-3 py-1.5">Bold</span>
+  </button>
+  <button
+    type="button"
+    class="ak-frame ak-frame-field/0.5 border-0 bg-transparent ak-ink-70 hover:ak-ink-100"
+  >
+    <span class="block px-3 py-1.5">Italic</span>
+  </button>
+  <button
+    type="button"
+    class="ak-frame ak-frame-field/0.5 border-0 bg-transparent ak-ink-70 hover:ak-ink-100"
+  >
+    <span class="block px-3 py-1.5">Link</span>
+  </button>
+</div>
+```
+
+Repeating a border or ring on every button would fragment the toolbar into unrelated boxes. `ak-frame-bordering` works on the group because its surface has an explicit lighten relationship. With an appearance-aware numeric `ak-layer-*`, choose a fixed `ak-frame-border` or `ak-frame-ring` instead.
+
+Frame padding describes the thickness between a material's silhouette and its contents or a nested surface. A generous inset makes one surface feel contained inside another. A hairline or half-step inset makes adjacent pieces feel cut from the same control, which can make a selected segment sit precisely inside a recessed track:
+
+```html
+<div
+  role="group"
+  aria-label="Period"
+  class="ak-layer ak-layer-darken-3 ak-frame ak-frame-field/px inline-flex"
+>
+  <button
+    type="button"
+    aria-pressed="false"
+    class="ak-frame ak-frame-field/0.5 border-0 bg-transparent"
+  >
+    <span class="block px-3 py-1.5">Day</span>
+  </button>
+  <button
+    type="button"
+    aria-pressed="true"
+    class="ak-layer ak-layer-lighten-6 ak-frame ak-frame-field/0.5 border-0"
+  >
+    <span class="block px-3 py-1.5">Week</span>
+  </button>
+  <button
+    type="button"
+    aria-pressed="false"
+    class="ak-frame ak-frame-field/0.5 border-0 bg-transparent"
+  >
+    <span class="block px-3 py-1.5">Month</span>
+  </button>
+</div>
+```
+
+The one-pixel track inset and half-step child insets create a crisp nested silhouette, while the inner spans preserve comfortable hit areas. The track and selected segment are the only distinct materials.
 
 ### Give isolated components their own shape
 
-Every isolated card, control, popover, dialog, and badge should declare a non-zero radius by default. An isolated `ak-frame` has a zero declared radius until a radius modifier is applied, while a nested frame may derive an effective concentric radius from its parent. Component recipes should still select a semantic radius and usually its padding:
-
-```css
-@theme {
-  --radius-card: var(--radius-2xl);
-  --spacing-card: --spacing(4);
-
-  --radius-field: var(--radius-xl);
-  --spacing-field: --spacing(2);
-
-  --radius-dialog: var(--radius-3xl);
-  --spacing-dialog: --spacing(6);
-
-  --radius-badge: calc(infinity * 1px);
-  --spacing-badge: --spacing(1.5);
-}
-```
+Every isolated card, control, popover, dialog, and badge should declare a non-zero radius by default. An isolated `ak-frame` has a zero declared radius until a radius modifier is applied, while a nested frame may derive an effective concentric radius from its parent. Define semantic radius and padding pairs in the [theme](#theming), then select them in component recipes:
 
 ```html
 <article class="ak-layer ak-layer-lighten-6 ak-frame ak-frame-card/card">
   ...
 </article>
-<button class="ak-layer ak-layer-6 ak-frame ak-frame-field/field">...</button>
+<button class="ak-layer ak-layer-primary ak-frame ak-frame-field/field">
+  Primary action
+</button>
 <div class="ak-layer ak-layer-lighten-6 ak-frame ak-frame-dialog/dialog">
   Dialog
 </div>
-<span class="ak-layer ak-layer-6 ak-frame ak-frame-badge/badge">Badge</span>
+<span
+  class="ak-layer ak-layer-warning ak-layer-mix-15 ak-frame ak-frame-badge/badge"
+>
+  Badge
+</span>
 ```
 
 These recipes own their shapes even when rendered without a parent frame. When frames are nested, Ariakit reconciles their effective radii with the parent's radius, padding, and border plus the child's frame margin so nearby corners remain concentric.
@@ -314,6 +390,12 @@ Local square corners are still appropriate when geometry is intentionally attach
 
 Frame padding and borders participate in concentric geometry. Use `ak-frame-p-*`, the combined `ak-frame-<radius>/<padding>` form, and `ak-frame-border`, `ak-frame-ring`, or `ak-frame-bordering` for component chrome. Do not override frame padding with `p-*`, `px-*`, or `py-*` on the same element. Put asymmetric layout spacing on an inner wrapper instead.
 
+### Read utility values
+
+Bare numeric modifiers use Ariakit's documented authoring scales. For example, lightness and alpha values use `0`–`100`, chroma values use `0`–`40`, and mix amounts use `0`–`100`.
+
+Arbitrary values and custom properties are raw CSS values. Percent-style modifiers use normalized `0`–`1` values in arbitrary or custom-property form, even when their bare numeric forms use Ariakit's `0`–`100` or `0`–`40` authoring scales. Use normalized OKLCH channel values like `ak-layer-l-[0.8]`, normalized percent-style values like `ak-layer-warm-[0.4]` or `ak-text-saturate-[0.25]`, raw deltas like `ak-layer-[calc(l+0.1)]`, percentages where CSS expects them like `ak-layer-mix-amount-[35%]`, and custom properties that already contain those raw values.
+
 ### Judge the whole scene
 
 Accessibility math protects contrast, not taste. Before shipping, inspect the complete scene and ask:
@@ -321,71 +403,15 @@ Accessibility math protects contrast, not taste. Before shipping, inspect the co
 - Can every layer be described as the canvas, raised, recessed, appearance-aware separation, semantic material, or interactive material?
 - Does removing any layer make the hierarchy clearer?
 - Do raised and recessed relationships remain coherent when only the canvas changes between light and dark?
+- Do hue choices make identity, status, and priority easier to scan without turning every surface into an accent?
 - Do hover, active, selected, focus, and disabled states change the existing material with a clear purpose?
+- Can a group own one surface and seam instead of bordering every control?
+- Would a hairline or half-step frame inset describe a nested relationship better than another roomy box?
 - Do isolated component recipes remain intentionally rounded, and can a square theme be achieved by changing shared tokens only?
 - Do nested corners and adaptive edges describe the intended material boundaries?
 - Does the composition remain coherent in [`contrast-more`](#accessibility), inside another semantic layer, and across supported browsers?
 
 Package contributors should use the existing light, dark, and high-contrast computed-style snapshot matrix. That sandbox deliberately exercises many utilities at once and is a behavior test, not an aesthetic example.
-
-## Theming
-
-Ariakit Tailwind integrates directly with Tailwind's theming system. Every `--color-*`, `--radius-*`, and `--spacing-*` token in your `@theme` block becomes available to the matching Ariakit utilities.
-
-```css
-@theme {
-  /* Any --color-* token can be used in ak-layer, ak-text, ak-edge, ak-outline */
-  --color-canvas: #f1f1f1;
-  --color-primary: #2563eb;
-  --color-warning: #d97706;
-
-  /* Any --radius-* / --spacing-* token can be used in ak-frame.
-   * Sharing names lets you reference both sides with a single modifier:
-   * ak-frame-field/field applies --radius-field AND --spacing-field. */
-  --radius-field: var(--radius-xl);
-  --spacing-field: --spacing(2);
-
-  --radius-card: var(--radius-2xl);
-  --spacing-card: --spacing(4);
-}
-
-/* Theme overrides per variant */
-:root {
-  @variant dark {
-    --color-canvas: #0b1110;
-  }
-}
-```
-
-With the theme above, you can use your custom colors anywhere Ariakit expects a color:
-
-<!-- prettier-ignore -->
-```diff
-- <body class="ak-layer ak-layer-white dark:ak-layer-gray-950">
-+ <body class="ak-layer ak-layer-canvas">
-```
-
-### Advanced theme tokens
-
-Ariakit Tailwind exposes additional tokens beyond `--color-*`, `--radius-*`, and `--spacing-*`:
-
-| Token family | Purpose                                                                                                                                                                                               | Defaults                                                                                                                                                                                                                                                                                                                                            |
-| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--contrast` | Global contrast preference (`0`–`100`). Utilities like `ak-text` push lightness farther from the layer as `--contrast` grows. Automatically set to `100` by the [`contrast-more`](#variants) variant. | `0`                                                                                                                                                                                                                                                                                                                                                 |
-| `--chroma-*` | Named chroma presets for `ak-layer-*`, `ak-text-*`, `ak-edge-*`, `ak-outline-*`, and all `-c-*` / `-max-c-*` / `-min-c-*` utilities.                                                                  | `grayscale` (0), `muted` (0.05), `balanced` (0.15), `vivid` (0.22), `neon` (0.32)                                                                                                                                                                                                                                                                   |
-| `--hue-*`    | Named hue presets (OKLCH degrees) for `-<hue>` / `-h-*` utilities.                                                                                                                                    | Absolute: `red`, `orange`, `yellow`, `green`, `cyan`, `blue`, `magenta`. Relational (relative to current hue): `complementary`, `split1`/`split2`, `analogous1`/`analogous2`, `triadic1`/`triadic2`, `tetradic1`/`tetradic2`/`tetradic3`, `square1`/`square2`/`square3`. `--hue-warm` and `--hue-cool` are used by `-warm-*` / `-cool-*` utilities. |
-| `--mix-*`    | Named `color-mix()` interpolation methods used by `ak-layer-mix-*`.                                                                                                                                   | Every CSS color-mix method, e.g. `oklab`, `oklch`, `lab`, `lch`, `hsl`, `hwb`, `srgb`, `srgb-linear`, `display-p3`, `rec2020`, etc. Hyphen-separated forms like `oklch-shorter-hue` are available via `ak-layer-mix-oklch-shorter-hue`.                                                                                                             |
-
-Override any of these in your own `@theme` block:
-
-```css
-@theme {
-  --contrast: 50;
-  --chroma-balanced: 0.18;
-  --hue-brand: 250;
-  --hue-warm: var(--hue-orange);
-}
-```
 
 ---
 
@@ -416,7 +442,7 @@ A layer automatically sets border and ring colors through the shared `--ak-edge`
 
 Use [`ak-edge`](#ak-edge) to fine-tune border and ring colors without touching the layer background.
 
-Custom backgrounds can read the resolved `--ak-layer` and `--ak-layer-parent` colors. See [Treat color as a material finish](#treat-color-as-a-material-finish) for patterns that stay related to their contrast context.
+Custom backgrounds can read the resolved `--ak-layer` color and `var(--ak-layer-parent, canvas)`. See [Treat color as a material finish](#treat-color-as-a-material-finish) for patterns that stay related to their contrast context.
 
 ### Setting the layer color
 
@@ -508,7 +534,7 @@ The static `ak-layer` class must be applied to the same element as `ak-state-*`.
 
 ## `ak-ink`
 
-Controls the opacity of text inside a layer — useful for secondary text, captions, and disabled states. It only sets text color, so it works either on the same element as [`ak-layer`](#ak-layer) (styling the layer's own text) or on a descendant element.
+Controls the opacity of text inside a layer, which is useful for secondary text, captions, and disabled states. It only sets text color, so it works either on the same element as [`ak-layer`](#ak-layer) (styling the layer's own text) or on a descendant element.
 
 ```html
 <div class="ak-layer ak-layer-canvas ak-ink-70">
@@ -597,7 +623,7 @@ Normal text should inherit the layer's text color without an extra utility. Use 
 | `ak-edge-color-<color>` | Explicit color-only alias. Useful for custom properties (`ak-edge-color-(--edge-color)`).                                                                     |
 | `ak-edge-<chroma>`      | Sets chroma from a named preset.                                                                                                                              |
 | `ak-edge-<hue>`         | Sets hue from a named preset.                                                                                                                                 |
-| `ak-edge-raw`           | Applies the color exactly as specified — shorthand for `ak-edge-100` + `ak-edge-push-0`.                                                                      |
+| `ak-edge-raw`           | Applies the color exactly as specified, a shorthand for `ak-edge-100` + `ak-edge-push-0`.                                                                     |
 | `ak-edge-inherit`       | Uses the edge from the nearest ancestor that explicitly sets a frame border, ring, or bordering width; falls back to the current layer edge when none exists. |
 
 ### Adjustments
@@ -688,7 +714,7 @@ Use `ak-frame-p-*` or the combined `ak-frame-<radius>/<padding>` form when paddi
 ```html
 <!-- radius 2xl, padding 1 -->
 <div class="ak-frame ak-frame-2xl/1">
-  <!-- nested child — radius adjusted to be concentric with the parent, padding 4 -->
+  <!-- nested child, radius adjusted to be concentric with the parent, padding 4 -->
   <div class="ak-frame ak-frame-2xl/4"></div>
 </div>
 ```
@@ -697,7 +723,7 @@ Use `ak-frame-p-*` or the combined `ak-frame-<radius>/<padding>` form when paddi
 > Border widths affect radius math. Always use `ak-frame-border` instead of Tailwind's `border` utility so concentric radii stay correct:
 >
 > ```html
-> <!-- ❌ — Tailwind border isn't factored into the radius calculation -->
+> <!-- ❌: Tailwind border isn't factored into the radius calculation -->
 > <div class="ak-frame ak-frame-xl/1 border">Border</div>
 >
 > <!-- ✅ -->

--- a/packages/ariakit-tailwind/readme.md
+++ b/packages/ariakit-tailwind/readme.md
@@ -174,32 +174,34 @@ The `body`, card, and well are materials. The `main`, `header`, heading, and par
 
 In ordinary lighting, an exposed surface catches more light while a cutout or well receives less. Ariakit expresses that directional relationship directly, and the same intent holds on light and dark canvases:
 
-| Intent                      | Visual role                                                                          | Utilities                                                                                 |
-| --------------------------- | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
-| Same plane                  | Content or layout that belongs to the current material                               | No new `ak-layer`                                                                         |
-| Raised or exposed           | Card, popover, floating toolbar, or control above its support                        | `ak-layer ak-layer-lighten-*`                                                             |
-| Recessed                    | Well, track, code area, media bed, input bed, or pressed region                      | `ak-layer ak-layer-darken-*`                                                              |
-| Appearance-aware separation | Selected row, adjacent pane, or neutral control that should contrast in either theme | `ak-layer ak-layer-*`                                                                     |
-| New material or pigment     | Canvas, primary action, warning, brand region, or another intentional color boundary | `ak-layer ak-layer-<color>`, optionally with `ak-layer-mix-*`                             |
-| Interactive response        | The same material responding to hover, press, focus, selection, or disabled state    | Variant-prefixed `ak-state-*`, `ak-ink-*`, `ak-outline-*`, and other contextual modifiers |
-| Parent-directed contrast    | A surface whose lightness must move against its supporting layer                     | `ak-layer-contrast`                                                                       |
-| Self-relative tonal push    | A surface that needs a minimum tonal move and must skip the ambiguous midrange       | `ak-layer-push-*`                                                                         |
+| Intent                      | Visual role                                                                                                   | Utilities                                                                                 |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Same plane                  | Content or layout that belongs to the current material                                                        | No new `ak-layer`                                                                         |
+| Raised or exposed           | Card, popover, floating toolbar, or control above its support                                                 | `ak-layer ak-layer-lighten-*`                                                             |
+| Recessed                    | Well, track, code area, media bed, input bed, or pressed region                                               | `ak-layer ak-layer-darken-*`                                                              |
+| Appearance-aware separation | Selected row, adjacent pane, or neutral standalone button that should remain visibly separate in either theme | `ak-layer ak-layer-*`                                                                     |
+| New material or pigment     | Canvas, primary action, warning, brand region, or another intentional color boundary                          | `ak-layer ak-layer-<color>`, optionally with `ak-layer-mix-*`                             |
+| Interactive response        | The same material responding to hover, press, focus, selection, or disabled state                             | Variant-prefixed `ak-state-*`, `ak-ink-*`, `ak-outline-*`, and other contextual modifiers |
+| Parent-directed contrast    | A surface whose lightness must move against its supporting layer                                              | `ak-layer-contrast`                                                                       |
+| Self-relative tonal push    | A surface that needs a minimum tonal move and must skip the ambiguous midrange                                | `ak-layer-push-*`                                                                         |
 
 Numeric `ak-layer-<number>` modifiers are not elevation values. They request appearance-aware separation from the selected source, which defaults to the parent layer. They normally move light sources darker and dark sources lighter, but the contrast-safe lightness pipeline may clamp the target or move it past an ambiguous midrange. Use them to separate a surface without declaring that it is above or below, and use `ak-layer-lighten-*` or `ak-layer-darken-*` when spatial direction matters.
 
+A neutral standalone button can use this material when its affordance should remain visible at rest. Use it selectively: buttons inside a toolbar or another shared surface can stay on that plane and rely on state or ink changes for interaction.
+
 Relative adjustments accumulate. Repeating them through wrappers creates competing boxes and can exhaust the useful tonal range. A practical test for every layer is: "Why is this a different material?" If the answer is only "because this element is nested," remove it.
 
-Interactive states usually change the existing material instead of creating another nested surface:
+Interactive states usually change the existing material instead of creating another nested surface. For routine hover feedback, prefer an appearance-aware tonal response so it remains perceptible when the component moves between light and dark scenes. Use a fixed lighten or darken direction only when that direction carries meaning, such as a pressed surface moving inward:
 
 ```html
 <button
-  class="ak-layer ak-layer-lighten-6 hover:ak-state-lighten-2 active:ak-state-darken-3 ak-frame ak-frame-field/field focus-visible:ak-outline focus-visible:ak-outline-primary focus-visible:outline-2"
+  class="ak-layer ak-layer-6 hover:ak-state-6 active:ak-state-darken-6 ak-frame ak-frame-field/field focus-visible:ak-outline focus-visible:ak-outline-primary focus-visible:outline-2"
 >
   Save
 </button>
 ```
 
-The button starts raised, becomes slightly more exposed on hover, and darkens when pressed. Its focus outline is an external signal, not another material.
+The button has its own neutral material because it needs to stand out from nearby content. Hover moves its tone in the useful direction for the current theme, while pressing intentionally darkens it. Its focus outline is an external signal, not another material.
 
 ### Treat color as a material finish
 
@@ -210,7 +212,7 @@ Treat hue as information. Keep most of the scene in one family, then spend stron
 ```html
 <div class="flex items-center gap-2">
   <button
-    class="ak-layer ak-layer-primary hover:ak-state-lighten-2 active:ak-state-darken-3 ak-frame ak-frame-field/field focus-visible:ak-outline focus-visible:ak-outline-primary focus-visible:outline-2"
+    class="ak-layer ak-layer-primary hover:ak-state-6 active:ak-state-darken-6 ak-frame ak-frame-field/field focus-visible:ak-outline focus-visible:ak-outline-primary focus-visible:outline-2"
   >
     Deploy now
   </button>
@@ -511,26 +513,28 @@ The explicit `ak-layer-mix-*` longhands configure the mix color, amount, and met
 
 `ak-state-*` utilities are companions to `ak-layer-*` that target interactive states (hover, active, focus). They shift the state layer's lightness, chroma, and hue separately from the idle layer setup. Descendant text and edges still respond to the resulting layer color.
 
+For routine hover feedback, prefer appearance-aware numeric `ak-state-*`. It chooses a useful lightness direction from the current material, so the response remains perceptible across light and dark scenes. Use `ak-state-lighten-*` or `ak-state-darken-*` when the direction itself is intentional.
+
 The static `ak-layer` class must be applied to the same element as `ak-state-*`. Keep `ak-layer` unprefixed, then add state utilities with variants such as `hover:` or `active:`.
 
 ```html
 <button
-  class="ak-layer ak-layer-primary hover:ak-state-lighten-2 active:ak-state-darken-3 ak-frame ak-frame-field/field"
+  class="ak-layer ak-layer-primary hover:ak-state-6 active:ak-state-darken-6 ak-frame ak-frame-field/field"
 >
   Primary action
 </button>
 ```
 
-| Utility                        | Description                                                                                                                                                            |
-| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ak-state-<value>`             | Adjusts lightness for interactive state (`0`–`100` for bare numbers), parallel to `ak-layer-<number>`. Custom properties can use `ak-state-(--depth)` with raw values. |
-| `ak-state-offset-<value>`      | Explicit lightness-offset alias for `ak-state-<value>`. Useful for custom properties (`ak-state-offset-(--depth)`). Arbitrary/custom-property values are raw.          |
-| `ak-state-lighten-<number>`    | Lightens in state context.                                                                                                                                             |
-| `ak-state-darken-<number>`     | Darkens in state context.                                                                                                                                              |
-| `ak-state-saturate-<number>`   | Increases chroma in state context.                                                                                                                                     |
-| `ak-state-desaturate-<number>` | Decreases chroma in state context.                                                                                                                                     |
-| `ak-state-push-<number>`       | Minimum lightness shift in state context.                                                                                                                              |
-| `ak-state-h-rotate-<number>`   | Rotates hue in state context.                                                                                                                                          |
+| Utility                        | Description                                                                                                                                                                                       |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ak-state-<value>`             | Applies an appearance-aware lightness offset for interactive state (`0`–`100` for bare numbers), parallel to `ak-layer-<number>`. Custom properties can use `ak-state-(--depth)` with raw values. |
+| `ak-state-offset-<value>`      | Explicit lightness-offset alias for `ak-state-<value>`. Useful for custom properties (`ak-state-offset-(--depth)`). Arbitrary/custom-property values are raw.                                     |
+| `ak-state-lighten-<number>`    | Lightens in state context when that fixed direction is intentional.                                                                                                                               |
+| `ak-state-darken-<number>`     | Darkens in state context when that fixed direction is intentional.                                                                                                                                |
+| `ak-state-saturate-<number>`   | Increases chroma in state context.                                                                                                                                                                |
+| `ak-state-desaturate-<number>` | Decreases chroma in state context.                                                                                                                                                                |
+| `ak-state-push-<number>`       | Minimum lightness shift in state context.                                                                                                                                                         |
+| `ak-state-h-rotate-<number>`   | Rotates hue in state context.                                                                                                                                                                     |
 
 ## `ak-ink`
 

--- a/packages/ariakit-tailwind/readme.md
+++ b/packages/ariakit-tailwind/readme.md
@@ -523,7 +523,7 @@ Custom backgrounds can read the resolved `--ak-layer` color and `var(--ak-layer-
 
 Combine freely: `ak-layer ak-layer-primary ak-layer-mix-30 ak-layer-mix-oklch` mixes the primary color 30% into the parent layer using OKLCH.
 
-The explicit `ak-layer-mix-*` longhands configure the mix color, amount, and method, but don't enable mixing by themselves. Pair them with `ak-layer-mix` when setting any of these values independently.
+The explicit `ak-layer-mix-color-*`, `ak-layer-mix-amount-*`, and `ak-layer-mix-method-*` longhands configure the mix color, amount, and method, but don't enable mixing by themselves. Pair them with `ak-layer-mix` when setting any of these values independently.
 
 ## `ak-state`
 

--- a/packages/ariakit-tailwind/readme.md
+++ b/packages/ariakit-tailwind/readme.md
@@ -182,7 +182,7 @@ In ordinary lighting, an exposed surface catches more light while a cutout or we
 | Appearance-aware separation | Selected row, adjacent pane, or neutral standalone button that should remain visibly separate in either theme | `ak-layer ak-layer-*`                                                                     |
 | New material or pigment     | Canvas, primary action, warning, brand region, or another intentional color boundary                          | `ak-layer ak-layer-<color>`, optionally with `ak-layer-mix-*`                             |
 | Interactive response        | The same material responding to hover, press, focus, selection, or disabled state                             | Variant-prefixed `ak-state-*`, `ak-ink-*`, `ak-outline-*`, and other contextual modifiers |
-| Parent-directed contrast    | A surface whose lightness must move against its supporting layer                                              | `ak-layer-contrast`                                                                       |
+| Parent-directed contrast    | A neutral or pigmented surface whose lightness must move against its supporting layer                         | `ak-layer ak-layer-contrast`, optionally with `ak-layer-<color>`                          |
 | Self-relative tonal push    | A surface that needs a minimum tonal move and must skip the ambiguous midrange                                | `ak-layer-push-*`                                                                         |
 
 Numeric `ak-layer-<number>` modifiers are not elevation values. They request appearance-aware separation from the selected source, which defaults to the parent layer. They normally move light sources darker and dark sources lighter, but the contrast-safe lightness pipeline may clamp the target or move it past an ambiguous midrange. Use them to separate a surface without declaring that it is above or below, and use `ak-layer-lighten-*` or `ak-layer-darken-*` when spatial direction matters.
@@ -212,7 +212,7 @@ Treat hue as information. Keep most of the scene in one family, then spend stron
 ```html
 <div class="flex items-center gap-2">
   <button
-    class="ak-layer ak-layer-primary hover:ak-state-6 active:ak-state-darken-6 ak-frame ak-frame-field/field focus-visible:ak-outline focus-visible:ak-outline-primary focus-visible:outline-2"
+    class="ak-layer ak-layer-primary ak-layer-contrast hover:ak-state-6 active:ak-state-darken-6 ak-frame ak-frame-field/field focus-visible:ak-outline focus-visible:ak-outline-primary focus-visible:outline-2"
   >
     Deploy now
   </button>
@@ -225,9 +225,25 @@ Treat hue as information. Keep most of the scene in one family, then spend stron
 </div>
 ```
 
-These materials do not need borders because pigment, tone, and shape already separate them from the canvas. Mixing creates a contextual solid color, not transparency and not another depth level. Hue and chroma adjustments similarly change the finish of the current material.
+A finish can be fixed or contextual. The primary action keeps one recognizable pigment but lets its tone move away from its support when needed. The default parent-directed contrast amount is usually a useful starting point, but it does not guarantee a particular contrast ratio. The badge softens its warning pigment into the surrounding material.
 
-Custom gradients, patterns, and textures are also surface paint. Derive them from the resolved layer variables so the visible pixels stay related to the contrast context:
+When belonging to the local material matters more than preserving one global swatch, derive the finish from the parent:
+
+```html
+<div class="ak-layer ak-layer-primary ak-frame ak-frame-card/card">
+  <span
+    class="ak-layer ak-layer-6 ak-layer-h-analogous1 ak-layer-c-muted ak-frame ak-frame-badge/badge"
+  >
+    Related material
+  </span>
+</div>
+```
+
+The child selects an analogous hue, a quieter chroma, and appearance-aware tonal separation from its parent. Complementary, analogous, and triadic hue tokens express other color relationships. Hue changes the pigment family, chroma changes its intensity, and lightness changes its tonal plane. A hue difference can be meaningful without implying depth, but it does not replace tonal separation or an edge when the boundary itself must remain perceivable.
+
+These materials do not need borders when pigment, tone, and shape already separate them from the canvas. Mixing creates a contextual solid color, not transparency and not another depth level.
+
+Custom gradients, patterns, and textures are also surface paint. Derive them from the resolved layer variables so the visible pixels stay related to the contrast context. Define repeated paint as a reusable Tailwind utility:
 
 ```html
 <div
@@ -238,15 +254,15 @@ Custom gradients, patterns, and textures are also surface paint. Derive them fro
 ```
 
 ```css
-.surface-pattern {
-  --pattern-color: color-mix(
+@utility surface-pattern {
+  --surface-pattern-color: color-mix(
     in oklab,
     var(--ak-layer),
     var(--ak-layer-parent, canvas) 35%
   );
   background-image: linear-gradient(
     135deg,
-    var(--pattern-color) 1px,
+    var(--surface-pattern-color) 1px,
     transparent 1px
   );
   background-size: 0.75rem 0.75rem;
@@ -460,27 +476,27 @@ Custom backgrounds can read the resolved `--ak-layer` color and `var(--ak-layer-
 
 ### Lightness adjustments
 
-| Utility                      | Description                                                                                                                                                            |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ak-layer-lighten-<number>`  | Lightens the layer by `<number>`%, useful for intentionally raised or exposed surfaces. Arbitrary values are raw (`ak-layer-lighten-[0.05]`).                          |
-| `ak-layer-darken-<number>`   | Darkens the layer by `<number>`%, useful for intentionally recessed or pressed surfaces. Arbitrary values are raw (`ak-layer-darken-[0.05]`).                          |
-| `ak-layer-push-<number>`     | Minimum lightness shift (self-relative), jumping the forbidden mid-luminance range where contrast math becomes unreliable.                                             |
-| `ak-layer-contrast`          | Adapts the layer to contrast against its parent (preset `25`).                                                                                                         |
-| `ak-layer-contrast-<number>` | Custom contrast amount (`0`–`100`, default `25`).                                                                                                                      |
-| `ak-layer-l-<value>`         | Sets absolute lightness (`0`–`100` for bare numbers, raw `0`–`1` for arbitrary/custom-property values).                                                                |
-| `ak-layer-max-<value>`       | Caps lightness (`0`–`100` for bare numbers, raw `0`–`1` for arbitrary/custom-property values) or caps chroma with a named chroma preset (`ak-layer-max-muted`).        |
-| `ak-layer-min-<value>`       | Floors lightness or chroma, same form as `max-*`.                                                                                                                      |
-| `ak-layer-max-l-<value>`     | Caps lightness specifically. Useful for custom properties without a typed arbitrary value hint (`ak-layer-max-l-(--max-l)`). Arbitrary/custom-property values are raw. |
-| `ak-layer-min-l-<value>`     | Floors lightness specifically. Arbitrary/custom-property values are raw.                                                                                               |
+| Utility                      | Description                                                                                                                                                                                        |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ak-layer-lighten-<number>`  | Lightens the layer by `<number>`%, useful for intentionally raised or exposed surfaces. Arbitrary values are raw (`ak-layer-lighten-[0.05]`).                                                      |
+| `ak-layer-darken-<number>`   | Darkens the layer by `<number>`%, useful for intentionally recessed or pressed surfaces. Arbitrary values are raw (`ak-layer-darken-[0.05]`).                                                      |
+| `ak-layer-push-<number>`     | Minimum lightness shift (self-relative), jumping the forbidden mid-luminance range where contrast math becomes unreliable.                                                                         |
+| `ak-layer-contrast`          | Applies a parent-directed tonal target (preset `25`), preserving hue and chroma. Lightness stays unchanged when it is already farther in that direction. This does not guarantee a contrast ratio. |
+| `ak-layer-contrast-<number>` | Custom contrast amount (`0`–`100`, default `25`).                                                                                                                                                  |
+| `ak-layer-l-<value>`         | Sets absolute lightness (`0`–`100` for bare numbers, raw `0`–`1` for arbitrary/custom-property values).                                                                                            |
+| `ak-layer-max-<value>`       | Caps lightness (`0`–`100` for bare numbers, raw `0`–`1` for arbitrary/custom-property values) or caps chroma with a named chroma preset (`ak-layer-max-muted`).                                    |
+| `ak-layer-min-<value>`       | Floors lightness or chroma, same form as `max-*`.                                                                                                                                                  |
+| `ak-layer-max-l-<value>`     | Caps lightness specifically. Useful for custom properties without a typed arbitrary value hint (`ak-layer-max-l-(--max-l)`). Arbitrary/custom-property values are raw.                             |
+| `ak-layer-min-l-<value>`     | Floors lightness specifically. Arbitrary/custom-property values are raw.                                                                                                                           |
 
 ### Hue adjustments
 
-| Utility                      | Description                                                                                                     |
-| ---------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `ak-layer-warm-<number>`     | Shifts hue toward `--hue-warm` by `<number>`%, along the shortest arc.                                          |
-| `ak-layer-cool-<number>`     | Shifts hue toward `--hue-cool` by `<number>`%, along the shortest arc.                                          |
-| `ak-layer-h-<value>`         | Sets absolute hue. Accepts a named hue (`ak-layer-h-blue`) or degrees (`ak-layer-h-240`, `ak-layer-h-(--hue)`). |
-| `ak-layer-h-rotate-<number>` | Rotates hue by `<number>` degrees. Accepts named relational hues (`ak-layer-h-rotate-complementary`).           |
+| Utility                      | Description                                                                                                                                                                   |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ak-layer-warm-<number>`     | Shifts hue toward `--hue-warm` by `<number>`%, along the shortest arc.                                                                                                        |
+| `ak-layer-cool-<number>`     | Shifts hue toward `--hue-cool` by `<number>`%, along the shortest arc.                                                                                                        |
+| `ak-layer-h-<value>`         | Sets hue from degrees or a named token. Relational presets such as `ak-layer-h-complementary`, `ak-layer-h-analogous1`, and `ak-layer-h-triadic1` derive from the source hue. |
+| `ak-layer-h-rotate-<number>` | Rotates the source hue by numeric degrees, for example `ak-layer-h-rotate-30`.                                                                                                |
 
 ### Chroma (saturation) adjustments
 


### PR DESCRIPTION
## Motivation

The utility reference explains individual Ariakit Tailwind classes, but it did not teach the material model that connects them. This made it easy to mirror DOM nesting with visual layers, use appearance-aware numeric offsets as elevation, mute semantic meaning with neutral surfaces, and give isolated components square or inconsistent geometry.

For example, structural wrappers should not become an arbitrary tonal staircase:

```diff
-<article class="ak-layer ak-layer-3">
-  <header class="ak-layer ak-layer-3">
-    <h2 class="ak-layer ak-layer-3">Deployment</h2>
-  </header>
-</article>
+<article class="ak-layer ak-layer-lighten-6 ak-frame ak-frame-card/card">
+  <header>
+    <h2>Deployment</h2>
+  </header>
+</article>
```

## Solution

Reorganize the README around Quick start, Theming, and a holistic Mental model that treats an interface as a small tree of intentional materials rather than a mirror of its DOM tree.

The new guidance:

- distinguishes raised `ak-layer-lighten-*`, recessed `ak-layer-darken-*`, and appearance-aware numeric `ak-layer-*` surfaces
- explains when structure should inherit a material instead of creating another layer
- uses a restrained numeric surface for a standalone neutral button while keeping grouped controls on their shared plane
- uses appearance-aware `hover:ak-state-6` for routine cross-theme feedback and reserves directional state modifiers for intentional effects such as a pressed recess
- treats hue as semantic information for identity, status, and priority
- distinguishes a fixed pigment with parent-directed `ak-layer-contrast` from parent-derived hue, chroma, and lightness relationships
- clarifies that contrast amounts are directional lightness targets rather than guaranteed contrast ratios, including the behavior of `ak-layer-contrast-0`
- distinguishes v0.1 contrast color-level suffixes from v0.2 contrast amounts and shows both preserving and intentionally removing parent contrast
- lets grouped controls share one surface and seam instead of bordering every child
- uses compact `px` and `0.5` frame insets to express tightly nested materials
- derives custom surface paint from `--ak-layer` and `var(--ak-layer-parent, canvas)` and packages repeated paint as an `@utility`
- reserves `ak-frame-bordering` for explicit lighten or darken relationships
- gives isolated components semantic non-zero radii by default and moves square themes to shared radius-token overrides
- consolidates theme setup and integrates the unique utility-composition and value-scale details into the Mental model
- updates the utility reference and v0.2 migration guide to reinforce the same material, color, boundary, and frame semantics

A patch changeset ensures the updated package documentation ships in the next `@ariakit/tailwind` release.

## Verification

- `pnpm lint-fix`
- `pnpm lint`
- `git diff --check`
- `pnpm exec changeset status --since=origin/main`
- `npm pack --dry-run --json`
- Tailwind v4 parsing of all 75 documented class and `@apply` candidates
- local light and dark browser comparisons of numeric layers, interactive states, parent-directed contrast, and parent-relative color harmony
- browser verification of reusable pattern paint on top-level and nested surfaces
- accessibility scan with no reported violations in the local comparison
- historical source verification against `@ariakit/tailwind@0.1.11`
- clean Ariakit native and Cursor pre-commit re-review passes for every follow-up commit
