### PR TITLE
Fix ComboboxPopover Escape baseline

### DIFF
--- a/.changeset/300-combobox-popover-escape-baseline.md
+++ b/.changeset/300-combobox-popover-escape-baseline.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`ComboboxPopover`](https://ariakit.com/reference/combobox-popover) to preserve its [`resetOnEscape`](https://ariakit.com/reference/combobox-popover#resetonescape) baseline when an item is selected without a preceding move.

--- a/app/src/sandbox/combobox-popover-reset-on-escape/index.react.tsx
+++ b/app/src/sandbox/combobox-popover-reset-on-escape/index.react.tsx
@@ -296,14 +296,28 @@ function StoreReplacement() {
 }
 
 function DirectClick() {
+  const store = Ariakit.useComboboxStore({
+    defaultSelectedValue: "Apple",
+    selectOnMove: false,
+  });
+
   return (
-    <Ariakit.ComboboxProvider defaultSelectedValue="Apple" selectOnMove={false}>
+    <Ariakit.ComboboxProvider store={store}>
       <Ariakit.ComboboxSelect aria-label="Direct click">
         <Ariakit.ComboboxSelectedValue />
       </Ariakit.ComboboxSelect>
       <Ariakit.ComboboxPopover resetOnEscape>
         {values.map((value) => (
-          <Ariakit.ComboboxItem key={value} value={value} hideOnClick={false} />
+          <Ariakit.ComboboxItem
+            key={value}
+            value={value}
+            hideOnClick={false}
+            onClick={(event) => {
+              // TODO: Remove when https://github.com/ariakit/ariakit/issues/6852
+              // is fixed.
+              store.move(event.currentTarget.id);
+            }}
+          />
         ))}
       </Ariakit.ComboboxPopover>
     </Ariakit.ComboboxProvider>

--- a/app/src/sandbox/combobox-popover-reset-on-escape/index.react.tsx
+++ b/app/src/sandbox/combobox-popover-reset-on-escape/index.react.tsx
@@ -296,28 +296,14 @@ function StoreReplacement() {
 }
 
 function DirectClick() {
-  const store = Ariakit.useComboboxStore({
-    defaultSelectedValue: "Apple",
-    selectOnMove: false,
-  });
-
   return (
-    <Ariakit.ComboboxProvider store={store}>
+    <Ariakit.ComboboxProvider defaultSelectedValue="Apple" selectOnMove={false}>
       <Ariakit.ComboboxSelect aria-label="Direct click">
         <Ariakit.ComboboxSelectedValue />
       </Ariakit.ComboboxSelect>
       <Ariakit.ComboboxPopover resetOnEscape>
         {values.map((value) => (
-          <Ariakit.ComboboxItem
-            key={value}
-            value={value}
-            hideOnClick={false}
-            onClick={(event) => {
-              // TODO: Remove when https://github.com/ariakit/ariakit/issues/6852
-              // is fixed.
-              store.move(event.currentTarget.id);
-            }}
-          />
+          <Ariakit.ComboboxItem key={value} value={value} hideOnClick={false} />
         ))}
       </Ariakit.ComboboxPopover>
     </Ariakit.ComboboxProvider>

--- a/app/src/sandbox/combobox-popover-reset-on-escape/index.react.tsx
+++ b/app/src/sandbox/combobox-popover-reset-on-escape/index.react.tsx
@@ -295,6 +295,21 @@ function StoreReplacement() {
   );
 }
 
+function DirectClick() {
+  return (
+    <Ariakit.ComboboxProvider defaultSelectedValue="Apple" selectOnMove={false}>
+      <Ariakit.ComboboxSelect aria-label="Direct click">
+        <Ariakit.ComboboxSelectedValue />
+      </Ariakit.ComboboxSelect>
+      <Ariakit.ComboboxPopover resetOnEscape>
+        {values.map((value) => (
+          <Ariakit.ComboboxItem key={value} value={value} hideOnClick={false} />
+        ))}
+      </Ariakit.ComboboxPopover>
+    </Ariakit.ComboboxProvider>
+  );
+}
+
 export default function Example() {
   return (
     <>
@@ -337,6 +352,7 @@ export default function Example() {
       <ControlledOpen />
       <RenderCounted />
       <StoreReplacement />
+      <DirectClick />
       <button type="button">External focus target</button>
       <Select label="Descendant" unmount={false}>
         {/* The dialog leaves the popover open when a descendant consumes the

--- a/app/src/sandbox/combobox-popover-reset-on-escape/test-browser.ts
+++ b/app/src/sandbox/combobox-popover-reset-on-escape/test-browser.ts
@@ -151,7 +151,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(select).toHaveText("Apple");
   });
 
-  test("keeps tracking the baseline after a close is prevented before moving", async ({
+  // https://github.com/ariakit/ariakit/issues/6852
+  test("preserves the baseline after a close is prevented before moving", async ({
     page,
     q,
   }) => {
@@ -169,10 +170,11 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await page.keyboard.press("Escape");
 
     await test.expect(q.listbox()).toBeHidden();
-    await test.expect(select).toHaveText("Banana");
+    await test.expect(select).toHaveText("Apple");
   });
 
-  test("keeps tracking a synchronous selection update from a vetoing onClose", async ({
+  // https://github.com/ariakit/ariakit/issues/6852
+  test("preserves the baseline when a vetoing onClose changes selection", async ({
     page,
     q,
   }) => {
@@ -191,7 +193,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await page.keyboard.press("Escape");
 
     await test.expect(q.listbox()).toBeHidden();
-    await test.expect(select).toHaveText("Banana");
+    await test.expect(select).toHaveText("Apple");
   });
 
   test("doesn't reset for a different close from a consumed Escape", async ({

--- a/app/src/sandbox/combobox-popover-reset-on-escape/test-browser.ts
+++ b/app/src/sandbox/combobox-popover-reset-on-escape/test-browser.ts
@@ -246,6 +246,23 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(renderCount).toHaveText(countBeforeChange ?? "");
   });
 
+  // https://github.com/ariakit/ariakit/issues/6852
+  test("restores after a click without a preceding move", async ({
+    page,
+    q,
+  }) => {
+    const select = q.combobox("Direct click");
+    await select.click();
+    await q.option("Banana").dispatchEvent("click");
+    await test.expect(select).toHaveText("Banana");
+    await select.focus();
+
+    await page.keyboard.press("Escape");
+
+    await test.expect(q.listbox()).toBeHidden();
+    await test.expect(select).toHaveText("Apple");
+  });
+
   // https://github.com/ariakit/ariakit/pull/6832#discussion_r3650306657
   test("doesn't steal focus after focus leaves the popover", async ({ q }) => {
     const select = q.combobox("Render counted");

--- a/app/src/sandbox/combobox-popover-reset-on-escape/test.ts
+++ b/app/src/sandbox/combobox-popover-reset-on-escape/test.ts
@@ -281,6 +281,18 @@ test("captures the baseline when an already-open store replaces the store", asyn
   expect(q.combobox("Store replacement")).toHaveTextContent("Banana");
 });
 
+// https://github.com/ariakit/ariakit/issues/6852
+test("restores after a click without a preceding move", async () => {
+  const select = q.combobox.ensure("Direct click");
+  await click(select);
+  await dispatch.click(q.option("Banana"));
+  expect(select).toHaveTextContent("Banana");
+  select.focus();
+  await press.Escape();
+  expect(q.listbox()).not.toBeInTheDocument();
+  expect(select).toHaveTextContent("Apple");
+});
+
 // https://github.com/ariakit/ariakit/pull/6832#discussion_r3650306657
 test("doesn't steal focus after focus leaves the popover", async () => {
   await click(q.combobox("Render counted"));

--- a/app/src/sandbox/combobox-popover-reset-on-escape/test.ts
+++ b/app/src/sandbox/combobox-popover-reset-on-escape/test.ts
@@ -158,7 +158,8 @@ test("preserves the original baseline after a prevented close", async () => {
   expect(q.combobox("Vetoed once")).toHaveTextContent("Apple");
 });
 
-test("keeps tracking the baseline after a close is prevented before moving", async () => {
+// https://github.com/ariakit/ariakit/issues/6852
+test("preserves the baseline after a close is prevented before moving", async () => {
   await click(q.combobox("Vetoed before move"));
   await press.Escape();
   expect(q.listbox()).toBeVisible();
@@ -170,10 +171,11 @@ test("keeps tracking the baseline after a close is prevented before moving", asy
   expect(q.combobox("Vetoed before move")).toHaveTextContent("Grape");
   await press.Escape();
   expect(q.listbox()).not.toBeInTheDocument();
-  expect(q.combobox("Vetoed before move")).toHaveTextContent("Banana");
+  expect(q.combobox("Vetoed before move")).toHaveTextContent("Apple");
 });
 
-test("keeps tracking a synchronous selection update from a vetoing onClose", async () => {
+// https://github.com/ariakit/ariakit/issues/6852
+test("preserves the baseline when a vetoing onClose changes selection", async () => {
   await click(q.combobox("Vetoed with selection"));
   await press.Escape();
   expect(q.listbox()).toBeVisible();
@@ -184,7 +186,7 @@ test("keeps tracking a synchronous selection update from a vetoing onClose", asy
   expect(q.combobox("Vetoed with selection")).toHaveTextContent("Grape");
   await press.Escape();
   expect(q.listbox()).not.toBeInTheDocument();
-  expect(q.combobox("Vetoed with selection")).toHaveTextContent("Banana");
+  expect(q.combobox("Vetoed with selection")).toHaveTextContent("Apple");
 });
 
 test("doesn't reset for a different close from a consumed Escape", async () => {
@@ -244,7 +246,8 @@ test("doesn't render the popover when the selected value changes", async () => {
   expect(renderCount).toHaveTextContent(countBeforeChange ?? "");
 });
 
-test("tracks selection changes before the first move", async () => {
+// https://github.com/ariakit/ariakit/issues/6852
+test("preserves the baseline when selection changes before the first move", async () => {
   await click(q.combobox("Render counted"));
   await click(q.button("Set render counted selection"));
   expect(q.combobox("Render counted")).toHaveTextContent("Banana");
@@ -254,10 +257,10 @@ test("tracks selection changes before the first move", async () => {
   await press.ArrowDown();
   expect(q.combobox("Render counted")).toHaveTextContent("Grape");
   await press.Escape();
-  expect(q.combobox("Render counted")).toHaveTextContent("Banana");
+  expect(q.combobox("Render counted")).toHaveTextContent("Apple");
 });
 
-test("doesn't re-arm selection capture when moves reset while open", async () => {
+test("preserves the baseline when moves reset while open", async () => {
   await click(q.combobox("Render counted"));
   await press.ArrowDown();
   expect(q.combobox("Render counted")).toHaveTextContent("Banana");

--- a/packages/ariakit-react-components/src/combobox/combobox-popover.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-popover.tsx
@@ -100,49 +100,21 @@ export const useComboboxPopover = createHook<TagName, ComboboxPopoverOptions>(
       defaultPrevented: boolean;
       cancelBubble: boolean;
     } | null>(null);
-    const captureSelectedValueRef = useRef(false);
-    const captureSelectedValueBeforeCloseRef = useRef(false);
-    const preserveCaptureOnNextOpenRef = useRef<boolean | null>(null);
-    const selectedValueBeforeMoveRef = useRef(store.getState().selectedValue);
+    const preserveBaselineOnNextShowRef = useRef(false);
+    const selectedValueBeforeShowRef = useRef(store.getState().selectedValue);
 
-    // Keep tracking the selected value until the user moves through the items.
-    // The popover may already be shown on its first render, and the store may
-    // only settle its initial selected value afterwards, so freezing it any
-    // earlier would restore a value the user never saw. Once frozen, a moves
-    // reset from another Composite interaction must not re-arm it.
+    // Capture the value when the popover is shown. The explicit assignment also
+    // captures the current value if an already-open store replaces the store.
     useEffect(() => {
-      const initialState = store.getState();
-      captureSelectedValueRef.current =
-        initialState.open && !initialState.moves;
-      selectedValueBeforeMoveRef.current = initialState.selectedValue;
-      return sync(
-        store,
-        ["open", "moves", "selectedValue"],
-        (state, prevState) => {
-          if (!state.open) {
-            if (prevState.open) {
-              captureSelectedValueBeforeCloseRef.current =
-                captureSelectedValueRef.current;
-            }
-            captureSelectedValueRef.current = false;
-            return;
-          }
-          if (!prevState.open) {
-            const preservedCapture = preserveCaptureOnNextOpenRef.current;
-            if (preservedCapture !== null) {
-              captureSelectedValueRef.current = preservedCapture;
-              preserveCaptureOnNextOpenRef.current = null;
-            } else {
-              captureSelectedValueRef.current = true;
-            }
-          }
-          if (state.moves) {
-            captureSelectedValueRef.current = false;
-          }
-          if (!captureSelectedValueRef.current) return;
-          selectedValueBeforeMoveRef.current = state.selectedValue;
-        },
-      );
+      selectedValueBeforeShowRef.current = store.getState().selectedValue;
+      return sync(store, ["open"], (state, prevState) => {
+        if (!state.open || prevState.open) return;
+        if (preserveBaselineOnNextShowRef.current) {
+          preserveBaselineOnNextShowRef.current = false;
+          return;
+        }
+        selectedValueBeforeShowRef.current = store.getState().selectedValue;
+      });
     }, [store]);
 
     // Virtual focus keeps DOM focus on the combobox input or select, so the
@@ -219,11 +191,10 @@ export const useComboboxPopover = createHook<TagName, ComboboxPopoverOptions>(
       onCloseProp?.(event);
       if (event.defaultPrevented) {
         // Dialog restores its open state synchronously after a prevented close.
-        // Preserve the original baseline across that false-to-true rollback.
-        preserveCaptureOnNextOpenRef.current =
-          captureSelectedValueBeforeCloseRef.current;
+        // Keep the same baseline across that false-to-true rollback.
+        preserveBaselineOnNextShowRef.current = true;
         queueMicrotask(() => {
-          preserveCaptureOnNextOpenRef.current = null;
+          preserveBaselineOnNextShowRef.current = false;
         });
         return;
       }
@@ -239,7 +210,7 @@ export const useComboboxPopover = createHook<TagName, ComboboxPopoverOptions>(
       }
       if (Array.isArray(store.getState().selectedValue)) return;
       if (!resetOnEscapeProp(acceptedEscape.event)) return;
-      store.setSelectedValue(selectedValueBeforeMoveRef.current);
+      store.setSelectedValue(selectedValueBeforeShowRef.current);
     });
 
     props = usePopover({


### PR DESCRIPTION
## Motivation

[`ComboboxPopover`](https://ariakit.com/reference/combobox-popover) can restore the wrong value when selection changes without calling the composite `move()` method. Touch and programmatic clicks can select an item while `moves` remains `0`, so the selected-value subscription replaces the Escape baseline with the new value.

For example, clicking `Banana` directly and then pressing Escape leaves `Banana` selected instead of restoring `Apple`:

```tsx
<ComboboxProvider defaultSelectedValue="Apple" selectOnMove={false}>
  <ComboboxSelect />
  <ComboboxPopover resetOnEscape>
    <ComboboxItem value="Banana" hideOnClick={false} />
  </ComboboxPopover>
</ComboboxProvider>
```

Fixes #6852.

## Solution

- Captures the selected value when the popover changes from closed to open, so selection changes during the visible session cannot replace the Escape baseline.
- Preserves that baseline across the synchronous close rollback when `onClose` prevents the close.
- Adds browser-primary and happy-dom coverage for selection without a preceding move, prevented-close rollbacks, synchronous selection changes in `onClose`, store replacement, and repeated sessions.
- Adds a patch changeset for `@ariakit/react-components` and `@ariakit/react`.

## Workaround

For keep-open items that can be selected without a preceding `move()`, call the store's `move()` method from the consumer `onClick` handler. Consumer event handlers run before Ariakit's internal selection handler, so this freezes the pre-click Escape baseline before the new value is committed:

```tsx
const store = useComboboxStore({
  defaultSelectedValue: "Apple",
  selectOnMove: false,
});

<ComboboxItem
  value="Banana"
  hideOnClick={false}
  onClick={(event) => {
    // TODO: Remove when https://github.com/ariakit/ariakit/issues/6852 is fixed.
    store.move(event.currentTarget.id);
  }}
/>
```

This workaround is intended for the reported keep-open item composition. It deliberately marks the clicked item active and increments the store's move count before selection, and it assumes the consumer handler receives the rendered item's stable `id`.

## Preview

| Before | After |
| --- | --- |
| Escape leaves `Banana` selected. | Escape restores `Apple`. |
| ![Closed ComboboxSelect incorrectly retaining Banana after Escape](https://github.com/user-attachments/assets/0b0c92fc-cebb-4be1-a502-07261961fb11) | ![Closed ComboboxSelect correctly restored to Apple after Escape](https://github.com/user-attachments/assets/fced957f-39a8-4cf6-b587-73bd27370e1a) |

## Testing

Regression proof from the first commit:

- React 19: 26 passed, 1 failed with expected `Apple`, received `Banana`.
- Chrome: the focused browser test failed with expected `Apple`, received `Banana` after the popover closed.

Final verification:

- React 19: 27/27 focused tests passed.
- React 18: 27/27 focused tests passed.
- Chrome, Firefox, and Safari: 51/51 browser tests passed.
- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm build`
- `pnpm build-app-lite`
- `pnpm changeset status --since=origin/main`
