### PR TITLE
Ignore local pnpm store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ playwright-report
 
 # dependencies
 node_modules
+.pnpm-store
 .pnp
 .pnp.js
 


### PR DESCRIPTION
## Motivation

A project-local `.pnpm-store` directory can be generated by pnpm and currently appears as untracked repository content.

## Solution

Add `.pnpm-store` alongside the other dependency artifacts in the root ignore file:

```gitignore
node_modules
.pnpm-store
.pnp
```

This ignores the store and its nested contents without changing the repository's pnpm configuration.
