### PR TITLE
Remove TypeScript release age exclusions

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,30 +15,6 @@ allowBuilds:
   sharp: true
   workerd: true
 
-minimumReleaseAgeExclude:
-  - "@typescript/typescript6@6.0.2"
-  - typescript@7.0.2
-  - "@typescript/typescript-aix-ppc64@7.0.2"
-  - "@typescript/typescript-darwin-arm64@7.0.2"
-  - "@typescript/typescript-darwin-x64@7.0.2"
-  - "@typescript/typescript-freebsd-arm64@7.0.2"
-  - "@typescript/typescript-freebsd-x64@7.0.2"
-  - "@typescript/typescript-linux-arm64@7.0.2"
-  - "@typescript/typescript-linux-arm@7.0.2"
-  - "@typescript/typescript-linux-loong64@7.0.2"
-  - "@typescript/typescript-linux-mips64el@7.0.2"
-  - "@typescript/typescript-linux-ppc64@7.0.2"
-  - "@typescript/typescript-linux-riscv64@7.0.2"
-  - "@typescript/typescript-linux-s390x@7.0.2"
-  - "@typescript/typescript-linux-x64@7.0.2"
-  - "@typescript/typescript-netbsd-arm64@7.0.2"
-  - "@typescript/typescript-netbsd-x64@7.0.2"
-  - "@typescript/typescript-openbsd-arm64@7.0.2"
-  - "@typescript/typescript-openbsd-x64@7.0.2"
-  - "@typescript/typescript-sunos-x64@7.0.2"
-  - "@typescript/typescript-win32-arm64@7.0.2"
-  - "@typescript/typescript-win32-x64@7.0.2"
-
 overrides:
   "@ariakit/components": "workspace:*"
   "@ariakit/react": "workspace:*"


### PR DESCRIPTION
## Motivation

The TypeScript 6.0.2 and 7.0.2 packages needed temporary pnpm release-age exclusions when the TypeScript setup was updated. Those releases are now outside the release-age window, so exceptions such as the following are no longer necessary:

```yaml
minimumReleaseAgeExclude:
  - "@typescript/typescript6@6.0.2"
  - typescript@7.0.2
```

## Solution

Remove the complete `minimumReleaseAgeExclude` block from `pnpm-workspace.yaml`. The TypeScript versions remain pinned in the package manifests; this only restores the normal supply-chain policy for those packages.

The workspace configuration now flows directly from build permissions to overrides:

```yaml
allowBuilds:
  # ...
  workerd: true

overrides:
  "@ariakit/components": "workspace:*"
```
