### PR TITLE
Expose SelectItem selection state

### DIFF
--- a/.changeset/200-select-item-selected.md
+++ b/.changeset/200-select-item-selected.md
@@ -1,0 +1,19 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+New `SelectItemSelected` component
+
+The new [`SelectItemSelected`](https://ariakit.com/reference/select-item-selected) value component exposes whether the closest [`SelectItem`](https://ariakit.com/reference/select-item) is selected through a required function child.
+
+```tsx
+<SelectItem value="Apple">
+  <SelectItemSelected>
+    {(selected) => (selected ? <CheckIcon /> : null)}
+  </SelectItemSelected>
+  Apple
+</SelectItem>
+```
+
+Thanks to [@jonrimmer](https://github.com/jonrimmer) for proposing the feature, and [@georgekaran](https://github.com/georgekaran) for the investigation and implementation work that informed this solution.

--- a/app/src/sandbox/select-item-4567/index.react.tsx
+++ b/app/src/sandbox/select-item-4567/index.react.tsx
@@ -9,21 +9,13 @@ export default function Example() {
       <Ariakit.Select />
       <Ariakit.SelectPopover gutter={4} sameWidth>
         {fruits.map((fruit) => (
-          <Ariakit.SelectItem
-            key={fruit}
-            value={fruit}
-            render={(props) => {
-              // TODO: Remove when https://github.com/ariakit/ariakit/issues/4567 is fixed.
-              const selected =
-                props["aria-selected"] === true ||
-                props["aria-selected"] === "true";
-              return (
-                <div {...props}>
-                  {props.children} ({selected ? "selected" : "not selected"})
-                </div>
-              );
-            }}
-          />
+          <Ariakit.SelectItem key={fruit} value={fruit}>
+            <Ariakit.SelectItemSelected>
+              {(selected) =>
+                `${fruit} (${selected ? "selected" : "not selected"})`
+              }
+            </Ariakit.SelectItemSelected>
+          </Ariakit.SelectItem>
         ))}
       </Ariakit.SelectPopover>
     </Ariakit.SelectProvider>

--- a/app/src/sandbox/select-item-4567/index.react.tsx
+++ b/app/src/sandbox/select-item-4567/index.react.tsx
@@ -1,0 +1,23 @@
+import * as Ariakit from "@ariakit/react";
+
+const fruits = ["Apple", "Banana", "Orange"];
+
+export default function Example() {
+  return (
+    <Ariakit.SelectProvider defaultValue={["Apple"]}>
+      <Ariakit.SelectLabel>Favorite fruits</Ariakit.SelectLabel>
+      <Ariakit.Select />
+      <Ariakit.SelectPopover gutter={4} sameWidth>
+        {fruits.map((fruit) => (
+          <Ariakit.SelectItem key={fruit} value={fruit}>
+            <Ariakit.SelectItemSelected>
+              {(selected) =>
+                `${fruit} (${selected ? "selected" : "not selected"})`
+              }
+            </Ariakit.SelectItemSelected>
+          </Ariakit.SelectItem>
+        ))}
+      </Ariakit.SelectPopover>
+    </Ariakit.SelectProvider>
+  );
+}

--- a/app/src/sandbox/select-item-4567/index.react.tsx
+++ b/app/src/sandbox/select-item-4567/index.react.tsx
@@ -9,13 +9,21 @@ export default function Example() {
       <Ariakit.Select />
       <Ariakit.SelectPopover gutter={4} sameWidth>
         {fruits.map((fruit) => (
-          <Ariakit.SelectItem key={fruit} value={fruit}>
-            <Ariakit.SelectItemSelected>
-              {(selected) =>
-                `${fruit} (${selected ? "selected" : "not selected"})`
-              }
-            </Ariakit.SelectItemSelected>
-          </Ariakit.SelectItem>
+          <Ariakit.SelectItem
+            key={fruit}
+            value={fruit}
+            render={(props) => {
+              // TODO: Remove when https://github.com/ariakit/ariakit/issues/4567 is fixed.
+              const selected =
+                props["aria-selected"] === true ||
+                props["aria-selected"] === "true";
+              return (
+                <div {...props}>
+                  {props.children} ({selected ? "selected" : "not selected"})
+                </div>
+              );
+            }}
+          />
         ))}
       </Ariakit.SelectPopover>
     </Ariakit.SelectProvider>

--- a/app/src/sandbox/select-item-4567/test-browser.ts
+++ b/app/src/sandbox/select-item-4567/test-browser.ts
@@ -1,0 +1,16 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/4567
+  test("exposes and updates the SelectItem selected state", async ({ q }) => {
+    await q.combobox("Favorite fruits").click();
+    await test.expect(q.option("Apple (selected)")).toBeVisible();
+    await test.expect(q.option("Banana (not selected)")).toBeVisible();
+
+    await q.option("Banana (not selected)").click();
+    await test.expect(q.option("Banana (selected)")).toBeVisible();
+
+    await q.option("Apple (selected)").click();
+    await test.expect(q.option("Apple (not selected)")).toBeVisible();
+  });
+});

--- a/app/src/sandbox/select-item-4567/test.ts
+++ b/app/src/sandbox/select-item-4567/test.ts
@@ -1,0 +1,15 @@
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// https://github.com/ariakit/ariakit/issues/4567
+test("exposes and updates the SelectItem selected state", async () => {
+  await click(q.combobox("Favorite fruits"));
+  expect(q.option("Apple (selected)")).toBeVisible();
+  expect(q.option("Banana (not selected)")).toBeVisible();
+
+  await click(q.option("Banana (not selected)"));
+  expect(q.option("Banana (selected)")).toBeVisible();
+
+  await click(q.option("Apple (selected)"));
+  expect(q.option("Apple (not selected)")).toBeVisible();
+});

--- a/components/select.md
+++ b/components/select.md
@@ -49,6 +49,7 @@ useSelectContext()
         <SelectRow>
           <SelectItem>
             <SelectItemCheck />
+            <SelectItemSelected />
           </SelectItem>
           <SelectSeparator />
         </SelectRow>

--- a/guide/500-value-components/readme.md
+++ b/guide/500-value-components/readme.md
@@ -6,26 +6,26 @@ group: Advanced
 
 <div data-description>
 
-Read and render a single value from an Ariakit provider or store without adding any element of your own.
+Read and render a single Ariakit value from a provider, store, or item context without adding any element of your own.
 
 </div>
 
 <aside data-type="note" title="Component stores">
 
-Value components are a convenience built on top of [component stores](/guide/component-stores). If you need arbitrary store fields or a computed selector, reach for [`useStoreState`](/guide/component-stores#reading-the-state) instead.
+Many value components are a convenience built on top of [component stores](/guide/component-stores). Item-scoped value components read from the closest item's context instead. If you need arbitrary store fields or a computed selector, reach for [`useStoreState`](/guide/component-stores#reading-the-state).
 
 </aside>
 
 ## Overview
 
-A value component reads one specific value from a provider or an explicit store and renders it. Unlike most Ariakit components, it:
+A value component reads one specific value from a provider, an explicit store, or the closest item context and renders it. Unlike most Ariakit components, it:
 
-- reads a single value from the nearest provider or from an explicit `store` prop
+- reads a single value from the nearest provider, an explicit `store` prop, or the closest item context
 - adds no element of its own, though it may return text or arbitrary JSX
 - exposes the value directly or through a `children` render function
 - does not accept HTML props such as `className`, `style`, or `ref`, because it has no element to receive them
 
-The stable public value components are [`SelectValue`](/reference/select-value) and [`ComboboxValue`](/reference/combobox-value), both exported from `@ariakit/react`.
+The stable public value components are [`SelectValue`](/reference/select-value), [`ComboboxValue`](/reference/combobox-value), and [`SelectItemSelected`](/reference/select-item-selected), all exported from `@ariakit/react`.
 
 This pattern is not inherently uncontrolled. Value components work with both controlled and uncontrolled providers and stores. Their main benefit is exposing state close to the JSX that needs it, without creating or passing a store solely for that purpose.
 
@@ -63,6 +63,21 @@ Pass a function as `children` to transform the value before rendering it. The fu
 ```
 
 Returning the raw value isn't always useful. For example, a multi-select renders its values with no separators between them. Use a function child whenever the value needs formatting or custom UI.
+
+## Rendering item state
+
+Item-scoped value components read state from the closest item instead of the provider or store. For example, use [`SelectItemSelected`](/reference/select-item-selected) inside a [`SelectItem`](/reference/select-item) to render custom UI based on whether that item is selected:
+
+```jsx {2-4}
+<SelectItem value="Apple">
+  <SelectItemSelected>
+    {(selected) => (selected ? <CheckIcon /> : null)}
+  </SelectItemSelected>
+  Apple
+</SelectItem>
+```
+
+The `children` function is required because a raw boolean doesn't produce visible output in React. It receives the current selected state and re-runs whenever that state changes.
 
 <aside data-type="note" title="The render prop">
 

--- a/packages/ariakit-react-components/package.json
+++ b/packages/ariakit-react-components/package.json
@@ -225,6 +225,7 @@
     "./select/select-item": "./src/select/select-item.tsx",
     "./select/select-item-check": "./src/select/select-item-check.tsx",
     "./select/select-item-offscreen": "./src/select/select-item-offscreen.tsx",
+    "./select/select-item-selected": "./src/select/select-item-selected.tsx",
     "./select/select-label": "./src/select/select-label.tsx",
     "./select/select-list": "./src/select/select-list.tsx",
     "./select/select-popover": "./src/select/select-popover.tsx",

--- a/packages/ariakit-react-components/src/select/select-item-selected.tsx
+++ b/packages/ariakit-react-components/src/select/select-item-selected.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react";
+import { useContext } from "react";
+import { SelectItemCheckedContext } from "./select-context.tsx";
+
+/**
+ * Exposes whether the closest
+ * [`SelectItem`](https://ariakit.com/reference/select-item) is selected through
+ * a function child.
+ *
+ * As a value component, it doesn't render any DOM elements and therefore
+ * doesn't accept HTML props.
+ * @see https://ariakit.com/components/select
+ * @example
+ * ```jsx {5-9}
+ * <SelectProvider>
+ *   <Select />
+ *   <SelectPopover>
+ *     <SelectItem value="Apple">
+ *       <SelectItemSelected>
+ *         {(selected) => (selected ? <CheckIcon /> : null)}
+ *       </SelectItemSelected>
+ *       Apple
+ *     </SelectItem>
+ *   </SelectPopover>
+ * </SelectProvider>
+ * ```
+ */
+export function SelectItemSelected({ children }: SelectItemSelectedProps) {
+  const selected = useContext(SelectItemCheckedContext);
+  return children(selected);
+}
+
+export interface SelectItemSelectedProps {
+  /**
+   * A function that gets called with the closest
+   * [`SelectItem`](https://ariakit.com/reference/select-item) component's
+   * selected state.
+   */
+  children: (selected: boolean) => ReactNode;
+}

--- a/packages/ariakit-react-components/src/select/select-item-selected.tsx
+++ b/packages/ariakit-react-components/src/select/select-item-selected.tsx
@@ -11,7 +11,7 @@ import { SelectItemCheckedContext } from "./select-context.tsx";
  * doesn't accept HTML props.
  * @see https://ariakit.com/components/select
  * @example
- * ```jsx {5-9}
+ * ```jsx {5-7}
  * <SelectProvider>
  *   <Select />
  *   <SelectPopover>

--- a/packages/ariakit-react/src/select.ts
+++ b/packages/ariakit-react/src/select.ts
@@ -39,6 +39,8 @@ export type {
   SelectItemCheckProps,
 } from "@ariakit/react-components/select/select-item-check";
 export { SelectItemCheck } from "@ariakit/react-components/select/select-item-check";
+export type { SelectItemSelectedProps } from "@ariakit/react-components/select/select-item-selected";
+export { SelectItemSelected } from "@ariakit/react-components/select/select-item-selected";
 export type {
   SelectLabelOptions,
   SelectLabelProps,


### PR DESCRIPTION
## Motivation

[`SelectItem`](https://ariakit.com/reference/select-item) calculates whether each option is selected, but descendants can only observe that state indirectly through the rendered `aria-selected` attribute. This makes custom item UI awkward when it needs the selection state as a JavaScript boolean.

```tsx
<SelectItem value="Apple">
  <SelectItemSelected>
    {(selected) => (selected ? <CheckIcon /> : null)}
  </SelectItemSelected>
  Apple
</SelectItem>
```

Fixes #4567.

## Solution

Add a DOM-less `SelectItemSelected` value component. Its required function child receives the closest `SelectItem`'s reactive selected state, using the same internal context that already drives `SelectItemCheck`.

The component is exported from `@ariakit/react-components/select/select-item-selected` and `@ariakit/react`. The value-components guide, Select component map, and release notes document the new API.

An app-owned multi-select fixture has equivalent Playwright and happy-dom regression tests covering initially selected and unselected items plus both reactive selection transitions. The focused tests pass with React 18 and React 19 and in Chrome, Firefox, and Safari.

## Workaround

On versions without `SelectItemSelected`, use `SelectItem`'s `render` callback and read the computed `aria-selected` prop:

```tsx
<SelectItem
  value="Apple"
  render={(props) => {
    // TODO: Remove when https://github.com/ariakit/ariakit/issues/4567 is fixed.
    const selected =
      props["aria-selected"] === true ||
      props["aria-selected"] === "true";
    return (
      <div {...props}>
        {selected && <CheckIcon aria-hidden />}
        {props.children}
      </div>
    );
  }}
/>
```

The callback owns the item's root element, so it must return an element and spread every received prop to preserve the item role, ARIA state, ref, keyboard behavior, and event handlers. If an item already has a custom `render` callback, fold this logic into that callback instead of adding a second one.