### PR TITLE
Support side-specific popover overflow padding

### DIFF
--- a/.changeset/200-popover-overflow-padding.md
+++ b/.changeset/200-popover-overflow-padding.md
@@ -1,0 +1,16 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Added support for side-specific `overflowPadding`
+
+The [`overflowPadding`](https://ariakit.com/reference/popover#overflowpadding) prop now accepts a number or an object with independent `top`, `right`, `bottom`, and `left` values. This applies to [`Popover`](https://ariakit.com/reference/popover) and components built on it, including [`ComboboxPopover`](https://ariakit.com/reference/combobox-popover), [`SelectPopover`](https://ariakit.com/reference/select-popover), `CompositeOverflow`, [`Hovercard`](https://ariakit.com/reference/hovercard), [`Menu`](https://ariakit.com/reference/menu), and [`Tooltip`](https://ariakit.com/reference/tooltip):
+
+```tsx
+<ComboboxPopover overflowPadding={{ top: 24, right: 32, left: 16 }} />
+```
+
+When [`overflowPadding`](https://ariakit.com/reference/popover#overflowpadding) is an object, the [`--popover-overflow-padding`](https://ariakit.com/guide/styling#--popover-overflow-padding) CSS variable uses the larger of the horizontal `left` and `right` values, treating omitted sides as `0`.
+
+Thanks to [@mririgoyen](https://github.com/mririgoyen) for reporting the issue, and to [@georgekaran](https://github.com/georgekaran) for providing the approach that informed this solution.

--- a/app/src/guides/ariakit-react/2-styling.mdx
+++ b/app/src/guides/ariakit-react/2-styling.mdx
@@ -255,6 +255,8 @@ The `--popover-available-width` variable exposes the available horizontal space 
 
 The `--popover-overflow-padding` variable exposes the amount of padding that should be added between the popover element and the viewport edges. You can use this in combination with `100%` or `100vw` values to make the popover element fill the entire viewport width, while still keeping the padding.
 
+When the [`overflowPadding`](/reference/popover/#overflowpadding) prop is a number, the variable uses that number. When the prop is an object, the variable uses the larger of its `left` and `right` values, treating an omitted horizontal side as `0`.
+
 ```css
 .popover {
   width: calc(100vw - var(--popover-overflow-padding) * 2);

--- a/app/src/sandbox/combobox-overflow-padding-5696/index.react.tsx
+++ b/app/src/sandbox/combobox-overflow-padding-5696/index.react.tsx
@@ -1,51 +1,19 @@
 import * as Ariakit from "@ariakit/react";
-import { useLayoutEffect, useState } from "react";
 import "./style.css";
 
-const overflowPadding = { top: 24, right: 32, left: 32 };
+const overflowPadding = {
+  top: 48,
+  right: 32,
+  left: 8,
+} satisfies Ariakit.ComboboxPopoverOptions["overflowPadding"];
 
 export default function Example() {
-  const [contentElement, setContentElement] = useState<HTMLDivElement | null>(
-    null,
-  );
-
-  useLayoutEffect(() => {
-    // Popover exposes positioning styles on the content element's parent.
-    const wrapper = contentElement?.parentElement;
-    if (!wrapper) return;
-
-    // The CSS variable is a single horizontal value, so use the widest side.
-    const value = `${Math.max(overflowPadding.left, overflowPadding.right)}px`;
-    const applyValue = () => {
-      if (
-        wrapper.style.getPropertyValue("--popover-overflow-padding") === value
-      ) {
-        return;
-      }
-      wrapper.style.setProperty("--popover-overflow-padding", value);
-    };
-
-    // TODO: Remove this workaround when
-    // https://github.com/ariakit/ariakit/issues/5696 is fixed.
-    applyValue();
-    // Ariakit rewrites the variable when positioning restarts, including reopen.
-    const OwnerMutationObserver =
-      wrapper.ownerDocument.defaultView?.MutationObserver;
-    // The initial correction still helps without MutationObserver support.
-    if (!OwnerMutationObserver) return;
-    const observer = new OwnerMutationObserver(applyValue);
-    observer.observe(wrapper, { attributes: true, attributeFilter: ["style"] });
-    return () => observer.disconnect();
-  }, [contentElement]);
-
   return (
     <Ariakit.ComboboxProvider defaultOpen>
       <Ariakit.ComboboxLabel>Favorite fruit</Ariakit.ComboboxLabel>
       <Ariakit.Combobox />
       <Ariakit.ComboboxPopover
-        ref={setContentElement}
         className="popover"
-        // @ts-expect-error #5696: Ariakit currently types this prop as number.
         overflowPadding={overflowPadding}
       >
         <Ariakit.ComboboxItem value="Apple" />

--- a/app/src/sandbox/combobox-overflow-padding-5696/index.react.tsx
+++ b/app/src/sandbox/combobox-overflow-padding-5696/index.react.tsx
@@ -1,0 +1,18 @@
+import * as Ariakit from "@ariakit/react";
+import "./style.css";
+
+export default function Example() {
+  return (
+    <Ariakit.ComboboxProvider defaultOpen>
+      <Ariakit.ComboboxLabel>Favorite fruit</Ariakit.ComboboxLabel>
+      <Ariakit.Combobox />
+      <Ariakit.ComboboxPopover
+        className="popover"
+        overflowPadding={{ top: 24, right: 32, left: 32 }}
+      >
+        <Ariakit.ComboboxItem value="Apple" />
+        <Ariakit.ComboboxItem value="Orange" />
+      </Ariakit.ComboboxPopover>
+    </Ariakit.ComboboxProvider>
+  );
+}

--- a/app/src/sandbox/combobox-overflow-padding-5696/index.react.tsx
+++ b/app/src/sandbox/combobox-overflow-padding-5696/index.react.tsx
@@ -1,24 +1,46 @@
 import * as Ariakit from "@ariakit/react";
+import { useCallback, useReducer, useRef, useState } from "react";
 import "./style.css";
 
-const overflowPadding = {
-  top: 48,
-  right: 32,
-  left: 8,
-} satisfies Ariakit.ComboboxPopoverOptions["overflowPadding"];
-
 export default function Example() {
+  const [, rerender] = useReducer((count) => count + 1, 0);
+  const positionUpdatesRef = useRef<HTMLOutputElement>(null);
+  const positionUpdates = useRef(0);
+  const [rightPadding, setRightPadding] = useState(32);
+  const updatePosition = useCallback<
+    NonNullable<Ariakit.PopoverOptions["updatePosition"]>
+  >(async ({ updatePosition }) => {
+    positionUpdates.current += 1;
+    if (positionUpdatesRef.current) {
+      positionUpdatesRef.current.value = `${positionUpdates.current}`;
+    }
+    await updatePosition();
+  }, []);
+
   return (
     <Ariakit.ComboboxProvider defaultOpen>
       <Ariakit.ComboboxLabel>Favorite fruit</Ariakit.ComboboxLabel>
       <Ariakit.Combobox />
+      <button onClick={rerender}>Rerender</button>
+      <button onClick={() => setRightPadding(40)}>Change padding</button>
       <Ariakit.ComboboxPopover
         className="popover"
-        overflowPadding={overflowPadding}
+        hideOnInteractOutside={false}
+        overflowPadding={
+          {
+            top: 48,
+            right: rightPadding,
+            left: 8,
+          } satisfies Ariakit.ComboboxPopoverOptions["overflowPadding"]
+        }
+        updatePosition={updatePosition}
       >
         <Ariakit.ComboboxItem value="Apple" />
         <Ariakit.ComboboxItem value="Orange" />
       </Ariakit.ComboboxPopover>
+      <output ref={positionUpdatesRef} aria-label="Position updates">
+        0
+      </output>
     </Ariakit.ComboboxProvider>
   );
 }

--- a/app/src/sandbox/combobox-overflow-padding-5696/index.react.tsx
+++ b/app/src/sandbox/combobox-overflow-padding-5696/index.react.tsx
@@ -1,14 +1,52 @@
 import * as Ariakit from "@ariakit/react";
+import { useLayoutEffect, useState } from "react";
 import "./style.css";
 
+const overflowPadding = { top: 24, right: 32, left: 32 };
+
 export default function Example() {
+  const [contentElement, setContentElement] = useState<HTMLDivElement | null>(
+    null,
+  );
+
+  useLayoutEffect(() => {
+    // Popover exposes positioning styles on the content element's parent.
+    const wrapper = contentElement?.parentElement;
+    if (!wrapper) return;
+
+    // The CSS variable is a single horizontal value, so use the widest side.
+    const value = `${Math.max(overflowPadding.left, overflowPadding.right)}px`;
+    const applyValue = () => {
+      if (
+        wrapper.style.getPropertyValue("--popover-overflow-padding") === value
+      ) {
+        return;
+      }
+      wrapper.style.setProperty("--popover-overflow-padding", value);
+    };
+
+    // TODO: Remove this workaround when
+    // https://github.com/ariakit/ariakit/issues/5696 is fixed.
+    applyValue();
+    // Ariakit rewrites the variable when positioning restarts, including reopen.
+    const OwnerMutationObserver =
+      wrapper.ownerDocument.defaultView?.MutationObserver;
+    // The initial correction still helps without MutationObserver support.
+    if (!OwnerMutationObserver) return;
+    const observer = new OwnerMutationObserver(applyValue);
+    observer.observe(wrapper, { attributes: true, attributeFilter: ["style"] });
+    return () => observer.disconnect();
+  }, [contentElement]);
+
   return (
     <Ariakit.ComboboxProvider defaultOpen>
       <Ariakit.ComboboxLabel>Favorite fruit</Ariakit.ComboboxLabel>
       <Ariakit.Combobox />
       <Ariakit.ComboboxPopover
+        ref={setContentElement}
         className="popover"
-        overflowPadding={{ top: 24, right: 32, left: 32 }}
+        // @ts-expect-error #5696: Ariakit currently types this prop as number.
+        overflowPadding={overflowPadding}
       >
         <Ariakit.ComboboxItem value="Apple" />
         <Ariakit.ComboboxItem value="Orange" />

--- a/app/src/sandbox/combobox-overflow-padding-5696/style.css
+++ b/app/src/sandbox/combobox-overflow-padding-5696/style.css
@@ -1,0 +1,4 @@
+.popover {
+  box-sizing: border-box;
+  width: calc(100vw - var(--popover-overflow-padding) * 2);
+}

--- a/app/src/sandbox/combobox-overflow-padding-5696/test-browser.ts
+++ b/app/src/sandbox/combobox-overflow-padding-5696/test-browser.ts
@@ -2,7 +2,7 @@
 import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
-  test("supports object overflow padding in CSS sizing", async ({
+  test("uses the greatest horizontal overflow padding for CSS sizing", async ({
     page,
     q,
   }) => {

--- a/app/src/sandbox/combobox-overflow-padding-5696/test-browser.ts
+++ b/app/src/sandbox/combobox-overflow-padding-5696/test-browser.ts
@@ -11,5 +11,13 @@ withFramework(import.meta.dirname, async ({ test }) => {
     const popover = q.listbox();
     await test.expect(popover).toBeVisible();
     await test.expect(popover).toHaveCSS("width", "736px");
+
+    const combobox = q.combobox("Favorite fruit");
+    await combobox.click();
+    await combobox.press("Escape");
+    await test.expect(popover).toBeHidden();
+    await combobox.click();
+    await test.expect(popover).toBeVisible();
+    await test.expect(popover).toHaveCSS("width", "736px");
   });
 });

--- a/app/src/sandbox/combobox-overflow-padding-5696/test-browser.ts
+++ b/app/src/sandbox/combobox-overflow-padding-5696/test-browser.ts
@@ -20,4 +20,40 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(popover).toBeVisible();
     await test.expect(popover).toHaveCSS("width", "736px");
   });
+
+  test("does not reposition when inline padding values are unchanged", async ({
+    q,
+  }) => {
+    const popover = q.listbox();
+    const positionUpdates = q.status("Position updates");
+    await test.expect(popover).toBeVisible();
+    await test.expect(positionUpdates).not.toHaveText("0");
+    const initialPositionUpdates = await positionUpdates.textContent();
+
+    await q.button("Rerender").click();
+
+    await test.expect(popover).toBeVisible();
+    await test.expect(positionUpdates).toHaveText(initialPositionUpdates ?? "");
+  });
+
+  test("repositions when an inline padding value changes", async ({
+    page,
+    q,
+  }) => {
+    await page.setViewportSize({ width: 800, height: 600 });
+
+    const popover = q.listbox();
+    const positionUpdates = q.status("Position updates");
+    await test.expect(popover).toBeVisible();
+    await test.expect(positionUpdates).not.toHaveText("0");
+    const initialPositionUpdates = await positionUpdates.textContent();
+
+    await q.button("Change padding").click();
+
+    await test.expect(popover).toBeVisible();
+    await test
+      .expect(positionUpdates)
+      .not.toHaveText(initialPositionUpdates ?? "");
+    await test.expect(popover).toHaveCSS("width", "720px");
+  });
 });

--- a/app/src/sandbox/combobox-overflow-padding-5696/test-browser.ts
+++ b/app/src/sandbox/combobox-overflow-padding-5696/test-browser.ts
@@ -1,0 +1,15 @@
+// See https://github.com/ariakit/ariakit/issues/5696
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("supports object overflow padding in CSS sizing", async ({
+    page,
+    q,
+  }) => {
+    await page.setViewportSize({ width: 800, height: 600 });
+
+    const popover = q.listbox();
+    await test.expect(popover).toBeVisible();
+    await test.expect(popover).toHaveCSS("width", "736px");
+  });
+});

--- a/app/src/sandbox/combobox-overflow-padding-5696/test.ts
+++ b/app/src/sandbox/combobox-overflow-padding-5696/test.ts
@@ -2,14 +2,14 @@
 import { click, press, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
-function expectOverflowPadding(popover: HTMLElement) {
+function expectOverflowPadding(popover: HTMLElement, value = "32px") {
   const wrapper = popover.parentElement;
   expect(wrapper).not.toBeNull();
   if (!wrapper) return;
   // Popover exposes positioning styles on the element's wrapper.
   expect(
     getComputedStyle(wrapper).getPropertyValue("--popover-overflow-padding"),
-  ).toBe("32px");
+  ).toBe(value);
 }
 
 test("uses the greatest horizontal overflow padding for CSS sizing", async () => {
@@ -23,4 +23,29 @@ test("uses the greatest horizontal overflow padding for CSS sizing", async () =>
   await click(combobox);
   expect(popover).toBeVisible();
   expectOverflowPadding(popover);
+});
+
+test("does not reposition when inline padding values are unchanged", async () => {
+  const popover = q.listbox.ensure();
+  const positionUpdates = q.status.ensure("Position updates");
+  const initialPositionUpdates = positionUpdates.textContent;
+  expect(Number(initialPositionUpdates)).toBeGreaterThan(0);
+
+  await click(q.button("Rerender"));
+
+  expect(popover).toBeVisible();
+  expect(positionUpdates.textContent).toBe(initialPositionUpdates);
+});
+
+test("repositions when an inline padding value changes", async () => {
+  const popover = q.listbox.ensure();
+  const positionUpdates = q.status.ensure("Position updates");
+  const initialPositionUpdates = positionUpdates.textContent;
+  expect(Number(initialPositionUpdates)).toBeGreaterThan(0);
+
+  await click(q.button("Change padding"));
+
+  expect(popover).toBeVisible();
+  expect(positionUpdates.textContent).not.toBe(initialPositionUpdates);
+  expectOverflowPadding(popover, "40px");
 });

--- a/app/src/sandbox/combobox-overflow-padding-5696/test.ts
+++ b/app/src/sandbox/combobox-overflow-padding-5696/test.ts
@@ -12,7 +12,7 @@ function expectOverflowPadding(popover: HTMLElement) {
   ).toBe("32px");
 }
 
-test("supports object overflow padding in CSS sizing", async () => {
+test("uses the greatest horizontal overflow padding for CSS sizing", async () => {
   const popover = q.listbox.ensure();
   expectOverflowPadding(popover);
 

--- a/app/src/sandbox/combobox-overflow-padding-5696/test.ts
+++ b/app/src/sandbox/combobox-overflow-padding-5696/test.ts
@@ -1,0 +1,9 @@
+// See https://github.com/ariakit/ariakit/issues/5696
+import { q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+test("supports object overflow padding in CSS sizing", () => {
+  const popover = q.listbox.ensure();
+  // Popover exposes positioning styles on the element's wrapper.
+  expect(popover.parentElement).toHaveStyle("--popover-overflow-padding: 32px");
+});

--- a/app/src/sandbox/combobox-overflow-padding-5696/test.ts
+++ b/app/src/sandbox/combobox-overflow-padding-5696/test.ts
@@ -1,9 +1,26 @@
 // See https://github.com/ariakit/ariakit/issues/5696
-import { q } from "@ariakit/test";
+import { click, press, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
-test("supports object overflow padding in CSS sizing", () => {
-  const popover = q.listbox.ensure();
+function expectOverflowPadding(popover: HTMLElement) {
+  const wrapper = popover.parentElement;
+  expect(wrapper).not.toBeNull();
+  if (!wrapper) return;
   // Popover exposes positioning styles on the element's wrapper.
-  expect(popover.parentElement).toHaveStyle("--popover-overflow-padding: 32px");
+  expect(
+    getComputedStyle(wrapper).getPropertyValue("--popover-overflow-padding"),
+  ).toBe("32px");
+}
+
+test("supports object overflow padding in CSS sizing", async () => {
+  const popover = q.listbox.ensure();
+  expectOverflowPadding(popover);
+
+  const combobox = q.combobox("Favorite fruit");
+  await click(combobox);
+  await press.Escape();
+  expect(popover).not.toBeVisible();
+  await click(combobox);
+  expect(popover).toBeVisible();
+  expectOverflowPadding(popover);
 });

--- a/guide/200-styling/readme.md
+++ b/guide/200-styling/readme.md
@@ -260,6 +260,8 @@ The `--popover-available-width` variable exposes the available horizontal space 
 
 The `--popover-overflow-padding` variable exposes the amount of padding that should be added between the popover element and the viewport edges. You can use this in combination with `100%` or `100vw` values to make the popover element fill the entire viewport width, while still keeping the padding.
 
+When the [`overflowPadding`](/reference/popover#overflowpadding) prop is a number, the variable uses that number. When the prop is an object, the variable uses the larger of its `left` and `right` values, treating an omitted horizontal side as `0`.
+
 ```css
 .popover {
   width: calc(100vw - var(--popover-overflow-padding) * 2);

--- a/packages/ariakit-react-components/src/popover/popover.tsx
+++ b/packages/ariakit-react-components/src/popover/popover.tsx
@@ -20,7 +20,6 @@ import {
   shift,
   size,
 } from "@floating-ui/dom";
-import type { Padding } from "@floating-ui/dom";
 import type { ElementType, HTMLAttributes } from "react";
 import { useRef, useState } from "react";
 import type { DialogOptions } from "../dialog/dialog.tsx";
@@ -42,6 +41,15 @@ interface AnchorRect {
   width?: number;
   height?: number;
 }
+
+interface OverflowPaddingObject {
+  top?: number;
+  right?: number;
+  bottom?: number;
+  left?: number;
+}
+
+type OverflowPadding = number | OverflowPaddingObject;
 
 function createDOMRect(x = 0, y = 0, width = 0, height = 0) {
   if (typeof DOMRect === "function") {
@@ -96,7 +104,7 @@ function roundByDPR(value: number) {
   return Math.round(value * dpr) / dpr;
 }
 
-function getOverflowPaddingValue(padding: Padding) {
+function getOverflowPaddingValue(padding: OverflowPadding) {
   if (typeof padding === "number") return padding;
   return Math.max(padding.left ?? 0, padding.right ?? 0);
 }
@@ -280,19 +288,19 @@ export const usePopover = createHook<TagName, PopoverOptions>(
     const overflowPaddingTop =
       typeof overflowPadding === "number"
         ? overflowPadding
-        : overflowPadding.top;
+        : (overflowPadding.top ?? 0);
     const overflowPaddingRight =
       typeof overflowPadding === "number"
         ? overflowPadding
-        : overflowPadding.right;
+        : (overflowPadding.right ?? 0);
     const overflowPaddingBottom =
       typeof overflowPadding === "number"
         ? overflowPadding
-        : overflowPadding.bottom;
+        : (overflowPadding.bottom ?? 0);
     const overflowPaddingLeft =
       typeof overflowPadding === "number"
         ? overflowPadding
-        : overflowPadding.left;
+        : (overflowPadding.left ?? 0);
 
     useSafeLayoutEffect(() => {
       if (!popoverElement?.isConnected) return;
@@ -700,7 +708,7 @@ export interface PopoverOptions<
    * - [Sliding Menu](https://ariakit.com/examples/menu-slide)
    * @default 8
    */
-  overflowPadding?: Padding;
+  overflowPadding?: OverflowPadding;
   /**
    * Function that returns the anchor element's DOMRect. If this is explicitly
    * passed, it will override the anchor `getBoundingClientRect` method.

--- a/packages/ariakit-react-components/src/popover/popover.tsx
+++ b/packages/ariakit-react-components/src/popover/popover.tsx
@@ -277,13 +277,36 @@ export const usePopover = createHook<TagName, PopoverOptions>(
     const getAnchorRectProp = useEvent(getAnchorRect);
     const updatePositionProp = useEvent(updatePosition);
     const hasCustomUpdatePosition = !!updatePosition;
+    const overflowPaddingTop =
+      typeof overflowPadding === "number"
+        ? overflowPadding
+        : overflowPadding.top;
+    const overflowPaddingRight =
+      typeof overflowPadding === "number"
+        ? overflowPadding
+        : overflowPadding.right;
+    const overflowPaddingBottom =
+      typeof overflowPadding === "number"
+        ? overflowPadding
+        : overflowPadding.bottom;
+    const overflowPaddingLeft =
+      typeof overflowPadding === "number"
+        ? overflowPadding
+        : overflowPadding.left;
 
     useSafeLayoutEffect(() => {
       if (!popoverElement?.isConnected) return;
 
+      const positioningPadding = {
+        top: overflowPaddingTop,
+        right: overflowPaddingRight,
+        bottom: overflowPaddingBottom,
+        left: overflowPaddingLeft,
+      };
+
       popoverElement.style.setProperty(
         "--popover-overflow-padding",
-        `${getOverflowPaddingValue(overflowPadding)}px`,
+        `${getOverflowPaddingValue(positioningPadding)}px`,
       );
 
       const anchor = getAnchorElement(anchorElement, getAnchorRectProp);
@@ -311,14 +334,22 @@ export const usePopover = createHook<TagName, PopoverOptions>(
 
         const middleware = [
           getOffsetMiddleware(arrow, { gutter, shift }),
-          getFlipMiddleware({ flip, overflowPadding }),
-          getShiftMiddleware({ slide, shift, overlap, overflowPadding }),
+          getFlipMiddleware({
+            flip,
+            overflowPadding: positioningPadding,
+          }),
+          getShiftMiddleware({
+            slide,
+            shift,
+            overlap,
+            overflowPadding: positioningPadding,
+          }),
           getArrowMiddleware(arrow, { arrowPadding }),
           getSizeMiddleware(
             {
               sameWidth,
               fitViewport,
-              overflowPadding,
+              overflowPadding: positioningPadding,
             },
             shouldCancelUpdate,
           ),
@@ -429,7 +460,10 @@ export const usePopover = createHook<TagName, PopoverOptions>(
       fitViewport,
       gutter,
       arrowPadding,
-      overflowPadding,
+      overflowPaddingTop,
+      overflowPaddingRight,
+      overflowPaddingBottom,
+      overflowPaddingLeft,
       getAnchorRectProp,
       hasCustomUpdatePosition,
       updatePositionProp,

--- a/packages/ariakit-react-components/src/popover/popover.tsx
+++ b/packages/ariakit-react-components/src/popover/popover.tsx
@@ -20,6 +20,7 @@ import {
   shift,
   size,
 } from "@floating-ui/dom";
+import type { Padding } from "@floating-ui/dom";
 import type { ElementType, HTMLAttributes } from "react";
 import { useRef, useState } from "react";
 import type { DialogOptions } from "../dialog/dialog.tsx";
@@ -93,6 +94,11 @@ function isValidPlacement(flip: string): flip is Placement {
 function roundByDPR(value: number) {
   const dpr = window.devicePixelRatio || 1;
   return Math.round(value * dpr) / dpr;
+}
+
+function getOverflowPaddingValue(padding: Padding) {
+  if (typeof padding === "number") return padding;
+  return Math.max(padding.left ?? 0, padding.right ?? 0);
 }
 
 function getOffsetMiddleware(
@@ -277,7 +283,7 @@ export const usePopover = createHook<TagName, PopoverOptions>(
 
       popoverElement.style.setProperty(
         "--popover-overflow-padding",
-        `${overflowPadding}px`,
+        `${getOverflowPaddingValue(overflowPadding)}px`,
       );
 
       const anchor = getAnchorElement(anchorElement, getAnchorRectProp);
@@ -649,15 +655,18 @@ export interface PopoverOptions<
    */
   arrowPadding?: number;
   /**
-   * The minimum padding between the popover and the viewport edge. This will be
-   * exposed to CSS as
+   * The minimum padding between the popover and the viewport edge. Pass a
+   * number to use the same padding on every side, or an object to define each
+   * side separately. This will be exposed to CSS as
    * [`--popover-overflow-padding`](https://ariakit.com/guide/styling#--popover-overflow-padding).
+   * When passing an object, the CSS variable is the maximum of the horizontal
+   * `left` and `right` values, with omitted sides treated as `0`.
    *
    * Live examples:
    * - [Sliding Menu](https://ariakit.com/examples/menu-slide)
    * @default 8
    */
-  overflowPadding?: number;
+  overflowPadding?: Padding;
   /**
    * Function that returns the anchor element's DOMRect. If this is explicitly
    * passed, it will override the anchor `getBoundingClientRect` method.


### PR DESCRIPTION
## Motivation

`ComboboxPopover` and other Popover-based components type `overflowPadding` as a number even though Floating UI accepts an object with independent sides. Consumers currently need an unsafe cast:

```tsx
<ComboboxPopover
  overflowPadding={{ top: 24, right: 32, left: 16 } as unknown as number}
/>
```

The cast reaches Floating UI, but Ariakit serializes the object to `--popover-overflow-padding: [object Object]px`, which breaks CSS calculations that use the documented custom property.

Fixes #5696.

## Solution

`PopoverOptions["overflowPadding"]` now accepts a number or an Ariakit-owned partial side object. Ariakit normalizes omitted sides to `0` and passes a complete side object to the `flip`, `shift`, and `size` middleware, preserving compatibility across the declared Floating UI dependency range.

The positioning effect depends on the four normalized side values rather than the object identity. Equivalent inline objects therefore do not restart positioning on unrelated renders, while changing any side does.

The CSS custom property remains one length. Numeric values are preserved; objects are reduced to the greatest horizontal side:

```ts
function getOverflowPaddingValue(padding: OverflowPadding) {
  if (typeof padding === "number") return padding;
  return Math.max(padding.left ?? 0, padding.right ?? 0);
}
```

A focused `ComboboxPopover` regression uses `{ top: 48, right: 32, left: 8 }` to distinguish the horizontal maximum from max-all, sum, and average mappings. Happy DOM verifies `--popover-overflow-padding: 32px`, while Chrome, Firefox, and Safari verify the resulting `736px` width at an `800px` viewport before and after reopening. The fixture also verifies that unchanged inline side values do not reposition and that changing one side does.

The public JSDoc, modern styling guide, legacy styling guide, and changeset document the object form and CSS reduction rule.

## Workaround

For currently released versions, pass the side-specific object under a scoped TypeScript directive and repair the scalar CSS custom property on the positioning wrapper:

```tsx
import * as Ariakit from "@ariakit/react";
import { useLayoutEffect, useState } from "react";

const overflowPadding = { top: 24, right: 32, left: 16 };

function Example() {
  const [contentElement, setContentElement] = useState<HTMLDivElement | null>(
    null,
  );

  useLayoutEffect(() => {
    const wrapper = contentElement?.parentElement;
    if (!wrapper) return;

    const value = `${Math.max(overflowPadding.left, overflowPadding.right)}px`;
    const applyValue = () => {
      if (
        wrapper.style.getPropertyValue("--popover-overflow-padding") === value
      ) {
        return;
      }
      wrapper.style.setProperty("--popover-overflow-padding", value);
    };

    // TODO: Remove this workaround when
    // https://github.com/ariakit/ariakit/issues/5696 is fixed.
    applyValue();
    const OwnerMutationObserver =
      wrapper.ownerDocument.defaultView?.MutationObserver;
    if (!OwnerMutationObserver) return;
    const observer = new OwnerMutationObserver(applyValue);
    observer.observe(wrapper, { attributes: true, attributeFilter: ["style"] });
    return () => observer.disconnect();
  }, [contentElement]);

  return (
    <Ariakit.ComboboxPopover
      ref={setContentElement}
      // @ts-expect-error #5696: Ariakit currently types this prop as number.
      overflowPadding={overflowPadding}
    />
  );
}
```

This workaround relies on the current Popover DOM structure, where the content element's parent is the positioning wrapper. Because `--popover-overflow-padding` is a single scalar, the example uses the widest horizontal side for CSS width calculations; adapt that reduction if your CSS has different semantics. The observer is required because Ariakit rewrites the wrapper style when positioning restarts, including after reopening. Without `MutationObserver`, only the initial correction is applied.
