### PR TITLE
Optimize Node performance confirmation reruns

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -771,59 +771,90 @@ jobs:
 
           run_baseline_bench_round() {
             local i="$1"
+            local suffix="$2"
+            local expected_count="$3"
+            shift 3
+            local bench_args=("$@")
+            local output_file="$GITHUB_WORKSPACE/.perf-results/baseline-$i$suffix.json"
 
             echo "::group::Round $i - baseline"
             local baseline_failed=0
             if ! (
               cd "$BASELINE_DIR" || exit 1
               pnpm exec vitest bench \
+                "${bench_args[@]}" \
                 --config vitest.bench.config.ts \
-                --outputJson "$GITHUB_WORKSPACE/.perf-results/baseline-$i.json"
+                --outputJson "$output_file"
             ); then
               echo "::warning::Baseline benchmark run failed for round $i; writing an empty baseline."
               baseline_failed=1
             fi
-            if [ "$baseline_failed" -eq 1 ] || [ ! -f ".perf-results/baseline-$i.json" ]; then
+            if [ "$baseline_failed" -eq 1 ] || [ ! -f "$output_file" ]; then
               if [ "$baseline_failed" -eq 0 ]; then
                 echo "::warning::No baseline benchmark results for round $i; writing an empty baseline."
               fi
-              printf '{"files":[]}\n' > ".perf-results/baseline-$i.json"
+              printf '{"files":[]}\n' > "$output_file"
+            fi
+            if [ "$expected_count" -gt 0 ] && ! pnpm exec ariakit perf-check-node-results "$output_file" "$expected_count"; then
+              echo "::endgroup::"
+              return 1
             fi
             echo "::endgroup::"
           }
 
           run_current_bench_round() {
             local i="$1"
+            local suffix="$2"
+            local expected_count="$3"
+            shift 3
+            local bench_args=("$@")
+            local output_file=".perf-results/current-$i$suffix.json"
 
             echo "::group::Round $i - current"
             pnpm exec vitest bench \
+              "${bench_args[@]}" \
               --config vitest.bench.config.ts \
-              --outputJson ".perf-results/current-$i.json"
-            if [ ! -f ".perf-results/current-$i.json" ]; then
-              echo "Missing current benchmark results for round $i" >&2
+              --outputJson "$output_file"
+            if [ ! -f "$output_file" ]; then
+              echo "Missing current benchmark results at $output_file" >&2
               exit 1
+            fi
+            if [ "$expected_count" -gt 0 ] && ! pnpm exec ariakit perf-check-node-results "$output_file" "$expected_count"; then
+              echo "::endgroup::"
+              return 1
             fi
             echo "::endgroup::"
           }
 
           run_bench_round() {
             local i="$1"
+            local suffix="$2"
+            local expected_count="$3"
+            local benchmark_file="$4"
+            local baseline_pattern="$5"
+            local current_pattern="$6"
+            local baseline_args=()
+            local current_args=()
+            if [ -n "$benchmark_file" ]; then
+              baseline_args=("$benchmark_file" --testNamePattern "$baseline_pattern")
+              current_args=("$benchmark_file" --testNamePattern "$current_pattern")
+            fi
 
             # Alternate sides first so same-runner drift cannot consistently
             # favor the baseline or current run across every paired round.
             if [ "$(( i % 2 ))" -eq 1 ]; then
               echo "Round $i order: baseline -> current"
-              run_baseline_bench_round "$i"
-              run_current_bench_round "$i"
+              run_baseline_bench_round "$i" "$suffix" "$expected_count" "${baseline_args[@]}"
+              run_current_bench_round "$i" "$suffix" "$expected_count" "${current_args[@]}"
             else
               echo "Round $i order: current -> baseline"
-              run_current_bench_round "$i"
-              run_baseline_bench_round "$i"
+              run_current_bench_round "$i" "$suffix" "$expected_count" "${current_args[@]}"
+              run_baseline_bench_round "$i" "$suffix" "$expected_count" "${baseline_args[@]}"
             fi
           }
 
           for i in $(seq 1 "$PERF_INITIAL_ROUNDS"); do
-            run_bench_round "$i"
+            run_bench_round "$i" "" 0 "" "" ""
           done
 
           run_node_compare() {
@@ -835,14 +866,34 @@ jobs:
 
           run_node_compare "Preliminary comparison"
 
-          # perf-compare writes the flagged benchmark files as a plain-text
-          # list, one per line, empty when the comparison is clean.
+          # perf-compare writes an empty file list when the comparison is clean
+          # and a per-file manifest of flagged benchmark names otherwise.
           if [ -s .perf-results/confirmation-files.txt ]; then
-            echo "Significant benchmark changes detected; running confirmation rounds."
+            mapfile -t confirmation_targets < <(
+              jq -r '.[] | @base64' .perf-results/confirmation-targets.json
+            )
+            if [ ${#confirmation_targets[@]} -eq 0 ]; then
+              echo "Missing Node benchmark confirmation targets" >&2
+              exit 1
+            fi
+            echo "Significant benchmark changes detected; running focused confirmation rounds."
             start_round=$((PERF_INITIAL_ROUNDS + 1))
             end_round=$((PERF_INITIAL_ROUNDS + PERF_CONFIRMATION_ROUNDS))
             for i in $(seq "$start_round" "$end_round"); do
-              run_bench_round "$i"
+              for target_index in "${!confirmation_targets[@]}"; do
+                target_json="$(printf '%s' "${confirmation_targets[$target_index]}" | base64 --decode)"
+                baseline_pattern="$(jq -r '.baselineTestNamePattern' <<< "$target_json")"
+                benchmark_count="$(jq -r '.benchmarkCount' <<< "$target_json")"
+                benchmark_file="$(jq -r '.file' <<< "$target_json")"
+                current_pattern="$(jq -r '.currentTestNamePattern' <<< "$target_json")"
+                run_bench_round \
+                  "$i" \
+                  "-t$target_index" \
+                  "$benchmark_count" \
+                  "$benchmark_file" \
+                  "$baseline_pattern" \
+                  "$current_pattern"
+              done
             done
 
             # No early stop between rounds: a mid-loop comparison requires

--- a/packages/ariakit-scripts/src/index.ts
+++ b/packages/ariakit-scripts/src/index.ts
@@ -83,6 +83,18 @@ program
     console.log(markdown);
   });
 
+program
+  .command("perf-check-node-results")
+  .description("Check focused Vitest benchmark results")
+  .argument("<file>", "Vitest benchmark JSON file")
+  .argument("<expected-count>", "Expected benchmark count", (value) =>
+    Number(value),
+  )
+  .action(async (file, expectedCount) => {
+    const { checkNodeBenchmarkResults } = await import("./perf-compare.ts");
+    checkNodeBenchmarkResults(file, expectedCount);
+  });
+
 try {
   await program.parseAsync();
 } catch (error) {

--- a/packages/ariakit-scripts/src/perf-compare.test.ts
+++ b/packages/ariakit-scripts/src/perf-compare.test.ts
@@ -302,6 +302,15 @@ function readConfirmationFilesList(dir: string) {
   );
 }
 
+function readConfirmationTargets(dir: string) {
+  return JSON.parse(
+    readFileSync(
+      path.join(dir, resultsDir, "confirmation-targets.json"),
+      "utf-8",
+    ),
+  );
+}
+
 function runCompare(
   dir: string,
   args: string[] = [],
@@ -324,6 +333,19 @@ function runCompareFailure(dir: string) {
     throw new Error("Expected performance comparison to fail");
   }
   return `${result.stderr}${result.stdout}`;
+}
+
+function runNodeResultsCheck(dir: string, file: string, expectedCount: number) {
+  return spawnSync(
+    process.execPath,
+    [
+      scriptPath,
+      "perf-check-node-results",
+      path.join(dir, resultsDir, file),
+      String(expectedCount),
+    ],
+    { cwd: dir, encoding: "utf-8" },
+  );
 }
 
 afterEach(() => {
@@ -515,6 +537,208 @@ test("describes Node multi-round comparisons by round agreement", () => {
   expect(readConfirmationFilesList(dir)).toBe(
     "packages/ariakit-store/benchmark/store.bench.ts\n",
   );
+  expect(summary.confirmationTargets).toEqual([
+    {
+      baselineTestNamePattern: "^(?:set state)$",
+      benchmarkCount: 1,
+      currentTestNamePattern: "^(?:set state)$",
+      file: "packages/ariakit-store/benchmark/store.bench.ts",
+    },
+  ]);
+  expect(readConfirmationTargets(dir)).toEqual(summary.confirmationTargets);
+});
+
+test("writes focused Node confirmation targets with raw benchmark names", () => {
+  const dir = createTempDir();
+  const benchmarkFile = "packages/ariakit-store/benchmark/store.bench.ts";
+  const flaggedGroup = `${benchmarkFile} > store > special`;
+  const stableGroup = `${benchmarkFile} > collection`;
+  for (const round of [1, 2]) {
+    writeJson(
+      dir,
+      `baseline-${round}.json`,
+      createBenchmarkReport([
+        {
+          fullName: flaggedGroup,
+          benchmarks: [
+            { name: "set [state]@1.2.3", hz: 1000 },
+            { name: "other (fast)@1.0.0", hz: 1000 },
+          ],
+        },
+        {
+          fullName: stableGroup,
+          benchmarks: [{ name: "set [state]@1.2.3", hz: 1000 }],
+        },
+      ]),
+    );
+    writeJson(
+      dir,
+      `current-${round}.json`,
+      createBenchmarkReport([
+        {
+          fullName: flaggedGroup,
+          benchmarks: [
+            { name: "set [state]@2.0.0", hz: 500 },
+            { name: "other (fast)@2.0.0", hz: 500 },
+          ],
+        },
+        {
+          fullName: stableGroup,
+          benchmarks: [{ name: "set [state]@2.0.0", hz: 1000 }],
+        },
+      ]),
+    );
+  }
+
+  runCompare(dir, ["--node"]);
+  const summary = readComparisonSummary(dir);
+
+  expect(summary.confirmationTargets).toEqual([
+    {
+      baselineTestNamePattern: String.raw`^(?:store(?: > | )special(?: > | )other \(fast\)@1\.0\.0|store(?: > | )special(?: > | )set \[state\]@1\.2\.3)$`,
+      benchmarkCount: 2,
+      currentTestNamePattern: String.raw`^(?:store(?: > | )special(?: > | )other \(fast\)@2\.0\.0|store(?: > | )special(?: > | )set \[state\]@2\.0\.0)$`,
+      file: benchmarkFile,
+    },
+  ]);
+  const target = summary.confirmationTargets.at(0);
+  if (!target) throw new Error("Missing confirmation target");
+  const baselinePattern = new RegExp(target.baselineTestNamePattern);
+  const currentPattern = new RegExp(target.currentTestNamePattern);
+  expect(baselinePattern.test("store special set [state]@1.2.3")).toBe(true);
+  expect(baselinePattern.test("store > special set [state]@1.2.3")).toBe(true);
+  expect(baselinePattern.test("store special other (fast)@1.0.0")).toBe(true);
+  expect(baselinePattern.test("collection set [state]@1.2.3")).toBe(false);
+  expect(currentPattern.test("store special set [state]@2.0.0")).toBe(true);
+  expect(currentPattern.test("store special set [state]@1.2.3")).toBe(false);
+  expect(summary.rows).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        label: "store > special > set [state]",
+        baselineBenchmarkPattern: String.raw`store(?: > | )special(?: > | )set \[state\]@1\.2\.3`,
+        currentBenchmarkPattern: String.raw`store(?: > | )special(?: > | )set \[state\]@2\.0\.0`,
+        significant: true,
+      }),
+      expect.objectContaining({
+        label: "collection > set [state]",
+        significant: false,
+      }),
+    ]),
+  );
+});
+
+test("groups Node confirmation targets by benchmark file", () => {
+  const dir = createTempDir();
+  const firstFile = "/repo/packages/first/benchmark/first.bench.ts";
+  const secondFile = "/repo/packages/second/benchmark/second.bench.ts";
+  const stableFile = "/repo/packages/stable/benchmark/stable.bench.ts";
+  const createReport = (changedHz: number) =>
+    createBenchmarkReportFromFiles([
+      {
+        filepath: firstFile,
+        groups: [
+          {
+            fullName: firstFile,
+            benchmarks: [{ name: "first", hz: changedHz }],
+          },
+        ],
+      },
+      {
+        filepath: secondFile,
+        groups: [
+          {
+            fullName: secondFile,
+            benchmarks: [{ name: "second", hz: changedHz }],
+          },
+        ],
+      },
+      {
+        filepath: stableFile,
+        groups: [
+          {
+            fullName: stableFile,
+            benchmarks: [{ name: "stable", hz: 1000 }],
+          },
+        ],
+      },
+    ]);
+
+  for (const round of [1, 2]) {
+    writeJson(dir, `baseline-${round}.json`, createReport(1000));
+    writeJson(dir, `current-${round}.json`, createReport(500));
+  }
+
+  runCompare(dir, ["--node"]);
+  const summary = readComparisonSummary(dir);
+
+  expect(summary.confirmationTargets).toEqual([
+    {
+      baselineTestNamePattern: "^(?:first)$",
+      benchmarkCount: 1,
+      currentTestNamePattern: "^(?:first)$",
+      file: "packages/first/benchmark/first.bench.ts",
+    },
+    {
+      baselineTestNamePattern: "^(?:second)$",
+      benchmarkCount: 1,
+      currentTestNamePattern: "^(?:second)$",
+      file: "packages/second/benchmark/second.bench.ts",
+    },
+  ]);
+});
+
+test("checks focused Node benchmark result counts", () => {
+  const dir = createTempDir();
+  writeJson(dir, "focused.json", createStoreBenchmarkReport(1000));
+
+  const success = runNodeResultsCheck(dir, "focused.json", 1);
+  expect(success.status).toBe(0);
+
+  const failure = runNodeResultsCheck(dir, "focused.json", 2);
+  expect(failure.status).toBe(1);
+  expect(`${failure.stderr}${failure.stdout}`).toContain(
+    "Expected 2 benchmark results",
+  );
+  expect(`${failure.stderr}${failure.stdout}`).toContain("found 1");
+});
+
+test("keeps stable Node benchmarks at the initial round count", () => {
+  const dir = createTempDir();
+  const createReport = (flaggedHz: number, includeStable: boolean) =>
+    createBenchmarkReport([
+      {
+        fullName: "packages/ariakit-store/benchmark/store.bench.ts",
+        benchmarks: [
+          { name: "flagged", hz: flaggedHz },
+          ...(includeStable ? [{ name: "stable", hz: 1000 }] : []),
+        ],
+      },
+    ]);
+
+  for (const round of [1, 2]) {
+    writeJson(dir, `baseline-${round}.json`, createReport(1000, true));
+    writeJson(dir, `current-${round}.json`, createReport(500, true));
+  }
+  for (const round of [3, 4, 5]) {
+    writeJson(dir, `baseline-${round}-t0.json`, createReport(1000, false));
+    writeJson(dir, `current-${round}-t0.json`, createReport(500, false));
+  }
+
+  const markdown = runCompare(dir, ["--node"]);
+  const summary = readComparisonSummary(dir);
+  const flagged = summary.rows.find(
+    (row: { label: string }) => row.label === "flagged",
+  );
+  const stable = summary.rows.find(
+    (row: { label: string }) => row.label === "stable",
+  );
+
+  expect(flagged?.pairedRoundsCount).toBe(5);
+  expect(flagged?.significant).toBe(true);
+  expect(stable?.pairedRoundsCount).toBe(2);
+  expect(stable?.significant).toBe(false);
+  expect(summary.pairedRoundsCount).toBeNull();
+  expect(markdown).toContain("mixed interleaved round counts");
 });
 
 test("does not flag noisy rounds that disagree on direction", () => {

--- a/packages/ariakit-scripts/src/perf-compare.ts
+++ b/packages/ariakit-scripts/src/perf-compare.ts
@@ -47,6 +47,8 @@ interface ComparisonRow {
   testFile: string;
   testTitle: string;
   label: string;
+  baselineBenchmarkPattern?: string;
+  currentBenchmarkPattern?: string;
   metric: MetricKey;
   baseline: number;
   current: number;
@@ -63,11 +65,19 @@ interface ComparisonRow {
   profileMode: boolean;
 }
 
+interface ConfirmationTarget {
+  baselineTestNamePattern: string;
+  benchmarkCount: number;
+  currentTestNamePattern: string;
+  file: string;
+}
+
 interface ComparisonSummary {
   rows: ComparisonRow[];
   hasSignificantChanges: boolean;
   hasCandidateChanges: boolean;
   confirmationFiles: string[];
+  confirmationTargets: ConfirmationTarget[];
   currentResults: AggregatedPerfResult[];
   profileModeMismatches: ProfileModeMismatch[];
   newTests: AggregatedPerfResult[];
@@ -81,6 +91,7 @@ interface PersistedComparisonSummary {
   hasSignificantChanges: boolean;
   hasCandidateChanges: boolean;
   confirmationFiles: string[];
+  confirmationTargets: ConfirmationTarget[];
   profileModeMismatches: ProfileModeMismatch[];
   newTests: PerfResult[];
   removedTests: PerfResult[];
@@ -254,6 +265,26 @@ function formatBenchmarkLabel({
   return parts.join(" > ");
 }
 
+/**
+ * Returns an escaped task pattern matched by Vitest's `--testNamePattern`.
+ * Vitest's report uses ` > ` between suites, but its task matcher uses spaces.
+ * Accept both because a suite name may itself contain the report separator.
+ */
+function formatBenchmarkPattern({
+  file,
+  groupName,
+  name,
+}: {
+  file: string;
+  groupName: string;
+  name: string;
+}) {
+  const parts = [...normalizeBenchmarkGroupName(groupName, file), name].filter(
+    Boolean,
+  );
+  return parts.map(escapeRegExp).join("(?: > | )");
+}
+
 function createNodeMetrics({ hz, mean }: { hz: number; mean: number }) {
   const total = hz > 0 ? hz : mean > 0 ? 1000 / mean : 0;
   return {
@@ -288,6 +319,11 @@ function resultsFromBenchmarkReport(report: BenchmarkReport): PerfResult[] {
             ? `${groupName} > ${normalizedName}`
             : normalizedName,
           label,
+          benchmarkPattern: formatBenchmarkPattern({
+            file: filePath,
+            groupName,
+            name,
+          }),
           metrics,
           raw: [metrics],
         });
@@ -295,6 +331,28 @@ function resultsFromBenchmarkReport(report: BenchmarkReport): PerfResult[] {
     }
   }
   return results;
+}
+
+/** Verifies that a focused Vitest report contains every expected benchmark. */
+export function checkNodeBenchmarkResults(
+  filePath: string,
+  expectedCount: number,
+) {
+  if (!Number.isInteger(expectedCount) || expectedCount < 0) {
+    throw new Error(`Invalid expected benchmark count: ${expectedCount}`);
+  }
+  const report = readJsonFile(filePath) as BenchmarkReport;
+  let actualCount = 0;
+  for (const file of report.files ?? []) {
+    for (const group of file.groups ?? []) {
+      actualCount += group.benchmarks?.length ?? 0;
+    }
+  }
+  if (actualCount !== expectedCount) {
+    throw new Error(
+      `Expected ${expectedCount} benchmark results in ${filePath}, found ${actualCount}`,
+    );
+  }
 }
 
 // Discover round files like `baseline-1-worker0.json` and
@@ -848,6 +906,44 @@ function getConfirmationFiles(rows: ComparisonRow[]): string[] {
   return [...files].sort();
 }
 
+/** Groups flagged Node benchmark task patterns by source file. */
+function getConfirmationTargets(rows: ComparisonRow[]): ConfirmationTarget[] {
+  const patternsByFile = new Map<
+    string,
+    Map<string, { baseline: string; current: string }>
+  >();
+  for (const row of rows) {
+    if (!row.significant && !row.candidate) continue;
+    if (!row.baselineBenchmarkPattern || !row.currentBenchmarkPattern) {
+      throw new Error(
+        `Missing benchmark patterns for comparison row: ${row.label}`,
+      );
+    }
+    let patterns = patternsByFile.get(row.testFile);
+    if (!patterns) {
+      patterns = new Map();
+      patternsByFile.set(row.testFile, patterns);
+    }
+    patterns.set(row.label, {
+      baseline: row.baselineBenchmarkPattern,
+      current: row.currentBenchmarkPattern,
+    });
+  }
+  return [...patternsByFile]
+    .sort(([fileA], [fileB]) => fileA.localeCompare(fileB))
+    .map(([file, patterns]) => {
+      const pairs = [...patterns.values()].sort((pairA, pairB) =>
+        pairA.current.localeCompare(pairB.current),
+      );
+      return {
+        baselineTestNamePattern: `^(?:${pairs.map((pair) => pair.baseline).join("|")})$`,
+        benchmarkCount: pairs.length,
+        currentTestNamePattern: `^(?:${pairs.map((pair) => pair.current).join("|")})$`,
+        file,
+      };
+    });
+}
+
 function compare(options: PerfCompareOptions): ComparisonSummary {
   const baseline = aggregateByKey(loadRounds("baseline", options));
   const current = aggregateByKey(loadRounds("current", options));
@@ -934,6 +1030,8 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
         testFile: cur.result.testFile,
         testTitle: cur.result.testTitle,
         label: cur.result.label,
+        baselineBenchmarkPattern: base.result.benchmarkPattern,
+        currentBenchmarkPattern: cur.result.benchmarkPattern,
         metric,
         baseline: baseVal,
         current: curVal,
@@ -960,6 +1058,7 @@ function compare(options: PerfCompareOptions): ComparisonSummary {
     hasSignificantChanges: rows.some((r) => r.significant),
     hasCandidateChanges: rows.some((r) => r.candidate),
     confirmationFiles: getConfirmationFiles(rows),
+    confirmationTargets: options.node ? getConfirmationTargets(rows) : [],
     currentResults: [...current.values()],
     profileModeMismatches,
     newTests,
@@ -1675,6 +1774,7 @@ function toPersistedSummary(
     hasSignificantChanges: summary.hasSignificantChanges,
     hasCandidateChanges: summary.hasCandidateChanges,
     confirmationFiles: summary.confirmationFiles,
+    confirmationTargets: summary.confirmationTargets,
     profileModeMismatches: summary.profileModeMismatches,
     newTests: summary.newTests.map((entry) => entry.result),
     removedTests: summary.removedTests.map((entry) => entry.result),
@@ -1696,12 +1796,17 @@ export function runPerfCompare(
     JSON.stringify(persistedSummary, null, 2),
   );
   writeFileSync(path.join(RESULTS_DIR, "comparison.md"), markdown);
-  // The perf workflow decides whether to run more confirmation rounds by
-  // reading this plain-text list (one flagged test file per line, empty when
-  // clean), so the shell needs no JSON parsing.
+  // The perf workflow uses the plain-text list as its confirmation gate and
+  // reads the JSON targets only when the list contains a flagged test file.
   writeFileSync(
     path.join(RESULTS_DIR, "confirmation-files.txt"),
     persistedSummary.confirmationFiles.map((file) => `${file}\n`).join(""),
+  );
+  // Node runs each file separately so duplicate benchmark names in different
+  // files cannot select stable cases through one global name pattern.
+  writeFileSync(
+    path.join(RESULTS_DIR, "confirmation-targets.json"),
+    JSON.stringify(persistedSummary.confirmationTargets, null, 2),
   );
 
   return { summary: persistedSummary, markdown };

--- a/packages/ariakit-scripts/src/perf.ts
+++ b/packages/ariakit-scripts/src/perf.ts
@@ -195,6 +195,8 @@ export interface PerfResult {
   testFile: string;
   testTitle: string;
   label: string;
+  /** Escaped Vitest task pattern used to select a Node benchmark. */
+  benchmarkPattern?: string;
   metrics: PerfMetrics;
   raw: PerfMetrics[];
   profileOnly?: boolean;


### PR DESCRIPTION
## Motivation

A significant result in any Node benchmark currently triggers three extra paired rounds of the entire benchmark suite:

```sh
pnpm exec vitest bench --config vitest.bench.config.ts
```

The current suite has 17 cases in one file, so one flagged case reruns all 17 on both baseline and current. Every future benchmark file would also be included, making confirmation progressively more expensive.

## Solution

Generate a per-file confirmation manifest containing only the flagged benchmark task patterns, then run each target with file and task filters:

```sh
pnpm exec vitest bench "$benchmark_file" \
  --testNamePattern "$test_name_pattern"
```

Baseline and current patterns are retained separately so normalized benchmark pairs with different raw version suffixes still select the correct task on each side. Focused results use suffixed round files, allowing flagged benchmarks to aggregate five paired rounds while stable benchmarks remain at the two preliminary rounds.

A tested `perf-check-node-results` command verifies that every focused invocation produced the expected benchmark count, preventing empty or partial reports from silently falling back to preliminary evidence.

## Testing

- `pnpm test packages/ariakit-scripts/src/perf-compare.test.ts`
- `pnpm tsc`
- `pnpm lint-fix`
- Prettier and extracted workflow shell syntax checks
- Real focused and no-match Vitest benchmark smoke tests
