### PR TITLE
Correct the mergeImports JSDoc about untransformed imports

### DIFF
--- a/app/src/lib/source.test.ts
+++ b/app/src/lib/source.test.ts
@@ -687,7 +687,7 @@ test("mergeImports preserves aliases in transformed imports", () => {
   `);
 });
 
-test("mergeImports preserves aliases in untouched imports", () => {
+test("mergeImports preserves aliases in untransformed imports", () => {
   const code = [
     'import { foo as bar, type Baz as Qux } from "keep";',
     "",
@@ -711,5 +711,33 @@ test("mergeImports preserves aliases in type-only imports", () => {
     "import type { T as U } from "./x";
 
     export const z: U = 1;"
+  `);
+});
+
+test("mergeImports normalizes untransformed value imports only", () => {
+  // An untransformed value import is re-emitted on a single line, while an
+  // untransformed `import type` declaration keeps its original text. The
+  // "reformats rewritten imports" test in source-plugin.test.ts depends on
+  // this collapse pushing the disclosure import past the print width, which
+  // is the only evidence there that Prettier ran over the merged output.
+  // Preserving the author's wrapping here would make that assertion vacuous.
+  const code = [
+    "import {",
+    "  Disclosure,",
+    "  DisclosureButton,",
+    '} from "./disclosure.tsx";',
+    "import type {",
+    "  DisclosureProps,",
+    '} from "./types.ts";',
+    "",
+    "export const x: DisclosureProps = Disclosure ?? DisclosureButton;",
+  ].join("\n");
+  expect(mergeImports(code, () => false)).toMatchInlineSnapshot(`
+    "import { Disclosure, DisclosureButton } from "./disclosure.tsx";
+    import type {
+      DisclosureProps,
+    } from "./types.ts";
+
+    export const x: DisclosureProps = Disclosure ?? DisclosureButton;"
   `);
 });

--- a/app/src/lib/source.ts
+++ b/app/src/lib/source.ts
@@ -421,8 +421,13 @@ function buildHoistedImports(
 }
 
 /**
- * Builds a replacement import statement for remaining (non-transformed)
+ * Builds a replacement import statement for remaining (untransformed)
  * specifiers. Returns empty string if no specifiers remain.
+ *
+ * The specifier list is re-emitted on one line per kind, which deliberately
+ * discards the author's original wrapping; any import-attributes clause is
+ * carried through verbatim. Restoring the original text here is not the fix
+ * for an over-width line.
  */
 function buildRemainingImport(
   remainingRuntime: string[],
@@ -473,16 +478,21 @@ function insertHoistedImports(hoisted: string, body: string): string {
  * to the top and separating runtime (`import { ... }`) and type-only
  * (`import type { ... }`) groups.
  *
- * - Applies the provided `transform` function to each original module path; if
- *   it returns a string, the corresponding specifiers are merged and hoisted.
- *   If it returns `false`, the original imports are left untouched.
- * - For mixed named imports that include both transformed and non-transformed
- *   specifiers, only the transformed specifiers are hoisted; the remaining
- *   specifiers stay in place and the original import line may be rewritten to
- *   preserve them without duplication.
- * - Deduplicates specifiers by their full text (preserving `as` aliases) and
- *   sorts both specifiers and module specifiers lexicographically within each
- *   group.
+ * - Applies the provided `transform` function to each original module path,
+ *   separately for its runtime and its type-only specifiers. When it returns a
+ *   string, the corresponding specifiers are merged and hoisted.
+ * - When `transform` returns `false`, the specifiers stay at their original
+ *   position. An untransformed `import type { ... }` declaration is left
+ *   alone, while an untransformed `import { ... }` declaration is rebuilt
+ *   from its parsed parts, so the author's wrapping of the specifier list
+ *   does not survive. That is deliberate; see `buildRemainingImport`.
+ * - When a declaration has both kinds and only one is transformed, only that
+ *   kind is hoisted; the other stays in place, and the original import line
+ *   is rewritten to preserve it without duplication.
+ * - Deduplicates hoisted specifiers by their full text (preserving `as`
+ *   aliases) and sorts both specifiers and module specifiers lexicographically
+ *   within each hoisted group. Specifiers left behind are neither sorted nor
+ *   deduplicated.
  * - Preserves overall content by removing the original named import statements
  *   and returning the full transformed content with hoisted imports. Any
  *   orphaned semicolon-only lines left by the removal are also cleaned up to
@@ -496,7 +506,8 @@ function insertHoistedImports(hoisted: string, body: string): string {
  *   split across runtime and type groups for the same module.
  *
  * @param content - The source code to transform
- * @param transform - Function returning new path or false to skip
+ * @param transform - Function returning a new path, or `false` to leave the
+ *   specifiers where they are
  */
 export function mergeImports(
   content: string,


### PR DESCRIPTION
## Motivation

Closes #6914.

`mergeImports` in `app/src/lib/source.ts` documented its `transform` callback like this:

> Applies the provided `transform` function to each original module path; if it returns a string, the corresponding specifiers are merged and hoisted. If it returns `false`, the original imports are left untouched.

The last sentence is wrong. When `transform` returns `false`, an `import { ... }` declaration still goes through `buildRemainingImport`, which rebuilds it from the parsed specifier list. The `disclosure` example shows it: its `_lib/ariakit/disclosure.react.tsx` import is not a merge target, is written across five lines in the source file, and comes out of the merge as a single 103-column line before Prettier re-wraps it.

The stale sentence invites a maintainer to treat that collapse as a bug and "fix" `buildRemainingImport` to preserve the original text. That would make `reformats rewritten imports` in `app/src/lib/source-plugin.test.ts` pass vacuously, since its expected string would then match the author's original wrapping whether or not Prettier ran.

## Solution

Documentation only, plus one regression test. No behavior changed.

Before:

```
 * - Applies the provided `transform` function to each original module path; if
 *   it returns a string, the corresponding specifiers are merged and hoisted.
 *   If it returns `false`, the original imports are left untouched.
 * - For mixed named imports that include both transformed and non-transformed
 *   specifiers, only the transformed specifiers are hoisted; the remaining
 *   specifiers stay in place and the original import line may be rewritten to
 *   preserve them without duplication.
 * - Deduplicates specifiers by their full text (preserving `as` aliases) and
 *   sorts both specifiers and module specifiers lexicographically within each
 *   group.
```

After:

```
 * - Applies the provided `transform` function to each original module path,
 *   separately for its runtime and its type-only specifiers. When it returns a
 *   string, the corresponding specifiers are merged and hoisted.
 * - When `transform` returns `false`, the specifiers stay at their original
 *   position. An untransformed `import type { ... }` declaration is left
 *   alone, while an untransformed `import { ... }` declaration is rebuilt
 *   from its parsed parts, so the author's wrapping of the specifier list
 *   does not survive. That is deliberate; see `buildRemainingImport`.
 * - When a declaration has both kinds and only one is transformed, only that
 *   kind is hoisted; the other stays in place, and the original import line
 *   is rewritten to preserve it without duplication.
 * - Deduplicates hoisted specifiers by their full text (preserving `as`
 *   aliases) and sorts both specifiers and module specifiers lexicographically
 *   within each hoisted group. Specifiers left behind are neither sorted nor
 *   deduplicated.
```

Three corrections beyond the sentence the issue names, each verified by running `mergeImports` directly:

- **The behavior is asymmetric.** An untransformed `import type { ... }` really is left alone (`replaceImportDeclarations` returns the original `match`). Only `import { ... }` is rebuilt. The issue's own framing over-generalizes here.
- **`transform` is keyed on `(path, kind)`**, so "mixed" can only mean the value and type kinds getting different answers, never a split within one kind. The precondition is now explicit.
- **Sorting and deduplication apply to hoisted specifiers only.** Specifiers left behind keep their source order and any duplicates, which the old wording left ambiguous.

`buildRemainingImport` also gains a short note, since that is the function someone would edit:

```
 * The specifier list is re-emitted on one line per kind, which deliberately
 * discards the author's original wrapping; any import-attributes clause is
 * carried through verbatim. Restoring the original text here is not the fix
 * for an over-width line.
```

The wording states the mechanism ("rebuilt from its parsed parts") rather than enumerating each normalization. That covers the wrapping, quote, and semicolon changes at once, and avoids replacing one stale absolute claim with several new ones.

### Regression test

`app/src/lib/source-plugin.test.ts` depends on the collapse but only observes it indirectly, and no test fed a multi-line untransformed declaration to `mergeImports`. Added one that pins both halves of the asymmetry:

```ts
test("mergeImports normalizes untransformed value imports only", () => {
```

Red-checked by patching the `IMPORT_NAMED` branch of `replaceImportDeclarations` to return the original `match` for untransformed multi-line declarations, i.e. exactly the refactor the issue warns about. The new test failed for the right reason (snapshot kept the original five-line wrapping) while all 40 pre-existing tests passed, including `reformats rewritten imports`. Three independent reviewers reproduced this and confirmed the new test is the unique guard under that patch.

Also renamed the neighbouring `mergeImports preserves aliases in untouched imports` to `... in untransformed imports`, since its own snapshot shows the declaration rebuilt into two lines and "untouched" is the word this PR retires.

No changeset: `app` is private and listed in the `ignore` array of `.changeset/config.json`, and nothing here is consumer-observable.

## Review gate reassessment

<details>
<summary>Cycle 3: Simplify — state the mechanism instead of enumerating normalizations</summary>

**Assessment**

Three consecutive review rounds each produced findings against one direction: expand the JSDoc until every claim is verifiable. Round 1 falsified "collapsed onto one line" and an unconditional "re-formats afterwards". Round 2 falsified "one line per kind" (multi-line import attributes survive verbatim) and a `transform` call count. Round 3 falsified "byte-for-byte intact" (`collapseExcessBlankLines` rewrites blank lines inside an untransformed `import type`), the implied exclusivity of quote normalization, and "lexicographically" as a description of `localeCompare`.

Each round's fix added a qualifier, and each qualifier was a new absolute one level down. Rounds 2 and 3 were almost entirely findings against text this task had introduced. Since the issue exists precisely because a stale absolute claim misled a reader, the direction was reproducing the defect it set out to fix.

Proportionality: `mergeImports` has exactly one production caller, `rewriteImportsForMergedTargets`, whose transform is pure, and it is not exported beyond the private `app` workspace. A four-line determinism contract documenting an unreachable hazard was not proportionate. The block had grown from 3 bullets to 7.

**Decision**

Simplify to 5 bullets, replacing enumerated outcomes with the underlying mechanism, and restore the original's accurate mixed-import bullet including "without duplication". Cut: the determinism bullet and its failure modes; the enumerated quote/semicolon normalization (universal, not `false`-specific); "byte-for-byte intact"; a duplicated invariant. Kept the "hoisted" scoping on the dedup/sort bullet, which is a genuine correction.

Intentionally unsupported, all Declined non-goals: documenting blank-line collapsing, quote normalization, or the two-pass determinism contract, each of which re-enters the enumeration pattern; "lexicographically" versus `localeCompare`, which is pre-existing house terminology also used in `sortStrings`' own JSDoc; memoizing `transform`, which would be an observable behavior change outside this task's scope.

A main-task assessment and an independent advisory subagent ran in parallel and converged on this direction. Five further gate passes followed the change, the last returning no findings.

</details>


## Follow-ups

While establishing the behavior this PR documents, `mergeImports` was found to drop side-effect-only named imports: `import {} from "./side.ts";` is deleted entirely, while the equivalent `import "./side.ts";` is preserved. It is latent (no empty-brace named imports exist under `app/src`) and unrelated to the wrapping behavior corrected here, so it is tracked separately in #6919 rather than fixed in this PR.
