### PR TITLE
Test selective CI labels

### DIFF
--- a/ci-label-smoke-test.md
+++ b/ci-label-smoke-test.md
@@ -1,0 +1,3 @@
+# CI label smoke test
+
+This temporary file creates a Main-only change so the additive `ci:*` labels can be verified on a pull request. This pull request will not be merged.


### PR DESCRIPTION
## Motivation

Validate that the selective-CI labels trigger a fresh plan on GitHub and only broaden the workflows selected by the merged orchestrator.

## Solution

Add a temporary root Markdown file that produces a Main-only baseline plan. Then apply each workflow-specific `ci:*` label individually, inspect the completed Plan job, and cancel the run after selection is proven. Finally, apply `ci:full` and confirm that it selects every applicable workflow.

This pull request is only a smoke test. It will be closed without merging and the temporary branch will be deleted after the checks are complete.
