### PR TITLE
Allow setup without package filters

### DIFF
--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -39,8 +39,4 @@ runs:
             args+=(--filter "$filter")
           fi
         done <<< "$FILTERS"
-        if [ "${#args[@]}" -eq 1 ]; then
-          echo "::error::setup requires 'filters', or install: \"false\" to skip installing" >&2
-          exit 1
-        fi
         pnpm install --fail-if-no-match "${args[@]}"


### PR DESCRIPTION
## Motivation

The setup action exposes `filters` as optional, but rejects empty input. After the main workflow stopped supplying redundant filters, the Lint and Type check jobs in [this run](https://github.com/ariakit/ariakit/actions/runs/30426788669/job/90494876513) failed during setup before their commands ran.

## Solution

Remove the empty-filter guard so an unfiltered setup performs the intended full-workspace install:

```sh
pnpm install --fail-if-no-match --frozen-lockfile
```

Non-empty filters continue to be appended as `--filter` arguments, and `install: "false"` continues to skip installation.

## Verification

- `pnpm install --fail-if-no-match --frozen-lockfile`
- `pnpm run lint`
- `pnpm run tsc -v`
