### PR TITLE
Preserve bare layer colors at higher contrast

### DIFF
--- a/.changeset/300-fix-layer-contrast-inheritance.md
+++ b/.changeset/300-fix-layer-contrast-inheritance.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/tailwind": patch
+---
+
+Fixed bare `ak-layer` elements to preserve inherited background colors when the global contrast setting increases.

--- a/app/src/sandbox/ariakit-tailwind-layer-contrast-inheritance/index.react.tsx
+++ b/app/src/sandbox/ariakit-tailwind-layer-contrast-inheritance/index.react.tsx
@@ -1,0 +1,37 @@
+import "./style.css";
+
+export default function Example() {
+  return (
+    <section aria-label="Parent layer" className="ak-layer [--contrast:5] p-4">
+      <section aria-label="Child layer" className="ak-layer p-4">
+        <section aria-label="Grandchild layer" className="ak-layer p-4">
+          Bare nested layers
+        </section>
+        <section
+          aria-label="Nested layer offset"
+          className="ak-layer ak-layer-offset-10 p-4"
+        >
+          Nested layer offset
+        </section>
+        <section
+          aria-label="Nested state darken"
+          className="ak-layer ak-state-darken-10 p-4"
+        >
+          Nested state darken
+        </section>
+      </section>
+      <section
+        aria-label="Direct layer offset"
+        className="ak-layer ak-layer-offset-10 p-4"
+      >
+        Direct layer offset
+      </section>
+      <section
+        aria-label="Direct state darken"
+        className="ak-layer ak-state-darken-10 p-4"
+      >
+        Direct state darken
+      </section>
+    </section>
+  );
+}

--- a/app/src/sandbox/ariakit-tailwind-layer-contrast-inheritance/style.css
+++ b/app/src/sandbox/ariakit-tailwind-layer-contrast-inheritance/style.css
@@ -1,0 +1,23 @@
+@import "tailwindcss" source(none);
+@import "@ariakit/tailwind";
+
+@source "./index.react.tsx";
+
+@theme {
+  --spacing: 0.25rem;
+  --spacing-px: 1px;
+  --radius: 0.25rem;
+}
+
+@theme inline {
+  --radius-none: 0;
+  --radius-xs: calc(var(--radius) * 0.5);
+  --radius-sm: calc(var(--radius) * 1);
+  --radius-md: calc(var(--radius) * 1.5);
+  --radius-lg: calc(var(--radius) * 2);
+  --radius-xl: calc(var(--radius) * 3);
+  --radius-2xl: calc(var(--radius) * 4);
+  --radius-3xl: calc(var(--radius) * 6);
+  --radius-4xl: calc(var(--radius) * 8);
+  --radius-full: calc(var(--radius) * infinity);
+}

--- a/app/src/sandbox/ariakit-tailwind-layer-contrast-inheritance/test-chrome.ts
+++ b/app/src/sandbox/ariakit-tailwind-layer-contrast-inheritance/test-chrome.ts
@@ -1,0 +1,58 @@
+import { expect } from "@playwright/test";
+import type { Locator } from "@playwright/test";
+import { withFramework } from "#app/test-utils/preview.ts";
+
+function getBackgroundColor(layer: Locator) {
+  return layer.evaluate((element) => getComputedStyle(element).backgroundColor);
+}
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  for (const scheme of ["light", "dark"] as const) {
+    test.describe(`${scheme} scheme`, () => {
+      test.use({ colorScheme: scheme });
+
+      test("inherits the parent color in bare nested layers", async ({ q }) => {
+        const parent = q.region("Parent layer");
+        const child = q.region("Child layer");
+        const grandchild = q.region("Grandchild layer");
+
+        for (const contrast of [0, 5, 50, 100]) {
+          await parent.evaluate((element, value) => {
+            element.style.setProperty("--contrast", String(value));
+          }, contrast);
+          const parentColor = await getBackgroundColor(parent);
+
+          await expect
+            .poll(() => getBackgroundColor(child), {
+              message: `Child should inherit at contrast ${contrast}`,
+            })
+            .toBe(parentColor);
+          await expect
+            .poll(() => getBackgroundColor(grandchild), {
+              message: `Grandchild should inherit at contrast ${contrast}`,
+            })
+            .toBe(parentColor);
+        }
+      });
+
+      test("preserves modifiers through a bare layer", async ({ q }) => {
+        const parentColor = await getBackgroundColor(q.region("Parent layer"));
+        const directOffsetColor = await getBackgroundColor(
+          q.region("Direct layer offset"),
+        );
+        const directStateColor = await getBackgroundColor(
+          q.region("Direct state darken"),
+        );
+
+        expect(directOffsetColor).not.toBe(parentColor);
+        expect(directStateColor).not.toBe(parentColor);
+        expect(await getBackgroundColor(q.region("Nested layer offset"))).toBe(
+          directOffsetColor,
+        );
+        expect(await getBackgroundColor(q.region("Nested state darken"))).toBe(
+          directStateColor,
+        );
+      });
+    });
+  }
+});

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
@@ -2398,14 +2398,14 @@
           "ak-layer-darken-<number>": {
             "class": "bg-[oklch(0.7834_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(0.9501_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.8501_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3771_0.368_264.28)] p-[4px] shadow-[oklch(0.3771_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3834_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2834_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1834_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0833_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.8667_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_1px]",
+              "10": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3167_0.368_264.28)] p-[4px] shadow-[oklch(0.3167_0.368_264.28)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
@@ -2526,57 +2526,57 @@
         "class": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
         "children": {
           "ak-text-l-<number>": {
-            "class": "bg-[oklch(0.0633_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_0_0)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_0.91_0)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.34_267.669)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.41_266.84)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.42_266.506)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.43_266.312)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.44_266.185)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(65.1614_3.44_266.097)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(76.7617_3.45_266.033)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(88.3619_3.45_265.986)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+              "0": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_0_0)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_0.91_0)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.34_267.669)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.41_266.84)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.42_266.506)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.43_266.312)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.44_266.185)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(65.1614_3.44_266.097)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(76.7617_3.45_266.033)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(88.3619_3.45_265.986)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-text-<number>": {
-            "class": "bg-[oklch(0.0633_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_0_0)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_0.91_0)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.34_267.669)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.41_266.84)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.42_266.506)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.43_266.312)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.44_266.185)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(65.1614_3.44_266.097)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(76.7617_3.45_266.033)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(88.3619_3.45_265.986)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+              "0": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_1.88_268.493)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.4_267.135)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.42_266.659)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.43_266.404)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.44_266.247)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.44_266.14)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(70.573_3.44_266.066)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(82.1732_3.45_266.01)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(93.7734_3.45_265.967)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-<number>": {
-            "class": "bg-[oklch(0.0633_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_80_38.473)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_71.72_144.885)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_80_288.648)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(79.7476_79.88_1.657)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.0633_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_80_38.473)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.1633_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_71.72_144.885)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.2633_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_80_288.648)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.3633_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(83.2889_40_1.657)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "40": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(83.2889_40_78.514)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "50": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0_/_0.7188)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "60": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.9134_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.93_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-state-<number>": {
-            "class": "bg-[oklch(0.0633_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_80_38.473)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.0633_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_80_38.473)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "10": "bg-[oklch(0.23_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(67.8802_71.72_144.885)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "20": "bg-[oklch(0.33_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(79.7476_80_288.648)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "30": "bg-[oklch(0.43_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(90.8912_40_1.657)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
@@ -2593,14 +2593,14 @@
           "ak-layer-darken-<number>": {
             "class": "bg-[oklch(0.7834_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(0.9501_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.8501_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3771_0.368_264.28)] p-[4px] shadow-[oklch(0.3771_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3834_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2834_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1834_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0833_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.8667_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_1px]",
+              "10": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3167_0.368_264.28)] p-[4px] shadow-[oklch(0.3167_0.368_264.28)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
@@ -2623,13 +2623,13 @@
             }
           },
           "ak-layer-push-<number>": {
-            "class": "bg-[oklch(0.0633_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[18px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-8px] ml-[-8px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[18px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-8px] ml-[-8px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-tl-[6px] rounded-bl-[6px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.2834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.23_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(86.1502_21.47_259.155)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.0633_0.0091_264.28)] text-[oklch(1_0_0)] rounded-tl-[6px] rounded-bl-[6px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.2834)_0px_0px_0px_1px]",
+              "10": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(86.1502_21.47_259.155)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "20": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] *:text-[lch(17.1886_40_177.505)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "30": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] *:text-[lch(17.1886_3.45_265.948)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7801_0.0091_264.28)] text-[oklch(0_0_0)] *:text-[lch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.7967_0.0091_264.28)] text-[oklch(0_0_0)] *:text-[lch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "50": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "60": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "70": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
@@ -2639,14 +2639,14 @@
             }
           },
           "ak-layer-contrast-<number>": {
-            "class": "bg-[oklch(0.0633_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
             "children": {
               "0": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
               "10": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
               "20": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7962_0.245_262.881)] text-[oklch(0_0_0)] *:text-[lch(11.0412_40_280.551)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.9168_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.7962_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.8584_0.245_262.881)] text-[oklch(0_0_0)] *:text-[lch(14.225_40_279.247)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
               "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
               "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
               "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
@@ -2655,29 +2655,29 @@
             }
           },
           "ak-layer-mix-<number>": {
-            "class": "bg-[oklch(0.0633_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0_0.0172_22.0669)] text-[oklch(1_0_0)] *:text-[lch(61.4645_15.03_116.918)] rounded-[10px] border-[1px] border-[oklch(1_0.0172_22.0669_/_0.1834)] p-[4px] shadow-[oklch(1_0.0172_22.0669_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.0459_0.0394_33.8555)] text-[oklch(1_0_0)] *:text-[lch(61.4645_33.27_42.273)] rounded-[10px] border-[1px] border-[oklch(1_0.0394_33.8555_/_0.1834)] p-[4px] shadow-[oklch(1_0.0394_33.8555_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.1105_0.0621_37.0926)] text-[oklch(1_0_0)] *:text-[lch(61.4645_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0621_37.0926_/_0.1834)] p-[4px] shadow-[oklch(1_0.0621_37.0926_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1751_0.0849_38.5945)] text-[oklch(1_0_0)] *:text-[lch(65.5939_28.09_309.978)] rounded-[10px] border-[1px] border-[oklch(1_0.0849_38.5945_/_0.1834)] p-[4px] shadow-[oklch(1_0.0849_38.5945_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2397_0.1077_39.4603)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1077_39.4603_/_0.1834)] p-[4px] shadow-[oklch(1_0.1077_39.4603_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.3043_0.1306_40.0232)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1306_40.0232_/_0.1834)] p-[4px] shadow-[oklch(1_0.1306_40.0232_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.3689_0.1534_40.4185)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1534_40.4185_/_0.1834)] p-[4px] shadow-[oklch(1_0.1534_40.4185_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.0633_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.1132_0.0172_22.0669)] text-[oklch(1_0_0)] *:text-[lch(61.4645_4_74.592)] rounded-[10px] border-[1px] border-[oklch(1_0.0172_22.0669_/_0.1834)] p-[4px] shadow-[oklch(1_0.0172_22.0669_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.1632_0.0394_33.8555)] text-[oklch(1_0_0)] *:text-[lch(63.5464_80_6.157)] rounded-[10px] border-[1px] border-[oklch(1_0.0394_33.8555_/_0.1834)] p-[4px] shadow-[oklch(1_0.0394_33.8555_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.2131_0.0621_37.0926)] text-[oklch(1_0_0)] *:text-[lch(67.8802_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0621_37.0926_/_0.1834)] p-[4px] shadow-[oklch(1_0.0621_37.0926_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.263_0.0849_38.5945)] text-[oklch(1_0_0)] *:text-[lch(70.456_31.63_312.007)] rounded-[10px] border-[1px] border-[oklch(1_0.0849_38.5945_/_0.1834)] p-[4px] shadow-[oklch(1_0.0849_38.5945_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.313_0.1077_39.4603)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1077_39.4603_/_0.1834)] p-[4px] shadow-[oklch(1_0.1077_39.4603_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.3629_0.1306_40.0232)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1306_40.0232_/_0.1834)] p-[4px] shadow-[oklch(1_0.1306_40.0232_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.4128_0.1534_40.4185)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1534_40.4185_/_0.1834)] p-[4px] shadow-[oklch(1_0.1534_40.4185_/_0.1834)_0px_0px_0px_0px]",
               "80": "bg-[oklch(0.423_0.1763_40.7113)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1763_40.7113_/_0.1834)] p-[4px] shadow-[oklch(1_0.1763_40.7113_/_0.1834)_0px_0px_0px_0px]",
               "90": "bg-[oklch(0.4179_0.1991_40.9369)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1991_40.9369_/_0.1834)] p-[4px] shadow-[oklch(1_0.1991_40.9369_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(0.7936_0.222_41.116)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.222_41.116_/_0.1834)] p-[4px] shadow-[oklch(1_0.222_41.116_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-saturate-<number>": {
-            "class": "bg-[oklch(0.0633_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[16px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] m-[16px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[16px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] m-[16px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0_0.1091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.1091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.1091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.2091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.2091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.2091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0_0.3091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.3091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.3091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0_0.368_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.368_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.368_264.28_/_0.1834)_0px_0px_0px_0px]"
+              "0": "bg-[oklch(0.0633_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.0633_0.1091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.1091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.1091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.0633_0.2091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.2091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.2091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0633_0.3091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.3091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.3091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.0633_0.368_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.368_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.368_264.28_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-desaturate-<number>": {
@@ -2692,27 +2692,27 @@
             }
           },
           "ak-layer-h-rotate-<number>": {
-            "class": "bg-[oklch(0.0633_0.0091_264.28)] text-[oklch(1_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(0_0.15_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_0.93_0)] rounded-[10px] border-[1px] border-[oklch(0_0.15_264.28_/_0.2834)] p-[4px] shadow-[oklch(0_0.15_264.28_/_0.2834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0_0.15_294.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_2_69.465)] rounded-[10px] border-[1px] border-[oklch(1_0_294.28_/_0.2834)] p-[4px] shadow-[oklch(1_0_294.28_/_0.2834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0_0.15_324.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_11.56_111.526)] rounded-[10px] border-[1px] border-[oklch(1_0.15_324.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_324.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.15_354.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_19.44_116.15)] rounded-[10px] border-[1px] border-[oklch(1_0.15_354.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_354.28_/_0.1834)_0px_0px_0px_0px]",
-              "120": "bg-[oklch(0_0.15_24.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_13.39_116.936)] rounded-[10px] border-[1px] border-[oklch(1_0.15_24.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_24.28_/_0.1834)_0px_0px_0px_0px]",
-              "180": "bg-[oklch(0_0.15_84.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_0.93_0)] rounded-[10px] border-[1px] border-[oklch(1_0.15_84.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_84.28_/_0.1834)_0px_0px_0px_0px]",
-              "240": "bg-[oklch(0_0.15_144.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_11.56_291.526)] rounded-[10px] border-[1px] border-[oklch(1_0.15_144.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_144.28_/_0.1834)_0px_0px_0px_0px]",
-              "300": "bg-[oklch(0_0.15_204.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_13.39_296.935)] rounded-[10px] border-[1px] border-[oklch(1_0.15_204.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_204.28_/_0.1834)_0px_0px_0px_0px]",
-              "360": "bg-[oklch(0_0.15_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_0.93_0)] rounded-[10px] border-[1px] border-[oklch(1_0.15_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_264.28_/_0.1834)_0px_0px_0px_0px]"
+              "0": "bg-[oklch(0.0633_0.15_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_8.51_357.849)] rounded-[10px] border-[1px] border-[oklch(0_0.15_264.28_/_0.2834)] p-[4px] shadow-[oklch(0_0.15_264.28_/_0.2834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0633_0.15_294.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_11.07_2.82)] rounded-[10px] border-[1px] border-[oklch(1_0_294.28_/_0.2834)] p-[4px] shadow-[oklch(1_0_294.28_/_0.2834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0633_0.15_324.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_8.63_20.246)] rounded-[10px] border-[1px] border-[oklch(1_0.15_324.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_324.28_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.0633_0.15_354.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_6.07_72.598)] rounded-[10px] border-[1px] border-[oklch(1_0.15_354.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_354.28_/_0.1834)_0px_0px_0px_0px]",
+              "120": "bg-[oklch(0.0633_0.15_24.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.78_110.387)] rounded-[10px] border-[1px] border-[oklch(1_0.15_24.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_24.28_/_0.1834)_0px_0px_0px_0px]",
+              "180": "bg-[oklch(0.0633_0.15_84.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_2.9_167.529)] rounded-[10px] border-[1px] border-[oklch(1_0.15_84.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_84.28_/_0.1834)_0px_0px_0px_0px]",
+              "240": "bg-[oklch(0.0633_0.15_144.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_27.01_294.298)] rounded-[10px] border-[1px] border-[oklch(1_0.15_144.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_144.28_/_0.1834)_0px_0px_0px_0px]",
+              "300": "bg-[oklch(0.0633_0.15_204.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_30.43_299.156)] rounded-[10px] border-[1px] border-[oklch(1_0.15_204.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_204.28_/_0.1834)_0px_0px_0px_0px]",
+              "360": "bg-[oklch(0.0633_0.15_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_8.51_357.849)] rounded-[10px] border-[1px] border-[oklch(1_0.15_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_264.28_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-<hue>": {
-            "class": "bg-[oklch(0.0633_0.0091_264.28)] text-[oklch(1_0_0)] rounded-b-[15px] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] mb-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-b-[15px] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] mb-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "red": "bg-[oklch(0_0.15_29.23)] text-[oklch(1_0_0)] *:text-[lch(61.4645_2.9_86.025)] rounded-bl-[11px] border-[1px] border-[oklch(1_0.15_29.23_/_0.1834)] p-[4px] mt-[-1px] mb-[-1px] ml-[-1px] shadow-[oklch(1_0.15_29.23_/_0.1834)_0px_0px_0px_0px]",
-              "green": "bg-[oklch(0_0.15_142.5)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.35_118.628)] rounded-[10px] border-[1px] border-[oklch(1_0.15_142.5_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_142.5_/_0.1834)_0px_0px_0px_0px]",
-              "blue": "bg-[oklch(0_0.15_264.05)] text-[oklch(1_0_0)] *:text-[lch(61.4645_19.29_296.333)] rounded-[10px] border-[1px] border-[oklch(1_0.15_264.05_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_264.05_/_0.1834)_0px_0px_0px_0px]",
-              "magenta": "bg-[oklch(0_0.15_328.36)] text-[oklch(1_0_0)] *:text-[lch(61.4645_2.06_302.003)] rounded-[10px] border-[1px] border-[oklch(1_0.15_328.36_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_328.36_/_0.1834)_0px_0px_0px_0px]",
-              "split1": "bg-[oklch(0_0.15_54.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_11.56_291.526)] rounded-[10px] border-[1px] border-[oklch(1_0.15_54.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_54.28_/_0.1834)_0px_0px_0px_0px]"
+              "red": "bg-[oklch(0.0633_0.15_29.23)] text-[oklch(1_0_0)] *:text-[lch(61.4645_11.06_3.514)] rounded-bl-[11px] border-[1px] border-[oklch(1_0.15_29.23_/_0.1834)] p-[4px] mt-[-1px] mb-[-1px] ml-[-1px] shadow-[oklch(1_0.15_29.23_/_0.1834)_0px_0px_0px_0px]",
+              "green": "bg-[oklch(0.0633_0.15_142.5)] text-[oklch(1_0_0)] *:text-[lch(61.4645_2.29_154.566)] rounded-[10px] border-[1px] border-[oklch(1_0.15_142.5_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_142.5_/_0.1834)_0px_0px_0px_0px]",
+              "blue": "bg-[oklch(0.0633_0.15_264.05)] text-[oklch(1_0_0)] *:text-[lch(61.4645_36.87_299.385)] rounded-[10px] border-[1px] border-[oklch(1_0.15_264.05_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_264.05_/_0.1834)_0px_0px_0px_0px]",
+              "magenta": "bg-[oklch(0.0633_0.15_328.36)] text-[oklch(1_0_0)] *:text-[lch(61.4645_11.46_314.765)] rounded-[10px] border-[1px] border-[oklch(1_0.15_328.36_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_328.36_/_0.1834)_0px_0px_0px_0px]",
+              "split1": "bg-[oklch(0.0633_0.15_54.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_27.01_294.298)] rounded-[10px] border-[1px] border-[oklch(1_0.15_54.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_54.28_/_0.1834)_0px_0px_0px_0px]"
             }
           }
         }
@@ -2721,65 +2721,65 @@
         "class": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
         "children": {
           "ak-text-l-<number>": {
-            "class": "bg-[oklch(0.1633_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(0.0799_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_0_0)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.0799_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_0.91_0)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.0799_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.34_267.669)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0799_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.41_266.84)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.0799_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.42_266.506)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.0799_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.43_266.312)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0799_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.44_266.185)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0799_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(65.1614_3.44_266.097)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.0799_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(76.7617_3.45_266.033)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.0799_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(88.3619_3.45_265.986)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0.0799_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+              "0": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_0_0)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_0.91_0)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_3.34_267.669)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_3.41_266.84)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_3.42_266.506)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_3.43_266.312)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_3.44_266.185)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_3.44_266.097)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(76.7617_3.45_266.033)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(88.3619_3.45_265.986)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-text-<number>": {
-            "class": "bg-[oklch(0.1633_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(0.0799_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_0.6_0)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.0799_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_2.79_267.967)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.0799_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.41_266.937)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0799_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.42_266.558)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.0799_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.43_266.343)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.0799_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.44_266.207)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0799_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(62.8356_3.44_266.113)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0799_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(74.4359_3.45_266.045)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.0799_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(86.0361_3.45_265.994)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.0799_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(97.6362_3.45_265.956)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0.0799_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+              "0": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_3.4_267.135)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_3.42_266.659)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_3.43_266.404)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_3.44_266.247)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_3.44_266.14)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(70.573_3.44_266.065)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(82.1732_3.45_266.01)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(93.7734_3.45_265.967)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-<number>": {
-            "class": "bg-[oklch(0.1633_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_80_38.473)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_71.72_144.885)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_80_288.648)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(79.7476_79.88_1.657)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(83.2889_40_78.514)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0_/_0.7188)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.9134_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.1633_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_80_38.473)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.2633_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_71.72_144.885)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.3633_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(83.2889_40_288.648)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_79.88_1.657)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_80_78.514)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0_/_0.5333)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.93_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-state-<number>": {
-            "class": "bg-[oklch(0.1633_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_80_38.473)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.23_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(67.8802_71.72_144.885)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.33_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(79.7476_80_288.648)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.43_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(90.8912_40_1.657)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.1633_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_80_38.473)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.2633_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_71.72_144.885)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.3633_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(83.2889_40_288.648)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(94.908_40_1.657)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "40": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(94.908_40_78.514)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "50": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0_/_0.8133)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "60": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.83_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.93_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.8633_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.9633_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
             }
@@ -2788,14 +2788,14 @@
           "ak-layer-darken-<number>": {
             "class": "bg-[oklch(0.7834_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(0.9501_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.8501_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3771_0.368_264.28)] p-[4px] shadow-[oklch(0.3771_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3834_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2834_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1834_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0833_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.8667_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_1px]",
+              "10": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3167_0.368_264.28)] p-[4px] shadow-[oklch(0.3167_0.368_264.28)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
@@ -2804,27 +2804,27 @@
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.1633_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2834)_0px_0px_0px_2px]",
             "children": {
-              "0": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.8134_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.9134_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.0799_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4834)_0px_0px_0px_1px]",
+              "10": "bg-[oklch(0.18_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.2799_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.38_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.8467_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.9467_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
-            "class": "bg-[oklch(0.1633_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[18px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-8px] ml-[-8px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[18px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-8px] ml-[-8px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-tl-[6px] rounded-bl-[6px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.2834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.23_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(86.1502_21.47_259.155)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.1633_0.0091_264.28)] text-[oklch(1_0_0)] rounded-tl-[6px] rounded-bl-[6px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.2834)_0px_0px_0px_1px]",
+              "10": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(86.1502_21.47_259.155)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "20": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] *:text-[lch(17.1886_40_177.505)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "30": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] *:text-[lch(17.1886_3.45_265.948)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7801_0.0091_264.28)] text-[oklch(0_0_0)] *:text-[lch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.8967_0.0091_264.28)] text-[oklch(0_0_0)] *:text-[lch(0.8055_0.85_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "50": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "60": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "70": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
@@ -2834,397 +2834,7 @@
             }
           },
           "ak-layer-contrast-<number>": {
-            "class": "bg-[oklch(0.1633_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-            "children": {
-              "0": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.7962_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.8584_0.245_262.881)] text-[oklch(0_0_0)] *:text-[lch(14.225_40_279.247)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]"
-            }
-          },
-          "ak-layer-mix-<number>": {
-            "class": "bg-[oklch(0.1633_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-            "children": {
-              "0": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.0532_0.0172_22.0669)] text-[oklch(1_0_0)] *:text-[lch(61.4645_5.23_109.958)] rounded-[10px] border-[1px] border-[oklch(1_0.0172_22.0669_/_0.1834)] p-[4px] shadow-[oklch(1_0.0172_22.0669_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.1098_0.0394_33.8555)] text-[oklch(1_0_0)] *:text-[lch(61.4645_67.23_8.563)] rounded-[10px] border-[1px] border-[oklch(1_0.0394_33.8555_/_0.1834)] p-[4px] shadow-[oklch(1_0.0394_33.8555_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.1664_0.0621_37.0926)] text-[oklch(1_0_0)] *:text-[lch(63.5464_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0621_37.0926_/_0.1834)] p-[4px] shadow-[oklch(1_0.0621_37.0926_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.223_0.0849_38.5945)] text-[oklch(1_0_0)] *:text-[lch(67.8802_31.93_312.795)] rounded-[10px] border-[1px] border-[oklch(1_0.0849_38.5945_/_0.1834)] p-[4px] shadow-[oklch(1_0.0849_38.5945_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2796_0.1077_39.4603)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1077_39.4603_/_0.1834)] p-[4px] shadow-[oklch(1_0.1077_39.4603_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.3362_0.1306_40.0232)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1306_40.0232_/_0.1834)] p-[4px] shadow-[oklch(1_0.1306_40.0232_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.3928_0.1534_40.4185)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1534_40.4185_/_0.1834)] p-[4px] shadow-[oklch(1_0.1534_40.4185_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.423_0.1763_40.7113)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1763_40.7113_/_0.1834)] p-[4px] shadow-[oklch(1_0.1763_40.7113_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.4179_0.1991_40.9369)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1991_40.9369_/_0.1834)] p-[4px] shadow-[oklch(1_0.1991_40.9369_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0.7936_0.222_41.116)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.222_41.116_/_0.1834)] p-[4px] shadow-[oklch(1_0.222_41.116_/_0.1834)_0px_0px_0px_0px]"
-            }
-          },
-          "ak-layer-saturate-<number>": {
-            "class": "bg-[oklch(0.1633_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[16px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] m-[16px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-            "children": {
-              "0": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0_0.1091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.1091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.1091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.2091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.2091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.2091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0_0.3091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.3091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.3091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0_0.368_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.368_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.368_264.28_/_0.1834)_0px_0px_0px_0px]"
-            }
-          },
-          "ak-layer-desaturate-<number>": {
-            "class": "bg-[oklch(0.1633_0.368_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(0.2467_0.368_29.23)] p-[4px] m-[-5px] shadow-[oklch(0.2467_0.368_29.23)_0px_0px_0px_0px]",
-            "children": {
-              "0": "bg-[oklch(0_0.368_264.28)] text-[oklch(1_0_0)] rounded-[8px] border-[1px] border-[oklch(1_0.368_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.368_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0_0.268_264.28)] text-[oklch(1_0_0)] rounded-[8px] border-[1px] border-[oklch(1_0.268_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.268_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.168_264.28)] text-[oklch(1_0_0)] rounded-[8px] border-[1px] border-[oklch(1_0.168_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.168_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0_0.068_264.28)] text-[oklch(1_0_0)] rounded-[8px] border-[1px] border-[oklch(1_0.068_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.068_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "cool": "bg-[oklch(0_0.15_220)] text-[oklch(1_0_0)] *:text-[lch(61.4645_6.03_283.491)] rounded-[8px] border-[1px] border-[oklch(0.0833_0.15_90)] p-[4px] shadow-[oklch(0.0833_0.15_90)_0px_0px_0px_0px]",
-              "warm": "bg-[oklch(0_0.15_90)] text-[oklch(1_0_0)] *:text-[lch(61.4645_19.37_116.454)] rounded-[8px] border-[1px] border-[oklch(0.0833_0.15_220)] p-[4px] shadow-[oklch(0.0833_0.15_220)_0px_0px_0px_0px]"
-            }
-          },
-          "ak-layer-h-rotate-<number>": {
-            "class": "bg-[oklch(0.1633_0.0091_264.28)] text-[oklch(1_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-            "children": {
-              "0": "bg-[oklch(0_0.15_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_0.93_0)] rounded-[10px] border-[1px] border-[oklch(0_0.15_264.28_/_0.2834)] p-[4px] shadow-[oklch(0_0.15_264.28_/_0.2834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0_0.15_294.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_2_69.465)] rounded-[10px] border-[1px] border-[oklch(1_0_294.28_/_0.2834)] p-[4px] shadow-[oklch(1_0_294.28_/_0.2834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0_0.15_324.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_11.56_111.526)] rounded-[10px] border-[1px] border-[oklch(1_0.15_324.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_324.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.15_354.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_19.44_116.15)] rounded-[10px] border-[1px] border-[oklch(1_0.15_354.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_354.28_/_0.1834)_0px_0px_0px_0px]",
-              "120": "bg-[oklch(0_0.15_24.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_13.39_116.936)] rounded-[10px] border-[1px] border-[oklch(1_0.15_24.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_24.28_/_0.1834)_0px_0px_0px_0px]",
-              "180": "bg-[oklch(0_0.15_84.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_0.93_0)] rounded-[10px] border-[1px] border-[oklch(1_0.15_84.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_84.28_/_0.1834)_0px_0px_0px_0px]",
-              "240": "bg-[oklch(0_0.15_144.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_11.56_291.526)] rounded-[10px] border-[1px] border-[oklch(1_0.15_144.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_144.28_/_0.1834)_0px_0px_0px_0px]",
-              "300": "bg-[oklch(0_0.15_204.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_13.39_296.935)] rounded-[10px] border-[1px] border-[oklch(1_0.15_204.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_204.28_/_0.1834)_0px_0px_0px_0px]",
-              "360": "bg-[oklch(0_0.15_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_0.93_0)] rounded-[10px] border-[1px] border-[oklch(1_0.15_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_264.28_/_0.1834)_0px_0px_0px_0px]"
-            }
-          },
-          "ak-layer-<hue>": {
-            "class": "bg-[oklch(0.1633_0.0091_264.28)] text-[oklch(1_0_0)] rounded-b-[15px] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] mb-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-            "children": {
-              "red": "bg-[oklch(0_0.15_29.23)] text-[oklch(1_0_0)] *:text-[lch(61.4645_2.9_86.025)] rounded-bl-[11px] border-[1px] border-[oklch(1_0.15_29.23_/_0.1834)] p-[4px] mt-[-1px] mb-[-1px] ml-[-1px] shadow-[oklch(1_0.15_29.23_/_0.1834)_0px_0px_0px_0px]",
-              "green": "bg-[oklch(0_0.15_142.5)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.35_118.628)] rounded-[10px] border-[1px] border-[oklch(1_0.15_142.5_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_142.5_/_0.1834)_0px_0px_0px_0px]",
-              "blue": "bg-[oklch(0_0.15_264.05)] text-[oklch(1_0_0)] *:text-[lch(61.4645_19.29_296.333)] rounded-[10px] border-[1px] border-[oklch(1_0.15_264.05_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_264.05_/_0.1834)_0px_0px_0px_0px]",
-              "magenta": "bg-[oklch(0_0.15_328.36)] text-[oklch(1_0_0)] *:text-[lch(61.4645_2.06_302.003)] rounded-[10px] border-[1px] border-[oklch(1_0.15_328.36_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_328.36_/_0.1834)_0px_0px_0px_0px]",
-              "split1": "bg-[oklch(0_0.15_54.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_11.56_291.526)] rounded-[10px] border-[1px] border-[oklch(1_0.15_54.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_54.28_/_0.1834)_0px_0px_0px_0px]"
-            }
-          }
-        }
-      },
-      "ak-layer-30": {
-        "class": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-        "children": {
-          "ak-text-l-<number>": {
-            "class": "bg-[oklch(0.2633_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-            "children": {
-              "0": "bg-[oklch(0.18_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_0_0)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.18_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_0.91_0)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.18_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_3.34_267.669)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.18_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_3.41_266.84)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.18_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_3.42_266.506)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.18_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_3.43_266.312)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.18_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_3.44_266.185)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.18_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(65.1614_3.44_266.097)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.18_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(76.7617_3.45_266.033)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.18_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(88.3619_3.45_265.986)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0.18_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
-            }
-          },
-          "ak-text-<number>": {
-            "class": "bg-[oklch(0.2633_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-            "children": {
-              "0": "bg-[oklch(0.18_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_2.79_267.967)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.18_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_3.41_266.937)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.18_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_3.42_266.558)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.18_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_3.43_266.343)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.18_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_3.44_266.207)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.18_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_3.44_266.113)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.18_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(74.4359_3.45_266.045)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.18_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(86.0361_3.45_265.994)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.18_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(97.6362_3.45_265.955)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.18_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0.18_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
-            }
-          },
-          "ak-layer-<number>": {
-            "class": "bg-[oklch(0.2633_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-            "children": {
-              "0": "bg-[oklch(0.0966_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_80_38.473)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.1966_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(65.5939_71.72_144.885)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.2966_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(73.3066_80_288.648)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(83.2889_40_1.657)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(83.2889_40_78.514)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0_/_0.7188)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.8633_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.9633_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
-            }
-          },
-          "ak-state-<number>": {
-            "class": "bg-[oklch(0.2633_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-            "children": {
-              "0": "bg-[oklch(0.0966_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_80_38.473)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.23_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(67.8802_71.72_144.885)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.33_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(79.7476_80_288.648)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.43_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(90.8912_40_1.657)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(94.908_40_78.514)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0_/_0.8133)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.83_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.93_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
-            }
-          },
-          "ak-layer-invert": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] *:text-[lch(17.1886_3.45_266.052)] rounded-[3.35544e+07px] border-[1px] border-[oklch(0.8531_0.3_264.28)] p-[4px] shadow-[oklch(0.8531_0.3_264.28)_0px_0px_0px_0px]",
-          "ak-layer-darken-<number>": {
-            "class": "bg-[oklch(0.7834_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-            "children": {
-              "0": "bg-[oklch(0.9501_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.8501_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3771_0.368_264.28)] p-[4px] shadow-[oklch(0.3771_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3834_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2834_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1834_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0833_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
-            }
-          },
-          "ak-layer-lighten-<number>": {
-            "class": "bg-[oklch(0.2167_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2834)_0px_0px_0px_2px]",
-            "children": {
-              "0": "bg-[oklch(0.05_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.15_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.25_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.35_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.45_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.8167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
-            }
-          },
-          "ak-layer-push-<number>": {
-            "class": "bg-[oklch(0.2633_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[18px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-8px] ml-[-8px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-            "children": {
-              "0": "bg-[oklch(0.0966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-tl-[6px] rounded-bl-[6px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.2834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.2799_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(86.1502_21.47_259.155)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] *:text-[lch(17.1886_40_177.505)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] *:text-[lch(17.1886_3.45_265.948)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.83_0.0091_264.28)] text-[oklch(0_0_0)] *:text-[lch(0.0225_0.11_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
-            }
-          },
-          "ak-layer-contrast-<number>": {
-            "class": "bg-[oklch(0.2633_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-            "children": {
-              "0": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.7962_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.8584_0.245_262.881)] text-[oklch(0_0_0)] *:text-[lch(14.225_40_279.247)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]"
-            }
-          },
-          "ak-layer-mix-<number>": {
-            "class": "bg-[oklch(0.2633_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-            "children": {
-              "0": "bg-[oklch(0.0966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.1432_0.0172_22.0669)] text-[oklch(1_0_0)] *:text-[lch(61.4645_6.83_78.465)] rounded-[10px] border-[1px] border-[oklch(1_0.0172_22.0669_/_0.1834)] p-[4px] shadow-[oklch(1_0.0172_22.0669_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.1898_0.0394_33.8555)] text-[oklch(1_0_0)] *:text-[lch(65.5939_80_7.558)] rounded-[10px] border-[1px] border-[oklch(1_0.0394_33.8555_/_0.1834)] p-[4px] shadow-[oklch(1_0.0394_33.8555_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.2364_0.0621_37.0926)] text-[oklch(1_0_0)] *:text-[lch(67.8802_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0621_37.0926_/_0.1834)] p-[4px] shadow-[oklch(1_0.0621_37.0926_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.283_0.0849_38.5945)] text-[oklch(1_0_0)] *:text-[lch(73.3066_31.52_311.687)] rounded-[10px] border-[1px] border-[oklch(1_0.0849_38.5945_/_0.1834)] p-[4px] shadow-[oklch(1_0.0849_38.5945_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.3296_0.1077_39.4603)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1077_39.4603_/_0.1834)] p-[4px] shadow-[oklch(1_0.1077_39.4603_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.3762_0.1306_40.0232)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1306_40.0232_/_0.1834)] p-[4px] shadow-[oklch(1_0.1306_40.0232_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.4228_0.1534_40.4185)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1534_40.4185_/_0.1834)] p-[4px] shadow-[oklch(1_0.1534_40.4185_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.423_0.1763_40.7113)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1763_40.7113_/_0.1834)] p-[4px] shadow-[oklch(1_0.1763_40.7113_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.4179_0.1991_40.9369)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1991_40.9369_/_0.1834)] p-[4px] shadow-[oklch(1_0.1991_40.9369_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0.7936_0.222_41.116)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.222_41.116_/_0.1834)] p-[4px] shadow-[oklch(1_0.222_41.116_/_0.1834)_0px_0px_0px_0px]"
-            }
-          },
-          "ak-layer-saturate-<number>": {
-            "class": "bg-[oklch(0.2633_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[16px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] m-[16px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-            "children": {
-              "0": "bg-[oklch(0.0966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.0966_0.1091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.1091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.1091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.0966_0.2091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.2091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.2091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.3091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.3091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.3091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.0966_0.368_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.368_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.368_264.28_/_0.1834)_0px_0px_0px_0px]"
-            }
-          },
-          "ak-layer-desaturate-<number>": {
-            "class": "bg-[oklch(0.2633_0.368_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(0.3467_0.368_29.23)] p-[4px] m-[-5px] shadow-[oklch(0.3467_0.368_29.23)_0px_0px_0px_0px]",
-            "children": {
-              "0": "bg-[oklch(0.0966_0.368_264.28)] text-[oklch(1_0_0)] rounded-[8px] border-[1px] border-[oklch(1_0.368_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.368_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.0966_0.268_264.28)] text-[oklch(1_0_0)] rounded-[8px] border-[1px] border-[oklch(1_0.268_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.268_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.0966_0.168_264.28)] text-[oklch(1_0_0)] rounded-[8px] border-[1px] border-[oklch(1_0.168_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.168_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.068_264.28)] text-[oklch(1_0_0)] rounded-[8px] border-[1px] border-[oklch(1_0.068_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.068_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "cool": "bg-[oklch(0.0966_0.15_220)] text-[oklch(1_0_0)] *:text-[lch(61.4645_23.94_283.09)] rounded-[8px] border-[1px] border-[oklch(0.18_0.15_90)] p-[4px] shadow-[oklch(0.18_0.15_90)_0px_0px_0px_0px]",
-              "warm": "bg-[oklch(0.0966_0.15_90)] text-[oklch(1_0_0)] *:text-[lch(61.4645_7.05_34.05)] rounded-[8px] border-[1px] border-[oklch(0.18_0.15_220)] p-[4px] shadow-[oklch(0.18_0.15_220)_0px_0px_0px_0px]"
-            }
-          },
-          "ak-layer-h-rotate-<number>": {
-            "class": "bg-[oklch(0.2633_0.0091_264.28)] text-[oklch(1_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-            "children": {
-              "0": "bg-[oklch(0.0966_0.15_264.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_16.31_356.886)] rounded-[10px] border-[1px] border-[oklch(0_0.15_264.28_/_0.2834)] p-[4px] shadow-[oklch(0_0.15_264.28_/_0.2834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.15_294.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_20.03_4.701)] rounded-[10px] border-[1px] border-[oklch(1_0_294.28_/_0.2834)] p-[4px] shadow-[oklch(1_0_294.28_/_0.2834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0966_0.15_324.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_16.95_8.149)] rounded-[10px] border-[1px] border-[oklch(1_0.15_324.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_324.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.0966_0.15_354.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_8.57_27.316)] rounded-[10px] border-[1px] border-[oklch(1_0.15_354.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_354.28_/_0.1834)_0px_0px_0px_0px]",
-              "120": "bg-[oklch(0.0966_0.15_24.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_3.05_98.017)] rounded-[10px] border-[1px] border-[oklch(1_0.15_24.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_24.28_/_0.1834)_0px_0px_0px_0px]",
-              "180": "bg-[oklch(0.0966_0.15_84.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_7.75_169.938)] rounded-[10px] border-[1px] border-[oklch(1_0.15_84.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_84.28_/_0.1834)_0px_0px_0px_0px]",
-              "240": "bg-[oklch(0.0966_0.15_144.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_33.58_291.927)] rounded-[10px] border-[1px] border-[oklch(1_0.15_144.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_144.28_/_0.1834)_0px_0px_0px_0px]",
-              "300": "bg-[oklch(0.0966_0.15_204.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_39.68_302.033)] rounded-[10px] border-[1px] border-[oklch(1_0.15_204.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_204.28_/_0.1834)_0px_0px_0px_0px]",
-              "360": "bg-[oklch(0.0966_0.15_264.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_16.31_356.886)] rounded-[10px] border-[1px] border-[oklch(1_0.15_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_264.28_/_0.1834)_0px_0px_0px_0px]"
-            }
-          },
-          "ak-layer-<hue>": {
-            "class": "bg-[oklch(0.2633_0.0091_264.28)] text-[oklch(1_0_0)] rounded-b-[15px] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] mb-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-            "children": {
-              "red": "bg-[oklch(0.0966_0.15_29.23)] text-[oklch(1_0_0)] *:text-[lch(61.4645_20.12_4.678)] rounded-bl-[11px] border-[1px] border-[oklch(1_0.15_29.23_/_0.1834)] p-[4px] mt-[-1px] mb-[-1px] ml-[-1px] shadow-[oklch(1_0.15_29.23_/_0.1834)_0px_0px_0px_0px]",
-              "green": "bg-[oklch(0.0966_0.15_142.5)] text-[oklch(1_0_0)] *:text-[lch(61.4645_5.94_154.707)] rounded-[10px] border-[1px] border-[oklch(1_0.15_142.5_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_142.5_/_0.1834)_0px_0px_0px_0px]",
-              "blue": "bg-[oklch(0.0966_0.15_264.05)] text-[oklch(1_0_0)] *:text-[lch(63.5464_45.25_300.196)] rounded-[10px] border-[1px] border-[oklch(1_0.15_264.05_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_264.05_/_0.1834)_0px_0px_0px_0px]",
-              "magenta": "bg-[oklch(0.0966_0.15_328.36)] text-[oklch(1_0_0)] *:text-[lch(61.4645_20.34_317.582)] rounded-[10px] border-[1px] border-[oklch(1_0.15_328.36_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_328.36_/_0.1834)_0px_0px_0px_0px]",
-              "split1": "bg-[oklch(0.0966_0.15_54.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_33.58_291.927)] rounded-[10px] border-[1px] border-[oklch(1_0.15_54.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_54.28_/_0.1834)_0px_0px_0px_0px]"
-            }
-          }
-        }
-      },
-      "ak-layer-40": {
-        "class": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-        "children": {
-          "ak-text-l-<number>": {
-            "class": "bg-[oklch(0.2938_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-            "children": {
-              "0": "bg-[oklch(0.2104_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(65.5939_0_0)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.2104_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(65.5939_0.91_0)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.2104_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(65.5939_3.34_267.669)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.2104_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(65.5939_3.41_266.84)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2104_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(65.5939_3.42_266.506)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2104_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(65.5939_3.43_266.312)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.2104_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(65.5939_3.44_266.185)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.2104_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(65.5939_3.44_266.097)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.2104_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(76.7617_3.45_266.033)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.2104_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(88.3619_3.45_265.986)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0.2104_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
-            }
-          },
-          "ak-text-<number>": {
-            "class": "bg-[oklch(0.2938_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-            "children": {
-              "0": "bg-[oklch(0.2104_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(65.5939_3.39_267.426)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.2104_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(65.5939_3.41_266.795)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.2104_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(65.5939_3.42_266.481)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.2104_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(65.5939_3.43_266.297)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2104_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(65.5939_3.44_266.174)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2104_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(66.369_3.44_266.09)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.2104_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(77.9693_3.45_266.028)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.2104_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(89.5695_3.45_265.982)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.2104_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.2104_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0.2104_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
-            }
-          },
-          "ak-layer-<number>": {
-            "class": "bg-[oklch(0.2938_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-            "children": {
-              "0": "bg-[oklch(0.1271_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_80_38.473)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.2271_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(67.8802_71.72_144.885)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.3271_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(79.7476_80_288.648)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(83.2889_40_1.657)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(83.2889_40_78.514)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0_/_0.7188)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.8938_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.9938_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
-            }
-          },
-          "ak-state-<number>": {
-            "class": "bg-[oklch(0.2938_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-            "children": {
-              "0": "bg-[oklch(0.1271_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_80_38.473)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.23_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(67.8802_71.72_144.885)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.33_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(79.7476_80_288.648)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.43_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(90.8912_40_1.657)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(94.908_40_78.514)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0_/_0.8133)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.83_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.93_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
-            }
-          },
-          "ak-layer-invert": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(94.908_3.43_266.377)] rounded-[3.35544e+07px] border-[1px] border-[oklch(0.5438_0.3_264.28)] p-[4px] shadow-[oklch(0.5438_0.3_264.28)_0px_0px_0px_0px]",
-          "ak-layer-darken-<number>": {
-            "class": "bg-[oklch(0.7834_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-            "children": {
-              "0": "bg-[oklch(0.9501_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.8501_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3771_0.368_264.28)] p-[4px] shadow-[oklch(0.3771_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3834_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2834_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1834_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0833_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
-            }
-          },
-          "ak-layer-lighten-<number>": {
-            "class": "bg-[oklch(0.2167_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2834)_0px_0px_0px_2px]",
-            "children": {
-              "0": "bg-[oklch(0.05_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.15_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.25_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.35_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.45_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.8167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
-            }
-          },
-          "ak-layer-push-<number>": {
-            "class": "bg-[oklch(0.2938_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[18px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-8px] ml-[-8px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-            "children": {
-              "0": "bg-[oklch(0.1271_0.0091_264.28)] text-[oklch(1_0_0)] rounded-tl-[6px] rounded-bl-[6px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.2834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.3104_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(86.1502_21.47_259.155)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] *:text-[lch(17.1886_40_177.505)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] *:text-[lch(17.1886_3.45_265.948)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.8605_0.0091_264.28)] text-[oklch(0_0_0)] *:text-[lch(0.1944_0.36_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
-            }
-          },
-          "ak-layer-contrast-<number>": {
-            "class": "bg-[oklch(0.2938_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
             "children": {
               "0": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
               "10": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
@@ -3240,15 +2850,15 @@
             }
           },
           "ak-layer-mix-<number>": {
-            "class": "bg-[oklch(0.2938_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(0.1271_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.1706_0.0172_22.0669)] text-[oklch(1_0_0)] *:text-[lch(63.5464_11.31_84.957)] rounded-[10px] border-[1px] border-[oklch(1_0.0172_22.0669_/_0.1834)] p-[4px] shadow-[oklch(1_0.0172_22.0669_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.2142_0.0394_33.8555)] text-[oklch(1_0_0)] *:text-[lch(67.8802_80_9.955)] rounded-[10px] border-[1px] border-[oklch(1_0.0394_33.8555_/_0.1834)] p-[4px] shadow-[oklch(1_0.0394_33.8555_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.2577_0.0621_37.0926)] text-[oklch(1_0_0)] *:text-[lch(70.456_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0621_37.0926_/_0.1834)] p-[4px] shadow-[oklch(1_0.0621_37.0926_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3013_0.0849_38.5945)] text-[oklch(1_0_0)] *:text-[lch(73.3066_31.44_311.426)] rounded-[10px] border-[1px] border-[oklch(1_0.0849_38.5945_/_0.1834)] p-[4px] shadow-[oklch(1_0.0849_38.5945_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.3449_0.1077_39.4603)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1077_39.4603_/_0.1834)] p-[4px] shadow-[oklch(1_0.1077_39.4603_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.3884_0.1306_40.0232)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1306_40.0232_/_0.1834)] p-[4px] shadow-[oklch(1_0.1306_40.0232_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.1633_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.2032_0.0172_22.0669)] text-[oklch(1_0_0)] *:text-[lch(65.5939_19.15_90.777)] rounded-[10px] border-[1px] border-[oklch(1_0.0172_22.0669_/_0.1834)] p-[4px] shadow-[oklch(1_0.0172_22.0669_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.2432_0.0394_33.8555)] text-[oklch(1_0_0)] *:text-[lch(70.456_80_14.222)] rounded-[10px] border-[1px] border-[oklch(1_0.0394_33.8555_/_0.1834)] p-[4px] shadow-[oklch(1_0.0394_33.8555_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.2831_0.0621_37.0926)] text-[oklch(1_0_0)] *:text-[lch(73.3066_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0621_37.0926_/_0.1834)] p-[4px] shadow-[oklch(1_0.0621_37.0926_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.323_0.0849_38.5945)] text-[oklch(1_0_0)] *:text-[lch(76.4118_31.36_311.149)] rounded-[10px] border-[1px] border-[oklch(1_0.0849_38.5945_/_0.1834)] p-[4px] shadow-[oklch(1_0.0849_38.5945_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.363_0.1077_39.4603)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1077_39.4603_/_0.1834)] p-[4px] shadow-[oklch(1_0.1077_39.4603_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.4029_0.1306_40.0232)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1306_40.0232_/_0.1834)] p-[4px] shadow-[oklch(1_0.1306_40.0232_/_0.1834)_0px_0px_0px_0px]",
               "70": "bg-[oklch(0.4281_0.1534_40.4185)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1534_40.4185_/_0.1834)] p-[4px] shadow-[oklch(1_0.1534_40.4185_/_0.1834)_0px_0px_0px_0px]",
               "80": "bg-[oklch(0.423_0.1763_40.7113)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1763_40.7113_/_0.1834)] p-[4px] shadow-[oklch(1_0.1763_40.7113_/_0.1834)_0px_0px_0px_0px]",
               "90": "bg-[oklch(0.4179_0.1991_40.9369)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1991_40.9369_/_0.1834)] p-[4px] shadow-[oklch(1_0.1991_40.9369_/_0.1834)_0px_0px_0px_0px]",
@@ -3256,48 +2866,438 @@
             }
           },
           "ak-layer-saturate-<number>": {
-            "class": "bg-[oklch(0.2938_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[16px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] m-[16px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[16px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] m-[16px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(0.1271_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.1271_0.1091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.1091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.1091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.1271_0.2091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.2091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.2091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.1271_0.3091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.3091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.3091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1271_0.368_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.368_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.368_264.28_/_0.1834)_0px_0px_0px_0px]"
+              "0": "bg-[oklch(0.1633_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.1633_0.1091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.1091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.1091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.1633_0.2091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.2091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.2091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.1633_0.3091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.3091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.3091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1633_0.368_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.368_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.368_264.28_/_0.1834)_0px_0px_0px_0px]"
+            }
+          },
+          "ak-layer-desaturate-<number>": {
+            "class": "bg-[oklch(0.1633_0.368_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(0.2467_0.368_29.23)] p-[4px] m-[-5px] shadow-[oklch(0.2467_0.368_29.23)_0px_0px_0px_0px]",
+            "children": {
+              "0": "bg-[oklch(0.0799_0.368_264.28)] text-[oklch(1_0_0)] rounded-[8px] border-[1px] border-[oklch(1_0.368_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.368_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.0799_0.268_264.28)] text-[oklch(1_0_0)] rounded-[8px] border-[1px] border-[oklch(1_0.268_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.268_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.0799_0.168_264.28)] text-[oklch(1_0_0)] rounded-[8px] border-[1px] border-[oklch(1_0.168_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.168_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0799_0.068_264.28)] text-[oklch(1_0_0)] rounded-[8px] border-[1px] border-[oklch(1_0.068_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.068_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "cool": "bg-[oklch(0.0799_0.15_220)] text-[oklch(1_0_0)] *:text-[lch(61.4645_21.17_286.262)] rounded-[8px] border-[1px] border-[oklch(0.1633_0.15_90)] p-[4px] shadow-[oklch(0.1633_0.15_90)_0px_0px_0px_0px]",
+              "warm": "bg-[oklch(0.0799_0.15_90)] text-[oklch(1_0_0)] *:text-[lch(61.4645_5.6_53.104)] rounded-[8px] border-[1px] border-[oklch(0.1633_0.15_220)] p-[4px] shadow-[oklch(0.1633_0.15_220)_0px_0px_0px_0px]"
+            }
+          },
+          "ak-layer-h-rotate-<number>": {
+            "class": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "children": {
+              "0": "bg-[oklch(0.1633_0.15_264.28)] text-[oklch(1_0_0)] *:text-[lch(65.5939_37.56_355.674)] rounded-[10px] border-[1px] border-[oklch(0_0.15_264.28_/_0.2834)] p-[4px] shadow-[oklch(0_0.15_264.28_/_0.2834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.1633_0.15_294.28)] text-[oklch(1_0_0)] *:text-[lch(65.5939_41.82_10.422)] rounded-[10px] border-[1px] border-[oklch(1_0_294.28_/_0.2834)] p-[4px] shadow-[oklch(1_0_294.28_/_0.2834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1633_0.15_324.28)] text-[oklch(1_0_0)] *:text-[lch(65.5939_37.37_13.146)] rounded-[10px] border-[1px] border-[oklch(1_0.15_324.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_324.28_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.1633_0.15_354.28)] text-[oklch(1_0_0)] *:text-[lch(65.5939_21.89_24.471)] rounded-[10px] border-[1px] border-[oklch(1_0.15_354.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_354.28_/_0.1834)_0px_0px_0px_0px]",
+              "120": "bg-[oklch(0.1633_0.15_24.28)] text-[oklch(1_0_0)] *:text-[lch(65.5939_10.24_101.129)] rounded-[10px] border-[1px] border-[oklch(1_0.15_24.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_24.28_/_0.1834)_0px_0px_0px_0px]",
+              "180": "bg-[oklch(0.1633_0.15_84.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_25.38_171.796)] rounded-[10px] border-[1px] border-[oklch(1_0.15_84.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_84.28_/_0.1834)_0px_0px_0px_0px]",
+              "240": "bg-[oklch(0.1633_0.15_144.28)] text-[oklch(1_0_0)] *:text-[lch(65.5939_41.95_284.985)] rounded-[10px] border-[1px] border-[oklch(1_0.15_144.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_144.28_/_0.1834)_0px_0px_0px_0px]",
+              "300": "bg-[oklch(0.1633_0.15_204.28)] text-[oklch(1_0_0)] *:text-[lch(65.5939_57.42_309.096)] rounded-[10px] border-[1px] border-[oklch(1_0.15_204.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_204.28_/_0.1834)_0px_0px_0px_0px]",
+              "360": "bg-[oklch(0.1633_0.15_264.28)] text-[oklch(1_0_0)] *:text-[lch(65.5939_37.56_355.674)] rounded-[10px] border-[1px] border-[oklch(1_0.15_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_264.28_/_0.1834)_0px_0px_0px_0px]"
+            }
+          },
+          "ak-layer-<hue>": {
+            "class": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-b-[15px] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] mb-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "children": {
+              "red": "bg-[oklch(0.1633_0.15_29.23)] text-[oklch(1_0_0)] *:text-[lch(65.5939_41.88_10.982)] rounded-bl-[11px] border-[1px] border-[oklch(1_0.15_29.23_/_0.1834)] p-[4px] mt-[-1px] mb-[-1px] ml-[-1px] shadow-[oklch(1_0.15_29.23_/_0.1834)_0px_0px_0px_0px]",
+              "green": "bg-[oklch(0.1633_0.15_142.5)] text-[oklch(1_0_0)] *:text-[lch(65.5939_21.36_148.997)] rounded-[10px] border-[1px] border-[oklch(1_0.15_142.5_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_142.5_/_0.1834)_0px_0px_0px_0px]",
+              "blue": "bg-[oklch(0.1633_0.15_264.05)] text-[oklch(1_0_0)] *:text-[lch(65.5939_58.68_302.187)] rounded-[10px] border-[1px] border-[oklch(1_0.15_264.05_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_264.05_/_0.1834)_0px_0px_0px_0px]",
+              "magenta": "bg-[oklch(0.1633_0.15_328.36)] text-[oklch(1_0_0)] *:text-[lch(65.5939_42.18_325.268)] rounded-[10px] border-[1px] border-[oklch(1_0.15_328.36_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_328.36_/_0.1834)_0px_0px_0px_0px]",
+              "split1": "bg-[oklch(0.1633_0.15_54.28)] text-[oklch(1_0_0)] *:text-[lch(65.5939_41.95_284.985)] rounded-[10px] border-[1px] border-[oklch(1_0.15_54.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_54.28_/_0.1834)_0px_0px_0px_0px]"
+            }
+          }
+        }
+      },
+      "ak-layer-30": {
+        "class": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+        "children": {
+          "ak-text-l-<number>": {
+            "class": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "children": {
+              "0": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(79.7476_0_0)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(79.7476_0.91_0)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(79.7476_3.34_267.669)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(79.7476_3.41_266.84)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(79.7476_3.42_266.506)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(79.7476_3.43_266.312)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(79.7476_3.44_266.185)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(79.7476_3.44_266.097)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(79.7476_3.45_266.033)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(88.3619_3.45_265.986)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+            }
+          },
+          "ak-text-<number>": {
+            "class": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "children": {
+              "0": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(79.7476_3.42_266.659)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(79.7476_3.43_266.404)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(79.7476_3.44_266.247)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(79.7476_3.44_266.14)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(79.7476_3.44_266.065)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(82.1732_3.45_266.01)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(93.7734_3.45_265.967)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+            }
+          },
+          "ak-layer-<number>": {
+            "class": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "children": {
+              "0": "bg-[oklch(0.2633_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_80_38.473)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.3633_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(83.2889_40_144.885)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.0633_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_80_288.648)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_79.88_1.657)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_80_78.514)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.93_0.0091_264.28)] text-[oklch(0_0_0_/_0.6441)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+            }
+          },
+          "ak-state-<number>": {
+            "class": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "children": {
+              "0": "bg-[oklch(0.2633_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_80_38.473)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.3633_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(83.2889_40_144.885)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.0633_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_80_288.648)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_79.88_1.657)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_80_78.514)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0_/_0.5333)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.8633_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.9633_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+            }
+          },
+          "ak-layer-invert": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] *:text-[lch(17.1886_3.45_266.052)] rounded-[3.35544e+07px] border-[1px] border-[oklch(0.8531_0.3_264.28)] p-[4px] shadow-[oklch(0.8531_0.3_264.28)_0px_0px_0px_0px]",
+          "ak-layer-darken-<number>": {
+            "class": "bg-[oklch(0.7834_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "children": {
+              "0": "bg-[oklch(0.8667_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_1px]",
+              "10": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3167_0.368_264.28)] p-[4px] shadow-[oklch(0.3167_0.368_264.28)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+            }
+          },
+          "ak-layer-lighten-<number>": {
+            "class": "bg-[oklch(0.2167_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2834)_0px_0px_0px_2px]",
+            "children": {
+              "0": "bg-[oklch(0.1333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4834)_0px_0px_0px_1px]",
+              "10": "bg-[oklch(0.2333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.3333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+            }
+          },
+          "ak-layer-push-<number>": {
+            "class": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[18px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-8px] ml-[-8px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "children": {
+              "0": "bg-[oklch(0.2633_0.0091_264.28)] text-[oklch(1_0_0)] rounded-tl-[6px] rounded-bl-[6px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.2834)_0px_0px_0px_1px]",
+              "10": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] *:text-[lch(17.1886_21.47_259.155)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] *:text-[lch(17.1886_40_177.505)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.8134_0.0091_264.28)] text-[oklch(0_0_0)] *:text-[lch(19.9962_3.45_265.948)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] *:text-[lch(1.4183_1.22_269.206)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+            }
+          },
+          "ak-layer-contrast-<number>": {
+            "class": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "children": {
+              "0": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.7962_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.9251_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] *:text-[lch(25.2896_80_276.896)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]"
+            }
+          },
+          "ak-layer-mix-<number>": {
+            "class": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "children": {
+              "0": "bg-[oklch(0.2633_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.2932_0.0172_22.0669)] text-[oklch(1_0_0)] *:text-[lch(73.3066_45.82_95.163)] rounded-[10px] border-[1px] border-[oklch(1_0.0172_22.0669_/_0.1834)] p-[4px] shadow-[oklch(1_0.0172_22.0669_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.3232_0.0394_33.8555)] text-[oklch(1_0_0)] *:text-[lch(76.4118_80_28.413)] rounded-[10px] border-[1px] border-[oklch(1_0.0394_33.8555_/_0.1834)] p-[4px] shadow-[oklch(1_0.0394_33.8555_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.3531_0.0621_37.0926)] text-[oklch(1_0_0)] *:text-[lch(79.7476_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0621_37.0926_/_0.1834)] p-[4px] shadow-[oklch(1_0.0621_37.0926_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.383_0.0849_38.5945)] text-[oklch(1_0_0)] *:text-[lch(83.2889_31.21_310.531)] rounded-[10px] border-[1px] border-[oklch(1_0.0849_38.5945_/_0.1834)] p-[4px] shadow-[oklch(1_0.0849_38.5945_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.413_0.1077_39.4603)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1077_39.4603_/_0.1834)] p-[4px] shadow-[oklch(1_0.1077_39.4603_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.4332_0.1306_40.0232)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1306_40.0232_/_0.1834)] p-[4px] shadow-[oklch(1_0.1306_40.0232_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.4281_0.1534_40.4185)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1534_40.4185_/_0.1834)] p-[4px] shadow-[oklch(1_0.1534_40.4185_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.423_0.1763_40.7113)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1763_40.7113_/_0.1834)] p-[4px] shadow-[oklch(1_0.1763_40.7113_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.4179_0.1991_40.9369)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1991_40.9369_/_0.1834)] p-[4px] shadow-[oklch(1_0.1991_40.9369_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0.7936_0.222_41.116)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.222_41.116_/_0.1834)] p-[4px] shadow-[oklch(1_0.222_41.116_/_0.1834)_0px_0px_0px_0px]"
+            }
+          },
+          "ak-layer-saturate-<number>": {
+            "class": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[16px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] m-[16px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "children": {
+              "0": "bg-[oklch(0.2633_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.2633_0.1091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.1091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.1091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.2633_0.2091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.2091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.2091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.2633_0.3091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.3091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.3091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2633_0.368_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.368_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.368_264.28_/_0.1834)_0px_0px_0px_0px]"
+            }
+          },
+          "ak-layer-desaturate-<number>": {
+            "class": "bg-[oklch(0.2633_0.368_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(0.3467_0.368_29.23)] p-[4px] m-[-5px] shadow-[oklch(0.3467_0.368_29.23)_0px_0px_0px_0px]",
+            "children": {
+              "0": "bg-[oklch(0.18_0.368_264.28)] text-[oklch(1_0_0)] rounded-[8px] border-[1px] border-[oklch(1_0.368_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.368_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.18_0.268_264.28)] text-[oklch(1_0_0)] rounded-[8px] border-[1px] border-[oklch(1_0.268_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.268_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.18_0.168_264.28)] text-[oklch(1_0_0)] rounded-[8px] border-[1px] border-[oklch(1_0.168_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.168_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.18_0.068_264.28)] text-[oklch(1_0_0)] rounded-[8px] border-[1px] border-[oklch(1_0.068_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.068_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "cool": "bg-[oklch(0.18_0.15_220)] text-[oklch(1_0_0)] *:text-[lch(65.5939_33.4_262.06)] rounded-[8px] border-[1px] border-[oklch(0.2633_0.15_90)] p-[4px] shadow-[oklch(0.2633_0.15_90)_0px_0px_0px_0px]",
+              "warm": "bg-[oklch(0.18_0.15_90)] text-[oklch(1_0_0)] *:text-[lch(65.5939_21.79_34.64)] rounded-[8px] border-[1px] border-[oklch(0.2633_0.15_220)] p-[4px] shadow-[oklch(0.2633_0.15_220)_0px_0px_0px_0px]"
+            }
+          },
+          "ak-layer-h-rotate-<number>": {
+            "class": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "children": {
+              "0": "bg-[oklch(0.2633_0.15_264.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_47.06_353.932)] rounded-[10px] border-[1px] border-[oklch(0_0.15_264.28_/_0.2834)] p-[4px] shadow-[oklch(0_0.15_264.28_/_0.2834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.2633_0.15_294.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_53.75_26.4)] rounded-[10px] border-[1px] border-[oklch(1_0_294.28_/_0.2834)] p-[4px] shadow-[oklch(1_0_294.28_/_0.2834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.2633_0.15_324.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_52.96_39.411)] rounded-[10px] border-[1px] border-[oklch(1_0.15_324.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_324.28_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.2633_0.15_354.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_42.07_58.921)] rounded-[10px] border-[1px] border-[oklch(1_0.15_354.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_354.28_/_0.1834)_0px_0px_0px_0px]",
+              "120": "bg-[oklch(0.2633_0.15_24.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_37.62_102.247)] rounded-[10px] border-[1px] border-[oklch(1_0.15_24.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_24.28_/_0.1834)_0px_0px_0px_0px]",
+              "180": "bg-[oklch(0.2633_0.15_84.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_56.89_174.497)] rounded-[10px] border-[1px] border-[oklch(1_0.15_84.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_84.28_/_0.1834)_0px_0px_0px_0px]",
+              "240": "bg-[oklch(0.2633_0.15_144.28)] text-[oklch(1_0_0)] *:text-[lch(73.3066_42.93_267.319)] rounded-[10px] border-[1px] border-[oklch(1_0.15_144.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_144.28_/_0.1834)_0px_0px_0px_0px]",
+              "300": "bg-[oklch(0.2633_0.15_204.28)] text-[oklch(1_0_0)] *:text-[lch(73.3066_62.37_308.588)] rounded-[10px] border-[1px] border-[oklch(1_0.15_204.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_204.28_/_0.1834)_0px_0px_0px_0px]",
+              "360": "bg-[oklch(0.2633_0.15_264.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_47.06_353.932)] rounded-[10px] border-[1px] border-[oklch(1_0.15_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_264.28_/_0.1834)_0px_0px_0px_0px]"
+            }
+          },
+          "ak-layer-<hue>": {
+            "class": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-b-[15px] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] mb-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "children": {
+              "red": "bg-[oklch(0.2633_0.15_29.23)] text-[oklch(1_0_0)] *:text-[lch(70.456_54.62_29.148)] rounded-bl-[11px] border-[1px] border-[oklch(1_0.15_29.23_/_0.1834)] p-[4px] mt-[-1px] mb-[-1px] ml-[-1px] shadow-[oklch(1_0.15_29.23_/_0.1834)_0px_0px_0px_0px]",
+              "green": "bg-[oklch(0.2633_0.15_142.5)] text-[oklch(1_0_0)] *:text-[lch(73.3066_51.54_141.813)] rounded-[10px] border-[1px] border-[oklch(1_0.15_142.5_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_142.5_/_0.1834)_0px_0px_0px_0px]",
+              "blue": "bg-[oklch(0.2633_0.15_264.05)] text-[oklch(1_0_0)] *:text-[lch(70.456_58.87_295.708)] rounded-[10px] border-[1px] border-[oklch(1_0.15_264.05_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_264.05_/_0.1834)_0px_0px_0px_0px]",
+              "magenta": "bg-[oklch(0.2633_0.15_328.36)] text-[oklch(1_0_0)] *:text-[lch(70.456_51.98_327.32)] rounded-[10px] border-[1px] border-[oklch(1_0.15_328.36_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_328.36_/_0.1834)_0px_0px_0px_0px]",
+              "split1": "bg-[oklch(0.2633_0.15_54.28)] text-[oklch(1_0_0)] *:text-[lch(70.456_42.93_267.319)] rounded-[10px] border-[1px] border-[oklch(1_0.15_54.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_54.28_/_0.1834)_0px_0px_0px_0px]"
+            }
+          }
+        }
+      },
+      "ak-layer-40": {
+        "class": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+        "children": {
+          "ak-text-l-<number>": {
+            "class": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "children": {
+              "0": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(83.2889_0_0)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(83.2889_0.91_0)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(83.2889_3.34_267.669)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(83.2889_3.41_266.84)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(83.2889_3.42_266.506)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(83.2889_3.43_266.312)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(83.2889_3.44_266.185)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(83.2889_3.44_266.097)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(83.2889_3.45_266.033)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(88.3619_3.45_265.986)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+            }
+          },
+          "ak-text-<number>": {
+            "class": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "children": {
+              "0": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(83.2889_3.42_266.566)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(83.2889_3.43_266.348)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(83.2889_3.44_266.21)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(83.2889_3.44_266.115)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(83.2889_3.45_266.046)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(85.7066_3.45_265.995)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(97.3068_3.45_265.956)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(99.9621_3.45_265.948)] rounded-[5px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+            }
+          },
+          "ak-layer-<number>": {
+            "class": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "children": {
+              "0": "bg-[oklch(0.2938_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(73.3066_80_38.473)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.1938_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(65.5939_71.72_144.885)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.0938_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_80_288.648)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_79.88_1.657)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.8605_0.0091_264.28)] text-[oklch(0_0_0)] *:text-[lch(25.2896_80_78.514)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.9605_0.0091_264.28)] text-[oklch(0_0_0_/_0.6234)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+            }
+          },
+          "ak-state-<number>": {
+            "class": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "children": {
+              "0": "bg-[oklch(0.2938_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(73.3066_80_38.473)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.3938_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(87.0112_40_144.885)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.0938_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_80_288.648)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_79.88_1.657)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_80_78.514)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.7938_0.0091_264.28)] text-[oklch(0_0_0_/_0.7367)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.8938_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.9938_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+            }
+          },
+          "ak-layer-invert": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] *:text-[lch(94.908_3.43_266.377)] rounded-[3.35544e+07px] border-[1px] border-[oklch(0.5438_0.3_264.28)] p-[4px] shadow-[oklch(0.5438_0.3_264.28)_0px_0px_0px_0px]",
+          "ak-layer-darken-<number>": {
+            "class": "bg-[oklch(0.7834_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "children": {
+              "0": "bg-[oklch(0.8667_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_1px]",
+              "10": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3167_0.368_264.28)] p-[4px] shadow-[oklch(0.3167_0.368_264.28)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+            }
+          },
+          "ak-layer-lighten-<number>": {
+            "class": "bg-[oklch(0.2167_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2834)_0px_0px_0px_2px]",
+            "children": {
+              "0": "bg-[oklch(0.1333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4834)_0px_0px_0px_1px]",
+              "10": "bg-[oklch(0.2333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.3333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+            }
+          },
+          "ak-layer-push-<number>": {
+            "class": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[18px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-8px] ml-[-8px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "children": {
+              "0": "bg-[oklch(0.2938_0.0091_264.28)] text-[oklch(1_0_0)] rounded-tl-[6px] rounded-bl-[6px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.2834)_0px_0px_0px_1px]",
+              "10": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] *:text-[lch(17.1886_21.47_259.155)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] *:text-[lch(17.1886_40_177.505)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.8438_0.0091_264.28)] text-[oklch(0_0_0)] *:text-[lch(25.2896_3.45_265.948)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] *:text-[lch(1.4183_1.22_269.206)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+            }
+          },
+          "ak-layer-contrast-<number>": {
+            "class": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "children": {
+              "0": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.7962_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.9251_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] *:text-[lch(25.2896_80_276.896)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1834)_0px_0px_0px_0px]"
+            }
+          },
+          "ak-layer-mix-<number>": {
+            "class": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "children": {
+              "0": "bg-[oklch(0.2938_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.3206_0.0172_22.0669)] text-[oklch(1_0_0)] *:text-[lch(76.4118_53.66_95.382)] rounded-[10px] border-[1px] border-[oklch(1_0.0172_22.0669_/_0.1834)] p-[4px] shadow-[oklch(1_0.0172_22.0669_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.3475_0.0394_33.8555)] text-[oklch(1_0_0)] *:text-[lch(79.7476_80_32.48)] rounded-[10px] border-[1px] border-[oklch(1_0.0394_33.8555_/_0.1834)] p-[4px] shadow-[oklch(1_0.0394_33.8555_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.3744_0.0621_37.0926)] text-[oklch(1_0_0)] *:text-[lch(83.2889_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.0621_37.0926_/_0.1834)] p-[4px] shadow-[oklch(1_0.0621_37.0926_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4013_0.0849_38.5945)] text-[oklch(1_0_0)] *:text-[lch(87.0112_31.18_310.376)] rounded-[10px] border-[1px] border-[oklch(1_0.0849_38.5945_/_0.1834)] p-[4px] shadow-[oklch(1_0.0849_38.5945_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.4282_0.1077_39.4603)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1077_39.4603_/_0.1834)] p-[4px] shadow-[oklch(1_0.1077_39.4603_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.4332_0.1306_40.0232)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1306_40.0232_/_0.1834)] p-[4px] shadow-[oklch(1_0.1306_40.0232_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.4281_0.1534_40.4185)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1534_40.4185_/_0.1834)] p-[4px] shadow-[oklch(1_0.1534_40.4185_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.423_0.1763_40.7113)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1763_40.7113_/_0.1834)] p-[4px] shadow-[oklch(1_0.1763_40.7113_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.4179_0.1991_40.9369)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.1991_40.9369_/_0.1834)] p-[4px] shadow-[oklch(1_0.1991_40.9369_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0.7936_0.222_41.116)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.222_41.116_/_0.1834)] p-[4px] shadow-[oklch(1_0.222_41.116_/_0.1834)_0px_0px_0px_0px]"
+            }
+          },
+          "ak-layer-saturate-<number>": {
+            "class": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[16px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] m-[16px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "children": {
+              "0": "bg-[oklch(0.2938_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.2938_0.1091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.1091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.1091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.2938_0.2091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.2091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.2091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.2938_0.3091_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.3091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.3091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2938_0.368_264.28)] text-[oklch(1_0_0)] rounded-[11px] border-[1px] border-[oklch(1_0.368_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.368_264.28_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-desaturate-<number>": {
             "class": "bg-[oklch(0.2938_0.368_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[1px] border-[oklch(0.3771_0.368_29.23)] p-[4px] m-[-5px] shadow-[oklch(0.3771_0.368_29.23)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(0.1271_0.368_264.28)] text-[oklch(1_0_0)] rounded-[8px] border-[1px] border-[oklch(1_0.368_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.368_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.1271_0.268_264.28)] text-[oklch(1_0_0)] rounded-[8px] border-[1px] border-[oklch(1_0.268_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.268_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.1271_0.168_264.28)] text-[oklch(1_0_0)] rounded-[8px] border-[1px] border-[oklch(1_0.168_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.168_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.1271_0.068_264.28)] text-[oklch(1_0_0)] rounded-[8px] border-[1px] border-[oklch(1_0.068_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.068_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "cool": "bg-[oklch(0.1271_0.15_220)] text-[oklch(1_0_0)] *:text-[lch(63.5464_28.19_276.527)] rounded-[8px] border-[1px] border-[oklch(0.2104_0.15_90)] p-[4px] shadow-[oklch(0.2104_0.15_90)_0px_0px_0px_0px]",
-              "warm": "bg-[oklch(0.1271_0.15_90)] text-[oklch(1_0_0)] *:text-[lch(61.4645_11.44_25.258)] rounded-[8px] border-[1px] border-[oklch(0.2104_0.15_220)] p-[4px] shadow-[oklch(0.2104_0.15_220)_0px_0px_0px_0px]"
+              "0": "bg-[oklch(0.2104_0.368_264.28)] text-[oklch(1_0_0)] rounded-[8px] border-[1px] border-[oklch(1_0.368_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.368_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.2104_0.268_264.28)] text-[oklch(1_0_0)] rounded-[8px] border-[1px] border-[oklch(1_0.268_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.268_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.2104_0.168_264.28)] text-[oklch(1_0_0)] rounded-[8px] border-[1px] border-[oklch(1_0.168_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.168_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.2104_0.068_264.28)] text-[oklch(1_0_0)] rounded-[8px] border-[1px] border-[oklch(1_0.068_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.068_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "cool": "bg-[oklch(0.2104_0.15_220)] text-[oklch(1_0_0)] *:text-[lch(67.8802_35.66_251.42)] rounded-[8px] border-[1px] border-[oklch(0.2938_0.15_90)] p-[4px] shadow-[oklch(0.2938_0.15_90)_0px_0px_0px_0px]",
+              "warm": "bg-[oklch(0.2104_0.15_90)] text-[oklch(1_0_0)] *:text-[lch(67.8802_27.62_46.685)] rounded-[8px] border-[1px] border-[oklch(0.2938_0.15_220)] p-[4px] shadow-[oklch(0.2938_0.15_220)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-h-rotate-<number>": {
-            "class": "bg-[oklch(0.2938_0.0091_264.28)] text-[oklch(1_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(0.1271_0.15_264.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_25.76_356.347)] rounded-[10px] border-[1px] border-[oklch(0_0.15_264.28_/_0.2834)] p-[4px] shadow-[oklch(0_0.15_264.28_/_0.2834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.1271_0.15_294.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_30.42_7.044)] rounded-[10px] border-[1px] border-[oklch(1_0_294.28_/_0.2834)] p-[4px] shadow-[oklch(1_0_294.28_/_0.2834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1271_0.15_324.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_26.34_8.699)] rounded-[10px] border-[1px] border-[oklch(1_0.15_324.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_324.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.1271_0.15_354.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_13.97_20.138)] rounded-[10px] border-[1px] border-[oklch(1_0.15_354.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_354.28_/_0.1834)_0px_0px_0px_0px]",
-              "120": "bg-[oklch(0.1271_0.15_24.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_4.92_96.779)] rounded-[10px] border-[1px] border-[oklch(1_0.15_24.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_24.28_/_0.1834)_0px_0px_0px_0px]",
-              "180": "bg-[oklch(0.1271_0.15_84.28)] text-[oklch(1_0_0)] *:text-[lch(61.4645_14.49_171.045)] rounded-[10px] border-[1px] border-[oklch(1_0.15_84.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_84.28_/_0.1834)_0px_0px_0px_0px]",
-              "240": "bg-[oklch(0.1271_0.15_144.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_38.26_289.1)] rounded-[10px] border-[1px] border-[oklch(1_0.15_144.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_144.28_/_0.1834)_0px_0px_0px_0px]",
-              "300": "bg-[oklch(0.1271_0.15_204.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_48.05_305.206)] rounded-[10px] border-[1px] border-[oklch(1_0.15_204.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_204.28_/_0.1834)_0px_0px_0px_0px]",
-              "360": "bg-[oklch(0.1271_0.15_264.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_25.76_356.347)] rounded-[10px] border-[1px] border-[oklch(1_0.15_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_264.28_/_0.1834)_0px_0px_0px_0px]"
+              "0": "bg-[oklch(0.2938_0.15_264.28)] text-[oklch(1_0_0)] *:text-[lch(73.3066_47.33_353.939)] rounded-[10px] border-[1px] border-[oklch(0_0.15_264.28_/_0.2834)] p-[4px] shadow-[oklch(0_0.15_264.28_/_0.2834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.2938_0.15_294.28)] text-[oklch(1_0_0)] *:text-[lch(73.3066_55.46_30.021)] rounded-[10px] border-[1px] border-[oklch(1_0_294.28_/_0.2834)] p-[4px] shadow-[oklch(1_0_294.28_/_0.2834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.2938_0.15_324.28)] text-[oklch(1_0_0)] *:text-[lch(73.3066_58.18_46.256)] rounded-[10px] border-[1px] border-[oklch(1_0.15_324.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_324.28_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.2938_0.15_354.28)] text-[oklch(1_0_0)] *:text-[lch(73.3066_50.08_65.665)] rounded-[10px] border-[1px] border-[oklch(1_0.15_354.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_354.28_/_0.1834)_0px_0px_0px_0px]",
+              "120": "bg-[oklch(0.2938_0.15_24.28)] text-[oklch(1_0_0)] *:text-[lch(73.3066_46.34_101.295)] rounded-[10px] border-[1px] border-[oklch(1_0.15_24.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_24.28_/_0.1834)_0px_0px_0px_0px]",
+              "180": "bg-[oklch(0.2938_0.15_84.28)] text-[oklch(1_0_0)] *:text-[lch(73.3066_59.75_174.788)] rounded-[10px] border-[1px] border-[oklch(1_0.15_84.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_84.28_/_0.1834)_0px_0px_0px_0px]",
+              "240": "bg-[oklch(0.2938_0.15_144.28)] text-[oklch(1_0_0)] *:text-[lch(76.4118_43.24_262.928)] rounded-[10px] border-[1px] border-[oklch(1_0.15_144.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_144.28_/_0.1834)_0px_0px_0px_0px]",
+              "300": "bg-[oklch(0.2938_0.15_204.28)] text-[oklch(1_0_0)] *:text-[lch(76.4118_61.05_307.211)] rounded-[10px] border-[1px] border-[oklch(1_0.15_204.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_204.28_/_0.1834)_0px_0px_0px_0px]",
+              "360": "bg-[oklch(0.2938_0.15_264.28)] text-[oklch(1_0_0)] *:text-[lch(73.3066_47.33_353.939)] rounded-[10px] border-[1px] border-[oklch(1_0.15_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_264.28_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-<hue>": {
-            "class": "bg-[oklch(0.2938_0.0091_264.28)] text-[oklch(1_0_0)] rounded-b-[15px] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] mb-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.3771_0.0091_264.28)] text-[oklch(1_0_0)] rounded-b-[15px] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] mb-[-5px] ml-[-5px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "red": "bg-[oklch(0.1271_0.15_29.23)] text-[oklch(1_0_0)] *:text-[lch(63.5464_30.52_7.163)] rounded-bl-[11px] border-[1px] border-[oklch(1_0.15_29.23_/_0.1834)] p-[4px] mt-[-1px] mb-[-1px] ml-[-1px] shadow-[oklch(1_0.15_29.23_/_0.1834)_0px_0px_0px_0px]",
-              "green": "bg-[oklch(0.1271_0.15_142.5)] text-[oklch(1_0_0)] *:text-[lch(63.5464_11.62_151.664)] rounded-[10px] border-[1px] border-[oklch(1_0.15_142.5_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_142.5_/_0.1834)_0px_0px_0px_0px]",
-              "blue": "bg-[oklch(0.1271_0.15_264.05)] text-[oklch(1_0_0)] *:text-[lch(63.5464_52.04_301.012)] rounded-[10px] border-[1px] border-[oklch(1_0.15_264.05_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_264.05_/_0.1834)_0px_0px_0px_0px]",
-              "magenta": "bg-[oklch(0.1271_0.15_328.36)] text-[oklch(1_0_0)] *:text-[lch(63.5464_30.13_320.79)] rounded-[10px] border-[1px] border-[oklch(1_0.15_328.36_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_328.36_/_0.1834)_0px_0px_0px_0px]",
-              "split1": "bg-[oklch(0.1271_0.15_54.28)] text-[oklch(1_0_0)] *:text-[lch(63.5464_38.26_289.1)] rounded-[10px] border-[1px] border-[oklch(1_0.15_54.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_54.28_/_0.1834)_0px_0px_0px_0px]"
+              "red": "bg-[oklch(0.2938_0.15_29.23)] text-[oklch(1_0_0)] *:text-[lch(73.3066_56.99_33.582)] rounded-bl-[11px] border-[1px] border-[oklch(1_0.15_29.23_/_0.1834)] p-[4px] mt-[-1px] mb-[-1px] ml-[-1px] shadow-[oklch(1_0.15_29.23_/_0.1834)_0px_0px_0px_0px]",
+              "green": "bg-[oklch(0.2938_0.15_142.5)] text-[oklch(1_0_0)] *:text-[lch(76.4118_54.89_137.777)] rounded-[10px] border-[1px] border-[oklch(1_0.15_142.5_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_142.5_/_0.1834)_0px_0px_0px_0px]",
+              "blue": "bg-[oklch(0.2938_0.15_264.05)] text-[oklch(1_0_0)] *:text-[lch(73.3066_57.34_292.734)] rounded-[10px] border-[1px] border-[oklch(1_0.15_264.05_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_264.05_/_0.1834)_0px_0px_0px_0px]",
+              "magenta": "bg-[oklch(0.2938_0.15_328.36)] text-[oklch(1_0_0)] *:text-[lch(73.3066_51.88_327.204)] rounded-[10px] border-[1px] border-[oklch(1_0.15_328.36_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_328.36_/_0.1834)_0px_0px_0px_0px]",
+              "split1": "bg-[oklch(0.2938_0.15_54.28)] text-[oklch(1_0_0)] *:text-[lch(73.3066_43.24_262.928)] rounded-[10px] border-[1px] border-[oklch(1_0.15_54.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.15_54.28_/_0.1834)_0px_0px_0px_0px]"
             }
           }
         }
@@ -3389,14 +3389,14 @@
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.2167_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2834)_0px_0px_0px_2px]",
             "children": {
-              "0": "bg-[oklch(0.05_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.15_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.25_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.35_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.45_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.8167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.9167_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.1333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4834)_0px_0px_0px_1px]",
+              "10": "bg-[oklch(0.2333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.3333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
@@ -2414,14 +2414,14 @@
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.2167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2834)_0px_0px_0px_2px]",
             "children": {
-              "0": "bg-[oklch(0.05_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.15_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.25_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.35_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.45_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.8167_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.9167_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.1333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4834)_0px_0px_0px_1px]",
+              "10": "bg-[oklch(0.2333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.3333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
@@ -2526,55 +2526,55 @@
         "class": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
         "children": {
           "ak-text-l-<number>": {
-            "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0.906_0.09_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(7.2371_0.35_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(18.8115_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(30.4115_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
+              "0": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0.906_0.09_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(7.2371_0.35_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(18.8115_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(30.4115_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-text-<number>": {
-            "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(30.4115_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(18.8115_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(7.2371_0.35_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0.906_0.09_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
+              "0": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(28.4801_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(16.8801_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(5.5767_0.3_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0.5249_0.06_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-<number>": {
-            "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
               "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_80_38.473)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_71.72_144.885)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_80_288.648)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.9667_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(35.1061_71.72_144.885)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.8667_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_80_288.648)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "30": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_79.88_1.657)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "40": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_80_78.514)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "50": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0_/_0.6961)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.3167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.2167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.1167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.0167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.1_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-state-<number>": {
-            "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
               "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_80_38.473)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "10": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_71.72_144.885)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
@@ -2609,28 +2609,28 @@
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.2167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2834)_0px_0px_0px_2px]",
             "children": {
-              "0": "bg-[oklch(0.05_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.15_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.25_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.35_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.45_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.8167_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.9167_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.1333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4834)_0px_0px_0px_1px]",
+              "10": "bg-[oklch(0.2333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.3333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
-            "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[18px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-8px] ml-[-8px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[18px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-8px] ml-[-8px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
               "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-tl-[6px] rounded-bl-[6px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.2834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_21.47_259.155)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_21.47_259.155)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "20": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(99.0429_20_131.99)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "30": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(100_0.38_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.35_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(79.7476_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3333_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(79.7476_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.15_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "60": "bg-[oklch(0.0833_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "70": "bg-[oklch(0.0833_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "80": "bg-[oklch(0.0833_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
@@ -2639,7 +2639,7 @@
             }
           },
           "ak-layer-contrast-<number>": {
-            "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
               "0": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
               "10": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
@@ -2655,23 +2655,23 @@
             }
           },
           "ak-layer-mix-<number>": {
-            "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
               "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "10": "bg-[oklch(1_0.0213_42.1982)] text-[oklch(0_0_0)] *:text-[lch(37.4589_60.86_102.462)] rounded-[10px] border-[1px] border-[oklch(0_0.0213_42.1982_/_0.1834)] p-[4px] shadow-[oklch(0_0.0213_42.1982_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0436_41.586)] text-[oklch(0_0_0)] *:text-[lch(37.4589_80_51.843)] rounded-[10px] border-[1px] border-[oklch(0_0.0436_41.586_/_0.1834)] p-[4px] shadow-[oklch(0_0.0436_41.586_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.9772_0.0659_41.3881)] text-[oklch(0_0_0)] *:text-[lch(32.7197_0.01_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0659_41.3881_/_0.1834)] p-[4px] shadow-[oklch(0_0.0659_41.3881_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.9418_0.0882_41.2902)] text-[oklch(0_0_0)] *:text-[lch(30.2938_32.39_125.941)] rounded-[10px] border-[1px] border-[oklch(0_0.0882_41.2902_/_0.1834)] p-[4px] shadow-[oklch(0_0.0882_41.2902_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.9064_0.1105_41.2319)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1105_41.2319_/_0.1834)] p-[4px] shadow-[oklch(0_0.1105_41.2319_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.871_0.1328_41.1931)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1328_41.1931_/_0.1834)] p-[4px] shadow-[oklch(0_0.1328_41.1931_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.8356_0.1551_41.1655)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1551_41.1655_/_0.1834)] p-[4px] shadow-[oklch(0_0.1551_41.1655_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.8002_0.1774_41.1449)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1774_41.1449_/_0.1834)] p-[4px] shadow-[oklch(0_0.1774_41.1449_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.9992_0.0436_41.586)] text-[oklch(0_0_0)] *:text-[lch(35.1061_80_51.869)] rounded-[10px] border-[1px] border-[oklch(0_0.0436_41.586_/_0.1834)] p-[4px] shadow-[oklch(0_0.0436_41.586_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.9655_0.0659_41.3881)] text-[oklch(0_0_0)] *:text-[lch(32.7197_0.01_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0659_41.3881_/_0.1834)] p-[4px] shadow-[oklch(0_0.0659_41.3881_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.9318_0.0882_41.2902)] text-[oklch(0_0_0)] *:text-[lch(27.8204_32.4_125.917)] rounded-[10px] border-[1px] border-[oklch(0_0.0882_41.2902_/_0.1834)] p-[4px] shadow-[oklch(0_0.0882_41.2902_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.898_0.1105_41.2319)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1105_41.2319_/_0.1834)] p-[4px] shadow-[oklch(0_0.1105_41.2319_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.8643_0.1328_41.1931)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1328_41.1931_/_0.1834)] p-[4px] shadow-[oklch(0_0.1328_41.1931_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.8306_0.1551_41.1655)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1551_41.1655_/_0.1834)] p-[4px] shadow-[oklch(0_0.1551_41.1655_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.7968_0.1774_41.1449)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1774_41.1449_/_0.1834)] p-[4px] shadow-[oklch(0_0.1774_41.1449_/_0.1834)_0px_0px_0px_0px]",
               "90": "bg-[oklch(0.7911_0.1997_41.1288)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1997_41.1288_/_0.1834)] p-[4px] shadow-[oklch(0_0.1997_41.1288_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(0.7936_0.222_41.116)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.222_41.116_/_0.1834)] p-[4px] shadow-[oklch(0_0.222_41.116_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-saturate-<number>": {
-            "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[16px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] m-[16px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[16px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] m-[16px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
               "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "10": "bg-[oklch(1_0.1011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.1011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.1011_197.14_/_0.1834)_0px_0px_0px_0px]",
@@ -2692,7 +2692,7 @@
             }
           },
           "ak-layer-h-rotate-<number>": {
-            "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1834)] border-b-[oklch(0_0.0011_197.14_/_0.1834)] border-l-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1834)] border-b-[oklch(0_0.0011_197.14_/_0.1834)] border-l-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
               "0": "bg-[oklch(1_0.15_197.14)] text-[oklch(0_0_0)] *:text-[lch(32.7197_56.05_291.765)] rounded-[10px] border-[1px] border-[oklch(0_0.15_197.14_/_0.2834)] p-[4px] shadow-[oklch(0_0.15_197.14_/_0.2834)_0px_0px_0px_0px]",
               "30": "bg-[oklch(1_0.15_227.14)] text-[oklch(0_0_0)] *:text-[lch(32.7197_53.75_316.058)] rounded-[10px] border-[1px] border-[oklch(1_0_227.14_/_0.2834)] p-[4px] shadow-[oklch(1_0_227.14_/_0.2834)_0px_0px_0px_0px]",
@@ -2706,7 +2706,7 @@
             }
           },
           "ak-layer-<hue>": {
-            "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-b-[15px] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1834)] border-b-[oklch(0_0.0011_197.14_/_0.1834)] border-l-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] mb-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-b-[15px] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1834)] border-b-[oklch(0_0.0011_197.14_/_0.1834)] border-l-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] mb-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
               "red": "bg-[oklch(1_0.15_29.23)] text-[oklch(0_0_0)] *:text-[lch(30.2938_54.47_33.498)] rounded-bl-[11px] border-[1px] border-[oklch(0_0.15_29.23_/_0.1834)] p-[4px] mt-[-1px] mb-[-1px] ml-[-1px] shadow-[oklch(0_0.15_29.23_/_0.1834)_0px_0px_0px_0px]",
               "green": "bg-[oklch(1_0.15_142.5)] text-[oklch(0_0_0)] *:text-[lch(32.7197_54.12_138.249)] rounded-[10px] border-[1px] border-[oklch(0_0.15_142.5_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_142.5_/_0.1834)_0px_0px_0px_0px]",
@@ -2721,66 +2721,66 @@
         "class": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
         "children": {
           "ak-text-l-<number>": {
-            "class": "bg-[oklch(0.9667_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0.906_0.09_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(7.2371_0.35_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(18.8115_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(30.4115_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
+              "0": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0.906_0.09_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(7.2371_0.35_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(18.8115_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-text-<number>": {
-            "class": "bg-[oklch(0.9667_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(30.4115_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(18.8115_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(7.2371_0.35_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0.906_0.09_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
+              "0": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(16.8801_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(5.5767_0.3_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0.5249_0.06_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-<number>": {
-            "class": "bg-[oklch(0.9667_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_80_38.473)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_71.72_144.885)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_80_288.648)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_79.88_1.657)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_80_78.514)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0_/_0.6961)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.3167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.2167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.1167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.0167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.9667_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(35.1061_80_38.473)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.8667_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_71.72_144.885)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_80_288.648)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_79.88_1.657)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_80_78.514)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0_/_0.6449)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.1_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-state-<number>": {
-            "class": "bg-[oklch(0.9667_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_80_38.473)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_71.72_144.885)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(19.9962_40_288.648)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.9667_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(35.1061_80_38.473)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.8667_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_71.72_144.885)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.7689_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(17.1886_40_288.648)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "30": "bg-[oklch(0.7689_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(17.1886_40_1.657)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "40": "bg-[oklch(0.7689_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(17.1886_40_78.514)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "50": "bg-[oklch(0.7689_0.0011_197.14)] text-[oklch(0_0_0_/_0.7528)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.1_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.3667_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.2667_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.1667_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.0667_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
@@ -2789,43 +2789,43 @@
             "class": "bg-[oklch(0.9667_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1834)] border-b-[oklch(0_0.0011_197.14_/_0.1834)] border-l-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
               "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.7834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.7_0.368_197.14)] p-[4px] shadow-[oklch(0.7_0.368_197.14)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.9501_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.8501_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.7689_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6855_0.368_197.14)] p-[4px] shadow-[oklch(0.6855_0.368_197.14)_0px_0px_0px_0px]",
               "40": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.4167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.3167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.2167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.1167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.0167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.3834_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.2834_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.1834_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.0833_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.2167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2834)_0px_0px_0px_2px]",
             "children": {
-              "0": "bg-[oklch(0.05_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.15_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.25_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.35_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.45_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.8167_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.9167_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.1333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4834)_0px_0px_0px_1px]",
+              "10": "bg-[oklch(0.2333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.3333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
-            "class": "bg-[oklch(0.9667_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[18px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-8px] ml-[-8px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[18px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-8px] ml-[-8px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-tl-[6px] rounded-bl-[6px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.2834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_21.47_259.155)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.9667_0.0011_197.14)] text-[oklch(0_0_0)] rounded-tl-[6px] rounded-bl-[6px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.2834)_0px_0px_0px_1px]",
+              "10": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(99.0429_20_259.155)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "20": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(99.0429_20_131.99)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(100_0.38_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.35_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(79.7476_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4167_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(100_0.38_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2333_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(67.8802_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.0833_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "60": "bg-[oklch(0.0833_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "70": "bg-[oklch(0.0833_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "80": "bg-[oklch(0.0833_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
@@ -2834,14 +2834,14 @@
             }
           },
           "ak-layer-contrast-<number>": {
-            "class": "bg-[oklch(0.9667_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
               "0": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
               "10": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
               "20": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2666_0.245_262.881)] text-[oklch(1_0_0)] *:text-[lch(70.456_80_309.677)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.0833_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.325_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1416_0.245_262.881)] text-[oklch(1_0_0)] *:text-[lch(65.5939_80_315.008)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
               "60": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
               "70": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
               "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
@@ -2850,29 +2850,29 @@
             }
           },
           "ak-layer-mix-<number>": {
-            "class": "bg-[oklch(0.9667_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(1_0.0213_42.1982)] text-[oklch(0_0_0)] *:text-[lch(37.4589_60.86_102.462)] rounded-[10px] border-[1px] border-[oklch(0_0.0213_42.1982_/_0.1834)] p-[4px] shadow-[oklch(0_0.0213_42.1982_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0436_41.586)] text-[oklch(0_0_0)] *:text-[lch(37.4589_80_51.843)] rounded-[10px] border-[1px] border-[oklch(0_0.0436_41.586_/_0.1834)] p-[4px] shadow-[oklch(0_0.0436_41.586_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.9772_0.0659_41.3881)] text-[oklch(0_0_0)] *:text-[lch(32.7197_0.01_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0659_41.3881_/_0.1834)] p-[4px] shadow-[oklch(0_0.0659_41.3881_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.9418_0.0882_41.2902)] text-[oklch(0_0_0)] *:text-[lch(30.2938_32.39_125.941)] rounded-[10px] border-[1px] border-[oklch(0_0.0882_41.2902_/_0.1834)] p-[4px] shadow-[oklch(0_0.0882_41.2902_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.9064_0.1105_41.2319)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1105_41.2319_/_0.1834)] p-[4px] shadow-[oklch(0_0.1105_41.2319_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.871_0.1328_41.1931)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1328_41.1931_/_0.1834)] p-[4px] shadow-[oklch(0_0.1328_41.1931_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.8356_0.1551_41.1655)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1551_41.1655_/_0.1834)] p-[4px] shadow-[oklch(0_0.1551_41.1655_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.8002_0.1774_41.1449)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1774_41.1449_/_0.1834)] p-[4px] shadow-[oklch(0_0.1774_41.1449_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.9667_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.943_0.0213_42.1982)] text-[oklch(0_0_0)] *:text-[lch(32.7197_61.42_102.093)] rounded-[10px] border-[1px] border-[oklch(0_0.0213_42.1982_/_0.1834)] p-[4px] shadow-[oklch(0_0.0213_42.1982_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.9192_0.0436_41.586)] text-[oklch(0_0_0)] *:text-[lch(30.2938_80_57.21)] rounded-[10px] border-[1px] border-[oklch(0_0.0436_41.586_/_0.1834)] p-[4px] shadow-[oklch(0_0.0436_41.586_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.8955_0.0659_41.3881)] text-[oklch(0_0_0)] *:text-[lch(25.2896_0.01_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0659_41.3881_/_0.1834)] p-[4px] shadow-[oklch(0_0.0659_41.3881_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.8718_0.0882_41.2902)] text-[oklch(0_0_0)] *:text-[lch(22.6877_32.44_125.761)] rounded-[10px] border-[1px] border-[oklch(0_0.0882_41.2902_/_0.1834)] p-[4px] shadow-[oklch(0_0.0882_41.2902_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.848_0.1105_41.2319)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1105_41.2319_/_0.1834)] p-[4px] shadow-[oklch(0_0.1105_41.2319_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.8243_0.1328_41.1931)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1328_41.1931_/_0.1834)] p-[4px] shadow-[oklch(0_0.1328_41.1931_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.8006_0.1551_41.1655)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1551_41.1655_/_0.1834)] p-[4px] shadow-[oklch(0_0.1551_41.1655_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.7886_0.1774_41.1449)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1774_41.1449_/_0.1834)] p-[4px] shadow-[oklch(0_0.1774_41.1449_/_0.1834)_0px_0px_0px_0px]",
               "90": "bg-[oklch(0.7911_0.1997_41.1288)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1997_41.1288_/_0.1834)] p-[4px] shadow-[oklch(0_0.1997_41.1288_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(0.7936_0.222_41.116)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.222_41.116_/_0.1834)] p-[4px] shadow-[oklch(0_0.222_41.116_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-saturate-<number>": {
-            "class": "bg-[oklch(0.9667_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[16px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] m-[16px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[16px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] m-[16px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(1_0.1011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.1011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.1011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.2011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.2011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.2011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.3011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.3011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.3011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(1_0.368_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.368_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.368_197.14_/_0.1834)_0px_0px_0px_0px]"
+              "0": "bg-[oklch(0.9667_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.9667_0.1011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.1011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.1011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.9667_0.2011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.2011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.2011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.9667_0.3011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.3011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.3011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.9667_0.368_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.368_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.368_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-desaturate-<number>": {
@@ -2887,27 +2887,27 @@
             }
           },
           "ak-layer-h-rotate-<number>": {
-            "class": "bg-[oklch(0.9667_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1834)] border-b-[oklch(0_0.0011_197.14_/_0.1834)] border-l-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1834)] border-b-[oklch(0_0.0011_197.14_/_0.1834)] border-l-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(1_0.15_197.14)] text-[oklch(0_0_0)] *:text-[lch(32.7197_56.05_291.765)] rounded-[10px] border-[1px] border-[oklch(0_0.15_197.14_/_0.2834)] p-[4px] shadow-[oklch(0_0.15_197.14_/_0.2834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.15_227.14)] text-[oklch(0_0_0)] *:text-[lch(32.7197_53.75_316.058)] rounded-[10px] border-[1px] border-[oklch(1_0_227.14_/_0.2834)] p-[4px] shadow-[oklch(1_0_227.14_/_0.2834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.15_257.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_49.82_345.932)] rounded-[10px] border-[1px] border-[oklch(0_0.15_257.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_257.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.15_287.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_51.65_20.438)] rounded-[10px] border-[1px] border-[oklch(0_0.15_287.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_287.14_/_0.1834)_0px_0px_0px_0px]",
-              "120": "bg-[oklch(1_0.15_317.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_59.6_50.726)] rounded-[10px] border-[1px] border-[oklch(0_0.15_317.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_317.14_/_0.1834)_0px_0px_0px_0px]",
-              "180": "bg-[oklch(1_0.15_17.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_61.52_99.976)] rounded-[10px] border-[1px] border-[oklch(0_0.15_17.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_17.14_/_0.1834)_0px_0px_0px_0px]",
-              "240": "bg-[oklch(1_0.15_77.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_52.82_166.449)] rounded-[10px] border-[1px] border-[oklch(0_0.15_77.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_77.14_/_0.1834)_0px_0px_0px_0px]",
-              "300": "bg-[oklch(1_0.15_137.14)] text-[oklch(0_0_0)] *:text-[lch(32.7197_49.9_233.913)] rounded-[10px] border-[1px] border-[oklch(0_0.15_137.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_137.14_/_0.1834)_0px_0px_0px_0px]",
-              "360": "bg-[oklch(1_0.15_197.14)] text-[oklch(0_0_0)] *:text-[lch(32.7197_56.05_291.765)] rounded-[10px] border-[1px] border-[oklch(0_0.15_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_197.14_/_0.1834)_0px_0px_0px_0px]"
+              "0": "bg-[oklch(0.9667_0.15_197.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_56.08_291.961)] rounded-[10px] border-[1px] border-[oklch(0_0.15_197.14_/_0.2834)] p-[4px] shadow-[oklch(0_0.15_197.14_/_0.2834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.9667_0.15_227.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_53.76_316.11)] rounded-[10px] border-[1px] border-[oklch(1_0_227.14_/_0.2834)] p-[4px] shadow-[oklch(1_0_227.14_/_0.2834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9667_0.15_257.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_49.78_345.925)] rounded-[10px] border-[1px] border-[oklch(0_0.15_257.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_257.14_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.9667_0.15_287.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_51.66_20.471)] rounded-[10px] border-[1px] border-[oklch(0_0.15_287.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_287.14_/_0.1834)_0px_0px_0px_0px]",
+              "120": "bg-[oklch(0.9667_0.15_317.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_59.84_50.777)] rounded-[10px] border-[1px] border-[oklch(0_0.15_317.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_317.14_/_0.1834)_0px_0px_0px_0px]",
+              "180": "bg-[oklch(0.9667_0.15_17.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_61.86_99.77)] rounded-[10px] border-[1px] border-[oklch(0_0.15_17.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_17.14_/_0.1834)_0px_0px_0px_0px]",
+              "240": "bg-[oklch(0.9667_0.15_77.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_52.88_166.46)] rounded-[10px] border-[1px] border-[oklch(0_0.15_77.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_77.14_/_0.1834)_0px_0px_0px_0px]",
+              "300": "bg-[oklch(0.9667_0.15_137.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_49.76_234.054)] rounded-[10px] border-[1px] border-[oklch(0_0.15_137.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_137.14_/_0.1834)_0px_0px_0px_0px]",
+              "360": "bg-[oklch(0.9667_0.15_197.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_56.08_291.961)] rounded-[10px] border-[1px] border-[oklch(0_0.15_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-<hue>": {
-            "class": "bg-[oklch(0.9667_0.0011_197.14)] text-[oklch(0_0_0)] rounded-b-[15px] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1834)] border-b-[oklch(0_0.0011_197.14_/_0.1834)] border-l-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] mb-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-b-[15px] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1834)] border-b-[oklch(0_0.0011_197.14_/_0.1834)] border-l-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] mb-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "red": "bg-[oklch(1_0.15_29.23)] text-[oklch(0_0_0)] *:text-[lch(30.2938_54.47_33.498)] rounded-bl-[11px] border-[1px] border-[oklch(0_0.15_29.23_/_0.1834)] p-[4px] mt-[-1px] mb-[-1px] ml-[-1px] shadow-[oklch(0_0.15_29.23_/_0.1834)_0px_0px_0px_0px]",
-              "green": "bg-[oklch(1_0.15_142.5)] text-[oklch(0_0_0)] *:text-[lch(32.7197_54.12_138.249)] rounded-[10px] border-[1px] border-[oklch(0_0.15_142.5_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_142.5_/_0.1834)_0px_0px_0px_0px]",
-              "blue": "bg-[oklch(1_0.15_264.05)] text-[oklch(0_0_0)] *:text-[lch(30.2938_54.2_272.601)] rounded-[10px] border-[1px] border-[oklch(0_0.15_264.05_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_264.05_/_0.1834)_0px_0px_0px_0px]",
-              "magenta": "bg-[oklch(1_0.15_328.36)] text-[oklch(0_0_0)] *:text-[lch(30.2938_52.06_326.356)] rounded-[10px] border-[1px] border-[oklch(0_0.15_328.36_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_328.36_/_0.1834)_0px_0px_0px_0px]",
-              "split1": "bg-[oklch(1_0.15_347.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_52.82_166.449)] rounded-[10px] border-[1px] border-[oklch(0_0.15_347.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_347.14_/_0.1834)_0px_0px_0px_0px]"
+              "red": "bg-[oklch(0.9667_0.15_29.23)] text-[oklch(0_0_0)] *:text-[lch(27.8204_54.55_33.547)] rounded-bl-[11px] border-[1px] border-[oklch(0_0.15_29.23_/_0.1834)] p-[4px] mt-[-1px] mb-[-1px] ml-[-1px] shadow-[oklch(0_0.15_29.23_/_0.1834)_0px_0px_0px_0px]",
+              "green": "bg-[oklch(0.9667_0.15_142.5)] text-[oklch(0_0_0)] *:text-[lch(30.2938_54.17_138.183)] rounded-[10px] border-[1px] border-[oklch(0_0.15_142.5_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_142.5_/_0.1834)_0px_0px_0px_0px]",
+              "blue": "bg-[oklch(0.9667_0.15_264.05)] text-[oklch(0_0_0)] *:text-[lch(27.8204_54.16_272.88)] rounded-[10px] border-[1px] border-[oklch(0_0.15_264.05_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_264.05_/_0.1834)_0px_0px_0px_0px]",
+              "magenta": "bg-[oklch(0.9667_0.15_328.36)] text-[oklch(0_0_0)] *:text-[lch(27.8204_52.04_326.371)] rounded-[10px] border-[1px] border-[oklch(0_0.15_328.36_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_328.36_/_0.1834)_0px_0px_0px_0px]",
+              "split1": "bg-[oklch(0.9667_0.15_347.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_52.88_166.46)] rounded-[10px] border-[1px] border-[oklch(0_0.15_347.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_347.14_/_0.1834)_0px_0px_0px_0px]"
             }
           }
         }
@@ -2916,66 +2916,66 @@
         "class": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
         "children": {
           "ak-text-l-<number>": {
-            "class": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0.906_0.09_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(7.2371_0.35_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(18.8115_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(30.4115_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
+              "0": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0.906_0.09_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(7.2371_0.35_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(18.8115_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-text-<number>": {
-            "class": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(30.4115_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(18.8115_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(7.2371_0.35_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0.906_0.09_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
+              "0": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(24.8694_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(13.2693_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(3.1924_0.2_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0.1294_0.02_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-<number>": {
-            "class": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_80_38.473)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_71.72_144.885)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_80_288.648)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_79.88_1.657)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_80_78.514)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0_/_0.6961)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.3167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.2167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.1167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.0167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(32.7197_80_38.473)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_71.72_144.885)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_80_288.648)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_79.88_1.657)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3689_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(83.2889_40_78.514)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2689_0.0011_197.14)] text-[oklch(1_0_0_/_0.6193)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1689_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.0689_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-state-<number>": {
-            "class": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_80_38.473)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_71.72_144.885)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(19.9962_40_288.648)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(32.7197_80_38.473)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.8356_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(22.6877_71.72_144.885)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.7689_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(17.1886_40_288.648)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "30": "bg-[oklch(0.7689_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(17.1886_40_1.657)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "40": "bg-[oklch(0.7689_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(17.1886_40_78.514)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.7689_0.0011_197.14)] text-[oklch(0_0_0_/_0.7528)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.1_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.4356_0.0011_197.14)] text-[oklch(1_0_0_/_0.7826)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.3356_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.2356_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.1356_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.0356_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
@@ -2984,43 +2984,43 @@
             "class": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1834)] border-b-[oklch(0_0.0011_197.14_/_0.1834)] border-l-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
               "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.7834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.7_0.368_197.14)] p-[4px] shadow-[oklch(0.7_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.4167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.3167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.2167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.1167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.0167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.9189_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.8189_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3789_0.368_197.14)] p-[4px] shadow-[oklch(0.3789_0.368_197.14)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.3522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.2522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.1522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.0522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.2167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2834)_0px_0px_0px_2px]",
             "children": {
-              "0": "bg-[oklch(0.05_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.15_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.25_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.35_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.45_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.8167_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.9167_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.1333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4834)_0px_0px_0px_1px]",
+              "10": "bg-[oklch(0.2333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.3333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
-            "class": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[18px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-8px] ml-[-8px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[18px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-8px] ml-[-8px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-tl-[6px] rounded-bl-[6px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.2834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_21.47_259.155)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] rounded-tl-[6px] rounded-bl-[6px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.2834)_0px_0px_0px_1px]",
+              "10": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(99.0429_20_259.155)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "20": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(99.0429_20_131.99)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(100_0.38_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.35_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(79.7476_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.3855_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(100_0.38_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2022_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(65.5939_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.0833_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "60": "bg-[oklch(0.0833_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "70": "bg-[oklch(0.0833_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "80": "bg-[oklch(0.0833_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
@@ -3029,14 +3029,14 @@
             }
           },
           "ak-layer-contrast-<number>": {
-            "class": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
               "0": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
               "10": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
               "20": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2666_0.245_262.881)] text-[oklch(1_0_0)] *:text-[lch(70.456_80_309.677)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.0833_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.325_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1416_0.245_262.881)] text-[oklch(1_0_0)] *:text-[lch(65.5939_80_315.008)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
               "60": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
               "70": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
               "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
@@ -3045,29 +3045,29 @@
             }
           },
           "ak-layer-mix-<number>": {
-            "class": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(1_0.0213_42.1982)] text-[oklch(0_0_0)] *:text-[lch(37.4589_60.86_102.462)] rounded-[10px] border-[1px] border-[oklch(0_0.0213_42.1982_/_0.1834)] p-[4px] shadow-[oklch(0_0.0213_42.1982_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0436_41.586)] text-[oklch(0_0_0)] *:text-[lch(37.4589_80_51.843)] rounded-[10px] border-[1px] border-[oklch(0_0.0436_41.586_/_0.1834)] p-[4px] shadow-[oklch(0_0.0436_41.586_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.9772_0.0659_41.3881)] text-[oklch(0_0_0)] *:text-[lch(32.7197_0.01_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0659_41.3881_/_0.1834)] p-[4px] shadow-[oklch(0_0.0659_41.3881_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.9418_0.0882_41.2902)] text-[oklch(0_0_0)] *:text-[lch(30.2938_32.39_125.941)] rounded-[10px] border-[1px] border-[oklch(0_0.0882_41.2902_/_0.1834)] p-[4px] shadow-[oklch(0_0.0882_41.2902_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.9064_0.1105_41.2319)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1105_41.2319_/_0.1834)] p-[4px] shadow-[oklch(0_0.1105_41.2319_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.871_0.1328_41.1931)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1328_41.1931_/_0.1834)] p-[4px] shadow-[oklch(0_0.1328_41.1931_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.8356_0.1551_41.1655)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1551_41.1655_/_0.1834)] p-[4px] shadow-[oklch(0_0.1551_41.1655_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.8002_0.1774_41.1449)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1774_41.1449_/_0.1834)] p-[4px] shadow-[oklch(0_0.1774_41.1449_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.915_0.0213_42.1982)] text-[oklch(0_0_0)] *:text-[lch(30.2938_61.75_101.894)] rounded-[10px] border-[1px] border-[oklch(0_0.0213_42.1982_/_0.1834)] p-[4px] shadow-[oklch(0_0.0213_42.1982_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.8943_0.0436_41.586)] text-[oklch(0_0_0)] *:text-[lch(27.8204_80_59.772)] rounded-[10px] border-[1px] border-[oklch(0_0.0436_41.586_/_0.1834)] p-[4px] shadow-[oklch(0_0.0436_41.586_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.8737_0.0659_41.3881)] text-[oklch(0_0_0)] *:text-[lch(25.2896_0.01_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0659_41.3881_/_0.1834)] p-[4px] shadow-[oklch(0_0.0659_41.3881_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.8531_0.0882_41.2902)] text-[oklch(0_0_0)] *:text-[lch(22.6877_32.45_125.707)] rounded-[10px] border-[1px] border-[oklch(0_0.0882_41.2902_/_0.1834)] p-[4px] shadow-[oklch(0_0.0882_41.2902_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8325_0.1105_41.2319)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1105_41.2319_/_0.1834)] p-[4px] shadow-[oklch(0_0.1105_41.2319_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.8118_0.1328_41.1931)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1328_41.1931_/_0.1834)] p-[4px] shadow-[oklch(0_0.1328_41.1931_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.7912_0.1551_41.1655)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1551_41.1655_/_0.1834)] p-[4px] shadow-[oklch(0_0.1551_41.1655_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.7886_0.1774_41.1449)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1774_41.1449_/_0.1834)] p-[4px] shadow-[oklch(0_0.1774_41.1449_/_0.1834)_0px_0px_0px_0px]",
               "90": "bg-[oklch(0.7911_0.1997_41.1288)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1997_41.1288_/_0.1834)] p-[4px] shadow-[oklch(0_0.1997_41.1288_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(0.7936_0.222_41.116)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.222_41.116_/_0.1834)] p-[4px] shadow-[oklch(0_0.222_41.116_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-saturate-<number>": {
-            "class": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[16px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] m-[16px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[16px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] m-[16px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(1_0.1011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.1011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.1011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.2011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.2011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.2011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.3011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.3011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.3011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(1_0.368_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.368_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.368_197.14_/_0.1834)_0px_0px_0px_0px]"
+              "0": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.9356_0.1011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.1011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.1011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.9356_0.2011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.2011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.2011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.9356_0.3011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.3011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.3011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.9356_0.368_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.368_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.368_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-desaturate-<number>": {
@@ -3082,27 +3082,27 @@
             }
           },
           "ak-layer-h-rotate-<number>": {
-            "class": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1834)] border-b-[oklch(0_0.0011_197.14_/_0.1834)] border-l-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1834)] border-b-[oklch(0_0.0011_197.14_/_0.1834)] border-l-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(1_0.15_197.14)] text-[oklch(0_0_0)] *:text-[lch(32.7197_56.05_291.765)] rounded-[10px] border-[1px] border-[oklch(0_0.15_197.14_/_0.2834)] p-[4px] shadow-[oklch(0_0.15_197.14_/_0.2834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.15_227.14)] text-[oklch(0_0_0)] *:text-[lch(32.7197_53.75_316.058)] rounded-[10px] border-[1px] border-[oklch(1_0_227.14_/_0.2834)] p-[4px] shadow-[oklch(1_0_227.14_/_0.2834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.15_257.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_49.82_345.932)] rounded-[10px] border-[1px] border-[oklch(0_0.15_257.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_257.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.15_287.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_51.65_20.438)] rounded-[10px] border-[1px] border-[oklch(0_0.15_287.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_287.14_/_0.1834)_0px_0px_0px_0px]",
-              "120": "bg-[oklch(1_0.15_317.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_59.6_50.726)] rounded-[10px] border-[1px] border-[oklch(0_0.15_317.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_317.14_/_0.1834)_0px_0px_0px_0px]",
-              "180": "bg-[oklch(1_0.15_17.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_61.52_99.976)] rounded-[10px] border-[1px] border-[oklch(0_0.15_17.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_17.14_/_0.1834)_0px_0px_0px_0px]",
-              "240": "bg-[oklch(1_0.15_77.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_52.82_166.449)] rounded-[10px] border-[1px] border-[oklch(0_0.15_77.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_77.14_/_0.1834)_0px_0px_0px_0px]",
-              "300": "bg-[oklch(1_0.15_137.14)] text-[oklch(0_0_0)] *:text-[lch(32.7197_49.9_233.913)] rounded-[10px] border-[1px] border-[oklch(0_0.15_137.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_137.14_/_0.1834)_0px_0px_0px_0px]",
-              "360": "bg-[oklch(1_0.15_197.14)] text-[oklch(0_0_0)] *:text-[lch(32.7197_56.05_291.765)] rounded-[10px] border-[1px] border-[oklch(0_0.15_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_197.14_/_0.1834)_0px_0px_0px_0px]"
+              "0": "bg-[oklch(0.9356_0.15_197.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_56.1_292.157)] rounded-[10px] border-[1px] border-[oklch(0_0.15_197.14_/_0.2834)] p-[4px] shadow-[oklch(0_0.15_197.14_/_0.2834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.9356_0.15_227.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_53.77_316.162)] rounded-[10px] border-[1px] border-[oklch(1_0_227.14_/_0.2834)] p-[4px] shadow-[oklch(1_0_227.14_/_0.2834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9356_0.15_257.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_49.74_345.919)] rounded-[10px] border-[1px] border-[oklch(0_0.15_257.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_257.14_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.9356_0.15_287.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_51.67_20.504)] rounded-[10px] border-[1px] border-[oklch(0_0.15_287.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_287.14_/_0.1834)_0px_0px_0px_0px]",
+              "120": "bg-[oklch(0.9356_0.15_317.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_60.08_50.833)] rounded-[10px] border-[1px] border-[oklch(0_0.15_317.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_317.14_/_0.1834)_0px_0px_0px_0px]",
+              "180": "bg-[oklch(0.9356_0.15_17.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_62.23_99.564)] rounded-[10px] border-[1px] border-[oklch(0_0.15_17.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_17.14_/_0.1834)_0px_0px_0px_0px]",
+              "240": "bg-[oklch(0.9356_0.15_77.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_52.95_166.471)] rounded-[10px] border-[1px] border-[oklch(0_0.15_77.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_77.14_/_0.1834)_0px_0px_0px_0px]",
+              "300": "bg-[oklch(0.9356_0.15_137.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_49.62_234.197)] rounded-[10px] border-[1px] border-[oklch(0_0.15_137.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_137.14_/_0.1834)_0px_0px_0px_0px]",
+              "360": "bg-[oklch(0.9356_0.15_197.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_56.1_292.157)] rounded-[10px] border-[1px] border-[oklch(0_0.15_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-<hue>": {
-            "class": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] rounded-b-[15px] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1834)] border-b-[oklch(0_0.0011_197.14_/_0.1834)] border-l-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] mb-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] rounded-b-[15px] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1834)] border-b-[oklch(0_0.0011_197.14_/_0.1834)] border-l-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] mb-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "red": "bg-[oklch(1_0.15_29.23)] text-[oklch(0_0_0)] *:text-[lch(30.2938_54.47_33.498)] rounded-bl-[11px] border-[1px] border-[oklch(0_0.15_29.23_/_0.1834)] p-[4px] mt-[-1px] mb-[-1px] ml-[-1px] shadow-[oklch(0_0.15_29.23_/_0.1834)_0px_0px_0px_0px]",
-              "green": "bg-[oklch(1_0.15_142.5)] text-[oklch(0_0_0)] *:text-[lch(32.7197_54.12_138.249)] rounded-[10px] border-[1px] border-[oklch(0_0.15_142.5_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_142.5_/_0.1834)_0px_0px_0px_0px]",
-              "blue": "bg-[oklch(1_0.15_264.05)] text-[oklch(0_0_0)] *:text-[lch(30.2938_54.2_272.601)] rounded-[10px] border-[1px] border-[oklch(0_0.15_264.05_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_264.05_/_0.1834)_0px_0px_0px_0px]",
-              "magenta": "bg-[oklch(1_0.15_328.36)] text-[oklch(0_0_0)] *:text-[lch(30.2938_52.06_326.356)] rounded-[10px] border-[1px] border-[oklch(0_0.15_328.36_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_328.36_/_0.1834)_0px_0px_0px_0px]",
-              "split1": "bg-[oklch(1_0.15_347.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_52.82_166.449)] rounded-[10px] border-[1px] border-[oklch(0_0.15_347.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_347.14_/_0.1834)_0px_0px_0px_0px]"
+              "red": "bg-[oklch(0.9356_0.15_29.23)] text-[oklch(0_0_0)] *:text-[lch(25.2896_54.63_33.597)] rounded-bl-[11px] border-[1px] border-[oklch(0_0.15_29.23_/_0.1834)] p-[4px] mt-[-1px] mb-[-1px] ml-[-1px] shadow-[oklch(0_0.15_29.23_/_0.1834)_0px_0px_0px_0px]",
+              "green": "bg-[oklch(0.9356_0.15_142.5)] text-[oklch(0_0_0)] *:text-[lch(27.8204_54.22_138.115)] rounded-[10px] border-[1px] border-[oklch(0_0.15_142.5_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_142.5_/_0.1834)_0px_0px_0px_0px]",
+              "blue": "bg-[oklch(0.9356_0.15_264.05)] text-[oklch(0_0_0)] *:text-[lch(25.2896_54.12_273.16)] rounded-[10px] border-[1px] border-[oklch(0_0.15_264.05_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_264.05_/_0.1834)_0px_0px_0px_0px]",
+              "magenta": "bg-[oklch(0.9356_0.15_328.36)] text-[oklch(0_0_0)] *:text-[lch(25.2896_52.03_326.386)] rounded-[10px] border-[1px] border-[oklch(0_0.15_328.36_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_328.36_/_0.1834)_0px_0px_0px_0px]",
+              "split1": "bg-[oklch(0.9356_0.15_347.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_52.95_166.471)] rounded-[10px] border-[1px] border-[oklch(0_0.15_347.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_347.14_/_0.1834)_0px_0px_0px_0px]"
             }
           }
         }
@@ -3111,66 +3111,66 @@
         "class": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[15px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
         "children": {
           "ak-text-l-<number>": {
-            "class": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0.906_0.09_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(7.2371_0.35_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(18.8115_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(30.4115_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
+              "0": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0.906_0.09_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(7.2371_0.35_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(18.8115_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-text-<number>": {
-            "class": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(30.4115_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(18.8115_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(7.2371_0.35_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0.906_0.09_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
+              "0": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(24.8694_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(13.2693_0.38_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(3.1924_0.2_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0.1294_0.02_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(0_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-<number>": {
-            "class": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_80_38.473)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_71.72_144.885)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_80_288.648)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_79.88_1.657)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_80_78.514)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0_/_0.6961)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.3167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.2167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.1167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.0167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(32.7197_80_38.473)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_71.72_144.885)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_80_288.648)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_79.88_1.657)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3689_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(83.2889_40_78.514)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2689_0.0011_197.14)] text-[oklch(1_0_0_/_0.6193)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1689_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.0689_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-state-<number>": {
-            "class": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(37.4589_80_38.473)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_71.72_144.885)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(19.9962_40_288.648)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(32.7197_80_38.473)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.8356_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(22.6877_71.72_144.885)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.7689_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(17.1886_40_288.648)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "30": "bg-[oklch(0.7689_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(17.1886_40_1.657)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "40": "bg-[oklch(0.7689_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(17.1886_40_78.514)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.7689_0.0011_197.14)] text-[oklch(0_0_0_/_0.7528)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.1_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.4356_0.0011_197.14)] text-[oklch(1_0_0_/_0.7826)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.3356_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.2356_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.1356_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.0356_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
@@ -3179,43 +3179,43 @@
             "class": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1834)] border-b-[oklch(0_0.0011_197.14_/_0.1834)] border-l-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
               "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.7834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.7_0.368_197.14)] p-[4px] shadow-[oklch(0.7_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.4167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.3167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.2167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.1167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.0167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.9189_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.8189_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3789_0.368_197.14)] p-[4px] shadow-[oklch(0.3789_0.368_197.14)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.3522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.2522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.1522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.0522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.2167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2834)_0px_0px_0px_2px]",
             "children": {
-              "0": "bg-[oklch(0.05_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.15_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.25_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.35_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.45_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.8167_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.9167_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.1333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4834)_0px_0px_0px_1px]",
+              "10": "bg-[oklch(0.2333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.3333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
-            "class": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[18px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-8px] ml-[-8px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[18px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-8px] ml-[-8px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-tl-[6px] rounded-bl-[6px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.2834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_21.47_259.155)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] rounded-tl-[6px] rounded-bl-[6px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.2834)_0px_0px_0px_1px]",
+              "10": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(99.0429_20_259.155)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "20": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(99.0429_20_131.99)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(100_0.38_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.35_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(79.7476_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.3855_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(100_0.38_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2022_0.0011_197.14)] text-[oklch(1_0_0)] *:text-[lch(65.5939_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.0833_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "60": "bg-[oklch(0.0833_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "70": "bg-[oklch(0.0833_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "80": "bg-[oklch(0.0833_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
@@ -3224,14 +3224,14 @@
             }
           },
           "ak-layer-contrast-<number>": {
-            "class": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
               "0": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
               "10": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
               "20": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4076_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2666_0.245_262.881)] text-[oklch(1_0_0)] *:text-[lch(70.456_80_309.677)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.0833_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.325_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1416_0.245_262.881)] text-[oklch(1_0_0)] *:text-[lch(65.5939_80_315.008)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
               "60": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
               "70": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
               "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1834)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1834)_0px_0px_0px_0px]",
@@ -3240,29 +3240,29 @@
             }
           },
           "ak-layer-mix-<number>": {
-            "class": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(1_0.0213_42.1982)] text-[oklch(0_0_0)] *:text-[lch(37.4589_60.86_102.462)] rounded-[10px] border-[1px] border-[oklch(0_0.0213_42.1982_/_0.1834)] p-[4px] shadow-[oklch(0_0.0213_42.1982_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0436_41.586)] text-[oklch(0_0_0)] *:text-[lch(37.4589_80_51.843)] rounded-[10px] border-[1px] border-[oklch(0_0.0436_41.586_/_0.1834)] p-[4px] shadow-[oklch(0_0.0436_41.586_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.9772_0.0659_41.3881)] text-[oklch(0_0_0)] *:text-[lch(32.7197_0.01_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0659_41.3881_/_0.1834)] p-[4px] shadow-[oklch(0_0.0659_41.3881_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.9418_0.0882_41.2902)] text-[oklch(0_0_0)] *:text-[lch(30.2938_32.39_125.941)] rounded-[10px] border-[1px] border-[oklch(0_0.0882_41.2902_/_0.1834)] p-[4px] shadow-[oklch(0_0.0882_41.2902_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.9064_0.1105_41.2319)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1105_41.2319_/_0.1834)] p-[4px] shadow-[oklch(0_0.1105_41.2319_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.871_0.1328_41.1931)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1328_41.1931_/_0.1834)] p-[4px] shadow-[oklch(0_0.1328_41.1931_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.8356_0.1551_41.1655)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1551_41.1655_/_0.1834)] p-[4px] shadow-[oklch(0_0.1551_41.1655_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.8002_0.1774_41.1449)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1774_41.1449_/_0.1834)] p-[4px] shadow-[oklch(0_0.1774_41.1449_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.915_0.0213_42.1982)] text-[oklch(0_0_0)] *:text-[lch(30.2938_61.75_101.894)] rounded-[10px] border-[1px] border-[oklch(0_0.0213_42.1982_/_0.1834)] p-[4px] shadow-[oklch(0_0.0213_42.1982_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.8943_0.0436_41.586)] text-[oklch(0_0_0)] *:text-[lch(27.8204_80_59.772)] rounded-[10px] border-[1px] border-[oklch(0_0.0436_41.586_/_0.1834)] p-[4px] shadow-[oklch(0_0.0436_41.586_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.8737_0.0659_41.3881)] text-[oklch(0_0_0)] *:text-[lch(25.2896_0.01_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0659_41.3881_/_0.1834)] p-[4px] shadow-[oklch(0_0.0659_41.3881_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.8531_0.0882_41.2902)] text-[oklch(0_0_0)] *:text-[lch(22.6877_32.45_125.707)] rounded-[10px] border-[1px] border-[oklch(0_0.0882_41.2902_/_0.1834)] p-[4px] shadow-[oklch(0_0.0882_41.2902_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8325_0.1105_41.2319)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1105_41.2319_/_0.1834)] p-[4px] shadow-[oklch(0_0.1105_41.2319_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.8118_0.1328_41.1931)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1328_41.1931_/_0.1834)] p-[4px] shadow-[oklch(0_0.1328_41.1931_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.7912_0.1551_41.1655)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1551_41.1655_/_0.1834)] p-[4px] shadow-[oklch(0_0.1551_41.1655_/_0.1834)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.7886_0.1774_41.1449)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1774_41.1449_/_0.1834)] p-[4px] shadow-[oklch(0_0.1774_41.1449_/_0.1834)_0px_0px_0px_0px]",
               "90": "bg-[oklch(0.7911_0.1997_41.1288)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.1997_41.1288_/_0.1834)] p-[4px] shadow-[oklch(0_0.1997_41.1288_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(0.7936_0.222_41.116)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.222_41.116_/_0.1834)] p-[4px] shadow-[oklch(0_0.222_41.116_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-saturate-<number>": {
-            "class": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[16px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] m-[16px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[16px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] m-[16px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "10": "bg-[oklch(1_0.1011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.1011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.1011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.2011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.2011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.2011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.3011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.3011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.3011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(1_0.368_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.368_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.368_197.14_/_0.1834)_0px_0px_0px_0px]"
+              "0": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "10": "bg-[oklch(0.9356_0.1011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.1011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.1011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.9356_0.2011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.2011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.2011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.9356_0.3011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.3011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.3011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.9356_0.368_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[1px] border-[oklch(0_0.368_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.368_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-desaturate-<number>": {
@@ -3277,27 +3277,27 @@
             }
           },
           "ak-layer-h-rotate-<number>": {
-            "class": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1834)] border-b-[oklch(0_0.0011_197.14_/_0.1834)] border-l-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1834)] border-b-[oklch(0_0.0011_197.14_/_0.1834)] border-l-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(1_0.15_197.14)] text-[oklch(0_0_0)] *:text-[lch(32.7197_56.05_291.765)] rounded-[10px] border-[1px] border-[oklch(0_0.15_197.14_/_0.2834)] p-[4px] shadow-[oklch(0_0.15_197.14_/_0.2834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.15_227.14)] text-[oklch(0_0_0)] *:text-[lch(32.7197_53.75_316.058)] rounded-[10px] border-[1px] border-[oklch(1_0_227.14_/_0.2834)] p-[4px] shadow-[oklch(1_0_227.14_/_0.2834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.15_257.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_49.82_345.932)] rounded-[10px] border-[1px] border-[oklch(0_0.15_257.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_257.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.15_287.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_51.65_20.438)] rounded-[10px] border-[1px] border-[oklch(0_0.15_287.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_287.14_/_0.1834)_0px_0px_0px_0px]",
-              "120": "bg-[oklch(1_0.15_317.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_59.6_50.726)] rounded-[10px] border-[1px] border-[oklch(0_0.15_317.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_317.14_/_0.1834)_0px_0px_0px_0px]",
-              "180": "bg-[oklch(1_0.15_17.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_61.52_99.976)] rounded-[10px] border-[1px] border-[oklch(0_0.15_17.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_17.14_/_0.1834)_0px_0px_0px_0px]",
-              "240": "bg-[oklch(1_0.15_77.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_52.82_166.449)] rounded-[10px] border-[1px] border-[oklch(0_0.15_77.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_77.14_/_0.1834)_0px_0px_0px_0px]",
-              "300": "bg-[oklch(1_0.15_137.14)] text-[oklch(0_0_0)] *:text-[lch(32.7197_49.9_233.913)] rounded-[10px] border-[1px] border-[oklch(0_0.15_137.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_137.14_/_0.1834)_0px_0px_0px_0px]",
-              "360": "bg-[oklch(1_0.15_197.14)] text-[oklch(0_0_0)] *:text-[lch(32.7197_56.05_291.765)] rounded-[10px] border-[1px] border-[oklch(0_0.15_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_197.14_/_0.1834)_0px_0px_0px_0px]"
+              "0": "bg-[oklch(0.9356_0.15_197.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_56.1_292.157)] rounded-[10px] border-[1px] border-[oklch(0_0.15_197.14_/_0.2834)] p-[4px] shadow-[oklch(0_0.15_197.14_/_0.2834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.9356_0.15_227.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_53.77_316.162)] rounded-[10px] border-[1px] border-[oklch(1_0_227.14_/_0.2834)] p-[4px] shadow-[oklch(1_0_227.14_/_0.2834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9356_0.15_257.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_49.74_345.919)] rounded-[10px] border-[1px] border-[oklch(0_0.15_257.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_257.14_/_0.1834)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.9356_0.15_287.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_51.67_20.504)] rounded-[10px] border-[1px] border-[oklch(0_0.15_287.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_287.14_/_0.1834)_0px_0px_0px_0px]",
+              "120": "bg-[oklch(0.9356_0.15_317.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_60.08_50.833)] rounded-[10px] border-[1px] border-[oklch(0_0.15_317.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_317.14_/_0.1834)_0px_0px_0px_0px]",
+              "180": "bg-[oklch(0.9356_0.15_17.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_62.23_99.564)] rounded-[10px] border-[1px] border-[oklch(0_0.15_17.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_17.14_/_0.1834)_0px_0px_0px_0px]",
+              "240": "bg-[oklch(0.9356_0.15_77.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_52.95_166.471)] rounded-[10px] border-[1px] border-[oklch(0_0.15_77.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_77.14_/_0.1834)_0px_0px_0px_0px]",
+              "300": "bg-[oklch(0.9356_0.15_137.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_49.62_234.197)] rounded-[10px] border-[1px] border-[oklch(0_0.15_137.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_137.14_/_0.1834)_0px_0px_0px_0px]",
+              "360": "bg-[oklch(0.9356_0.15_197.14)] text-[oklch(0_0_0)] *:text-[lch(27.8204_56.1_292.157)] rounded-[10px] border-[1px] border-[oklch(0_0.15_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_197.14_/_0.1834)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-<hue>": {
-            "class": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] rounded-b-[15px] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1834)] border-b-[oklch(0_0.0011_197.14_/_0.1834)] border-l-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] mb-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0.8522_0.0011_197.14)] text-[oklch(0_0_0)] rounded-b-[15px] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1834)] border-b-[oklch(0_0.0011_197.14_/_0.1834)] border-l-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] mb-[-5px] ml-[-5px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "red": "bg-[oklch(1_0.15_29.23)] text-[oklch(0_0_0)] *:text-[lch(30.2938_54.47_33.498)] rounded-bl-[11px] border-[1px] border-[oklch(0_0.15_29.23_/_0.1834)] p-[4px] mt-[-1px] mb-[-1px] ml-[-1px] shadow-[oklch(0_0.15_29.23_/_0.1834)_0px_0px_0px_0px]",
-              "green": "bg-[oklch(1_0.15_142.5)] text-[oklch(0_0_0)] *:text-[lch(32.7197_54.12_138.249)] rounded-[10px] border-[1px] border-[oklch(0_0.15_142.5_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_142.5_/_0.1834)_0px_0px_0px_0px]",
-              "blue": "bg-[oklch(1_0.15_264.05)] text-[oklch(0_0_0)] *:text-[lch(30.2938_54.2_272.601)] rounded-[10px] border-[1px] border-[oklch(0_0.15_264.05_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_264.05_/_0.1834)_0px_0px_0px_0px]",
-              "magenta": "bg-[oklch(1_0.15_328.36)] text-[oklch(0_0_0)] *:text-[lch(30.2938_52.06_326.356)] rounded-[10px] border-[1px] border-[oklch(0_0.15_328.36_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_328.36_/_0.1834)_0px_0px_0px_0px]",
-              "split1": "bg-[oklch(1_0.15_347.14)] text-[oklch(0_0_0)] *:text-[lch(30.2938_52.82_166.449)] rounded-[10px] border-[1px] border-[oklch(0_0.15_347.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_347.14_/_0.1834)_0px_0px_0px_0px]"
+              "red": "bg-[oklch(0.9356_0.15_29.23)] text-[oklch(0_0_0)] *:text-[lch(25.2896_54.63_33.597)] rounded-bl-[11px] border-[1px] border-[oklch(0_0.15_29.23_/_0.1834)] p-[4px] mt-[-1px] mb-[-1px] ml-[-1px] shadow-[oklch(0_0.15_29.23_/_0.1834)_0px_0px_0px_0px]",
+              "green": "bg-[oklch(0.9356_0.15_142.5)] text-[oklch(0_0_0)] *:text-[lch(27.8204_54.22_138.115)] rounded-[10px] border-[1px] border-[oklch(0_0.15_142.5_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_142.5_/_0.1834)_0px_0px_0px_0px]",
+              "blue": "bg-[oklch(0.9356_0.15_264.05)] text-[oklch(0_0_0)] *:text-[lch(25.2896_54.12_273.16)] rounded-[10px] border-[1px] border-[oklch(0_0.15_264.05_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_264.05_/_0.1834)_0px_0px_0px_0px]",
+              "magenta": "bg-[oklch(0.9356_0.15_328.36)] text-[oklch(0_0_0)] *:text-[lch(25.2896_52.03_326.386)] rounded-[10px] border-[1px] border-[oklch(0_0.15_328.36_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_328.36_/_0.1834)_0px_0px_0px_0px]",
+              "split1": "bg-[oklch(0.9356_0.15_347.14)] text-[oklch(0_0_0)] *:text-[lch(25.2896_52.95_166.471)] rounded-[10px] border-[1px] border-[oklch(0_0.15_347.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.15_347.14_/_0.1834)_0px_0px_0px_0px]"
             }
           }
         }
@@ -3373,14 +3373,14 @@
           "ak-layer-darken-<number>": {
             "class": "bg-[oklch(0.7834_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0011_197.14_/_0.1834)] border-b-[oklch(1_0.0011_197.14_/_0.1834)] border-l-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
             "children": {
-              "0": "bg-[oklch(0.9501_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.8501_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.7689_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3789_0.368_197.14)] p-[4px] shadow-[oklch(0.3789_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3834_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2834_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1834_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0833_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "0": "bg-[oklch(0.8667_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_1px]",
+              "10": "bg-[oklch(0.7689_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5834)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3167_0.368_197.14)] p-[4px] shadow-[oklch(0.3167_0.368_197.14)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
               "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -143,7 +143,14 @@ const utilities = new Set<ReturnType<typeof ak.utility>>();
  * Registers an `ak` utility and stores it for the exported input list.
  */
 function utility(...args: Parameters<typeof ak.utility>) {
-  const registeredUtility = ak.utility(...args);
+  const [name, ...children] = args;
+  // Any layer/state modifier preserves the existing global contrast bias.
+  // This flag lets bare nested ak-layer elements skip reapplying that bias.
+  const layerModifier =
+    name.startsWith("layer-") || name.startsWith("state-")
+      ? [set(vars.layerModified, 1)]
+      : [];
+  const registeredUtility = ak.utility(name, ...children, ...layerModifier);
   utilities.add(registeredUtility);
   return registeredUtility;
 }
@@ -211,6 +218,7 @@ function getRawPercentDeclarations(
 function getNegatedDeclarations(utilityRule: ReturnType<typeof utility>) {
   return utilityRule.children
     .filter((child) => child.type === "declaration")
+    .filter((child) => child.property !== vars.layerModified.ident)
     .map((child) => {
       if (child.value == null) return;
       return set(child.property, fn.neg(child.value));
@@ -555,6 +563,8 @@ const layerMathVars = {
   layerOffsetDelta: _ak.prop("lodl", { initial: 0 }),
   layerIdlePushValue: _ak.prop.zero("lipv"),
   layerIdlePushEnabled: _ak.prop.zero("lipe"),
+  layerModified: _ak.prop.zero("lm"),
+  layerContrastBiasMask: _ak.var("lcbm", 1),
   // These scratch vars only resolve the pushed lightness in ak-layer-push-*.
   // Keep them unregistered so each push utility avoids extra @property work.
   layerIdlePushBaseL: _ak.var("lipbl"),
@@ -600,6 +610,7 @@ const layerColorVars = {
   layerOffset: _ak.prop.canvas("lo"),
   layer: ak.prop.canvas("layer", { inherits: true }),
   layerParentContext: _ak.var("lpc"),
+  layerPresentContext: _ak.var("lprc"),
   layerEdgeContext: _ak.var("lec"),
   layerEdgeSourceContext: _ak.var("lesc"),
   layerParent: ak.var("layer-parent", "canvas"),
@@ -1157,6 +1168,7 @@ const layerContrastInactive = fn.sub(
 const layerIdleContrastBias = fn.mul(
   vars.layerContrastBias,
   layerContrastInactive,
+  vars.layerContrastBiasMask,
 );
 
 const layerIdle = fn.oklch(vars.layerIdleOffset, {
@@ -1340,6 +1352,14 @@ utility(
   at.variant(light, set(vars.edgePushDirection, -1)),
   at.variant(dark, set(vars.edgePushDirection, 1)),
   layerContext(({ provide, inherit }) => [
+    set(
+      vars.layerContrastBiasMask,
+      fn.max(
+        vars.layerModified,
+        fn.sub(1, inherit(vars.layerPresentContext, 0)),
+      ),
+    ),
+    set(provide(vars.layerPresentContext), 1),
     set(provide(vars.layerParentContext), vars.layer),
     set(vars.layerParent, inherit(vars.layerParentContext)),
     set(provide(vars.layerTextLContext), vars.layerTextL),

--- a/packages/ariakit-tailwind/src/output.css
+++ b/packages/ariakit-tailwind/src/output.css
@@ -134,7 +134,7 @@
   --_ak-ecv: calc(var(--_ak-ct) * 0.3334);
   --_ak-lib: oklch(from var(--_ak-layer-color, var(--ak-layer-parent, canvas)) var(--_ak-layer-lightness, calc(l + var(--_ak-layer-idle-relative-lightness) + (clamp(0, (var(--_ak-layer-idle-relative-lightness) * 1000000), 1) * var(--_ak-llfb)))) var(--_ak-layer-chroma, calc(c + var(--_ak-layer-idle-relative-chroma))) var(--_ak-layer-hue, calc(h + var(--_ak-layer-idle-relative-hue))));
   --_ak-lio: oklch(from var(--_ak-layer-mix, var(--_ak-lib)) var(--_ak-liprl, var(--_ak-layer-idle-lightness-offset-resolved, clamp(var(--_ak-layer-lightness-min), (l + var(--_ak-layer-idle-lightness-offset) + (clamp(0, (var(--_ak-layer-idle-lightness-offset) * 1000000), 1) * var(--_ak-llfb))), var(--_ak-layer-lightness-max)))) c h);
-  --_ak-li: oklch(from var(--_ak-lio) calc((((l + (var(--_ak-lcd) * max(0, ((clamp(0, (var(--_ak-lcpl) + ((var(--_ak-layer-idle-contrast-lightness) * var(--_ak-cps)) * var(--_ak-lcd))), 1) - l) * var(--_ak-lcd))))) * (var(--_ak-lcd) * var(--_ak-lcd))) + (l * (1 - (var(--_ak-lcd) * var(--_ak-lcd))))) + ((var(--_ak-lcb) * (1 - (var(--_ak-lcd) * var(--_ak-lcd)))) * (1 - var(--_ak-lipe)))) c h);
+  --_ak-li: oklch(from var(--_ak-lio) calc((((l + (var(--_ak-lcd) * max(0, ((clamp(0, (var(--_ak-lcpl) + ((var(--_ak-layer-idle-contrast-lightness) * var(--_ak-cps)) * var(--_ak-lcd))), 1) - l) * var(--_ak-lcd))))) * (var(--_ak-lcd) * var(--_ak-lcd))) + (l * (1 - (var(--_ak-lcd) * var(--_ak-lcd))))) + ((var(--_ak-lcb) * (1 - (var(--_ak-lcd) * var(--_ak-lcd))) * var(--_ak-lcbm, 1)) * (1 - var(--_ak-lipe)))) c h);
   --_ak-lb: oklch(from oklch(from var(--_ak-li) calc(l + var(--_ak-layer-relative-lightness) + (clamp(0, (var(--_ak-layer-relative-lightness) * 1000000), 1) * var(--_ak-llfb))) calc(c + var(--_ak-layer-relative-chroma)) calc(h + var(--_ak-layer-relative-hue))) calc(l + (clamp(0, (min((l - var(--_ak-fla)), (var(--_ak-flb) - l)) * 1000000), 1) * ((var(--_ak-fla) + (clamp(0, ((l - ((var(--_ak-fla) + var(--_ak-flb)) / 2)) * 1000000), 1) * (var(--_ak-flb) - var(--_ak-fla)))) - l))) c h);
   --_ak-lo: oklch(from var(--_ak-lb) var(--_ak-layer-lightness-offset-resolved, calc(l + var(--_ak-layer-lightness-offset) + (clamp(0, (var(--_ak-layer-lightness-offset) * 1000000), 1) * var(--_ak-llfb)))) c h);
   @variant ak-light {
@@ -145,12 +145,16 @@
   }
   @container (style(--_context-0: even)) or (not style(--_context-0)) {
     --_context-0: odd;
+    --_ak-lcbm: max(var(--_ak-lm), (1 - var(--_ak-lprc-even, 0)));
+    --_ak-lprc-odd: 1;
     --_ak-lpc-odd: var(--ak-layer);
     --ak-layer-parent: var(--_ak-lpc-even);
     --_ak-ltlc-odd: var(--_ak-ltl);
   }
   @container style(--_context-0: odd) {
     --_context-0: even;
+    --_ak-lcbm: max(var(--_ak-lm), (1 - var(--_ak-lprc-odd, 0)));
+    --_ak-lprc-even: 1;
     --_ak-lpc-even: var(--ak-layer);
     --ak-layer-parent: var(--_ak-lpc-odd);
     --_ak-ltlc-even: var(--_ak-ltl);
@@ -169,6 +173,7 @@
   --_ak-lill: calc(clamp(var(--_ak-layer-lightness-min), (l + var(--_ak-layer-idle-lightness-offset) + (clamp(0, (var(--_ak-layer-idle-lightness-offset) * 1000000), 1) * var(--_ak-llfb))), var(--_ak-layer-lightness-max)) + (0 * --value([number])));
   --_ak-lild: calc((var(--_ak-lill) - l) + (0 * --value([number])));
   --_ak-layer-idle-lightness-offset-resolved: calc((var(--_ak-lill) + (clamp(0, (max(var(--_ak-layer-idle-lightness-offset), (var(--_ak-layer-idle-lightness-offset) * -1)) * 1000000), 1) * ((var(--_ak-lild) + (clamp(0, (min(((l + var(--_ak-lild)) - var(--_ak-fla)), (var(--_ak-flb) - (l + var(--_ak-lild)))) * 1000000), 1) * (((var(--_ak-eb) - l) + (clamp(0, ((((l - clamp(0, (l + (var(--_ak-lild) * -1)), 1)) * var(--_ak-lod)) - ((var(--_ak-eb) - l) * var(--_ak-lod))) * 1000000), 1) * ((var(--_ak-lild) * -1) - (var(--_ak-eb) - l)))) - var(--_ak-lild)))) - var(--_ak-lild)))) + (0 * --value([number])));
+  --_ak-lm: 1;
 }
 
 @utility ak-layer-offset-* {
@@ -180,14 +185,17 @@
   --_ak-lill: calc(clamp(var(--_ak-layer-lightness-min), (l + var(--_ak-layer-idle-lightness-offset) + (clamp(0, (var(--_ak-layer-idle-lightness-offset) * 1000000), 1) * var(--_ak-llfb))), var(--_ak-layer-lightness-max)) + (0 * --value([*])));
   --_ak-lild: calc((var(--_ak-lill) - l) + (0 * --value([*])));
   --_ak-layer-idle-lightness-offset-resolved: calc((var(--_ak-lill) + (clamp(0, (max(var(--_ak-layer-idle-lightness-offset), (var(--_ak-layer-idle-lightness-offset) * -1)) * 1000000), 1) * ((var(--_ak-lild) + (clamp(0, (min(((l + var(--_ak-lild)) - var(--_ak-fla)), (var(--_ak-flb) - (l + var(--_ak-lild)))) * 1000000), 1) * (((var(--_ak-eb) - l) + (clamp(0, ((((l - clamp(0, (l + (var(--_ak-lild) * -1)), 1)) * var(--_ak-lod)) - ((var(--_ak-eb) - l) * var(--_ak-lod))) * 1000000), 1) * ((var(--_ak-lild) * -1) - (var(--_ak-eb) - l)))) - var(--_ak-lild)))) - var(--_ak-lild)))) + (0 * --value([*])));
+  --_ak-lm: 1;
 }
 
 @utility ak-layer-color-* {
   --_ak-layer-color: --value(--color-*, [*]);
+  --_ak-lm: 1;
 }
 
 @utility ak-layer-mix {
   --_ak-layer-mix: color-mix(in var(--_ak-layer-mix-method, oklab), var(--_ak-layer-mix-color, var(--ak-layer-parent, canvas)), var(--_ak-lib) var(--_ak-layer-mix-amount, 50%));
+  --_ak-lm: 1;
 }
 
 @utility ak-layer-mix-* {
@@ -196,49 +204,59 @@
   --_ak-layer-mix-method: --value(--mix-*);
   --_ak-layer-mix-amount: --value([percentage]);
   --_ak-layer-mix: color-mix(in var(--_ak-layer-mix-method, oklab), var(--_ak-layer-mix-color, var(--ak-layer-parent, canvas)), var(--_ak-lib) var(--_ak-layer-mix-amount, 50%));
+  --_ak-lm: 1;
 }
 
 @utility ak-layer-mix-color-* {
   --_ak-layer-mix-color: --value(--color-*, [*]);
+  --_ak-lm: 1;
 }
 
 @utility ak-layer-mix-amount-* {
   --_ak-layer-mix-amount: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") * 1%);
   --_ak-layer-mix-amount: --value([*]);
+  --_ak-lm: 1;
 }
 
 @utility ak-layer-mix-method-* {
   --_ak-layer-mix-method: --value(--mix-*, [*]);
+  --_ak-lm: 1;
 }
 
 @utility ak-layer-lighten-* {
   --_ak-layer-idle-relative-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-layer-idle-relative-lightness: --value([*]);
+  --_ak-lm: 1;
 }
 
 @utility ak-layer-darken-* {
   --_ak-layer-idle-relative-lightness: calc((--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * -1);
   --_ak-layer-idle-relative-lightness: calc(--value([*]) * -1);
+  --_ak-lm: 1;
 }
 
 @utility ak-state-lighten-* {
   --_ak-layer-relative-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-layer-relative-lightness: --value([*]);
+  --_ak-lm: 1;
 }
 
 @utility ak-state-darken-* {
   --_ak-layer-relative-lightness: calc((--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100) * -1);
   --_ak-layer-relative-lightness: calc(--value([*]) * -1);
+  --_ak-lm: 1;
 }
 
 @utility ak-layer-cool-* {
   --_ak-layer-hue: calc(h + ((mod(((var(--hue-cool, 220) - h) + 540), 360) - 180) * clamp(0, (--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100), 1)));
   --_ak-layer-hue: calc(h + ((mod(((var(--hue-cool, 220) - h) + 540), 360) - 180) * clamp(0, --value([*]), 1)));
+  --_ak-lm: 1;
 }
 
 @utility ak-layer-warm-* {
   --_ak-layer-hue: calc(h + ((mod(((var(--hue-warm, 90) - h) + 540), 360) - 180) * clamp(0, (--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100), 1)));
   --_ak-layer-hue: calc(h + ((mod(((var(--hue-warm, 90) - h) + 540), 360) - 180) * clamp(0, --value([*]), 1)));
+  --_ak-lm: 1;
 }
 
 @utility ak-layer-push-* {
@@ -248,7 +266,8 @@
   --_ak-lipv: calc(var(--_ak-layer-idle-push-lightness) * var(--_ak-cps));
   --_ak-lipbl: clamp(var(--_ak-layer-lightness-min), (l + (var(--_ak-layer-idle-lightness-offset) + (var(--_ak-lipv) * var(--_ak-lod))) + (clamp(0, ((var(--_ak-layer-idle-lightness-offset) + (var(--_ak-lipv) * var(--_ak-lod))) * 1000000), 1) * var(--_ak-llfb))), var(--_ak-layer-lightness-max));
   --_ak-lipl: clamp(0, (var(--_ak-lipbl) + (clamp(0, (min((var(--_ak-lipbl) - var(--_ak-fla)), (var(--_ak-flb) - var(--_ak-lipbl))) * 1000000), 1) * ((var(--_ak-fla) + (var(--_ak-odtl) * var(--_ak-bw))) - var(--_ak-lipbl)))), 1);
-  --_ak-liprl: calc(var(--_ak-lipl) + (var(--_ak-lcb) * (1 - (var(--_ak-lcd) * var(--_ak-lcd)))));
+  --_ak-liprl: calc(var(--_ak-lipl) + (var(--_ak-lcb) * (1 - (var(--_ak-lcd) * var(--_ak-lcd))) * var(--_ak-lcbm, 1)));
+  --_ak-lm: 1;
 }
 
 @utility ak-layer-contrast {
@@ -289,83 +308,99 @@
     --_ak-lcd: -1;
     --_ak-lcpl: 1;
   }
+  --_ak-lm: 1;
 }
 
 @utility ak-layer-contrast-* {
   --_ak-layer-idle-contrast-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-layer-idle-contrast-lightness: --value([*]);
+  --_ak-lm: 1;
 }
 
 @utility ak-layer-max-* {
   --_ak-layer-chroma-max: --value(--chroma-*);
   --_ak-layer-lightness-max: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-layer-lightness-max: --value([*]);
+  --_ak-lm: 1;
 }
 
 @utility ak-layer-min-* {
   --_ak-layer-chroma-min: --value(--chroma-*);
   --_ak-layer-lightness-min: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-layer-lightness-min: --value([*]);
+  --_ak-lm: 1;
 }
 
 @utility ak-layer-max-l-* {
   --_ak-layer-lightness-max: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-layer-lightness-max: --value([*]);
+  --_ak-lm: 1;
 }
 
 @utility ak-layer-min-l-* {
   --_ak-layer-lightness-min: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-layer-lightness-min: --value([*]);
+  --_ak-lm: 1;
 }
 
 @utility ak-layer-max-c-* {
   --_ak-layer-chroma-max: --value(--chroma-*);
   --_ak-layer-chroma-max: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
   --_ak-layer-chroma-max: --value([*]);
+  --_ak-lm: 1;
 }
 
 @utility ak-layer-min-c-* {
   --_ak-layer-chroma-min: --value(--chroma-*);
   --_ak-layer-chroma-min: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
   --_ak-layer-chroma-min: --value([*]);
+  --_ak-lm: 1;
 }
 
 @utility ak-layer-max-c-auto {
   --_ak-layer-chroma-max: calc(1.607162354 * l * (1 - l));
+  --_ak-lm: 1;
 }
 
 @utility ak-layer-saturate-* {
   --_ak-layer-idle-relative-chroma: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
   --_ak-layer-idle-relative-chroma: --value([*]);
+  --_ak-lm: 1;
 }
 
 @utility ak-layer-desaturate-* {
   --_ak-layer-idle-relative-chroma: calc((--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100) * -1);
   --_ak-layer-idle-relative-chroma: calc(--value([*]) * -1);
+  --_ak-lm: 1;
 }
 
 @utility ak-layer-h-rotate-* {
   --_ak-layer-idle-relative-hue: --value(number, [*], "0", "15", "30", "45", "60", "75", "90", "105", "120", "135", "150", "165", "180", "195", "210", "225", "240", "255", "270", "285", "300", "315", "330", "345", "360");
+  --_ak-lm: 1;
 }
 
 @utility ak-state-h-rotate-* {
   --_ak-layer-relative-hue: --value(number, [*], "0", "15", "30", "45", "60", "75", "90", "105", "120", "135", "150", "165", "180", "195", "210", "225", "240", "255", "270", "285", "300", "315", "330", "345", "360");
+  --_ak-lm: 1;
 }
 
 @utility ak-layer-l-* {
   --_ak-layer-lightness: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100") / 100);
   --_ak-layer-lightness: --value([*]);
+  --_ak-lm: 1;
 }
 
 @utility ak-layer-c-* {
   --_ak-layer-chroma: --value(--chroma-*);
   --_ak-layer-chroma: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
   --_ak-layer-chroma: --value([*]);
+  --_ak-lm: 1;
 }
 
 @utility ak-layer-h-* {
   --_ak-layer-hue: --value(--hue-*);
   --_ak-layer-hue: --value(number, [*], "0", "15", "30", "45", "60", "75", "90", "105", "120", "135", "150", "165", "180", "195", "210", "225", "240", "255", "270", "285", "300", "315", "330", "345", "360");
+  --_ak-lm: 1;
 }
 
 @utility ak-state-* {
@@ -377,6 +412,7 @@
   --_ak-lobl: calc((l + var(--_ak-layer-lightness-offset-delta) + (clamp(0, (var(--_ak-layer-lightness-offset-delta) * 1000000), 1) * var(--_ak-llfb))) + (0 * --value([*])));
   --_ak-lodl: calc((var(--_ak-lobl) - l) + (0 * --value([*])));
   --_ak-layer-lightness-offset-resolved: calc((var(--_ak-lobl) + (clamp(0, (max(var(--_ak-layer-lightness-offset-delta), (var(--_ak-layer-lightness-offset-delta) * -1)) * 1000000), 1) * ((var(--_ak-lodl) + (clamp(0, (min(((l + var(--_ak-lodl)) - var(--_ak-fla)), (var(--_ak-flb) - (l + var(--_ak-lodl)))) * 1000000), 1) * (((var(--_ak-eb) - l) + (clamp(0, ((((l - clamp(0, (l + (var(--_ak-lodl) * -1)), 1)) * var(--_ak-lod)) - ((var(--_ak-eb) - l) * var(--_ak-lod))) * 1000000), 1) * ((var(--_ak-lodl) * -1) - (var(--_ak-eb) - l)))) - var(--_ak-lodl)))) - var(--_ak-lodl)))) + (0 * --value([*])));
+  --_ak-lm: 1;
 }
 
 @utility ak-state-offset-* {
@@ -388,6 +424,7 @@
   --_ak-lobl: calc((l + var(--_ak-layer-lightness-offset-delta) + (clamp(0, (var(--_ak-layer-lightness-offset-delta) * 1000000), 1) * var(--_ak-llfb))) + (0 * --value([*])));
   --_ak-lodl: calc((var(--_ak-lobl) - l) + (0 * --value([*])));
   --_ak-layer-lightness-offset-resolved: calc((var(--_ak-lobl) + (clamp(0, (max(var(--_ak-layer-lightness-offset-delta), (var(--_ak-layer-lightness-offset-delta) * -1)) * 1000000), 1) * ((var(--_ak-lodl) + (clamp(0, (min(((l + var(--_ak-lodl)) - var(--_ak-fla)), (var(--_ak-flb) - (l + var(--_ak-lodl)))) * 1000000), 1) * (((var(--_ak-eb) - l) + (clamp(0, ((((l - clamp(0, (l + (var(--_ak-lodl) * -1)), 1)) * var(--_ak-lod)) - ((var(--_ak-eb) - l) * var(--_ak-lod))) * 1000000), 1) * ((var(--_ak-lodl) * -1) - (var(--_ak-eb) - l)))) - var(--_ak-lodl)))) - var(--_ak-lodl)))) + (0 * --value([*])));
+  --_ak-lm: 1;
 }
 
 @utility ak-state-push-* {
@@ -396,16 +433,19 @@
   --_ak-lpv: calc(var(--_ak-layer-push-lightness) * var(--_ak-cps));
   --_ak-lpbl: calc(l + (var(--_ak-lpv) * var(--_ak-lod)) + (clamp(0, ((var(--_ak-lpv) * var(--_ak-lod)) * 1000000), 1) * var(--_ak-llfb)));
   --_ak-lpl: clamp(0, (var(--_ak-lpbl) + (clamp(0, (min((var(--_ak-lpbl) - var(--_ak-fla)), (var(--_ak-flb) - var(--_ak-lpbl))) * 1000000), 1) * ((var(--_ak-fla) + (var(--_ak-odtl) * var(--_ak-bw))) - var(--_ak-lpbl)))), 1);
+  --_ak-lm: 1;
 }
 
 @utility ak-state-saturate-* {
   --_ak-layer-relative-chroma: calc(--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100);
   --_ak-layer-relative-chroma: --value([*]);
+  --_ak-lm: 1;
 }
 
 @utility ak-state-desaturate-* {
   --_ak-layer-relative-chroma: calc((--value(number, "0", "5", "10", "15", "20", "25", "30", "35", "40") / 100) * -1);
   --_ak-layer-relative-chroma: calc(--value([*]) * -1);
+  --_ak-lm: 1;
 }
 
 @utility ak-edge-* {
@@ -1454,6 +1494,12 @@
 }
 
 @property --_ak-lipe {
+  syntax: "<number>";
+  inherits: false;
+  initial-value: 0;
+}
+
+@property --_ak-lm {
   syntax: "<number>";
   inherits: false;
   initial-value: 0;


### PR DESCRIPTION
## Motivation

Bare nested `ak-layer` elements reapplied the global contrast bias to the inherited parent color. At intermediate contrast levels such as `5`, this made each unmodified dark layer progressively darker even though a bare layer should preserve its parent surface.

```html
<div class="ak-layer [--contrast:5]">
  <div class="ak-layer">Same background</div>
</div>
```

## Solution

Track whether a layer is nested and whether it has a `layer-*` or `state-*` modifier, then suppress the contrast bias only for nested bare layers. Top-level and modified layers retain their existing contrast behavior.

Add focused browser coverage for light and dark schemes at contrast levels `0`, `5`, `50`, and `100`, including modified layers nested through a bare layer. Regenerate the computed-style snapshots; the remaining changes are confined to the disabled high-contrast matrix, where contrast is scaled to an intermediate value.
