### PR TITLE
Stabilize CI dependency setup

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -206,6 +206,7 @@ jobs:
           --fail-if-no-match
           install
           --frozen-lockfile
+          --no-runtime
 
       - name: Build base app
         if: steps.baseline-rebuild.outputs.app == 'true'
@@ -445,7 +446,7 @@ jobs:
           # so husky's prepare step would otherwise rewrite `core.hooksPath`
           # to a relative path under a temporary worktree.
           HUSKY: 0
-        run: pnpm --filter 'app...' --fail-if-no-match install --frozen-lockfile --prefer-offline
+        run: pnpm --filter 'app...' --fail-if-no-match install --frozen-lockfile --no-runtime --prefer-offline
 
       - name: Install Playwright (baseline)
         working-directory: ${{ runner.temp }}/perf-baseline
@@ -772,7 +773,7 @@ jobs:
           # so husky's prepare step would otherwise rewrite `core.hooksPath`
           # to a relative path under a temporary worktree.
           HUSKY: 0
-        run: pnpm --filter './packages/*...' --fail-if-no-match install --frozen-lockfile --prefer-offline
+        run: pnpm --filter './packages/*...' --fail-if-no-match install --frozen-lockfile --no-runtime --prefer-offline
 
       - name: Download baseline artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -14,6 +14,8 @@ runs:
   steps:
     - name: Install pnpm
       uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+      with:
+        cache: ${{ inputs.install == 'true' }}
 
     - name: Set up Node
       uses: actions/setup-node@v7
@@ -33,10 +35,13 @@ runs:
       env:
         FILTERS: ${{ inputs.filters }}
       run: |
-        args=(--frozen-lockfile)
+        args=(--frozen-lockfile --no-runtime)
         while IFS= read -r filter; do
           if [ -n "$filter" ]; then
             args+=(--filter "$filter")
           fi
         done <<< "$FILTERS"
-        pnpm install --fail-if-no-match "${args[@]}"
+        if ! pnpm install --fail-if-no-match "${args[@]}"; then
+          echo "::warning::pnpm install failed; retrying once"
+          pnpm install --fail-if-no-match "${args[@]}"
+        fi

--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -14,8 +14,6 @@ runs:
   steps:
     - name: Install pnpm
       uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
-      with:
-        cache: ${{ inputs.install == 'true' }}
 
     - name: Set up Node
       uses: actions/setup-node@v7


### PR DESCRIPTION
## Motivation

Dependency setup can fail before tests start when pnpm exhausts its registry fetch retries. This affected [#6959](https://github.com/ariakit/ariakit/pull/6959) in [run 30432422539](https://github.com/ariakit/ariakit/actions/runs/30432422539).

CI already provisions Node with `actions/setup-node`, but pnpm can also download the `devEngines.runtime` archive during dependency installation. Monitoring this PR reproduced a separate timeout while a performance baseline install fetched Node 24.18.0.

## Solution

Skip pnpm's managed runtime in the shared setup action:

```bash
args=(--frozen-lockfile --no-runtime)
```

Apply `--no-runtime` to the three direct performance baseline installs as well.

Retry the identical shared install once if it fails:

```bash
if ! pnpm install --fail-if-no-match "${args[@]}"; then
  echo "::warning::pnpm install failed; retrying once"
  pnpm install --fail-if-no-match "${args[@]}"
fi
```

The retry reuses pnpm's partially populated store, preserves filters, and leaves a second failure fatal.

Keep cross-job pnpm store caching disabled. Monitoring showed that the cache made setup nearly neutral while adding expensive miss and save work, especially on macOS.

## Monitoring

- A cold macOS cache save took approximately 72 seconds.
- A macOS cache hit took approximately 24 seconds to restore, followed by approximately 43 seconds to install.
- A Linux cache hit took approximately 12 seconds to restore, followed by approximately 20 seconds to install.
- The cache-hit macOS OG job took 2m55s, compared with 3m07s for a prior uncached run. The small and noisy improvement did not justify the miss and save overhead.
- The final solution therefore keeps the retry and `--no-runtime`, and removes the cache option.
- The [final uncached run](https://github.com/ariakit/ariakit/actions/runs/30438905619) passed every check. The macOS OG install completed in 1m18.9s, Safari setup completed in 71 seconds, and the direct Chrome and Node baseline installs completed without fetching the managed Node runtime.

## Verification

- `pnpm lint-fix`
- `pnpm lint`
- `pnpm install --frozen-lockfile --no-runtime`
- `pnpm --filter 'app...' --fail-if-no-match install --frozen-lockfile --no-runtime --prefer-offline`
- `pnpm --filter './packages/*...' --fail-if-no-match install --frozen-lockfile --no-runtime --prefer-offline`
- Parsed `.github/workflows/setup/action.yml` and `.github/workflows/perf.yml` as YAML
- Validated the embedded setup script with `bash -n`
- Exercised retry success and terminal failure paths
- `git diff --check`
