### PR TITLE
Keep vitest.setup.ts loader-neutral

### DIFF
--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,6 +1,5 @@
 import "@testing-library/jest-dom/vitest";
 import * as matchers from "@testing-library/jest-dom/matchers";
-import { createElement, Suspense as ReactSuspense } from "react";
 import { expect, beforeEach } from "vitest";
 import failOnConsole from "vitest-fail-on-console";
 import { getTestLoader, isAllowedTestLoader } from "./test-loader.ts";
@@ -48,11 +47,12 @@ async function tryImport(path: string) {
 
 async function loadReact(dir: string) {
   const { render } = await import("@ariakit/test/react");
+  const { createElement, Suspense } = await import("react");
   const { component, failedImport } = await tryImport(
     `./${dir}/index.react.tsx`,
   );
   if (failedImport) return false;
-  const element = createElement(ReactSuspense, {
+  const element = createElement(Suspense, {
     fallback: null,
     // oxlint-disable-next-line react/no-children-prop -- createElement requires children prop
     children: createElement(component),


### PR DESCRIPTION
## Motivation

The shared root Vitest setup imports React unconditionally, so the core and Solid test suites evaluate React even though they do not use the React loader.

Fixes #6942.

## Solution

Load the React runtime symbols inside `loadReact`, alongside the existing lazy `@ariakit/test/react` import:

```ts
const { render } = await import("@ariakit/test/react");
const { createElement, Suspense } = await import("react");
```

A temporary assertion against Vitest's evaluated-module map confirmed that the core suite evaluated React before this change and did not evaluate it afterward. The assertion was removed after verification to avoid coupling the test setup to Vitest internals.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm test`: 61 files, 722 tests
- `pnpm test-react`: 183 files, 947 tests
- `pnpm test-react18`: 183 files, 947 tests
- `pnpm test-solid`: 6 files, 8 tests