### PR TITLE
Type-check the examples site-icon files

### DIFF
--- a/examples/tsconfig.react.json
+++ b/examples/tsconfig.react.json
@@ -1,5 +1,5 @@
 {
   "extends": "../tsconfig.react.json",
-  "include": ["env.d.ts", "**/*.react.tsx"],
+  "include": ["env.d.ts", "**/*.react.tsx", "**/site-icon.tsx"],
   "exclude": []
 }


### PR DESCRIPTION
## Motivation

The 60 `examples/*/site-icon.tsx` files do not match the React examples project's existing `**/*.react.tsx` include pattern. Since the website discovers these files by name instead of importing them from the example entry points, they were outside every project in the root TypeScript build graph and invisible to `pnpm tsc`.

## Solution

Include site icons explicitly in the React examples project:

```json
"include": ["env.d.ts", "**/*.react.tsx", "**/site-icon.tsx"]
```

The focused pattern keeps React and Solid project ownership separate while ensuring current and future site icons are checked by the root TypeScript command.

Closes #6940.

## Verification

- `pnpm tsc --pretty false`
- `pnpm lint`
- Confirmed all 60 site icons appear in the React project's `--listFilesOnly` output
- Confirmed all 189 example TypeScript sources belong to the React or Solid project, with no orphaned files
- Confirmed a deliberate temporary type error in a site icon fails the root `pnpm tsc` command
