### PR TITLE
Let the React 18 install recover from workspace settings changes

### DIFF
--- a/packages/ariakit-scripts/src/react18.test.ts
+++ b/packages/ariakit-scripts/src/react18.test.ts
@@ -1,9 +1,133 @@
-import { execFileSync } from "node:child_process";
-import { join } from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { delimiter, dirname, join } from "node:path";
 import { expect, test } from "vitest";
 import { getReact18Command } from "./react18.ts";
 
 const cliPath = join(import.meta.dirname, "index.ts");
+
+// Synced into the temporary workspace along with the rest of the fixture, so
+// its presence there identifies a workspace this file created.
+const fixtureMarker = ".ariakit-react18-fixture";
+
+interface React18Fixture {
+  fixturePath: string;
+  rootPath: string;
+  binPath: string;
+}
+
+// Stands in for pnpm when the temporary workspace still records the workspace
+// settings of an earlier run. Real pnpm recovers by purging and reinstalling
+// the modules directory, but it asks first and aborts with this error when
+// there is no TTY and the purge confirmation is still enabled. The tests spawn
+// the command without a TTY, so the stub always takes that branch.
+const stalePnpmSource = `#!/usr/bin/env node
+console.error("[stub-pnpm]", process.argv.slice(2).join(" "));
+if (process.argv.includes("--config.confirm-modules-purge=false")) {
+  process.exit(0);
+}
+console.error("ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY");
+console.error("Aborted removal of modules directory due to no TTY");
+process.exit(1);
+`;
+
+const failingPnpmSource = `#!/usr/bin/env node
+console.error("[stub-pnpm]", process.argv.slice(2).join(" "));
+console.error("ERR_PNPM_FETCH_404");
+process.exit(1);
+`;
+
+async function writeJsonFile(path: string, value: unknown) {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+/**
+ * Copies the environment without the variables that redirect where git
+ * resolves a repository.
+ *
+ * Both the fixture and the react18 command locate their repository through
+ * git. Left in place, these variables would point them at the caller's own
+ * checkout, and at the persistent workspace that `removeFixture` deletes.
+ */
+function getGitSafeEnv() {
+  const env = { ...process.env };
+
+  for (const key of ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR"]) {
+    delete env[key];
+  }
+
+  return env;
+}
+
+/**
+ * Creates a throwaway repository the react18 command can sync, along with a
+ * `pnpm` executable that shadows the real one through `PATH`.
+ */
+async function createFixture(pnpmSource: string): Promise<React18Fixture> {
+  const fixturePath = await mkdtemp(join(tmpdir(), "ariakit-react18-"));
+  const rootPath = join(fixturePath, "repo");
+  const binPath = join(fixturePath, "bin");
+
+  await mkdir(join(rootPath, "website"), { recursive: true });
+  await mkdir(binPath, { recursive: true });
+
+  await writeJsonFile(join(rootPath, "package.json"), {
+    name: "root",
+    private: true,
+    dependencies: { react: "19.2.8", "react-dom": "19.2.8" },
+  });
+  await writeJsonFile(join(rootPath, "website/package.json"), {
+    name: "website",
+    dependencies: { react: "18.3.1", "react-dom": "18.3.1" },
+    devDependencies: {
+      "@types/react": "18.3.27",
+      "@types/react-dom": "18.3.11",
+    },
+  });
+
+  await writeFile(join(rootPath, fixtureMarker), "");
+
+  const pnpmPath = join(binPath, "pnpm");
+  await writeFile(pnpmPath, pnpmSource);
+  await chmod(pnpmPath, 0o755);
+
+  execFileSync("git", ["init", "--quiet"], {
+    cwd: rootPath,
+    env: getGitSafeEnv(),
+  });
+
+  return { fixturePath, rootPath, binPath };
+}
+
+function runReact18(fixture: React18Fixture, commandArgs: string[]) {
+  const env = getGitSafeEnv();
+  env.PATH = [fixture.binPath, env.PATH].filter(Boolean).join(delimiter);
+
+  return spawnSync(
+    process.execPath,
+    [cliPath, "react18", "--", ...commandArgs],
+    { cwd: fixture.rootPath, encoding: "utf-8", env },
+  );
+}
+
+function findWorkspacePath(output: string) {
+  return output.match(/Syncing workspace to (.+)/)?.[1]?.trim();
+}
+
+async function removeFixture(fixture: React18Fixture, output: string) {
+  await rm(fixture.fixturePath, { recursive: true, force: true });
+
+  const workspacePath = findWorkspacePath(output);
+  if (!workspacePath) return;
+  // Checkouts on the same machine share the parent temp directory, and each
+  // keeps a workspace worth minutes of reinstalling. Only remove one this run
+  // is proven to own.
+  if (!existsSync(join(workspacePath, fixtureMarker))) return;
+
+  await rm(dirname(workspacePath), { recursive: true, force: true });
+}
 
 test("runs an explicit command with arguments", () => {
   expect(getReact18Command(["pnpm", "test", "--run"])).toEqual({
@@ -35,3 +159,48 @@ test("documents the explicit command syntax", () => {
     "Run `ariakit react18 -- <command>` in an isolated React 18 workspace",
   );
 });
+
+test.skipIf(process.platform === "win32")(
+  "installs the dependency graph without stalling on a modules purge",
+  async () => {
+    const fixture = await createFixture(stalePnpmSource);
+    const result = runReact18(fixture, [
+      "node",
+      "-e",
+      "process.stdout.write('react18-command-ran')",
+    ]);
+
+    try {
+      // Proves the stub ran instead of the real pnpm, which would satisfy the
+      // remaining assertions on its own.
+      expect(result.stderr).toContain("[stub-pnpm] install");
+      expect(result.stderr).not.toContain(
+        "ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY",
+      );
+      expect(result.stdout).toContain("react18-command-ran");
+      expect(result.status).toBe(0);
+    } finally {
+      await removeFixture(fixture, result.stderr ?? "");
+    }
+  },
+);
+
+test.skipIf(process.platform === "win32")(
+  "points at the temporary workspace when the install fails",
+  async () => {
+    const fixture = await createFixture(failingPnpmSource);
+    const result = runReact18(fixture, ["node", "--version"]);
+
+    try {
+      const workspacePath = findWorkspacePath(result.stderr ?? "");
+      expect(workspacePath).toBeTruthy();
+      expect(result.stderr).toContain(
+        `Failed to install the React 18 dependency graph in ${workspacePath}.`,
+      );
+      expect(result.stderr).toContain(`rm -rf "${workspacePath}"`);
+      expect(result.status).not.toBe(0);
+    } finally {
+      await removeFixture(fixture, result.stderr ?? "");
+    }
+  },
+);

--- a/packages/ariakit-scripts/src/react18.ts
+++ b/packages/ariakit-scripts/src/react18.ts
@@ -185,6 +185,44 @@ async function syncWorkspace(rootPath: string, workspacePath: string) {
   }
 }
 
+/**
+ * Installs the React 18 dependency graph in the temporary workspace.
+ *
+ * The workspace outlives a single run, so its `node_modules` can be recorded
+ * under workspace settings that no longer match the `pnpm-workspace.yaml` this
+ * run just synced. pnpm already detects that and recovers by purging and
+ * reinstalling the modules directory, but it asks before doing so and aborts
+ * outright when there is no TTY. Answering up front keeps pnpm's own check as
+ * the authority on when the recorded settings went stale, and the workspace is
+ * disposable either way.
+ *
+ * pnpm ignores unknown settings silently, so revisit the setting name whenever
+ * the pinned pnpm version changes.
+ */
+async function installDependencies(workspacePath: string) {
+  try {
+    await runChecked(
+      "pnpm",
+      [
+        "install",
+        "--no-frozen-lockfile",
+        "--prefer-offline",
+        "--config.confirm-modules-purge=false",
+      ],
+      { cwd: workspacePath },
+    );
+  } catch (error) {
+    throw new Error(
+      [
+        `Failed to install the React 18 dependency graph in ${workspacePath}.`,
+        "That workspace is reused between runs. Remove it to start from scratch:",
+        `  rm -rf "${workspacePath}"`,
+      ].join("\n"),
+      { cause: error },
+    );
+  }
+}
+
 async function getPackageJsonPaths(rootPath: string, directoryPath = rootPath) {
   const paths: string[] = [];
   const entries = await readdir(directoryPath, { withFileTypes: true });
@@ -411,11 +449,7 @@ export async function react18(args: string[]) {
   log(`Rewrote React dependencies in ${updatedCount} package.json files`);
 
   log("Installing React 18 dependency graph");
-  await runChecked(
-    "pnpm",
-    ["install", "--no-frozen-lockfile", "--prefer-offline"],
-    { cwd: workspacePath },
-  );
+  await installDependencies(workspacePath);
 
   const command = getReact18Command(args);
   const watcher = startWorkspaceWatcher(rootPath, workspacePath);


### PR DESCRIPTION
## Motivation

`ariakit react18`, the wrapper behind `pnpm test-react18`, rsyncs the repository into a persistent temp workspace under `$TMPDIR/ariakit-react18/<hash>/workspace` and runs its own `pnpm install` there. `node_modules` is excluded from the rsync, but `pnpm-workspace.yaml` is copied.

So a temp workspace that survives a workspace-settings change keeps a `node_modules/.modules.yaml` recorded under the old settings while receiving the new `pnpm-workspace.yaml`. pnpm detects the mismatch and wants to purge and reinstall the modules directory, which it asks about first. The inner install ran with no TTY, so it aborted:

```
[react18] Installing React 18 dependency graph
ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY  Aborted removal of modules directory due to no TTY
Error: pnpm install --no-frozen-lockfile --prefer-offline failed with 1
```

Nothing there names the temp workspace, the stale `.modules.yaml`, or the settings change, so it reads as the branch breaking the React 18 suite. That is the most expensive kind of false alarm on a branch whose entire risk is dependency resolution. The remedy was to delete the temp workspace, which is not discoverable from the error.

CI was never affected: runners start with an empty tmpdir, and `CI=true` already suppresses the confirmation. This is a local-contributor failure only.

## Solution

Pass `--config.confirm-modules-purge=false` to the inner install, and wrap install failures in an error that names the temp workspace and how to reset it.

```
Error: Failed to install the React 18 dependency graph in /.../ariakit-react18/38eb16db/workspace.
That workspace is reused between runs. Remove it to start from scratch:
  rm -rf "/.../ariakit-react18/38eb16db/workspace"
  [cause]: Error: pnpm install --no-frozen-lockfile --prefer-offline --config.confirm-modules-purge=false failed with 1
```

The original error is preserved as `cause`, so the wrapper only adds context.

### Why not detect the settings change here

The alternative was to record the incoming workspace settings, compare them against the temp workspace on the next run, and recreate it on a mismatch. pnpm already performs exactly that comparison, spanning `hoistPattern`, `publicHoistPattern`, `nodeLinker`, `storeDir`, `virtualStoreDir`, `virtualStoreDirMaxLength` and the included dependency fields, drawn from `pnpm-workspace.yaml`, `.npmrc`, `package.json`, environment variables and its own version. It also already resolves a mismatch by recreating just the modules directory. The only thing it could not do was answer its own question.

Reimplementing that comparison would duplicate a model that drifts with pnpm's settings surface, and a cheaper approximation such as hashing `pnpm-workspace.yaml` would be both over-inclusive (any unrelated edit to that file forces a full reinstall) and under-inclusive (an `.npmrc` or `storeDir` change would still break). Answering the prompt keeps pnpm's own check as the authority and is a one-argument change.

`--config.confirm-modules-purge=false` is the setting pnpm's own error hint names, and it is narrower than the alternatives. `CI=true` would misreport the environment and also changes lockfile and reporter behavior, `--force` triggers a full re-resolution that defeats `--prefer-offline`, and `--yes` auto-confirms every prompt. The npmrc-style environment variables (`npm_config_confirm_modules_purge`) are silently ignored by pnpm 11, which was verified directly.

### CI is unregressed

pnpm resolves the setting as `confirmModulesPurge && !ci`, so under `CI=true` the result is unchanged, and on a fresh runner there is nothing to purge. Verified locally with an emptied workspace under `CI=true`.

## Reproduction

1. Run `ariakit react18` once to populate `$TMPDIR/ariakit-react18/<hash>/workspace`.
2. Add or remove a setting in `pnpm-workspace.yaml` that pnpm records in `.modules.yaml`, such as `publicHoistPattern`.
3. Run `pnpm install` locally so the outer checkout matches the new settings.
4. Run `pnpm test-react18` again from a non-TTY shell.

Before this change, step 4 aborted with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`. After it, pnpm logs `Recreating .../workspace/node_modules` and the suite runs. The failure was confirmed in both directions, adding and removing a setting, and deleting the temp workspace was confirmed to clear it.

## Tests

Two CLI-level tests in `packages/ariakit-scripts/src/react18.test.ts` drive the real `ariakit react18` command against a throwaway repository with a stub `pnpm` shadowed onto `PATH`:

- One stubs the pnpm behavior this fixes, aborting unless the purge confirmation is disabled, and asserts the command completes and runs its wrapped command.
- One stubs an unrelated install failure and asserts the error names the temp workspace and the reset command.

Both were red-checked against the pre-fix implementation and failed for the expected reasons: the first on the real `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` output, the second on the opaque `pnpm install ... failed with 1` message. The first also pins a stub marker in stderr, so it cannot pass by silently falling through to the real pnpm.

Because the fixture drives a command that resolves its own repository through git, the tests clear `GIT_DIR`, `GIT_WORK_TREE` and `GIT_COMMON_DIR`, and cleanup only removes a temp workspace containing a fixture marker file. Both guards were verified by running the suite with those variables exported at a real checkout.

Closes #6936
