### PR TITLE
Fix initially open sibling dialogs

### DIFF
--- a/.changeset/300-initial-sibling-dialogs.md
+++ b/.changeset/300-initial-sibling-dialogs.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed initially open sibling [`Dialog`](https://ariakit.com/reference/dialog) components so the frontmost dialog remains interactive. Thanks to [@yishayhaz](https://github.com/yishayhaz).

--- a/app/src/sandbox/dialog-5238-nested/index.react.tsx
+++ b/app/src/sandbox/dialog-5238-nested/index.react.tsx
@@ -1,0 +1,43 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+
+export default function Example() {
+  const [childOpen, setChildOpen] = useState(true);
+  const [parentInteractions, setParentInteractions] = useState(0);
+  const [childInteractions, setChildInteractions] = useState(0);
+
+  return (
+    <Ariakit.Dialog open portal={false} backdrop={false}>
+      <Ariakit.DialogHeading>Parent</Ariakit.DialogHeading>
+      <button
+        type="button"
+        onClick={() => setParentInteractions((count) => count + 1)}
+      >
+        Interact with parent
+      </button>
+      <div role="status" aria-label="Parent count">
+        Parent interactions: {parentInteractions}
+      </div>
+
+      <Ariakit.Dialog
+        open={childOpen}
+        onClose={() => setChildOpen(false)}
+        portal={false}
+        backdrop={false}
+        unmountOnHide
+      >
+        <Ariakit.DialogHeading>Child</Ariakit.DialogHeading>
+        <button
+          type="button"
+          onClick={() => setChildInteractions((count) => count + 1)}
+        >
+          Interact with child
+        </button>
+        <div role="status" aria-label="Child count">
+          Child interactions: {childInteractions}
+        </div>
+        <Ariakit.DialogDismiss>Close child</Ariakit.DialogDismiss>
+      </Ariakit.Dialog>
+    </Ariakit.Dialog>
+  );
+}

--- a/app/src/sandbox/dialog-5238-nested/index.react.tsx
+++ b/app/src/sandbox/dialog-5238-nested/index.react.tsx
@@ -2,42 +2,107 @@ import * as Ariakit from "@ariakit/react";
 import { useState } from "react";
 
 export default function Example() {
+  const [parentOpen, setParentOpen] = useState(true);
+  const [parentPortal, setParentPortal] = useState(false);
   const [childOpen, setChildOpen] = useState(true);
+  const [childPortal, setChildPortal] = useState(false);
+  const [siblingOpen, setSiblingOpen] = useState(false);
+  const [remountKey, setRemountKey] = useState(0);
   const [parentInteractions, setParentInteractions] = useState(0);
   const [childInteractions, setChildInteractions] = useState(0);
+  const [siblingInteractions, setSiblingInteractions] = useState(0);
 
   return (
-    <Ariakit.Dialog open portal={false} backdrop={false}>
-      <Ariakit.DialogHeading>Parent</Ariakit.DialogHeading>
-      <button
-        type="button"
-        onClick={() => setParentInteractions((count) => count + 1)}
+    <>
+      <Ariakit.Dialog
+        key={remountKey}
+        open={parentOpen}
+        portal={parentPortal}
+        backdrop={false}
+        unmountOnHide={false}
       >
-        Interact with parent
-      </button>
-      <div role="status" aria-label="Parent count">
-        Parent interactions: {parentInteractions}
-      </div>
+        <Ariakit.DialogHeading>Parent</Ariakit.DialogHeading>
+        <button
+          type="button"
+          onClick={() => setParentInteractions((count) => count + 1)}
+        >
+          Interact with parent
+        </button>
+        <div role="status" aria-label="Parent count">
+          Parent interactions: {parentInteractions}
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            setParentOpen(true);
+            setChildOpen(true);
+            setChildPortal(true);
+            setRemountKey((key) => key + 1);
+          }}
+        >
+          Remount with portaled child
+        </button>
+
+        <Ariakit.Dialog
+          open={childOpen}
+          onClose={() => setChildOpen(false)}
+          portal={childPortal}
+          backdrop={false}
+          unmountOnHide
+        >
+          <Ariakit.DialogHeading>Child</Ariakit.DialogHeading>
+          <button
+            type="button"
+            onClick={() => setChildInteractions((count) => count + 1)}
+          >
+            Interact with child
+          </button>
+          <div role="status" aria-label="Child count">
+            Child interactions: {childInteractions}
+          </div>
+          <button type="button" onClick={() => setChildPortal(true)}>
+            Move child to portal
+          </button>
+          <button type="button" onClick={() => setParentOpen(false)}>
+            Hide parent
+          </button>
+          <button type="button" onClick={() => setParentOpen(true)}>
+            Show parent
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setParentOpen(true);
+              setParentPortal(true);
+              setChildOpen(true);
+              setChildPortal(true);
+              setSiblingOpen(true);
+              setRemountKey((key) => key + 1);
+            }}
+          >
+            Remount portaled branch with sibling
+          </button>
+          <Ariakit.DialogDismiss>Close child</Ariakit.DialogDismiss>
+        </Ariakit.Dialog>
+      </Ariakit.Dialog>
 
       <Ariakit.Dialog
-        open={childOpen}
-        onClose={() => setChildOpen(false)}
-        portal={false}
+        open={siblingOpen}
+        onClose={() => setSiblingOpen(false)}
         backdrop={false}
         unmountOnHide
       >
-        <Ariakit.DialogHeading>Child</Ariakit.DialogHeading>
+        <Ariakit.DialogHeading>Sibling</Ariakit.DialogHeading>
         <button
           type="button"
-          onClick={() => setChildInteractions((count) => count + 1)}
+          onClick={() => setSiblingInteractions((count) => count + 1)}
         >
-          Interact with child
+          Interact with sibling
         </button>
-        <div role="status" aria-label="Child count">
-          Child interactions: {childInteractions}
+        <div role="status" aria-label="Sibling count">
+          Sibling interactions: {siblingInteractions}
         </div>
-        <Ariakit.DialogDismiss>Close child</Ariakit.DialogDismiss>
       </Ariakit.Dialog>
-    </Ariakit.Dialog>
+    </>
   );
 }

--- a/app/src/sandbox/dialog-5238-nested/test-browser.ts
+++ b/app/src/sandbox/dialog-5238-nested/test-browser.ts
@@ -1,4 +1,9 @@
+import type { Locator } from "@playwright/test";
 import { withFramework } from "#app/test-utils/preview.ts";
+
+function isInert(locator: Locator) {
+  return locator.evaluate((element) => element.closest("[inert]") !== null);
+}
 
 withFramework(import.meta.dirname, async ({ test }) => {
   // Reproduces https://github.com/ariakit/ariakit/issues/5238
@@ -14,6 +19,14 @@ withFramework(import.meta.dirname, async ({ test }) => {
       .expect(q.status("Child count"))
       .toHaveText("Child interactions: 1");
 
+    await q.button("Move child to portal").click();
+    await test.expect.poll(() => isInert(q.dialog("Parent"))).toBe(true);
+    await test.expect(q.dialog("Child")).toBeVisible();
+    await q.button("Interact with child").click();
+    await test
+      .expect(q.status("Child count"))
+      .toHaveText("Child interactions: 2");
+
     await q.button("Close child").click();
     await test.expect(q.dialog("Child")).not.toBeVisible();
     await test.expect(q.dialog("Parent")).toBeVisible();
@@ -21,5 +34,45 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test
       .expect(q.status("Parent count"))
       .toHaveText("Parent interactions: 1");
+
+    await q.button("Remount with portaled child").click();
+    await test.expect.poll(() => isInert(q.dialog("Parent"))).toBe(true);
+    await test.expect(q.dialog("Child")).toBeVisible();
+    await q.button("Interact with child").click();
+    await test
+      .expect(q.status("Child count"))
+      .toHaveText("Child interactions: 3");
+  });
+
+  test("keeps a portaled child in front when its parent reopens", async ({
+    q,
+  }) => {
+    await q.button("Move child to portal").click();
+    await q.button("Hide parent").click();
+    await test.expect(q.dialog("Parent")).not.toBeVisible();
+    await test.expect(q.dialog("Child")).toBeVisible();
+
+    await q.button("Show parent").click();
+    await test.expect.poll(() => isInert(q.dialog("Parent"))).toBe(true);
+    await test.expect(q.dialog("Child")).toBeVisible();
+    await q.button("Interact with child").click();
+    await test
+      .expect(q.status("Child count"))
+      .toHaveText("Child interactions: 1");
+  });
+
+  test("keeps a later sibling in front of a portaled nested branch", async ({
+    q,
+  }) => {
+    await q.button("Remount portaled branch with sibling").click();
+
+    await test.expect.poll(() => isInert(q.dialog("Parent"))).toBe(true);
+    await test.expect.poll(() => isInert(q.dialog("Child"))).toBe(true);
+    await test.expect(q.dialog("Sibling")).toBeVisible();
+    await test.expect.poll(() => isInert(q.dialog("Sibling"))).toBe(false);
+    await q.button("Interact with sibling").click();
+    await test
+      .expect(q.status("Sibling count"))
+      .toHaveText("Sibling interactions: 1");
   });
 });

--- a/app/src/sandbox/dialog-5238-nested/test-browser.ts
+++ b/app/src/sandbox/dialog-5238-nested/test-browser.ts
@@ -1,0 +1,25 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // Reproduces https://github.com/ariakit/ariakit/issues/5238
+  test("keeps an initially open inline nested dialog in front", async ({
+    page,
+    q,
+  }) => {
+    await test.expect(page.locator("[data-dialog]")).toHaveCount(2);
+    await test.expect(q.dialog("Parent")).not.toBeVisible();
+    await test.expect(q.dialog("Child")).toBeVisible();
+    await q.button("Interact with child").click();
+    await test
+      .expect(q.status("Child count"))
+      .toHaveText("Child interactions: 1");
+
+    await q.button("Close child").click();
+    await test.expect(q.dialog("Child")).not.toBeVisible();
+    await test.expect(q.dialog("Parent")).toBeVisible();
+    await q.button("Interact with parent").click();
+    await test
+      .expect(q.status("Parent count"))
+      .toHaveText("Parent interactions: 1");
+  });
+});

--- a/app/src/sandbox/dialog-5238-nested/test.ts
+++ b/app/src/sandbox/dialog-5238-nested/test.ts
@@ -1,0 +1,17 @@
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/5238
+test("keeps an initially open inline nested dialog in front", async () => {
+  expect(document.querySelectorAll("[data-dialog]")).toHaveLength(2);
+  expect(q.dialog("Parent")).not.toBeInTheDocument();
+  expect(q.dialog("Child")).toBeVisible();
+  await click(q.button("Interact with child"));
+  expect(q.status("Child count")).toHaveTextContent("Child interactions: 1");
+
+  await click(q.button("Close child"));
+  expect(q.dialog.hidden("Child")).not.toBeInTheDocument();
+  expect(q.dialog("Parent")).toBeVisible();
+  await click(q.button("Interact with parent"));
+  expect(q.status("Parent count")).toHaveTextContent("Parent interactions: 1");
+});

--- a/app/src/sandbox/dialog-5238-nested/test.ts
+++ b/app/src/sandbox/dialog-5238-nested/test.ts
@@ -9,9 +9,46 @@ test("keeps an initially open inline nested dialog in front", async () => {
   await click(q.button("Interact with child"));
   expect(q.status("Child count")).toHaveTextContent("Child interactions: 1");
 
+  await click(q.button("Move child to portal"));
+  expect(q.dialog("Parent")).not.toBeInTheDocument();
+  expect(q.dialog("Child")).toBeVisible();
+  await click(q.button("Interact with child"));
+  expect(q.status("Child count")).toHaveTextContent("Child interactions: 2");
+
   await click(q.button("Close child"));
   expect(q.dialog.hidden("Child")).not.toBeInTheDocument();
   expect(q.dialog("Parent")).toBeVisible();
   await click(q.button("Interact with parent"));
   expect(q.status("Parent count")).toHaveTextContent("Parent interactions: 1");
+
+  await click(q.button("Remount with portaled child"));
+  expect(q.dialog("Parent")).not.toBeInTheDocument();
+  expect(q.dialog("Child")).toBeVisible();
+  await click(q.button("Interact with child"));
+  expect(q.status("Child count")).toHaveTextContent("Child interactions: 3");
+});
+
+test("keeps a portaled child in front when its parent reopens", async () => {
+  await click(q.button("Move child to portal"));
+  await click(q.button("Hide parent"));
+  expect(q.dialog("Parent")).not.toBeInTheDocument();
+  expect(q.dialog("Child")).toBeVisible();
+
+  await click(q.button("Show parent"));
+  expect(q.dialog("Parent")).not.toBeInTheDocument();
+  expect(q.dialog("Child")).toBeVisible();
+  await click(q.button("Interact with child"));
+  expect(q.status("Child count")).toHaveTextContent("Child interactions: 1");
+});
+
+test("keeps a later sibling in front of a portaled nested branch", async () => {
+  await click(q.button("Remount portaled branch with sibling"));
+
+  expect(q.dialog("Parent")).not.toBeInTheDocument();
+  expect(q.dialog("Child")).not.toBeInTheDocument();
+  expect(q.dialog("Sibling")).toBeVisible();
+  await click(q.button("Interact with sibling"));
+  expect(q.status("Sibling count")).toHaveTextContent(
+    "Sibling interactions: 1",
+  );
 });

--- a/app/src/sandbox/dialog-5238/index.react.tsx
+++ b/app/src/sandbox/dialog-5238/index.react.tsx
@@ -1,0 +1,61 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+
+export default function Example() {
+  const [orangesOpen, setOrangesOpen] = useState(true);
+  const [applesOpen, setApplesOpen] = useState(true);
+  const [orangesEaten, setOrangesEaten] = useState(0);
+  const [applesEaten, setApplesEaten] = useState(0);
+
+  return (
+    <>
+      <Ariakit.Dialog
+        open={orangesOpen}
+        onClose={() => setOrangesOpen(false)}
+        unmountOnHide
+        className="fixed inset-3 m-auto flex h-fit w-72 flex-col items-start gap-3 rounded-lg border border-gray-300 bg-white p-4 shadow-lg"
+      >
+        <Ariakit.DialogHeading className="text-lg font-medium">
+          Oranges
+        </Ariakit.DialogHeading>
+        <button
+          type="button"
+          className="rounded bg-orange-600 px-3 py-1 text-white"
+          onClick={() => setOrangesEaten((count) => count + 1)}
+        >
+          Eat orange
+        </button>
+        <div role="status" aria-label="Orange count">
+          Oranges eaten: {orangesEaten}
+        </div>
+        <Ariakit.DialogDismiss className="rounded border border-gray-300 px-3 py-1">
+          Close oranges
+        </Ariakit.DialogDismiss>
+      </Ariakit.Dialog>
+
+      <Ariakit.Dialog
+        open={applesOpen}
+        onClose={() => setApplesOpen(false)}
+        unmountOnHide
+        className="fixed inset-3 m-auto flex h-fit w-72 translate-x-6 translate-y-6 flex-col items-start gap-3 rounded-lg border border-gray-300 bg-white p-4 shadow-lg"
+      >
+        <Ariakit.DialogHeading className="text-lg font-medium">
+          Apples
+        </Ariakit.DialogHeading>
+        <button
+          type="button"
+          className="rounded bg-red-600 px-3 py-1 text-white"
+          onClick={() => setApplesEaten((count) => count + 1)}
+        >
+          Eat apple
+        </button>
+        <div role="status" aria-label="Apple count">
+          Apples eaten: {applesEaten}
+        </div>
+        <Ariakit.DialogDismiss className="rounded border border-gray-300 px-3 py-1">
+          Close apples
+        </Ariakit.DialogDismiss>
+      </Ariakit.Dialog>
+    </>
+  );
+}

--- a/app/src/sandbox/dialog-5238/index.react.tsx
+++ b/app/src/sandbox/dialog-5238/index.react.tsx
@@ -1,17 +1,23 @@
 import * as Ariakit from "@ariakit/react";
-import { useState } from "react";
+import { useId, useState } from "react";
 
 export default function Example() {
   const [orangesOpen, setOrangesOpen] = useState(true);
   const [applesOpen, setApplesOpen] = useState(true);
   const [orangesEaten, setOrangesEaten] = useState(0);
   const [applesEaten, setApplesEaten] = useState(0);
+  const applesDialogId = useId();
 
   return (
     <>
       <Ariakit.Dialog
         open={orangesOpen}
         onClose={() => setOrangesOpen(false)}
+        // Work around #5238 by preserving the foreground sibling dialog.
+        getPersistentElements={() => {
+          const applesDialog = document.getElementById(applesDialogId);
+          return applesDialog ? [applesDialog] : [];
+        }}
         unmountOnHide
         className="fixed inset-3 m-auto flex h-fit w-72 flex-col items-start gap-3 rounded-lg border border-gray-300 bg-white p-4 shadow-lg"
       >
@@ -34,6 +40,7 @@ export default function Example() {
       </Ariakit.Dialog>
 
       <Ariakit.Dialog
+        id={applesDialogId}
         open={applesOpen}
         onClose={() => setApplesOpen(false)}
         unmountOnHide

--- a/app/src/sandbox/dialog-5238/index.react.tsx
+++ b/app/src/sandbox/dialog-5238/index.react.tsx
@@ -6,12 +6,21 @@ export default function Example() {
   const [applesOpen, setApplesOpen] = useState(true);
   const [orangesEaten, setOrangesEaten] = useState(0);
   const [applesEaten, setApplesEaten] = useState(0);
+  const [replaceApplesBackdrop, setReplaceApplesBackdrop] = useState(false);
+  const [replaceOrangesDialog, setReplaceOrangesDialog] = useState(false);
 
   return (
     <>
       <Ariakit.Dialog
         open={orangesOpen}
         onClose={() => setOrangesOpen(false)}
+        render={
+          replaceOrangesDialog ? (
+            <div key="replacement" data-replacement-dialog="" />
+          ) : (
+            <div key="initial" />
+          )
+        }
         unmountOnHide
         className="fixed inset-3 m-auto flex h-fit w-72 flex-col items-start gap-3 rounded-lg border border-gray-300 bg-white p-4 shadow-lg"
       >
@@ -36,6 +45,13 @@ export default function Example() {
       <Ariakit.Dialog
         open={applesOpen}
         onClose={() => setApplesOpen(false)}
+        backdrop={
+          replaceApplesBackdrop ? (
+            <div key="replacement" data-replacement-backdrop="" />
+          ) : (
+            true
+          )
+        }
         unmountOnHide
         className="fixed inset-3 m-auto flex h-fit w-72 translate-x-6 translate-y-6 flex-col items-start gap-3 rounded-lg border border-gray-300 bg-white p-4 shadow-lg"
       >
@@ -52,6 +68,12 @@ export default function Example() {
         <div role="status" aria-label="Apple count">
           Apples eaten: {applesEaten}
         </div>
+        <button type="button" onClick={() => setReplaceApplesBackdrop(true)}>
+          Replace apple backdrop
+        </button>
+        <button type="button" onClick={() => setReplaceOrangesDialog(true)}>
+          Replace orange dialog
+        </button>
         <Ariakit.DialogDismiss className="rounded border border-gray-300 px-3 py-1">
           Close apples
         </Ariakit.DialogDismiss>

--- a/app/src/sandbox/dialog-5238/index.react.tsx
+++ b/app/src/sandbox/dialog-5238/index.react.tsx
@@ -1,23 +1,17 @@
 import * as Ariakit from "@ariakit/react";
-import { useId, useState } from "react";
+import { useState } from "react";
 
 export default function Example() {
   const [orangesOpen, setOrangesOpen] = useState(true);
   const [applesOpen, setApplesOpen] = useState(true);
   const [orangesEaten, setOrangesEaten] = useState(0);
   const [applesEaten, setApplesEaten] = useState(0);
-  const applesDialogId = useId();
 
   return (
     <>
       <Ariakit.Dialog
         open={orangesOpen}
         onClose={() => setOrangesOpen(false)}
-        // Work around #5238 by preserving the foreground sibling dialog.
-        getPersistentElements={() => {
-          const applesDialog = document.getElementById(applesDialogId);
-          return applesDialog ? [applesDialog] : [];
-        }}
         unmountOnHide
         className="fixed inset-3 m-auto flex h-fit w-72 flex-col items-start gap-3 rounded-lg border border-gray-300 bg-white p-4 shadow-lg"
       >
@@ -40,7 +34,6 @@ export default function Example() {
       </Ariakit.Dialog>
 
       <Ariakit.Dialog
-        id={applesDialogId}
         open={applesOpen}
         onClose={() => setApplesOpen(false)}
         unmountOnHide

--- a/app/src/sandbox/dialog-5238/index.react.tsx
+++ b/app/src/sandbox/dialog-5238/index.react.tsx
@@ -1,19 +1,61 @@
 import * as Ariakit from "@ariakit/react";
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+function createThirdPartyPortal(doc: Document) {
+  const portal = doc.createElement("div");
+  portal.dataset.thirdPartyPortal = "";
+  return portal;
+}
 
 export default function Example() {
   const [orangesOpen, setOrangesOpen] = useState(true);
   const [applesOpen, setApplesOpen] = useState(true);
+  const [orangesPortal, setOrangesPortal] = useState(true);
+  const [applesPortal, setApplesPortal] = useState(true);
+  const [orangesCustomPortal, setOrangesCustomPortal] = useState(false);
   const [orangesEaten, setOrangesEaten] = useState(0);
   const [applesEaten, setApplesEaten] = useState(0);
   const [replaceApplesBackdrop, setReplaceApplesBackdrop] = useState(false);
   const [replaceOrangesDialog, setReplaceOrangesDialog] = useState(false);
+  const [thirdPartyPortal, setThirdPartyPortal] = useState<HTMLElement | null>(
+    null,
+  );
+  const [thirdPartyInteractions, setThirdPartyInteractions] = useState(0);
+  const fullscreenHostRef = useRef<HTMLDivElement>(null);
+  const getCustomPortal = useCallback((dialog: HTMLElement) => {
+    const portal = dialog.ownerDocument.createElement("div");
+    portal.dataset.customPortal = "";
+    return portal;
+  }, []);
+
+  useEffect(() => {
+    if (!thirdPartyPortal) return;
+    thirdPartyPortal.ownerDocument.body.append(thirdPartyPortal);
+    return () => thirdPartyPortal.remove();
+  }, [thirdPartyPortal]);
 
   return (
     <>
+      <div ref={fullscreenHostRef} data-fullscreen-host="" />
+      <button
+        type="button"
+        onClick={() => {
+          setOrangesCustomPortal(false);
+          setOrangesPortal(false);
+          setApplesPortal(false);
+          setOrangesOpen(true);
+          setApplesOpen(false);
+        }}
+      >
+        Open inline orange dialog
+      </button>
+
       <Ariakit.Dialog
         open={orangesOpen}
         onClose={() => setOrangesOpen(false)}
+        portal={orangesPortal}
+        portalElement={orangesCustomPortal ? getCustomPortal : undefined}
         render={
           replaceOrangesDialog ? (
             <div key="replacement" data-replacement-dialog="" />
@@ -21,7 +63,6 @@ export default function Example() {
             <div key="initial" />
           )
         }
-        unmountOnHide
         className="fixed inset-3 m-auto flex h-fit w-72 flex-col items-start gap-3 rounded-lg border border-gray-300 bg-white p-4 shadow-lg"
       >
         <Ariakit.DialogHeading className="text-lg font-medium">
@@ -37,6 +78,27 @@ export default function Example() {
         <div role="status" aria-label="Orange count">
           Oranges eaten: {orangesEaten}
         </div>
+        <button type="button" onClick={() => setApplesOpen(true)}>
+          Open apples
+        </button>
+        <button
+          type="button"
+          onClick={(event) => {
+            setThirdPartyPortal(
+              createThirdPartyPortal(event.currentTarget.ownerDocument),
+            );
+          }}
+        >
+          Open third-party dialog
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            void fullscreenHostRef.current?.requestFullscreen();
+          }}
+        >
+          Enter fullscreen
+        </button>
         <Ariakit.DialogDismiss className="rounded border border-gray-300 px-3 py-1">
           Close oranges
         </Ariakit.DialogDismiss>
@@ -45,6 +107,7 @@ export default function Example() {
       <Ariakit.Dialog
         open={applesOpen}
         onClose={() => setApplesOpen(false)}
+        portal={applesPortal}
         backdrop={
           replaceApplesBackdrop ? (
             <div key="replacement" data-replacement-backdrop="" />
@@ -74,10 +137,53 @@ export default function Example() {
         <button type="button" onClick={() => setReplaceOrangesDialog(true)}>
           Replace orange dialog
         </button>
+        <button type="button" onClick={() => setOrangesOpen((open) => !open)}>
+          {orangesOpen ? "Hide orange dialog" : "Show orange dialog"}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setOrangesOpen(false);
+            setApplesOpen(false);
+          }}
+        >
+          Close both dialogs
+        </button>
+        <button type="button" onClick={() => setOrangesPortal(true)}>
+          Move orange dialog to portal
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setOrangesCustomPortal(true);
+            setOrangesPortal(true);
+          }}
+        >
+          Move orange dialog to custom portal
+        </button>
         <Ariakit.DialogDismiss className="rounded border border-gray-300 px-3 py-1">
           Close apples
         </Ariakit.DialogDismiss>
       </Ariakit.Dialog>
+
+      {thirdPartyPortal &&
+        createPortal(
+          <div role="dialog" aria-label="Third-party">
+            <button type="button" onClick={() => setApplesOpen(true)}>
+              Open apples from third-party
+            </button>
+            <button
+              type="button"
+              onClick={() => setThirdPartyInteractions((count) => count + 1)}
+            >
+              Interact with third-party
+            </button>
+            <div role="status" aria-label="Third-party count">
+              Third-party interactions: {thirdPartyInteractions}
+            </div>
+          </div>,
+          thirdPartyPortal,
+        )}
     </>
   );
 }

--- a/app/src/sandbox/dialog-5238/test-browser.ts
+++ b/app/src/sandbox/dialog-5238/test-browser.ts
@@ -1,4 +1,9 @@
+import type { Locator } from "@playwright/test";
 import { withFramework } from "#app/test-utils/preview.ts";
+
+function isInert(locator: Locator) {
+  return locator.evaluate((element) => element.closest("[inert]") !== null);
+}
 
 withFramework(import.meta.dirname, async ({ test }) => {
   // Reproduces https://github.com/ariakit/ariakit/issues/5238
@@ -7,6 +12,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
     q,
   }) => {
     await test.expect(q.dialog("Apples")).toBeVisible();
+    await test.expect.poll(() => isInert(q.dialog("Oranges"))).toBe(true);
     await q.button("Eat apple").click();
     await test.expect(q.status("Apple count")).toHaveText("Apples eaten: 1");
 
@@ -17,7 +23,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.dialog("Apples")).not.toBeVisible();
     await test.expect(page.locator("[data-dialog]")).toHaveCount(1);
     await test.expect(q.dialog("Oranges")).toBeVisible();
-    await q.button("Eat orange").click();
+    await q.button("Eat orange").press("Enter");
     await test.expect(q.status("Orange count")).toHaveText("Oranges eaten: 1");
   });
 
@@ -53,6 +59,122 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
     await test.expect(page.locator("[data-replacement-dialog]")).toBeVisible();
     await test.expect(q.dialog("Apples")).toBeVisible();
+    await test.expect.poll(() => isInert(q.dialog("Oranges"))).toBe(true);
+    await q.button("Eat apple").click();
+    await test.expect(q.status("Apple count")).toHaveText("Apples eaten: 1");
+  });
+
+  test("keeps an inline replacement behind the foreground dialog", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Close both dialogs").click();
+    await q.button("Open inline orange dialog").click();
+    await q.button("Open apples").click();
+    await q.button("Replace orange dialog").click();
+
+    await test.expect(page.locator("[data-replacement-dialog]")).toBeVisible();
+    await test.expect(q.dialog("Apples")).toBeVisible();
+    await test.expect.poll(() => isInert(q.dialog("Oranges"))).toBe(true);
+  });
+
+  test("keeps a custom-portaled background dialog inert", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Close both dialogs").click();
+    await q.button("Open inline orange dialog").click();
+    await q.button("Open apples").click();
+    await test.expect.poll(() => isInert(q.dialog("Oranges"))).toBe(true);
+    await q.button("Move orange dialog to custom portal").click();
+
+    await test.expect(page.locator("[data-custom-portal]")).toHaveCount(1);
+    await test.expect(q.dialog("Apples")).toBeVisible();
+    await test.expect.poll(() => isInert(q.dialog("Oranges"))).toBe(true);
+  });
+
+  test("keeps a reopened mounted sibling above the previous foreground", async ({
+    q,
+  }) => {
+    await q.button("Hide orange dialog").click();
+    await test.expect(q.dialog("Apples")).toBeVisible();
+
+    await q.button("Show orange dialog").click();
+    await test.expect(q.dialog("Oranges")).toBeVisible();
+    await test.expect.poll(() => isInert(q.dialog("Apples"))).toBe(true);
+    await q.button("Eat orange").click();
+    await test.expect(q.status("Orange count")).toHaveText("Oranges eaten: 1");
+  });
+
+  test("preserves third-party dialogs mounted after the background dialog", async ({
+    q,
+  }) => {
+    await q.button("Close apples").click();
+    await q.button("Open third-party dialog").click();
+    await test.expect(q.dialog("Third-party")).toBeVisible();
+    await test.expect.poll(() => isInert(q.dialog("Third-party"))).toBe(false);
+
+    await q.button("Open apples from third-party").press("Enter");
+    await test.expect(q.dialog("Apples")).toBeVisible();
+    await q.button("Close apples").click();
+
+    await test.expect(q.dialog("Third-party")).toBeVisible();
+    await test.expect.poll(() => isInert(q.dialog("Third-party"))).toBe(false);
+    await q.button("Interact with third-party").press("Enter");
+    await test
+      .expect(q.status("Third-party count"))
+      .toHaveText("Third-party interactions: 1");
+  });
+
+  test("preserves reopened sibling order in fullscreen", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Hide orange dialog").click();
+    await q.button("Show orange dialog").click();
+    await test.expect.poll(() => isInert(q.dialog("Oranges"))).toBe(false);
+    await test.expect.poll(() => isInert(q.dialog("Apples"))).toBe(true);
+    await q.button("Enter fullscreen").click();
+
+    const host = page.locator("[data-fullscreen-host]");
+    await page.waitForFunction(() => document.fullscreenElement != null);
+    await test.expect
+      .poll(() =>
+        host
+          .locator(":scope > div")
+          .evaluateAll((portals) =>
+            portals.flatMap((portal) =>
+              Array.from(
+                portal.querySelectorAll("[data-dialog]"),
+                (dialog) =>
+                  dialog.getAttribute("aria-label") ||
+                  dialog.getAttribute("aria-labelledby"),
+              ),
+            ),
+          ),
+      )
+      .toEqual([
+        await q.dialog("Apples").getAttribute("aria-labelledby"),
+        await q.dialog("Oranges").getAttribute("aria-labelledby"),
+      ]);
+    await test.expect.poll(() => isInert(q.dialog("Apples"))).toBe(true);
+    await test.expect.poll(() => isInert(q.dialog("Oranges"))).toBe(false);
+    await q.button("Eat orange").click();
+    await test.expect(q.status("Orange count")).toHaveText("Oranges eaten: 1");
+  });
+
+  test("preserves sibling order when the background moves into a portal", async ({
+    q,
+  }) => {
+    await q.button("Close both dialogs").click();
+    await q.button("Open inline orange dialog").click();
+    await q.button("Open apples").click();
+
+    await test.expect(q.dialog("Apples")).toBeVisible();
+    await test.expect.poll(() => isInert(q.dialog("Oranges"))).toBe(true);
+    await q.button("Move orange dialog to portal").click();
+    await test.expect(q.dialog("Apples")).toBeVisible();
+    await test.expect.poll(() => isInert(q.dialog("Oranges"))).toBe(true);
     await q.button("Eat apple").click();
     await test.expect(q.status("Apple count")).toHaveText("Apples eaten: 1");
   });

--- a/app/src/sandbox/dialog-5238/test-browser.ts
+++ b/app/src/sandbox/dialog-5238/test-browser.ts
@@ -1,0 +1,18 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // Reproduces https://github.com/ariakit/ariakit/issues/5238
+  test("keeps the frontmost initially open sibling dialog interactive", async ({
+    q,
+  }) => {
+    await test.expect(q.dialog("Apples")).toBeVisible();
+    await q.button("Eat apple").click();
+    await test.expect(q.status("Apple count")).toHaveText("Apples eaten: 1");
+
+    await q.button("Close apples").click();
+    await test.expect(q.dialog("Apples")).not.toBeVisible();
+    await test.expect(q.dialog("Oranges")).toBeVisible();
+    await q.button("Eat orange").click();
+    await test.expect(q.status("Orange count")).toHaveText("Oranges eaten: 1");
+  });
+});

--- a/app/src/sandbox/dialog-5238/test-browser.ts
+++ b/app/src/sandbox/dialog-5238/test-browser.ts
@@ -3,16 +3,57 @@ import { withFramework } from "#app/test-utils/preview.ts";
 withFramework(import.meta.dirname, async ({ test }) => {
   // Reproduces https://github.com/ariakit/ariakit/issues/5238
   test("keeps the frontmost initially open sibling dialog interactive", async ({
+    page,
     q,
   }) => {
     await test.expect(q.dialog("Apples")).toBeVisible();
     await q.button("Eat apple").click();
     await test.expect(q.status("Apple count")).toHaveText("Apples eaten: 1");
 
-    await q.button("Close apples").click();
+    const applesId = await q.dialog("Apples").getAttribute("id");
+    await page
+      .locator(`[data-backdrop="${applesId}"]`)
+      .click({ button: "right", position: { x: 4, y: 4 } });
     await test.expect(q.dialog("Apples")).not.toBeVisible();
+    await test.expect(page.locator("[data-dialog]")).toHaveCount(1);
     await test.expect(q.dialog("Oranges")).toBeVisible();
     await q.button("Eat orange").click();
     await test.expect(q.status("Orange count")).toHaveText("Oranges eaten: 1");
+  });
+
+  // Reproduces the backdrop replacement case found while fixing #5238.
+  test("keeps the background open after replacing the foreground backdrop", async ({
+    page,
+    q,
+  }) => {
+    const applesId = await q.dialog("Apples").getAttribute("id");
+    const previousBackdrop = page.locator(`[data-backdrop="${applesId}"]`);
+    await previousBackdrop.evaluate((element) => {
+      element.setAttribute("data-previous-backdrop", "");
+    });
+
+    await q.button("Replace apple backdrop").click();
+    await test.expect(page.locator("[data-previous-backdrop]")).toHaveCount(0);
+
+    await page
+      .locator("[data-replacement-backdrop]")
+      .click({ button: "right", position: { x: 4, y: 4 } });
+
+    await test.expect(q.dialog("Apples")).not.toBeVisible();
+    await test.expect(page.locator("[data-dialog]")).toHaveCount(1);
+    await test.expect(q.dialog("Oranges")).toBeVisible();
+  });
+
+  // Reproduces the dialog host replacement case found while fixing #5238.
+  test("preserves the stack order when replacing the background dialog", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Replace orange dialog").click();
+
+    await test.expect(page.locator("[data-replacement-dialog]")).toBeVisible();
+    await test.expect(q.dialog("Apples")).toBeVisible();
+    await q.button("Eat apple").click();
+    await test.expect(q.status("Apple count")).toHaveText("Apples eaten: 1");
   });
 });

--- a/app/src/sandbox/dialog-5238/test.ts
+++ b/app/src/sandbox/dialog-5238/test.ts
@@ -1,0 +1,17 @@
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/5238
+test("keeps the frontmost initially open sibling dialog interactive", async () => {
+  expect(q.dialog.hidden("Apples")).toBeVisible();
+  expect(q.dialog.hidden("Oranges")).toBeVisible();
+  expect(q.dialog("Apples")).toBeVisible();
+  await click(q.button("Eat apple"));
+  expect(q.status("Apple count")).toHaveTextContent("Apples eaten: 1");
+
+  await click(q.button("Close apples"));
+  expect(q.dialog("Apples")).not.toBeInTheDocument();
+  expect(q.dialog("Oranges")).toBeVisible();
+  await click(q.button("Eat orange"));
+  expect(q.status("Orange count")).toHaveTextContent("Oranges eaten: 1");
+});

--- a/app/src/sandbox/dialog-5238/test.ts
+++ b/app/src/sandbox/dialog-5238/test.ts
@@ -12,6 +12,7 @@ test("keeps the frontmost initially open sibling dialog interactive", async () =
   expect(q.dialog.hidden("Apples")).toBeVisible();
   expect(q.dialog.hidden("Oranges")).toBeVisible();
   expect(q.dialog("Apples")).toBeVisible();
+  expect(q.dialog("Oranges")).not.toBeInTheDocument();
   await click(q.button("Eat apple"));
   expect(q.status("Apple count")).toHaveTextContent("Apples eaten: 1");
 
@@ -48,6 +49,71 @@ test("preserves the stack order when replacing the background dialog", async () 
 
   expect(document.querySelector("[data-replacement-dialog]")).toBeVisible();
   expect(q.dialog("Apples")).toBeVisible();
+  expect(q.dialog("Oranges")).not.toBeInTheDocument();
+  await click(q.button("Eat apple"));
+  expect(q.status("Apple count")).toHaveTextContent("Apples eaten: 1");
+});
+
+test("keeps an inline replacement behind the foreground dialog", async () => {
+  await click(q.button("Close both dialogs"));
+  await click(q.button("Open inline orange dialog"));
+  await click(q.button("Open apples"));
+  await click(q.button("Replace orange dialog"));
+
+  expect(document.querySelector("[data-replacement-dialog]")).toBeVisible();
+  expect(q.dialog("Apples")).toBeVisible();
+  expect(q.dialog("Oranges")).not.toBeInTheDocument();
+});
+
+test("keeps a custom-portaled background dialog inert", async () => {
+  await click(q.button("Close both dialogs"));
+  await click(q.button("Open inline orange dialog"));
+  await click(q.button("Open apples"));
+  expect(q.dialog("Oranges")).not.toBeInTheDocument();
+  await click(q.button("Move orange dialog to custom portal"));
+
+  expect(document.querySelector("[data-custom-portal]")).toBeInTheDocument();
+  expect(q.dialog("Apples")).toBeVisible();
+  expect(q.dialog("Oranges")).not.toBeInTheDocument();
+});
+
+test("keeps a reopened mounted sibling above the previous foreground", async () => {
+  await click(q.button("Hide orange dialog"));
+  expect(q.dialog("Apples")).toBeVisible();
+
+  await click(q.button("Show orange dialog"));
+  expect(q.dialog("Oranges")).toBeVisible();
+  expect(q.dialog("Apples")).not.toBeInTheDocument();
+  await click(q.button("Eat orange"));
+  expect(q.status("Orange count")).toHaveTextContent("Oranges eaten: 1");
+});
+
+test("preserves third-party dialogs mounted after the background dialog", async () => {
+  await click(q.button("Close apples"));
+  await click(q.button("Open third-party dialog"));
+  expect(q.dialog("Third-party")).toBeVisible();
+
+  await click(q.button("Open apples from third-party"));
+  expect(q.dialog("Apples")).toBeVisible();
+  await click(q.button("Close apples"));
+
+  expect(q.dialog("Third-party")).toBeVisible();
+  await click(q.button("Interact with third-party"));
+  expect(q.status("Third-party count")).toHaveTextContent(
+    "Third-party interactions: 1",
+  );
+});
+
+test("preserves sibling order when the background moves into a portal", async () => {
+  await click(q.button("Close both dialogs"));
+  await click(q.button("Open inline orange dialog"));
+  await click(q.button("Open apples"));
+
+  expect(q.dialog("Apples")).toBeVisible();
+  expect(q.dialog("Oranges")).not.toBeInTheDocument();
+  await click(q.button("Move orange dialog to portal"));
+  expect(q.dialog("Apples")).toBeVisible();
+  expect(q.dialog("Oranges")).not.toBeInTheDocument();
   await click(q.button("Eat apple"));
   expect(q.status("Apple count")).toHaveTextContent("Apples eaten: 1");
 });

--- a/app/src/sandbox/dialog-5238/test.ts
+++ b/app/src/sandbox/dialog-5238/test.ts
@@ -1,5 +1,11 @@
-import { click, q } from "@ariakit/test";
+import { click, q, rightClick } from "@ariakit/test";
 import { expect, test } from "vitest";
+
+function getBackdrop(name: string) {
+  const dialog = q.dialog.hidden(name);
+  const selector = `[data-backdrop="${dialog?.id}"]`;
+  return document.querySelector<HTMLElement>(selector);
+}
 
 // Reproduces https://github.com/ariakit/ariakit/issues/5238
 test("keeps the frontmost initially open sibling dialog interactive", async () => {
@@ -9,9 +15,38 @@ test("keeps the frontmost initially open sibling dialog interactive", async () =
   await click(q.button("Eat apple"));
   expect(q.status("Apple count")).toHaveTextContent("Apples eaten: 1");
 
-  await click(q.button("Close apples"));
+  await rightClick(getBackdrop("Apples"));
   expect(q.dialog("Apples")).not.toBeInTheDocument();
+  expect(document.querySelectorAll("[data-dialog]")).toHaveLength(1);
   expect(q.dialog("Oranges")).toBeVisible();
   await click(q.button("Eat orange"));
   expect(q.status("Orange count")).toHaveTextContent("Oranges eaten: 1");
+});
+
+// Reproduces the backdrop replacement case found while fixing #5238.
+test("keeps the background open after replacing the foreground backdrop", async () => {
+  const previousBackdrop = getBackdrop("Apples");
+  previousBackdrop?.setAttribute("data-previous-backdrop", "");
+
+  await click(q.button("Replace apple backdrop"));
+  expect(document.querySelector("[data-previous-backdrop]")).toBeNull();
+
+  const replacementBackdrop = document.querySelector<HTMLElement>(
+    "[data-replacement-backdrop]",
+  );
+  await rightClick(replacementBackdrop);
+
+  expect(q.dialog("Apples")).not.toBeInTheDocument();
+  expect(document.querySelectorAll("[data-dialog]")).toHaveLength(1);
+  expect(q.dialog("Oranges")).toBeVisible();
+});
+
+// Reproduces the dialog host replacement case found while fixing #5238.
+test("preserves the stack order when replacing the background dialog", async () => {
+  await click(q.button("Replace orange dialog"));
+
+  expect(document.querySelector("[data-replacement-dialog]")).toBeVisible();
+  expect(q.dialog("Apples")).toBeVisible();
+  await click(q.button("Eat apple"));
+  expect(q.status("Apple count")).toHaveTextContent("Apples eaten: 1");
 });

--- a/app/src/sandbox/dialog-5238/test.ts
+++ b/app/src/sandbox/dialog-5238/test.ts
@@ -26,7 +26,8 @@ test("keeps the frontmost initially open sibling dialog interactive", async () =
 // Reproduces the backdrop replacement case found while fixing #5238.
 test("keeps the background open after replacing the foreground backdrop", async () => {
   const previousBackdrop = getBackdrop("Apples");
-  previousBackdrop?.setAttribute("data-previous-backdrop", "");
+  expect(previousBackdrop).toBeInTheDocument();
+  previousBackdrop!.setAttribute("data-previous-backdrop", "");
 
   await click(q.button("Replace apple backdrop"));
   expect(document.querySelector("[data-previous-backdrop]")).toBeNull();

--- a/packages/ariakit-react-components/package.json
+++ b/packages/ariakit-react-components/package.json
@@ -115,6 +115,7 @@
     "./dialog/utils/prepend-hidden-dismiss": "./src/dialog/utils/prepend-hidden-dismiss.ts",
     "./dialog/utils/supports-inert": "./src/dialog/utils/supports-inert.ts",
     "./dialog/utils/tree-cleanup": "./src/dialog/utils/tree-cleanup.ts",
+    "./dialog/utils/use-dialog-stack": "./src/dialog/utils/use-dialog-stack.ts",
     "./dialog/utils/use-hide-on-interact-outside": "./src/dialog/utils/use-hide-on-interact-outside.ts",
     "./dialog/utils/use-nested-dialogs": "./src/dialog/utils/use-nested-dialogs.tsx",
     "./dialog/utils/use-prevent-body-scroll": "./src/dialog/utils/use-prevent-body-scroll.ts",

--- a/packages/ariakit-react-components/src/dialog/dialog-backdrop.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog-backdrop.tsx
@@ -1,7 +1,7 @@
 import { useStoreState } from "@ariakit/react-store";
-import { useMergeRefs, useSafeLayoutEffect } from "@ariakit/react-utils";
-import { isValidElement, useRef } from "react";
-import type { RefObject } from "react";
+import { useSafeLayoutEffect } from "@ariakit/react-utils";
+import { isValidElement } from "react";
+import type { Ref } from "react";
 import { useDisclosureContent } from "../disclosure/disclosure-content.tsx";
 import { useDisclosureStore } from "../disclosure/disclosure-store.ts";
 import { Role } from "../role/role.tsx";
@@ -14,7 +14,7 @@ interface DialogBackdropProps extends Pick<
   "backdrop" | "alwaysVisible" | "hidden"
 > {
   store: DialogStore;
-  backdropRef?: RefObject<HTMLDivElement | null>;
+  backdropRef?: Ref<HTMLDivElement>;
 }
 
 export function DialogBackdrop({
@@ -24,21 +24,21 @@ export function DialogBackdrop({
   alwaysVisible,
   hidden,
 }: DialogBackdropProps) {
-  const ref = useRef<HTMLDivElement>(null);
   const disclosure = useDisclosureStore({ disclosure: store });
   const contentElement = useStoreState(store, "contentElement");
+  const backdropElement = useStoreState(disclosure, "contentElement");
 
   // Synchronize the backdrop's z-index with the dialog's in the layout phase,
   // where the commit's style recalc absorbs the getComputedStyle read. As a
   // passive effect, this read ran after other effects had already written
   // styles, forcing an extra full style recalc on every open.
   useSafeLayoutEffect(() => {
-    const backdrop = ref.current;
+    const backdrop = backdropElement;
     const dialog = contentElement;
     if (!backdrop) return;
     if (!dialog) return;
     backdrop.style.zIndex = getComputedStyle(dialog).zIndex;
-  }, [contentElement]);
+  }, [backdropElement, contentElement]);
 
   // Mark the backdrop element as an ancestor of the dialog, otherwise clicking
   // on it won't close the dialog when the dialog uses portal, in which case
@@ -46,13 +46,13 @@ export function DialogBackdrop({
   useSafeLayoutEffect(() => {
     const id = contentElement?.id;
     if (!id) return;
-    const backdrop = ref.current;
+    const backdrop = backdropElement;
     if (!backdrop) return;
     return markAncestor(backdrop, id);
-  }, [contentElement]);
+  }, [backdropElement, contentElement]);
 
   const props = useDisclosureContent({
-    ref: useMergeRefs(ref, backdropRef),
+    ref: backdropRef,
     store: disclosure,
     role: "presentation",
     "data-backdrop": contentElement?.id || "",

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -153,7 +153,10 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
   // domReady can be also the portal node element so it's updated when the
   // portal node changes (like in between re-renders), triggering effects
   // again.
-  const { portalRef, domReady } = usePortalRef(portal, props.portalRef);
+  const { portalRef, portalNode, domReady } = usePortalRef(
+    portal,
+    props.portalRef,
+  );
   // Sets preserveTabOrder to true only if the dialog is not a modal and is
   // open.
   const preserveTabOrderProp = props.preserveTabOrder;
@@ -290,6 +293,19 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
   }, [open, mounted, domReady]);
 
   const canTakeTreeSnapshot = open && domReady;
+  const getPersistentElementsProp = useEvent(getPersistentElements);
+  const stackPortal = portal && !props.portalElement ? portalNode : null;
+  const [
+    stackedElements,
+    setStackBackdrop,
+    stackTopologyVersion,
+    backgroundStackElements,
+  ] = useDialogStack(contentElement, modal && open, {
+    portal: stackPortal,
+    store,
+    nestedDialogs,
+  });
+  const backdropRefs = useMergeRefs(backdropRef, setStackBackdrop);
 
   useSafeLayoutEffect(() => {
     if (!id) return;
@@ -305,13 +321,6 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     return createWalkTreeSnapshot(id, [dialog]);
   }, [id, canTakeTreeSnapshot, unstable_treeSnapshotKey]);
 
-  const getPersistentElementsProp = useEvent(getPersistentElements);
-  const [stackedElements, setStackBackdrop] = useDialogStack(
-    contentElement,
-    modal && !!canTakeTreeSnapshot,
-  );
-  const backdropRefs = useMergeRefs(backdropRef, setStackBackdrop);
-
   // Disables/enables the element tree around the modal dialog element.
   useSafeLayoutEffect(() => {
     if (!id) return;
@@ -325,6 +334,16 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
       ...stackedElements,
       ...nestedDialogs.map((dialog) => dialog.getState().contentElement),
     ];
+    // The opening snapshot intentionally excludes DOM mounted later. A
+    // background dialog can still replace or move its host while open, so
+    // disable its current elements directly without recapturing unrelated
+    // third-party DOM.
+    const backgroundElements = backgroundStackElements.filter(
+      (backgroundElement) =>
+        !allElements.some(
+          (element) => element && contains(backgroundElement, element),
+        ),
+    );
     // Positively mark the elements the dialog knows about as "inside" so the
     // outside event listeners can recognize them even before the dialog has
     // been focused. The disclosure is excluded because it can change while
@@ -336,6 +355,7 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
       return chain(
         restoreInsideMarks,
         markAndDisableTreeOutside(id, allElements),
+        ...backgroundElements.map((element) => disableTree(element)),
       );
     }
     return chain(
@@ -348,6 +368,8 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     canTakeTreeSnapshot,
     getPersistentElementsProp,
     stackedElements,
+    stackTopologyVersion,
+    backgroundStackElements,
     nestedDialogs,
     modal,
     unstable_treeSnapshotKey,

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -68,6 +68,7 @@ import {
 } from "./utils/mark-tree-outside.ts";
 import { prependHiddenDismiss } from "./utils/prepend-hidden-dismiss.ts";
 import { supportsInert } from "./utils/supports-inert.ts";
+import { useDialogStack } from "./utils/use-dialog-stack.ts";
 import { useHideOnInteractOutside } from "./utils/use-hide-on-interact-outside.ts";
 import { useNestedDialogs } from "./utils/use-nested-dialogs.tsx";
 import { usePreventBodyScroll } from "./utils/use-prevent-body-scroll.ts";
@@ -305,6 +306,10 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
   }, [id, canTakeTreeSnapshot, unstable_treeSnapshotKey]);
 
   const getPersistentElementsProp = useEvent(getPersistentElements);
+  const stackedDialogs = useDialogStack(
+    contentElement,
+    modal && !!canTakeTreeSnapshot,
+  );
 
   // Disables/enables the element tree around the modal dialog element.
   useSafeLayoutEffect(() => {
@@ -316,6 +321,7 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     const allElements = [
       dialog,
       ...persistentElements,
+      ...stackedDialogs,
       ...nestedDialogs.map((dialog) => dialog.getState().contentElement),
     ];
     // Positively mark the elements the dialog knows about as "inside" so the
@@ -340,6 +346,7 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     store,
     canTakeTreeSnapshot,
     getPersistentElementsProp,
+    stackedDialogs,
     nestedDialogs,
     modal,
     unstable_treeSnapshotKey,

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -306,10 +306,11 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
   }, [id, canTakeTreeSnapshot, unstable_treeSnapshotKey]);
 
   const getPersistentElementsProp = useEvent(getPersistentElements);
-  const stackedDialogs = useDialogStack(
+  const [stackedElements, setStackBackdrop] = useDialogStack(
     contentElement,
     modal && !!canTakeTreeSnapshot,
   );
+  const backdropRefs = useMergeRefs(backdropRef, setStackBackdrop);
 
   // Disables/enables the element tree around the modal dialog element.
   useSafeLayoutEffect(() => {
@@ -321,7 +322,7 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     const allElements = [
       dialog,
       ...persistentElements,
-      ...stackedDialogs,
+      ...stackedElements,
       ...nestedDialogs.map((dialog) => dialog.getState().contentElement),
     ];
     // Positively mark the elements the dialog knows about as "inside" so the
@@ -346,7 +347,7 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     store,
     canTakeTreeSnapshot,
     getPersistentElementsProp,
-    stackedDialogs,
+    stackedElements,
     nestedDialogs,
     modal,
     unstable_treeSnapshotKey,
@@ -578,7 +579,7 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
           <DialogBackdrop
             store={store}
             backdrop={backdrop}
-            backdropRef={backdropRef}
+            backdropRef={backdropRefs}
             hidden={hiddenProp}
             alwaysVisible={alwaysVisible}
           />
@@ -586,7 +587,7 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
         </>
       );
     },
-    [store, backdrop, hiddenProp, alwaysVisible],
+    [store, backdrop, backdropRefs, hiddenProp, alwaysVisible],
   );
 
   const [headingId, setHeadingId] = useState<string>();

--- a/packages/ariakit-react-components/src/dialog/utils/use-dialog-stack.test.tsx
+++ b/packages/ariakit-react-components/src/dialog/utils/use-dialog-stack.test.tsx
@@ -1,0 +1,68 @@
+import { render } from "@ariakit/test/react";
+import { useLayoutEffect } from "react";
+import { expect, test } from "vitest";
+import { useDialogStack } from "./use-dialog-stack.ts";
+
+interface TestProps {
+  dialog: HTMLElement | null;
+  results: HTMLElement[][];
+}
+
+function Test({ dialog, results }: TestProps) {
+  const [stackedElements] = useDialogStack(dialog, true);
+  results.push(stackedElements);
+  return null;
+}
+
+test("reuses the empty result when the dialog registers", async () => {
+  const results: HTMLElement[][] = [];
+  const { rerender } = await render(<Test dialog={null} results={results} />);
+
+  await rerender(
+    <Test dialog={document.createElement("div")} results={results} />,
+  );
+
+  expect(results.every((elements) => elements.length === 0)).toBe(true);
+  expect(new Set(results).size).toBe(1);
+});
+
+interface StackTestProps {
+  background: HTMLElement;
+  foreground: HTMLElement;
+  backdrop: HTMLElement;
+  results: HTMLElement[][];
+}
+
+function StackTest({
+  background,
+  foreground,
+  backdrop,
+  results,
+}: StackTestProps) {
+  useDialogStack(background, true);
+  const [stackedElements, setBackdrop] = useDialogStack(foreground, true);
+  results.push(stackedElements);
+
+  useLayoutEffect(() => {
+    setBackdrop(backdrop);
+    return () => setBackdrop(null);
+  }, [backdrop, setBackdrop]);
+
+  return null;
+}
+
+test("reuses the empty result when the frontmost entry updates", async () => {
+  const results: HTMLElement[][] = [];
+  await render(
+    <StackTest
+      background={document.createElement("div")}
+      foreground={document.createElement("div")}
+      backdrop={document.createElement("div")}
+      results={results}
+    />,
+  );
+
+  expect(results.length).toBeGreaterThan(1);
+  expect(results.every((elements) => elements.length === 0)).toBe(true);
+  expect(new Set(results).size).toBe(1);
+});

--- a/packages/ariakit-react-components/src/dialog/utils/use-dialog-stack.test.tsx
+++ b/packages/ariakit-react-components/src/dialog/utils/use-dialog-stack.test.tsx
@@ -8,6 +8,12 @@ interface TestProps {
   results: HTMLElement[][];
 }
 
+function createConnectedElement() {
+  const element = document.createElement("div");
+  document.body.appendChild(element);
+  return element;
+}
+
 function Test({ dialog, results }: TestProps) {
   const [stackedElements] = useDialogStack(dialog, true);
   results.push(stackedElements);
@@ -17,10 +23,9 @@ function Test({ dialog, results }: TestProps) {
 test("reuses the empty result when the dialog registers", async () => {
   const results: HTMLElement[][] = [];
   const { rerender } = await render(<Test dialog={null} results={results} />);
+  const dialog = createConnectedElement();
 
-  await rerender(
-    <Test dialog={document.createElement("div")} results={results} />,
-  );
+  await rerender(<Test dialog={dialog} results={results} />);
 
   expect(results.every((elements) => elements.length === 0)).toBe(true);
   expect(new Set(results).size).toBe(1);
@@ -53,11 +58,14 @@ function StackTest({
 
 test("reuses the empty result when the frontmost entry updates", async () => {
   const results: HTMLElement[][] = [];
+  const background = createConnectedElement();
+  const foreground = createConnectedElement();
+  const backdrop = createConnectedElement();
   await render(
     <StackTest
-      background={document.createElement("div")}
-      foreground={document.createElement("div")}
-      backdrop={document.createElement("div")}
+      background={background}
+      foreground={foreground}
+      backdrop={backdrop}
       results={results}
     />,
   );

--- a/packages/ariakit-react-components/src/dialog/utils/use-dialog-stack.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/use-dialog-stack.ts
@@ -1,49 +1,220 @@
 import { useForceUpdate, useSafeLayoutEffect } from "@ariakit/react-utils";
 import { contains, getDocument } from "@ariakit/utils";
 import { useCallback, useMemo, useRef } from "react";
+import type { DialogStore } from "../dialog-store.ts";
+
+interface DialogStackOptions {
+  portal?: HTMLElement | null;
+  store?: DialogStore;
+  nestedDialogs?: DialogStore[];
+}
 
 interface DialogStackEntry {
   dialog: HTMLElement;
   backdrop: HTMLElement | null;
+  portal: HTMLElement | null;
+  document: Document;
+  activation: number;
+  groupActivation: number;
+  store?: DialogStore;
+  nestedDialogs: DialogStore[];
 }
 
 interface DialogStack {
   dialogs: DialogStackEntry[];
   listeners: Set<() => void>;
+  topologyVersion: number;
+  cleanup: () => void;
 }
 
 const dialogStacks = new WeakMap<Document, DialogStack>();
 const emptyElements: HTMLElement[] = [];
+const emptyDialogStores: DialogStore[] = [];
+let nextDialogActivation = 0;
 
 function getDialogStack(dialog: HTMLElement) {
   const doc = getDocument(dialog);
   const existingStack = dialogStacks.get(doc);
   if (existingStack) return existingStack;
-  const stack: DialogStack = { dialogs: [], listeners: new Set() };
+  const onFullscreenChange = () => {
+    const win = doc.defaultView;
+    if (!win) return;
+    win.queueMicrotask(() => {
+      if (dialogStacks.get(doc) !== stack) return;
+      if (!stack.dialogs.some((entry) => entry.portal)) return;
+      updateDialogStack(stack);
+    });
+  };
+  const stack: DialogStack = {
+    dialogs: [],
+    listeners: new Set(),
+    topologyVersion: 0,
+    cleanup() {
+      doc.removeEventListener("fullscreenchange", onFullscreenChange);
+    },
+  };
+  doc.addEventListener("fullscreenchange", onFullscreenChange);
   dialogStacks.set(doc, stack);
   return stack;
 }
 
+function isElementBefore(element: HTMLElement, nextElement: HTMLElement) {
+  const position = element.compareDocumentPosition(nextElement);
+  const Node = getDocument(element).defaultView?.Node;
+  if (!Node) return false;
+  return Boolean(position & Node.DOCUMENT_POSITION_FOLLOWING);
+}
+
+function syncPortalOrder(stack: DialogStack) {
+  // Default portal containers share a parent and rely on DOM order for visual
+  // stacking, so keep their physical order aligned with the dialog stack.
+  const nextPortals = new Map<HTMLElement, HTMLElement>();
+  const seenPortals = new Set<HTMLElement>();
+  for (let i = stack.dialogs.length - 1; i >= 0; i--) {
+    const entry = stack.dialogs[i];
+    if (!entry) continue;
+    const portal = entry.portal;
+    if (!portal) continue;
+    if (seenPortals.has(portal)) continue;
+    seenPortals.add(portal);
+    const parent = portal.parentElement;
+    if (!parent) continue;
+    const nextPortal = nextPortals.get(parent);
+    if (nextPortal && !isElementBefore(portal, nextPortal)) {
+      parent.insertBefore(portal, nextPortal);
+    }
+    nextPortals.set(parent, portal);
+  }
+}
+
 function updateDialogStack(stack: DialogStack) {
+  syncPortalOrder(stack);
+  stack.topologyVersion++;
   for (const listener of stack.listeners) {
     listener();
   }
 }
 
+function insertDialogStackEntry(stack: DialogStack, entry: DialogStackEntry) {
+  // A nested portal paints within its ancestor's portal, so keep the whole
+  // logical branch together when ordering it against sibling dialogs.
+  const descendants = stack.dialogs.filter((current) =>
+    isDialogStackAncestor(entry, current),
+  );
+  for (const descendant of descendants) {
+    const index = stack.dialogs.indexOf(descendant);
+    if (index >= 0) stack.dialogs.splice(index, 1);
+  }
+
+  const ancestor = getDialogStackAncestor(stack, entry);
+  entry.groupActivation = ancestor?.groupActivation ?? entry.activation;
+
+  let index = stack.dialogs.length;
+  if (ancestor) {
+    index = stack.dialogs.indexOf(ancestor) + 1;
+    while (index < stack.dialogs.length) {
+      const current = stack.dialogs[index];
+      if (!current) break;
+      if (!isDialogStackAncestor(ancestor, current)) break;
+      const currentAncestor = getDialogStackAncestor(stack, current);
+      if (
+        currentAncestor === ancestor &&
+        current.activation > entry.activation
+      ) {
+        break;
+      }
+      index++;
+    }
+  } else {
+    const nextGroupIndex = stack.dialogs.findIndex(
+      (current) => current.groupActivation > entry.groupActivation,
+    );
+    if (nextGroupIndex >= 0) index = nextGroupIndex;
+  }
+
+  stack.dialogs.splice(index, 0, entry);
+  for (const descendant of descendants) {
+    insertDialogStackEntry(stack, descendant);
+  }
+}
+
+function isDialogStackAncestor(
+  entry: DialogStackEntry,
+  nestedEntry: DialogStackEntry,
+) {
+  const nestedStore = nestedEntry.store;
+  if (nestedStore && entry.nestedDialogs.includes(nestedStore)) return true;
+  return contains(entry.dialog, nestedEntry.dialog);
+}
+
+function getDialogStackAncestor(stack: DialogStack, entry: DialogStackEntry) {
+  let ancestor: DialogStackEntry | undefined;
+  for (const current of stack.dialogs) {
+    if (current === entry) continue;
+    if (!isDialogStackAncestor(current, entry)) continue;
+    if (!ancestor || isDialogStackAncestor(ancestor, current)) {
+      ancestor = current;
+    }
+  }
+  return ancestor;
+}
+
+function reorderDialogStackEntry(stack: DialogStack, entry: DialogStackEntry) {
+  const index = stack.dialogs.indexOf(entry);
+  if (index < 0) return false;
+  const previousDialogs = stack.dialogs.slice();
+  stack.dialogs.splice(index, 1);
+  insertDialogStackEntry(stack, entry);
+  return previousDialogs.some(
+    (dialog, index) => stack.dialogs[index] !== dialog,
+  );
+}
+
+function haveSameDialogStores(
+  stores: DialogStore[],
+  nextStores: DialogStore[],
+) {
+  if (stores === nextStores) return true;
+  if (stores.length !== nextStores.length) return false;
+  for (const store of stores) {
+    if (!nextStores.includes(store)) return false;
+  }
+  return true;
+}
+
+function getDialogStackElements(entries: DialogStackEntry[]) {
+  return entries.flatMap(({ dialog, backdrop }) =>
+    backdrop ? [dialog, backdrop] : [dialog],
+  );
+}
+
+function getDialogPortal(
+  dialog: HTMLElement,
+  portal: HTMLElement | null | undefined,
+) {
+  if (!portal) return null;
+  if (!contains(portal, dialog)) return null;
+  return portal;
+}
+
 export function useDialogStack(
   dialog: HTMLElement | null | undefined,
   enabled: boolean,
+  options?: DialogStackOptions,
 ) {
+  const portal = options?.portal;
+  const store = options?.store;
+  const nestedDialogs = options?.nestedDialogs ?? emptyDialogStores;
   const [stackUpdated, forceUpdate] = useForceUpdate();
   const entryRef = useRef<DialogStackEntry | null>(null);
   const backdropRef = useRef<HTMLElement | null>(null);
+  const activationRef = useRef<number | null>(null);
 
   const removeEntry = useCallback(() => {
     const entry = entryRef.current;
     if (!entry) return;
     entryRef.current = null;
-    const doc = getDocument(entry.dialog);
-    const stack = dialogStacks.get(doc);
+    const stack = dialogStacks.get(entry.document);
     if (!stack) return;
     stack.listeners.delete(forceUpdate);
     const index = stack.dialogs.indexOf(entry);
@@ -52,7 +223,8 @@ export function useDialogStack(
     }
     updateDialogStack(stack);
     if (stack.dialogs.length === 0) {
-      dialogStacks.delete(doc);
+      stack.cleanup();
+      dialogStacks.delete(entry.document);
     }
   }, [forceUpdate]);
 
@@ -62,41 +234,73 @@ export function useDialogStack(
     if (!entry) return;
     if (entry.backdrop === backdrop) return;
     entry.backdrop = backdrop;
-    const stack = dialogStacks.get(getDocument(entry.dialog));
+    const stack = dialogStacks.get(entry.document);
     if (!stack) return;
     updateDialogStack(stack);
   }, []);
 
-  // Keep the entry for the lifetime of this opening so replacing the dialog
-  // element doesn't change its position in the stack.
+  // Keep the activation for the lifetime of this opening so transient portal
+  // states and replacement elements don't change its position in the stack.
   useSafeLayoutEffect(() => {
-    if (!enabled) return;
+    if (!enabled) {
+      activationRef.current = null;
+      return;
+    }
     return removeEntry;
   }, [enabled, removeEntry]);
 
   useSafeLayoutEffect(() => {
     if (!enabled) return;
     if (!dialog) return;
+    // Portals briefly expose their inline placeholder through the dialog ref.
+    // It may already be detached by the time this effect runs.
+    if (!dialog.isConnected) return;
     const entry = entryRef.current;
     if (entry) {
-      const previousDocument = getDocument(entry.dialog);
       const nextDocument = getDocument(dialog);
-      const stack = dialogStacks.get(previousDocument);
-      if (stack && previousDocument === nextDocument) {
-        if (entry.dialog === dialog) return;
+      const stack = dialogStacks.get(entry.document);
+      if (stack && entry.document === nextDocument) {
+        const nextPortal = getDialogPortal(dialog, portal);
+        const dialogUpdated = entry.dialog !== dialog;
+        const portalUpdated = entry.portal !== nextPortal;
+        const nestingUpdated =
+          entry.store !== store ||
+          !haveSameDialogStores(entry.nestedDialogs, nestedDialogs);
+        if (!dialogUpdated && !portalUpdated && !nestingUpdated) {
+          return;
+        }
         entry.dialog = dialog;
-        updateDialogStack(stack);
+        entry.portal = nextPortal;
+        entry.store = store;
+        entry.nestedDialogs = nestedDialogs;
+        const reordered =
+          nestingUpdated && reorderDialogStackEntry(stack, entry);
+        if (dialogUpdated || portalUpdated || reordered) {
+          updateDialogStack(stack);
+        }
         return;
       }
       removeEntry();
     }
+    const activation =
+      activationRef.current ?? (activationRef.current = ++nextDialogActivation);
+    const document = getDocument(dialog);
     const stack = getDialogStack(dialog);
-    const nextEntry = { dialog, backdrop: backdropRef.current };
+    const nextEntry = {
+      dialog,
+      backdrop: backdropRef.current,
+      portal: getDialogPortal(dialog, portal),
+      document,
+      activation,
+      groupActivation: activation,
+      store,
+      nestedDialogs,
+    };
     entryRef.current = nextEntry;
-    stack.dialogs.push(nextEntry);
-    updateDialogStack(stack);
     stack.listeners.add(forceUpdate);
-  }, [dialog, enabled, forceUpdate, removeEntry]);
+    insertDialogStackEntry(stack, nextEntry);
+    updateDialogStack(stack);
+  }, [dialog, enabled, forceUpdate, nestedDialogs, portal, removeEntry, store]);
 
   const stackedElements = useMemo(() => {
     // The registry lives outside React, so read its update signal here to
@@ -106,20 +310,49 @@ export function useDialogStack(
     if (!dialog) return emptyElements;
     const entry = entryRef.current;
     if (!entry) return emptyElements;
-    const stack = dialogStacks.get(getDocument(dialog));
+    const stack = dialogStacks.get(entry.document);
     if (!stack) return emptyElements;
     const index = stack.dialogs.indexOf(entry);
     if (index < 0) return emptyElements;
     // Inline nested dialogs register before their DOM ancestors, which are
     // behind the current dialog rather than later dialogs in the stack.
-    const elements = stack.dialogs
-      .slice(index + 1)
-      .filter((entry) => !contains(entry.dialog, dialog))
-      .flatMap(({ dialog, backdrop }) =>
-        backdrop ? [dialog, backdrop] : [dialog],
-      );
+    const elements = getDialogStackElements(
+      stack.dialogs
+        .slice(index + 1)
+        .filter((entry) => !contains(entry.dialog, dialog)),
+    );
     return elements.length ? elements : emptyElements;
   }, [dialog, enabled, stackUpdated]);
 
-  return [stackedElements, setBackdrop] as const;
+  const backgroundElements = useMemo(() => {
+    void stackUpdated;
+    if (!enabled) return emptyElements;
+    if (!dialog) return emptyElements;
+    const entry = entryRef.current;
+    if (!entry) return emptyElements;
+    const stack = dialogStacks.get(entry.document);
+    if (!stack) return emptyElements;
+    const index = stack.dialogs.indexOf(entry);
+    if (index <= 0) return emptyElements;
+    const elements = getDialogStackElements(stack.dialogs.slice(0, index));
+    return elements.length ? elements : emptyElements;
+  }, [dialog, enabled, stackUpdated]);
+
+  const topologyVersion = useMemo(() => {
+    // Host and portal changes alter the document topology even when
+    // stackedElements remains the shared empty array.
+    void stackUpdated;
+    if (!enabled) return 0;
+    const entry = entryRef.current;
+    if (!entry) return 0;
+    const stack = dialogStacks.get(entry.document);
+    return stack?.topologyVersion ?? 0;
+  }, [enabled, stackUpdated]);
+
+  return [
+    stackedElements,
+    setBackdrop,
+    topologyVersion,
+    backgroundElements,
+  ] as const;
 }

--- a/packages/ariakit-react-components/src/dialog/utils/use-dialog-stack.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/use-dialog-stack.ts
@@ -1,0 +1,69 @@
+import { useForceUpdate, useSafeLayoutEffect } from "@ariakit/react-utils";
+import { contains, getDocument } from "@ariakit/utils";
+import { useMemo } from "react";
+
+interface DialogStack {
+  dialogs: HTMLElement[];
+  listeners: Set<() => void>;
+}
+
+const dialogStacks = new WeakMap<Document, DialogStack>();
+
+function getDialogStack(dialog: HTMLElement) {
+  const doc = getDocument(dialog);
+  const existingStack = dialogStacks.get(doc);
+  if (existingStack) return existingStack;
+  const stack: DialogStack = { dialogs: [], listeners: new Set() };
+  dialogStacks.set(doc, stack);
+  return stack;
+}
+
+function updateDialogStack(stack: DialogStack) {
+  for (const listener of stack.listeners) {
+    listener();
+  }
+}
+
+export function useDialogStack(
+  dialog: HTMLElement | null | undefined,
+  enabled: boolean,
+) {
+  const [stackUpdated, forceUpdate] = useForceUpdate();
+
+  useSafeLayoutEffect(() => {
+    if (!enabled) return;
+    if (!dialog) return;
+    const stack = getDialogStack(dialog);
+    stack.dialogs.push(dialog);
+    updateDialogStack(stack);
+    stack.listeners.add(forceUpdate);
+    return () => {
+      stack.listeners.delete(forceUpdate);
+      const index = stack.dialogs.indexOf(dialog);
+      if (index >= 0) {
+        stack.dialogs.splice(index, 1);
+      }
+      updateDialogStack(stack);
+      if (stack.dialogs.length === 0) {
+        dialogStacks.delete(getDocument(dialog));
+      }
+    };
+  }, [dialog, enabled, forceUpdate]);
+
+  return useMemo(() => {
+    // The registry lives outside React, so read its update signal here to
+    // invalidate the derived array only when the stack changes.
+    void stackUpdated;
+    if (!enabled) return [];
+    if (!dialog) return [];
+    const stack = dialogStacks.get(getDocument(dialog));
+    if (!stack) return [];
+    const index = stack.dialogs.indexOf(dialog);
+    if (index < 0) return [];
+    // Inline nested dialogs register before their DOM ancestors, which are
+    // behind the current dialog rather than later dialogs in the stack.
+    return stack.dialogs
+      .slice(index + 1)
+      .filter((stackedDialog) => !contains(stackedDialog, dialog));
+  }, [dialog, enabled, stackUpdated]);
+}

--- a/packages/ariakit-react-components/src/dialog/utils/use-dialog-stack.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/use-dialog-stack.ts
@@ -1,13 +1,19 @@
 import { useForceUpdate, useSafeLayoutEffect } from "@ariakit/react-utils";
 import { contains, getDocument } from "@ariakit/utils";
-import { useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
+
+interface DialogStackEntry {
+  dialog: HTMLElement;
+  backdrop: HTMLElement | null;
+}
 
 interface DialogStack {
-  dialogs: HTMLElement[];
+  dialogs: DialogStackEntry[];
   listeners: Set<() => void>;
 }
 
 const dialogStacks = new WeakMap<Document, DialogStack>();
+const emptyElements: HTMLElement[] = [];
 
 function getDialogStack(dialog: HTMLElement) {
   const doc = getDocument(dialog);
@@ -29,41 +35,91 @@ export function useDialogStack(
   enabled: boolean,
 ) {
   const [stackUpdated, forceUpdate] = useForceUpdate();
+  const entryRef = useRef<DialogStackEntry | null>(null);
+  const backdropRef = useRef<HTMLElement | null>(null);
+
+  const removeEntry = useCallback(() => {
+    const entry = entryRef.current;
+    if (!entry) return;
+    entryRef.current = null;
+    const doc = getDocument(entry.dialog);
+    const stack = dialogStacks.get(doc);
+    if (!stack) return;
+    stack.listeners.delete(forceUpdate);
+    const index = stack.dialogs.indexOf(entry);
+    if (index >= 0) {
+      stack.dialogs.splice(index, 1);
+    }
+    updateDialogStack(stack);
+    if (stack.dialogs.length === 0) {
+      dialogStacks.delete(doc);
+    }
+  }, [forceUpdate]);
+
+  const setBackdrop = useCallback((backdrop: HTMLElement | null) => {
+    backdropRef.current = backdrop;
+    const entry = entryRef.current;
+    if (!entry) return;
+    if (entry.backdrop === backdrop) return;
+    entry.backdrop = backdrop;
+    const stack = dialogStacks.get(getDocument(entry.dialog));
+    if (!stack) return;
+    updateDialogStack(stack);
+  }, []);
+
+  // Keep the entry for the lifetime of this opening so replacing the dialog
+  // element doesn't change its position in the stack.
+  useSafeLayoutEffect(() => {
+    if (!enabled) return;
+    return removeEntry;
+  }, [enabled, removeEntry]);
 
   useSafeLayoutEffect(() => {
     if (!enabled) return;
     if (!dialog) return;
+    const entry = entryRef.current;
+    if (entry) {
+      const previousDocument = getDocument(entry.dialog);
+      const nextDocument = getDocument(dialog);
+      const stack = dialogStacks.get(previousDocument);
+      if (stack && previousDocument === nextDocument) {
+        if (entry.dialog === dialog) return;
+        entry.dialog = dialog;
+        updateDialogStack(stack);
+        return;
+      }
+      removeEntry();
+    }
     const stack = getDialogStack(dialog);
-    stack.dialogs.push(dialog);
+    const nextEntry = { dialog, backdrop: backdropRef.current };
+    entryRef.current = nextEntry;
+    stack.dialogs.push(nextEntry);
     updateDialogStack(stack);
     stack.listeners.add(forceUpdate);
-    return () => {
-      stack.listeners.delete(forceUpdate);
-      const index = stack.dialogs.indexOf(dialog);
-      if (index >= 0) {
-        stack.dialogs.splice(index, 1);
-      }
-      updateDialogStack(stack);
-      if (stack.dialogs.length === 0) {
-        dialogStacks.delete(getDocument(dialog));
-      }
-    };
-  }, [dialog, enabled, forceUpdate]);
+  }, [dialog, enabled, forceUpdate, removeEntry]);
 
-  return useMemo(() => {
+  const stackedElements = useMemo(() => {
     // The registry lives outside React, so read its update signal here to
     // invalidate the derived array only when the stack changes.
     void stackUpdated;
-    if (!enabled) return [];
-    if (!dialog) return [];
+    if (!enabled) return emptyElements;
+    if (!dialog) return emptyElements;
+    const entry = entryRef.current;
+    if (!entry) return emptyElements;
     const stack = dialogStacks.get(getDocument(dialog));
-    if (!stack) return [];
-    const index = stack.dialogs.indexOf(dialog);
-    if (index < 0) return [];
+    if (!stack) return emptyElements;
+    const index = stack.dialogs.indexOf(entry);
+    if (index < 0) return emptyElements;
     // Inline nested dialogs register before their DOM ancestors, which are
     // behind the current dialog rather than later dialogs in the stack.
-    return stack.dialogs
+    const elements = stack.dialogs
       .slice(index + 1)
-      .filter((stackedDialog) => !contains(stackedDialog, dialog));
+      .filter((entry) => !contains(entry.dialog, dialog))
+      .flatMap(({ dialog, backdrop }) =>
+        backdrop ? [dialog, backdrop] : [dialog],
+      );
+    return elements.length ? elements : emptyElements;
   }, [dialog, enabled, stackUpdated]);
+
+  return [stackedElements, setBackdrop] as const;
 }


### PR DESCRIPTION
## Motivation

When two sibling modal [`Dialog`](https://ariakit.com/reference/dialog) components mount open in the same render, each dialog snapshots and disables the other dialog's portal. Both dialogs become inert, so users cannot interact with either one.

```tsx
<Ariakit.Dialog open unmountOnHide>
  Oranges
</Ariakit.Dialog>
<Ariakit.Dialog open unmountOnHide>
  Apples
</Ariakit.Dialog>
```

Fixes #5238.

## Solution

Track open modal dialogs in activation order for each document. Earlier dialogs treat later dialogs as part of their modal context, while the frontmost dialog still disables every dialog behind it. Closing a dialog removes it from the stack and restores the next dialog.

The stack complements the existing React nesting and `getPersistentElements` paths without replacing each dialog's temporal tree snapshot. Inline nested dialogs are kept hierarchy-aware by excluding DOM ancestors that register after their children.

Add happy-dom and browser regression coverage for initially open siblings, plus initially open inline nested dialogs to protect the child-first layout-effect case.

## Workaround

Before this fix is available in a release, give the known foreground sibling a stable ID and return its element from the background dialog's `getPersistentElements` callback:

```tsx
const applesDialogId = useId();

<Ariakit.Dialog
  getPersistentElements={() => {
    const applesDialog = document.getElementById(applesDialogId);
    return applesDialog ? [applesDialog] : [];
  }}
>
  Oranges
</Ariakit.Dialog>

<Ariakit.Dialog id={applesDialogId}>Apples</Ariakit.Dialog>
```

This workaround assumes the application knows which sibling is in front. A dynamic dialog stack must return every later/frontmost dialog that should remain interactive.
