### PR TITLE
Use labels for selective dependency CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
         run: gh auth setup-git
 
       - name: Create PR or publish to npm
+        id: changesets
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           title: Publish
@@ -54,3 +55,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ""
+
+      - name: Label publish pull request
+        if: steps.changesets.outputs.pullRequestNumber != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.changesets.outputs.pullRequestNumber }}
+        run: gh pr edit "$PR_NUMBER" --add-label ci:publish

--- a/packages/ariakit-scripts/src/ci.test.ts
+++ b/packages/ariakit-scripts/src/ci.test.ts
@@ -243,6 +243,15 @@ test("classifies unexpected files on publish pull requests normally", () => {
   });
 });
 
+test("does not suppress private package manifests on publish pull requests", () => {
+  const plan = createCIPlan(
+    ["packages/ariakit-scripts/package.json", "pnpm-lock.yaml"],
+    { labels: ["ci:publish"] },
+  );
+
+  expect(Object.values(plan.workflows).every(Boolean)).toBe(true);
+});
+
 test("ignores labels that match inherited object properties", () => {
   const plan = createCIPlan(["readme.md"], {
     labels: ["toString", "constructor", "__proto__"],

--- a/packages/ariakit-scripts/src/ci.test.ts
+++ b/packages/ariakit-scripts/src/ci.test.ts
@@ -146,6 +146,113 @@ test("supports full and workflow-specific override labels", () => {
   expect(Object.values(fullPlan.workflows).every(Boolean)).toBe(true);
 });
 
+test("uses labels to select CI for recognized dependency updates", () => {
+  const plan = createCIPlan(["package.json", "pnpm-lock.yaml"], {
+    labels: ["ci:deps", "ci:perf"],
+  });
+
+  expect(plan.workflows).toEqual({
+    main: true,
+    app: false,
+    perf: true,
+    plus: false,
+    release_preview: false,
+    docs: false,
+    build_styles: false,
+    og_images: false,
+  });
+});
+
+test("keeps labeled dependency updates fail-closed for unknown manifests", () => {
+  const plan = createCIPlan(
+    ["packages/new-package/package.json", "pnpm-lock.yaml"],
+    { labels: ["ci:deps"] },
+  );
+
+  expect(Object.values(plan.workflows).every(Boolean)).toBe(true);
+});
+
+test("unions labeled dependency CI with mixed pull request changes", () => {
+  const plan = createCIPlan(
+    ["app/package.json", "app/src/components/button.tsx", "pnpm-lock.yaml"],
+    { labels: ["ci:deps"] },
+  );
+
+  expect(plan.workflows).toEqual({
+    main: true,
+    app: true,
+    perf: true,
+    plus: false,
+    release_preview: false,
+    docs: false,
+    build_styles: false,
+    og_images: true,
+  });
+});
+
+test("keeps ci:full authoritative for labeled dependency updates", () => {
+  const plan = createCIPlan(["package.json", "pnpm-lock.yaml"], {
+    labels: ["ci:deps", "ci:full"],
+  });
+
+  expect(Object.values(plan.workflows).every(Boolean)).toBe(true);
+});
+
+test("runs Main only for Changesets-generated publish metadata", () => {
+  const plan = createCIPlan(
+    [
+      ".changeset/example.md",
+      "packages/ariakit-react/CHANGELOG.md",
+      "packages/ariakit-react/package.json",
+      "pnpm-lock.yaml",
+    ],
+    { labels: ["ci:publish"] },
+  );
+
+  expect(plan.workflows).toEqual({
+    main: true,
+    app: false,
+    perf: false,
+    plus: false,
+    release_preview: false,
+    docs: false,
+    build_styles: false,
+    og_images: false,
+  });
+});
+
+test("classifies unexpected files on publish pull requests normally", () => {
+  const plan = createCIPlan(
+    [
+      "packages/ariakit-react/CHANGELOG.md",
+      "packages/ariakit-react/package.json",
+      "packages/ariakit-react/src/dialog/dialog.ts",
+    ],
+    { labels: ["ci:publish"] },
+  );
+
+  expect(plan.workflows).toMatchObject({
+    main: true,
+    app: true,
+    perf: true,
+    plus: true,
+    release_preview: true,
+    docs: true,
+    build_styles: false,
+    og_images: true,
+  });
+});
+
+test("ignores labels that match inherited object properties", () => {
+  const plan = createCIPlan(["readme.md"], {
+    labels: ["toString", "constructor", "__proto__"],
+  });
+
+  expect(plan.workflows.main).toBe(true);
+  expect(plan.workflows.app).toBe(false);
+  expect(plan.workflows.perf).toBe(false);
+});
+
 test("keeps both paths when git reports a rename", () => {
   expect(
     parseChangedFiles(

--- a/packages/ariakit-scripts/src/ci.ts
+++ b/packages/ariakit-scripts/src/ci.ts
@@ -77,6 +77,29 @@ const dependencyAndConfigNames = new Set([
   "yarn.lock",
 ]);
 
+const labeledDependencyManifests = new Set([
+  "app/package.json",
+  "examples/package.json",
+  "guide/package.json",
+  "nextjs/package.json",
+  "package.json",
+  "packages/ariakit-components/package.json",
+  "packages/ariakit-react-components/package.json",
+  "packages/ariakit-react-store/package.json",
+  "packages/ariakit-react-utils/package.json",
+  "packages/ariakit-react/package.json",
+  "packages/ariakit-solid-components/package.json",
+  "packages/ariakit-solid-store/package.json",
+  "packages/ariakit-solid-utils/package.json",
+  "packages/ariakit-solid/package.json",
+  "packages/ariakit-store/package.json",
+  "packages/ariakit-tailwind/package.json",
+  "packages/ariakit-test/package.json",
+  "packages/ariakit-utils/package.json",
+  "templates/react/package.json",
+  "website/package.json",
+]);
+
 function normalizeCIPath(file: string) {
   return file.replaceAll("\\", "/").replace(/^\.\/+/, "");
 }
@@ -120,6 +143,18 @@ function isAppRuntimePath(file: string) {
   if (!/^(?:app|nextjs)\//.test(file)) return false;
   if (isTestFile(file)) return false;
   return true;
+}
+
+function isLabeledDependencyFile(file: string) {
+  return file === "pnpm-lock.yaml" || labeledDependencyManifests.has(file);
+}
+
+function isPublishFile(file: string) {
+  return (
+    file === "pnpm-lock.yaml" ||
+    /^\.changeset\/[^/]+\.md$/i.test(file) ||
+    /^packages\/[^/]+\/(?:CHANGELOG\.md|package\.json)$/.test(file)
+  );
 }
 
 function addReason(plan: CIPlan, workflow: CIWorkflowName, reason: string) {
@@ -242,8 +277,18 @@ export function createCIPlan(
   };
 
   addReason(plan, "main", "Core and legacy browser tests run on every PR");
+  const labeledDependencyUpdate = labels.includes("ci:deps");
+  const publishUpdate = labels.includes("ci:publish");
   for (const file of files) {
+    if (publishUpdate && isPublishFile(file)) continue;
+    if (labeledDependencyUpdate && isLabeledDependencyFile(file)) continue;
     addFileReasons(plan, file);
+  }
+  if (labeledDependencyUpdate) {
+    addReason(plan, "main", "Dependency CI selected by labels");
+  }
+  if (publishUpdate) {
+    addReason(plan, "main", "Changesets publish metadata");
   }
 
   if (labels.includes("ci:full")) {
@@ -252,6 +297,7 @@ export function createCIPlan(
     }
   } else {
     for (const label of labels) {
+      if (!Object.hasOwn(workflowLabels, label)) continue;
       const workflow = workflowLabels[label];
       if (workflow) {
         addReason(plan, workflow, `Forced by ${label} label`);

--- a/packages/ariakit-scripts/src/ci.ts
+++ b/packages/ariakit-scripts/src/ci.ts
@@ -100,6 +100,22 @@ const labeledDependencyManifests = new Set([
   "website/package.json",
 ]);
 
+const publishPackageNames = new Set([
+  "ariakit-components",
+  "ariakit-react",
+  "ariakit-react-components",
+  "ariakit-react-store",
+  "ariakit-react-utils",
+  "ariakit-solid",
+  "ariakit-solid-components",
+  "ariakit-solid-store",
+  "ariakit-solid-utils",
+  "ariakit-store",
+  "ariakit-tailwind",
+  "ariakit-test",
+  "ariakit-utils",
+]);
+
 function normalizeCIPath(file: string) {
   return file.replaceAll("\\", "/").replace(/^\.\/+/, "");
 }
@@ -150,11 +166,12 @@ function isLabeledDependencyFile(file: string) {
 }
 
 function isPublishFile(file: string) {
-  return (
-    file === "pnpm-lock.yaml" ||
-    /^\.changeset\/[^/]+\.md$/i.test(file) ||
-    /^packages\/[^/]+\/(?:CHANGELOG\.md|package\.json)$/.test(file)
+  if (file === "pnpm-lock.yaml") return true;
+  if (/^\.changeset\/[^/]+\.md$/i.test(file)) return true;
+  const match = /^packages\/([^/]+)\/(?:CHANGELOG\.md|package\.json)$/.exec(
+    file,
   );
+  return !!match?.[1] && publishPackageNames.has(match[1]);
 }
 
 function addReason(plan: CIPlan, workflow: CIWorkflowName, reason: string) {

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
   "minimumReleaseAge": "3 days",
   "semanticCommits": "disabled",
+  "postUpdateOptions": ["pnpmDedupe"],
   "ignorePaths": [
     "**/node_modules/**",
     "**/bower_components/**",

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,6 @@
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
   "minimumReleaseAge": "3 days",
   "semanticCommits": "disabled",
-  "postUpdateOptions": ["pnpmDedupe"],
   "ignorePaths": [
     "**/node_modules/**",
     "**/bower_components/**",
@@ -145,6 +144,160 @@
       "automerge": true,
       "automergeType": "pr",
       "platformAutomerge": true
+    },
+    {
+      "description": "Select CI for reviewed root tooling updates",
+      "matchManagers": ["npm"],
+      "matchFileNames": ["package.json"],
+      "matchPackageNames": [
+        "@testing-library/jest-dom",
+        "@testing-library/react",
+        "@types/cross-spawn",
+        "@types/fs-extra",
+        "@types/node",
+        "@types/react",
+        "@types/react-dom",
+        "@vitest/coverage-v8",
+        "happy-dom",
+        "husky",
+        "lint-staged",
+        "oxfmt",
+        "oxlint",
+        "oxlint-tsgolint",
+        "prettier",
+        "prettier-plugin-tailwindcss",
+        "stylelint",
+        "stylelint-config-standard",
+        "vitest",
+        "vitest-fail-on-console"
+      ],
+      "addLabels": ["ci:deps"]
+    },
+    {
+      "description": "Run performance CI for Vitest updates",
+      "matchManagers": ["npm"],
+      "matchFileNames": ["package.json"],
+      "matchPackageNames": ["vitest"],
+      "addLabels": ["ci:perf"]
+    },
+    {
+      "description": "Run documentation CI for Oxfmt updates",
+      "matchManagers": ["npm"],
+      "matchFileNames": ["package.json"],
+      "matchPackageNames": ["oxfmt"],
+      "addLabels": ["ci:docs"]
+    },
+    {
+      "description": "Keep unreviewed root dependency updates on full CI",
+      "matchManagers": ["npm"],
+      "matchFileNames": ["package.json"],
+      "matchPackageNames": [
+        "!@testing-library/jest-dom",
+        "!@testing-library/react",
+        "!@types/cross-spawn",
+        "!@types/fs-extra",
+        "!@types/node",
+        "!@types/react",
+        "!@types/react-dom",
+        "!@vitest/coverage-v8",
+        "!happy-dom",
+        "!husky",
+        "!lint-staged",
+        "!oxfmt",
+        "!oxlint",
+        "!oxlint-tsgolint",
+        "!prettier",
+        "!prettier-plugin-tailwindcss",
+        "!stylelint",
+        "!stylelint-config-standard",
+        "!vitest",
+        "!vitest-fail-on-console"
+      ],
+      "addLabels": ["ci:full"]
+    },
+    {
+      "description": "Select Main CI for package development dependencies",
+      "matchManagers": ["npm"],
+      "matchFileNames": [
+        "packages/ariakit-components/package.json",
+        "packages/ariakit-react-components/package.json",
+        "packages/ariakit-react-store/package.json",
+        "packages/ariakit-react-utils/package.json",
+        "packages/ariakit-react/package.json",
+        "packages/ariakit-solid-components/package.json",
+        "packages/ariakit-solid-store/package.json",
+        "packages/ariakit-solid-utils/package.json",
+        "packages/ariakit-solid/package.json",
+        "packages/ariakit-store/package.json",
+        "packages/ariakit-tailwind/package.json",
+        "packages/ariakit-test/package.json",
+        "packages/ariakit-utils/package.json"
+      ],
+      "matchDepTypes": ["devDependencies"],
+      "addLabels": ["ci:deps"]
+    },
+    {
+      "description": "Select consumer CI for package runtime dependencies",
+      "matchManagers": ["npm"],
+      "matchFileNames": [
+        "packages/ariakit-components/package.json",
+        "packages/ariakit-react-components/package.json",
+        "packages/ariakit-react-store/package.json",
+        "packages/ariakit-react-utils/package.json",
+        "packages/ariakit-react/package.json",
+        "packages/ariakit-solid-components/package.json",
+        "packages/ariakit-solid-store/package.json",
+        "packages/ariakit-solid-utils/package.json",
+        "packages/ariakit-solid/package.json",
+        "packages/ariakit-store/package.json",
+        "packages/ariakit-tailwind/package.json",
+        "packages/ariakit-test/package.json",
+        "packages/ariakit-utils/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies",
+        "optionalDependencies",
+        "peerDependencies"
+      ],
+      "addLabels": [
+        "ci:deps",
+        "ci:app",
+        "ci:perf",
+        "ci:plus",
+        "ci:release-preview",
+        "ci:docs",
+        "ci:og-images"
+      ]
+    },
+    {
+      "description": "Select CI for app dependency updates",
+      "matchManagers": ["npm"],
+      "matchFileNames": ["app/package.json"],
+      "addLabels": ["ci:deps", "ci:app", "ci:perf", "ci:og-images"]
+    },
+    {
+      "description": "Select CI for Next.js dependency updates",
+      "matchManagers": ["npm"],
+      "matchFileNames": ["nextjs/package.json"],
+      "addLabels": ["ci:deps", "ci:app", "ci:perf"]
+    },
+    {
+      "description": "Select CI for website dependency updates",
+      "matchManagers": ["npm"],
+      "matchFileNames": ["website/package.json", "guide/package.json"],
+      "addLabels": ["ci:deps", "ci:plus"]
+    },
+    {
+      "description": "Select Main CI for example dependency updates",
+      "matchManagers": ["npm"],
+      "matchFileNames": ["examples/package.json"],
+      "addLabels": ["ci:deps"]
+    },
+    {
+      "description": "Select release CI for template dependency updates",
+      "matchManagers": ["npm"],
+      "matchFileNames": ["templates/react/package.json"],
+      "addLabels": ["ci:deps", "ci:release-preview"]
     },
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
## Motivation

[#6865](https://github.com/ariakit/ariakit/pull/6865) added path-based CI planning and deliberately treats dependency manifests and lockfiles as repository-wide inputs. That is the safe default, but it means every dependency update and Changesets-generated Publish PR runs full CI even when the automation that created the PR already knows its scope.

Ordinary pull requests should continue using the existing path heuristics. Only dependency-generated files need an explicit trust signal before they stop selecting full CI.

## Solution

Keep the existing file analysis and add two automation-owned markers:

```text
planned workflows = Main ∪ ordinary file impact ∪ CI lane labels
```

- A dependency PR without `ci:deps` remains full CI because its manifest or `pnpm-lock.yaml` is analyzed normally.
- With `ci:deps`, the planner ignores only the enumerated dependency manifests and `pnpm-lock.yaml`, then adds the `ci:*` lanes selected by Renovate.
- Any other changed file is still analyzed normally. A bug-fix PR that also updates a dependency therefore gets both its source-path lanes and its dependency labels.
- `ci:full` remains authoritative, and unknown package manifests are never suppressed.

Renovate uses [`addLabels`](https://docs.renovatebot.com/configuration-options/#addlabels) with conservative rules:

- reviewed root tooling updates run Main; Vitest also runs Performance, and Oxfmt also runs Docs;
- public-package development dependencies run Main;
- public-package runtime, peer, and optional dependencies run the package consumer lanes;
- app, Next.js, website/guide, examples, and the React template each select their corresponding consumer lanes;
- unreviewed root dependencies receive `ci:full`, including when grouped with a reviewed dependency;
- manifests outside the explicit allowlist remain full CI through the planner's normal fail-closed behavior.

The existing global `pnpmDedupe` post-update step remains enabled. Because deduplication can theoretically consolidate compatible transitive resolutions beyond the dependency that Renovate updated, the labels are a reviewed heuristic rather than deterministic proof over the entire lockfile. An audit of the 30 newest Renovate PRs found no case where deduplication crossed into an unrelated workspace that required an omitted CI lane. The largest selective candidates stayed within their expected dependency families, including [#6846](https://github.com/ariakit/ariakit/pull/6846), [#6815](https://github.com/ariakit/ariakit/pull/6815), and [#6861](https://github.com/ariakit/ariakit/pull/6861).

The Changesets workflow now adds `ci:publish` to the Publish PR it creates or updates. That marker suppresses only the generated set: one-level changeset files, public package manifests and changelogs, and the lockfile. A Publish PR like [#6820](https://github.com/ariakit/ariakit/pull/6820) therefore runs Main only. Unexpected files still go through the ordinary path classifier.

No changeset is needed because this changes internal CI automation only.

## Testing

- 24 focused CI planner and gate tests
- type-aware Oxlint on the planner and tests
- `tsc -b`
- Oxfmt on all changed files
- `git diff --check`
- official strict Renovate configuration validation
- Renovate local extraction across the workspace
- historical simulation of #6820 with and without `ci:publish`
- changed-file and lockfile-diff audit of the 30 newest Renovate PRs

## Implementation review reassessment

<details>
<summary>Cycle 3: Retain global deduplication with heuristic lane selection</summary>

**Assessment**

Review identified a theoretical case where global `pnpmDedupe` could consolidate an unrelated compatible transitive dependency outside the lanes selected for the direct update. Removing deduplication degraded lockfile hygiene, while moving it to weekly lockfile recreation introduced a new maintenance workflow and package-release-age policy.

The 30 newest Renovate PRs were inspected. No selective candidate contained an unrelated cross-workspace lockfile change that required an omitted lane. Small updates such as `lint-staged` changed only their own lock entries, while larger Oxc, Stylelint, Testing Library, and Radix updates remained within their dependency and peer graphs.

**Decision**

Retain the existing global `pnpmDedupe` behavior and define dependency lane selection as a conservative heuristic. Unknown manifests and unreviewed root dependencies remain full CI, `ci:full` remains authoritative, and ordinary mixed-PR files are still analyzed. Deterministic semantic attribution for an arbitrary transitive dedupe rewrite is intentionally outside this PR's scope.

</details>

## Review gate reassessment

<details>
<summary>Replace dependency inference with explicit automation labels</summary>

**Assessment**

An earlier design inferred dependency impact by parsing the lockfile and generated a bundled CI runner. Review showed that this created a second dependency-graph policy with a large maintenance and correctness surface. The label-driven design instead uses information already owned by Renovate and keeps the planner fail-closed when that information is absent.

**Decision**

Discard the dependency parser and bundle entirely. Keep the existing path planner, make selective dependency handling opt-in through explicit labels, and reserve full CI for unknown inputs. This is smaller, auditable in `renovate.json`, and preserves normal path analysis for mixed pull requests.

</details>

