### PR TITLE
Simplify React 18 command wrapper

### DIFF
--- a/app/src/sandbox/tooltip-fullscreen-portal/test-browser.ts
+++ b/app/src/sandbox/tooltip-fullscreen-portal/test-browser.ts
@@ -21,7 +21,8 @@ async function getPortalState(page: Page) {
 withFramework(import.meta.dirname, async ({ test }) => {
   // See https://github.com/ariakit/ariakit/issues/6585
   // To reproduce the React 18 StrictMode failure in a browser, serve the app
-  // with `pnpm react18 dev-app`. CI's React 18 signal comes from test.ts.
+  // with `pnpm react18 -- pnpm dev-app`. CI's React 18 signal comes from
+  // test.ts.
   test("does not leak duplicate tooltip portal containers", async ({
     page,
     q,

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "vitest",
     "bench": "vitest bench --config vitest.bench.config.ts",
     "test-react": "cross-env ARIAKIT_TEST_LOADER=react vitest",
-    "test-react18": "pnpm react18 test-react",
+    "test-react18": "ariakit react18 -- pnpm test-react",
     "test-solid": "cross-env ARIAKIT_TEST_LOADER=solid vitest",
     "playwright": "playwright test",
     "test-browser": "pnpm run playwright --project=chrome --project=safari --project=firefox",

--- a/packages/ariakit-scripts/src/index.ts
+++ b/packages/ariakit-scripts/src/index.ts
@@ -58,8 +58,11 @@ program
 
 program
   .command("react18")
-  .description("Run a command in an isolated React 18 workspace")
-  .argument("[command...]", "Root script or command to run")
+  .description(
+    "Run `ariakit react18 -- <command>` in an isolated React 18 workspace",
+  )
+  .usage("-- <command> [args...]")
+  .argument("[command...]", "Command and arguments following `--`")
   .allowUnknownOption()
   .helpOption(false)
   .action(react18);

--- a/packages/ariakit-scripts/src/react18.test.ts
+++ b/packages/ariakit-scripts/src/react18.test.ts
@@ -1,0 +1,37 @@
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+import { getReact18Command } from "./react18.ts";
+
+const cliPath = join(import.meta.dirname, "index.ts");
+
+test("runs an explicit command with arguments", () => {
+  expect(getReact18Command(["pnpm", "test", "--run"])).toEqual({
+    bin: "pnpm",
+    args: ["test", "--run"],
+  });
+});
+
+test("throws when the command is missing", () => {
+  expect(() => getReact18Command([])).toThrow(
+    "Missing command. Use `ariakit react18 -- <command>`.",
+  );
+});
+
+test("documents the explicit command syntax", () => {
+  const commandHelp = execFileSync(
+    process.execPath,
+    [cliPath, "help", "react18"],
+    { encoding: "utf-8" },
+  );
+  const programHelp = execFileSync(process.execPath, [cliPath, "--help"], {
+    encoding: "utf-8",
+  });
+
+  expect(commandHelp).toContain(
+    "Usage: ariakit react18 -- <command> [args...]",
+  );
+  expect(programHelp).toContain(
+    "Run `ariakit react18 -- <command>` in an isolated React 18 workspace",
+  );
+});

--- a/packages/ariakit-scripts/src/react18.ts
+++ b/packages/ariakit-scripts/src/react18.ts
@@ -15,7 +15,6 @@ import type { FSWatcher } from "chokidar";
 import {
   getCommandOutput,
   normalizePath,
-  readPackageJson,
   readPackageJsonFile,
   runCommand,
 } from "./utils.ts";
@@ -278,58 +277,26 @@ async function rewriteReactDependencies(rootPath: string) {
   return updatedCount;
 }
 
-function stripLeadingSeparator(args: string[]) {
-  const [firstArg, ...restArgs] = args;
-  return firstArg === "--" ? restArgs : args;
-}
-
 function isHelpCommand(args: string[]) {
-  const [command] = stripLeadingSeparator(args);
+  const [command] = args;
   return !command || command === "--help" || command === "-h";
 }
 
 function printHelp() {
   console.error(
     [
-      "Usage: ariakit react18 <script> [args...]",
-      "       ariakit react18 -- <command> [args...]",
+      "Usage: ariakit react18 -- <command> [args...]",
       "",
-      "Run a root script or arbitrary command in an isolated React 18 workspace.",
+      "Run a command in an isolated React 18 workspace.",
     ].join("\n"),
   );
 }
 
-function getReact18Command(rootPath: string, args: string[]): React18Command {
-  const [command, ...commandArgs] = stripLeadingSeparator(args);
+export function getReact18Command(args: string[]): React18Command {
+  const [command, ...commandArgs] = args;
 
   if (!command) {
-    throw new Error("Missing command. Use `ariakit react18 <script>`.");
-  }
-
-  const packageJson = readPackageJson(rootPath);
-  // The `react18` script would recurse here. Run the underlying test script
-  // directly instead.
-  if (command === "react18") {
-    log(`Mapping ${command} to test to avoid recursion`);
-    return {
-      bin: "pnpm",
-      args: ["run", "test", ...commandArgs],
-    };
-  }
-  // The `test-react18` script delegates to `react18 test-react`. Preserve the
-  // narrowed React test suite when users invoke it through the wrapper.
-  if (command === "test-react18") {
-    log(`Mapping ${command} to test-react to avoid recursion`);
-    return {
-      bin: "pnpm",
-      args: ["run", "test-react", ...commandArgs],
-    };
-  }
-  if (packageJson.scripts?.[command]) {
-    return {
-      bin: "pnpm",
-      args: ["run", command, ...commandArgs],
-    };
+    throw new Error("Missing command. Use `ariakit react18 -- <command>`.");
   }
 
   return {
@@ -450,7 +417,7 @@ export async function react18(args: string[]) {
     { cwd: workspacePath },
   );
 
-  const command = getReact18Command(workspacePath, args);
+  const command = getReact18Command(args);
   const watcher = startWorkspaceWatcher(rootPath, workspacePath);
 
   try {


### PR DESCRIPTION
## Motivation

The React 18 workspace wrapper currently treats its first argument as either a root package script or an arbitrary command. That requires reading `package.json` and maintaining special cases to avoid recursive scripts:

```sh
ariakit react18 test-react
```

Using an explicit command boundary makes the wrapper generic and removes the ambiguity between package scripts and executables.

## Solution

Forward the command and its arguments literally after `--`:

```sh
ariakit react18 -- pnpm test-react
```

This removes root-script resolution and recursion mappings, updates `test-react18` and the documented development invocation, and makes both custom and Commander-generated help advertise the explicit syntax. Focused tests cover literal argument forwarding, missing commands, and the generated help surfaces.

## Testing

- `pnpm tsc`
- `pnpm test packages/ariakit-scripts/src/react18.test.ts --run`
- `pnpm test-react18 packages/ariakit-react-utils/src/misc.test.ts --run`
