### PR TITLE
Support multi-select Combobox form values

### DIFF
--- a/.changeset/300-combobox-form-values.md
+++ b/.changeset/300-combobox-form-values.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed multi-selectable [`Combobox`](https://ariakit.com/reference/combobox) components to submit selected values to forms when a `name` is provided. Thanks to [@cloud-walker](https://github.com/cloud-walker) and [@georgekaran](https://github.com/georgekaran).

--- a/app/src/sandbox/combobox-5058/index.react.tsx
+++ b/app/src/sandbox/combobox-5058/index.react.tsx
@@ -9,8 +9,8 @@ const fruits = [
 ] as const;
 
 export default function Example() {
+  const [selectedValues, setSelectedValues] = useState<string[]>([]);
   const [submittedValues, setSubmittedValues] = useState<string[] | null>(null);
-  const [invalidTarget, setInvalidTarget] = useState("none");
 
   return (
     <>
@@ -22,7 +22,8 @@ export default function Example() {
         }}
       >
         <Ariakit.ComboboxProvider
-          defaultSelectedValue={[]}
+          selectedValue={selectedValues}
+          setSelectedValue={setSelectedValues}
           resetValueOnHide={false}
         >
           <Ariakit.ComboboxLabel>Favorite fruits</Ariakit.ComboboxLabel>
@@ -42,35 +43,28 @@ export default function Example() {
         </output>
       </form>
 
-      <form data-composite-false>
-        <Ariakit.ComboboxProvider defaultSelectedValue={["apple"]}>
-          <Ariakit.Combobox
-            aria-label="Non-composite fruits"
-            composite={false}
-            name="non-composite-fruits"
-          />
-        </Ariakit.ComboboxProvider>
-      </form>
+      <Ariakit.ComboboxProvider defaultSelectedValue={["apple"]}>
+        <Ariakit.Combobox
+          aria-label="Non-composite fruits"
+          composite={false}
+          form="non-composite-form"
+          name="non-composite-fruits"
+        />
+      </Ariakit.ComboboxProvider>
 
       <form
+        id="non-composite-form"
+        data-composite-false
         onSubmit={(event) => {
           event.preventDefault();
         }}
       >
-        <Ariakit.ComboboxProvider defaultSelectedValue={[]}>
-          <Ariakit.ComboboxLabel>Required fruits</Ariakit.ComboboxLabel>
-          <Ariakit.Combobox
-            name="required-fruits"
-            required
-            onInvalid={(event) => {
-              event.preventDefault();
-              setInvalidTarget(event.currentTarget.localName);
-            }}
-          />
-        </Ariakit.ComboboxProvider>
-        <button type="submit">Validate required fruits</button>
-        <p>Invalid target: {invalidTarget}</p>
+        <button type="submit">Submit non-composite fruits</button>
       </form>
+
+      <Ariakit.ComboboxProvider defaultSelectedValue="apple">
+        <Ariakit.Combobox aria-label="Single fruit" name="single-fruit" />
+      </Ariakit.ComboboxProvider>
     </>
   );
 }

--- a/app/src/sandbox/combobox-5058/index.react.tsx
+++ b/app/src/sandbox/combobox-5058/index.react.tsx
@@ -10,33 +10,67 @@ const fruits = [
 
 export default function Example() {
   const [submittedValues, setSubmittedValues] = useState<string[] | null>(null);
+  const [invalidTarget, setInvalidTarget] = useState("none");
 
   return (
-    <form
-      onSubmit={(event) => {
-        event.preventDefault();
-        const formData = new FormData(event.currentTarget);
-        setSubmittedValues(formData.getAll("fruits").map(String));
-      }}
-    >
-      <Ariakit.ComboboxProvider
-        defaultSelectedValue={[]}
-        resetValueOnHide={false}
+    <>
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          const formData = new FormData(event.currentTarget);
+          setSubmittedValues(formData.getAll("fruits").map(String));
+        }}
       >
-        <Ariakit.ComboboxLabel>Favorite fruits</Ariakit.ComboboxLabel>
-        <Ariakit.Combobox name="fruits" />
-        <Ariakit.ComboboxPopover>
-          {fruits.map(([value, label]) => (
-            <Ariakit.ComboboxItem key={value} value={value}>
-              {label}
-            </Ariakit.ComboboxItem>
-          ))}
-        </Ariakit.ComboboxPopover>
-      </Ariakit.ComboboxProvider>
-      <button type="submit">Submit</button>
-      <output>
-        {submittedValues ? JSON.stringify(submittedValues) : null}
-      </output>
-    </form>
+        <Ariakit.ComboboxProvider
+          defaultSelectedValue={[]}
+          resetValueOnHide={false}
+        >
+          <Ariakit.ComboboxLabel>Favorite fruits</Ariakit.ComboboxLabel>
+          <Ariakit.Combobox name="fruits" />
+          <Ariakit.ComboboxPopover>
+            {fruits.map(([value, label]) => (
+              <Ariakit.ComboboxItem key={value} value={value}>
+                {label}
+              </Ariakit.ComboboxItem>
+            ))}
+          </Ariakit.ComboboxPopover>
+        </Ariakit.ComboboxProvider>
+        <button type="submit">Submit</button>
+        <button type="reset">Reset</button>
+        <output>
+          {submittedValues ? JSON.stringify(submittedValues) : null}
+        </output>
+      </form>
+
+      <form data-composite-false>
+        <Ariakit.ComboboxProvider defaultSelectedValue={["apple"]}>
+          <Ariakit.Combobox
+            aria-label="Non-composite fruits"
+            composite={false}
+            name="non-composite-fruits"
+          />
+        </Ariakit.ComboboxProvider>
+      </form>
+
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+        }}
+      >
+        <Ariakit.ComboboxProvider defaultSelectedValue={[]}>
+          <Ariakit.ComboboxLabel>Required fruits</Ariakit.ComboboxLabel>
+          <Ariakit.Combobox
+            name="required-fruits"
+            required
+            onInvalid={(event) => {
+              event.preventDefault();
+              setInvalidTarget(event.currentTarget.localName);
+            }}
+          />
+        </Ariakit.ComboboxProvider>
+        <button type="submit">Validate required fruits</button>
+        <p>Invalid target: {invalidTarget}</p>
+      </form>
+    </>
   );
 }

--- a/app/src/sandbox/combobox-5058/index.react.tsx
+++ b/app/src/sandbox/combobox-5058/index.react.tsx
@@ -63,6 +63,17 @@ export default function Example() {
         <button type="submit">Submit non-composite fruits</button>
       </form>
 
+      <form aria-label="Disabled fruits">
+        <Ariakit.ComboboxProvider defaultSelectedValue={["apple"]}>
+          <Ariakit.Combobox
+            aria-disabled
+            aria-label="Disabled fruits"
+            composite={false}
+            name="disabled-fruits"
+          />
+        </Ariakit.ComboboxProvider>
+      </form>
+
       <Ariakit.ComboboxProvider defaultSelectedValue="apple">
         <Ariakit.Combobox aria-label="Single fruit" name="single-fruit" />
       </Ariakit.ComboboxProvider>

--- a/app/src/sandbox/combobox-5058/index.react.tsx
+++ b/app/src/sandbox/combobox-5058/index.react.tsx
@@ -9,6 +9,7 @@ const fruits = [
 ] as const;
 
 export default function Example() {
+  const [selectedValues, setSelectedValues] = useState<string[]>([]);
   const [submittedValues, setSubmittedValues] = useState<string[] | null>(null);
 
   return (
@@ -20,11 +21,12 @@ export default function Example() {
       }}
     >
       <Ariakit.ComboboxProvider
-        defaultSelectedValue={[]}
+        selectedValue={selectedValues}
+        setSelectedValue={setSelectedValues}
         resetValueOnHide={false}
       >
         <Ariakit.ComboboxLabel>Favorite fruits</Ariakit.ComboboxLabel>
-        <Ariakit.Combobox name="fruits" />
+        <Ariakit.Combobox />
         <Ariakit.ComboboxPopover>
           {fruits.map(([value, label]) => (
             <Ariakit.ComboboxItem key={value} value={value}>
@@ -33,6 +35,24 @@ export default function Example() {
           ))}
         </Ariakit.ComboboxPopover>
       </Ariakit.ComboboxProvider>
+      <select
+        hidden
+        name="fruits"
+        multiple
+        value={selectedValues}
+        onChange={(event) => {
+          setSelectedValues(
+            Array.from(
+              event.currentTarget.selectedOptions,
+              (option) => option.value,
+            ),
+          );
+        }}
+      >
+        {selectedValues.map((value, index) => (
+          <option key={index} value={value} />
+        ))}
+      </select>
       <button type="submit">Submit</button>
       <output>
         {submittedValues ? JSON.stringify(submittedValues) : null}

--- a/app/src/sandbox/combobox-5058/index.react.tsx
+++ b/app/src/sandbox/combobox-5058/index.react.tsx
@@ -9,7 +9,6 @@ const fruits = [
 ] as const;
 
 export default function Example() {
-  const [selectedValues, setSelectedValues] = useState<string[]>([]);
   const [submittedValues, setSubmittedValues] = useState<string[] | null>(null);
 
   return (
@@ -21,12 +20,11 @@ export default function Example() {
       }}
     >
       <Ariakit.ComboboxProvider
-        selectedValue={selectedValues}
-        setSelectedValue={setSelectedValues}
+        defaultSelectedValue={[]}
         resetValueOnHide={false}
       >
         <Ariakit.ComboboxLabel>Favorite fruits</Ariakit.ComboboxLabel>
-        <Ariakit.Combobox />
+        <Ariakit.Combobox name="fruits" />
         <Ariakit.ComboboxPopover>
           {fruits.map(([value, label]) => (
             <Ariakit.ComboboxItem key={value} value={value}>
@@ -35,24 +33,6 @@ export default function Example() {
           ))}
         </Ariakit.ComboboxPopover>
       </Ariakit.ComboboxProvider>
-      <select
-        hidden
-        name="fruits"
-        multiple
-        value={selectedValues}
-        onChange={(event) => {
-          setSelectedValues(
-            Array.from(
-              event.currentTarget.selectedOptions,
-              (option) => option.value,
-            ),
-          );
-        }}
-      >
-        {selectedValues.map((value, index) => (
-          <option key={index} value={value} />
-        ))}
-      </select>
       <button type="submit">Submit</button>
       <output>
         {submittedValues ? JSON.stringify(submittedValues) : null}

--- a/app/src/sandbox/combobox-5058/index.react.tsx
+++ b/app/src/sandbox/combobox-5058/index.react.tsx
@@ -1,0 +1,42 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+
+const fruits = [
+  ["apple", "Apple"],
+  ["banana", "Banana"],
+  ["orange", "Orange"],
+  ["grape", "Grape"],
+] as const;
+
+export default function Example() {
+  const [submittedValues, setSubmittedValues] = useState<string[] | null>(null);
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        const formData = new FormData(event.currentTarget);
+        setSubmittedValues(formData.getAll("fruits").map(String));
+      }}
+    >
+      <Ariakit.ComboboxProvider
+        defaultSelectedValue={[]}
+        resetValueOnHide={false}
+      >
+        <Ariakit.ComboboxLabel>Favorite fruits</Ariakit.ComboboxLabel>
+        <Ariakit.Combobox name="fruits" />
+        <Ariakit.ComboboxPopover>
+          {fruits.map(([value, label]) => (
+            <Ariakit.ComboboxItem key={value} value={value}>
+              {label}
+            </Ariakit.ComboboxItem>
+          ))}
+        </Ariakit.ComboboxPopover>
+      </Ariakit.ComboboxProvider>
+      <button type="submit">Submit</button>
+      <output>
+        {submittedValues ? JSON.stringify(submittedValues) : null}
+      </output>
+    </form>
+  );
+}

--- a/app/src/sandbox/combobox-5058/index.react.tsx
+++ b/app/src/sandbox/combobox-5058/index.react.tsx
@@ -54,6 +54,7 @@ export default function Example() {
 
       <form
         id="non-composite-form"
+        aria-label="Non-composite fruits"
         data-composite-false
         onSubmit={(event) => {
           event.preventDefault();

--- a/app/src/sandbox/combobox-5058/test-browser.ts
+++ b/app/src/sandbox/combobox-5058/test-browser.ts
@@ -1,0 +1,22 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/5058
+  test("submits every selected value", async ({ q }) => {
+    const combobox = q.combobox("Favorite fruits");
+    await combobox.click();
+    await q.option("Apple").click();
+    await q.option("Orange").click();
+    await combobox.fill("typed search");
+    await q.button("Submit").click();
+
+    await test.expect(q.status()).toHaveText('["apple","orange"]');
+  });
+
+  // https://github.com/ariakit/ariakit/issues/5058
+  test("does not submit an empty search value", async ({ q }) => {
+    await q.button("Submit").click();
+
+    await test.expect(q.status()).toHaveText("[]");
+  });
+});

--- a/app/src/sandbox/combobox-5058/test-browser.ts
+++ b/app/src/sandbox/combobox-5058/test-browser.ts
@@ -37,33 +37,23 @@ withFramework(import.meta.dirname, async ({ test }) => {
   });
 
   // https://github.com/ariakit/ariakit/pull/6795#discussion_r3623740406
-  test("submits selected values when composite is false", async ({ page }) => {
-    const form = page.locator("form[data-composite-false]");
-    const input = page.getByRole("combobox", { name: "Non-composite fruits" });
-    const hiddenInput = page.locator(
-      "input[type='hidden'][name='non-composite-fruits']",
-    );
+  test("submits selected values when composite is false", async ({ q }) => {
+    const form = q.form("Non-composite fruits");
+    const input = q.combobox("Non-composite fruits");
     const values = await form.evaluate((element) =>
       new FormData(element as HTMLFormElement).getAll("non-composite-fruits"),
     );
     const inputForm = await input.evaluate(
       (element) => (element as HTMLInputElement).form?.id ?? null,
     );
-    const hiddenInputForm = await hiddenInput.evaluate(
-      (element) => (element as HTMLInputElement).form?.id ?? null,
-    );
 
     test.expect(values).toEqual(["apple"]);
     test.expect(inputForm).toBe("non-composite-form");
-    test.expect(hiddenInputForm).toBe("non-composite-form");
   });
 
   // https://github.com/ariakit/ariakit/pull/6795#discussion_r3623937766
-  test("preserves implicit submission with an explicit form", async ({
-    page,
-    q,
-  }) => {
-    const form = page.locator("form[data-composite-false]");
+  test("preserves implicit submission with an explicit form", async ({ q }) => {
+    const form = q.form("Non-composite fruits");
     await form.evaluate((element) => {
       element.addEventListener(
         "submit",

--- a/app/src/sandbox/combobox-5058/test-browser.ts
+++ b/app/src/sandbox/combobox-5058/test-browser.ts
@@ -19,4 +19,32 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
     await test.expect(q.status()).toHaveText("[]");
   });
+
+  // https://github.com/ariakit/ariakit/pull/6795#discussion_r3623740406
+  test("submits selected values when composite is false", async ({ page }) => {
+    const values = await page
+      .locator("form[data-composite-false]")
+      .evaluate((form) =>
+        new FormData(form as HTMLFormElement).getAll("non-composite-fruits"),
+      );
+
+    test.expect(values).toEqual(["apple"]);
+  });
+
+  // https://github.com/ariakit/ariakit/pull/6795#discussion_r3623740398
+  test("relays invalid events to the Combobox input", async ({ q }) => {
+    await q.button("Validate required fruits").click();
+
+    await test.expect(q.text("Invalid target: input")).toBeVisible();
+  });
+
+  // https://github.com/ariakit/ariakit/pull/6795#discussion_r3623740415
+  test("keeps selected values in sync after form reset", async ({ q }) => {
+    await q.combobox("Favorite fruits").click();
+    await q.option("Apple").click();
+    await q.button("Reset").click();
+    await q.button("Submit").click();
+
+    await test.expect(q.status()).toHaveText('["apple"]');
+  });
 });

--- a/app/src/sandbox/combobox-5058/test-browser.ts
+++ b/app/src/sandbox/combobox-5058/test-browser.ts
@@ -8,6 +8,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await q.option("Apple").click();
     await q.option("Orange").click();
     await combobox.fill("typed search");
+    await combobox.press("Escape");
     await q.button("Submit").click();
 
     await test.expect(q.status()).toHaveText('["apple","orange"]');
@@ -21,27 +22,76 @@ withFramework(import.meta.dirname, async ({ test }) => {
   });
 
   // https://github.com/ariakit/ariakit/pull/6795#discussion_r3623740406
-  test("submits selected values when composite is false", async ({ page }) => {
-    const values = await page
-      .locator("form[data-composite-false]")
-      .evaluate((form) =>
-        new FormData(form as HTMLFormElement).getAll("non-composite-fruits"),
-      );
+  test("preserves the input label metadata after hydration", async ({ q }) => {
+    await q.combobox("Favorite fruits").click();
+    await q.option("Apple").click();
 
-    test.expect(values).toEqual(["apple"]);
+    const labels = await q.combobox("Favorite fruits").evaluate((element) => {
+      const input = element as HTMLInputElement;
+      return Array.from(input.labels ?? [], (label) =>
+        label.textContent?.trim(),
+      );
+    });
+
+    test.expect(labels).toEqual(["Favorite fruits"]);
   });
 
-  // https://github.com/ariakit/ariakit/pull/6795#discussion_r3623740398
-  test("relays invalid events to the Combobox input", async ({ q }) => {
-    await q.button("Validate required fruits").click();
+  // https://github.com/ariakit/ariakit/pull/6795#discussion_r3623740406
+  test("submits selected values when composite is false", async ({ page }) => {
+    const form = page.locator("form[data-composite-false]");
+    const input = page.getByRole("combobox", { name: "Non-composite fruits" });
+    const hiddenInput = page.locator(
+      "input[type='hidden'][name='non-composite-fruits']",
+    );
+    const values = await form.evaluate((element) =>
+      new FormData(element as HTMLFormElement).getAll("non-composite-fruits"),
+    );
+    const inputForm = await input.evaluate(
+      (element) => (element as HTMLInputElement).form?.id ?? null,
+    );
+    const hiddenInputForm = await hiddenInput.evaluate(
+      (element) => (element as HTMLInputElement).form?.id ?? null,
+    );
 
-    await test.expect(q.text("Invalid target: input")).toBeVisible();
+    test.expect(values).toEqual(["apple"]);
+    test.expect(inputForm).toBe("non-composite-form");
+    test.expect(hiddenInputForm).toBe("non-composite-form");
+  });
+
+  // https://github.com/ariakit/ariakit/pull/6795#discussion_r3623937766
+  test("preserves implicit submission with an explicit form", async ({
+    page,
+    q,
+  }) => {
+    const form = page.locator("form[data-composite-false]");
+    await form.evaluate((element) => {
+      element.addEventListener(
+        "submit",
+        (event) => {
+          event.preventDefault();
+          const submitter = (event as SubmitEvent).submitter;
+          element.setAttribute(
+            "data-submitter",
+            submitter?.textContent?.trim() ?? "",
+          );
+        },
+        { once: true },
+      );
+    });
+
+    await q.combobox("Non-composite fruits").press("Enter");
+
+    await test
+      .expect(form)
+      .toHaveAttribute("data-submitter", "Submit non-composite fruits");
   });
 
   // https://github.com/ariakit/ariakit/pull/6795#discussion_r3623740415
   test("keeps selected values in sync after form reset", async ({ q }) => {
-    await q.combobox("Favorite fruits").click();
+    const combobox = q.combobox("Favorite fruits");
+    await combobox.click();
     await q.option("Apple").click();
+    await combobox.press("Escape");
     await q.button("Reset").click();
     await q.button("Submit").click();
 

--- a/app/src/sandbox/combobox-5058/test-browser.ts
+++ b/app/src/sandbox/combobox-5058/test-browser.ts
@@ -51,6 +51,18 @@ withFramework(import.meta.dirname, async ({ test }) => {
     test.expect(inputForm).toBe("non-composite-form");
   });
 
+  // https://github.com/ariakit/ariakit/pull/6795#discussion_r3625787623
+  test("omits aria-disabled selected values", async ({ q }) => {
+    const form = q.form("Disabled fruits");
+    await test.expect(q.combobox("Disabled fruits")).toBeDisabled();
+
+    const values = await form.evaluate((element) =>
+      new FormData(element as HTMLFormElement).getAll("disabled-fruits"),
+    );
+
+    test.expect(values).toEqual([]);
+  });
+
   // https://github.com/ariakit/ariakit/pull/6795#discussion_r3623937766
   test("preserves implicit submission with an explicit form", async ({ q }) => {
     const form = q.form("Non-composite fruits");

--- a/app/src/sandbox/combobox-5058/test.ts
+++ b/app/src/sandbox/combobox-5058/test.ts
@@ -9,14 +9,9 @@ test("mirrors every selected value in the form control", async () => {
 
   expect(q.combobox("Favorite fruits")).not.toHaveAttribute("name");
 
-  const select = document.querySelector<HTMLSelectElement>(
-    "select[name='fruits'][multiple]",
-  );
-  const selectedValues = Array.from(
-    select?.selectedOptions ?? [],
-    (option) => option.value,
-  );
-  expect(selectedValues).toEqual(["apple", "orange"]);
+  const input = q.combobox("Favorite fruits") as HTMLInputElement;
+  const form = input.form!;
+  expect(new FormData(form).getAll("fruits")).toEqual(["apple", "orange"]);
 });
 
 // https://github.com/ariakit/ariakit/pull/6795#discussion_r3623740406
@@ -25,13 +20,16 @@ test("mirrors selected values when composite is false", () => {
     "form[data-composite-false]",
   );
   const formData = new FormData(form!);
+  const input = q.combobox("Non-composite fruits") as HTMLInputElement;
+  const hiddenInput = document.querySelector<HTMLInputElement>(
+    "input[type='hidden'][name='non-composite-fruits']",
+  );
 
   expect(formData.getAll("non-composite-fruits")).toEqual(["apple"]);
+  expect(input.form).toBe(form);
+  expect(hiddenInput?.form).toBe(form);
 });
 
-// https://github.com/ariakit/ariakit/pull/6795#discussion_r3623740398
-test("relays invalid events to the Combobox input", async () => {
-  await click(q.button("Validate required fruits"));
-
-  expect(q.text("Invalid target: input")).toBeInTheDocument();
+test("preserves the name for a single selected value", () => {
+  expect(q.combobox("Single fruit")).toHaveAttribute("name", "single-fruit");
 });

--- a/app/src/sandbox/combobox-5058/test.ts
+++ b/app/src/sandbox/combobox-5058/test.ts
@@ -18,3 +18,20 @@ test("mirrors every selected value in the form control", async () => {
   );
   expect(selectedValues).toEqual(["apple", "orange"]);
 });
+
+// https://github.com/ariakit/ariakit/pull/6795#discussion_r3623740406
+test("mirrors selected values when composite is false", () => {
+  const form = document.querySelector<HTMLFormElement>(
+    "form[data-composite-false]",
+  );
+  const formData = new FormData(form!);
+
+  expect(formData.getAll("non-composite-fruits")).toEqual(["apple"]);
+});
+
+// https://github.com/ariakit/ariakit/pull/6795#discussion_r3623740398
+test("relays invalid events to the Combobox input", async () => {
+  await click(q.button("Validate required fruits"));
+
+  expect(q.text("Invalid target: input")).toBeInTheDocument();
+});

--- a/app/src/sandbox/combobox-5058/test.ts
+++ b/app/src/sandbox/combobox-5058/test.ts
@@ -24,6 +24,14 @@ test("mirrors selected values when composite is false", () => {
   expect(input.form).toBe(form);
 });
 
+// https://github.com/ariakit/ariakit/pull/6795#discussion_r3625787623
+test("omits aria-disabled selected values", () => {
+  const form = q.form.ensure("Disabled fruits") as HTMLFormElement;
+
+  expect(q.combobox("Disabled fruits")).toBeDisabled();
+  expect(new FormData(form).getAll("disabled-fruits")).toEqual([]);
+});
+
 test("preserves the name for a single selected value", () => {
   expect(q.combobox("Single fruit")).toHaveAttribute("name", "single-fruit");
 });

--- a/app/src/sandbox/combobox-5058/test.ts
+++ b/app/src/sandbox/combobox-5058/test.ts
@@ -1,0 +1,20 @@
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// https://github.com/ariakit/ariakit/issues/5058
+test("mirrors every selected value in the form control", async () => {
+  await click(q.combobox("Favorite fruits"));
+  await click(q.option("Apple"));
+  await click(q.option("Orange"));
+
+  expect(q.combobox("Favorite fruits")).not.toHaveAttribute("name");
+
+  const select = document.querySelector<HTMLSelectElement>(
+    "select[name='fruits'][multiple]",
+  );
+  const selectedValues = Array.from(
+    select?.selectedOptions ?? [],
+    (option) => option.value,
+  );
+  expect(selectedValues).toEqual(["apple", "orange"]);
+});

--- a/app/src/sandbox/combobox-5058/test.ts
+++ b/app/src/sandbox/combobox-5058/test.ts
@@ -16,18 +16,12 @@ test("mirrors every selected value in the form control", async () => {
 
 // https://github.com/ariakit/ariakit/pull/6795#discussion_r3623740406
 test("mirrors selected values when composite is false", () => {
-  const form = document.querySelector<HTMLFormElement>(
-    "form[data-composite-false]",
-  );
-  const formData = new FormData(form!);
+  const form = q.form("Non-composite fruits") as HTMLFormElement;
+  const formData = new FormData(form);
   const input = q.combobox("Non-composite fruits") as HTMLInputElement;
-  const hiddenInput = document.querySelector<HTMLInputElement>(
-    "input[type='hidden'][name='non-composite-fruits']",
-  );
 
   expect(formData.getAll("non-composite-fruits")).toEqual(["apple"]);
   expect(input.form).toBe(form);
-  expect(hiddenInput?.form).toBe(form);
 });
 
 test("preserves the name for a single selected value", () => {

--- a/packages/ariakit-react-components/src/combobox/combobox.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox.tsx
@@ -19,6 +19,7 @@ import {
   getPopupRole,
   getScrollingElement,
   getTextboxSelection,
+  fireEvent,
   setSelectionRange,
   isFocusEventOutside,
   queueBeforeEvent,
@@ -703,6 +704,7 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
     const form = props.form;
     const required = props.required;
     const disabled = props.disabled;
+    const composite = props.composite !== false;
     const label = props["aria-label"];
     const labelledBy = props["aria-labelledby"];
     const baseElement = useStoreState(
@@ -710,6 +712,25 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       multiSelectable ? ["baseElement"] : [],
       (state) => (multiSelectable ? state.baseElement : null),
     );
+    const selectRef = useRef<HTMLSelectElement>(null);
+
+    useSafeLayoutEffect(() => {
+      const select = selectRef.current;
+      if (!select) return;
+      // Keep native form resets from clearing the mirrored selection while
+      // the Combobox store still holds the same values.
+      for (const option of select.options) {
+        option.defaultSelected = option.selected;
+      }
+    }, [selectedValue, baseElement, name, composite]);
+
+    const onInvalid = useEvent((event: SyntheticEvent<HTMLSelectElement>) => {
+      const element = ref.current;
+      if (!element) return;
+      event.stopPropagation();
+      const defaultAllowed = fireEvent(element, "invalid", event);
+      if (!defaultAllowed) event.preventDefault();
+    });
 
     props = useWrapElement(
       props,
@@ -718,11 +739,12 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
         if (!Array.isArray(selectedValue)) return element;
         // Wait until ComboboxLabel has associated itself with the input before
         // inserting another labelable element.
-        if (!baseElement) return element;
+        if (composite && !baseElement) return element;
         return (
           <>
             {element}
             <select
+              ref={selectRef}
               style={getVisuallyHiddenStyle()}
               tabIndex={-1}
               aria-hidden
@@ -735,6 +757,7 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
               multiple
               value={selectedValue}
               onFocus={() => ref.current?.focus()}
+              onInvalid={onInvalid}
               onChange={(event) => {
                 store?.setSelectedValue(getSelectedValues(event.target));
               }}
@@ -758,6 +781,8 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
         labelledBy,
         selectedValue,
         baseElement,
+        composite,
+        onInvalid,
       ],
     );
 

--- a/packages/ariakit-react-components/src/combobox/combobox.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox.tsx
@@ -16,6 +16,7 @@ import {
 import type { Props } from "@ariakit/react-utils";
 import { sync } from "@ariakit/store";
 import {
+  disabledFromProps,
   getPopupRole,
   getScrollingElement,
   getTextboxSelection,
@@ -697,6 +698,11 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       (state) => state.activeId === null,
     );
 
+    const formDisabled = disabledFromProps({
+      disabled,
+      "aria-disabled": props["aria-disabled"],
+    });
+
     const composite = props.composite !== false;
     const baseElement = useStoreState(
       store,
@@ -719,14 +725,14 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
                 type="hidden"
                 name={name}
                 form={form}
-                disabled={disabled}
+                disabled={formDisabled}
                 value={value}
               />
             ))}
           </>
         );
       },
-      [name, form, disabled, composite, baseElement, selectedValue],
+      [name, form, formDisabled, composite, baseElement, selectedValue],
     );
 
     const htmlProps = {

--- a/packages/ariakit-react-components/src/combobox/combobox.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox.tsx
@@ -8,6 +8,7 @@ import {
   useSafeLayoutEffect,
   useUpdateEffect,
   useUpdateLayoutEffect,
+  useWrapElement,
   createElement,
   createHook,
   forwardRef,
@@ -44,6 +45,7 @@ import type { CompositeOptions } from "../composite/composite.tsx";
 import { useComposite } from "../composite/composite.tsx";
 import type { PopoverAnchorOptions } from "../popover/popover-anchor.tsx";
 import { usePopoverAnchor } from "../popover/popover-anchor.tsx";
+import { getVisuallyHiddenStyle } from "../visually-hidden/visually-hidden.tsx";
 import { useComboboxProviderContext } from "./combobox-context.tsx";
 import type {
   ComboboxStore,
@@ -54,6 +56,10 @@ import type {
 const TagName = "input" satisfies ElementType;
 type TagName = typeof TagName;
 type HTMLType = HTMLElementTagNameMap[TagName];
+
+function getSelectedValues(select: HTMLSelectElement) {
+  return Array.from(select.selectedOptions).map((option) => option.value);
+}
 
 function isFirstItemAutoSelected(
   items: ComboboxStoreState["items"],
@@ -179,6 +185,13 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
     }, [inline]);
 
     const storeValue = useStoreState(store, "value");
+    const name = props.name;
+    const selectedValue = useStoreState(store, ["selectedValue"], (state) => {
+      if (!name) return;
+      if (!Array.isArray(state.selectedValue)) return;
+      return state.selectedValue;
+    });
+    const multiSelectable = Array.isArray(selectedValue);
 
     // Keep track of the previous selected values so we can set the
     // inlineActiveValue below only when the current activeValue isn't already
@@ -687,6 +700,67 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       (state) => state.activeId === null,
     );
 
+    const form = props.form;
+    const required = props.required;
+    const disabled = props.disabled;
+    const label = props["aria-label"];
+    const labelledBy = props["aria-labelledby"];
+    const baseElement = useStoreState(
+      store,
+      multiSelectable ? ["baseElement"] : [],
+      (state) => (multiSelectable ? state.baseElement : null),
+    );
+
+    props = useWrapElement(
+      props,
+      (element) => {
+        if (!name) return element;
+        if (!Array.isArray(selectedValue)) return element;
+        // Wait until ComboboxLabel has associated itself with the input before
+        // inserting another labelable element.
+        if (!baseElement) return element;
+        return (
+          <>
+            {element}
+            <select
+              style={getVisuallyHiddenStyle()}
+              tabIndex={-1}
+              aria-hidden
+              aria-label={label}
+              aria-labelledby={label != null ? undefined : labelledBy}
+              name={name}
+              form={form}
+              required={required}
+              disabled={disabled}
+              multiple
+              value={selectedValue}
+              onFocus={() => ref.current?.focus()}
+              onChange={(event) => {
+                store?.setSelectedValue(getSelectedValues(event.target));
+              }}
+            >
+              {selectedValue.map((value, index) => (
+                <option key={index} value={value}>
+                  {value}
+                </option>
+              ))}
+            </select>
+          </>
+        );
+      },
+      [
+        store,
+        name,
+        form,
+        required,
+        disabled,
+        label,
+        labelledBy,
+        selectedValue,
+        baseElement,
+      ],
+    );
+
     props = {
       role: "combobox",
       "aria-autocomplete": ariaAutoComplete,
@@ -697,6 +771,10 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       value,
       ...props,
       id,
+      "aria-required":
+        multiSelectable && required ? true : props["aria-required"],
+      name: multiSelectable ? undefined : name,
+      required: multiSelectable ? undefined : required,
       ref: useMergeRefs(ref, props.ref),
       onChange,
       onCompositionStart,

--- a/packages/ariakit-react-components/src/combobox/combobox.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox.tsx
@@ -19,7 +19,6 @@ import {
   getPopupRole,
   getScrollingElement,
   getTextboxSelection,
-  fireEvent,
   setSelectionRange,
   isFocusEventOutside,
   queueBeforeEvent,
@@ -46,7 +45,6 @@ import type { CompositeOptions } from "../composite/composite.tsx";
 import { useComposite } from "../composite/composite.tsx";
 import type { PopoverAnchorOptions } from "../popover/popover-anchor.tsx";
 import { usePopoverAnchor } from "../popover/popover-anchor.tsx";
-import { getVisuallyHiddenStyle } from "../visually-hidden/visually-hidden.tsx";
 import { useComboboxProviderContext } from "./combobox-context.tsx";
 import type {
   ComboboxStore,
@@ -57,10 +55,6 @@ import type {
 const TagName = "input" satisfies ElementType;
 type TagName = typeof TagName;
 type HTMLType = HTMLElementTagNameMap[TagName];
-
-function getSelectedValues(select: HTMLSelectElement) {
-  return Array.from(select.selectedOptions).map((option) => option.value);
-}
 
 function isFirstItemAutoSelected(
   items: ComboboxStoreState["items"],
@@ -702,88 +696,37 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
     );
 
     const form = props.form;
-    const required = props.required;
     const disabled = props.disabled;
     const composite = props.composite !== false;
-    const label = props["aria-label"];
-    const labelledBy = props["aria-labelledby"];
     const baseElement = useStoreState(
       store,
       multiSelectable ? ["baseElement"] : [],
       (state) => (multiSelectable ? state.baseElement : null),
     );
-    const selectRef = useRef<HTMLSelectElement>(null);
-
-    useSafeLayoutEffect(() => {
-      const select = selectRef.current;
-      if (!select) return;
-      // Keep native form resets from clearing the mirrored selection while
-      // the Combobox store still holds the same values.
-      for (const option of select.options) {
-        option.defaultSelected = option.selected;
-      }
-    }, [selectedValue, baseElement, name, composite]);
-
-    const onInvalid = useEvent((event: SyntheticEvent<HTMLSelectElement>) => {
-      const element = ref.current;
-      if (!element) return;
-      event.stopPropagation();
-      const defaultAllowed = fireEvent(element, "invalid", event);
-      if (!defaultAllowed) event.preventDefault();
-    });
 
     props = useWrapElement(
       props,
       (element) => {
         if (!name) return element;
         if (!Array.isArray(selectedValue)) return element;
-        // Wait until ComboboxLabel has associated itself with the input before
-        // inserting another labelable element.
         if (composite && !baseElement) return element;
         return (
           <>
             {element}
-            <select
-              ref={selectRef}
-              style={getVisuallyHiddenStyle()}
-              tabIndex={-1}
-              aria-hidden
-              aria-label={label}
-              aria-labelledby={label != null ? undefined : labelledBy}
-              name={name}
-              form={form}
-              required={required}
-              disabled={disabled}
-              multiple
-              value={selectedValue}
-              onFocus={() => ref.current?.focus()}
-              onInvalid={onInvalid}
-              onChange={(event) => {
-                store?.setSelectedValue(getSelectedValues(event.target));
-              }}
-            >
-              {selectedValue.map((value, index) => (
-                <option key={index} value={value}>
-                  {value}
-                </option>
-              ))}
-            </select>
+            {selectedValue.map((value, index) => (
+              <input
+                key={index}
+                type="hidden"
+                name={name}
+                form={form}
+                disabled={disabled}
+                value={value}
+              />
+            ))}
           </>
         );
       },
-      [
-        store,
-        name,
-        form,
-        required,
-        disabled,
-        label,
-        labelledBy,
-        selectedValue,
-        baseElement,
-        composite,
-        onInvalid,
-      ],
+      [name, form, disabled, composite, baseElement, selectedValue],
     );
 
     props = {
@@ -796,10 +739,7 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       value,
       ...props,
       id,
-      "aria-required":
-        multiSelectable && required ? true : props["aria-required"],
       name: multiSelectable ? undefined : name,
-      required: multiSelectable ? undefined : required,
       ref: useMergeRefs(ref, props.ref),
       onChange,
       onCompositionStart,

--- a/packages/ariakit-react-components/src/combobox/combobox.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox.tsx
@@ -134,6 +134,9 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
     setValueOnClick = true,
     moveOnKeyPress = true,
     autoComplete = "list",
+    name,
+    form,
+    disabled,
     ...props
   }) {
     const context = useComboboxProviderContext();
@@ -180,7 +183,6 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
     }, [inline]);
 
     const storeValue = useStoreState(store, "value");
-    const name = props.name;
     const selectedValue = useStoreState(store, ["selectedValue"], (state) => {
       if (!name) return;
       if (!Array.isArray(state.selectedValue)) return;
@@ -695,8 +697,6 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       (state) => state.activeId === null,
     );
 
-    const form = props.form;
-    const disabled = props.disabled;
     const composite = props.composite !== false;
     const baseElement = useStoreState(
       store,
@@ -729,7 +729,7 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       [name, form, disabled, composite, baseElement, selectedValue],
     );
 
-    props = {
+    const htmlProps = {
       role: "combobox",
       "aria-autocomplete": ariaAutoComplete,
       "aria-haspopup": getPopupRole(contentElement, "listbox"),
@@ -740,6 +740,8 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       ...props,
       id,
       name: multiSelectable ? undefined : name,
+      form,
+      disabled,
       ref: useMergeRefs(ref, props.ref),
       onChange,
       onCompositionStart,
@@ -748,6 +750,7 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       onKeyDown,
       onBlur,
     };
+    props = htmlProps;
 
     props = useComposite<TagName>({
       store,


### PR DESCRIPTION
## Motivation

A multi-select [`Combobox`](https://ariakit.com/reference/combobox) currently submits its transient search text when `name` is provided, rather than the array in `selectedValue`.

```tsx
<ComboboxProvider defaultSelectedValue={[]}>
  <Combobox name="fruits" />
</ComboboxProvider>
```

As a result, native `FormData.getAll("fruits")` cannot retrieve the selected values.

Fixes #5058.

## Solution

When `selectedValue` is an array and the `Combobox` has a `name`, remove the name from the visible query input and render one hidden input for each selected value:

```html
<input role="combobox" />
<input type="hidden" name="fruits" value="apple" />
<input type="hidden" name="fruits" value="orange" />
```

The hidden inputs receive the same `name`, `form`, and logical disabled state, including directly supplied `aria-disabled`. The visible input remains associated with its form and keeps its native query behavior, including constraint validation, invalid events, reset behavior, and implicit submission.

For composite Comboboxes, the hidden inputs mount after the base element is registered to preserve `ComboboxLabel` metadata in Firefox. `composite={false}` bypasses that gate and renders the hidden inputs immediately.

Single-value Combobox behavior is unchanged.

## Scope

This pull request only serializes array selections through native form controls. It does not add `ComboboxSelect`, selection-level constraint validation, selected-value autofill or native mutation synchronization, or pre-hydration serialization for the default composite path.

## Workaround

Before this fix, control the selected values, leave the search input unnamed, and mirror each selection into a hidden input:

```tsx
const [selectedValues, setSelectedValues] = useState<string[]>([]);

<ComboboxProvider
  selectedValue={selectedValues}
  setSelectedValue={setSelectedValues}
>
  <Combobox />
  {/* ... */}
</ComboboxProvider>

{selectedValues.map((value, index) => (
  <input key={index} type="hidden" name="fruits" value={value} />
))}
```

This workaround mirrors the currently selected values for form submission only.

## Testing

Regression coverage verifies controlled and default selected arrays, selected and empty arrays, exclusion of typed query text and `aria-disabled` selections, out-of-tree explicit form ownership with `composite={false}`, unchanged single-value naming, native implicit submission and reset behavior, and Firefox label metadata after hydration.

- `pnpm lint-fix`
- `pnpm exec tsc -p packages/ariakit-react-components/tsconfig.json --noEmit`
- `pnpm tsc`
- `pnpm test-react`
- `pnpm test-react18`
- `pnpm build`
- `pnpm -F app build-lite`
- `APP_PORT=54541 NEXTJS_PORT=54542 CI=true pnpm -F app test --project=chrome --project=firefox --project=safari sandbox/combobox-5058/test-browser.ts`

## Implementation review reassessment

<details>
<summary>Cycle 3: Continue the native form proxy design</summary>

**Assessment**

Review found three medium-severity gaps in the proxy around supported public behavior: `composite={false}` prevented it from mounting, required validation did not reach the Combobox `onInvalid` handler, and native form resets could desynchronize it from the store. Each failure is deterministic, but each is confined to the proxy lifecycle and can be corrected locally without expanding the public API or changing the overall design.

**Decision**

Continue with the native `<select multiple>` proxy because it directly supplies the repeated native form values requested in #5058. Mount it immediately when composite behavior is disabled, relay invalid events through the visible input, and preserve its mirrored defaults across native resets. `ComboboxSelect`, native option discovery for unselected values, and broader autofill semantics remain outside this issue.

</details>

<details>
<summary>Cycle 4: Cover delayed proxy mounts</summary>

**Assessment**

The staged review found that changing `name` or `composite` could mount the proxy without rerunning the layout effect that initializes its native reset defaults. This is a deterministic but narrow lifecycle gap in supported dynamic props; it does not indicate that the proxy abstraction or public behavior needs to change.

**Decision**

Keep the current design and include `name` and `composite` in the reset-synchronization dependencies. The follow-up staged review found no remaining correctness or regression issues.

</details>

<details>
<summary>Cycle 6: Narrow to serialization-only hidden inputs</summary>

**Assessment**

The core issue is deterministic and user-visible whenever a named Combobox has an array selection: the transient query is submitted instead of the selected values. The supported scope needed to fix it is selected-value serialization in an ordinary hydrated form.

The hidden `<select multiple>` direction expanded that narrow requirement into a form-control subsystem. It required bidirectional synchronization, reset defaults, validity and invalid-event bridging, explicit form ownership, implicit-submission handling, and label-registration policy. Repeated review findings showed that this complexity increased maintenance risk without being required by #5058.

**Decision**

Replace the hidden select with repeated hidden inputs derived directly from `selectedValue`, and leave the visible query input's native form behavior unchanged apart from removing its name in array-selection mode. This directly fixes `FormData.getAll(name)` while eliminating the mutable proxy state and validation bridge.

The Firefox label-registration gate remains because inserting sibling controls before `ComboboxLabel` registration loses input label metadata there. Pre-hydration serialization for the default composite path, selection-level constraint validation, selected-value autofill or native mutation synchronization, and `ComboboxSelect` are intentionally outside this pull request.

</details>
