### PR TITLE
Remove redundant test query ensures

### DIFF
--- a/app/src/sandbox/combobox-overflow-padding-5696/test.ts
+++ b/app/src/sandbox/combobox-overflow-padding-5696/test.ts
@@ -26,7 +26,7 @@ test("uses the greatest horizontal overflow padding for CSS sizing", async () =>
 });
 
 test("does not reposition when inline padding values are unchanged", async () => {
-  const popover = q.listbox.ensure();
+  const popover = q.listbox();
   const positionUpdates = q.status.ensure("Position updates");
   const initialPositionUpdates = positionUpdates.textContent;
   expect(Number(initialPositionUpdates)).toBeGreaterThan(0);

--- a/packages/ariakit-test/src/click.jsdom.test.ts
+++ b/packages/ariakit-test/src/click.jsdom.test.ts
@@ -37,21 +37,21 @@ function getDefaultSelectedValues() {
 test("clicking options does not change their default selectedness", async () => {
   setupMultiSelect();
 
-  await click(q.option.ensure("Apple"));
-  await click(q.option.ensure("Cherry"), { ctrlKey: true });
-  await click(q.option.ensure("Apple"), { ctrlKey: true });
+  await click(q.option("Apple"));
+  await click(q.option("Cherry"), { ctrlKey: true });
+  await click(q.option("Apple"), { ctrlKey: true });
 
   expect(getSelectedValues()).toEqual(["Cherry"]);
   expect(getDefaultSelectedValues()).toEqual(["Banana"]);
-  expect(q.option.ensure("Apple")).not.toHaveAttribute("selected");
-  expect(q.option.ensure("Banana")).toHaveAttribute("selected");
-  expect(q.option.ensure("Cherry")).not.toHaveAttribute("selected");
+  expect(q.option("Apple")).not.toHaveAttribute("selected");
+  expect(q.option("Banana")).toHaveAttribute("selected");
+  expect(q.option("Cherry")).not.toHaveAttribute("selected");
 });
 
 test("anchorless shift-click anchors at the first selected option", async () => {
   setupMultiSelect();
 
-  await click(q.option.ensure("Cherry"), { shiftKey: true });
+  await click(q.option("Cherry"), { shiftKey: true });
 
   expect(getSelectedValues()).toEqual(["Banana", "Cherry"]);
   expect(getDefaultSelectedValues()).toEqual(["Banana"]);

--- a/packages/ariakit-test/src/click.test.ts
+++ b/packages/ariakit-test/src/click.test.ts
@@ -17,7 +17,7 @@ test("shift-click exposes updated selectedOptions on change", async () => {
   `;
 
   const select = q.listbox.ensure("Fruits") as HTMLSelectElement;
-  const date = q.option.ensure("Date");
+  const date = q.option("Date");
   let changedSelection: string[] = [];
   let mouseUpSelection: string[] = [];
   select.addEventListener("mouseup", (event) => {

--- a/packages/ariakit-test/src/mouse-down.test.ts
+++ b/packages/ariakit-test/src/mouse-down.test.ts
@@ -42,7 +42,7 @@ beforeEach(() => {
 });
 
 async function selectParagraphText() {
-  await select(selectionText, q.text.ensure(/Keep this/));
+  await select(selectionText, q.text(/Keep this/));
   expect(document.getSelection()?.toString()).toBe(selectionText);
 }
 


### PR DESCRIPTION
## Motivation

Some Vitest tests call `.ensure()` before passing a query result to an interaction helper or matcher that already rejects missing elements. These wrappers add noise and make it less obvious where a non-null result is genuinely required.

For example:

```ts
await click(q.option.ensure("Apple"));
expect(q.option.ensure("Banana")).toHaveAttribute("selected");
```

## Solution

Use plain queries at ten sites where `click()`, `select()`, or the DOM matcher already provides clear null rejection:

```ts
await click(q.option("Apple"));
await select(selectionText, q.text(/Keep this/));
expect(q.option("Banana")).toHaveAttribute("selected");
```

Required `.ensure()` calls remain in place for direct property or method access, non-null helper arguments, listener setup, and explicit `type()` or `press()` targets.

## Testing

- `pnpm lint-fix`
- `pnpm test packages/ariakit-test/src/click.test.ts packages/ariakit-test/src/click.jsdom.test.ts packages/ariakit-test/src/mouse-down.test.ts`
- `pnpm test-react app/src/sandbox/combobox-overflow-padding-5696/test.ts`
- `pnpm tsc`
