### PR TITLE
Stabilize Next.js combobox new-tab tests

### DIFF
--- a/app/src/sandbox/combobox-select-nextjs-app-router/test-browser.ts
+++ b/app/src/sandbox/combobox-select-nextjs-app-router/test-browser.ts
@@ -6,6 +6,21 @@ async function getNewTabModifier(page: Page) {
   return isMac ? "Meta" : "Control";
 }
 
+/**
+ * Runs an action that opens a new tab and foregrounds the new page so Chrome
+ * doesn't defer Next.js hydration.
+ */
+async function openNewTab(page: Page, action: () => Promise<void>) {
+  // Keep the page-event deadline inside the 90-second slow-test budget so a
+  // missing tab is reported directly instead of timing out the whole test.
+  const [newPage] = await Promise.all([
+    page.context().waitForEvent("page", { timeout: 60_000 }),
+    action(),
+  ]);
+  await newPage.bringToFront();
+  return newPage;
+}
+
 function hasSearchParam(name: string, value: string | string[]) {
   return (url: URL) => {
     const values = Array.isArray(value) ? value : [value];
@@ -64,10 +79,9 @@ withFramework(import.meta.dirname, async ({ id, query, test }) => {
     const language = q.combobox("Language");
     await language.click();
     const modifier = await getNewTabModifier(page);
-    const [newPage] = await Promise.all([
-      page.context().waitForEvent("page"),
+    const newPage = await openNewTab(page, () =>
       q.option("French").click({ modifiers: [modifier] }),
-    ]);
+    );
 
     await newPage.waitForURL(hasSearchParam("lang", "fr"));
     const newLanguage = query(newPage).combobox("Language");
@@ -120,12 +134,18 @@ withFramework(import.meta.dirname, async ({ id, query, test }) => {
     await test.expect(q.option("Archived")).toHaveAttribute("data-active-item");
     await test.expect(status).toBeFocused();
 
-    const [newPage] = await Promise.all([
-      page.context().waitForEvent("page"),
-      browserName === "webkit"
-        ? q.option("Archived").click({ modifiers: [modifier] })
-        : page.keyboard.press(`${modifier}+Enter`),
-    ]);
+    const newPage = await openNewTab(page, async () => {
+      if (browserName === "webkit") {
+        await q.option("Archived").click({ modifiers: [modifier] });
+      } else {
+        await page.keyboard.down(modifier);
+        try {
+          await status.press("Enter");
+        } finally {
+          await page.keyboard.up(modifier);
+        }
+      }
+    });
 
     await newPage.waitForURL(hasSearchParam("status", ["draft", "archived"]));
     const newStatus = query(newPage).combobox("Status");


### PR DESCRIPTION
## Motivation

The Chrome app job in [run 30456179286](https://github.com/ariakit/ariakit/actions/runs/30456179286/job/90590599913) timed out twice in the multi-value Next.js Combobox new-tab test. The first attempt never observed the new page after `Control+Enter`. On retry, the new tab visibly rendered `2 selected`, but its accessible Combobox query remained pending while Chrome kept the tab in the background.

The flake did not reproduce in a 50-iteration local Chrome run with retries disabled, so the failure analysis relies on the CI trace and screenshots.

## Solution

Add a local `openNewTab` helper that registers the page event before the opening action, bounds that wait to 60 seconds, and foregrounds the new tab before querying its hydrated accessible UI. Both Next.js new-tab tests now share that lifecycle.

For the non-WebKit keyboard path, hold the new-tab modifier explicitly while pressing `Enter` and release it in `finally`. This preserves the tested keyboard interaction without increasing Playwright retries.

## Testing

- `pnpm build-app-lite`
- `pnpm -F app run test src/sandbox/combobox-select-nextjs-app-router/test-browser.ts --retries=0` (21/21 across Chrome, Firefox, and Safari)
- `pnpm -F app run test --project=chrome src/sandbox/combobox-select-nextjs-app-router/test-browser.ts --grep 'opens a multi-value option in a new tab' --retries=0 --repeat-each=100 --workers=4` (100/100)
- `pnpm lint`
- `pnpm tsc`
