### PR TITLE
Fix contains for form and select elements under happy-dom

### DIFF
--- a/.changeset/300-happy-dom-form-contains.md
+++ b/.changeset/300-happy-dom-form-contains.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/test": patch
+---
+
+Fixed `contains` reporting `false` for descendants of a `<form>` or `<select>` element when tests run on happy-dom, which made elements nested in a form look like they were outside an open modal dialog.

--- a/packages/ariakit-test/src/shims.test.ts
+++ b/packages/ariakit-test/src/shims.test.ts
@@ -502,6 +502,81 @@ test("doesn't submit or reset a form from a click on a disabled submit/reset con
   }
 });
 
+test("reports a form or select as containing its descendants", () => {
+  if (isBrowser) return;
+  // happy-dom's HTMLFormElement/HTMLSelectElement constructors return a Proxy
+  // (so `form.username` and `select[0]` work), but inserting one into a parent
+  // re-points the children it already has at the raw target instead of the
+  // proxy. `contains` compares against the proxy, so it walks a parent chain
+  // that never matches and returns false for those descendants. jsdom and real
+  // browsers return true, per the DOM spec's inclusive-descendant definition.
+  // https://dom.spec.whatwg.org/#dom-node-contains
+  for (const [parentTag, childTag] of [
+    ["form", "fieldset"],
+    ["select", "optgroup"],
+  ] as const) {
+    const container = document.createElement("div");
+    const parent = document.createElement(parentTag);
+    const child = document.createElement(childTag);
+    const grandchild = document.createElement("input");
+    child.append(grandchild);
+    parent.append(child);
+    // Inserting into a still-detached parent is enough to trigger the
+    // divergence, so the answers must already be right here.
+    container.append(parent);
+    expect(parent.contains(child)).toBe(true);
+    expect(parent.contains(grandchild)).toBe(true);
+
+    document.body.append(container);
+    // Appended after the insertion that broke the earlier children, so nothing
+    // re-points this one and it answers correctly on its own.
+    const late = document.createElement("input");
+    parent.append(late);
+    const outside = document.createElement("input");
+    container.append(outside);
+    try {
+      expect(parent.contains(parent)).toBe(true);
+      expect(parent.contains(child)).toBe(true);
+      expect(parent.contains(grandchild)).toBe(true);
+      expect(parent.contains(late)).toBe(true);
+      // Elements outside the parent are still reported as outside.
+      expect(parent.contains(outside)).toBe(false);
+      expect(parent.contains(container)).toBe(false);
+      expect(parent.contains(null)).toBe(false);
+      // The other direction never regressed, but it must keep working.
+      expect(container.contains(parent)).toBe(true);
+      expect(container.contains(grandchild)).toBe(true);
+      // The divergence outlives the subtree's removal from the document.
+      container.remove();
+      expect(parent.contains(grandchild)).toBe(true);
+    } finally {
+      container.remove();
+    }
+  }
+});
+
+test("reports a select nested in a form as containing its own descendants", () => {
+  if (isBrowser) return;
+  // Both elements are proxied, so resolving the outer one through its children
+  // only works if the inner one resolves through its children too.
+  const form = document.createElement("form");
+  const select = document.createElement("select");
+  const optgroup = document.createElement("optgroup");
+  const option = document.createElement("option");
+  optgroup.append(option);
+  select.append(optgroup);
+  form.append(select);
+  document.body.append(form);
+  try {
+    expect(form.contains(select)).toBe(true);
+    expect(form.contains(optgroup)).toBe(true);
+    expect(form.contains(option)).toBe(true);
+    expect(select.contains(option)).toBe(true);
+  } finally {
+    form.remove();
+  }
+});
+
 test("click(label) fires the associated control's click only once", async () => {
   if (isBrowser) return;
   // `click` suppresses happy-dom's automatic label-to-control click by

--- a/packages/ariakit-test/src/shims.ts
+++ b/packages/ariakit-test/src/shims.ts
@@ -98,6 +98,7 @@ function applyBrowserShims() {
         patchHappyDOMFormData(),
         patchHappyDOMSelectionChange(),
         patchHappyDOMAnimationFrame(),
+        patchHappyDOMProxiedContains(),
       ]
     : [];
 
@@ -293,6 +294,61 @@ function patchHappyDOMAnimationFrame() {
   return () => {
     window.requestAnimationFrame = originalRequestAnimationFrame;
     window.cancelAnimationFrame = originalCancelAnimationFrame;
+  };
+}
+
+// happy-dom's HTMLFormElement and HTMLSelectElement constructors return a Proxy
+// for their legacy member access (`form.username`, `select[0]`). Inserting one
+// into a parent re-points the children it already has at the raw target rather
+// than that proxy, while `contains()` compares against the proxy — so it walks a
+// parent chain that never matches and reports false for those descendants. jsdom
+// and real browsers return true, per the spec's inclusive-descendant definition.
+// Any insertion triggers it, including into a still-detached parent, and it
+// persists after the subtree is removed again.
+// Ariakit reads `contains` everywhere — most visibly, a modal dialog exempts
+// `getPersistentElements` from `inert` with it, so everything inside a <form>
+// looked like it was outside the dialog.
+// https://dom.spec.whatwg.org/#dom-node-contains
+// https://github.com/capricorn86/happy-dom/issues/2170
+//
+// Rather than reaching into happy-dom's internal symbols to repair the parent
+// reference, ask the children instead: their own parent chain is intact, so they
+// answer correctly. Only the two proxied element types get the override, and it
+// only does extra work once the native check has already returned false. The
+// same broken reference also breaks identity-based ancestor checks, which this
+// shim leaves alone: https://github.com/ariakit/ariakit/issues/6849
+//
+// TODO: Remove this shim once the upstream fix ships.
+// https://github.com/capricorn86/happy-dom/pull/2176
+function patchHappyDOMProxiedContains() {
+  const originalContains = window.Node.prototype.contains;
+  const restores: Array<() => void> = [];
+
+  for (const Constructor of [
+    window.HTMLFormElement,
+    window.HTMLSelectElement,
+  ]) {
+    if (!Constructor) continue;
+    Constructor.prototype.contains = function contains(otherNode) {
+      if (!otherNode) return false;
+      if (originalContains.call(this, otherNode)) return true;
+      for (const child of this.childNodes) {
+        // A child can be proxied too — a <select> inside a <form> — so go
+        // through its own `contains`, which unwraps every nested level and
+        // already reports a node as containing itself.
+        if (child.contains(otherNode)) return true;
+      }
+      return false;
+    };
+    restores.push(() => {
+      // The method is inherited from Node.prototype, so removing the override
+      // restores it rather than reassigning it.
+      Reflect.deleteProperty(Constructor.prototype, "contains");
+    });
+  }
+
+  return () => {
+    for (const restore of restores) restore();
   };
 }
 


### PR DESCRIPTION
## Motivation

This started as a report that a modal dialog's [`getPersistentElements`](https://ariakit.com/reference/dialog#getpersistentelements) exemption was not honoured when the persistent element sits deeper in the DOM: the element's ancestor chain was marked `inert` anyway, so `isFocusable()` returned `false` for it and `redirectFocusToBaseElement` bailed with the `virtualFocus` dev warning. It was surfaced while working on #6832.

**That root-cause framing turned out to be wrong, and the fix is not in the dialog code.**

DOM depth is irrelevant. `examples/combobox-tabs` already renders its combobox input one level deep inside `.combobox-wrapper` with a modal `ComboboxPopover`, and its `clear input with keyboard` test tabs from the open popover to a persistent control nested at that depth. It passes on `main`.

The actual trigger is a `<form>` (or `<select>`) ancestor, and the cause is a happy-dom defect, not an Ariakit one:

```ts
const container = document.createElement("div");
const form = document.createElement("form");
const input = document.createElement("input");
form.append(input);

form.contains(input); // true
container.append(form);
form.contains(input); // false  <- happy-dom only
```

happy-dom's `HTMLFormElement` and `HTMLSelectElement` constructors return a `Proxy` for their legacy member access (`form.username`, `select[0]`). Inserting one into a parent re-points the children it already has at the raw target rather than that proxy, while `contains()` compares against the proxy, so it walks a parent chain that never matches. jsdom and real browsers return `true`, per the spec's [inclusive-descendant definition](https://dom.spec.whatwg.org/#dom-node-contains). Upstream: [capricorn86/happy-dom#2170](https://github.com/capricorn86/happy-dom/issues/2170), with an open unmerged fix in [capricorn86/happy-dom#2176](https://github.com/capricorn86/happy-dom/pull/2176).

Ariakit reads `contains` everywhere. `shouldWalkElement` in `walk-tree-outside.ts` exempts persistent elements from `inert` by asking whether a candidate outside element contains one of them, so under happy-dom a `<form>` ancestor was never recognised as containing the persistent element and got marked `inert`:

```
<form inert>          <- the bug
  <div>
    <input role="combobox" aria-controls="popover">   <- persistent element
```

**No shipped code was ever affected**, since real browsers implement `contains` correctly. What was affected is every Ariakit test whose subject sits inside a `<form>` or `<select>`, where the failure is silent and misattributes itself to the dialog and focus code.

## Solution

Normalize the divergence in `@ariakit/test`, whose documented job is exactly this. It joins four existing `patchHappyDOM*` shims in `packages/ariakit-test/src/shims.ts`.

Rather than reaching into happy-dom's internal symbols to repair the parent reference, the override resolves through the children, whose own parent chain is intact:

```ts
Constructor.prototype.contains = function contains(otherNode) {
  if (!otherNode) return false;
  if (originalContains.call(this, otherNode)) return true;
  for (const child of this.childNodes) {
    if (child.contains(otherNode)) return true;
  }
  return false;
};
```

Only `HTMLFormElement` and `HTMLSelectElement` get the override; they are the only `Node` subclasses happy-dom proxies. The fallback runs only after the native check has already returned `false`, and the recursion goes through the patched `contains` so a `<select>` nested in a `<form>` is unwrapped at every level. Once the upstream fix ships, the native check succeeds and the fallback becomes dead code, so the shim carries a `TODO` with the upstream PR link.

### Deliberately not covered

The same broken reference also makes `parentElement`/`closest` hand back the raw target, which breaks identity-based ancestor checks (`isElementInside`'s `WeakSet` walk in `tree-cleanup.ts`, `addRoleNoneCleanup`'s guard in `disable-tree.ts`) when a persistent element is itself a `<form>`/`<select>`. Covering that needs either a global `parentNode`/`parentElement` getter patch or happy-dom's internal `PropertySymbol.proxy`, both a much larger blast radius than the reported bug, and nothing in the repo exercises it today. Registered as #6849.

## Verification

Regression coverage in `packages/ariakit-test/src/shims.test.ts`, red-checked both ways: without the shim registered both new tests fail, and replacing the recursive `child.contains(otherNode)` with the unpatched `contains` fails only the nested select-in-form test, proving the recursion is load-bearing.

`pnpm lint` and `pnpm tsc` clean. Suites before and after the fix:

| Suite | Before | After |
| --- | --- | --- |
| `pnpm test-react examples app/src/sandbox` | 197 files / 882 passed | 197 files / 882 passed |
| `pnpm test` | 57 files / 631 passed, 1 failed (new test) | 57 files / 633 passed |
| `pnpm test-react` | — | 205 files / 931 passed |
| `pnpm test-solid` | — | 7 files / 9 passed |
| `pnpm test-react18` | — | 205 files / 923 passed, 8 skipped |

No regressions, and no existing test depended on the broken behavior.

## Review gate reassessment

<details>
<summary>Cycle 3: Continue the narrow public-API shim, subtract instead of polishing</summary>

**Assessment**

Issue severity is medium for test infrastructure and zero for shipped code: real browsers and jsdom are spec-correct. Expected frequency is currently latent (no existing repo test places a dialog, combobox, or select inside a `<form>`), but not hypothetical, since it already misdirected a full investigation into `dialog/`. Supported scope is `@ariakit/test` consumers on happy-dom. Implementation complexity is low and does not grow: one helper matching four existing siblings, a 20-line body with one branch and one loop, no state, no abstraction, no public contract, and no production code touched.

Of roughly 13 findings across three rounds, only three were substantive: narrowing the patch from `Node.prototype.contains` to the two proxied constructors, the untested recursion, and a false claim about what depends on `parentElement` identity. The design converged at the first of those and has not moved since. The remaining findings were comment-precision churn, driven by a comment block that asserted more independently falsifiable claims about happy-dom internals than the change needed.

The decisive evidence was that the `compareDocumentPosition` sentence was still wrong after three rounds, and round 3's proposed rewording would also have been wrong: `form.compareDocumentPosition(descendant)` returns `2` (`DOCUMENT_POSITION_PRECEDING`), not `DISCONNECTED`, versus `20` for a non-proxied control. An independent complexity subagent and the orchestrator reached the same conclusion separately.

An upward-walk implementation was evaluated as an alternative and rejected: it would depend on happy-dom's `ClassMethodBinder` binding `this` to the raw target, which is more internals-dependent than the current approach's use of public `childNodes` and `contains`.

**Decision**

Continue the current design; do not revert, extend, or re-implement it. Change round 3's disposition from rewording the inaccurate paragraph to deleting it, replacing it with a single pointer to #6849, which is already the durable record for that gap. The comment block went from 30 lines to 22. Intentionally unsupported and recorded in #6849: `form.contains(rawTargetAlias)`, identity comparisons that mix proxy-returning accessors with raw-returning ones, and `compareDocumentPosition` in the ancestor direction (no reachable Ariakit call site).

</details>
