### PR TITLE
Declare workspace dependencies and remove the unused website Vite plugin

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@ariakit/react": "workspace:*",
     "@ariakit/react-components": "workspace:*",
+    "@ariakit/react-store": "workspace:*",
     "@ariakit/react-utils": "workspace:*",
     "@ariakit/solid": "workspace:*",
     "@ariakit/solid-components": "workspace:*",

--- a/packages/ariakit-react-components/package.json
+++ b/packages/ariakit-react-components/package.json
@@ -36,7 +36,8 @@
   "devDependencies": {
     "@ariakit/scripts": "workspace:*",
     "react": "19.2.8",
-    "react-dom": "19.2.8"
+    "react-dom": "19.2.8",
+    "vitest": "4.1.10"
   },
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",

--- a/packages/ariakit-react-utils/package.json
+++ b/packages/ariakit-react-utils/package.json
@@ -32,7 +32,8 @@
   },
   "devDependencies": {
     "@ariakit/scripts": "workspace:*",
-    "react": "19.2.8"
+    "react": "19.2.8",
+    "vitest": "4.1.10"
   },
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/packages/ariakit-solid-components/package.json
+++ b/packages/ariakit-solid-components/package.json
@@ -37,7 +37,8 @@
     "@ariakit/utils": "workspace:*"
   },
   "devDependencies": {
-    "@ariakit/scripts": "workspace:*"
+    "@ariakit/scripts": "workspace:*",
+    "solid-js": "1.9.14"
   },
   "peerDependencies": {
     "solid-js": "^1.8"

--- a/packages/ariakit-solid-utils/package.json
+++ b/packages/ariakit-solid-utils/package.json
@@ -39,7 +39,9 @@
     "@solid-primitives/utils": "^6.4.0"
   },
   "devDependencies": {
-    "@ariakit/scripts": "workspace:*"
+    "@ariakit/scripts": "workspace:*",
+    "solid-js": "1.9.14",
+    "vitest": "4.1.10"
   },
   "peerDependencies": {
     "solid-js": "^1.8"

--- a/packages/ariakit-solid/package.json
+++ b/packages/ariakit-solid/package.json
@@ -43,7 +43,8 @@
     "@ariakit/solid-components": "workspace:*"
   },
   "devDependencies": {
-    "@ariakit/scripts": "workspace:*"
+    "@ariakit/scripts": "workspace:*",
+    "solid-js": "1.9.14"
   },
   "peerDependencies": {
     "solid-js": "^1.8"

--- a/packages/ariakit-test/package.json
+++ b/packages/ariakit-test/package.json
@@ -35,7 +35,8 @@
     "@playwright/test": "1.62.0",
     "@testing-library/react": "16.3.2",
     "react": "19.2.8",
-    "react-dom": "19.2.8"
+    "react-dom": "19.2.8",
+    "vitest": "4.1.10"
   },
   "peerDependencies": {
     "@playwright/test": "^1.27.0",

--- a/packages/ariakit-utils/package.json
+++ b/packages/ariakit-utils/package.json
@@ -26,7 +26,8 @@
     "docs": "ariakit docs --write"
   },
   "devDependencies": {
-    "@ariakit/scripts": "workspace:*"
+    "@ariakit/scripts": "workspace:*",
+    "vitest": "4.1.10"
   },
   "exports": {
     ".": "./src/index.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,9 @@ importers:
       '@ariakit/react-components':
         specifier: workspace:*
         version: link:../packages/ariakit-react-components
+      '@ariakit/react-store':
+        specifier: workspace:*
+        version: link:../packages/ariakit-react-store
       '@ariakit/react-utils':
         specifier: workspace:*
         version: link:../packages/ariakit-react-utils
@@ -610,6 +613,9 @@ importers:
       react-dom:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(yaml@2.9.0))
 
   packages/ariakit-react-store:
     dependencies:
@@ -651,6 +657,9 @@ importers:
       react:
         specifier: 19.2.8
         version: 19.2.8
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(yaml@2.9.0))
 
   packages/ariakit-scripts:
     dependencies:
@@ -691,13 +700,13 @@ importers:
       '@ariakit/solid-components':
         specifier: workspace:*
         version: link:../ariakit-solid-components
-      solid-js:
-        specifier: ^1.8
-        version: 1.9.14
     devDependencies:
       '@ariakit/scripts':
         specifier: workspace:*
         version: link:../ariakit-scripts
+      solid-js:
+        specifier: 1.9.14
+        version: 1.9.14
 
   packages/ariakit-solid-components:
     dependencies:
@@ -707,13 +716,13 @@ importers:
       '@ariakit/utils':
         specifier: workspace:*
         version: link:../ariakit-utils
-      solid-js:
-        specifier: ^1.8
-        version: 1.9.14
     devDependencies:
       '@ariakit/scripts':
         specifier: workspace:*
         version: link:../ariakit-scripts
+      solid-js:
+        specifier: 1.9.14
+        version: 1.9.14
 
   packages/ariakit-solid-store:
     dependencies:
@@ -736,13 +745,16 @@ importers:
       '@solid-primitives/utils':
         specifier: ^6.4.0
         version: 6.4.1(solid-js@1.9.14)
-      solid-js:
-        specifier: ^1.8
-        version: 1.9.14
     devDependencies:
       '@ariakit/scripts':
         specifier: workspace:*
         version: link:../ariakit-scripts
+      solid-js:
+        specifier: 1.9.14
+        version: 1.9.14
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(yaml@2.9.0))
 
   packages/ariakit-store:
     dependencies:
@@ -790,12 +802,18 @@ importers:
       react-dom:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(yaml@2.9.0))
 
   packages/ariakit-utils:
     devDependencies:
       '@ariakit/scripts':
         specifier: workspace:*
         version: link:../ariakit-scripts
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(yaml@2.9.0))
 
   templates/react:
     dependencies:
@@ -1107,6 +1125,9 @@ importers:
       '@types/fs-extra':
         specifier: 11.0.4
         version: 11.0.4
+      '@types/hast':
+        specifier: 3.0.5
+        version: 3.0.5
       '@types/lodash':
         specifier: 4.17.24
         version: 4.17.24
@@ -1131,9 +1152,9 @@ importers:
       '@types/textarea-caret':
         specifier: 3.0.4
         version: 3.0.4
-      '@vitejs/plugin-react':
-        specifier: 6.0.1
-        version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0))
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0))
 
 packages:
 
@@ -4420,9 +4441,6 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
-  '@rolldown/pluginutils@1.0.0-rc.7':
-    resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
-
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
@@ -5450,19 +5468,6 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
-
-  '@vitejs/plugin-react@6.0.1':
-    resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    peerDependencies:
-      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
-      babel-plugin-react-compiler: ^1.0.0
-      vite: ^8.0.0
-    peerDependenciesMeta:
-      '@rolldown/plugin-babel':
-        optional: true
-      babel-plugin-react-compiler:
-        optional: true
 
   '@vitejs/plugin-react@6.0.4':
     resolution: {integrity: sha512-XcCQz0TBpBgljhj0gMuuDj49i6Ytqh5q1osT/Gp5uAVJUCTWxyskk/l1jwYYiu2xcNHHipdMz40EGfM1VdamVg==}
@@ -14316,8 +14321,6 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
-  '@rolldown/pluginutils@1.0.0-rc.7': {}
-
   '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/pluginutils@5.3.0(rollup@4.59.0)':
@@ -15359,13 +15362,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0)
-    optionalDependencies:
-      babel-plugin-react-compiler: 1.0.0
-
   '@vitejs/plugin-react@6.0.4(babel-plugin-react-compiler@1.0.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
@@ -15402,6 +15398,14 @@ snapshots:
       '@vitest/utils': 4.1.10
       chai: 6.2.2
       tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0))':
     dependencies:
@@ -21196,6 +21200,36 @@ snapshots:
       chalk: 5.6.2
       vite: 8.1.5(@types/node@24.13.3)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0)
       vitest: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0))
+
+  vitest@4.1.10(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.12.2
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+      happy-dom: 20.11.1
+      jsdom: 29.1.1(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0)):
     dependencies:

--- a/website/package.json
+++ b/website/package.json
@@ -99,6 +99,7 @@
     "@types/babel__core": "7.20.5",
     "@types/cross-spawn": "6.0.6",
     "@types/fs-extra": "11.0.4",
+    "@types/hast": "3.0.5",
     "@types/lodash": "4.17.24",
     "@types/lodash-es": "4.17.12",
     "@types/marked": "5.0.2",
@@ -107,6 +108,6 @@
     "@types/react": "18.3.28",
     "@types/react-dom": "18.3.7",
     "@types/textarea-caret": "3.0.4",
-    "@vitejs/plugin-react": "6.0.1"
+    "vitest": "4.1.10"
   }
 }


### PR DESCRIPTION
## Motivation

Workspaces in this repository import packages they never declare. Those imports only resolve because Node walks up into the repository-root `node_modules`, or because `pnpm-workspace.yaml` sets `publicHoistPattern: ["*react*", "*testing-library*"]` and hoists matching packages into the root.

Nothing is broken today, because the packages involved stay in the root `devDependencies`. The declarations are missing, not the packages. But the hidden coupling means every further reduction of the root manifest is a potential type-check or test-run break, and the break surfaces at the first CI job that installs under a narrower filter rather than at install time.

Separately, `website/package.json` declares `"@vitejs/plugin-react": "6.0.1"` that nothing in the workspace resolves. The website builds with Next.js 14 and webpack, has no Vite config, and its `test` script is `playwright test`. The only two occurrences under `website/` are inside generated StackBlitz template strings in `website/lib/stackblitz.ts`, which emit a hardcoded `"@vitejs/plugin-react": "^3.0.0"` into the *sandbox's* own manifest and an `import react from "@vitejs/plugin-react"` into the *sandbox's* `vite.config.ts`. Neither is a real import by the website, and neither reads the declared version.

Closes #6907
Closes #6910

## Solution

Declare every package a workspace imports in that workspace's own `package.json`, and drop the unused website declaration.

Rather than trusting the list in #6907, this audits every workspace in `pnpm-workspace.yaml` by extracting import specifiers from all tracked sources, tests, configs, and scripts and diffing them against each manifest.

**`vitest`** is imported by test files in six workspaces that never declared it:

- `packages/ariakit-react-components`, `packages/ariakit-react-utils`, `packages/ariakit-solid-utils`, `packages/ariakit-test`, `packages/ariakit-utils`
- `website`, whose `build-pages/get-page-content.test.ts` and `build-pages/reference-utils.test.ts` run in the default root suite

**`solid-js`** is imported by the sources of `packages/ariakit-solid-components` and `packages/ariakit-solid-utils`, which declared it only as a `peerDependency`. Both now also declare it in `devDependencies` so type-checks and tests resolve it locally, matching how every React package already pairs its `react` peer with an exact `devDependencies` entry.

Two further gaps the issue does not mention, both found by the audit:

- `website` imports `hast` types in eight files, including JSDoc `import("hast")` in `build-pages/*.js`, without declaring `@types/hast`. This is invisible today because `website` is absent from the root `tsc -b` project graph and `website/next.config.js` sets `typescript: { ignoreBuildErrors: true }`.
- `app` imports `@ariakit/react-store` in `src/sandbox/store-keyed-subscriptions/{index.react.tsx,test.ts}` without declaring it.

### Corrections to the issue text

#6907 lists four packages as declaring `solid-js` only as a `peerDependency` while their sources import it. Only two of them actually do:

- `packages/ariakit-solid-store` is left unchanged. It has no `solid-js` reference at all: no import, and no `peerDependency` either. Its `src/index.ts` is just `export * from "@ariakit/store"`.
- `packages/ariakit-solid` does declare the peer, but its own `src/**` never imports `solid-js`; it is a pure re-export facade over `@ariakit/solid-components`. It still gains the `devDependencies` entry, because `@ariakit/react` is the identically shaped facade and already declares `react`/`react-dom` there, and because the lockfile shows pnpm's auto-installed peer was already materializing `solid-js` for it at an unpinned `^1.8`. Declaring `1.9.14` explicitly is resolution-neutral and pins it to the version used everywhere else.

### Versions

Every added version matches what `pnpm-lock.yaml` already resolved, so no second version of anything is introduced: `vitest@4.1.10`, `solid-js@1.9.14`, `@types/hast@3.0.5`. Published packages use exact versions for dev dependencies, private workspaces use exact versions, and the internal reference uses `workspace:*`.

The lockfile diff adds no package version anywhere. It removes two (`@vitejs/plugin-react@6.0.1` and `@rolldown/pluginutils@1.0.0-rc.7`, its only dependent) and adds two peer-resolution *variants* of already-present packages.

## Verification

`pnpm lint-fix`, `pnpm tsc`, `pnpm test` (61 files / 716 tests), `pnpm test-react` (183 / 947), `pnpm test-solid` (6 / 8), and `pnpm build-website-lite` all pass. `pnpm build` followed by `pnpm clean` leaves only the intended manifest and lockfile changes.

Because a full unfiltered install masks exactly the problem #6907 describes, each CI install filter in `.github/workflows/` was re-run from a wiped `node_modules` and followed by that job's real command:

| Filter | Command | Result |
| --- | --- | --- |
| `./packages/*...` | `pnpm run docs` | pass, no generated drift |
| `root...` | `pnpm run build` | pass |
| `app...` + `website...` | `pnpm test` | pass (61 files / 716 tests) |
| `app...` + `website...` + `./templates/*...` | `pnpm run tsc -v` | pass |
| `website...` | `pnpm run build-website-lite` | pass |
| `app...` | `pnpm run lint`, `pnpm run lint-css` | pass |
| `app...` | `pnpm test-react`, `pnpm test-solid` | pass |

Under `./packages/*...`, every newly declared package now resolves from the workspace's own `node_modules` (`packages/*/node_modules/vitest` and `packages/*/node_modules/solid-js`) instead of from the root.

Note that pnpm always installs the root project regardless of filter, so root hoisting still masks these imports today. That is why this change is a prerequisite for narrowing the root manifest rather than something whose effect is visible on its own.

### `website...` install measurements

Measured from a wiped `node_modules` with `pnpm install --fail-if-no-match --frozen-lockfile --filter 'website...'`, comparing sorted `node_modules/.pnpm` entry sets:

| State | `node_modules/.pnpm` entries | `du -sh node_modules` |
| --- | --- | --- |
| `main` | 1092 | 856M |
| Dropping `@vitejs/plugin-react` alone (#6910) | 1089 | 854M |
| This PR (both issues) | 1092 | 859M |

Removing `@vitejs/plugin-react` drops it and `@rolldown/pluginutils@1.0.0-rc.7`. Declaring `vitest` in `website` then adds two entries back, but they are duplicate peer-resolution variants of packages already in this closure, not new packages: `vitest@4.1.10` was already present twice through the `@ariakit/*` workspace dependencies. The website variant is keyed on `@types/node@24.12.2`/`esbuild@0.28.1`/`jiti@1.21.7` while the existing ones are keyed on `@types/node@24.13.3`, so pnpm materializes a third instantiation of the same 4.1.10 version.

## Review gate reassessment

<details>
<summary>Cycle 3: Continue the current direction unchanged</summary>

**Assessment**

Issue severity is low and entirely contributor-facing: nothing is broken for consumers today, and the change ships no code. Supported scope is every workspace in `pnpm-workspace.yaml`. Likely user impact is zero for package consumers and positive for contributors, since it removes the hidden root-hoisting coupling. Expected frequency is high in the sense that the masked failure mode is hit on every further reduction of the root manifest.

Implementation complexity is minimal: ten declaration lines across nine manifests plus a mechanically regenerated lockfile. No branches, state, helpers, abstractions, tests, documentation, public contracts, or platform policy are added, and there is no interaction with surrounding runtime behavior. Maintenance complexity decreases, because each workspace becomes self-describing and pnpm's strict layout enforces it.

The three finding-bearing rounds did not indicate accumulating complexity. The reviewed snapshot is byte-identical across all three rounds, and no round produced a defect in committed content or required an implementation change. Round 1 returned two out-of-scope observations about pre-existing code and one PR-description request. Round 2 corrected the scope of a follow-up issue. Round 3 refined prose that had not been written yet. The cycles converged on documentation accuracy, not on design churn, so the cadence's usual signal does not apply here.

**Decision**

Continue unchanged. The two inclusions that go beyond the literal issue text are both kept: `solid-js` on `packages/ariakit-solid` for parity with the identically shaped `@ariakit/react` facade and to pin an already auto-installed peer, and `vitest`/`@types/hast` on `website` because they are real undeclared imports in that workspace's own files and #6907's stated outcome covers every workspace. Closing both issues in one PR remains appropriate: their lockfile edits interleave in the same importer and snapshot regions, so splitting them would force one to rebase onto the other for no reviewer benefit.

Round 3's claim that the `website...` closure loses three packages and gains none was rejected against an empirical set diff of both installs, which shows two removed and two added, with `babel-plugin-react-compiler@1.0.0` present in both. Its underlying point, that `vitest` was already in the closure, was accepted and is reflected above. No disposition changed as a result of this reassessment, so no re-verification was required.

Follow-ups identified and left out of scope: deduping the `website` Vite/Vitest peer-resolution variant, the dead `website/build-pages/deps.ts` module, and removing `publicHoistPattern` once no workspace depends on it. The dedupe follow-up should note that `renovate.json` disables `website/package.json` wholesale, so the new `vitest` and `@types/hast` pins are frozen and will drift from root's over time, which is the mechanism that makes the duplicate variant worse.

</details>
