### PR TITLE
Render submenu triggers as native buttons

### DIFF
--- a/.changeset/300-menu-button-native-submenu.md
+++ b/.changeset/300-menu-button-native-submenu.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Updated [`MenuButton`](https://ariakit.com/reference/menu-button) to render as a native `button` by default when used as a submenu trigger, with default TypeScript props and refs typed as `HTMLButtonElement`.

--- a/app/src/sandbox/menu-modal-composition/menu.react.tsx
+++ b/app/src/sandbox/menu-modal-composition/menu.react.tsx
@@ -31,7 +31,9 @@ export interface MenuProps extends Ariakit.MenuButtonProps {
   label: React.ReactNode;
 }
 
-export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
+type MenuElement = HTMLButtonElement;
+
+export const Menu = React.forwardRef<MenuElement, MenuProps>(function Menu(
   { label, children, ...props },
   ref,
 ) {

--- a/app/src/sandbox/menu-modal-composition/menu.react.tsx
+++ b/app/src/sandbox/menu-modal-composition/menu.react.tsx
@@ -31,92 +31,93 @@ export interface MenuProps extends Ariakit.MenuButtonProps {
   label: React.ReactNode;
 }
 
-type MenuElement = HTMLButtonElement;
+export const Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
+  function Menu({ label, children, ...props }, ref) {
+    const inModal = React.useContext(ModalContext);
+    const parent = React.useContext(MenuContext);
+    const menu = Ariakit.useMenuStore({ parent });
+    // There are 3 ways Ariakit can identify nested dialogs (including menu
+    // popovers):
+    //
+    // 1. They are nested in the React tree.
+    // 2. They are appended to the body element after the parent dialog is opened.
+    // 3. They are referenced in the getPersistentElements prop of the parent
+    //     dialog.
+    //
+    // By dynamically mounting the menu popover using the mounted state, we're
+    // relying on (2). This ensures parent menus won't close when we interact with
+    // nested menus, even when they're not nested in the React tree, which is the
+    // case when using the WordPress SlotFill module.
+    const mounted = Ariakit.useStoreState(menu, "mounted");
 
-export const Menu = React.forwardRef<MenuElement, MenuProps>(function Menu(
-  { label, children, ...props },
-  ref,
-) {
-  const inModal = React.useContext(ModalContext);
-  const parent = React.useContext(MenuContext);
-  const menu = Ariakit.useMenuStore({ parent });
-  // There are 3 ways Ariakit can identify nested dialogs (including menu
-  // popovers):
-  //
-  // 1. They are nested in the React tree.
-  // 2. They are appended to the body element after the parent dialog is opened.
-  // 3. They are referenced in the getPersistentElements prop of the parent
-  //     dialog.
-  //
-  // By dynamically mounting the menu popover using the mounted state, we're
-  // relying on (2). This ensures parent menus won't close when we interact with
-  // nested menus, even when they're not nested in the React tree, which is the
-  // case when using the WordPress SlotFill module.
-  const mounted = Ariakit.useStoreState(menu, "mounted");
-
-  return (
-    <>
-      <Ariakit.MenuButton
-        ref={ref}
-        {...props}
-        store={menu}
-        className={clsx(
-          !menu.parent &&
-            "inline-flex min-h-10 items-center gap-2 rounded border border-gray-300 bg-white px-4 font-medium text-black",
-          props.className,
+    return (
+      <>
+        <Ariakit.MenuButton
+          ref={ref}
+          {...props}
+          store={menu}
+          className={clsx(
+            !menu.parent &&
+              "inline-flex min-h-10 items-center gap-2 rounded border border-gray-300 bg-white px-4 font-medium text-black",
+            props.className,
+          )}
+          // Passing props.render to MenuItem here is not mandatory, but it's
+          // necessary if we want to support the `render` prop on our abstracted
+          // Menu component.
+          render={
+            menu.parent ? <MenuItem render={props.render} /> : props.render
+          }
+        >
+          <span className="flex-1">{label}</span>
+          <Ariakit.MenuButtonArrow />
+        </Ariakit.MenuButton>
+        {mounted && (
+          // By default, Ariakit portals that are nested in the React tree will be
+          // also nested in the DOM tree. This allows us to keep them in the
+          // correct order. However, the WordPress Modal component will disable
+          // all existing elements in the DOM, including existing portals. So,
+          // instead of nesting newly opened menus (that could be inside the
+          // modal) in existing portals that could've been disabled by the
+          // WordPress Modal, we always append them to the body element.
+          <Ariakit.PortalContext.Provider value={globalThis.document?.body}>
+            <Ariakit.Menu
+              portal
+              // Can't display the menu as a modal when it's nested within a
+              // WordPress Modal component. Otherwise, clicking outside the menu
+              // would also close the WordPress Modal.
+              modal={!inModal}
+              store={menu}
+              overflowPadding={16}
+              gutter={menu.parent ? 16 : 8}
+              shift={menu.parent ? -9 : 0}
+              style={{ zIndex: inModal ? 100 : 50 }}
+              className="max-h-[calc(100vh-2rem)] min-w-48 overflow-auto rounded-lg border border-gray-300 bg-white p-1 text-black shadow-lg outline-none"
+              hideOnHoverOutside={false}
+              hideOnEscape={(event) => {
+                const disclosure = menu.getState().disclosureElement;
+                const nativeEvent =
+                  "nativeEvent" in event ? event.nativeEvent : event;
+                if (
+                  disclosure &&
+                  nativeEvent.composedPath().includes(disclosure)
+                ) {
+                  // The disclosure isn't in the menu's React subtree, so the
+                  // menu can't stop the event at its own boundary.
+                  event.stopPropagation();
+                }
+                return true;
+              }}
+            >
+              <MenuContext.Provider value={menu}>
+                {children}
+              </MenuContext.Provider>
+            </Ariakit.Menu>
+          </Ariakit.PortalContext.Provider>
         )}
-        // Passing props.render to MenuItem here is not mandatory, but it's
-        // necessary if we want to support the `render` prop on our abstracted
-        // Menu component.
-        render={menu.parent ? <MenuItem render={props.render} /> : props.render}
-      >
-        <span className="flex-1">{label}</span>
-        <Ariakit.MenuButtonArrow />
-      </Ariakit.MenuButton>
-      {mounted && (
-        // By default, Ariakit portals that are nested in the React tree will be
-        // also nested in the DOM tree. This allows us to keep them in the
-        // correct order. However, the WordPress Modal component will disable
-        // all existing elements in the DOM, including existing portals. So,
-        // instead of nesting newly opened menus (that could be inside the
-        // modal) in existing portals that could've been disabled by the
-        // WordPress Modal, we always append them to the body element.
-        <Ariakit.PortalContext.Provider value={globalThis.document?.body}>
-          <Ariakit.Menu
-            portal
-            // Can't display the menu as a modal when it's nested within a
-            // WordPress Modal component. Otherwise, clicking outside the menu
-            // would also close the WordPress Modal.
-            modal={!inModal}
-            store={menu}
-            overflowPadding={16}
-            gutter={menu.parent ? 16 : 8}
-            shift={menu.parent ? -9 : 0}
-            style={{ zIndex: inModal ? 100 : 50 }}
-            className="max-h-[calc(100vh-2rem)] min-w-48 overflow-auto rounded-lg border border-gray-300 bg-white p-1 text-black shadow-lg outline-none"
-            hideOnHoverOutside={false}
-            hideOnEscape={(event) => {
-              const disclosure = menu.getState().disclosureElement;
-              const nativeEvent =
-                "nativeEvent" in event ? event.nativeEvent : event;
-              if (
-                disclosure &&
-                nativeEvent.composedPath().includes(disclosure)
-              ) {
-                // The disclosure isn't in the menu's React subtree, so the
-                // menu can't stop the event at its own boundary.
-                event.stopPropagation();
-              }
-              return true;
-            }}
-          >
-            <MenuContext.Provider value={menu}>{children}</MenuContext.Provider>
-          </Ariakit.Menu>
-        </Ariakit.PortalContext.Provider>
-      )}
-    </>
-  );
-});
+      </>
+    );
+  },
+);
 
 export function createMenuSlot(name: string, bubblesVirtually = false) {
   const SlotFill = createSlotFill(name);

--- a/app/src/sandbox/menu-motion-transitions/menu.react.tsx
+++ b/app/src/sandbox/menu-motion-transitions/menu.react.tsx
@@ -15,7 +15,9 @@ export interface MenuProps extends Ariakit.MenuButtonProps {
   exit?: MotionProps["exit"];
 }
 
-export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
+type MenuElement = HTMLButtonElement;
+
+export const Menu = React.forwardRef<MenuElement, MenuProps>(function Menu(
   {
     open,
     setOpen,

--- a/app/src/sandbox/menu-motion-transitions/menu.react.tsx
+++ b/app/src/sandbox/menu-motion-transitions/menu.react.tsx
@@ -15,62 +15,62 @@ export interface MenuProps extends Ariakit.MenuButtonProps {
   exit?: MotionProps["exit"];
 }
 
-type MenuElement = HTMLButtonElement;
-
-export const Menu = React.forwardRef<MenuElement, MenuProps>(function Menu(
-  {
-    open,
-    setOpen,
-    label,
-    children,
-    animate,
-    transition,
-    variants,
-    initial,
-    exit,
-    ...props
+export const Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
+  function Menu(
+    {
+      open,
+      setOpen,
+      label,
+      children,
+      animate,
+      transition,
+      variants,
+      initial,
+      exit,
+      ...props
+    },
+    ref,
+  ) {
+    const menu = Ariakit.useMenuStore({ open, setOpen });
+    const currentPlacement = Ariakit.useStoreState(menu, "currentPlacement");
+    const mounted = Ariakit.useStoreState(menu, "mounted");
+    return (
+      <MotionConfig reducedMotion="user">
+        <Ariakit.MenuButton
+          store={menu}
+          ref={ref}
+          {...props}
+          className={clsx("button", props.className)}
+        >
+          {label}
+          <Ariakit.MenuButtonArrow />
+        </Ariakit.MenuButton>
+        <AnimatePresence>
+          {mounted && (
+            <Ariakit.Menu
+              store={menu}
+              alwaysVisible
+              className="menu"
+              data-placement={currentPlacement}
+              render={
+                <motion.div
+                  initial={initial}
+                  exit={exit}
+                  animate={animate}
+                  variants={variants}
+                  transition={transition}
+                />
+              }
+            >
+              <Ariakit.MenuArrow className="menu-arrow" />
+              {children}
+            </Ariakit.Menu>
+          )}
+        </AnimatePresence>
+      </MotionConfig>
+    );
   },
-  ref,
-) {
-  const menu = Ariakit.useMenuStore({ open, setOpen });
-  const currentPlacement = Ariakit.useStoreState(menu, "currentPlacement");
-  const mounted = Ariakit.useStoreState(menu, "mounted");
-  return (
-    <MotionConfig reducedMotion="user">
-      <Ariakit.MenuButton
-        store={menu}
-        ref={ref}
-        {...props}
-        className={clsx("button", props.className)}
-      >
-        {label}
-        <Ariakit.MenuButtonArrow />
-      </Ariakit.MenuButton>
-      <AnimatePresence>
-        {mounted && (
-          <Ariakit.Menu
-            store={menu}
-            alwaysVisible
-            className="menu"
-            data-placement={currentPlacement}
-            render={
-              <motion.div
-                initial={initial}
-                exit={exit}
-                animate={animate}
-                variants={variants}
-                transition={transition}
-              />
-            }
-          >
-            <Ariakit.MenuArrow className="menu-arrow" />
-            {children}
-          </Ariakit.Menu>
-        )}
-      </AnimatePresence>
-    </MotionConfig>
-  );
-});
+);
 
 export interface MenuItemProps extends React.ComponentPropsWithoutRef<
   typeof MotionMenuItem

--- a/app/src/sandbox/menu-nested-interactions/menu.react.tsx
+++ b/app/src/sandbox/menu-nested-interactions/menu.react.tsx
@@ -16,11 +16,13 @@ export const MenuItem = React.forwardRef<HTMLDivElement, MenuItemProps>(
   },
 );
 
-export interface MenuProps extends Ariakit.MenuButtonProps<"div"> {
+export interface MenuProps extends Ariakit.MenuButtonProps {
   label: React.ReactNode;
 }
 
-export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
+type MenuElement = HTMLButtonElement;
+
+export const Menu = React.forwardRef<MenuElement, MenuProps>(function Menu(
   { label, children, ...props },
   ref,
 ) {

--- a/app/src/sandbox/menu-nested-interactions/menu.react.tsx
+++ b/app/src/sandbox/menu-nested-interactions/menu.react.tsx
@@ -20,27 +20,24 @@ export interface MenuProps extends Ariakit.MenuButtonProps {
   label: React.ReactNode;
 }
 
-type MenuElement = HTMLButtonElement;
-
-export const Menu = React.forwardRef<MenuElement, MenuProps>(function Menu(
-  { label, children, ...props },
-  ref,
-) {
-  const menu = Ariakit.useMenuStore();
-  return (
-    <Ariakit.MenuProvider store={menu}>
-      <Ariakit.MenuButton
-        ref={ref}
-        {...props}
-        className={clsx(!menu.parent && "button", props.className)}
-        render={menu.parent ? <MenuItem render={props.render} /> : undefined}
-      >
-        <span className="label">{label}</span>
-        <Ariakit.MenuButtonArrow />
-      </Ariakit.MenuButton>
-      <Ariakit.Menu gutter={8} shift={menu.parent ? -9 : 0} className="menu">
-        {children}
-      </Ariakit.Menu>
-    </Ariakit.MenuProvider>
-  );
-});
+export const Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
+  function Menu({ label, children, ...props }, ref) {
+    const menu = Ariakit.useMenuStore();
+    return (
+      <Ariakit.MenuProvider store={menu}>
+        <Ariakit.MenuButton
+          ref={ref}
+          {...props}
+          className={clsx(!menu.parent && "button", props.className)}
+          render={menu.parent ? <MenuItem render={props.render} /> : undefined}
+        >
+          <span className="label">{label}</span>
+          <Ariakit.MenuButtonArrow />
+        </Ariakit.MenuButton>
+        <Ariakit.Menu gutter={8} shift={menu.parent ? -9 : 0} className="menu">
+          {children}
+        </Ariakit.Menu>
+      </Ariakit.MenuProvider>
+    );
+  },
+);

--- a/app/src/sandbox/menu-nested-search-interactions/menu.react.tsx
+++ b/app/src/sandbox/menu-nested-search-interactions/menu.react.tsx
@@ -19,85 +19,85 @@ export interface MenuProps extends Ariakit.MenuButtonProps {
   trigger?: Ariakit.MenuButtonProps["render"];
 }
 
-type MenuElement = HTMLButtonElement;
+export const Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
+  function Menu(
+    {
+      label,
+      children,
+      values,
+      onValuesChange,
+      searchValue,
+      onSearch,
+      combobox,
+      trigger,
+      ...props
+    },
+    ref,
+  ) {
+    const parent = Ariakit.useMenuContext();
+    const searchable = searchValue != null || !!onSearch || !!combobox;
 
-export const Menu = React.forwardRef<MenuElement, MenuProps>(function Menu(
-  {
-    label,
-    children,
-    values,
-    onValuesChange,
-    searchValue,
-    onSearch,
-    combobox,
-    trigger,
-    ...props
-  },
-  ref,
-) {
-  const parent = Ariakit.useMenuContext();
-  const searchable = searchValue != null || !!onSearch || !!combobox;
-
-  const element = (
-    <Ariakit.MenuProvider
-      showTimeout={100}
-      placement={parent ? "right" : "left"}
-      values={values}
-      setValues={onValuesChange}
-    >
-      <Ariakit.MenuButton
-        ref={ref}
-        {...props}
-        className={clsx(!parent && "button", props.className)}
-        render={parent ? <MenuItem render={trigger} /> : trigger}
+    const element = (
+      <Ariakit.MenuProvider
+        showTimeout={100}
+        placement={parent ? "right" : "left"}
+        values={values}
+        setValues={onValuesChange}
       >
-        <span className="label">{label}</span>
-        <Ariakit.MenuButtonArrow className="button-arrow" />
-      </Ariakit.MenuButton>
-      <Ariakit.Menu
-        portal
-        overlap
-        unmountOnHide
-        gutter={parent ? -4 : 4}
-        className={clsx("menu", searchable && "search-menu")}
-      >
-        <SearchableContext.Provider value={searchable}>
-          {searchable ? (
-            <React.Fragment>
-              <div className="combobox-wrapper">
-                <Ariakit.Combobox
-                  autoSelect
-                  render={combobox}
-                  className="combobox"
-                />
-              </div>
-              <Ariakit.ComboboxList className="combobox-list">
-                {children}
-              </Ariakit.ComboboxList>
-            </React.Fragment>
-          ) : (
-            children
-          )}
-        </SearchableContext.Provider>
-      </Ariakit.Menu>
-    </Ariakit.MenuProvider>
-  );
-
-  if (searchable) {
-    return (
-      <Ariakit.ComboboxProvider
-        resetValueOnHide
-        includesBaseElement={false}
-        value={searchValue}
-        setValue={onSearch}
-      >
-        {element}
-      </Ariakit.ComboboxProvider>
+        <Ariakit.MenuButton
+          ref={ref}
+          {...props}
+          className={clsx(!parent && "button", props.className)}
+          render={parent ? <MenuItem render={trigger} /> : trigger}
+        >
+          <span className="label">{label}</span>
+          <Ariakit.MenuButtonArrow className="button-arrow" />
+        </Ariakit.MenuButton>
+        <Ariakit.Menu
+          portal
+          overlap
+          unmountOnHide
+          gutter={parent ? -4 : 4}
+          className={clsx("menu", searchable && "search-menu")}
+        >
+          <SearchableContext.Provider value={searchable}>
+            {searchable ? (
+              <React.Fragment>
+                <div className="combobox-wrapper">
+                  <Ariakit.Combobox
+                    autoSelect
+                    render={combobox}
+                    className="combobox"
+                  />
+                </div>
+                <Ariakit.ComboboxList className="combobox-list">
+                  {children}
+                </Ariakit.ComboboxList>
+              </React.Fragment>
+            ) : (
+              children
+            )}
+          </SearchableContext.Provider>
+        </Ariakit.Menu>
+      </Ariakit.MenuProvider>
     );
-  }
 
-  return element;
-});
+    if (searchable) {
+      return (
+        <Ariakit.ComboboxProvider
+          resetValueOnHide
+          includesBaseElement={false}
+          value={searchValue}
+          setValue={onSearch}
+        >
+          {element}
+        </Ariakit.ComboboxProvider>
+      );
+    }
+
+    return element;
+  },
+);
 
 export interface MenuSeparatorProps extends Ariakit.MenuSeparatorProps {}
 

--- a/app/src/sandbox/menu-nested-search-interactions/menu.react.tsx
+++ b/app/src/sandbox/menu-nested-search-interactions/menu.react.tsx
@@ -9,7 +9,7 @@ import * as React from "react";
 
 const SearchableContext = React.createContext(false);
 
-export interface MenuProps extends Ariakit.MenuButtonProps<"div"> {
+export interface MenuProps extends Ariakit.MenuButtonProps {
   label?: React.ReactNode;
   values?: Ariakit.MenuProviderProps["values"];
   onValuesChange?: Ariakit.MenuProviderProps["setValues"];
@@ -19,7 +19,9 @@ export interface MenuProps extends Ariakit.MenuButtonProps<"div"> {
   trigger?: Ariakit.MenuButtonProps["render"];
 }
 
-export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
+type MenuElement = HTMLButtonElement;
+
+export const Menu = React.forwardRef<MenuElement, MenuProps>(function Menu(
   {
     label,
     children,

--- a/app/src/sandbox/menu-slide-navigation/index.react.tsx
+++ b/app/src/sandbox/menu-slide-navigation/index.react.tsx
@@ -1,12 +1,25 @@
+import { useState } from "react";
 import { Menu, MenuGroup, MenuItem, MenuSeparator } from "./menu.react.tsx";
 
 export default function Example() {
+  const [bookmarksButton, setBookmarksButton] =
+    useState<HTMLButtonElement | null>(null);
   return (
     <Menu label="Options">
       <MenuItem label="New Tab" />
       <MenuItem label="New Window" />
       <MenuSeparator />
-      <Menu label="Bookmarks">
+      <Menu
+        ref={setBookmarksButton}
+        id="bookmarks-menu-button"
+        data-ref-id={bookmarksButton?.id}
+        label="Bookmarks"
+        onKeyDown={(event) => {
+          if (event.key === "ArrowDown") {
+            event.preventDefault();
+          }
+        }}
+      >
         <MenuItem label="Bookmark current tab" />
         <MenuItem label="Search bookmarks" />
         <MenuItem label="Show bookmarks toolbar" />

--- a/app/src/sandbox/menu-slide-navigation/menu.react.tsx
+++ b/app/src/sandbox/menu-slide-navigation/menu.react.tsx
@@ -2,7 +2,6 @@ import * as Ariakit from "@ariakit/react";
 import * as React from "react";
 import { flushSync } from "react-dom";
 
-interface MenuButtonProps extends React.ComponentPropsWithRef<"div"> {}
 interface MenuContextProps {
   getWrapper: () => HTMLElement | null;
   getMenu: () => HTMLElement | null;
@@ -11,12 +10,14 @@ interface MenuContextProps {
 
 const MenuContext = React.createContext<MenuContextProps | null>(null);
 
-export interface MenuProps extends React.ComponentPropsWithoutRef<"div"> {
+export interface MenuProps extends React.ComponentPropsWithoutRef<"button"> {
   label: React.ReactNode;
   disabled?: boolean;
 }
 
-export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
+type MenuElement = HTMLButtonElement;
+
+export const Menu = React.forwardRef<MenuElement, MenuProps>(function Menu(
   { label, children, ...props },
   ref,
 ) {
@@ -84,13 +85,13 @@ export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
     return () => parentWrapper.removeEventListener("scroll", onScroll);
   }, [parent, menu]);
 
-  const renderMenuButton = (menuButtonProps: MenuButtonProps) => (
+  const menuButton = (
     <Ariakit.MenuButton
+      ref={ref}
       store={menu}
       showOnHover={false}
       className="button"
       render={<button />}
-      {...menuButtonProps}
     >
       <span className="label">{label}</span>
       <Ariakit.MenuButtonArrow />
@@ -119,15 +120,13 @@ export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
         // MenuItem components into a single component, so it works as a
         // submenu button.
         <Ariakit.MenuItem
-          ref={ref}
           focusOnHover={false}
           className="w-full rounded p-2 text-left"
-          {...props}
-          render={renderMenuButton}
+          render={React.cloneElement(menuButton, props)}
         />
       ) : (
         // Otherwise, we just render the menu button.
-        renderMenuButton({ ref, ...props })
+        React.cloneElement(menuButton, props)
       )}
       <Ariakit.Menu
         store={menu}

--- a/app/src/sandbox/menu-slide-navigation/menu.react.tsx
+++ b/app/src/sandbox/menu-slide-navigation/menu.react.tsx
@@ -2,6 +2,7 @@ import * as Ariakit from "@ariakit/react";
 import * as React from "react";
 import { flushSync } from "react-dom";
 
+interface MenuButtonProps extends React.ComponentPropsWithRef<"button"> {}
 interface MenuContextProps {
   getWrapper: () => HTMLElement | null;
   getMenu: () => HTMLElement | null;
@@ -82,12 +83,13 @@ export const Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
       return () => parentWrapper.removeEventListener("scroll", onScroll);
     }, [parent, menu]);
 
-    const menuButton = (
+    const renderMenuButton = (menuButtonProps?: MenuButtonProps) => (
       <Ariakit.MenuButton
         ref={ref}
         store={menu}
         showOnHover={false}
         className="button"
+        {...(menuButtonProps ?? props)}
         render={<button />}
       >
         <span className="label">{label}</span>
@@ -117,13 +119,16 @@ export const Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
           // MenuItem components into a single component, so it works as a
           // submenu button.
           <Ariakit.MenuItem
+            id={props.id}
+            disabled={props.disabled}
+            aria-disabled={props["aria-disabled"]}
             focusOnHover={false}
             className="w-full rounded p-2 text-left"
-            render={React.cloneElement(menuButton, props)}
+            render={renderMenuButton(props)}
           />
         ) : (
           // Otherwise, we just render the menu button.
-          React.cloneElement(menuButton, props)
+          renderMenuButton()
         )}
         <Ariakit.Menu
           store={menu}

--- a/app/src/sandbox/menu-slide-navigation/menu.react.tsx
+++ b/app/src/sandbox/menu-slide-navigation/menu.react.tsx
@@ -15,166 +15,164 @@ export interface MenuProps extends React.ComponentPropsWithoutRef<"button"> {
   disabled?: boolean;
 }
 
-type MenuElement = HTMLButtonElement;
+export const Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
+  function Menu({ label, children, ...props }, ref) {
+    const parent = React.useContext(MenuContext);
+    const isSubmenu = !!parent;
 
-export const Menu = React.forwardRef<MenuElement, MenuProps>(function Menu(
-  { label, children, ...props },
-  ref,
-) {
-  const parent = React.useContext(MenuContext);
-  const isSubmenu = !!parent;
+    const menu = Ariakit.useMenuStore({
+      placement: isSubmenu ? "right-start" : "bottom-start",
+      animated: isSubmenu ? 500 : false,
+    });
 
-  const menu = Ariakit.useMenuStore({
-    placement: isSubmenu ? "right-start" : "bottom-start",
-    animated: isSubmenu ? 500 : false,
-  });
+    const open = Ariakit.useStoreState(menu, "open");
+    const autoFocusOnShow = Ariakit.useStoreState(menu, "autoFocusOnShow");
 
-  const open = Ariakit.useStoreState(menu, "open");
-  const autoFocusOnShow = Ariakit.useStoreState(menu, "autoFocusOnShow");
+    // By default, submenus don't automatically receive focus when they open.
+    // But here we want them to always receive focus.
+    React.useLayoutEffect(() => {
+      if (!autoFocusOnShow) {
+        menu.setAutoFocusOnShow(true);
+      }
+    }, [autoFocusOnShow, menu]);
 
-  // By default, submenus don't automatically receive focus when they open.
-  // But here we want them to always receive focus.
-  React.useLayoutEffect(() => {
-    if (!autoFocusOnShow) {
-      menu.setAutoFocusOnShow(true);
-    }
-  }, [autoFocusOnShow, menu]);
+    // We only want to delay hiding the menu, so we immediately stop the
+    // animation when it's opening.
+    React.useLayoutEffect(() => {
+      if (open) {
+        menu.stopAnimation();
+      }
+    }, [open, menu]);
 
-  // We only want to delay hiding the menu, so we immediately stop the
-  // animation when it's opening.
-  React.useLayoutEffect(() => {
-    if (open) {
-      menu.stopAnimation();
-    }
-  }, [open, menu]);
+    const contextValue = React.useMemo<MenuContextProps>(
+      () => ({
+        getWrapper: () =>
+          parent?.getWrapper() || menu.getState().popoverElement,
+        getMenu: () => menu.getState().baseElement,
+        getOffsetRight: () =>
+          (parent?.getOffsetRight() ?? 0) +
+          (menu.getState().baseElement?.offsetWidth ?? 0),
+      }),
+      [menu, parent],
+    );
 
-  const contextValue = React.useMemo<MenuContextProps>(
-    () => ({
-      getWrapper: () => parent?.getWrapper() || menu.getState().popoverElement,
-      getMenu: () => menu.getState().baseElement,
-      getOffsetRight: () =>
-        (parent?.getOffsetRight() ?? 0) +
-        (menu.getState().baseElement?.offsetWidth ?? 0),
-    }),
-    [menu, parent],
-  );
+    // Hide the submenu when it's not visible on scroll.
+    React.useEffect(() => {
+      if (!parent) return;
+      const parentWrapper = parent.getWrapper();
+      if (!parentWrapper) return;
+      let timeout = 0;
+      const onScroll = () => {
+        clearTimeout(timeout);
+        timeout = window.setTimeout(() => {
+          // In right-to-left layouts, scrollLeft is negative.
+          const scrollLeft = Math.abs(parentWrapper.scrollLeft);
+          const wrapperOffset = scrollLeft + parentWrapper.clientWidth;
+          if (wrapperOffset <= parent.getOffsetRight()) {
+            // Since the submenu is not visible anymore at this point, we want
+            // to hide it completely right away. That's why we syncrhonously
+            // hide it and immediately stops the animation so it's completely
+            // unmounted.
+            flushSync(menu.hide);
+            menu.stopAnimation();
+          }
+        }, 100);
+      };
+      parentWrapper.addEventListener("scroll", onScroll);
+      return () => parentWrapper.removeEventListener("scroll", onScroll);
+    }, [parent, menu]);
 
-  // Hide the submenu when it's not visible on scroll.
-  React.useEffect(() => {
-    if (!parent) return;
-    const parentWrapper = parent.getWrapper();
-    if (!parentWrapper) return;
-    let timeout = 0;
-    const onScroll = () => {
-      clearTimeout(timeout);
-      timeout = window.setTimeout(() => {
-        // In right-to-left layouts, scrollLeft is negative.
-        const scrollLeft = Math.abs(parentWrapper.scrollLeft);
-        const wrapperOffset = scrollLeft + parentWrapper.clientWidth;
-        if (wrapperOffset <= parent.getOffsetRight()) {
-          // Since the submenu is not visible anymore at this point, we want
-          // to hide it completely right away. That's why we syncrhonously
-          // hide it and immediately stops the animation so it's completely
-          // unmounted.
-          flushSync(menu.hide);
-          menu.stopAnimation();
-        }
-      }, 100);
-    };
-    parentWrapper.addEventListener("scroll", onScroll);
-    return () => parentWrapper.removeEventListener("scroll", onScroll);
-  }, [parent, menu]);
-
-  const menuButton = (
-    <Ariakit.MenuButton
-      ref={ref}
-      store={menu}
-      showOnHover={false}
-      className="button"
-      render={<button />}
-    >
-      <span className="label">{label}</span>
-      <Ariakit.MenuButtonArrow />
-    </Ariakit.MenuButton>
-  );
-
-  const wrapperProps = {
-    // This is necessary so Chrome scrolls the submenu into view.
-    style: { left: "auto" },
-    className: !isSubmenu
-      ? "z-50 flex w-80 snap-x snap-mandatory overflow-x-scroll scroll-smooth rounded-lg bg-white shadow-lg"
-      : "",
-  };
-
-  const autoFocus = (element: HTMLElement) => {
-    if (!isSubmenu) return true;
-    element.focus({ preventScroll: true });
-    element.scrollIntoView({ block: "nearest", inline: "start" });
-    return false;
-  };
-
-  return (
-    <>
-      {isSubmenu ? (
-        // If it's a submenu, we have to combine the MenuButton and the
-        // MenuItem components into a single component, so it works as a
-        // submenu button.
-        <Ariakit.MenuItem
-          focusOnHover={false}
-          className="w-full rounded p-2 text-left"
-          render={React.cloneElement(menuButton, props)}
-        />
-      ) : (
-        // Otherwise, we just render the menu button.
-        React.cloneElement(menuButton, props)
-      )}
-      <Ariakit.Menu
+    const menuButton = (
+      <Ariakit.MenuButton
+        ref={ref}
         store={menu}
-        className="flex h-80 w-80 flex-none snap-start flex-col overflow-y-auto bg-white p-2"
-        unmountOnHide
-        portal={isSubmenu}
-        portalElement={parent?.getWrapper}
-        wrapperProps={wrapperProps}
-        autoFocusOnShow={autoFocus}
-        autoFocusOnHide={autoFocus}
-        overflowPadding={isSubmenu ? 0 : 8}
-        gutter={isSubmenu ? 0 : 8}
-        flip={!isSubmenu}
-        getAnchorRect={(anchor) => {
-          return (
-            parent?.getMenu()?.getBoundingClientRect() ||
-            anchor?.getBoundingClientRect() ||
-            null
-          );
-        }}
+        showOnHover={false}
+        className="button"
+        render={<button />}
       >
-        <MenuContext.Provider value={contextValue}>
-          {isSubmenu && (
-            <>
-              <div className="header">
-                <Ariakit.MenuItem
-                  hideOnClick={false}
-                  focusOnHover={false}
-                  onClick={menu.hide}
-                  className="w-full rounded p-2 text-left"
-                  aria-label="Back to parent menu"
-                  render={<button />}
-                >
-                  <Ariakit.MenuButtonArrow placement="left" />
-                </Ariakit.MenuItem>
-                <Ariakit.MenuHeading className="heading">
-                  {label}
-                </Ariakit.MenuHeading>
-              </div>
-              <MenuSeparator />
-            </>
-          )}
-          {children}
-        </MenuContext.Provider>
-      </Ariakit.Menu>
-    </>
-  );
-});
+        <span className="label">{label}</span>
+        <Ariakit.MenuButtonArrow />
+      </Ariakit.MenuButton>
+    );
+
+    const wrapperProps = {
+      // This is necessary so Chrome scrolls the submenu into view.
+      style: { left: "auto" },
+      className: !isSubmenu
+        ? "z-50 flex w-80 snap-x snap-mandatory overflow-x-scroll scroll-smooth rounded-lg bg-white shadow-lg"
+        : "",
+    };
+
+    const autoFocus = (element: HTMLElement) => {
+      if (!isSubmenu) return true;
+      element.focus({ preventScroll: true });
+      element.scrollIntoView({ block: "nearest", inline: "start" });
+      return false;
+    };
+
+    return (
+      <>
+        {isSubmenu ? (
+          // If it's a submenu, we have to combine the MenuButton and the
+          // MenuItem components into a single component, so it works as a
+          // submenu button.
+          <Ariakit.MenuItem
+            focusOnHover={false}
+            className="w-full rounded p-2 text-left"
+            render={React.cloneElement(menuButton, props)}
+          />
+        ) : (
+          // Otherwise, we just render the menu button.
+          React.cloneElement(menuButton, props)
+        )}
+        <Ariakit.Menu
+          store={menu}
+          className="flex h-80 w-80 flex-none snap-start flex-col overflow-y-auto bg-white p-2"
+          unmountOnHide
+          portal={isSubmenu}
+          portalElement={parent?.getWrapper}
+          wrapperProps={wrapperProps}
+          autoFocusOnShow={autoFocus}
+          autoFocusOnHide={autoFocus}
+          overflowPadding={isSubmenu ? 0 : 8}
+          gutter={isSubmenu ? 0 : 8}
+          flip={!isSubmenu}
+          getAnchorRect={(anchor) => {
+            return (
+              parent?.getMenu()?.getBoundingClientRect() ||
+              anchor?.getBoundingClientRect() ||
+              null
+            );
+          }}
+        >
+          <MenuContext.Provider value={contextValue}>
+            {isSubmenu && (
+              <>
+                <div className="header">
+                  <Ariakit.MenuItem
+                    hideOnClick={false}
+                    focusOnHover={false}
+                    onClick={menu.hide}
+                    className="w-full rounded p-2 text-left"
+                    aria-label="Back to parent menu"
+                    render={<button />}
+                  >
+                    <Ariakit.MenuButtonArrow placement="left" />
+                  </Ariakit.MenuItem>
+                  <Ariakit.MenuHeading className="heading">
+                    {label}
+                  </Ariakit.MenuHeading>
+                </div>
+                <MenuSeparator />
+              </>
+            )}
+            {children}
+          </MenuContext.Provider>
+        </Ariakit.Menu>
+      </>
+    );
+  },
+);
 
 export interface MenuItemProps extends React.ComponentPropsWithoutRef<"button"> {
   label: React.ReactNode;

--- a/app/src/sandbox/menu-slide-navigation/test-chrome-safari.ts
+++ b/app/src/sandbox/menu-slide-navigation/test-chrome-safari.ts
@@ -18,6 +18,27 @@ const getMenuItem = (
 ) => locator.locator(`role=${role}[name='${name}']`);
 
 withFramework(import.meta.dirname, async ({ test }) => {
+  test("forwards nested trigger ids and refs", async ({ page }) => {
+    await getMenuButton(page).click();
+    const bookmarksButton = getMenuItem(page, "Bookmarks");
+    await expect(bookmarksButton).toHaveAttribute(
+      "data-ref-id",
+      "bookmarks-menu-button",
+    );
+    await expect(bookmarksButton).toHaveAttribute(
+      "id",
+      "bookmarks-menu-button",
+    );
+  });
+
+  test("runs consumer events before menu item behavior", async ({ page }) => {
+    await getMenuButton(page).click();
+    const bookmarksButton = getMenuItem(page, "Bookmarks");
+    await bookmarksButton.focus();
+    await page.keyboard.press("ArrowDown");
+    await expect(bookmarksButton).toBeFocused();
+  });
+
   test("show/hide with click", async ({ page }) => {
     await getMenuButton(page).click();
     await expect(getMenu(page, "Options")).toBeVisible();

--- a/app/src/sandbox/menu-slide-navigation/test.ts
+++ b/app/src/sandbox/menu-slide-navigation/test.ts
@@ -1,0 +1,20 @@
+import { click, focus, press, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+test("forwards nested trigger ids and refs", async () => {
+  await click(q.button("Options"));
+  const bookmarksButton = q.menuitem("Bookmarks");
+  expect(bookmarksButton).toHaveAttribute(
+    "data-ref-id",
+    "bookmarks-menu-button",
+  );
+  expect(bookmarksButton).toHaveAttribute("id", "bookmarks-menu-button");
+});
+
+test("runs consumer events before menu item behavior", async () => {
+  await click(q.button("Options"));
+  const bookmarksButton = q.menuitem("Bookmarks");
+  await focus(bookmarksButton);
+  await press.ArrowDown();
+  expect(bookmarksButton).toHaveFocus();
+});

--- a/app/src/sandbox/menubar-interactions/menu.react.tsx
+++ b/app/src/sandbox/menubar-interactions/menu.react.tsx
@@ -26,7 +26,7 @@ export const Menu = React.forwardRef<HTMLDivElement, Ariakit.MenuProps>(
 
 interface MenuButtonProps extends Ariakit.MenuButtonProps {}
 
-export const MenuButton = React.forwardRef<HTMLDivElement, MenuButtonProps>(
+export const MenuButton = React.forwardRef<HTMLButtonElement, MenuButtonProps>(
   function MenuButton(props, ref) {
     const menu = Ariakit.useMenuContext();
     return (

--- a/app/src/sandbox/menubar-interactions/test-browser.ts
+++ b/app/src/sandbox/menubar-interactions/test-browser.ts
@@ -3,6 +3,12 @@ import { expect } from "@playwright/test";
 import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
+  test("renders submenu triggers as native buttons", async ({ page }) => {
+    const q = query(page);
+    await q.menuitem("File").click();
+    await expect(q.menuitem("Share")).toHaveJSProperty("tagName", "BUTTON");
+  });
+
   test("re-open submenu and shift-tab back to the parent menu", async ({
     page,
   }) => {

--- a/app/src/sandbox/menubar-interactions/test-browser.ts
+++ b/app/src/sandbox/menubar-interactions/test-browser.ts
@@ -3,12 +3,6 @@ import { expect } from "@playwright/test";
 import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
-  test("renders submenu triggers as native buttons", async ({ page }) => {
-    const q = query(page);
-    await q.menuitem("File").click();
-    await expect(q.menuitem("Share")).toHaveJSProperty("tagName", "BUTTON");
-  });
-
   test("re-open submenu and shift-tab back to the parent menu", async ({
     page,
   }) => {

--- a/app/src/sandbox/menubar-interactions/test.ts
+++ b/app/src/sandbox/menubar-interactions/test.ts
@@ -1,6 +1,11 @@
 import { click, hover, press, q, sleep, type } from "@ariakit/test";
 import { expect, test } from "vitest";
 
+test("renders submenu triggers as native buttons", async () => {
+  await click(q.menuitem("File"));
+  expect(q.menuitem.ensure("Share").tagName).toBe("BUTTON");
+});
+
 test("show/hide on click", async () => {
   expect(q.menu("File")).not.toBeInTheDocument();
   await click(q.menuitem("File"));

--- a/app/src/sandbox/menubar-interactions/test.ts
+++ b/app/src/sandbox/menubar-interactions/test.ts
@@ -1,11 +1,6 @@
 import { click, hover, press, q, sleep, type } from "@ariakit/test";
 import { expect, test } from "vitest";
 
-test("renders submenu triggers as native buttons", async () => {
-  await click(q.menuitem("File"));
-  expect(q.menuitem.ensure("Share").tagName).toBe("BUTTON");
-});
-
 test("show/hide on click", async () => {
   expect(q.menu("File")).not.toBeInTheDocument();
   await click(q.menuitem("File"));

--- a/app/src/sandbox/menubar-navigation/menubar.react.tsx
+++ b/app/src/sandbox/menubar-navigation/menubar.react.tsx
@@ -78,7 +78,7 @@ export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
   { shift = 0, placement = "bottom", label, href, children, ...props },
   ref,
 ) {
-  const [menuButton, setMenuButton] = React.useState<HTMLDivElement | null>(
+  const [menuButton, setMenuButton] = React.useState<HTMLButtonElement | null>(
     null,
   );
 

--- a/app/src/sandbox/native-button-semantics/test-browser.ts
+++ b/app/src/sandbox/native-button-semantics/test-browser.ts
@@ -59,8 +59,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.button("Disabled button")).toBeDisabled();
 
     const nestedMenuButton = q.menuitem("Nested menu");
-    await test.expect(nestedMenuButton).toHaveJSProperty("tagName", "DIV");
-    await test.expect(nestedMenuButton).not.toHaveAttribute("type");
+    await test.expect(nestedMenuButton).toHaveJSProperty("tagName", "BUTTON");
+    await test.expect(nestedMenuButton).toHaveAttribute("type", "button");
   });
 
   test("updates custom focusability", async ({ q }) => {

--- a/app/src/sandbox/native-button-semantics/test.ts
+++ b/app/src/sandbox/native-button-semantics/test.ts
@@ -20,8 +20,8 @@ function expectSharedButtonTypes(query: ReturnType<typeof q.within>) {
   expect(query.button("Toolbar item")).toHaveAttribute("type", "button");
   expect(query.button("Root menu")).toHaveAttribute("type", "button");
   const nestedMenuButton = query.menuitem("Nested menu");
-  expect(nestedMenuButton).toHaveProperty("tagName", "DIV");
-  expect(nestedMenuButton).not.toHaveAttribute("type");
+  expect(nestedMenuButton).toHaveProperty("tagName", "BUTTON");
+  expect(nestedMenuButton).toHaveAttribute("type", "button");
 }
 
 function expectServerButtonTypes(query: ReturnType<typeof q.within>) {

--- a/examples/menu-framer-motion/menu.tsx
+++ b/examples/menu-framer-motion/menu.tsx
@@ -15,7 +15,9 @@ export interface MenuProps extends Ariakit.MenuButtonProps {
   exit?: MotionProps["exit"];
 }
 
-export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
+type MenuElement = HTMLButtonElement;
+
+export const Menu = React.forwardRef<MenuElement, MenuProps>(function Menu(
   {
     open,
     setOpen,

--- a/examples/menu-framer-motion/menu.tsx
+++ b/examples/menu-framer-motion/menu.tsx
@@ -15,64 +15,64 @@ export interface MenuProps extends Ariakit.MenuButtonProps {
   exit?: MotionProps["exit"];
 }
 
-type MenuElement = HTMLButtonElement;
-
-export const Menu = React.forwardRef<MenuElement, MenuProps>(function Menu(
-  {
-    open,
-    setOpen,
-    label,
-    children,
-    animate,
-    transition,
-    variants,
-    initial,
-    exit,
-    ...props
+export const Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
+  function Menu(
+    {
+      open,
+      setOpen,
+      label,
+      children,
+      animate,
+      transition,
+      variants,
+      initial,
+      exit,
+      ...props
+    },
+    ref,
+  ) {
+    const menu = Ariakit.useMenuStore({ open, setOpen });
+    const currentPlacement = Ariakit.useStoreState(menu, "currentPlacement");
+    const mounted = Ariakit.useStoreState(menu, "mounted");
+    return (
+      <MotionConfig reducedMotion="user">
+        <Ariakit.MenuButton
+          store={menu}
+          ref={ref}
+          {...props}
+          className={clsx("button", props.className)}
+        >
+          {label}
+          <Ariakit.MenuButtonArrow />
+        </Ariakit.MenuButton>
+        <AnimatePresence>
+          {mounted && (
+            <Ariakit.Menu
+              store={menu}
+              alwaysVisible
+              className="menu"
+              // We'll use this data attribute to style the transform-origin
+              // property based on the menu's placement. See style.css.
+              data-placement={currentPlacement}
+              render={
+                <motion.div
+                  initial={initial}
+                  exit={exit}
+                  animate={animate}
+                  variants={variants}
+                  transition={transition}
+                />
+              }
+            >
+              <Ariakit.MenuArrow className="menu-arrow" />
+              {children}
+            </Ariakit.Menu>
+          )}
+        </AnimatePresence>
+      </MotionConfig>
+    );
   },
-  ref,
-) {
-  const menu = Ariakit.useMenuStore({ open, setOpen });
-  const currentPlacement = Ariakit.useStoreState(menu, "currentPlacement");
-  const mounted = Ariakit.useStoreState(menu, "mounted");
-  return (
-    <MotionConfig reducedMotion="user">
-      <Ariakit.MenuButton
-        store={menu}
-        ref={ref}
-        {...props}
-        className={clsx("button", props.className)}
-      >
-        {label}
-        <Ariakit.MenuButtonArrow />
-      </Ariakit.MenuButton>
-      <AnimatePresence>
-        {mounted && (
-          <Ariakit.Menu
-            store={menu}
-            alwaysVisible
-            className="menu"
-            // We'll use this data attribute to style the transform-origin
-            // property based on the menu's placement. See style.css.
-            data-placement={currentPlacement}
-            render={
-              <motion.div
-                initial={initial}
-                exit={exit}
-                animate={animate}
-                variants={variants}
-                transition={transition}
-              />
-            }
-          >
-            <Ariakit.MenuArrow className="menu-arrow" />
-            {children}
-          </Ariakit.Menu>
-        )}
-      </AnimatePresence>
-    </MotionConfig>
-  );
-});
+);
 
 export interface MenuItemProps extends React.ComponentPropsWithoutRef<
   typeof MotionMenuItem

--- a/examples/menu-nested-combobox/menu.tsx
+++ b/examples/menu-nested-combobox/menu.tsx
@@ -19,85 +19,85 @@ export interface MenuProps extends Ariakit.MenuButtonProps {
   trigger?: Ariakit.MenuButtonProps["render"];
 }
 
-type MenuElement = HTMLButtonElement;
+export const Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
+  function Menu(
+    {
+      label,
+      children,
+      values,
+      onValuesChange,
+      searchValue,
+      onSearch,
+      combobox,
+      trigger,
+      ...props
+    },
+    ref,
+  ) {
+    const parent = Ariakit.useMenuContext();
+    const searchable = searchValue != null || !!onSearch || !!combobox;
 
-export const Menu = React.forwardRef<MenuElement, MenuProps>(function Menu(
-  {
-    label,
-    children,
-    values,
-    onValuesChange,
-    searchValue,
-    onSearch,
-    combobox,
-    trigger,
-    ...props
-  },
-  ref,
-) {
-  const parent = Ariakit.useMenuContext();
-  const searchable = searchValue != null || !!onSearch || !!combobox;
-
-  const element = (
-    <Ariakit.MenuProvider
-      showTimeout={100}
-      placement={parent ? "right" : "left"}
-      values={values}
-      setValues={onValuesChange}
-    >
-      <Ariakit.MenuButton
-        ref={ref}
-        {...props}
-        className={clsx(!parent && "button", props.className)}
-        render={parent ? <MenuItem render={trigger} /> : trigger}
+    const element = (
+      <Ariakit.MenuProvider
+        showTimeout={100}
+        placement={parent ? "right" : "left"}
+        values={values}
+        setValues={onValuesChange}
       >
-        <span className="label">{label}</span>
-        <Ariakit.MenuButtonArrow className="button-arrow" />
-      </Ariakit.MenuButton>
-      <Ariakit.Menu
-        portal
-        overlap
-        unmountOnHide
-        gutter={parent ? -4 : 4}
-        className={clsx("menu", searchable && "search-menu")}
-      >
-        <SearchableContext.Provider value={searchable}>
-          {searchable ? (
-            <React.Fragment>
-              <div className="combobox-wrapper">
-                <Ariakit.Combobox
-                  autoSelect
-                  render={combobox}
-                  className="combobox"
-                />
-              </div>
-              <Ariakit.ComboboxList className="combobox-list">
-                {children}
-              </Ariakit.ComboboxList>
-            </React.Fragment>
-          ) : (
-            children
-          )}
-        </SearchableContext.Provider>
-      </Ariakit.Menu>
-    </Ariakit.MenuProvider>
-  );
-
-  if (searchable) {
-    return (
-      <Ariakit.ComboboxProvider
-        resetValueOnHide
-        includesBaseElement={false}
-        value={searchValue}
-        setValue={onSearch}
-      >
-        {element}
-      </Ariakit.ComboboxProvider>
+        <Ariakit.MenuButton
+          ref={ref}
+          {...props}
+          className={clsx(!parent && "button", props.className)}
+          render={parent ? <MenuItem render={trigger} /> : trigger}
+        >
+          <span className="label">{label}</span>
+          <Ariakit.MenuButtonArrow className="button-arrow" />
+        </Ariakit.MenuButton>
+        <Ariakit.Menu
+          portal
+          overlap
+          unmountOnHide
+          gutter={parent ? -4 : 4}
+          className={clsx("menu", searchable && "search-menu")}
+        >
+          <SearchableContext.Provider value={searchable}>
+            {searchable ? (
+              <React.Fragment>
+                <div className="combobox-wrapper">
+                  <Ariakit.Combobox
+                    autoSelect
+                    render={combobox}
+                    className="combobox"
+                  />
+                </div>
+                <Ariakit.ComboboxList className="combobox-list">
+                  {children}
+                </Ariakit.ComboboxList>
+              </React.Fragment>
+            ) : (
+              children
+            )}
+          </SearchableContext.Provider>
+        </Ariakit.Menu>
+      </Ariakit.MenuProvider>
     );
-  }
 
-  return element;
-});
+    if (searchable) {
+      return (
+        <Ariakit.ComboboxProvider
+          resetValueOnHide
+          includesBaseElement={false}
+          value={searchValue}
+          setValue={onSearch}
+        >
+          {element}
+        </Ariakit.ComboboxProvider>
+      );
+    }
+
+    return element;
+  },
+);
 
 export interface MenuSeparatorProps extends Ariakit.MenuSeparatorProps {}
 

--- a/examples/menu-nested-combobox/menu.tsx
+++ b/examples/menu-nested-combobox/menu.tsx
@@ -9,7 +9,7 @@ import * as React from "react";
 
 const SearchableContext = React.createContext(false);
 
-export interface MenuProps extends Ariakit.MenuButtonProps<"div"> {
+export interface MenuProps extends Ariakit.MenuButtonProps {
   label?: React.ReactNode;
   values?: Ariakit.MenuProviderProps["values"];
   onValuesChange?: Ariakit.MenuProviderProps["setValues"];
@@ -19,7 +19,9 @@ export interface MenuProps extends Ariakit.MenuButtonProps<"div"> {
   trigger?: Ariakit.MenuButtonProps["render"];
 }
 
-export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
+type MenuElement = HTMLButtonElement;
+
+export const Menu = React.forwardRef<MenuElement, MenuProps>(function Menu(
   {
     label,
     children,

--- a/examples/menu-nested/menu.tsx
+++ b/examples/menu-nested/menu.tsx
@@ -16,11 +16,13 @@ export const MenuItem = React.forwardRef<HTMLDivElement, MenuItemProps>(
   },
 );
 
-export interface MenuProps extends Ariakit.MenuButtonProps<"div"> {
+export interface MenuProps extends Ariakit.MenuButtonProps {
   label: React.ReactNode;
 }
 
-export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
+type MenuElement = HTMLButtonElement;
+
+export const Menu = React.forwardRef<MenuElement, MenuProps>(function Menu(
   { label, children, ...props },
   ref,
 ) {

--- a/examples/menu-nested/menu.tsx
+++ b/examples/menu-nested/menu.tsx
@@ -20,27 +20,24 @@ export interface MenuProps extends Ariakit.MenuButtonProps {
   label: React.ReactNode;
 }
 
-type MenuElement = HTMLButtonElement;
-
-export const Menu = React.forwardRef<MenuElement, MenuProps>(function Menu(
-  { label, children, ...props },
-  ref,
-) {
-  const menu = Ariakit.useMenuStore();
-  return (
-    <Ariakit.MenuProvider store={menu}>
-      <Ariakit.MenuButton
-        ref={ref}
-        {...props}
-        className={clsx(!menu.parent && "button", props.className)}
-        render={menu.parent ? <MenuItem render={props.render} /> : undefined}
-      >
-        <span className="label">{label}</span>
-        <Ariakit.MenuButtonArrow />
-      </Ariakit.MenuButton>
-      <Ariakit.Menu gutter={8} shift={menu.parent ? -9 : 0} className="menu">
-        {children}
-      </Ariakit.Menu>
-    </Ariakit.MenuProvider>
-  );
-});
+export const Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
+  function Menu({ label, children, ...props }, ref) {
+    const menu = Ariakit.useMenuStore();
+    return (
+      <Ariakit.MenuProvider store={menu}>
+        <Ariakit.MenuButton
+          ref={ref}
+          {...props}
+          className={clsx(!menu.parent && "button", props.className)}
+          render={menu.parent ? <MenuItem render={props.render} /> : undefined}
+        >
+          <span className="label">{label}</span>
+          <Ariakit.MenuButtonArrow />
+        </Ariakit.MenuButton>
+        <Ariakit.Menu gutter={8} shift={menu.parent ? -9 : 0} className="menu">
+          {children}
+        </Ariakit.Menu>
+      </Ariakit.MenuProvider>
+    );
+  },
+);

--- a/examples/menu-slide/menu.tsx
+++ b/examples/menu-slide/menu.tsx
@@ -15,164 +15,162 @@ export interface MenuProps extends React.ComponentPropsWithoutRef<"button"> {
   disabled?: boolean;
 }
 
-type MenuElement = HTMLButtonElement;
+export const Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
+  function Menu({ label, children, ...props }, ref) {
+    const parent = React.useContext(MenuContext);
+    const isSubmenu = !!parent;
 
-export const Menu = React.forwardRef<MenuElement, MenuProps>(function Menu(
-  { label, children, ...props },
-  ref,
-) {
-  const parent = React.useContext(MenuContext);
-  const isSubmenu = !!parent;
+    const menu = Ariakit.useMenuStore({
+      placement: isSubmenu ? "right-start" : "bottom-start",
+      animated: isSubmenu ? 500 : false,
+    });
 
-  const menu = Ariakit.useMenuStore({
-    placement: isSubmenu ? "right-start" : "bottom-start",
-    animated: isSubmenu ? 500 : false,
-  });
+    const open = Ariakit.useStoreState(menu, "open");
+    const autoFocusOnShow = Ariakit.useStoreState(menu, "autoFocusOnShow");
 
-  const open = Ariakit.useStoreState(menu, "open");
-  const autoFocusOnShow = Ariakit.useStoreState(menu, "autoFocusOnShow");
+    // By default, submenus don't automatically receive focus when they open.
+    // But here we want them to always receive focus.
+    React.useLayoutEffect(() => {
+      if (!autoFocusOnShow) {
+        menu.setAutoFocusOnShow(true);
+      }
+    }, [autoFocusOnShow, menu]);
 
-  // By default, submenus don't automatically receive focus when they open.
-  // But here we want them to always receive focus.
-  React.useLayoutEffect(() => {
-    if (!autoFocusOnShow) {
-      menu.setAutoFocusOnShow(true);
-    }
-  }, [autoFocusOnShow, menu]);
+    // We only want to delay hiding the menu, so we immediately stop the
+    // animation when it's opening.
+    React.useLayoutEffect(() => {
+      if (open) {
+        menu.stopAnimation();
+      }
+    }, [open, menu]);
 
-  // We only want to delay hiding the menu, so we immediately stop the
-  // animation when it's opening.
-  React.useLayoutEffect(() => {
-    if (open) {
-      menu.stopAnimation();
-    }
-  }, [open, menu]);
+    const contextValue = React.useMemo<MenuContextProps>(
+      () => ({
+        getWrapper: () =>
+          parent?.getWrapper() || menu.getState().popoverElement,
+        getMenu: () => menu.getState().baseElement,
+        getOffsetRight: () =>
+          (parent?.getOffsetRight() ?? 0) +
+          (menu.getState().baseElement?.offsetWidth ?? 0),
+      }),
+      [menu, parent],
+    );
 
-  const contextValue = React.useMemo<MenuContextProps>(
-    () => ({
-      getWrapper: () => parent?.getWrapper() || menu.getState().popoverElement,
-      getMenu: () => menu.getState().baseElement,
-      getOffsetRight: () =>
-        (parent?.getOffsetRight() ?? 0) +
-        (menu.getState().baseElement?.offsetWidth ?? 0),
-    }),
-    [menu, parent],
-  );
+    // Hide the submenu when it's not visible on scroll.
+    React.useEffect(() => {
+      if (!parent) return;
+      const parentWrapper = parent.getWrapper();
+      if (!parentWrapper) return;
+      let timeout = 0;
+      const onScroll = () => {
+        clearTimeout(timeout);
+        timeout = window.setTimeout(() => {
+          // In right-to-left layouts, scrollLeft is negative.
+          const scrollLeft = Math.abs(parentWrapper.scrollLeft);
+          const wrapperOffset = scrollLeft + parentWrapper.clientWidth;
+          if (wrapperOffset <= parent.getOffsetRight()) {
+            // Since the submenu is not visible anymore at this point, we want
+            // to hide it completely right away. That's why we syncrhonously
+            // hide it and immediately stops the animation so it's completely
+            // unmounted.
+            flushSync(menu.hide);
+            menu.stopAnimation();
+          }
+        }, 100);
+      };
+      parentWrapper.addEventListener("scroll", onScroll);
+      return () => parentWrapper.removeEventListener("scroll", onScroll);
+    }, [parent, menu]);
 
-  // Hide the submenu when it's not visible on scroll.
-  React.useEffect(() => {
-    if (!parent) return;
-    const parentWrapper = parent.getWrapper();
-    if (!parentWrapper) return;
-    let timeout = 0;
-    const onScroll = () => {
-      clearTimeout(timeout);
-      timeout = window.setTimeout(() => {
-        // In right-to-left layouts, scrollLeft is negative.
-        const scrollLeft = Math.abs(parentWrapper.scrollLeft);
-        const wrapperOffset = scrollLeft + parentWrapper.clientWidth;
-        if (wrapperOffset <= parent.getOffsetRight()) {
-          // Since the submenu is not visible anymore at this point, we want
-          // to hide it completely right away. That's why we syncrhonously
-          // hide it and immediately stops the animation so it's completely
-          // unmounted.
-          flushSync(menu.hide);
-          menu.stopAnimation();
-        }
-      }, 100);
-    };
-    parentWrapper.addEventListener("scroll", onScroll);
-    return () => parentWrapper.removeEventListener("scroll", onScroll);
-  }, [parent, menu]);
-
-  const menuButton = (
-    <Ariakit.MenuButton
-      ref={ref}
-      store={menu}
-      showOnHover={false}
-      className="button"
-      render={<button />}
-    >
-      <span className="label">{label}</span>
-      <Ariakit.MenuButtonArrow />
-    </Ariakit.MenuButton>
-  );
-
-  const wrapperProps = {
-    // This is necessary so Chrome scrolls the submenu into view.
-    style: { left: "auto" },
-    className: !isSubmenu ? "menu-wrapper" : "",
-  };
-
-  const autoFocus = (element: HTMLElement) => {
-    if (!isSubmenu) return true;
-    element.focus({ preventScroll: true });
-    element.scrollIntoView({ block: "nearest", inline: "start" });
-    return false;
-  };
-
-  return (
-    <>
-      {isSubmenu ? (
-        // If it's a submenu, we have to combine the MenuButton and the
-        // MenuItem components into a single component, so it works as a
-        // submenu button.
-        <Ariakit.MenuItem
-          focusOnHover={false}
-          className="menu-item"
-          render={React.cloneElement(menuButton, props)}
-        />
-      ) : (
-        // Otherwise, we just render the menu button.
-        React.cloneElement(menuButton, props)
-      )}
-      <Ariakit.Menu
+    const menuButton = (
+      <Ariakit.MenuButton
+        ref={ref}
         store={menu}
-        className="menu"
-        unmountOnHide
-        portal={isSubmenu}
-        portalElement={parent?.getWrapper}
-        wrapperProps={wrapperProps}
-        autoFocusOnShow={autoFocus}
-        autoFocusOnHide={autoFocus}
-        overflowPadding={isSubmenu ? 0 : 8}
-        gutter={isSubmenu ? 0 : 8}
-        flip={!isSubmenu}
-        getAnchorRect={(anchor) => {
-          return (
-            parent?.getMenu()?.getBoundingClientRect() ||
-            anchor?.getBoundingClientRect() ||
-            null
-          );
-        }}
+        showOnHover={false}
+        className="button"
+        render={<button />}
       >
-        <MenuContext.Provider value={contextValue}>
-          {isSubmenu && (
-            <>
-              <div className="header">
-                <Ariakit.MenuItem
-                  hideOnClick={false}
-                  focusOnHover={false}
-                  onClick={menu.hide}
-                  className="menu-item"
-                  aria-label="Back to parent menu"
-                  render={<button />}
-                >
-                  <Ariakit.MenuButtonArrow placement="left" />
-                </Ariakit.MenuItem>
-                <Ariakit.MenuHeading className="heading">
-                  {label}
-                </Ariakit.MenuHeading>
-              </div>
-              <MenuSeparator />
-            </>
-          )}
-          {children}
-        </MenuContext.Provider>
-      </Ariakit.Menu>
-    </>
-  );
-});
+        <span className="label">{label}</span>
+        <Ariakit.MenuButtonArrow />
+      </Ariakit.MenuButton>
+    );
+
+    const wrapperProps = {
+      // This is necessary so Chrome scrolls the submenu into view.
+      style: { left: "auto" },
+      className: !isSubmenu ? "menu-wrapper" : "",
+    };
+
+    const autoFocus = (element: HTMLElement) => {
+      if (!isSubmenu) return true;
+      element.focus({ preventScroll: true });
+      element.scrollIntoView({ block: "nearest", inline: "start" });
+      return false;
+    };
+
+    return (
+      <>
+        {isSubmenu ? (
+          // If it's a submenu, we have to combine the MenuButton and the
+          // MenuItem components into a single component, so it works as a
+          // submenu button.
+          <Ariakit.MenuItem
+            focusOnHover={false}
+            className="menu-item"
+            render={React.cloneElement(menuButton, props)}
+          />
+        ) : (
+          // Otherwise, we just render the menu button.
+          React.cloneElement(menuButton, props)
+        )}
+        <Ariakit.Menu
+          store={menu}
+          className="menu"
+          unmountOnHide
+          portal={isSubmenu}
+          portalElement={parent?.getWrapper}
+          wrapperProps={wrapperProps}
+          autoFocusOnShow={autoFocus}
+          autoFocusOnHide={autoFocus}
+          overflowPadding={isSubmenu ? 0 : 8}
+          gutter={isSubmenu ? 0 : 8}
+          flip={!isSubmenu}
+          getAnchorRect={(anchor) => {
+            return (
+              parent?.getMenu()?.getBoundingClientRect() ||
+              anchor?.getBoundingClientRect() ||
+              null
+            );
+          }}
+        >
+          <MenuContext.Provider value={contextValue}>
+            {isSubmenu && (
+              <>
+                <div className="header">
+                  <Ariakit.MenuItem
+                    hideOnClick={false}
+                    focusOnHover={false}
+                    onClick={menu.hide}
+                    className="menu-item"
+                    aria-label="Back to parent menu"
+                    render={<button />}
+                  >
+                    <Ariakit.MenuButtonArrow placement="left" />
+                  </Ariakit.MenuItem>
+                  <Ariakit.MenuHeading className="heading">
+                    {label}
+                  </Ariakit.MenuHeading>
+                </div>
+                <MenuSeparator />
+              </>
+            )}
+            {children}
+          </MenuContext.Provider>
+        </Ariakit.Menu>
+      </>
+    );
+  },
+);
 
 export interface MenuItemProps extends React.ComponentPropsWithoutRef<"button"> {
   label: React.ReactNode;

--- a/examples/menu-slide/menu.tsx
+++ b/examples/menu-slide/menu.tsx
@@ -2,7 +2,6 @@ import * as Ariakit from "@ariakit/react";
 import * as React from "react";
 import { flushSync } from "react-dom";
 
-interface MenuButtonProps extends React.ComponentPropsWithRef<"div"> {}
 interface MenuContextProps {
   getWrapper: () => HTMLElement | null;
   getMenu: () => HTMLElement | null;
@@ -11,12 +10,14 @@ interface MenuContextProps {
 
 const MenuContext = React.createContext<MenuContextProps | null>(null);
 
-export interface MenuProps extends React.ComponentPropsWithoutRef<"div"> {
+export interface MenuProps extends React.ComponentPropsWithoutRef<"button"> {
   label: React.ReactNode;
   disabled?: boolean;
 }
 
-export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
+type MenuElement = HTMLButtonElement;
+
+export const Menu = React.forwardRef<MenuElement, MenuProps>(function Menu(
   { label, children, ...props },
   ref,
 ) {
@@ -84,13 +85,13 @@ export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
     return () => parentWrapper.removeEventListener("scroll", onScroll);
   }, [parent, menu]);
 
-  const renderMenuButton = (menuButtonProps: MenuButtonProps) => (
+  const menuButton = (
     <Ariakit.MenuButton
+      ref={ref}
       store={menu}
       showOnHover={false}
       className="button"
       render={<button />}
-      {...menuButtonProps}
     >
       <span className="label">{label}</span>
       <Ariakit.MenuButtonArrow />
@@ -117,15 +118,13 @@ export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
         // MenuItem components into a single component, so it works as a
         // submenu button.
         <Ariakit.MenuItem
-          ref={ref}
           focusOnHover={false}
           className="menu-item"
-          {...props}
-          render={renderMenuButton}
+          render={React.cloneElement(menuButton, props)}
         />
       ) : (
         // Otherwise, we just render the menu button.
-        renderMenuButton({ ref, ...props })
+        React.cloneElement(menuButton, props)
       )}
       <Ariakit.Menu
         store={menu}

--- a/examples/menu-slide/menu.tsx
+++ b/examples/menu-slide/menu.tsx
@@ -2,6 +2,7 @@ import * as Ariakit from "@ariakit/react";
 import * as React from "react";
 import { flushSync } from "react-dom";
 
+interface MenuButtonProps extends React.ComponentPropsWithRef<"button"> {}
 interface MenuContextProps {
   getWrapper: () => HTMLElement | null;
   getMenu: () => HTMLElement | null;
@@ -82,12 +83,13 @@ export const Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
       return () => parentWrapper.removeEventListener("scroll", onScroll);
     }, [parent, menu]);
 
-    const menuButton = (
+    const renderMenuButton = (menuButtonProps?: MenuButtonProps) => (
       <Ariakit.MenuButton
         ref={ref}
         store={menu}
         showOnHover={false}
         className="button"
+        {...(menuButtonProps ?? props)}
         render={<button />}
       >
         <span className="label">{label}</span>
@@ -115,13 +117,16 @@ export const Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
           // MenuItem components into a single component, so it works as a
           // submenu button.
           <Ariakit.MenuItem
+            id={props.id}
+            disabled={props.disabled}
+            aria-disabled={props["aria-disabled"]}
             focusOnHover={false}
             className="menu-item"
-            render={React.cloneElement(menuButton, props)}
+            render={renderMenuButton(props)}
           />
         ) : (
           // Otherwise, we just render the menu button.
-          React.cloneElement(menuButton, props)
+          renderMenuButton()
         )}
         <Ariakit.Menu
           store={menu}

--- a/examples/menubar-navigation/menubar.tsx
+++ b/examples/menubar-navigation/menubar.tsx
@@ -72,7 +72,7 @@ export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
   { shift = 0, placement = "bottom", label, href, children, ...props },
   ref,
 ) {
-  const [menuButton, setMenuButton] = React.useState<HTMLDivElement | null>(
+  const [menuButton, setMenuButton] = React.useState<HTMLButtonElement | null>(
     null,
   );
 

--- a/examples/menubar/menu.tsx
+++ b/examples/menubar/menu.tsx
@@ -26,7 +26,7 @@ export const Menu = React.forwardRef<HTMLDivElement, Ariakit.MenuProps>(
 
 interface MenuButtonProps extends Ariakit.MenuButtonProps {}
 
-export const MenuButton = React.forwardRef<HTMLDivElement, MenuButtonProps>(
+export const MenuButton = React.forwardRef<HTMLButtonElement, MenuButtonProps>(
   function MenuButton(props, ref) {
     const menu = Ariakit.useMenuContext();
     return (

--- a/packages/ariakit-react-components/src/menu/menu-button.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-button.tsx
@@ -27,7 +27,6 @@ import type { BasePlacement } from "../popover/__utils.ts";
 import { getBasePlacement } from "../popover/__utils.ts";
 import type { PopoverDisclosureOptions } from "../popover/popover-disclosure.tsx";
 import { usePopoverDisclosure } from "../popover/popover-disclosure.tsx";
-import { Role } from "../role/role.tsx";
 import {
   MenuContextProvider,
   useMenuProviderContext,
@@ -35,7 +34,7 @@ import {
 import type { MenuStore, MenuStoreState } from "./menu-store.ts";
 
 const TagName = "button" satisfies ElementType;
-type TagName = typeof TagName | "div";
+type TagName = typeof TagName;
 type HTMLType = HTMLElementTagNameMap[TagName];
 
 function getInitialFocus(event: KeyboardEvent, dir: BasePlacement) {
@@ -109,7 +108,7 @@ export const useMenuButton = createHook<TagName, MenuButtonOptions>(
     const onFocusProp = props.onFocus;
 
     const onFocus = useEvent((event: FocusEvent<HTMLType>) => {
-      onFocusProp?.(event as any);
+      onFocusProp?.(event);
       if (isDisabled(event.currentTarget)) return;
       if (event.defaultPrevented) return;
       // Reset the autoFocusOnShow state so we can focus the menu button while
@@ -137,7 +136,7 @@ export const useMenuButton = createHook<TagName, MenuButtonOptions>(
     const onKeyDownProp = props.onKeyDown;
 
     const onKeyDown = useEvent((event: KeyboardEvent<HTMLType>) => {
-      onKeyDownProp?.(event as any);
+      onKeyDownProp?.(event);
       if (isDisabled(event.currentTarget)) return;
       if (event.defaultPrevented) return;
       const initialFocus = getInitialFocus(event, dir);
@@ -158,7 +157,7 @@ export const useMenuButton = createHook<TagName, MenuButtonOptions>(
     const onClickProp = props.onClick;
 
     const onClick = useEvent((event: MouseEvent<HTMLType>) => {
-      onClickProp?.(event as any);
+      onClickProp?.(event);
       if (event.defaultPrevented) return;
       if (!store) return;
       const isKeyboardClick = !event.detail;
@@ -187,17 +186,6 @@ export const useMenuButton = createHook<TagName, MenuButtonOptions>(
       ),
       [store],
     );
-
-    if (hasParentMenu) {
-      // On Safari, VO+Space triggers a click twice on native button elements
-      // with role menuitem (https://bugs.webkit.org/show_bug.cgi?id=228318).
-      // So, if the menu button is rendered within a menu, we need to render it
-      // as another element.
-      props = {
-        ...props,
-        render: <Role.div render={props.render} />,
-      };
-    }
 
     // We'll use this id to render the aria-labelledby attribute on the menu.
     const id = useId(props.id);
@@ -302,8 +290,6 @@ export const useMenuButton = createHook<TagName, MenuButtonOptions>(
 export const MenuButton = forwardRef(function MenuButton(
   props: MenuButtonProps,
 ) {
-  // useMenuButton renders nested menu buttons as a div, so apply the default
-  // button type only after the hook has chosen the final host.
   const htmlProps = useMenuButton(props);
   return createElement(TagName, withDefaultButtonType(htmlProps));
 });


### PR DESCRIPTION
## Motivation

`MenuButton` used to render nested submenu triggers as a `div` to avoid a Safari and VoiceOver double-click bug. The workaround is no longer needed in current Safari, while the default `"button" | "div"` host leaks into TypeScript props and refs.

## Solution

Remove the Safari workaround so default submenu triggers stay native buttons, and narrow the default `MenuButton` tag and ref contract to `HTMLButtonElement` without making the component generic.

Explicit composition such as `<MenuButton render={<MenuItem />} />` still renders the supplied `MenuItem` host.

Add happy-dom and cross-browser Playwright coverage for native submenu triggers, slide-menu ref and ID forwarding, and consumer event cancellation. Update affected examples to use the narrow button contract.

## Implementation review reassessment

<details>
<summary>Cycle 3: Keep the narrow contract and simplify example composition</summary>

**Assessment**

The old Safari workaround affects a narrower legacy-browser case, while the default `"button" | "div"` type affects every TypeScript consumer. The core change remains small and removes runtime host switching, event casts, and an import. The repeated findings clustered around an unnecessary `cloneElement` rewrite in the slide-menu examples and duplicate menubar assertions, not the core contract.

**Decision**

Keep the non-generic `HTMLButtonElement` default contract and preserve explicit `MenuItem` composition as the intentional runtime-host override. Restore the existing `renderMenuButton` composition in the slide-menu examples so behavior props continue through `MenuItem`, remove the redundant menubar tests, and retain the dedicated native-button semantics unit and browser coverage. Do not add a host-aware union, generic abstraction, or other machinery for explicit `render` overrides.

</details>

## Review gate reassessment

<details>
<summary>Cycle 3: Keep the reviewed composition after a style-only finding</summary>

**Assessment**

The third pre-commit review cycle found only an unbraced non-early-exit conditional in the new regression fixture. The earlier semantic findings—nested ref and ID propagation and consumer event cancellation order—are covered by focused happy-dom and cross-browser tests and were independently verified in the final gate.

**Decision**

Keep the current element-render composition because it preserves consumer → `MenuItem` → `MenuButton` behavior without widening the public `MenuButton` contract. Apply the local brace fix, rerun lint and focused tests, and require a final clean fresh-context review before committing.

</details>

## Preview

<img width="1000" height="700" alt="Share submenu trigger highlighted as a native button" src="https://github.com/user-attachments/assets/95a25578-65ba-4726-874d-1be825c50463" />

The highlighted `Share` submenu trigger is a native `<button>` after opening the `File` menu. The badge was generated from the element `tagName` during capture.