### PR TITLE
Add 1Password environment command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,8 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env.*
-.dev.vars
 
 # vercel
 .vercel

--- a/app/astro.config.ts
+++ b/app/astro.config.ts
@@ -8,7 +8,6 @@
  * SPDX-License-Identifier: UNLICENSED
  */
 import { join } from "node:path";
-import { loadEnvFile } from "node:process";
 import cloudflare from "@astrojs/cloudflare";
 import { rehypeHeadingIds, unified } from "@astrojs/markdown-remark";
 import mdx from "@astrojs/mdx";
@@ -28,10 +27,6 @@ import {
 } from "./src/lib/rehype.ts";
 import { sourcePlugin } from "./src/lib/source-plugin.ts";
 import { getPlusAccountPath, getPlusCheckoutPath } from "./src/lib/url.ts";
-
-try {
-  loadEnvFile(join(import.meta.dirname, "../.dev.vars"));
-} catch (_error) {}
 
 const port = Number(process.env.APP_PORT) || 4321;
 const hasClerk = process.env.PUBLIC_CLERK_PUBLISHABLE_KEY;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev-package-json": "node scripts/build/package-json-dev.js",
     "dev": "conc -r 'pnpm:dev-package-json' 'pnpm -F website run dev'",
     "dev-lite": "cross-env DISABLE_SHIKI=true pnpm run dev",
+    "op-env": "ariakit op-env",
     "dev-app": "ariakit dev",
     "dev-app-lite": "cross-env DISABLE_SYNTAX_HIGHLIGHTING=true pnpm run dev-app",
     "build-app": "pnpm -F nextjs run build-worker && pnpm -F app run build",

--- a/packages/ariakit-scripts/src/index.ts
+++ b/packages/ariakit-scripts/src/index.ts
@@ -3,6 +3,7 @@
 import { program } from "commander";
 import { build, clean } from "./build.ts";
 import { dev } from "./dev.ts";
+import { runWithOpEnv } from "./op-env.ts";
 import { react18 } from "./react18.ts";
 
 program.name("ariakit");
@@ -37,6 +38,14 @@ program
   .option("--clean", "Clean and watch package builds", true)
   .option("--no-clean", "Use current package exports without cleaning")
   .action(dev);
+
+program
+  .command("op-env")
+  .description("Run a command with a 1Password Environment")
+  .argument("[command...]", "Root script or command to run")
+  .allowUnknownOption()
+  .helpOption(false)
+  .action(runWithOpEnv);
 
 program
   .command("docs")

--- a/packages/ariakit-scripts/src/op-env.test.ts
+++ b/packages/ariakit-scripts/src/op-env.test.ts
@@ -1,0 +1,155 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdtempSync,
+  mkdirSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { afterEach, expect, test } from "vitest";
+
+const cliPath = join(import.meta.dirname, "index.ts");
+const fixturePaths: string[] = [];
+
+interface EnvFixtureOptions {
+  configured?: boolean;
+}
+
+function createEnvFixture({ configured = true }: EnvFixtureOptions = {}) {
+  const rootPath = mkdtempSync(join(tmpdir(), "ariakit-env-"));
+  const binPath = join(rootPath, "bin");
+  fixturePaths.push(rootPath);
+
+  mkdirSync(binPath);
+  writeFileSync(
+    join(rootPath, "package.json"),
+    `${JSON.stringify(
+      {
+        private: true,
+        scripts: {
+          "op-env": "ariakit op-env",
+          "dev-app": "ariakit dev",
+          playwright: "playwright test",
+          "preview-app": "preview app",
+          "preview-app-lite": "preview app lite",
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  execFileSync("git", ["init", "--quiet"], { cwd: rootPath });
+  if (configured) {
+    execFileSync(
+      "git",
+      ["config", "--local", "ariakit.op-env", "test-environment-id"],
+      { cwd: rootPath },
+    );
+  }
+
+  const opPath = join(binPath, "op");
+  writeFileSync(
+    opPath,
+    `#!/usr/bin/env node
+console.log(JSON.stringify({
+  args: process.argv.slice(2),
+  cwd: process.cwd(),
+  includeProcessEnv: process.env.CLOUDFLARE_INCLUDE_PROCESS_ENV ?? null,
+}));
+`,
+  );
+  chmodSync(opPath, 0o755);
+
+  const env = { ...process.env };
+  env.PATH = [binPath, process.env.PATH].filter(Boolean).join(delimiter);
+  delete env.CLOUDFLARE_INCLUDE_PROCESS_ENV;
+
+  return { rootPath, env };
+}
+
+function runOpEnv(rootPath: string, env: NodeJS.ProcessEnv, ...args: string[]) {
+  return spawnSync(process.execPath, [cliPath, "op-env", ...args], {
+    cwd: rootPath,
+    encoding: "utf-8",
+    env,
+  });
+}
+
+afterEach(() => {
+  for (const fixturePath of fixturePaths.splice(0)) {
+    rmSync(fixturePath, { recursive: true, force: true });
+  }
+});
+
+test("runs root scripts from the repository root", () => {
+  const { rootPath, env } = createEnvFixture();
+  const nestedPath = join(rootPath, "packages", "example");
+  mkdirSync(nestedPath, { recursive: true });
+
+  const result = runOpEnv(nestedPath, env, "dev-app", "--port", "4321");
+
+  expect(result.status).toBe(0);
+  const output = JSON.parse(result.stdout);
+  expect(output).toEqual({
+    args: [
+      "run",
+      "--environment",
+      "test-environment-id",
+      "--",
+      "pnpm",
+      "run",
+      "dev-app",
+      "--port",
+      "4321",
+    ],
+    cwd: realpathSync(rootPath),
+    includeProcessEnv: null,
+  });
+});
+
+test.each(["preview-app", "preview-app-lite"])(
+  "includes process env for the %s script",
+  (script) => {
+    const { rootPath, env } = createEnvFixture();
+
+    const result = runOpEnv(rootPath, env, script);
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout).includeProcessEnv).toBe("true");
+  },
+);
+
+test("runs colliding commands after the argument separator", () => {
+  const { rootPath, env } = createEnvFixture();
+
+  const result = runOpEnv(rootPath, env, "--", "playwright", "--help");
+
+  expect(result.status).toBe(0);
+  expect(JSON.parse(result.stdout).args).toEqual([
+    "run",
+    "--environment",
+    "test-environment-id",
+    "--",
+    "playwright",
+    "--help",
+  ]);
+});
+
+test("explains how to configure the 1Password Environment", () => {
+  const { rootPath, env } = createEnvFixture({ configured: false });
+
+  const result = runOpEnv(rootPath, env, "dev-app");
+
+  expect(result.status).toBe(1);
+  expect(result.stderr).toContain(
+    "No 1Password Environment is configured for this repository.",
+  );
+  expect(result.stderr).toContain(
+    "git config --local ariakit.op-env <environment-id>",
+  );
+  expect(result.stderr).toContain("pnpm op-env <script>");
+});

--- a/packages/ariakit-scripts/src/op-env.ts
+++ b/packages/ariakit-scripts/src/op-env.ts
@@ -1,0 +1,130 @@
+import { spawnSync } from "node:child_process";
+import { getCommandOutput, readPackageJson, runCommand } from "./utils.ts";
+
+interface EnvCommand {
+  bin: string;
+  args: string[];
+  includeProcessEnv: boolean;
+}
+
+const gitConfigKey = "ariakit.op-env";
+const previewScripts = new Set(["preview-app", "preview-app-lite"]);
+
+function isRawCommand(rawArgs: string[]) {
+  const commandIndex = rawArgs.indexOf("op-env");
+  if (commandIndex === -1) return false;
+  return rawArgs[commandIndex + 1] === "--";
+}
+
+function isHelpCommand(args: string[]) {
+  const [command] = args;
+  return !command || command === "--help" || command === "-h";
+}
+
+function printHelp() {
+  console.error(
+    [
+      "Usage: ariakit op-env <script> [args...]",
+      "       ariakit op-env -- <command> [args...]",
+      "",
+      "Run a root script or arbitrary command with a 1Password Environment.",
+    ].join("\n"),
+  );
+}
+
+function getRepositoryRoot() {
+  return getCommandOutput(
+    "git",
+    ["rev-parse", "--show-toplevel"],
+    process.cwd(),
+  );
+}
+
+function getEnvironmentId(rootPath: string) {
+  const result = spawnSync(
+    "git",
+    ["config", "--local", "--get", gitConfigKey],
+    {
+      cwd: rootPath,
+      encoding: "utf-8",
+    },
+  );
+
+  if (result.error) throw result.error;
+  if (result.status === 0) return result.stdout.trim() || undefined;
+  if (result.status === 1) return;
+
+  throw new Error(`git config failed with ${result.status}`);
+}
+
+function printConfigurationHelp() {
+  console.error(
+    [
+      "No 1Password Environment is configured for this repository.",
+      "",
+      "1. In 1Password, open Developer > Environments.",
+      "2. Open the environment and select Manage environment > Copy environment ID.",
+      "3. From this repository, run:",
+      "",
+      `   git config --local ${gitConfigKey} <environment-id>`,
+      "",
+      "Then retry with `pnpm op-env <script>`.",
+    ].join("\n"),
+  );
+}
+
+function getEnvCommand(
+  rootPath: string,
+  args: string[],
+  rawCommand: boolean,
+): EnvCommand {
+  const [command, ...commandArgs] = args;
+  if (!command) {
+    throw new Error("Missing command. Use `ariakit op-env <script>`.");
+  }
+  if (command === "op-env") {
+    throw new Error("The op-env script cannot invoke itself.");
+  }
+
+  const packageJson = readPackageJson(rootPath);
+  if (!rawCommand && packageJson.scripts?.[command]) {
+    return {
+      bin: "pnpm",
+      args: ["run", command, ...commandArgs],
+      includeProcessEnv: previewScripts.has(command),
+    };
+  }
+
+  return {
+    bin: command,
+    args: commandArgs,
+    includeProcessEnv: false,
+  };
+}
+
+export async function runWithOpEnv(args: string[]) {
+  if (isHelpCommand(args)) {
+    printHelp();
+    process.exitCode = args.length ? 0 : 1;
+    return;
+  }
+
+  const rootPath = getRepositoryRoot();
+  const environmentId = getEnvironmentId(rootPath);
+  if (!environmentId) {
+    printConfigurationHelp();
+    process.exitCode = 1;
+    return;
+  }
+
+  const command = getEnvCommand(rootPath, args, isRawCommand(process.argv));
+  const env = command.includeProcessEnv
+    ? { ...process.env, CLOUDFLARE_INCLUDE_PROCESS_ENV: "true" }
+    : undefined;
+
+  process.exitCode = await runCommand(
+    "op",
+    ["run", "--environment", environmentId, "--", command.bin, ...command.args],
+    { cwd: rootPath, env },
+  );
+}

--- a/packages/ariakit-scripts/src/react18.ts
+++ b/packages/ariakit-scripts/src/react18.ts
@@ -1,4 +1,3 @@
-import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   mkdir,
@@ -14,20 +13,17 @@ import { delimiter, dirname, isAbsolute, join, relative } from "node:path";
 import { watch } from "chokidar";
 import type { FSWatcher } from "chokidar";
 import {
+  getCommandOutput,
   normalizePath,
   readPackageJson,
   readPackageJsonFile,
+  runCommand,
 } from "./utils.ts";
-import type { PackageJson } from "./utils.ts";
+import type { PackageJson, RunCommandOptions } from "./utils.ts";
 
 interface React18Command {
   bin: string;
   args: string[];
-}
-
-interface RunCommandOptions {
-  cwd: string;
-  env?: NodeJS.ProcessEnv;
 }
 
 const dependencyFields = [
@@ -51,7 +47,7 @@ const excludedSegments = new Set([
   "test-results",
 ]);
 
-const excludedFiles = new Set([".DS_Store", ".dev.vars", "pnpm-lock.yaml"]);
+const excludedFiles = new Set([".DS_Store", "pnpm-lock.yaml"]);
 const excludedFilePatterns = [".env*", "*.pem"];
 
 const pathKey =
@@ -65,27 +61,6 @@ function log(message: string) {
 function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
   if (!(error instanceof Error)) return false;
   return "code" in error;
-}
-
-function getCommandOutput(command: string, args: string[], cwd: string) {
-  const result = spawnSync(command, args, {
-    cwd,
-    encoding: "utf-8",
-  });
-
-  if (result.error) throw result.error;
-  if (result.status) {
-    const commandText = [command, ...args].join(" ");
-    throw new Error(`${commandText} failed with ${result.status}`);
-  }
-
-  const output = result.stdout.trim();
-  if (!output) {
-    const commandText = [command, ...args].join(" ");
-    throw new Error(`${commandText} returned empty output`);
-  }
-
-  return output;
 }
 
 function getRepositoryRoot() {
@@ -123,51 +98,6 @@ function shouldIgnoreWatchPath(rootPath: string, path: string) {
   if (normalizedPath === "package.json") return true;
 
   return shouldIgnoreRelativePath(normalizedPath);
-}
-
-async function runCommand(
-  command: string,
-  args: string[],
-  options: RunCommandOptions,
-) {
-  return await new Promise<number>((resolvePromise, reject) => {
-    const child = spawn(command, args, {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: "inherit",
-    });
-
-    const onSigint = () => child.kill("SIGINT");
-    const onSigterm = () => child.kill("SIGTERM");
-    const cleanup = () => {
-      process.off("SIGINT", onSigint);
-      process.off("SIGTERM", onSigterm);
-    };
-
-    child.on("error", (error) => {
-      cleanup();
-      reject(error);
-    });
-    child.on("exit", (code, signal) => {
-      cleanup();
-      if (code != null) {
-        resolvePromise(code);
-        return;
-      }
-      if (signal === "SIGINT") {
-        resolvePromise(130);
-        return;
-      }
-      if (signal === "SIGTERM") {
-        resolvePromise(143);
-        return;
-      }
-      resolvePromise(1);
-    });
-
-    process.once("SIGINT", onSigint);
-    process.once("SIGTERM", onSigterm);
-  });
 }
 
 async function runChecked(

--- a/packages/ariakit-scripts/src/utils.test.ts
+++ b/packages/ariakit-scripts/src/utils.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "vitest";
+import { getCommandOutput } from "./utils.ts";
+
+test("throws when the command is terminated by a signal", () => {
+  const script = [
+    'require("node:fs").writeSync(1, "partial output");',
+    'process.kill(process.pid, "SIGTERM");',
+  ].join("\n");
+
+  expect(() =>
+    getCommandOutput(process.execPath, ["-e", script], process.cwd()),
+  ).toThrow("failed with SIGTERM");
+});

--- a/packages/ariakit-scripts/src/utils.ts
+++ b/packages/ariakit-scripts/src/utils.ts
@@ -1,6 +1,12 @@
+import { spawn, spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join, sep } from "node:path";
+
+export interface RunCommandOptions {
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+}
 
 export interface PackageJson {
   name: string;
@@ -15,6 +21,72 @@ export interface PackageJson {
 
 export function normalizePath(path: string) {
   return path.split(sep).join("/");
+}
+
+export function getCommandOutput(command: string, args: string[], cwd: string) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf-8",
+  });
+
+  if (result.error) throw result.error;
+  if (result.status) {
+    const commandText = [command, ...args].join(" ");
+    throw new Error(`${commandText} failed with ${result.status}`);
+  }
+
+  const output = result.stdout.trim();
+  if (!output) {
+    const commandText = [command, ...args].join(" ");
+    throw new Error(`${commandText} returned empty output`);
+  }
+
+  return output;
+}
+
+export async function runCommand(
+  command: string,
+  args: string[],
+  options: RunCommandOptions,
+) {
+  return await new Promise<number>((resolvePromise, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: "inherit",
+    });
+
+    const onSigint = () => child.kill("SIGINT");
+    const onSigterm = () => child.kill("SIGTERM");
+    const cleanup = () => {
+      process.off("SIGINT", onSigint);
+      process.off("SIGTERM", onSigterm);
+    };
+
+    child.on("error", (error) => {
+      cleanup();
+      reject(error);
+    });
+    child.on("exit", (code, signal) => {
+      cleanup();
+      if (code != null) {
+        resolvePromise(code);
+        return;
+      }
+      if (signal === "SIGINT") {
+        resolvePromise(130);
+        return;
+      }
+      if (signal === "SIGTERM") {
+        resolvePromise(143);
+        return;
+      }
+      resolvePromise(1);
+    });
+
+    process.once("SIGINT", onSigint);
+    process.once("SIGTERM", onSigterm);
+  });
 }
 
 /**

--- a/packages/ariakit-scripts/src/utils.ts
+++ b/packages/ariakit-scripts/src/utils.ts
@@ -30,9 +30,11 @@ export function getCommandOutput(command: string, args: string[], cwd: string) {
   });
 
   if (result.error) throw result.error;
-  if (result.status) {
+  if (result.status !== 0) {
     const commandText = [command, ...args].join(" ");
-    throw new Error(`${commandText} failed with ${result.status}`);
+    throw new Error(
+      `${commandText} failed with ${result.signal ?? result.status}`,
+    );
   }
 
   const output = result.stdout.trim();


### PR DESCRIPTION
## Motivation

Optional site features depend on local secrets, but most contributors should be able to develop and build the site without configuring them. The existing plaintext `.dev.vars` workflow also does not provide a convenient opt-in setup shared across linked worktrees.

## Solution

Add an opt-in command that reads a 1Password Environment ID from local Git configuration:

```sh
git config --local ariakit.op-env <environment-id>
pnpm op-env dev-app
```

`op-env` uses `op run --environment` for root scripts and raw commands, prints setup instructions when configuration is missing, and enables Wrangler process-environment forwarding only for `preview-app` and `preview-app-lite`.

Remove the explicit `.dev.vars` loader, ignore `.env` files instead, and add focused CLI coverage for script forwarding, raw-command dispatch, preview behavior, and missing configuration.

## Testing

- `pnpm lint`
- `pnpm tsc`
- `pnpm test packages/ariakit-scripts/src`
- `pnpm build-app-lite`
- Live 1Password Environment smoke test without printing secret values
