### PR TITLE
Stop perf.test.ts from crashing a child process during a passing run

### DIFF
--- a/packages/ariakit-scripts/src/perf.test.ts
+++ b/packages/ariakit-scripts/src/perf.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -33,6 +35,10 @@ const envNames = [
 const originalValues = new Map(
   envNames.map((name) => [name, process.env[name]]),
 );
+
+test("runs without DOM shims", () => {
+  expect(globalThis.document).toBeUndefined();
+});
 
 function clearPerfEnv() {
   for (const name of envNames) {


### PR DESCRIPTION
## Motivation

Running `pnpm test packages/ariakit-scripts/src/perf.test.ts` reports a passing suite while a child Node process crashes trying to connect to `localhost:3000`, adding misleading stack traces to otherwise successful output.

The runtime `@playwright/test` import is evaluated under the repository's default Happy DOM Vitest environment. Happy DOM treats Playwright's entry file as a synchronous script resource and launches a child process to fetch it from its default origin. The perf unit tests do not need a DOM, so that child should not exist in this suite.

## Solution

Run this test file in Vitest's Node environment and assert that DOM shims remain unavailable:

```ts
// @vitest-environment node

test("runs without DOM shims", () => {
  expect(globalThis.document).toBeUndefined();
});
```

This removes the unintended Happy DOM resource-fetch path instead of hiding its request error. The assertion fails if the suite falls back to the global Happy DOM environment, preserving the regression boundary.

Fixes #6948

## Verification

- Removing the environment directive reproduces the child-process crash and makes the new regression test fail.
- `pnpm test packages/ariakit-scripts/src/perf.test.ts` (25 tests)
- `pnpm test packages/ariakit-scripts/src` (185 tests)
- `pnpm tsc`
- `pnpm lint-fix`
