### PR TITLE
Remove the publicHoistPattern escape hatch

### DIFF
--- a/guide/package.json
+++ b/guide/package.json
@@ -5,5 +5,8 @@
   "type": "module",
   "exports": {
     "./*": "./*"
+  },
+  "dependencies": {
+    "react": "19.2.8"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -470,7 +470,11 @@ importers:
         specifier: 3.0.4
         version: 3.0.4
 
-  guide: {}
+  guide:
+    dependencies:
+      react:
+        specifier: 19.2.8
+        version: 19.2.8
 
   nextjs:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,8 +39,4 @@ peerDependencyRules:
     react: "19"
     react-dom: "19"
 
-publicHoistPattern:
-  - "*react*"
-  - "*testing-library*"
-
 saveExact: true


### PR DESCRIPTION
## Motivation

`pnpm-workspace.yaml` set `publicHoistPattern: ["*react*", "*testing-library*"]`, which symlinks every matching package into the repository-root `node_modules`, where Node's upward resolution finds it from any workspace regardless of what that workspace declares.

That is one of the two mechanisms #6907 named as hiding undeclared workspace dependencies. [`c3cea84a0`](https://github.com/ariakit/ariakit/commit/c3cea84a0) fixed the declarations, but the escape hatch that had been masking them stayed configured, so the same class of defect could silently return and every further reduction of the root dependency set was being evaluated against a workspace graph this setting partially concealed.

Closes #6922

## Solution

Delete the `publicHoistPattern` block, and declare `react` in `guide`, the one workspace that was relying on the root for it.

No workspace *failed* to resolve a package once the pattern was gone, so nothing here is a repair. The `guide` declaration is added because that workspace's JSX injects `react/jsx-runtime`, which it previously resolved by walking up into the root `node_modules`. That is the pattern this change exists to eliminate, and it is worth closing while the root manifest is actively shrinking.

pnpm does not record `publicHoistPattern` as lockfile state (`settings:` holds only `autoInstallPeers` and `excludeLinksFromLockfile`), so the deletion itself changes no resolution. The only lockfile change is the `guide` importer entry, and it introduces no new package version.

### What was actually being publicly hoisted

The pattern is a substring match, so it reached far past React itself. Comparing the root `node_modules` before and after a full install, these 64 entries stop being symlinked there:

`@ariakit/react`, `@ariakit/react-components`, `@ariakit/react-store`, `@ariakit/react-utils`, `@astrojs/react`, `@babel/plugin-transform-react-display-name`, `@babel/plugin-transform-react-jsx`, `@babel/plugin-transform-react-jsx-development`, `@babel/plugin-transform-react-jsx-self`, `@babel/plugin-transform-react-jsx-source`, `@babel/plugin-transform-react-pure-annotations`, `@babel/preset-react`, `@base-ui/react`, `@clerk/clerk-react`, `@emotion/react`, `@floating-ui/react-dom`, `@radix-ui/react-arrow`, `@radix-ui/react-collection`, `@radix-ui/react-compose-refs`, `@radix-ui/react-context`, `@radix-ui/react-direction`, `@radix-ui/react-dismissable-layer`, `@radix-ui/react-focus-guards`, `@radix-ui/react-focus-scope`, `@radix-ui/react-id`, `@radix-ui/react-popover`, `@radix-ui/react-popper`, `@radix-ui/react-portal`, `@radix-ui/react-presence`, `@radix-ui/react-primitive`, `@radix-ui/react-select`, `@radix-ui/react-slot`, `@radix-ui/react-use-callback-ref`, `@radix-ui/react-use-controllable-state`, `@radix-ui/react-use-effect-event`, `@radix-ui/react-use-layout-effect`, `@radix-ui/react-use-previous`, `@radix-ui/react-use-rect`, `@radix-ui/react-use-size`, `@radix-ui/react-visually-hidden`, `@react-aria/utils`, `@react-types/shared`, `@stripe/react-stripe-js`, `@tanstack/react-query`, `@testing-library/dom`, `@testing-library/react`, `@use-gesture/react`, `babel-plugin-react-compiler`, `hoist-non-react-statics`, `lucide-react`, `react-aria`, `react-aria-components`, `react-colorful`, `react-day-picker`, `react-is`, `react-markdown`, `react-refresh`, `react-remove-scroll`, `react-remove-scroll-bar`, `react-router`, `react-stately`, `react-style-singleton`, `react-toastify`, `template-react`.

That list splits cleanly, and the split is the actual safety argument. 44 of the 64 are declared by no workspace manifest and are never used as a module specifier anywhere in the repository. 43 of those are transitive dependencies of `@wordpress/components`, `react-aria-components`, `@radix-ui/*`, `@clerk/astro`, `@vitejs/plugin-react`, and `@babel/preset-react`. The 44th is `template-react`, which was only ever caught because the `templates/react` workspace is *named* `template-react`; it is consumed through a relative path, never as a package specifier.

Two of the 44 do appear as plain strings, and neither is a dependency: `template-react` as that workspace's own `name`, and `react-aria` as a documentation tag id in `app/src/lib/tags.ts`.

The remaining 20 are already declared by every workspace that uses them, so they simply move from the root into those workspaces' own `node_modules`:

| Package | Declared by |
| --- | --- |
| `@ariakit/react` | `app`, `examples`, `nextjs`, `templates/react`, `website` |
| `@ariakit/react-components` | `app`, `examples`, `packages/ariakit-react`, `templates/react`, `website` |
| `@ariakit/react-store` | `app`, `packages/ariakit-react-components`, `templates/react`, `website` |
| `@ariakit/react-utils` | `app`, `packages/ariakit-react-components`, `packages/ariakit-react-store`, `templates/react`, `website` |
| `@astrojs/react`, `@react-aria/utils`, `lucide-react`, `react-aria-components` | `app` |
| `@babel/preset-react`, `@clerk/clerk-react`, `@stripe/react-stripe-js`, `react-markdown` | `website` |
| `@radix-ui/react-popover`, `@radix-ui/react-select` | `app`, `examples` |
| `@tanstack/react-query` | `app`, `website` |
| `react-router`, `react-toastify` | `examples` |
| `babel-plugin-react-compiler` | `nextjs` |
| `@testing-library/dom`, `@testing-library/react` | `packages/ariakit-test` |

The four `@ariakit/*` workspace links joined this set during review: [`9c2c97e7a`](https://github.com/ariakit/ariakit/commit/9c2c97e7a) removed them from the root manifest, so the hoist pattern became the only thing putting them at the root. They match `*react*` by name.

None of the 64 is declared by the root manifest, an empty intersection. That is what makes the general rule concrete here: public hoisting only ever added packages root does not declare, so removing it cannot take away anything root provides.

`react`, `react-dom`, `@types/react`, `@types/react-dom`, `@testing-library/jest-dom`, and `@vitejs/plugin-react` all stay at the root, because the root manifest declares them itself.

None of the 64 declares a `bin`, so no root `node_modules/.bin` entry is lost either.

The result is that the root `node_modules` now contains exactly root's 41 declared devDependencies plus the `node` runtime entry, and nothing else, under every CI filter. Before this change it carried up to 64 additional hoisted entries depending on the filter.

### Only `guide` needed a declaration

Every workspace was audited for references to a `*react*` or `*testing-library*` package that its own manifest does not declare, covering import and re-export specifiers, `require()` and `createRequire()`, JSDoc `import()` types, tsconfig `types` and `jsxImportSource`, bundler config strings for Babel presets, webpack loaders, Vite and Astro plugins, and the files generated under `website/.pages/`.

`guide` was the only workspace that needed one, and it is covered below. No other workspace lost a package it resolves. Three further undeclared references do exist. None is affected by this change, because each resolves through something `publicHoistPattern` never governed, so none of them blocks this PR. They are pre-existing gaps of the same family #6907 addressed, and they are recorded here so they are not lost.

Two of them resolve through packages the root manifest declares itself, which `publicHoistPattern` never governed: `packages/ariakit-scripts/src/docs.test.ts` reads `react/package.json` through `createRequire` without `packages/ariakit-scripts` declaring `react`, and `app/tsconfig.test.json` inherits `types: ["node", "@testing-library/jest-dom"]` from the root `tsconfig.test.json` without `app` declaring it.

The third is harmless for a different reason. `website/env.d.ts` carries a stale ambient `declare module "react-toastify/dist/ReactToastify.css"` while `website` does not declare `react-toastify`, which is one of the 64 packages that stop being hoisted. An ambient declaration triggers no module resolution, and nothing under `website/` imports that specifier, so it cannot break.

### `guide`

#6922 flagged `guide` as the one workspace to settle before removing the setting: it declares no dependencies at all, yet its seven `site-icon.tsx` files are JSX, so the automatic runtime injects `react/jsx-runtime` into them.

`guide` now declares `react` at `19.2.8`, which is the one dependency its own files actually pull in.

The investigation showed that `guide` does not *fail* to resolve React once the pattern is gone, so by the issue's literal criterion no declaration was required. It is added anyway, for two reasons. Without it, `guide` resolves `react/jsx-runtime` by walking up into the repository-root `node_modules`, which is the exact pattern this change exists to eliminate, and it works only because the root manifest happens to declare `react`. That is not a stable footing: #6929 removed twelve entries from root during this PR's review, and #6922 names further reduction of the root dependency set as the direction of travel. Declaring it also means `ariakit react18` rewrites `guide` like every other workspace instead of leaving it to inherit root's rewrite.

The declaration is resolution-neutral. `guide` resolved `react/jsx-runtime` to `.pnpm/react@19.2.8/node_modules/react` before, and resolves to the identical path after, because `19.2.8` is what root and `examples` already use, so no second copy is materialized. The lockfile gains only a `guide` importer entry and no new package version.

`@types/react` is deliberately not added, because declaring it in `guide` would be a genuine no-op. `tsconfig.base.json` sets `types: ["node"]`, so a `guide`-local `@types/react` would never be auto-included. TypeScript does type-check `guide`'s JSX against React's types, but it reaches them through the UMD global that `@types/react` declares (`export as namespace React`), which supplies `JSX.IntrinsicElements` under `"jsx": "preserve"`. Those types enter the `tsconfig.node.json` program because `templates/react` imports React, not because of anything `guide` declares.

Positive evidence that `guide` is fine, rather than an inference from the absence of a failing check:

- `pnpm build-website-lite` under the narrow `website...` filter prerenders all seven guide icons. Fingerprinting each icon's longest `path`/`polyline` attribute against the built output finds all 7 of 7 in prerendered HTML, so every one of them compiled and rendered.
- The injected specifier never reaches node resolution at all. Next.js aliases `react/jsx-runtime$` to its own bundled React in `next/dist/build/create-compiler-aliases.js` line 190, and again for the vendored app-page layers at lines 209 and 217.
- That alias is provably in force rather than merely present. React `19.2.8`, which is what upward resolution finds, creates elements tagged `Symbol.for("react.transitional.element")`. Both the React `18.3.1` that `website` declares and the copy Next actually renders with (`next/dist/compiled/react`) expect `Symbol.for("react.element")`. If the specifier had fallen through to root's React 19, server rendering would have thrown instead of emitting the icons.
- The same generated `website/.pages/icons.ts` also re-exports the `examples/*/site-icon.tsx` files, and `examples` declares `react` at `19.2.8` against `website`'s `18.3.1`. Those icons render today, which independently confirms that the alias intercepts regardless of what a workspace declares, and that a `19.2.8` declaration in a workspace the website renders is already normal here.

The React 18 suite deserves its own check. `ariakit react18` rewrites React versions only where a manifest already declares them (`updateReactDependencies` in `packages/ariakit-scripts/src/react18.ts` skips any name not already present), and it rsyncs `pnpm-workspace.yaml` into its temp workspace, so this change applies there too. Before this PR, `guide` declared nothing and was therefore never rewritten; it landed on React 18 only by walking up to root's rewritten copy.

Running `pnpm test-react18` from a wiped temp workspace on both sides and resolving from the temp `guide/` directory:

| | base | this PR |
| --- | --- | --- |
| `pnpm test-react18` | pass (183 files / 947 tests) | pass (183 files / 947 tests) |
| temp root `react` declaration | `18.3.1` | `18.3.1` |
| temp `guide` `react` declaration | none, never rewritten | `18.3.1`, rewritten |
| temp `guide/node_modules` | absent | `react` |
| `guide` resolves `react/jsx-runtime` to | `18.3.1`, via root | `18.3.1`, via its own declaration |
| temp root `node_modules` entries | 106 | 42 |

The resolved version is the same either way, which is why removing the hoist pattern alone would not have broken anything: `guide` never received React through public hoisting, it walked up to root's `node_modules/react`, and that exists because root declares `react` itself. Public hoisting only ever added packages root does not declare. What the declaration changes is that `guide` now gets React 18 on its own terms rather than by inheriting a root entry that a live workstream is shrinking.

One correction to the issue text: `guide` *is* type-checked. All seven files are in the root `tsconfig.node.json` project, which `tsc -b` builds, confirmed with `tsc -p tsconfig.node.json --showConfig`. That check does not exercise React resolution, though, since `tsconfig.base.json` sets `"jsx": "preserve"` with no `jsxImportSource`, so TypeScript resolves no React specifier relative to `guide`. It is the build evidence above, not the type check, that establishes the behavior.

## Verification

Because a full unfiltered install masks exactly the problem #6907 describes, every filter set that selects a distinct set of projects was installed from a wiped `node_modules`, mirroring `.github/workflows/setup/action.yml` with `pnpm_config_verify_deps_before_run=false pnpm install --fail-if-no-match --frozen-lockfile --filter <each filter>`, and then followed by a real job command from that set. Several CI jobs share each filter set, so this replays one command per set rather than every job. The one remaining filter set is equivalent to a covered one, as noted below the table.

| Filter set | Command | Result |
| --- | --- | --- |
| `app...` `./packages/*...` `examples...` `./templates/*...` | `pnpm run lint`, `pnpm run lint-css` | pass |
| `app...` `website...` `./templates/*...` `./packages/*...` | `pnpm run tsc -v` | pass |
| `./packages/*...` | `pnpm run build`, `pnpm run clean` | pass, no generated drift |
| `./packages/*...` | `pnpm run docs` | pass, no generated drift |
| `app...` `website...` `./packages/*...` | `pnpm test` | pass (61 files / 720 tests) |
| `app...` `./packages/*...` | `pnpm test-react` | pass (183 files / 947 tests) |
| `app...` `./packages/*...` | `pnpm test-solid` | pass (6 files / 8 tests) |
| `root...` | `pnpm test-react18` | pass (183 files / 947 tests) |
| `website...` | `pnpm run build-website-lite` | pass |
| `app...` | `pnpm -F nextjs run tsc`, `pnpm run build-app-lite` | pass |

One further filter set appears in `deploy.yml`, `deploy-preview.yml`, and `perf.yml`: `app...` combined with `nextjs...`. It is equivalent to `app...` on its own, because `app/package.json` already declares `nextjs` in `devDependencies`, so both select the same 15 workspace projects. `deploy.yml` then runs `pnpm run build-app`, the non-lite form of the `build-app-lite` verified above.

Some jobs were not replayed locally, all of them under filter sets already covered above. `app.yml` and `plus.yml` run `pnpm -F app test` and `pnpm -F website test` against artifacts produced by builds that are verified here. `og-images.yml` runs `pnpm -F app run og-image-generate`, and `perf.yml` runs `pnpm -F app run test-perf` and `pnpm -F app run perf-compare`; the app and worker builds `perf.yml` depends on are the non-lite form of the verified `build-app-lite`. `build-styles.yml` uses `install: "false"` and so is unaffected either way.

Since `pnpm-workspace.yaml` is in `dependencyAndConfigNames` and `isFullCIPath` returns true for it (`packages/ariakit-scripts/src/ci.ts`), this PR triggers the full CI matrix, so all of those jobs run there.

`pnpm build` followed by `pnpm clean` leaves `git status --short` showing only the three files this PR changes.

One local note. pnpm records `publicHoistPattern` in `node_modules/.modules.yaml`, so changing it makes pnpm purge and rebuild `node_modules` on the next install. CI runners always start clean and suppress the confirmation, so nothing there is affected. In an existing local checkout the first install after this lands will purge `node_modules`, which is a confirmation prompt interactively and an `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` error in a shell with no TTY.

The same applies to the React 18 workspace, and there a plain `pnpm install` does not fix it. `ariakit react18` rsyncs the repository to `$TMPDIR/ariakit-react18/<hash>/workspace` but excludes `node_modules`, so a temp workspace left over from before this change keeps its old modules directory and its next install hits the same purge, surfacing as an opaque `pnpm install ... failed with 1`. Deleting `$TMPDIR/ariakit-react18` once clears it.

Every install measured above was run from a wiped `node_modules`, and both React 18 runs from a wiped temp workspace, so none of the numbers are affected by a stale modules directory.

### Install measurements

Measured per filter from a wiped `node_modules`, before and after the removal.

| Filter set | `.pnpm` entries | `du -sk node_modules` | Root entries before | after |
| --- | --- | --- | --- | --- |
| `app...` `./packages/*...` `examples...` `./templates/*...` | 1367 both | 1874160 KB both | 98 | 42 |
| `app...` `website...` `./templates/*...` `./packages/*...` | 1752 both | 2283292 KB both | 106 | 42 |
| `./packages/*...` | 526 both | 407212 KB both | 50 | 42 |
| `app...` `website...` `./packages/*...` | 1751 both | 2283224 KB both | 105 | 42 |
| `app...` `./packages/*...` | 1363 both | 1869952 KB both | 95 | 42 |
| `root...` | 518 both | 405552 KB both | 46 | 42 |
| `website...` | 1087 both | 875580 KB both | 89 | 42 |
| `app...` | 1363 both | 1869952 KB both | 95 | 42 |

The install floor does not move in either direction. Public hoisting only adds symlinks to the root `node_modules`; it never changes which packages are materialized in the virtual store, so `.pnpm` entry counts and `du -sk` totals are identical for every filter. What changes is only the root `node_modules` layout, which collapses to the constant 42 described above.

To be precise about what each column proves: the removed entries are symlinks, which occupy 0 KB, so `du` could not have detected this change in either direction. The `.pnpm` entry count is the column that would reveal a package genuinely appearing or disappearing, and it does not move. The root-entry column is what actually changes.

These numbers also confirm that pnpm installs the workspace root project regardless of filter, which is why root's own declarations remain available everywhere.

## Review gate reassessment

<details>
<summary>Cycle 6: Declare react in guide, keep everything else unchanged</summary>

**Assessment**

Issue severity is low and entirely contributor-facing: nothing is broken for consumers, and the change ships no runtime code. Supported scope is every workspace in `pnpm-workspace.yaml`. Likely user impact is zero for package consumers and positive for contributors, since the root `node_modules` becomes exactly root's own declarations and a missing declaration now fails at install time rather than at the first narrow-filter CI job. Expected frequency is high in the sense that the masked failure mode is hit on every further reduction of the root manifest, which is an active workstream.

Implementation complexity is minimal and mostly negative: the change deletes four lines of configuration and adds one dependency line. It introduces no branches, state, helpers, abstractions, tests, documentation, public contracts, or platform policy. Maintenance complexity decreases, because one non-default pnpm setting goes away and pnpm's strict layout now enforces mechanically what [`c3cea84a0`](https://github.com/ariakit/ariakit/commit/c3cea84a0) established by hand.

Six finding-bearing rounds sounds like accumulating complexity, but the reviewed implementation was byte-identical across the first five and no round ever identified a defect in committed content. The findings clustered into description accuracy and a base branch that moved four times during review, including one move that materially invalidated the measurements. Those are properties of the review context, not of the design.

**Decision**

Keep the `publicHoistPattern` deletion exactly as it is, and add `react` to `guide`.

The original reasoning for leaving `guide` undeclared was that its only consumer aliases the specifier away, that root's own `react` makes resolution identical either way, and that any declared version would misstate the effective runtime. The third reason does not survive comparison with `examples`, which declares `react` at `19.2.8` while being rendered through Next's bundled React in the same generated `icons.ts`. The second reason rests on root's manifest, which #6929 shrank by twelve entries during this review and which #6922 names as the direction of further work. Leaving the one workspace the issue singled out dependent on upward root resolution would contradict the purpose of the change.

`@types/react` is deliberately not added. `guide` is type-checked under `tsconfig.node.json`, which sets `"jsx": "preserve"` with no `jsxImportSource`, so TypeScript resolves no React specifier from `guide` and the declaration would be unused. This is the respect in which `guide` genuinely differs from `examples`, whose config sets `"jsx": "react-jsx"`.

</details>

## Changeset

None. `pnpm-workspace.yaml` is not published, and no workspace manifest changed, so no published package's `dependencies` or `peerDependencies` moved.

Verified at source rather than cited: `getPackageDependencies` in `packages/ariakit-scripts/src/build.ts` still merges only `dependencies` and `peerDependencies`, and it is the only place either the generated `exports` map or the bundling externals predicate reads manifest dependency data. `devDependencies` is never read there, so a devDependency-only addition could not alter bundling or `dist` even if one had been needed.

Confirmed empirically as well. Building the published packages on this branch and on the base produces 1233 built artifacts whose `shasum` values match one for one, with identical generated `exports` maps.
