### PR TITLE
Add keyed store subscriptions

### DIFF
--- a/.changeset/200-keyed-object-store-subscriptions.md
+++ b/.changeset/200-keyed-object-store-subscriptions.md
@@ -1,0 +1,15 @@
+---
+"@ariakit/react-store": patch
+"@ariakit/react-components": patch
+---
+
+Keyed object store subscriptions
+
+The `useStoreStateObject` hook now accepts selector dependency keys, so selectors skip unrelated store updates while receiving the complete store state at runtime. The key list must include every store key a selector reads, or its result may stay stale.
+
+```ts
+const values = useStoreStateObject(store, ["value"], {
+  value: "value",
+  valueLength: (state) => state.value.length,
+});
+```

--- a/.changeset/200-keyed-store-subscriptions.md
+++ b/.changeset/200-keyed-store-subscriptions.md
@@ -4,8 +4,17 @@
 "@ariakit/react": patch
 ---
 
-Added keyed store subscriptions
+Keyed store subscriptions
 
-The [`useStoreState`](https://ariakit.com/reference/use-store-state) and `useStoreStateObject` hooks now accept selector dependency keys, so selectors skip unrelated store updates while receiving the complete store state at runtime.
+The [`useStoreState`](https://ariakit.com/reference/use-store-state) and `useStoreStateObject` hooks now accept selector dependency keys, so selectors skip unrelated store updates while receiving the complete store state at runtime. The key list must include every store key a selector reads, or its result may stay stale.
 
-Updated React components to use keyed selector subscriptions internally.
+```ts
+const isEmpty = useStoreState(store, ["value"], (state) => !state.value);
+
+const values = useStoreStateObject(store, ["value"], {
+  value: "value",
+  valueLength: (state) => state.value.length,
+});
+```
+
+React components now use keyed selector subscriptions internally.

--- a/.changeset/200-keyed-store-subscriptions.md
+++ b/.changeset/200-keyed-store-subscriptions.md
@@ -6,15 +6,10 @@
 
 Keyed store subscriptions
 
-The [`useStoreState`](https://ariakit.com/reference/use-store-state) and `useStoreStateObject` hooks now accept selector dependency keys, so selectors skip unrelated store updates while receiving the complete store state at runtime. The key list must include every store key a selector reads, or its result may stay stale.
+The [`useStoreState`](https://ariakit.com/reference/use-store-state) hook now accepts selector dependency keys, so selectors skip unrelated store updates while receiving the complete store state at runtime. The key list must include every store key a selector reads, or its result may stay stale.
 
 ```ts
 const isEmpty = useStoreState(store, ["value"], (state) => !state.value);
-
-const values = useStoreStateObject(store, ["value"], {
-  value: "value",
-  valueLength: (state) => state.value.length,
-});
 ```
 
 React components now use keyed selector subscriptions internally.

--- a/.changeset/200-keyed-store-subscriptions.md
+++ b/.changeset/200-keyed-store-subscriptions.md
@@ -1,0 +1,11 @@
+---
+"@ariakit/react-store": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Added keyed store subscriptions
+
+The [`useStoreState`](https://ariakit.com/reference/use-store-state) and `useStoreStateObject` hooks now accept selector dependency keys, so selectors skip unrelated store updates while receiving the complete store state at runtime.
+
+Updated React components to use keyed selector subscriptions internally.

--- a/.changeset/300-nan-store-keys.md
+++ b/.changeset/300-nan-store-keys.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/store": patch
+"@ariakit/solid-store": patch
+---
+
+Fixed store subscriptions to respond consistently to updates made with `NaN` keys.

--- a/.changeset/300-nan-store-keys.md
+++ b/.changeset/300-nan-store-keys.md
@@ -1,5 +1,8 @@
 ---
 "@ariakit/store": patch
+"@ariakit/react-store": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
 "@ariakit/solid-store": patch
 ---
 

--- a/app/src/sandbox/combobox-select-tag-tooltip-element-id/index.react.tsx
+++ b/app/src/sandbox/combobox-select-tag-tooltip-element-id/index.react.tsx
@@ -1,0 +1,137 @@
+import * as Ariakit from "@ariakit/react";
+import { TagInput } from "@ariakit/react-components/tag/tag-input";
+import { TagList } from "@ariakit/react-components/tag/tag-list";
+import { TagListLabel } from "@ariakit/react-components/tag/tag-list-label";
+import { TagProvider } from "@ariakit/react-components/tag/tag-provider";
+import { useEffect, useState } from "react";
+
+function DynamicCombobox() {
+  const [id, setId] = useState("combobox-before");
+  return (
+    <>
+      <button type="button" onClick={() => setId("combobox-after")}>
+        Change combobox id
+      </button>
+      <Ariakit.Combobox id={id} />
+    </>
+  );
+}
+
+function ComboboxExample() {
+  return (
+    <section aria-label="Combobox">
+      <Ariakit.ComboboxProvider defaultValue="Apple">
+        <Ariakit.ComboboxLabel>Combobox label</Ariakit.ComboboxLabel>
+        <DynamicCombobox />
+        <Ariakit.ComboboxCancel />
+      </Ariakit.ComboboxProvider>
+    </section>
+  );
+}
+
+function DynamicSelectLabel() {
+  const [id, setId] = useState("select-label-before");
+  return (
+    <>
+      <button type="button" onClick={() => setId("select-label-after")}>
+        Change select label id
+      </button>
+      <Ariakit.SelectLabel id={id}>Select label</Ariakit.SelectLabel>
+    </>
+  );
+}
+
+function SelectExample() {
+  return (
+    <section aria-label="Select">
+      <Ariakit.SelectProvider defaultValue="Apple">
+        <DynamicSelectLabel />
+        <Ariakit.Select>Apple</Ariakit.Select>
+        <Ariakit.SelectList alwaysVisible>
+          <Ariakit.SelectItem value="Apple" />
+        </Ariakit.SelectList>
+      </Ariakit.SelectProvider>
+    </section>
+  );
+}
+
+function DynamicTagLabel() {
+  const [id, setId] = useState("tag-label-before");
+  return (
+    <>
+      <button type="button" onClick={() => setId("tag-label-after")}>
+        Change tag label id
+      </button>
+      <TagListLabel id={id}>Tag label</TagListLabel>
+    </>
+  );
+}
+
+function DynamicTagInput() {
+  const [id, setId] = useState("tag-input-before");
+  return (
+    <>
+      <button type="button" onClick={() => setId("tag-input-after")}>
+        Change tag input id
+      </button>
+      <TagInput id={id} />
+    </>
+  );
+}
+
+function TagExample() {
+  return (
+    <section aria-label="Tag">
+      <TagProvider>
+        <DynamicTagLabel />
+        <TagList>
+          <DynamicTagInput />
+        </TagList>
+      </TagProvider>
+    </section>
+  );
+}
+
+function DynamicTooltip() {
+  const [id, setId] = useState("tooltip-before");
+  return (
+    <>
+      <button type="button" onClick={() => setId("tooltip-after")}>
+        Change tooltip id
+      </button>
+      <Ariakit.Tooltip id={id} portal={false}>
+        Tooltip label
+      </Ariakit.Tooltip>
+    </>
+  );
+}
+
+function TooltipExample() {
+  const [type, setType] = useState<"description" | "label">("description");
+
+  // Switch after initialization so this covers the legacy label behavior
+  // without triggering its creation-time deprecation warning.
+  useEffect(() => setType("label"), []);
+
+  return (
+    <section aria-label="Tooltip">
+      <Ariakit.TooltipProvider open type={type}>
+        <Ariakit.TooltipAnchor render={<button type="button" />}>
+          Tooltip anchor
+        </Ariakit.TooltipAnchor>
+        <DynamicTooltip />
+      </Ariakit.TooltipProvider>
+    </section>
+  );
+}
+
+export default function Example() {
+  return (
+    <>
+      <ComboboxExample />
+      <SelectExample />
+      <TagExample />
+      <TooltipExample />
+    </>
+  );
+}

--- a/app/src/sandbox/combobox-select-tag-tooltip-element-id/test-browser.ts
+++ b/app/src/sandbox/combobox-select-tag-tooltip-element-id/test-browser.ts
@@ -1,0 +1,89 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test, query }) => {
+  test("updates combobox relationships when the input id changes", async ({
+    q,
+  }) => {
+    const section = query(q.region("Combobox"));
+    const label = section.text("Combobox label");
+    const combobox = section.combobox("Combobox label");
+    const cancel = section.button("Clear input");
+
+    await test.expect(label).toHaveAttribute("for", "combobox-before");
+    await test
+      .expect(cancel)
+      .toHaveAttribute("aria-controls", "combobox-before");
+
+    await section.button("Change combobox id").click();
+
+    await test.expect(label).toHaveAttribute("for", "combobox-after");
+    await test
+      .expect(cancel)
+      .toHaveAttribute("aria-controls", "combobox-after");
+    await test.expect(combobox).toHaveAttribute("id", "combobox-after");
+  });
+
+  test("updates select relationships when the label id changes", async ({
+    q,
+  }) => {
+    const section = query(q.region("Select"));
+    const select = section.combobox("Select label");
+    const list = section.listbox("Select label");
+
+    await test
+      .expect(select)
+      .toHaveAttribute("aria-labelledby", "select-label-before");
+    await test
+      .expect(list)
+      .toHaveAttribute("aria-labelledby", "select-label-before");
+
+    await section.button("Change select label id").click();
+
+    await test
+      .expect(select)
+      .toHaveAttribute("aria-labelledby", "select-label-after");
+    await test
+      .expect(list)
+      .toHaveAttribute("aria-labelledby", "select-label-after");
+  });
+
+  test("updates tag relationships when element ids change", async ({ q }) => {
+    const section = query(q.region("Tag"));
+    const label = section.text("Tag label");
+    const input = section.textbox("Tag label");
+    const list = section.listbox("Tag label");
+
+    await test.expect(label).toHaveAttribute("for", "tag-input-before");
+    await test
+      .expect(list)
+      .toHaveAttribute("aria-labelledby", "tag-label-before");
+
+    await section.button("Change tag input id").click();
+
+    await test.expect(label).toHaveAttribute("for", "tag-input-after");
+    await test.expect(input).toHaveAttribute("id", "tag-input-after");
+
+    await section.button("Change tag label id").click();
+
+    await test
+      .expect(list)
+      .toHaveAttribute("aria-labelledby", "tag-label-after");
+  });
+
+  test("updates the tooltip anchor when the content id changes", async ({
+    q,
+  }) => {
+    const section = query(q.region("Tooltip"));
+    const anchor = section.button("Tooltip label");
+
+    await test
+      .expect(anchor)
+      .toHaveAttribute("aria-labelledby", "tooltip-before");
+
+    await section.button("Change tooltip id").click();
+
+    await test
+      .expect(anchor)
+      .toHaveAttribute("aria-labelledby", "tooltip-after");
+  });
+});

--- a/app/src/sandbox/combobox-select-tag-tooltip-element-id/test.ts
+++ b/app/src/sandbox/combobox-select-tag-tooltip-element-id/test.ts
@@ -1,0 +1,18 @@
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+test("updates combobox relationships when the input id changes", async () => {
+  const section = q.within(q.region("Combobox"));
+  const label = section.text.ensure("Combobox label");
+  const combobox = section.combobox("Combobox label");
+  const cancel = section.button("Clear input");
+
+  expect(label).toHaveAttribute("for", "combobox-before");
+  expect(cancel).toHaveAttribute("aria-controls", "combobox-before");
+
+  await click(section.button("Change combobox id"));
+
+  await expect.poll(() => label.getAttribute("for")).toBe("combobox-after");
+  expect(cancel).toHaveAttribute("aria-controls", "combobox-after");
+  expect(combobox).toHaveAttribute("id", "combobox-after");
+});

--- a/app/src/sandbox/combobox-select-tag-tooltip-element-id/test.ts
+++ b/app/src/sandbox/combobox-select-tag-tooltip-element-id/test.ts
@@ -16,3 +16,16 @@ test("updates combobox relationships when the input id changes", async () => {
   expect(cancel).toHaveAttribute("aria-controls", "combobox-after");
   expect(combobox).toHaveAttribute("id", "combobox-after");
 });
+
+test("updates the tooltip anchor when the content id changes", async () => {
+  const section = q.within(q.region("Tooltip"));
+  const anchor = section.button.ensure("Tooltip label");
+
+  expect(anchor).toHaveAttribute("aria-labelledby", "tooltip-before");
+
+  await click(section.button("Change tooltip id"));
+
+  await expect
+    .poll(() => anchor.getAttribute("aria-labelledby"))
+    .toBe("tooltip-after");
+});

--- a/app/src/sandbox/store-keyed-subscriptions/index.react.tsx
+++ b/app/src/sandbox/store-keyed-subscriptions/index.react.tsx
@@ -134,10 +134,42 @@ function DirectValues({ store }: StoreProps) {
   );
 }
 
+function DynamicSelectors({ store }: StoreProps) {
+  const [key, setKey] = useState<keyof TestState>("foo");
+  const value = useStoreState(store, [key], (state) => state[key]);
+  const object = useStoreStateObject(store, [key], {
+    value: (state) => state[key],
+  });
+
+  return (
+    <>
+      <button type="button" onClick={() => setKey("bar")}>
+        Subscribe to bar
+      </button>
+      <p>
+        Dynamic selector value:{" "}
+        <output aria-label="Dynamic selector value">
+          {key}:{value}
+        </output>
+      </p>
+      <p>
+        Dynamic object selector value:{" "}
+        <output aria-label="Dynamic object selector value">
+          {key}:{object.value}
+        </output>
+      </p>
+    </>
+  );
+}
+
 function Controls({ store, calls }: SelectorProps) {
+  const [hydrated, setHydrated] = useState(false);
   const [, forceUpdate] = useReducer((count: number) => count + 1, 0);
 
-  useEffect(() => forceUpdate(), []);
+  useEffect(() => setHydrated(true), []);
+
+  const getCallCount = (key: keyof SelectorCalls) =>
+    hydrated ? calls[key] : 0;
 
   const update = (key: keyof TestState) => {
     store.setState(key, (value) => value + 1);
@@ -154,24 +186,32 @@ function Controls({ store, calls }: SelectorProps) {
       </button>
       <p>
         useStoreState calls:{" "}
-        <output aria-label="useStoreState calls">{calls.state}</output>
+        <output aria-label="useStoreState calls">
+          {getCallCount("state")}
+        </output>
       </p>
       <p>
         useStoreStateObject calls:{" "}
-        <output aria-label="useStoreStateObject calls">{calls.object}</output>
+        <output aria-label="useStoreStateObject calls">
+          {getCallCount("object")}
+        </output>
       </p>
       <p>
         Unkeyed selector calls:{" "}
-        <output aria-label="Unkeyed selector calls">{calls.unkeyed}</output>
+        <output aria-label="Unkeyed selector calls">
+          {getCallCount("unkeyed")}
+        </output>
       </p>
       <p>
         Empty selector calls:{" "}
-        <output aria-label="Empty selector calls">{calls.empty}</output>
+        <output aria-label="Empty selector calls">
+          {getCallCount("empty")}
+        </output>
       </p>
       <p>
         Empty object selector calls:{" "}
         <output aria-label="Empty object selector calls">
-          {calls.emptyObject}
+          {getCallCount("emptyObject")}
         </output>
       </p>
     </>
@@ -196,6 +236,7 @@ export default function Example() {
       <EmptyObjectSelector store={store} calls={calls.current} />
       <DirectValues store={store} />
       <MixedValues store={store} />
+      <DynamicSelectors store={store} />
       <OptionalSelector store={store} />
       <Controls store={store} calls={calls.current} />
     </>

--- a/app/src/sandbox/store-keyed-subscriptions/index.react.tsx
+++ b/app/src/sandbox/store-keyed-subscriptions/index.react.tsx
@@ -1,0 +1,203 @@
+import { useStoreState, useStoreStateObject } from "@ariakit/react-store";
+import { createStore } from "@ariakit/store";
+import type { Store } from "@ariakit/store";
+import { useEffect, useReducer, useRef, useState } from "react";
+
+interface TestState {
+  foo: number;
+  bar: number;
+}
+
+interface SelectorCalls {
+  state: number;
+  object: number;
+  unkeyed: number;
+  empty: number;
+  emptyObject: number;
+}
+
+interface StoreProps {
+  store: Store<TestState>;
+}
+
+interface SelectorProps extends StoreProps {
+  calls: SelectorCalls;
+}
+
+function KeyedSelectors({ store, calls }: SelectorProps) {
+  const value = useStoreState(store, ["foo"], (state) => {
+    calls.state += 1;
+    return state.foo;
+  });
+  const object = useStoreStateObject(store, ["foo"], {
+    value: (state) => {
+      calls.object += 1;
+      return state.foo;
+    },
+  });
+  const runtimeBar = useStoreState(store, ["foo"], (state) =>
+    Reflect.get(state, "bar"),
+  );
+
+  return (
+    <>
+      <p>
+        Selector value: <output aria-label="Selector value">{value}</output>
+      </p>
+      <p>
+        Object selector value:{" "}
+        <output aria-label="Object selector value">{object.value}</output>
+      </p>
+      <p>
+        Runtime bar: <output aria-label="Runtime bar">{runtimeBar}</output>
+      </p>
+    </>
+  );
+}
+
+function EmptySelector({ store, calls }: SelectorProps) {
+  useStoreState(store, [], () => {
+    calls.empty += 1;
+    return null;
+  });
+  return null;
+}
+
+function UnkeyedSelector({ store, calls }: SelectorProps) {
+  useStoreState(store, (state) => {
+    calls.unkeyed += 1;
+    return state.foo;
+  });
+  return null;
+}
+
+function EmptyObjectSelector({ store, calls }: SelectorProps) {
+  useStoreStateObject(store, [], {
+    value: () => {
+      calls.emptyObject += 1;
+      return null;
+    },
+  });
+  return null;
+}
+
+function MixedValues({ store }: StoreProps) {
+  const values = useStoreStateObject(store, ["foo"], {
+    directBar: "bar",
+    doubledFoo: (state) => state.foo * 2,
+  });
+
+  return (
+    <>
+      <p>
+        Mixed direct bar:{" "}
+        <output aria-label="Mixed direct bar">{values.directBar}</output>
+      </p>
+      <p>
+        Mixed doubled foo:{" "}
+        <output aria-label="Mixed doubled foo">{values.doubledFoo}</output>
+      </p>
+    </>
+  );
+}
+
+function OptionalSelector({ store }: StoreProps) {
+  const [currentStore, setCurrentStore] = useState<Store<TestState>>();
+  const value = useStoreState(currentStore, ["foo"], (state) => state?.foo);
+
+  return (
+    <>
+      <button type="button" onClick={() => setCurrentStore(store)}>
+        Use optional store
+      </button>
+      <p>
+        Optional value:{" "}
+        <output aria-label="Optional value">{value ?? "none"}</output>
+      </p>
+    </>
+  );
+}
+
+function DirectValues({ store }: StoreProps) {
+  const foo = useStoreState(store, "foo");
+  const { bar } = useStoreStateObject(store, { bar: "bar" });
+
+  return (
+    <>
+      <p>
+        Direct foo: <output aria-label="Direct foo">{foo}</output>
+      </p>
+      <p>
+        Direct bar: <output aria-label="Direct bar">{bar}</output>
+      </p>
+    </>
+  );
+}
+
+function Controls({ store, calls }: SelectorProps) {
+  const [, forceUpdate] = useReducer((count: number) => count + 1, 0);
+
+  useEffect(() => forceUpdate(), []);
+
+  const update = (key: keyof TestState) => {
+    store.setState(key, (value) => value + 1);
+    forceUpdate();
+  };
+
+  return (
+    <>
+      <button type="button" onClick={() => update("foo")}>
+        Update foo
+      </button>
+      <button type="button" onClick={() => update("bar")}>
+        Update bar
+      </button>
+      <p>
+        useStoreState calls:{" "}
+        <output aria-label="useStoreState calls">{calls.state}</output>
+      </p>
+      <p>
+        useStoreStateObject calls:{" "}
+        <output aria-label="useStoreStateObject calls">{calls.object}</output>
+      </p>
+      <p>
+        Unkeyed selector calls:{" "}
+        <output aria-label="Unkeyed selector calls">{calls.unkeyed}</output>
+      </p>
+      <p>
+        Empty selector calls:{" "}
+        <output aria-label="Empty selector calls">{calls.empty}</output>
+      </p>
+      <p>
+        Empty object selector calls:{" "}
+        <output aria-label="Empty object selector calls">
+          {calls.emptyObject}
+        </output>
+      </p>
+    </>
+  );
+}
+
+export default function Example() {
+  const [store] = useState(() => createStore<TestState>({ foo: 0, bar: 0 }));
+  const calls = useRef<SelectorCalls>({
+    state: 0,
+    object: 0,
+    unkeyed: 0,
+    empty: 0,
+    emptyObject: 0,
+  });
+
+  return (
+    <>
+      <KeyedSelectors store={store} calls={calls.current} />
+      <UnkeyedSelector store={store} calls={calls.current} />
+      <EmptySelector store={store} calls={calls.current} />
+      <EmptyObjectSelector store={store} calls={calls.current} />
+      <DirectValues store={store} />
+      <MixedValues store={store} />
+      <OptionalSelector store={store} />
+      <Controls store={store} calls={calls.current} />
+    </>
+  );
+}

--- a/app/src/sandbox/store-keyed-subscriptions/index.react.tsx
+++ b/app/src/sandbox/store-keyed-subscriptions/index.react.tsx
@@ -14,6 +14,7 @@ interface SelectorCalls {
   unkeyed: number;
   empty: number;
   emptyObject: number;
+  conditional: number;
 }
 
 interface StoreProps {
@@ -84,6 +85,28 @@ function EmptyObjectSelector({ store, calls }: SelectorProps) {
     },
   });
   return null;
+}
+
+function ConditionalSelector({ store, calls }: SelectorProps) {
+  const [enabled, setEnabled] = useState(false);
+  const value = useStoreState(store, enabled ? ["foo"] : [], (state) => {
+    calls.conditional += 1;
+    return enabled ? state.foo : null;
+  });
+
+  return (
+    <>
+      <button type="button" onClick={() => setEnabled((value) => !value)}>
+        {enabled ? "Pause conditional selector" : "Enable conditional selector"}
+      </button>
+      <p>
+        Conditional selector value:{" "}
+        <output aria-label="Conditional selector value">
+          {value ?? "paused"}
+        </output>
+      </p>
+    </>
+  );
 }
 
 function MixedValues({ store }: StoreProps) {
@@ -238,6 +261,12 @@ function Controls({ store, calls }: SelectorProps) {
           {getCallCount("emptyObject")}
         </output>
       </p>
+      <p>
+        Conditional selector calls:{" "}
+        <output aria-label="Conditional selector calls">
+          {getCallCount("conditional")}
+        </output>
+      </p>
     </>
   );
 }
@@ -250,6 +279,7 @@ export default function Example() {
     unkeyed: 0,
     empty: 0,
     emptyObject: 0,
+    conditional: 0,
   });
 
   return (
@@ -258,6 +288,7 @@ export default function Example() {
       <UnkeyedSelector store={store} calls={calls.current} />
       <EmptySelector store={store} calls={calls.current} />
       <EmptyObjectSelector store={store} calls={calls.current} />
+      <ConditionalSelector store={store} calls={calls.current} />
       <DirectValues store={store} />
       <MixedValues store={store} />
       <DynamicSelectors store={store} />

--- a/app/src/sandbox/store-keyed-subscriptions/index.react.tsx
+++ b/app/src/sandbox/store-keyed-subscriptions/index.react.tsx
@@ -34,6 +34,7 @@ function KeyedSelectors({ store, calls }: SelectorProps) {
       calls.object += 1;
       return state.foo;
     },
+    runtimeBar: (state) => Reflect.get(state, "bar"),
   });
   const runtimeBar = useStoreState(store, ["foo"], (state) =>
     Reflect.get(state, "bar"),
@@ -47,6 +48,10 @@ function KeyedSelectors({ store, calls }: SelectorProps) {
       <p>
         Object selector value:{" "}
         <output aria-label="Object selector value">{object.value}</output>
+      </p>
+      <p>
+        Object runtime bar:{" "}
+        <output aria-label="Object runtime bar">{object.runtimeBar}</output>
       </p>
       <p>
         Runtime bar: <output aria-label="Runtime bar">{runtimeBar}</output>
@@ -104,15 +109,34 @@ function MixedValues({ store }: StoreProps) {
 function OptionalSelector({ store }: StoreProps) {
   const [currentStore, setCurrentStore] = useState<Store<TestState>>();
   const value = useStoreState(currentStore, ["foo"], (state) => state?.foo);
+  const object = useStoreStateObject(currentStore, ["foo"], {
+    directBar: "bar",
+    derivedFoo: (state) => state?.foo,
+  });
 
   return (
     <>
       <button type="button" onClick={() => setCurrentStore(store)}>
         Use optional store
       </button>
+      <button type="button" onClick={() => setCurrentStore(undefined)}>
+        Clear optional store
+      </button>
       <p>
         Optional value:{" "}
         <output aria-label="Optional value">{value ?? "none"}</output>
+      </p>
+      <p>
+        Optional object direct bar:{" "}
+        <output aria-label="Optional object direct bar">
+          {object.directBar ?? "none"}
+        </output>
+      </p>
+      <p>
+        Optional object derived foo:{" "}
+        <output aria-label="Optional object derived foo">
+          {object.derivedFoo ?? "none"}
+        </output>
       </p>
     </>
   );

--- a/app/src/sandbox/store-keyed-subscriptions/test-browser.ts
+++ b/app/src/sandbox/store-keyed-subscriptions/test-browser.ts
@@ -127,4 +127,42 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(selectorValue).toHaveText("bar:2");
     await test.expect(objectValue).toHaveText("bar:2");
   });
+
+  test("attaches and detaches conditional selector dependencies", async ({
+    q,
+  }) => {
+    const selectorValue = q.status("Conditional selector value");
+    const calls = q.status("Conditional selector calls");
+    const pausedCalls = await calls.innerText();
+
+    await test.expect(selectorValue).toHaveText("paused");
+
+    await q.button("Update foo").click();
+
+    await test.expect(selectorValue).toHaveText("paused");
+    await test.expect(calls).toHaveText(pausedCalls);
+
+    await q.button("Enable conditional selector").click();
+
+    await test.expect(selectorValue).toHaveText("1");
+
+    await q.button("Update foo").click();
+
+    await test.expect(selectorValue).toHaveText("2");
+    await test.expect(calls).not.toHaveText(pausedCalls);
+
+    await q.button("Pause conditional selector").click();
+
+    await test.expect(selectorValue).toHaveText("paused");
+
+    await q.button("Update bar").click();
+
+    await test.expect(selectorValue).toHaveText("paused");
+    const detachedCalls = await calls.innerText();
+
+    await q.button("Update foo").click();
+
+    await test.expect(selectorValue).toHaveText("paused");
+    await test.expect(calls).toHaveText(detachedCalls);
+  });
 });

--- a/app/src/sandbox/store-keyed-subscriptions/test-browser.ts
+++ b/app/src/sandbox/store-keyed-subscriptions/test-browser.ts
@@ -1,6 +1,25 @@
-import { withFramework } from "#app/test-utils/preview.ts";
+import { gotoAndSettle, withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
+  test("hydrates deterministic selector counters", async ({ page, q }) => {
+    const hydrationErrors: string[] = [];
+    page.on("console", (message) => {
+      if (message.type() === "error") {
+        hydrationErrors.push(message.text());
+      }
+    });
+    page.on("pageerror", (error) => hydrationErrors.push(error.message));
+
+    // Re-navigate with listeners attached to capture errors from hydration.
+    await gotoAndSettle(page, page.url());
+
+    await test.expect(q.status("useStoreState calls")).not.toHaveText("0");
+    await test
+      .expect(q.status("useStoreStateObject calls"))
+      .not.toHaveText("0");
+    test.expect(hydrationErrors).toEqual([]);
+  });
+
   test("runs selectors only for subscribed keys", async ({ q }) => {
     const stateCalls = await q.status("useStoreState calls").innerText();
     const objectCalls = await q.status("useStoreStateObject calls").innerText();
@@ -53,5 +72,33 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
     await q.button("Update foo").click();
     await test.expect(q.status("Optional value")).toHaveText("2");
+  });
+
+  test("updates dynamic selector dependencies", async ({ q }) => {
+    const selectorValue = q.status("Dynamic selector value");
+    const objectValue = q.status("Dynamic object selector value");
+
+    await test.expect(selectorValue).toHaveText("foo:0");
+    await test.expect(objectValue).toHaveText("foo:0");
+
+    await q.button("Update bar").click();
+
+    await test.expect(selectorValue).toHaveText("foo:0");
+    await test.expect(objectValue).toHaveText("foo:0");
+
+    await q.button("Subscribe to bar").click();
+
+    await test.expect(selectorValue).toHaveText("bar:1");
+    await test.expect(objectValue).toHaveText("bar:1");
+
+    await q.button("Update foo").click();
+
+    await test.expect(selectorValue).toHaveText("bar:1");
+    await test.expect(objectValue).toHaveText("bar:1");
+
+    await q.button("Update bar").click();
+
+    await test.expect(selectorValue).toHaveText("bar:2");
+    await test.expect(objectValue).toHaveText("bar:2");
   });
 });

--- a/app/src/sandbox/store-keyed-subscriptions/test-browser.ts
+++ b/app/src/sandbox/store-keyed-subscriptions/test-browser.ts
@@ -1,0 +1,57 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("runs selectors only for subscribed keys", async ({ q }) => {
+    const stateCalls = await q.status("useStoreState calls").innerText();
+    const objectCalls = await q.status("useStoreStateObject calls").innerText();
+    const unkeyedCalls = await q.status("Unkeyed selector calls").innerText();
+    const emptyCalls = await q.status("Empty selector calls").innerText();
+    const emptyObjectCalls = await q
+      .status("Empty object selector calls")
+      .innerText();
+
+    await test.expect(q.status("Optional value")).toHaveText("none");
+
+    await q.button("Update bar").click();
+
+    await test.expect(q.status("useStoreState calls")).toHaveText(stateCalls);
+    await test
+      .expect(q.status("useStoreStateObject calls"))
+      .toHaveText(objectCalls);
+    await test.expect(q.status("Empty selector calls")).toHaveText(emptyCalls);
+    await test
+      .expect(q.status("Empty object selector calls"))
+      .toHaveText(emptyObjectCalls);
+    await test
+      .expect(q.status("Unkeyed selector calls"))
+      .not.toHaveText(unkeyedCalls);
+    await test.expect(q.status("Direct bar")).toHaveText("1");
+    await test.expect(q.status("Mixed direct bar")).toHaveText("1");
+    await test.expect(q.status("Mixed doubled foo")).toHaveText("0");
+    await test.expect(q.status("Runtime bar")).toHaveText("0");
+
+    await q.button("Update foo").click();
+
+    await test
+      .expect(q.status("useStoreState calls"))
+      .not.toHaveText(stateCalls);
+    await test
+      .expect(q.status("useStoreStateObject calls"))
+      .not.toHaveText(objectCalls);
+    await test.expect(q.status("Empty selector calls")).toHaveText(emptyCalls);
+    await test
+      .expect(q.status("Empty object selector calls"))
+      .toHaveText(emptyObjectCalls);
+    await test.expect(q.status("Selector value")).toHaveText("1");
+    await test.expect(q.status("Object selector value")).toHaveText("1");
+    await test.expect(q.status("Direct foo")).toHaveText("1");
+    await test.expect(q.status("Mixed doubled foo")).toHaveText("2");
+    await test.expect(q.status("Runtime bar")).toHaveText("1");
+
+    await q.button("Use optional store").click();
+    await test.expect(q.status("Optional value")).toHaveText("1");
+
+    await q.button("Update foo").click();
+    await test.expect(q.status("Optional value")).toHaveText("2");
+  });
+});

--- a/app/src/sandbox/store-keyed-subscriptions/test-browser.ts
+++ b/app/src/sandbox/store-keyed-subscriptions/test-browser.ts
@@ -30,6 +30,12 @@ withFramework(import.meta.dirname, async ({ test }) => {
       .innerText();
 
     await test.expect(q.status("Optional value")).toHaveText("none");
+    await test
+      .expect(q.status("Optional object direct bar"))
+      .toHaveText("none");
+    await test
+      .expect(q.status("Optional object derived foo"))
+      .toHaveText("none");
 
     await q.button("Update bar").click();
 
@@ -48,6 +54,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.status("Mixed direct bar")).toHaveText("1");
     await test.expect(q.status("Mixed doubled foo")).toHaveText("0");
     await test.expect(q.status("Runtime bar")).toHaveText("0");
+    await test.expect(q.status("Object runtime bar")).toHaveText("0");
 
     await q.button("Update foo").click();
 
@@ -66,12 +73,31 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.status("Direct foo")).toHaveText("1");
     await test.expect(q.status("Mixed doubled foo")).toHaveText("2");
     await test.expect(q.status("Runtime bar")).toHaveText("1");
+    await test.expect(q.status("Object runtime bar")).toHaveText("1");
 
     await q.button("Use optional store").click();
     await test.expect(q.status("Optional value")).toHaveText("1");
+    await test.expect(q.status("Optional object direct bar")).toHaveText("1");
+    await test.expect(q.status("Optional object derived foo")).toHaveText("1");
+
+    await q.button("Update bar").click();
+    await test.expect(q.status("Optional value")).toHaveText("1");
+    await test.expect(q.status("Optional object direct bar")).toHaveText("2");
+    await test.expect(q.status("Optional object derived foo")).toHaveText("1");
 
     await q.button("Update foo").click();
     await test.expect(q.status("Optional value")).toHaveText("2");
+    await test.expect(q.status("Optional object direct bar")).toHaveText("2");
+    await test.expect(q.status("Optional object derived foo")).toHaveText("2");
+
+    await q.button("Clear optional store").click();
+    await test.expect(q.status("Optional value")).toHaveText("none");
+    await test
+      .expect(q.status("Optional object direct bar"))
+      .toHaveText("none");
+    await test
+      .expect(q.status("Optional object derived foo"))
+      .toHaveText("none");
   });
 
   test("updates dynamic selector dependencies", async ({ q }) => {

--- a/app/src/sandbox/store-keyed-subscriptions/test.ts
+++ b/app/src/sandbox/store-keyed-subscriptions/test.ts
@@ -195,3 +195,39 @@ test("updates dynamic selector dependencies", async () => {
   expect(selectorValue).toHaveTextContent("bar:2");
   expect(objectValue).toHaveTextContent("bar:2");
 });
+
+test("attaches and detaches conditional selector dependencies", async () => {
+  const selectorValue = q.status("Conditional selector value");
+  const calls = q.status.ensure("Conditional selector calls");
+  const pausedCalls = calls.textContent;
+
+  expect(selectorValue).toHaveTextContent("paused");
+
+  await click(q.button("Update foo"));
+
+  expect(selectorValue).toHaveTextContent("paused");
+  expect(calls.textContent).toBe(pausedCalls);
+
+  await click(q.button("Enable conditional selector"));
+
+  expect(selectorValue).toHaveTextContent("1");
+
+  await click(q.button("Update foo"));
+
+  expect(selectorValue).toHaveTextContent("2");
+  expect(calls.textContent).not.toBe(pausedCalls);
+
+  await click(q.button("Pause conditional selector"));
+
+  expect(selectorValue).toHaveTextContent("paused");
+
+  await click(q.button("Update bar"));
+
+  expect(selectorValue).toHaveTextContent("paused");
+  const detachedCalls = calls.textContent;
+
+  await click(q.button("Update foo"));
+
+  expect(selectorValue).toHaveTextContent("paused");
+  expect(calls.textContent).toBe(detachedCalls);
+});

--- a/app/src/sandbox/store-keyed-subscriptions/test.ts
+++ b/app/src/sandbox/store-keyed-subscriptions/test.ts
@@ -136,3 +136,31 @@ test("runs selectors only for subscribed keys", async () => {
   await click(q.button("Update foo"));
   expect(q.status("Optional value")).toHaveTextContent("2");
 });
+
+test("updates dynamic selector dependencies", async () => {
+  const selectorValue = q.status("Dynamic selector value");
+  const objectValue = q.status("Dynamic object selector value");
+
+  expect(selectorValue).toHaveTextContent("foo:0");
+  expect(objectValue).toHaveTextContent("foo:0");
+
+  await click(q.button("Update bar"));
+
+  expect(selectorValue).toHaveTextContent("foo:0");
+  expect(objectValue).toHaveTextContent("foo:0");
+
+  await click(q.button("Subscribe to bar"));
+
+  expect(selectorValue).toHaveTextContent("bar:1");
+  expect(objectValue).toHaveTextContent("bar:1");
+
+  await click(q.button("Update foo"));
+
+  expect(selectorValue).toHaveTextContent("bar:1");
+  expect(objectValue).toHaveTextContent("bar:1");
+
+  await click(q.button("Update bar"));
+
+  expect(selectorValue).toHaveTextContent("bar:2");
+  expect(objectValue).toHaveTextContent("bar:2");
+});

--- a/app/src/sandbox/store-keyed-subscriptions/test.ts
+++ b/app/src/sandbox/store-keyed-subscriptions/test.ts
@@ -1,0 +1,138 @@
+import { useStoreState, useStoreStateObject } from "@ariakit/react-store";
+import { createStore } from "@ariakit/store";
+import { click, q } from "@ariakit/test";
+import { expect, expectTypeOf, test } from "vitest";
+
+test("supports keyed selector types", () => {
+  const store = createStore({
+    a: "a",
+    bar: "bar",
+    foo: "foo",
+    key: "key",
+    otherKey: "otherKey",
+  });
+  const countStore = createStore({ kind: "count" as const, count: 0 });
+  const labelStore = createStore({ kind: "label" as const, label: "" });
+
+  const useCheckTypes = (optionalStore?: typeof store) => {
+    expectTypeOf(useStoreState(store, "key")).toEqualTypeOf<string>();
+    expectTypeOf(
+      useStoreState(store, (state) => state.key),
+    ).toEqualTypeOf<string>();
+    expectTypeOf(
+      useStoreState(store, ["key"], (state) => state.key),
+    ).toEqualTypeOf<string>();
+
+    const object = useStoreStateObject(store, {
+      foo: "otherKey",
+      bar: (state) => state.key,
+    });
+    expectTypeOf(object).toEqualTypeOf<{ foo: string; bar: string }>();
+
+    const keyedObject = useStoreStateObject(store, ["key"], {
+      foo: "otherKey",
+      bar: (state) => state.key,
+    });
+    expectTypeOf(keyedObject).toEqualTypeOf<{ foo: string; bar: string }>();
+
+    const multiKeyedObject = useStoreStateObject(store, ["foo", "bar"], {
+      a: "a",
+      foo: (state) => state.foo,
+      bar: (state) => state.bar,
+    });
+    expectTypeOf(multiKeyedObject).toEqualTypeOf<{
+      a: string;
+      foo: string;
+      bar: string;
+    }>();
+
+    const optionalKey = useStoreState(
+      optionalStore,
+      ["key"],
+      (state) => state?.key,
+    );
+    expectTypeOf(optionalKey).toEqualTypeOf<string | undefined>();
+
+    const unionStore: typeof countStore | typeof labelStore =
+      Math.random() > 0.5 ? countStore : labelStore;
+    const unionValue = useStoreState(
+      unionStore,
+      ["kind", "count", "label"],
+      (state) => (state.kind === "count" ? state.count : state.label),
+    );
+    expectTypeOf(unionValue).toEqualTypeOf<number | string>();
+
+    // @ts-expect-error Selector reads an undeclared key.
+    useStoreState(store, ["foo"], (state) => state.bar);
+    // @ts-expect-error Key arrays require a third selector argument.
+    useStoreState(store, ["foo"]);
+    // @ts-expect-error The third argument must be a function.
+    useStoreState(store, ["foo"], "foo");
+    // @ts-expect-error The store and third argument have invalid types.
+    useStoreState("store", ["foo"], "foo");
+    // @ts-expect-error Object selector reads an undeclared key.
+    useStoreStateObject(store, ["foo"], { bar: (state) => state.bar });
+    // @ts-expect-error Key arrays require a third object argument.
+    useStoreStateObject(store, ["foo"]);
+    // @ts-expect-error The third argument must be an object.
+    useStoreStateObject(store, ["foo"], (state) => state.foo);
+  };
+
+  expectTypeOf(useCheckTypes).toEqualTypeOf<
+    (optionalStore?: typeof store) => void
+  >();
+});
+
+test("runs selectors only for subscribed keys", async () => {
+  const stateCalls = q.status.ensure("useStoreState calls").textContent;
+  const objectCalls = q.status.ensure("useStoreStateObject calls").textContent;
+  const unkeyedCalls = q.status.ensure("Unkeyed selector calls").textContent;
+  const emptyCalls = q.status.ensure("Empty selector calls").textContent;
+  const emptyObjectCalls = q.status.ensure(
+    "Empty object selector calls",
+  ).textContent;
+
+  expect(q.status("Optional value")).toHaveTextContent("none");
+
+  await click(q.button("Update bar"));
+
+  expect(q.status.ensure("useStoreState calls").textContent).toBe(stateCalls);
+  expect(q.status.ensure("useStoreStateObject calls").textContent).toBe(
+    objectCalls,
+  );
+  expect(q.status.ensure("Empty selector calls").textContent).toBe(emptyCalls);
+  expect(q.status.ensure("Empty object selector calls").textContent).toBe(
+    emptyObjectCalls,
+  );
+  expect(q.status.ensure("Unkeyed selector calls").textContent).not.toBe(
+    unkeyedCalls,
+  );
+  expect(q.status("Direct bar")).toHaveTextContent("1");
+  expect(q.status("Mixed direct bar")).toHaveTextContent("1");
+  expect(q.status("Mixed doubled foo")).toHaveTextContent("0");
+  expect(q.status("Runtime bar")).toHaveTextContent("0");
+
+  await click(q.button("Update foo"));
+
+  expect(q.status.ensure("useStoreState calls").textContent).not.toBe(
+    stateCalls,
+  );
+  expect(q.status.ensure("useStoreStateObject calls").textContent).not.toBe(
+    objectCalls,
+  );
+  expect(q.status.ensure("Empty selector calls").textContent).toBe(emptyCalls);
+  expect(q.status.ensure("Empty object selector calls").textContent).toBe(
+    emptyObjectCalls,
+  );
+  expect(q.status("Selector value")).toHaveTextContent("1");
+  expect(q.status("Object selector value")).toHaveTextContent("1");
+  expect(q.status("Direct foo")).toHaveTextContent("1");
+  expect(q.status("Mixed doubled foo")).toHaveTextContent("2");
+  expect(q.status("Runtime bar")).toHaveTextContent("1");
+
+  await click(q.button("Use optional store"));
+  expect(q.status("Optional value")).toHaveTextContent("1");
+
+  await click(q.button("Update foo"));
+  expect(q.status("Optional value")).toHaveTextContent("2");
+});

--- a/app/src/sandbox/store-keyed-subscriptions/test.ts
+++ b/app/src/sandbox/store-keyed-subscriptions/test.ts
@@ -53,6 +53,15 @@ test("supports keyed selector types", () => {
     );
     expectTypeOf(optionalKey).toEqualTypeOf<string | undefined>();
 
+    const optionalObject = useStoreStateObject(optionalStore, ["key"], {
+      direct: "otherKey",
+      derived: (state) => state?.key,
+    });
+    expectTypeOf(optionalObject).toEqualTypeOf<{
+      direct: string | undefined;
+      derived: string | undefined;
+    }>();
+
     const unionStore: typeof countStore | typeof labelStore =
       Math.random() > 0.5 ? countStore : labelStore;
     const unionValue = useStoreState(
@@ -72,6 +81,10 @@ test("supports keyed selector types", () => {
     useStoreState("store", ["foo"], "foo");
     // @ts-expect-error Object selector reads an undeclared key.
     useStoreStateObject(store, ["foo"], { bar: (state) => state.bar });
+    useStoreStateObject(optionalStore, ["foo"], {
+      // @ts-expect-error Optional object selector reads an undeclared key.
+      bar: (state) => state?.bar,
+    });
     // @ts-expect-error Key arrays require a third object argument.
     useStoreStateObject(store, ["foo"]);
     // @ts-expect-error The third argument must be an object.
@@ -93,6 +106,8 @@ test("runs selectors only for subscribed keys", async () => {
   ).textContent;
 
   expect(q.status("Optional value")).toHaveTextContent("none");
+  expect(q.status("Optional object direct bar")).toHaveTextContent("none");
+  expect(q.status("Optional object derived foo")).toHaveTextContent("none");
 
   await click(q.button("Update bar"));
 
@@ -111,6 +126,7 @@ test("runs selectors only for subscribed keys", async () => {
   expect(q.status("Mixed direct bar")).toHaveTextContent("1");
   expect(q.status("Mixed doubled foo")).toHaveTextContent("0");
   expect(q.status("Runtime bar")).toHaveTextContent("0");
+  expect(q.status("Object runtime bar")).toHaveTextContent("0");
 
   await click(q.button("Update foo"));
 
@@ -129,12 +145,27 @@ test("runs selectors only for subscribed keys", async () => {
   expect(q.status("Direct foo")).toHaveTextContent("1");
   expect(q.status("Mixed doubled foo")).toHaveTextContent("2");
   expect(q.status("Runtime bar")).toHaveTextContent("1");
+  expect(q.status("Object runtime bar")).toHaveTextContent("1");
 
   await click(q.button("Use optional store"));
   expect(q.status("Optional value")).toHaveTextContent("1");
+  expect(q.status("Optional object direct bar")).toHaveTextContent("1");
+  expect(q.status("Optional object derived foo")).toHaveTextContent("1");
+
+  await click(q.button("Update bar"));
+  expect(q.status("Optional value")).toHaveTextContent("1");
+  expect(q.status("Optional object direct bar")).toHaveTextContent("2");
+  expect(q.status("Optional object derived foo")).toHaveTextContent("1");
 
   await click(q.button("Update foo"));
   expect(q.status("Optional value")).toHaveTextContent("2");
+  expect(q.status("Optional object direct bar")).toHaveTextContent("2");
+  expect(q.status("Optional object derived foo")).toHaveTextContent("2");
+
+  await click(q.button("Clear optional store"));
+  expect(q.status("Optional value")).toHaveTextContent("none");
+  expect(q.status("Optional object direct bar")).toHaveTextContent("none");
+  expect(q.status("Optional object derived foo")).toHaveTextContent("none");
 });
 
 test("updates dynamic selector dependencies", async () => {

--- a/packages/ariakit-react-components/src/checkbox/checkbox.tsx
+++ b/packages/ariakit-react-components/src/checkbox/checkbox.tsx
@@ -66,7 +66,7 @@ export const useCheckbox = createHook<TagName, CheckboxOptions>(
 
     const [_checked, setChecked] = useState(defaultChecked ?? false);
 
-    const checked = useStoreState(store, (state) => {
+    const checked = useStoreState(store, ["value"], (state) => {
       if (checkedProp !== undefined) return checkedProp;
       if (state?.value === undefined) return _checked;
       if (valueProp != null) {

--- a/packages/ariakit-react-components/src/collection/collection-renderer.tsx
+++ b/packages/ariakit-react-components/src/collection/collection-renderer.tsx
@@ -449,6 +449,7 @@ export function useCollectionRenderer<T extends Item = any>({
 
   const items = useStoreState(
     store,
+    ["items"],
     (state) => itemsProp ?? (state?.items as T[]),
   );
 

--- a/packages/ariakit-react-components/src/combobox/combobox-cancel.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-cancel.tsx
@@ -1,5 +1,6 @@
 import { useStoreState } from "@ariakit/react-store";
 import {
+  useAttribute,
   useEvent,
   useWrapElement,
   createElement,
@@ -71,11 +72,9 @@ export const useComboboxCancel = createHook<TagName, ComboboxCancelOptions>(
       store?.move(null);
     });
 
-    const comboboxId = useStoreState(
-      store,
-      ["baseElement"],
-      (state) => state.baseElement?.id,
-    );
+    const baseElement = useStoreState(store, "baseElement");
+    useAttribute(baseElement, "id");
+    const comboboxId = baseElement?.id;
     const empty = useStoreState(
       store,
       ["value"],

--- a/packages/ariakit-react-components/src/combobox/combobox-cancel.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-cancel.tsx
@@ -71,8 +71,16 @@ export const useComboboxCancel = createHook<TagName, ComboboxCancelOptions>(
       store?.move(null);
     });
 
-    const comboboxId = useStoreState(store, (state) => state.baseElement?.id);
-    const empty = useStoreState(store, (state) => state.value === "");
+    const comboboxId = useStoreState(
+      store,
+      ["baseElement"],
+      (state) => state.baseElement?.id,
+    );
+    const empty = useStoreState(
+      store,
+      ["value"],
+      (state) => state.value === "",
+    );
 
     props = useWrapElement(
       props,

--- a/packages/ariakit-react-components/src/combobox/combobox-item-value.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item-value.tsx
@@ -203,7 +203,11 @@ export const useComboboxItemValue = createHook<
   const itemContext = useContext(ComboboxItemValueContext);
   const itemValue = value ?? itemContext;
 
-  const inputValue = useStoreState(store, (state) => userValue ?? state?.value);
+  const inputValue = useStoreState(
+    store,
+    ["value"],
+    (state) => userValue ?? state?.value,
+  );
 
   const children = useMemo(() => {
     if (!itemValue) return;

--- a/packages/ariakit-react-components/src/combobox/combobox-item.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item.tsx
@@ -89,7 +89,7 @@ export const useComboboxItem = createHook<TagName, ComboboxItemOptions>(
     );
 
     const { resetValueOnSelectState, multiSelectable, selected } =
-      useStoreStateObject(store, {
+      useStoreStateObject(store, ["selectedValue"], {
         resetValueOnSelectState: "resetValueOnSelect",
         multiSelectable(state) {
           return Array.isArray(state.selectedValue);

--- a/packages/ariakit-react-components/src/combobox/combobox-label.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-label.tsx
@@ -1,5 +1,6 @@
 import { useStoreState } from "@ariakit/react-store";
 import {
+  useAttribute,
   createElement,
   createHook,
   forwardRef,
@@ -36,11 +37,9 @@ export const useComboboxLabel = createHook<TagName, ComboboxLabelOptions>(
         "ComboboxLabel must receive a `store` prop or be wrapped in a ComboboxProvider component.",
     );
 
-    const comboboxId = useStoreState(
-      store,
-      ["baseElement"],
-      (state) => state.baseElement?.id,
-    );
+    const baseElement = useStoreState(store, "baseElement");
+    useAttribute(baseElement, "id");
+    const comboboxId = baseElement?.id;
 
     props = {
       htmlFor: comboboxId,

--- a/packages/ariakit-react-components/src/combobox/combobox-label.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-label.tsx
@@ -36,7 +36,11 @@ export const useComboboxLabel = createHook<TagName, ComboboxLabelOptions>(
         "ComboboxLabel must receive a `store` prop or be wrapped in a ComboboxProvider component.",
     );
 
-    const comboboxId = useStoreState(store, (state) => state.baseElement?.id);
+    const comboboxId = useStoreState(
+      store,
+      ["baseElement"],
+      (state) => state.baseElement?.id,
+    );
 
     props = {
       htmlFor: comboboxId,

--- a/packages/ariakit-react-components/src/combobox/combobox-list.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-list.tsx
@@ -60,7 +60,7 @@ export const useComboboxList = createHook<TagName, ComboboxListOptions>(
     const hidden = isHidden(mounted, props.hidden, alwaysVisible);
     const style = hidden ? { ...props.style, display: "none" } : props.style;
 
-    const multiSelectable = useStoreState(store, (state) =>
+    const multiSelectable = useStoreState(store, ["selectedValue"], (state) =>
       Array.isArray(state.selectedValue),
     );
     const role = useAttribute(ref, "role", props.role);

--- a/packages/ariakit-react-components/src/combobox/combobox-popover.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-popover.tsx
@@ -72,6 +72,7 @@ export const useComboboxPopover = createHook<TagName, ComboboxPopoverOptions>(
     // take a new snapshot of the tree when new items are rendered.
     const treeSnapshotKey = useStoreState(
       store.tag,
+      ["renderedItems"],
       (state) => state?.renderedItems.length,
     );
 

--- a/packages/ariakit-react-components/src/combobox/combobox.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox.tsx
@@ -162,6 +162,7 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
     // first item on every keypress.
     const autoSelect = useStoreState(
       store,
+      ["virtualFocus"],
       (state) => state.virtualFocus && autoSelectProp,
     );
 
@@ -191,23 +192,27 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       });
     }, [store]);
 
-    const inlineActiveValue = useStoreState(store, (state) => {
-      if (!inline) return;
-      if (!canInline) return;
-      // It doesn't make sense to inline the active value if it's already
-      // selected or just got deselected. Inlining the value typically implies
-      // an addition, but if the value is already selected, the action actually
-      // becomes a deletion. If the value was just deselected, pressing Enter
-      // again would reselect it, but it's not the usual path, so we also take
-      // into account the previously selected values. See tag-combobox test
-      // named "deselecting a tag should not highlight the input text if it is
-      // not the first combobox item".
-      if (state.activeValue && Array.isArray(state.selectedValue)) {
-        if (state.selectedValue.includes(state.activeValue)) return;
-        if (prevSelectedValueRef.current?.includes(state.activeValue)) return;
-      }
-      return state.activeValue;
-    });
+    const inlineActiveValue = useStoreState(
+      store,
+      ["activeValue", "selectedValue", "activeId"],
+      (state) => {
+        if (!inline) return;
+        if (!canInline) return;
+        // It doesn't make sense to inline the active value if it's already
+        // selected or just got deselected. Inlining the value typically implies
+        // an addition, but if the value is already selected, the action actually
+        // becomes a deletion. If the value was just deselected, pressing Enter
+        // again would reselect it, but it's not the usual path, so we also take
+        // into account the previously selected values. See tag-combobox test
+        // named "deselecting a tag should not highlight the input text if it is
+        // not the first combobox item".
+        if (state.activeValue && Array.isArray(state.selectedValue)) {
+          if (state.selectedValue.includes(state.activeValue)) return;
+          if (prevSelectedValueRef.current?.includes(state.activeValue)) return;
+        }
+        return state.activeValue;
+      },
+    );
 
     const items = useStoreState(store, "renderedItems");
     const open = useStoreState(store, "open");
@@ -678,6 +683,7 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
 
     const isActiveItem = useStoreState(
       store,
+      ["activeId"],
       (state) => state.activeId === null,
     );
 

--- a/packages/ariakit-react-components/src/composite/composite-item-offscreen.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-item-offscreen.tsx
@@ -5,12 +5,12 @@ import { disabledFromProps, getPopupItemRole } from "@ariakit/utils";
 import type { ElementType } from "react";
 import type { CollectionItemOptions } from "../collection/collection-item-offscreen.tsx";
 import { useCollectionItemOffscreen } from "../collection/collection-item-offscreen.tsx";
-import type { ComboboxStoreState } from "../combobox/combobox-store.ts";
+import type { ComboboxStore } from "../combobox/combobox-store.ts";
 import { Role } from "../role/role.tsx";
-import type { SelectStoreState } from "../select/select-store.ts";
+import type { SelectStore } from "../select/select-store.ts";
 import { useCompositeScopedContext } from "./composite-context.tsx";
 import * as Base from "./composite-item.tsx";
-import type { CompositeStoreState } from "./composite-store.ts";
+import type { CompositeStore } from "./composite-store.ts";
 
 const TagName = "button" satisfies ElementType;
 type TagName = typeof TagName;
@@ -30,26 +30,33 @@ export function useCompositeItemOffscreen<
   store = store || context;
 
   const id = useId(props.id);
+  // The public prop uses the base CompositeStore type, but this component is
+  // also rendered by Combobox and Select stores with additional state keys.
+  // oxlint-disable-next-line no-unnecessary-type-assertion
+  const stateStore = store as
+    | CompositeStore
+    | ComboboxStore
+    | SelectStore
+    | undefined;
 
   const { storeId, active, listElement, offscreenRoot } = useStoreStateObject(
-    store,
+    stateStore,
+    ["value", "activeId", "listElement", "contentElement"],
     {
       storeId: "id",
-      active(
-        state?: CompositeStoreState | ComboboxStoreState | SelectStoreState,
-      ) {
+      active(state) {
         if (!state) return;
         if (!("selectedValue" in state) && "value" in state) {
           if (state.value === value) return true;
         }
         return !!id && state.activeId === id;
       },
-      listElement(state?: CompositeStoreState | SelectStoreState) {
+      listElement(state) {
         if (!state) return;
         if (!("listElement" in state)) return;
         return state.listElement;
       },
-      offscreenRoot(state?: CompositeStoreState | ComboboxStoreState) {
+      offscreenRoot(state) {
         if (props.offscreenRoot) return props.offscreenRoot;
         if (!state) return;
         if (!("contentElement" in state)) return;

--- a/packages/ariakit-react-components/src/composite/composite-item.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-item.tsx
@@ -181,23 +181,11 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
       return row.id;
     };
 
-    const {
-      rowId,
-      baseElement,
-      isActiveItem,
-      ariaSetSize,
-      ariaPosInSet,
-      isTabbable,
-    } = useStoreStateObject(
-      store,
-      ["baseElement", "activeId", "renderedItems", "virtualFocus", "items"],
-      {
+    const { rowId, baseElement, ariaSetSize, ariaPosInSet } =
+      useStoreStateObject(store, ["baseElement", "renderedItems"], {
         rowId: getRowId,
         baseElement(state) {
           return state?.baseElement || undefined;
-        },
-        isActiveItem(state) {
-          return !!state && state.activeId === id;
         },
         ariaSetSize(state) {
           if (ariaSetSizeProp != null) return ariaSetSizeProp;
@@ -218,6 +206,15 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
           return (
             row.ariaPosInSet + itemsInRow.findIndex((item) => item.id === id)
           );
+        },
+      });
+
+    const { isActiveItem, isTabbable } = useStoreStateObject(
+      store,
+      ["activeId", "renderedItems", "virtualFocus", "items"],
+      {
+        isActiveItem(state) {
+          return !!state && state.activeId === id;
         },
         isTabbable(state) {
           if (!state?.renderedItems.length) return true;

--- a/packages/ariakit-react-components/src/composite/composite-item.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-item.tsx
@@ -173,7 +173,7 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
     // render. They can't read the destructured rowId const since it's declared
     // by the same statement they're arguments to, which would hit the temporal
     // dead zone. See https://github.com/ariakit/ariakit/issues/6334
-    const getRowId = (state?: CompositeStoreState) => {
+    const getRowId = (state?: Pick<CompositeStoreState, "baseElement">) => {
       if (rowIdProp) return rowIdProp;
       if (!state) return;
       if (!row?.baseElement) return;
@@ -188,50 +188,54 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
       ariaSetSize,
       ariaPosInSet,
       isTabbable,
-    } = useStoreStateObject(store, {
-      rowId: getRowId,
-      baseElement(state) {
-        return state?.baseElement || undefined;
+    } = useStoreStateObject(
+      store,
+      ["baseElement", "activeId", "renderedItems", "virtualFocus", "items"],
+      {
+        rowId: getRowId,
+        baseElement(state) {
+          return state?.baseElement || undefined;
+        },
+        isActiveItem(state) {
+          return !!state && state.activeId === id;
+        },
+        ariaSetSize(state) {
+          if (ariaSetSizeProp != null) return ariaSetSizeProp;
+          if (!state) return;
+          if (!row?.ariaSetSize) return;
+          if (row.baseElement !== state.baseElement) return;
+          return row.ariaSetSize;
+        },
+        ariaPosInSet(state) {
+          if (ariaPosInSetProp != null) return ariaPosInSetProp;
+          if (!state) return;
+          if (!row?.ariaPosInSet) return;
+          if (row.baseElement !== state.baseElement) return;
+          const rowId = getRowId(state);
+          const itemsInRow = state.renderedItems.filter(
+            (item) => item.rowId === rowId,
+          );
+          return (
+            row.ariaPosInSet + itemsInRow.findIndex((item) => item.id === id)
+          );
+        },
+        isTabbable(state) {
+          if (!state?.renderedItems.length) return true;
+          if (state.virtualFocus) return false;
+          if (tabbable) return true;
+          if (state.activeId === null) return false;
+          // If activeId refers to an item that's disabled or not connected to the
+          // DOM, we make all items tabbable so users can tab into the composite
+          // widget. Once the activeId is valid, we restore the roving tabindex. See
+          // https://github.com/ariakit/ariakit/issues/3232
+          // https://github.com/ariakit/ariakit/issues/4129
+          const item = store?.item(state.activeId);
+          if (item?.disabled) return true;
+          if (!item?.element) return true;
+          return state.activeId === id;
+        },
       },
-      isActiveItem(state) {
-        return !!state && state.activeId === id;
-      },
-      ariaSetSize(state) {
-        if (ariaSetSizeProp != null) return ariaSetSizeProp;
-        if (!state) return;
-        if (!row?.ariaSetSize) return;
-        if (row.baseElement !== state.baseElement) return;
-        return row.ariaSetSize;
-      },
-      ariaPosInSet(state) {
-        if (ariaPosInSetProp != null) return ariaPosInSetProp;
-        if (!state) return;
-        if (!row?.ariaPosInSet) return;
-        if (row.baseElement !== state.baseElement) return;
-        const rowId = getRowId(state);
-        const itemsInRow = state.renderedItems.filter(
-          (item) => item.rowId === rowId,
-        );
-        return (
-          row.ariaPosInSet + itemsInRow.findIndex((item) => item.id === id)
-        );
-      },
-      isTabbable(state) {
-        if (!state?.renderedItems.length) return true;
-        if (state.virtualFocus) return false;
-        if (tabbable) return true;
-        if (state.activeId === null) return false;
-        // If activeId refers to an item that's disabled or not connected to the
-        // DOM, we make all items tabbable so users can tab into the composite
-        // widget. Once the activeId is valid, we restore the roving tabindex. See
-        // https://github.com/ariakit/ariakit/issues/3232
-        // https://github.com/ariakit/ariakit/issues/4129
-        const item = store?.item(state.activeId);
-        if (item?.disabled) return true;
-        if (!item?.element) return true;
-        return state.activeId === id;
-      },
-    });
+    );
 
     const getItem = useCallback<NonNullable<CollectionItemOptions["getItem"]>>(
       (item) => {

--- a/packages/ariakit-react-components/src/composite/composite-renderer.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-renderer.tsx
@@ -16,6 +16,7 @@ import {
   useCollectionRenderer,
 } from "../collection/collection-renderer.tsx";
 import type { CollectionStoreItem } from "../collection/collection-store.ts";
+import type { SelectStore } from "../select/select-store.ts";
 import { useCompositeScopedContext } from "./composite-context.tsx";
 import type { CompositeStore, CompositeStoreItem } from "./composite-store.ts";
 
@@ -146,12 +147,15 @@ export function useCompositeRenderer<T extends Item = any>({
 
   const orientation = useStoreState(
     store,
+    ["orientation"],
     (state) =>
       orientationProp ??
       (state?.orientation === "both" ? "vertical" : state?.orientation),
   );
 
-  const items = useStoreState(store, (state) => {
+  // SelectRenderer passes a SelectStore through the base CompositeStore type.
+  const stateStore = store as typeof store | SelectStore;
+  const items = useStoreState(stateStore, ["mounted", "items"], (state) => {
     if (!state) return props.items;
     if ("mounted" in state && !state.mounted) return 0;
     return props.items ?? (state.items as T[]);

--- a/packages/ariakit-react-components/src/composite/composite-row.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-row.tsx
@@ -57,6 +57,7 @@ export const useCompositeRow = createHook<TagName, CompositeRowOptions>(
 
     const baseElement = useStoreState(
       store,
+      ["baseElement"],
       (state) => state.baseElement || undefined,
     );
 

--- a/packages/ariakit-react-components/src/composite/composite-row.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-row.tsx
@@ -55,11 +55,7 @@ export const useCompositeRow = createHook<TagName, CompositeRowOptions>(
 
     const id = useId(props.id);
 
-    const baseElement = useStoreState(
-      store,
-      ["baseElement"],
-      (state) => state.baseElement || undefined,
-    );
+    const baseElement = useStoreState(store, "baseElement") || undefined;
 
     const providerValue = useMemo(
       () => ({ id, baseElement, ariaSetSize, ariaPosInSet }),

--- a/packages/ariakit-react-components/src/composite/composite-separator.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-separator.tsx
@@ -44,6 +44,7 @@ export const useCompositeSeparator = createHook<
 
   const orientation = useStoreState(
     store,
+    ["orientation"],
     (state) =>
       orientationProp ??
       (state.orientation === "horizontal" ? "vertical" : "horizontal"),

--- a/packages/ariakit-react-components/src/composite/composite.tsx
+++ b/packages/ariakit-react-components/src/composite/composite.tsx
@@ -259,14 +259,15 @@ export const useComposite = createHook<TagName, CompositeOptions>(
     );
 
     const virtualFocus = useStoreState(store, "virtualFocus");
-    // Only track the activeId state when virtual focus is enabled. It's used
-    // solely by the effect below, which is a no-op otherwise, so this avoids
-    // re-rendering the composite component on every active item change when
-    // moving through items with roving tabindex.
+    // Only track the activeId state when composite and virtual focus are
+    // enabled. It's shared by the effect below and aria-activedescendant, both
+    // of which are no-ops otherwise, so this avoids re-rendering the composite
+    // component on every active item change when moving through items with
+    // roving tabindex.
     const activeId = useStoreState(
       store,
-      virtualFocus ? ["activeId"] : [],
-      (state) => (virtualFocus ? state.activeId : null),
+      composite && virtualFocus ? ["activeId"] : [],
+      (state) => (composite && virtualFocus ? state.activeId : null),
     );
 
     // At this point, if the activeId has changed and we still have a
@@ -503,12 +504,12 @@ export const useComposite = createHook<TagName, CompositeOptions>(
 
     const activeDescendant = useStoreState(
       store,
-      composite && virtualFocus ? ["activeId", "items"] : [],
-      (state) => {
+      composite && virtualFocus ? ["items"] : [],
+      () => {
         if (!store) return;
         if (!composite) return;
         if (!virtualFocus) return;
-        return getEnabledItem(store, state.activeId)?.id;
+        return getEnabledItem(store, activeId)?.id;
       },
     );
 

--- a/packages/ariakit-react-components/src/composite/composite.tsx
+++ b/packages/ariakit-react-components/src/composite/composite.tsx
@@ -136,7 +136,7 @@ function useScheduleFocus(store: CompositeStore) {
   // Only track the active item while a focus is scheduled. Otherwise, this
   // subscription would re-render the composite component on every active item
   // change, such as when moving through items with arrow keys.
-  const activeItem = useStoreState(store, (state) =>
+  const activeItem = useStoreState(store, ["activeId", "items"], (state) =>
     scheduled ? getEnabledItem(store, state.activeId) : null,
   );
   useEffect(() => {
@@ -261,8 +261,10 @@ export const useComposite = createHook<TagName, CompositeOptions>(
     // solely by the effect below, which is a no-op otherwise, so this avoids
     // re-rendering the composite component on every active item change when
     // moving through items with roving tabindex.
-    const activeId = useStoreState(store, (state) =>
-      state.virtualFocus ? state.activeId : null,
+    const activeId = useStoreState(
+      store,
+      ["virtualFocus", "activeId"],
+      (state) => (state.virtualFocus ? state.activeId : null),
     );
 
     // At this point, if the activeId has changed and we still have a
@@ -497,12 +499,16 @@ export const useComposite = createHook<TagName, CompositeOptions>(
       [store, composite, focusOnMove],
     );
 
-    const activeDescendant = useStoreState(store, (state) => {
-      if (!store) return;
-      if (!composite) return;
-      if (!state.virtualFocus) return;
-      return getEnabledItem(store, state.activeId)?.id;
-    });
+    const activeDescendant = useStoreState(
+      store,
+      ["virtualFocus", "activeId", "items"],
+      (state) => {
+        if (!store) return;
+        if (!composite) return;
+        if (!state.virtualFocus) return;
+        return getEnabledItem(store, state.activeId)?.id;
+      },
+    );
 
     props = {
       "aria-activedescendant": activeDescendant,
@@ -518,6 +524,7 @@ export const useComposite = createHook<TagName, CompositeOptions>(
 
     const focusable = useStoreState(
       store,
+      ["virtualFocus", "activeId"],
       (state) => composite && (state.virtualFocus || state.activeId === null),
     );
 

--- a/packages/ariakit-react-components/src/composite/composite.tsx
+++ b/packages/ariakit-react-components/src/composite/composite.tsx
@@ -136,8 +136,10 @@ function useScheduleFocus(store: CompositeStore) {
   // Only track the active item while a focus is scheduled. Otherwise, this
   // subscription would re-render the composite component on every active item
   // change, such as when moving through items with arrow keys.
-  const activeItem = useStoreState(store, ["activeId", "items"], (state) =>
-    scheduled ? getEnabledItem(store, state.activeId) : null,
+  const activeItem = useStoreState(
+    store,
+    scheduled ? ["activeId", "items"] : [],
+    (state) => (scheduled ? getEnabledItem(store, state.activeId) : null),
   );
   useEffect(() => {
     const activeElement = activeItem?.element;
@@ -263,8 +265,8 @@ export const useComposite = createHook<TagName, CompositeOptions>(
     // moving through items with roving tabindex.
     const activeId = useStoreState(
       store,
-      ["virtualFocus", "activeId"],
-      (state) => (state.virtualFocus ? state.activeId : null),
+      virtualFocus ? ["activeId"] : [],
+      (state) => (virtualFocus ? state.activeId : null),
     );
 
     // At this point, if the activeId has changed and we still have a
@@ -501,11 +503,11 @@ export const useComposite = createHook<TagName, CompositeOptions>(
 
     const activeDescendant = useStoreState(
       store,
-      ["virtualFocus", "activeId", "items"],
+      composite && virtualFocus ? ["activeId", "items"] : [],
       (state) => {
         if (!store) return;
         if (!composite) return;
-        if (!state.virtualFocus) return;
+        if (!virtualFocus) return;
         return getEnabledItem(store, state.activeId)?.id;
       },
     );
@@ -524,8 +526,8 @@ export const useComposite = createHook<TagName, CompositeOptions>(
 
     const focusable = useStoreState(
       store,
-      ["virtualFocus", "activeId"],
-      (state) => composite && (state.virtualFocus || state.activeId === null),
+      composite && !virtualFocus ? ["activeId"] : [],
+      (state) => composite && (virtualFocus || state.activeId === null),
     );
 
     props = useFocusable({ focusable, ...props });

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -158,6 +158,7 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
   const preserveTabOrderProp = props.preserveTabOrder;
   const preserveTabOrder = useStoreState(
     store,
+    ["mounted"],
     (state) => preserveTabOrderProp && !modal && state.mounted,
   );
   const id = useId(props.id);
@@ -633,6 +634,7 @@ export function createDialogComponent<T extends DialogOptions>(
     const store = props.store || context;
     const mounted = useStoreState(
       store,
+      ["mounted"],
       (state) => !props.unmountOnHide || state?.mounted || !!props.open,
     );
     if (!mounted) return null;

--- a/packages/ariakit-react-components/src/disclosure/disclosure-content.tsx
+++ b/packages/ariakit-react-components/src/disclosure/disclosure-content.tsx
@@ -317,6 +317,7 @@ export const DisclosureContent = forwardRef(function DisclosureContent({
   const store = props.store || context;
   const mounted = useStoreState(
     store,
+    ["mounted"],
     (state) => !unmountOnHide || state?.mounted,
   );
   if (mounted === false) return null;

--- a/packages/ariakit-react-components/src/form/form-control.tsx
+++ b/packages/ariakit-react-components/src/form/form-control.tsx
@@ -75,7 +75,7 @@ function useControlState(form: FormStore, name: string) {
     let prevItems: FormStoreState["items"] | undefined;
     let prevIds: ControlItemIds = {};
 
-    return (state: FormStoreState) => {
+    return (state: Pick<FormStoreState, "items">) => {
       if (state.items !== prevItems) {
         prevItems = state.items;
         prevIds = getControlItemIds(state.items, name);
@@ -84,7 +84,7 @@ function useControlState(form: FormStore, name: string) {
     };
   }, [name]);
 
-  return useStoreStateObject(form, {
+  return useStoreStateObject(form, ["items", "errors", "touched"], {
     labelId: (state) => getItemIds(state).labelId,
     errorId: (state) => getItemIds(state).errorId,
     descriptionId: (state) => getItemIds(state).descriptionId,

--- a/packages/ariakit-react-components/src/form/form-error.tsx
+++ b/packages/ariakit-react-components/src/form/form-error.tsx
@@ -61,7 +61,7 @@ export const useFormError = createHook<TagName, FormErrorOptions>(
       component: "FormError",
     });
 
-    const children = useStoreState(form, () => {
+    const children = useStoreState(form, ["errors", "touched"], () => {
       const error = form.getError(name);
       if (error == null) return;
       if (!form.getFieldTouched(name)) return;

--- a/packages/ariakit-react-components/src/form/form-label.tsx
+++ b/packages/ariakit-react-components/src/form/form-label.tsx
@@ -70,7 +70,7 @@ export const useFormLabel = createHook<TagName, FormLabelOptions>(
       component: "FormLabel",
     });
 
-    const field = useStoreState(form, (state) =>
+    const field = useStoreState(form, ["items"], (state) =>
       state.items.find((item) => item.type === "field" && item.name === name),
     );
     const fieldTagName = useTagName(field?.element, "input");

--- a/packages/ariakit-react-components/src/form/form-radio.tsx
+++ b/packages/ariakit-react-components/src/form/form-radio.tsx
@@ -54,6 +54,7 @@ export const useFormRadio = createHook<TagName, FormRadioOptions>(
     const checkedProp = props.checked;
     const checked = useStoreState(
       form,
+      ["values"],
       () => checkedProp ?? form.getValue(name) === value,
     );
 

--- a/packages/ariakit-react-components/src/form/form-store.ts
+++ b/packages/ariakit-react-components/src/form/form-store.ts
@@ -34,7 +34,7 @@ export function useFormValue<T = any>(
   store: FormStoreHookStore,
   name: StringLike,
 ): T {
-  return useStoreState(store, () => store.getValue<T>(name));
+  return useStoreState(store, ["values"], () => store.getValue<T>(name));
 }
 
 /**

--- a/packages/ariakit-react-components/src/hovercard/hovercard.tsx
+++ b/packages/ariakit-react-components/src/hovercard/hovercard.tsx
@@ -383,6 +383,7 @@ export const useHovercard = createHook<TagName, HovercardOptions>(
     // If the hovercard is modal, we should always autoFocus on show.
     const autoFocusOnShow = useStoreState(
       store,
+      ["autoFocusOnShow"],
       (state) => modal || state.autoFocusOnShow,
     );
 

--- a/packages/ariakit-react-components/src/menu/menu-button.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-button.tsx
@@ -130,7 +130,7 @@ export const useMenuButton = createHook<TagName, MenuButtonOptions>(
       }
     });
 
-    const dir = useStoreState(store, (state) =>
+    const dir = useStoreState(store, ["placement"], (state) =>
       getBasePlacement(state.placement),
     );
 

--- a/packages/ariakit-react-components/src/menu/menu-item-checkbox.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-item-checkbox.tsx
@@ -99,7 +99,7 @@ export const useMenuItemCheckbox = createHook<TagName, MenuItemCheckboxOptions>(
     }, [store, name, value, checked]);
 
     const checkboxStore = useCheckboxStore({
-      value: useStoreState(store, (state) => state.values[name]),
+      value: useStoreState(store, ["values"], (state) => state.values[name]),
       setValue(internalValue) {
         store?.setValue(name, () => {
           if (checked === undefined) return internalValue;

--- a/packages/ariakit-react-components/src/menu/menu-item-radio.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-item-radio.tsx
@@ -84,6 +84,7 @@ export const useMenuItemRadio = createHook<TagName, MenuItemRadioOptions>(
 
     const isChecked = useStoreState(
       store,
+      ["values"],
       (state) => state.values[name] === value,
     );
 

--- a/packages/ariakit-react-components/src/menu/menu-item.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-item.tsx
@@ -111,7 +111,7 @@ export const useMenuItem = createHook<TagName, MenuItemOptions>(
       hideMenu();
     });
 
-    const contentElement = useStoreState(store, (state) =>
+    const contentElement = useStoreState(store, ["contentElement"], (state) =>
       "contentElement" in state ? state.contentElement : null,
     );
 

--- a/packages/ariakit-react-components/src/menu/menu-list.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-list.tsx
@@ -84,15 +84,16 @@ export const useMenuList = createHook<TagName, MenuListOptions>(
     const id = useId(props.id);
 
     const onKeyDownProp = props.onKeyDown;
-    const dir = useStoreState(store, (state) =>
+    const dir = useStoreState(store, ["placement"], (state) =>
       getBasePlacement(state.placement),
     );
-    const orientation = useStoreState(store, (state) =>
+    const orientation = useStoreState(store, ["orientation"], (state) =>
       state.orientation === "both" ? undefined : state.orientation,
     );
     const isHorizontal = orientation !== "vertical";
     const isMenubarHorizontal = useStoreState(
       parentMenubar,
+      ["orientation"],
       (state) => !!state && state.orientation !== "vertical",
     );
 

--- a/packages/ariakit-react-components/src/menu/menu.tsx
+++ b/packages/ariakit-react-components/src/menu/menu.tsx
@@ -91,25 +91,29 @@ export const useMenu = createHook<TagName, MenuOptions>(function useMenu({
   // re-renders only when the resolved element changes, not whenever
   // `renderedItems` gets a new array identity. Returning `undefined` means
   // auto focus on show is disabled.
-  const initialFocusElement = useStoreState(store, (state) => {
-    if (!state.autoFocusOnShow) return;
-    const isEnabled = (item: (typeof state.renderedItems)[number]) =>
-      !item.disabled && !!item.element;
-    switch (state.initialFocus) {
-      case "first":
-        return state.renderedItems.find(isEnabled)?.element || null;
-      case "last":
-        for (let i = state.renderedItems.length - 1; i >= 0; i -= 1) {
-          const item = state.renderedItems[i];
-          if (item && isEnabled(item)) {
-            return item.element;
+  const initialFocusElement = useStoreState(
+    store,
+    ["autoFocusOnShow", "initialFocus", "renderedItems", "baseElement"],
+    (state) => {
+      if (!state.autoFocusOnShow) return;
+      const isEnabled = (item: (typeof state.renderedItems)[number]) =>
+        !item.disabled && !!item.element;
+      switch (state.initialFocus) {
+        case "first":
+          return state.renderedItems.find(isEnabled)?.element || null;
+        case "last":
+          for (let i = state.renderedItems.length - 1; i >= 0; i -= 1) {
+            const item = state.renderedItems[i];
+            if (item && isEnabled(item)) {
+              return item.element;
+            }
           }
-        }
-        return null;
-      default:
-        return state.baseElement;
-    }
-  });
+          return null;
+        default:
+          return state.baseElement;
+      }
+    },
+  );
 
   // Sets the initial focus ref.
   useEffect(() => {

--- a/packages/ariakit-react-components/src/menubar/menubar.tsx
+++ b/packages/ariakit-react-components/src/menubar/menubar.tsx
@@ -60,7 +60,7 @@ export const useMenubar = createHook<TagName, MenubarOptions>(
       rtl,
     });
 
-    const orientation = useStoreState(store, (state) =>
+    const orientation = useStoreState(store, ["orientation"], (state) =>
       !composite || state.orientation === "both"
         ? undefined
         : state.orientation,

--- a/packages/ariakit-react-components/src/popover/popover-arrow.tsx
+++ b/packages/ariakit-react-components/src/popover/popover-arrow.tsx
@@ -155,7 +155,7 @@ export const usePopoverArrow = createHook<TagName, PopoverArrowOptions>(
         "PopoverArrow must be wrapped in a Popover component.",
     );
 
-    const dir = useStoreState(store, (state) =>
+    const dir = useStoreState(store, ["currentPlacement"], (state) =>
       getBasePlacement(state.currentPlacement),
     );
 

--- a/packages/ariakit-react-components/src/popover/popover-disclosure-arrow.tsx
+++ b/packages/ariakit-react-components/src/popover/popover-disclosure-arrow.tsx
@@ -46,6 +46,7 @@ export const usePopoverDisclosureArrow = createHook<
 
   const position = useStoreState(
     store,
+    ["placement"],
     (state) => placement || state.placement,
   );
   const dir = getBasePlacement(position);

--- a/packages/ariakit-react-components/src/radio/radio.tsx
+++ b/packages/ariakit-react-components/src/radio/radio.tsx
@@ -67,6 +67,7 @@ export const useRadio = createHook<TagName, RadioOptions>(function useRadio({
   const ref = useRef<HTMLType>(null);
   const isChecked = useStoreState(
     store,
+    ["value"],
     (state) => checked ?? getIsChecked(value, state?.value),
   );
 

--- a/packages/ariakit-react-components/src/select/select-item.tsx
+++ b/packages/ariakit-react-components/src/select/select-item.tsx
@@ -80,7 +80,7 @@ export const useSelectItem = createHook<TagName, SelectItemOptions>(
     const disabled = disabledFromProps(props);
 
     const { listElement, multiSelectable, selected, autoFocus } =
-      useStoreStateObject(store, {
+      useStoreStateObject(store, ["value", "activeId", "items"], {
         listElement: "listElement",
         multiSelectable(state) {
           return Array.isArray(state.value);

--- a/packages/ariakit-react-components/src/select/select-list.tsx
+++ b/packages/ariakit-react-components/src/select/select-list.tsx
@@ -152,6 +152,7 @@ export const useSelectList = createHook<TagName, SelectListOptions>(
 
     const labelId = useStoreState(
       store,
+      ["labelElement"],
       (state) => headingId || state.labelElement?.id,
     );
 

--- a/packages/ariakit-react-components/src/select/select-list.tsx
+++ b/packages/ariakit-react-components/src/select/select-list.tsx
@@ -1,5 +1,6 @@
 import { useStoreState } from "@ariakit/react-store";
 import {
+  useAttribute,
   useBooleanEvent,
   useEvent,
   useId,
@@ -150,11 +151,11 @@ export const useSelectList = createHook<TagName, SelectListOptions>(
       };
     }
 
-    const labelId = useStoreState(
-      store,
-      ["labelElement"],
-      (state) => headingId || state.labelElement?.id,
+    const labelElement = useStoreState(store, ["labelElement"], (state) =>
+      headingId ? null : state.labelElement,
     );
+    useAttribute(labelElement, "id");
+    const labelId = headingId || labelElement?.id;
 
     props = {
       "aria-labelledby": props["aria-label"] != null ? undefined : labelId,

--- a/packages/ariakit-react-components/src/select/select-renderer.tsx
+++ b/packages/ariakit-react-components/src/select/select-renderer.tsx
@@ -77,13 +77,17 @@ function useSelectRenderer<T extends Item = any>({
   const context = useSelectContext();
   store = store || context;
 
-  const items = useStoreState(store, (state) => {
+  const items = useStoreState(store, ["mounted", "items"], (state) => {
     if (!state) return itemsProp;
     if (!state.mounted) return 0;
     return itemsProp ?? (state.items as T[]);
   });
 
-  const value = useStoreState(store, (state) => valueProp ?? state?.value);
+  const value = useStoreState(
+    store,
+    ["value"],
+    (state) => valueProp ?? state?.value,
+  );
 
   const valueIndices = useMemo(() => {
     if (!items) return [];

--- a/packages/ariakit-react-components/src/select/select-value.tsx
+++ b/packages/ariakit-react-components/src/select/select-value.tsx
@@ -71,7 +71,7 @@ export function SelectValue({
   const context = useSelectContext();
   store = store || context;
 
-  const value = useStoreState(store, (state) => {
+  const value = useStoreState(store, ["value"], (state) => {
     if (!state?.value.length) return fallback;
     return state.value;
   });

--- a/packages/ariakit-react-components/src/select/select.tsx
+++ b/packages/ariakit-react-components/src/select/select.tsx
@@ -1,5 +1,6 @@
 import { useStoreState } from "@ariakit/react-store";
 import {
+  useAttribute,
   useBooleanEvent,
   useEvent,
   useMergeRefs,
@@ -173,11 +174,9 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
     setAutofill(false);
   }, [value]);
 
-  const labelId = useStoreState(
-    store,
-    ["labelElement"],
-    (state) => state.labelElement?.id,
-  );
+  const labelElement = useStoreState(store, "labelElement");
+  useAttribute(labelElement, "id");
+  const labelId = labelElement?.id;
   const label = props["aria-label"];
   const labelledBy = props["aria-labelledby"] || labelId;
   const items = useStoreState(store, ["items"], (state) => {

--- a/packages/ariakit-react-components/src/select/select.tsx
+++ b/packages/ariakit-react-components/src/select/select.tsx
@@ -173,10 +173,14 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
     setAutofill(false);
   }, [value]);
 
-  const labelId = useStoreState(store, (state) => state.labelElement?.id);
+  const labelId = useStoreState(
+    store,
+    ["labelElement"],
+    (state) => state.labelElement?.id,
+  );
   const label = props["aria-label"];
   const labelledBy = props["aria-labelledby"] || labelId;
-  const items = useStoreState(store, (state) => {
+  const items = useStoreState(store, ["items"], (state) => {
     if (!name) return;
     return state.items;
   });

--- a/packages/ariakit-react-components/src/tab/tab-list.tsx
+++ b/packages/ariakit-react-components/src/tab/tab-list.tsx
@@ -45,7 +45,7 @@ export const useTabList = createHook<TagName, TabListOptions>(
         "TabList must receive a `store` prop or be wrapped in a TabProvider component.",
     );
 
-    const orientation = useStoreState(store, (state) =>
+    const orientation = useStoreState(store, ["orientation"], (state) =>
       state.orientation === "both" ? undefined : state.orientation,
     );
 

--- a/packages/ariakit-react-components/src/tab/tab-panel.tsx
+++ b/packages/ariakit-react-components/src/tab/tab-panel.tsx
@@ -67,10 +67,12 @@ export const useTabPanel = createHook<TagName, TabPanelOptions>(
 
     const tabId = useStoreState(
       store.panels,
+      ["items"],
       () => tabIdProp || store?.panels.item(id)?.tabId,
     );
     const open = useStoreState(
       store,
+      ["selectedId"],
       (state) => !!tabId && state.selectedId === tabId,
     );
 

--- a/packages/ariakit-react-components/src/tab/tab.tsx
+++ b/packages/ariakit-react-components/src/tab/tab.tsx
@@ -76,19 +76,26 @@ export const useTab = createHook<TagName, TabOptions>(function useTab({
     store?.setSelectedId(id);
   });
 
-  const panelId = useStoreState(store.panels, () => store.panel(id)?.id);
+  const panelId = useStoreState(
+    store.panels,
+    ["items"],
+    () => store.panel(id)?.id,
+  );
   const shouldRegisterItem = defaultId ? props.shouldRegisterItem : false;
 
   const isActive = useStoreState(
     store,
+    ["activeId"],
     (state) => !!id && state.activeId === id,
   );
   const selected = useStoreState(
     store,
+    ["selectedId"],
     (state) => !!id && state.selectedId === id,
   );
   const hasActiveItem = useStoreState(
     store,
+    ["activeId", "items"],
     (state) => !!store.item(state.activeId),
   );
   const canRegisterComposedItem = isActive || (selected && !hasActiveItem);

--- a/packages/ariakit-react-components/src/tag/tag-list-label.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-list-label.tsx
@@ -36,7 +36,11 @@ export const useTagListLabel = createHook<TagName, TagListLabelOptions>(
     );
 
     const id = useId(props.id);
-    const htmlFor = useStoreState(store, (state) => state.inputElement?.id);
+    const htmlFor = useStoreState(
+      store,
+      ["inputElement"],
+      (state) => state.inputElement?.id,
+    );
 
     props = {
       htmlFor,

--- a/packages/ariakit-react-components/src/tag/tag-list-label.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-list-label.tsx
@@ -1,5 +1,6 @@
 import { useStoreState } from "@ariakit/react-store";
 import {
+  useAttribute,
   useId,
   useMergeRefs,
   createElement,
@@ -36,11 +37,9 @@ export const useTagListLabel = createHook<TagName, TagListLabelOptions>(
     );
 
     const id = useId(props.id);
-    const htmlFor = useStoreState(
-      store,
-      ["inputElement"],
-      (state) => state.inputElement?.id,
-    );
+    const inputElement = useStoreState(store, "inputElement");
+    useAttribute(inputElement, "id");
+    const htmlFor = inputElement?.id;
 
     props = {
       htmlFor,

--- a/packages/ariakit-react-components/src/tag/tag-list.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-list.tsx
@@ -1,5 +1,6 @@
 import { useStoreState } from "@ariakit/react-store";
 import {
+  useAttribute,
   useEvent,
   useWrapElement,
   createElement,
@@ -114,11 +115,9 @@ export const useTagList = createHook<TagName, TagListOptions>(
       (state) => state.renderedItems,
     );
     const itemIds = items.filter((item) => !!item.value).map((item) => item.id);
-    const labelId = useStoreState(
-      store,
-      ["labelElement"],
-      (state) => state.labelElement?.id,
-    );
+    const labelElement = useStoreState(store, "labelElement");
+    useAttribute(labelElement, "id");
+    const labelId = labelElement?.id;
 
     // Remove aria attributes from tha TagList element and add them to a
     // separate div that will serve as the accessible listbox element.

--- a/packages/ariakit-react-components/src/tag/tag-list.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-list.tsx
@@ -105,12 +105,20 @@ export const useTagList = createHook<TagName, TagListOptions>(
 
     props = useComposite({ store, ...props });
 
-    const orientation = useStoreState(store, (state) =>
+    const orientation = useStoreState(store, ["orientation"], (state) =>
       state.orientation === "both" ? undefined : state.orientation,
     );
-    const items = useStoreState(store, (state) => state.renderedItems);
+    const items = useStoreState(
+      store,
+      ["renderedItems"],
+      (state) => state.renderedItems,
+    );
     const itemIds = items.filter((item) => !!item.value).map((item) => item.id);
-    const labelId = useStoreState(store, (state) => state.labelElement?.id);
+    const labelId = useStoreState(
+      store,
+      ["labelElement"],
+      (state) => state.labelElement?.id,
+    );
 
     // Remove aria attributes from tha TagList element and add them to a
     // separate div that will serve as the accessible listbox element.

--- a/packages/ariakit-react-components/src/tag/tag-list.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-list.tsx
@@ -109,11 +109,7 @@ export const useTagList = createHook<TagName, TagListOptions>(
     const orientation = useStoreState(store, ["orientation"], (state) =>
       state.orientation === "both" ? undefined : state.orientation,
     );
-    const items = useStoreState(
-      store,
-      ["renderedItems"],
-      (state) => state.renderedItems,
-    );
+    const items = useStoreState(store, "renderedItems");
     const itemIds = items.filter((item) => !!item.value).map((item) => item.id);
     const labelElement = useStoreState(store, "labelElement");
     useAttribute(labelElement, "id");

--- a/packages/ariakit-react-components/src/toolbar/toolbar.tsx
+++ b/packages/ariakit-react-components/src/toolbar/toolbar.tsx
@@ -52,7 +52,7 @@ export const useToolbar = createHook<TagName, ToolbarOptions>(
       rtl,
     });
 
-    const orientation = useStoreState(store, (state) =>
+    const orientation = useStoreState(store, ["orientation"], (state) =>
       state.orientation === "both" ? undefined : state.orientation,
     );
 

--- a/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
+++ b/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
@@ -150,8 +150,11 @@ export const useTooltipAnchor = createHook<TagName, TooltipAnchorOptions>(
       }
     });
 
-    const labelledBy = useStoreState(store, (state) =>
-      state.type === "label" ? state.contentElement?.id : undefined,
+    const labelledBy = useStoreState(
+      store,
+      ["type", "contentElement"],
+      (state) =>
+        state.type === "label" ? state.contentElement?.id : undefined,
     );
 
     props = {

--- a/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
+++ b/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
@@ -1,5 +1,6 @@
 import { useStoreState } from "@ariakit/react-store";
 import {
+  useAttribute,
   useEvent,
   createElement,
   createHook,
@@ -150,12 +151,13 @@ export const useTooltipAnchor = createHook<TagName, TooltipAnchorOptions>(
       }
     });
 
-    const labelledBy = useStoreState(
+    const labelElement = useStoreState(
       store,
       ["type", "contentElement"],
-      (state) =>
-        state.type === "label" ? state.contentElement?.id : undefined,
+      (state) => (state.type === "label" ? state.contentElement : null),
     );
+    useAttribute(labelElement, "id");
+    const labelledBy = labelElement?.id;
 
     props = {
       "aria-labelledby": props["aria-label"] == null ? labelledBy : undefined,

--- a/packages/ariakit-react-components/src/tooltip/tooltip.tsx
+++ b/packages/ariakit-react-components/src/tooltip/tooltip.tsx
@@ -60,7 +60,7 @@ export const useTooltip = createHook<TagName, TooltipOptions>(
       [store],
     );
 
-    const role = useStoreState(store, (state) =>
+    const role = useStoreState(store, ["type"], (state) =>
       state.type === "description" ? "tooltip" : "none",
     );
 

--- a/packages/ariakit-react-store/readme.md
+++ b/packages/ariakit-react-store/readme.md
@@ -68,9 +68,15 @@ interface UseState<S> {
 ### `useStoreState`
 
 ```ts
-type StateStore<T = CoreStore> = T | null | undefined;
+type StateStore<T = CoreStore<any>> = T | null | undefined;
 
-type StateKey<T = CoreStore> = keyof StoreState<T>;
+type StateKey<T = CoreStore<any>> = keyof StoreState<T>;
+
+type SelectorStateKey<T> = T extends CoreStore ? StateKey<T> : never;
+
+type SelectorState<T, K extends PropertyKey> = T extends CoreStore
+  ? Pick<StoreState<T>, Extract<K, StateKey<T>>>
+  : never;
 
 function useStoreState<T extends CoreStore>(store: T): StoreState<T>;
 function useStoreState<T extends CoreStore>(
@@ -92,9 +98,19 @@ function useStoreState<T extends CoreStore, V>(
   store: StateStore<T>,
   selector: (state?: StoreState<T>) => V,
 ): V;
+function useStoreState<T extends CoreStore, K extends SelectorStateKey<T>, V>(
+  store: T,
+  keys: readonly K[],
+  selector: (state: SelectorState<T, K>) => V,
+): V;
+function useStoreState<T extends CoreStore, K extends SelectorStateKey<T>, V>(
+  store: StateStore<T>,
+  keys: readonly K[],
+  selector: (state?: SelectorState<T, K>) => V,
+): V;
 ```
 
-Receives an Ariakit store object (which can be `null` or `undefined`) and returns the current state. If a key is provided as the second argument, it returns the value of that key. If a selector function is provided, the state is passed to it, and its return value is used.
+Receives an Ariakit store object (which can be `null` or `undefined`) and returns the current state. If a key is provided as the second argument, it returns the value of that key. If a selector function is provided, the state is passed to it, and its return value is used. Selector calls can pass the state keys they read as the second argument to skip unrelated store updates. This list must include every store key the selector reads, or the returned snapshot may stay stale. An empty list means store updates will never notify the selector.
 
 The component using this hook will re-render when the returned value changes.
 
@@ -127,6 +143,19 @@ const value = Ariakit.useStoreState(combobox, (state) => state.value);
 
 Example:
 
+Subscribing only to the state keys read by a selector:
+
+```js
+const tab = Ariakit.useTabStore();
+const selected = Ariakit.useStoreState(
+  tab,
+  ["selectedId"],
+  (state) => state.selectedId === "details",
+);
+```
+
+Example:
+
 Accessing the state of a store that may be `null` or `undefined` (for
 example, using a context):
 
@@ -142,26 +171,32 @@ const value = Ariakit.useStoreState(combobox, "value");
 ### `useStoreStateObject`
 
 ```ts
-type StateStore<T = CoreStore> = T | null | undefined;
+type StateStore<T = CoreStore<any>> = T | null | undefined;
 
-type StateKey<T = CoreStore> = keyof StoreState<T>;
+type StateKey<T = CoreStore<any>> = keyof StoreState<T>;
 
-type StoreStateObject<
-  T extends StateStore,
-  S extends StoreState<T> | undefined,
-> = Record<string, StateKey<T> | ((state: S) => any)>;
+type SelectorStateKey<T> = T extends CoreStore ? StateKey<T> : never;
+
+type SelectorState<T, K extends PropertyKey> = T extends CoreStore
+  ? Pick<StoreState<T>, Extract<K, StateKey<T>>>
+  : never;
+
+type StoreStateObject<T extends StateStore, S> = Record<
+  string,
+  StateKey<T> | ((state: S) => any)
+>;
 
 type StoreStateObjectResult<
   T extends StateStore,
   S extends StoreState<T> | undefined,
-  O extends StoreStateObject<T, S>,
+  O extends Record<string, StateKey<T> | AnyFunction>,
 > = {
   [K in keyof O]: O[K] extends keyof StoreState<T>
     ? O[K] extends keyof S
       ? S[O[K]]
       : StoreState<T>[O[K]] | undefined
-    : O[K] extends (state: S) => infer R
-      ? R
+    : O[K] extends AnyFunction
+      ? ReturnType<O[K]>
       : never;
 };
 
@@ -173,9 +208,38 @@ function useStoreStateObject<
   T extends StateStore,
   O extends StoreStateObject<T, StoreState<T> | undefined>,
 >(store: T, object: O): StoreStateObjectResult<T, StoreState<T> | undefined, O>;
+function useStoreStateObject<
+  T extends CoreStore,
+  K extends SelectorStateKey<T>,
+  O extends StoreStateObject<T, SelectorState<T, K>>,
+>(
+  store: T,
+  keys: readonly K[],
+  object: O,
+): StoreStateObjectResult<T, StoreState<T>, O>;
+function useStoreStateObject<
+  T extends CoreStore,
+  K extends SelectorStateKey<T>,
+  O extends StoreStateObject<T, SelectorState<T, K> | undefined>,
+>(
+  store: StateStore<T>,
+  keys: readonly K[],
+  object: O,
+): StoreStateObjectResult<T, StoreState<T> | undefined, O>;
 ```
 
-Receives an Ariakit store object (which can be `null` or `undefined`) and returns the current state. Unlike `useStoreState`, this hook receives an object with keys that map to store keys or selector functions.
+Receives an Ariakit store object (which can be `null` or `undefined`) and returns the current state. Unlike `useStoreState`, this hook receives an object with keys that map to store keys or selector functions. Store keys in the object are always subscribed to. When selector dependency keys are passed as the second argument, they must include every store key read by every selector, or the returned snapshot may stay stale. An empty list means only direct store keys in the object will notify the selectors.
+
+Example:
+
+Reading direct and derived values with selector dependencies:
+
+```js
+const values = useStoreStateObject(store, ["value"], {
+  value: "value",
+  valueLength: (state) => state.value.length,
+});
+```
 
 <div align="right">
   <a href="#api-reference">&uarr; back to top</a>

--- a/packages/ariakit-react-store/src/index.tsx
+++ b/packages/ariakit-react-store/src/index.tsx
@@ -6,12 +6,7 @@ import {
 import { batch, init, subscribe, sync } from "@ariakit/store";
 import type { Store as CoreStore, State, StoreState } from "@ariakit/store";
 import { hasOwnProperty, identity } from "@ariakit/utils";
-import type {
-  AnyFunction,
-  AnyObject,
-  PickByValue,
-  SetState,
-} from "@ariakit/utils";
+import type { AnyFunction, PickByValue, SetState } from "@ariakit/utils";
 import * as React from "react";
 import { useSyncExternalStore } from "use-sync-external-store/shim";
 
@@ -49,16 +44,68 @@ export interface UseState<S> {
   <V>(selector: (state: S) => V): V;
 }
 
-type StateStore<T = CoreStore> = T | null | undefined;
-type StateKey<T = CoreStore> = keyof StoreState<T>;
+type StateStore<T = CoreStore<any>> = T | null | undefined;
+type StateKey<T = CoreStore<any>> = keyof StoreState<T>;
+type SelectorStateKey<T> = T extends CoreStore ? StateKey<T> : never;
+type SelectorState<T, K extends PropertyKey> = T extends CoreStore
+  ? Pick<StoreState<T>, Extract<K, StateKey<T>>>
+  : never;
+type StoreKey = PropertyKey;
+type InternalStoreStateObject = Record<string, StoreKey | AnyFunction>;
 
 const noopSubscribe = () => () => {};
+
+function isStoreKeyArray(value: unknown): value is readonly StoreKey[] {
+  return Array.isArray(value);
+}
+
+function isSameStoreKey(key: StoreKey, other: StoreKey | undefined) {
+  return key === other || (key !== key && other !== other);
+}
+
+function hasSameStoreKeys(
+  keys: readonly StoreKey[] | null,
+  otherKeys: readonly StoreKey[],
+) {
+  if (keys?.length !== otherKeys.length) return false;
+  for (let index = 0; index < keys.length; index += 1) {
+    const key = keys[index];
+    if (key === undefined) return false;
+    if (isSameStoreKey(key, otherKeys[index])) continue;
+    return false;
+  }
+  return true;
+}
+
+function useStableStoreKeys<K extends StoreKey>(
+  keys: readonly K[] | null,
+): K[] | null {
+  const keysRef = React.useRef<K[] | null>(null);
+  const currentKeys = keysRef.current;
+
+  if (keys === null) {
+    keysRef.current = null;
+    return null;
+  }
+
+  if (hasSameStoreKeys(currentKeys, keys)) {
+    return currentKeys;
+  }
+
+  const nextKeys = [...keys];
+  keysRef.current = nextKeys;
+  return nextKeys;
+}
 
 /**
  * Receives an Ariakit store object (which can be `null` or `undefined`) and
  * returns the current state. If a key is provided as the second argument, it
  * returns the value of that key. If a selector function is provided, the state
- * is passed to it, and its return value is used.
+ * is passed to it, and its return value is used. Selector calls can pass the
+ * state keys they read as the second argument to skip unrelated store updates.
+ * This list must include every store key the selector reads, or the returned
+ * snapshot may stay stale. An empty list means store updates will never notify
+ * the selector.
  *
  * The component using this hook will re-render when the returned value changes.
  * @example
@@ -78,6 +125,16 @@ const noopSubscribe = () => () => {};
  * ```js
  * const combobox = Ariakit.useComboboxStore();
  * const value = Ariakit.useStoreState(combobox, (state) => state.value);
+ * ```
+ * @example
+ * Subscribing only to the state keys read by a selector:
+ * ```js
+ * const tab = Ariakit.useTabStore();
+ * const selected = Ariakit.useStoreState(
+ *   tab,
+ *   ["selectedId"],
+ *   (state) => state.selectedId === "details",
+ * );
  * ```
  * @example
  * Accessing the state of a store that may be `null` or `undefined` (for
@@ -114,55 +171,126 @@ export function useStoreState<T extends CoreStore, V>(
   selector: (state?: StoreState<T>) => V,
 ): V;
 
+export function useStoreState<
+  T extends CoreStore,
+  K extends SelectorStateKey<T>,
+  V,
+>(store: T, keys: readonly K[], selector: (state: SelectorState<T, K>) => V): V;
+
+export function useStoreState<
+  T extends CoreStore,
+  K extends SelectorStateKey<T>,
+  V,
+>(
+  store: StateStore<T>,
+  keys: readonly K[],
+  selector: (state?: SelectorState<T, K>) => V,
+): V;
+
 export function useStoreState(
   store: StateStore,
-  keyOrSelector: StateKey | ((state?: AnyObject) => any) = identity,
+  keyOrKeysOrSelector: StoreKey | readonly StoreKey[] | AnyFunction = identity,
+  selector?: AnyFunction,
 ) {
+  const keys = isStoreKeyArray(keyOrKeysOrSelector)
+    ? keyOrKeysOrSelector
+    : typeof keyOrKeysOrSelector === "function"
+      ? null
+      : [keyOrKeysOrSelector];
+  const subscriptionKeys = useStableStoreKeys(keys);
+
   const storeSubscribe = React.useCallback(
     (callback: () => void) => {
       if (!store) return noopSubscribe();
-      return subscribe(store, null, callback);
+      return subscribe(store, subscriptionKeys, callback);
     },
-    [store],
+    [store, subscriptionKeys],
   );
 
   const getSnapshot = () => {
-    const key = typeof keyOrSelector === "string" ? keyOrSelector : null;
-    const selector = typeof keyOrSelector === "function" ? keyOrSelector : null;
     const state = store?.getState();
-    if (selector) return selector(state);
+    if (isStoreKeyArray(keyOrKeysOrSelector)) {
+      return selector?.(state);
+    }
+    if (typeof keyOrKeysOrSelector === "function") {
+      return keyOrKeysOrSelector(state);
+    }
     if (!state) return;
-    if (!key) return;
-    if (!hasOwnProperty(state, key)) return;
-    return state[key];
+    if (!hasOwnProperty(state, keyOrKeysOrSelector)) return;
+    return state[keyOrKeysOrSelector];
   };
 
   return useSyncExternalStore(storeSubscribe, getSnapshot, getSnapshot);
 }
 
-type StoreStateObject<
-  T extends StateStore,
-  S extends StoreState<T> | undefined,
-> = Record<string, StateKey<T> | ((state: S) => any)>;
+type StoreStateObject<T extends StateStore, S> = Record<
+  string,
+  StateKey<T> | ((state: S) => any)
+>;
 
 type StoreStateObjectResult<
   T extends StateStore,
   S extends StoreState<T> | undefined,
-  O extends StoreStateObject<T, S>,
+  O extends Record<string, StateKey<T> | AnyFunction>,
 > = {
   [K in keyof O]: O[K] extends keyof StoreState<T>
     ? O[K] extends keyof S
       ? S[O[K]]
       : StoreState<T>[O[K]] | undefined
-    : O[K] extends (state: S) => infer R
-      ? R
+    : O[K] extends AnyFunction
+      ? ReturnType<O[K]>
       : never;
 };
+
+function getStoreStateObjectKeys(
+  object: InternalStoreStateObject,
+  selectorKeys?: readonly StoreKey[],
+) {
+  const keys: StoreKey[] = [];
+  let hasSelector = false;
+
+  for (const prop in object) {
+    const keyOrSelector = object[prop];
+    if (keyOrSelector === undefined) continue;
+    if (typeof keyOrSelector === "function") {
+      hasSelector = true;
+      continue;
+    }
+    if (keys.includes(keyOrSelector)) continue;
+    keys.push(keyOrSelector);
+  }
+
+  if (!hasSelector) return keys;
+  if (!selectorKeys) return null;
+
+  for (const key of selectorKeys) {
+    if (keys.includes(key)) continue;
+    keys.push(key);
+  }
+
+  return keys;
+}
 
 /**
  * Receives an Ariakit store object (which can be `null` or `undefined`) and
  * returns the current state. Unlike `useStoreState`, this hook receives an
- * object with keys that map to store keys or selector functions.
+ * object with keys that map to store keys or selector functions. Store keys in
+ * the object are always subscribed to. When selector dependency keys are
+ * passed as the second argument, they must include every store key read by
+ * every selector, or the returned snapshot may stay stale. An empty list means
+ * only direct store keys in the object will notify the selectors.
+ * @example
+ * Reading direct and derived values with selector dependencies:
+ * ```js
+ * const values = useStoreStateObject(
+ *   store,
+ *   ["value"],
+ *   {
+ *     value: "value",
+ *     valueLength: (state) => state.value.length,
+ *   },
+ * );
+ * ```
  */
 export function useStoreStateObject<
   T extends CoreStore,
@@ -174,20 +302,48 @@ export function useStoreStateObject<
   O extends StoreStateObject<T, StoreState<T> | undefined>,
 >(store: T, object: O): StoreStateObjectResult<T, StoreState<T> | undefined, O>;
 
+export function useStoreStateObject<
+  T extends CoreStore,
+  K extends SelectorStateKey<T>,
+  O extends StoreStateObject<T, SelectorState<T, K>>,
+>(
+  store: T,
+  keys: readonly K[],
+  object: O,
+): StoreStateObjectResult<T, StoreState<T>, O>;
+
+export function useStoreStateObject<
+  T extends CoreStore,
+  K extends SelectorStateKey<T>,
+  O extends StoreStateObject<T, SelectorState<T, K> | undefined>,
+>(
+  store: StateStore<T>,
+  keys: readonly K[],
+  object: O,
+): StoreStateObjectResult<T, StoreState<T> | undefined, O>;
+
 export function useStoreStateObject(
   store: StateStore,
-  object: StoreStateObject<StateStore, State | undefined>,
+  objectOrKeys: InternalStoreStateObject | readonly StoreKey[],
+  object?: InternalStoreStateObject,
 ) {
+  const stateObject = isStoreKeyArray(objectOrKeys)
+    ? (object ?? {})
+    : objectOrKeys;
+  const selectorKeys = isStoreKeyArray(objectOrKeys) ? objectOrKeys : undefined;
   const objRef = React.useRef(
     {} as StoreStateObjectResult<StateStore, State, any>,
+  );
+  const subscriptionKeys = useStableStoreKeys(
+    getStoreStateObjectKeys(stateObject, selectorKeys),
   );
 
   const storeSubscribe = React.useCallback(
     (callback: () => void) => {
       if (!store) return noopSubscribe();
-      return subscribe(store, null, callback);
+      return subscribe(store, subscriptionKeys, callback);
     },
-    [store],
+    [store, subscriptionKeys],
   );
 
   const getSnapshot = () => {
@@ -195,8 +351,9 @@ export function useStoreStateObject(
     let updated = false;
     const obj = objRef.current;
 
-    for (const prop in object) {
-      const keyOrSelector = object[prop];
+    for (const prop in stateObject) {
+      const keyOrSelector = stateObject[prop];
+      if (keyOrSelector === undefined) continue;
 
       if (typeof keyOrSelector === "function") {
         const value = keyOrSelector(state);
@@ -211,14 +368,14 @@ export function useStoreStateObject(
         }
       }
 
-      if (typeof keyOrSelector === "string") {
-        if (!state) continue;
-        if (!hasOwnProperty(state, keyOrSelector)) continue;
-        const value = state[keyOrSelector];
-        if (!Object.is(value, obj[prop])) {
-          obj[prop] = value;
-          updated = true;
-        }
+      if (typeof keyOrSelector === "function") continue;
+      const value =
+        state && hasOwnProperty(state, keyOrSelector)
+          ? state[keyOrSelector]
+          : undefined;
+      if (!Object.is(value, obj[prop])) {
+        obj[prop] = value;
+        updated = true;
       }
     }
 

--- a/packages/ariakit-react-store/src/index.tsx
+++ b/packages/ariakit-react-store/src/index.tsx
@@ -202,6 +202,7 @@ export function useStoreState(
   const storeSubscribe = React.useCallback(
     (callback: () => void) => {
       if (!store) return noopSubscribe();
+      if (subscriptionKeys?.length === 0) return noopSubscribe();
       return subscribe(store, subscriptionKeys, callback);
     },
     [store, subscriptionKeys],
@@ -341,6 +342,7 @@ export function useStoreStateObject(
   const storeSubscribe = React.useCallback(
     (callback: () => void) => {
       if (!store) return noopSubscribe();
+      if (subscriptionKeys?.length === 0) return noopSubscribe();
       return subscribe(store, subscriptionKeys, callback);
     },
     [store, subscriptionKeys],

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -85,7 +85,7 @@ function hasUpdatedKey<S>(
   for (const currentKey of keys) {
     if (updatedKey instanceof Set) {
       if (updatedKey.has(currentKey)) return true;
-    } else if (currentKey === updatedKey) {
+    } else if (isSameValue(currentKey, updatedKey)) {
       return true;
     }
   }

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -187,6 +187,29 @@ test("subscribes to selected state changes", () => {
   expect(calls).toEqual([[1, 0]]);
 });
 
+test("subscribes to NaN state keys on all listener paths", () => {
+  const getCalls = (forceSlowPath = false) => {
+    const key = Number.NaN;
+    const store = createStore({ [key]: 0 });
+    let calls = 0;
+
+    if (forceSlowPath) {
+      subscribe(store, null, () => {});
+    }
+
+    subscribe(store, [key], (state, prevState) => {
+      calls += 1;
+      expect(state[key]).toBe(1);
+      expect(prevState[key]).toBe(0);
+    });
+    store.setState(key, 1);
+    return calls;
+  };
+
+  expect(getCalls()).toBe(1);
+  expect(getCalls(true)).toBe(1);
+});
+
 test("captures selected state keys when subscribing", () => {
   const store = createStore({ count: 0, label: "a" });
   const keys: Array<"count" | "label"> = ["count"];


### PR DESCRIPTION
## Motivation

Selector functions passed to store hooks currently run after every store update, even when the selector only reads one or two state keys. This creates avoidable work across React components with frequently changing stores.

```ts
useStoreState(store, (state) => state.value);
```

The hooks also have no way to express selector dependencies, so TypeScript cannot catch reads that would make a filtered subscription stale.

## Solution

Added overloads that accept dependency keys before the selector or state object:

```ts
useStoreState(store, ["value"], (state) => state.value);

useStoreStateObject(store, ["value"], {
  direct: "otherKey",
  derived: (state) => state.value,
});
```

The declared keys narrow the selector state in TypeScript and filter store notifications at runtime, while selectors still receive the complete state object. Direct key mappings are subscribed automatically, dependency arrays are stabilized by value, and existing unkeyed selector calls preserve their behavior.

`useStoreState` is available from `@ariakit/react`, `@ariakit/react-components/store`, and `@ariakit/react-store`. `useStoreStateObject` is available from the latter two store entrypoints and is documented in a separate release note.

Updated all selector-form subscriptions across `@ariakit/react-components` to declare their dependencies. Expensive Composite row calculations are isolated from `activeId` updates, direct reads use the direct-key overload, and mutable element IDs remain observed after the migration.

Also aligned `NaN` key matching between the store's fast and slow subscription paths.

## Testing

- `pnpm test-react` — 193 files, 853 tests
- `pnpm test-react18` — 193 files, 845 passed and 8 expected skips
- `pnpm test packages/ariakit-store/src/test.ts` — 92 tests
- Focused component sandboxes in React 19 and React 18 — 6 tests each
- Keyed-store sandbox in React 19 and React 18 — 4 tests each
- Keyed-store browser sandbox in Chrome, Firefox, and Safari — 12 tests
- Mutable-element-ID browser sandbox in Chrome, Firefox, and Safari — 12 tests
- `pnpm tsc`
- `pnpm lint`
- `pnpm build`
- `pnpm build-app-lite`
- `pnpm build-website-lite`
- Modern and legacy reference extractor tests
