### PR TITLE
Remove unnecessary exception handling

### DIFF
--- a/app/src/lib/build-styles.ts
+++ b/app/src/lib/build-styles.ts
@@ -945,10 +945,7 @@ async function main() {
       );
       process.exitCode = 1;
     }
-    // cleanup temp file
-    try {
-      await fs.unlink(tempOut);
-    } catch {}
+    await fs.unlink(tempOut);
     return;
   }
   console.log(`Wrote ${toPosix(out)}`);

--- a/packages/ariakit-components/src/collection/collection-store.test.ts
+++ b/packages/ariakit-components/src/collection/collection-store.test.ts
@@ -630,13 +630,10 @@ test.each([
     store = createCollectionStore({ store: parent });
     const derivedStore = deriveItemsStore(store, kind);
 
-    try {
-      derivedStore.setState("items", (items) => [...items, { id: "apple" }]);
+    derivedStore.setState("items", (items) => [...items, { id: "apple" }]);
 
-      expect(observedIds).toEqual(["apple", expectedItemId]);
-    } finally {
-      stopSync();
-    }
+    expect(observedIds).toEqual(["apple", expectedItemId]);
+    stopSync();
   },
 );
 

--- a/packages/ariakit-components/src/disclosure/disclosure-store.test.ts
+++ b/packages/ariakit-components/src/disclosure/disclosure-store.test.ts
@@ -6,17 +6,14 @@ test("updates a standalone store", () => {
   const store = createDisclosureStore();
   const stop = init(store);
 
-  try {
-    store.show();
-    expect(store.getState().open).toBe(true);
-    expect(store.getState().mounted).toBe(true);
+  store.show();
+  expect(store.getState().open).toBe(true);
+  expect(store.getState().mounted).toBe(true);
 
-    store.hide();
-    expect(store.getState().open).toBe(false);
-    expect(store.getState().mounted).toBe(false);
-  } finally {
-    stop();
-  }
+  store.hide();
+  expect(store.getState().open).toBe(false);
+  expect(store.getState().mounted).toBe(false);
+  stop();
 });
 
 test("syncs with a disclosure store", () => {
@@ -24,12 +21,9 @@ test("syncs with a disclosure store", () => {
   const store = createDisclosureStore({ disclosure });
   const stop = init(store);
 
-  try {
-    expect(store.getState().open).toBe(true);
+  expect(store.getState().open).toBe(true);
 
-    disclosure.hide();
-    expect(store.getState().open).toBe(false);
-  } finally {
-    stop();
-  }
+  disclosure.hide();
+  expect(store.getState().open).toBe(false);
+  stop();
 });

--- a/packages/ariakit-scripts/src/index.ts
+++ b/packages/ariakit-scripts/src/index.ts
@@ -95,9 +95,4 @@ program
     checkNodeBenchmarkResults(file, expectedCount);
   });
 
-try {
-  await program.parseAsync();
-} catch (error) {
-  console.error(error);
-  process.exitCode = 1;
-}
+await program.parseAsync();

--- a/website/components/plus.tsx
+++ b/website/components/plus.tsx
@@ -371,9 +371,7 @@ export function PlusCheckoutFrame(props: PlusCheckoutFrameProps) {
 
     processClientSecret();
     return () => {
-      try {
-        controller.abort();
-      } catch {}
+      controller.abort();
       controller.signal.removeEventListener("abort", onAbort);
     };
   }, [userId, priceId, redirectUrl]);

--- a/website/lib/stripe.ts
+++ b/website/lib/stripe.ts
@@ -438,7 +438,7 @@ export async function createCheckout({
 export async function getCheckout(session: Stripe.Checkout.Session | string) {
   if (!stripe) return;
   try {
-    return expand(stripe.checkout.sessions, session);
+    return await expand(stripe.checkout.sessions, session);
   } catch (error) {
     console.error(error);
     return;


### PR DESCRIPTION
## Motivation

A repo-wide audit covered all 167 language-level `try` statements. Six wrappers added no recovery or necessary cleanup, while one necessary async catch returned a promise without awaiting it and therefore could not catch a rejection.

These defensive boundaries obscured the places where errors are intentionally handled and made straightforward code harder to follow.

## Solution

Remove the six unnecessary wrappers while leaving the other 161 necessary exception and cleanup boundaries in place. This simplifies temporary-file cleanup, test-local listener cleanup, CLI failure propagation, and `AbortController` cleanup. For example, the CLI now lets its top-level await propagate failures directly:

```ts
await program.parseAsync();
```

Keep the Stripe error boundary and await the expansion inside it so asynchronous retrieval errors reach the existing catch:

```ts
try {
  return await expand(stripe.checkout.sessions, session);
} catch (error) {
  console.error(error);
  return;
}
```

## Verification

- `pnpm lint-fix`
- Focused component tests: 2 files, 32 tests passed
- Performance CLI tests: 1 file, 58 tests passed
- Style index check passed and left no temporary output
- `pnpm tsc`: 0 errors, warnings, or hints
- `pnpm test`: 54 files, 614 tests passed
- `pnpm build-website-lite`
- `git diff --check`
- Fresh pre-commit review: no findings
