### PR TITLE
Add CollectionRenderer performance tests

### DIFF
--- a/app/src/sandbox/collection-renderer-perf/index.react.tsx
+++ b/app/src/sandbox/collection-renderer-perf/index.react.tsx
@@ -1,0 +1,124 @@
+import { CollectionRenderer } from "@ariakit/react-components/collection/collection-renderer";
+import type { CollectionRendererItemObject } from "@ariakit/react-components/collection/collection-renderer";
+import { useCollectionStore } from "@ariakit/react-components/collection/collection-store";
+import { useState } from "react";
+import "./style.css";
+
+const groupCount = 200;
+const itemsPerGroup = 50;
+const itemSize = 20;
+const groupSize = itemsPerGroup * itemSize;
+
+interface RendererItem extends CollectionRendererItemObject {
+  id: string;
+  label: string;
+  items?: RendererItem[];
+}
+
+const groups = Array.from({ length: groupCount }, (_, groupIndex) => {
+  const groupNumber = groupIndex + 1;
+  const items = Array.from({ length: itemsPerGroup }, (_, itemIndex) => {
+    const itemNumber = groupIndex * itemsPerGroup + itemIndex + 1;
+    return { id: `item-${itemNumber}`, label: `Item ${itemNumber}` };
+  });
+  return {
+    id: `group-${groupNumber}`,
+    label: `Group ${groupNumber}`,
+    items,
+  };
+}) satisfies readonly RendererItem[];
+
+const storeItems: RendererItem[] = [];
+
+const persistentGroupIndices = Array.from(
+  { length: groupCount },
+  (_, index) => index,
+);
+
+function RendererBenchmark() {
+  const store = useCollectionStore({ defaultItems: storeItems });
+  const [itemsVisible, setItemsVisible] = useState(true);
+  const [updates, setUpdates] = useState(0);
+
+  return (
+    <section className="benchmark">
+      <div className="controls">
+        <button
+          className="button"
+          type="button"
+          onClick={() => setUpdates((value) => value + 1)}
+        >
+          Rerender nested renderers
+        </button>
+        <button
+          className="button"
+          type="button"
+          onClick={() => setItemsVisible((visible) => !visible)}
+        >
+          Toggle renderer items
+        </button>
+        <output aria-label="Updates">{updates}</output>
+        <output aria-label="Items visible">
+          {itemsVisible ? "yes" : "no"}
+        </output>
+      </div>
+      <div className="scroller" role="region" aria-label="Renderer viewport">
+        <CollectionRenderer
+          id="renderer-groups"
+          store={store}
+          items={itemsVisible ? groups : 0}
+          itemSize={groupSize}
+          persistentIndices={persistentGroupIndices}
+          renderOnResize={false}
+          className="renderer"
+          role="list"
+          aria-label="Renderer items"
+        >
+          {(group) => (
+            <CollectionRenderer
+              id={group.id}
+              key={group.id}
+              store={store}
+              items={group.items}
+              itemSize={itemSize}
+              renderOnResize={false}
+              ref={group.ref}
+              style={group.style}
+              className="group"
+              role="group"
+              aria-label={group.label}
+            >
+              {(item) => (
+                <div
+                  id={item.id}
+                  key={item.id}
+                  ref={item.ref}
+                  style={item.style}
+                  className="item"
+                  role="listitem"
+                  aria-label={item.label}
+                  data-update={updates}
+                >
+                  {item.label}
+                </div>
+              )}
+            </CollectionRenderer>
+          )}
+        </CollectionRenderer>
+      </div>
+    </section>
+  );
+}
+
+export default function Example() {
+  const [mounted, setMounted] = useState(false);
+
+  return (
+    <main className="root">
+      <button className="button" type="button" onClick={() => setMounted(true)}>
+        Mount nested renderers
+      </button>
+      {mounted ? <RendererBenchmark /> : null}
+    </main>
+  );
+}

--- a/app/src/sandbox/collection-renderer-perf/perf-chrome.ts
+++ b/app/src/sandbox/collection-renderer-perf/perf-chrome.ts
@@ -1,0 +1,120 @@
+import type { query } from "@ariakit/test/playwright";
+import { expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { flushFrames, withFramework } from "#app/test-utils/preview.ts";
+
+const groupCount = 200;
+const itemsPerGroup = 50;
+const itemSize = 20;
+const groupSize = itemsPerGroup * itemSize;
+const updateCount = 20;
+const toggleCount = 10;
+const scrollGroupIndices = Array.from({ length: 20 }, (_, index) => {
+  return Math.min((index + 1) * 10, groupCount - 1);
+});
+
+type Query = ReturnType<typeof query>;
+
+function getGroupFirstItemLabel(groupIndex: number) {
+  return `Item ${groupIndex * itemsPerGroup + 1}`;
+}
+
+async function verifyRendererMounted(q: Query) {
+  await expect(q.listitem("Item 10")).toBeVisible();
+}
+
+async function mountRenderer(page: Page, q: Query) {
+  await q.button("Mount nested renderers").click();
+  await verifyRendererMounted(q);
+  await flushFrames(page);
+}
+
+async function rerenderNestedRenderers(page: Page, q: Query) {
+  const updateButton = q.button("Rerender nested renderers");
+  for (let index = 0; index < updateCount; index += 1) {
+    await updateButton.click();
+  }
+  await flushFrames(page);
+  await expect(q.status("Updates")).toHaveText(String(updateCount));
+  await expect(q.listitem("Item 10")).toHaveAttribute(
+    "data-update",
+    String(updateCount),
+  );
+}
+
+async function verifyNestedRenderersUpdated(q: Query) {
+  await expect(q.status("Updates")).toHaveText(String(updateCount));
+  await expect(q.listitem("Item 10")).toHaveAttribute(
+    "data-update",
+    String(updateCount),
+  );
+}
+
+async function toggleRendererItems(page: Page, q: Query) {
+  const toggleButton = q.button("Toggle renderer items");
+  for (let index = 0; index < toggleCount; index += 1) {
+    const itemsVisible = index % 2 === 1;
+    await toggleButton.click();
+    await flushFrames(page);
+    await expect(q.status("Items visible")).toHaveText(
+      itemsVisible ? "yes" : "no",
+    );
+    await expect(q.listitem("Item 10")).toHaveCount(itemsVisible ? 1 : 0);
+  }
+}
+
+async function verifyRendererItemsVisible(q: Query) {
+  await expect(q.status("Items visible")).toHaveText("yes");
+  await expect(q.listitem("Item 10")).toBeVisible();
+}
+
+async function scrollNestedRenderers(page: Page, q: Query) {
+  const scroller = q.region("Renderer viewport");
+  for (const groupIndex of scrollGroupIndices) {
+    await scroller.evaluate((element, scrollTop) => {
+      element.scrollTop = scrollTop;
+      element.dispatchEvent(new Event("scroll"));
+    }, groupIndex * groupSize);
+    await flushFrames(page);
+    await expect(q.listitem(getGroupFirstItemLabel(groupIndex))).toBeVisible();
+  }
+}
+
+async function verifyRendererScrolled(q: Query) {
+  const finalGroupIndex = scrollGroupIndices.at(-1) ?? groupCount - 1;
+  await expect(q.listitem("Item 1")).toHaveCount(0);
+  await expect(
+    q.listitem(getGroupFirstItemLabel(finalGroupIndex)),
+  ).toBeVisible();
+}
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("mount nested renderers", async ({ perf }) => {
+    await perf.measure(({ page, q }) => mountRenderer(page, q), {
+      verify: ({ q }) => verifyRendererMounted(q),
+    });
+  });
+
+  test("rerender nested renderers", async ({ perf }) => {
+    await perf.measure(({ page, q }) => rerenderNestedRenderers(page, q), {
+      setup: ({ page, q }) => mountRenderer(page, q),
+      scriptProfile: true,
+      profileLimit: 20,
+      verify: ({ q }) => verifyNestedRenderersUpdated(q),
+    });
+  });
+
+  test("toggle renderer items", async ({ perf }) => {
+    await perf.measure(({ page, q }) => toggleRendererItems(page, q), {
+      setup: ({ page, q }) => mountRenderer(page, q),
+      verify: ({ q }) => verifyRendererItemsVisible(q),
+    });
+  });
+
+  test("scroll nested renderers", async ({ perf }) => {
+    await perf.measure(({ page, q }) => scrollNestedRenderers(page, q), {
+      setup: ({ page, q }) => mountRenderer(page, q),
+      verify: ({ q }) => verifyRendererScrolled(q),
+    });
+  });
+});

--- a/app/src/sandbox/collection-renderer-perf/style.css
+++ b/app/src/sandbox/collection-renderer-perf/style.css
@@ -1,0 +1,56 @@
+/* No transitions or animations: this sandbox is used by perf tests. */
+
+.root,
+.benchmark,
+.controls {
+  display: flex;
+  align-items: flex-start;
+}
+
+.root,
+.benchmark {
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.root {
+  padding: 1rem;
+}
+
+.controls {
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.button {
+  border: 1px solid hsl(204 10% 80%);
+  border-radius: 0.5rem;
+  background: white;
+  padding: 0.5rem 1rem;
+  color: hsl(204 10% 10%);
+  font: inherit;
+}
+
+.scroller {
+  width: 20rem;
+  height: 200px;
+  border: 1px solid hsl(204 10% 80%);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.renderer,
+.group,
+.item {
+  width: 100%;
+}
+
+.item {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid hsl(204 10% 90%);
+  background: white;
+  padding-inline: 0.5rem;
+  color: hsl(204 10% 10%);
+}


### PR DESCRIPTION
## Motivation

[Add scrollElement to collection renderers](https://github.com/ariakit/ariakit/pull/6806) changes how `CollectionRenderer` resolves and shares its scroll element, but the existing Chrome performance matrix does not render `CollectionRenderer` directly. The test needs to land on `main` first so that PR can compare against identical benchmark definitions.

## Solution

Add a dedicated `collection-renderer-perf` sandbox with 10,000 fixed-size items across 200 persistent nested renderers sharing one store. It measures automatic scroller detection during mount, stable-data rerenders, item removal and restoration, and scrolling through distant windows. The rerender row also collects a separate script profile.

The fixture uses only APIs available on `main` and relies on automatic scroller detection. After this merges, #6806 can update from `main` and rerun the same rows against the established baseline.

## Preview

<img width="542" height="348" alt="Mounted CollectionRenderer performance sandbox" src="https://github.com/user-attachments/assets/19307961-70f5-44ab-bd8c-10a98fbfa8ae" />

[Watch the interaction walkthrough with Playwright action highlights: mount, rerender, remove/restore, and scroll (WebM)](https://github.com/user-attachments/assets/d31a3f09-8d32-4994-86e0-822e0bdd387b)