### PR TITLE
Disable the webpack filesystem cache for website builds

### DIFF
--- a/.github/workflows/plus.yml
+++ b/.github/workflows/plus.yml
@@ -37,13 +37,6 @@ jobs:
           engines: chromium
           workspace: website
 
-      - name: Cache Next.js
-        uses: actions/cache@v6
-        with:
-          path: website/.next
-          key: nextjs-${{ github.run_id }}
-          restore-keys: nextjs-
-
       - name: Build website
         run: pnpm run build-website-lite
 

--- a/website/next.config.js
+++ b/website/next.config.js
@@ -34,6 +34,18 @@ const nextConfig = {
     ignoreBuildErrors: true,
   },
   webpack(config, context) {
+    // Vercel restores `.next/cache` from the previous deployment, and webpack's
+    // persistent filesystem cache can come back with a context entry whose
+    // `hash` is undefined, crashing the build in
+    // `FileSystemInfo._resolveContextTsh`. A crashed build never uploads a new
+    // cache, so every later build restores the same broken one and fails the
+    // same way until someone clears it by hand. Keeping the cache in memory for
+    // builds persists nothing for the next build to restore. `next dev` still
+    // gets the filesystem cache, since it is never restored across machines.
+    if (!context.dev) {
+      config.cache = { type: "memory" };
+    }
+
     if (context.isServer) {
       config.plugins.push(
         new context.webpack.DefinePlugin({


### PR DESCRIPTION
## Motivation

Vercel deployments for `website` have been failing on every build that restores a build cache:

```
TypeError: Cannot read properties of undefined (reading 'length')
    at WasmHash._updateWithBuffer (next/dist/compiled/webpack/bundle5.js:28:1384455)
    at WasmHash.update (...)
    at BatchedHash.update (...)
    at processQueue (...)
```

Decoding those byte offsets against the bundled webpack in `next@14.2.35` places the crash in `FileSystemInfo._resolveContextTsh`, at `hash.update(entry.hash)` where `entry.hash` is `undefined`. That is webpack's persistent filesystem cache path, so the crash only happens when a previous build's cache is restored.

The failure cannot self-heal. A crashed build never uploads a new cache, so every later build restores the same broken cache and dies the same way. Production stayed red from the [`1e1fa6f`](https://github.com/ariakit/ariakit/commit/1e1fa6f) deployment that uploaded the bad cache until a deployment happened to run without it.

The deployment history isolates the cache as the only variable. Commit `0e8f9d3` failed with a restored cache and succeeded eleven minutes later with no cache, unchanged. Failing builds die about one minute in, while cacheless builds finish in four to five minutes.

## Solution

Use an in-memory webpack cache for builds, so nothing is written for a later build to restore and nothing on disk is read back:

```js
if (!context.dev) {
  config.cache = { type: "memory" };
}
```

The gate is `!context.dev` rather than `process.env.CI` on purpose. Vercel only exposes `CI` when a project has "Enable access to System Environment Variables" checked, and the same applies to `VERCEL`, so an env-var gate could silently do nothing. `context.dev` comes from Next.js itself and always reflects the actual build mode. `next dev` keeps the filesystem cache, since a dev server cache is never restored across machines.

`{ type: "memory" }` is used instead of `cache: false` because webpack only registers `MemoryCachePlugin` when `cache` is an object. Production builds already ran with `maxMemoryGenerations: Infinity`, so this keeps the in-build memory caching they had and removes only the disk serialization.

This also removes the `plus` workflow's `website/.next` cache step. That step existed for the webpack cache this change removes. `cleanDistDir` defaults to true and deletes everything under `.next` except `cache` at build start, so all the step can carry forward is `.next/cache`, which is now about 92 KB: five npm `dist-tags` responses that `website/components/header.tsx` deliberately cache-busts per build with `NEXT_BUILD_ID`, plus one reusable 66 KB newsletter response. Saving a roughly 68 MB archive on every run for that is not worth competing with the Playwright cache under the repository cache budget, and `main.yml` already runs the same `build-website-lite` with no cache step at all.

## Verification

- `pnpm build` in `website`, with and without `CI=1`: exits 0, and `.next/cache/webpack` is no longer created. Before this change that directory existed and `.next/cache` totalled 665 MB.
- Confirmed in `next@14.2.35` that `webpack5Config.cache` and `webpackConfig.cache.name` are both assigned before the user `webpack()` hook runs, and that nothing reassigns `.cache` afterwards, so the override survives.
- `pnpm tsc` and `pnpm lint` are clean.

## Follow-up

After this merges, the poisoned cache is inert because webpack no longer reads it, so builds should go green immediately. The stale `.next/cache/webpack` directory will still be restored and re-uploaded on each deployment, costing roughly 558 MB of transfer per build, until one "Redeploy without existing Build Cache" sheds it. That is a one-time dashboard action rather than something worth automating from `next.config.js`.
