### PR TITLE
Reuse setup action for Chrome baseline

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -73,10 +73,19 @@ jobs:
       actions: read
       contents: read
     steps:
+      # Keep the current setup action at the workspace root while the source
+      # used to build the baseline lives in its own checkout below.
+      - name: Checkout workflow repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/workflows/setup
+
       - name: Checkout baseline repository
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.base.sha }}
+          path: .perf-baseline
           persist-credentials: false
 
       - name: Find base app artifact
@@ -119,7 +128,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: app-build
-          path: app
+          path: .perf-baseline/app
           github-token: ${{ github.token }}
           run-id: ${{ steps.find-base-artifact.outputs.run-id }}
 
@@ -130,7 +139,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: nextjs-dist
-          path: nextjs/.open-next
+          path: .perf-baseline/nextjs/.open-next
           github-token: ${{ github.token }}
           run-id: ${{ steps.find-base-artifact.outputs.run-id }}
 
@@ -139,10 +148,10 @@ jobs:
         if: steps.base-artifact.outcome == 'success'
         run: |
           shopt -s nullglob
-          maps=(app/dist/client/_astro/*.js.map)
+          maps=(.perf-baseline/app/dist/client/_astro/*.js.map)
           if [ ${#maps[@]} -gt 0 ]; then
             echo "missing=false" >> "$GITHUB_OUTPUT"
-          elif grep -q "PERF_SOURCE_MAP" app/astro.config.ts; then
+          elif grep -q "PERF_SOURCE_MAP" .perf-baseline/app/astro.config.ts; then
             # app.yml artifacts intentionally omit source maps so ordinary app
             # artifacts stay smaller. Perf rebuilds only the base app artifact
             # when source maps are needed for readable script profiles.
@@ -171,45 +180,26 @@ jobs:
         if: steps.baseline-rebuild.outputs.app == 'true'
         run: |
           rm -rf \
-            app/dist \
-            app/.wrangler
+            .perf-baseline/app/dist \
+            .perf-baseline/app/.wrangler
 
       - name: Clean base Next.js artifact
         if: steps.baseline-rebuild.outputs.nextjs == 'true'
-        run: rm -rf nextjs/.open-next
+        run: rm -rf .perf-baseline/nextjs/.open-next
 
-      - name: Install pnpm
+      - name: Set up baseline environment
         if: steps.baseline-rebuild.outputs.app == 'true' || steps.baseline-rebuild.outputs.nextjs == 'true'
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
-
-      - name: Set up Node
-        if: steps.baseline-rebuild.outputs.app == 'true' || steps.baseline-rebuild.outputs.nextjs == 'true'
-        uses: actions/setup-node@v7
-        with:
-          node-version-file: package.json
-
-      - name: Allow partial install
-        if: steps.baseline-rebuild.outputs.app == 'true' || steps.baseline-rebuild.outputs.nextjs == 'true'
-        # Keep pnpm from replacing the filtered baseline install below with a
-        # full workspace install before either build command.
-        run: echo "pnpm_config_verify_deps_before_run=false" >> "$GITHUB_ENV"
-
-      - name: Install dependencies
-        if: steps.baseline-rebuild.outputs.app == 'true' || steps.baseline-rebuild.outputs.nextjs == 'true'
+        uses: ./.github/workflows/setup
         env:
           HUSKY: 0
-        # `app...` already selects `nextjs` through `app`'s `workspace:*`
-        # devDependency, so a separate `nextjs...` filter is redundant.
-        run: >-
-          pnpm
-          --filter 'app...'
-          --fail-if-no-match
-          install
-          --frozen-lockfile
-          --no-runtime
+        with:
+          filters: app...
+          package-json-file: .perf-baseline/package.json
+          working-directory: .perf-baseline
 
       - name: Build base app
         if: steps.baseline-rebuild.outputs.app == 'true'
+        working-directory: .perf-baseline
         env:
           CLOUDFLARE_ENV: preview
           PERF_SOURCE_MAP: true
@@ -217,9 +207,11 @@ jobs:
 
       - name: Build base Next.js app
         if: steps.baseline-rebuild.outputs.nextjs == 'true'
+        working-directory: .perf-baseline
         run: pnpm -F nextjs run build-worker
 
       - name: Check baseline artifacts
+        working-directory: .perf-baseline
         run: |
           for path in \
             app/dist \
@@ -235,7 +227,7 @@ jobs:
       - name: Pack baseline artifacts
         run: |
           tar -czf "$RUNNER_TEMP/perf-chrome-baseline-build.tar.gz" \
-            -C . \
+            -C .perf-baseline \
             app/dist \
             app/.wrangler/deploy/config.json \
             nextjs/.open-next

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -73,20 +73,20 @@ jobs:
       actions: read
       contents: read
     steps:
-      # Keep the current setup action at the workspace root while the source
-      # used to build the baseline lives in its own checkout below.
-      - name: Checkout workflow repository
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-          sparse-checkout: .github/workflows/setup
-
       - name: Checkout baseline repository
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.base.sha }}
-          path: .perf-baseline
           persist-credentials: false
+
+      # Keep the current setup action in a separate checkout while the
+      # workspace root contains the source used to build the baseline.
+      - name: Checkout workflow repository
+        uses: actions/checkout@v7
+        with:
+          path: .perf-workflow
+          persist-credentials: false
+          sparse-checkout: .github/workflows/setup
 
       - name: Find base app artifact
         id: find-base-artifact
@@ -128,7 +128,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: app-build
-          path: .perf-baseline/app
+          path: app
           github-token: ${{ github.token }}
           run-id: ${{ steps.find-base-artifact.outputs.run-id }}
 
@@ -139,7 +139,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: nextjs-dist
-          path: .perf-baseline/nextjs/.open-next
+          path: nextjs/.open-next
           github-token: ${{ github.token }}
           run-id: ${{ steps.find-base-artifact.outputs.run-id }}
 
@@ -148,10 +148,10 @@ jobs:
         if: steps.base-artifact.outcome == 'success'
         run: |
           shopt -s nullglob
-          maps=(.perf-baseline/app/dist/client/_astro/*.js.map)
+          maps=(app/dist/client/_astro/*.js.map)
           if [ ${#maps[@]} -gt 0 ]; then
             echo "missing=false" >> "$GITHUB_OUTPUT"
-          elif grep -q "PERF_SOURCE_MAP" .perf-baseline/app/astro.config.ts; then
+          elif grep -q "PERF_SOURCE_MAP" app/astro.config.ts; then
             # app.yml artifacts intentionally omit source maps so ordinary app
             # artifacts stay smaller. Perf rebuilds only the base app artifact
             # when source maps are needed for readable script profiles.
@@ -180,25 +180,23 @@ jobs:
         if: steps.baseline-rebuild.outputs.app == 'true'
         run: |
           rm -rf \
-            .perf-baseline/app/dist \
-            .perf-baseline/app/.wrangler
+            app/dist \
+            app/.wrangler
 
       - name: Clean base Next.js artifact
         if: steps.baseline-rebuild.outputs.nextjs == 'true'
-        run: rm -rf .perf-baseline/nextjs/.open-next
+        run: rm -rf nextjs/.open-next
 
       - name: Set up baseline environment
         if: steps.baseline-rebuild.outputs.app == 'true' || steps.baseline-rebuild.outputs.nextjs == 'true'
-        uses: ./.github/workflows/setup
+        uses: ./.perf-workflow/.github/workflows/setup
         env:
           HUSKY: 0
         with:
           filters: app...
-          working-directory: .perf-baseline
 
       - name: Build base app
         if: steps.baseline-rebuild.outputs.app == 'true'
-        working-directory: .perf-baseline
         env:
           CLOUDFLARE_ENV: preview
           PERF_SOURCE_MAP: true
@@ -206,11 +204,9 @@ jobs:
 
       - name: Build base Next.js app
         if: steps.baseline-rebuild.outputs.nextjs == 'true'
-        working-directory: .perf-baseline
         run: pnpm -F nextjs run build-worker
 
       - name: Check baseline artifacts
-        working-directory: .perf-baseline
         run: |
           for path in \
             app/dist \
@@ -226,7 +222,7 @@ jobs:
       - name: Pack baseline artifacts
         run: |
           tar -czf "$RUNNER_TEMP/perf-chrome-baseline-build.tar.gz" \
-            -C .perf-baseline \
+            -C . \
             app/dist \
             app/.wrangler/deploy/config.json \
             nextjs/.open-next

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -194,7 +194,6 @@ jobs:
           HUSKY: 0
         with:
           filters: app...
-          package-json-file: .perf-baseline/package.json
           working-directory: .perf-baseline
 
       - name: Build base app

--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -8,22 +8,17 @@ inputs:
   install:
     description: Whether to install dependencies
     default: "true"
-  working-directory:
-    description: Directory containing package.json and dependencies
-    default: "."
 
 runs:
   using: "composite"
   steps:
     - name: Install pnpm
       uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
-      with:
-        package_json_file: ${{ inputs.working-directory }}/package.json
 
     - name: Set up Node
       uses: actions/setup-node@v7
       with:
-        node-version-file: ${{ inputs.working-directory }}/package.json
+        node-version-file: package.json
 
     - name: Allow partial install
       if: inputs.filters != '' || inputs.install != 'true'
@@ -35,7 +30,6 @@ runs:
     - name: Install dependencies
       if: inputs.install == 'true'
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
       env:
         FILTERS: ${{ inputs.filters }}
       run: |

--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -8,11 +8,8 @@ inputs:
   install:
     description: Whether to install dependencies
     default: "true"
-  package-json-file:
-    description: Package manifest used to select pnpm and Node.js versions
-    default: package.json
   working-directory:
-    description: Directory where dependencies are installed
+    description: Directory containing package.json and dependencies
     default: "."
 
 runs:
@@ -21,12 +18,12 @@ runs:
     - name: Install pnpm
       uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
       with:
-        package_json_file: ${{ inputs.package-json-file }}
+        package_json_file: ${{ inputs.working-directory }}/package.json
 
     - name: Set up Node
       uses: actions/setup-node@v7
       with:
-        node-version-file: ${{ inputs.package-json-file }}
+        node-version-file: ${{ inputs.working-directory }}/package.json
 
     - name: Allow partial install
       if: inputs.filters != '' || inputs.install != 'true'

--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -8,17 +8,25 @@ inputs:
   install:
     description: Whether to install dependencies
     default: "true"
+  package-json-file:
+    description: Package manifest used to select pnpm and Node.js versions
+    default: package.json
+  working-directory:
+    description: Directory where dependencies are installed
+    default: "."
 
 runs:
   using: "composite"
   steps:
     - name: Install pnpm
       uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+      with:
+        package_json_file: ${{ inputs.package-json-file }}
 
     - name: Set up Node
       uses: actions/setup-node@v7
       with:
-        node-version-file: package.json
+        node-version-file: ${{ inputs.package-json-file }}
 
     - name: Allow partial install
       if: inputs.filters != '' || inputs.install != 'true'
@@ -30,6 +38,7 @@ runs:
     - name: Install dependencies
       if: inputs.install == 'true'
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       env:
         FILTERS: ${{ inputs.filters }}
       run: |


### PR DESCRIPTION
## Motivation

The `Prepare Chrome baseline` job duplicated the repository setup action's pnpm, Node, partial-install, and dependency-install steps. Calling the local action after checking out the pull request's base SHA at the workspace root would otherwise resolve `./.github/workflows/setup` from the base revision instead of the current workflow revision.

The duplicated install logic could drift from the shared setup behavior:

```yaml
- name: Install pnpm
  uses: pnpm/action-setup@...
- name: Set up Node
  uses: actions/setup-node@v7
- name: Install dependencies
  run: pnpm --filter 'app...' install ...
```

## Solution

Keep the baseline source at the workspace root so package resolution and build tools see the repository layout they expect. After that checkout, sparsely check out the current workflow revision under `.perf-workflow` and invoke its existing setup action:

```yaml
- name: Checkout workflow repository
  uses: actions/checkout@v7
  with:
    path: .perf-workflow
    sparse-checkout: .github/workflows/setup

- name: Set up baseline environment
  uses: ./.perf-workflow/.github/workflows/setup
  with:
    filters: app...
```

This reuses the current setup implementation without moving the action, changing its interface, or relocating the baseline workspace and artifacts.

## Verification

- `pnpm lint-fix`
- `pnpm lint`
- Parsed the changed workflow with Ruby's YAML parser
- Ran actionlint v1.7.12, ignoring only established stale metadata warnings for `actions/create-github-app-token@v3`
- Ran a focused structural contract check for checkout ordering, paths, setup-action resolution, and the absence of the abandoned nested baseline
- Reproduced the runner layout in a temporary directory, installed the `app...` dependency graph, verified `@ariakit/utils` resolved from the baseline root, and completed the full baseline Astro build with source maps enabled
- `git diff --check origin/main...HEAD`

No changeset is included because this only refactors CI workflow setup and does not change a published package.
