### PR TITLE
Add composite scroll regression coverage from PR 7006

### DIFF
--- a/app/src/sandbox/combobox-select-scroll-into-view/test-browser.ts
+++ b/app/src/sandbox/combobox-select-scroll-into-view/test-browser.ts
@@ -1,4 +1,4 @@
-import { withFramework } from "#app/test-utils/preview.ts";
+import { flushFrames, withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
   // https://github.com/ariakit/ariakit/issues/6858
@@ -43,6 +43,38 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(selected).toBeVisible({ timeout: 2_000 });
     await test.expect(selected).toHaveAttribute("data-active-item");
     await test.expect(selected).toBeInViewport();
+  });
+
+  // The counterpart of the test above: the selection is only allowed to claim
+  // the list while the user has not moved yet.
+  // https://github.com/ariakit/ariakit/pull/6832
+  test("keeps the keyboard position when the selection registers late", async ({
+    page,
+    q,
+  }) => {
+    const select = q.combobox("Late items");
+    const listbox = q.listbox("Late items options");
+    const activeItem = listbox.locator("[data-active-item]");
+    const selected = q.option("Item 24");
+    await select.click();
+    await test.expect(select).toHaveAttribute("aria-expanded", "true");
+
+    // Moving before the selection registers hands the list to the user. The
+    // absence is asserted after the move so it also proves the move won the
+    // race against the fixture's late registration.
+    await page.keyboard.press("ArrowDown");
+    await test.expect(selected).toHaveCount(0);
+    await test.expect(activeItem).toHaveText("Item 1");
+
+    await test.expect(selected).toBeVisible({ timeout: 2_000 });
+    // A scroll would land on the frame after the next paint, so wait one frame
+    // past that checkpoint instead of reading the position while it is still
+    // pending.
+    await flushFrames(page, 3);
+
+    await test.expect(activeItem).toHaveText("Item 1");
+    await test.expect(selected).not.toBeInViewport();
+    test.expect(await listbox.evaluate((element) => element.scrollTop)).toBe(0);
   });
 
   test("auto-selects the first filtered option and restores it on reopen", async ({

--- a/app/src/sandbox/combobox-select-scroll-into-view/test.ts
+++ b/app/src/sandbox/combobox-select-scroll-into-view/test.ts
@@ -1,0 +1,24 @@
+import { click, press, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// The selected item only claims the active state while the user has not moved
+// yet, so a registration that lands afterwards must not steal it back. The
+// scroll side of this invariant is browser-only and lives in test-browser.ts.
+// https://github.com/ariakit/ariakit/pull/6832
+test("keeps the keyboard position when the selection registers late", async () => {
+  const select = q.combobox("Late items");
+  await click(select);
+
+  // The absence is asserted after the move so it also proves the move won the
+  // race against the fixture's late registration.
+  await press.ArrowDown();
+  expect(q.option("Item 24")).not.toBeInTheDocument();
+  expect(q.option("Item 1")).toHaveAttribute("data-active-item");
+
+  await expect
+    .poll(q.option.lazy("Item 24"), { timeout: 2_000 })
+    .toBeInTheDocument();
+
+  expect(q.option("Item 1")).toHaveAttribute("data-active-item");
+  expect(q.option("Item 24")).not.toHaveAttribute("data-active-item");
+});

--- a/app/src/sandbox/composite-navigation/index.react.tsx
+++ b/app/src/sandbox/composite-navigation/index.react.tsx
@@ -69,6 +69,22 @@ function FocusShiftGrid({
   );
 }
 
+/**
+ * Items far enough apart that reaching one with the keyboard can only be seen
+ * by the page scrolling to reveal it.
+ */
+function DistantComposite() {
+  return (
+    <Ariakit.CompositeProvider>
+      <Ariakit.Composite aria-label="Distant fruits">
+        <Ariakit.CompositeItem>Near fruit</Ariakit.CompositeItem>
+        <div style={{ height: 900 }} />
+        <Ariakit.CompositeItem>Distant fruit</Ariakit.CompositeItem>
+      </Ariakit.Composite>
+    </Ariakit.CompositeProvider>
+  );
+}
+
 export default function Example() {
   return (
     <main>
@@ -76,6 +92,9 @@ export default function Example() {
       <BasicComposite />
       <FocusShiftGrid prefix="0" />
       <FocusShiftGrid prefix="1" focusShift />
+      {/* Kept last so the first tab stop on the page stays in the basic
+      composite, which the existing navigation tests rely on. */}
+      <DistantComposite />
     </main>
   );
 }

--- a/app/src/sandbox/composite-navigation/test-browser.ts
+++ b/app/src/sandbox/composite-navigation/test-browser.ts
@@ -1,0 +1,29 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // Composite items are focused with `preventScroll`, so the item is only
+  // revealed because the composite scrolls it into view afterwards. Without
+  // that, keyboard navigation would silently move focus off screen.
+  test("scrolls the page to reveal the item reached with the keyboard", async ({
+    page,
+    q,
+  }) => {
+    const near = q.button("Near fruit");
+    const distant = q.button("Distant fruit");
+    await near.focus();
+    await test.expect(near).toBeFocused();
+    await test.expect(distant).not.toBeInViewport();
+    const scrollY = await page.evaluate(() => window.scrollY);
+
+    await page.keyboard.press("ArrowDown");
+
+    await test.expect(distant).toHaveAttribute("data-active-item");
+    await test.expect(distant).toBeFocused();
+    await test.expect(distant).toBeInViewport();
+    // Pin the movement to the document scroller so a scrollable wrapper added
+    // to the fixture later cannot silently satisfy the viewport check instead.
+    await test.expect
+      .poll(() => page.evaluate(() => window.scrollY))
+      .toBeGreaterThan(scrollY);
+  });
+});


### PR DESCRIPTION
## Motivation

[PR 7006](https://github.com/ariakit/ariakit/pull/7006) is being closed as too complex: it added around 1450 net lines of new runtime code to unify composite focus presentation. That runtime is discarded, but the pull request also wrote a large amount of test coverage, and some of it passes against current `main`. Those tests describe behavior `main` already gets right and that nothing else guards, so they are worth keeping even though the implementation is not.

Two invariants stood out as genuinely uncovered:

Keyboard navigation in a plain composite must scroll the document to reveal the item it moves to. `Composite` focuses items with `preventScroll` and then scrolls them into view itself, so this only works because of `focusIntoView`:

```ts
element.focus({ preventScroll: true });
element.scrollIntoView({ block: "nearest", inline: "nearest", ...options });
```

Nothing asserted that the document actually moves, so removing the second line kept every existing test green.

A selection that registers after the user has already moved must not take the active item back. `combobox-store.ts` guards this, and its own comment says so ("Stop once the user moves so later item registrations don't steal active state"), but only the positive branch was covered: `combobox-select-scroll-into-view` asserted that a late selection *does* present when the user has not navigated, and nothing asserted the negative branch.

## Solution

Land those two invariants, reworked rather than copied, and drop the other thirteen candidates.

`combobox-select-scroll-into-view` gains "keeps the keyboard position when the selection registers late", sitting directly beside its existing positive counterpart. It needs **no fixture change**: the `Late items` fixture already models async arrival with a real 750ms timer. PR 7006 instead added new fixture plumbing plus a focus-stealing button driven by `element.evaluate((el) => el.click())`; using the existing fixture avoids both.

`composite-navigation` gains "scrolls the page to reveal the item reached with the keyboard", plus a `DistantComposite` sibling. PR 7006 put an inline composite inside the combobox-specific `combobox-select-open-page-scroll`, where the neighbouring test asserts the page must *not* scroll, and asserted the scroll through a `window.inlineCompositeScrollEvents` global probe. Here it lives with the other composite navigation coverage and asserts through `toBeInViewport()` and `window.scrollY`, with a `not.toBeInViewport()` precondition the original lacked.

The `DistantComposite` sibling is appended last on purpose. The existing `composite-navigation` tests depend on `press.Tab()` landing on the "Apple" button, so anything rendered before the basic composite would change the first tab stop.

### Both tests are proven red

- Removing `element.scrollIntoView(...)` from `focusIntoView` fails the composite test with `toBeInViewport() failed / viewport ratio 0`.
- Removing the `moves`/`activeId` reset in `combobox-store.ts` fails both the browser and happy-dom combobox tests with `Expected "Item 1" / Received "Item 24"`, and only those tests.

### Why the "centers" tests were dropped

Three of the passing candidates assert `Math.abs(centerOffset) <= 1` inside the listbox scrollport. `main` has no centering code (every `scrollIntoView` in `packages/` uses `block: "nearest"`) because centering was reverted in [`1dd7a72`](https://github.com/ariakit/ariakit/commit/1dd7a7245). Measuring the same fixtures on `main` shows the alignment is an engine artifact of native focus scrolling, not library behavior:

| engine | centerOffset | topOffset | at max scroll? |
| --- | --- | --- | --- |
| Chrome | 0 | 43 | no |
| Firefox | 0 | 43 | no |
| Safari | 43 | 86 (`clientHeight - itemHeight`, pure edge alignment) | no |

Safari lands exactly where `block: "nearest"` says it should. Since these are `test-browser.ts` files, they run in Chrome, Firefox and Safari, so all three fail on Safari today. A test named "centers ..." that only passes on Blink and Gecko documents the browser, not Ariakit.

## Per-test decisions

Scope is the 15 of PR 7006's 28 browser tests that pass against `main`. The other 13 fail because they need the discarded runtime, new fixture UI, or both. Ten of these 15 are titles that already exist on `main` byte-identically, so there was nothing to cherry-pick for them.

| # | Test | Decision | Reason |
| --- | --- | --- | --- |
| 1 | redirects focus to the select when an option is focused on mount | Dropped | Already on `main`. PR 7006's only delta monkey-patches `element.focus` to assert `{ preventScroll: true }`, mocking the behavior under test and pinning an implementation detail. |
| 2 | discards the redirect when the option loses focus before the listbox is available | Dropped | Already on `main` byte-identically; PR 7006 changes nothing. |
| 3 | keeps the page in place while the popup is being positioned | Dropped | Already on `main`; PR 7006's only delta is a reworded comment. |
| 4 | lets an inline composite present into the document | **Kept, reworked** | Real uncovered contract. Rehomed to `composite-navigation`; the `window` scroll-event probe was replaced with `toBeInViewport()` and a `not.toBeInViewport()` precondition. |
| 5 | focuses a far item reached through typeahead | Dropped | Already on `main`. PR 7006's rewrite adds centering geometry and fails on Safari; `main`'s version is left untouched. |
| 6 | keyboard opening centers the last selected value | Dropped | Asserts centering. Fails on Safari, flaky on Firefox, and re-asserts behavior reverted in [`1dd7a72`](https://github.com/ariakit/ariakit/commit/1dd7a7245). |
| 7 | centers the selected item that owns real focus in an unmounted popup | Dropped | Asserts centering; fails on Safari. |
| 8 | navigation cancels a late selected-item presentation | **Kept, reworked** | Real uncovered contract. Rehomed to `combobox-select-scroll-into-view` beside its positive counterpart, using the existing fixture instead of new plumbing and a synthetic click. |
| 9 | centers the deprecated SelectPopover value | Dropped | Asserts centering; fails on Safari. |
| 10 | cancels presentation when real focus moves | Dropped | Already on `main` byte-identically. |
| 11 | cancels presentation when real focus moves in an unmounted popup | Dropped | Already on `main` byte-identically. |
| 12 | does not refocus a late item after focus leaves the composite | Dropped | Already on `main` byte-identically. |
| 13 | only focuses the latest item after rapid unresolved moves | Dropped | Already on `main` byte-identically. |
| 14 | does not present an unresolved generic item | Dropped | Already on `main` byte-identically. |
| 15 | presents a rendered generic autofocus item | Dropped | Already on `main` byte-identically. |

PR 7006's happy-dom files were not carried over. `composite-late-item-focus/test.ts` and `combobox-select-selected-value-presentation/test.ts` assert on `scrollIntoView.mock.instances` and captured scroll writes, which mocks the behavior under test, and scroll geometry is browser-only anyway.

A happy-dom duplicate is added only for the combobox test, covering the part that is honestly observable there: the active item is plain DOM state, so `data-active-item` is asserted in happy-dom while the scroll and viewport assertions stay browser-only. The composite test is purely geometric and stays browser-only.

## Verification

- Chrome, Firefox and Safari across both touched sandboxes: 30/30 passing, no flakes, including every pre-existing test in both fixtures.
- `pnpm test` and `pnpm test-react18` for both sandboxes: 5/5 each.
- `pnpm lint-fix` and `pnpm tsc` clean.

No changeset: this changes tests only, no shipped code.
