### PR TITLE
Add selective CI orchestration

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -3,7 +3,7 @@ name: app
 on:
   push:
     branches: [main]
-  pull_request:
+  workflow_call:
 
 permissions:
   contents: read
@@ -178,7 +178,7 @@ jobs:
         if: failure() && (steps.test.outcome == 'failure' || steps.test-visual.outcome == 'failure' || steps.update-screenshots.outcome == 'failure')
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.project }}-test-results
+          name: app-${{ matrix.project }}-test-results
           path: app/test-results
           retention-days: 7
 

--- a/.github/workflows/build-styles.yml
+++ b/.github/workflows/build-styles.yml
@@ -3,10 +3,10 @@ name: build-styles
 on:
   push:
     branches: [main]
-  pull_request:
+  workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: build-styles-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,21 +2,18 @@ name: CI
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 permissions:
   contents: read
 
 concurrency:
-  # Keep metadata-only edits from replacing pending real CI work.
-  group: ci-${{ github.ref }}-${{ github.event.action == 'edited' && github.event.changes.base == null && 'metadata' || 'work' }}
+  group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   plan:
     name: Plan
-    # Base edits change the diff; title and body edits do not.
-    if: github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     outputs:
       main: ${{ steps.plan.outputs.main }}
@@ -126,9 +123,8 @@ jobs:
     secrets: inherit
 
   gate:
-    # Metadata-only runs must not shadow the real Gate result for this commit.
-    name: ${{ github.event.action == 'edited' && github.event.changes.base == null && 'Metadata / Gate' || 'Gate' }}
-    if: always() && (github.event.action != 'edited' || github.event.changes.base != null)
+    name: Gate
+    if: always()
     needs:
       - plan
       - main
@@ -163,9 +159,8 @@ jobs:
     # Preserve the current required status names until the main ruleset is
     # migrated to require Gate. Reusable jobs use prefixed check names, so
     # removing these aliases before that migration would block automerge.
-    # Metadata-only runs use distinct names to preserve the real CI results.
-    name: ${{ github.event.action == 'edited' && github.event.changes.base == null && format('Metadata / {0}', matrix.name) || matrix.name }}
-    if: always() && (github.event.action != 'edited' || github.event.changes.base != null)
+    name: ${{ matrix.name }}
+    if: always()
     needs: gate
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,15 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.ref }}
+  # Keep metadata-only edits from replacing pending real CI work.
+  group: ci-${{ github.ref }}-${{ github.event.action == 'edited' && github.event.changes.base == null && 'metadata' || 'work' }}
   cancel-in-progress: true
 
 jobs:
   plan:
     name: Plan
+    # Base edits change the diff; title and body edits do not.
+    if: github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     outputs:
       main: ${{ steps.plan.outputs.main }}
@@ -127,8 +130,9 @@ jobs:
     secrets: inherit
 
   gate:
-    name: Gate
-    if: always()
+    # Metadata-only runs must not shadow the real Gate result for this commit.
+    name: ${{ github.event.action == 'edited' && github.event.changes.base == null && 'Metadata / Gate' || 'Gate' }}
+    if: always() && (github.event.action != 'edited' || github.event.changes.base != null)
     needs:
       - plan
       - main
@@ -164,8 +168,9 @@ jobs:
     # Preserve the current required status names until the main ruleset is
     # migrated to require Gate. Reusable jobs use prefixed check names, so
     # removing these aliases before that migration would block automerge.
-    name: ${{ matrix.name }}
-    if: always()
+    # Metadata-only runs use distinct names to preserve the real CI results.
+    name: ${{ github.event.action == 'edited' && github.event.changes.base == null && format('Metadata / {0}', matrix.name) || matrix.name }}
+    if: always() && (github.event.action != 'edited' || github.event.changes.base != null)
     needs: gate
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,197 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  plan:
+    name: Plan
+    runs-on: ubuntu-latest
+    outputs:
+      main: ${{ steps.plan.outputs.main }}
+      app: ${{ steps.plan.outputs.app }}
+      perf: ${{ steps.plan.outputs.perf }}
+      plus: ${{ steps.plan.outputs.plus }}
+      release_preview: ${{ steps.plan.outputs.release_preview }}
+      docs: ${{ steps.plan.outputs.docs }}
+      build_styles: ${{ steps.plan.outputs.build_styles }}
+      og_images: ${{ steps.plan.outputs.og_images }}
+      plan: ${{ steps.plan.outputs.plan }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up environment
+        uses: ./.github/workflows/setup
+
+      - name: Plan CI
+        id: plan
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          CI_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: >-
+          pnpm exec ariakit ci-plan
+          --base "$BASE_SHA"
+          --head "$HEAD_SHA"
+          --base-ref "$BASE_REF"
+          --labels "$CI_LABELS"
+          --output "$GITHUB_OUTPUT"
+
+  main:
+    name: Main
+    needs: plan
+    if: needs.plan.outputs.main == 'true'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/main.yml
+    secrets: inherit
+
+  app:
+    name: App
+    needs: plan
+    if: needs.plan.outputs.app == 'true'
+    permissions:
+      actions: read
+      contents: read
+      deployments: write
+      statuses: write
+    uses: ./.github/workflows/app.yml
+    secrets: inherit
+
+  perf:
+    name: Performance
+    needs: plan
+    if: needs.plan.outputs.perf == 'true'
+    permissions:
+      actions: read
+      contents: read
+    uses: ./.github/workflows/perf.yml
+    secrets: inherit
+
+  plus:
+    name: Plus
+    needs: plan
+    if: needs.plan.outputs.plus == 'true'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/plus.yml
+    secrets: inherit
+
+  release_preview:
+    name: Release preview
+    needs: plan
+    if: needs.plan.outputs.release_preview == 'true'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/release-preview.yml
+    secrets: inherit
+
+  docs:
+    name: Docs
+    needs: plan
+    if: needs.plan.outputs.docs == 'true'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/docs.yml
+    secrets: inherit
+
+  build_styles:
+    name: Build styles
+    needs: plan
+    if: needs.plan.outputs.build_styles == 'true'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-styles.yml
+    secrets: inherit
+
+  og_images:
+    name: OG images
+    needs: plan
+    if: needs.plan.outputs.og_images == 'true'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/og-images.yml
+    secrets: inherit
+
+  gate:
+    name: Gate
+    if: always()
+    needs:
+      - plan
+      - main
+      - app
+      - perf
+      - plus
+      - release_preview
+      - docs
+      - build_styles
+      - og_images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up environment
+        uses: ./.github/workflows/setup
+
+      - name: Verify CI results
+        env:
+          CI_PLAN: ${{ needs.plan.outputs.plan }}
+          CI_RESULTS: ${{ toJSON(needs) }}
+        run: >-
+          pnpm exec ariakit ci-gate
+          --plan "$CI_PLAN"
+          --results "$CI_RESULTS"
+
+  required:
+    # Preserve the current required status names until the main ruleset is
+    # migrated to require Gate. Reusable jobs use prefixed check names, so
+    # removing these aliases before that migration would block automerge.
+    name: ${{ matrix.name }}
+    if: always()
+    needs: gate
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        name:
+          - Lint
+          - Type check
+          - Build packages
+          - Test
+          - Test React
+          - Test Solid
+          - Test Android
+          - Test Chrome
+          - Test Firefox
+          - Test macOS
+          - Test Safari
+          - Visual / Finalize
+          - Preview / Deploy
+          - Generate OG images
+    steps:
+      - name: Verify gate
+        env:
+          GATE_RESULT: ${{ needs.gate.result }}
+        run: |
+          if [ "$GATE_RESULT" != "success" ]; then
+            echo "CI gate result was $GATE_RESULT" >&2
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,39 +154,3 @@ jobs:
           CI_PLAN: ${{ needs.plan.outputs.plan }}
           CI_RESULTS: ${{ toJSON(needs) }}
         run: node packages/ariakit-scripts/src/ci-run.ts gate
-
-  required:
-    # Preserve the current required status names until the main ruleset is
-    # migrated to require Gate. Reusable jobs use prefixed check names, so
-    # removing these aliases before that migration would block automerge.
-    name: ${{ matrix.name }}
-    if: always()
-    needs: gate
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        name:
-          - Lint
-          - Type check
-          - Build packages
-          - Test
-          - Test React
-          - Test Solid
-          - Test Android
-          - Test Chrome
-          - Test Firefox
-          - Test macOS
-          - Test Safari
-          - Visual / Finalize
-          - Preview / Deploy
-          - Generate OG images
-    steps:
-      - name: Verify gate
-        env:
-          GATE_RESULT: ${{ needs.gate.result }}
-        run: |
-          if [ "$GATE_RESULT" != "success" ]; then
-            echo "CI gate result was $GATE_RESULT" >&2
-            exit 1
-          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Set up environment
-        uses: ./.github/workflows/setup
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: package.json
 
       - name: Plan CI
         id: plan
@@ -45,13 +47,7 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           CI_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
-        run: >-
-          pnpm exec ariakit ci-plan
-          --base "$BASE_SHA"
-          --head "$HEAD_SHA"
-          --base-ref "$BASE_REF"
-          --labels "$CI_LABELS"
-          --output "$GITHUB_OUTPUT"
+        run: node packages/ariakit-scripts/src/ci-run.ts plan
 
   main:
     name: Main
@@ -152,17 +148,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up environment
-        uses: ./.github/workflows/setup
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: package.json
 
       - name: Verify CI results
         env:
           CI_PLAN: ${{ needs.plan.outputs.plan }}
           CI_RESULTS: ${{ toJSON(needs) }}
-        run: >-
-          pnpm exec ariakit ci-gate
-          --plan "$CI_PLAN"
-          --results "$CI_RESULTS"
+        run: node packages/ariakit-scripts/src/ci-run.ts gate
 
   required:
     # Preserve the current required status names until the main ruleset is

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -11,7 +11,7 @@ jobs:
       name: Preview
       url: ${{ steps.preview-url.outputs.commit_url }}
     concurrency:
-      group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+      group: deploy-preview-${{ github.head_ref || github.ref_name }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,10 +3,10 @@ name: docs
 on:
   push:
     branches: [main]
-  pull_request:
+  workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: docs-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: main
 on:
   push:
     branches: [main]
-  pull_request:
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/og-images.yml
+++ b/.github/workflows/og-images.yml
@@ -3,10 +3,10 @@ name: og-images
 on:
   push:
     branches: [main]
-  pull_request:
+  workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: og-images-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,13 +1,13 @@
 name: perf
 
 on:
-  pull_request:
+  workflow_call:
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: perf-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -32,7 +32,7 @@ jobs:
       - name: Upload app artifact
         uses: actions/upload-artifact@v7
         with:
-          name: app-build
+          name: perf-app-build
           path: |
             app/dist
             app/.wrangler/deploy/config.json
@@ -57,7 +57,7 @@ jobs:
       - name: Upload Next.js artifact
         uses: actions/upload-artifact@v7
         with:
-          name: nextjs-dist
+          name: perf-nextjs-dist
           path: nextjs/.open-next
           retention-days: 7
           include-hidden-files: true
@@ -463,13 +463,13 @@ jobs:
       - name: Download app artifact
         uses: actions/download-artifact@v8
         with:
-          name: app-build
+          name: perf-app-build
           path: app
 
       - name: Download Next.js artifact
         uses: actions/download-artifact@v8
         with:
-          name: nextjs-dist
+          name: perf-nextjs-dist
           path: nextjs/.open-next
 
       - name: Run interleaved perf tests

--- a/.github/workflows/plus.yml
+++ b/.github/workflows/plus.yml
@@ -3,7 +3,7 @@ name: plus
 on:
   push:
     branches: [main, next]
-  pull_request:
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -1,8 +1,7 @@
 name: release-preview
 
 on:
-  pull_request:
-    branches: [main]
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -107,15 +107,15 @@ jobs:
             };
             const jobs = await listWorkflowRunJobs();
             const artifacts = await listWorkflowRunArtifacts();
+            const { getVisualProject } = await import(
+              `${process.env.GITHUB_WORKSPACE}/packages/ariakit-scripts/src/ci-visual.js`
+            );
             const screenshotJobs = jobs
               .filter((job) => job.steps?.some((step) => step.name === "Upload screenshots"))
               .map((job) => {
-                const project = job.name.startsWith("Test ")
-                  ? job.name.slice(5).toLowerCase()
-                  : undefined;
                 return {
                   name: job.name,
-                  project,
+                  project: getVisualProject(job.name),
                 };
               });
             const invalidScreenshotJobs = screenshotJobs.filter((job) => !job.project);

--- a/packages/ariakit-scripts/src/ci-run.ts
+++ b/packages/ariakit-scripts/src/ci-run.ts
@@ -1,0 +1,34 @@
+import { runCIGate, runCIPlan } from "./ci.ts";
+
+function getEnvironmentVariable(name: string) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing environment variable: ${name}`);
+  }
+  return value;
+}
+
+function runCICommand(command: string | undefined) {
+  if (command === "plan") {
+    runCIPlan({
+      base: getEnvironmentVariable("BASE_SHA"),
+      head: getEnvironmentVariable("HEAD_SHA"),
+      baseRef: getEnvironmentVariable("BASE_REF"),
+      labels: getEnvironmentVariable("CI_LABELS"),
+      output: getEnvironmentVariable("GITHUB_OUTPUT"),
+    });
+    return;
+  }
+
+  if (command === "gate") {
+    runCIGate({
+      plan: getEnvironmentVariable("CI_PLAN"),
+      results: getEnvironmentVariable("CI_RESULTS"),
+    });
+    return;
+  }
+
+  throw new Error(`Unknown CI command: ${command ?? ""}`);
+}
+
+runCICommand(process.argv[2]);

--- a/packages/ariakit-scripts/src/ci-visual.js
+++ b/packages/ariakit-scripts/src/ci-visual.js
@@ -1,0 +1,8 @@
+/**
+ * @param {string} jobName
+ */
+export function getVisualProject(jobName) {
+  const localName = jobName.split(" / ").at(-1);
+  if (!localName?.startsWith("Test ")) return;
+  return localName.slice(5).toLowerCase();
+}

--- a/packages/ariakit-scripts/src/ci-visual.test.ts
+++ b/packages/ariakit-scripts/src/ci-visual.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "vitest";
+import { getVisualProject } from "./ci-visual.js";
+
+test("gets the browser project from direct and reusable workflow job names", () => {
+  expect(getVisualProject("Test Chrome")).toBe("chrome");
+  expect(getVisualProject("App / Test Firefox")).toBe("firefox");
+});
+
+test("ignores unrelated workflow jobs", () => {
+  expect(getVisualProject("App / Build app")).toBeUndefined();
+});

--- a/packages/ariakit-scripts/src/ci.test.ts
+++ b/packages/ariakit-scripts/src/ci.test.ts
@@ -1,0 +1,170 @@
+import { expect, test } from "vitest";
+import {
+  assertCIGate,
+  ciWorkflowNames,
+  createCIPlan,
+  parseChangedFiles,
+} from "./ci.ts";
+import type { CIGateResult } from "./ci.ts";
+
+function getResults(
+  plan: ReturnType<typeof createCIPlan>,
+  overrides: Record<string, CIGateResult> = {},
+) {
+  const results: Record<string, CIGateResult> = {
+    plan: { result: "success" },
+  };
+  for (const workflow of ciWorkflowNames) {
+    results[workflow] = {
+      result: plan.workflows[workflow] ? "success" : "skipped",
+    };
+  }
+  return { ...results, ...overrides };
+}
+
+test("keeps core and legacy browser tests on every pull request", () => {
+  const plan = createCIPlan(["readme.md"]);
+
+  expect(plan.workflows).toEqual({
+    main: true,
+    app: false,
+    perf: false,
+    plus: false,
+    release_preview: false,
+    docs: false,
+    build_styles: false,
+    og_images: false,
+  });
+});
+
+test("runs every workflow for dependency and CI infrastructure changes", () => {
+  for (const file of [
+    "pnpm-lock.yaml",
+    "app/package.json",
+    "app/astro.config.mjs",
+    "app/wrangler.jsonc",
+    ".changeset/config.json",
+    "website/build-pages/config.js",
+    "packages/ariakit-components/package.json",
+    "packages/ariakit-components/tsconfig.json",
+    ".github/workflows/ci.yml",
+    "packages/ariakit-scripts/src/ci.ts",
+  ]) {
+    const plan = createCIPlan([file]);
+    expect(Object.values(plan.workflows).every(Boolean), file).toBe(true);
+  }
+});
+
+test("runs app, performance, docs, release, and website checks for package code", () => {
+  const plan = createCIPlan([
+    "packages/ariakit-components/src/dialog/dialog.ts",
+  ]);
+
+  expect(plan.workflows).toMatchObject({
+    main: true,
+    app: true,
+    perf: true,
+    plus: true,
+    release_preview: true,
+    docs: true,
+    build_styles: false,
+    og_images: false,
+  });
+});
+
+test("does not run performance checks for package tests", () => {
+  const plan = createCIPlan([
+    "packages/ariakit-components/src/dialog/dialog.test.ts",
+  ]);
+
+  expect(plan.workflows.main).toBe(true);
+  expect(plan.workflows.perf).toBe(false);
+});
+
+test("runs app tests without treating them as performance inputs", () => {
+  const plan = createCIPlan(["app/src/lib/og-image-key.test.ts"]);
+
+  expect(plan.workflows.app).toBe(true);
+  expect(plan.workflows.perf).toBe(false);
+});
+
+test("falls back to full CI for unknown non-documentation paths", () => {
+  for (const file of [
+    "tooling/new-config.json",
+    "tooling/new-config.test.ts",
+  ]) {
+    const plan = createCIPlan([file]);
+    expect(Object.values(plan.workflows).every(Boolean), file).toBe(true);
+  }
+});
+
+test("runs generated asset workflows only for their inputs", () => {
+  const stylesPlan = createCIPlan(["app/src/styles/ak-button.css"]);
+  expect(stylesPlan.workflows.build_styles).toBe(true);
+  expect(stylesPlan.workflows.og_images).toBe(true);
+
+  const ogPlan = createCIPlan(["app/src/pages/og-image/api.ts"]);
+  expect(ogPlan.workflows.og_images).toBe(true);
+  expect(ogPlan.workflows.build_styles).toBe(false);
+});
+
+test("runs release previews for changesets only on main pull requests", () => {
+  expect(
+    createCIPlan([".changeset/example.md"], { baseRef: "main" }).workflows
+      .release_preview,
+  ).toBe(true);
+  expect(
+    createCIPlan([".changeset/example.md"], { baseRef: "next" }).workflows
+      .release_preview,
+  ).toBe(false);
+});
+
+test("supports full and workflow-specific override labels", () => {
+  const perfPlan = createCIPlan(["readme.md"], { labels: ["ci:perf"] });
+  expect(perfPlan.workflows.perf).toBe(true);
+  expect(perfPlan.workflows.app).toBe(false);
+
+  const fullPlan = createCIPlan(["readme.md"], { labels: ["ci:full"] });
+  expect(Object.values(fullPlan.workflows).every(Boolean)).toBe(true);
+});
+
+test("keeps both paths when git reports a rename", () => {
+  expect(
+    parseChangedFiles(
+      [
+        "M",
+        "readme.md",
+        "R100",
+        "packages/old/src/index.ts",
+        "packages/new/src/index.ts",
+        "",
+      ].join("\0"),
+    ),
+  ).toEqual([
+    "readme.md",
+    "packages/old/src/index.ts",
+    "packages/new/src/index.ts",
+  ]);
+});
+
+test("accepts successful selected workflows and skipped unselected workflows", () => {
+  const plan = createCIPlan(["readme.md"]);
+
+  expect(() => assertCIGate(plan, getResults(plan))).not.toThrow();
+});
+
+test("rejects failed selected workflows", () => {
+  const plan = createCIPlan(["readme.md"]);
+
+  expect(() =>
+    assertCIGate(plan, getResults(plan, { main: { result: "failure" } })),
+  ).toThrow("main: expected success, received failure");
+});
+
+test("rejects workflows that run outside the plan", () => {
+  const plan = createCIPlan(["readme.md"]);
+
+  expect(() =>
+    assertCIGate(plan, getResults(plan, { perf: { result: "success" } })),
+  ).toThrow("perf: expected skipped, received success");
+});

--- a/packages/ariakit-scripts/src/ci.test.ts
+++ b/packages/ariakit-scripts/src/ci.test.ts
@@ -4,6 +4,7 @@ import {
   ciWorkflowNames,
   createCIPlan,
   parseChangedFiles,
+  serializeCIGatePlan,
 } from "./ci.ts";
 import type { CIGateResult } from "./ci.ts";
 
@@ -145,6 +146,20 @@ test("keeps both paths when git reports a rename", () => {
     "packages/old/src/index.ts",
     "packages/new/src/index.ts",
   ]);
+});
+
+test("serializes a compact gate plan for large changes", () => {
+  const files = Array.from({ length: 200 }, (_, index) => {
+    return `packages/ariakit-components/src/long-component-name-${index}/long-source-file-name-${index}.ts`;
+  });
+  const plan = createCIPlan(files, { baseRef: "main" });
+  const gatePlan = serializeCIGatePlan(plan);
+
+  expect(new TextEncoder().encode(gatePlan).byteLength).toBeLessThan(1024);
+  expect(JSON.parse(gatePlan)).toEqual({
+    version: 1,
+    workflows: plan.workflows,
+  });
 });
 
 test("accepts successful selected workflows and skipped unselected workflows", () => {

--- a/packages/ariakit-scripts/src/ci.test.ts
+++ b/packages/ariakit-scripts/src/ci.test.ts
@@ -69,7 +69,7 @@ test("runs app, performance, docs, release, and website checks for package code"
     release_preview: true,
     docs: true,
     build_styles: false,
-    og_images: false,
+    og_images: true,
   });
 });
 
@@ -107,6 +107,23 @@ test("runs generated asset workflows only for their inputs", () => {
   const ogPlan = createCIPlan(["app/src/pages/og-image/api.ts"]);
   expect(ogPlan.workflows.og_images).toBe(true);
   expect(ogPlan.workflows.build_styles).toBe(false);
+});
+
+test("runs OG generation for package runtime imported by the renderer", () => {
+  const plan = createCIPlan([
+    "packages/ariakit-react-components/src/popover/popover-arrow-path.ts",
+  ]);
+
+  expect(plan.workflows.og_images).toBe(true);
+});
+
+test("skips OG generation for package tests and readmes", () => {
+  for (const file of [
+    "packages/ariakit-react-components/src/popover/popover.test.ts",
+    "packages/ariakit-react-components/readme.md",
+  ]) {
+    expect(createCIPlan([file]).workflows.og_images, file).toBe(false);
+  }
 });
 
 test("runs release previews for changesets only on main pull requests", () => {

--- a/packages/ariakit-scripts/src/ci.ts
+++ b/packages/ariakit-scripts/src/ci.ts
@@ -1,0 +1,424 @@
+import { execFileSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
+
+export const ciWorkflowNames = [
+  "main",
+  "app",
+  "perf",
+  "plus",
+  "release_preview",
+  "docs",
+  "build_styles",
+  "og_images",
+] as const;
+
+export type CIWorkflowName = (typeof ciWorkflowNames)[number];
+
+export interface CIPlan {
+  version: 1;
+  baseRef: string;
+  files: string[];
+  labels: string[];
+  workflows: Record<CIWorkflowName, boolean>;
+  reasons: Record<CIWorkflowName, string[]>;
+}
+
+export interface CreateCIPlanOptions {
+  baseRef?: string;
+  labels?: string[];
+}
+
+export interface RunCIPlanOptions {
+  base: string;
+  head: string;
+  baseRef: string;
+  labels: string;
+  output: string;
+}
+
+export interface CIGateResult {
+  result?: string;
+}
+
+export interface RunCIGateOptions {
+  plan: string;
+  results: string;
+}
+
+type CIResults = Record<string, CIGateResult | undefined>;
+
+interface CIGatePlan {
+  version: 1;
+  workflows: Record<CIWorkflowName, boolean>;
+}
+
+const workflowLabels: Record<string, CIWorkflowName> = {
+  "ci:app": "app",
+  "ci:build-styles": "build_styles",
+  "ci:docs": "docs",
+  "ci:main": "main",
+  "ci:og-images": "og_images",
+  "ci:perf": "perf",
+  "ci:plus": "plus",
+  "ci:release-preview": "release_preview",
+};
+
+const dependencyAndConfigNames = new Set([
+  ".npmrc",
+  "bun.lock",
+  "bun.lockb",
+  "package-lock.json",
+  "package.json",
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
+  "wrangler.json",
+  "wrangler.jsonc",
+  "wrangler.toml",
+  "yarn.lock",
+]);
+
+function normalizeCIPath(file: string) {
+  return file.replaceAll("\\", "/").replace(/^\.\/+/, "");
+}
+
+function isMarkdown(file: string) {
+  return /\.(?:md|mdx)$/i.test(file);
+}
+
+function isTestFile(file: string) {
+  return (
+    /(?:^|\/)__tests__\//.test(file) ||
+    /(?:^|\/)__screenshots__\//.test(file) ||
+    /\.(?:test|spec)\.[cm]?[jt]sx?$/.test(file)
+  );
+}
+
+function isFullCIPath(file: string) {
+  if (
+    file.startsWith(".github/") ||
+    file.startsWith("packages/ariakit-scripts/") ||
+    file.startsWith("patches/") ||
+    file.startsWith("scripts/")
+  ) {
+    return true;
+  }
+  const name = file.slice(file.lastIndexOf("/") + 1);
+  if (dependencyAndConfigNames.has(name)) return true;
+  if (/(?:^|\.)config(?:\.|$)/.test(name)) return true;
+  if (/^tsconfig(?:\.[^/]+)?\.json$/.test(name)) return true;
+  if (!file.includes("/") && !isMarkdown(file)) return true;
+  return false;
+}
+
+function isPackageRuntimePath(file: string) {
+  if (!file.startsWith("packages/")) return false;
+  if (isMarkdown(file) || isTestFile(file)) return false;
+  return true;
+}
+
+function isAppRuntimePath(file: string) {
+  if (!/^(?:app|nextjs)\//.test(file)) return false;
+  if (isTestFile(file)) return false;
+  return true;
+}
+
+function addReason(plan: CIPlan, workflow: CIWorkflowName, reason: string) {
+  plan.workflows[workflow] = true;
+  const reasons = plan.reasons[workflow];
+  if (!reasons.includes(reason)) {
+    reasons.push(reason);
+  }
+}
+
+function addFullCIReason(plan: CIPlan, file: string) {
+  for (const workflow of ciWorkflowNames) {
+    addReason(plan, workflow, `Repository-wide CI input: ${file}`);
+  }
+}
+
+function addFileReasons(plan: CIPlan, file: string) {
+  if (isFullCIPath(file)) {
+    addFullCIReason(plan, file);
+    return;
+  }
+
+  let matched = false;
+  if (/^(?:app|nextjs)\//.test(file) || isPackageRuntimePath(file)) {
+    addReason(plan, "app", `App input: ${file}`);
+    matched = true;
+  }
+
+  if (isAppRuntimePath(file) || isPackageRuntimePath(file)) {
+    addReason(plan, "perf", `Performance-sensitive runtime: ${file}`);
+    matched = true;
+  }
+
+  if (isPackageRuntimePath(file)) {
+    addReason(plan, "release_preview", `Publishable package input: ${file}`);
+    matched = true;
+  }
+
+  if (
+    isPackageRuntimePath(file) ||
+    /^packages\/[^/]+\/readme\.md$/i.test(file)
+  ) {
+    addReason(plan, "docs", `API documentation input: ${file}`);
+    matched = true;
+  }
+
+  if (/^(?:website|guide)\//.test(file) || isPackageRuntimePath(file)) {
+    addReason(plan, "plus", `Plus website input: ${file}`);
+    matched = true;
+  }
+
+  if (
+    file.startsWith("app/src/styles/") ||
+    /^app\/src\/lib\/(?:build-styles|styles(?:-json-types|-shared)?)\.ts$/.test(
+      file,
+    )
+  ) {
+    addReason(plan, "build_styles", `Generated styles input: ${file}`);
+    matched = true;
+  }
+
+  if (
+    file.startsWith("app/public/og-image/") ||
+    (file.startsWith("app/src/") && !isTestFile(file))
+  ) {
+    addReason(plan, "og_images", `OG image input: ${file}`);
+    matched = true;
+  }
+
+  if (file.startsWith(".changeset/") || file.startsWith("templates/")) {
+    addReason(plan, "release_preview", `Release preview input: ${file}`);
+    matched = true;
+  }
+
+  const safelyCoveredByMain =
+    isMarkdown(file) ||
+    file.startsWith("examples/") ||
+    (file.startsWith("packages/") && isTestFile(file));
+  if (!matched && !safelyCoveredByMain) {
+    addFullCIReason(plan, file);
+  }
+}
+
+export function createCIPlan(
+  changedFiles: string[],
+  options: CreateCIPlanOptions = {},
+) {
+  const files = [
+    ...new Set(changedFiles.map(normalizeCIPath).filter(Boolean)),
+  ].sort();
+  const labels = [...new Set(options.labels ?? [])].sort();
+  const workflows: Record<CIWorkflowName, boolean> = {
+    main: false,
+    app: false,
+    perf: false,
+    plus: false,
+    release_preview: false,
+    docs: false,
+    build_styles: false,
+    og_images: false,
+  };
+  const reasons: Record<CIWorkflowName, string[]> = {
+    main: [],
+    app: [],
+    perf: [],
+    plus: [],
+    release_preview: [],
+    docs: [],
+    build_styles: [],
+    og_images: [],
+  };
+  const plan: CIPlan = {
+    version: 1,
+    baseRef: options.baseRef ?? "",
+    files,
+    labels,
+    workflows,
+    reasons,
+  };
+
+  addReason(plan, "main", "Core and legacy browser tests run on every PR");
+  for (const file of files) {
+    addFileReasons(plan, file);
+  }
+
+  if (labels.includes("ci:full")) {
+    for (const workflow of ciWorkflowNames) {
+      addReason(plan, workflow, "Forced by ci:full label");
+    }
+  } else {
+    for (const label of labels) {
+      const workflow = workflowLabels[label];
+      if (workflow) {
+        addReason(plan, workflow, `Forced by ${label} label`);
+      }
+    }
+  }
+
+  if (plan.baseRef && plan.baseRef !== "main") {
+    plan.workflows.release_preview = false;
+    plan.reasons.release_preview = [];
+  }
+
+  return plan;
+}
+
+export function getChangedFiles(base: string, head: string) {
+  const output = execFileSync(
+    "git",
+    [
+      "diff",
+      "--find-renames",
+      "--name-status",
+      "--diff-filter=ACDMRTUXB",
+      "-z",
+      `${base}...${head}`,
+    ],
+    { encoding: "utf-8", maxBuffer: 10 * 1024 * 1024 },
+  );
+  return parseChangedFiles(output);
+}
+
+export function parseChangedFiles(output: string) {
+  const fields = output.split("\0");
+  const files: string[] = [];
+  let index = 0;
+  while (index < fields.length) {
+    const status = fields[index++];
+    if (!status) break;
+    const file = fields[index++];
+    if (!file) {
+      throw new Error(`Missing path for git diff status: ${status}`);
+    }
+    files.push(file);
+    if (status.startsWith("R") || status.startsWith("C")) {
+      const destination = fields[index++];
+      if (!destination) {
+        throw new Error(`Missing destination for git diff status: ${status}`);
+      }
+      files.push(destination);
+    }
+  }
+  return files;
+}
+
+function parseJSON(value: string, label: string) {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return parsed;
+  } catch (error) {
+    throw new Error(`Invalid ${label} JSON`, { cause: error });
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseCIPlan(value: string) {
+  const plan = parseJSON(value, "CI plan");
+  if (!isRecord(plan)) {
+    throw new Error("CI plan must be an object");
+  }
+  if (plan.version !== 1) {
+    throw new Error(`Unsupported CI plan version: ${String(plan.version)}`);
+  }
+  if (!isRecord(plan.workflows)) {
+    throw new Error("CI plan is missing workflows");
+  }
+  for (const workflow of ciWorkflowNames) {
+    if (typeof plan.workflows[workflow] !== "boolean") {
+      throw new Error(`CI plan is missing workflow: ${workflow}`);
+    }
+  }
+  return {
+    version: 1,
+    workflows: {
+      main: plan.workflows.main === true,
+      app: plan.workflows.app === true,
+      perf: plan.workflows.perf === true,
+      plus: plan.workflows.plus === true,
+      release_preview: plan.workflows.release_preview === true,
+      docs: plan.workflows.docs === true,
+      build_styles: plan.workflows.build_styles === true,
+      og_images: plan.workflows.og_images === true,
+    },
+  } satisfies CIGatePlan;
+}
+
+function parseCIResults(value: string) {
+  const results = parseJSON(value, "CI results");
+  if (!isRecord(results)) {
+    throw new Error("CI results must be an object");
+  }
+  const parsedResults: CIResults = {};
+  for (const [name, result] of Object.entries(results)) {
+    if (!isRecord(result)) continue;
+    parsedResults[name] = {
+      result: typeof result.result === "string" ? result.result : undefined,
+    };
+  }
+  return parsedResults;
+}
+
+export function assertCIGate(plan: CIGatePlan, results: CIResults) {
+  const failures: string[] = [];
+  if (results.plan?.result !== "success") {
+    failures.push(`plan: expected success, received ${results.plan?.result}`);
+  }
+
+  for (const workflow of ciWorkflowNames) {
+    const expected = plan.workflows[workflow] ? "success" : "skipped";
+    const actual = results[workflow]?.result;
+    if (actual !== expected) {
+      failures.push(`${workflow}: expected ${expected}, received ${actual}`);
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`CI gate failed:\n- ${failures.join("\n- ")}`);
+  }
+}
+
+export function runCIPlan(options: RunCIPlanOptions) {
+  const files = getChangedFiles(options.base, options.head);
+  const parsedLabels = parseJSON(options.labels, "CI labels");
+  if (
+    !Array.isArray(parsedLabels) ||
+    !parsedLabels.every((label) => typeof label === "string")
+  ) {
+    throw new Error("CI labels must be an array of strings");
+  }
+  const plan = createCIPlan(files, {
+    baseRef: options.baseRef,
+    labels: parsedLabels,
+  });
+  for (const workflow of ciWorkflowNames) {
+    appendFileSync(
+      options.output,
+      `${workflow}=${String(plan.workflows[workflow])}\n`,
+    );
+  }
+  appendFileSync(options.output, `plan=${JSON.stringify(plan)}\n`);
+
+  console.log(`Changed files (${files.length}):`);
+  for (const file of files) {
+    console.log(`- ${file}`);
+  }
+  console.log("CI plan:");
+  for (const workflow of ciWorkflowNames) {
+    const state = plan.workflows[workflow] ? "run" : "skip";
+    const reason = plan.reasons[workflow].join("; ");
+    console.log(`- ${workflow}: ${state}${reason ? ` (${reason})` : ""}`);
+  }
+}
+
+export function runCIGate(options: RunCIGateOptions) {
+  const plan = parseCIPlan(options.plan);
+  const results = parseCIResults(options.results);
+  assertCIGate(plan, results);
+  console.log("All planned CI workflows completed with the expected result.");
+}

--- a/packages/ariakit-scripts/src/ci.ts
+++ b/packages/ariakit-scripts/src/ci.ts
@@ -383,6 +383,13 @@ export function assertCIGate(plan: CIGatePlan, results: CIResults) {
   }
 }
 
+export function serializeCIGatePlan(plan: CIPlan) {
+  return JSON.stringify({
+    version: plan.version,
+    workflows: plan.workflows,
+  } satisfies CIGatePlan);
+}
+
 export function runCIPlan(options: RunCIPlanOptions) {
   const files = getChangedFiles(options.base, options.head);
   const parsedLabels = parseJSON(options.labels, "CI labels");
@@ -402,7 +409,7 @@ export function runCIPlan(options: RunCIPlanOptions) {
       `${workflow}=${String(plan.workflows[workflow])}\n`,
     );
   }
-  appendFileSync(options.output, `plan=${JSON.stringify(plan)}\n`);
+  appendFileSync(options.output, `plan=${serializeCIGatePlan(plan)}\n`);
 
   console.log(`Changed files (${files.length}):`);
   for (const file of files) {

--- a/packages/ariakit-scripts/src/ci.ts
+++ b/packages/ariakit-scripts/src/ci.ts
@@ -183,7 +183,8 @@ function addFileReasons(plan: CIPlan, file: string) {
 
   if (
     file.startsWith("app/public/og-image/") ||
-    (file.startsWith("app/src/") && !isTestFile(file))
+    (file.startsWith("app/src/") && !isTestFile(file)) ||
+    isPackageRuntimePath(file)
   ) {
     addReason(plan, "og_images", `OG image input: ${file}`);
     matched = true;

--- a/packages/ariakit-scripts/src/index.ts
+++ b/packages/ariakit-scripts/src/index.ts
@@ -68,29 +68,6 @@ program
   .action(react18);
 
 program
-  .command("ci-plan")
-  .description("Plan pull request CI workflows from changed files")
-  .requiredOption("--base <sha>", "Base commit SHA")
-  .requiredOption("--head <sha>", "Head commit SHA")
-  .requiredOption("--base-ref <name>", "Pull request base branch")
-  .requiredOption("--labels <json>", "Pull request label names")
-  .requiredOption("--output <path>", "GitHub Actions output file")
-  .action(async (options) => {
-    const { runCIPlan } = await import("./ci.ts");
-    runCIPlan(options);
-  });
-
-program
-  .command("ci-gate")
-  .description("Verify that planned CI workflows completed successfully")
-  .requiredOption("--plan <json>", "Serialized CI plan")
-  .requiredOption("--results <json>", "Serialized GitHub Actions job results")
-  .action(async (options) => {
-    const { runCIGate } = await import("./ci.ts");
-    runCIGate(options);
-  });
-
-program
   .command("perf-compare")
   .description("Compare performance results")
   .option("--node", "Compare Vitest benchmark results")

--- a/packages/ariakit-scripts/src/index.ts
+++ b/packages/ariakit-scripts/src/index.ts
@@ -68,6 +68,29 @@ program
   .action(react18);
 
 program
+  .command("ci-plan")
+  .description("Plan pull request CI workflows from changed files")
+  .requiredOption("--base <sha>", "Base commit SHA")
+  .requiredOption("--head <sha>", "Head commit SHA")
+  .requiredOption("--base-ref <name>", "Pull request base branch")
+  .requiredOption("--labels <json>", "Pull request label names")
+  .requiredOption("--output <path>", "GitHub Actions output file")
+  .action(async (options) => {
+    const { runCIPlan } = await import("./ci.ts");
+    runCIPlan(options);
+  });
+
+program
+  .command("ci-gate")
+  .description("Verify that planned CI workflows completed successfully")
+  .requiredOption("--plan <json>", "Serialized CI plan")
+  .requiredOption("--results <json>", "Serialized GitHub Actions job results")
+  .action(async (options) => {
+    const { runCIGate } = await import("./ci.ts");
+    runCIGate(options);
+  });
+
+program
   .command("perf-compare")
   .description("Compare performance results")
   .option("--node", "Compare Vitest benchmark results")


### PR DESCRIPTION
## Motivation

Pull requests currently run every specialized CI workflow, including performance and browser-heavy lanes, even when a change cannot affect them. Dependency, configuration, and unknown changes still need a conservative fallback because their impact cannot be determined reliably from filenames alone.

The final required-check contract also needs to remain stable when specialized workflows are skipped. Main should keep its duplicate legacy browser coverage until the legacy website migration is complete, while branch protection requires one aggregate result instead of leaf checks that may not exist.

## Solution

- Add a single `CI` pull request orchestrator backed by tested planning and gating functions and a dependency-free runner in `ariakit-scripts`.
- Always run Main, including its current legacy browser jobs, while conditionally calling reusable App, Perf, Plus, release preview, docs, styles, and OG image workflows.
- Treat dependency, configuration, workflow, script, and unknown non-documentation paths as full CI. Labels can only broaden the plan.
- Run Plan and Gate through a dependency-free `ariakit-scripts` entry point with the repository's pinned Node version, so neither job installs workspace dependencies on the serialized critical path.
- Preserve direct push workflows, and namespace called-workflow concurrency groups and artifacts to avoid caller collisions.
- Make `Gate` the sole required-check contract. The Main ruleset must require `Gate` instead of the 14 legacy contexts before this PR can merge.
- Preserve visual screenshot updates when GitHub prefixes nested reusable-workflow job names.

### Automatic workflow selection

The Plan job classifies every path from the merge-base diff. Renames and copies classify both the old and new path. Main starts enabled and cannot be skipped; the remaining workflows are enabled when any changed path matches their inputs.

| Workflow | Automatically triggered by |
| --- | --- |
| Main | Every pull request, including the current legacy browser tests. |
| App | Any file under `app/` or `nextjs/`, plus runtime package code. This includes app browser, visual, and preview jobs. |
| Perf | Non-test runtime code under `app/`, `nextjs/`, or `packages/`. Individual performance scenarios are not guessed; when Perf is selected, its complete dynamic matrix runs. |
| Plus | Files under `website/` or `guide/`, plus runtime package code consumed by the website. |
| Release preview | Files under `.changeset/` or `templates/`, plus publishable package runtime code. This workflow is enabled only for pull requests targeting `main`. |
| Docs | Runtime package code and package `readme.md` files. |
| Build styles | Files under `app/src/styles/` and the `build-styles`, `styles`, `styles-json-types`, or `styles-shared` helpers under `app/src/lib/`. |
| Generate OG images | Files under `app/public/og-image/`, non-test files under `app/src/`, and runtime package code imported by the renderer. |

Here, runtime package code means a non-Markdown, non-test file under `packages/`. Repository infrastructure has higher precedence and selects full CI.

### Fail-closed rules

All applicable workflows run when the change could have repository-wide effects or the planner does not recognize a non-documentation path. Release preview remains limited to pull requests targeting `main`. The fail-closed inputs include:

- `.github/`, `packages/ariakit-scripts/`, `patches/`, and `scripts/`;
- dependency manifests, lockfiles, workspace settings, `.npmrc`, Wrangler files, and `package.json` files at any depth;
- `config.*`, `*.config.*`, and `tsconfig*.json` files at any depth;
- root-level non-Markdown files;
- any unmatched non-Markdown path.

Only explicit low-risk categories can remain Main-only, such as unmatched Markdown, examples, and package test or screenshot files. Known specialized roots still select their owning workflow, so an app test selects App and a package README selects Docs.

Labels only add work and never suppress an inferred workflow. `ci:full` enables every applicable workflow. The workflow-specific labels are `ci:main`, `ci:app`, `ci:perf`, `ci:plus`, `ci:release-preview`, `ci:docs`, `ci:build-styles`, and `ci:og-images`. Adding or removing any label reruns the planner. These `ci:*` labels are supported planner inputs but are not currently configured in the repository.

Title/body edits and base retargets do not start CI in v1. After retargeting, trigger a fresh supported event by pushing a new head commit, changing an existing label, or closing and reopening the pull request.

Examples:

```text
readme.md                                      -> Main
packages/ariakit-components/src/dialog.test.ts -> Main
app/src/lib/example.test.ts                    -> Main + App
packages/ariakit-components/src/dialog.ts      -> Main + App + Perf + Plus + Release preview + Docs + Generate OG images
app/src/pages/example.ts                       -> Main + App + Perf + Generate OG images
pnpm-lock.yaml                                 -> All workflows
tooling/new-file.ts                            -> All workflows (unknown path fallback)
```

The Plan logs retain the complete changed-file list and per-workflow reasons. Gate receives only the plan version and workflow booleans, then fails unless planning succeeded, every selected workflow succeeded, and every unselected workflow was skipped.

## Implementation review reassessment

<details>
<summary>Cycle 3: Narrow edited-event support</summary>

**Assessment**

Three finding-bearing implementation cycles exposed a large Gate payload, destructive metadata-edit cancellation and duplicated setup cost, then a misleading all-skipped metadata check suite. The core orchestrator remains justified by the original scope, but metadata edits are frequent during ordinary PR maintenance and GitHub's commit rollup made the head appear green while the real suite was still running.

Keeping automatic base-retarget handling would require another event-routing workflow or a reusable wrapper that republishes all 14 required aliases. That would add maintenance complexity to an already substantial workflow and still create an edit-event check suite. The metadata behavior is also platform-sensitive and has no practical repository regression harness.

**Decision**

Keep the conservative selective-CI orchestrator, but remove the `edited` activity type and all metadata-specific routing. Title/body edits now create no CI run. Base retargets intentionally require a subsequent supported PR event in v1. A separate base-change wrapper and an explicit metadata-status job are intentionally unsupported because they add complexity without removing the misleading check-suite behavior.

</details>

## Review gate reassessment

<details>
<summary>Cycle 3: Continue the conservative orchestrator design</summary>

**Assessment**

Three finding-bearing review cycles exposed boundary conditions around nested configuration paths, reusable-workflow job prefixes, pull request retargeting, and unknown test-like paths. These issues had medium-to-high potential impact because a missed lane could produce a false-green gate, but their expected frequency ranges from uncommon to occasional.

The implementation is substantial but bounded: one planner/gate policy, one orchestrator, reusable workflow conversions, and focused tests. Its main maintenance cost is the explicit repository path policy and GitHub reusable-workflow semantics. Each review correction remained localized and did not add another state machine, policy layer, or public contract.

The supported scope stays deliberately conservative: Main always runs; known specialized inputs select their workflows; dependency, configuration, and unrecognized non-documentation paths fail closed to full CI; overrides only add work.

**Decision**

Continue the orchestrator direction and address every finding. Simplifying by weakening the fallback or omitting base-retarget handling would violate the reliability contract that motivated this change. No identified edge case is intentionally unsupported. Use `Gate` as the sole required-check contract; compatibility aliases are intentionally omitted.

</details>
