### PR TITLE
Keep Radix combobox open on resize

### DIFF
--- a/examples/combobox-radix-select/index.react.tsx
+++ b/examples/combobox-radix-select/index.react.tsx
@@ -6,13 +6,52 @@ import {
 } from "@ariakit/react";
 import * as RadixSelect from "@radix-ui/react-select";
 import { matchSorter } from "match-sorter";
-import { startTransition, useMemo, useState } from "react";
+import {
+  startTransition,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { CheckIcon, ChevronUpDownIcon, SearchIcon } from "./icons.tsx";
 import { languages } from "./languages.ts";
 import "./style.css";
 
-export default function Example() {
+function useRadixSelectOpenState() {
   const [open, setOpen] = useState(false);
+  const isWindowResizingRef = useRef(false);
+
+  useEffect(() => {
+    let resetTimer = 0;
+    const onResize = () => {
+      isWindowResizingRef.current = true;
+      // Browsers may run microtasks between event listeners, so clear the
+      // marker in the next task, after Radix handles this event.
+      window.clearTimeout(resetTimer);
+      resetTimer = window.setTimeout(() => {
+        isWindowResizingRef.current = false;
+      }, 0);
+    };
+    // Mark the resize before Radix handles it, but let the event reach Floating
+    // UI so the popover can reposition.
+    window.addEventListener("resize", onResize, true);
+    return () => {
+      window.removeEventListener("resize", onResize, true);
+      window.clearTimeout(resetTimer);
+    };
+  }, []);
+
+  const onOpenChange = useCallback((nextOpen: boolean) => {
+    if (!nextOpen && isWindowResizingRef.current) return;
+    setOpen(nextOpen);
+  }, []);
+
+  return { open, setOpen, onOpenChange };
+}
+
+export default function Example() {
+  const { open, setOpen, onOpenChange } = useRadixSelectOpenState();
   const [value, setValue] = useState("");
   const [searchValue, setSearchValue] = useState("");
 
@@ -34,7 +73,7 @@ export default function Example() {
       value={value}
       onValueChange={setValue}
       open={open}
-      onOpenChange={setOpen}
+      onOpenChange={onOpenChange}
     >
       <ComboboxProvider
         open={open}

--- a/examples/combobox-radix-select/readme.md
+++ b/examples/combobox-radix-select/readme.md
@@ -18,7 +18,9 @@ Rendering a searchable [Radix UI](https://radix-ui.com) Select component with a 
 
 <aside data-type="note" title="Note">
 
-This example is designed for those who are already using Radix UI in their projects and can't easily switch away from it. If you're starting from scratch or can update your custom select widgets to use Ariakit, we recommend checking out the [Select with Combobox](/examples/select-combobox) example instead, which uses the Ariakit [Select](/components/select) component.
+Radix UI Select [doesn't currently provide first-class Combobox support](https://github.com/radix-ui/primitives/pull/2635#issuecomment-5018225573). This example is designed for those who are already using Radix UI in their projects and can't easily switch away from it. It includes targeted integration workarounds that may need to be revisited when upgrading Radix UI.
+
+If you're starting from scratch or can update your custom select widgets to use Ariakit, we recommend checking out the [Select with Combobox](/examples/select-combobox) example instead, which uses the Ariakit [Select](/components/select) component.
 
 </aside>
 
@@ -57,9 +59,9 @@ Explore the Ariakit components used in this example:
 We can share state between Ariakit and Radix UI by passing our own `open` state to both Radix's `Root` and Ariakit's [`ComboboxProvider`](/reference/combobox-provider):
 
 ```jsx
-const [open, setOpen] = useState(false);
+const { open, setOpen, onOpenChange } = useRadixSelectOpenState();
 
-<RadixSelect.Root open={open} onOpenChange={setOpen}>
+<RadixSelect.Root open={open} onOpenChange={onOpenChange}>
   <ComboboxProvider open={open} setOpen={setOpen}>
 ```
 
@@ -70,6 +72,44 @@ You can learn more about this Ariakit feature in the guide:
 - [](/guide/component-providers)
 
 </div>
+
+## Keeping the Select open when the viewport resizes
+
+Radix Select closes its popup when the window resizes. On mobile browsers, showing the on-screen keyboard may resize the window and immediately close the popup. Since this example uses Radix's `position="popper"` mode, its Floating UI positioning already reacts to viewport changes. We can keep this controlled Select open while the resize event is being handled and let the popup reposition instead:
+
+```jsx "onOpenChange" "addEventListener"
+function useRadixSelectOpenState() {
+  const [open, setOpen] = useState(false);
+  const isWindowResizingRef = useRef(false);
+
+  useEffect(() => {
+    let resetTimer = 0;
+    const onResize = () => {
+      isWindowResizingRef.current = true;
+      window.clearTimeout(resetTimer);
+      resetTimer = window.setTimeout(() => {
+        isWindowResizingRef.current = false;
+      }, 0);
+    };
+    window.addEventListener("resize", onResize, true);
+    return () => {
+      window.removeEventListener("resize", onResize, true);
+      window.clearTimeout(resetTimer);
+    };
+  }, []);
+
+  const onOpenChange = useCallback((nextOpen) => {
+    if (!nextOpen && isWindowResizingRef.current) return;
+    setOpen(nextOpen);
+  }, []);
+
+  return { open, setOpen, onOpenChange };
+}
+```
+
+The capture listener marks the current resize before Radix handles it without stopping propagation, so Floating UI and other resize listeners still run. The timer clears the marker in the next task because browsers may run microtasks between event listeners.
+
+This intentionally keeps the popup open for every window resize, including virtual keyboards, orientation changes, and ordinary resizing. Browsers don't expose a reliable way to distinguish those causes.
 
 ## Filtering options
 

--- a/examples/combobox-radix-select/test-mobile.ts
+++ b/examples/combobox-radix-select/test-mobile.ts
@@ -1,0 +1,35 @@
+import { query } from "@ariakit/test/playwright";
+import { expect } from "@playwright/test";
+import { test } from "../test-utils.ts";
+
+// https://github.com/ariakit/ariakit/issues/3274
+test("keeps the select open when the viewport resizes", async ({ page }) => {
+  const q = query(page);
+  const select = q.combobox("Language");
+  const input = q.combobox("Search languages");
+  const dialog = q.dialog("Languages");
+
+  await select.tap();
+  await expect(dialog).toBeVisible();
+  await expect(input).toBeFocused();
+
+  const viewport = page.viewportSize();
+  if (!viewport) throw new Error("Expected the page to have a viewport");
+
+  await page.setViewportSize({
+    width: viewport.width,
+    height: viewport.height - 200,
+  });
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => requestAnimationFrame(() => resolve())),
+  );
+
+  await expect(dialog).toBeVisible();
+  await expect(dialog).toBeInViewport({ ratio: 1 });
+  await expect(input).toBeFocused();
+
+  await page.keyboard.press("Escape");
+  await expect(dialog).not.toBeVisible();
+  await expect(select).toBeFocused();
+});


### PR DESCRIPTION
## Motivation

Fixes #3274.

The Radix Select with Combobox example closes as soon as Chrome on Android shows the on-screen keyboard. Radix Select listens to every `window.resize` event and synchronously calls `onOpenChange(false)`, while showing a mobile keyboard can resize the window.

A viewport-dimension heuristic would not be portable across iOS or pages using `interactive-widget=resizes-content`. The [Radix maintainer's follow-up](https://github.com/radix-ui/primitives/pull/2635#issuecomment-5018225573) also clarifies that filterable Select is not a first-class supported composition, so this should remain an explicit example-level integration workaround.

## Solution

Keep the example's controlled Select open only when Radix requests a close while the current window resize event is being handled:

```tsx
const onOpenChange = (nextOpen: boolean) => {
  if (!nextOpen && isWindowResizingRef.current) return;
  setOpen(nextOpen);
};
```

A capture listener marks the resize before Radix's listener runs, then clears the marker in the next task. It does not stop propagation, so Floating UI can still react to the resize and reposition the `position="popper"` popup. Escape, selection, outside interaction, and other ordinary close paths remain unchanged.

The example documentation now explains the workaround and the broader Radix Combobox limitation. A focused mobile Playwright regression verifies that resizing keeps the dialog fully visible and focused, then verifies that Escape still closes it and restores trigger focus.

## Testing

- `pnpm test-react examples/combobox-radix-select/test.ts`
- `pnpm test-react18 examples/combobox-radix-select/test.ts`
- iOS/WebKit and Android/Chromium mobile Playwright projects for `examples/combobox-radix-select/test-mobile.ts` (using an equivalent temporary port-only config because local port 3000 was occupied)
- `pnpm tsc`
- `pnpm lint`
- `pnpm build-website-lite`
