### PR TITLE
Let Dialog children handle Escape

### DIFF
--- a/.changeset/300-dialog-child-escape.md
+++ b/.changeset/300-dialog-child-escape.md
@@ -19,6 +19,8 @@ The [`Dialog`](https://ariakit.com/reference/dialog) component and components th
 </Dialog>
 ```
 
-**Note:** If an ancestor capture handler stops an <kbd>Esc</kbd> event from inside before it reaches the enclosing component, that component now remains open.
+When the component handles an <kbd>Esc</kbd> event from its React subtree, it also stops the event at its boundary. This keeps an enclosing third-party React dialog with a bubble handler open while the Ariakit component closes.
+
+An ancestor capture handler that stops <kbd>Esc</kbd> before it reaches the component owns the event. If [`hideOnEscape`](https://ariakit.com/reference/dialog#hideonescape) runs before such a handler, it can call `event.stopPropagation()` to keep the event from reaching it.
 
 Thanks to [@boaz-wiz](https://github.com/boaz-wiz) for reporting the issue.

--- a/.changeset/300-dialog-child-escape.md
+++ b/.changeset/300-dialog-child-escape.md
@@ -3,4 +3,22 @@
 "@ariakit/react": patch
 ---
 
-Fixed [`Dialog`](https://ariakit.com/reference/dialog) and components that inherit its default Escape handling, such as [`Popover`](https://ariakit.com/reference/popover) and [`ComboboxPopover`](https://ariakit.com/reference/combobox-popover), so descendants can call `event.stopPropagation()` on Escape without hiding the enclosing component. Thanks to [@boaz-wiz](https://github.com/boaz-wiz).
+Handling <kbd>Esc</kbd> in nested widgets
+
+The [`Dialog`](https://ariakit.com/reference/dialog) component and components that inherit its default <kbd>Esc</kbd> handling, including [`Popover`](https://ariakit.com/reference/popover), [`ComboboxPopover`](https://ariakit.com/reference/combobox-popover), and [`SelectPopover`](https://ariakit.com/reference/select-popover), now let descendants call `event.stopPropagation()` on <kbd>Esc</kbd> without hiding the enclosing component. This allows a nested widget to dismiss itself first.
+
+```tsx
+<Dialog>
+  <input
+    onKeyDown={(event) => {
+      if (event.key !== "Escape") return;
+      event.stopPropagation();
+      closeSuggestions();
+    }}
+  />
+</Dialog>
+```
+
+**Note:** If an ancestor capture handler stops an <kbd>Esc</kbd> event from inside before it reaches the enclosing component, that component now remains open.
+
+Thanks to [@boaz-wiz](https://github.com/boaz-wiz) for reporting the issue.

--- a/.changeset/300-dialog-child-escape.md
+++ b/.changeset/300-dialog-child-escape.md
@@ -12,6 +12,7 @@ The [`Dialog`](https://ariakit.com/reference/dialog) component and components th
   <input
     onKeyDown={(event) => {
       if (event.key !== "Escape") return;
+      if (!suggestionsOpen) return;
       event.stopPropagation();
       closeSuggestions();
     }}

--- a/.changeset/300-dialog-child-escape.md
+++ b/.changeset/300-dialog-child-escape.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Dialog`](https://ariakit.com/reference/dialog) and [`Popover`](https://ariakit.com/reference/popover) so descendants can call `event.stopPropagation()` on Escape without hiding the enclosing component. Thanks to [@boaz-wiz](https://github.com/boaz-wiz).

--- a/.changeset/300-dialog-child-escape.md
+++ b/.changeset/300-dialog-child-escape.md
@@ -3,4 +3,4 @@
 "@ariakit/react": patch
 ---
 
-Fixed [`Dialog`](https://ariakit.com/reference/dialog) and [`Popover`](https://ariakit.com/reference/popover) so descendants can call `event.stopPropagation()` on Escape without hiding the enclosing component. Thanks to [@boaz-wiz](https://github.com/boaz-wiz).
+Fixed [`Dialog`](https://ariakit.com/reference/dialog) and components that inherit its default Escape handling, such as [`Popover`](https://ariakit.com/reference/popover) and [`ComboboxPopover`](https://ariakit.com/reference/combobox-popover), so descendants can call `event.stopPropagation()` on Escape without hiding the enclosing component. Thanks to [@boaz-wiz](https://github.com/boaz-wiz).

--- a/.changeset/300-dialog-child-escape.md
+++ b/.changeset/300-dialog-child-escape.md
@@ -22,6 +22,8 @@ The [`Dialog`](https://ariakit.com/reference/dialog) component and components th
 
 When the component handles an <kbd>Esc</kbd> event from its React subtree, it also stops the event at its boundary. This keeps an enclosing third-party React dialog with a bubble handler open while the Ariakit component closes.
 
+When it handles <kbd>Esc</kbd> through the document fallback, such as when focus is on its disclosure, it stops the event at `document` before it reaches `window` bubble listeners.
+
 An ancestor capture handler that stops <kbd>Esc</kbd> before it reaches the component owns the event. If [`hideOnEscape`](https://ariakit.com/reference/dialog#hideonescape) runs before such a handler, it can call `event.stopPropagation()` to keep the event from reaching it.
 
 Thanks to [@boaz-wiz](https://github.com/boaz-wiz) for reporting the issue.

--- a/app/src/sandbox/dialog-5179/index.react.tsx
+++ b/app/src/sandbox/dialog-5179/index.react.tsx
@@ -147,6 +147,11 @@ export default function Example() {
     <>
       <DialogExample />
       <DialogExample name="Outer ancestor dialog" portal={false} stopOnEscape />
+      <DialogExample
+        name="Outer capture dialog"
+        portal={false}
+        stopOnEscapeCapture
+      />
       <DialogExample name="Own bubble dialog" stopDialogOnEscape />
       <DialogExample name="Own capture dialog" stopDialogOnEscapeCapture />
       <button onClick={() => setShowDocumentRoot(true)}>

--- a/app/src/sandbox/dialog-5179/index.react.tsx
+++ b/app/src/sandbox/dialog-5179/index.react.tsx
@@ -1,5 +1,6 @@
 import * as Ariakit from "@ariakit/react";
-import { useId, useState } from "react";
+import { useEffect, useId, useState } from "react";
+import { createRoot } from "react-dom/client";
 
 function Autocomplete() {
   const [open, setOpen] = useState(true);
@@ -33,25 +34,45 @@ function Autocomplete() {
   );
 }
 
-export default function Example() {
-  const dialog = Ariakit.useDialogStore();
+interface DialogExampleProps {
+  portal?: boolean;
+}
+
+function DialogExample({ portal }: DialogExampleProps) {
   return (
-    <>
-      <Ariakit.DialogDisclosure store={dialog}>
-        Open dialog
-      </Ariakit.DialogDisclosure>
-      <Ariakit.Dialog
-        store={dialog}
-        hideOnEscape={false}
-        onKeyDown={(event) => {
-          if (event.key !== "Escape") return;
-          // TODO: Remove when https://github.com/ariakit/ariakit/issues/5179 is fixed.
-          dialog.hide();
-        }}
-      >
+    <Ariakit.DialogProvider>
+      <Ariakit.DialogDisclosure>Open dialog</Ariakit.DialogDisclosure>
+      <Ariakit.Dialog portal={portal}>
         <Ariakit.DialogHeading>Dialog</Ariakit.DialogHeading>
         <Autocomplete />
       </Ariakit.Dialog>
+    </Ariakit.DialogProvider>
+  );
+}
+
+function DocumentRootExample() {
+  const [iframe, setIframe] = useState<HTMLIFrameElement | null>(null);
+
+  useEffect(() => {
+    const document = iframe?.contentDocument;
+    if (!document) return;
+    const root = createRoot(document);
+    root.render(<DialogExample portal={false} />);
+    return () => root.unmount();
+  }, [iframe]);
+
+  return <iframe ref={setIframe} title="Document root example" />;
+}
+
+export default function Example() {
+  const [showDocumentRoot, setShowDocumentRoot] = useState(false);
+  return (
+    <>
+      <DialogExample />
+      <button onClick={() => setShowDocumentRoot(true)}>
+        Show document root example
+      </button>
+      {showDocumentRoot && <DocumentRootExample />}
     </>
   );
 }

--- a/app/src/sandbox/dialog-5179/index.react.tsx
+++ b/app/src/sandbox/dialog-5179/index.react.tsx
@@ -13,16 +13,21 @@ function ReactPortal({ children }: { children: ReactNode }) {
 
 interface AutocompleteProps {
   capture?: boolean;
+  preventDefault?: boolean;
 }
 
-function Autocomplete({ capture }: AutocompleteProps) {
+function Autocomplete({ capture, preventDefault }: AutocompleteProps) {
   const [open, setOpen] = useState(true);
   const inputId = useId();
   const listboxId = useId();
   const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key !== "Escape") return;
     if (!open) return;
-    event.stopPropagation();
+    if (preventDefault) {
+      event.preventDefault();
+    } else {
+      event.stopPropagation();
+    }
     setOpen(false);
   };
 
@@ -55,6 +60,7 @@ interface DialogExampleProps {
   name?: string;
   portal?: boolean;
   portalChild?: "ariakit" | "react";
+  preventDefault?: boolean;
   stopDialogOnEscape?: boolean;
   stopDialogOnEscapeCapture?: boolean;
   stopOnEscape?: boolean;
@@ -67,6 +73,7 @@ function DialogExample({
   name = "Dialog",
   portal,
   portalChild,
+  preventDefault,
   stopDialogOnEscape,
   stopDialogOnEscapeCapture,
   stopOnEscape,
@@ -77,7 +84,9 @@ function DialogExample({
     if (event.key !== "Escape") return;
     event.stopPropagation();
   };
-  const autocomplete = <Autocomplete capture={capture} />;
+  const autocomplete = (
+    <Autocomplete capture={capture} preventDefault={preventDefault} />
+  );
   const dialog = (
     <Ariakit.DialogProvider open={open} setOpen={setOpen}>
       <Ariakit.DialogDisclosure>
@@ -162,14 +171,18 @@ function ThirdPartyDialogExample({ capture }: ThirdPartyDialogExampleProps) {
 }
 
 interface HideOnEscapeExampleProps {
+  accept?: boolean;
   name: string;
   portalChild?: boolean;
+  preventDefault?: boolean;
   stop?: boolean;
 }
 
 function HideOnEscapeExample({
+  accept,
   name,
   portalChild,
+  preventDefault,
   stop,
 }: HideOnEscapeExampleProps) {
   const [calls, setCalls] = useState(0);
@@ -184,9 +197,9 @@ function HideOnEscapeExample({
         hideOnInteractOutside={portalChild ? false : undefined}
         hideOnEscape={(event) => {
           setCalls((calls) => calls + 1);
-          if (!stop) return false;
-          event.stopPropagation();
-          return true;
+          if (preventDefault) event.preventDefault();
+          if (stop) event.stopPropagation();
+          return accept ?? !!stop;
         }}
       >
         <Ariakit.DialogHeading>{name}</Ariakit.DialogHeading>
@@ -206,6 +219,11 @@ export function DocumentRootDocument() {
           capture
           name="Document root capture dialog"
           portal={false}
+        />
+        <DialogExample
+          name="Document root prevented dialog"
+          portal={false}
+          preventDefault
         />
         <DialogExample
           name="Document root own bubble dialog"
@@ -279,6 +297,12 @@ export default function Example() {
       <ThirdPartyDialogExample />
       <ThirdPartyDialogExample capture />
       <HideOnEscapeExample name="Rejected callback dialog" />
+      <HideOnEscapeExample accept name="Accepted callback dialog" />
+      <HideOnEscapeExample
+        accept
+        name="Prevented callback dialog"
+        preventDefault
+      />
       <HideOnEscapeExample
         name="React portal callback dialog"
         portalChild

--- a/app/src/sandbox/dialog-5179/index.react.tsx
+++ b/app/src/sandbox/dialog-5179/index.react.tsx
@@ -1,7 +1,15 @@
 import * as Ariakit from "@ariakit/react";
-import type { KeyboardEvent } from "react";
+import type { KeyboardEvent, ReactNode } from "react";
 import { useEffect, useId, useState } from "react";
+import { createPortal } from "react-dom";
 import { createRoot } from "react-dom/client";
+
+function ReactPortal({ children }: { children: ReactNode }) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  if (!mounted) return null;
+  return createPortal(children, document.body);
+}
 
 interface AutocompleteProps {
   capture?: boolean;
@@ -46,6 +54,7 @@ interface DialogExampleProps {
   modal?: boolean;
   name?: string;
   portal?: boolean;
+  portalChild?: "ariakit" | "react";
   stopDialogOnEscape?: boolean;
   stopDialogOnEscapeCapture?: boolean;
   stopOnEscape?: boolean;
@@ -57,28 +66,38 @@ function DialogExample({
   modal,
   name = "Dialog",
   portal,
+  portalChild,
   stopDialogOnEscape,
   stopDialogOnEscapeCapture,
   stopOnEscape,
   stopOnEscapeCapture,
 }: DialogExampleProps) {
+  const [open, setOpen] = useState(false);
   const onKeyDown = (event: KeyboardEvent<HTMLElement>) => {
     if (event.key !== "Escape") return;
     event.stopPropagation();
   };
+  const autocomplete = <Autocomplete capture={capture} />;
   const dialog = (
-    <Ariakit.DialogProvider>
+    <Ariakit.DialogProvider open={open} setOpen={setOpen}>
       <Ariakit.DialogDisclosure>
         Open {name.toLowerCase()}
       </Ariakit.DialogDisclosure>
       <Ariakit.Dialog
         modal={modal}
         portal={portal}
+        hideOnInteractOutside={portalChild ? false : undefined}
         onKeyDown={stopDialogOnEscape ? onKeyDown : undefined}
         onKeyDownCapture={stopDialogOnEscapeCapture ? onKeyDown : undefined}
       >
         <Ariakit.DialogHeading>{name}</Ariakit.DialogHeading>
-        <Autocomplete capture={capture} />
+        {!open && portalChild ? null : portalChild === "ariakit" ? (
+          <Ariakit.Portal>{autocomplete}</Ariakit.Portal>
+        ) : portalChild === "react" ? (
+          <ReactPortal>{autocomplete}</ReactPortal>
+        ) : (
+          autocomplete
+        )}
       </Ariakit.Dialog>
     </Ariakit.DialogProvider>
   );
@@ -90,6 +109,90 @@ function DialogExample({
     >
       {dialog}
     </div>
+  );
+}
+
+interface ThirdPartyDialogExampleProps {
+  capture?: boolean;
+}
+
+function ThirdPartyDialogExample({ capture }: ThirdPartyDialogExampleProps) {
+  const [open, setOpen] = useState(false);
+  const name = capture ? "Capture third-party dialog" : "Third-party dialog";
+  const nestedName = capture
+    ? "Shielded Ariakit dialog"
+    : "Nested Ariakit dialog";
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "Escape") return;
+    setOpen(false);
+  };
+  if (!open) {
+    return (
+      <button onClick={() => setOpen(true)}>Open {name.toLowerCase()}</button>
+    );
+  }
+  return (
+    <div
+      role="dialog"
+      aria-label={name}
+      onKeyDown={capture ? undefined : onKeyDown}
+      onKeyDownCapture={capture ? onKeyDown : undefined}
+    >
+      <Ariakit.DialogProvider>
+        <Ariakit.DialogDisclosure>
+          Open {nestedName.toLowerCase()}
+        </Ariakit.DialogDisclosure>
+        <Ariakit.Dialog
+          modal={false}
+          hideOnEscape={
+            capture
+              ? (event) => {
+                  event.stopPropagation();
+                  return true;
+                }
+              : undefined
+          }
+        >
+          <Ariakit.DialogHeading>{nestedName}</Ariakit.DialogHeading>
+          <button>Inside {nestedName.toLowerCase()}</button>
+        </Ariakit.Dialog>
+      </Ariakit.DialogProvider>
+    </div>
+  );
+}
+
+interface HideOnEscapeExampleProps {
+  name: string;
+  portalChild?: boolean;
+  stop?: boolean;
+}
+
+function HideOnEscapeExample({
+  name,
+  portalChild,
+  stop,
+}: HideOnEscapeExampleProps) {
+  const [calls, setCalls] = useState(0);
+  const content = <button>Callback calls: {calls}</button>;
+  return (
+    <Ariakit.DialogProvider>
+      <Ariakit.DialogDisclosure>
+        Open {name.toLowerCase()}
+      </Ariakit.DialogDisclosure>
+      <Ariakit.Dialog
+        modal={false}
+        hideOnInteractOutside={portalChild ? false : undefined}
+        hideOnEscape={(event) => {
+          setCalls((calls) => calls + 1);
+          if (!stop) return false;
+          event.stopPropagation();
+          return true;
+        }}
+      >
+        <Ariakit.DialogHeading>{name}</Ariakit.DialogHeading>
+        {portalChild ? <ReactPortal>{content}</ReactPortal> : content}
+      </Ariakit.Dialog>
+    </Ariakit.DialogProvider>
   );
 }
 
@@ -116,10 +219,16 @@ export function DocumentRootDocument() {
         />
         <DialogExample
           modal={false}
+          name="Document root global dialog"
+          portal={false}
+        />
+        <DialogExample
+          modal={false}
           name="Document root outside dialog"
           portal={false}
           stopOnEscapeCapture
         />
+        <HideOnEscapeExample name="Document root callback dialog" stop />
       </body>
     </html>
   );
@@ -154,6 +263,27 @@ export default function Example() {
       />
       <DialogExample name="Own bubble dialog" stopDialogOnEscape />
       <DialogExample name="Own capture dialog" stopDialogOnEscapeCapture />
+      <DialogExample modal={false} name="Outside dialog" />
+      <DialogExample
+        modal={false}
+        name="Ariakit Portal child dialog"
+        portal={false}
+        portalChild="ariakit"
+      />
+      <DialogExample
+        modal={false}
+        name="React portal child dialog"
+        portal={false}
+        portalChild="react"
+      />
+      <ThirdPartyDialogExample />
+      <ThirdPartyDialogExample capture />
+      <HideOnEscapeExample name="Rejected callback dialog" />
+      <HideOnEscapeExample
+        name="React portal callback dialog"
+        portalChild
+        stop
+      />
       <button onClick={() => setShowDocumentRoot(true)}>
         Show document root example
       </button>

--- a/app/src/sandbox/dialog-5179/index.react.tsx
+++ b/app/src/sandbox/dialog-5179/index.react.tsx
@@ -252,24 +252,44 @@ export function DocumentRootDocument() {
   );
 }
 
-function DocumentRootExample() {
+interface DocumentRootExampleProps {
+  stopPropagation?: "bubble" | "capture";
+}
+
+function DocumentRootExample({ stopPropagation }: DocumentRootExampleProps) {
   const [iframe, setIframe] = useState<HTMLIFrameElement | null>(null);
 
   useEffect(() => {
     const document = iframe?.contentDocument;
     if (!document) return;
+    const capture = stopPropagation === "capture";
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.stopPropagation();
+    };
+    if (stopPropagation) {
+      document.addEventListener("keydown", onKeyDown, capture);
+    }
     // Delegate React events to the document itself to reproduce the listener
     // ordering where React capture runs before the Dialog effect.
     const root = createRoot(document);
     root.render(<DocumentRootDocument />);
-    return () => root.unmount();
-  }, [iframe]);
+    return () => {
+      root.unmount();
+      document.removeEventListener("keydown", onKeyDown, capture);
+    };
+  }, [iframe, stopPropagation]);
 
-  return <iframe ref={setIframe} title="Document root example" />;
+  const title = stopPropagation
+    ? `Pre-stopped ${stopPropagation} document root example`
+    : "Document root example";
+  return <iframe ref={setIframe} title={title} />;
 }
 
 export default function Example() {
-  const [showDocumentRoot, setShowDocumentRoot] = useState(false);
+  const [documentRoot, setDocumentRoot] = useState<
+    "bubble" | "capture" | "default" | null
+  >(null);
   return (
     <>
       <DialogExample />
@@ -308,10 +328,22 @@ export default function Example() {
         portalChild
         stop
       />
-      <button onClick={() => setShowDocumentRoot(true)}>
+      <button onClick={() => setDocumentRoot("default")}>
         Show document root example
       </button>
-      {showDocumentRoot && <DocumentRootExample />}
+      <button onClick={() => setDocumentRoot("capture")}>
+        Show pre-stopped capture document root example
+      </button>
+      <button onClick={() => setDocumentRoot("bubble")}>
+        Show pre-stopped bubble document root example
+      </button>
+      {documentRoot && (
+        <DocumentRootExample
+          stopPropagation={
+            documentRoot === "default" ? undefined : documentRoot
+          }
+        />
+      )}
     </>
   );
 }

--- a/app/src/sandbox/dialog-5179/index.react.tsx
+++ b/app/src/sandbox/dialog-5179/index.react.tsx
@@ -46,6 +46,8 @@ interface DialogExampleProps {
   modal?: boolean;
   name?: string;
   portal?: boolean;
+  stopDialogOnEscape?: boolean;
+  stopDialogOnEscapeCapture?: boolean;
   stopOnEscape?: boolean;
   stopOnEscapeCapture?: boolean;
 }
@@ -55,25 +57,32 @@ function DialogExample({
   modal,
   name = "Dialog",
   portal,
+  stopDialogOnEscape,
+  stopDialogOnEscapeCapture,
   stopOnEscape,
   stopOnEscapeCapture,
 }: DialogExampleProps) {
+  const onKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    if (event.key !== "Escape") return;
+    event.stopPropagation();
+  };
   const dialog = (
     <Ariakit.DialogProvider>
       <Ariakit.DialogDisclosure>
         Open {name.toLowerCase()}
       </Ariakit.DialogDisclosure>
-      <Ariakit.Dialog modal={modal} portal={portal}>
+      <Ariakit.Dialog
+        modal={modal}
+        portal={portal}
+        onKeyDown={stopDialogOnEscape ? onKeyDown : undefined}
+        onKeyDownCapture={stopDialogOnEscapeCapture ? onKeyDown : undefined}
+      >
         <Ariakit.DialogHeading>{name}</Ariakit.DialogHeading>
         <Autocomplete capture={capture} />
       </Ariakit.Dialog>
     </Ariakit.DialogProvider>
   );
   if (!stopOnEscape && !stopOnEscapeCapture) return dialog;
-  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key !== "Escape") return;
-    event.stopPropagation();
-  };
   return (
     <div
       onKeyDown={stopOnEscape ? onKeyDown : undefined}
@@ -81,6 +90,38 @@ function DialogExample({
     >
       {dialog}
     </div>
+  );
+}
+
+export function DocumentRootDocument() {
+  return (
+    <html>
+      <head />
+      <body>
+        <DialogExample name="Document root dialog" portal={false} />
+        <DialogExample
+          capture
+          name="Document root capture dialog"
+          portal={false}
+        />
+        <DialogExample
+          name="Document root own bubble dialog"
+          portal={false}
+          stopDialogOnEscape
+        />
+        <DialogExample
+          name="Document root own capture dialog"
+          portal={false}
+          stopDialogOnEscapeCapture
+        />
+        <DialogExample
+          modal={false}
+          name="Document root outside dialog"
+          portal={false}
+          stopOnEscapeCapture
+        />
+      </body>
+    </html>
   );
 }
 
@@ -93,22 +134,7 @@ function DocumentRootExample() {
     // Delegate React events to the document itself to reproduce the listener
     // ordering where React capture runs before the Dialog effect.
     const root = createRoot(document);
-    root.render(
-      <>
-        <DialogExample name="Document root dialog" portal={false} />
-        <DialogExample
-          capture
-          name="Document root capture dialog"
-          portal={false}
-        />
-        <DialogExample
-          modal={false}
-          name="Document root outside dialog"
-          portal={false}
-          stopOnEscapeCapture
-        />
-      </>,
-    );
+    root.render(<DocumentRootDocument />);
     return () => root.unmount();
   }, [iframe]);
 
@@ -121,6 +147,8 @@ export default function Example() {
     <>
       <DialogExample />
       <DialogExample name="Outer ancestor dialog" portal={false} stopOnEscape />
+      <DialogExample name="Own bubble dialog" stopDialogOnEscape />
+      <DialogExample name="Own capture dialog" stopDialogOnEscapeCapture />
       <button onClick={() => setShowDocumentRoot(true)}>
         Show document root example
       </button>

--- a/app/src/sandbox/dialog-5179/index.react.tsx
+++ b/app/src/sandbox/dialog-5179/index.react.tsx
@@ -1,11 +1,22 @@
 import * as Ariakit from "@ariakit/react";
+import type { KeyboardEvent } from "react";
 import { useEffect, useId, useState } from "react";
 import { createRoot } from "react-dom/client";
 
-function Autocomplete() {
+interface AutocompleteProps {
+  capture?: boolean;
+}
+
+function Autocomplete({ capture }: AutocompleteProps) {
   const [open, setOpen] = useState(true);
   const inputId = useId();
   const listboxId = useId();
+  const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== "Escape") return;
+    if (!open) return;
+    event.stopPropagation();
+    setOpen(false);
+  };
 
   return (
     <div>
@@ -16,12 +27,8 @@ function Autocomplete() {
         aria-controls={listboxId}
         aria-expanded={open}
         aria-autocomplete="list"
-        onKeyDown={(event) => {
-          if (event.key !== "Escape") return;
-          if (!open) return;
-          event.stopPropagation();
-          setOpen(false);
-        }}
+        onKeyDown={capture ? undefined : onKeyDown}
+        onKeyDownCapture={capture ? onKeyDown : undefined}
       />
       {open && (
         <div id={listboxId} role="listbox" aria-label="Suggestions">
@@ -35,18 +42,45 @@ function Autocomplete() {
 }
 
 interface DialogExampleProps {
+  capture?: boolean;
+  modal?: boolean;
+  name?: string;
   portal?: boolean;
+  stopOnEscape?: boolean;
+  stopOnEscapeCapture?: boolean;
 }
 
-function DialogExample({ portal }: DialogExampleProps) {
-  return (
+function DialogExample({
+  capture,
+  modal,
+  name = "Dialog",
+  portal,
+  stopOnEscape,
+  stopOnEscapeCapture,
+}: DialogExampleProps) {
+  const dialog = (
     <Ariakit.DialogProvider>
-      <Ariakit.DialogDisclosure>Open dialog</Ariakit.DialogDisclosure>
-      <Ariakit.Dialog portal={portal}>
-        <Ariakit.DialogHeading>Dialog</Ariakit.DialogHeading>
-        <Autocomplete />
+      <Ariakit.DialogDisclosure>
+        Open {name.toLowerCase()}
+      </Ariakit.DialogDisclosure>
+      <Ariakit.Dialog modal={modal} portal={portal}>
+        <Ariakit.DialogHeading>{name}</Ariakit.DialogHeading>
+        <Autocomplete capture={capture} />
       </Ariakit.Dialog>
     </Ariakit.DialogProvider>
+  );
+  if (!stopOnEscape && !stopOnEscapeCapture) return dialog;
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "Escape") return;
+    event.stopPropagation();
+  };
+  return (
+    <div
+      onKeyDown={stopOnEscape ? onKeyDown : undefined}
+      onKeyDownCapture={stopOnEscapeCapture ? onKeyDown : undefined}
+    >
+      {dialog}
+    </div>
   );
 }
 
@@ -56,8 +90,25 @@ function DocumentRootExample() {
   useEffect(() => {
     const document = iframe?.contentDocument;
     if (!document) return;
+    // Delegate React events to the document itself to reproduce the listener
+    // ordering where React capture runs before the Dialog effect.
     const root = createRoot(document);
-    root.render(<DialogExample portal={false} />);
+    root.render(
+      <>
+        <DialogExample name="Document root dialog" portal={false} />
+        <DialogExample
+          capture
+          name="Document root capture dialog"
+          portal={false}
+        />
+        <DialogExample
+          modal={false}
+          name="Document root outside dialog"
+          portal={false}
+          stopOnEscapeCapture
+        />
+      </>,
+    );
     return () => root.unmount();
   }, [iframe]);
 
@@ -69,6 +120,7 @@ export default function Example() {
   return (
     <>
       <DialogExample />
+      <DialogExample name="Outer ancestor dialog" portal={false} stopOnEscape />
       <button onClick={() => setShowDocumentRoot(true)}>
         Show document root example
       </button>

--- a/app/src/sandbox/dialog-5179/index.react.tsx
+++ b/app/src/sandbox/dialog-5179/index.react.tsx
@@ -1,0 +1,46 @@
+import * as Ariakit from "@ariakit/react";
+import { useId, useState } from "react";
+
+function Autocomplete() {
+  const [open, setOpen] = useState(true);
+  const inputId = useId();
+  const listboxId = useId();
+
+  return (
+    <div>
+      <label htmlFor={inputId}>Search</label>
+      <input
+        id={inputId}
+        role="combobox"
+        aria-controls={listboxId}
+        aria-expanded={open}
+        aria-autocomplete="list"
+        onKeyDown={(event) => {
+          if (event.key !== "Escape") return;
+          if (!open) return;
+          event.stopPropagation();
+          setOpen(false);
+        }}
+      />
+      {open && (
+        <div id={listboxId} role="listbox" aria-label="Suggestions">
+          <div role="option" aria-selected="false">
+            Ariakit
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function Example() {
+  return (
+    <Ariakit.DialogProvider>
+      <Ariakit.DialogDisclosure>Open dialog</Ariakit.DialogDisclosure>
+      <Ariakit.Dialog>
+        <Ariakit.DialogHeading>Dialog</Ariakit.DialogHeading>
+        <Autocomplete />
+      </Ariakit.Dialog>
+    </Ariakit.DialogProvider>
+  );
+}

--- a/app/src/sandbox/dialog-5179/index.react.tsx
+++ b/app/src/sandbox/dialog-5179/index.react.tsx
@@ -34,13 +34,24 @@ function Autocomplete() {
 }
 
 export default function Example() {
+  const dialog = Ariakit.useDialogStore();
   return (
-    <Ariakit.DialogProvider>
-      <Ariakit.DialogDisclosure>Open dialog</Ariakit.DialogDisclosure>
-      <Ariakit.Dialog>
+    <>
+      <Ariakit.DialogDisclosure store={dialog}>
+        Open dialog
+      </Ariakit.DialogDisclosure>
+      <Ariakit.Dialog
+        store={dialog}
+        hideOnEscape={false}
+        onKeyDown={(event) => {
+          if (event.key !== "Escape") return;
+          // TODO: Remove when https://github.com/ariakit/ariakit/issues/5179 is fixed.
+          dialog.hide();
+        }}
+      >
         <Ariakit.DialogHeading>Dialog</Ariakit.DialogHeading>
         <Autocomplete />
       </Ariakit.Dialog>
-    </Ariakit.DialogProvider>
+    </>
   );
 }

--- a/app/src/sandbox/dialog-5179/test-browser.ts
+++ b/app/src/sandbox/dialog-5179/test-browser.ts
@@ -149,6 +149,29 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(dialogQuery.button("Callback calls: 1")).toBeVisible();
   });
 
+  test("calls an accepted hideOnEscape callback once", async ({ q }) => {
+    const disclosure = q.button("Open accepted callback dialog");
+    await disclosure.click();
+    const dialog = q.dialog("Accepted callback dialog");
+    await test.expect(dialog).toBeVisible();
+
+    await query(dialog).button("Callback calls: 0").press("Escape");
+
+    await test.expect(dialog).toBeHidden();
+    await disclosure.click();
+    await test.expect(query(dialog).button("Callback calls: 1")).toBeVisible();
+  });
+
+  test("accepts default prevention from hideOnEscape", async ({ q }) => {
+    await q.button("Open prevented callback dialog").click();
+    const dialog = q.dialog("Prevented callback dialog");
+    await test.expect(dialog).toBeVisible();
+
+    await query(dialog).button("Callback calls: 0").press("Escape");
+
+    await test.expect(dialog).toBeHidden();
+  });
+
   test("hides when hideOnEscape stops Escape from a React portal", async ({
     q,
   }) => {
@@ -206,6 +229,33 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     const listbox = dialogQuery.listbox("Suggestions");
 
     await openDialog.click();
+    await test.expect(input).toBeFocused();
+    await test.expect(listbox).toBeVisible();
+
+    await input.press("Escape");
+
+    await test.expect(listbox).toBeHidden();
+    await test.expect(dialog).toBeVisible();
+
+    await input.press("Escape");
+
+    await test.expect(dialog).toBeHidden();
+  });
+
+  test("respects default prevention delegated to document", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Show document root example").click();
+    const frame = query(
+      page.frameLocator('iframe[title="Document root example"]'),
+    );
+    const dialog = frame.dialog("Document root prevented dialog");
+    const dialogQuery = query(dialog);
+    const input = dialogQuery.combobox("Search");
+    const listbox = dialogQuery.listbox("Suggestions");
+
+    await frame.button("Open document root prevented dialog").click();
     await test.expect(input).toBeFocused();
     await test.expect(listbox).toBeVisible();
 

--- a/app/src/sandbox/dialog-5179/test-browser.ts
+++ b/app/src/sandbox/dialog-5179/test-browser.ts
@@ -18,74 +18,32 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(q.dialog("Dialog")).toBeHidden();
   });
 
-  test("clears a stopped event before it is reused", async ({ q }) => {
-    await q.button("Open dialog").click();
-    const input = q.combobox("Search");
-    const event = await input.evaluateHandle((element) => {
-      const KeyboardEvent = element.ownerDocument.defaultView?.KeyboardEvent;
-      if (!KeyboardEvent) throw new Error("KeyboardEvent is not available");
-      return new KeyboardEvent("keydown", {
-        key: "Escape",
-        bubbles: true,
-        cancelable: true,
-      });
+  for (const portal of ["Ariakit Portal", "React portal"]) {
+    test(`lets a ${portal} child handle Escape before the dialog`, async ({
+      q,
+    }) => {
+      const dialogName = `${portal} child dialog`;
+      await q.button(`Open ${dialogName.toLowerCase()}`).click();
+      const input = q.combobox("Search");
+      await test.expect(q.dialog(dialogName)).toBeVisible();
+      await test.expect(q.listbox("Suggestions")).toBeVisible();
+
+      await input.focus();
+      await test.expect(input).toBeFocused();
+      await test.expect(q.dialog(dialogName)).toBeVisible();
+
+      await input.press("Escape");
+
+      await test.expect(q.listbox("Suggestions")).toBeHidden();
+      await test.expect(q.dialog(dialogName)).toBeVisible();
+
+      await input.press("Escape");
+
+      await test.expect(q.dialog(dialogName)).toBeHidden();
     });
+  }
 
-    await input.evaluate(
-      (element, event) => element.dispatchEvent(event),
-      event,
-    );
-
-    await test.expect(q.listbox("Suggestions")).toBeHidden();
-    await test.expect(q.dialog("Dialog")).toBeVisible();
-
-    await input.evaluate((element, event) => {
-      event.preventDefault();
-      element.dispatchEvent(event);
-    }, event);
-
-    await test.expect(q.dialog("Dialog")).toBeVisible();
-  });
-
-  test("hides on a non-bubbling Escape", async ({ q }) => {
-    await q.button("Open dialog").click();
-    const input = q.combobox("Search");
-    await test.expect(q.dialog("Dialog")).toBeVisible();
-
-    await input.evaluate((element) => {
-      const KeyboardEvent = element.ownerDocument.defaultView?.KeyboardEvent;
-      if (!KeyboardEvent) throw new Error("KeyboardEvent is not available");
-      element.dispatchEvent(
-        new KeyboardEvent("keydown", {
-          key: "Escape",
-          bubbles: false,
-          cancelable: true,
-        }),
-      );
-    });
-
-    await test.expect(q.dialog("Dialog")).toBeHidden();
-  });
-
-  test("hides before an outside ancestor handles Escape", async ({
-    page,
-    q,
-  }) => {
-    await q.button("Open outer ancestor dialog").click();
-    await test.expect(q.dialog("Outer ancestor dialog")).toBeVisible();
-    await test.expect(q.combobox("Search")).toBeFocused();
-
-    await page.keyboard.press("Escape");
-
-    await test.expect(q.listbox("Suggestions")).toBeHidden();
-    await test.expect(q.dialog("Outer ancestor dialog")).toBeVisible();
-
-    await page.keyboard.press("Escape");
-
-    await test.expect(q.dialog("Outer ancestor dialog")).toBeHidden();
-  });
-
-  test("lets an outside capture handler own Escape", async ({ q }) => {
+  test("lets an ancestor capture handler own Escape", async ({ q }) => {
     await q.button("Open outer capture dialog").click();
     const dialog = q.dialog("Outer capture dialog");
     const dialogQuery = query(dialog);
@@ -99,6 +57,28 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
 
     await test.expect(dialogQuery.listbox("Suggestions")).toBeVisible();
     await test.expect(dialog).toBeVisible();
+  });
+
+  test("closes on an unclaimed Escape outside the dialog", async ({ q }) => {
+    const disclosure = q.button("Open outside dialog");
+    await disclosure.click();
+    await test.expect(q.dialog("Outside dialog")).toBeVisible();
+
+    await disclosure.focus();
+    await disclosure.press("Escape");
+
+    await test.expect(q.dialog("Outside dialog")).toBeHidden();
+  });
+
+  test("lets an ancestor capture handler own Escape outside", async ({ q }) => {
+    const disclosure = q.button("Open outer capture dialog");
+    await disclosure.click();
+    await test.expect(q.dialog("Outer capture dialog")).toBeVisible();
+
+    await disclosure.focus();
+    await disclosure.press("Escape");
+
+    await test.expect(q.dialog("Outer capture dialog")).toBeVisible();
   });
 
   test("hides after its own bubble handler stops Escape", async ({
@@ -127,6 +107,60 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await input.press("Escape");
 
     await test.expect(q.dialog("Own capture dialog")).toBeHidden();
+  });
+
+  test("stops Escape before a third-party dialog bubble handler", async ({
+    q,
+  }) => {
+    await q.button("Open third-party dialog").click();
+    await q.button("Open nested ariakit dialog").click();
+    await test.expect(q.dialog("Third-party dialog")).toBeVisible();
+    await test.expect(q.dialog("Nested Ariakit dialog")).toBeVisible();
+
+    await q.button("Inside nested ariakit dialog").press("Escape");
+
+    await test.expect(q.dialog("Nested Ariakit dialog")).toBeHidden();
+    await test.expect(q.dialog("Third-party dialog")).toBeVisible();
+  });
+
+  test("can stop Escape before a third-party dialog capture handler", async ({
+    q,
+  }) => {
+    await q.button("Open capture third-party dialog").click();
+    await q.button("Open shielded ariakit dialog").click();
+    await test.expect(q.dialog("Capture third-party dialog")).toBeVisible();
+    await test.expect(q.dialog("Shielded Ariakit dialog")).toBeVisible();
+
+    await q.button("Inside shielded ariakit dialog").press("Escape");
+
+    await test.expect(q.dialog("Shielded Ariakit dialog")).toBeHidden();
+    await test.expect(q.dialog("Capture third-party dialog")).toBeVisible();
+  });
+
+  test("calls a rejected hideOnEscape callback once", async ({ q }) => {
+    await q.button("Open rejected callback dialog").click();
+    const dialog = q.dialog("Rejected callback dialog");
+    const dialogQuery = query(dialog);
+    await test.expect(dialog).toBeVisible();
+
+    await dialogQuery.button("Callback calls: 0").press("Escape");
+
+    await test.expect(dialog).toBeVisible();
+    await test.expect(dialogQuery.button("Callback calls: 1")).toBeVisible();
+  });
+
+  test("hides when hideOnEscape stops Escape from a React portal", async ({
+    q,
+  }) => {
+    await q.button("Open react portal callback dialog").click();
+    const dialog = q.dialog("React portal callback dialog");
+    const button = q.button("Callback calls: 0");
+    await test.expect(dialog).toBeVisible();
+
+    await button.focus();
+    await button.press("Escape");
+
+    await test.expect(dialog).toBeHidden();
   });
 
   test("respects a child handler delegated to document", async ({
@@ -235,7 +269,44 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(dialog).toBeHidden();
   });
 
-  test("keeps global Escape after an outside capture handler", async ({
+  test("hides when hideOnEscape stops Escape in a document root", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Show document root example").click();
+    const frame = query(
+      page.frameLocator('iframe[title="Document root example"]'),
+    );
+    const dialog = frame.dialog("Document root callback dialog");
+    await frame.button("Open document root callback dialog").click();
+    await test.expect(dialog).toBeVisible();
+
+    await query(dialog).button("Callback calls: 0").press("Escape");
+
+    await test.expect(dialog).toBeHidden();
+  });
+
+  test("closes on global Escape outside a document-root dialog", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Show document root example").click();
+    const frame = query(
+      page.frameLocator('iframe[title="Document root example"]'),
+    );
+    const disclosure = frame.button("Open document root global dialog");
+    const dialog = frame.dialog("Document root global dialog");
+
+    await disclosure.click();
+    await test.expect(dialog).toBeVisible();
+
+    await disclosure.focus();
+    await disclosure.press("Escape");
+
+    await test.expect(dialog).toBeHidden();
+  });
+
+  test("lets an ancestor capture handler own global Escape", async ({
     page,
     q,
   }) => {
@@ -253,10 +324,10 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(disclosure).toBeFocused();
     await disclosure.press("Escape");
 
-    await test.expect(dialog).toBeHidden();
+    await test.expect(dialog).toBeVisible();
   });
 
-  test("lets an outside capture handler own Escape in a document root", async ({
+  test("lets an ancestor capture handler own Escape in a document root", async ({
     page,
     q,
   }) => {

--- a/app/src/sandbox/dialog-5179/test-browser.ts
+++ b/app/src/sandbox/dialog-5179/test-browser.ts
@@ -1,6 +1,6 @@
 import { withFramework } from "#app/test-utils/preview.ts";
 
-withFramework(import.meta.dirname, async ({ test }) => {
+withFramework(import.meta.dirname, async ({ test, query }) => {
   // https://github.com/ariakit/ariakit/issues/5179
   test("lets a child handle Escape before the dialog", async ({ page, q }) => {
     await q.button("Open dialog").click();
@@ -47,16 +47,37 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.dialog("Dialog")).toBeVisible();
   });
 
+  test("hides before an outside ancestor handles Escape", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Open outer ancestor dialog").click();
+    await test.expect(q.dialog("Outer ancestor dialog")).toBeVisible();
+    await test.expect(q.combobox("Search")).toBeFocused();
+
+    await page.keyboard.press("Escape");
+
+    await test.expect(q.listbox("Suggestions")).toBeHidden();
+    await test.expect(q.dialog("Outer ancestor dialog")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+
+    await test.expect(q.dialog("Outer ancestor dialog")).toBeHidden();
+  });
+
   test("respects a child handler delegated to document", async ({
     page,
     q,
   }) => {
     await q.button("Show document root example").click();
-    const frame = page.frameLocator('iframe[title="Document root example"]');
-    const openDialog = frame.getByRole("button", { name: "Open dialog" });
-    const dialog = frame.getByRole("dialog", { name: "Dialog" });
-    const input = frame.getByRole("combobox", { name: "Search" });
-    const listbox = frame.getByRole("listbox", { name: "Suggestions" });
+    const frame = query(
+      page.frameLocator('iframe[title="Document root example"]'),
+    );
+    const openDialog = frame.button("Open document root dialog");
+    const dialog = frame.dialog("Document root dialog");
+    const dialogQuery = query(dialog);
+    const input = dialogQuery.combobox("Search");
+    const listbox = dialogQuery.listbox("Suggestions");
 
     await openDialog.click();
     await test.expect(input).toBeFocused();
@@ -68,6 +89,55 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(dialog).toBeVisible();
 
     await input.press("Escape");
+
+    await test.expect(dialog).toBeHidden();
+  });
+
+  test("respects a child capture handler delegated to document", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Show document root example").click();
+    const frame = query(
+      page.frameLocator('iframe[title="Document root example"]'),
+    );
+    const openDialog = frame.button("Open document root capture dialog");
+    const dialog = frame.dialog("Document root capture dialog");
+    const dialogQuery = query(dialog);
+    const input = dialogQuery.combobox("Search");
+    const listbox = dialogQuery.listbox("Suggestions");
+
+    await openDialog.click();
+    await test.expect(input).toBeFocused();
+    await test.expect(listbox).toBeVisible();
+
+    await input.press("Escape");
+
+    await test.expect(listbox).toBeHidden();
+    await test.expect(dialog).toBeVisible();
+
+    await input.press("Escape");
+
+    await test.expect(dialog).toBeHidden();
+  });
+
+  test("keeps global Escape after an outside capture handler", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Show document root example").click();
+    const frame = query(
+      page.frameLocator('iframe[title="Document root example"]'),
+    );
+    const disclosure = frame.button("Open document root outside dialog");
+    const dialog = frame.dialog("Document root outside dialog");
+
+    await disclosure.click();
+    await test.expect(dialog).toBeVisible();
+
+    await disclosure.focus();
+    await test.expect(disclosure).toBeFocused();
+    await disclosure.press("Escape");
 
     await test.expect(dialog).toBeHidden();
   });

--- a/app/src/sandbox/dialog-5179/test-browser.ts
+++ b/app/src/sandbox/dialog-5179/test-browser.ts
@@ -17,4 +17,58 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
     await test.expect(q.dialog("Dialog")).toBeHidden();
   });
+
+  test("clears a stopped event before it is reused", async ({ q }) => {
+    await q.button("Open dialog").click();
+    const input = q.combobox("Search");
+    const event = await input.evaluateHandle((element) => {
+      const KeyboardEvent = element.ownerDocument.defaultView?.KeyboardEvent;
+      if (!KeyboardEvent) throw new Error("KeyboardEvent is not available");
+      return new KeyboardEvent("keydown", {
+        key: "Escape",
+        bubbles: true,
+        cancelable: true,
+      });
+    });
+
+    await input.evaluate(
+      (element, event) => element.dispatchEvent(event),
+      event,
+    );
+
+    await test.expect(q.listbox("Suggestions")).toBeHidden();
+    await test.expect(q.dialog("Dialog")).toBeVisible();
+
+    await input.evaluate((element, event) => {
+      event.preventDefault();
+      element.dispatchEvent(event);
+    }, event);
+
+    await test.expect(q.dialog("Dialog")).toBeVisible();
+  });
+
+  test("respects a child handler delegated to document", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Show document root example").click();
+    const frame = page.frameLocator('iframe[title="Document root example"]');
+    const openDialog = frame.getByRole("button", { name: "Open dialog" });
+    const dialog = frame.getByRole("dialog", { name: "Dialog" });
+    const input = frame.getByRole("combobox", { name: "Search" });
+    const listbox = frame.getByRole("listbox", { name: "Suggestions" });
+
+    await openDialog.click();
+    await test.expect(input).toBeFocused();
+    await test.expect(listbox).toBeVisible();
+
+    await input.press("Escape");
+
+    await test.expect(listbox).toBeHidden();
+    await test.expect(dialog).toBeVisible();
+
+    await input.press("Escape");
+
+    await test.expect(dialog).toBeHidden();
+  });
 });

--- a/app/src/sandbox/dialog-5179/test-browser.ts
+++ b/app/src/sandbox/dialog-5179/test-browser.ts
@@ -85,6 +85,22 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(q.dialog("Outer ancestor dialog")).toBeHidden();
   });
 
+  test("lets an outside capture handler own Escape", async ({ q }) => {
+    await q.button("Open outer capture dialog").click();
+    const dialog = q.dialog("Outer capture dialog");
+    const dialogQuery = query(dialog);
+    const input = dialogQuery.combobox("Search");
+
+    await test.expect(dialog).toBeVisible();
+    await test.expect(input).toBeFocused();
+    await test.expect(dialogQuery.listbox("Suggestions")).toBeVisible();
+
+    await input.press("Escape");
+
+    await test.expect(dialogQuery.listbox("Suggestions")).toBeVisible();
+    await test.expect(dialog).toBeVisible();
+  });
+
   test("hides after its own bubble handler stops Escape", async ({
     page,
     q,
@@ -238,5 +254,30 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await disclosure.press("Escape");
 
     await test.expect(dialog).toBeHidden();
+  });
+
+  test("lets an outside capture handler own Escape in a document root", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Show document root example").click();
+    const frame = query(
+      page.frameLocator('iframe[title="Document root example"]'),
+    );
+    await frame.button("Open document root outside dialog").click();
+
+    const dialog = frame.dialog("Document root outside dialog");
+    const dialogQuery = query(dialog);
+    const input = dialogQuery.combobox("Search");
+    const listbox = dialogQuery.listbox("Suggestions");
+
+    await test.expect(dialog).toBeVisible();
+    await test.expect(input).toBeFocused();
+    await test.expect(listbox).toBeVisible();
+
+    await input.press("Escape");
+
+    await test.expect(listbox).toBeVisible();
+    await test.expect(dialog).toBeVisible();
   });
 });

--- a/app/src/sandbox/dialog-5179/test-browser.ts
+++ b/app/src/sandbox/dialog-5179/test-browser.ts
@@ -1,4 +1,10 @@
+import type { Locator } from "@playwright/test";
 import { withFramework } from "#app/test-utils/preview.ts";
+
+async function activate(button: Locator) {
+  await button.focus();
+  await button.press("Enter");
+}
 
 withFramework(import.meta.dirname, async ({ test, query }) => {
   // https://github.com/ariakit/ariakit/issues/5179
@@ -186,6 +192,35 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(dialog).toBeHidden();
   });
 
+  for (const phase of ["capture", "bubble"] as const) {
+    test(`does not reclaim Escape stopped before React's document ${phase} listener`, async ({
+      page,
+      q,
+    }) => {
+      await q.button(`Show pre-stopped ${phase} document root example`).click();
+      const frame = query(
+        page.frameLocator(
+          `iframe[title="Pre-stopped ${phase} document root example"]`,
+        ),
+      );
+      const name = `Document root own ${phase} dialog`;
+      const dialog = frame.dialog(name);
+      const disclosure = frame.button(`Open ${name.toLowerCase()}`);
+      await activate(disclosure);
+      const input = query(dialog).combobox("Search");
+      await test.expect(dialog).toBeVisible();
+
+      if (phase === "bubble") {
+        await input.press("Escape");
+        await test.expect(frame.listbox("Suggestions")).toBeHidden();
+      }
+
+      await input.press("Escape");
+
+      await test.expect(dialog).toBeVisible();
+    });
+  }
+
   test("respects a child handler delegated to document", async ({
     page,
     q,
@@ -200,7 +235,7 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     const input = dialogQuery.combobox("Search");
     const listbox = dialogQuery.listbox("Suggestions");
 
-    await openDialog.click();
+    await activate(openDialog);
     await test.expect(input).toBeFocused();
     await test.expect(listbox).toBeVisible();
 
@@ -228,7 +263,7 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     const input = dialogQuery.combobox("Search");
     const listbox = dialogQuery.listbox("Suggestions");
 
-    await openDialog.click();
+    await activate(openDialog);
     await test.expect(input).toBeFocused();
     await test.expect(listbox).toBeVisible();
 
@@ -255,7 +290,7 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     const input = dialogQuery.combobox("Search");
     const listbox = dialogQuery.listbox("Suggestions");
 
-    await frame.button("Open document root prevented dialog").click();
+    await activate(frame.button("Open document root prevented dialog"));
     await test.expect(input).toBeFocused();
     await test.expect(listbox).toBeVisible();
 
@@ -283,7 +318,7 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     const input = dialogQuery.combobox("Search");
     const listbox = dialogQuery.listbox("Suggestions");
 
-    await openDialog.click();
+    await activate(openDialog);
     await test.expect(input).toBeFocused();
     await test.expect(listbox).toBeVisible();
 
@@ -310,7 +345,7 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     const dialogQuery = query(dialog);
     const input = dialogQuery.combobox("Search");
 
-    await openDialog.click();
+    await activate(openDialog);
     await test.expect(input).toBeFocused();
     await test.expect(dialog).toBeVisible();
 
@@ -328,7 +363,7 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
       page.frameLocator('iframe[title="Document root example"]'),
     );
     const dialog = frame.dialog("Document root callback dialog");
-    await frame.button("Open document root callback dialog").click();
+    await activate(frame.button("Open document root callback dialog"));
     await test.expect(dialog).toBeVisible();
 
     await query(dialog).button("Callback calls: 0").press("Escape");
@@ -347,7 +382,7 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     const disclosure = frame.button("Open document root global dialog");
     const dialog = frame.dialog("Document root global dialog");
 
-    await disclosure.click();
+    await activate(disclosure);
     await test.expect(dialog).toBeVisible();
 
     await disclosure.focus();
@@ -367,7 +402,7 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     const disclosure = frame.button("Open document root outside dialog");
     const dialog = frame.dialog("Document root outside dialog");
 
-    await disclosure.click();
+    await activate(disclosure);
     await test.expect(dialog).toBeVisible();
 
     await disclosure.focus();
@@ -385,7 +420,7 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     const frame = query(
       page.frameLocator('iframe[title="Document root example"]'),
     );
-    await frame.button("Open document root outside dialog").click();
+    await activate(frame.button("Open document root outside dialog"));
 
     const dialog = frame.dialog("Document root outside dialog");
     const dialogQuery = query(dialog);

--- a/app/src/sandbox/dialog-5179/test-browser.ts
+++ b/app/src/sandbox/dialog-5179/test-browser.ts
@@ -47,6 +47,26 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(q.dialog("Dialog")).toBeVisible();
   });
 
+  test("hides on a non-bubbling Escape", async ({ q }) => {
+    await q.button("Open dialog").click();
+    const input = q.combobox("Search");
+    await test.expect(q.dialog("Dialog")).toBeVisible();
+
+    await input.evaluate((element) => {
+      const KeyboardEvent = element.ownerDocument.defaultView?.KeyboardEvent;
+      if (!KeyboardEvent) throw new Error("KeyboardEvent is not available");
+      element.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Escape",
+          bubbles: false,
+          cancelable: true,
+        }),
+      );
+    });
+
+    await test.expect(q.dialog("Dialog")).toBeHidden();
+  });
+
   test("hides before an outside ancestor handles Escape", async ({
     page,
     q,

--- a/app/src/sandbox/dialog-5179/test-browser.ts
+++ b/app/src/sandbox/dialog-5179/test-browser.ts
@@ -85,6 +85,34 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(q.dialog("Outer ancestor dialog")).toBeHidden();
   });
 
+  test("hides after its own bubble handler stops Escape", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Open own bubble dialog").click();
+    await test.expect(q.dialog("Own bubble dialog")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+
+    await test.expect(q.listbox("Suggestions")).toBeHidden();
+    await test.expect(q.dialog("Own bubble dialog")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+
+    await test.expect(q.dialog("Own bubble dialog")).toBeHidden();
+  });
+
+  test("hides after its own capture handler stops Escape", async ({ q }) => {
+    await q.button("Open own capture dialog").click();
+    const input = q.combobox("Search");
+    await test.expect(q.dialog("Own capture dialog")).toBeVisible();
+    await test.expect(input).toBeFocused();
+
+    await input.press("Escape");
+
+    await test.expect(q.dialog("Own capture dialog")).toBeHidden();
+  });
+
   test("respects a child handler delegated to document", async ({
     page,
     q,
@@ -134,6 +162,56 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await input.press("Escape");
 
     await test.expect(listbox).toBeHidden();
+    await test.expect(dialog).toBeVisible();
+
+    await input.press("Escape");
+
+    await test.expect(dialog).toBeHidden();
+  });
+
+  test("hides after its own bubble handler delegated to document", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Show document root example").click();
+    const frame = query(
+      page.frameLocator('iframe[title="Document root example"]'),
+    );
+    const openDialog = frame.button("Open document root own bubble dialog");
+    const dialog = frame.dialog("Document root own bubble dialog");
+    const dialogQuery = query(dialog);
+    const input = dialogQuery.combobox("Search");
+    const listbox = dialogQuery.listbox("Suggestions");
+
+    await openDialog.click();
+    await test.expect(input).toBeFocused();
+    await test.expect(listbox).toBeVisible();
+
+    await input.press("Escape");
+
+    await test.expect(listbox).toBeHidden();
+    await test.expect(dialog).toBeVisible();
+
+    await input.press("Escape");
+
+    await test.expect(dialog).toBeHidden();
+  });
+
+  test("hides after its own capture handler delegated to document", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Show document root example").click();
+    const frame = query(
+      page.frameLocator('iframe[title="Document root example"]'),
+    );
+    const openDialog = frame.button("Open document root own capture dialog");
+    const dialog = frame.dialog("Document root own capture dialog");
+    const dialogQuery = query(dialog);
+    const input = dialogQuery.combobox("Search");
+
+    await openDialog.click();
+    await test.expect(input).toBeFocused();
     await test.expect(dialog).toBeVisible();
 
     await input.press("Escape");

--- a/app/src/sandbox/dialog-5179/test-browser.ts
+++ b/app/src/sandbox/dialog-5179/test-browser.ts
@@ -1,0 +1,20 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/5179
+  test("lets a child handle Escape before the dialog", async ({ page, q }) => {
+    await q.button("Open dialog").click();
+    await test.expect(q.dialog("Dialog")).toBeVisible();
+    await test.expect(q.combobox("Search")).toBeFocused();
+    await test.expect(q.listbox("Suggestions")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+
+    await test.expect(q.listbox("Suggestions")).toBeHidden();
+    await test.expect(q.dialog("Dialog")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+
+    await test.expect(q.dialog("Dialog")).toBeHidden();
+  });
+});

--- a/app/src/sandbox/dialog-5179/test.ts
+++ b/app/src/sandbox/dialog-5179/test.ts
@@ -1,4 +1,4 @@
-import { click, dispatch, press, q } from "@ariakit/test";
+import { click, focus, press, q } from "@ariakit/test";
 import { act, createElement } from "react";
 import { createRoot } from "react-dom/client";
 import { expect, test } from "vitest";
@@ -44,22 +44,31 @@ test("lets a child handle Escape before the dialog", async () => {
   expect(q.dialog("Dialog")).not.toBeInTheDocument();
 });
 
-test("hides before an outside ancestor handles Escape", async () => {
-  await click(q.button("Open outer ancestor dialog"));
-  expect(q.dialog("Outer ancestor dialog")).toBeVisible();
-  expect(q.combobox("Search")).toHaveFocus();
+test.each(["Ariakit Portal", "React portal"])(
+  "lets a %s child handle Escape before the dialog",
+  async (portal) => {
+    const dialogName = `${portal} child dialog`;
+    await click(q.button(`Open ${dialogName.toLowerCase()}`));
+    const input = q.combobox.ensure("Search");
+    expect(q.dialog(dialogName)).toBeVisible();
+    expect(q.listbox("Suggestions")).toBeVisible();
 
-  await press.Escape();
+    await focus(input);
+    expect(input).toHaveFocus();
+    expect(q.dialog(dialogName)).toBeVisible();
 
-  expect(q.listbox("Suggestions")).not.toBeInTheDocument();
-  expect(q.dialog("Outer ancestor dialog")).toBeVisible();
+    await press.Escape(input);
 
-  await press.Escape();
+    expect(q.listbox("Suggestions")).not.toBeInTheDocument();
+    expect(q.dialog(dialogName)).toBeVisible();
 
-  expect(q.dialog("Outer ancestor dialog")).not.toBeInTheDocument();
-});
+    await press.Escape(input);
 
-test("lets an outside capture handler own Escape", async () => {
+    expect(q.dialog(dialogName)).not.toBeInTheDocument();
+  },
+);
+
+test("lets an ancestor capture handler own Escape", async () => {
   await click(q.button("Open outer capture dialog"));
   const dialog = q.dialog("Outer capture dialog");
   const input = q.within(dialog).combobox.ensure("Search");
@@ -73,6 +82,28 @@ test("lets an outside capture handler own Escape", async () => {
 
   expect(listbox).toBeVisible();
   expect(dialog).toBeVisible();
+});
+
+test("closes on an unclaimed Escape outside the dialog", async () => {
+  const disclosure = q.button("Open outside dialog");
+  await click(disclosure);
+  expect(q.dialog("Outside dialog")).toBeVisible();
+
+  await focus(disclosure);
+  await press.Escape(disclosure);
+
+  expect(q.dialog("Outside dialog")).not.toBeInTheDocument();
+});
+
+test("lets an ancestor capture handler own Escape outside the dialog", async () => {
+  const disclosure = q.button("Open outer capture dialog");
+  await click(disclosure);
+  expect(q.dialog("Outer capture dialog")).toBeVisible();
+
+  await focus(disclosure);
+  await press.Escape(disclosure);
+
+  expect(q.dialog("Outer capture dialog")).toBeVisible();
 });
 
 test("hides after its own bubble handler stops Escape", async () => {
@@ -98,17 +129,52 @@ test("hides after its own capture handler stops Escape", async () => {
   expect(q.dialog("Own capture dialog")).not.toBeInTheDocument();
 });
 
-test("hides on a non-bubbling Escape", async () => {
-  await click(q.button("Open dialog"));
-  expect(q.dialog("Dialog")).toBeVisible();
+test("stops Escape before a third-party dialog bubble handler", async () => {
+  await click(q.button("Open third-party dialog"));
+  await click(q.button("Open nested ariakit dialog"));
+  expect(q.dialog("Third-party dialog")).toBeVisible();
+  expect(q.dialog("Nested Ariakit dialog")).toBeVisible();
 
-  await dispatch.keyDown(q.combobox("Search"), {
-    key: "Escape",
-    bubbles: false,
-    cancelable: true,
-  });
+  await press.Escape(q.button("Inside nested ariakit dialog"));
 
-  expect(q.dialog("Dialog")).not.toBeInTheDocument();
+  expect(q.dialog("Nested Ariakit dialog")).not.toBeInTheDocument();
+  expect(q.dialog("Third-party dialog")).toBeVisible();
+});
+
+test("can stop Escape before a third-party dialog capture handler", async () => {
+  await click(q.button("Open capture third-party dialog"));
+  await click(q.button("Open shielded ariakit dialog"));
+  expect(q.dialog("Capture third-party dialog")).toBeVisible();
+  expect(q.dialog("Shielded Ariakit dialog")).toBeVisible();
+
+  await press.Escape(q.button("Inside shielded ariakit dialog"));
+
+  expect(q.dialog("Shielded Ariakit dialog")).not.toBeInTheDocument();
+  expect(q.dialog("Capture third-party dialog")).toBeVisible();
+});
+
+test("calls a rejected hideOnEscape callback once", async () => {
+  await click(q.button("Open rejected callback dialog"));
+  const dialog = q.dialog("Rejected callback dialog");
+  const button = q.within(dialog).button.ensure("Callback calls: 0");
+  expect(dialog).toBeVisible();
+
+  await press.Escape(button);
+
+  expect(dialog).toBeVisible();
+  expect(q.within(dialog).button("Callback calls: 1")).toBeVisible();
+});
+
+test("hides when hideOnEscape stops Escape from a React portal", async () => {
+  await click(q.button("Open react portal callback dialog"));
+  const dialog = q.dialog("React portal callback dialog");
+  const button = q.button.ensure("Callback calls: 0");
+  expect(dialog).toBeVisible();
+
+  await focus(button);
+  await press.Escape(button);
+
+  expect(dialog).not.toBeVisible();
 });
 
 test("lets a child capture Escape in a document root", async () => {
@@ -143,19 +209,32 @@ test("hides after its own capture handler in a document root", async () => {
   });
 });
 
-test("keeps global Escape outside a document-root dialog", async () => {
+test("hides when hideOnEscape stops Escape in a document root", async () => {
   await withDocumentRoot(async (q) => {
-    const disclosure = q.button("Open document root outside dialog");
-    await click(disclosure);
-    expect(q.dialog("Document root outside dialog")).toBeVisible();
+    await click(q.button("Open document root callback dialog"));
+    const dialog = q.dialog("Document root callback dialog");
+    const button = q.within(dialog).button.ensure("Callback calls: 0");
+    expect(dialog).toBeVisible();
 
-    await press.Escape(disclosure);
+    await press.Escape(button);
 
-    expect(q.dialog("Document root outside dialog")).not.toBeInTheDocument();
+    expect(dialog).not.toBeVisible();
   });
 });
 
-test("lets an outside capture handler own Escape in a document root", async () => {
+test("closes on global Escape outside a document-root dialog", async () => {
+  await withDocumentRoot(async (q) => {
+    const disclosure = q.button("Open document root global dialog");
+    await click(disclosure);
+    expect(q.dialog("Document root global dialog")).toBeVisible();
+
+    await press.Escape(disclosure);
+
+    expect(q.dialog("Document root global dialog")).not.toBeInTheDocument();
+  });
+});
+
+test("lets an ancestor capture handler own Escape in a document root", async () => {
   await withDocumentRoot(async (q) => {
     await click(q.button("Open document root outside dialog"));
     const dialog = q.dialog("Document root outside dialog");

--- a/app/src/sandbox/dialog-5179/test.ts
+++ b/app/src/sandbox/dialog-5179/test.ts
@@ -165,6 +165,31 @@ test("calls a rejected hideOnEscape callback once", async () => {
   expect(q.within(dialog).button("Callback calls: 1")).toBeVisible();
 });
 
+test("calls an accepted hideOnEscape callback once", async () => {
+  const disclosure = q.button("Open accepted callback dialog");
+  await click(disclosure);
+  const dialog = q.dialog("Accepted callback dialog");
+  const button = q.within(dialog).button.ensure("Callback calls: 0");
+  expect(dialog).toBeVisible();
+
+  await press.Escape(button);
+
+  expect(dialog).not.toBeVisible();
+  await click(disclosure);
+  expect(q.within(dialog).button("Callback calls: 1")).toBeVisible();
+});
+
+test("accepts default prevention from hideOnEscape", async () => {
+  await click(q.button("Open prevented callback dialog"));
+  const dialog = q.dialog("Prevented callback dialog");
+  const button = q.within(dialog).button.ensure("Callback calls: 0");
+  expect(dialog).toBeVisible();
+
+  await press.Escape(button);
+
+  expect(dialog).not.toBeVisible();
+});
+
 test("hides when hideOnEscape stops Escape from a React portal", async () => {
   await click(q.button("Open react portal callback dialog"));
   const dialog = q.dialog("React portal callback dialog");
@@ -192,6 +217,60 @@ test("lets a child capture Escape in a document root", async () => {
     await press.Escape(input);
 
     expect(q.dialog("Document root capture dialog")).not.toBeInTheDocument();
+  });
+});
+
+test("lets a child handle Escape in a document root", async () => {
+  await withDocumentRoot(async (q) => {
+    await click(q.button("Open document root dialog"));
+    const input = q.combobox.ensure("Search");
+    expect(q.dialog("Document root dialog")).toBeVisible();
+    expect(q.listbox("Suggestions")).toBeVisible();
+
+    await press.Escape(input);
+
+    expect(q.listbox("Suggestions")).not.toBeInTheDocument();
+    expect(q.dialog("Document root dialog")).toBeVisible();
+
+    await press.Escape(input);
+
+    expect(q.dialog("Document root dialog")).not.toBeInTheDocument();
+  });
+});
+
+test("respects default prevention in a document root", async () => {
+  await withDocumentRoot(async (q) => {
+    await click(q.button("Open document root prevented dialog"));
+    const input = q.combobox.ensure("Search");
+    expect(q.dialog("Document root prevented dialog")).toBeVisible();
+    expect(q.listbox("Suggestions")).toBeVisible();
+
+    await press.Escape(input);
+
+    expect(q.listbox("Suggestions")).not.toBeInTheDocument();
+    expect(q.dialog("Document root prevented dialog")).toBeVisible();
+
+    await press.Escape(input);
+
+    expect(q.dialog("Document root prevented dialog")).not.toBeInTheDocument();
+  });
+});
+
+test("hides after its own bubble handler in a document root", async () => {
+  await withDocumentRoot(async (q) => {
+    await click(q.button("Open document root own bubble dialog"));
+    const input = q.combobox.ensure("Search");
+    expect(q.dialog("Document root own bubble dialog")).toBeVisible();
+    expect(q.listbox("Suggestions")).toBeVisible();
+
+    await press.Escape(input);
+
+    expect(q.listbox("Suggestions")).not.toBeInTheDocument();
+    expect(q.dialog("Document root own bubble dialog")).toBeVisible();
+
+    await press.Escape(input);
+
+    expect(q.dialog("Document root own bubble dialog")).not.toBeInTheDocument();
   });
 });
 
@@ -231,6 +310,18 @@ test("closes on global Escape outside a document-root dialog", async () => {
     await press.Escape(disclosure);
 
     expect(q.dialog("Document root global dialog")).not.toBeInTheDocument();
+  });
+});
+
+test("lets an ancestor capture handler own global Escape", async () => {
+  await withDocumentRoot(async (q) => {
+    const disclosure = q.button("Open document root outside dialog");
+    await click(disclosure);
+    expect(q.dialog("Document root outside dialog")).toBeVisible();
+
+    await press.Escape(disclosure);
+
+    expect(q.dialog("Document root outside dialog")).toBeVisible();
   });
 });
 

--- a/app/src/sandbox/dialog-5179/test.ts
+++ b/app/src/sandbox/dialog-5179/test.ts
@@ -1,5 +1,31 @@
 import { click, dispatch, press, q } from "@ariakit/test";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
 import { expect, test } from "vitest";
+import { DocumentRootDocument } from "./index.react.tsx";
+
+async function withDocumentRoot(
+  callback: (query: ReturnType<typeof q.within>) => Promise<void>,
+) {
+  const scope = globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean };
+  const previousActEnvironment = scope.IS_REACT_ACT_ENVIRONMENT;
+  scope.IS_REACT_ACT_ENVIRONMENT = true;
+  const iframe = document.createElement("iframe");
+  document.body.appendChild(iframe);
+  const frameDocument = iframe.contentDocument;
+  if (!frameDocument) throw new Error("iframe document is not available");
+  const root = createRoot(frameDocument);
+  try {
+    await act(async () => {
+      root.render(createElement(DocumentRootDocument));
+    });
+    await callback(q.within(frameDocument.body));
+  } finally {
+    await act(async () => root.unmount());
+    iframe.remove();
+    scope.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+  }
+}
 
 // https://github.com/ariakit/ariakit/issues/5179
 test("lets a child handle Escape before the dialog", async () => {
@@ -33,6 +59,29 @@ test("hides before an outside ancestor handles Escape", async () => {
   expect(q.dialog("Outer ancestor dialog")).not.toBeInTheDocument();
 });
 
+test("hides after its own bubble handler stops Escape", async () => {
+  await click(q.button("Open own bubble dialog"));
+  expect(q.dialog("Own bubble dialog")).toBeVisible();
+
+  await press.Escape();
+
+  expect(q.listbox("Suggestions")).not.toBeInTheDocument();
+  expect(q.dialog("Own bubble dialog")).toBeVisible();
+
+  await press.Escape();
+
+  expect(q.dialog("Own bubble dialog")).not.toBeInTheDocument();
+});
+
+test("hides after its own capture handler stops Escape", async () => {
+  await click(q.button("Open own capture dialog"));
+  expect(q.dialog("Own capture dialog")).toBeVisible();
+
+  await press.Escape(q.combobox.ensure("Search"));
+
+  expect(q.dialog("Own capture dialog")).not.toBeInTheDocument();
+});
+
 test("hides on a non-bubbling Escape", async () => {
   await click(q.button("Open dialog"));
   expect(q.dialog("Dialog")).toBeVisible();
@@ -44,4 +93,48 @@ test("hides on a non-bubbling Escape", async () => {
   });
 
   expect(q.dialog("Dialog")).not.toBeInTheDocument();
+});
+
+test("lets a child capture Escape in a document root", async () => {
+  await withDocumentRoot(async (q) => {
+    await click(q.button("Open document root capture dialog"));
+    const input = q.combobox.ensure("Search");
+    expect(q.dialog("Document root capture dialog")).toBeVisible();
+    expect(q.listbox("Suggestions")).toBeVisible();
+
+    await press.Escape(input);
+
+    expect(q.listbox("Suggestions")).not.toBeInTheDocument();
+    expect(q.dialog("Document root capture dialog")).toBeVisible();
+
+    await press.Escape(input);
+
+    expect(q.dialog("Document root capture dialog")).not.toBeInTheDocument();
+  });
+});
+
+test("hides after its own capture handler in a document root", async () => {
+  await withDocumentRoot(async (q) => {
+    await click(q.button("Open document root own capture dialog"));
+    const input = q.combobox.ensure("Search");
+    expect(q.dialog("Document root own capture dialog")).toBeVisible();
+
+    await press.Escape(input);
+
+    expect(
+      q.dialog("Document root own capture dialog"),
+    ).not.toBeInTheDocument();
+  });
+});
+
+test("keeps global Escape outside a document-root dialog", async () => {
+  await withDocumentRoot(async (q) => {
+    const disclosure = q.button("Open document root outside dialog");
+    await click(disclosure);
+    expect(q.dialog("Document root outside dialog")).toBeVisible();
+
+    await press.Escape(disclosure);
+
+    expect(q.dialog("Document root outside dialog")).not.toBeInTheDocument();
+  });
 });

--- a/app/src/sandbox/dialog-5179/test.ts
+++ b/app/src/sandbox/dialog-5179/test.ts
@@ -59,6 +59,22 @@ test("hides before an outside ancestor handles Escape", async () => {
   expect(q.dialog("Outer ancestor dialog")).not.toBeInTheDocument();
 });
 
+test("lets an outside capture handler own Escape", async () => {
+  await click(q.button("Open outer capture dialog"));
+  const dialog = q.dialog("Outer capture dialog");
+  const input = q.within(dialog).combobox.ensure("Search");
+  const listbox = q.within(dialog).listbox("Suggestions");
+
+  expect(dialog).toBeVisible();
+  expect(input).toHaveFocus();
+  expect(listbox).toBeVisible();
+
+  await press.Escape(input);
+
+  expect(listbox).toBeVisible();
+  expect(dialog).toBeVisible();
+});
+
 test("hides after its own bubble handler stops Escape", async () => {
   await click(q.button("Open own bubble dialog"));
   expect(q.dialog("Own bubble dialog")).toBeVisible();
@@ -136,5 +152,23 @@ test("keeps global Escape outside a document-root dialog", async () => {
     await press.Escape(disclosure);
 
     expect(q.dialog("Document root outside dialog")).not.toBeInTheDocument();
+  });
+});
+
+test("lets an outside capture handler own Escape in a document root", async () => {
+  await withDocumentRoot(async (q) => {
+    await click(q.button("Open document root outside dialog"));
+    const dialog = q.dialog("Document root outside dialog");
+    const input = q.within(dialog).combobox.ensure("Search");
+    const listbox = q.within(dialog).listbox("Suggestions");
+
+    expect(dialog).toBeVisible();
+    expect(input).toHaveFocus();
+    expect(listbox).toBeVisible();
+
+    await press.Escape(input);
+
+    expect(listbox).toBeVisible();
+    expect(dialog).toBeVisible();
   });
 });

--- a/app/src/sandbox/dialog-5179/test.ts
+++ b/app/src/sandbox/dialog-5179/test.ts
@@ -6,6 +6,7 @@ import { DocumentRootDocument } from "./index.react.tsx";
 
 async function withDocumentRoot(
   callback: (query: ReturnType<typeof q.within>) => Promise<void>,
+  stopPropagation?: "bubble" | "capture",
 ) {
   const scope = globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean };
   const previousActEnvironment = scope.IS_REACT_ACT_ENVIRONMENT;
@@ -14,6 +15,14 @@ async function withDocumentRoot(
   document.body.appendChild(iframe);
   const frameDocument = iframe.contentDocument;
   if (!frameDocument) throw new Error("iframe document is not available");
+  const capture = stopPropagation === "capture";
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (event.key !== "Escape") return;
+    event.stopPropagation();
+  };
+  if (stopPropagation) {
+    frameDocument.addEventListener("keydown", onKeyDown, capture);
+  }
   const root = createRoot(frameDocument);
   try {
     await act(async () => {
@@ -22,10 +31,32 @@ async function withDocumentRoot(
     await callback(q.within(frameDocument.body));
   } finally {
     await act(async () => root.unmount());
+    frameDocument.removeEventListener("keydown", onKeyDown, capture);
     iframe.remove();
     scope.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
   }
 }
+
+test.each(["capture", "bubble"] as const)(
+  "does not reclaim Escape stopped before React's document %s listener",
+  async (phase) => {
+    await withDocumentRoot(async (q) => {
+      const name = `Document root own ${phase} dialog`;
+      await click(q.button(`Open ${name.toLowerCase()}`));
+      const input = q.combobox.ensure("Search");
+      expect(q.dialog(name)).toBeVisible();
+
+      if (phase === "bubble") {
+        await press.Escape(input);
+        expect(q.listbox("Suggestions")).not.toBeInTheDocument();
+      }
+
+      await press.Escape(input);
+
+      expect(q.dialog(name)).toBeVisible();
+    }, phase);
+  },
+);
 
 // https://github.com/ariakit/ariakit/issues/5179
 test("lets a child handle Escape before the dialog", async () => {

--- a/app/src/sandbox/dialog-5179/test.ts
+++ b/app/src/sandbox/dialog-5179/test.ts
@@ -17,3 +17,18 @@ test("lets a child handle Escape before the dialog", async () => {
 
   expect(q.dialog("Dialog")).not.toBeInTheDocument();
 });
+
+test("hides before an outside ancestor handles Escape", async () => {
+  await click(q.button("Open outer ancestor dialog"));
+  expect(q.dialog("Outer ancestor dialog")).toBeVisible();
+  expect(q.combobox("Search")).toHaveFocus();
+
+  await press.Escape();
+
+  expect(q.listbox("Suggestions")).not.toBeInTheDocument();
+  expect(q.dialog("Outer ancestor dialog")).toBeVisible();
+
+  await press.Escape();
+
+  expect(q.dialog("Outer ancestor dialog")).not.toBeInTheDocument();
+});

--- a/app/src/sandbox/dialog-5179/test.ts
+++ b/app/src/sandbox/dialog-5179/test.ts
@@ -1,4 +1,4 @@
-import { click, press, q } from "@ariakit/test";
+import { click, dispatch, press, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 // https://github.com/ariakit/ariakit/issues/5179
@@ -31,4 +31,17 @@ test("hides before an outside ancestor handles Escape", async () => {
   await press.Escape();
 
   expect(q.dialog("Outer ancestor dialog")).not.toBeInTheDocument();
+});
+
+test("hides on a non-bubbling Escape", async () => {
+  await click(q.button("Open dialog"));
+  expect(q.dialog("Dialog")).toBeVisible();
+
+  await dispatch.keyDown(q.combobox("Search"), {
+    key: "Escape",
+    bubbles: false,
+    cancelable: true,
+  });
+
+  expect(q.dialog("Dialog")).not.toBeInTheDocument();
 });

--- a/app/src/sandbox/dialog-5179/test.ts
+++ b/app/src/sandbox/dialog-5179/test.ts
@@ -1,0 +1,19 @@
+import { click, press, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// https://github.com/ariakit/ariakit/issues/5179
+test("lets a child handle Escape before the dialog", async () => {
+  await click(q.button("Open dialog"));
+  expect(q.dialog("Dialog")).toBeVisible();
+  expect(q.combobox("Search")).toHaveFocus();
+  expect(q.listbox("Suggestions")).toBeVisible();
+
+  await press.Escape();
+
+  expect(q.listbox("Suggestions")).not.toBeInTheDocument();
+  expect(q.dialog("Dialog")).toBeVisible();
+
+  await press.Escape();
+
+  expect(q.dialog("Dialog")).not.toBeInTheDocument();
+});

--- a/examples/menu-wordpress-modal/menu.tsx
+++ b/examples/menu-wordpress-modal/menu.tsx
@@ -86,13 +86,6 @@ export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
             style={{ zIndex: inModal ? 100 : 50 }}
             className="menu"
             hideOnHoverOutside={false}
-            hideOnEscape={(event) => {
-              // Avoid passing the Escape keydown event to the WordPress Modal.
-              // Otherwise, the WordPress Modal would close when pressing Escape
-              // on a nested menu.
-              event.stopPropagation();
-              return true;
-            }}
           >
             <MenuContext.Provider value={menu}>{children}</MenuContext.Provider>
           </Ariakit.Menu>

--- a/examples/menu-wordpress-modal/menu.tsx
+++ b/examples/menu-wordpress-modal/menu.tsx
@@ -86,6 +86,20 @@ export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
             style={{ zIndex: inModal ? 100 : 50 }}
             className="menu"
             hideOnHoverOutside={false}
+            hideOnEscape={(event) => {
+              const disclosure = menu.getState().disclosureElement;
+              const nativeEvent =
+                "nativeEvent" in event ? event.nativeEvent : event;
+              if (
+                disclosure &&
+                nativeEvent.composedPath().includes(disclosure)
+              ) {
+                // The disclosure isn't in the menu's React subtree, so the
+                // menu can't stop the event at its own boundary.
+                event.stopPropagation();
+              }
+              return true;
+            }}
           >
             <MenuContext.Provider value={menu}>{children}</MenuContext.Provider>
           </Ariakit.Menu>

--- a/examples/menu-wordpress-modal/test-chrome.ts
+++ b/examples/menu-wordpress-modal/test-chrome.ts
@@ -29,6 +29,26 @@ const getMenu = (page: Page, name?: string) => getPopup(page, "menu", name);
 const getAccessibleMenu = (page: Page, name?: string) =>
   getAccessiblePopup(page, "menu", name);
 
+test("keeps the modal open when Escape closes a menu from its disclosure", async ({
+  page,
+}) => {
+  await getButton(page, "Options").click();
+  await getMenuItem(page, "Nested").click();
+  await expect(getAccessibleModal(page)).toBeVisible();
+
+  const disclosure = getButton(page, "Menu");
+  await disclosure.click();
+  await expect(getAccessibleMenu(page, "Menu")).toBeVisible();
+
+  await disclosure.focus();
+  await expect(disclosure).toBeFocused();
+  await page.keyboard.press("Escape");
+
+  await expect(getMenu(page, "Menu")).not.toBeVisible();
+  await page.waitForTimeout(300);
+  await expect(getAccessibleModal(page)).toBeVisible();
+});
+
 for (const menuitem of [
   "Nested",
   "Sibling",

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -505,13 +505,22 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
   }, [hasOpened, mayAutoFocusOnHide, focusOnHide]);
 
   const hideOnEscapeProp = useBooleanEvent(hideOnEscape);
+  const [pendingEscapeEvents] = useState(() => new WeakSet<KeyboardEvent>());
+
+  const onKeyDownProp = props.onKeyDown;
+
+  const onKeyDown = useEvent((event: ReactKeyboardEvent<HTMLType>) => {
+    onKeyDownProp?.(event);
+    if (!pendingEscapeEvents.delete(event.nativeEvent)) return;
+    if (event.isPropagationStopped()) return;
+    store.hide();
+  });
 
   // Hide on Escape.
   useEffect(() => {
     if (!domReady) return;
     if (!mounted) return;
-    const pendingEscapeEvents = new WeakSet<KeyboardEvent>();
-    const onKeyDownCapture = (event: KeyboardEvent) => {
+    const onDocumentKeyDownCapture = (event: KeyboardEvent) => {
       // Clear state left by a previous stopped dispatch if the event is reused.
       pendingEscapeEvents.delete(event);
       if (event.key !== "Escape") return;
@@ -530,9 +539,10 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
       // This considers valid targets the elements that belong to this dialog
       // tree, including elements marked as outside by this dialog so Escape can
       // close the topmost dialog even when focus is outside.
+      const targetInsideDialog = contains(dialog, target);
       const isValidTarget = () => {
         if (isElement(target) && target.tagName === "BODY") return true;
-        if (contains(dialog, target)) return true;
+        if (targetInsideDialog) return true;
         if (!disclosureElement) return true;
         if (contains(disclosureElement, target)) return true;
         if (isElement(target) && isElementMarked(target, dialog.id)) {
@@ -541,33 +551,36 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
         return false;
       };
       if (!isValidTarget()) return;
+      const propagationStopped = event.cancelBubble;
       if (!hideOnEscapeProp(event)) return;
-      // The bubble listener won't run if the hideOnEscape callback stopped
-      // propagation or the event doesn't bubble, so we hide immediately in
-      // these cases.
-      if (event.cancelBubble || !event.bubbles) {
+      // Propagation may already be stopped when React delegates capture events
+      // to document before this listener.
+      if (propagationStopped && targetInsideDialog) return;
+      // Inside events are committed by the dialog's React handler after its
+      // descendants. Events that can't reach it retain the global behavior.
+      if (event.cancelBubble || !event.bubbles || !targetInsideDialog) {
         store.hide();
         return;
       }
       pendingEscapeEvents.add(event);
     };
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (!pendingEscapeEvents.delete(event)) return;
-      // React may delegate events to document, where stopPropagation doesn't
-      // prevent later listeners on the same target.
-      if (event.cancelBubble) return;
-      store.hide();
-    };
     // Listen on the document so Escape works even when the dialog isn't
-    // focused. The capture listener lets hideOnEscape stop the event before it
-    // reaches third-party dialogs. The bubble listener lets descendants stop
-    // the event before this dialog hides.
+    // focused and hideOnEscape can stop the event before third-party dialogs.
     const win = contentElement ? getWindow(contentElement) : undefined;
-    return chain(
-      addGlobalEventListener("keydown", onKeyDownCapture, true, win),
-      addGlobalEventListener("keydown", onKeyDown, false, win),
+    return addGlobalEventListener(
+      "keydown",
+      onDocumentKeyDownCapture,
+      true,
+      win,
     );
-  }, [store, domReady, mounted, contentElement, hideOnEscapeProp]);
+  }, [
+    store,
+    domReady,
+    mounted,
+    contentElement,
+    hideOnEscapeProp,
+    pendingEscapeEvents,
+  ]);
 
   // Resets the heading levels inside the modal dialog so they start with h1.
   props = useWrapElement(
@@ -628,6 +641,7 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     ...props,
     id,
     ref: useMergeRefs(ref, props.ref),
+    onKeyDown,
   };
 
   props = useFocusableContainer({

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -505,31 +505,47 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
   }, [hasOpened, mayAutoFocusOnHide, focusOnHide]);
 
   const hideOnEscapeProp = useBooleanEvent(hideOnEscape);
-  const [escapeEvents] = useState(
-    () => new WeakMap<KeyboardEvent, "pending" | "stoppedAtDialog">(),
-  );
+  const [escapeEvents] = useState(() => new WeakMap<KeyboardEvent, boolean>());
 
   const onKeyDownProp = props.onKeyDown;
   const onKeyDownCaptureProp = props.onKeyDownCapture;
 
+  const acceptEscape = useEvent((event: KeyboardEvent) => {
+    if (escapeEvents.has(event)) return escapeEvents.get(event) === true;
+    if (event.key !== "Escape") return false;
+    if (!event.bubbles) return false;
+    if (event.defaultPrevented) return false;
+    const dialog = ref.current;
+    if (!mounted) return false;
+    if (!dialog) return false;
+    // Ignore the event if the current dialog is marked by another dialog.
+    // This guarantees that only the topmost dialog will close on Escape.
+    if (isElementMarked(dialog)) return false;
+    const accepted = hideOnEscapeProp(event);
+    escapeEvents.set(event, accepted);
+    return accepted;
+  });
+
   const onKeyDown = useEvent((event: ReactKeyboardEvent<HTMLType>) => {
     onKeyDownProp?.(event);
-    if (escapeEvents.get(event.nativeEvent) !== "pending") return;
-    escapeEvents.delete(event.nativeEvent);
+    const nativeEvent = event.nativeEvent;
+    const accepted = escapeEvents.get(nativeEvent);
+    escapeEvents.delete(nativeEvent);
+    if (!accepted) return;
+    event.stopPropagation();
     store.hide();
   });
 
   const onKeyDownCapture = useEvent((event: ReactKeyboardEvent<HTMLType>) => {
-    onKeyDownCaptureProp?.(event);
-    if (event.key !== "Escape") return;
-    if (!event.isPropagationStopped()) return;
     const nativeEvent = event.nativeEvent;
-    const document = event.currentTarget.ownerDocument;
-    if (nativeEvent.currentTarget === document) {
-      escapeEvents.set(nativeEvent, "stoppedAtDialog");
-      return;
-    }
-    if (escapeEvents.get(nativeEvent) !== "pending") return;
+    const wasPropagationStopped = nativeEvent.cancelBubble;
+    const accepted = acceptEscape(nativeEvent);
+    onKeyDownCaptureProp?.(event);
+    if (!accepted) return;
+    const stoppedAtDialog =
+      event.isPropagationStopped() ||
+      (!wasPropagationStopped && nativeEvent.cancelBubble);
+    if (!stoppedAtDialog) return;
     escapeEvents.delete(nativeEvent);
     store.hide();
   });
@@ -539,16 +555,14 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     if (!domReady) return;
     if (!mounted) return;
     const onDocumentKeyDownCapture = (event: KeyboardEvent) => {
-      // Clear state left by a previous stopped dispatch if the event is reused.
-      const stoppedAtDialog = escapeEvents.get(event) === "stoppedAtDialog";
-      escapeEvents.delete(event);
-      if (event.key !== "Escape") return;
-      if (event.defaultPrevented) return;
+      // React may delegate capture events to document before this listener.
+      if (event.cancelBubble) {
+        escapeEvents.delete(event);
+        return;
+      }
+      if (escapeEvents.has(event)) return;
       const dialog = ref.current;
       if (!dialog) return;
-      // Ignore the event if the current dialog is marked by another dialog.
-      // This guarantees that only the topmost dialog will close on Escape.
-      if (isElementMarked(dialog)) return;
       const target = event.target;
       // Guard against non-node targets (e.g. a synthetic event dispatched on
       // window) so `contains` doesn't throw. `isNode` rather than `isElement`
@@ -570,41 +584,30 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
         return false;
       };
       if (!isValidTarget()) return;
-      const propagationStopped = event.cancelBubble;
-      if (!hideOnEscapeProp(event)) return;
-      // Propagation may already be stopped when React delegates capture events
-      // to document before this listener.
-      if (propagationStopped && targetInsideDialog && !stoppedAtDialog) {
-        return;
-      }
-      // Inside events are committed by the dialog's React handler after its
-      // descendants. Events that can't reach it retain the global behavior.
-      if (event.cancelBubble || !event.bubbles || !targetInsideDialog) {
-        store.hide();
-        return;
-      }
-      // If an ancestor capture handler stops propagation before the event
-      // reaches this dialog boundary, that handler owns Escape and the dialog
-      // remains open.
-      escapeEvents.set(event, "pending");
+      if (!acceptEscape(event)) return;
+      if (!event.cancelBubble) return;
+      escapeEvents.delete(event);
+      store.hide();
+    };
+    const onDocumentKeyDown = (event: KeyboardEvent) => {
+      const accepted = escapeEvents.get(event);
+      escapeEvents.delete(event);
+      if (!accepted) return;
+      // A React root on document may stop propagation before this listener is
+      // called on the same node.
+      if (event.cancelBubble) return;
+      event.stopPropagation();
+      store.hide();
     };
     // Listen on the document so Escape works even when the dialog isn't
-    // focused and hideOnEscape can stop the event before third-party dialogs.
+    // focused. When this listener runs first, hideOnEscape can also stop the
+    // event before third-party dialogs.
     const win = contentElement ? getWindow(contentElement) : undefined;
-    return addGlobalEventListener(
-      "keydown",
-      onDocumentKeyDownCapture,
-      true,
-      win,
+    return chain(
+      addGlobalEventListener("keydown", onDocumentKeyDownCapture, true, win),
+      addGlobalEventListener("keydown", onDocumentKeyDown, false, win),
     );
-  }, [
-    store,
-    domReady,
-    mounted,
-    contentElement,
-    hideOnEscapeProp,
-    escapeEvents,
-  ]);
+  }, [store, domReady, mounted, contentElement, acceptEscape, escapeEvents]);
 
   // Resets the heading levels inside the modal dialog so they start with h1.
   props = useWrapElement(
@@ -860,9 +863,11 @@ export interface DialogOptions<T extends ElementType = TagName>
    * event that initiated the hide action, which could be either a native
    * keyboard event or a React synthetic event.
    *
-   * **Note**: When placing Ariakit dialogs inside third-party dialogs, using
-   * `event.stopPropagation()` within this function will stop the event from
-   * reaching the third-party dialog, closing only the Ariakit dialog.
+   * **Note**: The dialog stops handled Escape events from its React subtree
+   * before they reach ancestor React bubble handlers. An ancestor capture
+   * handler can own the event by stopping its propagation. If this function
+   * runs before such a handler, it can call `event.stopPropagation()` to
+   * prevent the handler from receiving the event.
    * @default true
    */
   hideOnEscape?: BooleanOrCallback<KeyboardEvent | ReactKeyboardEvent>;

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -505,15 +505,25 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
   }, [hasOpened, mayAutoFocusOnHide, focusOnHide]);
 
   const hideOnEscapeProp = useBooleanEvent(hideOnEscape);
-  const [escapeEvents] = useState(() => new WeakMap<KeyboardEvent, boolean>());
+  const [escapeEvents] = useState(
+    () =>
+      new WeakMap<
+        KeyboardEvent,
+        { accepted: boolean; defaultPrevented: boolean }
+      >(),
+  );
 
   const onKeyDownProp = props.onKeyDown;
   const onKeyDownCaptureProp = props.onKeyDownCapture;
 
   const acceptEscape = useEvent((event: KeyboardEvent) => {
-    if (escapeEvents.has(event)) return escapeEvents.get(event) === true;
     if (event.key !== "Escape") return false;
     if (!event.bubbles) return false;
+    const result = escapeEvents.get(event);
+    if (result) {
+      if (event.defaultPrevented && !result.defaultPrevented) return false;
+      return result.accepted;
+    }
     if (event.defaultPrevented) return false;
     const dialog = ref.current;
     if (!mounted) return false;
@@ -522,32 +532,37 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     // This guarantees that only the topmost dialog will close on Escape.
     if (isElementMarked(dialog)) return false;
     const accepted = hideOnEscapeProp(event);
-    escapeEvents.set(event, accepted);
+    escapeEvents.set(event, {
+      accepted,
+      defaultPrevented: event.defaultPrevented,
+    });
     return accepted;
+  });
+
+  const hideOnEscapeEvent = useEvent((event: KeyboardEvent) => {
+    const accepted = acceptEscape(event);
+    escapeEvents.delete(event);
+    if (!accepted) return false;
+    store.hide();
+    return true;
   });
 
   const onKeyDown = useEvent((event: ReactKeyboardEvent<HTMLType>) => {
     onKeyDownProp?.(event);
     const nativeEvent = event.nativeEvent;
-    const accepted = escapeEvents.get(nativeEvent);
-    escapeEvents.delete(nativeEvent);
-    if (!accepted) return;
+    if (!hideOnEscapeEvent(nativeEvent)) return;
     event.stopPropagation();
-    store.hide();
   });
 
   const onKeyDownCapture = useEvent((event: ReactKeyboardEvent<HTMLType>) => {
     const nativeEvent = event.nativeEvent;
     const wasPropagationStopped = nativeEvent.cancelBubble;
-    const accepted = acceptEscape(nativeEvent);
     onKeyDownCaptureProp?.(event);
-    if (!accepted) return;
     const stoppedAtDialog =
       event.isPropagationStopped() ||
       (!wasPropagationStopped && nativeEvent.cancelBubble);
     if (!stoppedAtDialog) return;
-    escapeEvents.delete(nativeEvent);
-    store.hide();
+    hideOnEscapeEvent(nativeEvent);
   });
 
   // Hide on Escape.
@@ -555,7 +570,6 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     if (!domReady) return;
     if (!mounted) return;
     const onDocumentKeyDownCapture = (event: KeyboardEvent) => {
-      // React may delegate capture events to document before this listener.
       if (event.cancelBubble) {
         escapeEvents.delete(event);
         return;
@@ -572,10 +586,9 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
       // This considers valid targets the elements that belong to this dialog
       // tree, including elements marked as outside by this dialog so Escape can
       // close the topmost dialog even when focus is outside.
-      const targetInsideDialog = contains(dialog, target);
       const isValidTarget = () => {
         if (isElement(target) && target.tagName === "BODY") return true;
-        if (targetInsideDialog) return true;
+        if (contains(dialog, target)) return true;
         if (!disclosureElement) return true;
         if (contains(disclosureElement, target)) return true;
         if (isElement(target) && isElementMarked(target, dialog.id)) {
@@ -586,28 +599,34 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
       if (!isValidTarget()) return;
       if (!acceptEscape(event)) return;
       if (!event.cancelBubble) return;
-      escapeEvents.delete(event);
-      store.hide();
+      hideOnEscapeEvent(event);
     };
     const onDocumentKeyDown = (event: KeyboardEvent) => {
-      const accepted = escapeEvents.get(event);
-      escapeEvents.delete(event);
-      if (!accepted) return;
-      // A React root on document may stop propagation before this listener is
-      // called on the same node.
-      if (event.cancelBubble) return;
+      if (!escapeEvents.has(event)) return;
+      if (event.cancelBubble) {
+        escapeEvents.delete(event);
+        return;
+      }
+      if (!hideOnEscapeEvent(event)) return;
       event.stopPropagation();
-      store.hide();
     };
     // Listen on the document so Escape works even when the dialog isn't
-    // focused. When this listener runs first, hideOnEscape can also stop the
-    // event before third-party dialogs.
+    // focused. Capture preflights DOM-owned events so hideOnEscape can stop
+    // them, while the hide is committed only after descendants handle them.
     const win = contentElement ? getWindow(contentElement) : undefined;
     return chain(
       addGlobalEventListener("keydown", onDocumentKeyDownCapture, true, win),
       addGlobalEventListener("keydown", onDocumentKeyDown, false, win),
     );
-  }, [store, domReady, mounted, contentElement, acceptEscape, escapeEvents]);
+  }, [
+    store,
+    domReady,
+    mounted,
+    contentElement,
+    hideOnEscapeEvent,
+    acceptEscape,
+    escapeEvents,
+  ]);
 
   // Resets the heading levels inside the modal dialog so they start with h1.
   props = useWrapElement(

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -583,6 +583,9 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
         store.hide();
         return;
       }
+      // If an ancestor capture handler stops propagation before the event
+      // reaches this dialog boundary, that handler owns Escape and the dialog
+      // remains open.
       escapeEvents.set(event, "pending");
     };
     // Listen on the document so Escape works even when the dialog isn't

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -505,14 +505,32 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
   }, [hasOpened, mayAutoFocusOnHide, focusOnHide]);
 
   const hideOnEscapeProp = useBooleanEvent(hideOnEscape);
-  const [pendingEscapeEvents] = useState(() => new WeakSet<KeyboardEvent>());
+  const [escapeEvents] = useState(
+    () => new WeakMap<KeyboardEvent, "pending" | "stoppedAtDialog">(),
+  );
 
   const onKeyDownProp = props.onKeyDown;
+  const onKeyDownCaptureProp = props.onKeyDownCapture;
 
   const onKeyDown = useEvent((event: ReactKeyboardEvent<HTMLType>) => {
     onKeyDownProp?.(event);
-    if (!pendingEscapeEvents.delete(event.nativeEvent)) return;
-    if (event.isPropagationStopped()) return;
+    if (escapeEvents.get(event.nativeEvent) !== "pending") return;
+    escapeEvents.delete(event.nativeEvent);
+    store.hide();
+  });
+
+  const onKeyDownCapture = useEvent((event: ReactKeyboardEvent<HTMLType>) => {
+    onKeyDownCaptureProp?.(event);
+    if (event.key !== "Escape") return;
+    if (!event.isPropagationStopped()) return;
+    const nativeEvent = event.nativeEvent;
+    const document = event.currentTarget.ownerDocument;
+    if (nativeEvent.currentTarget === document) {
+      escapeEvents.set(nativeEvent, "stoppedAtDialog");
+      return;
+    }
+    if (escapeEvents.get(nativeEvent) !== "pending") return;
+    escapeEvents.delete(nativeEvent);
     store.hide();
   });
 
@@ -522,7 +540,8 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     if (!mounted) return;
     const onDocumentKeyDownCapture = (event: KeyboardEvent) => {
       // Clear state left by a previous stopped dispatch if the event is reused.
-      pendingEscapeEvents.delete(event);
+      const stoppedAtDialog = escapeEvents.get(event) === "stoppedAtDialog";
+      escapeEvents.delete(event);
       if (event.key !== "Escape") return;
       if (event.defaultPrevented) return;
       const dialog = ref.current;
@@ -555,14 +574,16 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
       if (!hideOnEscapeProp(event)) return;
       // Propagation may already be stopped when React delegates capture events
       // to document before this listener.
-      if (propagationStopped && targetInsideDialog) return;
+      if (propagationStopped && targetInsideDialog && !stoppedAtDialog) {
+        return;
+      }
       // Inside events are committed by the dialog's React handler after its
       // descendants. Events that can't reach it retain the global behavior.
       if (event.cancelBubble || !event.bubbles || !targetInsideDialog) {
         store.hide();
         return;
       }
-      pendingEscapeEvents.add(event);
+      escapeEvents.set(event, "pending");
     };
     // Listen on the document so Escape works even when the dialog isn't
     // focused and hideOnEscape can stop the event before third-party dialogs.
@@ -579,7 +600,7 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     mounted,
     contentElement,
     hideOnEscapeProp,
-    pendingEscapeEvents,
+    escapeEvents,
   ]);
 
   // Resets the heading levels inside the modal dialog so they start with h1.
@@ -642,6 +663,7 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     id,
     ref: useMergeRefs(ref, props.ref),
     onKeyDown,
+    onKeyDownCapture,
   };
 
   props = useFocusableContainer({

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -548,8 +548,13 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
   });
 
   const onKeyDown = useEvent((event: ReactKeyboardEvent<HTMLType>) => {
-    onKeyDownProp?.(event);
     const nativeEvent = event.nativeEvent;
+    const wasPropagationStopped = nativeEvent.cancelBubble;
+    onKeyDownProp?.(event);
+    if (wasPropagationStopped) {
+      escapeEvents.delete(nativeEvent);
+      return;
+    }
     if (!hideOnEscapeEvent(nativeEvent)) return;
     event.stopPropagation();
   });
@@ -558,9 +563,12 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     const nativeEvent = event.nativeEvent;
     const wasPropagationStopped = nativeEvent.cancelBubble;
     onKeyDownCaptureProp?.(event);
+    if (wasPropagationStopped) {
+      escapeEvents.delete(nativeEvent);
+      return;
+    }
     const stoppedAtDialog =
-      event.isPropagationStopped() ||
-      (!wasPropagationStopped && nativeEvent.cancelBubble);
+      event.isPropagationStopped() || nativeEvent.cancelBubble;
     if (!stoppedAtDialog) return;
     hideOnEscapeEvent(nativeEvent);
   });
@@ -570,6 +578,8 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     if (!domReady) return;
     if (!mounted) return;
     const onDocumentKeyDownCapture = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      if (!event.bubbles) return;
       if (event.cancelBubble) {
         escapeEvents.delete(event);
         return;

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -510,7 +510,10 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
   useEffect(() => {
     if (!domReady) return;
     if (!mounted) return;
-    const onKeyDown = (event: KeyboardEvent) => {
+    const pendingEscapeEvents = new WeakSet<KeyboardEvent>();
+    const onKeyDownCapture = (event: KeyboardEvent) => {
+      // Clear state left by a previous stopped dispatch if the event is reused.
+      pendingEscapeEvents.delete(event);
       if (event.key !== "Escape") return;
       if (event.defaultPrevented) return;
       const dialog = ref.current;
@@ -539,14 +542,31 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
       };
       if (!isValidTarget()) return;
       if (!hideOnEscapeProp(event)) return;
+      // The bubble listener won't run if the hideOnEscape callback stopped
+      // propagation or the event doesn't bubble, so we hide immediately in
+      // these cases.
+      if (event.cancelBubble || !event.bubbles) {
+        store.hide();
+        return;
+      }
+      pendingEscapeEvents.add(event);
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!pendingEscapeEvents.delete(event)) return;
+      // React may delegate events to document, where stopPropagation doesn't
+      // prevent later listeners on the same target.
+      if (event.cancelBubble) return;
       store.hide();
     };
-    // We're attatching the listener to the document instead of the dialog
-    // element so we can listen to the Escape key anywhere in the document, even
-    // when the dialog is not focused. By using the capture phase, users can
-    // call `event.stopPropagation()` on the `hideOnEscape` function prop.
+    // Listen on the document so Escape works even when the dialog isn't
+    // focused. The capture listener lets hideOnEscape stop the event before it
+    // reaches third-party dialogs. The bubble listener lets descendants stop
+    // the event before this dialog hides.
     const win = contentElement ? getWindow(contentElement) : undefined;
-    return addGlobalEventListener("keydown", onKeyDown, true, win);
+    return chain(
+      addGlobalEventListener("keydown", onKeyDownCapture, true, win),
+      addGlobalEventListener("keydown", onKeyDown, false, win),
+    );
   }, [store, domReady, mounted, contentElement, hideOnEscapeProp]);
 
   // Resets the heading levels inside the modal dialog so they start with h1.


### PR DESCRIPTION
## Motivation

`Dialog` listens for <kbd>Esc</kbd> on the document during the capture phase, so it hides before a descendant can handle the key and call `event.stopPropagation()`. This prevents nested widgets such as autocomplete popups or Monaco's find widget from consuming <kbd>Esc</kbd> while keeping the dialog open.

```tsx
<input
  onKeyDown={(event) => {
    if (event.key !== "Escape") return;
    if (!suggestionsOpen) return;
    event.stopPropagation();
    closeSuggestions();
  }}
/>
```

Fixes #5179.

## Solution

Treat normal bubbling <kbd>Esc</kbd> propagation as event ownership. The document capture listener preflights qualifying events, but the hide is committed only after descendant handlers: at the Dialog's React bubble boundary for events from its subtree, or at the document bubble boundary when focus is outside.

This lets descendant bubble or capture handlers stop <kbd>Esc</kbd>. A later `event.preventDefault()` also vetoes an accepted event when the accepting callback did not already prevent the same event. When Dialog handles an event from its React subtree, it stops propagation at its boundary by default, so an enclosing third-party React dialog with a bubble handler remains open. When Dialog handles through the document fallback, it stops at `document` before `window` bubble listeners.

React's logical event path provides the same target-first behavior for both `Ariakit.Portal` and arbitrary portals created with `createPortal`. In particular, a third-party portal such as WordPress `Modal` can handle and prevent <kbd>Esc</kbd> before a logical parent Menu evaluates its own handling.

`hideOnEscape` is still preflighted for qualifying DOM-owned, disclosure, and global targets. This preserves use cases where the callback must synchronously call `event.stopPropagation()` before an enclosing handler, such as an Ariakit Tooltip whose focused disclosure is inside a WordPress Modal. An ancestor capture handler that runs first can still own the event by stopping it. Likewise, if an earlier document capture or bubble listener has already stopped the event before React or Ariakit's applicable document listener runs, Ariakit does not reclaim it.

```tsx
<Dialog
  hideOnEscape={(event) => {
    event.stopPropagation();
    return true;
  }}
/>
```

A per-event `WeakMap` caches the accepted result and whether the callback itself prevented the default, so `hideOnEscape` runs at most once. The DOM exposes one sticky `defaultPrevented` flag: a callback that calls `event.preventDefault()` and returns `true` explicitly accepts that event, and a later prevention of the same event cannot be distinguished from the callback's own prevention.

The WordPress example keeps a selective Menu workaround for the case where the open Menu's disclosure has focus outside the Menu's React subtree. It stops only that disclosure-path event so the Menu closes without also closing the enclosing WordPress Modal.

```tsx
hideOnEscape={(event) => {
  const nativeEvent = "nativeEvent" in event ? event.nativeEvent : event;
  if (nativeEvent.composedPath().includes(disclosure)) {
    event.stopPropagation();
  }
  return true;
}}
```

Non-bubbling manually dispatched keyboard events, redispatching the same native event object, and synchronously replacing the Dialog from an accepting `hideOnEscape` callback are not compatibility requirements for this propagation-based contract.

Add focused happy-dom and browser regression coverage for descendant and Dialog-owned bubble/capture handlers, Ariakit and React portals, outside focus, third-party React dialogs, document-delegated React roots, callback evaluation, later default prevention, ancestor capture ownership, prior document-listener ownership, and the focused WordPress Menu disclosure. The focused suites pass 25 cases under both React 18 and React 19, 75 browser cases across Chrome, Firefox, and Safari, and 35 WordPress integration cases with both WordPress Components 36 and 37.

## Implementation review reassessment

<details>
<summary>Keep synchronous preflight only where it supports a real capture-shield use case</summary>

Repeated portal and listener-order findings showed that synchronously claiming every <kbd>Esc</kbd> during capture breaks target-first ownership for arbitrary third-party portals and requires growing special-case state.

The final implementation preflights only qualifying DOM/disclosure/global targets, defers the committed hide until the Dialog or document bubble boundary, and lets the logical target handle arbitrary React-portal events first. The remaining preflight and per-event cache are necessary for the verified Tooltip-in-WordPress capture shield, global outside-focus handling, callback-once semantics, and cancellation that occurs after acceptance.

</details>

<details>
<summary>Keep native sticky cancellation and a selective disclosure shield</summary>

A native form experiment confirmed that descendant `preventDefault()` cancels an ancestor-associated default action, but `defaultPrevented` remains one sticky flag throughout the event path. Distinguishing a later prevention after an accepting callback has already prevented the event would require per-listener instrumentation rather than native event semantics, so that combination is an explicit callback-contract limit.

The remaining review fixes are narrow: leave events already stopped before React or Ariakit's document listener with that listener, filter non-<kbd>Esc</kbd> events before fallback traversal, and keep the WordPress Menu shield only for its disclosure path. Preserving an accepted event across a synchronous Dialog remount would require cross-lifecycle state and remains outside the supported contract.

</details>

## Workaround

Until this release is available, disable the built-in capture-phase <kbd>Esc</kbd> handler and close the dialog from an element-level bubble handler instead:

```tsx
const dialog = useDialogStore();

<Dialog
  store={dialog}
  hideOnEscape={false}
  onKeyDown={(event) => {
    if (event.key !== "Escape") return;
    if (event.defaultPrevented) return;
    // TODO: Remove when https://github.com/ariakit/ariakit/issues/5179 is fixed.
    dialog.hide();
  }}
/>;
```

Because this workaround checks `defaultPrevented`, a descendant can call `event.stopPropagation()` or `event.preventDefault()` to consume <kbd>Esc</kbd> before `Dialog` hides. The workaround is element-scoped, so it does not preserve Ariakit's normal global <kbd>Esc</kbd> handling when focus is outside the dialog subtree.
