### PR TITLE
Update pnpm to v11.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,5 +145,5 @@
       "onFail": "download"
     }
   },
-  "packageManager": "pnpm@11.11.0"
+  "packageManager": "pnpm@11.13.0"
 }


### PR DESCRIPTION
## Motivation

Keep the repository on the requested pnpm 11 release:

```json
"packageManager": "pnpm@11.11.0"
```

## Solution

Update the root package-manager pin and validate the workspace with pnpm 11.13.0:

```json
"packageManager": "pnpm@11.13.0"
```

The lockfile remains unchanged after `pnpm i` and the configured `pnpm dedupe` post-update operation.

## Dependencies

| Declaration | Workspace | Old | New | Release |
| --- | --- | --- | --- | --- |
| `packageManager` (`pnpm`) | root | 11.11.0 | 11.13.0 | [pnpm 11.13.0](https://github.com/pnpm/pnpm/releases/tag/v11.13.0) |

## Verification

- `pnpm i`
- `pnpm dedupe`
- `pnpm build`
- `pnpm lint-fix`
- `pnpm tsc`
