### PR TITLE
Drop the redundant nextjs install filter from the deploy workflows

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -76,9 +76,9 @@ jobs:
       - name: Set up environment
         uses: ./.github/workflows/setup
         with:
-          filters: |
-            app...
-            nextjs...
+          # `app...` already selects `nextjs` through `app`'s `workspace:*`
+          # devDependency, so a separate `nextjs...` entry is redundant.
+          filters: app...
 
       - name: Download Next.js app artifact
         id: download-nextjs-artifact

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Set up environment
         uses: ./.github/workflows/setup
         with:
-          filters: |
-            app...
-            nextjs...
+          # `app...` already selects `nextjs` through `app`'s `workspace:*`
+          # devDependency, so a separate `nextjs...` entry is redundant.
+          filters: app...
 
       - name: Build app
         run: pnpm run build-app


### PR DESCRIPTION
Closes #6933

## Motivation

`.github/workflows/deploy.yml` and `.github/workflows/deploy-preview.yml` both passed a two-entry install filter list:

```yaml
filters: |
  app...
  nextjs...
```

`app/package.json` declares `"nextjs": "workspace:*"` under `devDependencies`, and pnpm's trailing `...` selects a package together with its dependencies, so `app...` already selected `nextjs` and everything `nextjs` depends on. The second entry was a strict no-op.

This costs nothing at install time, so it was not a performance problem. It was a correctness-of-intent problem: a reader encountering the second filter reasonably infers that `app` does not depend on `nextjs` and that the job needs it selected separately. That inference is wrong, and it is exactly the kind of thing that makes the next person hesitate to narrow a filter, or narrow the wrong one.

## Solution

Both jobs now install with `app...` alone, and a comment records why the second entry is unnecessary, so it is not re-added later by someone who assumes it was an oversight.

```yaml
# `app...` already selects `nextjs` through `app`'s `workspace:*`
# devDependency, so a separate `nextjs...` entry is redundant.
filters: app...
```

The comment names the devDependency explicitly rather than saying "depends on", because `app`'s `dependencies` block holds 63 entries and `nextjs` is not among them. A reader who checks `dependencies` first and stops there would conclude the comment was stale.

This also converges on the form the rest of the repository already uses. The `build-nextjs` job in `app.yml` installs `app...` alone and then runs `pnpm -F nextjs run tsc` and `pnpm -F nextjs run build-worker`, and the `build-nextjs` job in `perf.yml` does the same, so the invariant is already load-bearing in CI today.

## Set equality evidence

Workspace project selection, from `pnpm list --filter <entry> --depth -1 --json`:

| Filter | Projects selected |
| --- | --- |
| `app...` | 15 of 21, including `nextjs` |
| `nextjs...` | 9, every one of them already in `app...` |
| `app...` plus `nextjs...` | the same 15 as `app...` alone |

Both installs were then reproduced for real, mirroring `.github/workflows/setup/action.yml` exactly (`pnpm_config_verify_deps_before_run=false`, then `pnpm install --fail-if-no-match --frozen-lockfile --filter <each>`), each from a fully cleaned `node_modules`:

| | Two filters | One filter |
| --- | --- | --- |
| pnpm scope line | `Scope: 15 of 21 workspace projects` | `Scope: 15 of 21 workspace projects` |
| `node_modules/.pnpm` entries | 1363 | 1363 |

The sets were compared, not only the counts. `comm` over the sorted `node_modules/.pnpm` listings is empty in both directions, and a fuller manifest containing that listing plus every project-level `node_modules` directory and its sorted direct entries is byte-identical between the two installs. `git status --short` was empty after each, so the lockfile was untouched.

Under `app...` alone, `nextjs/node_modules` is fully populated, including `next`, `wrangler`, and `@opennextjs`.

## Verification

`deploy.yml` runs `pnpm run build-app`. That succeeded against the `app...`-only install, producing `nextjs/.open-next`, `app/dist`, and `app/.wrangler/deploy/config.json`, which are exactly the `nextjs-dist` and `app-build` artifacts that `deploy-preview.yml` downloads.

`deploy-preview.yml` runs no pnpm script. It downloads those artifacts and hands off to `cloudflare/wrangler-action` with `workingDirectory: nextjs` and `workingDirectory: app`. All four wrangler invocations the two jobs use were exercised against the `app...`-only install and exited 0: `versions upload --dry-run` and `deploy --dry-run`, each in `nextjs/` and in `app/`.

`setup/action.yml` errors when `filters` is empty, so the single-entry list was checked against that guard. It builds `args` of length 3 and passes; only an empty value trips the `::error::` branch.

All 14 workflow files and `setup/action.yml` still parse. Both changed steps resolve to `with.filters === "app..."`, with their job step lists unchanged at 5 and 12 steps.

No changeset. The change is CI-only and has no consumer-observable effect.

### Jobs that a real run on this PR cannot confirm

`deploy-preview.yml` is exercised here. Any `.github/` path makes `isFullCIPath` in `packages/ariakit-scripts/src/ci.ts` plan every workflow, so `ci.yml` runs `app.yml`, which calls `deploy-preview.yml`.

The `Deploy to production` job in `deploy.yml` is not, and cannot be. It is `on: workflow_dispatch` and gated on `github.ref == 'refs/heads/main'`, so it never runs from a pull request. It can only be confirmed by a manual dispatch after merge.

## Filter redundancy sweep

#6933 asked for the other multi-entry filter lists to be re-checked for the same redundancy, in particular the Type check job's `app... website... ./templates/*...`.

The sweep covered both forms present in `.github/workflows/`: `filters:` inputs to the `setup` action, and raw `pnpm --filter ... install` invocations. Each entry in each list was tested for whether it contributes any workspace project the other entries in that list do not.

| List | Verdict |
| --- | --- |
| `main.yml` Lint | every entry required: `app...` adds `app` and `nextjs`, `./packages/*...` adds `@ariakit/solid-store`, `examples...` adds `examples`, `./templates/*...` adds `template-react` |
| `main.yml` Type check | every entry required: as above, plus `website...` adding `examples`, `guide`, and `website` |
| `main.yml` Test | every entry required |
| `main.yml` Test React | every entry required |
| `main.yml` Test Solid | every entry required |

So the Type check job named in the issue is clean, as are the other `main.yml` lists.

One instance survives, and it is out of scope for this pull request: `.github/workflows/perf.yml` lines 203-204, in the `chrome-baseline` job, passes the same `app...` plus `nextjs...` pair. It is a raw `pnpm --filter` invocation rather than a `filters:` input, which is why a sweep framed around `filters:` values would pass over it. It needs its own change and is not tracked here.

## Review gate reassessment

<details>
<summary>Cycle 3: Continue the two-line comment direction</summary>

**Assessment**

Issue severity is correctness of intent only, with no runtime behavior change, since the install set is provably identical. Expected frequency is low but real: the misleading inference fires whenever a maintainer reads these two filter blocks and reasons about narrowing them, which the recent sweeps behind #6894, #6908, #6915, and #6929 show happens a few times a year. Supported scope is exactly two `filters:` inputs. Impact on library consumers is nil; the cost is a wasted inference by a maintainer.

Implementation complexity has not grown since the first reviewed state: two files, three lines removed and three added in each, with no added branches, state, helpers, abstractions, tests, public contracts, changeset, or lockfile change. Maintenance complexity is two comment lines per file, whose only failure mode is harmless imprecision if `nextjs` were ever promoted out of `devDependencies`.

The repeated rounds were not caused by the mechanism. Round 1's only actionable finding was a wording fix to the comment this change adds. Rounds 2 and 3 produced no findings about the diff at all: one concerned a sibling file that is out of scope, the other concerned follow-up bookkeeping. A review track that has stopped finding problems in the code and moved on to scope and process is converged, not struggling.

**Decision**

Continue unchanged. Complexity is already at the floor, so there is no machinery to remove or simplify.

Recording the rationale only in this description was considered and rejected. #6933 permits it ("a comment or the PR description"), but its stated purpose is that the entry not be re-added by a future reader of `deploy.yml`, and a pull request description is invisible there. Adding a test asserting that `nextjs...` stays a subset of `app...` was rejected as disproportionate machinery for a zero-cost invariant that eight other call sites already rely on silently.

Deliberately left unsupported: production-only installs, since the proof relies on plain `--filter` traversing devDependencies and no `--prod` or `--filter-prod` appears anywhere under `.github/workflows/`; and mechanical enforcement of the invariant, which the `build-nextjs` jobs in `app.yml` and `perf.yml` would already fail on loudly.

</details>
