### PR TITLE
Fix Select typeahead with late items

### DIFF
--- a/.changeset/300-select-late-items-typeahead.md
+++ b/.changeset/300-select-late-items-typeahead.md
@@ -1,7 +1,9 @@
 ---
+"@ariakit/store": patch
 "@ariakit/components": patch
 "@ariakit/react-components": patch
 "@ariakit/react": patch
+"@ariakit/solid-store": patch
 ---
 
 Fixed [`Select`](https://ariakit.com/reference/select) to update its value when typeahead moves to an item that was added after store creation while its option element is unmounted.

--- a/.changeset/300-select-late-items-typeahead.md
+++ b/.changeset/300-select-late-items-typeahead.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/components": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Select`](https://ariakit.com/reference/select) to update its value when typeahead moves to an item that was added after store creation while its option element is unmounted.

--- a/app/src/sandbox/select-6733/index.react.tsx
+++ b/app/src/sandbox/select-6733/index.react.tsx
@@ -1,7 +1,7 @@
 import * as Ariakit from "@ariakit/react";
 import { SelectRenderer } from "@ariakit/react-components/select/select-renderer";
 import type { SelectStoreItem } from "@ariakit/react-components/select/select-store";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 const fruits: SelectStoreItem[] = [
   { id: "apple", value: "Apple" },
@@ -25,6 +25,21 @@ function Fixture({ label, renderer }: FixtureProps) {
     setValue,
   });
   const activeId = Ariakit.useStoreState(select, "activeId");
+  const mounted = Ariakit.useStoreState(select, "mounted");
+  const moves = Ariakit.useStoreState(select, "moves");
+  const previousMoves = useRef(moves);
+
+  // TODO: Remove this workaround after
+  // https://github.com/ariakit/ariakit/issues/6733 is fixed.
+  useEffect(() => {
+    if (previousMoves.current === moves) return;
+    previousMoves.current = moves;
+    if (mounted) return;
+    if (!activeId) return;
+    const item = items.find((item) => item.id === activeId);
+    if (!item || item.disabled || item.value == null) return;
+    setValue(item.value);
+  }, [activeId, items, mounted, moves]);
 
   const loadOptions = () => {
     setItems(fruits);

--- a/app/src/sandbox/select-6733/index.react.tsx
+++ b/app/src/sandbox/select-6733/index.react.tsx
@@ -1,7 +1,7 @@
 import * as Ariakit from "@ariakit/react";
 import { SelectRenderer } from "@ariakit/react-components/select/select-renderer";
 import type { SelectStoreItem } from "@ariakit/react-components/select/select-store";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 
 const fruits: SelectStoreItem[] = [
   { id: "apple", value: "Apple" },
@@ -25,21 +25,6 @@ function Fixture({ label, renderer }: FixtureProps) {
     setValue,
   });
   const activeId = Ariakit.useStoreState(select, "activeId");
-  const mounted = Ariakit.useStoreState(select, "mounted");
-  const moves = Ariakit.useStoreState(select, "moves");
-  const previousMoves = useRef(moves);
-
-  // TODO: Remove this workaround after
-  // https://github.com/ariakit/ariakit/issues/6733 is fixed.
-  useEffect(() => {
-    if (previousMoves.current === moves) return;
-    previousMoves.current = moves;
-    if (mounted) return;
-    if (!activeId) return;
-    const item = items.find((item) => item.id === activeId);
-    if (!item || item.disabled || item.value == null) return;
-    setValue(item.value);
-  }, [activeId, items, mounted, moves]);
 
   const loadOptions = () => {
     setItems(fruits);

--- a/app/src/sandbox/select-6733/index.react.tsx
+++ b/app/src/sandbox/select-6733/index.react.tsx
@@ -1,0 +1,72 @@
+import * as Ariakit from "@ariakit/react";
+import { SelectRenderer } from "@ariakit/react-components/select/select-renderer";
+import type { SelectStoreItem } from "@ariakit/react-components/select/select-store";
+import { useRef, useState } from "react";
+
+const fruits: SelectStoreItem[] = [
+  { id: "apple", value: "Apple" },
+  { id: "banana", value: "Banana" },
+  { id: "orange", value: "Orange" },
+];
+
+interface FixtureProps {
+  label: string;
+  renderer?: boolean;
+}
+
+function Fixture({ label, renderer }: FixtureProps) {
+  const [items, setItems] = useState<SelectStoreItem[]>([]);
+  const [value, setValue] = useState("Orange");
+  const selectRef = useRef<HTMLButtonElement>(null);
+  const select = Ariakit.useSelectStore<string>({
+    items,
+    setItems,
+    value,
+    setValue,
+  });
+  const activeId = Ariakit.useStoreState(select, "activeId");
+
+  const loadOptions = () => {
+    setItems(fruits);
+    selectRef.current?.focus();
+  };
+
+  return (
+    <section>
+      <h2>{label}</h2>
+      <button type="button" onClick={loadOptions}>
+        Load {label.toLowerCase()} options
+      </button>
+      <Ariakit.SelectLabel store={select}>{label}</Ariakit.SelectLabel>
+      <Ariakit.Select ref={selectRef} store={select}>
+        {value}
+      </Ariakit.Select>
+      <Ariakit.SelectPopover store={select} unmountOnHide={!renderer}>
+        {renderer ? (
+          <SelectRenderer<SelectStoreItem> store={select} items={items}>
+            {({ value, ...item }) => (
+              <Ariakit.SelectItem key={item.id} value={value} {...item} />
+            )}
+          </SelectRenderer>
+        ) : (
+          items.map((item) => <Ariakit.SelectItem key={item.id} {...item} />)
+        )}
+      </Ariakit.SelectPopover>
+      <p>
+        Active item:{" "}
+        <output aria-label={`${label} active item`}>
+          {activeId ?? "null"}
+        </output>
+      </p>
+    </section>
+  );
+}
+
+export default function Example() {
+  return (
+    <>
+      <Fixture label="Fruit" />
+      <Fixture label="Rendered fruit" renderer />
+    </>
+  );
+}

--- a/app/src/sandbox/select-6733/test-browser.ts
+++ b/app/src/sandbox/select-6733/test-browser.ts
@@ -1,0 +1,37 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/6733
+  test("typeahead updates the value for late unmounted items", async ({
+    q,
+  }) => {
+    await q.button("Load fruit options").click();
+
+    const select = q.combobox("Fruit");
+    await test.expect(select).toBeFocused();
+    await test.expect(q.option("Apple")).toHaveCount(0);
+
+    await select.press("a");
+
+    await test.expect(q.status("Fruit active item")).toHaveText("apple");
+    await test.expect(select).toHaveText("Apple");
+  });
+
+  // https://github.com/ariakit/ariakit/issues/6733
+  test("typeahead updates the value for late SelectRenderer items", async ({
+    q,
+  }) => {
+    await q.button("Load rendered fruit options").click();
+
+    const select = q.combobox("Rendered fruit");
+    await test.expect(select).toBeFocused();
+    await test.expect(q.option("Apple")).toHaveCount(0);
+
+    await select.press("a");
+
+    await test
+      .expect(q.status("Rendered fruit active item"))
+      .toHaveText("apple");
+    await test.expect(select).toHaveText("Apple");
+  });
+});

--- a/app/src/sandbox/select-6733/test.ts
+++ b/app/src/sandbox/select-6733/test.ts
@@ -1,0 +1,30 @@
+import { click, press, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// https://github.com/ariakit/ariakit/issues/6733
+test("typeahead updates the value for late unmounted items", async () => {
+  await click(q.button("Load fruit options"));
+
+  const select = q.combobox.ensure("Fruit");
+  expect(select).toHaveFocus();
+  expect(q.option("Apple")).not.toBeInTheDocument();
+
+  await press("a", select);
+
+  expect(q.status("Fruit active item")).toHaveTextContent("apple");
+  expect(select).toHaveTextContent("Apple");
+});
+
+// https://github.com/ariakit/ariakit/issues/6733
+test("typeahead updates the value for late SelectRenderer items", async () => {
+  await click(q.button("Load rendered fruit options"));
+
+  const select = q.combobox.ensure("Rendered fruit");
+  expect(select).toHaveFocus();
+  expect(q.option("Apple")).not.toBeInTheDocument();
+
+  await press("a", select);
+
+  expect(q.status("Rendered fruit active item")).toHaveTextContent("apple");
+  expect(select).toHaveTextContent("Apple");
+});

--- a/packages/ariakit-components/src/select/select-store.test.ts
+++ b/packages/ariakit-components/src/select/select-store.test.ts
@@ -217,6 +217,52 @@ test.each([
   ["public", false],
   ["registered", true],
 ] as const)(
+  "does not overwrite a value reasserted by a backing store with a %s item",
+  async (_, registered) => {
+    const backing = createStore({ value: "Orange" });
+    const mover = createSelectStore({ store: backing });
+    const stop = init(mover);
+    const unregister = registered ? mover.registerItem(apple) : undefined;
+
+    try {
+      if (!registered) {
+        mover.setState("items", [apple]);
+      }
+      mover.move("apple");
+      queueMicrotask(() => backing.setState("value", "Orange"));
+      await flushBatch();
+
+      expect(backing.getState().value).toBe("Orange");
+      expect(mover.getState().value).toBe("Orange");
+    } finally {
+      unregister?.();
+      stop();
+    }
+  },
+);
+
+test("does not cancel the fallback after an unrelated backing write", async () => {
+  const backing = createStore({ flag: false, value: "Orange" });
+  const mover = createSelectStore({ store: backing });
+  const stop = init(mover);
+
+  try {
+    mover.setState("items", [apple]);
+    mover.move("apple");
+    queueMicrotask(() => backing.setState("flag", false));
+    await flushBatch();
+
+    expect(backing.getState().value).toBe("Apple");
+    expect(mover.getState().value).toBe("Apple");
+  } finally {
+    stop();
+  }
+});
+
+test.each([
+  ["public", false],
+  ["registered", true],
+] as const)(
   "does not overwrite a value reasserted across derived stores with a %s item",
   async (_, registered) => {
     const backing = createStore({ value: "Orange" });
@@ -248,6 +294,30 @@ test.each([
     }
   },
 );
+
+test("does not overwrite a value reasserted by a derived backing store", async () => {
+  const backing = createStore({ value: "Orange" });
+  const writer = pick(backing, ["value"]);
+  const mover = createSelectStore({
+    store: pick(backing, ["value"]),
+  });
+  const stopWriter = init(writer);
+  const stopMover = init(mover);
+
+  try {
+    mover.setState("items", [apple]);
+    mover.move("apple");
+    queueMicrotask(() => writer.setState("value", "Orange"));
+    await flushBatch();
+
+    expect(backing.getState().value).toBe("Orange");
+    expect(writer.getState().value).toBe("Orange");
+    expect(mover.getState().value).toBe("Orange");
+  } finally {
+    stopMover();
+    stopWriter();
+  }
+});
 
 test.each([
   ["public", false],
@@ -301,7 +371,7 @@ test("does not share value writes between merged parent stores", async () => {
   try {
     mover.setState("items", [apple]);
     mover.move("apple");
-    queueMicrotask(() => writer.setValue("Orange"));
+    queueMicrotask(() => writerBacking.setState("value", "Orange"));
     await flushBatch();
 
     expect(writer.getState().value).toBe("Orange");

--- a/packages/ariakit-components/src/select/select-store.test.ts
+++ b/packages/ariakit-components/src/select/select-store.test.ts
@@ -9,6 +9,7 @@ function flushBatch() {
 }
 
 const apple: SelectStoreItem = { id: "apple", value: "Apple" };
+const banana: SelectStoreItem = { id: "banana", value: "Banana" };
 
 test("sets the value only from eligible late public items", async () => {
   const store = createSelectStore({ defaultValue: "Orange" });
@@ -120,6 +121,23 @@ test("does not overwrite a value set after moving", async () => {
     await flushBatch();
 
     expect(store.getState().value).toBe("Banana");
+  } finally {
+    stop();
+  }
+});
+
+test("does not set the value after the active id changes", async () => {
+  const store = createSelectStore({ defaultValue: "Orange" });
+  const stop = init(store);
+
+  try {
+    store.setState("items", [apple, banana]);
+    store.move("apple");
+    queueMicrotask(() => store.setActiveId("banana"));
+    await flushBatch();
+
+    expect(store.getState().activeId).toBe("banana");
+    expect(store.getState().value).toBe("Orange");
   } finally {
     stop();
   }

--- a/packages/ariakit-components/src/select/select-store.test.ts
+++ b/packages/ariakit-components/src/select/select-store.test.ts
@@ -1,4 +1,4 @@
-import { init } from "@ariakit/store";
+import { createStore, init, mergeStore, pick } from "@ariakit/store";
 import { expect, test } from "vitest";
 import { createCompositeStore } from "../composite/composite-store.ts";
 import { createSelectStore } from "./select-store.ts";
@@ -139,6 +139,178 @@ test("does not overwrite a reasserted value after moving", async () => {
     expect(store.getState().value).toBe("Orange");
   } finally {
     stop();
+  }
+});
+
+test("does not overwrite a value reasserted with setState", async () => {
+  const store = createSelectStore({ defaultValue: "Orange" });
+  const stop = init(store);
+
+  try {
+    store.setState("items", [apple]);
+    store.move("apple");
+    queueMicrotask(() => store.setState("value", "Orange"));
+    await flushBatch();
+
+    expect(store.getState().value).toBe("Orange");
+  } finally {
+    stop();
+  }
+});
+
+test.each([
+  ["setValue", "parent"],
+  ["setValue", "child"],
+  ["setState", "parent"],
+  ["setState", "child"],
+] as const)(
+  "does not overwrite a value reasserted with %s by a synchronized %s store",
+  async (method, target) => {
+    const parent = createSelectStore({ defaultValue: "Orange" });
+    const child = createSelectStore({ store: parent });
+    const stop = init(child);
+
+    try {
+      child.setState("items", [apple]);
+      child.move("apple");
+      queueMicrotask(() => {
+        const store = target === "parent" ? parent : child;
+        if (method === "setValue") {
+          store.setValue("Orange");
+        } else {
+          store.setState("value", "Orange");
+        }
+      });
+      await flushBatch();
+
+      expect(parent.getState().value).toBe("Orange");
+      expect(child.getState().value).toBe("Orange");
+    } finally {
+      stop();
+    }
+  },
+);
+
+test("does not overwrite a value reasserted by a sibling store", async () => {
+  const backing = createStore<{ value: string }>({ value: "Orange" });
+  const writer = createSelectStore({ store: backing });
+  const mover = createSelectStore({ store: backing });
+  const stopWriter = init(writer);
+  const stopMover = init(mover);
+
+  try {
+    mover.setState("items", [apple]);
+    mover.move("apple");
+    queueMicrotask(() => writer.setValue("Orange"));
+    await flushBatch();
+
+    expect(backing.getState().value).toBe("Orange");
+    expect(writer.getState().value).toBe("Orange");
+    expect(mover.getState().value).toBe("Orange");
+  } finally {
+    stopMover();
+    stopWriter();
+  }
+});
+
+test.each([
+  ["public", false],
+  ["registered", true],
+] as const)(
+  "does not overwrite a value reasserted across derived stores with a %s item",
+  async (_, registered) => {
+    const backing = createStore({ value: "Orange" });
+    const writer = createSelectStore({
+      store: pick(backing, ["value"]),
+    });
+    const mover = createSelectStore({
+      store: pick(backing, ["value"]),
+    });
+    const stopWriter = init(writer);
+    const stopMover = init(mover);
+    const unregister = registered ? mover.registerItem(apple) : undefined;
+
+    try {
+      if (!registered) {
+        mover.setState("items", [apple]);
+      }
+      mover.move("apple");
+      queueMicrotask(() => writer.setValue("Orange"));
+      await flushBatch();
+
+      expect(backing.getState().value).toBe("Orange");
+      expect(writer.getState().value).toBe("Orange");
+      expect(mover.getState().value).toBe("Orange");
+    } finally {
+      unregister?.();
+      stopMover();
+      stopWriter();
+    }
+  },
+);
+
+test.each([
+  ["public", false],
+  ["registered", true],
+] as const)(
+  "does not share value writes through a synchronized store with a %s item",
+  async (_, registered) => {
+    const composite = createCompositeStore<SelectStoreItem>();
+    const writer = createSelectStore({
+      store: composite,
+      defaultValue: "Orange",
+    });
+    const mover = createSelectStore({
+      store: composite,
+      defaultValue: "Orange",
+    });
+    const stopWriter = init(writer);
+    const stopMover = init(mover);
+    const unregister = registered ? mover.registerItem(apple) : undefined;
+
+    try {
+      if (!registered) {
+        mover.setState("items", [apple]);
+      }
+      mover.move("apple");
+      queueMicrotask(() => writer.setValue("Orange"));
+      await flushBatch();
+
+      expect(writer.getState().value).toBe("Orange");
+      expect(mover.getState().value).toBe("Apple");
+    } finally {
+      unregister?.();
+      stopMover();
+      stopWriter();
+    }
+  },
+);
+
+test("does not share value writes between merged parent stores", async () => {
+  const writerBacking = createStore({ value: "Orange" });
+  const moverBacking = createStore({ value: "Orange" });
+  const writer = createSelectStore({ store: writerBacking });
+  const mover = createSelectStore({ store: moverBacking });
+  const bridge = createSelectStore({
+    store: mergeStore(writerBacking, moverBacking),
+  });
+  const stopWriter = init(writer);
+  const stopMover = init(mover);
+  const stopBridge = init(bridge);
+
+  try {
+    mover.setState("items", [apple]);
+    mover.move("apple");
+    queueMicrotask(() => writer.setValue("Orange"));
+    await flushBatch();
+
+    expect(writer.getState().value).toBe("Orange");
+    expect(mover.getState().value).toBe("Apple");
+    expect(bridge.getState().value).toBe("Apple");
+  } finally {
+    stopBridge();
+    stopMover();
+    stopWriter();
   }
 });
 

--- a/packages/ariakit-components/src/select/select-store.test.ts
+++ b/packages/ariakit-components/src/select/select-store.test.ts
@@ -126,6 +126,22 @@ test("does not overwrite a value set after moving", async () => {
   }
 });
 
+test("does not overwrite a reasserted value after moving", async () => {
+  const store = createSelectStore({ defaultValue: "Orange" });
+  const stop = init(store);
+
+  try {
+    store.setState("items", [apple]);
+    store.move("apple");
+    queueMicrotask(() => store.setValue("Orange"));
+    await flushBatch();
+
+    expect(store.getState().value).toBe("Orange");
+  } finally {
+    stop();
+  }
+});
+
 test("does not overwrite a value that changes back after moving", async () => {
   const store = createSelectStore({
     defaultValue: "Orange",

--- a/packages/ariakit-components/src/select/select-store.test.ts
+++ b/packages/ariakit-components/src/select/select-store.test.ts
@@ -126,6 +126,33 @@ test("does not overwrite a value set after moving", async () => {
   }
 });
 
+test("does not overwrite a value that changes back after moving", async () => {
+  const store = createSelectStore({
+    defaultValue: "Orange",
+    setValueOnMove: true,
+  });
+  const stop = init(store);
+
+  try {
+    store.show();
+    await flushBatch();
+
+    store.setState("items", [apple, banana]);
+    store.move("apple");
+    queueMicrotask(() => {
+      store.setValue("Banana");
+      store.setValue("Orange");
+    });
+    await flushBatch();
+
+    expect(store.getState().mounted).toBe(true);
+    expect(store.getState().activeId).toBe("apple");
+    expect(store.getState().value).toBe("Orange");
+  } finally {
+    stop();
+  }
+});
+
 test("does not set the value after the active id changes", async () => {
   const store = createSelectStore({ defaultValue: "Orange" });
   const stop = init(store);

--- a/packages/ariakit-components/src/select/select-store.test.ts
+++ b/packages/ariakit-components/src/select/select-store.test.ts
@@ -1,0 +1,138 @@
+import { init } from "@ariakit/store";
+import { expect, test } from "vitest";
+import { createCompositeStore } from "../composite/composite-store.ts";
+import { createSelectStore } from "./select-store.ts";
+import type { SelectStoreItem } from "./select-store.ts";
+
+function flushBatch() {
+  return new Promise<void>((resolve) => queueMicrotask(resolve));
+}
+
+const apple: SelectStoreItem = { id: "apple", value: "Apple" };
+
+test("sets the value only from eligible late public items", async () => {
+  const store = createSelectStore({ defaultValue: "Orange" });
+  const stop = init(store);
+
+  try {
+    store.setState("items", [
+      { id: "disabled", value: "Disabled", disabled: true },
+      { id: "valueless" },
+      apple,
+    ]);
+    store.move("disabled");
+    await flushBatch();
+
+    expect(store.getState().value).toBe("Orange");
+
+    store.move("valueless");
+    await flushBatch();
+
+    expect(store.getState().value).toBe("Orange");
+
+    store.move("apple");
+    await flushBatch();
+
+    expect(store.getState().value).toBe("Apple");
+  } finally {
+    stop();
+  }
+});
+
+test("does not set the value from an item unregistered after moving", async () => {
+  const store = createSelectStore({ defaultValue: "Orange" });
+  const stop = init(store);
+
+  try {
+    const unregister = store.registerItem(apple);
+    await flushBatch();
+
+    store.move("apple");
+    unregister();
+    await flushBatch();
+
+    expect(store.getState().items).toEqual([]);
+    expect(store.getState().value).toBe("Orange");
+  } finally {
+    stop();
+  }
+});
+
+test("sets the value from an unregistered item in a composed store", async () => {
+  const composite = createCompositeStore<SelectStoreItem>();
+  const store = createSelectStore({ store: composite, defaultValue: "Orange" });
+  const stop = init(store);
+
+  try {
+    composite.setState("items", [apple]);
+    composite.move("apple");
+    await flushBatch();
+
+    expect(store.getState().value).toBe("Apple");
+  } finally {
+    stop();
+  }
+});
+
+test("does not use an item added after moving", async () => {
+  const store = createSelectStore({ defaultValue: "Orange" });
+  const stop = init(store);
+
+  try {
+    store.move("apple");
+    queueMicrotask(() => {
+      store.setState("items", [apple]);
+    });
+    await flushBatch();
+
+    expect(store.getState().value).toBe("Orange");
+  } finally {
+    stop();
+  }
+});
+
+test("prefers newly registered item metadata", async () => {
+  const store = createSelectStore({ defaultValue: "Orange" });
+  const stop = init(store);
+
+  try {
+    store.setState("items", [apple]);
+    store.move("apple");
+    queueMicrotask(() => {
+      store.registerItem({ ...apple, disabled: true });
+    });
+    await flushBatch();
+
+    expect(store.getState().value).toBe("Orange");
+  } finally {
+    stop();
+  }
+});
+
+test("does not overwrite a value set after moving", async () => {
+  const store = createSelectStore({ defaultValue: "Orange" });
+  const stop = init(store);
+
+  try {
+    store.setState("items", [apple]);
+    store.move("apple");
+    queueMicrotask(() => store.setValue("Banana"));
+    await flushBatch();
+
+    expect(store.getState().value).toBe("Banana");
+  } finally {
+    stop();
+  }
+});
+
+test("does not set the value after the store is destroyed", async () => {
+  const store = createSelectStore({ defaultValue: "Orange" });
+  const stop = init(store);
+
+  store.setState("items", [apple]);
+  store.move("apple");
+  queueMicrotask(stop);
+  await flushBatch();
+
+  expect(store.getState().value).toBe("Orange");
+});

--- a/packages/ariakit-components/src/select/select-store.ts
+++ b/packages/ariakit-components/src/select/select-store.ts
@@ -170,6 +170,9 @@ export function createSelectStore({
     select.setState("value", item.value);
   };
 
+  // Tracks strict-equal setter calls that state subscriptions don't observe.
+  let setValueVersion = 0;
+
   // Sets the select value when the active item changes by moving (which usually
   // happens when moving to an item using the keyboard).
   setup(select, () =>
@@ -190,6 +193,7 @@ export function createSelectStore({
       if (publicItem.disabled) return;
       if (publicItem.value == null) return;
 
+      const setValueVersionAtBatch = setValueVersion;
       let canceled = false;
       const stopValueSubscription = subscribe(select, ["value"], () => {
         canceled = true;
@@ -197,6 +201,7 @@ export function createSelectStore({
       queueMicrotask(() => {
         stopValueSubscription();
         if (canceled) return;
+        if (setValueVersion !== setValueVersionAtBatch) return;
         const currentState = select.getState();
         if (currentState.moves !== moves) return;
         if (currentState.activeId !== activeId) return;
@@ -219,7 +224,10 @@ export function createSelectStore({
     ...popover,
     ...select,
     combobox,
-    setValue: (value) => select.setState("value", value),
+    setValue: (value) => {
+      setValueVersion += 1;
+      select.setState("value", value);
+    },
     setLabelElement: (element) => select.setState("labelElement", element),
     setSelectElement: (element) => select.setState("selectElement", element),
     setListElement: (element) => select.setState("listElement", element),

--- a/packages/ariakit-components/src/select/select-store.ts
+++ b/packages/ariakit-components/src/select/select-store.ts
@@ -162,18 +162,49 @@ export function createSelectStore({
     }),
   );
 
+  const setValueFromItem = (item: SelectStoreItem | null | undefined) => {
+    if (!item) return;
+    if (item.disabled) return;
+    if (item.value == null) return;
+    select.setState("value", item.value);
+  };
+
   // Sets the select value when the active item changes by moving (which usually
   // happens when moving to an item using the keyboard).
   setup(select, () =>
-    batch(select, ["setValueOnMove", "moves"], (state) => {
-      const { mounted, value, activeId } = select.getState();
-      if (!state.setValueOnMove && mounted) return;
+    batch(select, ["setValueOnMove", "moves"], () => {
+      const { activeId, items, mounted, moves, setValueOnMove, value } =
+        select.getState();
+      if (!setValueOnMove && mounted) return;
       if (Array.isArray(value)) return;
-      if (!state.moves) return;
+      if (!moves) return;
       if (!activeId) return;
       const item = composite.item(activeId);
-      if (!item || item.disabled || item.value == null) return;
-      select.setState("value", item.value);
+      if (item) {
+        setValueFromItem(item);
+        return;
+      }
+      const publicItem = items.find((item) => item.id === activeId);
+      if (!publicItem) return;
+      if (publicItem.disabled) return;
+      if (publicItem.value == null) return;
+
+      let canceled = false;
+      queueMicrotask(() => {
+        if (canceled) return;
+        const currentState = select.getState();
+        if (currentState.moves !== moves) return;
+        if (currentState.activeId !== activeId) return;
+        if (currentState.value !== value) return;
+        const currentItem =
+          composite.item(activeId) ??
+          currentState.items.find((item) => item.id === activeId);
+        setValueFromItem(currentItem);
+      });
+
+      return () => {
+        canceled = true;
+      };
     }),
   );
 

--- a/packages/ariakit-components/src/select/select-store.ts
+++ b/packages/ariakit-components/src/select/select-store.ts
@@ -4,6 +4,7 @@ import {
   mergeStore,
   omit,
   setup,
+  subscribe,
   sync,
   throwOnConflictingProps,
 } from "@ariakit/store";
@@ -190,7 +191,11 @@ export function createSelectStore({
       if (publicItem.value == null) return;
 
       let canceled = false;
+      const stopValueSubscription = subscribe(select, ["value"], () => {
+        canceled = true;
+      });
       queueMicrotask(() => {
+        stopValueSubscription();
         if (canceled) return;
         const currentState = select.getState();
         if (currentState.moves !== moves) return;
@@ -204,6 +209,7 @@ export function createSelectStore({
 
       return () => {
         canceled = true;
+        stopValueSubscription();
       };
     }),
   );

--- a/packages/ariakit-components/src/select/select-store.ts
+++ b/packages/ariakit-components/src/select/select-store.ts
@@ -9,7 +9,7 @@ import {
   throwOnConflictingProps,
 } from "@ariakit/store";
 import type { Store, StoreOptions, StoreProps } from "@ariakit/store";
-import { toArray, defaultValue } from "@ariakit/utils";
+import { toArray, defaultValue, hasOwnProperty } from "@ariakit/utils";
 import type { PickRequired, SetState } from "@ariakit/utils";
 import type { ComboboxStore } from "../combobox/combobox-store.ts";
 import type {
@@ -28,6 +28,59 @@ import { createPopoverStore } from "../popover/popover-store.ts";
 
 type MutableValue<T extends SelectStoreValue = SelectStoreValue> =
   T extends string ? string : T;
+
+interface ValueWriteTracker {
+  version: number;
+}
+
+interface StoreWithInternals extends Store {
+  __unstableInternals?: {
+    stores?: ReadonlyArray<Store | undefined>;
+  };
+}
+
+const valueWriteTrackerMap = new WeakMap<object, ValueWriteTracker>();
+
+function getValueWriteTrackers(store: Store) {
+  const roots = new Set<object>();
+  const visited = new Set<object>();
+
+  const visit = (store: StoreWithInternals) => {
+    // Store objects may be spread while preserving the same internals.
+    const identity = store.__unstableInternals ?? store;
+    if (visited.has(identity)) return;
+    visited.add(identity);
+
+    let hasValueParent = false;
+    for (const parent of store.__unstableInternals?.stores ?? []) {
+      if (!parent) continue;
+      if (!hasOwnProperty(parent.getState(), "value")) continue;
+      hasValueParent = true;
+      visit(parent);
+    }
+    if (!hasValueParent) {
+      roots.add(identity);
+    }
+  };
+
+  visit(store);
+
+  const trackers: ValueWriteTracker[] = [];
+  for (const root of roots) {
+    const tracker = valueWriteTrackerMap.get(root) ?? { version: 0 };
+    valueWriteTrackerMap.set(root, tracker);
+    trackers.push(tracker);
+  }
+  return trackers;
+}
+
+function getValueWriteVersion(trackers: ValueWriteTracker[]) {
+  let version = 0;
+  for (const tracker of trackers) {
+    version += tracker.version;
+  }
+  return version;
+}
 
 export function createSelectStore<
   T extends SelectStoreValue = SelectStoreValue,
@@ -119,6 +172,8 @@ export function createSelectStore({
 
   const select = createStore(initialState, composite, popover, store);
 
+  const valueWriteTrackers = getValueWriteTrackers(select);
+
   // Automatically sets the default value if it's not set.
   setup(select, () =>
     sync(select, ["value", "items"], (state) => {
@@ -170,9 +225,6 @@ export function createSelectStore({
     select.setState("value", item.value);
   };
 
-  // Tracks strict-equal setter calls that state subscriptions don't observe.
-  let setValueVersion = 0;
-
   // Sets the select value when the active item changes by moving (which usually
   // happens when moving to an item using the keyboard).
   setup(select, () =>
@@ -193,7 +245,7 @@ export function createSelectStore({
       if (publicItem.disabled) return;
       if (publicItem.value == null) return;
 
-      const setValueVersionAtBatch = setValueVersion;
+      const valueWriteVersion = getValueWriteVersion(valueWriteTrackers);
       let canceled = false;
       const stopValueSubscription = subscribe(select, ["value"], () => {
         canceled = true;
@@ -201,7 +253,9 @@ export function createSelectStore({
       queueMicrotask(() => {
         stopValueSubscription();
         if (canceled) return;
-        if (setValueVersion !== setValueVersionAtBatch) return;
+        if (getValueWriteVersion(valueWriteTrackers) !== valueWriteVersion) {
+          return;
+        }
         const currentState = select.getState();
         if (currentState.moves !== moves) return;
         if (currentState.activeId !== activeId) return;
@@ -219,15 +273,22 @@ export function createSelectStore({
     }),
   );
 
+  const setState: SelectStore["setState"] = (key, value) => {
+    if (key === "value") {
+      for (const tracker of valueWriteTrackers) {
+        tracker.version += 1;
+      }
+    }
+    select.setState(key, value);
+  };
+
   return {
     ...composite,
     ...popover,
     ...select,
     combobox,
-    setValue: (value) => {
-      setValueVersion += 1;
-      select.setState("value", value);
-    },
+    setState,
+    setValue: (value) => setState("value", value),
     setLabelElement: (element) => select.setState("labelElement", element),
     setSelectElement: (element) => select.setState("selectElement", element),
     setListElement: (element) => select.setState("listElement", element),

--- a/packages/ariakit-components/src/select/select-store.ts
+++ b/packages/ariakit-components/src/select/select-store.ts
@@ -31,18 +31,22 @@ type MutableValue<T extends SelectStoreValue = SelectStoreValue> =
 
 interface ValueWriteTracker {
   version: number;
+  subscriptions: number;
+  subscribeSameValue?: (listener: (key: PropertyKey) => void) => () => void;
+  unsubscribeSameValue?: () => void;
 }
 
 interface StoreWithInternals extends Store {
   __unstableInternals?: {
     stores?: ReadonlyArray<Store | undefined>;
+    subscribeSameValue?: (listener: (key: PropertyKey) => void) => () => void;
   };
 }
 
 const valueWriteTrackerMap = new WeakMap<object, ValueWriteTracker>();
 
 function getValueWriteTrackers(store: Store) {
-  const roots = new Set<object>();
+  const roots = new Map<object, StoreWithInternals>();
   const visited = new Set<object>();
 
   const visit = (store: StoreWithInternals) => {
@@ -59,19 +63,44 @@ function getValueWriteTrackers(store: Store) {
       visit(parent);
     }
     if (!hasValueParent) {
-      roots.add(identity);
+      roots.set(identity, store);
     }
   };
 
   visit(store);
 
   const trackers: ValueWriteTracker[] = [];
-  for (const root of roots) {
-    const tracker = valueWriteTrackerMap.get(root) ?? { version: 0 };
-    valueWriteTrackerMap.set(root, tracker);
+  for (const [identity, root] of roots) {
+    let tracker = valueWriteTrackerMap.get(identity);
+    if (!tracker) {
+      const nextTracker: ValueWriteTracker = {
+        version: 0,
+        subscriptions: 0,
+        subscribeSameValue: root.__unstableInternals?.subscribeSameValue,
+      };
+      tracker = nextTracker;
+      valueWriteTrackerMap.set(identity, nextTracker);
+    }
     trackers.push(tracker);
   }
   return trackers;
+}
+
+function retainValueWriteTracker(tracker: ValueWriteTracker) {
+  tracker.subscriptions += 1;
+  if (tracker.subscriptions === 1) {
+    tracker.unsubscribeSameValue = tracker.subscribeSameValue?.((key) => {
+      if (key === "value") {
+        tracker.version += 1;
+      }
+    });
+  }
+  return () => {
+    tracker.subscriptions -= 1;
+    if (tracker.subscriptions) return;
+    tracker.unsubscribeSameValue?.();
+    tracker.unsubscribeSameValue = undefined;
+  };
 }
 
 function getValueWriteVersion(trackers: ValueWriteTracker[]) {
@@ -174,6 +203,15 @@ export function createSelectStore({
 
   const valueWriteTrackers = getValueWriteTrackers(select);
 
+  setup(select, () => {
+    const releases = valueWriteTrackers.map(retainValueWriteTracker);
+    return () => {
+      for (const release of releases) {
+        release();
+      }
+    };
+  });
+
   // Automatically sets the default value if it's not set.
   setup(select, () =>
     sync(select, ["value", "items"], (state) => {
@@ -222,6 +260,7 @@ export function createSelectStore({
     if (!item) return;
     if (item.disabled) return;
     if (item.value == null) return;
+    if (select.getState().value === item.value) return;
     select.setState("value", item.value);
   };
 

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -435,7 +435,7 @@ export function createStore<S extends State>(
       const internals = (
         store as Store & { __unstableInternals?: StoreInternals }
       ).__unstableInternals;
-      internals?.notifySameValue(key);
+      internals?.notifySameValue?.(key);
     }
   };
 

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -19,6 +19,9 @@ type Sync<S, K extends keyof S> = (
 
 type StoreSetup = (callback: () => void | (() => void)) => () => void;
 type StoreInit = () => () => void;
+type SameValueListener = (key: PropertyKey) => void;
+type StoreSubscribeSameValue = (listener: SameValueListener) => () => void;
+type StoreNotifySameValue = (key: PropertyKey) => void;
 // These three are intentionally identical `Sync<S, K>` signatures; they differ
 // only in runtime timing semantics, not in types: subscribe fires after a
 // change; sync fires immediately on registration and synchronously on every
@@ -60,6 +63,8 @@ interface FastPathFrame<S> {
 
 interface StoreInternals<S = State> {
   stores: ReadonlyArray<Store<Partial<S>> | undefined>;
+  subscribeSameValue: StoreSubscribeSameValue;
+  notifySameValue: StoreNotifySameValue;
   setup: StoreSetup;
   init: StoreInit;
   subscribe: StoreSubscribe<S>;
@@ -388,6 +393,7 @@ export function createStore<S extends State>(
   let batchPending = false;
   let inDispatch = false;
   let updatedKeys = new Set<keyof S>();
+  let sameValueListeners: Set<SameValueListener> | undefined;
   const instances = new Set<symbol>();
 
   const setups = new Set<() => void | (() => void)>();
@@ -405,6 +411,32 @@ export function createStore<S extends State>(
   const storeSetup: StoreSetup = (callback) => {
     setups.add(callback);
     return () => setups.delete(callback);
+  };
+
+  const storeSubscribeSameValue: StoreSubscribeSameValue = (listener) => {
+    sameValueListeners ??= new Set();
+    sameValueListeners.add(listener);
+    return () => {
+      sameValueListeners?.delete(listener);
+      if (!sameValueListeners?.size) {
+        sameValueListeners = undefined;
+      }
+    };
+  };
+
+  const storeNotifySameValue: StoreNotifySameValue = (key) => {
+    for (const listener of sameValueListeners ?? []) {
+      listener(key);
+    }
+    for (const store of stores) {
+      const storeState = store?.getState?.();
+      if (!storeState) continue;
+      if (!hasOwnProperty(storeState, key)) continue;
+      const internals = (
+        store as Store & { __unstableInternals?: StoreInternals }
+      ).__unstableInternals;
+      internals?.notifySameValue(key);
+    }
   };
 
   const storeInit: StoreInit = () => {
@@ -722,7 +754,13 @@ export function createStore<S extends State>(
     const currentValue = state[key];
     const nextValue = applyState(value, () => currentValue);
 
-    if (isSameValue(nextValue, currentValue)) return;
+    if (isSameValue(nextValue, currentValue)) {
+      // Normal subscriptions do not observe same-value setter calls.
+      if (!fromStores) {
+        storeNotifySameValue(key);
+      }
+      return;
+    }
 
     // Track the active dispatch so storeBatch can distinguish idle
     // registration (refresh prevStateBatch) from registration during an
@@ -845,6 +883,8 @@ export function createStore<S extends State>(
     setState,
     __unstableInternals: {
       stores,
+      subscribeSameValue: storeSubscribeSameValue,
+      notifySameValue: storeNotifySameValue,
       setup: storeSetup,
       init: storeInit,
       subscribe: storeSubscribe,

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -59,6 +59,7 @@ interface FastPathFrame<S> {
 }
 
 interface StoreInternals<S = State> {
+  stores: ReadonlyArray<Store<Partial<S>> | undefined>;
   setup: StoreSetup;
   init: StoreInit;
   subscribe: StoreSubscribe<S>;
@@ -843,6 +844,7 @@ export function createStore<S extends State>(
     getState,
     setState,
     __unstableInternals: {
+      stores,
       setup: storeSetup,
       init: storeInit,
       subscribe: storeSubscribe,


### PR DESCRIPTION
## Motivation

When a controlled `Select` receives items after store creation while its options are unmounted, closed-trigger typeahead can move the active item without updating the selected value. The same mismatch occurs when `SelectRenderer` renders zero items while the Select is closed.

```tsx
const select = useSelectStore({ items, value, setValue });

<Select store={select}>{value}</Select>
<SelectPopover store={select} unmountOnHide>
  {items.map((item) => (
    <SelectItem key={item.id} {...item} />
  ))}
</SelectPopover>
```

After loading Apple and typing <kbd>a</kbd>, `activeId` becomes `apple`, but the trigger still shows Orange.

## Solution

Keep registered collection items as the authoritative fast path. When typeahead moves to an eligible item that exists only in the public `items` state, defer that fallback by one microtask so any pending item unregistration can first reach public state. Before updating the value, revalidate the move, active item, current value, and store lifetime, then resolve registered metadata again before using the public item.

```ts
const item = composite.item(activeId);
if (item) {
  setValueFromItem(item);
  return;
}

const publicItem = items.find((item) => item.id === activeId);
if (!publicItem) return;

queueMicrotask(() => {
  const currentItem =
    composite.item(activeId) ??
    select.getState().items.find((item) => item.id === activeId);
  setValueFromItem(currentItem);
});
```

The regression coverage includes the reported unmounted-popover case and `SelectRenderer` in happy-dom and Chrome, Firefox, and Safari. Store-level tests cover disabled and valueless items, composed stores, same-task unregistration, newly registered metadata, post-move additions and value writes, and teardown cancellation.

## Workaround

When ordinary `SelectItem` elements are mapped directly, keeping them mounted with `unmountOnHide={false}` registers late items before closed-trigger typeahead needs them. That does not cover `SelectRenderer`, which deliberately renders zero items while the Select is closed.

For a controlled single-value Select whose items may arrive asynchronously, mirror only closed-state moves from the application-owned items into the value:

```tsx
const activeId = useStoreState(select, "activeId");
const mounted = useStoreState(select, "mounted");
const moves = useStoreState(select, "moves");
const previousMoves = useRef(moves);

// TODO: Remove after https://github.com/ariakit/ariakit/issues/6733 is fixed.
useEffect(() => {
  if (previousMoves.current === moves) return;
  previousMoves.current = moves;
  if (mounted) return;
  if (!activeId) return;
  const item = items.find((item) => item.id === activeId);
  if (!item || item.disabled || item.value == null) return;
  setValue(item.value);
}, [activeId, items, mounted, moves]);
```

This temporary workaround assumes a controlled single-value Select and treats the application-owned `items` array as authoritative. It only synchronizes moves made while the Select is closed, so normal open-popover navigation remains unchanged. It is not suitable for multi-select values or applications that intentionally keep `activeId` and `value` independent while closed.

Fixes #6733

