### PR TITLE
Give nextjs its own JSX type configuration

### DIFF
--- a/nextjs/tsconfig.json
+++ b/nextjs/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "jsxImportSource": "react",
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "paths": {
@@ -11,8 +10,7 @@
       "react/*": ["./node_modules/@types/react/*"],
       "react-dom/*": ["./node_modules/@types/react-dom/*"]
     },
-    "plugins": [{ "name": "next" }],
-    "types": []
+    "plugins": [{ "name": "next" }]
   },
   "include": [
     "next-env.d.ts",

--- a/nextjs/tsconfig.json
+++ b/nextjs/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "react",
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "paths": {
@@ -9,7 +11,8 @@
       "react/*": ["./node_modules/@types/react/*"],
       "react-dom/*": ["./node_modules/@types/react-dom/*"]
     },
-    "plugins": [{ "name": "next" }]
+    "plugins": [{ "name": "next" }],
+    "types": []
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
## Motivation

`nextjs/tsconfig.json` extends the shared base configuration and inherits `"jsx": "preserve"`. Three pages that contain JSX but have no React import therefore obtain `JSX.IntrinsicElements` from ambient React declarations loaded by unrelated files in the same TypeScript program.

For example, this page type-checks in the full program but fails with `TS7026` when those unrelated ambient providers are removed:

```tsx
export default function Home() {
  return <h1>Hello World</h1>;
}
```

The Next.js TypeScript plugin adds editor diagnostics and completions, but it does not set compiler options for standalone `tsc`. Next.js also skips automatic tsconfig correction when a config uses `extends`, while this workspace's type-check script ultimately runs `next typegen && tsc`.

## Solution

Override only the JSX mode in the Next.js workspace:

```json
{
  "jsx": "react-jsx"
}
```

This makes TypeScript resolve `react/jsx-runtime` for each JSX file instead of relying on an ambient global. An explicit `jsxImportSource` is unnecessary because TypeScript defaults the automatic runtime to React, and changing the inherited `types` list is unrelated to the JSX resolution defect.

Keeping the override local also avoids inheriting the root-oriented include and exclude policy from `tsconfig.react.json`.

## Verification

- A focused comparison of the three affected pages produced 24 `TS7026` errors with inherited `jsx: preserve` and zero errors with `jsx: react-jsx`.
- Resolution tracing confirms that each affected page resolves the local `react/jsx-runtime` declaration.
- A deliberate invalid JSX prop in an affected page made the real Next.js type check fail with `TS2322`, proving the CI command enforces the file.
- `pnpm lint-fix`
- `CI=true pnpm tsc`
- `CI=true pnpm -F nextjs run tsc`
- `CI=true pnpm -F nextjs run build-worker`

No changeset is included because this only changes private type-check configuration and has no consumer-observable package effect.

Closes #6949
