### PR TITLE
Fix legacy example title overflow

### DIFF
--- a/website/components/header.tsx
+++ b/website/components/header.tsx
@@ -61,7 +61,7 @@ export async function Header() {
           <span className="sr-only">Ariakit</span>
           <HeaderLogo />
         </Link>
-        <div className="flex items-center gap-1 overflow-x-clip px-1">
+        <div className="flex min-w-0 items-center gap-1 overflow-x-clip px-1">
           <HeaderVersionSelect versions={versions} />
           <HeaderNav />
         </div>

--- a/website/playwright.config.ts
+++ b/website/playwright.config.ts
@@ -42,6 +42,14 @@ export default defineConfig({
   },
   projects: [
     {
+      name: "mobile",
+      testMatch: /header/,
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 360, height: 800 },
+      },
+    },
+    {
       name: "plus",
       testMatch: /ariakit-plus/,
       retries: CI ? 3 : 1,

--- a/website/tests/header.ts
+++ b/website/tests/header.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "@playwright/test";
+
+test("truncates a long page title without overflowing the header", async ({
+  page,
+}) => {
+  await page.goto("/examples/select-next-router");
+
+  const currentPage = page.getByRole("combobox", { name: "Current page" });
+  const title = currentPage.locator(".truncate");
+
+  await expect(title).toHaveText("Combobox Select with Next.js App Router");
+  await expect(title).toHaveCSS("text-overflow", "ellipsis");
+
+  const metrics = await title.evaluate((element) => {
+    const header = element.closest(".sticky");
+    if (!header) {
+      throw new Error("Header not found");
+    }
+    return {
+      titleClientWidth: element.clientWidth,
+      titleScrollWidth: element.scrollWidth,
+      headerClientWidth: header.clientWidth,
+      headerScrollWidth: header.scrollWidth,
+    };
+  });
+
+  expect(metrics.titleScrollWidth).toBeGreaterThan(metrics.titleClientWidth);
+  expect(metrics.headerScrollWidth).toBeLessThanOrEqual(
+    metrics.headerClientWidth,
+  );
+});


### PR DESCRIPTION
## Motivation

Long example titles in the legacy website header retain their intrinsic width on mobile. This forces the header beyond the viewport and introduces horizontal scrolling on pages such as `/examples/select-next-router`.

## Solution

Allow the header navigation flex item to shrink so the existing title truncation can take effect:

```tsx
<div className="flex min-w-0 items-center gap-1 overflow-x-clip px-1">
```

Add a 360px-wide Playwright project and regression test that verifies the title is actually truncated and the header's scroll width stays within its client width.

## Preview

At a 360px mobile viewport, the long current-page title is truncated and the header remains within the viewport.

<img width="360" height="732" alt="Long legacy example title truncated within the mobile header" src="https://github.com/user-attachments/assets/8d6c2935-f170-466e-bb58-ee4cc8ea6217" />

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm build-website-lite`
- `pnpm -F website test header.ts --retries=0`
- Regression proof: the focused test fails against the previous flex sizing because the title does not truncate, then passes with `min-w-0`
