### PR TITLE
Select dependency CI from package manifests

### DIFF
--- a/packages/ariakit-scripts/src/ci.test.ts
+++ b/packages/ariakit-scripts/src/ci.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { expect, test } from "vitest";
 import {
   assertCIGate,
@@ -569,6 +571,15 @@ packages:
 
   expect(parseLockfileImporterChanges(base, head)).toEqual(["app", "website"]);
   expect(parseLockfileImporterChanges("invalid", head)).toBeUndefined();
+});
+
+test("parses the repository lockfile", () => {
+  const lockfile = readFileSync(
+    join(import.meta.dirname, "../../../pnpm-lock.yaml"),
+    "utf-8",
+  );
+
+  expect(parseLockfileImporterChanges(lockfile, lockfile)).toEqual([]);
 });
 
 test("rejects importer membership changes", () => {

--- a/packages/ariakit-scripts/src/ci.test.ts
+++ b/packages/ariakit-scripts/src/ci.test.ts
@@ -103,6 +103,21 @@ test("selects CI from reviewed root dependency updates", () => {
   expectSelectedWorkflows(plan, ["main", "perf", "docs"]);
 });
 
+test("runs Docs for reviewed root type dependencies", () => {
+  const plan = createCIPlan(["package.json", "pnpm-lock.yaml"], {
+    changedLockfileImporters: ["."],
+    packageJSONChanges: [
+      getPackageJSONChange(
+        "package.json",
+        { devDependencies: { "@types/react": "19.2.16" } },
+        { devDependencies: { "@types/react": "19.2.17" } },
+      ),
+    ],
+  });
+
+  expectSelectedWorkflows(plan, ["main", "docs"]);
+});
+
 test("keeps unreviewed root dependency updates on full CI", () => {
   const plan = createCIPlan(["package.json", "pnpm-lock.yaml"], {
     packageJSONChanges: [
@@ -235,22 +250,38 @@ test("keeps metadata for undeclared peers on full CI", () => {
   expect(Object.values(plan.workflows).every(Boolean)).toBe(true);
 });
 
-test("keeps public package development dependencies on Main CI", () => {
+test("keeps other public package development dependencies on Main CI", () => {
   const plan = createCIPlan(
-    ["packages/ariakit-react/package.json", "pnpm-lock.yaml"],
+    ["packages/ariakit-react-utils/package.json", "pnpm-lock.yaml"],
     {
-      changedLockfileImporters: ["packages/ariakit-react"],
+      changedLockfileImporters: ["packages/ariakit-react-utils"],
       packageJSONChanges: [
         getPackageJSONChange(
-          "packages/ariakit-react/package.json",
-          { devDependencies: { "@types/react": "19.2.16" } },
-          { devDependencies: { "@types/react": "19.2.17" } },
+          "packages/ariakit-react-utils/package.json",
+          { devDependencies: { react: "19.2.7" } },
+          { devDependencies: { react: "19.2.8" } },
         ),
       ],
     },
   );
 
   expectSelectedWorkflows(plan, ["main"]);
+});
+
+test("runs Docs for public package type dependencies", () => {
+  const file = "packages/ariakit-react-store/package.json";
+  const plan = createCIPlan([file, "pnpm-lock.yaml"], {
+    changedLockfileImporters: ["packages/ariakit-react-store"],
+    packageJSONChanges: [
+      getPackageJSONChange(
+        file,
+        { devDependencies: { "@types/use-sync-external-store": "1.4.0" } },
+        { devDependencies: { "@types/use-sync-external-store": "1.5.0" } },
+      ),
+    ],
+  });
+
+  expectSelectedWorkflows(plan, ["main", "docs"]);
 });
 
 test("keeps private package dependency updates on full CI", () => {

--- a/packages/ariakit-scripts/src/ci.test.ts
+++ b/packages/ariakit-scripts/src/ci.test.ts
@@ -3,6 +3,7 @@ import {
   assertCIGate,
   ciWorkflowNames,
   createCIPlan,
+  parseLockfileImporterChanges,
   parseChangedFiles,
   serializeCIGatePlan,
 } from "./ci.ts";
@@ -75,6 +76,7 @@ test("fails closed without dependency details and for CI infrastructure", () => 
 
 test("selects CI from reviewed root dependency updates", () => {
   const plan = createCIPlan(["package.json", "pnpm-lock.yaml"], {
+    changedLockfileImporters: ["."],
     packageJSONChanges: [
       getPackageJSONChange(
         "package.json",
@@ -115,6 +117,7 @@ test("keeps unreviewed root dependency updates on full CI", () => {
 
 test("selects CI from workspace dependency updates", () => {
   const plan = createCIPlan(["app/package.json", "pnpm-lock.yaml"], {
+    changedLockfileImporters: ["app"],
     packageJSONChanges: [
       getPackageJSONChange(
         "app/package.json",
@@ -131,6 +134,7 @@ test("selects consumer CI for public package runtime dependencies", () => {
   const plan = createCIPlan(
     ["packages/ariakit-react/package.json", "pnpm-lock.yaml"],
     {
+      changedLockfileImporters: ["packages/ariakit-react"],
       packageJSONChanges: [
         getPackageJSONChange(
           "packages/ariakit-react/package.json",
@@ -197,6 +201,7 @@ test("keeps public package development dependencies on Main CI", () => {
   const plan = createCIPlan(
     ["packages/ariakit-react/package.json", "pnpm-lock.yaml"],
     {
+      changedLockfileImporters: ["packages/ariakit-react"],
       packageJSONChanges: [
         getPackageJSONChange(
           "packages/ariakit-react/package.json",
@@ -237,6 +242,7 @@ test("unions dependency CI with ordinary file heuristics", () => {
   const plan = createCIPlan(
     ["app/package.json", "pnpm-lock.yaml", "website/src/pages/index.tsx"],
     {
+      changedLockfileImporters: ["app"],
       packageJSONChanges: [
         getPackageJSONChange(
           "app/package.json",
@@ -248,6 +254,22 @@ test("unions dependency CI with ordinary file heuristics", () => {
   );
 
   expectSelectedWorkflows(plan, ["main", "app", "perf", "plus", "og_images"]);
+});
+
+test("fails closed when the lockfile changes an unrelated importer", () => {
+  const options = {
+    packageJSONChanges: [
+      getPackageJSONChange(
+        "app/package.json",
+        { dependencies: { "@clerk/astro": "4.0.0" } },
+        { dependencies: { "@clerk/astro": "4.0.1" } },
+      ),
+    ],
+    changedLockfileImporters: ["app", "website"],
+  };
+  const plan = createCIPlan(["app/package.json", "pnpm-lock.yaml"], options);
+
+  expect(Object.values(plan.workflows).every(Boolean)).toBe(true);
 });
 
 test("falls back to full CI for package metadata changes", () => {
@@ -474,6 +496,89 @@ test("keeps both paths when git reports a rename", () => {
     "packages/old/src/index.ts",
     "packages/new/src/index.ts",
   ]);
+});
+
+test("compares exact lockfile importer blocks", () => {
+  const base = `lockfileVersion: '9.0'
+
+importers:
+
+  app:
+    dependencies:
+      astro:
+        specifier: 7.0.0
+        version: 7.0.0
+
+  website: {}
+
+packages:
+  astro@7.0.0: {}
+`;
+  const head = `lockfileVersion: '9.0'
+
+importers:
+
+  app:
+    dependencies:
+      astro:
+        specifier: 7.0.1
+        version: 7.0.1
+
+  website:
+    dependencies: {}
+
+packages:
+  astro@7.0.1: {}
+`;
+
+  expect(parseLockfileImporterChanges(base, head)).toEqual(["app", "website"]);
+  expect(parseLockfileImporterChanges("invalid", head)).toBeUndefined();
+});
+
+test("rejects importer membership changes", () => {
+  const base = `lockfileVersion: '9.0'
+
+importers:
+
+  app: {}
+
+packages: {}
+`;
+  const added = base.replace("  app: {}", "  app: {}\n\n  website: {}");
+
+  expect(parseLockfileImporterChanges(base, added)).toBeUndefined();
+  expect(parseLockfileImporterChanges(added, base)).toBeUndefined();
+});
+
+test("rejects malformed importer blocks", () => {
+  const base = `lockfileVersion: '9.0'
+
+importers:
+
+  app: {}
+
+packages: {}
+`;
+  const malformedInline = base.replace("  app: {}", "  app: []");
+  const malformedIndentation = base.replace("  app: {}", "   app: {}");
+  const malformedBlockSequence = base.replace("  app: {}", "  app:\n    []");
+  const malformedBlockScalar = base.replace("  app: {}", "  app:\n    value");
+  const commentsOnlyBlock = base.replace(
+    "  app: {}",
+    "  app:\n    # no importer data",
+  );
+
+  expect(parseLockfileImporterChanges(base, malformedInline)).toBeUndefined();
+  expect(
+    parseLockfileImporterChanges(base, malformedIndentation),
+  ).toBeUndefined();
+  expect(
+    parseLockfileImporterChanges(base, malformedBlockSequence),
+  ).toBeUndefined();
+  expect(
+    parseLockfileImporterChanges(base, malformedBlockScalar),
+  ).toBeUndefined();
+  expect(parseLockfileImporterChanges(base, commentsOnlyBlock)).toBeUndefined();
 });
 
 test("serializes a compact gate plan for large changes", () => {

--- a/packages/ariakit-scripts/src/ci.test.ts
+++ b/packages/ariakit-scripts/src/ci.test.ts
@@ -6,7 +6,7 @@ import {
   parseChangedFiles,
   serializeCIGatePlan,
 } from "./ci.ts";
-import type { CIGateResult } from "./ci.ts";
+import type { CIGateResult, CIWorkflowName, PackageJSONChange } from "./ci.ts";
 
 function getResults(
   plan: ReturnType<typeof createCIPlan>,
@@ -21,6 +21,23 @@ function getResults(
     };
   }
   return { ...results, ...overrides };
+}
+
+function getPackageJSONChange(
+  file: string,
+  base: Record<string, unknown>,
+  head: Record<string, unknown>,
+): PackageJSONChange {
+  return { file, base, head };
+}
+
+function expectSelectedWorkflows(
+  plan: ReturnType<typeof createCIPlan>,
+  workflows: CIWorkflowName[],
+) {
+  expect(
+    ciWorkflowNames.filter((workflow) => plan.workflows[workflow]),
+  ).toEqual(workflows);
 }
 
 test("keeps core and legacy browser tests on every pull request", () => {
@@ -38,7 +55,7 @@ test("keeps core and legacy browser tests on every pull request", () => {
   });
 });
 
-test("runs every workflow for dependency and CI infrastructure changes", () => {
+test("fails closed without dependency details and for CI infrastructure", () => {
   for (const file of [
     "pnpm-lock.yaml",
     "app/package.json",
@@ -54,6 +71,305 @@ test("runs every workflow for dependency and CI infrastructure changes", () => {
     const plan = createCIPlan([file]);
     expect(Object.values(plan.workflows).every(Boolean), file).toBe(true);
   }
+});
+
+test("selects CI from reviewed root dependency updates", () => {
+  const plan = createCIPlan(["package.json", "pnpm-lock.yaml"], {
+    packageJSONChanges: [
+      getPackageJSONChange(
+        "package.json",
+        {
+          devDependencies: {
+            "lint-staged": "17.1.1",
+            oxfmt: "0.59.0",
+            vitest: "4.1.9",
+          },
+        },
+        {
+          devDependencies: {
+            "lint-staged": "17.2.0",
+            oxfmt: "0.60.0",
+            vitest: "4.1.10",
+          },
+        },
+      ),
+    ],
+  });
+
+  expectSelectedWorkflows(plan, ["main", "perf", "docs"]);
+});
+
+test("keeps unreviewed root dependency updates on full CI", () => {
+  const plan = createCIPlan(["package.json", "pnpm-lock.yaml"], {
+    packageJSONChanges: [
+      getPackageJSONChange(
+        "package.json",
+        { devDependencies: { vite: "8.1.4" } },
+        { devDependencies: { vite: "8.1.5" } },
+      ),
+    ],
+  });
+
+  expect(Object.values(plan.workflows).every(Boolean)).toBe(true);
+});
+
+test("selects CI from workspace dependency updates", () => {
+  const plan = createCIPlan(["app/package.json", "pnpm-lock.yaml"], {
+    packageJSONChanges: [
+      getPackageJSONChange(
+        "app/package.json",
+        { dependencies: { "@clerk/astro": "4.0.0" } },
+        { dependencies: { "@clerk/astro": "4.0.1" } },
+      ),
+    ],
+  });
+
+  expectSelectedWorkflows(plan, ["main", "app", "perf", "og_images"]);
+});
+
+test("selects consumer CI for public package runtime dependencies", () => {
+  const plan = createCIPlan(
+    ["packages/ariakit-react/package.json", "pnpm-lock.yaml"],
+    {
+      packageJSONChanges: [
+        getPackageJSONChange(
+          "packages/ariakit-react/package.json",
+          { peerDependencies: { react: ">=18" } },
+          { peerDependencies: { react: ">=19" } },
+        ),
+      ],
+    },
+  );
+
+  expectSelectedWorkflows(plan, [
+    "main",
+    "app",
+    "perf",
+    "plus",
+    "release_preview",
+    "docs",
+    "og_images",
+  ]);
+});
+
+test("keeps public peer dependency metadata changes on full CI", () => {
+  const plan = createCIPlan(
+    ["packages/ariakit-test/package.json", "pnpm-lock.yaml"],
+    {
+      packageJSONChanges: [
+        getPackageJSONChange(
+          "packages/ariakit-test/package.json",
+          {
+            peerDependencies: { react: ">=18" },
+            peerDependenciesMeta: { react: { optional: true } },
+          },
+          {
+            peerDependencies: { react: ">=18" },
+            peerDependenciesMeta: { react: { optional: false } },
+          },
+        ),
+      ],
+    },
+  );
+
+  expect(Object.values(plan.workflows).every(Boolean)).toBe(true);
+});
+
+test("keeps metadata for undeclared peers on full CI", () => {
+  const file = "packages/ariakit-test/package.json";
+  const plan = createCIPlan([file, "pnpm-lock.yaml"], {
+    packageJSONChanges: [
+      getPackageJSONChange(
+        file,
+        { peerDependencies: {} },
+        {
+          peerDependencies: {},
+          peerDependenciesMeta: { ghost: { optional: true } },
+        },
+      ),
+    ],
+  });
+
+  expect(Object.values(plan.workflows).every(Boolean)).toBe(true);
+});
+
+test("keeps public package development dependencies on Main CI", () => {
+  const plan = createCIPlan(
+    ["packages/ariakit-react/package.json", "pnpm-lock.yaml"],
+    {
+      packageJSONChanges: [
+        getPackageJSONChange(
+          "packages/ariakit-react/package.json",
+          { devDependencies: { "@types/react": "19.2.16" } },
+          { devDependencies: { "@types/react": "19.2.17" } },
+        ),
+      ],
+    },
+  );
+
+  expectSelectedWorkflows(plan, ["main"]);
+});
+
+test("keeps private package dependency updates on full CI", () => {
+  const plan = createCIPlan(
+    ["packages/ariakit-scripts/package.json", "pnpm-lock.yaml"],
+    {
+      packageJSONChanges: [
+        getPackageJSONChange(
+          "packages/ariakit-scripts/package.json",
+          {
+            private: true,
+            dependencies: { "rolldown-plugin-dts": "0.27.12" },
+          },
+          {
+            private: true,
+            dependencies: { "rolldown-plugin-dts": "0.27.13" },
+          },
+        ),
+      ],
+    },
+  );
+
+  expect(Object.values(plan.workflows).every(Boolean)).toBe(true);
+});
+
+test("unions dependency CI with ordinary file heuristics", () => {
+  const plan = createCIPlan(
+    ["app/package.json", "pnpm-lock.yaml", "website/src/pages/index.tsx"],
+    {
+      packageJSONChanges: [
+        getPackageJSONChange(
+          "app/package.json",
+          { dependencies: { "@clerk/astro": "4.0.0" } },
+          { dependencies: { "@clerk/astro": "4.0.1" } },
+        ),
+      ],
+    },
+  );
+
+  expectSelectedWorkflows(plan, ["main", "app", "perf", "plus", "og_images"]);
+});
+
+test("falls back to full CI for package metadata changes", () => {
+  const plan = createCIPlan(["app/package.json", "pnpm-lock.yaml"], {
+    packageJSONChanges: [
+      getPackageJSONChange(
+        "app/package.json",
+        { scripts: { build: "astro build" } },
+        { scripts: { build: "astro check && astro build" } },
+      ),
+    ],
+  });
+
+  expect(Object.values(plan.workflows).every(Boolean)).toBe(true);
+});
+
+test("does not scope lockfile changes without a dependency update", () => {
+  const plan = createCIPlan(["app/package.json", "pnpm-lock.yaml"], {
+    packageJSONChanges: [
+      getPackageJSONChange("app/package.json", {}, { devDependencies: {} }),
+    ],
+  });
+
+  expect(Object.values(plan.workflows).every(Boolean)).toBe(true);
+});
+
+test("does not scope lockfile changes with empty peer metadata", () => {
+  const file = "packages/ariakit-test/package.json";
+  const plan = createCIPlan([file, "pnpm-lock.yaml"], {
+    packageJSONChanges: [
+      getPackageJSONChange(file, {}, { peerDependenciesMeta: {} }),
+    ],
+  });
+
+  expect(Object.values(plan.workflows).every(Boolean)).toBe(true);
+});
+
+test("does not use package versions to scope lockfile changes", () => {
+  const plan = createCIPlan(
+    ["packages/ariakit-react/package.json", "pnpm-lock.yaml"],
+    {
+      packageJSONChanges: [
+        getPackageJSONChange(
+          "packages/ariakit-react/package.json",
+          { version: "0.4.35" },
+          { version: "0.4.36" },
+        ),
+      ],
+    },
+  );
+
+  expect(Object.values(plan.workflows).every(Boolean)).toBe(true);
+});
+
+test("requires every changed manifest to scope the lockfile", () => {
+  const plan = createCIPlan(
+    [
+      "app/package.json",
+      "packages/ariakit-react/package.json",
+      "pnpm-lock.yaml",
+    ],
+    {
+      packageJSONChanges: [
+        getPackageJSONChange(
+          "app/package.json",
+          { dependencies: { "@clerk/astro": "4.0.0" } },
+          { dependencies: { "@clerk/astro": "4.0.1" } },
+        ),
+        getPackageJSONChange(
+          "packages/ariakit-react/package.json",
+          { version: "0.4.35" },
+          { version: "0.4.36" },
+        ),
+      ],
+    },
+  );
+
+  expect(Object.values(plan.workflows).every(Boolean)).toBe(true);
+});
+
+test("rejects empty dependency metadata in grouped lockfile updates", () => {
+  const plan = createCIPlan(
+    ["app/package.json", "examples/package.json", "pnpm-lock.yaml"],
+    {
+      packageJSONChanges: [
+        getPackageJSONChange(
+          "app/package.json",
+          { dependencies: { "@clerk/astro": "4.0.0" } },
+          { dependencies: { "@clerk/astro": "4.0.1" } },
+        ),
+        getPackageJSONChange(
+          "examples/package.json",
+          {},
+          { devDependencies: {} },
+        ),
+      ],
+    },
+  );
+
+  expect(Object.values(plan.workflows).every(Boolean)).toBe(true);
+});
+
+test("avoids full CI for generated publish metadata", () => {
+  const plan = createCIPlan(
+    [
+      ".changeset/example.md",
+      "packages/ariakit-react/CHANGELOG.md",
+      "packages/ariakit-react/package.json",
+    ],
+    {
+      baseRef: "main",
+      packageJSONChanges: [
+        getPackageJSONChange(
+          "packages/ariakit-react/package.json",
+          { version: "0.4.35" },
+          { version: "0.4.36" },
+        ),
+      ],
+    },
+  );
+
+  expectSelectedWorkflows(plan, ["main", "release_preview"]);
 });
 
 test("runs app, performance, docs, release, and website checks for package code", () => {

--- a/packages/ariakit-scripts/src/ci.test.ts
+++ b/packages/ariakit-scripts/src/ci.test.ts
@@ -34,7 +34,7 @@ function getPackageJSONChange(
 
 function expectSelectedWorkflows(
   plan: ReturnType<typeof createCIPlan>,
-  workflows: CIWorkflowName[],
+  workflows: readonly CIWorkflowName[],
 ) {
   expect(
     ciWorkflowNames.filter((workflow) => plan.workflows[workflow]),
@@ -115,19 +115,55 @@ test("keeps unreviewed root dependency updates on full CI", () => {
   expect(Object.values(plan.workflows).every(Boolean)).toBe(true);
 });
 
-test("selects CI from workspace dependency updates", () => {
-  const plan = createCIPlan(["app/package.json", "pnpm-lock.yaml"], {
-    changedLockfileImporters: ["app"],
+test.each([
+  {
+    file: "app/package.json",
+    workflows: ["main", "app", "perf", "og_images"],
+  },
+  { file: "examples/package.json", workflows: ["main"] },
+  { file: "guide/package.json", workflows: ["main", "plus"] },
+  {
+    file: "nextjs/package.json",
+    workflows: ["main", "app", "perf"],
+  },
+  {
+    file: "templates/react/package.json",
+    workflows: ["main", "release_preview"],
+  },
+  { file: "website/package.json", workflows: ["main", "plus"] },
+] satisfies Array<{ file: string; workflows: CIWorkflowName[] }>)(
+  "selects CI from $file dependency updates",
+  ({ file, workflows }) => {
+    const importer = file.replace(/\/package\.json$/, "");
+    const plan = createCIPlan([file, "pnpm-lock.yaml"], {
+      changedLockfileImporters: [importer],
+      packageJSONChanges: [
+        getPackageJSONChange(
+          file,
+          { dependencies: { dependency: "1.0.0" } },
+          { dependencies: { dependency: "1.0.1" } },
+        ),
+      ],
+    });
+
+    expectSelectedWorkflows(plan, workflows);
+  },
+);
+
+test("keeps unknown workspace dependency updates on full CI", () => {
+  const file = "foo/package.json";
+  const plan = createCIPlan([file, "pnpm-lock.yaml"], {
+    changedLockfileImporters: ["foo"],
     packageJSONChanges: [
       getPackageJSONChange(
-        "app/package.json",
-        { dependencies: { "@clerk/astro": "4.0.0" } },
-        { dependencies: { "@clerk/astro": "4.0.1" } },
+        file,
+        { dependencies: { dependency: "1.0.0" } },
+        { dependencies: { dependency: "1.0.1" } },
       ),
     ],
   });
 
-  expectSelectedWorkflows(plan, ["main", "app", "perf", "og_images"]);
+  expect(Object.values(plan.workflows).every(Boolean)).toBe(true);
 });
 
 test("selects consumer CI for public package runtime dependencies", () => {

--- a/packages/ariakit-scripts/src/ci.ts
+++ b/packages/ariakit-scripts/src/ci.ts
@@ -241,6 +241,9 @@ function addPackageJSONReasons(plan: CIPlan, change: PackageJSONChange) {
   const fields = getChangedFields(change.base, change.head);
   const dependencyNames = getChangedDependencyNames(change.base, change.head);
   if (!dependencyNames) return false;
+  const hasTypeDependencyChange = dependencyNames.some((name) => {
+    return name.startsWith("@types/");
+  });
 
   if (file === "package.json") {
     if (!hasOnlyFields(fields, dependencyFieldSet)) return false;
@@ -251,7 +254,7 @@ function addPackageJSONReasons(plan: CIPlan, change: PackageJSONChange) {
     if (dependencyNames.includes("vitest")) {
       addDependencyReason(plan, "perf", file);
     }
-    if (dependencyNames.includes("oxfmt")) {
+    if (dependencyNames.includes("oxfmt") || hasTypeDependencyChange) {
       addDependencyReason(plan, "docs", file);
     }
     return true;
@@ -279,6 +282,9 @@ function addPackageJSONReasons(plan: CIPlan, change: PackageJSONChange) {
     return false;
   }
   addDependencyReason(plan, "main", file);
+  if (hasTypeDependencyChange) {
+    addDependencyReason(plan, "docs", file);
+  }
   if (fields.some((field) => runtimeDependencyFieldSet.has(field))) {
     for (const workflow of publicPackageWorkflows) {
       addDependencyReason(plan, workflow, file);

--- a/packages/ariakit-scripts/src/ci.ts
+++ b/packages/ariakit-scripts/src/ci.ts
@@ -80,6 +80,11 @@ const dependencyFields = [
 ] as const;
 
 const dependencyFieldSet = new Set<string>(dependencyFields);
+const runtimeDependencyFieldSet = new Set([
+  "dependencies",
+  "optionalDependencies",
+  "peerDependencies",
+]);
 const publicPackageFields = new Set([...dependencyFieldSet, "version"]);
 const publicPackageWorkflows = [
   "app",
@@ -219,17 +224,6 @@ function explainsLockfileChange(change: PackageJSONChange) {
   return Boolean(dependencyNames?.length);
 }
 
-function hasRuntimeDependencyChange(
-  base: Record<string, unknown>,
-  head: Record<string, unknown>,
-) {
-  return (
-    !isDeepStrictEqual(base.dependencies, head.dependencies) ||
-    !isDeepStrictEqual(base.optionalDependencies, head.optionalDependencies) ||
-    !isDeepStrictEqual(base.peerDependencies, head.peerDependencies)
-  );
-}
-
 function hasOnlyFields(fields: string[], allowedFields: Set<string>) {
   return fields.every((field) => allowedFields.has(field));
 }
@@ -274,8 +268,8 @@ function addPackageJSONReasons(plan: CIPlan, change: PackageJSONChange) {
   }
 
   if (!/^packages\/[^/]+\/package\.json$/.test(file)) return false;
-  if (change.base.private === true || change.head.private === true)
-    return false;
+  if (change.base.private === true) return false;
+  if (change.head.private === true) return false;
   if (!hasOnlyFields(fields, publicPackageFields)) return false;
   if (
     fields.includes("version") &&
@@ -285,7 +279,7 @@ function addPackageJSONReasons(plan: CIPlan, change: PackageJSONChange) {
     return false;
   }
   addDependencyReason(plan, "main", file);
-  if (hasRuntimeDependencyChange(change.base, change.head)) {
+  if (fields.some((field) => runtimeDependencyFieldSet.has(field))) {
     for (const workflow of publicPackageWorkflows) {
       addDependencyReason(plan, workflow, file);
     }
@@ -555,6 +549,7 @@ function parseLockfileImporters(value: string) {
     const content = /^( {4}(?: {2})*)([^#\s][^:]*):(.*)$/.exec(line);
     if (!content) return;
     const indentation = content[1];
+    if (!indentation) return;
     if (indentation.length === 4) {
       if (!saveCurrentField()) return;
       const value = content[3];

--- a/packages/ariakit-scripts/src/ci.ts
+++ b/packages/ariakit-scripts/src/ci.ts
@@ -501,18 +501,9 @@ function parseLockfileImporters(value: string) {
   const importers = new Map<string, string>();
   let currentImporter: string | undefined;
   let currentBlock: string[] = [];
-  let currentImporterIsEmpty = false;
-  let currentImporterHasContent = false;
-  let currentFieldNeedsContent = false;
-  let currentFieldHasContent = false;
-  const saveCurrentField = () => {
-    return !currentFieldNeedsContent || currentFieldHasContent;
-  };
   const saveCurrentImporter = () => {
     if (!currentImporter) return true;
     if (importers.has(currentImporter)) return false;
-    if (!saveCurrentField()) return false;
-    if (!currentImporterIsEmpty && !currentImporterHasContent) return false;
     importers.set(currentImporter, currentBlock.join("\n").trimEnd());
     return true;
   };
@@ -524,43 +515,19 @@ function parseLockfileImporters(value: string) {
       if (!/^[^:\s][^:]*:/.test(line)) return;
       break;
     }
-    const match = /^  ([a-zA-Z0-9._@/-]+):(.*)$/.exec(line);
+    const match = /^  ([a-zA-Z0-9._@/-]+):(?: \{\})?$/.exec(line);
     if (match) {
-      const value = match[2];
-      if (value !== "" && value !== " {}") return;
       if (!saveCurrentImporter()) return;
       currentImporter = match[1];
       currentBlock = [line];
-      currentImporterIsEmpty = value === " {}";
-      currentImporterHasContent = false;
-      currentFieldNeedsContent = false;
-      currentFieldHasContent = false;
-      continue;
-    }
-    if (!currentImporter) {
-      if (line) return;
       continue;
     }
     if (!line) {
-      currentBlock.push(line);
+      if (currentImporter) currentBlock.push(line);
       continue;
     }
-    if (currentImporterIsEmpty) return;
-    const content = /^( {4}(?: {2})*)([^#\s][^:]*):(.*)$/.exec(line);
-    if (!content) return;
-    const indentation = content[1];
-    if (!indentation) return;
-    if (indentation.length === 4) {
-      if (!saveCurrentField()) return;
-      const value = content[3];
-      if (value !== "" && value !== " {}") return;
-      currentImporterHasContent = true;
-      currentFieldNeedsContent = value === "";
-      currentFieldHasContent = false;
-    } else {
-      if (!currentImporterHasContent) return;
-      currentFieldHasContent = true;
-    }
+    if (!currentImporter) return;
+    if (!/^ {4}(?: {2})*[^#\s][^:]*:/.test(line)) return;
     currentBlock.push(line);
   }
   if (!saveCurrentImporter()) return;

--- a/packages/ariakit-scripts/src/ci.ts
+++ b/packages/ariakit-scripts/src/ci.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { appendFileSync } from "node:fs";
+import { isDeepStrictEqual } from "node:util";
 
 export const ciWorkflowNames = [
   "main",
@@ -24,6 +25,13 @@ export interface CIPlan {
 
 export interface CreateCIPlanOptions {
   baseRef?: string;
+  packageJSONChanges?: PackageJSONChange[];
+}
+
+export interface PackageJSONChange {
+  file: string;
+  base: Record<string, unknown>;
+  head: Record<string, unknown>;
 }
 
 export interface RunCIPlanOptions {
@@ -62,6 +70,60 @@ const dependencyAndConfigNames = new Set([
   "wrangler.toml",
   "yarn.lock",
 ]);
+
+const dependencyFields = [
+  "dependencies",
+  "devDependencies",
+  "optionalDependencies",
+  "peerDependencies",
+] as const;
+
+const dependencyFieldSet = new Set<string>(dependencyFields);
+const publicPackageFields = new Set([...dependencyFieldSet, "version"]);
+const publicPackageWorkflows = [
+  "app",
+  "perf",
+  "plus",
+  "release_preview",
+  "docs",
+  "og_images",
+] as const satisfies readonly CIWorkflowName[];
+
+// Root tools outside this reviewed set can affect any workspace, so they
+// continue to fail closed to full CI.
+const rootMainDependencies = new Set([
+  "@testing-library/jest-dom",
+  "@testing-library/react",
+  "@types/cross-spawn",
+  "@types/fs-extra",
+  "@types/node",
+  "@types/react",
+  "@types/react-dom",
+  "@vitest/coverage-v8",
+  "happy-dom",
+  "husky",
+  "lint-staged",
+  "oxfmt",
+  "oxlint",
+  "oxlint-tsgolint",
+  "prettier",
+  "prettier-plugin-tailwindcss",
+  "stylelint",
+  "stylelint-config-standard",
+  "vitest",
+  "vitest-fail-on-console",
+]);
+
+const workspaceDependencyWorkflows = new Map<string, readonly CIWorkflowName[]>(
+  [
+    ["app/package.json", ["app", "perf", "og_images"]],
+    ["examples/package.json", []],
+    ["guide/package.json", ["plus"]],
+    ["nextjs/package.json", ["app", "perf"]],
+    ["templates/react/package.json", ["release_preview"]],
+    ["website/package.json", ["plus"]],
+  ],
+);
 
 function normalizeCIPath(file: string) {
   return file.replaceAll("\\", "/").replace(/^\.\/+/, "");
@@ -105,6 +167,128 @@ function isPackageRuntimePath(file: string) {
 function isAppRuntimePath(file: string) {
   if (!/^(?:app|nextjs)\//.test(file)) return false;
   if (isTestFile(file)) return false;
+  return true;
+}
+
+function getChangedFields(
+  base: Record<string, unknown>,
+  head: Record<string, unknown>,
+) {
+  const fields = new Set([...Object.keys(base), ...Object.keys(head)]);
+  return [...fields].filter((field) => {
+    return !isDeepStrictEqual(base[field], head[field]);
+  });
+}
+
+function getStringRecord(value: unknown) {
+  if (value === undefined) return {};
+  if (!isRecord(value)) return;
+  const record: Record<string, string> = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (typeof item !== "string") return;
+    record[key] = item;
+  }
+  return record;
+}
+
+function getChangedDependencyNames(
+  base: Record<string, unknown>,
+  head: Record<string, unknown>,
+) {
+  const names = new Set<string>();
+  for (const field of dependencyFields) {
+    if (isDeepStrictEqual(base[field], head[field])) continue;
+    const baseDependencies = getStringRecord(base[field]);
+    const headDependencies = getStringRecord(head[field]);
+    if (!baseDependencies || !headDependencies) return;
+    for (const name of new Set([
+      ...Object.keys(baseDependencies),
+      ...Object.keys(headDependencies),
+    ])) {
+      if (baseDependencies[name] !== headDependencies[name]) {
+        names.add(name);
+      }
+    }
+  }
+  return [...names].sort();
+}
+
+function explainsLockfileChange(change: PackageJSONChange) {
+  const dependencyNames = getChangedDependencyNames(change.base, change.head);
+  return Boolean(dependencyNames?.length);
+}
+
+function hasRuntimeDependencyChange(
+  base: Record<string, unknown>,
+  head: Record<string, unknown>,
+) {
+  return (
+    !isDeepStrictEqual(base.dependencies, head.dependencies) ||
+    !isDeepStrictEqual(base.optionalDependencies, head.optionalDependencies) ||
+    !isDeepStrictEqual(base.peerDependencies, head.peerDependencies)
+  );
+}
+
+function hasOnlyFields(fields: string[], allowedFields: Set<string>) {
+  return fields.every((field) => allowedFields.has(field));
+}
+
+function addDependencyReason(
+  plan: CIPlan,
+  workflow: CIWorkflowName,
+  file: string,
+) {
+  addReason(plan, workflow, `Dependency metadata: ${file}`);
+}
+
+function addPackageJSONReasons(plan: CIPlan, change: PackageJSONChange) {
+  const file = normalizeCIPath(change.file);
+  const fields = getChangedFields(change.base, change.head);
+  const dependencyNames = getChangedDependencyNames(change.base, change.head);
+  if (!dependencyNames) return false;
+
+  if (file === "package.json") {
+    if (!hasOnlyFields(fields, dependencyFieldSet)) return false;
+    if (dependencyNames.some((name) => !rootMainDependencies.has(name))) {
+      return false;
+    }
+    addDependencyReason(plan, "main", file);
+    if (dependencyNames.includes("vitest")) {
+      addDependencyReason(plan, "perf", file);
+    }
+    if (dependencyNames.includes("oxfmt")) {
+      addDependencyReason(plan, "docs", file);
+    }
+    return true;
+  }
+
+  const workspaceWorkflows = workspaceDependencyWorkflows.get(file);
+  if (workspaceWorkflows) {
+    if (!hasOnlyFields(fields, dependencyFieldSet)) return false;
+    addDependencyReason(plan, "main", file);
+    for (const workflow of workspaceWorkflows) {
+      addDependencyReason(plan, workflow, file);
+    }
+    return true;
+  }
+
+  if (!/^packages\/[^/]+\/package\.json$/.test(file)) return false;
+  if (change.base.private === true || change.head.private === true)
+    return false;
+  if (!hasOnlyFields(fields, publicPackageFields)) return false;
+  if (
+    fields.includes("version") &&
+    (typeof change.base.version !== "string" ||
+      typeof change.head.version !== "string")
+  ) {
+    return false;
+  }
+  addDependencyReason(plan, "main", file);
+  if (hasRuntimeDependencyChange(change.base, change.head)) {
+    for (const workflow of publicPackageWorkflows) {
+      addDependencyReason(plan, workflow, file);
+    }
+  }
   return true;
 }
 
@@ -197,6 +381,20 @@ export function createCIPlan(
   const files = [
     ...new Set(changedFiles.map(normalizeCIPath).filter(Boolean)),
   ].sort();
+  const packageJSONChanges = new Map(
+    (options.packageJSONChanges ?? []).map((change) => {
+      return [normalizeCIPath(change.file), change] as const;
+    }),
+  );
+  const changedPackageJSONFiles = files.filter((file) => {
+    return /(?:^|\/)package\.json$/.test(file);
+  });
+  const hasScopedPackageJSONChanges =
+    changedPackageJSONFiles.length > 0 &&
+    changedPackageJSONFiles.every((file) => {
+      const change = packageJSONChanges.get(file);
+      return change ? explainsLockfileChange(change) : false;
+    });
   const workflows: Record<CIWorkflowName, boolean> = {
     main: false,
     app: false,
@@ -227,6 +425,13 @@ export function createCIPlan(
 
   addReason(plan, "main", "Core and legacy browser tests run on every PR");
   for (const file of files) {
+    // The manifest diff is the policy input. A lockfile-only change still
+    // falls through to full CI because no manifest explains its scope.
+    if (file === "pnpm-lock.yaml" && hasScopedPackageJSONChanges) continue;
+    const packageJSONChange = packageJSONChanges.get(file);
+    if (packageJSONChange && addPackageJSONReasons(plan, packageJSONChange)) {
+      continue;
+    }
     addFileReasons(plan, file);
   }
 
@@ -252,6 +457,45 @@ export function getChangedFiles(base: string, head: string) {
     { encoding: "utf-8", maxBuffer: 10 * 1024 * 1024 },
   );
   return parseChangedFiles(output);
+}
+
+function readPackageJSON(revision: string, file: string) {
+  try {
+    const value = execFileSync("git", ["show", `${revision}:${file}`], {
+      encoding: "utf-8",
+      maxBuffer: 10 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const packageJSON: unknown = JSON.parse(value);
+    if (!isRecord(packageJSON)) return;
+    return packageJSON;
+  } catch {
+    return;
+  }
+}
+
+export function getPackageJSONChanges(
+  base: string,
+  head: string,
+  files: string[],
+) {
+  const mergeBase = execFileSync("git", ["merge-base", base, head], {
+    encoding: "utf-8",
+  }).trim();
+  const changes: PackageJSONChange[] = [];
+  for (const changedFile of files) {
+    const file = normalizeCIPath(changedFile);
+    if (!/(?:^|\/)package\.json$/.test(file)) continue;
+    const basePackageJSON = readPackageJSON(mergeBase, file);
+    const headPackageJSON = readPackageJSON(head, file);
+    if (!basePackageJSON || !headPackageJSON) continue;
+    changes.push({
+      file,
+      base: basePackageJSON,
+      head: headPackageJSON,
+    });
+  }
+  return changes;
 }
 
 export function parseChangedFiles(output: string) {
@@ -366,6 +610,11 @@ export function runCIPlan(options: RunCIPlanOptions) {
   const files = getChangedFiles(options.base, options.head);
   const plan = createCIPlan(files, {
     baseRef: options.baseRef,
+    packageJSONChanges: getPackageJSONChanges(
+      options.base,
+      options.head,
+      files,
+    ),
   });
   for (const workflow of ciWorkflowNames) {
     appendFileSync(

--- a/packages/ariakit-scripts/src/ci.ts
+++ b/packages/ariakit-scripts/src/ci.ts
@@ -25,6 +25,7 @@ export interface CIPlan {
 
 export interface CreateCIPlanOptions {
   baseRef?: string;
+  changedLockfileImporters?: string[];
   packageJSONChanges?: PackageJSONChange[];
 }
 
@@ -389,11 +390,20 @@ export function createCIPlan(
   const changedPackageJSONFiles = files.filter((file) => {
     return /(?:^|\/)package\.json$/.test(file);
   });
+  const changedPackageJSONFileSet = new Set(changedPackageJSONFiles);
   const hasScopedPackageJSONChanges =
     changedPackageJSONFiles.length > 0 &&
     changedPackageJSONFiles.every((file) => {
       const change = packageJSONChanges.get(file);
       return change ? explainsLockfileChange(change) : false;
+    });
+  const changedLockfileImporters = options.changedLockfileImporters ?? [];
+  const hasScopedLockfileChanges =
+    changedLockfileImporters.length > 0 &&
+    changedLockfileImporters.every((importer) => {
+      const file =
+        importer === "." ? "package.json" : `${importer}/package.json`;
+      return changedPackageJSONFileSet.has(normalizeCIPath(file));
     });
   const workflows: Record<CIWorkflowName, boolean> = {
     main: false,
@@ -425,9 +435,15 @@ export function createCIPlan(
 
   addReason(plan, "main", "Core and legacy browser tests run on every PR");
   for (const file of files) {
-    // The manifest diff is the policy input. A lockfile-only change still
-    // falls through to full CI because no manifest explains its scope.
-    if (file === "pnpm-lock.yaml" && hasScopedPackageJSONChanges) continue;
+    // Manifest and importer diffs together establish whether the generated
+    // lockfile is fully attributable to the changed manifests.
+    if (
+      file === "pnpm-lock.yaml" &&
+      hasScopedPackageJSONChanges &&
+      hasScopedLockfileChanges
+    ) {
+      continue;
+    }
     const packageJSONChange = packageJSONChanges.get(file);
     if (packageJSONChange && addPackageJSONReasons(plan, packageJSONChange)) {
       continue;
@@ -461,17 +477,115 @@ export function getChangedFiles(base: string, head: string) {
 
 function readPackageJSON(revision: string, file: string) {
   try {
-    const value = execFileSync("git", ["show", `${revision}:${file}`], {
-      encoding: "utf-8",
-      maxBuffer: 10 * 1024 * 1024,
-      stdio: ["ignore", "pipe", "ignore"],
-    });
+    const value = readRevisionFile(revision, file);
+    if (value === undefined) return;
     const packageJSON: unknown = JSON.parse(value);
     if (!isRecord(packageJSON)) return;
     return packageJSON;
   } catch {
     return;
   }
+}
+
+function readRevisionFile(revision: string, file: string) {
+  try {
+    return execFileSync("git", ["show", `${revision}:${file}`], {
+      encoding: "utf-8",
+      maxBuffer: 10 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return;
+  }
+}
+
+function parseLockfileImporters(value: string) {
+  const lines = value.replaceAll("\r\n", "\n").split("\n");
+  const importersIndex = lines.indexOf("importers:");
+  if (importersIndex < 0) return;
+
+  const importers = new Map<string, string>();
+  let currentImporter: string | undefined;
+  let currentBlock: string[] = [];
+  let currentImporterIsEmpty = false;
+  let currentImporterHasContent = false;
+  let currentFieldNeedsContent = false;
+  let currentFieldHasContent = false;
+  const saveCurrentField = () => {
+    return !currentFieldNeedsContent || currentFieldHasContent;
+  };
+  const saveCurrentImporter = () => {
+    if (!currentImporter) return true;
+    if (importers.has(currentImporter)) return false;
+    if (!saveCurrentField()) return false;
+    if (!currentImporterIsEmpty && !currentImporterHasContent) return false;
+    importers.set(currentImporter, currentBlock.join("\n").trimEnd());
+    return true;
+  };
+
+  for (let index = importersIndex + 1; index < lines.length; index++) {
+    const line = lines[index];
+    if (line === undefined) return;
+    if (line && !line.startsWith(" ")) {
+      if (!/^[^:\s][^:]*:/.test(line)) return;
+      break;
+    }
+    const match = /^  ([a-zA-Z0-9._@/-]+):(.*)$/.exec(line);
+    if (match) {
+      const value = match[2];
+      if (value !== "" && value !== " {}") return;
+      if (!saveCurrentImporter()) return;
+      currentImporter = match[1];
+      currentBlock = [line];
+      currentImporterIsEmpty = value === " {}";
+      currentImporterHasContent = false;
+      currentFieldNeedsContent = false;
+      currentFieldHasContent = false;
+      continue;
+    }
+    if (!currentImporter) {
+      if (line) return;
+      continue;
+    }
+    if (!line) {
+      currentBlock.push(line);
+      continue;
+    }
+    if (currentImporterIsEmpty) return;
+    const content = /^( {4}(?: {2})*)([^#\s][^:]*):(.*)$/.exec(line);
+    if (!content) return;
+    const indentation = content[1];
+    if (indentation.length === 4) {
+      if (!saveCurrentField()) return;
+      const value = content[3];
+      if (value !== "" && value !== " {}") return;
+      currentImporterHasContent = true;
+      currentFieldNeedsContent = value === "";
+      currentFieldHasContent = false;
+    } else {
+      if (!currentImporterHasContent) return;
+      currentFieldHasContent = true;
+    }
+    currentBlock.push(line);
+  }
+  if (!saveCurrentImporter()) return;
+  if (importers.size === 0) return;
+  return importers;
+}
+
+export function parseLockfileImporterChanges(base: string, head: string) {
+  const baseImporters = parseLockfileImporters(base);
+  const headImporters = parseLockfileImporters(head);
+  if (!baseImporters || !headImporters) return;
+  if (baseImporters.size !== headImporters.size) return;
+  for (const importer of baseImporters.keys()) {
+    if (!headImporters.has(importer)) return;
+  }
+  return [...baseImporters.keys()]
+    .filter((importer) => {
+      return baseImporters.get(importer) !== headImporters.get(importer);
+    })
+    .sort();
 }
 
 export function getPackageJSONChanges(
@@ -496,6 +610,21 @@ export function getPackageJSONChanges(
     });
   }
   return changes;
+}
+
+export function getLockfileImporterChanges(
+  base: string,
+  head: string,
+  files: string[],
+) {
+  if (!files.map(normalizeCIPath).includes("pnpm-lock.yaml")) return;
+  const mergeBase = execFileSync("git", ["merge-base", base, head], {
+    encoding: "utf-8",
+  }).trim();
+  const baseLockfile = readRevisionFile(mergeBase, "pnpm-lock.yaml");
+  const headLockfile = readRevisionFile(head, "pnpm-lock.yaml");
+  if (baseLockfile === undefined || headLockfile === undefined) return;
+  return parseLockfileImporterChanges(baseLockfile, headLockfile);
 }
 
 export function parseChangedFiles(output: string) {
@@ -610,6 +739,11 @@ export function runCIPlan(options: RunCIPlanOptions) {
   const files = getChangedFiles(options.base, options.head);
   const plan = createCIPlan(files, {
     baseRef: options.baseRef,
+    changedLockfileImporters: getLockfileImporterChanges(
+      options.base,
+      options.head,
+      files,
+    ),
     packageJSONChanges: getPackageJSONChanges(
       options.base,
       options.head,


### PR DESCRIPTION
## Motivation

#6878 removed the CI label overrides. Dependency changes would therefore continue to run full CI whenever the planner sees `package.json` or `pnpm-lock.yaml`, even when the changed manifest identifies a narrower affected workspace.

The latest 40 Renovate pull requests all changed at least one `package.json`, so manifest diffs provide a useful semantic input without relying on labels. We should also keep the global Renovate `pnpmDedupe` behavior, which means an update may rewrite lockfile importers whose manifests were not touched. Those unrelated importer changes must make the planner fall back to full CI.

## Solution

The `CI` workflow is triggered automatically when a pull request is opened, synchronized, or reopened. Its Plan job compares the pull request merge base with the head commit, classifies the changed paths and manifests, and exposes one boolean output per reusable workflow. Each selected workflow runs through `workflow_call`; the always-running Gate validates that every selected workflow succeeded and every unselected workflow was skipped.

For dependency changes, the planner compares each changed `package.json` and selects workflows from the changed dependency fields and the manifest's workspace role. Ordinary source changes continue to use the existing path heuristics, and their workflows are unioned with the dependency selection.

A shared lockfile is ignored only when both sources of evidence agree:

```ts
const hasScopedLockfileChanges =
  changedLockfileImporters.length > 0 &&
  changedLockfileImporters.every((importer) => {
    const file =
      importer === "." ? "package.json" : `${importer}/package.json`;
    return changedPackageJSONFileSet.has(file);
  });
```

The runner reads only the raw `importers:` blocks from the merge-base and head lockfiles. It identifies importer boundaries and compares each block exactly; it does not interpret generated package or snapshot entries, or attempt to validate the full nested YAML schema. Importer evidence is trusted only when both lockfiles expose the same importer set, at least one importer block changed, and every changed importer maps to a changed manifest with a concrete dependency update. Missing or unsupported sections, invalid or ambiguous importer boundaries, added or removed importers, and unrelated importer changes run full CI. Main's frozen install remains responsible for validating the lockfile itself. This protects selective routing when global `pnpmDedupe` rewrites another workspace without turning the planner into a lockfile-schema implementation.

The manifest heuristics intentionally stay conservative:

- reviewed root development tools select Main, with Vitest also selecting Performance and Oxfmt or conventional `@types/*` changes also selecting Docs;
- app, website, guide, examples, Next.js, and template manifests select their explicitly mapped consumer workflows;
- public package runtime and peer dependency changes select all consumer workflows, while public development dependencies select Main and conventional `@types/*` changes also select Docs;
- unknown root dependencies, unknown workspaces, private package changes, scripts/configuration, unsupported manifests, unreadable snapshots, lockfile-only updates, and `peerDependenciesMeta` changes run full CI;
- public version-only Publish metadata without a lockfile selects Main and Release preview;
- a lockfile accompanying a version-only or otherwise unexplained manifest change runs full CI.

This keeps the planner independent of Renovate labels and retains `pnpmDedupe`.

## Verification

- `pnpm test packages/ariakit-scripts/src/ci.test.ts --run` (45 tests)
- `pnpm lint`
- targeted type-aware Oxlint and Oxfmt
- `pnpm tsc`
- verified that the committed `pnpm-lock.yaml` parses, including quoted scoped keys, `workspace:*`, `link:` values, and peer-suffixed versions
- replayed dependency commits from the latest 40 Renovate pull requests: 22 select narrower CI and 18 conservatively remain full CI
- replayed the grouped `@types/node` update from #6695: unrelated lockfile importers force full CI
- replayed Publish pull request #6820: Main and Release preview

No changeset is needed because this only changes repository CI infrastructure.

## Review gate reassessment

<details>
<summary>Cycle 3: Narrow lockfile explanation to concrete dependency records</summary>

**Assessment**

Three review rounds found fail-open boundaries in the lockfile explanation. The first affected grouped manifest changes generally; the next two involved semantic edge cases in nested `peerDependenciesMeta`. Those metadata cases are very rare, but they violate the planner's fail-closed contract. Preserving selective handling for them required normalization, nested-field validation, and cross-field referential checks in an already substantial repository-specific policy.

The useful scope is ordinary changes to `dependencies`, `devDependencies`, `optionalDependencies`, and `peerDependencies`. Adding exact lockfile-importer attribution keeps 22 of the 40 sampled Renovate updates selective while sending 18 uncertain updates through full CI.

**Decision**

Continue the package-manifest design, but narrow lockfile explanation to concrete dependency-record changes and validate importer attribution independently. Keep metadata-only changes, lockfile-only changes, importer membership drift, unreadable manifests, unknown root tools, private packages, unsupported manifests, and version-only changes with a lockfile on the full-CI fallback.

This retains the observed safe savings while reducing schema responsibility and protecting the global deduplication workflow.

</details>

## Implementation review reassessment

<details>
<summary>Cycle 3: Continue with narrow type-package Docs routing</summary>

**Assessment**

The original task addresses a frequent repository cost: all 40 sampled Renovate pull requests changed manifests, and the current planner keeps 22 of those updates on narrower CI while conservatively sending 18 through full CI.

The first review cycle found a material correctness gap in grouped lockfile updates: 6 of 94 historically scoped plans contained changes to importers whose manifests were untouched and could skip an affected workflow. Exact, fail-closed importer comparison was therefore proportionate. The routing-table coverage and comparison/style cleanups were small hardening changes. The second cycle added a real-lockfile regression guard and simplified the parser by removing nested-shape state, reducing rather than expanding its schema responsibility.

The implementation has nevertheless grown from 249 production and 318 test lines added in the first reviewed state to 345 production and 470 test lines in the current state. That maintenance cost is material, but it remains bounded to a conservative manifest policy, exact importer-block comparison, and focused coverage.

The cycle-3 Docs concern is technically valid: generated README signatures can depend on resolved type packages, while reviewed root dependencies and public package development dependencies can select Main without Docs. However, the likely impact is low. Main is always selected and its default test suite already verifies that generated package README content is current under the repository's React types, so type-induced drift should block the pull request. The skipped Docs workflow primarily removes automatic writeback, and Docs also runs on pushes to `main`.

The expected frequency is rare. The review replay found no reachable instance in 400 commits, and the observed `@types/react` update currently falls back to full CI because an unrelated importer changes. That fallback is incidental rather than a supported guarantee.

**Decision**

Continue the current selective planner and retain the simplified, fail-closed lockfile importer comparison. Address the cycle-3 finding only for conventional `@types/*` dependency changes by selecting Docs in the existing reviewed-root and public-package branches, with focused routing tests.

Do not add dependency-graph analysis or attempt to classify every package that ships declarations. Non-`@types/*` development dependencies that could indirectly affect inferred documentation remain intentionally outside automatic Docs routing; Main's generated-readme assertion remains the correctness backstop.

</details>
