### PR TITLE
Give guide its own JSX type configuration

### DIFF
--- a/guide/package.json
+++ b/guide/package.json
@@ -8,5 +8,8 @@
   },
   "dependencies": {
     "react": "19.2.8"
+  },
+  "devDependencies": {
+    "@types/react": "19.2.17"
   }
 }

--- a/guide/tsconfig.json
+++ b/guide/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "react",
+    "types": []
+  },
+  "include": ["**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -475,6 +475,10 @@ importers:
       react:
         specifier: 19.2.8
         version: 19.2.8
+    devDependencies:
+      '@types/react':
+        specifier: 19.2.17
+        version: 19.2.17
 
   nextjs:
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     { "path": "./packages/ariakit-test/tsconfig.json" },
     { "path": "./examples/tsconfig.react.json" },
     { "path": "./examples/tsconfig.solid.json" },
+    { "path": "./guide/tsconfig.json" },
     { "path": "./app/tsconfig.json" }
   ]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -5,6 +5,7 @@
     "website",
     "app",
     "examples",
+    "guide",
     "packages",
     "nextjs",
     "coverage",


### PR DESCRIPTION
## Motivation

`tsconfig.base.json` sets `"jsx": "preserve"` with no `jsxImportSource`, so TypeScript resolves `JSX.IntrinsicElements` from the ambient UMD global that `@types/react` declares with `export as namespace React`, rather than from a per-file import. It also sets `"types": ["node"]`, so a `guide`-local `@types/react` would never be auto-included.

The seven `guide/*/site-icon.tsx` files contain JSX and import nothing:

```tsx
export default function Icon() {
  return (
    <svg width="24" height="24" viewBox="0 0 24 24">
      <polyline points="4 17 10 11 4 5" />
    </svg>
  );
}
```

They type-checked only because *other* files in the `tsconfig.node.json` program happen to import React. Isolated, they fail:

```sh
tsc --ignoreConfig --noEmit --strict --jsx preserve --types node \
  --moduleResolution nodenext --module nodenext --lib DOM,ESNext \
  guide/100-getting-started/site-icon.tsx
# 4x TS7026: JSX element implicitly has type 'any' because no interface
# 'JSX.IntrinsicElements' exists.
```

The same command with `--types node,react` exits 0.

This is the TypeScript half of the hidden coupling that #6922 and #6932 addressed on the pnpm side. Note that the providers were broader than the issue assumed: removing `templates/react`'s React import alone does **not** break `guide`. The types arrive from a union of unrelated sources, and only when all of them are gone does `guide` fail.

| Neutralization in the `tsconfig.node.json` program | `guide` `TS7026` |
| --- | --- |
| none | 0 |
| `templates/react/src/app.tsx` drops `import { useState } from "react"` | 0 |
| `templates/react/src/{app,main}.tsx` removed entirely | 0 |
| + `vitest.setup.ts` drops its static `react` import | 0 |
| + `vitest.setup.ts` drops `await import("@ariakit/test/react")` | **37 across all 7 files** |

## Solution

Give `guide` its own project so its JSX types come from its own configuration:

```json
{
  "extends": "../tsconfig.base.json",
  "compilerOptions": {
    "jsx": "react-jsx",
    "jsxImportSource": "react",
    "types": []
  },
  "include": ["**/*"]
}
```

`--explainFiles` confirms the mechanism changed: each of the seven files now resolves `react/jsx-runtime` as a per-file import, instead of reading an ambient global that something else supplied.

```
Imported via "react/jsx-runtime" from file 'guide/100-getting-started/site-icon.tsx'
  with packageId '@types/react/jsx-runtime.d.ts@19.2.17'
  to import 'jsx' and 'jsxs' factory functions
```

Three supporting changes:

- **`@types/react` in `guide/package.json`.** Without it, `guide` resolves React types by walking up to the *root* manifest, which is the same implicit coupling #6932 closed. This makes the workspace supply its own types.
- **`guide` added to `tsconfig.node.json`'s `exclude`.** Only removing the files from that program actually fixes anything. With the new project present but `guide` still in the node program, the guide project is clean while `tsconfig.node.json` still reports the same 37 `TS7026`. This also restores the file's existing invariant: `website`, `app`, `examples`, `packages`, and `nextjs` are all already excluded because they own their configs.
- **A reference from the root `tsconfig.json`**, so `tsc -b` builds the project.

`jsxImportSource: "react"` is explicit rather than required: `jsx: "react-jsx"` alone already defaults to `react/jsx-runtime`. It is declared because this change is about `guide` stating its own configuration instead of inheriting behavior implicitly, and because `tsconfig.react.json` and `tsconfig.react.test.json` declare both together.

## Verification

The fix is only meaningful if `guide` survives losing every external React provider, and if it is still genuinely checked afterwards.

**Before/after, under identical neutralization of every React provider in the program:**

| | `guide` errors |
| --- | --- |
| before | 37 `TS7026` across all 7 files |
| after | **0** |

**Still enforced, not merely present.** All 7 files appear in `guide/tsconfig.json`'s `--listFiles` and 0 remain in `tsconfig.node.json`'s; `tsc -b --dry --force` lists the project. A deliberate type error makes `pnpm tsc` exit 1:

```
guide/200-styling/site-icon.tsx(10,7): error TS2322: Type '{ deliberatelyWrong: true; }'
  is not assignable to type 'string | number | undefined'.
  The expected type comes from property 'strokeWidth' which is declared here
  on type 'SVGProps<SVGSVGElement>'
```

**No other workspace changed.** Per-project `--listFiles` was captured for all 27 projects before and after; the only difference anywhere is the 7 files leaving `tsconfig.node.json`. Every config that extends `tsconfig.node.json` overrides `exclude`, so the new entry is inert for all of them.

Also run: `pnpm tsc`, `pnpm lint`, `pnpm test` (720 passed), `pnpm build` + `pnpm clean`, and `pnpm build-website-lite`. Under a from-scratch install matching the CI type-check job's filters, `guide` is in scope via `website...` and `pnpm run tsc -v` exits 0; under the lint job's filters, which do not install `guide`, `pnpm run lint` still exits 0.

No changeset: this is type-check configuration with no consumer-observable effect, and `guide` is in `.changeset/config.json`'s `ignore`.

## Known limitation

This fixes `guide`'s own program. The legacy `website` build compiles the same icons through generated, gitignored `website/.pages/icons.ts`, and `website/tsconfig.json` is a standalone config with `jsx: preserve` and no `jsxImportSource`. Under TypeScript 6 (which `.vscode/settings.json` pins the editor to) those files still resolve JSX ambiently there. That is a property of the website's own configuration, outside what a `guide`-scoped config can control, and outside what this issue asks for.

Closes #6935
