### PR TITLE
Fix Dialog performance benchmark ownership

### DIFF
--- a/app/src/sandbox/dialog-perf/index.react.tsx
+++ b/app/src/sandbox/dialog-perf/index.react.tsx
@@ -1,5 +1,4 @@
 import * as Ariakit from "@ariakit/react";
-import { useState } from "react";
 import "./style.css";
 
 const items = Array.from({ length: 3000 }, (_, index) => ({
@@ -19,10 +18,10 @@ const fields = [
 ];
 
 export default function Example() {
-  const [open, setOpen] = useState(false);
+  const dialog = Ariakit.useDialogStore();
   return (
     <div className="root">
-      <Ariakit.Button className="button" onClick={() => setOpen(true)}>
+      <Ariakit.Button className="button" onClick={dialog.show}>
         Open dialog
       </Ariakit.Button>
       <ul className="grid">
@@ -36,8 +35,7 @@ export default function Example() {
       </ul>
       <Ariakit.Dialog
         className="dialog"
-        open={open}
-        onClose={() => setOpen(false)}
+        store={dialog}
         unmountOnHide
         backdrop={<div className="backdrop" />}
       >


### PR DESCRIPTION
## Motivation

The Dialog Chrome performance fixture currently keeps its `open` state in the component that owns the entire 3,000-card tree:

```tsx
const [open, setOpen] = useState(false);

<Ariakit.Button onClick={() => setOpen(true)}>Open dialog</Ariakit.Button>
<Ariakit.Dialog open={open} onClose={() => setOpen(false)} />
```

Opening or closing the Dialog therefore rerenders 3,000 unrelated `Ariakit.Button` hook chains. This makes the benchmark account for fixture ownership work that is not part of the Dialog interaction and distorted the performance signal observed in #6694.

This is a fixture-definition problem, not a timing/accounting problem in `perf.measure()`.

## Solution

Move the open state into a Dialog store without subscribing the component that renders the card tree:

```tsx
const dialog = Ariakit.useDialogStore();

<Ariakit.Button onClick={dialog.show}>Open dialog</Ariakit.Button>
<Ariakit.Dialog store={dialog} unmountOnHide />
```

The fixture keeps the original DOM and source order, all 3,000 outside cards and buttons, the existing dialog content, `unmountOnHide`, and the backdrop. The open and close performance interactions are unchanged. The large outside DOM therefore remains available for inert/tree walks, style and layout work, focus handling, portal work, and scroll locking, while dialog state changes no longer rerender unrelated Button hook chains.

A component-extraction alternative was intentionally avoided because it changes fixture ownership and source order and has shown substantially different rendering cost.

This PR's first performance comparison intentionally reflects a benchmark-definition change because the current side uses the corrected fixture while `main` uses the old owner-state fixture. After this change merges, its results become the fair baseline for future Dialog implementation comparisons. This fixture change is separate from #6694 so that PR can continue comparing identical fixture definitions.

No changeset is included because this only changes an internal performance fixture and does not affect a published package or consumer-observable behavior.

## Validation

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm build-app-lite`
- Production-backed focused Chrome performance test with 5 iterations and 1 warmup: open and close pass
- Source-mapped script profile: top Ariakit work resolves to Dialog internals, including `dialog.tsx`, body-scroll prevention, and outside-tree walking, rather than the 3,000 outside Button hook chains
- Local corrected-fixture sample: open 7.83 ms scripting, 28.98 ms rendering, 36.83 ms total; close 1.98 ms scripting, 25.99 ms rendering, 27.81 ms total
- Independent native Codex and Cursor pre-commit reviews: no findings
