### PR TITLE
Prevent OG metadata from blocking dev SSR

### DIFF
--- a/app/src/components/meta.astro
+++ b/app/src/components/meta.astro
@@ -8,10 +8,10 @@
  *
  * SPDX-License-Identifier: UNLICENSED
  */
-import { getOGImageItem } from "#app/pages/og-image/api.ts";
-import type { GetOGImageItemParams } from "#app/pages/og-image/api.ts";
+import { getPageOGImagePath } from "#app/lib/og-image-path.ts";
+import type { GetPageOGImagePathParams } from "#app/lib/og-image-path.ts";
 
-interface Props extends GetOGImageItemParams {
+interface Props extends GetPageOGImagePathParams {
   title?: string;
   description?: string;
 }
@@ -22,15 +22,13 @@ const {
   id,
   type,
   framework,
+  pagePath,
   title: pageTitle = DEFAULT_TITLE,
   description = "Toolkit with accessible components, styles, and examples for your next web app. Built for React, Solid, HTML, and more.",
 } = Astro.props;
 
-const ogImageItem = await getOGImageItem({ id, type, framework });
-
-const ogImage = ogImageItem?.imagePath
-  ? new URL(ogImageItem.imagePath, Astro.site).href
-  : new URL("/og-image/default.png", Astro.site).href;
+const ogImagePath = getPageOGImagePath({ id, type, framework, pagePath });
+const ogImage = new URL(ogImagePath, Astro.site).href;
 
 const title =
   pageTitle === DEFAULT_TITLE

--- a/app/src/lib/og-image-path.test.ts
+++ b/app/src/lib/og-image-path.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2025-present Ariakit FZ-LLC. All Rights Reserved.
+ *
+ * This software is proprietary. See the license.md file in the root of this
+ * package for licensing terms.
+ *
+ * SPDX-License-Identifier: UNLICENSED
+ */
+import { expect, test } from "vitest";
+import { getOGImagePath, getPageOGImagePath } from "./og-image-path.ts";
+
+test("getOGImagePath converts page paths to image paths", () => {
+  expect(getOGImagePath("/")).toBe("/og-image/default.png");
+  expect(getOGImagePath("/react/components/dialog/")).toBe(
+    "/og-image/react_components_dialog.png",
+  );
+});
+
+test.each([
+  [{}, "/og-image/default.png"],
+  [{ type: "pages" as const }, "/og-image/default.png"],
+  [
+    { type: "components" as const, framework: "react" as const },
+    "/og-image/react_components.png",
+  ],
+  [
+    {
+      id: "dialog",
+      type: "components" as const,
+      framework: "react" as const,
+    },
+    "/og-image/react_components_dialog.png",
+  ],
+  [
+    {
+      id: "ariakit-react/getting-started",
+      type: "components" as const,
+      framework: "react" as const,
+      pagePath: "/react/components/getting-started/",
+    },
+    "/og-image/react_components_getting-started.png",
+  ],
+  [
+    {
+      id: "ariakit-tailwind/setup",
+      type: "styles" as const,
+      framework: "tailwind" as const,
+      pagePath: "/styles/setup/",
+    },
+    "/og-image/styles_setup.png",
+  ],
+  [
+    {
+      id: "",
+      type: "examples" as const,
+      framework: "react" as const,
+    },
+    "/og-image/default.png",
+  ],
+])("getPageOGImagePath maps %o to %s", (params, expected) => {
+  expect(getPageOGImagePath(params)).toBe(expected);
+});

--- a/app/src/lib/og-image-path.ts
+++ b/app/src/lib/og-image-path.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2025-present Ariakit FZ-LLC. All Rights Reserved.
+ *
+ * This software is proprietary. See the license.md file in the root of this
+ * package for licensing terms.
+ *
+ * SPDX-License-Identifier: UNLICENSED
+ */
+import type { Framework } from "./schemas.ts";
+import { trim } from "./string.ts";
+
+export interface GetPageOGImagePathParams {
+  id?: string;
+  type?: "pages" | "examples" | "components" | "styles";
+  framework?: Framework;
+  pagePath?: string;
+}
+
+export function getOGImagePath(pagePath: string) {
+  const imageName = trim(pagePath, "/").replaceAll("/", "_") || "default";
+  return `/og-image/${imageName}.png`;
+}
+
+export function getPageOGImagePath({
+  id,
+  type = "pages",
+  framework,
+  pagePath,
+}: GetPageOGImagePathParams) {
+  if (pagePath) {
+    return getOGImagePath(pagePath);
+  }
+  if (type === "pages") {
+    return getOGImagePath("/default");
+  }
+  if (type !== "components" && type !== "examples") {
+    return getOGImagePath("/default");
+  }
+  if (!framework) {
+    return getOGImagePath("/default");
+  }
+  if (id === "") {
+    return getOGImagePath("/default");
+  }
+  const resolvedPagePath = id
+    ? `/${framework}/${type}/${id}`
+    : `/${framework}/${type}`;
+  return getOGImagePath(resolvedPagePath);
+}

--- a/app/src/pages/[...guide].astro
+++ b/app/src/pages/[...guide].astro
@@ -26,12 +26,12 @@ export const getStaticPaths = (async () => {
       getGuideDetail(entry);
     return {
       params: { guide: path },
-      props: { entry, framework, groupLabel, groupPath, type },
+      props: { entry, framework, groupLabel, groupPath, path, type },
     };
   });
 }) satisfies GetStaticPaths;
 
-const { entry, groupLabel, groupPath, framework, type } = Astro.props;
+const { entry, groupLabel, groupPath, framework, path, type } = Astro.props;
 const { Content, headings } = await render(entry);
 
 const guides = (
@@ -52,6 +52,7 @@ const title = entry.data.title;
     {framework}
     {type}
     {title}
+    pagePath={path}
     description={entry.data.description}
   />
   <ContainerLeftMenu>

--- a/app/src/pages/og-image/api.ts
+++ b/app/src/pages/og-image/api.ts
@@ -12,13 +12,9 @@ import { getCollection } from "astro:content";
 import { uniq } from "#app/lib/array.ts";
 import { getGuideDetail } from "#app/lib/content.ts";
 import { getOGImageItemKey } from "#app/lib/og-image-key.ts";
-import { trim } from "#app/lib/string.ts";
+import { getOGImagePath } from "#app/lib/og-image-path.ts";
 
 const types = ["pages", "examples", "components", "styles"] as const;
-
-function getImagePath(path: string) {
-  return `/og-image/${trim(path, "/").replaceAll("/", "_")}.png`;
-}
 
 export interface OGImageItem {
   type: (typeof types)[number];
@@ -71,7 +67,7 @@ async function computeOGImageItems(): Promise<OGImageItem[]> {
     return frameworks.map((framework) => {
       return {
         path: `/${framework}${path}`,
-        imagePath: getImagePath(`${framework}${path}`),
+        imagePath: getOGImagePath(`${framework}${path}`),
         type,
         framework,
         id: entry.id,
@@ -86,7 +82,7 @@ async function computeOGImageItems(): Promise<OGImageItem[]> {
     return {
       path,
       type,
-      imagePath: getImagePath(path),
+      imagePath: getOGImagePath(path),
       title: data.title,
       framework,
       id,
@@ -101,7 +97,7 @@ async function computeOGImageItems(): Promise<OGImageItem[]> {
     const path = "/examples";
     return {
       path: `/${framework}${path}`,
-      imagePath: getImagePath(`/${framework}${path}`),
+      imagePath: getOGImagePath(`/${framework}${path}`),
       type: "examples",
       framework,
     } as const;
@@ -115,7 +111,7 @@ async function computeOGImageItems(): Promise<OGImageItem[]> {
     const path = "/components";
     return {
       path: `/${framework}${path}`,
-      imagePath: getImagePath(`/${framework}${path}`),
+      imagePath: getOGImagePath(`/${framework}${path}`),
       type: "components",
       framework,
     } as const;
@@ -124,12 +120,12 @@ async function computeOGImageItems(): Promise<OGImageItem[]> {
   const genericPages = [
     {
       path: "/",
-      imagePath: getImagePath("/default"),
+      imagePath: getOGImagePath("/default"),
       type: "pages",
     },
     {
       path: "/changelog",
-      imagePath: getImagePath("/changelog"),
+      imagePath: getOGImagePath("/changelog"),
       type: "pages",
       title: "Changelog",
     },


### PR DESCRIPTION

## Motivation

During an intermittent Astro dev-server failure, the collection-wide OG image lookup can remain pending after a source reload. Shared page metadata awaited that lookup:

```ts
const ogImageItem = await getOGImageItem({ id, type, framework });
```

Because `getOGImageItem()` memoized the same `getOGImageItems()` promise for every page, one pending content lookup blocked otherwise unrelated SSR routes. The server returned `200`, streamed only the 108-byte prefix through the opening `<head>`, and then stopped; `/og-image/api` waited before headers while Vite-owned endpoints stayed healthy.

The linked cold-optimizer issue and fix provide related upstream context, but do not cover this source-reload failure mode: [withastro/astro#17166](https://github.com/withastro/astro/issues/17166), [withastro/astro#17187](https://github.com/withastro/astro/pull/17187).

## Solution

Derive the OG image filename synchronously from routing metadata that each page already has:

```ts
const ogImagePath = getPageOGImagePath({ id, type, framework, pagePath });
```

Component and example paths follow the existing `/{framework}/{type}/{id}` convention. Guides pass their canonical public path explicitly because their content IDs include a collection group that is not part of the public URL. The collection-wide lookup remains available to `/og-image/api` and the image generator, but shared `<Meta>` rendering no longer depends on it.

Focused tests cover default images, collection indexes, component entries, guide paths, style paths, and empty IDs.

## Preview

The browser preview was captured from commit `17fee0f28` on the isolated Astro dev server after reload verification:

<img width="1440" height="900" alt="ariakit-astro-dev-preview" src="https://github.com/user-attachments/assets/333fe62f-cdb3-4428-8cdb-1ec2420816f5" />

## Verification

- Forced-pending HTTP regression: before the change `/` streamed 108 bytes and timed out; after the change it completed with `200` and approximately 2.8 MB while `/og-image/api` remained deliberately pending.
- Six source edits produced `[vite] program reload`; root, API, component, guide, and example requests completed after every reload.
- `pnpm test` — 57 files and 631 tests passed.
- `pnpm tsc` — passed with zero Astro diagnostics.
- `pnpm build-app-lite` — passed.
- `pnpm lint-fix` — passed.
