### PR TITLE
Deprecate Select APIs

### DIFF
--- a/.changeset/290-select-deprecation.md
+++ b/.changeset/290-select-deprecation.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/components": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Deprecated the [`Select`](https://ariakit.com/reference/select) APIs in favor of their [`ComboboxSelect`](https://ariakit.com/reference/combobox-select) counterparts.

--- a/.changeset/290-select-deprecation.md
+++ b/.changeset/290-select-deprecation.md
@@ -1,7 +1,0 @@
----
-"@ariakit/components": patch
-"@ariakit/react-components": patch
-"@ariakit/react": patch
----
-
-Deprecated the [`Select`](https://ariakit.com/reference/select) APIs in favor of their [`ComboboxSelect`](https://ariakit.com/reference/combobox-select) counterparts.

--- a/app/src/lib/jsdoc-loader.test.ts
+++ b/app/src/lib/jsdoc-loader.test.ts
@@ -245,3 +245,41 @@ test("loads Combobox Select prop metadata", async () => {
     );
   }
 });
+
+test("loads Select deprecation metadata", async () => {
+  const { context, entries } = getLoaderContext();
+  const loader = jsdoc({
+    corePath: join(process.cwd(), "packages/ariakit-react-components"),
+    framework: "react",
+    packagePath: join(process.cwd(), "packages/ariakit-react"),
+  });
+
+  await loader.load(context);
+
+  const replacements = {
+    select: "ComboboxSelect",
+    "select-anchor": "ComboboxAnchor",
+    "select-arrow": "ComboboxSelectArrow",
+    "select-dismiss": "ComboboxDismiss",
+    "select-group": "ComboboxGroup",
+    "select-group-label": "ComboboxGroupLabel",
+    "select-heading": "ComboboxHeading",
+    "select-item": "ComboboxItem",
+    "select-item-check": "ComboboxItemCheck",
+    "select-item-selected": "ComboboxItemSelected",
+    "select-label": "ComboboxSelectLabel",
+    "select-list": "ComboboxList",
+    "select-popover": "ComboboxPopover",
+    "select-provider": "ComboboxProvider",
+    "select-row": "ComboboxRow",
+    "select-separator": "ComboboxGroup",
+    "select-value": "ComboboxSelectedValue",
+    "use-select-context": "useComboboxContext",
+    "use-select-store": "useComboboxStore",
+  };
+
+  for (const [slug, replacement] of Object.entries(replacements)) {
+    const reference = getReference(entries, `react/select/${slug}`);
+    expect(reference.deprecated).toEqual(expect.stringContaining(replacement));
+  }
+});

--- a/components/select.md
+++ b/components/select.md
@@ -9,39 +9,15 @@ tags:
 
 <div data-description>
 
-The Select components are deprecated. Use [Combobox](/components/combobox) with [`ComboboxSelect`](/reference/combobox-select) to select a value from a list of options.
+Select a value from a list of options presented in a dropdown menu, similar to the native HTML select element. This component is based on the [WAI-ARIA Combobox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/).
 
 </div>
 
 <div data-tags></div>
 
-<aside data-type="warn" title="Deprecated">
+<a href="../examples/select/index.react.tsx" data-playground>Example</a>
 
-The Select APIs remain available for compatibility, but they will be removed in a future release. Use [`ComboboxProvider`](/reference/combobox-provider), [`ComboboxSelect`](/reference/combobox-select), and the corresponding Combobox components for new code. The replacement supports both standard and filterable selects through one store.
-
-</aside>
-
-<a href="../examples/select-combobox/index.react.tsx" data-playground>ComboboxSelect example</a>
-
-## Migration
-
-Replace Select components with their Combobox counterparts:
-
-```jsx
-<ComboboxProvider>
-  <ComboboxSelectLabel>Favorite fruit</ComboboxSelectLabel>
-  <ComboboxSelect>
-    <ComboboxSelectedValue />
-    <ComboboxSelectArrow />
-  </ComboboxSelect>
-  <ComboboxPopover>
-    <ComboboxItem value="Apple" />
-    <ComboboxItem value="Banana" />
-  </ComboboxPopover>
-</ComboboxProvider>
-```
-
-## Deprecated API
+## API
 
 ```jsx
 useSelectStore()

--- a/components/select.md
+++ b/components/select.md
@@ -9,15 +9,39 @@ tags:
 
 <div data-description>
 
-Select a value from a list of options presented in a dropdown menu, similar to the native HTML select element. This component is based on the [WAI-ARIA Combobox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/).
+The Select components are deprecated. Use [Combobox](/components/combobox) with [`ComboboxSelect`](/reference/combobox-select) to select a value from a list of options.
 
 </div>
 
 <div data-tags></div>
 
-<a href="../examples/select/index.react.tsx" data-playground>Example</a>
+<aside data-type="warn" title="Deprecated">
 
-## API
+The Select APIs remain available for compatibility, but they will be removed in a future release. Use [`ComboboxProvider`](/reference/combobox-provider), [`ComboboxSelect`](/reference/combobox-select), and the corresponding Combobox components for new code. The replacement supports both standard and filterable selects through one store.
+
+</aside>
+
+<a href="../examples/select-combobox/index.react.tsx" data-playground>ComboboxSelect example</a>
+
+## Migration
+
+Replace Select components with their Combobox counterparts:
+
+```jsx
+<ComboboxProvider>
+  <ComboboxSelectLabel>Favorite fruit</ComboboxSelectLabel>
+  <ComboboxSelect>
+    <ComboboxSelectedValue />
+    <ComboboxSelectArrow />
+  </ComboboxSelect>
+  <ComboboxPopover>
+    <ComboboxItem value="Apple" />
+    <ComboboxItem value="Banana" />
+  </ComboboxPopover>
+</ComboboxProvider>
+```
+
+## Deprecated API
 
 ```jsx
 useSelectStore()

--- a/guide/500-value-components/readme.md
+++ b/guide/500-value-components/readme.md
@@ -25,7 +25,7 @@ A value component reads one specific value from a provider, an explicit store, o
 - exposes the value directly or through a `children` render function
 - does not accept HTML props such as `className`, `style`, or `ref`, because it has no element to receive them
 
-The stable public value components are [`ComboboxValue`](/reference/combobox-value), [`ComboboxSelectedValue`](/reference/combobox-selected-value), [`ComboboxItemSelected`](/reference/combobox-item-selected), [`SelectValue`](/reference/select-value), and [`SelectItemSelected`](/reference/select-item-selected), all exported from `@ariakit/react`.
+The stable public value components are [`ComboboxValue`](/reference/combobox-value), [`ComboboxSelectedValue`](/reference/combobox-selected-value), and [`ComboboxItemSelected`](/reference/combobox-item-selected), all exported from `@ariakit/react`.
 
 This pattern is not inherently uncontrolled. Value components work with both controlled and uncontrolled providers and stores. Their main benefit is exposing state close to the JSX that needs it, without creating or passing a store solely for that purpose.
 
@@ -47,21 +47,6 @@ In its shortest form, a value component renders the current value as-is. No wrap
 ```
 
 [`ComboboxSelectedValue`](/reference/combobox-selected-value) accepts a `fallback` prop that's used when the current selected value is an empty string or empty array.
-
-[`SelectValue`](/reference/select-value) remains available for rendering a Select store's `value` state in the same way:
-
-```jsx {3}
-<SelectProvider defaultValue="Apple">
-  <Select>
-    <SelectValue fallback="Choose a fruit" />
-    <SelectArrow />
-  </Select>
-  <SelectPopover>
-    <SelectItem value="Apple" />
-    <SelectItem value="Banana" />
-  </SelectPopover>
-</SelectProvider>
-```
 
 ## Rendering custom JSX
 
@@ -92,8 +77,6 @@ Item-scoped value components read state from the closest item instead of the pro
 ```
 
 The `children` function is required because a raw boolean doesn't produce visible output in React. It receives the current selected state and re-runs whenever that state changes.
-
-[`SelectItemSelected`](/reference/select-item-selected) provides the same item-scoped state inside a [`SelectItem`](/reference/select-item).
 
 <aside data-type="note" title="The render prop">
 

--- a/packages/ariakit-components/src/select/select-store.ts
+++ b/packages/ariakit-components/src/select/select-store.ts
@@ -28,12 +28,14 @@ import { createPopoverStore } from "../popover/popover-store.ts";
 type MutableValue<T extends SelectStoreValue = SelectStoreValue> =
   T extends string ? string : T;
 
+/** @deprecated Use `createComboboxStore` instead. */
 export function createSelectStore<
   T extends SelectStoreValue = SelectStoreValue,
 >(
   props: PickRequired<SelectStoreProps<T>, "value" | "defaultValue">,
 ): SelectStore<T>;
 
+/** @deprecated Use `createComboboxStore` instead. */
 export function createSelectStore(props?: SelectStoreProps): SelectStore;
 
 export function createSelectStore({
@@ -196,12 +198,15 @@ export function createSelectStore({
   };
 }
 
+/** @deprecated Use `ComboboxStoreSelectedValue` instead. */
 export type SelectStoreValue = string | readonly string[];
 
+/** @deprecated Use `ComboboxStoreItem` instead. */
 export interface SelectStoreItem extends CompositeStoreItem {
   value?: string;
 }
 
+/** @deprecated Use `ComboboxStoreState` instead. */
 export interface SelectStoreState<T extends SelectStoreValue = SelectStoreValue>
   extends CompositeStoreState<SelectStoreItem>, PopoverStoreState {
   /** @default true */
@@ -238,6 +243,7 @@ export interface SelectStoreState<T extends SelectStoreValue = SelectStoreValue>
   listElement: HTMLElement | null;
 }
 
+/** @deprecated Use `ComboboxStoreFunctions` instead. */
 export interface SelectStoreFunctions<
   T extends SelectStoreValue = SelectStoreValue,
 >
@@ -268,6 +274,7 @@ export interface SelectStoreFunctions<
   setListElement: SetState<SelectStoreState<T>["listElement"]>;
 }
 
+/** @deprecated Use `ComboboxStoreOptions` instead. */
 export interface SelectStoreOptions<
   T extends SelectStoreValue = SelectStoreValue,
 >
@@ -295,8 +302,10 @@ export interface SelectStoreOptions<
   defaultValue?: SelectStoreState<T>["value"];
 }
 
+/** @deprecated Use `ComboboxStoreProps` instead. */
 export interface SelectStoreProps<T extends SelectStoreValue = SelectStoreValue>
   extends SelectStoreOptions<T>, StoreProps<SelectStoreState<T>> {}
 
+/** @deprecated Use `ComboboxStore` instead. */
 export interface SelectStore<T extends SelectStoreValue = SelectStoreValue>
   extends SelectStoreFunctions<T>, Store<SelectStoreState<T>> {}

--- a/packages/ariakit-react-components/src/select/select-anchor.tsx
+++ b/packages/ariakit-react-components/src/select/select-anchor.tsx
@@ -11,6 +11,7 @@ type TagName = typeof TagName;
 
 /**
  * Returns props to create a `SelectAnchor` component.
+ * @deprecated Use `useComboboxAnchor` instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx
@@ -32,6 +33,8 @@ export const useSelectAnchor = createHook<TagName, SelectAnchorOptions>(
 /**
  * Renders an element that acts as the anchor for the
  * [`SelectPopover`](https://ariakit.com/reference/select-popover) component.
+ * @deprecated Use
+ * [`ComboboxAnchor`](https://ariakit.com/reference/combobox-anchor) instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {3}
@@ -49,6 +52,7 @@ export const SelectAnchor = forwardRef(function SelectAnchor(
   return createElement(TagName, htmlProps);
 });
 
+/** @deprecated Use `ComboboxAnchorOptions` instead. */
 export interface SelectAnchorOptions<
   T extends ElementType = TagName,
 > extends PopoverAnchorOptions<T> {
@@ -62,6 +66,7 @@ export interface SelectAnchorOptions<
   store?: SelectStore;
 }
 
+/** @deprecated Use `ComboboxAnchorProps` instead. */
 export type SelectAnchorProps<T extends ElementType = TagName> = Props<
   T,
   SelectAnchorOptions<T>

--- a/packages/ariakit-react-components/src/select/select-arrow.tsx
+++ b/packages/ariakit-react-components/src/select/select-arrow.tsx
@@ -11,6 +11,7 @@ type TagName = typeof TagName;
 
 /**
  * Returns props to create a `SelectArrow` component.
+ * @deprecated Use `useComboboxSelectArrow` instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx
@@ -39,6 +40,9 @@ export const useSelectArrow = createHook<TagName, SelectArrowOptions>(
  * Renders an arrow pointing to the select popover position. It's usually
  * rendered inside the [`Select`](https://ariakit.com/reference/select)
  * component.
+ * @deprecated Use
+ * [`ComboboxSelectArrow`](https://ariakit.com/reference/combobox-select-arrow)
+ * instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {4}
@@ -61,6 +65,7 @@ export const SelectArrow = forwardRef(function SelectArrow(
   return createElement(TagName, htmlProps);
 });
 
+/** @deprecated Use `ComboboxSelectArrowOptions` instead. */
 export interface SelectArrowOptions<
   T extends ElementType = TagName,
 > extends PopoverDisclosureArrowOptions<T> {
@@ -74,6 +79,7 @@ export interface SelectArrowOptions<
   store?: SelectStore;
 }
 
+/** @deprecated Use `ComboboxSelectArrowProps` instead. */
 export type SelectArrowProps<T extends ElementType = TagName> = Props<
   T,
   SelectArrowOptions<T>

--- a/packages/ariakit-react-components/src/select/select-context.tsx
+++ b/packages/ariakit-react-components/src/select/select-context.tsx
@@ -18,6 +18,9 @@ const ctx = createStoreContext<SelectStore>(
 
 /**
  * Returns the select store from the nearest select container.
+ * @deprecated Use
+ * [`useComboboxContext`](https://ariakit.com/reference/use-combobox-context)
+ * instead.
  * @example
  * function Select() {
  *   const store = useSelectContext();
@@ -31,16 +34,22 @@ const ctx = createStoreContext<SelectStore>(
  */
 export const useSelectContext = ctx.useContext;
 
+/** @deprecated Use `useComboboxScopedContext` instead. */
 export const useSelectScopedContext = ctx.useScopedContext;
 
+/** @deprecated Use `useComboboxProviderContext` instead. */
 export const useSelectProviderContext = ctx.useProviderContext;
 
+/** @deprecated Use `ComboboxContextProvider` instead. */
 export const SelectContextProvider = ctx.ContextProvider;
 
+/** @deprecated Use `ComboboxScopedContextProvider` instead. */
 export const SelectScopedContextProvider = ctx.ScopedContextProvider;
 
+/** @deprecated Use `ComboboxItemCheckedContext` instead. */
 export const SelectItemCheckedContext = createContext(false);
 
+/** @deprecated Use `ComboboxHeadingContext` instead. */
 export const SelectHeadingContext = createContext<
   [string | undefined, Dispatch<SetStateAction<string | undefined>>] | null
 >(null);

--- a/packages/ariakit-react-components/src/select/select-dismiss.tsx
+++ b/packages/ariakit-react-components/src/select/select-dismiss.tsx
@@ -12,6 +12,7 @@ type TagName = typeof TagName;
 
 /**
  * Returns props to create a `SelectDismiss` component.
+ * @deprecated Use `useComboboxDismiss` instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx
@@ -38,6 +39,8 @@ export const useSelectDismiss = createHook<TagName, SelectDismissOptions>(
  * [`SelectItem`](https://ariakit.com/reference/select-item) elements must be
  * rendered within a [`SelectList`](https://ariakit.com/reference/select-list)
  * instead of directly within the popover.
+ * @deprecated Use
+ * [`ComboboxDismiss`](https://ariakit.com/reference/combobox-dismiss) instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {4}
@@ -60,6 +63,7 @@ export const SelectDismiss = forwardRef(function SelectDismiss(
   return createElement(TagName, htmlProps);
 });
 
+/** @deprecated Use `ComboboxDismissOptions` instead. */
 export interface SelectDismissOptions<
   T extends ElementType = TagName,
 > extends PopoverDismissOptions<T> {
@@ -74,6 +78,7 @@ export interface SelectDismissOptions<
   store?: SelectStore;
 }
 
+/** @deprecated Use `ComboboxDismissProps` instead. */
 export type SelectDismissProps<T extends ElementType = TagName> = Props<
   T,
   SelectDismissOptions<T>

--- a/packages/ariakit-react-components/src/select/select-group-label.tsx
+++ b/packages/ariakit-react-components/src/select/select-group-label.tsx
@@ -12,6 +12,7 @@ type TagName = typeof TagName;
  * Returns props to create a `SelectGroupLabel` component. This hook must be
  * used in a component that's wrapped with `SelectGroup` so the
  * `aria-labelledby` prop is properly set on the select group element.
+ * @deprecated Use `useComboboxGroupLabel` instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx
@@ -31,6 +32,9 @@ export const useSelectGroupLabel = createHook<TagName, SelectGroupLabelOptions>(
  * Renders a label in a select group. This component must be wrapped with
  * [`SelectGroup`](https://ariakit.com/reference/select-group) so the
  * `aria-labelledby` prop is properly set on the select group element.
+ * @deprecated Use
+ * [`ComboboxGroupLabel`](https://ariakit.com/reference/combobox-group-label)
+ * instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {5,10}
@@ -58,6 +62,7 @@ export const SelectGroupLabel = forwardRef(function SelectGroupLabel(
   return createElement(TagName, htmlProps);
 });
 
+/** @deprecated Use `ComboboxGroupLabelOptions` instead. */
 export interface SelectGroupLabelOptions<
   T extends ElementType = TagName,
 > extends CompositeGroupLabelOptions<T> {
@@ -72,6 +77,7 @@ export interface SelectGroupLabelOptions<
   store?: SelectStore;
 }
 
+/** @deprecated Use `ComboboxGroupLabelProps` instead. */
 export type SelectGroupLabelProps<T extends ElementType = TagName> = Props<
   T,
   SelectGroupLabelOptions<T>

--- a/packages/ariakit-react-components/src/select/select-group.tsx
+++ b/packages/ariakit-react-components/src/select/select-group.tsx
@@ -10,6 +10,7 @@ type TagName = typeof TagName;
 
 /**
  * Returns props to create a `SelectGroup` component.
+ * @deprecated Use `useComboboxGroup` instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx
@@ -37,6 +38,8 @@ export const useSelectGroup = createHook<TagName, SelectGroupOptions>(
  * elements. Optionally, a
  * [`SelectGroupLabel`](https://ariakit.com/reference/select-group-label) can be
  * rendered as a child to provide a label for the group.
+ * @deprecated Use
+ * [`ComboboxGroup`](https://ariakit.com/reference/combobox-group) instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {4-8}
@@ -59,6 +62,7 @@ export const SelectGroup = forwardRef(function SelectGroup(
   return createElement(TagName, htmlProps);
 });
 
+/** @deprecated Use `ComboboxGroupOptions` instead. */
 export interface SelectGroupOptions<
   T extends ElementType = TagName,
 > extends CompositeGroupOptions<T> {
@@ -73,6 +77,7 @@ export interface SelectGroupOptions<
   store?: SelectStore;
 }
 
+/** @deprecated Use `ComboboxGroupProps` instead. */
 export type SelectGroupProps<T extends ElementType = TagName> = Props<
   T,
   SelectGroupOptions<T>

--- a/packages/ariakit-react-components/src/select/select-heading.tsx
+++ b/packages/ariakit-react-components/src/select/select-heading.tsx
@@ -18,6 +18,7 @@ type TagName = typeof TagName;
 
 /**
  * Returns props to create a `SelectHeading` component.
+ * @deprecated Use `useComboboxHeading` instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx
@@ -56,6 +57,8 @@ export const useSelectHeading = createHook<TagName, SelectHeadingOptions>(
  * [`SelectItem`](https://ariakit.com/reference/select-item) elements must be
  * rendered within a [`SelectList`](https://ariakit.com/reference/select-list)
  * instead of directly within the popover.
+ * @deprecated Use
+ * [`ComboboxHeading`](https://ariakit.com/reference/combobox-heading) instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {4}
@@ -78,6 +81,7 @@ export const SelectHeading = forwardRef(function SelectHeading(
   return createElement(TagName, htmlProps);
 });
 
+/** @deprecated Use `ComboboxHeadingOptions` instead. */
 export interface SelectHeadingOptions<
   T extends ElementType = TagName,
 > extends PopoverHeadingOptions<T> {
@@ -94,6 +98,7 @@ export interface SelectHeadingOptions<
   store?: SelectStore;
 }
 
+/** @deprecated Use `ComboboxHeadingProps` instead. */
 export type SelectHeadingProps<T extends ElementType = TagName> = Props<
   T,
   SelectHeadingOptions<T>

--- a/packages/ariakit-react-components/src/select/select-item-check.tsx
+++ b/packages/ariakit-react-components/src/select/select-item-check.tsx
@@ -14,6 +14,7 @@ type TagName = typeof TagName;
  * Returns props to create a `SelectItemCheck` component. This hook must be used
  * in a component that's wrapped with `SelectItem` or the `checked` prop must be
  * explicitly passed to the component.
+ * @deprecated Use `useComboboxItemCheck` instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx
@@ -39,6 +40,9 @@ export const useSelectItemCheck = createHook<TagName, SelectItemCheckOptions>(
  * [`SelectItem`](https://ariakit.com/reference/select-item) component, the
  * [`checked`](https://ariakit.com/reference/select-item-check#checked) prop is
  * automatically derived from the context.
+ * @deprecated Use
+ * [`ComboboxItemCheck`](https://ariakit.com/reference/combobox-item-check)
+ * instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {5,9}
@@ -64,6 +68,7 @@ export const SelectItemCheck = forwardRef(function SelectItemCheck(
   return createElement(TagName, htmlProps);
 });
 
+/** @deprecated Use `ComboboxItemCheckOptions` instead. */
 export interface SelectItemCheckOptions<
   T extends ElementType = TagName,
 > extends CheckboxCheckOptions<T> {
@@ -80,6 +85,7 @@ export interface SelectItemCheckOptions<
   store?: SelectStore;
 }
 
+/** @deprecated Use `ComboboxItemCheckProps` instead. */
 export type SelectItemCheckProps<T extends ElementType = TagName> = Props<
   T,
   SelectItemCheckOptions<T>

--- a/packages/ariakit-react-components/src/select/select-item-offscreen.tsx
+++ b/packages/ariakit-react-components/src/select/select-item-offscreen.tsx
@@ -10,6 +10,7 @@ import * as Base from "./select-item.tsx";
 const TagName = "div" satisfies ElementType;
 type TagName = typeof TagName;
 
+/** @deprecated Use `useComboboxItemOffscreen` instead. */
 export function useSelectItemOffscreen<
   T extends ElementType,
   // oxlint-disable-next-line no-unnecessary-type-parameters
@@ -20,6 +21,7 @@ export function useSelectItemOffscreen<
   return useCompositeItemOffscreen({ store, value, ...props });
 }
 
+/** @deprecated Use `ComboboxItem` from the offscreen module instead. */
 export const SelectItem = forwardRef(function SelectItem({
   offscreenMode,
   offscreenRoot,
@@ -62,9 +64,11 @@ export const SelectItem = forwardRef(function SelectItem({
   return <Component {...htmlProps} />;
 });
 
+/** @deprecated Use `ComboboxItemOptions` from the offscreen module instead. */
 export interface SelectItemOptions<T extends ElementType = TagName>
   extends Base.SelectItemOptions<T>, Omit<CompositeItemOptions<T>, "store"> {}
 
+/** @deprecated Use `ComboboxItemProps` from the offscreen module instead. */
 export type SelectItemProps<T extends ElementType = TagName> = Props<
   T,
   SelectItemOptions<T>

--- a/packages/ariakit-react-components/src/select/select-item-selected.tsx
+++ b/packages/ariakit-react-components/src/select/select-item-selected.tsx
@@ -9,6 +9,9 @@ import { SelectItemCheckedContext } from "./select-context.tsx";
  *
  * As a value component, it doesn't render any DOM elements and therefore
  * doesn't accept HTML props.
+ * @deprecated Use
+ * [`ComboboxItemSelected`](https://ariakit.com/reference/combobox-item-selected)
+ * instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {5-7}
@@ -30,6 +33,7 @@ export function SelectItemSelected({ children }: SelectItemSelectedProps) {
   return children(selected);
 }
 
+/** @deprecated Use `ComboboxItemSelectedProps` instead. */
 export interface SelectItemSelectedProps {
   /**
    * A function that gets called with the closest

--- a/packages/ariakit-react-components/src/select/select-item.tsx
+++ b/packages/ariakit-react-components/src/select/select-item.tsx
@@ -48,6 +48,7 @@ function isSelected(
 
 /**
  * Returns props to create a `SelectItem` component.
+ * @deprecated Use `useComboboxItem` instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx
@@ -211,6 +212,8 @@ export const useSelectItem = createHook<TagName, SelectItemOptions>(
  * By default, the [`value`](https://ariakit.com/reference/select-item#value)
  * prop will be rendered as the children, but this can be overriden if a custom
  * children is provided.
+ * @deprecated Use
+ * [`ComboboxItem`](https://ariakit.com/reference/combobox-item) instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {4-5}
@@ -230,6 +233,7 @@ export const SelectItem = memo(
   }),
 );
 
+/** @deprecated Use `ComboboxItemOptions` instead. */
 export interface SelectItemOptions<T extends ElementType = TagName>
   extends CompositeItemOptions<T>, CompositeHoverOptions<T> {
   /**
@@ -275,6 +279,7 @@ export interface SelectItemOptions<T extends ElementType = TagName>
   setValueOnClick?: BooleanOrCallback<MouseEvent<HTMLElement>>;
 }
 
+/** @deprecated Use `ComboboxItemProps` instead. */
 export type SelectItemProps<T extends ElementType = TagName> = Props<
   T,
   SelectItemOptions<T>

--- a/packages/ariakit-react-components/src/select/select-label.tsx
+++ b/packages/ariakit-react-components/src/select/select-label.tsx
@@ -22,6 +22,7 @@ type HTMLType = HTMLElementTagNameMap[TagName];
  * select element, we can't use the native label element. The `SelectLabel`
  * component will move focus to the `Select` component when the user clicks on
  * the label.
+ * @deprecated Use `useComboboxSelectLabel` instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx
@@ -78,6 +79,9 @@ export const useSelectLabel = createHook<TagName, SelectLabelOptions>(
  * component. Since it's not a native select element, we can't use the native
  * label element. This component will move focus to the
  * [`Select`](https://ariakit.com/reference/select) component when clicked.
+ * @deprecated Use
+ * [`ComboboxSelectLabel`](https://ariakit.com/reference/combobox-select-label)
+ * instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {2}
@@ -98,6 +102,7 @@ export const SelectLabel = memo(
   }),
 );
 
+/** @deprecated Use `ComboboxSelectLabelOptions` instead. */
 export interface SelectLabelOptions<
   _T extends ElementType = TagName,
 > extends Options {
@@ -111,6 +116,7 @@ export interface SelectLabelOptions<
   store?: SelectStore;
 }
 
+/** @deprecated Use `ComboboxSelectLabelProps` instead. */
 export type SelectLabelProps<T extends ElementType = TagName> = Props<
   T,
   SelectLabelOptions<T>

--- a/packages/ariakit-react-components/src/select/select-list.tsx
+++ b/packages/ariakit-react-components/src/select/select-list.tsx
@@ -39,6 +39,7 @@ const SelectListContext = createContext<
 
 /**
  * Returns props to create a `SelectList` component.
+ * @deprecated Use `useComboboxList` instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx
@@ -183,6 +184,8 @@ export const useSelectList = createHook<TagName, SelectListOptions>(
  *
  * The `aria-labelledby` prop is set to the
  * [`Select`](https://ariakit.com/reference/select) element's `id` by default.
+ * @deprecated Use
+ * [`ComboboxList`](https://ariakit.com/reference/combobox-list) instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {5-8}
@@ -205,6 +208,7 @@ export const SelectList = forwardRef(function SelectList(
   return createElement(TagName, htmlProps);
 });
 
+/** @deprecated Use `ComboboxListOptions` instead. */
 export interface SelectListOptions<T extends ElementType = TagName>
   extends
     CompositeOptions<T>,
@@ -236,6 +240,7 @@ export interface SelectListOptions<T extends ElementType = TagName>
   hideOnEnter?: BooleanOrCallback<KeyboardEvent<HTMLElement>>;
 }
 
+/** @deprecated Use `ComboboxListProps` instead. */
 export type SelectListProps<T extends ElementType = TagName> = Props<
   T,
   SelectListOptions<T>

--- a/packages/ariakit-react-components/src/select/select-popover.tsx
+++ b/packages/ariakit-react-components/src/select/select-popover.tsx
@@ -13,6 +13,7 @@ type TagName = typeof TagName;
 
 /**
  * Returns props to create a `SelectPopover` component.
+ * @deprecated Use `useComboboxPopover` instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx
@@ -38,6 +39,8 @@ export const useSelectPopover = createHook<TagName, SelectPopoverOptions>(
  * Renders a select popover. The `role` attribute is set to `listbox` by
  * default, but can be overriden by any other valid select popup role
  * (`listbox`, `menu`, `tree`, `grid` or `dialog`).
+ * @deprecated Use
+ * [`ComboboxPopover`](https://ariakit.com/reference/combobox-popover) instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {3-6}
@@ -58,9 +61,11 @@ export const SelectPopover = createDialogComponent(
   useSelectProviderContext,
 );
 
+/** @deprecated Use `ComboboxPopoverOptions` instead. */
 export interface SelectPopoverOptions<T extends ElementType = TagName>
   extends SelectListOptions<T>, Omit<PopoverOptions<T>, "store"> {}
 
+/** @deprecated Use `ComboboxPopoverProps` instead. */
 export type SelectPopoverProps<T extends ElementType = TagName> = Props<
   T,
   SelectPopoverOptions<T>

--- a/packages/ariakit-react-components/src/select/select-provider.tsx
+++ b/packages/ariakit-react-components/src/select/select-provider.tsx
@@ -9,6 +9,9 @@ type Value = SelectStoreValue;
 /**
  * Provides a select store to [Select](https://ariakit.com/components/select)
  * components.
+ * @deprecated Use
+ * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)
+ * instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx
@@ -27,6 +30,7 @@ export function SelectProvider<T extends Value = Value>(
   props: PickRequired<SelectProviderProps<T>, "value" | "defaultValue">,
 ): ReactElement;
 
+/** @deprecated Use `ComboboxProvider` instead. */
 export function SelectProvider(props?: SelectProviderProps): ReactElement;
 
 export function SelectProvider(props: SelectProviderProps = {}) {
@@ -38,6 +42,7 @@ export function SelectProvider(props: SelectProviderProps = {}) {
   );
 }
 
+/** @deprecated Use `ComboboxProviderProps` instead. */
 export interface SelectProviderProps<
   T extends Value = Value,
 > extends SelectStoreProps<T> {

--- a/packages/ariakit-react-components/src/select/select-renderer.tsx
+++ b/packages/ariakit-react-components/src/select/select-renderer.tsx
@@ -112,6 +112,7 @@ function useSelectRenderer<T extends Item = any>({
   });
 }
 
+/** @deprecated Use `ComboboxRenderer` instead. */
 export const SelectRenderer = forwardRef(function SelectRenderer<
   T extends Item = any,
 >(props: SelectRendererProps<T>) {
@@ -119,19 +120,27 @@ export const SelectRenderer = forwardRef(function SelectRenderer<
   return createElement(TagName, htmlProps);
 });
 
-export {
-  getCompositeRendererItem as getSelectRendererItem,
-  getCompositeRendererItemId as getSelectRendererItemId,
-};
+/** @deprecated Use `getComboboxRendererItem` instead. */
+export const getSelectRendererItem: typeof getCompositeRendererItem =
+  getCompositeRendererItem;
 
+/** @deprecated Use `getComboboxRendererItemId` instead. */
+export const getSelectRendererItemId: typeof getCompositeRendererItemId =
+  getCompositeRendererItemId;
+
+/** @deprecated Use `ComboboxRendererItemObject` instead. */
 export type SelectRendererItemObject = ItemObject;
+/** @deprecated Use `ComboboxRendererItem` instead. */
 export type SelectRendererItem = Item;
+/** @deprecated Use `ComboboxRendererBaseItemProps` instead. */
 export type SelectRendererBaseItemProps = BaseItemProps;
+/** @deprecated Use `ComboboxRendererItemProps` instead. */
 export type SelectRendererItemProps<
   T extends Item,
   P extends BaseItemProps = BaseItemProps,
 > = ItemProps<T, P>;
 
+/** @deprecated Use `ComboboxRendererOptions` instead. */
 export interface SelectRendererOptions<T extends Item = any> extends Omit<
   CompositeRendererOptions<T>,
   "store"
@@ -157,6 +166,7 @@ export interface SelectRendererOptions<T extends Item = any> extends Omit<
   value?: SelectStoreValue;
 }
 
+/** @deprecated Use `ComboboxRendererProps` instead. */
 export interface SelectRendererProps<T extends Item = any> extends Props<
   TagName,
   SelectRendererOptions<T>

--- a/packages/ariakit-react-components/src/select/select-row.tsx
+++ b/packages/ariakit-react-components/src/select/select-row.tsx
@@ -13,6 +13,7 @@ type TagName = typeof TagName;
 
 /**
  * Returns props to create a `SelectRow` component.
+ * @deprecated Use `useComboboxRow` instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx
@@ -54,6 +55,8 @@ export const useSelectRow = createHook<TagName, SelectRowOptions>(
  * [`SelectItem`](https://ariakit.com/reference/select-item) elements wrapped
  * within this component will automatically receive a
  * [`rowId`](https://ariakit.com/reference/select-item#rowid) prop.
+ * @deprecated Use
+ * [`ComboboxRow`](https://ariakit.com/reference/combobox-row) instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {4-11}
@@ -77,6 +80,7 @@ export const SelectRow = forwardRef(function SelectRow(props: SelectRowProps) {
   return createElement(TagName, htmlProps);
 });
 
+/** @deprecated Use `ComboboxRowOptions` instead. */
 export interface SelectRowOptions<
   T extends ElementType = TagName,
 > extends CompositeRowOptions<T> {
@@ -91,6 +95,7 @@ export interface SelectRowOptions<
   store?: SelectStore;
 }
 
+/** @deprecated Use `ComboboxRowProps` instead. */
 export type SelectRowProps<T extends ElementType = TagName> = Props<
   T,
   SelectRowOptions<T>

--- a/packages/ariakit-react-components/src/select/select-separator.tsx
+++ b/packages/ariakit-react-components/src/select/select-separator.tsx
@@ -11,7 +11,7 @@ type TagName = typeof TagName;
 
 /**
  * Returns props to create a `SelectSeparator` component.
- * @deprecated Use `useSelectGroup` with CSS borders instead.
+ * @deprecated Use `useComboboxGroup` with CSS borders instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx
@@ -37,8 +37,9 @@ export const useSelectSeparator = createHook<TagName, SelectSeparatorOptions>(
 /**
  * Renders a divider between
  * [`SelectItem`](https://ariakit.com/reference/select-item) elements.
- * @deprecated Use [`SelectGroup`](https://ariakit.com/reference/select-group)
- * with CSS borders instead.
+ * @deprecated Use
+ * [`ComboboxGroup`](https://ariakit.com/reference/combobox-group) with CSS
+ * borders instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {5}
@@ -60,6 +61,7 @@ export const SelectSeparator = forwardRef(function SelectSeparator(
   return createElement(TagName, htmlProps);
 });
 
+/** @deprecated Use `ComboboxGroupOptions` with CSS borders instead. */
 export interface SelectSeparatorOptions<
   T extends ElementType = TagName,
 > extends CompositeSeparatorOptions<T> {
@@ -74,6 +76,7 @@ export interface SelectSeparatorOptions<
   store?: SelectStore;
 }
 
+/** @deprecated Use `ComboboxGroupProps` with CSS borders instead. */
 export type SelectSeparatorProps<T extends ElementType = TagName> = Props<
   T,
   SelectSeparatorOptions<T>

--- a/packages/ariakit-react-components/src/select/select-store.ts
+++ b/packages/ariakit-react-components/src/select/select-store.ts
@@ -21,6 +21,7 @@ import type {
 } from "../popover/popover-store.ts";
 import { usePopoverStoreProps } from "../popover/popover-store.ts";
 
+/** @deprecated Use `useComboboxStoreOptions` instead. */
 export function useSelectStoreOptions<T extends Core.SelectStoreOptions>(
   props: T,
 ) {
@@ -32,6 +33,7 @@ export function useSelectStoreOptions<T extends Core.SelectStoreOptions>(
   return useCompositeStoreOptions(props);
 }
 
+/** @deprecated Use `useComboboxStoreProps` instead. */
 export function useSelectStoreProps<T extends Core.SelectStore>(
   store: T,
   update: () => void,
@@ -53,6 +55,9 @@ export function useSelectStoreProps<T extends Core.SelectStore>(
 /**
  * Creates a select store to control the state of
  * [Select](https://ariakit.com/components/select) components.
+ * @deprecated Use
+ * [`useComboboxStore`](https://ariakit.com/reference/use-combobox-store)
+ * instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx
@@ -69,6 +74,7 @@ export function useSelectStore<T extends SelectStoreValue = SelectStoreValue>(
   props: PickRequired<SelectStoreProps<T>, "value" | "defaultValue">,
 ): SelectStore<T>;
 
+/** @deprecated Use `useComboboxStore` instead. */
 export function useSelectStore(props?: SelectStoreProps): SelectStore;
 
 export function useSelectStore(props: SelectStoreProps = {}): SelectStore {
@@ -77,16 +83,20 @@ export function useSelectStore(props: SelectStoreProps = {}): SelectStore {
   return useSelectStoreProps(store, update, props);
 }
 
+/** @deprecated Use `ComboboxStoreSelectedValue` instead. */
 export type SelectStoreValue = Core.SelectStoreValue;
 
+/** @deprecated Use `ComboboxStoreItem` instead. */
 export interface SelectStoreItem extends Core.SelectStoreItem {}
 
+/** @deprecated Use `ComboboxStoreState` instead. */
 export interface SelectStoreState<T extends SelectStoreValue = SelectStoreValue>
   extends
     Core.SelectStoreState<T>,
     CompositeStoreState<SelectStoreItem>,
     PopoverStoreState {}
 
+/** @deprecated Use `ComboboxStoreFunctions` instead. */
 export interface SelectStoreFunctions<
   T extends SelectStoreValue = SelectStoreValue,
 >
@@ -96,6 +106,7 @@ export interface SelectStoreFunctions<
     CompositeStoreFunctions<SelectStoreItem>,
     PopoverStoreFunctions {}
 
+/** @deprecated Use `ComboboxStoreOptions` instead. */
 export interface SelectStoreOptions<
   T extends SelectStoreValue = SelectStoreValue,
 >
@@ -117,11 +128,13 @@ export interface SelectStoreOptions<
   combobox?: ComboboxStore | null;
 }
 
+/** @deprecated Use `ComboboxStoreProps` instead. */
 export interface SelectStoreProps<T extends SelectStoreValue = SelectStoreValue>
   extends
     SelectStoreOptions<T>,
     Omit<Core.SelectStoreProps<T>, "combobox" | "disclosure"> {}
 
+/** @deprecated Use `ComboboxStore` instead. */
 export interface SelectStore<T extends SelectStoreValue = SelectStoreValue>
   extends
     SelectStoreFunctions<T>,

--- a/packages/ariakit-react-components/src/select/select-value.tsx
+++ b/packages/ariakit-react-components/src/select/select-value.tsx
@@ -24,6 +24,9 @@ type Value = SelectStoreValue;
  * [`children`](https://ariakit.com/reference/select-value#children) function
  * that gets called with the current value as an argument. This is handy for
  * rendering the value in a custom way.
+ * @deprecated Use
+ * [`ComboboxSelectedValue`](https://ariakit.com/reference/combobox-selected-value)
+ * instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {3}
@@ -63,6 +66,7 @@ export function SelectValue<T extends Value = Value>(
   props: PickRequired<SelectValueProps<T>, "fallback">,
 ): T;
 
+/** @deprecated Use `ComboboxSelectedValue` instead. */
 export function SelectValue(props?: SelectValueProps): Value;
 
 export function SelectValue({
@@ -85,6 +89,7 @@ export function SelectValue({
   return value;
 }
 
+/** @deprecated Use `ComboboxSelectedValueProps` instead. */
 export interface SelectValueProps<T extends Value = Value> {
   /**
    * Object returned by the

--- a/packages/ariakit-react-components/src/select/select.tsx
+++ b/packages/ariakit-react-components/src/select/select.tsx
@@ -73,6 +73,7 @@ function nextWithValue(store: SelectStore, next: SelectStore["next"]) {
 
 /**
  * Returns props to create a `Select` component.
+ * @deprecated Use `useComboboxSelect` instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx
@@ -298,6 +299,8 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
  * rendered as the children, followed by a
  * [`SelectArrow`](https://ariakit.com/reference/select-arrow) component. This
  * can be customized by passing different children to the component.
+ * @deprecated Use
+ * [`ComboboxSelect`](https://ariakit.com/reference/combobox-select) instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {2}
@@ -315,6 +318,7 @@ export const Select = forwardRef(function Select(props: SelectProps) {
   return createElement(TagName, htmlProps);
 });
 
+/** @deprecated Use `ComboboxSelectOptions` instead. */
 export interface SelectOptions<T extends ElementType = TagName>
   extends
     PopoverDisclosureOptions<T>,
@@ -363,6 +367,7 @@ export interface SelectOptions<T extends ElementType = TagName>
   >;
 }
 
+/** @deprecated Use `ComboboxSelectProps` instead. */
 export type SelectProps<T extends ElementType = TagName> = Props<
   T,
   SelectOptions<T>

--- a/website/build-pages/reference-utils.test.ts
+++ b/website/build-pages/reference-utils.test.ts
@@ -12,6 +12,10 @@ const headingFilename = join(
   process.cwd(),
   "packages/ariakit-react/src/heading.ts",
 );
+const selectFilename = join(
+  process.cwd(),
+  "packages/ariakit-react/src/select.ts",
+);
 
 function getReference(filename: string, name: string) {
   const reference = getReferences(filename).find((reference) => {
@@ -91,5 +95,34 @@ test("loads Combobox Select prop metadata", () => {
     expect(store.description).toContain(
       "https://ariakit.com/reference/combobox-provider",
     );
+  }
+});
+
+test("loads Select deprecation metadata", () => {
+  const replacements = {
+    Select: "ComboboxSelect",
+    SelectAnchor: "ComboboxAnchor",
+    SelectArrow: "ComboboxSelectArrow",
+    SelectDismiss: "ComboboxDismiss",
+    SelectGroup: "ComboboxGroup",
+    SelectGroupLabel: "ComboboxGroupLabel",
+    SelectHeading: "ComboboxHeading",
+    SelectItem: "ComboboxItem",
+    SelectItemCheck: "ComboboxItemCheck",
+    SelectItemSelected: "ComboboxItemSelected",
+    SelectLabel: "ComboboxSelectLabel",
+    SelectList: "ComboboxList",
+    SelectPopover: "ComboboxPopover",
+    SelectProvider: "ComboboxProvider",
+    SelectRow: "ComboboxRow",
+    SelectSeparator: "ComboboxGroup",
+    SelectValue: "ComboboxSelectedValue",
+    useSelectContext: "useComboboxContext",
+    useSelectStore: "useComboboxStore",
+  };
+
+  for (const [name, replacement] of Object.entries(replacements)) {
+    const reference = getReference(selectFilename, name);
+    expect(reference.deprecated).toEqual(expect.stringContaining(replacement));
   }
 });


### PR DESCRIPTION
## Motivation

The Select APIs remain available for compatibility, but ComboboxSelect and the corresponding Combobox APIs are now the canonical path for standard and filterable selects. Consumers need consistent editor guidance without a runtime warning or behavior change.

Fixes #6836.

## Solution

- Adds `@deprecated` replacement guidance to the public Select components, hooks, stores, overloads, renderer helpers, options, props, and types across the core and React packages.
- Covers the deprecation metadata in both reference-generation pipelines.
- Removes legacy Select value-component guidance while preserving the `select-legacy` sandbox.

For example, TypeScript now surfaces the replacement directly:

```ts
/** @deprecated Use `ComboboxSelect` instead. */
export const Select = forwardRef(/* ... */);
```

## Testing

- `pnpm lint-fix`
- `pnpm test app/src/lib/jsdoc-loader.test.ts website/build-pages/reference-utils.test.ts --run`
- `pnpm tsc`
- `pnpm build`
- `pnpm -F @ariakit/react-components build`
- `pnpm build-app-lite`
- `pnpm build-website-lite`