### PR TITLE
Skip Playwright system dependencies in the perf baseline install

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -448,7 +448,20 @@ jobs:
 
       - name: Install Playwright (baseline)
         working-directory: ${{ runner.temp }}/perf-baseline
-        run: pnpm --filter app exec playwright install --with-deps chromium
+        # No `--with-deps` here. The runner image already provides every library
+        # Chromium needs, and the current-branch step above skips its own
+        # `--with-deps` whenever the browser cache hits, so the rest of CI
+        # already launches browsers without it. The only packages it added were
+        # ~21 MB of optional fonts, re-fetched from the Ubuntu mirror on every
+        # job; when that mirror degrades the step has stalled for ~10 minutes.
+        # Dropping them keeps baseline and current on the same fonts, because
+        # both sides run on this runner after this step.
+        #
+        # The install stays unconditional so a baseline pinned to a different
+        # Playwright version still downloads its own browser build. It is a
+        # no-op when the version matches the current branch, since both
+        # checkouts share `~/.cache/ms-playwright` through `$HOME`.
+        run: pnpm --filter app exec playwright install chromium
 
       - name: Download baseline artifacts
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Motivation

The `Install Playwright (baseline)` step in the Chrome perf jobs intermittently stalls for ~10 minutes. In [run 30348304300](https://github.com/ariakit/ariakit/actions/runs/30348304300), 8 of 10 jobs finished that step in 12-19s while two did not:

| Job | Duration | apt fetch |
| --- | --- | --- |
| `Chrome (composite-perf)` | 621s | `Fetched 21.1 MB in 10min 8s (34.7 kB/s)` |
| `Chrome (menu-perf)` | 546s | `Fetched 21.1 MB in 8min 52s (39.6 kB/s)` |

For scale, the `apt-get update` a few seconds earlier in the same step pulled 10.9 MB at 8191 kB/s, so `azure.archive.ubuntu.com` degraded roughly 200x mid-step.

The step is the only thing in CI still exposed to that mirror, because it bypasses the `install-playwright` composite action:

```yaml
- name: Install Playwright (baseline)
  working-directory: ${{ runner.temp }}/perf-baseline
  run: pnpm --filter app exec playwright install --with-deps chromium
```

The composite action caches `~/.cache/ms-playwright` and skips the install entirely on a cache hit, so the current-branch `Install Playwright` step is normally a no-op and never reaches `--with-deps`. Every other browser job (`App / Test Chrome`, Firefox, Safari, `og-images`) already launches browsers that way.

Because both checkouts share `$HOME`, the baseline step downloaded no browser either — the logs show apt finishing at `10:04:56` and the step ending at `10:05:02`. All of its time was apt work. The runner image already provides every library Chromium needs (every one reported `already the newest version`); the only packages `--with-deps` newly installed were 9 optional font packages totalling 21.1 MB, re-fetched on every job of every perf run.

## Solution

Drop `--with-deps` from the baseline step so it no longer touches apt:

```yaml
run: pnpm --filter app exec playwright install chromium
```

`playwright install` resolves and downloads browsers independently of dependency installation, so the install stays unconditional and a baseline pinned to a different Playwright version still downloads its own browser build. It is a no-op when the version matches the current branch.

Keeping it unconditional is why this does not reuse the composite action for the baseline. The composite's cache key is `hashFiles('pnpm-lock.yaml')`, and `hashFiles()` [can only read files inside `GITHUB_WORKSPACE`](https://docs.github.com/en/actions/reference/workflows-and-actions/expressions). The baseline worktree lives at `$RUNNER_TEMP/perf-baseline` (`/home/runner/work/_temp/perf-baseline`), outside the workspace, so the key could only ever describe the head lockfile. On a Renovate Playwright bump the head key would hit its cache, the baseline install would be skipped, and the baseline would launch a Playwright version whose browser build was never downloaded.

### Effect on measurements

Perf jobs currently do get those fonts, since the baseline step was the only thing installing them. Dropping them changes the font environment identically for both sides: baseline and current run in the same job on the same runner after this step, and each matrix job pairs its own baseline/current rounds, so `perf-compare` never compares across runners. Only absolute numbers may shift; the baseline-vs-current deltas the workflow reports are unaffected.

The head-side composite still runs `--with-deps` on a lockfile change, so system dependencies are still installed whenever they could actually change. This narrows the mirror exposure from every perf job to lockfile-change runs only.
