### PR TITLE
Drop the redundant nextjs filter from the perf chrome-baseline install

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -198,10 +198,11 @@ jobs:
         if: steps.baseline-rebuild.outputs.app == 'true' || steps.baseline-rebuild.outputs.nextjs == 'true'
         env:
           HUSKY: 0
+        # `app...` already selects `nextjs` through `app`'s `workspace:*`
+        # devDependency, so a separate `nextjs...` filter is redundant.
         run: >-
           pnpm
           --filter 'app...'
-          --filter 'nextjs...'
           --fail-if-no-match
           install
           --frozen-lockfile


### PR DESCRIPTION
## Motivation

The `chrome-baseline` job installs the dependency graph selected by both `app...` and `nextjs...`, even though `app` declares `nextjs` as a `workspace:*` devDependency. The second filter adds no packages and can mislead future maintenance by suggesting that `app` does not already reach `nextjs`.

This install runs after checking out the pull request base SHA. The dependency relationship is safe across the relevant history: `app` began depending on `nextjs` in [`17e08491d`](https://github.com/ariakit/ariakit/commit/17e08491d0a0e06c86a8101da60aeb1c99b02ad2), before the `chrome-baseline` job was introduced in [`d1b28a4ea`](https://github.com/ariakit/ariakit/commit/d1b28a4ea020f1c09cab42ee4ec2d0ef25b1fef7) and before the filtered install was added in [`9001af55b`](https://github.com/ariakit/ariakit/commit/9001af55b3f50199b16f8924e4d46b35b9696dbc).

## Solution

Remove the redundant `nextjs...` filter and document why `app...` is sufficient next to the historical-base install:

```yaml
pnpm
--filter 'app...'
--fail-if-no-match
install
--frozen-lockfile
```

This is the perf-workflow counterpart to #6943, which applied the same cleanup to the deploy workflows.

## Verification

- Ran the two-filter and one-filter installs in isolated worktrees with the workflow's partial-install settings. Their `node_modules/.pnpm` entry sets were identical (1,363 entries).
- Confirmed `app...` selects 15 workspace projects and `nextjs...` selects a nine-project subset.
- Confirmed the `app` to `nextjs` dependency predates the `chrome-baseline` job and its filtered install.
- Ran `pnpm lint-fix`.
- Audited other direct workflow `pnpm --filter` invocations; no other raw multi-filter case remains.
- No changeset is needed for this workflow-only maintenance change.

Closes #6944
