### PR TITLE
Stabilize the dialog test context

### DIFF
--- a/app/src/sandbox/dialog-nested-variants/test-browser.ts
+++ b/app/src/sandbox/dialog-nested-variants/test-browser.ts
@@ -1,6 +1,12 @@
 import type { Locator, Page } from "@playwright/test";
 import { expect } from "@playwright/test";
+import { test } from "#app/test-utils/fixtures.ts";
 import { withFramework } from "#app/test-utils/preview.ts";
+
+// This 29-test matrix uses the same options and navigates back to the preview
+// before every test. Reuse one context per worker so WebKit doesn't keep
+// opening contexts against the same long-lived browser process.
+test.use({ reuseContext: true });
 
 withFramework(import.meta.dirname, async ({ test }) => {
   function query(locator: Page | Locator) {


### PR DESCRIPTION
## Motivation

A recent Safari job retried the `dialog-nested-variants` matrix after Playwright failed before the test body while creating a fresh context:

```text
browser.newContext: Target page, context or browser has been closed
```

The file defines 29 tests with identical context options, and every test navigates back to the same component preview. Playwright otherwise opens a new context for each case against its worker-scoped browser. The exact test passed 60/60 with retries disabled before this change, which isolates the flaky boundary to browser/context setup rather than the interaction assertions.

## Solution

Reuse the context only for this dialog matrix:

```ts
test.use({ reuseContext: true });
```

Playwright resets the reused page before each case, and the existing preview hook then performs a fresh navigation. Keeping the option file-scoped avoids repeated WebKit context creation without weakening isolation for the rest of the browser suite. A Safari-wide experiment was rejected because global reuse exposed state-sensitive failures in the offscreen and scroll-lock tests.

Verification:

- 87/87 dialog cases passed across Chrome, Firefox, and Safari with retries disabled
- 290/290 Safari dialog cases passed across 10 repeats with retries disabled
- 29/29 Safari dialog cases passed sequentially through one reused context
- the full retry-disabled Safari suite completed all 29 dialog cases, including the formerly retried case, without a context-creation failure
- `pnpm lint-fix`
- `pnpm tsc`

The full-suite run had one earlier unrelated combobox assertion failure; that exact test passed 60/60 on immediate isolated retry with retries disabled.
