### PR TITLE
Handle formatter signal termination

### DIFF
--- a/packages/ariakit-scripts/src/docs.test.ts
+++ b/packages/ariakit-scripts/src/docs.test.ts
@@ -1,4 +1,5 @@
 import {
+  chmodSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -7,8 +8,8 @@ import {
 } from "node:fs";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { afterEach, expect, test } from "vitest";
+import { delimiter, join } from "node:path";
+import { afterEach, expect, test, vi } from "vitest";
 import {
   generateDocsMarkdown,
   getDocsMarkers,
@@ -40,9 +41,45 @@ function createPackage() {
 }
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   for (const root of roots.splice(0)) {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("ignores partial formatter output after signal termination", () => {
+  const root = createPackage();
+  const binPath = join(root, "bin");
+  mkdirSync(binPath);
+  writeFileSync(
+    join(root, "src", "index.ts"),
+    [
+      "/** Foo helper. */",
+      "export function foo() {",
+      "  return true;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+
+  const oxfmtPath = join(binPath, "oxfmt");
+  writeFileSync(
+    oxfmtPath,
+    `#!/usr/bin/env node
+require("node:fs").writeSync(1, "partial output");
+process.kill(process.pid, "SIGTERM");
+`,
+  );
+  chmodSync(oxfmtPath, 0o755);
+  vi.stubEnv(
+    "PATH",
+    [binPath, process.env.PATH].filter(Boolean).join(delimiter),
+  );
+
+  const markdown = generateDocsMarkdown({ rootPath: root });
+
+  expect(markdown).toContain("## API reference");
+  expect(markdown).not.toBe("partial output");
 });
 
 test("generates markdown from exported JSDoc and TypeScript declarations", () => {

--- a/packages/ariakit-scripts/src/docs.ts
+++ b/packages/ariakit-scripts/src/docs.ts
@@ -792,7 +792,7 @@ function formatMarkdown(markdown: string) {
   });
 
   if (result.error) return markdown;
-  if (result.status) return markdown;
+  if (result.status !== 0) return markdown;
   return result.stdout || markdown;
 }
 


### PR DESCRIPTION
## Motivation

#6705 hardened shared command execution against signal termination. A follow-up audit found the documentation formatter still treated a signal-derived `null` status as success, so partial formatter stdout could replace otherwise valid generated Markdown.

## Solution

Treat only exit status `0` as successful formatting:

```ts
if (result.status !== 0) return markdown;
```

Add public-surface regression coverage through `generateDocsMarkdown` with a fake formatter that writes partial output and then terminates with `SIGTERM`.

## Testing

- Red check on `origin/main`: the regression returned `partial output` and failed
- `pnpm test packages/ariakit-scripts/src/docs.test.ts` (35 tests)
- `pnpm test packages/ariakit-scripts/src` (127 tests)
- `pnpm tsc`
- `pnpm lint-fix`

No changeset is needed because `@ariakit/scripts` is private development tooling.
