### PR TITLE
Fix published package contents

### DIFF
--- a/.changeset/300-publish-package-dist.md
+++ b/.changeset/300-publish-package-dist.md
@@ -1,0 +1,11 @@
+---
+"@ariakit/components": patch
+"@ariakit/react-components": patch
+"@ariakit/react-store": patch
+"@ariakit/react-utils": patch
+"@ariakit/solid-store": patch
+"@ariakit/store": patch
+"@ariakit/react": patch
+---
+
+Fixed published packages omitting their build output. Thanks to [@shahednasser](https://github.com/shahednasser).

--- a/packages/ariakit-components/.npmignore
+++ b/packages/ariakit-components/.npmignore
@@ -8,3 +8,5 @@ tsconfig*.json
 *.log
 *.config.*
 *.lock
+# Include package build output ignored at the workspace root.
+!dist/

--- a/packages/ariakit-react-components/.npmignore
+++ b/packages/ariakit-react-components/.npmignore
@@ -8,3 +8,5 @@ tsconfig*.json
 *.log
 *.config.*
 *.lock
+# Include package build output ignored at the workspace root.
+!dist/

--- a/packages/ariakit-react-store/.npmignore
+++ b/packages/ariakit-react-store/.npmignore
@@ -8,3 +8,5 @@ tsconfig*.json
 *.log
 *.config.*
 *.lock
+# Include package build output ignored at the workspace root.
+!dist/

--- a/packages/ariakit-react-utils/.npmignore
+++ b/packages/ariakit-react-utils/.npmignore
@@ -8,3 +8,5 @@ tsconfig*.json
 *.log
 *.config.*
 *.lock
+# Include package build output ignored at the workspace root.
+!dist/

--- a/packages/ariakit-scripts/src/build.test.ts
+++ b/packages/ariakit-scripts/src/build.test.ts
@@ -358,3 +358,23 @@ test("omits the use client banner for non-React packages", async () => {
     await rm(rootPath, { recursive: true, force: true });
   }
 });
+
+test("includes build output in published packages", async () => {
+  const rootPath = await createBuildFixture({
+    sources: {
+      "index.ts": "export {};\n",
+    },
+  });
+
+  try {
+    runBuild(rootPath);
+
+    const npmignore = await readFile(join(rootPath, ".npmignore"), "utf-8");
+
+    expect(npmignore).toContain(
+      "# Include package build output ignored at the workspace root.\n!dist/\n",
+    );
+  } finally {
+    await rm(rootPath, { recursive: true, force: true });
+  }
+});

--- a/packages/ariakit-scripts/src/build.ts
+++ b/packages/ariakit-scripts/src/build.ts
@@ -293,7 +293,12 @@ function writeGitignore(rootPath: string, isSolid: boolean) {
 }
 
 function writeNpmignore(rootPath: string) {
-  const contents = ["# Automatically generated", ...npmIgnoreEntries];
+  const contents = [
+    "# Automatically generated",
+    ...npmIgnoreEntries,
+    "# Include package build output ignored at the workspace root.",
+    `!${distDir}/`,
+  ];
   writeFileSync(join(rootPath, ".npmignore"), `${contents.join("\n")}\n`);
 }
 

--- a/packages/ariakit-solid-components/.npmignore
+++ b/packages/ariakit-solid-components/.npmignore
@@ -8,3 +8,5 @@ tsconfig*.json
 *.log
 *.config.*
 *.lock
+# Include package build output ignored at the workspace root.
+!dist/

--- a/packages/ariakit-solid-store/.npmignore
+++ b/packages/ariakit-solid-store/.npmignore
@@ -8,3 +8,5 @@ tsconfig*.json
 *.log
 *.config.*
 *.lock
+# Include package build output ignored at the workspace root.
+!dist/

--- a/packages/ariakit-solid-utils/.npmignore
+++ b/packages/ariakit-solid-utils/.npmignore
@@ -8,3 +8,5 @@ tsconfig*.json
 *.log
 *.config.*
 *.lock
+# Include package build output ignored at the workspace root.
+!dist/

--- a/packages/ariakit-solid/.npmignore
+++ b/packages/ariakit-solid/.npmignore
@@ -8,3 +8,5 @@ tsconfig*.json
 *.log
 *.config.*
 *.lock
+# Include package build output ignored at the workspace root.
+!dist/

--- a/packages/ariakit-store/.npmignore
+++ b/packages/ariakit-store/.npmignore
@@ -8,3 +8,5 @@ tsconfig*.json
 *.log
 *.config.*
 *.lock
+# Include package build output ignored at the workspace root.
+!dist/

--- a/packages/ariakit-test/.npmignore
+++ b/packages/ariakit-test/.npmignore
@@ -8,3 +8,5 @@ tsconfig*.json
 *.log
 *.config.*
 *.lock
+# Include package build output ignored at the workspace root.
+!dist/

--- a/packages/ariakit-utils/.npmignore
+++ b/packages/ariakit-utils/.npmignore
@@ -8,3 +8,5 @@ tsconfig*.json
 *.log
 *.config.*
 *.lock
+# Include package build output ignored at the workspace root.
+!dist/


### PR DESCRIPTION
## Motivation

`@ariakit/react-components@0.3.2` was published without its `dist` directory even though its exports resolve to `dist` files. pnpm 11.13 started applying workspace-root ignore files while publishing workspace packages, so the root `dist` rule removed each updated package's build output.

Closes #6738.

## Solution

Follow pnpm's package-level override pattern from [pnpm/pnpm#12878](https://github.com/pnpm/pnpm/pull/12878) and generate this rule in each modern package's `.npmignore`:

```gitignore
# Include package build output ignored at the workspace root.
!dist/
```

This preserves the workspace-root ignore rules while explicitly including package build output. The change also adds a focused generator test and patch changesets for the affected releases, including `@ariakit/react` so its exact `@ariakit/react-components` dependency is updated.

## Verification

- `pnpm run build`
- `pnpm publish --dry-run --no-git-checks --json` with and without `!dist/` (red/green)
- `pnpm test packages/ariakit-scripts/src/build.test.ts`
- `pnpm exec changeset status --output /dev/stdout`
- `pnpm run tsc`
- `pnpm run lint`
