### PR TITLE
Update pnpm to v11.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,5 +144,5 @@
       "onFail": "download"
     }
   },
-  "packageManager": "pnpm@11.16.0"
+  "packageManager": "pnpm@11.17.0"
 }


### PR DESCRIPTION
## Motivation

The repository pins pnpm 11.16.0. pnpm 11.17.0 republishes packages affected by the packing bug in pnpm 11.13.1 through 11.16.0, which caused published tarballs to omit most compiled files, and includes the latest pnpm fixes.

## Solution

Update the root package-manager pin:

```json
"packageManager": "pnpm@11.17.0"
```

The pnpm 11.17.0 workspace install and configured `pnpm dedupe` operation completed without lockfile changes. `pnpm lint-fix` and `pnpm tsc` pass.

## Dependencies

| Declaration | Workspace | Old | New | Release |
| --- | --- | --- | --- | --- |
| `packageManager` (`pnpm`) | root | `11.16.0` | `11.17.0` | [pnpm 11.17.0](https://github.com/pnpm/pnpm/releases/tag/v11.17.0) |