### PR TITLE
Add ComboboxSelect scroll regression tests

### DIFF
--- a/app/src/sandbox/combobox-select-scroll-into-view/index.react.tsx
+++ b/app/src/sandbox/combobox-select-scroll-into-view/index.react.tsx
@@ -27,7 +27,6 @@ function Fixture({ label, lateItems }: FixtureProps) {
 
   return (
     <Ariakit.ComboboxProvider
-      open={open}
       setOpen={setOpen}
       defaultSelectedValue={selectedValue}
     >

--- a/app/src/sandbox/combobox-select-scroll-into-view/index.react.tsx
+++ b/app/src/sandbox/combobox-select-scroll-into-view/index.react.tsx
@@ -1,0 +1,67 @@
+import * as Ariakit from "@ariakit/react";
+import { useEffect, useState } from "react";
+
+const items = Array.from({ length: 30 }, (_, index) => `Item ${index + 1}`);
+const selectedValue = "Item 24";
+
+interface FixtureProps {
+  label: string;
+  lateItems?: boolean;
+}
+
+function Fixture({ label, lateItems }: FixtureProps) {
+  const [open, setOpen] = useState(false);
+  const [showLateItems, setShowLateItems] = useState(false);
+
+  useEffect(() => {
+    if (!lateItems) return;
+    if (!open) {
+      setShowLateItems(false);
+      return;
+    }
+    const timeout = window.setTimeout(() => setShowLateItems(true), 750);
+    return () => window.clearTimeout(timeout);
+  }, [lateItems, open]);
+
+  const renderedItems = lateItems && !showLateItems ? items.slice(0, 4) : items;
+
+  return (
+    <Ariakit.ComboboxProvider
+      open={open}
+      setOpen={setOpen}
+      defaultSelectedValue={selectedValue}
+    >
+      <Ariakit.ComboboxSelectLabel>{label}</Ariakit.ComboboxSelectLabel>
+      <Ariakit.ComboboxSelect style={{ display: "block" }} />
+      <Ariakit.ComboboxPopover
+        unmountOnHide
+        gutter={4}
+        sameWidth
+        aria-label={`${label} options`}
+        style={{
+          background: "white",
+          border: "1px solid gray",
+          maxHeight: 120,
+          overflow: "auto",
+        }}
+      >
+        {renderedItems.map((item) => (
+          <Ariakit.ComboboxItem
+            key={item}
+            value={item}
+            style={{ display: "block", padding: "4px 8px" }}
+          />
+        ))}
+      </Ariakit.ComboboxPopover>
+    </Ariakit.ComboboxProvider>
+  );
+}
+
+export default function Example() {
+  return (
+    <>
+      <Fixture label="Pointer race" />
+      <Fixture label="Late items" lateItems />
+    </>
+  );
+}

--- a/app/src/sandbox/combobox-select-scroll-into-view/test-browser.ts
+++ b/app/src/sandbox/combobox-select-scroll-into-view/test-browser.ts
@@ -1,4 +1,4 @@
-import { flushFrames, withFramework } from "#app/test-utils/preview.ts";
+import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
   // https://github.com/ariakit/ariakit/issues/6858
@@ -20,26 +20,16 @@ withFramework(import.meta.dirname, async ({ test }) => {
     const listX = selectX;
     const listY = selectBox.y + selectBox.height + 12;
 
-    // Pointer entry only intersects the vulnerable opening window, so retry the
-    // complete interaction until hover actually retargets the active item.
-    await test
-      .expect(async () => {
-        try {
-          await page.mouse.move(selectX, selectY);
-          await page.mouse.down();
-          await page.mouse.up();
-          await page.mouse.move(listX, listY);
-          await flushFrames(page, 8);
+    // The fixed path presents the selection before pointer entry. The broken
+    // path lets this hover retarget the pending scroll, leaving it offscreen.
+    await page.mouse.move(selectX, selectY);
+    await page.mouse.down();
+    await page.mouse.up();
+    await page.mouse.move(listX, listY);
 
-          await test.expect(activeItem).toHaveCount(1);
-          test.expect(await activeItem.textContent()).not.toBe("Item 24");
-          await test.expect(selected).toBeInViewport();
-        } finally {
-          await page.keyboard.press("Escape");
-          await test.expect(listbox).not.toBeVisible();
-        }
-      })
-      .toPass({ timeout: 20_000 });
+    await test.expect(activeItem).toHaveCount(1);
+    await test.expect(activeItem).not.toHaveText("Item 24");
+    await test.expect(selected).toBeInViewport();
   });
 
   // https://github.com/ariakit/ariakit/issues/6858

--- a/app/src/sandbox/combobox-select-scroll-into-view/test-browser.ts
+++ b/app/src/sandbox/combobox-select-scroll-into-view/test-browser.ts
@@ -8,7 +8,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
   }) => {
     const select = q.combobox("Pointer race");
     const selected = q.option("Item 24");
-    let hovered = false;
+    const listbox = q.listbox("Pointer race options");
+    const activeItem = listbox.locator("[data-active-item]");
 
     const selectBox = await select.boundingBox();
     if (!selectBox) {
@@ -19,27 +20,26 @@ withFramework(import.meta.dirname, async ({ test }) => {
     const listX = selectX;
     const listY = selectBox.y + selectBox.height + 12;
 
-    for (let attempt = 0; attempt < 20; attempt += 1) {
-      await page.mouse.move(selectX, selectY);
-      await page.mouse.down();
-      await page.mouse.up();
-      await page.mouse.move(listX, listY);
-      await flushFrames(page, 8);
+    // Pointer entry only intersects the vulnerable opening window, so retry the
+    // complete interaction until hover actually retargets the active item.
+    await test
+      .expect(async () => {
+        try {
+          await page.mouse.move(selectX, selectY);
+          await page.mouse.down();
+          await page.mouse.up();
+          await page.mouse.move(listX, listY);
+          await flushFrames(page, 8);
 
-      const listbox = q.listbox("Pointer race options");
-      const activeItem = listbox.locator("[data-active-item]");
-      await test.expect(activeItem).toHaveCount(1);
-      const activeValue = await activeItem.textContent();
-      if (activeValue !== "Item 24") {
-        hovered = true;
-      }
-      await test.expect(selected).toBeInViewport();
-
-      await page.keyboard.press("Escape");
-      await test.expect(listbox).not.toBeVisible();
-    }
-
-    test.expect(hovered).toBe(true);
+          await test.expect(activeItem).toHaveCount(1);
+          test.expect(await activeItem.textContent()).not.toBe("Item 24");
+          await test.expect(selected).toBeInViewport();
+        } finally {
+          await page.keyboard.press("Escape");
+          await test.expect(listbox).not.toBeVisible();
+        }
+      })
+      .toPass({ timeout: 20_000 });
   });
 
   // https://github.com/ariakit/ariakit/issues/6858

--- a/app/src/sandbox/combobox-select-scroll-into-view/test-browser.ts
+++ b/app/src/sandbox/combobox-select-scroll-into-view/test-browser.ts
@@ -1,0 +1,55 @@
+import { flushFrames, withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/6858
+  test("does not lose the opening selection to immediate pointer movement", async ({
+    page,
+    q,
+  }) => {
+    const select = q.combobox("Pointer race");
+    const selected = q.option("Item 24");
+    let hovered = false;
+
+    const selectBox = await select.boundingBox();
+    if (!selectBox) {
+      throw new Error("The select is not visible.");
+    }
+    const selectX = selectBox.x + selectBox.width / 2;
+    const selectY = selectBox.y + selectBox.height / 2;
+    const listX = selectX;
+    const listY = selectBox.y + selectBox.height + 12;
+
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      await page.mouse.move(selectX, selectY);
+      await page.mouse.down();
+      await page.mouse.up();
+      await page.mouse.move(listX, listY);
+      await flushFrames(page, 8);
+
+      const listbox = q.listbox("Pointer race options");
+      const activeItem = listbox.locator("[data-active-item]");
+      await test.expect(activeItem).toHaveCount(1);
+      const activeValue = await activeItem.textContent();
+      if (activeValue !== "Item 24") {
+        hovered = true;
+      }
+      await test.expect(selected).toBeInViewport();
+
+      await page.keyboard.press("Escape");
+      await test.expect(listbox).not.toBeVisible();
+    }
+
+    test.expect(hovered).toBe(true);
+  });
+
+  // https://github.com/ariakit/ariakit/issues/6858
+  test("presents the selection when its item registers late", async ({ q }) => {
+    await q.combobox("Late items").click();
+
+    const selected = q.option("Item 24");
+    await test.expect(selected).toHaveCount(0);
+    await test.expect(selected).toBeVisible({ timeout: 2_000 });
+    await test.expect(selected).toHaveAttribute("data-active-item");
+    await test.expect(selected).toBeInViewport();
+  });
+});

--- a/app/src/sandbox/combobox-select-scroll-into-view/test.ts
+++ b/app/src/sandbox/combobox-select-scroll-into-view/test.ts
@@ -1,4 +1,4 @@
-import { click, q, waitFor } from "@ariakit/test";
+import { click, q } from "@ariakit/test";
 import { expect, test, vi } from "vitest";
 
 // https://github.com/ariakit/ariakit/issues/6858
@@ -7,12 +7,10 @@ test("presents the selection when its item registers late", async () => {
   await click(q.combobox("Late items"));
   expect(q.option("Item 24")).not.toBeInTheDocument();
 
-  await waitFor(() => expect(q.option("Item 24")).toBeInTheDocument(), {
-    timeout: 3000,
-  });
+  await expect
+    .poll(q.option.lazy("Item 24"), { timeout: 3000 })
+    .toBeInTheDocument();
   const selected = q.option.ensure("Item 24");
   expect(selected).toHaveAttribute("data-active-item");
-  await waitFor(() => {
-    expect(scrollIntoView.mock.instances).toContain(selected);
-  });
+  await expect.poll(() => scrollIntoView.mock.instances).toContain(selected);
 });

--- a/app/src/sandbox/combobox-select-scroll-into-view/test.ts
+++ b/app/src/sandbox/combobox-select-scroll-into-view/test.ts
@@ -12,5 +12,7 @@ test("presents the selection when its item registers late", async () => {
   });
   const selected = q.option.ensure("Item 24");
   expect(selected).toHaveAttribute("data-active-item");
-  expect(scrollIntoView.mock.instances).toContain(selected);
+  await waitFor(() => {
+    expect(scrollIntoView.mock.instances).toContain(selected);
+  });
 });

--- a/app/src/sandbox/combobox-select-scroll-into-view/test.ts
+++ b/app/src/sandbox/combobox-select-scroll-into-view/test.ts
@@ -1,0 +1,16 @@
+import { click, q, waitFor } from "@ariakit/test";
+import { expect, test, vi } from "vitest";
+
+// https://github.com/ariakit/ariakit/issues/6858
+test("presents the selection when its item registers late", async () => {
+  using scrollIntoView = vi.spyOn(HTMLElement.prototype, "scrollIntoView");
+  await click(q.combobox("Late items"));
+  expect(q.option("Item 24")).not.toBeInTheDocument();
+
+  await waitFor(() => expect(q.option("Item 24")).toBeInTheDocument(), {
+    timeout: 3000,
+  });
+  const selected = q.option.ensure("Item 24");
+  expect(selected).toHaveAttribute("data-active-item");
+  expect(scrollIntoView.mock.instances).toContain(selected);
+});


### PR DESCRIPTION
## Motivation

[Issue #6858](https://github.com/ariakit/ariakit/issues/6858) documented two scroll scheduling gaps found while ComboboxSelect was under review: immediate pointer entry could retarget the opening scroll, and a selected item registering after the old frame window could remain offscreen. Current `main` already handles both cases through Composite's scheduled focus and presentation path, but the exact regressions were not preserved in durable coverage.

## Solution

Add a semantic `combobox-select-scroll-into-view` sandbox and two browser tests. The first performs a single real-pointer opening sequence, verifies that hover retargets the active item, and confirms that the selected option remains in the viewport. The second registers the selected option 750 ms after opening, then checks that it becomes active and scrolls into view.

Add focused happy-dom coverage for the late-registration path by spying on `scrollIntoView` and proving that the selected option's own element receives the call. The integration test polls the lazy option query with the existing 3-second allowance, then polls the semantic presentation outcome because Composite intentionally schedules this work after paint, which can complete after item registration under React 18.

```ts
await expect
  .poll(q.option.lazy("Item 24"), { timeout: 3000 })
  .toBeInTheDocument();
const selected = q.option.ensure("Item 24");
await expect.poll(() => scrollIntoView.mock.instances).toContain(selected);
```

The browser tests preserve the real pointer, animation-frame, overflow, clipping, and viewport behavior across Chrome, Firefox, and Safari. The integration test adds a direct, geometry-independent assertion for which element receives `scrollIntoView`.

## Verification

- Focused browser matrix: 6/6 passed across Chrome, Firefox, and Safari with no retries.
- Focused React 19 integration test: 1/1 passed.
- Focused React 18 integration test: 1/1 passed.
- `pnpm lint-fix` passed.
- `pnpm tsc` passed with no diagnostics.
- The exact browser tests fail against known-broken commit [`26037e64`](https://github.com/ariakit/ariakit/commit/26037e64a4ca03fea47a509291171c5a6aea0ed4) with viewport ratio 0.
- The exact `expect.poll` integration test fails against the same known-broken commit because the selected option never receives `scrollIntoView`.

## Preview

Exact [`a962b4363`](https://github.com/ariakit/ariakit/commit/a962b436369fc1eea51acd8944832f89958f8f3e) behavior revision: pointer hover retargets the active option while Item 24 remains visible, then a selected Item 24 registering after 750 ms becomes active and scrolls into view. Later commits change only integration-test assertion timing and expression.

[ariakit-6872-a962b4363-short.webm](https://github.com/user-attachments/assets/988fe298-fe13-47e4-abf0-9f1470ff2bd3)

## Implementation review reassessment

<details>
<summary>Cycle 3: Keep split browser and happy-dom coverage</summary>

**Assessment**

The protected regression has medium user impact: an asynchronously registered or virtualized selected option can remain offscreen, leaving the visible popup disconnected from its selected value. The late-registration path is uncommon but realistic, and both React 18 and React 19 are supported. Real pointer input, geometry, clipping, and viewport placement remain browser-only concerns.

The repeated cycles came from over-modeling the pointer timing with retries and frame flushing, controlling the fixture's open state unnecessarily, and finally assuming that item registration and Composite's deliberately post-paint presentation complete together. The first two sources of complexity were removed. The remaining happy-dom duplicate is small and checks a distinct contract: the late selected element itself receives `scrollIntoView`.

**Decision**

Keep the simplified fixture, linear browser tests, and focused happy-dom duplicate. Use `expect.poll` for the semantic DOM and `scrollIntoView` outcomes so React scheduler timing is not part of the contract; do not add sleeps, manual frame counts, or a longer custom timeout. Happy-dom intentionally does not attempt to prove pointer or layout behavior, which remains covered by the three browser projects.

</details>
