### PR TITLE
Clarify ComboboxPopover Escape reset semantics

### DIFF
--- a/packages/ariakit-react-components/src/combobox/combobox-popover.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-popover.tsx
@@ -372,8 +372,10 @@ export interface ComboboxPopoverOptions<T extends ElementType = TagName>
    * should be restored to the value it had before the first item movement when
    * the popover accepts Escape and the cancelable close event isn't prevented.
    * Selection changes made before any item movement become part of the value
-   * Escape restores. A descendant that handles Escape itself leaves the value
-   * alone. Defaults to the store's
+   * Escape restores.
+   *
+   * A descendant that handles Escape itself leaves the value alone. Defaults
+   * to the store's
    * [`selectOnMove`](https://ariakit.com/reference/combobox-provider#selectonmove)
    * value, since moving through items is what changes the selected value while
    * the popover is open. This has no effect when the combobox supports multiple

--- a/packages/ariakit-react-components/src/combobox/combobox-popover.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-popover.tsx
@@ -369,10 +369,11 @@ export interface ComboboxPopoverOptions<T extends ElementType = TagName>
   /**
    * Whether the combobox
    * [`selectedValue`](https://ariakit.com/reference/combobox-provider#selectedvalue)
-   * should be restored to the value it had before the popover was shown when
+   * should be restored to the value it had before the first item movement when
    * the popover accepts Escape and the cancelable close event isn't prevented.
-   * A descendant that handles Escape itself leaves the value alone. Defaults
-   * to the store's
+   * Selection changes made before any item movement become part of the value
+   * Escape restores. A descendant that handles Escape itself leaves the value
+   * alone. Defaults to the store's
    * [`selectOnMove`](https://ariakit.com/reference/combobox-provider#selectonmove)
    * value, since moving through items is what changes the selected value while
    * the popover is open. This has no effect when the combobox supports multiple


### PR DESCRIPTION
## Motivation

The `ComboboxPopover` `resetOnEscape` documentation says it restores `selectedValue` from before the popover was shown. The implementation instead tracks selection changes until the first item movement, so a direct selection made before movement becomes the value Escape restores.

This made the keep-open direct-click case discussed in #6852 and #6891 look inconsistent even though resetting item activation is outside the supported interaction contract.

## Solution

Clarify that `resetOnEscape` restores the value from before the first item movement and that earlier selection changes become part of the restoration baseline. Separate that baseline explanation from the Escape conditions and defaults in two paragraphs. Runtime behavior is unchanged.

## Preview

The generated `ComboboxPopover` reference now separates the movement-scoped baseline from the Escape conditions and defaults:

<img width="1280" height="720" alt="Rendered ComboboxPopover resetOnEscape reference split into two paragraphs" src="https://github.com/user-attachments/assets/9db3379a-6ced-4af7-89e0-477a0b600d1c" />

## Testing

- `pnpm lint-fix`
- `pnpm test app/src/lib/jsdoc-loader.test.ts`
- `pnpm test website/build-pages/reference-utils.test.ts`
- `pnpm build-app-lite`
- `pnpm build-website-lite`
