### PR TITLE
Make PopoverAnchor changeset a single paragraph

### DIFF
--- a/.changeset/300-popover-anchor-precedence.md
+++ b/.changeset/300-popover-anchor-precedence.md
@@ -4,8 +4,4 @@
 "@ariakit/react": patch
 ---
 
-`PopoverAnchor` takes precedence over `PopoverDisclosure`
-
-Fixed [`PopoverDisclosure`](https://ariakit.com/reference/popover-disclosure) so it no longer overrides a separate [`PopoverAnchor`](https://ariakit.com/reference/popover-anchor) as the popover positioning anchor.
-
-Thanks to [@bengry](https://github.com/bengry) for reporting the issue and providing the reproduction and workaround.
+Fixed [`PopoverDisclosure`](https://ariakit.com/reference/popover-disclosure) so it no longer overrides a separate [`PopoverAnchor`](https://ariakit.com/reference/popover-anchor) as the popover positioning anchor. Thanks to [@bengry](https://github.com/bengry).


### PR DESCRIPTION
## Motivation

The `PopoverAnchor` precedence changeset describes a simple patch, but it splits its title, summary, and acknowledgment across multiple paragraphs. Simple changesets should use one continuous description paragraph so the generated changelog entry stays concise.

## Solution

Collapse the entry into a single paragraph while preserving the package frontmatter, linked API names, user-facing fix summary, and contributor credit:

```md
Fixed [`PopoverDisclosure`](https://ariakit.com/reference/popover-disclosure) so it no longer overrides a separate [`PopoverAnchor`](https://ariakit.com/reference/popover-anchor) as the popover positioning anchor. Thanks to [@bengry](https://github.com/bengry).
```

## Acknowledgments

Thanks to [@bengry](https://github.com/bengry) for reporting [#3729](https://github.com/ariakit/ariakit/issues/3729) and providing the reproduction and workaround.
