### PR TITLE
Shard Safari browser tests

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -67,7 +67,7 @@ jobs:
           include-hidden-files: true
 
   test:
-    name: Test ${{ matrix.name }}
+    name: Test ${{ matrix.name }}${{ matrix.shard && format(' ({0})', join(matrix.shard, '/')) || '' }}
     needs: [build, build-nextjs]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -94,6 +94,13 @@ jobs:
             engine: webkit
             project: safari
             test: pnpm -F app run test
+            shard: [1, 2]
+          - os: macos-latest
+            name: Safari
+            engine: webkit
+            project: safari
+            test: pnpm -F app run test
+            shard: [2, 2]
           - os: macos-latest
             name: iOS
             engine: webkit
@@ -130,13 +137,13 @@ jobs:
 
       - name: Test
         id: test
-        run: ${{ matrix.test }} --project ${{ matrix.project }} --pass-with-no-tests --grep-invert @visual
+        run: ${{ matrix.test }} --project ${{ matrix.project }} --pass-with-no-tests --grep-invert @visual ${{ matrix.shard && format('--shard={0}', join(matrix.shard, '/')) || '' }}
 
       - name: Upload test results to GitHub
         if: failure() && steps.test.outcome == 'failure'
         uses: actions/upload-artifact@v7
         with:
-          name: app-${{ matrix.project }}-test-results
+          name: app-${{ matrix.project }}${{ matrix.shard && format('-{0}', join(matrix.shard, '-')) || '' }}-test-results
           path: app/test-results
           retention-days: 7
 


### PR DESCRIPTION
## Motivation

The app's non-visual Safari browser tests currently run in one macOS job. The browser test matrix needs optional sharding so slower projects can be split without also sharding visual regression tests.

## Solution

Add optional shard metadata to the non-visual browser matrix and configure Safari with two shards:

```yaml
shard: [1, 2]
```

Use `join` to format the same metadata as `1/2` for the job name and Playwright flag, and `1-2` for valid, unique test-result artifacts. This creates `Test Safari (1/2)` and `Test Safari (2/2)` while leaving the other browser projects and the visual matrix unsharded.

## Verification

The unsharded Safari suite lists 406 non-visual tests. The two shards list 203 tests each.