### PR TITLE
Preserve ComboboxPopover persistent elements

### DIFF
--- a/.changeset/300-combobox-popover-persistent-elements.md
+++ b/.changeset/300-combobox-popover-persistent-elements.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`ComboboxPopover`](https://ariakit.com/reference/combobox-popover) to honor consumer-provided [`getPersistentElements`](https://ariakit.com/reference/dialog#getpersistentelements) callbacks, so interacting with the returned elements no longer dismisses a non-modal popover. Thanks to [@georgekaran](https://github.com/georgekaran).

--- a/app/src/sandbox/dialog-persistent-elements/index.react.tsx
+++ b/app/src/sandbox/dialog-persistent-elements/index.react.tsx
@@ -17,6 +17,13 @@ function ComboboxPersistentElement() {
           getPersistentElements={() =>
             persistentRef.current ? [persistentRef.current] : []
           }
+          hideOnInteractOutside={(event) => {
+            const persistentElement = persistentRef.current;
+            if (!persistentElement) return true;
+            const nativeEvent =
+              "nativeEvent" in event ? event.nativeEvent : event;
+            return !nativeEvent.composedPath().includes(persistentElement);
+          }}
         >
           {comboboxValues.map((value) => (
             <Ariakit.ComboboxItem key={value} value={value} />

--- a/app/src/sandbox/dialog-persistent-elements/index.react.tsx
+++ b/app/src/sandbox/dialog-persistent-elements/index.react.tsx
@@ -1,6 +1,39 @@
 import * as Ariakit from "@ariakit/react";
 import { useCallback, useRef, useState } from "react";
 
+const comboboxValues = ["Apple", "Banana", "Grape"];
+
+function ComboboxPersistentElement() {
+  const [actions, setActions] = useState(0);
+  const persistentRef = useRef<HTMLButtonElement>(null);
+
+  return (
+    <div className="flex flex-col items-start gap-3">
+      <Ariakit.ComboboxProvider>
+        <Ariakit.ComboboxLabel>Fruit</Ariakit.ComboboxLabel>
+        <Ariakit.Combobox />
+        <Ariakit.ComboboxPopover
+          modal={false}
+          getPersistentElements={() =>
+            persistentRef.current ? [persistentRef.current] : []
+          }
+        >
+          {comboboxValues.map((value) => (
+            <Ariakit.ComboboxItem key={value} value={value} />
+          ))}
+        </Ariakit.ComboboxPopover>
+      </Ariakit.ComboboxProvider>
+      <button
+        ref={persistentRef}
+        onClick={() => setActions((count) => count + 1)}
+      >
+        Persistent combobox action
+      </button>
+      <div role="status">Combobox actions: {actions}</div>
+    </div>
+  );
+}
+
 // Reproduces a non-modal dialog with getPersistentElements closing when the
 // user interacts with a persistent element before the dialog has been focused.
 // To see the bug:
@@ -194,6 +227,8 @@ export default function Example() {
       />
 
       <div ref={setShadowHost} data-testid="shadow-host" />
+
+      <ComboboxPersistentElement />
 
       {shadowDialogPortal && showShadowDialog && (
         <Ariakit.Portal portalElement={shadowDialogPortal}>

--- a/app/src/sandbox/dialog-persistent-elements/index.react.tsx
+++ b/app/src/sandbox/dialog-persistent-elements/index.react.tsx
@@ -17,13 +17,6 @@ function ComboboxPersistentElement() {
           getPersistentElements={() =>
             persistentRef.current ? [persistentRef.current] : []
           }
-          hideOnInteractOutside={(event) => {
-            const persistentElement = persistentRef.current;
-            if (!persistentElement) return true;
-            const nativeEvent =
-              "nativeEvent" in event ? event.nativeEvent : event;
-            return !nativeEvent.composedPath().includes(persistentElement);
-          }}
         >
           {comboboxValues.map((value) => (
             <Ariakit.ComboboxItem key={value} value={value} />

--- a/app/src/sandbox/dialog-persistent-elements/test-browser.ts
+++ b/app/src/sandbox/dialog-persistent-elements/test-browser.ts
@@ -8,6 +8,20 @@ async function moveMouseTo(page: Page, locator: Locator) {
 }
 
 withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/6863
+  test("keeps a ComboboxPopover open when interacting with a persistent element", async ({
+    page,
+    q,
+  }) => {
+    await q.combobox("Fruit").click();
+    await test.expect(q.option("Apple")).toBeVisible();
+
+    await q.button("Persistent combobox action").click();
+    await test.expect(q.status()).toHaveText("Combobox actions: 1");
+    await page.waitForTimeout(250);
+    await test.expect(q.option("Apple")).toBeVisible();
+  });
+
   // https://github.com/ariakit/ariakit/issues/6344
   test("stays open when interacting with a persistent element before the dialog is focused", async ({
     page,

--- a/app/src/sandbox/dialog-persistent-elements/test.ts
+++ b/app/src/sandbox/dialog-persistent-elements/test.ts
@@ -1,6 +1,16 @@
 import { click, dispatch, mouseDown, q, rightClick } from "@ariakit/test";
 import { expect, test } from "vitest";
 
+// https://github.com/ariakit/ariakit/issues/6863
+test("keeps a ComboboxPopover open when interacting with a persistent element", async () => {
+  await click(q.combobox("Fruit"));
+  expect(q.option("Apple")).toBeVisible();
+
+  await click(q.button("Persistent combobox action"));
+  expect(q.status()).toHaveTextContent("Combobox actions: 1");
+  expect(q.option("Apple")).toBeVisible();
+});
+
 // Reproduces https://github.com/ariakit/ariakit/issues/6344
 test("stays open when interacting with a persistent element before the dialog is focused", async () => {
   await click(q.button("Open dialog"));

--- a/packages/ariakit-react-components/src/combobox/combobox-popover.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-popover.tsx
@@ -194,6 +194,7 @@ export const useComboboxPopover = createHook<TagName, ComboboxPopoverOptions>(
 
     const hideOnEscapeProp = useBooleanEvent(props.hideOnEscape ?? true);
     const onCloseProp = props.onClose;
+    const getPersistentElementsProp = props.getPersistentElements;
 
     const hideOnEscape = useEvent((event: KeyboardEvent) => {
       const accepted = hideOnEscapeProp(event);
@@ -263,7 +264,7 @@ export const useComboboxPopover = createHook<TagName, ComboboxPopoverOptions>(
       // are rendered outside of it in the list of persistent elements, so they
       // make part of the modal context and users can tab through them.
       getPersistentElements() {
-        const elements = props.getPersistentElements?.() || [];
+        const elements = getPersistentElementsProp?.() || [];
         if (!modal) return elements;
         if (!store) return elements;
         const { baseElement, contentElement, inputElement, selectElement } =


### PR DESCRIPTION
## Motivation

[`ComboboxPopover`](https://ariakit.com/reference/combobox-popover) loses a consumer-supplied [`getPersistentElements`](https://ariakit.com/reference/dialog#getpersistentelements) callback after its props object is reassigned by the underlying popover and dialog hooks.

```tsx
<ComboboxPopover
  getPersistentElements={() =>
    persistentButtonRef.current ? [persistentButtonRef.current] : []
  }
/>
```

The returned element never joins the dialog context, so interacting with it dismisses the popover even though the element's action still runs.

## Solution

Capture the consumer callback before `usePopover` transforms and reassigns `props`, then call the captured value from the wrapper passed to the popover:

```ts
const getPersistentElementsProp = props.getPersistentElements;

// Later, inside the composed callback:
const elements = getPersistentElementsProp?.() || [];
```

This preserves consumer elements for non-modal dismissal handling and merges them with Ariakit's internal controls for modal popovers. The public-API sandbox now has happy-dom and Chromium regression coverage.

Fixes #6863.

## Workaround

For non-modal popovers, compose [`hideOnInteractOutside`](https://ariakit.com/reference/dialog#hideoninteractoutside) to prevent the affected persistent element from dismissing the popover:

```tsx
<ComboboxPopover
  getPersistentElements={() =>
    persistentButtonRef.current ? [persistentButtonRef.current] : []
  }
  hideOnInteractOutside={(event) => {
    // TODO: Remove after https://github.com/ariakit/ariakit/issues/6863 is fixed.
    const persistentButton = persistentButtonRef.current;
    if (!persistentButton) return true;
    const nativeEvent = "nativeEvent" in event ? event.nativeEvent : event;
    return !nativeEvent.composedPath().includes(persistentButton);
  }}
/>
```

This workaround covers outside-interaction dismissal for a non-modal popover. It does not restore the modal focus and inert behavior that `getPersistentElements` is also meant to provide.

## Preview

The affected source was unchanged between `b05bf359a` and the base commit `8c8c97207`. [Watch the persistent action run while the popover incorrectly closes](https://github.com/user-attachments/assets/770972bf-2654-473b-8679-5b61167ddc22).

The permanent Chromium regression now performs the same interaction, waits for asynchronous dismissal, and confirms the `Apple` option remains visible.

## Testing

- Broken implementation: React 19, React 18, and Chromium each failed only the new regression after the action count updated because the `Apple` option disappeared.
- Final fix: React 19 passed 13/13 focused tests.
- Final fix: React 18 passed 13/13 focused tests.
- Final fix: Chromium passed 13/13 focused tests.
- `pnpm build`
- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm -F app run build-lite`

## Follow-ups

- #6892 tracks the separate disabled `Select` and `ComboboxSelect` form-submission bug found during the requested audit.

## Acknowledgments

Thanks to [@georgekaran](https://github.com/georgekaran) for providing the proof branch, reproduction approach, and callback-capture fix. George is credited in the relevant commits and changeset.