### PR TITLE
Prevent disabled Select values from submitting

### DIFF
--- a/.changeset/300-disabled-select-form-values.md
+++ b/.changeset/300-disabled-select-form-values.md
@@ -3,4 +3,4 @@
 "@ariakit/react": patch
 ---
 
-Fixed disabled [`Select`](https://ariakit.com/reference/select) and `ComboboxSelect` controls so their values are omitted from form submission when [`accessibleWhenDisabled`](https://ariakit.com/reference/focusable#accessiblewhendisabled) is used or the visible control is rendered with an element that doesn't support the native `disabled` attribute. Thanks to [@georgekaran](https://github.com/georgekaran).
+Fixed disabled [`Select`](https://ariakit.com/reference/select) and [`ComboboxSelect`](https://ariakit.com/reference/combobox-select) controls so their values are omitted from form submission when [`accessibleWhenDisabled`](https://ariakit.com/reference/focusable#accessiblewhendisabled) is used or the visible control is rendered with an element that doesn't support the native `disabled` attribute. Thanks to [@georgekaran](https://github.com/georgekaran).

--- a/.changeset/300-disabled-select-form-values.md
+++ b/.changeset/300-disabled-select-form-values.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed disabled [`Select`](https://ariakit.com/reference/select) and `ComboboxSelect` controls so their values are omitted from form submission when [`accessibleWhenDisabled`](https://ariakit.com/reference/focusable#accessiblewhendisabled) is used or the visible control is rendered with an element that doesn't support the native `disabled` attribute. Thanks to [@georgekaran](https://github.com/georgekaran).

--- a/app/src/sandbox/combobox-select-form-disabled/index.react.tsx
+++ b/app/src/sandbox/combobox-select-form-disabled/index.react.tsx
@@ -1,31 +1,101 @@
 import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
 
 export default function Example() {
+  const [renderedDisabled, setRenderedDisabled] = useState(false);
+  const [submittedNames, setSubmittedNames] = useState<string[] | null>(null);
+
   return (
-    <form
-      onSubmit={(event) => {
-        event.preventDefault();
-        const data = new FormData(event.currentTarget);
-        window.alert(data.get("select"));
-      }}
-    >
-      <Ariakit.ComboboxProvider defaultSelectedValue="Apple">
-        <Ariakit.ComboboxSelectLabel>
-          Favorite fruit
-        </Ariakit.ComboboxSelectLabel>
-        <Ariakit.ComboboxSelect
-          name="select"
-          disabled
-          className="pointer-events-none"
-        />
-        <Ariakit.ComboboxPopover gutter={4} sameWidth unmountOnHide>
-          <Ariakit.ComboboxItem value="Apple" />
-          <Ariakit.ComboboxItem value="Banana" />
-          <Ariakit.ComboboxItem value="Grape" />
-          <Ariakit.ComboboxItem value="Orange" />
-        </Ariakit.ComboboxPopover>
-      </Ariakit.ComboboxProvider>
-      <Ariakit.Button type="submit">Submit</Ariakit.Button>
-    </form>
+    <>
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          const data = new FormData(event.currentTarget);
+          window.alert(data.get("select"));
+        }}
+      >
+        <Ariakit.ComboboxProvider defaultSelectedValue="Apple">
+          <Ariakit.ComboboxSelectLabel>
+            Favorite fruit
+          </Ariakit.ComboboxSelectLabel>
+          <Ariakit.ComboboxSelect
+            name="select"
+            disabled
+            className="pointer-events-none"
+          />
+          <Ariakit.ComboboxPopover gutter={4} sameWidth unmountOnHide>
+            <Ariakit.ComboboxItem value="Apple" />
+            <Ariakit.ComboboxItem value="Banana" />
+            <Ariakit.ComboboxItem value="Grape" />
+            <Ariakit.ComboboxItem value="Orange" />
+          </Ariakit.ComboboxPopover>
+        </Ariakit.ComboboxProvider>
+        <Ariakit.Button type="submit">Submit</Ariakit.Button>
+      </form>
+
+      <form
+        aria-label="Transformed disabled selects"
+        onSubmit={(event) => {
+          event.preventDefault();
+          const data = new FormData(event.currentTarget);
+          setSubmittedNames([...data.keys()]);
+        }}
+      >
+        <Ariakit.SelectProvider defaultValue="Apple">
+          <Ariakit.SelectLabel>Select accessible</Ariakit.SelectLabel>
+          <Ariakit.Select
+            name="select-accessible"
+            disabled
+            accessibleWhenDisabled
+          />
+        </Ariakit.SelectProvider>
+
+        <Ariakit.ComboboxProvider defaultSelectedValue="Apple">
+          <Ariakit.ComboboxSelectLabel>
+            Combobox accessible
+          </Ariakit.ComboboxSelectLabel>
+          <Ariakit.ComboboxSelect
+            name="combobox-accessible"
+            disabled
+            accessibleWhenDisabled
+          />
+        </Ariakit.ComboboxProvider>
+
+        <Ariakit.SelectProvider defaultValue="Apple">
+          <Ariakit.SelectLabel>Select rendered</Ariakit.SelectLabel>
+          <Ariakit.Select
+            name="select-rendered"
+            disabled={renderedDisabled}
+            render={<div />}
+          />
+        </Ariakit.SelectProvider>
+
+        <Ariakit.ComboboxProvider defaultSelectedValue="Apple">
+          <Ariakit.ComboboxSelectLabel>
+            Combobox rendered
+          </Ariakit.ComboboxSelectLabel>
+          <Ariakit.ComboboxSelect
+            name="combobox-rendered"
+            disabled={renderedDisabled}
+            render={<div />}
+          />
+        </Ariakit.ComboboxProvider>
+
+        <label>
+          <input
+            type="checkbox"
+            checked={renderedDisabled}
+            onChange={(event) => setRenderedDisabled(event.target.checked)}
+          />
+          Disable rendered selects
+        </label>
+        <button type="submit">Submit transformed selects</button>
+        <output>
+          {submittedNames
+            ? submittedNames.join(", ") || "No values submitted"
+            : "Not submitted"}
+        </output>
+      </form>
+    </>
   );
 }

--- a/app/src/sandbox/combobox-select-form-disabled/index.react.tsx
+++ b/app/src/sandbox/combobox-select-form-disabled/index.react.tsx
@@ -2,7 +2,6 @@ import * as Ariakit from "@ariakit/react";
 import { useState } from "react";
 
 export default function Example() {
-  const accessibleDisabled = true;
   const [renderedDisabled, setRenderedDisabled] = useState(false);
   const [submittedNames, setSubmittedNames] = useState<string[] | null>(null);
 
@@ -45,8 +44,8 @@ export default function Example() {
         <Ariakit.SelectProvider defaultValue="Apple">
           <Ariakit.SelectLabel>Select accessible</Ariakit.SelectLabel>
           <Ariakit.Select
-            name={accessibleDisabled ? undefined : "select-accessible"}
-            disabled={accessibleDisabled}
+            name="select-accessible"
+            disabled
             accessibleWhenDisabled
           />
         </Ariakit.SelectProvider>
@@ -56,8 +55,8 @@ export default function Example() {
             Combobox accessible
           </Ariakit.ComboboxSelectLabel>
           <Ariakit.ComboboxSelect
-            name={accessibleDisabled ? undefined : "combobox-accessible"}
-            disabled={accessibleDisabled}
+            name="combobox-accessible"
+            disabled
             accessibleWhenDisabled
           />
         </Ariakit.ComboboxProvider>
@@ -65,7 +64,7 @@ export default function Example() {
         <Ariakit.SelectProvider defaultValue="Apple">
           <Ariakit.SelectLabel>Select rendered</Ariakit.SelectLabel>
           <Ariakit.Select
-            name={renderedDisabled ? undefined : "select-rendered"}
+            name="select-rendered"
             disabled={renderedDisabled}
             render={<div />}
           />
@@ -76,7 +75,7 @@ export default function Example() {
             Combobox rendered
           </Ariakit.ComboboxSelectLabel>
           <Ariakit.ComboboxSelect
-            name={renderedDisabled ? undefined : "combobox-rendered"}
+            name="combobox-rendered"
             disabled={renderedDisabled}
             render={<div />}
           />

--- a/app/src/sandbox/combobox-select-form-disabled/index.react.tsx
+++ b/app/src/sandbox/combobox-select-form-disabled/index.react.tsx
@@ -62,6 +62,18 @@ export default function Example() {
         </Ariakit.ComboboxProvider>
 
         <Ariakit.SelectProvider defaultValue="Apple">
+          <Ariakit.SelectLabel>Select aria disabled</Ariakit.SelectLabel>
+          <Ariakit.Select name="select-aria" aria-disabled />
+        </Ariakit.SelectProvider>
+
+        <Ariakit.ComboboxProvider defaultSelectedValue="Apple">
+          <Ariakit.ComboboxSelectLabel>
+            Combobox aria disabled
+          </Ariakit.ComboboxSelectLabel>
+          <Ariakit.ComboboxSelect name="combobox-aria" aria-disabled />
+        </Ariakit.ComboboxProvider>
+
+        <Ariakit.SelectProvider defaultValue="Apple">
           <Ariakit.SelectLabel>Select rendered</Ariakit.SelectLabel>
           <Ariakit.Select
             name="select-rendered"

--- a/app/src/sandbox/combobox-select-form-disabled/index.react.tsx
+++ b/app/src/sandbox/combobox-select-form-disabled/index.react.tsx
@@ -2,6 +2,7 @@ import * as Ariakit from "@ariakit/react";
 import { useState } from "react";
 
 export default function Example() {
+  const accessibleDisabled = true;
   const [renderedDisabled, setRenderedDisabled] = useState(false);
   const [submittedNames, setSubmittedNames] = useState<string[] | null>(null);
 
@@ -44,8 +45,8 @@ export default function Example() {
         <Ariakit.SelectProvider defaultValue="Apple">
           <Ariakit.SelectLabel>Select accessible</Ariakit.SelectLabel>
           <Ariakit.Select
-            name="select-accessible"
-            disabled
+            name={accessibleDisabled ? undefined : "select-accessible"}
+            disabled={accessibleDisabled}
             accessibleWhenDisabled
           />
         </Ariakit.SelectProvider>
@@ -55,8 +56,8 @@ export default function Example() {
             Combobox accessible
           </Ariakit.ComboboxSelectLabel>
           <Ariakit.ComboboxSelect
-            name="combobox-accessible"
-            disabled
+            name={accessibleDisabled ? undefined : "combobox-accessible"}
+            disabled={accessibleDisabled}
             accessibleWhenDisabled
           />
         </Ariakit.ComboboxProvider>
@@ -64,7 +65,7 @@ export default function Example() {
         <Ariakit.SelectProvider defaultValue="Apple">
           <Ariakit.SelectLabel>Select rendered</Ariakit.SelectLabel>
           <Ariakit.Select
-            name="select-rendered"
+            name={renderedDisabled ? undefined : "select-rendered"}
             disabled={renderedDisabled}
             render={<div />}
           />
@@ -75,7 +76,7 @@ export default function Example() {
             Combobox rendered
           </Ariakit.ComboboxSelectLabel>
           <Ariakit.ComboboxSelect
-            name="combobox-rendered"
+            name={renderedDisabled ? undefined : "combobox-rendered"}
             disabled={renderedDisabled}
             render={<div />}
           />

--- a/app/src/sandbox/combobox-select-form-disabled/test-browser.ts
+++ b/app/src/sandbox/combobox-select-form-disabled/test-browser.ts
@@ -11,6 +11,22 @@ withFramework(import.meta.dirname, async ({ test }) => {
   });
 
   // https://github.com/ariakit/ariakit/issues/6892
+  test("aria-disabled selects do not submit values", async ({ q }) => {
+    await test
+      .expect(q.combobox("Select aria disabled"))
+      .toHaveAttribute("aria-disabled", "true");
+    await test
+      .expect(q.combobox("Combobox aria disabled"))
+      .toHaveAttribute("aria-disabled", "true");
+
+    await q.button("Submit transformed selects").click();
+
+    await test
+      .expect(q.status())
+      .toHaveText("select-rendered, combobox-rendered");
+  });
+
+  // https://github.com/ariakit/ariakit/issues/6892
   test("rendered disabled selects do not submit values", async ({ q }) => {
     await q.checkbox("Disable rendered selects").click();
 

--- a/app/src/sandbox/combobox-select-form-disabled/test-browser.ts
+++ b/app/src/sandbox/combobox-select-form-disabled/test-browser.ts
@@ -1,0 +1,28 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/6892
+  test("accessible disabled selects do not submit values", async ({ q }) => {
+    await q.button("Submit transformed selects").click();
+
+    await test
+      .expect(q.status())
+      .toHaveText("select-rendered, combobox-rendered");
+  });
+
+  // https://github.com/ariakit/ariakit/issues/6892
+  test("rendered disabled selects do not submit values", async ({ q }) => {
+    await q.checkbox("Disable rendered selects").click();
+
+    await test
+      .expect(q.combobox("Select rendered"))
+      .toHaveAttribute("aria-disabled", "true");
+    await test
+      .expect(q.combobox("Combobox rendered"))
+      .toHaveAttribute("aria-disabled", "true");
+
+    await q.button("Submit transformed selects").click();
+
+    await test.expect(q.status()).toHaveText("No values submitted");
+  });
+});

--- a/app/src/sandbox/combobox-select-form-disabled/test.ts
+++ b/app/src/sandbox/combobox-select-form-disabled/test.ts
@@ -4,14 +4,14 @@ import { expect, test, vi } from "vitest";
 const spyOnAlert = () => vi.spyOn(window, "alert").mockImplementation(() => {});
 
 test("disabled select is visually and semantically disabled", () => {
-  const button = q.combobox();
+  const button = q.combobox("Favorite fruit");
   expect(button).toBeDisabled();
   expect(button).toHaveAttribute("aria-disabled", "true");
   expect(button).toHaveStyle("pointer-events: none");
 });
 
 test("disabled select cannot be opened with click", async () => {
-  await click(q.combobox());
+  await click(q.combobox("Favorite fruit"));
   expect(q.listbox()).not.toBeInTheDocument();
 });
 
@@ -30,4 +30,29 @@ test("disabled select does not submit value", async () => {
   await press.Tab();
   await press.Enter();
   expect(alert).toHaveBeenCalledWith(null);
+});
+
+// https://github.com/ariakit/ariakit/issues/6892
+test("accessible disabled selects do not submit values", async () => {
+  await click(q.button("Submit transformed selects"));
+
+  expect(q.status()).toHaveTextContent(/^select-rendered, combobox-rendered$/);
+});
+
+// https://github.com/ariakit/ariakit/issues/6892
+test("rendered disabled selects do not submit values", async () => {
+  await click(q.checkbox("Disable rendered selects"));
+
+  expect(q.combobox("Select rendered")).toHaveAttribute(
+    "aria-disabled",
+    "true",
+  );
+  expect(q.combobox("Combobox rendered")).toHaveAttribute(
+    "aria-disabled",
+    "true",
+  );
+
+  await click(q.button("Submit transformed selects"));
+
+  expect(q.status()).toHaveTextContent("No values submitted");
 });

--- a/app/src/sandbox/combobox-select-form-disabled/test.ts
+++ b/app/src/sandbox/combobox-select-form-disabled/test.ts
@@ -40,6 +40,22 @@ test("accessible disabled selects do not submit values", async () => {
 });
 
 // https://github.com/ariakit/ariakit/issues/6892
+test("aria-disabled selects do not submit values", async () => {
+  expect(q.combobox("Select aria disabled")).toHaveAttribute(
+    "aria-disabled",
+    "true",
+  );
+  expect(q.combobox("Combobox aria disabled")).toHaveAttribute(
+    "aria-disabled",
+    "true",
+  );
+
+  await click(q.button("Submit transformed selects"));
+
+  expect(q.status()).toHaveTextContent(/^select-rendered, combobox-rendered$/);
+});
+
+// https://github.com/ariakit/ariakit/issues/6892
 test("rendered disabled selects do not submit values", async () => {
   await click(q.checkbox("Disable rendered selects"));
 

--- a/packages/ariakit-react-components/src/combobox/combobox-select.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-select.tsx
@@ -112,6 +112,7 @@ export const useComboboxSelect = createHook<TagName, ComboboxSelectOptions>(
     );
 
     const onKeyDownProp = props.onKeyDown;
+    const disabledProp = props.disabled;
     const showOnKeyDownProp = useBooleanEvent(showOnKeyDown);
     const moveOnKeyDownProp = useBooleanEvent(moveOnKeyDown);
     const placement = useStoreState(store, "placement");
@@ -218,7 +219,7 @@ export const useComboboxSelect = createHook<TagName, ComboboxSelectOptions>(
               name={name}
               form={form}
               required={required}
-              disabled={props.disabled}
+              disabled={disabledProp}
               value={selectedValue}
               multiple={multiSelectable}
               // Although visually hidden and not tabbable, this element remains
@@ -264,7 +265,7 @@ export const useComboboxSelect = createHook<TagName, ComboboxSelectOptions>(
         selectedValue,
         multiSelectable,
         values,
-        props.disabled,
+        disabledProp,
       ],
     );
 

--- a/packages/ariakit-react-components/src/combobox/combobox-select.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-select.tsx
@@ -12,6 +12,7 @@ import {
 import type { Props } from "@ariakit/react-utils";
 import {
   toArray,
+  disabledFromProps,
   getActiveElement,
   getPopupRole,
   queueBeforeEvent,
@@ -112,7 +113,7 @@ export const useComboboxSelect = createHook<TagName, ComboboxSelectOptions>(
     );
 
     const onKeyDownProp = props.onKeyDown;
-    const disabledProp = props.disabled;
+    const disabledProp = disabledFromProps(props);
     const showOnKeyDownProp = useBooleanEvent(showOnKeyDown);
     const moveOnKeyDownProp = useBooleanEvent(moveOnKeyDown);
     const placement = useStoreState(store, "placement");

--- a/packages/ariakit-react-components/src/select/select.tsx
+++ b/packages/ariakit-react-components/src/select/select.tsx
@@ -12,6 +12,7 @@ import {
 import type { Props } from "@ariakit/react-utils";
 import {
   toArray,
+  disabledFromProps,
   getPopupRole,
   queueBeforeEvent,
   invariant,
@@ -103,7 +104,7 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
   );
 
   const onKeyDownProp = props.onKeyDown;
-  const disabledProp = props.disabled;
+  const disabledProp = disabledFromProps(props);
   const showOnKeyDownProp = useBooleanEvent(showOnKeyDown);
   const moveOnKeyDownProp = useBooleanEvent(moveOnKeyDown);
   const placement = useStoreState(store, "placement");

--- a/packages/ariakit-react-components/src/select/select.tsx
+++ b/packages/ariakit-react-components/src/select/select.tsx
@@ -103,6 +103,7 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
   );
 
   const onKeyDownProp = props.onKeyDown;
+  const disabledProp = props.disabled;
   const showOnKeyDownProp = useBooleanEvent(showOnKeyDown);
   const moveOnKeyDownProp = useBooleanEvent(moveOnKeyDown);
   const placement = useStoreState(store, "placement");
@@ -209,7 +210,7 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
             name={name}
             form={form}
             required={required}
-            disabled={props.disabled}
+            disabled={disabledProp}
             value={value}
             multiple={multiSelectable}
             // Even though this element is visually hidden and is not
@@ -257,7 +258,7 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
       value,
       multiSelectable,
       values,
-      props.disabled,
+      disabledProp,
     ],
   );
 


### PR DESCRIPTION
## Motivation

Disabled [`Select`](https://ariakit.com/reference/select) and `ComboboxSelect` controls can still contribute their hidden native select values to form submission when `accessibleWhenDisabled` is used or the visible control renders an element that does not support the native `disabled` attribute.

Fixes #6892.

## Solution

Resolve the consumer-provided disabled state before Ariakit transforms the visible element props in both `Select` and `ComboboxSelect`:

```tsx
const disabledProp = disabledFromProps(props);
```

This captures both `disabled` and `aria-disabled`. The hidden native select and its wrapper dependency array use that effective state, so the native form control remains disabled when `accessibleWhenDisabled` or a custom rendered element removes the native `disabled` prop from the visible control, without regressing the supported `aria-disabled` path.

Browser-first and happy-dom regressions cover both components through `accessibleWhenDisabled`, `aria-disabled`, and `render={<div />}` after the disabled state changes.

## Workaround

Omit `name` while the control is disabled so the hidden native select cannot participate in form submission:

```tsx
<Select
  // TODO: Remove this condition after https://github.com/ariakit/ariakit/issues/6892 is fixed.
  name={disabled ? undefined : "fruit"}
  disabled={disabled}
/>
```

Use the same conditional `name` with `ComboboxSelect`. This preserves the disabled and accessible behavior but temporarily removes the control from form submission only while disabled.

## Preview

Reproduction at [`e21ee71bf`](https://github.com/ariakit/ariakit/commit/e21ee71bf9b1efa2ce63358b0e71ddb40ef1322e) — after the two custom-rendered controls are toggled disabled, the four controls affected by the original bug still expose their names:

![Disabled Select and ComboboxSelect values still appear after form submission](https://github.com/user-attachments/assets/6635aaf0-1d5b-498e-a849-921a9a3701c1)

Workaround at [`bbe34b083`](https://github.com/ariakit/ariakit/commit/bbe34b083d7496cc7c8c3b3aa07210cdf4c5e089) — conditionally omitting `name` keeps those four disabled controls out of form submission:

![Disabled Select and ComboboxSelect workaround reports no submitted values](https://github.com/user-attachments/assets/0dc30fb3-3067-4571-9c86-6f1dc4aeade1)

Solution at [`ac02b7d77`](https://github.com/ariakit/ariakit/commit/ac02b7d7778f2e1f88e93387075a54512829823a) — the current fixture covers six disabled controls across `accessibleWhenDisabled`, `aria-disabled`, and custom rendering, and submits no values:

<img width="564" height="408" alt="Six disabled Select and ComboboxSelect controls report no submitted values" src="https://github.com/user-attachments/assets/802bef4e-f7f1-40bf-8dbf-952496654aa9" />

## Acknowledgments

Thanks to [@georgekaran](https://github.com/georgekaran) for diagnosing the transformed-props cause and providing the proof implementation and tests that informed this fix.
