### PR TITLE
Remove the unreferenced website/build-pages/deps.ts re-export

### DIFF
--- a/website/build-pages/deps.ts
+++ b/website/build-pages/deps.ts
@@ -1,4 +1,0 @@
-// @ts-ignore
-import deps from "../.pages/deps.ts";
-
-export default deps as Record<string, unknown>;


### PR DESCRIPTION
## Motivation

`website/build-pages/deps.ts` existed only to re-export a generated module:

```ts
// @ts-ignore
import deps from "../.pages/deps.ts";

export default deps as Record<string, unknown>;
```

Nothing imported it, and nothing ever had. Because it never entered the webpack graph, the undeclared specifiers inside the generated `website/.pages/deps.ts` were invisible to every check, and the `@ts-ignore` suppressed whatever that generated module would otherwise report. The file was simultaneously unused and unverifiable, so anyone auditing declared-versus-imported dependencies had to rediscover that it was dead before concluding its specifiers were harmless. That was the cost paid during #6907.

Closes #6921

## Solution

Delete `website/build-pages/deps.ts`, and nothing else.

### Deadness evidence

A plain text search is not sufficient on its own, so each non-literal resolution mechanism was ruled out separately.

**Literal references**

- `git grep -n 'build-pages/deps'` over tracked files returns zero hits.
- `rg -n --no-ignore --hidden '\.pages/deps'` returns exactly one hit: the deleted file's own line 2.
- `git log -S 'build-pages/deps' --all` is empty. The string has never existed in any file content in repository history. The file was created in `198b760c8` and touched once more in `6f8b32c3d`, and had no importer at either commit.

**Sibling relative imports**, the spelling a `build-pages/deps` search would miss: every module specifier used by every file inside `website/build-pages/` was extracted and sorted. No `./deps`, `./deps.js`, or `./deps.ts` appears.

**Aliases and bare specifiers**

- The website's only path alias is `@/*` to `./*` (`website/tsconfig.json`). A repo-wide search for `@/build-pages` returns 60+ importers covering 19 sibling modules; `deps.ts` is absent. Every other `.pages` re-export shim (`index.ts`, `contents.ts`, `links.ts`, `icons.ts`, `images.ts`, `examples.ts`) has real importers, and `deps.ts` alone had none.
- `website/package.json` declares `"exports": {"./*": "./*"}`, so a cross-workspace bare specifier was theoretically possible. No workspace depends on `website`, so that path is unreachable.
- `website/next.config.js` sets `resolve.alias` to only `sugarss: false` and `babylon: false`.

**Dynamic and glob mechanisms**: zero hits repo-wide for `require.context`, `import.meta.glob`, `globby`, `fast-glob`, and `tinyglobby`, and zero non-literal `import(`/`require(` anywhere under `website/`. The only non-literal `import()` in the repository is in `vitest.setup.ts`, whose call sites build `index.react.tsx` and `index.solid.tsx` paths.

**Directory enumeration**: the only `readdirSync`/`globSync` sites under `website/` read the repo-root `components/` directory, the `sourceContext` list (`guide`, `components`, `examples`, `website/app/(examples)/previews`, `packages/ariakit-react/src`), and a `**/{page,default,layout,loading}.{js,jsx,ts,tsx}` pattern. None enumerate `website/build-pages/`.

**Entry-point discovery**: the legacy website build has no location-based convention that would pick the file up. `website/next.config.js` references `build-pages` only to import `config.js` and `pages-webpack-plugin.js`, no webpack rule keys off files in that directory, and Next.js file-based routing scans `website/app/`.

**Module-graph proof, independent of text matching**: TypeScript's own resolved module graph (`referencedMap` in `website/tsconfig.tsbuildinfo`, produced from a build with the file still present) records `build-pages/index.ts` with 10 referrers, `links.ts` with 3, `contents.ts` and `examples.ts` with 2, `icons.ts`/`images.ts`/`changelog.ts` with 1 each, and `build-pages/deps.ts` with **zero**.

**Webpack-resolution proof**: the generated `website/.pages/deps.ts` contains the literal `import("motion/react")`, but `motion` is not declared by `website/package.json` and `require.resolve("motion/react")` from `website/` throws `MODULE_NOT_FOUND`. A literal `import()` of an unresolvable specifier is a hard `next build` failure, and `typescript.ignoreBuildErrors` does not cover webpack resolution. Since `next build` succeeds on unmodified `main`, that module provably never entered either the client or server webpack graph.

### Verification

- `pnpm run build-website-lite` on unmodified `main`: exit 0, all seven `.pages/*` artifacts produced.
- After the deletion, and after removing `website/.pages` and `website/.next` so regeneration is proven fresh: exit 0, all seven artifacts regenerated including `website/.pages/deps.ts`, byte-identical at 1183 bytes. No warning mentions deps or a missing module; the only warnings are pre-existing Clerk and Edge Runtime `process.emit` notices from `node_modules`.
- `pnpm run tsc`: exit 0.
- `pnpm lint-fix`: exit 0, no changes.

One caveat is worth stating, because a green `pnpm tsc` proves less here than it looks. The root `tsconfig.json` has no `website` project reference, `website/next.config.js` sets `typescript.ignoreBuildErrors: true` and `eslint.ignoreDuringBuilds: true`, and `oxlint.config.ts` lists `website` in `ignorePatterns`. No repository check typechecks or lints this file, so the `@ts-ignore` was suppressing an error nothing would ever report.

To avoid resting on a check the `@ts-ignore` was suppressing, the website's own program was compiled directly, both with and without the file:

```
pnpm -F website exec tsc --noEmit -p tsconfig.json --ignoreDeprecations 6.0
```

With the file: 1238 error lines. Without it: 1235. The deletion introduces **zero** new type errors and removes three, all `TS2307 Cannot find module` inside the generated `.pages/deps.ts` for `motion/react`, `react-router`, and `@ariakit/solid` — undeclared specifiers that only entered the program because this shim imported them.

### On the generator

Issue #6921 asked to confirm that `website/.pages/deps.ts` is still generated *and consumed through some other path*, so that removing the re-export would not quietly orphan the generator. The first half holds: generation is unaffected, and `writeFiles` reaches `writeFileIfNeeded(depsFile, depsContents)` unconditionally.

The second half does not. The deleted file was the only referrer of `website/.pages/deps.ts`, so this change does leave the deps-generation block orphaned, and `getPageExternalDeps` has exactly one caller, inside that block in `website/build-pages/pages-webpack-plugin.js`.

That does not make this change incorrect or unsafe. The whole chain was already dead — the generated artifact only ever fed a file that fed nothing — so this removes one link from an already-dead chain rather than creating new deadness, and the build passes because nothing consumes the artifact. Removing `website/build-pages/get-page-external-deps.js` and the generation block is separable follow-up work tracked in #6925. Note that `getExampleDeps` itself is **not** dead: it has live request-time consumers in `website/components/page-example.tsx` and `website/app/previews/[page]/page.tsx`.

### Changeset

None. `website` is listed in the `ignore` array of `.changeset/config.json`, `website/package.json` is `private`, and removing unreferenced internal code has no consumer-observable effect.

