### PR TITLE
Exercise Safari click focus in sandbox tests

### DIFF
--- a/app/src/sandbox/combobox-popover-reset-on-escape/index.react.tsx
+++ b/app/src/sandbox/combobox-popover-reset-on-escape/index.react.tsx
@@ -163,6 +163,7 @@ function DescendantClose() {
         ))}
         <button
           type="button"
+          tabIndex={0}
           onKeyDown={(event) => {
             if (event.key !== "Escape") return;
             event.preventDefault();
@@ -307,6 +308,7 @@ export default function Example() {
       <Select label="Propagation" unmount={false}>
         <button
           type="button"
+          tabIndex={0}
           onKeyDown={(event) => {
             if (event.key !== "Escape") return;
             event.stopPropagation();
@@ -343,6 +345,7 @@ export default function Example() {
         escape key, so the previewed selection has to survive it. */}
         <button
           type="button"
+          tabIndex={0}
           onKeyDown={(event) => {
             if (event.key !== "Escape") return;
             event.preventDefault();

--- a/app/src/sandbox/combobox-popover-reset-on-escape/test-browser.ts
+++ b/app/src/sandbox/combobox-popover-reset-on-escape/test-browser.ts
@@ -42,9 +42,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
     await test.expect(select).toHaveText("Banana");
 
-    // Focused rather than clicked because WebKit doesn't move focus to a
-    // button on click, which would send the escape key somewhere else.
-    await q.button("Handles escape").focus();
+    const button = q.button("Handles escape");
+    await button.click();
+    await test.expect(button).toBeFocused();
     await page.keyboard.press("Escape");
 
     // The popover staying open is what proves the reset can't have committed,
@@ -64,7 +64,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
     await test.expect(select).toHaveText("Banana");
 
-    await q.button("Stops propagation").focus();
+    const button = q.button("Stops propagation");
+    await button.click();
+    await test.expect(button).toBeFocused();
     await page.keyboard.press("Escape");
 
     // The popover staying open is what proves the reset can't have committed,
@@ -202,8 +204,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await select.click();
     await page.keyboard.press("ArrowDown");
     await test.expect(select).toHaveText("Banana");
-    // WebKit doesn't move focus to a button on click.
-    await q.button("Consumes Escape and closes").focus();
+    const button = q.button("Consumes Escape and closes");
+    await button.click();
+    await test.expect(button).toBeFocused();
 
     await page.keyboard.press("Escape");
 


### PR DESCRIPTION
## Motivation

The ComboboxPopover Escape sandbox focuses descendant native buttons programmatically so Safari sends Escape to the intended handler:

```ts
await q.button("Handles escape").focus();
```

That bypasses the pointer interaction a user would perform and hides Safari's native click-focus behavior documented in [ariakit/skills#354](https://github.com/ariakit/skills/pull/354).

## Solution

Give the three descendant native buttons an explicit `tabIndex={0}`, click them in the browser tests, and assert that focus moved before pressing Escape:

```tsx
<button type="button" tabIndex={0}>
```

```ts
const button = q.button("Handles escape");
await button.click();
await test.expect(button).toBeFocused();
```

This keeps the existing Escape consumption, propagation, and close semantics while exercising the real Safari click path.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm -F app run build-lite`
- `pnpm test-safari src/sandbox/combobox-popover-reset-on-escape/test-browser.ts` (16 passed)
- Safari red check without `tabIndex`: all three changed cases failed at `toBeFocused()`; restoring `tabIndex` made the full file pass
