### PR TITLE
Fix Combobox inline autocomplete caret reset

### DIFF
--- a/.changeset/300-combobox-inline-caret.md
+++ b/.changeset/300-combobox-inline-caret.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Combobox`](https://ariakit.com/reference/combobox) inline autocomplete to preserve a user-adjusted caret when asynchronously rendered results update.

--- a/app/src/sandbox/combobox-inline-autocomplete/index.react.tsx
+++ b/app/src/sandbox/combobox-inline-autocomplete/index.react.tsx
@@ -9,7 +9,7 @@ function DelayedResults() {
   const pending = inputValue !== query;
 
   useEffect(() => {
-    const timeout = window.setTimeout(() => setQuery(inputValue), 1000);
+    const timeout = window.setTimeout(() => setQuery(inputValue), 2000);
     return () => window.clearTimeout(timeout);
   }, [inputValue]);
 

--- a/app/src/sandbox/combobox-inline-autocomplete/index.react.tsx
+++ b/app/src/sandbox/combobox-inline-autocomplete/index.react.tsx
@@ -1,4 +1,5 @@
 import * as Ariakit from "@ariakit/react";
+import type { KeyboardEvent } from "react";
 import { useEffect, useMemo, useState } from "react";
 
 const recipes = ["Apple", "Grape", "Orange", "Strawberry", "Watermelon"];
@@ -20,13 +21,22 @@ function DelayedResults() {
     );
   }, [query]);
 
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== "ArrowLeft") return;
+    setInputValue(event.currentTarget.value);
+  };
+
   return (
     <Ariakit.ComboboxProvider
       inputValue={inputValue}
       setInputValue={setInputValue}
     >
       <Ariakit.ComboboxLabel>Recipe</Ariakit.ComboboxLabel>
-      <Ariakit.Combobox autoComplete="both" autoSelect />
+      <Ariakit.Combobox
+        autoComplete="both"
+        autoSelect
+        onKeyDown={handleKeyDown}
+      />
       <div role="status">
         {pending ? "Updating results…" : "Results updated"}
       </div>

--- a/app/src/sandbox/combobox-inline-autocomplete/index.react.tsx
+++ b/app/src/sandbox/combobox-inline-autocomplete/index.react.tsx
@@ -1,4 +1,43 @@
 import * as Ariakit from "@ariakit/react";
+import { useEffect, useMemo, useState } from "react";
+
+const recipes = ["Apple", "Grape", "Orange", "Strawberry", "Watermelon"];
+
+function DelayedResults() {
+  const [inputValue, setInputValue] = useState("");
+  const [query, setQuery] = useState("");
+  const pending = inputValue !== query;
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => setQuery(inputValue), 1000);
+    return () => window.clearTimeout(timeout);
+  }, [inputValue]);
+
+  const matches = useMemo(() => {
+    const normalizedQuery = query.toLowerCase();
+    return recipes.filter((recipe) =>
+      recipe.toLowerCase().includes(normalizedQuery),
+    );
+  }, [query]);
+
+  return (
+    <Ariakit.ComboboxProvider
+      inputValue={inputValue}
+      setInputValue={setInputValue}
+    >
+      <Ariakit.ComboboxLabel>Recipe</Ariakit.ComboboxLabel>
+      <Ariakit.Combobox autoComplete="both" autoSelect />
+      <div role="status">
+        {pending ? "Updating results…" : "Results updated"}
+      </div>
+      <Ariakit.ComboboxPopover>
+        {matches.map((recipe) => (
+          <Ariakit.ComboboxItem key={recipe} value={recipe} />
+        ))}
+      </Ariakit.ComboboxPopover>
+    </Ariakit.ComboboxProvider>
+  );
+}
 
 export default function Example() {
   const combobox = Ariakit.useComboboxStore();
@@ -35,6 +74,7 @@ export default function Example() {
           🍉 Watermelon
         </Ariakit.ComboboxItem>
       </Ariakit.ComboboxPopover>
+      <DelayedResults />
     </>
   );
 }

--- a/app/src/sandbox/combobox-inline-autocomplete/index.react.tsx
+++ b/app/src/sandbox/combobox-inline-autocomplete/index.react.tsx
@@ -1,5 +1,4 @@
 import * as Ariakit from "@ariakit/react";
-import type { KeyboardEvent } from "react";
 import { useEffect, useMemo, useState } from "react";
 
 const recipes = ["Apple", "Grape", "Orange", "Strawberry", "Watermelon"];
@@ -21,22 +20,13 @@ function DelayedResults() {
     );
   }, [query]);
 
-  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (event.key !== "ArrowLeft") return;
-    setInputValue(event.currentTarget.value);
-  };
-
   return (
     <Ariakit.ComboboxProvider
       inputValue={inputValue}
       setInputValue={setInputValue}
     >
       <Ariakit.ComboboxLabel>Recipe</Ariakit.ComboboxLabel>
-      <Ariakit.Combobox
-        autoComplete="both"
-        autoSelect
-        onKeyDown={handleKeyDown}
-      />
+      <Ariakit.Combobox autoComplete="both" autoSelect />
       <div role="status">
         {pending ? "Updating results…" : "Results updated"}
       </div>

--- a/app/src/sandbox/combobox-inline-autocomplete/test-browser.ts
+++ b/app/src/sandbox/combobox-inline-autocomplete/test-browser.ts
@@ -11,6 +11,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await combobox.pressSequentially("ap");
     await test.expect(q.status()).toHaveText("Updating results…");
     await combobox.press("ArrowLeft");
+    await test.expect(q.status()).toHaveText("Updating results…");
     await test.expect(q.status()).toHaveText("Results updated");
     await combobox.pressSequentially("pp");
     await test.expect(combobox).toHaveValue("apppple");

--- a/app/src/sandbox/combobox-inline-autocomplete/test-browser.ts
+++ b/app/src/sandbox/combobox-inline-autocomplete/test-browser.ts
@@ -1,0 +1,18 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/6916
+  test("preserves a user-adjusted caret when delayed results update", async ({
+    q,
+  }) => {
+    const combobox = q.combobox("Recipe");
+
+    await combobox.click();
+    await combobox.pressSequentially("ap");
+    await test.expect(q.status()).toHaveText("Updating results…");
+    await combobox.press("ArrowLeft");
+    await test.expect(q.status()).toHaveText("Results updated");
+    await combobox.pressSequentially("pp");
+    await test.expect(combobox).toHaveValue("apppple");
+  });
+});

--- a/app/src/sandbox/combobox-inline-autocomplete/test-browser.ts
+++ b/app/src/sandbox/combobox-inline-autocomplete/test-browser.ts
@@ -9,8 +9,10 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
     await combobox.click();
     await combobox.pressSequentially("ap");
-    await test.expect(q.status()).toHaveText("Updating results…");
+    await test.expect(combobox).toHaveValue("apple");
     await combobox.press("ArrowLeft");
+    // Keep results pending until after the caret moves. Otherwise, the final
+    // assertion could pass without exercising the highlighting effect.
     await test.expect(q.status()).toHaveText("Updating results…");
     await test.expect(q.status()).toHaveText("Results updated");
     await combobox.pressSequentially("pp");

--- a/packages/ariakit-react-components/src/combobox/combobox.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox.tsx
@@ -231,6 +231,13 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
     const items = useStoreState(store, "renderedItems");
     const open = useStoreState(store, "open");
     const contentElement = useStoreState(store, "contentElement");
+    // Depend on this boolean in the highlighting effect so equivalent item
+    // updates don't re-highlight a user-adjusted caret.
+    const firstItemAutoSelected = isFirstItemAutoSelected(
+      items,
+      inlineActiveValue,
+      autoSelect,
+    );
 
     // The current input value may differ from state.inputValue when
     // autoComplete is either "both" or "inline", in which case it will be
@@ -240,11 +247,6 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
     const inputValue = useMemo(() => {
       if (!inline) return storeInputValue;
       if (!canInline) return storeInputValue;
-      const firstItemAutoSelected = isFirstItemAutoSelected(
-        items,
-        inlineActiveValue,
-        autoSelect,
-      );
       if (firstItemAutoSelected) {
         // If the first item is auto selected, we should append the completion
         // string to the end of the value. This will be highlited in the effect
@@ -259,9 +261,8 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
     }, [
       inline,
       canInline,
-      items,
+      firstItemAutoSelected,
       inlineActiveValue,
-      autoSelect,
       storeInputValue,
     ]);
 
@@ -283,11 +284,6 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       if (!inline) return;
       if (!canInline) return;
       if (!inlineActiveValue) return;
-      const firstItemAutoSelected = isFirstItemAutoSelected(
-        items,
-        inlineActiveValue,
-        autoSelect,
-      );
       if (!firstItemAutoSelected) return;
       if (!hasCompletionString(storeInputValue, inlineActiveValue)) return;
       let cleanup = noop;
@@ -321,8 +317,7 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       inline,
       canInline,
       inlineActiveValue,
-      items,
-      autoSelect,
+      firstItemAutoSelected,
       storeInputValue,
     ]);
 


### PR DESCRIPTION
## Motivation

A controlled [`Combobox`](https://ariakit.com/reference/combobox) with `autoComplete="both"` and `autoSelect` can reselect its inline completion when delayed search results commit. If the user moved the caret before that update, their next keystrokes replace the completion.

The same behavior is present in the published `@ariakit/react@0.4.35` package when its legacy `value` and `setValue` controlled props are used, so #6900 exposed but did not introduce the bug.

Fixes #6916.

## Solution

Add a delayed-results variant to the existing inline-autocomplete sandbox and an authoritative browser regression test that follows the reported interaction.

Derive whether the first item is auto-selected once, then make the inline-value memo and completion-highlighting effect depend on that boolean instead of the `renderedItems` array identity. Replacing the results with an equivalent list no longer reruns the highlighting effect or overwrites a user-adjusted caret. A real completion-target change still reruns the effect through the derived boolean or `inlineActiveValue`.

Add patch changesets for `@ariakit/react-components` and `@ariakit/react` because the later investigation confirmed that the published package is affected.

## Preview

- [Before: current-main browser reproduction](https://github.com/user-attachments/assets/007a66a5-4e88-4104-8479-abe2cf61c955)
- [After: caret preserved on the fixed revision](https://github.com/user-attachments/assets/809a4b88-fbd5-46d2-a9b9-e57f6b7dcea9)

## Workaround

Commit the displayed inline completion to controlled state when the reported `ArrowLeft` interaction occurs:

```tsx
const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
  if (event.key !== "ArrowLeft") return;
  // TODO: Remove after https://github.com/ariakit/ariakit/issues/6916 is fixed.
  setInputValue(event.currentTarget.value);
};

<Ariakit.Combobox
  autoComplete="both"
  autoSelect
  onKeyDown={handleKeyDown}
/>;
```

This preserves inline completion and the native caret movement, but it is intentionally limited to the reported `ArrowLeft` keyboard path and commits the displayed completion earlier than normal. If inline completion is not required, switching to `autoComplete="list"` is a simpler workaround.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm test-react app/src/sandbox/combobox-inline-autocomplete/test.ts` (3 tests)
- `pnpm -F app run build-lite`
- `pnpm -F app test src/sandbox/combobox-inline-autocomplete/test-browser.ts` (Chrome, Firefox, and Safari)
- `pnpm build`
- `pnpm clean`
- `pnpm test-react` (947 tests)
- `pnpm test-react18` (947 tests)
- `pnpm changeset status`
