### PR TITLE
Simplify performance changesets

### DIFF
--- a/.changeset/200-react-component-performance.md
+++ b/.changeset/200-react-component-performance.md
@@ -3,4 +3,4 @@
 "@ariakit/react": patch
 ---
 
-Improved [`Tab`](https://ariakit.com/reference/tab) performance during mounting, rendering, and navigation and [`TabPanel`](https://ariakit.com/reference/tab-panel) performance during rendering and navigation, with the mount improvements also benefiting other native [`Focusable`](https://ariakit.com/reference/focusable) elements.
+Improved React component mount performance by 12–21% in browser benchmarks.

--- a/.changeset/200-react-component-performance.md
+++ b/.changeset/200-react-component-performance.md
@@ -3,6 +3,4 @@
 "@ariakit/react": patch
 ---
 
-Improved React component performance
-
-Improved [`Tab`](https://ariakit.com/reference/tab) performance during mounting, rendering, and navigation, and [`TabPanel`](https://ariakit.com/reference/tab-panel) performance during rendering and navigation. The mount improvements also apply to other native [`Focusable`](https://ariakit.com/reference/focusable) elements.
+Improved [`Tab`](https://ariakit.com/reference/tab) performance during mounting, rendering, and navigation and [`TabPanel`](https://ariakit.com/reference/tab-panel) performance during rendering and navigation, with the mount improvements also benefiting other native [`Focusable`](https://ariakit.com/reference/focusable) elements.

--- a/.changeset/200-store-performance.md
+++ b/.changeset/200-store-performance.md
@@ -4,4 +4,4 @@
 "@ariakit/react": patch
 ---
 
-Improved [`useCollectionStore`](https://ariakit.com/reference/use-collection-store) performance when populating large collections, [`useCompositeStore`](https://ariakit.com/reference/use-composite-store) performance during sequential and multi-row keyboard navigation (including when finding the last enabled item), [`useDisclosureStore`](https://ariakit.com/reference/use-disclosure-store) performance when creating stores, and [`useTabStore`](https://ariakit.com/reference/use-tab-store) performance when keyboard focus and selection remain synchronized, with these improvements also benefiting components built on the stores such as [`Tab`](https://ariakit.com/reference/tab) and [`TabPanel`](https://ariakit.com/reference/tab-panel).
+Improved store performance by 13–4,834% in targeted benchmarks.

--- a/.changeset/200-store-performance.md
+++ b/.changeset/200-store-performance.md
@@ -4,4 +4,4 @@
 "@ariakit/react": patch
 ---
 
-Improved store performance by 13–4,834% in targeted benchmarks.
+Improved store performance across targeted benchmarks, reaching up to 49× the previous throughput.

--- a/.changeset/200-store-performance.md
+++ b/.changeset/200-store-performance.md
@@ -4,10 +4,4 @@
 "@ariakit/react": patch
 ---
 
-Improved store performance
-
-Improved [`useCollectionStore`](https://ariakit.com/reference/use-collection-store) performance when populating large collections and [`useCompositeStore`](https://ariakit.com/reference/use-composite-store) performance during sequential and multi-row keyboard navigation, including when finding the last enabled item.
-
-Reduced the work performed by [`useDisclosureStore`](https://ariakit.com/reference/use-disclosure-store) when creating stores and by [`useTabStore`](https://ariakit.com/reference/use-tab-store) when keyboard focus and selection stay synchronized.
-
-These improvements also apply to components built on the stores, including [`Tab`](https://ariakit.com/reference/tab) and [`TabPanel`](https://ariakit.com/reference/tab-panel).
+Improved [`useCollectionStore`](https://ariakit.com/reference/use-collection-store) performance when populating large collections, [`useCompositeStore`](https://ariakit.com/reference/use-composite-store) performance during sequential and multi-row keyboard navigation (including when finding the last enabled item), [`useDisclosureStore`](https://ariakit.com/reference/use-disclosure-store) performance when creating stores, and [`useTabStore`](https://ariakit.com/reference/use-tab-store) performance when keyboard focus and selection remain synchronized, with these improvements also benefiting components built on the stores such as [`Tab`](https://ariakit.com/reference/tab) and [`TabPanel`](https://ariakit.com/reference/tab-panel).


### PR DESCRIPTION
## Motivation

The pending React component and store performance changesets are too detailed for concise release notes.

## Solution

Replace each with a short, single-sentence summary and quantify the improvements using confirmed results from [PR #6694's final performance report](https://github.com/ariakit/ariakit/pull/6694#issuecomment-4942217323). The React component entry reports 12–21% mount improvements from browser benchmarks; the store entry reports targeted Node benchmark gains reaching up to 49× the previous throughput.
