### PR TITLE
Clarify ComboboxPopover selected value wording

### DIFF
--- a/.changeset/200-combobox-popover-reset-on-escape.md
+++ b/.changeset/200-combobox-popover-reset-on-escape.md
@@ -5,10 +5,10 @@
 
 New `resetOnEscape` prop on Combobox popovers
 
-[`ComboboxPopover`](https://ariakit.com/reference/combobox-popover) now supports a [`resetOnEscape`](https://ariakit.com/reference/combobox-popover#resetonescape) prop that restores the value the combobox had before the first item movement. Selection changes made before any item movement become part of the value Escape restores:
+[`ComboboxPopover`](https://ariakit.com/reference/combobox-popover) now supports a [`resetOnEscape`](https://ariakit.com/reference/combobox-popover#resetonescape) prop that restores the selected value the combobox had before the first item movement. Selection changes made before any item movement become part of the selected value Escape restores:
 
 ```tsx
 <ComboboxPopover resetOnEscape={false} />
 ```
 
-It's enabled by default when [`selectOnMove`](https://ariakit.com/reference/combobox-provider#selectonmove) is enabled, which is when moving through items can change the selected value. The value is restored when the popover accepts Escape and its close event isn't prevented. A descendant that handles Escape itself, or an `onClose` handler that prevents the close, preserves the previewed value.
+It's enabled by default when [`selectOnMove`](https://ariakit.com/reference/combobox-provider#selectonmove) is enabled, which is when moving through items can change the selected value. The selected value is restored when the popover accepts Escape and its close event isn't prevented. A descendant that handles Escape itself, or an `onClose` handler that prevents the close, preserves the previewed selected value.

--- a/.changeset/200-combobox-popover-reset-on-escape.md
+++ b/.changeset/200-combobox-popover-reset-on-escape.md
@@ -5,7 +5,7 @@
 
 New `resetOnEscape` prop on Combobox popovers
 
-[`ComboboxPopover`](https://ariakit.com/reference/combobox-popover) now supports a [`resetOnEscape`](https://ariakit.com/reference/combobox-popover#resetonescape) prop that restores the value the combobox had before the popover was shown:
+[`ComboboxPopover`](https://ariakit.com/reference/combobox-popover) now supports a [`resetOnEscape`](https://ariakit.com/reference/combobox-popover#resetonescape) prop that restores the value the combobox had before the first item movement. Selection changes made before any item movement become part of the value Escape restores:
 
 ```tsx
 <ComboboxPopover resetOnEscape={false} />

--- a/packages/ariakit-react-components/src/combobox/combobox-popover.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-popover.tsx
@@ -367,15 +367,15 @@ export interface ComboboxPopoverOptions<T extends ElementType = TagName>
    */
   typeahead?: CompositeTypeaheadOptions<T>["typeahead"];
   /**
-   * Whether the combobox
+   * Whether the combobox's
    * [`selectedValue`](https://ariakit.com/reference/combobox-provider#selectedvalue)
-   * should be restored to the value it had before the first item movement when
+   * should be restored to what it was before the first item movement when
    * the popover accepts Escape and the cancelable close event isn't prevented.
-   * Selection changes made before any item movement become part of the value
-   * Escape restores.
+   * Selection changes made before any item movement become part of the selected
+   * value Escape restores.
    *
-   * A descendant that handles Escape itself leaves the value alone. Defaults
-   * to the store's
+   * A descendant that handles Escape itself leaves the selected value alone.
+   * Defaults to the store's
    * [`selectOnMove`](https://ariakit.com/reference/combobox-provider#selectonmove)
    * value, since moving through items is what changes the selected value while
    * the popover is open. This has no effect when the combobox supports multiple


### PR DESCRIPTION
## Motivation

PR #6895 clarified that `resetOnEscape` restores the `selectedValue` captured before the first item movement. The pending release note still described the older open-session baseline, and its generic “value” wording could be confused with the combobox input value:

```md
restores the value the combobox had before the popover was shown
```

## Solution

Align the pending changeset with the movement-scoped baseline and consistently call the restored state the selected value:

```md
restores the selected value the combobox had before the first item movement
```

Update the public JSDoc to name and link `selectedValue` directly, with matching terminology in both paragraphs. Runtime behavior is unchanged.

## Preview

<img width="992" height="293" alt="ComboboxPopover resetOnEscape documentation using selected value terminology" src="https://github.com/user-attachments/assets/03b932a4-964f-4080-aec0-8ab879221dda" />

## Testing

- `pnpm lint-fix`
- `pnpm test app/src/lib/jsdoc-loader.test.ts`
- `pnpm test website/build-pages/reference-utils.test.ts`
- `pnpm changeset status --since=origin/main`
- `pnpm build-website-lite`
