### PR TITLE
Add value components guide

### DIFF
--- a/guide/400-component-providers/readme.md
+++ b/guide/400-component-providers/readme.md
@@ -102,5 +102,6 @@ Continue reading our [Guide](/guide) to learn more about Ariakit:
 
 - [](/guide/composition)
 - [](/guide/component-stores)
+- [](/guide/value-components)
 
 </div>

--- a/guide/400-component-stores/readme.md
+++ b/guide/400-component-stores/readme.md
@@ -225,5 +225,6 @@ Continue reading our [Guide](/guide) to learn more about Ariakit:
 <div data-cards>
 
 - [](/guide/component-providers)
+- [](/guide/value-components)
 
 </div>

--- a/guide/500-value-components/readme.md
+++ b/guide/500-value-components/readme.md
@@ -1,0 +1,92 @@
+---
+group: Advanced
+---
+
+# Value components
+
+<div data-description>
+
+Read and render a single value from an Ariakit provider or store without adding any element of your own.
+
+</div>
+
+<aside data-type="note" title="Component stores">
+
+Value components are a convenience built on top of [component stores](/guide/component-stores). If you need arbitrary store fields or a computed selector, reach for [`useStoreState`](/guide/component-stores#reading-the-state) instead.
+
+</aside>
+
+## Overview
+
+A value component reads one specific value from a provider or an explicit store and renders it. Unlike most Ariakit components, it:
+
+- reads a single value from the nearest provider or from an explicit `store` prop
+- adds no element of its own, though it may return text or arbitrary JSX
+- exposes the value directly or through a `children` render function
+- does not accept HTML props such as `className`, `style`, or `ref`, because it has no element to receive them
+
+The stable public value components are [`SelectValue`](/reference/select-value) and [`ComboboxValue`](/reference/combobox-value), both exported from `@ariakit/react`.
+
+This pattern is not inherently uncontrolled. Value components work with both controlled and uncontrolled providers and stores. Their main benefit is exposing state close to the JSX that needs it, without creating or passing a store solely for that purpose.
+
+## Rendering a value directly
+
+In its shortest form, a value component renders the current value as-is. No wrapper element is added around it, so it sits directly wherever you place it:
+
+```jsx {3}
+<SelectProvider defaultValue="Apple">
+  <Select>
+    <SelectValue fallback="Choose a fruit" />
+    <SelectArrow />
+  </Select>
+  <SelectPopover>
+    <SelectItem value="Apple" />
+    <SelectItem value="Banana" />
+    <SelectItem value="Orange" />
+  </SelectPopover>
+</SelectProvider>
+```
+
+[`SelectValue`](/reference/select-value) accepts a `fallback` prop that's used when the current value is an empty string or empty array.
+
+## Rendering custom JSX
+
+Pass a function as `children` to transform the value before rendering it. The function receives the current value and returns whatever you want to render:
+
+```jsx {3-5}
+<ComboboxProvider>
+  <Combobox />
+  <ComboboxValue>
+    {(value) => <output>Current value: {value || "empty"}</output>}
+  </ComboboxValue>
+</ComboboxProvider>
+```
+
+Returning the raw value isn't always useful. For example, a multi-select renders its values with no separators between them. Use a function child whenever the value needs formatting or custom UI.
+
+<aside data-type="note" title="The render prop">
+
+The `children` render function is not the same as Ariakit's generic [`render`](/guide/composition) prop. The `render` prop composes or replaces an element; a value component has no element, so its function child is only about turning a value into JSX.
+
+</aside>
+
+## Choosing an API
+
+Value components are one of several ways to work with Ariakit state. Pick based on what the surrounding code needs:
+
+- Use a value component when a small section of JSX only needs one exposed value.
+- Use controlled provider props when application state must own, persist, validate, or share the value. See [Component providers](/guide/component-providers).
+- Use [`useStoreState`](/guide/component-stores#reading-the-state) when a component needs arbitrary store fields, multiple values, or a computed selector.
+- Use `store.getState()` for event-only reads that shouldn't trigger a re-render.
+- Use context hooks for lower-level descendant components that need access to the complete store.
+
+## Next steps
+
+Continue reading our [Guide](/guide) to learn more about Ariakit:
+
+<div data-cards>
+
+- [](/guide/component-providers)
+- [](/guide/component-stores)
+
+</div>

--- a/guide/500-value-components/site-icon.tsx
+++ b/guide/500-value-components/site-icon.tsx
@@ -1,0 +1,18 @@
+export default function Icon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      className="h-8 w-8 stroke-blue-700 dark:stroke-blue-400"
+      strokeWidth={1.5}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M8.25 3.75H6.75A2.25 2.25 0 004.5 6v3a2.25 2.25 0 01-2.25 2.25v1.5A2.25 2.25 0 014.5 15v3a2.25 2.25 0 002.25 2.25h1.5M15.75 3.75h1.5A2.25 2.25 0 0119.5 6v3a2.25 2.25 0 002.25 2.25v1.5A2.25 2.25 0 0019.5 15v3a2.25 2.25 0 01-2.25 2.25h-1.5"
+      />
+    </svg>
+  );
+}

--- a/packages/ariakit-react-components/src/select/select-value.tsx
+++ b/packages/ariakit-react-components/src/select/select-value.tsx
@@ -14,9 +14,11 @@ type Value = SelectStoreValue;
  * As a value component, it doesn't render any DOM elements and therefore
  * doesn't accept HTML props. It can optionally accept a
  * [`fallback`](https://ariakit.com/reference/select-value#fallback) prop to use
- * as a default value if the store's
+ * as a default value if the store's value is an empty string or empty array.
+ *
+ * The store's
  * [`value`](https://ariakit.com/reference/use-select-store#value) is
- * `undefined`.
+ * otherwise rendered as-is.
  *
  * Additionally, it takes a
  * [`children`](https://ariakit.com/reference/select-value#children) function
@@ -94,9 +96,12 @@ export interface SelectValueProps<T extends Value = Value> {
    */
   store?: SelectStore<T>;
   /**
-   * The value to use as a default if the store's
+   * The value to use as a default if the store's value is an empty string or
+   * empty array.
+   *
+   * The store's
    * [`value`](https://ariakit.com/reference/use-select-store#value) is
-   * `undefined`.
+   * otherwise rendered as-is.
    * @default ""
    */
   fallback?: T;


### PR DESCRIPTION
## Motivation

Ariakit value components are currently explained only on individual API reference pages. Users have to infer that these components expose provider or store state without rendering a wrapper element, and how they compare with controlled state, `useStoreState`, context hooks, and event-only `getState()` reads.

This incorporates [the first guide draft from @georgekaran](https://github.com/ariakit/ariakit/issues/6744#issuecomment-4992733517).

Closes #6744.

## Solution

Add a **Value components** page to the Advanced guide group. The guide documents the stable public `SelectValue` and `ComboboxValue` APIs, including direct rendering and `children` render functions:

```jsx
<ComboboxProvider>
  <Combobox />
  <ComboboxValue>
    {(value) => <output>Current value: {value || "empty"}</output>}
  </ComboboxValue>
</ComboboxProvider>
```

The guide also explains that value components render no element of their own, work with controlled and uncontrolled stores, and are distinct from Ariakit's generic `render` prop. Navigation cards link the new page with the Component providers and Component stores guides, and a site icon registers it with the guide index.

Finally, align the generated `SelectValue` reference with its implementation by documenting that `fallback` is used for an empty string or empty array.

## Verification

- `pnpm lint-fix`
- `pnpm test app/src/lib/jsdoc-loader.test.ts website/build-pages/reference-utils.test.ts`
- `pnpm tsc`
- `pnpm build-app-lite`
- `pnpm build-website-lite`
- `pnpm --filter ./app build`
