### PR TITLE
Disable persisted checkout credentials in the remaining CI workflows

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up environment
         uses: ./.github/workflows/setup
@@ -42,6 +44,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up environment
         uses: ./.github/workflows/setup
@@ -103,6 +107,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up environment
         uses: ./.github/workflows/setup

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up environment
         uses: ./.github/workflows/setup

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up environment
         uses: ./.github/workflows/setup
@@ -35,6 +37,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up environment
         uses: ./.github/workflows/setup
@@ -54,6 +58,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up environment
         uses: ./.github/workflows/setup
@@ -90,6 +96,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up environment
         uses: ./.github/workflows/setup
@@ -114,6 +122,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up environment
         uses: ./.github/workflows/setup

--- a/.github/workflows/plus.yml
+++ b/.github/workflows/plus.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up environment
         uses: ./.github/workflows/setup

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -14,6 +14,10 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          # The base-branch fetch below runs anonymously against this public
+          # repository, so the job does not need the persisted token. Keep it
+          # disabled so `pnpm install` and the build cannot read it.
+          persist-credentials: false
 
       - name: Fetch base branch
         run: git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}


### PR DESCRIPTION
## Motivation

Fixes #6897.

`actions/checkout` writes its token into `.git/config` by default and leaves it there for the rest of the job. Any repository code that runs afterwards — `pnpm install` lifecycle scripts, package scripts, build tooling — can read it. `ci.yml` triggers on `pull_request` and reaches `main.yml`, `app.yml`, and `plus.yml` through `workflow_call`, so this is a live path, and for same-repo branch PRs the persisted token is writable.

The repository already applied the mitigation, just not everywhere. On `9001af55b` there were 28 `actions/checkout` steps, 17 of which set `persist-credentials: false`:

| workflow | checkouts missing the setting |
| --- | --- |
| `main.yml` | 5 of 5 |
| `app.yml` | 3 of 3 |
| `deploy.yml` | 1 of 1 |
| `plus.yml` | 1 of 1 |
| `release-preview.yml` | 1 of 1 |

`ci.yml`, `perf.yml`, `visual.yml`, `docs.yml`, `og-images.yml`, `build-styles.yml`, `release.yml`, and `deploy-preview.yml` already covered every one of theirs, so these five files were a gap rather than a deliberate exception.

## Solution

Add `persist-credentials: false` to the remaining 11 checkout steps, bringing the repository to 28 of 28.

Each job was checked before flipping it:

- **`main.yml`** (lint, typescript, build, test, website), **`app.yml`** (build, build-nextjs, test), and **`plus.yml`** (test) run no `git` command at all. `pnpm-lock.yaml` has no git-protocol dependencies, and the only install lifecycle hook is the root `prepare: husky`, which just writes a local `core.hooksPath`.
- **`app.yml`**'s `test-finalize` and `deploy-preview` jobs are reusable-workflow calls. They run on their own runners with their own checkouts in `visual.yml` and `deploy-preview.yml`, which already set the flag. `visual.yml`'s write-back goes through `commit-or-pr`, which builds its own auth with `gh auth setup-git` before pushing.
- **`deploy.yml`** passes `gitHubToken: ${{ secrets.GITHUB_TOKEN }}` to `cloudflare/wrangler-action` as an explicit action input, which is independent of the credential `actions/checkout` persists.
- **`release-preview.yml`** is the only job that touches `origin`, via `git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}`. That fetch works anonymously because the repository is public, so the step keeps working without the token. `pkg-pr-new` authenticates through Actions environment variables and the pkg.pr.new service, not `.git/config`.

Since `release-preview.yml` is the one file where a `git fetch origin` sits directly below the checkout, it gets a short comment recording why the setting is safe there, so the reasoning survives for the next reader:

```yaml
- name: Checkout repository
  uses: actions/checkout@v7
  with:
    fetch-depth: 0
    # The base-branch fetch below runs anonymously against this public
    # repository, so the job does not need the persisted token. Keep it
    # disabled so `pnpm install` and the build cannot read it.
    persist-credentials: false
```

The anonymous-fetch assumption is already proven in CI rather than only in theory. `perf.yml`'s `chrome` and `node` jobs run `git fetch --depth=1 origin "$BASE_SHA" || git fetch origin "$BASE_REF"` under `persist-credentials: false` and `bash -e`. In run [30341095787](https://github.com/ariakit/ariakit/actions/runs/30341095787), the `Performance / Node` job's `Set up baseline worktree` step logged `From https://github.com/ariakit/ariakit` / `* branch e1467694… -> FETCH_HEAD` / `Preparing worktree (detached HEAD e146769)` and succeeded. The same "anonymous fetch, explicit token only for writes" split is what `commit-or-pr` and `release.yml` already do deliberately.

No changeset: this only touches CI configuration and does not affect shipped package code.

## Follow-ups

- #6905 — nothing enforces the 28-of-28 invariant for future checkout steps, so a new workflow or job can silently reintroduce the persisted token. Registered separately because choosing between a local check and adopting `actionlint` is its own tooling decision.
