### PR TITLE
Use Astro for app previews

### DIFF
--- a/app/astro.config.ts
+++ b/app/astro.config.ts
@@ -29,6 +29,7 @@ import { sourcePlugin } from "./src/lib/source-plugin.ts";
 import { getPlusAccountPath, getPlusCheckoutPath } from "./src/lib/url.ts";
 
 const port = Number(process.env.APP_PORT) || 4321;
+const inspectorPort = Number(process.env.APP_INSPECTOR_PORT) || 0;
 const hasClerk = process.env.PUBLIC_CLERK_PUBLISHABLE_KEY;
 const viteCacheDir = process.env.APP_VITE_CACHE_DIR;
 
@@ -53,6 +54,7 @@ export default defineConfig({
 
   adapter: cloudflare({
     imageService: "compile",
+    inspectorPort,
   }),
 
   build: {

--- a/app/package.json
+++ b/app/package.json
@@ -21,7 +21,7 @@
     "build": "astro build",
     "build-lite": "cross-env DISABLE_REFERENCE_LINKS=true pnpm run build",
     "build-min": "cross-env DISABLE_SYNTAX_HIGHLIGHTING=true pnpm run build-lite",
-    "preview": "wrangler dev",
+    "preview": "astro preview",
     "preview-lite": "cross-env DISABLE_REFERENCE_LINKS=true pnpm run preview",
     "preview-stripe": "concurrently -k -r 'pnpm:preview' 'pnpm:listen-*'",
     "preview-stripe-lite": "concurrently -k -r 'pnpm:preview-lite' 'pnpm:listen-*'",

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -9,14 +9,14 @@ const HEADED = process.env.PWHEADED === "true";
 const PERF = process.env.PERF_TEST === "true";
 const port = Number(process.env.APP_PORT) || 4321;
 const nextjsPort = Number(process.env.NEXTJS_PORT) || 3000;
-// Pin the wrangler dev inspector ports outside the OS ephemeral range in CI.
-// When unset, wrangler preselects a random free high port and workerd binds
+// Pin the workerd inspector ports outside the OS ephemeral range in CI.
+// When unset, the preview server preselects a random free high port and workerd binds
 // it later, so another process (such as a browser connection claiming it as
 // an outbound source port) can take it in between, which kills the server
 // with a fatal "Address already in use" on startup. Only pin by default in
 // CI, where each job owns the runner: fixed local defaults would make
 // concurrent sessions (such as per-worktree servers on overridden app ports)
-// collide deterministically. Zero means "let wrangler pick".
+// collide deterministically. Zero means "let the preview server pick".
 const inspectorPort = Number(process.env.APP_INSPECTOR_PORT) || (CI ? 9339 : 0);
 const nextjsInspectorPort =
   Number(process.env.NEXTJS_INSPECTOR_PORT) || (CI ? 9340 : 0);
@@ -44,7 +44,12 @@ export default defineConfig({
   snapshotPathTemplate: "{testDir}/{testFileDir}/__snapshots__/{arg}{ext}",
   webServer: [
     {
-      command: `pnpm run preview-lite --log-level warn --port ${port}${inspectorPortArg(inspectorPort)} --var NEXTJS_PORT:${nextjsPort}`,
+      command: `pnpm run preview-lite --port ${port}`,
+      env: {
+        APP_INSPECTOR_PORT: String(inspectorPort),
+        CLOUDFLARE_INCLUDE_PROCESS_ENV: "true",
+        NEXTJS_PORT: String(nextjsPort),
+      },
       reuseExistingServer: !CI,
       stdout: CI ? "pipe" : "ignore",
       port,


### PR DESCRIPTION
## Motivation

The app build and preview currently enter Cloudflare through different runtime paths:

```sh
astro build
wrangler dev
```

Both commands persist local state in `app/.wrangler/state`. When their bundled Cloudflare runtimes disagree on the SQLite cache schema, previewing can leave an `_cf_ALARM` table that the next build cannot read. This makes otherwise unrelated builds fail until an agent deletes generated state.

Browser tests also need to keep choosing `NEXTJS_PORT` per run so concurrent agents can isolate their app, Next.js, and inspector servers without writing a shared `.dev.vars` file.

## Solution

Use Astro's Cloudflare-aware `astro preview` command, keeping builds and previews on the adapter's runtime path. Configure the app inspector through the Cloudflare adapter instead of a Wrangler-only CLI argument.

Playwright passes `NEXTJS_PORT` and `APP_INSPECTOR_PORT` through its `webServer.env` option and opts the preview child into Cloudflare's documented process-environment bindings. Agents can continue using ordinary per-process values:

```sh
APP_PORT=44321 \
NEXTJS_PORT=43001 \
APP_INSPECTOR_PORT=44322 \
NEXTJS_INSPECTOR_PORT=43002 \
pnpm -F app test-chrome src/sandbox/counter-nextjs/test-browser.ts
```

No env file, generated-config mutation, cache deletion, or custom preview wrapper is needed.

## Testing

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm build-app-lite`
- Isolated-port `counter-nextjs` Chrome test
- A second `pnpm build-app-lite` without clearing `.wrangler/state`
- The same build, browser test, and rebuild sequence with `CLOUDFLARE_ENV=preview`
