### PR TITLE
Prevent stale Select focus-visible state

### DIFF
--- a/.changeset/200-warn-once.md
+++ b/.changeset/200-warn-once.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/utils": patch
+---
+
+Added a `warnOnce` utility that logs each warning once per message and optional object key. Thanks to [@ItaiYosephi](https://github.com/ItaiYosephi).

--- a/.changeset/300-composite-virtual-focus.md
+++ b/.changeset/300-composite-virtual-focus.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Composite`](https://ariakit.com/reference/composite) and derived widgets such as [`SelectList`](https://ariakit.com/reference/select-list) to clear stale focus-visible state and warn in development when virtual focus is used with a non-focusable composite element. Thanks to [@ItaiYosephi](https://github.com/ItaiYosephi).

--- a/app/src/sandbox/select-4767/index.react.tsx
+++ b/app/src/sandbox/select-4767/index.react.tsx
@@ -2,7 +2,7 @@ import * as Ariakit from "@ariakit/react";
 
 export default function Example() {
   return (
-    <Ariakit.SelectProvider defaultValue="Apple">
+    <Ariakit.SelectProvider defaultValue="Apple" virtualFocus={false}>
       <Ariakit.SelectLabel>Favorite fruit</Ariakit.SelectLabel>
       <Ariakit.Select />
       <Ariakit.SelectPopover gutter={4} sameWidth>

--- a/app/src/sandbox/select-4767/index.react.tsx
+++ b/app/src/sandbox/select-4767/index.react.tsx
@@ -1,0 +1,17 @@
+import * as Ariakit from "@ariakit/react";
+
+export default function Example() {
+  return (
+    <Ariakit.SelectProvider defaultValue="Apple">
+      <Ariakit.SelectLabel>Favorite fruit</Ariakit.SelectLabel>
+      <Ariakit.Select />
+      <Ariakit.SelectPopover gutter={4} sameWidth>
+        <Ariakit.SelectList focusable={false}>
+          <Ariakit.SelectItem value="Apple" />
+          <Ariakit.SelectItem value="Banana" />
+          <Ariakit.SelectItem value="Orange" />
+        </Ariakit.SelectList>
+      </Ariakit.SelectPopover>
+    </Ariakit.SelectProvider>
+  );
+}

--- a/app/src/sandbox/select-4767/index.react.tsx
+++ b/app/src/sandbox/select-4767/index.react.tsx
@@ -1,17 +1,37 @@
 import * as Ariakit from "@ariakit/react";
 
-export default function Example() {
+interface FruitSelectProps {
+  focusable?: boolean;
+  label: string;
+  virtualFocus?: boolean;
+}
+
+function FruitSelect({ focusable, label, virtualFocus }: FruitSelectProps) {
   return (
-    <Ariakit.SelectProvider defaultValue="Apple" virtualFocus={false}>
-      <Ariakit.SelectLabel>Favorite fruit</Ariakit.SelectLabel>
+    <Ariakit.SelectProvider defaultValue="Apple" virtualFocus={virtualFocus}>
+      <Ariakit.SelectLabel>{label}</Ariakit.SelectLabel>
       <Ariakit.Select />
       <Ariakit.SelectPopover gutter={4} sameWidth>
-        <Ariakit.SelectList focusable={false}>
+        <Ariakit.SelectList focusable={focusable}>
           <Ariakit.SelectItem value="Apple" />
           <Ariakit.SelectItem value="Banana" />
           <Ariakit.SelectItem value="Orange" />
         </Ariakit.SelectList>
       </Ariakit.SelectPopover>
     </Ariakit.SelectProvider>
+  );
+}
+
+export default function Example() {
+  return (
+    <>
+      <FruitSelect label="Favorite fruit" focusable={false} />
+      <FruitSelect label="Virtual focus fruit" />
+      <FruitSelect
+        label="Real focus fruit"
+        focusable={false}
+        virtualFocus={false}
+      />
+    </>
   );
 }

--- a/app/src/sandbox/select-4767/test-browser.ts
+++ b/app/src/sandbox/select-4767/test-browser.ts
@@ -1,0 +1,26 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// https://github.com/ariakit/ariakit/issues/4767
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("clears focus-visible when focus moves to another option", async ({
+    page,
+    q,
+  }) => {
+    await q.combobox("Favorite fruit").click();
+    const apple = q.option("Apple");
+    await test.expect(apple).toBeFocused();
+
+    await page.keyboard.press("ArrowDown");
+    const banana = q.option("Banana");
+    await test.expect(banana).toBeFocused();
+    await test.expect(banana).toHaveAttribute("data-focus-visible", "true");
+
+    await page.keyboard.press("ArrowDown");
+
+    const orange = q.option("Orange");
+    await test.expect(orange).toBeFocused();
+    await test.expect(orange).toHaveAttribute("data-focus-visible", "true");
+    await test.expect(apple).not.toHaveAttribute("data-focus-visible");
+    await test.expect(banana).not.toHaveAttribute("data-focus-visible");
+  });
+});

--- a/app/src/sandbox/select-4767/test-browser.ts
+++ b/app/src/sandbox/select-4767/test-browser.ts
@@ -2,7 +2,7 @@ import { withFramework } from "#app/test-utils/preview.ts";
 
 // https://github.com/ariakit/ariakit/issues/4767
 withFramework(import.meta.dirname, async ({ test }) => {
-  test("clears focus-visible when focus moves to another option", async ({
+  test("clears focus-visible when the virtual focus owner isn't focusable", async ({
     page,
     q,
   }) => {
@@ -17,6 +17,59 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
     await page.keyboard.press("ArrowDown");
 
+    const orange = q.option("Orange");
+    await test.expect(orange).toBeFocused();
+    await test.expect(orange).toHaveAttribute("data-focus-visible", "true");
+    await test.expect(apple).not.toHaveAttribute("data-focus-visible");
+    await test.expect(banana).not.toHaveAttribute("data-focus-visible");
+  });
+
+  test("preserves virtual focus with a focusable owner", async ({
+    page,
+    q,
+  }) => {
+    await q.combobox("Virtual focus fruit").click();
+    const listbox = q.listbox();
+    await test.expect(listbox).toBeFocused();
+
+    await page.keyboard.press("ArrowDown");
+    const banana = q.option("Banana");
+    await test.expect(listbox).toBeFocused();
+    await test
+      .expect(listbox)
+      .toHaveAttribute(
+        "aria-activedescendant",
+        (await banana.getAttribute("id"))!,
+      );
+    await test.expect(banana).toHaveAttribute("data-focus-visible", "true");
+
+    await page.keyboard.press("ArrowDown");
+    const orange = q.option("Orange");
+    await test.expect(listbox).toBeFocused();
+    await test
+      .expect(listbox)
+      .toHaveAttribute(
+        "aria-activedescendant",
+        (await orange.getAttribute("id"))!,
+      );
+    await test.expect(orange).toHaveAttribute("data-focus-visible", "true");
+    await test.expect(banana).not.toHaveAttribute("data-focus-visible");
+  });
+
+  test("preserves real focus with a non-focusable owner", async ({
+    page,
+    q,
+  }) => {
+    await q.combobox("Real focus fruit").click();
+    const apple = q.option("Apple");
+    await test.expect(apple).toBeFocused();
+
+    await page.keyboard.press("ArrowDown");
+    const banana = q.option("Banana");
+    await test.expect(banana).toBeFocused();
+    await test.expect(banana).toHaveAttribute("data-focus-visible", "true");
+
+    await page.keyboard.press("ArrowDown");
     const orange = q.option("Orange");
     await test.expect(orange).toBeFocused();
     await test.expect(orange).toHaveAttribute("data-focus-visible", "true");

--- a/app/src/sandbox/select-4767/test.ts
+++ b/app/src/sandbox/select-4767/test.ts
@@ -1,0 +1,22 @@
+import { click, press, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// https://github.com/ariakit/ariakit/issues/4767
+test("clears focus-visible when focus moves to another option", async () => {
+  await click(q.combobox("Favorite fruit"));
+  const apple = q.option("Apple");
+  expect(document.activeElement).toBe(apple);
+
+  await press.ArrowDown();
+  const banana = q.option("Banana");
+  expect(document.activeElement).toBe(banana);
+  expect(banana).toHaveAttribute("data-focus-visible", "true");
+
+  await press.ArrowDown();
+
+  const orange = q.option("Orange");
+  expect(document.activeElement).toBe(orange);
+  expect(orange).toHaveAttribute("data-focus-visible", "true");
+  expect(apple).not.toHaveAttribute("data-focus-visible");
+  expect(banana).not.toHaveAttribute("data-focus-visible");
+});

--- a/app/src/sandbox/select-4767/test.ts
+++ b/app/src/sandbox/select-4767/test.ts
@@ -1,8 +1,14 @@
 import { click, press, q } from "@ariakit/test";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
+
+const virtualFocusWarning =
+  "A composite widget with `virtualFocus` enabled requires a focusable " +
+  "composite element. Set the `focusable` prop to `true` or the " +
+  "`virtualFocus` option to `false`.";
 
 // https://github.com/ariakit/ariakit/issues/4767
-test("clears focus-visible when focus moves to another option", async () => {
+test("clears focus-visible when the virtual focus owner isn't focusable", async () => {
+  using consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
   await click(q.combobox("Favorite fruit"));
   const apple = q.option("Apple");
   expect(document.activeElement).toBe(apple);
@@ -19,4 +25,49 @@ test("clears focus-visible when focus moves to another option", async () => {
   expect(orange).toHaveAttribute("data-focus-visible", "true");
   expect(apple).not.toHaveAttribute("data-focus-visible");
   expect(banana).not.toHaveAttribute("data-focus-visible");
+  expect(consoleWarn).toHaveBeenCalledTimes(1);
+  expect(consoleWarn).toHaveBeenCalledWith(virtualFocusWarning);
+});
+
+test("preserves virtual focus with a focusable owner", async () => {
+  using consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  await click(q.combobox("Virtual focus fruit"));
+  const listbox = q.listbox();
+  expect(document.activeElement).toBe(listbox);
+
+  await press.ArrowDown();
+  const banana = q.option("Banana");
+  expect(document.activeElement).toBe(listbox);
+  expect(banana?.id).toBeTruthy();
+  expect(listbox?.getAttribute("aria-activedescendant")).toBe(banana?.id);
+  expect(banana).toHaveAttribute("data-focus-visible", "true");
+
+  await press.ArrowDown();
+  const orange = q.option("Orange");
+  expect(document.activeElement).toBe(listbox);
+  expect(orange?.id).toBeTruthy();
+  expect(listbox?.getAttribute("aria-activedescendant")).toBe(orange?.id);
+  expect(orange).toHaveAttribute("data-focus-visible", "true");
+  expect(banana).not.toHaveAttribute("data-focus-visible");
+  expect(consoleWarn).not.toHaveBeenCalled();
+});
+
+test("preserves real focus with a non-focusable owner", async () => {
+  using consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  await click(q.combobox("Real focus fruit"));
+  const apple = q.option("Apple");
+  expect(document.activeElement).toBe(apple);
+
+  await press.ArrowDown();
+  const banana = q.option("Banana");
+  expect(document.activeElement).toBe(banana);
+  expect(banana).toHaveAttribute("data-focus-visible", "true");
+
+  await press.ArrowDown();
+  const orange = q.option("Orange");
+  expect(document.activeElement).toBe(orange);
+  expect(orange).toHaveAttribute("data-focus-visible", "true");
+  expect(apple).not.toHaveAttribute("data-focus-visible");
+  expect(banana).not.toHaveAttribute("data-focus-visible");
+  expect(consoleWarn).not.toHaveBeenCalled();
 });

--- a/packages/ariakit-react-components/src/composite/composite-item.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-item.tsx
@@ -18,6 +18,7 @@ import {
   getTextboxSelection,
   getTextboxValue,
   isButton,
+  isFocusable,
   isTextbox,
   isTextField,
   isPortalEvent,
@@ -25,6 +26,7 @@ import {
   disabledFromProps,
   removeUndefinedValues,
   isSafari,
+  warnOnce,
 } from "@ariakit/utils";
 import type { BooleanOrCallback } from "@ariakit/utils";
 import type {
@@ -300,6 +302,17 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
         relatedTarget: Element | null,
         baseElement: HTMLElement,
       ) => {
+        if (!isFocusable(baseElement)) {
+          if (process.env.NODE_ENV !== "production") {
+            warnOnce(
+              "A composite widget with `virtualFocus` enabled requires a " +
+                "focusable composite element. Set the `focusable` prop to " +
+                "`true` or the `virtualFocus` option to `false`.",
+              baseElement,
+            );
+          }
+          return;
+        }
         // Safari doesn't scroll the element into view when another element is
         // immediately focused. So we have to do it manually here.
         if (isSafari() && currentTarget.hasAttribute("data-autofocus")) {

--- a/packages/ariakit-react-components/src/composite/composite.tsx
+++ b/packages/ariakit-react-components/src/composite/composite.tsx
@@ -636,6 +636,15 @@ export interface CompositeOptions<
    */
   focusOnMove?: boolean;
   /**
+   * Determines whether [Focusable](https://ariakit.com/components/focusable)
+   * features are active on the composite element.
+   *
+   * When the store's
+   * [`virtualFocus`](https://ariakit.com/reference/composite-provider#virtualfocus)
+   * state is `true`, the rendered composite element must remain focusable so it
+   * can own DOM focus and expose the active item through
+   * `aria-activedescendant`.
+   *
    * @see https://ariakit.com/reference/focusable
    */
   focusable?: FocusableOptions<T>["focusable"];

--- a/packages/ariakit-utils/readme.md
+++ b/packages/ariakit-utils/readme.md
@@ -114,6 +114,7 @@ This package is ESM-only and exposes a single public entrypoint.
   - [`identity`](#identity)
   - [`beforePaint`](#beforepaint)
   - [`afterPaint`](#afterpaint)
+  - [`warnOnce`](#warnonce)
   - [`invariant`](#invariant)
   - [`getKeys`](#getkeys)
   - [`isFalsyBooleanCallback`](#isfalsybooleancallback)
@@ -1444,6 +1445,26 @@ function afterPaint(cb: () => void = noop): () => void;
 ```
 
 Runs after the next paint.
+
+<div align="right">
+  <a href="#api-reference">&uarr; back to top</a>
+</div>
+
+#### `warnOnce`
+
+```ts
+function warnOnce(message: string, key?: object): void;
+```
+
+Logs a warning only once for each message and key.
+
+Example:
+
+```ts
+if (process.env.NODE_ENV !== "production") {
+  warnOnce("Warning");
+}
+```
 
 <div align="right">
   <a href="#api-reference">&uarr; back to top</a>

--- a/packages/ariakit-utils/src/misc.test.ts
+++ b/packages/ariakit-utils/src/misc.test.ts
@@ -1,10 +1,11 @@
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import {
   applyState,
   defaultValue,
   isEmpty,
   isInteger,
   shallowEqual,
+  warnOnce,
 } from "./misc.ts";
 
 test("isInteger preserves its loose numeric coercion behavior", () => {
@@ -61,4 +62,25 @@ test("defaultValue returns the first defined value", () => {
   expect(defaultValue(undefined, false, true)).toBe(false);
   expect(defaultValue(undefined, 0, 1)).toBe(0);
   expect(defaultValue(undefined, undefined)).toBeUndefined();
+});
+
+test("warnOnce logs each warning once", () => {
+  using consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  warnOnce("First warning");
+  warnOnce("First warning");
+  warnOnce("Second warning");
+  expect(consoleWarn.mock.calls).toEqual([
+    ["First warning"],
+    ["Second warning"],
+  ]);
+});
+
+test("warnOnce distinguishes keys", () => {
+  using consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const firstKey = {};
+  const secondKey = {};
+  warnOnce("Scoped warning", firstKey);
+  warnOnce("Scoped warning", firstKey);
+  warnOnce("Scoped warning", secondKey);
+  expect(consoleWarn).toHaveBeenCalledTimes(2);
 });

--- a/packages/ariakit-utils/src/misc.ts
+++ b/packages/ariakit-utils/src/misc.ts
@@ -218,6 +218,28 @@ export function afterPaint(cb: () => void = noop) {
   return () => cancelAnimationFrame(raf);
 }
 
+const defaultWarnOnceKey = {};
+const warningMessages = new WeakMap<object, Set<string>>();
+
+/**
+ * Logs a warning only once for each message and key.
+ * @example
+ * if (process.env.NODE_ENV !== "production") {
+ *   warnOnce("Warning");
+ * }
+ */
+export function warnOnce(message: string, key?: object) {
+  const warningKey = key || defaultWarnOnceKey;
+  let messages = warningMessages.get(warningKey);
+  if (!messages) {
+    messages = new Set();
+    warningMessages.set(warningKey, messages);
+  }
+  if (messages.has(message)) return;
+  messages.add(message);
+  console.warn(message);
+}
+
 /**
  * Asserts that a condition is true, otherwise throws an error.
  * @example


### PR DESCRIPTION
## Motivation

When a `Select` uses its default virtual-focus model with an explicitly non-focusable list, focus redirection cannot return DOM focus to the listbox. The failed redirect was still treated as successful, so the previous option blur cleanup was suppressed and `data-focus-visible` remained stale.

```tsx
<SelectList focusable={false}>
  <SelectItem value="Apple" />
  <SelectItem value="Banana" />
</SelectList>
```

Fixes #4767.

## Solution

Composite items now verify that the connected composite owner is focusable before treating a virtual-focus redirect as successful. When it is not, Ariakit keeps normal item blur cleanup active and emits one development warning per composite owner through the shared `warnOnce` utility.

The regression sandbox covers the unsupported combination, the default supported virtual-focus model, and the supported real-focus model. Happy DOM and Playwright tests verify focus ownership, `aria-activedescendant`, warning behavior, and `data-focus-visible` cleanup. The `focusable` reference documentation now explains the DOM-focus requirement when `virtualFocus` is enabled.

## Workaround

Disable virtual focus when the list should not receive DOM focus. This lets the options own real DOM focus, so their normal blur cleanup removes `data-focus-visible` when navigation moves to another option.

```tsx
// TODO: Remove after https://github.com/ariakit/ariakit/issues/4767 is fixed.
<SelectProvider defaultValue="Apple" virtualFocus={false}>
  <Select />
  <SelectPopover>
    <SelectList focusable={false}>
      <SelectItem value="Apple" />
      <SelectItem value="Banana" />
    </SelectList>
  </SelectPopover>
</SelectProvider>
```

This intentionally switches from the `aria-activedescendant` virtual-focus model to real option focus. Apps that rely on the listbox retaining DOM focus or on its `aria-activedescendant` state should keep the list focusable instead.