### PR TITLE
Add tooltip performance sandbox

### DIFF
--- a/app/src/sandbox/tooltip-perf/index.react.tsx
+++ b/app/src/sandbox/tooltip-perf/index.react.tsx
@@ -1,0 +1,110 @@
+import * as Ariakit from "@ariakit/react";
+import "./style.css";
+
+const tools = ["Tool 1", "Tool 2", "Tool 3"];
+
+interface TooltipButtonOptions {
+  tooltip: string;
+}
+
+function TooltipButton({
+  tooltip,
+  ...props
+}: Ariakit.ButtonProps & TooltipButtonOptions) {
+  return (
+    <Ariakit.TooltipProvider>
+      <Ariakit.Tooltip className="tooltip">{tooltip}</Ariakit.Tooltip>
+      <Ariakit.TooltipAnchor render={<Ariakit.Button {...props} />} />
+    </Ariakit.TooltipProvider>
+  );
+}
+
+function ToolbarButton(props: Ariakit.ButtonProps) {
+  return <Ariakit.ToolbarItem render={<Ariakit.Button {...props} />} />;
+}
+
+function IndependentTooltipToolbar() {
+  const label = "Independent tooltips";
+  return (
+    <section>
+      <h2>{label}</h2>
+      <Ariakit.ToolbarProvider>
+        <Ariakit.Toolbar aria-label={label} className="toolbar">
+          {tools.map((tool) => (
+            <Ariakit.ToolbarItem
+              key={tool}
+              className="toolbar-item"
+              render={<TooltipButton tooltip={`${label}: ${tool}`} />}
+            >
+              {tool}
+            </Ariakit.ToolbarItem>
+          ))}
+        </Ariakit.Toolbar>
+      </Ariakit.ToolbarProvider>
+    </section>
+  );
+}
+
+function SharedTooltip() {
+  const store = Ariakit.useTooltipContext();
+  const anchorElement = Ariakit.useStoreState(store, "anchorElement");
+  return (
+    <Ariakit.Tooltip className="tooltip" portal={false}>
+      {anchorElement?.dataset.tooltip}
+    </Ariakit.Tooltip>
+  );
+}
+
+function SharedTooltipToolbar() {
+  const label = "Shared tooltip";
+  return (
+    <section>
+      <h2>{label}</h2>
+      <Ariakit.TooltipProvider>
+        <Ariakit.ToolbarProvider>
+          <Ariakit.Toolbar aria-label={label} className="toolbar">
+            {tools.map((tool) => (
+              <Ariakit.TooltipAnchor
+                key={tool}
+                data-tooltip={`${label}: ${tool}`}
+                render={<ToolbarButton className="toolbar-item" />}
+              >
+                {tool}
+              </Ariakit.TooltipAnchor>
+            ))}
+          </Ariakit.Toolbar>
+        </Ariakit.ToolbarProvider>
+        <SharedTooltip />
+      </Ariakit.TooltipProvider>
+    </section>
+  );
+}
+
+function ToolbarWithoutTooltips() {
+  const label = "No tooltips";
+  return (
+    <section>
+      <h2>{label}</h2>
+      <Ariakit.ToolbarProvider>
+        <Ariakit.Toolbar aria-label={label} className="toolbar">
+          {tools.map((tool) => (
+            <ToolbarButton key={tool} className="toolbar-item">
+              {tool}
+            </ToolbarButton>
+          ))}
+        </Ariakit.Toolbar>
+      </Ariakit.ToolbarProvider>
+    </section>
+  );
+}
+
+export default function Example() {
+  return (
+    <main className="root">
+      <h1>Tooltip performance</h1>
+      <IndependentTooltipToolbar />
+      <SharedTooltipToolbar />
+      <ToolbarWithoutTooltips />
+    </main>
+  );
+}

--- a/app/src/sandbox/tooltip-perf/perf-chrome.ts
+++ b/app/src/sandbox/tooltip-perf/perf-chrome.ts
@@ -3,7 +3,7 @@ import { expect } from "@playwright/test";
 import type { Page } from "@playwright/test";
 import { withFramework } from "#app/test-utils/preview.ts";
 
-const moveCount = 120;
+const moveCount = 121;
 type Query = ReturnType<typeof query>;
 
 interface ToolbarCase {
@@ -87,10 +87,11 @@ async function moveAcrossItems(page: Page) {
 async function verifyMovedAcrossItems(q: Query, toolbarCase: ToolbarCase) {
   const toolbar = getToolbar(q, toolbarCase);
   await expect(toolbar).toHaveAttribute("data-move-count", String(moveCount));
-  await expect(getItem(q, toolbarCase, "Tool 1")).toBeFocused();
+  await expect(getItem(q, toolbarCase, "Tool 2")).toBeFocused();
   if (toolbarCase.hasTooltip) {
-    await expect(getTooltip(q, toolbarCase, "Tool 1")).toBeVisible();
+    await expect(getTooltip(q, toolbarCase, "Tool 2")).toBeVisible();
   }
+  await expect(q.tooltip()).toHaveCount(toolbarCase.hasTooltip ? 1 : 0);
 }
 
 // https://github.com/ariakit/ariakit/issues/4428

--- a/app/src/sandbox/tooltip-perf/perf-chrome.ts
+++ b/app/src/sandbox/tooltip-perf/perf-chrome.ts
@@ -1,0 +1,120 @@
+import { query } from "@ariakit/test/playwright";
+import { expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { withFramework } from "#app/test-utils/preview.ts";
+
+const moveCount = 120;
+type Query = ReturnType<typeof query>;
+
+interface ToolbarCase {
+  label: string;
+  hasTooltip: boolean;
+}
+
+const independentTooltips = {
+  label: "Independent tooltips",
+  hasTooltip: true,
+} satisfies ToolbarCase;
+
+const sharedTooltip = {
+  label: "Shared tooltip",
+  hasTooltip: true,
+} satisfies ToolbarCase;
+
+const noTooltips = {
+  label: "No tooltips",
+  hasTooltip: false,
+} satisfies ToolbarCase;
+
+function getToolbar(q: Query, toolbarCase: ToolbarCase) {
+  return q.toolbar(toolbarCase.label);
+}
+
+function getItem(q: Query, toolbarCase: ToolbarCase, name: string) {
+  const toolbar = getToolbar(q, toolbarCase);
+  return query(toolbar).button(name);
+}
+
+function getTooltip(q: Query, toolbarCase: ToolbarCase, item: string) {
+  return q.tooltip(`${toolbarCase.label}: ${item}`);
+}
+
+async function setupToolbar(page: Page, q: Query, toolbarCase: ToolbarCase) {
+  const toolbar = getToolbar(q, toolbarCase);
+  const firstItem = getItem(q, toolbarCase, "Tool 1");
+  await firstItem.focus();
+  await page.keyboard.press("ArrowRight");
+  await expect(getItem(q, toolbarCase, "Tool 2")).toBeFocused();
+  await page.keyboard.press("ArrowRight");
+  await expect(getItem(q, toolbarCase, "Tool 3")).toBeFocused();
+  await page.keyboard.press("ArrowRight");
+  await expect(firstItem).toBeFocused();
+  if (toolbarCase.hasTooltip) {
+    await expect(getTooltip(q, toolbarCase, "Tool 1")).toBeVisible();
+  }
+  await toolbar.evaluate((element, expectedMoveCount) => {
+    const items = Array.from(element.querySelectorAll("button"));
+    // Setup ends on the first item, so measured moves must repeat 2 → 3 → 1.
+    const expectedItems = [items[1], items[2], items[0]];
+    let actualMoveCount = 0;
+    let valid = true;
+    element.addEventListener("focusin", (event) => {
+      if (!valid) return;
+      const expectedItem =
+        expectedItems[actualMoveCount % expectedItems.length];
+      actualMoveCount += 1;
+      if (
+        event.target !== expectedItem ||
+        actualMoveCount > expectedMoveCount
+      ) {
+        valid = false;
+        element.setAttribute("data-move-count", "invalid");
+        return;
+      }
+      if (actualMoveCount === expectedMoveCount) {
+        element.setAttribute("data-move-count", String(actualMoveCount));
+      }
+    });
+  }, moveCount);
+}
+
+async function moveAcrossItems(page: Page) {
+  for (let index = 0; index < moveCount; index++) {
+    await page.keyboard.press("ArrowRight");
+  }
+}
+
+async function verifyMovedAcrossItems(q: Query, toolbarCase: ToolbarCase) {
+  const toolbar = getToolbar(q, toolbarCase);
+  await expect(toolbar).toHaveAttribute("data-move-count", String(moveCount));
+  await expect(getItem(q, toolbarCase, "Tool 1")).toBeFocused();
+  if (toolbarCase.hasTooltip) {
+    await expect(getTooltip(q, toolbarCase, "Tool 1")).toBeVisible();
+  }
+}
+
+// https://github.com/ariakit/ariakit/issues/4428
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("move across items with independent tooltips", async ({ perf }) => {
+    await perf.measure(({ page }) => moveAcrossItems(page), {
+      scriptProfile: true,
+      profileLimit: 20,
+      setup: ({ page, q }) => setupToolbar(page, q, independentTooltips),
+      verify: ({ q }) => verifyMovedAcrossItems(q, independentTooltips),
+    });
+  });
+
+  test("move across items with a shared tooltip", async ({ perf }) => {
+    await perf.measure(({ page }) => moveAcrossItems(page), {
+      setup: ({ page, q }) => setupToolbar(page, q, sharedTooltip),
+      verify: ({ q }) => verifyMovedAcrossItems(q, sharedTooltip),
+    });
+  });
+
+  test("move across items without tooltips", async ({ perf }) => {
+    await perf.measure(({ page }) => moveAcrossItems(page), {
+      setup: ({ page, q }) => setupToolbar(page, q, noTooltips),
+      verify: ({ q }) => verifyMovedAcrossItems(q, noTooltips),
+    });
+  });
+});

--- a/app/src/sandbox/tooltip-perf/style.css
+++ b/app/src/sandbox/tooltip-perf/style.css
@@ -1,0 +1,54 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  align-items: flex-start;
+  padding: 1rem;
+}
+
+.root h1,
+.root h2 {
+  margin: 0;
+}
+
+.root section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.root h2 {
+  font-size: 1rem;
+}
+
+.toolbar {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.toolbar-item {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid hsl(204 10% 80%);
+  border-radius: 0.5rem;
+  background: white;
+  color: hsl(204 10% 10%);
+  font: inherit;
+  padding: 0.5rem 1rem;
+}
+
+.toolbar-item:focus-visible {
+  outline: 2px solid hsl(204 100% 40%);
+  outline-offset: 1px;
+}
+
+.tooltip {
+  z-index: 10;
+  border-radius: 0.375rem;
+  background: hsl(204 10% 10%);
+  color: white;
+  font: inherit;
+  font-size: 0.875rem;
+  padding: 0.375rem 0.5rem;
+}


### PR DESCRIPTION
## Motivation

Issue #4428 is still reproducible after the recent performance improvements: Tooltip navigation is materially faster than in `@ariakit/react@0.4.15`, but rapid traversal still costs substantially more main-thread time than the no-tooltip control on constrained or busy devices.

Before attempting another optimization, we need a stable production-browser baseline for the three topologies in the reported reproduction:

```tsx
<ToolbarItem render={<ButtonWithTooltip />} /> // Independent Tooltip store
<TooltipAnchor render={<ToolbarButton />} />   // Shared Tooltip store
<ToolbarButton />                              // No-Tooltip control
```

## Solution

Add a `tooltip-perf` sandbox that preserves the reported three-item Toolbar composition and covers independent tooltips, one shared non-portaled tooltip, and a no-tooltip control.

Each Chrome performance test warms a complete keyboard-navigation cycle, measures 121 rapid `ArrowRight` presses, and verifies the exact repeating focus sequence plus a final focused item and Tooltip state that differ from setup:

```ts
await perf.measure(({ page }) => moveAcrossItems(page), {
  setup: ({ page, q }) => setupToolbar(page, q, toolbarCase),
  verify: ({ q }) => verifyMovedAcrossItems(q, toolbarCase),
});
```

The independent-tooltip case also collects a separate diagnostic script profile while keeping its timing samples unprofiled. Existing sandbox discovery adds the file to performance CI automatically.

This PR only establishes the benchmark; Tooltip optimization remains follow-up work.

## Testing

- `pnpm run build-app-lite`
- `pnpm exec oxfmt --check app/src/sandbox/tooltip-perf/index.react.tsx app/src/sandbox/tooltip-perf/perf-chrome.ts`
- `pnpm exec oxlint --disable-nested-config app/src/sandbox/tooltip-perf/index.react.tsx app/src/sandbox/tooltip-perf/perf-chrome.ts`
- `pnpm exec stylelint app/src/sandbox/tooltip-perf/style.css`
- `pnpm exec tsc -p app/tsconfig.react.json --pretty false`
- Focused production performance smoke: 3 tests passed with one timing sample per case and one independent script-profile sample
