### PR TITLE
Test controlled Combobox Escape reset

### DIFF
--- a/app/src/sandbox/combobox-popover-reset-on-escape/index.react.tsx
+++ b/app/src/sandbox/combobox-popover-reset-on-escape/index.react.tsx
@@ -42,11 +42,13 @@ function Select({
 // the public resetOnEscape callback runs once for an accepted close, and not at
 // all when the popover stays open.
 function Counted({
+  controlled,
   vetoClose,
   vetoOnce,
   vetoBeforeMove,
   vetoWithSelection,
 }: {
+  controlled?: boolean;
   vetoClose?: boolean;
   vetoOnce?: boolean;
   vetoBeforeMove?: boolean;
@@ -57,7 +59,16 @@ function Counted({
   const [events, setEvents] = useState<string[]>([]);
   const hasOneShotVeto = !!(vetoOnce || vetoBeforeMove || vetoWithSelection);
   const [vetoReady, setVetoReady] = useState(!hasOneShotVeto);
+  const [open, setOpen] = useState(false);
   const store = Ariakit.useComboboxStore({
+    open: controlled ? open : undefined,
+    setOpen: controlled
+      ? (nextOpen) => {
+          if (nextOpen) {
+            setOpen(true);
+          }
+        }
+      : undefined,
     defaultSelectedValue: "Apple",
     selectOnMove: true,
   });
@@ -71,12 +82,13 @@ function Counted({
         : vetoClose
           ? "Vetoed"
           : "Counted";
+  const ariaLabel = controlled ? "Controlled counted" : label;
   return (
     <Ariakit.ComboboxProvider store={store}>
-      <Ariakit.ComboboxSelect aria-label={label}>
+      <Ariakit.ComboboxSelect aria-label={ariaLabel}>
         <Ariakit.ComboboxSelectedValue />
       </Ariakit.ComboboxSelect>
-      <div role="status" aria-label={`${label} counts`}>
+      <div role="status" aria-label={`${ariaLabel} counts`}>
         {`reset:${reset} close:${close} events:${events.join(",")}`}
       </div>
       {hasOneShotVeto && (
@@ -314,6 +326,7 @@ export default function Example() {
         }}
       />
       <Counted />
+      <Counted controlled />
       {/* A prevented close request keeps the popover open, so the previewed
       value should not be restored. */}
       <Counted vetoClose />

--- a/app/src/sandbox/combobox-popover-reset-on-escape/test-browser.ts
+++ b/app/src/sandbox/combobox-popover-reset-on-escape/test-browser.ts
@@ -101,6 +101,23 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(counts).toHaveText("reset:1 close:1 events:close,reset");
   });
 
+  test("runs reset once for a controlled close request", async ({
+    page,
+    q,
+  }) => {
+    const select = q.combobox("Controlled counted");
+    const counts = q.status("Controlled counted counts");
+    await select.click();
+    await page.keyboard.press("ArrowDown");
+    await test.expect(select).toHaveText("Banana");
+
+    await page.keyboard.press("Escape");
+
+    await test.expect(q.listbox()).toBeVisible();
+    await test.expect(select).toHaveText("Apple");
+    await test.expect(counts).toHaveText(/^reset:1\b/);
+  });
+
   test("doesn't reset when onClose prevents the close", async ({ page, q }) => {
     const select = q.combobox("Vetoed");
     const counts = q.status("Vetoed counts");

--- a/app/src/sandbox/combobox-popover-reset-on-escape/test.ts
+++ b/app/src/sandbox/combobox-popover-reset-on-escape/test.ts
@@ -113,6 +113,16 @@ test("reports one closing Escape per keypress", async () => {
   );
 });
 
+test("reports one reset for a controlled close request", async () => {
+  await click(q.combobox("Controlled counted"));
+  await press.ArrowDown();
+  expect(q.combobox("Controlled counted")).toHaveTextContent("Banana");
+  await press.Escape();
+  expect(q.listbox()).toBeVisible();
+  expect(q.combobox("Controlled counted")).toHaveTextContent("Apple");
+  expect(q.status("Controlled counted counts")).toHaveTextContent(/^reset:1\b/);
+});
+
 test("reports nothing when a descendant keeps the popover open", async () => {
   await click(q.combobox("Counted"));
   await click(q.button("Swallows escape"));


### PR DESCRIPTION
## Motivation

A `ComboboxSelect` re-dispatches keyboard events through Composite so the active
item can handle them. When `open` is controlled and the owner rejects a close
request, the same Escape interaction can overlap with controlled-state
resynchronization.

The existing tests covered proxy dispatch and controlled close requests
separately, but did not verify that `resetOnEscape` still runs exactly once at
their intersection. A Dialog-level completion experiment exposed this gap by
invoking the public reset callback twice in Chromium.

## Solution

- Adds a controlled-open variant to the existing counted Escape fixture.
- Verifies that Escape restores the pre-move selected value exactly once while
  the controlled popover remains visible.
- Covers the contract in both the happy-dom integration suite and the
  Chrome/Firefox/Safari browser suite.

## Testing

- React 19: 26/26 focused tests passed
- React 18: 26/26 focused tests passed
- Chrome, Firefox, and Safari: 48/48 browser tests passed
- `pnpm lint`
- `pnpm tsc`
- `pnpm build-app-lite`
- `pnpm clean` followed by a React 19 source-mode rerun
