### PR TITLE
Create changeset overviews

### DIFF
--- a/.changeset/200-overview-react-components.md
+++ b/.changeset/200-overview-react-components.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/react-components": patch
+---
+
+Overview
+
+This version adds explicit scroll element control for collection renderers, custom typeahead labels for composite items, and selected-state rendering for select items. It also improves disabled radio groups, hidden popover performance, nested <kbd>Esc</kbd> handling, dialogs across portals and shadow roots, multi-select combobox form values, typeahead with unmounted options, and composite virtual focus.

--- a/.changeset/200-overview-react.md
+++ b/.changeset/200-overview-react.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/react": patch
+---
+
+Overview
+
+This version adds custom typeahead labels for composite items and selected-state rendering for select items. It also improves disabled radio groups, hidden popover performance, nested <kbd>Esc</kbd> handling, dialogs across portals and shadow roots, multi-select combobox form values, typeahead with unmounted options, and composite virtual focus.


### PR DESCRIPTION
## Motivation

The upcoming release contains multiple multi-paragraph changelog entries for the React packages. These packages need concise overviews that introduce the main release themes before the detailed updates.

## Solution

Add separate overview changesets for `@ariakit/react-components` and `@ariakit/react`, since explicit collection renderer scroll element control applies only to the components package. Each entry summarizes the package's new APIs, performance improvements, and behavior fixes.

Each entry follows the required overview structure:

```md
Overview

This version ...
```
