### PR TITLE
Support custom Select typeahead text

### DIFF
--- a/.changeset/200-composite-typeahead-text.md
+++ b/.changeset/200-composite-typeahead-text.md
@@ -4,4 +4,16 @@
 "@ariakit/react": patch
 ---
 
-Added the [`typeaheadText`](https://ariakit.com/reference/composite-item#typeaheadtext) prop to [`CompositeItem`](https://ariakit.com/reference/composite-item) and components built on it, including [`SelectItem`](https://ariakit.com/reference/select-item) and [`ComboboxItem`](https://ariakit.com/reference/combobox-item), so typeahead can match a label independently of custom rendered content. Thanks to [@Dremora](https://github.com/Dremora) and [@georgekaran](https://github.com/georgekaran).
+Custom typeahead text for composite items
+
+The new [`typeaheadText`](https://ariakit.com/reference/composite-item#typeaheadtext) prop lets [`CompositeItem`](https://ariakit.com/reference/composite-item) use an explicit label for typeahead matching when its rendered content starts with an emoji or other decoration.
+
+```tsx
+<SelectItem typeaheadText="Canada" value="Canada">
+  <span aria-hidden>🇨🇦</span> Canada
+</SelectItem>
+```
+
+Set [`typeaheadText`](https://ariakit.com/reference/composite-item#typeaheadtext) to an empty string to exclude an item from typeahead matching. The prop is also available on these components exported by `@ariakit/react` and built on [`CompositeItem`](https://ariakit.com/reference/composite-item): [`ComboboxItem`](https://ariakit.com/reference/combobox-item), [`FormRadio`](https://ariakit.com/reference/form-radio), [`MenuItem`](https://ariakit.com/reference/menu-item), [`MenuItemCheckbox`](https://ariakit.com/reference/menu-item-checkbox), [`MenuItemRadio`](https://ariakit.com/reference/menu-item-radio), [`Radio`](https://ariakit.com/reference/radio), [`SelectItem`](https://ariakit.com/reference/select-item), [`Tab`](https://ariakit.com/reference/tab), [`ToolbarContainer`](https://ariakit.com/reference/toolbar-container), [`ToolbarInput`](https://ariakit.com/reference/toolbar-input), and [`ToolbarItem`](https://ariakit.com/reference/toolbar-item).
+
+Thanks to [@Dremora](https://github.com/Dremora) for reporting the issue and providing the reproduction, and [@georgekaran](https://github.com/georgekaran) for the investigation and implementation work that informed this solution.

--- a/.changeset/200-composite-typeahead-text.md
+++ b/.changeset/200-composite-typeahead-text.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/components": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Added the [`typeaheadText`](https://ariakit.com/reference/composite-item#typeaheadtext) prop to [`CompositeItem`](https://ariakit.com/reference/composite-item) and components built on it, including [`SelectItem`](https://ariakit.com/reference/select-item) and [`ComboboxItem`](https://ariakit.com/reference/combobox-item), so typeahead can match a label independently of custom rendered content. Thanks to [@Dremora](https://github.com/Dremora) and [@georgekaran](https://github.com/georgekaran).

--- a/app/src/sandbox/composite-offscreen-props/index.react.tsx
+++ b/app/src/sandbox/composite-offscreen-props/index.react.tsx
@@ -26,6 +26,7 @@ export default function Example() {
         preventScrollOnKeyDown={() => true}
         shouldRegisterItem
         tabbable
+        typeaheadText="Archive command"
         value="Archive"
       />
     </Ariakit.Composite>

--- a/app/src/sandbox/composite-offscreen-props/test-browser.ts
+++ b/app/src/sandbox/composite-offscreen-props/test-browser.ts
@@ -6,6 +6,7 @@ const leakedAttributes = [
   "clickonspace",
   "focusable",
   "shouldregisteritem",
+  "typeaheadtext",
 ] as const;
 
 withFramework(import.meta.dirname, async ({ test }) => {
@@ -25,6 +26,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
     const item = q.button("Archive");
     await test.expect(item).toHaveAttribute("data-offscreen");
     await test.expect(item).toHaveAttribute("aria-disabled", "true");
+    await test
+      .expect(item)
+      .toHaveAttribute("data-typeahead-text", "Archive command");
     await test.expect(item).not.toHaveAttribute("disabled");
 
     for (const attribute of leakedAttributes) {

--- a/app/src/sandbox/composite-offscreen-props/test.ts
+++ b/app/src/sandbox/composite-offscreen-props/test.ts
@@ -7,6 +7,7 @@ const leakedAttributes = [
   "clickonspace",
   "focusable",
   "shouldregisteritem",
+  "typeaheadtext",
 ] as const;
 
 test("omits composite option props from the offscreen placeholder", () => {
@@ -14,6 +15,7 @@ test("omits composite option props from the offscreen placeholder", () => {
 
   expect(item).toHaveAttribute("data-offscreen");
   expect(item).toHaveAttribute("aria-disabled", "true");
+  expect(item).toHaveAttribute("data-typeahead-text", "Archive command");
   expect(item).not.toHaveAttribute("disabled");
 
   for (const attribute of leakedAttributes) {

--- a/app/src/sandbox/select-typeahead-2699/index.react.tsx
+++ b/app/src/sandbox/select-typeahead-2699/index.react.tsx
@@ -1,31 +1,74 @@
 import * as Ariakit from "@ariakit/react";
-import "./style.css";
+import { SelectItem as OffscreenSelectItem } from "@ariakit/react-components/select/select-item-offscreen";
+import { useState } from "react";
 
 const countries = [
   { value: "Brazil", flag: "🇧🇷" },
+  { value: "Citrus", flag: "" },
   { value: "Canada", flag: "🇨🇦" },
   { value: "Japan", flag: "🇯🇵" },
   { value: "Mexico", flag: "🇲🇽" },
 ];
 
+const offscreenCountries = [
+  { value: "Brazil", flag: "🇧🇷" },
+  ...Array.from({ length: 25 }, (_, index) => ({
+    value: `Item ${index + 1}`,
+    flag: "🏳️",
+  })),
+  { value: "Canada", flag: "🇨🇦" },
+];
+
 export default function Example() {
+  const [useAliases, setUseAliases] = useState(false);
+
   return (
-    <Ariakit.SelectProvider defaultValue="Brazil">
-      <Ariakit.SelectLabel>Country</Ariakit.SelectLabel>
-      <Ariakit.Select />
-      <Ariakit.SelectPopover gutter={4} sameWidth>
-        {countries.map((country) => (
-          <Ariakit.SelectItem
-            key={country.value}
-            aria-label={country.value}
-            className="item"
-            data-flag={country.flag}
-            value={country.value}
-          >
-            {country.value}
-          </Ariakit.SelectItem>
-        ))}
-      </Ariakit.SelectPopover>
-    </Ariakit.SelectProvider>
+    <>
+      <Ariakit.SelectProvider defaultValue="Brazil">
+        <Ariakit.SelectLabel>Country</Ariakit.SelectLabel>
+        <Ariakit.Select />
+        <Ariakit.SelectPopover gutter={4} sameWidth>
+          {countries.map((country) => (
+            <Ariakit.SelectItem
+              key={country.value}
+              typeaheadText={
+                country.value === "Citrus"
+                  ? ""
+                  : useAliases && country.value === "Canada"
+                    ? "Dominion"
+                    : country.value
+              }
+              value={country.value}
+            >
+              <span aria-hidden>{country.flag}</span> {country.value}
+            </Ariakit.SelectItem>
+          ))}
+        </Ariakit.SelectPopover>
+      </Ariakit.SelectProvider>
+      <button type="button" onClick={() => setUseAliases(true)}>
+        Use country aliases
+      </button>
+      <Ariakit.SelectProvider defaultValue="Brazil">
+        <Ariakit.SelectLabel>Virtualized country</Ariakit.SelectLabel>
+        <Ariakit.Select />
+        <Ariakit.SelectPopover
+          gutter={4}
+          sameWidth
+          style={{ maxHeight: 80, overflow: "auto" }}
+        >
+          {offscreenCountries.map((country) => (
+            <OffscreenSelectItem
+              key={country.value}
+              offscreenMode="passive"
+              typeaheadText={country.value}
+              value={country.value}
+              style={{ display: "block" }}
+            >
+              <span aria-hidden>{country.flag}</span> {country.value}
+            </OffscreenSelectItem>
+          ))}
+        </Ariakit.SelectPopover>
+      </Ariakit.SelectProvider>
+    </>
   );
 }

--- a/app/src/sandbox/select-typeahead-2699/index.react.tsx
+++ b/app/src/sandbox/select-typeahead-2699/index.react.tsx
@@ -1,0 +1,24 @@
+import * as Ariakit from "@ariakit/react";
+
+const countries = [
+  { value: "Brazil", flag: "🇧🇷" },
+  { value: "Canada", flag: "🇨🇦" },
+  { value: "Japan", flag: "🇯🇵" },
+  { value: "Mexico", flag: "🇲🇽" },
+];
+
+export default function Example() {
+  return (
+    <Ariakit.SelectProvider defaultValue="Brazil">
+      <Ariakit.SelectLabel>Country</Ariakit.SelectLabel>
+      <Ariakit.Select />
+      <Ariakit.SelectPopover gutter={4} sameWidth>
+        {countries.map((country) => (
+          <Ariakit.SelectItem key={country.value} value={country.value}>
+            <span aria-hidden>{country.flag}</span> {country.value}
+          </Ariakit.SelectItem>
+        ))}
+      </Ariakit.SelectPopover>
+    </Ariakit.SelectProvider>
+  );
+}

--- a/app/src/sandbox/select-typeahead-2699/index.react.tsx
+++ b/app/src/sandbox/select-typeahead-2699/index.react.tsx
@@ -1,4 +1,5 @@
 import * as Ariakit from "@ariakit/react";
+import "./style.css";
 
 const countries = [
   { value: "Brazil", flag: "🇧🇷" },
@@ -14,8 +15,14 @@ export default function Example() {
       <Ariakit.Select />
       <Ariakit.SelectPopover gutter={4} sameWidth>
         {countries.map((country) => (
-          <Ariakit.SelectItem key={country.value} value={country.value}>
-            <span aria-hidden>{country.flag}</span> {country.value}
+          <Ariakit.SelectItem
+            key={country.value}
+            aria-label={country.value}
+            className="item"
+            data-flag={country.flag}
+            value={country.value}
+          >
+            {country.value}
           </Ariakit.SelectItem>
         ))}
       </Ariakit.SelectPopover>

--- a/app/src/sandbox/select-typeahead-2699/style.css
+++ b/app/src/sandbox/select-typeahead-2699/style.css
@@ -1,4 +1,0 @@
-.item::before {
-  margin-inline-end: 0.25em;
-  content: attr(data-flag);
-}

--- a/app/src/sandbox/select-typeahead-2699/style.css
+++ b/app/src/sandbox/select-typeahead-2699/style.css
@@ -1,0 +1,4 @@
+.item::before {
+  margin-inline-end: 0.25em;
+  content: attr(data-flag);
+}

--- a/app/src/sandbox/select-typeahead-2699/test-browser.ts
+++ b/app/src/sandbox/select-typeahead-2699/test-browser.ts
@@ -2,13 +2,19 @@ import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
   // https://github.com/ariakit/ariakit/issues/2699
-  test("matches custom item content while open", async ({ page, q }) => {
+  test("matches custom item content and skips empty text while open", async ({
+    page,
+    q,
+  }) => {
     await page.keyboard.press("Tab");
     await page.keyboard.press("Enter");
     await test.expect(q.option("Brazil")).toHaveAttribute("data-active-item");
 
     await page.keyboard.press("c");
 
+    await test
+      .expect(q.option("Citrus"))
+      .not.toHaveAttribute("data-active-item");
     await test.expect(q.option("Canada")).toHaveAttribute("data-active-item");
   });
 
@@ -17,7 +23,25 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
     await page.keyboard.press("c");
 
-    await test.expect(q.combobox("Country")).toContainText("Canada");
+    await test.expect(q.combobox(/^Country$/)).toContainText("Canada");
     await test.expect(q.listbox()).not.toBeAttached();
+  });
+
+  test("updates custom item text", async ({ page, q }) => {
+    await q.button("Use country aliases").click();
+    await q.combobox(/^Country$/).click();
+
+    await page.keyboard.press("d");
+
+    await test.expect(q.option("Canada")).toHaveAttribute("data-active-item");
+  });
+
+  test("matches custom content on an offscreen item", async ({ page, q }) => {
+    await q.combobox(/^Virtualized country$/).click();
+    await test.expect(q.option("Canada")).toHaveAttribute("data-offscreen");
+
+    await page.keyboard.press("c");
+
+    await test.expect(q.option("Canada")).toHaveAttribute("data-active-item");
   });
 });

--- a/app/src/sandbox/select-typeahead-2699/test-browser.ts
+++ b/app/src/sandbox/select-typeahead-2699/test-browser.ts
@@ -1,0 +1,23 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/2699
+  test("matches custom item content while open", async ({ page, q }) => {
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("Enter");
+    await test.expect(q.option("Brazil")).toHaveAttribute("data-active-item");
+
+    await page.keyboard.press("c");
+
+    await test.expect(q.option("Canada")).toHaveAttribute("data-active-item");
+  });
+
+  test("matches custom item content while closed", async ({ page, q }) => {
+    await page.keyboard.press("Tab");
+
+    await page.keyboard.press("c");
+
+    await test.expect(q.combobox("Country")).toContainText("Canada");
+    await test.expect(q.listbox()).not.toBeAttached();
+  });
+});

--- a/app/src/sandbox/select-typeahead-2699/test.ts
+++ b/app/src/sandbox/select-typeahead-2699/test.ts
@@ -1,14 +1,15 @@
-import { press, q } from "@ariakit/test";
+import { click, press, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 // https://github.com/ariakit/ariakit/issues/2699
-test("matches custom item content while open", async () => {
+test("matches custom item content and skips empty text while open", async () => {
   await press.Tab();
   await press.Enter();
   expect(q.option("Brazil")).toHaveAttribute("data-active-item");
 
   await press("c");
 
+  expect(q.option("Citrus")).not.toHaveAttribute("data-active-item");
   expect(q.option("Canada")).toHaveAttribute("data-active-item");
 });
 
@@ -17,6 +18,24 @@ test("matches custom item content while closed", async () => {
 
   await press("c");
 
-  expect(q.combobox("Country")).toHaveTextContent("Canada");
+  expect(q.combobox(/^Country$/)).toHaveTextContent("Canada");
   expect(q.listbox()).not.toBeInTheDocument();
+});
+
+test("updates custom item text", async () => {
+  await click(q.button("Use country aliases"));
+  await click(q.combobox(/^Country$/));
+
+  await press("d");
+
+  expect(q.option("Canada")).toHaveAttribute("data-active-item");
+});
+
+test("matches custom content on an offscreen item", async () => {
+  await click(q.combobox(/^Virtualized country$/));
+  expect(q.option("Canada")).toHaveAttribute("data-offscreen");
+
+  await press("c");
+
+  expect(q.option("Canada")).toHaveAttribute("data-active-item");
 });

--- a/app/src/sandbox/select-typeahead-2699/test.ts
+++ b/app/src/sandbox/select-typeahead-2699/test.ts
@@ -1,0 +1,22 @@
+import { press, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// https://github.com/ariakit/ariakit/issues/2699
+test("matches custom item content while open", async () => {
+  await press.Tab();
+  await press.Enter();
+  expect(q.option("Brazil")).toHaveAttribute("data-active-item");
+
+  await press("c");
+
+  expect(q.option("Canada")).toHaveAttribute("data-active-item");
+});
+
+test("matches custom item content while closed", async () => {
+  await press.Tab();
+
+  await press("c");
+
+  expect(q.combobox("Country")).toHaveTextContent("Canada");
+  expect(q.listbox()).not.toBeInTheDocument();
+});

--- a/packages/ariakit-components/src/composite/composite-store.ts
+++ b/packages/ariakit-components/src/composite/composite-store.ts
@@ -542,6 +542,10 @@ export interface CompositeStoreItem extends CollectionStoreItem {
    * The item children. This can be used for typeahead purposes.
    */
   children?: string;
+  /**
+   * The text used by typeahead to match this item.
+   */
+  typeaheadText?: string;
 }
 
 export interface CompositeStoreState<

--- a/packages/ariakit-react-components/src/combobox/combobox-item-offscreen.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item-offscreen.tsx
@@ -65,6 +65,7 @@ export const ComboboxItem = forwardRef(function ComboboxItem({
     blurOnHoverEnd,
     moveOnKeyPress,
     tabbable,
+    typeaheadText,
     clickOnEnter,
     clickOnSpace,
     focusable,

--- a/packages/ariakit-react-components/src/composite/composite-item-offscreen.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-item-offscreen.tsx
@@ -83,6 +83,7 @@ export function useCompositeItemOffscreen<
       "aria-disabled": disabled || undefined,
       "data-disabled": trulyDisabled || undefined,
       "data-offscreen-id": storeId,
+      "data-typeahead-text": props.typeaheadText,
     };
   }
 
@@ -112,6 +113,7 @@ export const CompositeItem = forwardRef(function CompositeItem({
     preventScrollOnKeyDown,
     moveOnKeyPress,
     tabbable,
+    typeaheadText,
     clickOnEnter,
     clickOnSpace,
     focusable,

--- a/packages/ariakit-react-components/src/composite/composite-item.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-item.tsx
@@ -154,6 +154,7 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
     moveOnKeyPress = true,
     tabbable = false,
     getItem: getItemProp,
+    typeaheadText,
     "aria-setsize": ariaSetSizeProp,
     "aria-posinset": ariaPosInSetProp,
     ...props
@@ -243,13 +244,14 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
           rowId,
           disabled: trulyDisabled,
           children: item.element?.textContent,
+          typeaheadText,
         };
         if (getItemProp) {
           return getItemProp(nextItem);
         }
         return nextItem;
       },
-      [id, rowId, trulyDisabled, getItemProp],
+      [id, rowId, trulyDisabled, typeaheadText, getItemProp],
     );
 
     const onFocusProp = props.onFocus;
@@ -636,6 +638,17 @@ export interface CompositeItemOptions<T extends ElementType = TagName>
    * - [Navigation Menubar](https://ariakit.com/examples/menubar-navigation)
    */
   tabbable?: boolean;
+  /**
+   * The text used by typeahead to match this item. Use this when the rendered
+   * text starts with decorative or custom content.
+   *
+   * Set this to an empty string to exclude the item from typeahead matching.
+   * @example
+   * ```jsx
+   * <CompositeItem typeaheadText="Canada">🇨🇦 Canada</CompositeItem>
+   * ```
+   */
+  typeaheadText?: string;
 }
 
 export type CompositeItemProps<T extends ElementType = TagName> = Props<

--- a/packages/ariakit-react-components/src/composite/composite-typeahead.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-typeahead.tsx
@@ -75,13 +75,14 @@ function getEnabledItems(items: CompositeStoreItem[]) {
 
 function itemTextStartsWith(item: CompositeStoreItem, text: string) {
   const itemText =
-    item.element?.textContent ||
-    item.children ||
-    // The composite item object itself doesn't include a value property, but
-    // other components like Select do. Since CompositeTypeahead is a generic
-    // component that can be used with those as well, we also consider the value
-    // property as a fallback for the typeahead text content.
-    ("value" in item && (item.value as string | undefined));
+    item.typeaheadText ??
+    (item.element?.textContent ||
+      item.children ||
+      // The composite item object itself doesn't include a value property, but
+      // other components like Select do. Since CompositeTypeahead is a generic
+      // component that can be used with those as well, we also consider the
+      // value property as a fallback for the typeahead text content.
+      ("value" in item && (item.value as string | undefined)));
   if (!itemText) return false;
   return normalizeString(itemText)
     .trim()
@@ -177,7 +178,11 @@ export const useCompositeTypeahead = createHook<
     for (const element of offscreenItems) {
       if (element.hasAttribute("data-disabled")) continue;
       if ("disabled" in element && !!element.disabled) continue;
-      enabledItems.push({ id: element.id, element });
+      enabledItems.push({
+        id: element.id,
+        element,
+        typeaheadText: element.dataset.typeaheadText,
+      });
     }
     // If there are offscreen items, we need to sort the enabled items based on
     // their DOM position so offscreen elements above the viewport are correctly

--- a/packages/ariakit-react-components/src/select/select-item-offscreen.tsx
+++ b/packages/ariakit-react-components/src/select/select-item-offscreen.tsx
@@ -47,6 +47,7 @@ export const SelectItem = forwardRef(function SelectItem({
     preventScrollOnKeyDown,
     moveOnKeyPress,
     tabbable,
+    typeaheadText,
     clickOnEnter,
     clickOnSpace,
     focusable,


### PR DESCRIPTION
## Motivation

Select typeahead currently matches an item's rendered text content. When decorative or custom content appears before the human-readable label, typing the label's first character cannot focus the item.

```tsx
<SelectItem value="Canada">
  <span aria-hidden>🇨🇦</span> Canada
</SelectItem>
```

Thanks to @Dremora for reporting this in #2699 and @georgekaran for the investigation and implementation work in #3298 that informed this solution.

## Solution

Add a `typeaheadText` prop to `CompositeItem` and components built on it, including `SelectItem` and `ComboboxItem`. The explicit text takes precedence over rendered text, item children, and value fallbacks.

```tsx
<SelectItem typeaheadText={country.value} value={country.value}>
  <span aria-hidden>{country.flag}</span> {country.value}
</SelectItem>
```

An empty string excludes an item from typeahead matching, and prop updates immediately update its registered match text. Passive and offscreen items carry the same metadata on their placeholder elements so virtualized lists behave consistently without leaking the camelCase prop to the DOM.

The regression coverage exercises open and closed Selects, empty-string opt-out, runtime prop updates, passive offscreen items, disabled offscreen semantics, and DOM prop filtering in both browser and happy-dom tests. The commit history intentionally records the failing reproduction, the passing userland workaround, and the final library fix as separate stages.

## Workaround

When content before the item label is purely decorative, render it with CSS generated content so the item's actual text starts with the searchable label. Keep an explicit accessible name so generated content does not affect it.

```tsx
// TODO: Remove after https://github.com/ariakit/ariakit/issues/2699 is fixed.
<SelectItem
  aria-label={country.value}
  className="item"
  data-flag={country.flag}
  value={country.value}
>
  {country.value}
</SelectItem>
```

```css
.item::before {
  margin-inline-end: 0.25em;
  content: attr(data-flag);
}
```

This workaround is limited to decorative content that can be rendered with CSS. It does not cover arbitrary rich content, aliases, or searchable text that intentionally differs from the visible label.

Fixes #2699
