### PR TITLE
Fix Menu default-open focus

### DIFF
--- a/.changeset/300-menu-default-open-focus.md
+++ b/.changeset/300-menu-default-open-focus.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Menu`](https://ariakit.com/reference/menu) to move focus inside when it mounts already open in non-modal mode. Thanks to [@ciampo](https://github.com/ciampo).

--- a/app/src/sandbox/menu-2946/index.react.tsx
+++ b/app/src/sandbox/menu-2946/index.react.tsx
@@ -1,0 +1,20 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+
+export default function Example() {
+  const [created, setCreated] = useState(false);
+
+  if (!created) {
+    return <button onClick={() => setCreated(true)}>Add item</button>;
+  }
+
+  return (
+    <Ariakit.MenuProvider defaultOpen>
+      <Ariakit.MenuButton>Actions for new item</Ariakit.MenuButton>
+      <Ariakit.Menu modal={false}>
+        <Ariakit.MenuItem>Rename</Ariakit.MenuItem>
+        <Ariakit.MenuItem>Duplicate</Ariakit.MenuItem>
+      </Ariakit.Menu>
+    </Ariakit.MenuProvider>
+  );
+}

--- a/app/src/sandbox/menu-2946/index.react.tsx
+++ b/app/src/sandbox/menu-2946/index.react.tsx
@@ -1,5 +1,24 @@
 import * as Ariakit from "@ariakit/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+
+function NewItemActions() {
+  const store = Ariakit.useMenuStore({ defaultOpen: true });
+
+  useEffect(() => {
+    // TODO: Remove after https://github.com/ariakit/ariakit/issues/2946
+    store.setAutoFocusOnShow(true);
+  }, [store]);
+
+  return (
+    <Ariakit.MenuProvider store={store}>
+      <Ariakit.MenuButton>Actions for new item</Ariakit.MenuButton>
+      <Ariakit.Menu modal={false}>
+        <Ariakit.MenuItem>Rename</Ariakit.MenuItem>
+        <Ariakit.MenuItem>Duplicate</Ariakit.MenuItem>
+      </Ariakit.Menu>
+    </Ariakit.MenuProvider>
+  );
+}
 
 export default function Example() {
   const [created, setCreated] = useState(false);
@@ -8,13 +27,5 @@ export default function Example() {
     return <button onClick={() => setCreated(true)}>Add item</button>;
   }
 
-  return (
-    <Ariakit.MenuProvider defaultOpen>
-      <Ariakit.MenuButton>Actions for new item</Ariakit.MenuButton>
-      <Ariakit.Menu modal={false}>
-        <Ariakit.MenuItem>Rename</Ariakit.MenuItem>
-        <Ariakit.MenuItem>Duplicate</Ariakit.MenuItem>
-      </Ariakit.Menu>
-    </Ariakit.MenuProvider>
-  );
+  return <NewItemActions />;
 }

--- a/app/src/sandbox/menu-2946/index.react.tsx
+++ b/app/src/sandbox/menu-2946/index.react.tsx
@@ -1,31 +1,28 @@
 import * as Ariakit from "@ariakit/react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
-function NewItemActions() {
-  const store = Ariakit.useMenuStore({ defaultOpen: true });
+export default function Example() {
+  const [mode, setMode] = useState<"active" | "passive">();
 
-  useEffect(() => {
-    // TODO: Remove after https://github.com/ariakit/ariakit/issues/2946
-    store.setAutoFocusOnShow(true);
-  }, [store]);
+  if (!mode) {
+    return (
+      <>
+        <button onClick={() => setMode("active")}>Add item</button>
+        <button onClick={() => setMode("passive")}>Add passive item</button>
+      </>
+    );
+  }
 
   return (
-    <Ariakit.MenuProvider store={store}>
+    <Ariakit.MenuProvider defaultOpen>
       <Ariakit.MenuButton>Actions for new item</Ariakit.MenuButton>
-      <Ariakit.Menu modal={false}>
+      <Ariakit.Menu
+        autoFocusOnShow={mode === "passive" ? false : undefined}
+        modal={false}
+      >
         <Ariakit.MenuItem>Rename</Ariakit.MenuItem>
         <Ariakit.MenuItem>Duplicate</Ariakit.MenuItem>
       </Ariakit.Menu>
     </Ariakit.MenuProvider>
   );
-}
-
-export default function Example() {
-  const [created, setCreated] = useState(false);
-
-  if (!created) {
-    return <button onClick={() => setCreated(true)}>Add item</button>;
-  }
-
-  return <NewItemActions />;
 }

--- a/app/src/sandbox/menu-2946/index.react.tsx
+++ b/app/src/sandbox/menu-2946/index.react.tsx
@@ -1,24 +1,226 @@
 import * as Ariakit from "@ariakit/react";
-import { useState } from "react";
+import { useMenu } from "@ariakit/react-components/menu/menu";
+import { useLayoutEffect, useState } from "react";
+
+type Mode =
+  | "active"
+  | "passive"
+  | "modal"
+  | "controlled"
+  | "headless"
+  | "relationship"
+  | "hidden"
+  | "lazy"
+  | "late"
+  | "late-controlled"
+  | "deferred";
+
+function DeferredActions() {
+  const [open, setOpen] = useState(false);
+  const store = Ariakit.useMenuStore();
+
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Show deferred actions</button>
+      <Ariakit.Menu open={open} store={store}>
+        <Ariakit.MenuItem>Archive</Ariakit.MenuItem>
+      </Ariakit.Menu>
+    </>
+  );
+}
+
+function HeadlessActions() {
+  const store = Ariakit.useMenuStore({ defaultOpen: true });
+  const props = useMenu({
+    store,
+    "aria-label": "Hook actions",
+  });
+
+  return (
+    <Ariakit.Role {...props}>
+      <Ariakit.MenuItem store={store}>Inspect</Ariakit.MenuItem>
+    </Ariakit.Role>
+  );
+}
+
+function PassiveActions() {
+  const store = Ariakit.useMenuStore({ defaultOpen: true });
+  const autoFocusOnShow = Ariakit.useStoreState(store, "autoFocusOnShow");
+
+  return (
+    <>
+      <Ariakit.MenuButton store={store}>
+        Actions for new item
+      </Ariakit.MenuButton>
+      <Ariakit.Menu autoFocusOnShow={false} store={store}>
+        <Ariakit.MenuItem>Rename</Ariakit.MenuItem>
+        <Ariakit.MenuItem>Duplicate</Ariakit.MenuItem>
+      </Ariakit.Menu>
+      <span>Store autofocus: {autoFocusOnShow ? "enabled" : "disabled"}</span>
+    </>
+  );
+}
+
+function HiddenOnMountActions() {
+  const store = Ariakit.useMenuStore({ defaultOpen: true });
+
+  useLayoutEffect(() => {
+    store.hide();
+  }, [store]);
+
+  return (
+    <>
+      <button onClick={store.show}>Show initially hidden actions</button>
+      <Ariakit.Menu store={store}>
+        <Ariakit.MenuItem>Download</Ariakit.MenuItem>
+      </Ariakit.Menu>
+    </>
+  );
+}
+
+function LazyActions() {
+  const [showMenu, setShowMenu] = useState(false);
+  const store = Ariakit.useMenuStore();
+
+  return (
+    <>
+      <button
+        onClick={() => {
+          store.show();
+          setShowMenu(true);
+        }}
+      >
+        Show lazy actions
+      </button>
+      {showMenu && (
+        <Ariakit.Menu store={store}>
+          <Ariakit.MenuItem>Export</Ariakit.MenuItem>
+        </Ariakit.Menu>
+      )}
+    </>
+  );
+}
+
+function LateActions({ controlled = false }: { controlled?: boolean }) {
+  const [showMenu, setShowMenu] = useState(false);
+  const store = Ariakit.useMenuStore({ defaultOpen: !controlled });
+  const label = controlled ? "Late controlled actions" : "Late actions";
+
+  return (
+    <>
+      <button onClick={() => setShowMenu(true)}>
+        Render {controlled ? "controlled" : "default-open"} actions
+      </button>
+      {showMenu && (
+        <Ariakit.Menu
+          aria-label={label}
+          open={controlled ? true : undefined}
+          store={store}
+        >
+          <Ariakit.MenuItem>{controlled ? "Publish" : "Move"}</Ariakit.MenuItem>
+        </Ariakit.Menu>
+      )}
+    </>
+  );
+}
+
+function RelationshipActions() {
+  const [hasParent, setHasParent] = useState(false);
+  const parent = Ariakit.useMenuStore();
+  const store = Ariakit.useMenuStore({
+    defaultOpen: true,
+    parent: hasParent ? parent : null,
+  });
+
+  return (
+    <>
+      <Ariakit.MenuButton store={store}>
+        Actions for related item
+      </Ariakit.MenuButton>
+      <Ariakit.Menu autoFocusOnHide={false} modal={false} store={store}>
+        <Ariakit.MenuItem
+          hideOnClick={false}
+          onClick={() => {
+            store.setAutoFocusOnShow(false);
+            setHasParent(true);
+          }}
+        >
+          {hasParent ? "Parent changed" : "Change parent"}
+        </Ariakit.MenuItem>
+      </Ariakit.Menu>
+    </>
+  );
+}
 
 export default function Example() {
-  const [mode, setMode] = useState<"active" | "passive">();
+  const [mode, setMode] = useState<Mode>();
 
   if (!mode) {
     return (
       <>
         <button onClick={() => setMode("active")}>Add item</button>
         <button onClick={() => setMode("passive")}>Add passive item</button>
+        <button onClick={() => setMode("modal")}>Add modal item</button>
+        <button onClick={() => setMode("controlled")}>
+          Add controlled item
+        </button>
+        <button onClick={() => setMode("headless")}>Add hook item</button>
+        <button onClick={() => setMode("relationship")}>
+          Add related item
+        </button>
+        <button onClick={() => setMode("hidden")}>
+          Add initially hidden item
+        </button>
+        <button onClick={() => setMode("lazy")}>Add lazy item</button>
+        <button onClick={() => setMode("late")}>
+          Add late default-open item
+        </button>
+        <button onClick={() => setMode("late-controlled")}>
+          Add late controlled item
+        </button>
+        <button onClick={() => setMode("deferred")}>Add deferred item</button>
       </>
     );
   }
 
+  if (mode === "relationship") {
+    return <RelationshipActions />;
+  }
+
+  if (mode === "headless") {
+    return <HeadlessActions />;
+  }
+
+  if (mode === "passive") {
+    return <PassiveActions />;
+  }
+
+  if (mode === "deferred") {
+    return <DeferredActions />;
+  }
+
+  if (mode === "hidden") {
+    return <HiddenOnMountActions />;
+  }
+
+  if (mode === "lazy") {
+    return <LazyActions />;
+  }
+
+  if (mode === "late") {
+    return <LateActions />;
+  }
+
+  if (mode === "late-controlled") {
+    return <LateActions controlled />;
+  }
+
   return (
-    <Ariakit.MenuProvider defaultOpen>
+    <Ariakit.MenuProvider defaultOpen={mode !== "controlled"}>
       <Ariakit.MenuButton>Actions for new item</Ariakit.MenuButton>
       <Ariakit.Menu
-        autoFocusOnShow={mode === "passive" ? false : undefined}
-        modal={false}
+        modal={mode === "modal"}
+        open={mode === "controlled" ? true : undefined}
       >
         <Ariakit.MenuItem>Rename</Ariakit.MenuItem>
         <Ariakit.MenuItem>Duplicate</Ariakit.MenuItem>

--- a/app/src/sandbox/menu-2946/test-browser.ts
+++ b/app/src/sandbox/menu-2946/test-browser.ts
@@ -20,5 +20,101 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
     await test.expect(q.menu("Actions for new item")).toBeVisible();
     await test.expect(page.locator("body")).toBeFocused();
+    await test.expect(q.text("Store autofocus: disabled")).toBeVisible();
+  });
+
+  test("preserves modal menu item focus when mounting open", async ({ q }) => {
+    await q.button("Add modal item").click();
+
+    const item = q.menuitem("Rename");
+    await test.expect(item).toBeFocused();
+    await test.expect(item).toHaveAttribute("data-active-item");
+  });
+
+  test("focuses a conditionally mounted controlled-open menu", async ({
+    q,
+  }) => {
+    await q.button("Add controlled item").click();
+
+    await test.expect(q.menu("Actions for new item")).toBeFocused();
+  });
+
+  test("focuses a conditionally mounted menu created with useMenu", async ({
+    q,
+  }) => {
+    await q.button("Add hook item").click();
+
+    await test.expect(q.menu("Hook actions")).toBeFocused();
+  });
+
+  test("does not refocus an open menu when its store is replaced", async ({
+    q,
+  }) => {
+    await q.button("Add related item").click();
+    await q.menuitem("Change parent").focus();
+    await q.menuitem("Change parent").click();
+
+    await test.expect(q.menuitem("Parent changed")).toBeFocused();
+  });
+
+  test("does not autofocus a menu opened after mounting", async ({ q }) => {
+    await q.button("Add deferred item").click();
+    const button = q.button("Show deferred actions");
+    await button.focus();
+    await button.click();
+
+    await test.expect(q.menuitem("Archive")).toBeVisible();
+    await test.expect(q.menu()).not.toBeFocused();
+    await test.expect(q.menuitem("Archive")).not.toBeFocused();
+  });
+
+  test("does not autofocus after closing before passive effects", async ({
+    q,
+  }) => {
+    await q.button("Add initially hidden item").click();
+    const button = q.button("Show initially hidden actions");
+    await button.focus();
+    await button.click();
+
+    await test.expect(q.menuitem("Download")).toBeVisible();
+    await test.expect(q.menu()).not.toBeFocused();
+    await test.expect(q.menuitem("Download")).not.toBeFocused();
+  });
+
+  test("does not autofocus a lazily rendered menu", async ({ q }) => {
+    await q.button("Add lazy item").click();
+    const button = q.button("Show lazy actions");
+    await button.focus();
+    await button.click();
+
+    await test.expect(q.menuitem("Export")).toBeVisible();
+    await test.expect(q.menu()).not.toBeFocused();
+    await test.expect(q.menuitem("Export")).not.toBeFocused();
+  });
+
+  test("does not autofocus a default-open menu rendered after its store commits", async ({
+    q,
+  }) => {
+    await q.button("Add late default-open item").click();
+    const button = q.button("Render default-open actions");
+    await button.focus();
+    await button.click();
+
+    await test.expect(q.menuitem("Move")).toBeVisible();
+    await test.expect(q.menu("Late actions")).not.toBeFocused();
+    await test.expect(q.menuitem("Move")).not.toBeFocused();
+  });
+
+  test("does not autofocus a controlled-open menu rendered after its store commits", async ({
+    q,
+  }) => {
+    await q.button("Add late controlled item").click();
+    const button = q.button("Render controlled actions");
+    await button.focus();
+    await button.click();
+
+    await test.expect(q.menuitem("Publish")).toBeVisible();
+    await test.expect(q.menu("Late controlled actions")).not.toBeFocused();
+    await test.expect(q.menuitem("Publish")).not.toBeFocused();
   });
 });

--- a/app/src/sandbox/menu-2946/test-browser.ts
+++ b/app/src/sandbox/menu-2946/test-browser.ts
@@ -1,0 +1,17 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // Reproduces https://github.com/ariakit/ariakit/issues/2946#issuecomment-4977621514
+  test("focuses a conditionally mounted menu that opens by default", async ({
+    q,
+  }) => {
+    await q.button("Add item").click();
+
+    const menu = q.menu("Actions for new item");
+    await test.expect(menu).toBeVisible();
+    await test.expect(menu).toBeFocused();
+    await test
+      .expect(q.menuitem("Rename"))
+      .not.toHaveAttribute("data-active-item");
+  });
+});

--- a/app/src/sandbox/menu-2946/test-browser.ts
+++ b/app/src/sandbox/menu-2946/test-browser.ts
@@ -14,4 +14,11 @@ withFramework(import.meta.dirname, async ({ test }) => {
       .expect(q.menuitem("Rename"))
       .not.toHaveAttribute("data-active-item");
   });
+
+  test("respects autofocus opt-out when mounting open", async ({ page, q }) => {
+    await q.button("Add passive item").click();
+
+    await test.expect(q.menu("Actions for new item")).toBeVisible();
+    await test.expect(page.locator("body")).toBeFocused();
+  });
 });

--- a/app/src/sandbox/menu-2946/test.ts
+++ b/app/src/sandbox/menu-2946/test.ts
@@ -10,3 +10,10 @@ test("focuses a conditionally mounted menu that opens by default", async () => {
   expect(menu).toHaveFocus();
   expect(q.menuitem("Rename")).not.toHaveAttribute("data-active-item");
 });
+
+test("respects autofocus opt-out when mounting open", async () => {
+  await click(q.button("Add passive item"));
+
+  expect(q.menu("Actions for new item")).toBeVisible();
+  expect(document.body).toHaveFocus();
+});

--- a/app/src/sandbox/menu-2946/test.ts
+++ b/app/src/sandbox/menu-2946/test.ts
@@ -1,4 +1,4 @@
-import { click, q } from "@ariakit/test";
+import { click, focus, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 // Reproduces https://github.com/ariakit/ariakit/issues/2946#issuecomment-4977621514
@@ -16,4 +16,88 @@ test("respects autofocus opt-out when mounting open", async () => {
 
   expect(q.menu("Actions for new item")).toBeVisible();
   expect(document.body).toHaveFocus();
+  expect(q.text("Store autofocus: disabled")).toBeVisible();
+});
+
+test("preserves modal menu item focus when mounting open", async () => {
+  await click(q.button("Add modal item"));
+
+  const item = q.menuitem("Rename");
+  expect(item).toHaveFocus();
+  expect(item).toHaveAttribute("data-active-item");
+});
+
+test("focuses a conditionally mounted controlled-open menu", async () => {
+  await click(q.button("Add controlled item"));
+
+  expect(q.menu("Actions for new item")).toHaveFocus();
+});
+
+test("focuses a conditionally mounted menu created with useMenu", async () => {
+  await click(q.button("Add hook item"));
+
+  expect(q.menu("Hook actions")).toHaveFocus();
+});
+
+test("does not refocus an open menu when its store is replaced", async () => {
+  await click(q.button("Add related item"));
+  await focus(q.menuitem("Change parent"));
+  await click(q.menuitem("Change parent"));
+
+  expect(q.menuitem("Parent changed")).toHaveFocus();
+});
+
+test("does not autofocus a menu opened after mounting", async () => {
+  await click(q.button("Add deferred item"));
+  const button = q.button("Show deferred actions");
+  await focus(button);
+  await click(button);
+
+  expect(q.menuitem("Archive")).toBeVisible();
+  expect(q.menu()).not.toHaveFocus();
+  expect(q.menuitem("Archive")).not.toHaveFocus();
+});
+
+test("does not autofocus after closing before passive effects", async () => {
+  await click(q.button("Add initially hidden item"));
+  const button = q.button("Show initially hidden actions");
+  await focus(button);
+  await click(button);
+
+  expect(q.menuitem("Download")).toBeVisible();
+  expect(q.menu()).not.toHaveFocus();
+  expect(q.menuitem("Download")).not.toHaveFocus();
+});
+
+test("does not autofocus a lazily rendered menu", async () => {
+  await click(q.button("Add lazy item"));
+  const button = q.button("Show lazy actions");
+  await focus(button);
+  await click(button);
+
+  expect(q.menuitem("Export")).toBeVisible();
+  expect(q.menu()).not.toHaveFocus();
+  expect(q.menuitem("Export")).not.toHaveFocus();
+});
+
+test("does not autofocus a default-open menu rendered after its store commits", async () => {
+  await click(q.button("Add late default-open item"));
+  const button = q.button("Render default-open actions");
+  await focus(button);
+  await click(button);
+
+  expect(q.menuitem("Move")).toBeVisible();
+  expect(q.menu("Late actions")).not.toHaveFocus();
+  expect(q.menuitem("Move")).not.toHaveFocus();
+});
+
+test("does not autofocus a controlled-open menu rendered after its store commits", async () => {
+  await click(q.button("Add late controlled item"));
+  const button = q.button("Render controlled actions");
+  await focus(button);
+  await click(button);
+
+  expect(q.menuitem("Publish")).toBeVisible();
+  expect(q.menu("Late controlled actions")).not.toHaveFocus();
+  expect(q.menuitem("Publish")).not.toHaveFocus();
 });

--- a/app/src/sandbox/menu-2946/test.ts
+++ b/app/src/sandbox/menu-2946/test.ts
@@ -1,0 +1,12 @@
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/2946#issuecomment-4977621514
+test("focuses a conditionally mounted menu that opens by default", async () => {
+  await click(q.button("Add item"));
+
+  const menu = q.menu("Actions for new item");
+  expect(menu).toBeVisible();
+  expect(menu).toHaveFocus();
+  expect(q.menuitem("Rename")).not.toHaveAttribute("data-active-item");
+});

--- a/packages/ariakit-react-components/src/menu/__utils.ts
+++ b/packages/ariakit-react-components/src/menu/__utils.ts
@@ -1,0 +1,15 @@
+export interface MenuStoreSetup {
+  autoFocusOnMount: boolean;
+  hasCommitted: boolean;
+}
+
+const menuStoreSetups = new WeakMap<object, MenuStoreSetup>();
+
+export function setMenuStoreSetup(store: object, setup: MenuStoreSetup) {
+  menuStoreSetups.set(store, setup);
+}
+
+export function getMenuStoreSetup(store?: object | null) {
+  if (!store) return;
+  return menuStoreSetups.get(store);
+}

--- a/packages/ariakit-react-components/src/menu/menu-store.ts
+++ b/packages/ariakit-react-components/src/menu/menu-store.ts
@@ -1,9 +1,12 @@
 import * as Core from "@ariakit/components/menu/menu-store";
 import { useStore, useStoreProps } from "@ariakit/react-store";
 import type { Store } from "@ariakit/react-store";
-import { useUpdateEffect } from "@ariakit/react-utils";
+import {
+  useInitialValue,
+  useSafeLayoutEffect,
+  useUpdateEffect,
+} from "@ariakit/react-utils";
 import type { BivariantCallback, PickRequired } from "@ariakit/utils";
-import { useEffect } from "react";
 import { useComboboxProviderContext } from "../combobox/combobox-context.tsx";
 import type { ComboboxStore } from "../combobox/combobox-store.ts";
 import type {
@@ -20,6 +23,7 @@ import type {
 import { useHovercardStoreProps } from "../hovercard/hovercard-store.ts";
 import { useMenubarContext } from "../menubar/menubar-context.tsx";
 import type { MenubarStore } from "../menubar/menubar-store.ts";
+import { setMenuStoreSetup } from "./__utils.ts";
 import { useMenuContext } from "./menu-context.tsx";
 
 export function useMenuStoreProps<T extends Core.MenuStore>(
@@ -75,15 +79,18 @@ export function useMenuStore(props: MenuStoreProps = {}): MenuStore {
     combobox: props.combobox !== undefined ? props.combobox : combobox,
   };
   const [store, update] = useStore(Core.createMenuStore, props);
-  useEffect(() => {
-    // Menus that mount already open don't go through the MenuButton
-    // interactions that enable automatic focus.
-    const { open, autoFocusOnShow } = store.getState();
-    if (!open) return;
-    if (autoFocusOnShow) return;
-    store.setAutoFocusOnShow(true);
-  }, [store]);
-  return useMenuStoreProps(store, update, props);
+  const setup = useInitialValue(() => ({
+    autoFocusOnMount: store.getState().open,
+    hasCommitted: false,
+  }));
+  // Keep the initial setup associated with replacement store wrappers.
+  setMenuStoreSetup(store, setup);
+  const storeWithProps = useMenuStoreProps(store, update, props);
+  // Mount autofocus only applies to menus rendered in the initial commit.
+  useSafeLayoutEffect(() => {
+    setup.hasCommitted = true;
+  }, [setup]);
+  return storeWithProps;
 }
 
 export type MenuStoreValues = Core.MenuStoreValues;

--- a/packages/ariakit-react-components/src/menu/menu-store.ts
+++ b/packages/ariakit-react-components/src/menu/menu-store.ts
@@ -3,6 +3,7 @@ import { useStore, useStoreProps } from "@ariakit/react-store";
 import type { Store } from "@ariakit/react-store";
 import { useUpdateEffect } from "@ariakit/react-utils";
 import type { BivariantCallback, PickRequired } from "@ariakit/utils";
+import { useEffect } from "react";
 import { useComboboxProviderContext } from "../combobox/combobox-context.tsx";
 import type { ComboboxStore } from "../combobox/combobox-store.ts";
 import type {
@@ -74,6 +75,14 @@ export function useMenuStore(props: MenuStoreProps = {}): MenuStore {
     combobox: props.combobox !== undefined ? props.combobox : combobox,
   };
   const [store, update] = useStore(Core.createMenuStore, props);
+  useEffect(() => {
+    // Menus that mount already open don't go through the MenuButton
+    // interactions that enable automatic focus.
+    const { open, autoFocusOnShow } = store.getState();
+    if (!open) return;
+    if (autoFocusOnShow) return;
+    store.setAutoFocusOnShow(true);
+  }, [store]);
   return useMenuStoreProps(store, update, props);
 }
 

--- a/packages/ariakit-react-components/src/menu/menu.tsx
+++ b/packages/ariakit-react-components/src/menu/menu.tsx
@@ -4,6 +4,7 @@ import {
   createElement,
   createHook,
   forwardRef,
+  useInitialValue,
 } from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
 import {
@@ -17,13 +18,51 @@ import { createRef, useEffect, useMemo, useRef, useState } from "react";
 import { createDialogComponent } from "../dialog/dialog.tsx";
 import type { HovercardOptions } from "../hovercard/hovercard.tsx";
 import { useHovercard } from "../hovercard/hovercard.tsx";
+import { getMenuStoreSetup } from "./__utils.ts";
 import { useMenuProviderContext } from "./menu-context.tsx";
 import type { MenuListOptions } from "./menu-list.tsx";
 import { useMenuList } from "./menu-list.tsx";
+import type { MenuStore } from "./menu-store.ts";
 
 const TagName = "div" satisfies ElementType;
 type TagName = typeof TagName;
 type HTMLType = HTMLElementTagNameMap[TagName];
+
+interface AutoFocusOnMountOptions {
+  store: MenuStore | null | undefined;
+  modal: boolean;
+  open?: boolean;
+  autoFocusOnShow?: HovercardOptions["autoFocusOnShow"];
+}
+
+function useAutoFocusOnMount({
+  store,
+  modal,
+  open,
+  autoFocusOnShow,
+}: AutoFocusOnMountOptions) {
+  const setup = getMenuStoreSetup(store);
+  const initial = useInitialValue({
+    store,
+    setup,
+    modal,
+    open: !setup?.hasCommitted && (open ?? setup?.autoFocusOnMount),
+    autoFocusOnShow,
+  });
+
+  useEffect(() => {
+    // Menus that mount already open don't go through the MenuButton
+    // interactions that enable automatic focus.
+    if (!initial.store) return;
+    if (!initial.open) return;
+    if (initial.modal) return;
+    if (initial.autoFocusOnShow === false) return;
+    const { open, autoFocusOnShow } = initial.store.getState();
+    if (!open) return;
+    if (autoFocusOnShow) return;
+    initial.store.setAutoFocusOnShow(true);
+  }, [initial]);
+}
 
 /**
  * Returns props to create a `Menu` component.
@@ -66,6 +105,7 @@ export const useMenu = createHook<TagName, MenuOptions>(function useMenu({
   const parentIsMenubar = !!parentMenubar && !hasParentMenu;
   // If it's a submenu, it shouldn't behave like a modal dialog.
   const modal = hasParentMenu ? false : modalProp;
+  const open = props.open;
 
   props = {
     ...props,
@@ -244,8 +284,17 @@ export const useMenu = createHook<TagName, MenuOptions>(function useMenu({
     ...props,
   };
 
+  useAutoFocusOnMount({ store, modal, open, autoFocusOnShow });
+
   return props;
 });
+
+const MenuImpl = forwardRef(function MenuImpl(props: MenuProps) {
+  const htmlProps = useMenu(props);
+  return createElement(TagName, htmlProps);
+});
+
+const MenuWithStore = createDialogComponent(MenuImpl, useMenuProviderContext);
 
 /**
  * Renders a dropdown menu element that's controlled by a
@@ -267,13 +316,19 @@ export const useMenu = createHook<TagName, MenuOptions>(function useMenu({
  * </MenuProvider>
  * ```
  */
-export const Menu = createDialogComponent(
-  forwardRef(function Menu(props: MenuProps) {
-    const htmlProps = useMenu(props);
-    return createElement(TagName, htmlProps);
-  }),
-  useMenuProviderContext,
-);
+export const Menu = forwardRef(function Menu(props: MenuProps) {
+  const context = useMenuProviderContext();
+  const store = props.store || context;
+  const modal = store?.parent ? false : (props.modal ?? false);
+  useAutoFocusOnMount({
+    store,
+    modal,
+    open: props.open,
+    autoFocusOnShow: props.autoFocusOnShow,
+  });
+
+  return <MenuWithStore {...props} />;
+});
 
 export interface MenuOptions<T extends ElementType = TagName>
   extends MenuListOptions<T>, Omit<HovercardOptions<T>, "store"> {}


### PR DESCRIPTION
## Motivation

A non-modal `Menu` that is conditionally mounted already open does not receive focus. This happens in flows that replace an action button with the next available menu, such as:

```tsx
<button onClick={() => setCreated(true)}>Add item</button>

{created && (
  <MenuProvider defaultOpen>
    <MenuButton>Actions for new item</MenuButton>
    <Menu modal={false}>...</Menu>
  </MenuProvider>
)}
```

The menu becomes visible, but focus falls back to the document body and the first item is marked active.

## Solution

Record whether a React menu store starts open, then let `Menu` consume that setup only when it renders in the store's initial commit. For an eligible non-modal menu, enable the store's `autoFocusOnShow` state after mount, mirroring the `MenuButton` interactions that normally opt into automatic focus.

The mount snapshot and commit-expiring setup preserve the surrounding focus behavior:

```tsx
<Menu modal={false}>...</Menu> // Focuses the menu container on the initial open mount.
<Menu modal>...</Menu> // Keeps Dialog's first-item autofocus behavior.
<Menu autoFocusOnShow={false}>...</Menu> // Leaves focus unchanged.
```

Replacement store wrappers retain the same initial setup without rerunning mount autofocus. Menus rendered lazily or opened after the store's first commit remain ineligible, while controlled menus rendered open in that initial commit are supported. The same behavior is available through the public `Menu` component and the deep-exported `useMenu` hook.

The `menu-2946` sandbox uses the concrete reported active-element flow and covers 11 mount, modal, opt-out, controlled, hook, replacement, hidden, lazy, and delayed scenarios in happy-dom and browser tests. The focused suite passes with React 18 and React 19, and the browser matrix passes in Chrome, Firefox, and Safari.

## Workaround

Before this fix is released, a menu that is intentionally mounted already open can create its store in the mounted subtree and enable autofocus after mount:

```tsx
function NewItemActions() {
  const store = useMenuStore({ defaultOpen: true });

  useEffect(() => {
    // TODO: Remove after https://github.com/ariakit/ariakit/issues/2946
    store.setAutoFocusOnShow(true);
  }, [store]);

  return <MenuProvider store={store}>...</MenuProvider>;
}
```

This workaround assumes the newly mounted menu should take focus and keeps the default menu-container target. It only covers the initial mount; later programmatic opens still need to set `autoFocusOnShow` as part of the opening action. For passive menus opened from restored state that should not move focus, keep `autoFocusOnShow={false}` on `Menu` instead.
