### PR TITLE
Limit Safari launch timeout in CI

### DIFF
--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -126,7 +126,16 @@ export default defineConfig({
         {
           name: "safari",
           testMatch: testMatchersFor("safari", "browser"),
-          use: devices["Desktop Safari"],
+          use: {
+            ...devices["Desktop Safari"],
+            launchOptions: {
+              slowMo: HEADED ? 150 : undefined,
+              // Healthy macOS CI launches complete initial page setup within
+              // 24 seconds; fail a wedged WebKit process without waiting for
+              // Playwright's three-minute default.
+              timeout: CI ? 45_000 : undefined,
+            },
+          },
           retries: CI ? 3 : 1,
         },
         {

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -6,6 +6,7 @@ if (process.argv.includes("--headed")) {
 
 const CI = !!process.env.CI;
 const HEADED = process.env.PWHEADED === "true";
+const slowMo = HEADED ? 150 : undefined;
 const PERF = process.env.PERF_TEST === "true";
 const port = Number(process.env.APP_PORT) || 4321;
 const nextjsPort = Number(process.env.NEXTJS_PORT) || 3000;
@@ -66,7 +67,7 @@ export default defineConfig({
     screenshot: "only-on-failure",
     trace: "on-first-retry",
     launchOptions: {
-      slowMo: HEADED ? 150 : undefined,
+      slowMo,
     },
   },
   expect: {
@@ -129,7 +130,7 @@ export default defineConfig({
           use: {
             ...devices["Desktop Safari"],
             launchOptions: {
-              slowMo: HEADED ? 150 : undefined,
+              slowMo,
               // Healthy macOS CI launches complete initial page setup within
               // 24 seconds; fail a wedged WebKit process without waiting for
               // Playwright's three-minute default.


### PR DESCRIPTION
## Motivation

The [app Safari job](https://github.com/ariakit/ariakit/actions/runs/29850198253/job/88701254517) took 24.9 minutes after replacement WebKit processes wedged during retries. Each launch attempt could wait Playwright's 180,000 ms default before failing.

A workflow or job timeout would also cap legitimately long test runs. The failure should instead be bounded at the browser-launch operation that wedged.

Across the latest 59 completed app Safari jobs on the current macOS runner image, the conservative startup upper bound had an 8.17-second median, 14.86-second p95, and 23.51-second maximum. This includes worker setup, context and page creation, and initial navigation, so the browser launch itself completed sooner.

## Solution

Hoist the existing headed-mode delay and set a 45-second browser launch timeout only for the app Safari project in CI:

```ts
const slowMo = HEADED ? 150 : undefined;

launchOptions: {
  slowMo,
  timeout: CI ? 45_000 : undefined,
}
```

Playwright merges project `use` objects shallowly, so Safari still declares `slowMo`; sharing the value keeps the base and Safari settings in sync.

This leaves more than 21 seconds of headroom over the observed maximum while cutting a wedged launch wait by 75%. Other browser projects keep Playwright's default, non-CI Safari runs keep the default, and local headed Safari retains its existing `slowMo` setting.

The Safari retry count and workflow-level timeouts remain unchanged.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- Loaded the config with CI enabled and confirmed Safari resolves to `{ "timeout": 45000 }`
- Loaded the headed config with CI unset and confirmed Safari resolves to `{ "slowMo": 150 }`
- `env CI=true pnpm -F app exec playwright test --list --project safari --grep-invert @visual` (285 tests listed)
