### PR TITLE
Align the website @types/node pin with the other workspaces

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1138,8 +1138,8 @@ importers:
         specifier: 5.0.2
         version: 5.0.2
       '@types/node':
-        specifier: 24.12.2
-        version: 24.12.2
+        specifier: 24.13.3
+        version: 24.13.3
       '@types/postcss-import':
         specifier: 14.0.3
         version: 14.0.3
@@ -1154,7 +1154,7 @@ importers:
         version: 3.0.4
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0))
 
 packages:
 
@@ -5224,9 +5224,6 @@ packages:
 
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
-
-  '@types/node@24.12.2':
-    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
 
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
@@ -10015,9 +10012,6 @@ packages:
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-
-  undici-types@7.16.0:
-    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
@@ -15202,10 +15196,6 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@24.12.2':
-    dependencies:
-      undici-types: 7.16.0
-
   '@types/node@24.13.3':
     dependencies:
       undici-types: 7.18.2
@@ -15399,14 +15389,6 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.1.10
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0)
-
   '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
@@ -15414,6 +15396,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.1.5(@types/node@24.13.3)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0)
+
+  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(yaml@2.9.0))':
     dependencies:
@@ -20854,8 +20844,6 @@ snapshots:
 
   undici-types@5.26.5: {}
 
-  undici-types@7.16.0: {}
-
   undici-types@7.18.2: {}
 
   undici@7.24.8: {}
@@ -21141,21 +21129,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.5
-      postcss: 8.5.19
-      rolldown: 1.1.5
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 24.12.2
-      esbuild: 0.28.1
-      fsevents: 2.3.3
-      jiti: 1.21.7
-      terser: 5.46.0
-      yaml: 2.9.0
-
   vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -21166,6 +21139,21 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.13.3
       esbuild: 0.27.4
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      terser: 5.46.0
+      yaml: 2.9.0
+
+  vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.19
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.13.3
+      esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 1.21.7
       terser: 5.46.0
@@ -21201,36 +21189,6 @@ snapshots:
       vite: 8.1.5(@types/node@24.13.3)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0)
       vitest: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0))
 
-  vitest@4.1.10(@types/node@24.12.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.4
-      pathe: 2.0.3
-      picomatch: 4.0.5
-      std-env: 4.0.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 24.12.2
-      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
-      happy-dom: 20.11.1
-      jsdom: 29.1.1(@noble/hashes@1.8.0)
-    transitivePeerDependencies:
-      - msw
-
   vitest@4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
@@ -21252,6 +21210,36 @@ snapshots:
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.1.5(@types/node@24.13.3)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.13.3
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+      happy-dom: 20.11.1
+      jsdom: 29.1.1(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.46.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.13.3

--- a/website/package.json
+++ b/website/package.json
@@ -103,7 +103,7 @@
     "@types/lodash": "4.17.24",
     "@types/lodash-es": "4.17.12",
     "@types/marked": "5.0.2",
-    "@types/node": "24.12.2",
+    "@types/node": "24.13.3",
     "@types/postcss-import": "14.0.3",
     "@types/react": "18.3.28",
     "@types/react-dom": "18.3.7",


### PR DESCRIPTION
## Motivation

Partially addresses #6920.

Two things up front. **This does not reduce the peer-variant count: there are three `vite@8.1.5` and three `vitest@4.1.10` variants before and after.** The issue's stated Expected outcome, that a filtered install materializes each of them once, is therefore not met, so no closing keyword is used here. Issue #6920 stays open as the tracking record for the structural `esbuild` and `jiti` split described below.

`pnpm-lock.yaml` carries three peer variants each of `vite@8.1.5` and `vitest@4.1.10`, differing only in their resolved peers. Each is a separate directory under `node_modules/.pnpm`, so a filter spanning more than one materializes Vite and Vitest more than once. Before this change:

| Variant | Peers | Resolved by |
| --- | --- | --- |
| A | `(@types/node@24.13.3)(esbuild@0.27.4)(jiti@1.21.7)` | root |
| B | `(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)` | `app`, the eight `packages/*` that declare `vitest`, and `templates/react` (which declares only `vite`) |
| C | `(@types/node@24.12.2)(esbuild@0.28.1)(jiti@1.21.7)` | `website` |

`terser@5.46.0` and `yaml@2.9.0` are identical across all three and are omitted.

The root project is installed even under `--filter`, so every CI filter carries variant A on top of whatever else it selects. That is why `root...` and `app...` already materialize two variants today, while `website...` and the unfiltered install materialize three.

`vite@8.1.5` declares `esbuild` (`^0.27.0 || ^0.28.0`) and `jiti` (`>=1.21.0`) as **optional** peers, so pnpm resolves them from whatever is present in each workspace's closure. Three independent axes drive the split.

**`@types/node` is genuine pin drift**, and the only axis a pin the repository already declares can fix. Root, `app`, and `nextjs` pin `24.13.3`; `website` pinned `24.12.2`.

**`esbuild` is a hard version conflict.** `tsup@8.5.1`, a root devDependency, carries `esbuild@0.27.4` as a regular dependency. In `app`, `wrangler@4.114.0` pins `esbuild@0.28.1` exactly and `astro@7.1.3` requires `^0.28.0`. The ranges are disjoint. `website` has no `esbuild` requirement of its own; its `0.28.1` comes from pnpm resolving the unconstrained (`*`) optional peer of `terser-webpack-plugin@5.4.0`, reached through the `webpack@5.105.4` that `website` declares directly.

**`jiti` is also a hard version conflict.** `tailwindcss@3.4.18`, a `website` dependency, requires `jiti@^1.21.7`. `@tailwindcss/node@4.3.3`, which requires `jiti@^2.7.0`, is reached from `app` through `@tailwindcss/vite@4.3.3`. The ranges are disjoint, and `renovate.json` deliberately freezes `tailwindcss` at `^3`.

## Solution

Align the one axis that is real drift, and leave the two that are load bearing.

`website/package.json` now pins `@types/node` at `24.13.3`, matching root, `app`, and `nextjs`, followed by a regenerated `pnpm-lock.yaml`.

This also removes a real inconsistency inside `website`. Before this change, `website` pinned `@types/node@24.12.2` while its own `@types/*` dependencies resolved `24.13.3`: both `@types/cross-spawn@6.0.6` and `@types/fs-extra@11.0.4` listed `'@types/node': 24.13.3`.

Every lockfile hunk follows from that single manifest edit. The `website` importer re-pins `@types/node` and re-keys its `vitest` entry, `@types/node@24.12.2` drops out because nothing else referenced it and takes `undici-types@7.16.0` with it, and `website`'s `vite`, `vitest`, and `@vitest/mocker` entries are re-keyed onto the `24.13.3` axis. The remaining churn is YAML key re-sorting; root's variant is untouched.

### Why the other two axes are not collapsed here

`website`'s variant is re-keyed from `(@types/node@24.12.2)(esbuild@0.28.1)(jiti@1.21.7)` to `(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)`. The issue predicted that aligning `@types/node` alone would most likely produce a fourth variant. It renames the third instead, because the `24.12.2` variant had no other consumer.

Retiring the `esbuild@^0.27.0` constraint means removing or replacing root's `tsup`, which is still on `packages/ariakit-react`'s build path. Retiring the `jiti@^1.21.7` constraint means moving `website` off Tailwind v3, a legacy-stack migration that Renovate freezes on purpose. Both are upgrades this change should not attempt.

Two alternatives were evaluated. Declaring `esbuild` and `jiti` in `package.json` files that do not import them, purely to steer pnpm's optional peer resolution, was measured to collapse three variants into two, and it would not add packages to any filter, since `root...` already materializes both `esbuild` and both `jiti` versions today. **It was rejected on policy, not because it fails.** It declares dependencies those workspaces do not use, which is the inverse of the rule that [`a20506c`](https://github.com/ariakit/ariakit/commit/a20506c6b) and [`c3cea84`](https://github.com/ariakit/ariakit/commit/c3cea84a0) have just been enforcing, and it adds two more drift-prone pins to fight drift. If that trade is worth making, `pnpm-workspace.yaml` `overrides` is the mechanism designed for it. The other alternative, `pnpm dedupe`, shifts root's `jiti` to `2.7.0` and `tsup`'s `postcss` to `8.5.19` without collapsing any variant, so it is unrelated churn here.

## Measurements

Each install was reproduced the way `.github/workflows/setup/action.yml` does it, with `pnpm_config_verify_deps_before_run=false` and `pnpm install --fail-if-no-match --frozen-lockfile --filter <filter>`, after deleting every `node_modules` directory first. Counts are `ls node_modules/.pnpm | wc -l`; sizes are `du -sh node_modules`.

| Filter | Packages before | Packages after | Size before | Size after |
| --- | --- | --- | --- | --- |
| `root...` | 528 | 528 | 398M | 398M |
| `app...` | 1365 | 1365 | 1.8G | 1.8G |
| `website...` | 1092 | **1090** | 859M | **856M** |
| unfiltered | 1756 | **1754** | 2.2G | 2.2G |

### Set difference

`root...` and `app...` are identical before and after: the set difference is empty in both directions, as expected since `website` is in neither closure.

`website...` and the unfiltered install share the same set difference. Five entries removed:

```
@types+node@24.12.2
undici-types@7.16.0
vite@8.1.5_@types+node@24.12.2_esbuild@0.28.1_jiti@1.21.7_terser@5.46.0_yaml@2.9.0
vitest@4.1.10_@types+node@24.12.2_@vitest+coverage-v8@4.1.10_happy-dom@20.11.1_jsdom@29_417f70782cb9cb3ada9153e6936f243b
@vitest+mocker@4.1.10_vite@8.1.5_@types+node@24.12.2_esbuild@0.28.1_jiti@1.21.7_terser@5.46.0_yaml@2.9.0_
```

Three entries added:

```
vite@8.1.5_@types+node@24.13.3_esbuild@0.28.1_jiti@1.21.7_terser@5.46.0_yaml@2.9.0
vitest@4.1.10_@types+node@24.13.3_@vitest+coverage-v8@4.1.10_happy-dom@20.11.1_jsdom@29_52e000e84eab3b21969e09e405742e68
@vitest+mocker@4.1.10_vite@8.1.5_@types+node@24.13.3_esbuild@0.28.1_jiti@1.21.7_terser@5.46.0_yaml@2.9.0_
```

Three of the five removals are the same Vite, Vitest, and mocker packages re-keyed onto the new axis, not genuine removals. The real net change is the two packages that disappear.

## Renovate

`renovate.json` disables `website/package.json` wholesale:

```json
{
  "matchFileNames": ["website/package.json"],
  "enabled": false
}
```

That rule arrived in [`dcba034`](https://github.com/ariakit/ariakit/commit/dcba03460893105c53f497d80bc67b07977266c3), "Split website and site dependencies" (#5561), whose stated purpose was to "disable Renovate updates for the dependencies now owned by website while keeping site updates enabled". `site` is the workspace now called `app`. The exclusion is deliberate: `website` is the legacy stack being replaced, and unfreezing `next`, `react`, `webpack`, or `tailwindcss` there would be churn on a workspace slated for removal.

That reasoning still holds for the runtime stack, so this change does not touch `renovate.json`. Re-enabling automation for a workspace is a maintainer decision.

The recommendation is to **narrow the exclusion rather than remove it**. The blanket rule also freezes the shared development tooling pins that are supposed to track the rest of the repository, and those are exactly the ones that drift into peer-variant splits. Without that, the next `@types/node` bump to root, `app`, and `nextjs` re-creates the divergence this change just removed, so the alignment is point in time. A later rule overrides the blanket disable, since Renovate applies `packageRules` in order:

```json
{
  "matchFileNames": ["website/package.json"],
  "matchPackageNames": ["@types/node", "vitest"],
  "enabled": true
}
```

## Verification

`pnpm lint-fix`, `pnpm tsc`, `pnpm test`, `pnpm test-react`, `pnpm test-solid`, `pnpm build-website-lite`, and `pnpm build` followed by `pnpm clean` all pass.

Worth being precise about what `pnpm tsc` covers here, since this is a types-only bump. It reaches `website` partly: `tsconfig.test.json`, referenced from the root `tsconfig.json`, pulls in eight files under `website/build-pages`, which are checked with `checkJs` and `strict` from `tsconfig.base.json`. It does not reach the Next.js app sources, because `tsconfig.node.json` excludes `website`, and `next build` does not check them either, since `website/next.config.js` sets `typescript.ignoreBuildErrors`. So the evidence for this bump is those `build-pages` files type checking plus `pnpm build-website-lite` compiling the site, not a full `website` typecheck.

An earlier run against the previous base saw a single flaky `app/src/sandbox/hovercard-interactions` failure that passed on rerun and in isolation. After rebasing, the full suite passes. The `app...` closure is identical before and after this change, so no `app` test can be affected by it.

No changeset is included: `website` is private and listed in the `ignore` array of `.changeset/config.json`, no published `packages/*` manifest changed, and no `packages/*` importer moved in the lockfile.

## Review gate reassessment

<details>
<summary>Cycle 3: Continue the one-pin direction, compress the description</summary>

**Assessment**

Issue severity is low: nothing is broken, and #6920 says so. Supported scope is four workspaces' `@types/node` pin, with no public API, runtime behavior, or consumer-visible surface. User impact for library consumers is zero; the contributor and CI impact is 2 packages and 3M on one filter. Expected frequency is every CI install, but the per-install delta is a rounding error. The correctness win, `website` no longer resolving two different `24.x` versions of `@types/node` at once, is worth more than the size win.

Implementation complexity is effectively nil: one version literal plus a mechanically regenerated lockfile, with no branches, state, helpers, abstractions, tests, or public contracts added. Maintenance complexity is negative for the code, one fewer divergent pin, and positive only for this description.

Nine findings across three gate rounds caused the cadence. None concerned the diff, and every round concluded the code should ship as staged. Seven concerned this description and two concerned the `Closes` keyword. Most of the seven landed in the multi-hop causal derivation of each peer axis. That prose, not the design, was generating the findings, and an independent advisory pass found a further latent ambiguity in it.

**Decision**

Continue the current direction with no code change. The scope is correct: the task said to prefer the minimum change and to land whatever partial convergence is genuinely correct rather than forcing full convergence, and the `esbuild` and `jiti` axes are disjoint third-party ranges that no manifest pin can fully reconcile.

Compress this description instead, keeping every required element (the measurement table, the set difference, the per-variant diagnosis, and the Renovate recommendation) while dropping derivation narrative that is not load bearing and decays as dependencies move. Correct the two outstanding factual findings, disambiguate the `tsup` sentence, and state plainly that the rejected alternative was rejected on policy rather than because it fails to work, so the trade is visible rather than buried.

Drop the `Closes` keyword. This pull request does not achieve #6920's stated outcome, so closing it would mark unmet work as done. #6920 stays open as the tracking record for the structural `esbuild` and `jiti` split, and the full constraint analysis is recorded above so a reviewer sees it without opening the issue.

No verification rerun is required, because the reviewed code snapshot is unchanged.

</details>
