### PR TITLE
Remove CI label overrides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read
@@ -43,7 +43,6 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
-          CI_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: node packages/ariakit-scripts/src/ci-run.ts plan
 
   main:

--- a/packages/ariakit-scripts/src/ci-run.ts
+++ b/packages/ariakit-scripts/src/ci-run.ts
@@ -14,7 +14,6 @@ function runCICommand(command: string | undefined) {
       base: getEnvironmentVariable("BASE_SHA"),
       head: getEnvironmentVariable("HEAD_SHA"),
       baseRef: getEnvironmentVariable("BASE_REF"),
-      labels: getEnvironmentVariable("CI_LABELS"),
       output: getEnvironmentVariable("GITHUB_OUTPUT"),
     });
     return;

--- a/packages/ariakit-scripts/src/ci.test.ts
+++ b/packages/ariakit-scripts/src/ci.test.ts
@@ -137,13 +137,8 @@ test("runs release previews for changesets only on main pull requests", () => {
   ).toBe(false);
 });
 
-test("supports full and workflow-specific override labels", () => {
-  const perfPlan = createCIPlan(["readme.md"], { labels: ["ci:perf"] });
-  expect(perfPlan.workflows.perf).toBe(true);
-  expect(perfPlan.workflows.app).toBe(false);
-
-  const fullPlan = createCIPlan(["readme.md"], { labels: ["ci:full"] });
-  expect(Object.values(fullPlan.workflows).every(Boolean)).toBe(true);
+test("keeps labels out of CI plans", () => {
+  expect(createCIPlan(["readme.md"])).not.toHaveProperty("labels");
 });
 
 test("keeps both paths when git reports a rename", () => {

--- a/packages/ariakit-scripts/src/ci.ts
+++ b/packages/ariakit-scripts/src/ci.ts
@@ -18,21 +18,18 @@ export interface CIPlan {
   version: 1;
   baseRef: string;
   files: string[];
-  labels: string[];
   workflows: Record<CIWorkflowName, boolean>;
   reasons: Record<CIWorkflowName, string[]>;
 }
 
 export interface CreateCIPlanOptions {
   baseRef?: string;
-  labels?: string[];
 }
 
 export interface RunCIPlanOptions {
   base: string;
   head: string;
   baseRef: string;
-  labels: string;
   output: string;
 }
 
@@ -51,17 +48,6 @@ interface CIGatePlan {
   version: 1;
   workflows: Record<CIWorkflowName, boolean>;
 }
-
-const workflowLabels: Record<string, CIWorkflowName> = {
-  "ci:app": "app",
-  "ci:build-styles": "build_styles",
-  "ci:docs": "docs",
-  "ci:main": "main",
-  "ci:og-images": "og_images",
-  "ci:perf": "perf",
-  "ci:plus": "plus",
-  "ci:release-preview": "release_preview",
-};
 
 const dependencyAndConfigNames = new Set([
   ".npmrc",
@@ -211,7 +197,6 @@ export function createCIPlan(
   const files = [
     ...new Set(changedFiles.map(normalizeCIPath).filter(Boolean)),
   ].sort();
-  const labels = [...new Set(options.labels ?? [])].sort();
   const workflows: Record<CIWorkflowName, boolean> = {
     main: false,
     app: false,
@@ -236,7 +221,6 @@ export function createCIPlan(
     version: 1,
     baseRef: options.baseRef ?? "",
     files,
-    labels,
     workflows,
     reasons,
   };
@@ -244,19 +228,6 @@ export function createCIPlan(
   addReason(plan, "main", "Core and legacy browser tests run on every PR");
   for (const file of files) {
     addFileReasons(plan, file);
-  }
-
-  if (labels.includes("ci:full")) {
-    for (const workflow of ciWorkflowNames) {
-      addReason(plan, workflow, "Forced by ci:full label");
-    }
-  } else {
-    for (const label of labels) {
-      const workflow = workflowLabels[label];
-      if (workflow) {
-        addReason(plan, workflow, `Forced by ${label} label`);
-      }
-    }
   }
 
   if (plan.baseRef && plan.baseRef !== "main") {
@@ -393,16 +364,8 @@ export function serializeCIGatePlan(plan: CIPlan) {
 
 export function runCIPlan(options: RunCIPlanOptions) {
   const files = getChangedFiles(options.base, options.head);
-  const parsedLabels = parseJSON(options.labels, "CI labels");
-  if (
-    !Array.isArray(parsedLabels) ||
-    !parsedLabels.every((label) => typeof label === "string")
-  ) {
-    throw new Error("CI labels must be an array of strings");
-  }
   const plan = createCIPlan(files, {
     baseRef: options.baseRef,
-    labels: parsedLabels,
   });
   for (const workflow of ciWorkflowNames) {
     appendFileSync(


### PR DESCRIPTION
## Motivation

The CI planner supported `ci:*` labels that manually forced individual workflows or the full CI suite:

```ts
createCIPlan(files, { baseRef, labels });
```

Those labels have been removed from the repository. Keeping label-driven overrides would leave obsolete plumbing and make workflow selection depend on both labels and changed-file heuristics.

## Solution

Remove the `labeled` and `unlabeled` workflow triggers, the `CI_LABELS` environment input, label fields in the planner interfaces and output, and the workflow override mapping and branches.

The planner now relies exclusively on changed-file heuristics:

```ts
createCIPlan(files, { baseRef });
```

The former override tests are replaced with a focused regression assertion that CI plans no longer expose label data.

## Verification

- `pnpm test packages/ariakit-scripts/src/ci.test.ts --run`
- `pnpm tsc`
- `git diff --cached --check`
