### PR TITLE
Restore legacy Select valueless item coverage

### DIFF
--- a/app/src/sandbox/select-legacy/public-cases/basic.react.tsx
+++ b/app/src/sandbox/select-legacy/public-cases/basic.react.tsx
@@ -130,3 +130,66 @@ export function LegacyPublicSelectDefaultOpenCase() {
     </Ariakit.SelectProvider>
   );
 }
+
+export function LegacyPublicSelectValuelessItemsCase() {
+  const [showCustomInput, setShowCustomInput] = useState(false);
+  const fruit = Ariakit.useSelectStore({ defaultValue: "Cherry" });
+  const color = Ariakit.useSelectStore({ defaultValue: "Green" });
+  const shape = Ariakit.useSelectStore({
+    defaultValue: "Triangle",
+    focusLoop: true,
+  });
+  return (
+    <>
+      <div>
+        <Ariakit.SelectLabel store={fruit}>
+          Valueless favorite fruit
+        </Ariakit.SelectLabel>
+        <Ariakit.Select store={fruit} />
+        <Ariakit.SelectPopover store={fruit}>
+          <Ariakit.SelectItem value="Apple" />
+          <Ariakit.SelectItem value="Banana" />
+          <Ariakit.SelectItem value="Cherry" />
+          <Ariakit.SelectItem hideOnClick onClick={() => fruit.setValue("")}>
+            Clear selection
+          </Ariakit.SelectItem>
+          <Ariakit.SelectItem
+            hideOnClick
+            onClick={() => setShowCustomInput(true)}
+          >
+            Other fruit…
+          </Ariakit.SelectItem>
+        </Ariakit.SelectPopover>
+        {showCustomInput && <input aria-label="Other fruit" />}
+      </div>
+      <div>
+        <Ariakit.SelectLabel store={color}>
+          Valueless favorite color
+        </Ariakit.SelectLabel>
+        <Ariakit.Select store={color} showOnKeyDown={false} />
+        <Ariakit.SelectPopover store={color}>
+          <Ariakit.SelectItem value="Red" />
+          <Ariakit.SelectItem value="Green" />
+          <Ariakit.SelectItem value="Blue" />
+          <Ariakit.SelectItem hideOnClick onClick={() => color.setValue("")}>
+            Clear selection
+          </Ariakit.SelectItem>
+        </Ariakit.SelectPopover>
+      </div>
+      <div>
+        <Ariakit.SelectLabel store={shape}>
+          Valueless favorite shape
+        </Ariakit.SelectLabel>
+        <Ariakit.Select store={shape} showOnKeyDown={false} />
+        <Ariakit.SelectPopover store={shape}>
+          <Ariakit.SelectItem value="Square" />
+          <Ariakit.SelectItem value="Circle" />
+          <Ariakit.SelectItem value="Triangle" />
+          <Ariakit.SelectItem hideOnClick onClick={() => shape.setValue("")}>
+            Clear selection
+          </Ariakit.SelectItem>
+        </Ariakit.SelectPopover>
+      </div>
+    </>
+  );
+}

--- a/app/src/sandbox/select-legacy/public-cases/cases.react.tsx
+++ b/app/src/sandbox/select-legacy/public-cases/cases.react.tsx
@@ -6,6 +6,7 @@ import {
   LegacyPublicSelectFormDisabledCase,
   LegacyPublicSelectItemsUnmountCase,
   LegacyPublicSelectMultipleCase,
+  LegacyPublicSelectValuelessItemsCase,
 } from "./basic.react.tsx";
 import {
   LegacyPublicSelectComboboxCase,
@@ -43,6 +44,7 @@ export const legacyPublicSelectCases = {
   "public-select-form-disabled": LegacyPublicSelectFormDisabledCase,
   "public-select-items-unmount": LegacyPublicSelectItemsUnmountCase,
   "public-select-default-open-controlled": LegacyPublicSelectDefaultOpenCase,
+  "public-select-valueless-items": LegacyPublicSelectValuelessItemsCase,
   "public-select-animated": LegacyPublicSelectAnimatedCase,
   "public-select-animated-store": LegacyPublicSelectAnimatedStoreCase,
   "public-select-grid": LegacyPublicSelectGridCase,

--- a/app/src/sandbox/select-legacy/public-tests/basic.react.test.ts
+++ b/app/src/sandbox/select-legacy/public-tests/basic.react.test.ts
@@ -1,4 +1,4 @@
-import { click, dispatch, focus, q } from "@ariakit/test";
+import { click, dispatch, focus, press, q } from "@ariakit/test";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 describe("public-select", () => {
@@ -119,5 +119,42 @@ describe("public-select-default-open-controlled", () => {
     expect(q.listbox()).not.toBeInTheDocument();
     await click(select);
     expect(q.listbox()).toBeVisible();
+  });
+});
+
+describe("public-select-valueless-items", () => {
+  beforeEach(async () => {
+    await click(q.button("Show public-select-valueless-items"));
+  });
+
+  // The page-freeze variant (two trailing items without value) is covered only
+  // by the browser test: on the buggy code, the keydown handler loops forever
+  // synchronously, which would hang the happy-dom worker instead of failing.
+  // https://github.com/ariakit/ariakit/issues/6319
+  test("arrow keys on the closed select skip the trailing item without value", async () => {
+    const select = q.combobox("Valueless favorite color");
+    await click(select);
+    expect(q.option("Green")).toBeVisible();
+    await press.Escape();
+    expect(select).toHaveFocus();
+    expect(select).toHaveTextContent("Green");
+    await press.ArrowDown();
+    expect(select).toHaveTextContent("Blue");
+    await press.ArrowDown();
+    expect(select).toHaveTextContent("Blue");
+    await press.ArrowUp();
+    expect(select).toHaveTextContent("Green");
+  });
+
+  // https://github.com/ariakit/ariakit/issues/6319
+  test("arrow keys on the closed select with focusLoop wrap past the item without value", async () => {
+    const select = q.combobox("Valueless favorite shape");
+    await click(select);
+    expect(q.option("Triangle")).toBeVisible();
+    await press.Escape();
+    expect(select).toHaveFocus();
+    expect(select).toHaveTextContent("Triangle");
+    await press.ArrowDown();
+    expect(select).toHaveTextContent("Square");
   });
 });

--- a/app/src/sandbox/select-legacy/test-public-browser.ts
+++ b/app/src/sandbox/select-legacy/test-public-browser.ts
@@ -64,4 +64,58 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await checkLegacyAnimatedSelects(page, showCase);
     await checkLegacySelectComboboxOffscreenLayout(page, showCase);
   });
+
+  // https://github.com/ariakit/ariakit/issues/6319
+  test("arrow key on the closed legacy Select does not freeze the page when all following items have no value", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Show public-select-valueless-items").click();
+    const select = q.combobox("Valueless favorite fruit");
+    await select.click();
+    await test.expect(q.option("Cherry")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await test.expect(q.option("Cherry")).toBeHidden();
+    await test.expect(select).toBeFocused();
+    await page.keyboard.press("ArrowDown");
+    await test.expect(q.option("Cherry")).toBeVisible();
+    await test.expect(q.option("Cherry")).toHaveAttribute("data-active-item");
+  });
+
+  // https://github.com/ariakit/ariakit/issues/6319
+  test("arrow keys on the closed legacy Select skip the trailing item without value", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Show public-select-valueless-items").click();
+    const select = q.combobox("Valueless favorite color");
+    await select.click();
+    await test.expect(q.option("Green")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await test.expect(q.option("Green")).toBeHidden();
+    await test.expect(select).toBeFocused();
+    await page.keyboard.press("ArrowDown");
+    await test.expect(select).toContainText("Blue");
+    await page.keyboard.press("ArrowDown");
+    await test.expect(select).toContainText("Blue");
+    await page.keyboard.press("ArrowUp");
+    await test.expect(select).toContainText("Green");
+  });
+
+  // https://github.com/ariakit/ariakit/issues/6319
+  test("arrow keys on the closed legacy Select with focusLoop wrap past the item without value", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Show public-select-valueless-items").click();
+    const select = q.combobox("Valueless favorite shape");
+    await select.click();
+    await test.expect(q.option("Triangle")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await test.expect(q.option("Triangle")).toBeHidden();
+    await test.expect(select).toBeFocused();
+    await test.expect(select).toContainText("Triangle");
+    await page.keyboard.press("ArrowDown");
+    await test.expect(select).toContainText("Square");
+  });
 });


### PR DESCRIPTION
## Motivation

PR #6832 migrated the #6319 regression sandbox from the legacy [`Select`](https://ariakit.com/reference/select) components to `ComboboxSelect`. The legacy API is still public, but its closed-select navigation path no longer had a regression test for trailing [`SelectItem`](https://ariakit.com/reference/select-item) components without a value.

Current behavior is correct. This change restores coverage so a future Select-store or composite refactor cannot reintroduce the page freeze, off-by-one navigation, or `focusLoop` regression with CI remaining green.

Fixes #6855

## Solution

Add a `public-select-valueless-items` case to the existing semantic `select-legacy` sandbox using the public legacy APIs:

```tsx
<Ariakit.SelectItem value="Cherry" />
<Ariakit.SelectItem>Clear selection</Ariakit.SelectItem>
<Ariakit.SelectItem>Other fruit…</Ariakit.SelectItem>
```

The authoritative browser coverage verifies three contracts in Chromium, Firefox, and WebKit:

- ArrowDown does not freeze when two valueless items follow the active item.
- Closed-select navigation skips one trailing valueless item without going off by one.
- `focusLoop` wraps past a valueless item to the next valued item.

The latter two paths also have happy-dom duplicates. The freeze path remains browser-only because the known-broken synchronous loop would hang the happy-dom worker instead of producing a bounded failure.

No changeset is included because this PR changes regression coverage only, not shipped behavior.

## Verification

Against the known-broken pre-#6590 `nextWithValue` implementation, the two happy-dom tests fail at the expected navigation assertions, and the browser test times out exactly on `page.keyboard.press("ArrowDown")`.

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm test-react --run` (943 tests)
- `pnpm build-app-lite`
- `pnpm -F app test src/sandbox/select-legacy/test-public-browser.ts --retries=0` (12 tests across Chromium, Firefox, and WebKit)
