### PR TITLE
Support disabled RadioGroup

### DIFF
--- a/.changeset/200-radio-group-disabled.md
+++ b/.changeset/200-radio-group-disabled.md
@@ -1,0 +1,17 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+`RadioGroup` disables descendant radios
+
+The [`RadioGroup`](https://ariakit.com/reference/radio-group) `disabled` prop now marks the group as disabled and disables descendant [`Radio`](https://ariakit.com/reference/radio) components, including radios rendered as custom elements.
+
+```tsx
+<RadioGroup disabled>
+  <Radio value="Apple" />
+  <Radio value="Orange" />
+</RadioGroup>
+```
+
+Thanks to [@kripod](https://github.com/kripod) for reporting the issue.

--- a/app/src/sandbox/radio-group-3851/index.react.tsx
+++ b/app/src/sandbox/radio-group-3851/index.react.tsx
@@ -3,7 +3,11 @@ import * as Ariakit from "@ariakit/react";
 export default function Example() {
   return (
     <Ariakit.RadioProvider>
-      <Ariakit.RadioGroup aria-label="Fruits" disabled>
+      <Ariakit.RadioGroup
+        aria-label="Fruits"
+        disabled
+        render={<fieldset disabled />}
+      >
         <label>
           <Ariakit.Radio value="apple" />
           Apple

--- a/app/src/sandbox/radio-group-3851/index.react.tsx
+++ b/app/src/sandbox/radio-group-3851/index.react.tsx
@@ -1,0 +1,22 @@
+import * as Ariakit from "@ariakit/react";
+
+export default function Example() {
+  return (
+    <Ariakit.RadioProvider>
+      <Ariakit.RadioGroup aria-label="Fruits" disabled>
+        <label>
+          <Ariakit.Radio value="apple" />
+          Apple
+        </label>
+        <label>
+          <Ariakit.Radio value="orange" />
+          Orange
+        </label>
+        <label>
+          <Ariakit.Radio value="watermelon" />
+          Watermelon
+        </label>
+      </Ariakit.RadioGroup>
+    </Ariakit.RadioProvider>
+  );
+}

--- a/app/src/sandbox/radio-group-3851/index.react.tsx
+++ b/app/src/sandbox/radio-group-3851/index.react.tsx
@@ -3,23 +3,20 @@ import * as Ariakit from "@ariakit/react";
 export default function Example() {
   return (
     <Ariakit.RadioProvider>
-      <Ariakit.RadioGroup
-        aria-label="Fruits"
-        disabled
-        render={<fieldset disabled />}
-      >
+      <Ariakit.RadioGroup aria-label="Fruits" disabled>
         <label>
           <Ariakit.Radio value="apple" />
           Apple
         </label>
         <label>
-          <Ariakit.Radio value="orange" />
+          <Ariakit.Radio disabled={false} value="orange" />
           Orange
         </label>
         <label>
           <Ariakit.Radio value="watermelon" />
           Watermelon
         </label>
+        <Ariakit.Radio render={<div>Banana</div>} value="banana" />
       </Ariakit.RadioGroup>
     </Ariakit.RadioProvider>
   );

--- a/app/src/sandbox/radio-group-3851/test-browser.ts
+++ b/app/src/sandbox/radio-group-3851/test-browser.ts
@@ -2,9 +2,15 @@ import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
   // https://github.com/ariakit/ariakit/issues/3851
-  test("disabled prop disables the radios", async ({ q }) => {
+  test("disabled prop disables the group and radios", async ({ q }) => {
+    await test
+      .expect(q.radiogroup("Fruits"))
+      .toHaveAttribute("aria-disabled", "true");
     await test.expect(q.radio("Apple")).toBeDisabled();
     await test.expect(q.radio("Orange")).toBeDisabled();
     await test.expect(q.radio("Watermelon")).toBeDisabled();
+    await test
+      .expect(q.radio("Banana"))
+      .toHaveAttribute("aria-disabled", "true");
   });
 });

--- a/app/src/sandbox/radio-group-3851/test-browser.ts
+++ b/app/src/sandbox/radio-group-3851/test-browser.ts
@@ -1,0 +1,10 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/3851
+  test("disabled prop disables the radios", async ({ q }) => {
+    await test.expect(q.radio("Apple")).toBeDisabled();
+    await test.expect(q.radio("Orange")).toBeDisabled();
+    await test.expect(q.radio("Watermelon")).toBeDisabled();
+  });
+});

--- a/app/src/sandbox/radio-group-3851/test.ts
+++ b/app/src/sandbox/radio-group-3851/test.ts
@@ -1,0 +1,9 @@
+import { q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// https://github.com/ariakit/ariakit/issues/3851
+test("disabled prop disables the radios", () => {
+  expect(q.radio("Apple")).toBeDisabled();
+  expect(q.radio("Orange")).toBeDisabled();
+  expect(q.radio("Watermelon")).toBeDisabled();
+});

--- a/app/src/sandbox/radio-group-3851/test.ts
+++ b/app/src/sandbox/radio-group-3851/test.ts
@@ -2,8 +2,10 @@ import { q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 // https://github.com/ariakit/ariakit/issues/3851
-test("disabled prop disables the radios", () => {
+test("disabled prop disables the group and radios", () => {
+  expect(q.radiogroup("Fruits")).toHaveAttribute("aria-disabled", "true");
   expect(q.radio("Apple")).toBeDisabled();
   expect(q.radio("Orange")).toBeDisabled();
   expect(q.radio("Watermelon")).toBeDisabled();
+  expect(q.radio("Banana")).toHaveAttribute("aria-disabled", "true");
 });

--- a/packages/ariakit-react-components/src/radio/radio-context.tsx
+++ b/packages/ariakit-react-components/src/radio/radio-context.tsx
@@ -1,4 +1,5 @@
 import { createStoreContext } from "@ariakit/react-utils";
+import { createContext } from "react";
 import {
   CompositeContextProvider,
   CompositeScopedContextProvider,
@@ -32,3 +33,5 @@ export const useRadioProviderContext = ctx.useProviderContext;
 export const RadioContextProvider = ctx.ContextProvider;
 
 export const RadioScopedContextProvider = ctx.ScopedContextProvider;
+
+export const RadioGroupDisabledContext = createContext(false);

--- a/packages/ariakit-react-components/src/radio/radio-group.tsx
+++ b/packages/ariakit-react-components/src/radio/radio-group.tsx
@@ -6,11 +6,17 @@ import {
   forwardRef,
 } from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
-import { invariant, isFocusEventOutside } from "@ariakit/utils";
+import {
+  disabledFromProps,
+  invariant,
+  isFocusEventOutside,
+} from "@ariakit/utils";
 import type { ElementType, FocusEvent } from "react";
+import { useContext } from "react";
 import type { CompositeOptions } from "../composite/composite.tsx";
 import { useComposite } from "../composite/composite.tsx";
 import {
+  RadioGroupDisabledContext,
   RadioScopedContextProvider,
   useRadioProviderContext,
 } from "./radio-context.tsx";
@@ -55,6 +61,8 @@ export const useRadioGroup = createHook<TagName, RadioGroupOptions>(
   function useRadioGroup({ store, ...props }) {
     const context = useRadioProviderContext();
     store = store || context;
+    const parentDisabled = useContext(RadioGroupDisabledContext);
+    const disabled = parentDisabled || disabledFromProps(props);
 
     invariant(
       store,
@@ -66,10 +74,12 @@ export const useRadioGroup = createHook<TagName, RadioGroupOptions>(
       props,
       (element) => (
         <RadioScopedContextProvider value={store}>
-          {element}
+          <RadioGroupDisabledContext.Provider value={disabled}>
+            {element}
+          </RadioGroupDisabledContext.Provider>
         </RadioScopedContextProvider>
       ),
-      [store],
+      [store, disabled],
     );
 
     const onBlurCaptureProp = props.onBlurCapture;
@@ -85,6 +95,7 @@ export const useRadioGroup = createHook<TagName, RadioGroupOptions>(
     props = {
       role: "radiogroup",
       ...props,
+      "aria-disabled": disabled || undefined,
       onBlurCapture,
     };
 
@@ -118,6 +129,12 @@ export const RadioGroup = forwardRef(function RadioGroup(
 export interface RadioGroupOptions<
   T extends ElementType = TagName,
 > extends CompositeOptions<T> {
+  /**
+   * Determines if the radio group and its descendant
+   * [`Radio`](https://ariakit.com/reference/radio) components are disabled.
+   * @default false
+   */
+  disabled?: boolean;
   /**
    * Object returned by the
    * [`useRadioStore`](https://ariakit.com/reference/use-radio-store) hook. If

--- a/packages/ariakit-react-components/src/radio/radio.tsx
+++ b/packages/ariakit-react-components/src/radio/radio.tsx
@@ -14,10 +14,13 @@ import type { Props } from "@ariakit/react-utils";
 import { disabledFromProps, removeUndefinedValues } from "@ariakit/utils";
 import type { BivariantCallback } from "@ariakit/utils";
 import type { ChangeEvent, ElementType, FocusEvent, MouseEvent } from "react";
-import { useEffect, useRef } from "react";
+import { useContext, useEffect, useRef } from "react";
 import type { CompositeItemOptions } from "../composite/composite-item.tsx";
 import { useCompositeItem } from "../composite/composite-item.tsx";
-import { useRadioContext } from "./radio-context.tsx";
+import {
+  RadioGroupDisabledContext,
+  useRadioContext,
+} from "./radio-context.tsx";
 import type { RadioStore, RadioStoreState } from "./radio-store.ts";
 
 const TagName = "input" satisfies ElementType;
@@ -61,6 +64,7 @@ export const useRadio = createHook<TagName, RadioOptions>(function useRadio({
 }) {
   const context = useRadioContext();
   store = store || context;
+  const groupDisabled = useContext(RadioGroupDisabledContext);
 
   const id = useId(props.id);
 
@@ -91,7 +95,7 @@ export const useRadio = createHook<TagName, RadioOptions>(function useRadio({
   const onChangeProp = props.onChange;
   const tagName = useTagName(ref, TagName);
   const nativeRadio = isNativeRadio(tagName, props.type);
-  const disabled = disabledFromProps(props);
+  const disabled = groupDisabled || disabledFromProps(props);
   // When the checked property is programmatically set on the change event, we
   // need to schedule the element's property update, so the controlled
   // isChecked state can be taken into account.
@@ -168,6 +172,7 @@ export const useRadio = createHook<TagName, RadioOptions>(function useRadio({
     type: nativeRadio ? "radio" : undefined,
     "aria-checked": isChecked,
     ...props,
+    disabled: disabled || undefined,
     id,
     ref: useMergeRefs(ref, props.ref),
     onChange,


### PR DESCRIPTION
## Motivation

The [`RadioGroup`](https://ariakit.com/reference/radio-group) `disabled` prop currently has no effect when the component uses its default `div` element. Descendant [`Radio`](https://ariakit.com/reference/radio) components remain enabled unless consumers render the group as a disabled `fieldset` themselves.

Fixes #3851.

## Solution

Propagate the effective `RadioGroup` disabled state through a scoped React context. The default `div` now receives `aria-disabled`, and descendant `Radio` components merge the group state after their own props so native radios receive `disabled` and custom-rendered radios receive `aria-disabled`. A descendant `disabled={false}` cannot opt out of a disabled group.

Add an isolated regression sandbox with happy-dom and Chrome, Firefox, and Safari coverage, plus public prop documentation and release metadata.

## Workaround

Render [`RadioGroup`](https://ariakit.com/reference/radio-group) as a natively disabled `fieldset` while passing the same state to the component:

```tsx
<RadioGroup
  disabled={disabled}
  render={
    // TODO: Remove after https://github.com/ariakit/ariakit/issues/3851 is fixed.
    <fieldset disabled={disabled} />
  }
>
  {children}
</RadioGroup>
```

This relies on native `fieldset` behavior, so it covers descendant form controls such as the default input-based [`Radio`](https://ariakit.com/reference/radio). It does not disable a custom non-form element rendered through `Radio`, and native controls inside the `fieldset`'s first `legend` are exempt from fieldset disabling.
