### PR TITLE
Move ComboboxSelect popup role assertion to browser tests

### DIFF
--- a/app/src/sandbox/combobox-select/test-browser.ts
+++ b/app/src/sandbox/combobox-select/test-browser.ts
@@ -11,8 +11,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     test(`${label} reflects the popup role when opened`, async ({ q }) => {
       const select = q.combobox(label);
       await select.click();
-      test.expect(await q.dialog(label).isVisible()).toBe(true);
-      test.expect(await select.getAttribute("aria-haspopup")).toBe("dialog");
+      await test.expect(q.dialog(label)).toBeVisible();
+      await test.expect(select).toHaveAttribute("aria-haspopup", "dialog");
     });
 
     test(`${label} auto-selects and restores filtered values`, async ({

--- a/app/src/sandbox/combobox-select/test-browser.ts
+++ b/app/src/sandbox/combobox-select/test-browser.ts
@@ -7,6 +7,14 @@ const cases = [
 
 withFramework(import.meta.dirname, async ({ test }) => {
   for (const [label, searchLabel] of cases) {
+    // https://github.com/ariakit/ariakit/issues/6902
+    test(`${label} reflects the popup role when opened`, async ({ q }) => {
+      const select = q.combobox(label);
+      await select.click();
+      test.expect(await q.dialog(label).isVisible()).toBe(true);
+      test.expect(await select.getAttribute("aria-haspopup")).toBe("dialog");
+    });
+
     test(`${label} auto-selects and restores filtered values`, async ({
       page,
       q,

--- a/app/src/sandbox/combobox-select/test-browser.ts
+++ b/app/src/sandbox/combobox-select/test-browser.ts
@@ -11,8 +11,11 @@ withFramework(import.meta.dirname, async ({ test }) => {
     test(`${label} reflects the popup role when opened`, async ({ q }) => {
       const select = q.combobox(label);
       await select.click();
-      await test.expect(q.dialog(label)).toBeVisible();
-      await test.expect(select).toHaveAttribute("aria-haspopup", "dialog");
+      // One-shot reads instead of Playwright's retrying matchers. Otherwise
+      // toHaveAttribute waits until aria-haspopup settles and can pass even
+      // when the dialog was already visible with the listbox fallback.
+      test.expect(await q.dialog(label).isVisible()).toBe(true);
+      test.expect(await select.getAttribute("aria-haspopup")).toBe("dialog");
     });
 
     test(`${label} auto-selects and restores filtered values`, async ({

--- a/app/src/sandbox/combobox-select/test.ts
+++ b/app/src/sandbox/combobox-select/test.ts
@@ -13,7 +13,6 @@ describe.each(cases)("%s", (label, searchLabel) => {
 
     await click(select);
     expect(q.dialog(label)).toBeVisible();
-    expect(select).toHaveAttribute("aria-haspopup", "dialog");
     expect(q.listbox(label)).toBeVisible();
     expect(q.combobox(searchLabel)).toHaveFocus();
     expect(q.option("Apple")).toHaveFocus();


### PR DESCRIPTION
## Motivation

The happy-dom `ComboboxSelect` test checks `aria-haspopup` immediately after opening the Provider fixture. Because the popup role is synchronized through `useAttribute` and a `MutationObserver`, happy-dom can expose the intermediate `listbox` fallback even after the dialog is visible. This makes the full React suite fail on a clean macOS checkout while the same component state is already correct in real browsers.

Fixes #6902.

## Solution

Move the popup-role contract to the existing authoritative browser test for both the Provider and Store fixtures:

```ts
await select.click();
test.expect(await q.dialog(label).isVisible()).toBe(true);
test.expect(await select.getAttribute("aria-haspopup")).toBe("dialog");
```

The browser assertion deliberately uses immediate reads rather than Playwright's retrying matchers, so it still protects the requirement that the visible dialog and `aria-haspopup="dialog"` appear together. The rest of the pointer, keyboard, focus, and filtering coverage remains in the happy-dom suite.

This is a test-only change with no visual UI output change, so the automated accessibility assertion is the relevant browser evidence.

## Verification

- `pnpm test-react run` (947 tests)
- `pnpm tsc`
- `pnpm -F app test src/sandbox/combobox-select/test-browser.ts` (12 tests across Chromium, Firefox, and WebKit)
