### PR TITLE
Prefer semantic assertions over frame waits

### DIFF
--- a/app/src/sandbox/button-ref-cleanup/test-chrome-firefox.ts
+++ b/app/src/sandbox/button-ref-cleanup/test-chrome-firefox.ts
@@ -20,6 +20,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.text("Button object ref detached: yes")).toBeVisible();
     await page.keyboard.press("b");
     await page.keyboard.press("b");
+    // Cleanup removes the shortcut, so the key presses produce no positive
+    // state to await. Cross its update checkpoint before asserting no change.
     await flushFrames(page);
     await test.expect(q.text("Button shortcut count: 2")).toBeVisible();
     await test.expect(q.text("Button shortcut count: 3")).toBeHidden();
@@ -40,6 +42,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.text("Portal cleanup connected: yes")).toBeVisible();
     await page.keyboard.press("p");
     await page.keyboard.press("p");
+    // Cleanup removes the shortcut, so the key presses produce no positive
+    // state to await. Cross its update checkpoint before asserting no change.
     await flushFrames(page);
     await test.expect(q.text("Portal shortcut count: 2")).toBeVisible();
     await test.expect(q.text("Portal shortcut count: 3")).toBeHidden();
@@ -57,6 +61,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.text("Connected portal root")).toBeVisible();
     await page.keyboard.press("c");
     await page.keyboard.press("c");
+    // Cleanup removes the shortcut, so the key presses produce no positive
+    // state to await. Cross its update checkpoint before asserting no change.
     await flushFrames(page);
     await test
       .expect(q.text("Connected portal shortcut count: 2"))

--- a/app/src/sandbox/collection-renderer-perf/perf-chrome.ts
+++ b/app/src/sandbox/collection-renderer-perf/perf-chrome.ts
@@ -1,7 +1,6 @@
 import type { query } from "@ariakit/test/playwright";
 import { expect } from "@playwright/test";
-import type { Page } from "@playwright/test";
-import { flushFrames, withFramework } from "#app/test-utils/preview.ts";
+import { withFramework } from "#app/test-utils/preview.ts";
 
 const groupCount = 200;
 const itemsPerGroup = 50;
@@ -23,18 +22,16 @@ async function verifyRendererMounted(q: Query) {
   await expect(q.listitem("Item 10")).toBeVisible();
 }
 
-async function mountRenderer(page: Page, q: Query) {
+async function mountRenderer(q: Query) {
   await q.button("Mount nested renderers").click();
   await verifyRendererMounted(q);
-  await flushFrames(page);
 }
 
-async function rerenderNestedRenderers(page: Page, q: Query) {
+async function rerenderNestedRenderers(q: Query) {
   const updateButton = q.button("Rerender nested renderers");
   for (let index = 0; index < updateCount; index += 1) {
     await updateButton.click();
   }
-  await flushFrames(page);
   await expect(q.status("Updates")).toHaveText(String(updateCount));
   await expect(q.listitem("Item 10")).toHaveAttribute(
     "data-update",
@@ -50,12 +47,11 @@ async function verifyNestedRenderersUpdated(q: Query) {
   );
 }
 
-async function toggleRendererItems(page: Page, q: Query) {
+async function toggleRendererItems(q: Query) {
   const toggleButton = q.button("Toggle renderer items");
   for (let index = 0; index < toggleCount; index += 1) {
     const itemsVisible = index % 2 === 1;
     await toggleButton.click();
-    await flushFrames(page);
     await expect(q.status("Items visible")).toHaveText(
       itemsVisible ? "yes" : "no",
     );
@@ -68,14 +64,13 @@ async function verifyRendererItemsVisible(q: Query) {
   await expect(q.listitem("Item 10")).toBeVisible();
 }
 
-async function scrollNestedRenderers(page: Page, q: Query) {
+async function scrollNestedRenderers(q: Query) {
   const scroller = q.region("Renderer viewport");
   for (const groupIndex of scrollGroupIndices) {
     await scroller.evaluate((element, scrollTop) => {
       element.scrollTop = scrollTop;
       element.dispatchEvent(new Event("scroll"));
     }, groupIndex * groupSize);
-    await flushFrames(page);
     await expect(q.listitem(getGroupFirstItemLabel(groupIndex))).toBeVisible();
   }
 }
@@ -90,14 +85,14 @@ async function verifyRendererScrolled(q: Query) {
 
 withFramework(import.meta.dirname, async ({ test }) => {
   test("mount nested renderers", async ({ perf }) => {
-    await perf.measure(({ page, q }) => mountRenderer(page, q), {
+    await perf.measure(({ q }) => mountRenderer(q), {
       verify: ({ q }) => verifyRendererMounted(q),
     });
   });
 
   test("rerender nested renderers", async ({ perf }) => {
-    await perf.measure(({ page, q }) => rerenderNestedRenderers(page, q), {
-      setup: ({ page, q }) => mountRenderer(page, q),
+    await perf.measure(({ q }) => rerenderNestedRenderers(q), {
+      setup: ({ q }) => mountRenderer(q),
       scriptProfile: true,
       profileLimit: 20,
       verify: ({ q }) => verifyNestedRenderersUpdated(q),
@@ -105,15 +100,15 @@ withFramework(import.meta.dirname, async ({ test }) => {
   });
 
   test("toggle renderer items", async ({ perf }) => {
-    await perf.measure(({ page, q }) => toggleRendererItems(page, q), {
-      setup: ({ page, q }) => mountRenderer(page, q),
+    await perf.measure(({ q }) => toggleRendererItems(q), {
+      setup: ({ q }) => mountRenderer(q),
       verify: ({ q }) => verifyRendererItemsVisible(q),
     });
   });
 
   test("scroll nested renderers", async ({ perf }) => {
-    await perf.measure(({ page, q }) => scrollNestedRenderers(page, q), {
-      setup: ({ page, q }) => mountRenderer(page, q),
+    await perf.measure(({ q }) => scrollNestedRenderers(q), {
+      setup: ({ q }) => mountRenderer(q),
       verify: ({ q }) => verifyRendererScrolled(q),
     });
   });

--- a/app/src/sandbox/combobox-select-3837/test-browser.ts
+++ b/app/src/sandbox/combobox-select-3837/test-browser.ts
@@ -74,11 +74,15 @@ withFramework(import.meta.dirname, async ({ test }) => {
       el.style.setProperty("--popover-available-height", "120px");
     });
 
-    // Wait until the popover has actually shrunk, then let the virtualizer and
-    // any focus side effects settle across a few frames.
+    // Wait until the popover and its virtualized window have actually shrunk.
     await test.expect
       .poll(() => popover.evaluate((el) => el.clientHeight))
       .toBeLessThan(heightBefore);
+    await test.expect
+      .poll(() => q.option().count())
+      .toBeLessThan(renderedBefore);
+    // Focus staying on the input is an absence of side effects, so cross the
+    // remaining focus checkpoint before asserting that nothing moved.
     await flushFrames(page, 5);
 
     // The auto-selected item is still active, but focus must have stayed on the

--- a/app/src/sandbox/combobox-select-animation/test-safari.ts
+++ b/app/src/sandbox/combobox-select-animation/test-safari.ts
@@ -20,6 +20,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await page.keyboard.press("Enter");
 
     await test.expect(q.listbox("Favorite fruit")).toBeVisible();
+    // A prevented scroll has no positive completion state, so wait through the
+    // pending presentation callback and Safari's smooth-scroll checkpoint.
     await flushFrames(page, 2);
     test
       .expect(

--- a/app/src/sandbox/combobox-select-renderer/test-browser.ts
+++ b/app/src/sandbox/combobox-select-renderer/test-browser.ts
@@ -53,6 +53,8 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
         const asyncOptions = query(scroller);
 
         await q.button("Connect scroll element").click();
+        // The empty renderer connects the explicit ref in passive effects, but
+        // exposes no rendered item that can signal when those effects finish.
         await flushFrames(page);
         await q.button("Load async items").click();
         await test.expect(asyncOptions.option("Async item 1")).toBeVisible();
@@ -61,7 +63,6 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
           element.scrollTop = 2000;
           element.dispatchEvent(new Event("scroll"));
         });
-        await flushFrames(page);
 
         await test
           .expect(q.status("Async scroll status"))
@@ -78,16 +79,20 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
         const asyncOptions = query(scroller);
 
         await q.button("Connect scroll element").click();
+        // The empty renderer connects the explicit ref in passive effects, but
+        // exposes no rendered item that can signal when those effects finish.
         await flushFrames(page);
         await q.button("Load async items").click();
         await scroller.evaluate((element) => {
           element.scrollTop = 2000;
           element.dispatchEvent(new Event("scroll"));
         });
-        await flushFrames(page);
         await test.expect(asyncOptions.option("Async item 51")).toBeVisible();
 
         await q.button("Disable scroll element and double item size").click();
+        // Disabling viewport updates intentionally leaves the rendered window
+        // unchanged, so wait through the passive update before asserting that
+        // absence of change.
         await flushFrames(page);
 
         await test.expect(asyncOptions.option("Async item 51")).toHaveCount(1);
@@ -103,18 +108,22 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
         const asyncOptions = query(scroller);
 
         await q.button("Connect scroll element").click();
+        // The empty renderer connects the explicit ref in passive effects, but
+        // exposes no rendered item that can signal when those effects finish.
         await flushFrames(page);
         await q.button("Load async items").click();
         await scroller.evaluate((element) => {
           element.scrollTop = 2000;
           element.dispatchEvent(new Event("scroll"));
         });
-        await flushFrames(page);
         await test.expect(asyncOptions.option("Async item 51")).toBeVisible();
 
         await q
           .button("Disconnect scroll element and double item size")
           .click();
+        // Disconnecting viewport updates intentionally leaves the rendered
+        // window unchanged, so wait through the passive update before asserting
+        // that absence of change.
         await flushFrames(page);
 
         await test.expect(asyncOptions.option("Async item 51")).toHaveCount(1);
@@ -123,7 +132,6 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
 
       // https://github.com/ariakit/ariakit/pull/6806#discussion_r3633347050
       test("auto-detects the scroller for omitted nested renderers", async ({
-        page,
         q,
       }) => {
         const scroller = q.listbox("Nested auto items");
@@ -134,7 +142,6 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
           element.scrollTop = 2000;
           element.dispatchEvent(new Event("scroll"));
         });
-        await flushFrames(page);
 
         await test.expect(nestedOptions.option("Async item 51")).toBeVisible();
       });
@@ -149,19 +156,19 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
 
         await test.expect(directOptions.option("Async item 1")).toBeVisible();
         await q.button("Use direct scroll element").click();
+        // The renderer accepts the direct element in passive effects, but the
+        // rendered window stays unchanged until the subsequent scroll.
         await flushFrames(page);
         await scroller.evaluate((element) => {
           element.scrollTop = 2000;
           element.dispatchEvent(new Event("scroll"));
         });
-        await flushFrames(page);
 
         await test.expect(directOptions.option("Async item 51")).toBeVisible();
       });
 
       // https://github.com/ariakit/ariakit/pull/6806#discussion_r3633901198
       test("resolves an ancestor ref after the initial commit", async ({
-        page,
         q,
       }) => {
         const scroller = q.listbox("Initial ref items");
@@ -174,7 +181,6 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
           element.scrollTop = 2000;
           element.dispatchEvent(new Event("scroll"));
         });
-        await flushFrames(page);
 
         await test
           .expect(initialRefOptions.option("Async item 51"))
@@ -183,7 +189,6 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
 
       // https://github.com/ariakit/ariakit/pull/6806#discussion_r3635028432
       test("revalidates an inherited scroll target before passive updates", async ({
-        page,
         q,
       }) => {
         const scroller = q.listbox("Inherited target items");
@@ -197,7 +202,6 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
           element.scrollTop = 2000;
           element.dispatchEvent(new Event("scroll"));
         });
-        await flushFrames(page);
         await test
           .expect(inheritedOptions.option("Async item 51"))
           .toBeVisible();
@@ -207,7 +211,6 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
         await q
           .button("Use inner scroll element and update child class")
           .click();
-        await flushFrames(page);
 
         await test.expect(mountedItems).toContainText(/Async item 2(?:,|$)/);
         await test
@@ -219,7 +222,6 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
         await q
           .button("Use outer scroll element and increase overscan")
           .click();
-        await flushFrames(page);
 
         await test.expect(mountedItems).toContainText(/Async item 51(?:,|$)/);
         await test

--- a/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
@@ -49,9 +49,6 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(select).toHaveAttribute("aria-expanded", "true");
 
     await test.expect(q.combobox("Search Filterable fruit")).toBeFocused();
-    // Three frames cross Composite's after-paint presentation callback plus
-    // WebKit's scroll step before checking the viewport.
-    await flushFrames(page, 3);
     await test.expect(watermelon).toBeInViewport();
     test.expect(await page.evaluate(() => window.scrollY)).toBe(100);
   });

--- a/app/src/sandbox/composite-renderer-6215/test-browser.ts
+++ b/app/src/sandbox/composite-renderer-6215/test-browser.ts
@@ -20,7 +20,11 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
     // The list renders and measures items to begin with. Anchor the pattern so
     // it doesn't also match the "Refresh items" control.
-    await test.expect(q.button(/^item /).first()).toBeVisible();
+    const firstItem = q.button(/^item /).first();
+    await test.expect(firstItem).toBeVisible();
+    const itemHeight = await firstItem.evaluate(
+      (element) => element.getBoundingClientRect().height,
+    );
 
     // Scroll through the whole list so many item nodes mount and unmount.
     const maxScroll = await scroller.evaluate(
@@ -30,15 +34,20 @@ withFramework(import.meta.dirname, async ({ test }) => {
       await scroller.evaluate((element, y) => {
         element.scrollTop = y;
       }, top);
-      await flushFrames(page);
+      const visibleItemIndex = Math.floor(top / itemHeight);
+      await test.expect(q.button(`item ${visibleItemIndex}`)).toBeVisible();
     }
     await scroller.evaluate((element) => {
       element.scrollTop = element.scrollHeight;
     });
-    await flushFrames(page);
+    await test.expect(q.button("item 198")).toBeVisible();
     await scroller.evaluate((element) => {
       element.scrollTop = 0;
     });
+    await test.expect(q.button("item 1")).toBeVisible();
+    // The leak counter samples detached nodes on its own frame loop. Its
+    // expected zero is not a positive completion state, so cross that loop
+    // after the rendered item confirms the final scroll has completed.
     await flushFrames(page);
 
     // Scrolled-out items must have been unobserved — no detached node retained.
@@ -46,11 +55,16 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
     // Re-rendering items to new nodes (same id) must unobserve the old nodes.
     await q.button("Refresh items").click();
+    // Refreshing preserves every visible label, and the expected leak count is
+    // still zero, so neither exposes a positive completion state to await.
     await flushFrames(page);
     await test.expect(detachedCount).toHaveText("0");
 
     // Unmounting the list must disconnect the observer — still nothing retained.
     await q.button("Unmount the list").click();
+    await test.expect(q.button(/^item /)).toHaveCount(0);
+    // The list removal is observable above, but the negative leak counter is
+    // sampled on the following frames and could otherwise pass while stale.
     await flushFrames(page);
     await test.expect(detachedCount).toHaveText("0");
   });

--- a/app/src/sandbox/menu-initial-focus-render/test-browser.ts
+++ b/app/src/sandbox/menu-initial-focus-render/test-browser.ts
@@ -10,6 +10,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.menu()).toBeVisible();
     await test.expect(q.menuitem("Edit")).toBeVisible();
 
+    // Opening can finish one-time focus work on the next frames. The stable
+    // render count has no separate observable completion state to await.
     await flushFrames(page);
 
     const menuRenders = q.status("Menu renders");

--- a/app/src/sandbox/popover-disclosure-render/test-chrome-firefox.ts
+++ b/app/src/sandbox/popover-disclosure-render/test-chrome-firefox.ts
@@ -26,10 +26,10 @@ withFramework(import.meta.dirname, async ({ test }) => {
       await q.button(`Toggle ${label} popover`).click();
       await test.expect(q.dialog()).toBeVisible();
 
-      // The first click also moves focus into the button, which updates
-      // one-time focus state, so sample the render counts only after that
-      // settles.
       await q.button(`Set ${label} disclosure element`).click();
+      // The first click also moves focus into the button, which updates
+      // one-time focus state. Its final render has no separate observable
+      // completion state, so wait before sampling the counts.
       await flushFrames(page);
 
       const popoverRenders = q.status(`${label} popover renders`);
@@ -65,6 +65,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.dialog()).toBeVisible();
 
     await q.button("Set Fallback disclosure element").click();
+    // The first click also moves focus into the button, which updates
+    // one-time focus state. Its final render has no separate observable
+    // completion state, so wait before sampling the count.
     await flushFrames(page);
 
     const popoverRenders = q.status("Fallback popover renders");


### PR DESCRIPTION
## Motivation

The `flushFrames` helper is intended for checkpoints that cannot be expressed through observable state, but several browser and performance tests waited for frames immediately before retrying DOM assertions. This obscured the behavior that actually marked the interaction as complete.

```ts
await flushFrames(page);
await expect(item).toBeVisible();
```

Other legitimate waits covered negative assertions, passive-effect handoffs, or render-count sampling without explaining why frames were required.

## Solution

Replace redundant frame waits with retrying assertions that describe the completed behavior.

```ts
await expect(item).toBeVisible();
```

Retain waits where no positive observable completion state exists and add a rationale immediately above each call. The scroll assertions use non-persistent virtualized items so they cannot pass before the requested window renders.

Performance callbacks now end on observable assertions. The shared performance harness still calls `settleQuiescent()` after each interaction, which waits two animation frames and polls scripting, layout, and style work until quiet before collecting the closing metrics and INP entries.

## Testing

- `pnpm lint-fix`
- `pnpm tsc`
- 48 focused Chrome browser tests
- 6 focused Safari browser tests
- 4 focused performance tests
