### PR TITLE
Add Combobox input value APIs

### DIFF
--- a/.changeset/200-combobox-input-value.md
+++ b/.changeset/200-combobox-input-value.md
@@ -1,0 +1,18 @@
+---
+"@ariakit/components": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Combobox input value APIs
+
+Added the [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue), [`defaultInputValue`](https://ariakit.com/reference/combobox-provider#defaultinputvalue), and [`setInputValue`](https://ariakit.com/reference/combobox-provider#setinputvalue) props, the [`resetInputValue`](https://ariakit.com/reference/use-combobox-store#resetinputvalue) store method, and the [`ComboboxInputValue`](https://ariakit.com/reference/combobox-input-value) component. These APIs distinguish the text in the combobox input from its [`selectedValue`](https://ariakit.com/reference/combobox-provider#selectedvalue) state.
+
+```tsx
+<ComboboxProvider inputValue={query} setInputValue={setQuery}>
+  <Combobox />
+  <ComboboxInputValue>
+    {(inputValue) => `Current input: ${inputValue}`}
+  </ComboboxInputValue>
+</ComboboxProvider>
+```

--- a/.changeset/290-combobox-value.md
+++ b/.changeset/290-combobox-value.md
@@ -1,7 +1,0 @@
----
-"@ariakit/components": patch
-"@ariakit/react-components": patch
-"@ariakit/react": patch
----
-
-Deprecated the Combobox input [`value`](https://ariakit.com/reference/combobox-provider#value), [`defaultValue`](https://ariakit.com/reference/combobox-provider#defaultvalue), [`setValue`](https://ariakit.com/reference/combobox-provider#setvalue), and [`resetValue`](https://ariakit.com/reference/use-combobox-store#resetvalue) APIs and [`ComboboxValue`](https://ariakit.com/reference/combobox-value) in favor of [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue), [`defaultInputValue`](https://ariakit.com/reference/combobox-provider#defaultinputvalue), [`setInputValue`](https://ariakit.com/reference/combobox-provider#setinputvalue), [`resetInputValue`](https://ariakit.com/reference/use-combobox-store#resetinputvalue), and [`ComboboxInputValue`](https://ariakit.com/reference/combobox-input-value).

--- a/.changeset/290-combobox-value.md
+++ b/.changeset/290-combobox-value.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/components": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Deprecated the Combobox input [`value`](https://ariakit.com/reference/combobox-provider#value), [`defaultValue`](https://ariakit.com/reference/combobox-provider#defaultvalue), [`setValue`](https://ariakit.com/reference/combobox-provider#setvalue), and [`resetValue`](https://ariakit.com/reference/use-combobox-store#resetvalue) APIs and [`ComboboxValue`](https://ariakit.com/reference/combobox-value) in favor of [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue), [`defaultInputValue`](https://ariakit.com/reference/combobox-provider#defaultinputvalue), [`setInputValue`](https://ariakit.com/reference/combobox-provider#setinputvalue), [`resetInputValue`](https://ariakit.com/reference/use-combobox-store#resetinputvalue), and [`ComboboxInputValue`](https://ariakit.com/reference/combobox-input-value).

--- a/app/src/examples/combobox-group/combobox.react.tsx
+++ b/app/src/examples/combobox-group/combobox.react.tsx
@@ -10,7 +10,11 @@ export interface ComboboxProps extends Omit<ak.ComboboxProps, "onChange"> {
 export const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
   function Combobox({ value, onChange, children, ...props }, ref) {
     return (
-      <ak.ComboboxProvider value={value} setValue={onChange} placement="bottom">
+      <ak.ComboboxProvider
+        inputValue={value}
+        setInputValue={onChange}
+        placement="bottom"
+      >
         <ak.Combobox
           ref={ref}
           {...props}

--- a/app/src/lib/jsdoc-loader.test.ts
+++ b/app/src/lib/jsdoc-loader.test.ts
@@ -281,6 +281,7 @@ test("loads Combobox input value metadata", async () => {
   const value = getReference(entries, "react/combobox/combobox-value");
   getParamProp(value, "store");
   getParamProp(value, "children");
+  expect(value.description).toContain("Renders the current");
   expect(value.deprecated).toEqual(
     expect.stringContaining("ComboboxInputValue"),
   );

--- a/app/src/lib/jsdoc-loader.test.ts
+++ b/app/src/lib/jsdoc-loader.test.ts
@@ -246,6 +246,46 @@ test("loads Combobox Select prop metadata", async () => {
   }
 });
 
+test("loads Combobox input value metadata", async () => {
+  const { context, entries } = getLoaderContext();
+  const loader = jsdoc({
+    corePath: join(process.cwd(), "packages/ariakit-react-components"),
+    framework: "react",
+    packagePath: join(process.cwd(), "packages/ariakit-react"),
+  });
+
+  await loader.load(context);
+
+  const provider = getReference(entries, "react/combobox/combobox-provider");
+  getParamProp(provider, "inputValue");
+  getParamProp(provider, "defaultInputValue");
+  getParamProp(provider, "setInputValue");
+
+  const replacements = {
+    value: "inputValue",
+    defaultValue: "defaultInputValue",
+    setValue: "setInputValue",
+  };
+
+  for (const [name, replacement] of Object.entries(replacements)) {
+    const prop = getParamProp(provider, name);
+    expect(prop.deprecated).toEqual(expect.stringContaining(replacement));
+  }
+
+  const inputValue = getReference(
+    entries,
+    "react/combobox/combobox-input-value",
+  );
+  getParamProp(inputValue, "children");
+
+  const value = getReference(entries, "react/combobox/combobox-value");
+  getParamProp(value, "store");
+  getParamProp(value, "children");
+  expect(value.deprecated).toEqual(
+    expect.stringContaining("ComboboxInputValue"),
+  );
+});
+
 test("loads Select deprecation metadata", async () => {
   const { context, entries } = getLoaderContext();
   const loader = jsdoc({

--- a/app/src/sandbox/combobox-group-basic/combobox.react.tsx
+++ b/app/src/sandbox/combobox-group-basic/combobox.react.tsx
@@ -10,7 +10,7 @@ export interface ComboboxProps extends Omit<Ariakit.ComboboxProps, "onChange"> {
 export const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
   function Combobox({ value, onChange, children, ...props }, ref) {
     return (
-      <Ariakit.ComboboxProvider value={value} setValue={onChange}>
+      <Ariakit.ComboboxProvider inputValue={value} setInputValue={onChange}>
         <Ariakit.Combobox
           ref={ref}
           {...props}

--- a/app/src/sandbox/combobox-tabs/combobox.react.tsx
+++ b/app/src/sandbox/combobox-tabs/combobox.react.tsx
@@ -12,7 +12,7 @@ export interface ComboboxProviderProps extends Ariakit.ComboboxProviderProps {
   tabId?: Ariakit.TabProviderProps["selectedId"];
   setTabId?: (id: string) => void;
   defaultTabId?: Ariakit.TabProviderProps["defaultSelectedId"];
-  onSearch?: Ariakit.ComboboxProviderProps["setValue"];
+  onSearch?: Ariakit.ComboboxProviderProps["setInputValue"];
   onTabChange?: (id: string) => void;
 }
 
@@ -24,14 +24,16 @@ export function ComboboxProvider({
   onTabChange,
   ...props
 }: ComboboxProviderProps) {
+  const setInputValue = props.setInputValue ?? props.setValue;
   return (
     <Ariakit.ComboboxProvider
       {...props}
-      // If consumers want to control the state, they should use `setValue`. If
-      // a search operation is needed, `onSearch` should be used to ensure the
-      // input remains responsive to user input, thanks to startTransition.
-      setValue={(value) => {
-        props.setValue?.(value);
+      // If consumers want to control the state, they should use
+      // `setInputValue`. If a search operation is needed, `onSearch` should be
+      // used to ensure the input remains responsive to user input, thanks to
+      // startTransition.
+      setInputValue={(value) => {
+        setInputValue?.(value);
         React.startTransition(() => {
           onSearch?.(value);
         });

--- a/components/combobox.md
+++ b/components/combobox.md
@@ -56,7 +56,7 @@ useComboboxContext()
   </ComboboxSelect>
   <ComboboxCancel />
   <ComboboxDisclosure />
-  <ComboboxValue />
+  <ComboboxInputValue />
   <ComboboxList />
   <ComboboxPopover>
     <ComboboxInput />

--- a/examples/combobox-filtering-integrated/combobox.tsx
+++ b/examples/combobox-filtering-integrated/combobox.tsx
@@ -15,8 +15,8 @@ const ComboboxContext = React.createContext<{
 }>({});
 
 export interface ComboboxProps extends Omit<Ariakit.ComboboxProps, "onChange"> {
-  value?: Ariakit.ComboboxProviderProps["value"];
-  onChange?: Ariakit.ComboboxProviderProps["setValue"];
+  value?: Ariakit.ComboboxProviderProps["inputValue"];
+  onChange?: Ariakit.ComboboxProviderProps["setInputValue"];
   children?: React.ReactNode;
 }
 
@@ -24,8 +24,11 @@ export const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
   function Combobox({ value, onChange, children, ...props }, ref) {
     const [list, setList] = React.useState<string[]>([]);
 
-    const combobox = Ariakit.useComboboxStore({ value, setValue: onChange });
-    const searchValue = Ariakit.useStoreState(combobox, "value");
+    const combobox = Ariakit.useComboboxStore({
+      inputValue: value,
+      setInputValue: onChange,
+    });
+    const searchValue = Ariakit.useStoreState(combobox, "inputValue");
 
     // Use deferred value to avoid lag when typing.
     const deferredValue = React.useDeferredValue(searchValue);

--- a/examples/combobox-filtering-integrated/readme.md
+++ b/examples/combobox-filtering-integrated/readme.md
@@ -48,18 +48,21 @@ However, the filtering logic can't change the order of the items. That is, the f
 
 ## Exposing `value` and `onChange` props
 
-In this `Combobox` implementation, we're exposing custom `value` and `onChange` props so that the component can be used as a controlled input. This is done by passing the [`value`](/reference/use-combobox-store#value) and [`setValue`](/reference/use-combobox-store#setvalue) props to the lower-level [`useComboboxStore`](/reference/use-combobox-store) hook:
+In this `Combobox` implementation, we're exposing custom `value` and `onChange` props so that the component can be used as a controlled input. This is done by passing the [`inputValue`](/reference/use-combobox-store#inputvalue) and [`setInputValue`](/reference/use-combobox-store#setinputvalue) props to the lower-level [`useComboboxStore`](/reference/use-combobox-store) hook:
 
-```js "value"1 "setValue:"
+```js "inputValue:"1 "setInputValue:"
 function Combobox({ value, onChange }) {
-  const combobox = useComboboxStore({ value, setValue: onChange });
+  const combobox = useComboboxStore({
+    inputValue: value,
+    setInputValue: onChange,
+  });
 }
 ```
 
 We can use the custom [`useStoreState`](/reference/use-store-state) hook provided by Ariakit to access the current value, regardless if it's controlled or uncontrolled:
 
 ```js
-const searchValue = useStoreState(combobox, "value");
+const searchValue = useStoreState(combobox, "inputValue");
 ```
 
 You can learn more about these functions on the [Component stores](/guide/component-stores) guide.

--- a/examples/combobox-group/combobox.tsx
+++ b/examples/combobox-group/combobox.tsx
@@ -10,7 +10,7 @@ export interface ComboboxProps extends Omit<Ariakit.ComboboxProps, "onChange"> {
 export const Combobox = React.forwardRef<HTMLInputElement, ComboboxProps>(
   function Combobox({ value, onChange, children, ...props }, ref) {
     return (
-      <Ariakit.ComboboxProvider value={value} setValue={onChange}>
+      <Ariakit.ComboboxProvider inputValue={value} setInputValue={onChange}>
         <Ariakit.Combobox
           ref={ref}
           {...props}

--- a/examples/combobox-tabs/combobox.tsx
+++ b/examples/combobox-tabs/combobox.tsx
@@ -12,7 +12,7 @@ export interface ComboboxProviderProps extends Ariakit.ComboboxProviderProps {
   tabId?: Ariakit.TabProviderProps["selectedId"];
   setTabId?: (id: string) => void;
   defaultTabId?: Ariakit.TabProviderProps["defaultSelectedId"];
-  onSearch?: Ariakit.ComboboxProviderProps["setValue"];
+  onSearch?: Ariakit.ComboboxProviderProps["setInputValue"];
   onTabChange?: (id: string) => void;
 }
 
@@ -24,14 +24,16 @@ export function ComboboxProvider({
   onTabChange,
   ...props
 }: ComboboxProviderProps) {
+  const setInputValue = props.setInputValue ?? props.setValue;
   return (
     <Ariakit.ComboboxProvider
       {...props}
-      // If consumers want to control the state, they should use `setValue`. If
-      // a search operation is needed, `onSearch` should be used to ensure the
-      // input remains responsive to user input, thanks to startTransition.
-      setValue={(value) => {
-        props.setValue?.(value);
+      // If consumers want to control the state, they should use
+      // `setInputValue`. If a search operation is needed, `onSearch` should be
+      // used to ensure the input remains responsive to user input, thanks to
+      // startTransition.
+      setInputValue={(value) => {
+        setInputValue?.(value);
         React.startTransition(() => {
           onSearch?.(value);
         });

--- a/examples/combobox-textarea/index.react.tsx
+++ b/examples/combobox-textarea/index.react.tsx
@@ -19,7 +19,7 @@ export default function Example() {
 
   const combobox = Ariakit.useComboboxStore();
 
-  const searchValue = Ariakit.useStoreState(combobox, "value");
+  const searchValue = Ariakit.useStoreState(combobox, "inputValue");
   const deferredSearchValue = React.useDeferredValue(searchValue);
 
   const matches = React.useMemo(() => {
@@ -72,7 +72,7 @@ export default function Example() {
     // Sets our textarea value.
     setValue(event.target.value);
     // Sets the combobox value that will be used to search in the list.
-    combobox.setValue(searchValue);
+    combobox.setInputValue(searchValue);
   };
 
   const onItemClick = (value: string) => () => {

--- a/examples/dialog-combobox-command-menu/command-menu.tsx
+++ b/examples/dialog-combobox-command-menu/command-menu.tsx
@@ -11,7 +11,7 @@ import { forwardRef, startTransition } from "react";
 export interface CommandMenuProps extends Ariakit.DialogProps {
   open?: Ariakit.DialogStoreProps["open"];
   onOpenChange?: Ariakit.DialogStoreProps["setOpen"];
-  onSearch?: Ariakit.ComboboxProviderProps["setValue"];
+  onSearch?: Ariakit.ComboboxProviderProps["setInputValue"];
 }
 
 export const CommandMenu = forwardRef<HTMLDivElement, CommandMenuProps>(
@@ -31,7 +31,7 @@ export const CommandMenu = forwardRef<HTMLDivElement, CommandMenuProps>(
           focusLoop={false}
           includesBaseElement={false}
           resetValueOnHide
-          setValue={(value) => {
+          setInputValue={(value) => {
             startTransition(() => {
               onSearch?.(value);
             });

--- a/examples/dialog-combobox-tab-command-menu/command-menu.tsx
+++ b/examples/dialog-combobox-tab-command-menu/command-menu.tsx
@@ -25,7 +25,7 @@ export interface CommandMenuProps extends Ariakit.DialogProps {
   setTab?: (id: string) => void;
   defaultTab?: Ariakit.TabProviderProps["defaultSelectedId"];
   onTabChange?: (id: string) => void;
-  onSearch?: Ariakit.ComboboxProviderProps["setValue"];
+  onSearch?: Ariakit.ComboboxProviderProps["setInputValue"];
 }
 
 export const CommandMenu = forwardRef<HTMLDivElement, CommandMenuProps>(
@@ -52,7 +52,7 @@ export const CommandMenu = forwardRef<HTMLDivElement, CommandMenuProps>(
           focusShift
           focusWrap="horizontal"
           resetValueOnHide
-          setValue={(value) => {
+          setInputValue={(value) => {
             startTransition(() => {
               onSearch?.(value);
             });

--- a/guide/500-value-components/readme.md
+++ b/guide/500-value-components/readme.md
@@ -25,7 +25,7 @@ A value component reads one specific value from a provider, an explicit store, o
 - exposes the value directly or through a `children` render function
 - does not accept HTML props such as `className`, `style`, or `ref`, because it has no element to receive them
 
-The stable public value components are [`ComboboxValue`](/reference/combobox-value), [`ComboboxSelectedValue`](/reference/combobox-selected-value), and [`ComboboxItemSelected`](/reference/combobox-item-selected), all exported from `@ariakit/react`.
+The stable public value components are [`ComboboxInputValue`](/reference/combobox-input-value), [`ComboboxSelectedValue`](/reference/combobox-selected-value), and [`ComboboxItemSelected`](/reference/combobox-item-selected), all exported from `@ariakit/react`.
 
 This pattern is not inherently uncontrolled. Value components work with both controlled and uncontrolled providers and stores. Their main benefit is exposing state close to the JSX that needs it, without creating or passing a store solely for that purpose.
 
@@ -55,9 +55,9 @@ Pass a function as `children` to transform the value before rendering it. The fu
 ```jsx {3-5}
 <ComboboxProvider>
   <Combobox />
-  <ComboboxValue>
+  <ComboboxInputValue>
     {(value) => <output>Current value: {value || "empty"}</output>}
-  </ComboboxValue>
+  </ComboboxInputValue>
 </ComboboxProvider>
 ```
 

--- a/packages/ariakit-components/src/combobox/combobox-store.test.ts
+++ b/packages/ariakit-components/src/combobox/combobox-store.test.ts
@@ -2,6 +2,89 @@ import { createStore, init } from "@ariakit/store";
 import { expect, test } from "vitest";
 import { createComboboxStore } from "./combobox-store.ts";
 
+test("throws on cross-alias defaults with connected stores", () => {
+  const legacySource = createStore({ value: "Apple" });
+  expect(() =>
+    createComboboxStore({
+      store: legacySource,
+      defaultInputValue: "Banana",
+    }),
+  ).toThrow("Passing a store prop in conjunction with a default state");
+
+  const source = createStore({ inputValue: "Apple" });
+  expect(() =>
+    createComboboxStore({
+      store: source,
+      defaultValue: "Banana",
+    }),
+  ).toThrow("Passing a store prop in conjunction with a default state");
+});
+
+test("supports input value aliases", () => {
+  const store = createComboboxStore({
+    inputValue: "Apple",
+    value: "Deprecated",
+  });
+  const stop = init(store);
+
+  expect(store.getState().inputValue).toBe("Apple");
+  expect(store.getState().value).toBe("Apple");
+
+  store.setInputValue("Banana");
+  expect(store.getState().inputValue).toBe("Banana");
+  expect(store.getState().value).toBe("Banana");
+
+  store.setValue("Orange");
+  expect(store.getState().inputValue).toBe("Orange");
+  expect(store.getState().value).toBe("Orange");
+
+  store.setState("inputValue", "Grape");
+  expect(store.getState().inputValue).toBe("Grape");
+  expect(store.getState().value).toBe("Grape");
+
+  store.setState("value", "Strawberry");
+  expect(store.getState().inputValue).toBe("Strawberry");
+  expect(store.getState().value).toBe("Strawberry");
+
+  store.resetInputValue();
+  expect(store.getState().inputValue).toBe("Apple");
+  expect(store.getState().value).toBe("Apple");
+
+  store.setInputValue("Watermelon");
+  store.resetValue();
+  expect(store.getState().inputValue).toBe("Apple");
+  expect(store.getState().value).toBe("Apple");
+  stop();
+});
+
+test("syncs input value aliases with connected stores", () => {
+  const legacySource = createStore({ value: "Apple" });
+  const legacyStore = createComboboxStore({ store: legacySource });
+  const stopLegacyStore = init(legacyStore);
+
+  expect(legacyStore.getState().inputValue).toBe("Apple");
+
+  legacySource.setState("value", "Banana");
+  expect(legacyStore.getState().inputValue).toBe("Banana");
+
+  legacyStore.setInputValue("Orange");
+  expect(legacySource.getState().value).toBe("Orange");
+  stopLegacyStore();
+
+  const source = createStore({ inputValue: "Grape" });
+  const store = createComboboxStore({ store: source });
+  const stopStore = init(store);
+
+  expect(store.getState().value).toBe("Grape");
+
+  source.setState("inputValue", "Strawberry");
+  expect(store.getState().value).toBe("Strawberry");
+
+  store.setValue("Watermelon");
+  expect(source.getState().inputValue).toBe("Watermelon");
+  stopStore();
+});
+
 test("syncs the combobox element with the anchor element", () => {
   const store = createComboboxStore();
   const stop = init(store);

--- a/packages/ariakit-components/src/combobox/combobox-store.ts
+++ b/packages/ariakit-components/src/combobox/combobox-store.ts
@@ -50,8 +50,15 @@ export function createComboboxStore({
   ...props
 }: ComboboxStoreProps = {}): ComboboxStore {
   const store = mergeStore(props.store, pick(tag, ["value", "rtl"]));
+  const defaultInputValue = defaultValue(
+    props.defaultInputValue,
+    props.defaultValue,
+  );
 
-  throwOnConflictingProps(props, store);
+  throwOnConflictingProps(
+    { ...props, defaultInputValue, defaultValue: defaultInputValue },
+    store,
+  );
 
   const tagState = tag?.getState();
   const syncState = store?.getState();
@@ -94,10 +101,12 @@ export function createComboboxStore({
     ),
   });
 
-  const value = defaultValue(
+  const inputValue = defaultValue(
+    props.inputValue,
     props.value,
+    syncState?.inputValue,
     syncState?.value,
-    props.defaultValue,
+    defaultInputValue,
     "",
   );
 
@@ -120,7 +129,8 @@ export function createComboboxStore({
   const initialState: ComboboxStoreState = {
     ...composite.getState(),
     ...popover.getState(),
-    value,
+    inputValue,
+    value: inputValue,
     selectedValue,
     resetValueOnSelect: defaultValue(
       props.resetValueOnSelect,
@@ -145,6 +155,16 @@ export function createComboboxStore({
   };
 
   const combobox = createStore(initialState, composite, popover, store);
+  setup(combobox, () =>
+    chain(
+      sync(combobox, ["inputValue"], (state) => {
+        combobox.setState("value", state.inputValue);
+      }),
+      sync(combobox, ["value"], (state) => {
+        combobox.setState("inputValue", state.value);
+      }),
+    ),
+  );
   let resolveSelectedItemOnOpen = false;
   const selectDefaultOptions = new Set<keyof ComboboxStoreState>();
   if (props.focusLoop === undefined && syncState?.focusLoop === undefined) {
@@ -325,7 +345,7 @@ export function createComboboxStore({
     sync(combobox, ["resetValueOnHide", "mounted"], (state) => {
       if (!state.resetValueOnHide) return;
       if (state.mounted) return;
-      combobox.setState("value", value);
+      combobox.setState("inputValue", inputValue);
     }),
   );
 
@@ -414,7 +434,23 @@ export function createComboboxStore({
     }),
   );
 
+  const setInputValue: ComboboxStore["setInputValue"] = (value) => {
+    combobox.setState("inputValue", value);
+    combobox.setState("value", combobox.getState().inputValue);
+  };
+
+  const resetInputValue = () => setInputValue(initialState.inputValue);
+
   const setState: ComboboxStore["setState"] = (key, value) => {
+    if (key === "inputValue" || key === "value") {
+      combobox.setState(key, value);
+      if (key === "inputValue") {
+        combobox.setState("value", combobox.getState().inputValue);
+      } else {
+        combobox.setState("inputValue", combobox.getState().value);
+      }
+      return;
+    }
     selectDefaultOptions.delete(key);
     if (key === "selectedValue") {
       shouldSetDefaultSelectedValue = false;
@@ -428,8 +464,10 @@ export function createComboboxStore({
     ...combobox,
     setState,
     tag,
-    setValue: (value) => combobox.setState("value", value),
-    resetValue: () => combobox.setState("value", initialState.value),
+    setInputValue,
+    resetInputValue,
+    setValue: setInputValue,
+    resetValue: resetInputValue,
     setSelectedValue: (selectedValue) =>
       setState("selectedValue", selectedValue),
     setInputElement: (element) => combobox.setState("inputElement", element),
@@ -486,6 +524,13 @@ export interface ComboboxStoreState<
    *   Combobox](https://ariakit.com/examples/combobox-textarea)
    * - [Command Menu with
    *   Tabs](https://ariakit.com/examples/dialog-combobox-tab-command-menu)
+   */
+  inputValue: string;
+  /**
+   * The combobox input value.
+   * @deprecated Use
+   * [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue)
+   * instead.
    */
   value: string;
   /**
@@ -595,20 +640,39 @@ export interface ComboboxStoreFunctions<
     CompositeStoreFunctions<ComboboxStoreItem>,
     PopoverStoreFunctions {
   /**
-   * Sets the [`value`](https://ariakit.com/reference/combobox-provider#value)
+   * Sets the
+   * [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue)
    * state.
    *
    * Live examples:
    * - [Textarea with inline
    *   Combobox](https://ariakit.com/examples/combobox-textarea)
    * @example
-   * store.setValue("Hello world");
-   * store.setValue((value) => value + "!");
+   * store.setInputValue("Hello world");
+   * store.setInputValue((value) => value + "!");
+   */
+  setInputValue: SetState<ComboboxStoreState<T>["inputValue"]>;
+  /**
+   * Resets the
+   * [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue)
+   * state to its initial value.
+   */
+  resetInputValue: () => void;
+  /**
+   * Sets the
+   * [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue)
+   * state.
+   * @deprecated Use [`setInputValue`](https://ariakit.com/reference/combobox-provider#setinputvalue)
+   * instead.
    */
   setValue: SetState<ComboboxStoreState<T>["value"]>;
   /**
-   * Resets the [`value`](https://ariakit.com/reference/combobox-provider#value)
+   * Resets the
+   * [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue)
    * state to its initial value.
+   * @deprecated Use
+   * [`resetInputValue`](https://ariakit.com/reference/use-combobox-store#resetinputvalue)
+   * instead.
    */
   resetValue: () => void;
   /**
@@ -646,6 +710,7 @@ export interface ComboboxStoreOptions<
       | "focusWrap"
       | "orientation"
       | "virtualFocus"
+      | "inputValue"
       | "value"
       | "selectedValue"
       | "selectOnMove"
@@ -658,6 +723,14 @@ export interface ComboboxStoreOptions<
   defaultActiveId?: CompositeStoreOptions<ComboboxStoreItem>["activeId"];
   /**
    * The initial value of the combobox input.
+   * @default ""
+   */
+  defaultInputValue?: ComboboxStoreState<T>["inputValue"];
+  /**
+   * The initial value of the combobox input.
+   * @deprecated Use
+   * [`defaultInputValue`](https://ariakit.com/reference/combobox-provider#defaultinputvalue)
+   * instead.
    * @default ""
    */
   defaultValue?: ComboboxStoreState<T>["value"];

--- a/packages/ariakit-react-components/package.json
+++ b/packages/ariakit-react-components/package.json
@@ -69,6 +69,7 @@
     "./combobox/combobox-group-label": "./src/combobox/combobox-group-label.tsx",
     "./combobox/combobox-heading": "./src/combobox/combobox-heading.tsx",
     "./combobox/combobox-input": "./src/combobox/combobox-input.tsx",
+    "./combobox/combobox-input-value": "./src/combobox/combobox-input-value.tsx",
     "./combobox/combobox-item": "./src/combobox/combobox-item.tsx",
     "./combobox/combobox-item-check": "./src/combobox/combobox-item-check.tsx",
     "./combobox/combobox-item-offscreen": "./src/combobox/combobox-item-offscreen.tsx",

--- a/packages/ariakit-react-components/src/combobox/combobox-cancel.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-cancel.tsx
@@ -68,9 +68,9 @@ export const useComboboxCancel = createHook<TagName, ComboboxCancelOptions>(
     const onClick = useEvent((event: MouseEvent<HTMLType>) => {
       onClickProp?.(event);
       if (event.defaultPrevented) return;
-      store?.setValue("");
       // Move focus to the combobox input.
       store?.move(null);
+      store?.setInputValue("");
     });
 
     const baseElement = useStoreState(store, "baseElement");
@@ -78,8 +78,8 @@ export const useComboboxCancel = createHook<TagName, ComboboxCancelOptions>(
     const comboboxId = baseElement?.id;
     const empty = useStoreState(
       store,
-      ["value"],
-      (state) => state.value === "",
+      ["inputValue"],
+      (state) => state.inputValue === "",
     );
 
     props = useWrapElement(

--- a/packages/ariakit-react-components/src/combobox/combobox-input-value.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-input-value.tsx
@@ -1,0 +1,68 @@
+import { useStoreState } from "@ariakit/react-store";
+import { invariant } from "@ariakit/utils";
+import type { ReactNode } from "react";
+import { useComboboxContext } from "./combobox-context.tsx";
+import type { ComboboxStore, ComboboxStoreState } from "./combobox-store.ts";
+
+/**
+ * Renders the current
+ * [`inputValue`](https://ariakit.com/reference/use-combobox-store#inputvalue)
+ * state in the
+ * [combobox store](https://ariakit.com/reference/use-combobox-store).
+ *
+ * As a value component, it doesn't render any DOM elements and therefore
+ * doesn't accept HTML props.
+ *
+ * It takes a
+ * [`children`](https://ariakit.com/reference/combobox-input-value#children)
+ * function that gets called with the current input value as an argument. This
+ * can be used as an uncontrolled API to render the combobox input value in a
+ * custom way.
+ * @see https://ariakit.com/components/combobox
+ * @example
+ * ```jsx {3-5}
+ * <ComboboxProvider>
+ *   <Combobox />
+ *   <ComboboxInputValue>
+ *     {(value) => `Current input value: ${value}`}
+ *   </ComboboxInputValue>
+ * </ComboboxProvider>
+ * ```
+ */
+export function ComboboxInputValue({
+  store,
+  children,
+}: ComboboxInputValueProps = {}) {
+  const context = useComboboxContext();
+  store = store || context;
+
+  invariant(
+    store,
+    process.env.NODE_ENV !== "production" &&
+      "ComboboxInputValue must receive a `store` prop or be wrapped in a ComboboxProvider component.",
+  );
+
+  const inputValue = useStoreState(store, "inputValue");
+
+  if (children) {
+    return children(inputValue);
+  }
+
+  return inputValue;
+}
+
+export interface ComboboxInputValueProps {
+  /**
+   * Object returned by the
+   * [`useComboboxStore`](https://ariakit.com/reference/use-combobox-store)
+   * hook. If not provided, the closest
+   * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)
+   * component's context will be used.
+   */
+  store?: ComboboxStore;
+  /**
+   * A function that gets called with the current input value as an argument. It
+   * can be used to render the combobox input value in a custom way.
+   */
+  children?: (value: ComboboxStoreState["inputValue"]) => ReactNode;
+}

--- a/packages/ariakit-react-components/src/combobox/combobox-item-value.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item-value.tsx
@@ -181,7 +181,7 @@ function splitValue(itemValue?: string | null, userValue?: string | string[]) {
  * @see https://ariakit.com/components/combobox
  * @example
  * ```jsx
- * const store = useComboboxStore({ value: "p" });
+ * const store = useComboboxStore({ inputValue: "p" });
  * const props = useComboboxItemValue({ store, value: "Apple" });
  * <Role {...props} />
  * // This will result in the following DOM:
@@ -205,8 +205,8 @@ export const useComboboxItemValue = createHook<
 
   const inputValue = useStoreState(
     store,
-    ["value"],
-    (state) => userValue ?? state?.value,
+    ["inputValue"],
+    (state) => userValue ?? state?.inputValue,
   );
 
   const children = useMemo(() => {
@@ -236,15 +236,15 @@ export const useComboboxItemValue = createHook<
  * [`ComboboxItem`](https://ariakit.com/reference/combobox-item) component's
  * [`value`](https://ariakit.com/reference/combobox-item#value) prop. The user
  * input value is automatically set to the combobox store's
- * [`value`](https://ariakit.com/reference/use-combobox-store#value) state. Both
- * values can be overridden by providing the
+ * [`inputValue`](https://ariakit.com/reference/use-combobox-store#inputvalue)
+ * state. Both values can be overridden by providing the
  * [`value`](https://ariakit.com/reference/combobox-item-value#value) and
  * [`userValue`](https://ariakit.com/reference/combobox-item-value#uservalue)
  * props, respectively.
  * @see https://ariakit.com/components/combobox
  * @example
  * ```jsx {5} "value"
- * <ComboboxProvider value="p">
+ * <ComboboxProvider inputValue="p">
  *   <Combobox />
  *   <ComboboxPopover>
  *     <ComboboxItem value="Apple">
@@ -293,8 +293,8 @@ export interface ComboboxItemValueOptions<
   value?: string;
   /**
    * The current user input value. If not provided, the combobox store's
-   * [`value`](https://ariakit.com/reference/use-combobox-store#value) state
-   * will be used.
+   * [`inputValue`](https://ariakit.com/reference/use-combobox-store#inputvalue)
+   * state will be used.
    *
    * This is the value used to highlight the matching portions of the item
    * value. It can be customized to highlight different portions.

--- a/packages/ariakit-react-components/src/combobox/combobox-item.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item.tsx
@@ -160,7 +160,7 @@ export const useComboboxItem = createHook<TagName, ComboboxItemOptions>(
       if (value != null) {
         if (selectValueOnClickProp(event)) {
           if (resetValueOnSelectProp(event)) {
-            store?.resetValue();
+            store?.resetInputValue();
           }
           store?.setSelectedValue((prevValue) => {
             if (!Array.isArray(prevValue)) return value;
@@ -171,7 +171,7 @@ export const useComboboxItem = createHook<TagName, ComboboxItemOptions>(
           });
         }
         if (setValueOnClickProp(event)) {
-          store?.setValue(value);
+          store?.setInputValue(value);
         }
       }
       if (hideOnClickProp(event)) {
@@ -205,7 +205,7 @@ export const useComboboxItem = createHook<TagName, ComboboxItemOptions>(
         if (baseElement === selectElement) return;
         if (isTextField(baseElement)) {
           queueMicrotask(() => baseElement.focus());
-          store?.setValue(baseElement.value);
+          store?.setInputValue(baseElement.value);
           return;
         }
         baseElement.focus();
@@ -214,7 +214,7 @@ export const useComboboxItem = createHook<TagName, ComboboxItemOptions>(
           // necessary because the value may temporarily change based on the
           // currently selected item, but it'll be reset to the original value
           // when the combobox input is focused.
-          store?.setValue(baseElement.value);
+          store?.setInputValue(baseElement.value);
         }
       }
     });
@@ -380,8 +380,8 @@ export interface ComboboxItemOptions<T extends ElementType = TagName>
   hideOnClick?: BooleanOrCallback<MouseEvent<HTMLElement>>;
   /**
    * Whether to set the combobox
-   * [`value`](https://ariakit.com/reference/combobox-provider#value) state
-   * using this item's
+   * [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue)
+   * state using this item's
    * [`value`](https://ariakit.com/reference/combobox-item#value) when the item
    * is clicked. The default is `true`, unless
    * [`ComboboxSelect`](https://ariakit.com/reference/combobox-select) is

--- a/packages/ariakit-react-components/src/combobox/combobox-provider.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-provider.tsx
@@ -15,7 +15,7 @@ type Value = ComboboxStoreSelectedValue;
  * @see https://ariakit.com/components/combobox
  * @example
  * ```jsx
- * <ComboboxProvider defaultValue="">
+ * <ComboboxProvider defaultInputValue="">
  *   <Combobox />
  *   <ComboboxPopover>
  *     <ComboboxItem value="Apple" />

--- a/packages/ariakit-react-components/src/combobox/combobox-store.ts
+++ b/packages/ariakit-react-components/src/combobox/combobox-store.ts
@@ -39,7 +39,11 @@ export function useComboboxStoreProps<T extends Core.ComboboxStore>(
 ) {
   useUpdateEffect(update, [props.tag]);
 
-  useStoreProps(store, props, "value", "setValue");
+  const inputValueProps = {
+    inputValue: props.inputValue ?? props.value,
+    setInputValue: props.setInputValue ?? props.setValue,
+  };
+  useStoreProps(store, inputValueProps, "inputValue", "setInputValue");
   useStoreProps(store, props, "selectedValue", "setSelectedValue");
   useStoreProps(store, props, "selectOnMove");
   useStoreProps(store, props, "resetValueOnHide");
@@ -122,8 +126,8 @@ export interface ComboboxStoreOptions<
     PopoverStoreOptions {
   /**
    * A callback that gets called when the
-   * [`value`](https://ariakit.com/reference/combobox-provider#value) state
-   * changes.
+   * [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue)
+   * state changes.
    *
    * Live examples:
    * - [Combobox with integrated
@@ -134,6 +138,15 @@ export interface ComboboxStoreOptions<
    *   Combobox](https://ariakit.com/examples/combobox-multiple)
    * - [Menu with Combobox](https://ariakit.com/examples/menu-combobox)
    * - [Select with Combobox](https://ariakit.com/examples/select-combobox)
+   */
+  setInputValue?: (value: ComboboxStoreState<T>["inputValue"]) => void;
+  /**
+   * A callback that gets called when the
+   * [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue)
+   * state changes.
+   * @deprecated Use
+   * [`setInputValue`](https://ariakit.com/reference/combobox-provider#setinputvalue)
+   * instead.
    */
   setValue?: (value: ComboboxStoreState<T>["value"]) => void;
   /**

--- a/packages/ariakit-react-components/src/combobox/combobox-value.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-value.tsx
@@ -1,63 +1,18 @@
-import { useStoreState } from "@ariakit/react-store";
-import { invariant } from "@ariakit/utils";
-import type { ReactNode } from "react";
-import { useComboboxContext } from "./combobox-context.tsx";
-import type { ComboboxStore, ComboboxStoreState } from "./combobox-store.ts";
+import type { ComboboxInputValueProps } from "./combobox-input-value.tsx";
+import { ComboboxInputValue } from "./combobox-input-value.tsx";
 
 /**
- * Renders the current
- * [`value`](https://ariakit.com/reference/use-combobox-store#value) state in
- * the [combobox store](https://ariakit.com/reference/use-combobox-store).
- *
- * As a value component, it doesn't render any DOM elements and therefore
- * doesn't accept HTML props.
- *
- * It takes a
- * [`children`](https://ariakit.com/reference/combobox-value#children) function
- * that gets called with the current value as an argument. This can be used as
- * an uncontrolled API to render the combobox value in a custom way.
- * @see https://ariakit.com/components/combobox
- * @example
- * ```jsx {3-5}
- * <ComboboxProvider>
- *   <Combobox />
- *   <ComboboxValue>
- *     {(value) => `Current value: ${value}`}
- *   </ComboboxValue>
- * </ComboboxProvider>
- * ```
+ * @deprecated Use
+ * [`ComboboxInputValue`](https://ariakit.com/reference/combobox-input-value)
+ * instead.
  */
-export function ComboboxValue({ store, children }: ComboboxValueProps = {}) {
-  const context = useComboboxContext();
-  store = store || context;
-
-  invariant(
-    store,
-    process.env.NODE_ENV !== "production" &&
-      "ComboboxValue must receive a `store` prop or be wrapped in a ComboboxProvider component.",
-  );
-
-  const value = useStoreState(store, "value");
-
-  if (children) {
-    return children(value);
-  }
-
-  return value;
+export function ComboboxValue(props: ComboboxValueProps = {}) {
+  return <ComboboxInputValue {...props} />;
 }
 
-export interface ComboboxValueProps {
-  /**
-   * Object returned by the
-   * [`useComboboxStore`](https://ariakit.com/reference/use-combobox-store)
-   * hook. If not provided, the closest
-   * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)
-   * component's context will be used.
-   */
-  store?: ComboboxStore;
-  /**
-   * A function that gets called with the current value as an argument. It can
-   * be used to render the combobox value in a custom way.
-   */
-  children?: (value: ComboboxStoreState["value"]) => ReactNode;
-}
+/**
+ * @deprecated Use
+ * [`ComboboxInputValueProps`](https://ariakit.com/reference/combobox-input-value)
+ * instead.
+ */
+export interface ComboboxValueProps extends ComboboxInputValueProps {}

--- a/packages/ariakit-react-components/src/combobox/combobox-value.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-value.tsx
@@ -2,9 +2,30 @@ import type { ComboboxInputValueProps } from "./combobox-input-value.tsx";
 import { ComboboxInputValue } from "./combobox-input-value.tsx";
 
 /**
+ * Renders the current
+ * [`value`](https://ariakit.com/reference/use-combobox-store#value) state in
+ * the [combobox store](https://ariakit.com/reference/use-combobox-store).
+ *
+ * As a value component, it doesn't render any DOM elements and therefore
+ * doesn't accept HTML props.
+ *
+ * It takes a
+ * [`children`](https://ariakit.com/reference/combobox-value#children) function
+ * that gets called with the current value as an argument. This can be used as
+ * an uncontrolled API to render the combobox value in a custom way.
  * @deprecated Use
  * [`ComboboxInputValue`](https://ariakit.com/reference/combobox-input-value)
  * instead.
+ * @see https://ariakit.com/components/combobox
+ * @example
+ * ```jsx {3-5}
+ * <ComboboxProvider>
+ *   <Combobox />
+ *   <ComboboxValue>
+ *     {(value) => `Current value: ${value}`}
+ *   </ComboboxValue>
+ * </ComboboxProvider>
+ * ```
  */
 export function ComboboxValue(props: ComboboxValueProps = {}) {
   return <ComboboxInputValue {...props} />;

--- a/packages/ariakit-react-components/src/combobox/combobox.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox.tsx
@@ -237,7 +237,7 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
     // the active item value or a combination of the input value and the active
     // item value if it's the first item and it's been auto selected. This will
     // only affect the element's value, not the combobox state.
-    const value = useMemo(() => {
+    const inputValue = useMemo(() => {
       if (!inline) return storeInputValue;
       if (!canInline) return storeInputValue;
       const firstItemAutoSelected = isFirstItemAutoSelected(
@@ -527,7 +527,7 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       );
       const onBlur = (event: FocusEvent) => {
         if (elements.every((el) => isFocusEventOutside(event, el))) {
-          store?.setInputValue(value);
+          store?.setInputValue(inputValue);
         }
       };
       for (const element of elements) {
@@ -538,7 +538,7 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
           element.removeEventListener("focusout", onBlur);
         }
       };
-    }, [inline, contentElement, store, value]);
+    }, [inline, contentElement, store, inputValue]);
 
     const canShow = (event: SyntheticEvent) => {
       const currentTarget = event.currentTarget as HTMLType;
@@ -653,7 +653,7 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
         store.setActiveId(null);
       }
       if (setValueOnClickProp(event)) {
-        store.setInputValue(value);
+        store.setInputValue(inputValue);
       }
       if (showOnClickProp(event)) {
         queueBeforeEvent(event.currentTarget, "mouseup", store.show);
@@ -769,7 +769,7 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       "aria-expanded": open,
       "aria-controls": contentElement?.id,
       "data-active-item": isActiveItem || undefined,
-      value,
+      value: inputValue,
       ...props,
       id,
       name: multiSelectable ? undefined : name,

--- a/packages/ariakit-react-components/src/combobox/combobox.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox.tsx
@@ -186,7 +186,7 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       setCanInline(true);
     }, [inline]);
 
-    const storeValue = useStoreState(store, "value");
+    const storeInputValue = useStoreState(store, "inputValue");
     const selectedValue = useStoreState(store, ["selectedValue"], (state) => {
       if (!name) return;
       if (!Array.isArray(state.selectedValue)) return;
@@ -232,14 +232,14 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
     const open = useStoreState(store, "open");
     const contentElement = useStoreState(store, "contentElement");
 
-    // The current input value may differ from state.value when
+    // The current input value may differ from state.inputValue when
     // autoComplete is either "both" or "inline", in which case it will be
     // the active item value or a combination of the input value and the active
     // item value if it's the first item and it's been auto selected. This will
     // only affect the element's value, not the combobox state.
     const value = useMemo(() => {
-      if (!inline) return storeValue;
-      if (!canInline) return storeValue;
+      if (!inline) return storeInputValue;
+      if (!canInline) return storeInputValue;
       const firstItemAutoSelected = isFirstItemAutoSelected(
         items,
         inlineActiveValue,
@@ -249,14 +249,21 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
         // If the first item is auto selected, we should append the completion
         // string to the end of the value. This will be highlited in the effect
         // below.
-        if (hasCompletionString(storeValue, inlineActiveValue)) {
-          const slice = inlineActiveValue?.slice(storeValue.length) || "";
-          return storeValue + slice;
+        if (hasCompletionString(storeInputValue, inlineActiveValue)) {
+          const slice = inlineActiveValue?.slice(storeInputValue.length) || "";
+          return storeInputValue + slice;
         }
-        return storeValue;
+        return storeInputValue;
       }
-      return inlineActiveValue || storeValue;
-    }, [inline, canInline, items, inlineActiveValue, autoSelect, storeValue]);
+      return inlineActiveValue || storeInputValue;
+    }, [
+      inline,
+      canInline,
+      items,
+      inlineActiveValue,
+      autoSelect,
+      storeInputValue,
+    ]);
 
     // Listen to the combobox-item-move event that's dispacthed the ComboboxItem
     // component so we can enable the inline autocomplete when the user moves
@@ -282,7 +289,7 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
         autoSelect,
       );
       if (!firstItemAutoSelected) return;
-      if (!hasCompletionString(storeValue, inlineActiveValue)) return;
+      if (!hasCompletionString(storeInputValue, inlineActiveValue)) return;
       let cleanup = noop;
       // For some reason, this setSelectionRange may run before the value is
       // updated in the DOM. We're using a microtask to make sure it runs after
@@ -292,7 +299,7 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
         const element = ref.current;
         if (!element) return;
         const { start: prevStart, end: prevEnd } = getTextboxSelection(element);
-        const nextStart = storeValue.length;
+        const nextStart = storeInputValue.length;
         const nextEnd = inlineActiveValue.length;
         setSelectionRange(element, nextStart, nextEnd);
         cleanup = () => {
@@ -316,7 +323,7 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       inlineActiveValue,
       items,
       autoSelect,
-      storeValue,
+      storeInputValue,
     ]);
 
     const getAutoSelectIdProp = useEvent(getAutoSelectId);
@@ -382,10 +389,10 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
     // programmatically.
     useSafeLayoutEffect(() => {
       userScrolledRef.current = false;
-      if (!storeValue) return;
+      if (!storeInputValue) return;
       if (composingRef.current) return;
       canAutoSelectRef.current = true;
-    }, [storeValue]);
+    }, [storeInputValue]);
 
     // Reset the changed flag when the popover is not open so we don't try to
     // auto select an item after the popover closes (for example, in the middle
@@ -438,7 +445,7 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
           ? selectedValue.includes(activeValue)
           : selectedValue === activeValue);
       const preserveSelectedValue =
-        !!selectElement && !storeValue && activeValueSelected;
+        !!selectElement && !storeInputValue && activeValueSelected;
       if (autoSelect && canAutoSelect && !preserveSelectedValue) {
         const userAutoSelectId = getAutoSelectIdProp(items);
         const autoSelectId =
@@ -502,7 +509,7 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       store,
       open,
       valueUpdated,
-      storeValue,
+      storeInputValue,
       autoSelect,
       resetValueOnSelect,
       getAutoSelectIdProp,
@@ -520,7 +527,7 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       );
       const onBlur = (event: FocusEvent) => {
         if (elements.every((el) => isFocusEventOutside(event, el))) {
-          store?.setValue(value);
+          store?.setInputValue(value);
         }
       };
       for (const element of elements) {
@@ -568,15 +575,15 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
         }
       }
       if (setValueOnChangeProp(event)) {
-        const isSameValue = value === store.getState().value;
-        store.setValue(value);
+        const isSameValue = value === store.getState().inputValue;
+        store.setInputValue(value);
         // When the value is not set synchronously, the selection range may be
         // lost. See combobox-group "keep caret position when typing" test.
         queueMicrotask(() => {
           setSelectionRange(currentTarget, selectionStart, selectionEnd);
         });
         if (inline && autoSelect && isSameValue) {
-          // The store.setValue(event.target.value) above may not trigger a
+          // The store.setInputValue(event.target.value) above may not trigger a
           // state update. For example, say the first item starts with "t". The
           // user starts typing "t", then the first item is auto selected and
           // the inline completion string is appended and highlited. The user
@@ -646,7 +653,7 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
         store.setActiveId(null);
       }
       if (setValueOnClickProp(event)) {
-        store.setValue(value);
+        store.setInputValue(value);
       }
       if (showOnClickProp(event)) {
         queueBeforeEvent(event.currentTarget, "mouseup", store.show);
@@ -897,14 +904,16 @@ export interface ComboboxOptions<
   ) => string | null | undefined;
   /**
    * Whether the items will be filtered based on
-   * [`value`](https://ariakit.com/reference/combobox-provider#value) and
+   * [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue)
+   * and
    * whether the input value will temporarily change based on the active item.
    *
    * This prop is based on the standard
    * [`aria-autocomplete`](https://w3c.github.io/aria/#aria-autocomplete)
    * attribute, accepting the same values:
    * - `list` (default): indicates that the items will be dynamically rendered
-   *   based on [`value`](https://ariakit.com/reference/combobox-provider#value)
+   *   based on
+   *   [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue)
    *   and the input value will _not_ change based on the active item. The
    *   filtering logic must be implemented by the consumer of this component.
    * - `inline`: indicates that the items are static, that is, they won't be
@@ -912,7 +921,8 @@ export interface ComboboxOptions<
    *   item. Ariakit will automatically provide the inline autocompletion
    *   behavior.
    * - `both`: indicates that the items will be dynamically rendered based on
-   *   [`value`](https://ariakit.com/reference/combobox-provider#value) and the
+   *   [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue)
+   *   and the
    *   input value will temporarily change based on the active item. The
    *   filtering logic must be implemented by the consumer of this component,
    *   whereas Ariakit will automatically provide the inline autocompletion
@@ -1022,10 +1032,12 @@ export interface ComboboxOptions<
   showOnKeyPress?: BooleanOrCallback<ReactKeyboardEvent<HTMLElement>>;
   /**
    * Whether the combobox
-   * [`value`](https://ariakit.com/reference/combobox-provider#value) state
+   * [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue)
+   * state
    * should be updated when the input value changes. This is useful if you want
    * to customize how the store
-   * [`value`](https://ariakit.com/reference/combobox-provider#value) is updated
+   * [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue)
+   * is updated
    * based on the input element's value.
    *
    * Live examples:
@@ -1036,14 +1048,15 @@ export interface ComboboxOptions<
   setValueOnChange?: BooleanOrCallback<ChangeEvent<HTMLElement>>;
   /**
    * Whether the combobox
-   * [`value`](https://ariakit.com/reference/combobox-provider#value) state
+   * [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue)
+   * state
    * should be updated when the combobox input element gets clicked. This
    * usually only applies when
    * [`autoComplete`](https://ariakit.com/reference/combobox#autocomplete) is
    * `both` or `inline`, because the input value will temporarily change based
    * on the active item and the store
-   * [`value`](https://ariakit.com/reference/combobox-provider#value) will not
-   * be updated until the user confirms the selection.
+   * [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue)
+   * will not be updated until the user confirms the selection.
    * @default true
    */
   setValueOnClick?: BooleanOrCallback<MouseEvent<HTMLElement>>;

--- a/packages/ariakit-react/src/combobox.ts
+++ b/packages/ariakit-react/src/combobox.ts
@@ -8,6 +8,8 @@ export type {
   ComboboxInputProps,
 } from "@ariakit/react-components/combobox/combobox-input";
 export { ComboboxInput } from "@ariakit/react-components/combobox/combobox-input";
+export type { ComboboxInputValueProps } from "@ariakit/react-components/combobox/combobox-input-value";
+export { ComboboxInputValue } from "@ariakit/react-components/combobox/combobox-input-value";
 export type {
   ComboboxAnchorOptions,
   ComboboxAnchorProps,

--- a/website/build-pages/reference-utils.test.ts
+++ b/website/build-pages/reference-utils.test.ts
@@ -121,6 +121,7 @@ test("loads Combobox input value metadata", () => {
   const value = getReference(comboboxFilename, "ComboboxValue");
   getProp(value, "store");
   getProp(value, "children");
+  expect(value.description).toContain("Renders the current");
   expect(value.deprecated).toEqual(
     expect.stringContaining("ComboboxInputValue"),
   );

--- a/website/build-pages/reference-utils.test.ts
+++ b/website/build-pages/reference-utils.test.ts
@@ -52,7 +52,7 @@ test("uses props parameters as reference props", () => {
 test("uses typed destructured props parameters as reference props", () => {
   const comboboxProps = getReference(
     comboboxFilename,
-    "ComboboxValue",
+    "ComboboxInputValue",
   ).props.map((prop) => {
     return prop.name;
   });
@@ -96,6 +96,34 @@ test("loads Combobox Select prop metadata", () => {
       "https://ariakit.com/reference/combobox-provider",
     );
   }
+});
+
+test("loads Combobox input value metadata", () => {
+  const provider = getReference(comboboxFilename, "ComboboxProvider");
+  getProp(provider, "inputValue");
+  getProp(provider, "defaultInputValue");
+  getProp(provider, "setInputValue");
+
+  const replacements = {
+    value: "inputValue",
+    defaultValue: "defaultInputValue",
+    setValue: "setInputValue",
+  };
+
+  for (const [name, replacement] of Object.entries(replacements)) {
+    const prop = getProp(provider, name);
+    expect(prop.deprecated).toEqual(expect.stringContaining(replacement));
+  }
+
+  const inputValue = getReference(comboboxFilename, "ComboboxInputValue");
+  getProp(inputValue, "children");
+
+  const value = getReference(comboboxFilename, "ComboboxValue");
+  getProp(value, "store");
+  getProp(value, "children");
+  expect(value.deprecated).toEqual(
+    expect.stringContaining("ComboboxInputValue"),
+  );
 });
 
 test("loads Select deprecation metadata", () => {


### PR DESCRIPTION
## Motivation

Combobox currently uses `value` for the text in the input and `selectedValue` for the committed selection. With Combobox Select unifying the selection APIs, naming the text state `inputValue` creates a migration path that can eventually free `value` for selection without changing behavior today.

## Solution

Add `inputValue`, `defaultInputValue`, `setInputValue`, `resetInputValue`, and `ComboboxInputValue`. Keep the existing APIs as synchronized, JSDoc-deprecated aliases, with the new names taking precedence when both are provided.

```diff
-<ComboboxProvider value={query} setValue={setQuery}>
+<ComboboxProvider inputValue={query} setInputValue={setQuery}>
   <Combobox />
-  <ComboboxValue />
+  <ComboboxInputValue />
 </ComboboxProvider>
```

Update internal consumers and representative examples to the canonical names, while preserving legacy controlled callbacks, connected stores, default-state conflict validation, reset behavior, and keyboard focus.

## Review gate reassessment

<details>
<summary>Cycle 3: Continue the synchronized compatibility alias design</summary>

**Assessment**

The third finding was low severity but deterministic: every generated `ComboboxValue` reference lost its `store` and `children` props. This metadata is part of the supported soft-deprecation path, and its likely impact is on users consulting the legacy reference while migrating. A local typed wrapper and focused assertions restore it with minimal implementation and maintenance cost.

The synchronized state keys, controlled-prop precedence, connected-store handling, and conflict validation carry intrinsic complexity, but that complexity follows directly from preserving `value` as a supported alias. The first review cycle identified compatibility gaps in that contract; the next two cycles found static changeset and reference-metadata omissions rather than architectural instability.

**Decision**

Continue the current design and preserve `ComboboxValue` as a typed wrapper around `ComboboxInputValue`. Do not broaden the reference extractor, narrow the compatibility contract, or leave any known migration edge case unsupported.

</details>

## Verification

- `pnpm lint`
- `pnpm tsc`
- Core Combobox store tests
- Combobox React sandbox tests, including legacy tabs
- JSDoc and website reference metadata tests
- `pnpm changeset status`
- `pnpm build`
- `pnpm build-website-lite`
- `pnpm build-app-lite`
- Package dry-runs and public export resolution
