### PR TITLE
Create changeset overviews

### DIFF
--- a/.changeset/200-overview-react-components.md
+++ b/.changeset/200-overview-react-components.md
@@ -1,0 +1,8 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Overview
+
+This version adds React Compiler-compatible form hooks and side-specific popover overflow padding, improves store and component performance, and refines modal scroll locking and native button markup. It also includes fixes for Korean IME focus, controlled `NaN` values, and focus-visible styling.

--- a/.changeset/200-overview-react-store.md
+++ b/.changeset/200-overview-react-store.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/react-store": patch
+---
+
+Overview
+
+This version adds keyed selector subscriptions to reduce updates from unrelated state changes, lowers React store subscription overhead, and fixes unnecessary controlled `NaN` callbacks and subscriptions with `NaN` keys.


### PR DESCRIPTION
## Motivation

The upcoming release contains multiple multi-paragraph changelog entries for the React packages. These packages need concise overviews that introduce the main release themes before the detailed updates.

## Solution

Add a shared overview changeset for `@ariakit/react-components` and `@ariakit/react`, since their release summaries overlap. Add a separate overview for `@ariakit/react-store`, whose changes focus on keyed subscriptions and `NaN` handling.

Each entry follows the required overview structure:

```md
Overview

This version ...
```
