### PR TITLE
Declare react in packages/ariakit-scripts

### DIFF
--- a/packages/ariakit-scripts/package.json
+++ b/packages/ariakit-scripts/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@playwright/test": "1.62.0",
+    "react": "19.2.8",
     "vitest": "4.1.10"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -659,6 +659,9 @@ importers:
       '@playwright/test':
         specifier: 1.62.0
         version: 1.62.0
+      react:
+        specifier: 19.2.8
+        version: 19.2.8
       vitest:
         specifier: 4.1.10
         version: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(yaml@2.9.0))


### PR DESCRIPTION
## Motivation

`packages/ariakit-scripts/src/docs.test.ts` resolves React at runtime to decide whether to skip the readme-docs check:

```ts
const reactMajor = Number.parseInt(
  createRequire(import.meta.url)("react/package.json").version,
  10,
);

test.skipIf(reactMajor < 19).each(docsPackages)(
```

`packages/ariakit-scripts/package.json` declared `react` in no dependency field, so that specifier resolved only by walking up to the repository root manifest, which declares `"react": "19.2.8"`. Because the require goes through `createRequire` rather than a static import, no type check, lint rule, or bundler pass reports it.

This is the same class as #6907: a workspace resolving a package through the root manifest instead of its own.

## Solution

Declare `react` in the `@ariakit/scripts` manifest so the workspace resolves the version it actually uses.

```diff
   "devDependencies": {
     "@playwright/test": "1.62.0",
+    "react": "19.2.8",
     "vitest": "4.1.10"
   }
```

`devDependencies` because `react` is reached only from `docs.test.ts`; nothing under `packages/ariakit-scripts/src/` imports React at runtime. An exact version rather than a caret range because `@ariakit/scripts` is `private: true`, and the repository pins exact versions for private workspaces and the root. `@types/react` is deliberately not added: the specifier is reached through `createRequire(...)(...)`, which is typed `any`, and no source in this workspace type-checks against React types.

The `pnpm-lock.yaml` diff is the corresponding three-line entry in the `packages/ariakit-scripts` importer block. No `packages:` or `snapshots:` entries change, because `react@19.2.8` was already resolved for other importers.

## React 18 skip behavior

`packages/ariakit-scripts/src/react18.ts` rewrites `react` in every manifest that declares it, sourcing target versions from `website/package.json`. Adding this declaration therefore brings the `@ariakit/scripts` manifest into that rewrite, which is intended but had to be confirmed rather than assumed, since this file reads `react` specifically to branch on the major version.

Both branches were measured before and after the change:

| Run | `packages/ariakit-scripts` react | Resolved from | `reactMajor` | Docs tests |
| --- | --- | --- | --- | --- |
| Default, before | not declared | root `node_modules` | 19 | 35 passed, 0 skipped |
| Default, after | `19.2.8` | `packages/ariakit-scripts/node_modules` | 19 | 35 passed, 0 skipped |
| `ariakit react18`, before | not declared | workspace root `node_modules` (18.3.1) | 18 | 28 passed, **7 skipped** |
| `ariakit react18`, after | rewritten to `18.3.1` | `packages/ariakit-scripts/node_modules` (18.3.1) | 18 | 28 passed, **7 skipped** |

The React 18 rewrite count moves from 11 to 12 manifests, the single added manifest being `packages/ariakit-scripts/package.json`. The comment above the `reactMajor` computation stays accurate: every workspace pins the same exact React version and `react18.ts` rewrites them together, so this workspace's pin cannot drift from the rest of the repository.

## Verification

- `pnpm test packages/ariakit-scripts/src/docs.test.ts` from the repository root, under a full install and under the `main.yml` test-job filters (`app...`, `website...`, `./packages/*...`): 35 passed, the seven `readme docs are up to date` cases running.
- `ariakit react18 -- pnpm test packages/ariakit-scripts/src/docs.test.ts`: 28 passed, 7 skipped.
- The narrowest filter that reaches this workspace, `./packages/ariakit-scripts...` from `perf.yml`, re-run against a cleaned `node_modules`. Resolution goes to `packages/ariakit-scripts/node_modules/react` with the declaration and to the root without it.
- `pnpm lint-fix`, `pnpm tsc`, `pnpm test` (720 passed), and `pnpm build` followed by `pnpm clean`.

No changeset: `@ariakit/scripts` is `private: true`, is listed in `.changeset/config.json`'s `ignore`, and appears only under `devDependencies` in all thirteen of its consumers, so a devDependency addition here cannot reach published output.

## Scope note

Under every current CI filter this was latent rather than breaking. `pnpm` always installs the workspace root project regardless of `--filter`, so the root `react` was reachable even under `./packages/ariakit-scripts...`; verified by observing `oxlint`, declared only by the root manifest, present at `node_modules/oxlint` after that filtered install. The fix removes the dependence on the root manifest rather than repairing an active failure.

## Audit

Issue #6934 also asks for a wider sweep of `createRequire`, `require.resolve`, `import.meta.resolve`, and dynamic `import()` specifiers that static analysis misses. Every workspace manifest was checked against every such site found in the repository's own sources.

`packages/ariakit-scripts/src/docs.test.ts` was the only undeclared case; it is fixed here. Everything else resolves a package its own workspace declares. Three observations were recorded for separate triage rather than changed here: two build-time sites that resolve fully computed bare specifiers taken from example sources (`app/src/lib/source-plugin.ts` via `import-meta-resolve`, and `website/build-pages/get-example-deps.js` via `resolve-from`, whose result is written into generated StackBlitz dependencies), and five React packages that declare `react` but resolve `@types/react` through the root manifest.

Closes #6934
