### PR TITLE
Remove obsolete .nvmrc fallback

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -184,8 +184,7 @@ jobs:
         if: steps.baseline-rebuild.outputs.app == 'true' || steps.baseline-rebuild.outputs.nextjs == 'true'
         uses: actions/setup-node@v6
         with:
-          # The baseline checkout may predate the package.json runtime config.
-          node-version-file: ${{ hashFiles('.nvmrc') != '' && '.nvmrc' || 'package.json' }}
+          node-version-file: package.json
 
       - name: Install dependencies
         if: steps.baseline-rebuild.outputs.app == 'true' || steps.baseline-rebuild.outputs.nextjs == 'true'


### PR DESCRIPTION
## Motivation

[#6710](https://github.com/ariakit/ariakit/pull/6710) kept a temporary `.nvmrc` fallback because its Chrome performance baseline checked out the pre-migration base commit. That PR has merged, so current `main` now declares Node through `package.json.devEngines.runtime` and no longer contains `.nvmrc`.

The compatibility expression is now the repository's last meaningful `.nvmrc` reference.

## Solution

Use the steady-state runtime declaration directly when rebuilding Chrome baseline artifacts:

```yaml
node-version-file: package.json
```

This matches the shared workflow setup and Chrome matrix setup while removing the obsolete transition logic.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm exec node --version` (`v24.18.0`)
- `pnpm lint`
- `git diff --check`
- Verified no non-lockfile `.nvmrc` or nvm references remain
