### PR TITLE
Standardize changeset contributor credit wording

### DIFF
--- a/.changeset/200-dialog-scrollbar-gutter.md
+++ b/.changeset/200-dialog-scrollbar-gutter.md
@@ -26,4 +26,4 @@ The `--scrollbar-width` CSS variable is now only defined in the fallback path fo
 }
 ```
 
-Thanks to [@mirka](https://github.com/mirka) for reporting the issue, and to [@benrodrs](https://github.com/benrodrs) for documenting a workaround that informed this solution.
+Thanks to [@mirka](https://github.com/mirka) for reporting the issue, and [@benrodrs](https://github.com/benrodrs) for documenting a workaround that informed this solution.

--- a/.changeset/200-popover-overflow-padding.md
+++ b/.changeset/200-popover-overflow-padding.md
@@ -13,4 +13,4 @@ The [`overflowPadding`](https://ariakit.com/reference/popover#overflowpadding) p
 
 When [`overflowPadding`](https://ariakit.com/reference/popover#overflowpadding) is an object, the [`--popover-overflow-padding`](https://ariakit.com/guide/styling#--popover-overflow-padding) CSS variable uses the larger of the horizontal `left` and `right` values, treating omitted sides as `0`.
 
-Thanks to [@mririgoyen](https://github.com/mririgoyen) for reporting the issue, and to [@georgekaran](https://github.com/georgekaran) for providing the approach that informed this solution.
+Thanks to [@mririgoyen](https://github.com/mririgoyen) for reporting the issue, and [@georgekaran](https://github.com/georgekaran) for providing the approach that informed this solution.


### PR DESCRIPTION
## Motivation

Current unreleased changesets repeat `to` before later contributor clauses:

```md
Thanks to A for X, and to B for Y.
```

Contributor credits should instead use one leading `Thanks to` for the complete natural-language list.

## Solution

Updated every applicable current changeset to remove only the repeated preposition while preserving contributor links, contribution descriptions, ordering, and all unrelated content:

```md
Thanks to A for X, and B for Y.
```

## Verification

- Ran `pnpm lint-fix`.
- Ran `pnpm changeset status`.
- Ran `git diff --check`.
- Scanned all current changeset credit sentences and confirmed no repeated contributor `and to` wording remains.

## Follow-up

The shared contributor-credit guidance in the [Ariakit skills repository](https://github.com/ariakit/skills) still documents the older repeated `and to` form. It should be aligned separately through the skill-update workflow so future authoring guidance matches this convention.
