### PR TITLE
Stabilize dialog backdrop Safari test

### DIFF
--- a/app/src/sandbox/dialog-backdrop-6339/index.react.tsx
+++ b/app/src/sandbox/dialog-backdrop-6339/index.react.tsx
@@ -2,16 +2,17 @@ import * as Ariakit from "@ariakit/react";
 
 // See https://github.com/ariakit/ariakit/issues/6339
 //
-// The backdrop has a 500ms opacity transition: it should fade in when the
-// dialog opens and fade out when it closes. There are two dialogs:
+// The backdrop has an opacity transition: it should fade in when the dialog
+// opens and fade out when it closes. There are two dialogs:
 //
 // - "Show dialog": the panel has no transition at all, so it snaps in place
 //   while the backdrop fades. Before the fix, the enter fade works, but on
 //   close the dialog hides instantly: the backdrop never receives
 //   `data-leave` and the exit fade is skipped.
-// - "Show fast dialog": the panel has a shorter 150ms transition. Before the
-//   fix, the panel's own timeout stopped the shared animation state early,
-//   hiding the backdrop at 150ms and cutting its 500ms exit fade short.
+// - "Show fast dialog": the panel has a shorter 150ms transition and the
+//   backdrop uses a 2s transition to leave enough timing headroom for the
+//   browser test. Before the fix, the panel's own timeout stopped the shared
+//   animation state early, hiding the backdrop at 150ms.
 //
 // The styles are inlined in a <style> tag (rather than a style.css import) on
 // purpose: CSS imports are only processed in vitest for the allowlist in the
@@ -27,6 +28,9 @@ const css = `
   }
   .backdrop[data-enter] {
     opacity: 1;
+  }
+  .backdrop-long {
+    transition-duration: 2s;
   }
   .dialog {
     position: fixed;
@@ -78,12 +82,12 @@ export default function Example() {
       </Ariakit.Dialog>
       <Ariakit.Dialog
         store={fastDialog}
-        backdrop={<div className="backdrop" />}
+        backdrop={<div className="backdrop backdrop-long" />}
         className="dialog dialog-fast"
       >
         <Ariakit.DialogHeading>Fast</Ariakit.DialogHeading>
         <p>
-          The panel fades in over 150ms while the backdrop fades over 500ms. On
+          The panel fades in over 150ms while the backdrop fades over 2s. On
           close, the backdrop should finish its longer fade out.
         </p>
         <Ariakit.DialogDismiss>Close</Ariakit.DialogDismiss>

--- a/app/src/sandbox/dialog-backdrop-6339/index.react.tsx
+++ b/app/src/sandbox/dialog-backdrop-6339/index.react.tsx
@@ -10,7 +10,7 @@ import * as Ariakit from "@ariakit/react";
 //   close the dialog hides instantly: the backdrop never receives
 //   `data-leave` and the exit fade is skipped.
 // - "Show fast dialog": the panel has a shorter 150ms transition and the
-//   backdrop uses a 2s transition to leave enough timing headroom for the
+//   backdrop uses a 2s exit transition to leave enough timing headroom for the
 //   browser test. Before the fix, the panel's own timeout stopped the shared
 //   animation state early, hiding the backdrop at 150ms.
 //
@@ -29,7 +29,7 @@ const css = `
   .backdrop[data-enter] {
     opacity: 1;
   }
-  .backdrop-long {
+  .backdrop-long[data-leave] {
     transition-duration: 2s;
   }
   .dialog {
@@ -87,8 +87,8 @@ export default function Example() {
       >
         <Ariakit.DialogHeading>Fast</Ariakit.DialogHeading>
         <p>
-          The panel fades in over 150ms while the backdrop fades over 2s. On
-          close, the backdrop should finish its longer fade out.
+          The panel fades in over 150ms while the backdrop fades in over 500ms.
+          On close, the backdrop should finish its longer 2s fade out.
         </p>
         <Ariakit.DialogDismiss>Close</Ariakit.DialogDismiss>
       </Ariakit.Dialog>

--- a/app/src/sandbox/dialog-backdrop-6339/test-browser.ts
+++ b/app/src/sandbox/dialog-backdrop-6339/test-browser.ts
@@ -35,9 +35,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.button("Show fast dialog")).toBeFocused();
     await test.expect(backdrop).toHaveAttribute("data-leave", "true");
     // Wait past the panel's 150ms transition. The backdrop must keep leaving
-    // until its own 500ms transition ends. Before the fix, the panel's shorter
-    // timeout stopped the shared animation state, hiding the backdrop at
-    // 150ms.
+    // until its own 2s transition ends. Before the fix, the panel's shorter
+    // timeout stopped the shared animation state, hiding the backdrop at 150ms.
     await page.waitForTimeout(250);
     await test.expect(backdrop).toHaveAttribute("data-leave", "true");
     await test.expect(backdrop).toBeVisible();

--- a/app/src/sandbox/dialog-backdrop-6339/test.ts
+++ b/app/src/sandbox/dialog-backdrop-6339/test.ts
@@ -36,11 +36,13 @@ test("backdrop finishes its longer fade out when the panel has a shorter transit
   expect(q.button("Show fast dialog")).toHaveFocus();
   await expect.poll(() => backdrop.getAttribute("data-leave")).toBe("true");
   // Wait past the panel's 150ms transition. The backdrop must keep leaving
-  // until its own 500ms transition ends. Before the fix, the panel's shorter
+  // until its own 2s transition ends. Before the fix, the panel's shorter
   // timeout stopped the shared animation state, hiding the backdrop at 150ms.
   await sleep(250);
   expect(backdrop).toHaveAttribute("data-leave", "true");
   expect(backdrop).not.toHaveStyle("display: none");
   // After the backdrop's transition ends, it hides.
-  await expect.poll(() => backdrop.style.display).toBe("none");
+  await expect
+    .poll(() => backdrop.style.display, { timeout: 3000 })
+    .toBe("none");
 });


### PR DESCRIPTION
## Motivation

The Safari `app.yml` job frequently reports `dialog-backdrop-6339/test-browser` as flaky because the 500ms backdrop assertion window can expire under CI load. In the latest sample, 13 of 49 valid Safari jobs retried this test, including 8 of the latest 20.

## Solution

Give only the fast-dialog fixture a 2s backdrop exit transition while keeping its enter transition at 500ms and the panel at 150ms. The test still checks after 250ms that the panel's shorter timeout did not stop the backdrop, but now has enough scheduling headroom on macOS CI. Extend the happy-dom poll timeout accordingly.

```css
.backdrop-long[data-leave] {
  transition-duration: 2s;
}
```

## Preview

[Fast 500ms entrance and 2s exit](https://github.com/user-attachments/assets/25e44432-442d-446d-b7a4-eecde66da29a)

## Verification

- `pnpm test-react app/src/sandbox/dialog-backdrop-6339/test.ts` — 2 tests passed
- `pnpm test-react18 app/src/sandbox/dialog-backdrop-6339/test.ts` — 2 tests passed
- `APP_PORT=44331 NEXTJS_PORT=44332 APP_INSPECTOR_PORT=19441 NEXTJS_INSPECTOR_PORT=19442 pnpm -F app run test-safari src/sandbox/dialog-backdrop-6339/test-browser.ts --repeat-each=5 --workers=3 --retries=0` — 10/10 passed
- `pnpm tsc`
- `pnpm --filter ./app build`