### PR TITLE
Update lucide-react to v1.25.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -84,7 +84,7 @@
     "import-meta-resolve": "4.2.0",
     "kleur": "4.1.5",
     "lodash-es": "4.18.1",
-    "lucide-react": "1.24.0",
+    "lucide-react": "1.25.0",
     "match-sorter": "8.3.0",
     "motion": "12.42.2",
     "parse-numeric-range": "1.3.0",

--- a/app/src/components/code-block.react.tsx
+++ b/app/src/components/code-block.react.tsx
@@ -10,7 +10,7 @@
 import * as ak from "@ariakit/react";
 import { invariant } from "@ariakit/utils";
 import { clsx } from "clsx";
-import { SplitSquareHorizontal } from "lucide-react";
+import { SquareSplitHorizontal } from "lucide-react";
 import * as React from "react";
 import useLocalStorageState from "use-local-storage-state";
 import { Icon } from "#app/icons/icon.react.tsx";
@@ -739,7 +739,7 @@ export function CodeBlockTabs({
                       wide ? "@max-lg:hidden" : "hidden",
                     )}
                   >
-                    <SplitSquareHorizontal className="size-4" />
+                    <SquareSplitHorizontal className="size-4" />
                     <span className="@max-lg:sr-only flex gap-2 items-center">
                       Code{" "}
                       <span

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,8 +330,8 @@ importers:
         specifier: 4.18.1
         version: 4.18.1
       lucide-react:
-        specifier: 1.24.0
-        version: 1.24.0(react@19.2.7)
+        specifier: 1.25.0
+        version: 1.25.0(react@19.2.7)
       match-sorter:
         specifier: 8.3.0
         version: 8.3.0
@@ -7695,8 +7695,8 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-react@1.24.0:
-    resolution: {integrity: sha512-YT6mBD8lGKkg4nM39enlm94/sfJIiW0YKUT60fBy4YK8tai31ylg1VhGNWxkpSKHo9UagfnZqwIff3HTDQwXeA==}
+  lucide-react@1.25.0:
+    resolution: {integrity: sha512-/mdJTRbiwcLOQ1NZZK1amZF9rIZyvO18D6r9TngE6TG1NmqHgFuT4eE7Xrkm9UsXMbBJD1NlfwHVltCDWHrOTw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -17849,7 +17849,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@1.24.0(react@19.2.7):
+  lucide-react@1.25.0(react@19.2.7):
     dependencies:
       react: 19.2.7
 


### PR DESCRIPTION
## Motivation

Keep the app's icon dependency current with the requested stable `lucide-react` release and align its usage with Lucide's canonical icon name.

## Solution

Update the app's exact `lucide-react` pin from `1.24.0` to `1.25.0`, regenerate the pnpm lockfile, and apply the configured `pnpmDedupe` post-update operation.

Replace the legacy compatibility alias with the canonical export:

```tsx
import { SquareSplitHorizontal } from "lucide-react";
```

Both names resolve to the same icon implementation in `1.25.0`, so this does not change rendered behavior.

## Dependencies

| Package | Workspace | Old | New | Links |
| --- | --- | --- | --- | --- |
| `lucide-react` | `app` | `1.24.0` | `1.25.0` | [Source](https://github.com/lucide-icons/lucide/tree/main/packages/lucide-react) · [Compare](https://github.com/lucide-icons/lucide/compare/1.24.0...1.25.0) |

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm build-app-lite`
