### PR TITLE
Fix composite presentation outliving its component

### DIFF
--- a/.changeset/300-composite-presentation-owner.md
+++ b/.changeset/300-composite-presentation-owner.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Composite`](https://ariakit.com/reference/composite) moving DOM focus on its own after being unmounted while it was focused.

--- a/.changeset/300-composite-presentation-owner.md
+++ b/.changeset/300-composite-presentation-owner.md
@@ -1,6 +1,0 @@
----
-"@ariakit/react-components": patch
-"@ariakit/react": patch
----
-
-Fixed [`Composite`](https://ariakit.com/reference/composite) moving DOM focus on its own after being unmounted while it was focused.

--- a/app/src/sandbox/composite-presentation-cancel-on-unmount/index.react.tsx
+++ b/app/src/sandbox/composite-presentation-cancel-on-unmount/index.react.tsx
@@ -1,5 +1,4 @@
 import * as Ariakit from "@ariakit/react";
-import type { FocusEvent } from "react";
 import { useRef, useState } from "react";
 import { flushSync } from "react-dom";
 
@@ -28,32 +27,6 @@ export default function Example() {
   const [open, setOpen] = useState(true);
   const [loaded, setLoaded] = useState(false);
   const [dismissOnFocus, setDismissOnFocus] = useState(false);
-  // TODO: Remove along with its uses once
-  // https://github.com/ariakit/ariakit/issues/7024 is fixed. Marks the focus
-  // events this panel is about to discard, so the handler below can tell the
-  // composite not to schedule a presentation for them.
-  const dismissingRef = useRef(false);
-
-  // TODO: Reduce to the `dismissOnFocus` branch once
-  // https://github.com/ariakit/ariakit/issues/7024 is fixed. A presentation
-  // scheduled for a focus that is discarded in the same task can be created
-  // after the panel's cleanup, and it then parks on the store for good.
-  // Preventing the event is the composite's own opt-out, so nothing is
-  // scheduled in the first place.
-  const onFocus = (event: FocusEvent) => {
-    if (dismissingRef.current || dismissOnFocus) {
-      event.preventDefault();
-    }
-    if (!dismissOnFocus) return;
-    setDismissOnFocus(false);
-    flushSync(() => setOpen(false));
-  };
-
-  const focusPanelBeforeDismissing = () => {
-    dismissingRef.current = true;
-    panelRef.current?.focus();
-    dismissingRef.current = false;
-  };
 
   return (
     <>
@@ -68,7 +41,7 @@ export default function Example() {
           type="button"
           tabIndex={0}
           onClick={() => {
-            focusPanelBeforeDismissing();
+            panelRef.current?.focus();
             setOpen(false);
           }}
         >
@@ -78,7 +51,7 @@ export default function Example() {
           type="button"
           tabIndex={0}
           onClick={() => {
-            focusPanelBeforeDismissing();
+            panelRef.current?.focus();
             flushSync(() => setOpen(false));
           }}
         >
@@ -109,7 +82,11 @@ export default function Example() {
           aria-label="Shortcuts"
           tabIndex={0}
           style={{ height: 60, overflow: "auto" }}
-          onFocus={onFocus}
+          onFocus={() => {
+            if (!dismissOnFocus) return;
+            setDismissOnFocus(false);
+            flushSync(() => setOpen(false));
+          }}
         >
           <button type="button" tabIndex={0}>
             Edit shortcuts

--- a/app/src/sandbox/composite-presentation-cancel-on-unmount/index.react.tsx
+++ b/app/src/sandbox/composite-presentation-cancel-on-unmount/index.react.tsx
@@ -1,0 +1,104 @@
+import * as Ariakit from "@ariakit/react";
+import { useRef, useState } from "react";
+import { flushSync } from "react-dom";
+
+/**
+ * A shortcuts panel whose store is created by this page, so it outlives every
+ * mount of the panel itself.
+ *
+ * Focusing a virtual focus composite schedules a presentation for its active
+ * item in a microtask, so the panel can be dismissed before that microtask
+ * runs. The controls below dismiss it at each of the moments an app
+ * realistically would: in a later task, in the same handler that focused it,
+ * synchronously with `flushSync`, which apps reach for when they need the
+ * collapsed layout before the task ends, and from the panel's own focus
+ * handler, which runs before the composite queues anything at all.
+ *
+ * The recent files entry is loaded on demand, which registers a composite item
+ * long after the panel was dismissed. The panel scrolls and that entry is
+ * marked as a presentation target, so presenting it is observable too.
+ */
+export default function Example() {
+  const store = Ariakit.useCompositeStore({
+    virtualFocus: true,
+    defaultActiveId: "recent",
+  });
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(true);
+  const [loaded, setLoaded] = useState(false);
+  const [dismissOnFocus, setDismissOnFocus] = useState(false);
+
+  return (
+    <>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+        <button type="button" tabIndex={0} onClick={() => setOpen(true)}>
+          Show shortcuts
+        </button>
+        <button type="button" tabIndex={0} onClick={() => setOpen(false)}>
+          Hide shortcuts
+        </button>
+        <button
+          type="button"
+          tabIndex={0}
+          onClick={() => {
+            panelRef.current?.focus();
+            setOpen(false);
+          }}
+        >
+          Focus and hide shortcuts
+        </button>
+        <button
+          type="button"
+          tabIndex={0}
+          onClick={() => {
+            panelRef.current?.focus();
+            flushSync(() => setOpen(false));
+          }}
+        >
+          Focus and hide shortcuts synchronously
+        </button>
+        <button type="button" tabIndex={0} onClick={() => setLoaded(true)}>
+          Load recent files
+        </button>
+        <button type="button" tabIndex={0} onClick={() => store.move("recent")}>
+          Highlight recent files
+        </button>
+        <button
+          type="button"
+          tabIndex={0}
+          onClick={() => {
+            setDismissOnFocus(true);
+            setOpen(true);
+          }}
+        >
+          Hide shortcuts on focus
+        </button>
+      </div>
+      {open && (
+        <Ariakit.Composite
+          store={store}
+          ref={panelRef}
+          role="toolbar"
+          aria-label="Shortcuts"
+          tabIndex={0}
+          style={{ height: 60, overflow: "auto" }}
+          onFocus={() => {
+            if (!dismissOnFocus) return;
+            setDismissOnFocus(false);
+            flushSync(() => setOpen(false));
+          }}
+        >
+          <button type="button" tabIndex={0}>
+            Edit shortcuts
+          </button>
+          <div style={{ height: 200 }} />
+          {loaded && (
+            <Ariakit.CompositeItem data-autofocus id="recent">
+              Recent files
+            </Ariakit.CompositeItem>
+          )}
+        </Ariakit.Composite>
+      )}
+    </>
+  );
+}

--- a/app/src/sandbox/composite-presentation-cancel-on-unmount/index.react.tsx
+++ b/app/src/sandbox/composite-presentation-cancel-on-unmount/index.react.tsx
@@ -1,4 +1,5 @@
 import * as Ariakit from "@ariakit/react";
+import type { FocusEvent } from "react";
 import { useRef, useState } from "react";
 import { flushSync } from "react-dom";
 
@@ -27,6 +28,32 @@ export default function Example() {
   const [open, setOpen] = useState(true);
   const [loaded, setLoaded] = useState(false);
   const [dismissOnFocus, setDismissOnFocus] = useState(false);
+  // TODO: Remove along with its uses once
+  // https://github.com/ariakit/ariakit/issues/7024 is fixed. Marks the focus
+  // events this panel is about to discard, so the handler below can tell the
+  // composite not to schedule a presentation for them.
+  const dismissingRef = useRef(false);
+
+  // TODO: Reduce to the `dismissOnFocus` branch once
+  // https://github.com/ariakit/ariakit/issues/7024 is fixed. A presentation
+  // scheduled for a focus that is discarded in the same task can be created
+  // after the panel's cleanup, and it then parks on the store for good.
+  // Preventing the event is the composite's own opt-out, so nothing is
+  // scheduled in the first place.
+  const onFocus = (event: FocusEvent) => {
+    if (dismissingRef.current || dismissOnFocus) {
+      event.preventDefault();
+    }
+    if (!dismissOnFocus) return;
+    setDismissOnFocus(false);
+    flushSync(() => setOpen(false));
+  };
+
+  const focusPanelBeforeDismissing = () => {
+    dismissingRef.current = true;
+    panelRef.current?.focus();
+    dismissingRef.current = false;
+  };
 
   return (
     <>
@@ -41,7 +68,7 @@ export default function Example() {
           type="button"
           tabIndex={0}
           onClick={() => {
-            panelRef.current?.focus();
+            focusPanelBeforeDismissing();
             setOpen(false);
           }}
         >
@@ -51,7 +78,7 @@ export default function Example() {
           type="button"
           tabIndex={0}
           onClick={() => {
-            panelRef.current?.focus();
+            focusPanelBeforeDismissing();
             flushSync(() => setOpen(false));
           }}
         >
@@ -82,11 +109,7 @@ export default function Example() {
           aria-label="Shortcuts"
           tabIndex={0}
           style={{ height: 60, overflow: "auto" }}
-          onFocus={() => {
-            if (!dismissOnFocus) return;
-            setDismissOnFocus(false);
-            flushSync(() => setOpen(false));
-          }}
+          onFocus={onFocus}
         >
           <button type="button" tabIndex={0}>
             Edit shortcuts

--- a/app/src/sandbox/composite-presentation-cancel-on-unmount/test-browser.ts
+++ b/app/src/sandbox/composite-presentation-cancel-on-unmount/test-browser.ts
@@ -1,0 +1,125 @@
+import type { query } from "@ariakit/test/playwright";
+import type { Page } from "@playwright/test";
+import { flushFrames, withFramework } from "#app/test-utils/preview.ts";
+
+type Query = ReturnType<typeof query>;
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  /**
+   * Reopens the panel, puts DOM focus on a plain button inside it, then loads
+   * the recent files entry. Registering that item is the store update that
+   * would wake a presentation the dismissed panel left behind, and focus being
+   * inside the panel again is what lets that presentation move focus.
+   */
+  const loadRecentFilesWithFocusInside = async (q: Query, page: Page) => {
+    await q.button("Show shortcuts").click();
+    const editShortcuts = q.button("Edit shortcuts");
+    await editShortcuts.focus();
+    // Clicked through the DOM so the click doesn't move focus out of the panel.
+    await q.button("Load recent files").evaluate((element) => {
+      if (element instanceof HTMLElement) element.click();
+    });
+    await test.expect(q.button("Recent files")).toBeVisible();
+    // An abandoned presentation has no positive state, so wait through the
+    // checkpoint where the focus move would have landed. The item registers in
+    // a passive effect, which React flushes in a later scheduler task.
+    await flushFrames(page);
+    return editShortcuts;
+  };
+
+  /**
+   * Dismisses the panel the way that strands a presentation, then reopens it
+   * with the recent files entry registered and active, the panel scrolled to
+   * the top, and DOM focus outside the panel. That is the starting state for a
+   * presentation that should still happen.
+   */
+  const reopenWithRecentFilesLoaded = async (q: Query) => {
+    await q.button("Focus and hide shortcuts synchronously").click();
+    await q.button("Show shortcuts").click();
+    await q.button("Load recent files").click();
+    const panel = q.toolbar("Shortcuts");
+    await test
+      .expect(q.button("Recent files"))
+      .toHaveAttribute("data-active-item");
+    test.expect(await panel.evaluate((element) => element.scrollTop)).toBe(0);
+    return panel;
+  };
+
+  test("keeps focus after the panel is hidden in a later task", async ({
+    page,
+    q,
+  }) => {
+    await q.toolbar("Shortcuts").focus();
+    await q.button("Hide shortcuts").click();
+
+    const editShortcuts = await loadRecentFilesWithFocusInside(q, page);
+    await test.expect(editShortcuts).toBeFocused();
+  });
+
+  test("keeps focus after the panel is hidden by the handler that focused it", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Focus and hide shortcuts").click();
+
+    const editShortcuts = await loadRecentFilesWithFocusInside(q, page);
+    await test.expect(editShortcuts).toBeFocused();
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7024
+  test("keeps focus after the panel is hidden synchronously", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Focus and hide shortcuts synchronously").click();
+
+    const editShortcuts = await loadRecentFilesWithFocusInside(q, page);
+    await test.expect(editShortcuts).toBeFocused();
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7024
+  test("keeps focus after tabbing into a panel that hides itself", async ({
+    page,
+    q,
+  }) => {
+    const arm = q.button("Hide shortcuts on focus");
+    await arm.click();
+    await test.expect(arm).toBeFocused();
+    await page.keyboard.press("Tab");
+    await test.expect(q.toolbar("Shortcuts")).toBeHidden();
+
+    const editShortcuts = await loadRecentFilesWithFocusInside(q, page);
+    await test.expect(editShortcuts).toBeFocused();
+  });
+
+  // Refusing to present after the panel goes away must not outlive the panel
+  // itself, so the two presentations a reopened panel schedules are pinned
+  // here: the one its own focus handler queues, and the one a programmatic
+  // move requests. The scroll is what discriminates, because the entry is
+  // already the active item before either action.
+  test("presents the active item when the reopened panel is focused", async ({
+    q,
+  }) => {
+    const panel = await reopenWithRecentFilesLoaded(q);
+
+    await panel.focus();
+
+    await test.expect
+      .poll(() => panel.evaluate((element) => element.scrollTop))
+      .toBeGreaterThan(0);
+    await test.expect(panel).toBeFocused();
+  });
+
+  test("presents the active item when a move targets the reopened panel", async ({
+    q,
+  }) => {
+    const panel = await reopenWithRecentFilesLoaded(q);
+
+    await q.button("Highlight recent files").click();
+
+    await test.expect
+      .poll(() => panel.evaluate((element) => element.scrollTop))
+      .toBeGreaterThan(0);
+    await test.expect(panel).toBeFocused();
+  });
+});

--- a/app/src/sandbox/composite-presentation-cancel-on-unmount/test.ts
+++ b/app/src/sandbox/composite-presentation-cancel-on-unmount/test.ts
@@ -1,0 +1,74 @@
+import { click, focus, press, q, sleep } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// `test-browser.ts` is authoritative for which dismissal strands a
+// presentation. When the panel is dismissed in the same task that focused it,
+// Chromium commits a batched unmount after the microtask the composite queued
+// and a `flushSync` unmount before it, while the simulated events here commit
+// both before that microtask, so those two dismissals are not split the same
+// way. A dismissal in a later task behaves alike in both. The outcome asserted
+// in both files is the same either way: nothing may move focus on its own
+// after the panel is dismissed.
+// https://github.com/ariakit/ariakit/issues/7024
+
+/**
+ * Reopens the panel, puts DOM focus on a plain button inside it, then loads the
+ * recent files entry. Registering that item is the store update that would wake
+ * a presentation the dismissed panel left behind, and focus being inside the
+ * panel again is what lets that presentation move focus.
+ */
+async function loadRecentFilesWithFocusInside() {
+  await click(q.button("Show shortcuts"));
+  const editShortcuts = q.button.ensure("Edit shortcuts");
+  await focus(editShortcuts);
+  // Clicked through the DOM so the click doesn't move focus out of the panel.
+  q.button.ensure("Load recent files").click();
+  await sleep();
+  expect(q.button("Recent files")).toBeVisible();
+  return editShortcuts;
+}
+
+test("keeps focus after the panel is hidden in a later task", async () => {
+  await focus(q.toolbar("Shortcuts"));
+  await click(q.button("Hide shortcuts"));
+
+  expect(await loadRecentFilesWithFocusInside()).toHaveFocus();
+});
+
+test("keeps focus after the panel is hidden by the handler that focused it", async () => {
+  await click(q.button("Focus and hide shortcuts"));
+
+  expect(await loadRecentFilesWithFocusInside()).toHaveFocus();
+});
+
+test("keeps focus after the panel is hidden synchronously", async () => {
+  await click(q.button("Focus and hide shortcuts synchronously"));
+
+  expect(await loadRecentFilesWithFocusInside()).toHaveFocus();
+});
+
+test("keeps focus after tabbing into a panel that hides itself", async () => {
+  const arm = q.button.ensure("Hide shortcuts on focus");
+  await click(arm);
+  expect(arm).toHaveFocus();
+  await press.Tab();
+  expect(q.toolbar("Shortcuts")).not.toBeInTheDocument();
+
+  expect(await loadRecentFilesWithFocusInside()).toHaveFocus();
+});
+
+// Refusing to present after the panel goes away must not outlive the panel
+// itself. The scroll that discriminates in the browser is invisible here, so
+// the move is driven from outside the panel instead, and the handoff it
+// triggers is what proves the presentation ran: the entry takes focus and
+// hands it back to the panel.
+test("presents the active item when a move targets the reopened panel", async () => {
+  await click(q.button("Focus and hide shortcuts synchronously"));
+  await click(q.button("Show shortcuts"));
+  await click(q.button("Load recent files"));
+  expect(q.button("Recent files")).toHaveAttribute("data-active-item");
+
+  await click(q.button("Highlight recent files"));
+
+  expect(q.toolbar("Shortcuts")).toHaveFocus();
+});

--- a/packages/ariakit-react-components/src/composite/composite-item.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-item.tsx
@@ -50,8 +50,8 @@ import {
   focusSilently,
   getEnabledItem,
   isItem,
-  presentItem,
   selectTextField,
+  usePresentItem,
 } from "./utils.ts";
 
 const TagName = "button" satisfies ElementType;
@@ -287,9 +287,7 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
     // update by unregistering it, even when the composite element never
     // arrives. Redirects are only scheduled for such items.
     const cancelScheduledFocusRedirectRef = useRef<(() => void) | null>(null);
-    // Holds the canceller of the presentation scheduled when this item hands
-    // focus back to the composite element, so a later one supersedes it.
-    const cancelPresentationRef = useRef<(() => void) | null>(null);
+    const present = usePresentItem(store);
 
     const onFocus = useEvent((event: FocusEvent<HTMLType>) => {
       onFocusProp?.(event);
@@ -352,12 +350,7 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
         // focus escape during it does leave the request running.
         // See https://github.com/ariakit/ariakit/issues/7020
         if (store.item(id)) {
-          cancelPresentationRef.current?.();
-          cancelPresentationRef.current = presentItem({
-            store,
-            id,
-            markedOnly: true,
-          });
+          present({ id, markedOnly: true });
         }
         hasFocusedComposite.current = true;
         // If the previously focused element is a composite or composite item

--- a/packages/ariakit-react-components/src/composite/composite.tsx
+++ b/packages/ariakit-react-components/src/composite/composite.tsx
@@ -32,7 +32,7 @@ import type {
   KeyboardEvent as ReactKeyboardEvent,
   RefObject,
 } from "react";
-import { useCallback, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import type { FocusableOptions } from "../focusable/focusable.tsx";
 import { useFocusable } from "../focusable/focusable.tsx";
 import {
@@ -40,15 +40,14 @@ import {
   useCompositeProviderContext,
 } from "./composite-context.tsx";
 import type { CompositeStore, CompositeStoreItem } from "./composite-store.ts";
-import type { PresentItemParams } from "./utils.ts";
 import {
   findFirstEnabledItem,
   getEnabledItem,
   groupItemsByRows,
   isItem,
   ownsFocus,
-  presentItem,
   silentlyFocused,
+  usePresentItem,
 } from "./utils.ts";
 
 const TagName = "div" satisfies ElementType;
@@ -113,41 +112,6 @@ function findFirstEnabledItemInTheLastRow(items: CompositeStoreItem[]) {
   return findFirstEnabledItem(
     flatten2DArray(reverseArray(groupItemsByRows(items))),
   );
-}
-
-/**
- * Keeps at most one pending presentation per composite, so the newest request
- * wins. That's what lets a later move take over from the presentation an open
- * scheduled, while an activity that only changes the active item without asking
- * for a new presentation, such as hover, leaves the pending one alone.
- */
-function usePresentItem(store: CompositeStore) {
-  const cancelRef = useRef<(() => void) | null>(null);
-  const cancel = useCallback(() => {
-    cancelRef.current?.();
-    cancelRef.current = null;
-  }, []);
-  const present = useCallback(
-    (params: Omit<PresentItemParams, "store">) => {
-      cancel();
-      const cancelCurrent = presentItem({ store, ...params });
-      cancelRef.current = cancelCurrent;
-      return cancelCurrent;
-    },
-    [store, cancel],
-  );
-  // Deliberately not scoped to the store, and deliberately without a mounted
-  // flag. The effect-driven request is created by a child of this component,
-  // and React runs a child's passive setup before its parent's, so anything
-  // reset here is still reset when the child asks again: a remount would drop
-  // that request rather than protect it.
-  // A request that has already resolved its item terminates on its own when
-  // that item leaves the DOM. One queued from an event handler after this
-  // cleanup never resolves an item, so it can still outlive the component;
-  // giving the request a single owner is tracked in
-  // https://github.com/ariakit/ariakit/issues/7024.
-  useEffect(() => cancel, [cancel]);
-  return present;
 }
 
 type PresentItem = ReturnType<typeof usePresentItem>;

--- a/packages/ariakit-react-components/src/composite/utils.ts
+++ b/packages/ariakit-react-components/src/composite/utils.ts
@@ -1,4 +1,5 @@
 import * as Core from "@ariakit/components/composite/composite-store";
+import { useSafeLayoutEffect } from "@ariakit/react-utils";
 import { subscribe } from "@ariakit/store";
 import {
   getActiveElement,
@@ -6,6 +7,7 @@ import {
   isTextField,
   isVisible,
 } from "@ariakit/utils";
+import { useCallback, useRef } from "react";
 import type { CompositeStore, CompositeStoreState } from "./composite-store.ts";
 
 export const flipItems = Core.flipItems;
@@ -95,7 +97,7 @@ export interface PresentItemParams {
  * view is the only part that can move the page, so it's the only part that has
  * to wait for the popup to be placed.
  */
-export function presentItem({
+function presentItem({
   store,
   id,
   focus,
@@ -227,6 +229,58 @@ export function presentItem({
   unsubscribe = subscribe(store, keys, present);
   present();
   return cancel;
+}
+
+/**
+ * Gives a component a single owner for the presentations it asks for, so no
+ * call site has to track them itself. Keeps at most one pending presentation
+ * per component, so the newest request wins: that's what lets a later move take
+ * over from the presentation an open scheduled, while an activity that only
+ * changes the active item without asking for a new presentation, such as hover,
+ * leaves the pending one alone.
+ *
+ * The owner is the store the component is currently rendering with, recorded in
+ * a layout effect. Two things follow from that. Cancellation is scoped to the
+ * store the request was made against, so a component that swaps its `store`
+ * prop can't cancel the incoming store's request or strand the outgoing one.
+ * And a request asked for once the owner is gone is refused rather than
+ * created, which for some requests is the only thing that can stop them.
+ * `presentItem` retires a parked request through the popup state it watches or
+ * the item id it was given, so one with neither, on a store that outlives the
+ * component, would stay there for good.
+ *
+ * Layout is what makes the second part work in both directions. Its cleanup
+ * runs while the unmount is still being committed, before any event handler or
+ * microtask that follows it, and its setup runs before every passive setup in
+ * the commit, including those of children that ask for a presentation of their
+ * own. The initial value covers the render before the first setup.
+ */
+export function usePresentItem(store?: CompositeStore) {
+  const cancelRef = useRef<(() => void) | null>(null);
+  const ownerRef = useRef(store);
+  const cancel = useCallback(() => {
+    cancelRef.current?.();
+    cancelRef.current = null;
+  }, []);
+  const present = useCallback(
+    (params: Omit<PresentItemParams, "store">) => {
+      if (!store) return;
+      if (ownerRef.current !== store) return;
+      cancel();
+      const cancelCurrent = presentItem({ store, ...params });
+      cancelRef.current = cancelCurrent;
+      return cancelCurrent;
+    },
+    [store, cancel],
+  );
+  useSafeLayoutEffect(() => {
+    ownerRef.current = store;
+    return () => {
+      ownerRef.current = undefined;
+      cancel();
+    };
+  }, [store, cancel]);
+  return present;
 }
 
 /**


### PR DESCRIPTION
## Motivation

`Composite` schedules a presentation for its active item from a microtask queued in its focus handler, and `usePresentItem` cancels the pending one from an effect cleanup. When the unmount is committed synchronously, the cleanup runs before the microtask, so there is nothing to cancel and the request is created afterwards against a store that is still alive.

```jsx
const store = Ariakit.useCompositeStore({ virtualFocus: true });

// Strands a presentation on the store.
<Ariakit.Composite store={store} onFocus={() => flushSync(() => setMounted(false))} />
```

That request never resolves an item, and nothing retires it while that stays true: the abandon reasons that watch the store are inert for it, and the one that watches the item is only reachable once an item resolves. So it stays subscribed, and the next update that does resolve the active item while DOM focus happens to be inside the composite again wakes it: focus is taken from whatever the user was on, with nothing having asked for it.

Each component that creates a request also reimplements the bookkeeping that cancels it, and the copy in `CompositeItem` records no store identity and has no cleanup at all. Fixes #7024.

## Solution

`usePresentItem` moves to `composite/utils.ts` and becomes the single owner of the presentations a component asks for, so no call site tracks them itself. It records the store it is presenting for in a layout effect, and refuses any request whose store is not the current owner.

The layout effect is what closes the report. Its cleanup runs while the unmount is still being committed, before the microtask the focus handler queued, so the request is refused instead of created. The passive cleanup it replaces ran at that point too, but it had nothing to cancel yet, and a passive setup could not have restored ownership either: `Composite`'s own passive setup runs after the child that asks for the effect driven presentation, so every remount would have dropped that request rather than protected it.

Recording the store, rather than a mounted flag, is what makes cancellation safe across a `store` prop swap. A stale handler bound to the outgoing store can no longer cancel the incoming store's request, and the outgoing store's request is cancelled by the effect that owned it.

[`CompositeItem`](https://ariakit.com/reference/composite-item) uses the same hook now, in place of the bookkeeping that recorded no store identity and had no cleanup at all. `presentItem` is no longer exported, so the entry point that bypasses the owner is gone.

`app/src/sandbox/composite-presentation-cancel-on-unmount/` reproduces it. A virtual focus shortcuts panel whose store is created above it can be dismissed in a later task, in the same handler that focused it, synchronously with `flushSync`, and from its own focus handler. Reopening it, focusing a plain button inside it and loading an entry then shows whether the dismissed panel left a presentation behind.

The two tests that dismiss the panel synchronously failed in Chromium, Firefox and WebKit before this change and pass with it, with the sandbox workaround reverted. Two further tests pin the presentations a reopened panel should still perform, so a fix that over-cancels turns those red instead; both stay green.

### No changeset

`presentItem`, `usePresentItem` and the bug this fixes were all introduced by #7009, whose changeset is still pending, so this behavior has never been released. There is no shipped behavior to describe in the changelog. #7031 fixed the sibling case in the same family the same way.

Reviewing that question surfaced the opposite case in the same module, a released export removed by #7009 with no entry at all, which is out of scope here and tracked in https://github.com/ariakit/ariakit/issues/7041.

## Preview

The reported symptom, recorded on `main` during triage: <kbd>Tab</kbd> moves into the composite and it unmounts itself, it is mounted again, a plain button inside it is focused, and then registering an item pulls focus off that button with no interaction.

https://github.com/user-attachments/assets/508ed450-fa78-444a-9554-31fe74124e16

No recording of the fixed behavior was captured, because the fixed behavior is the absence of that focus move and has no positive visual state. It is covered instead by the four browser tests that assert focus stays where the user left it, across Chromium, Firefox and WebKit.

## Workaround

Until this ships, prevent the focus event whose presentation is about to be discarded. `Composite` calls the `onFocus` prop first and bails out of the rest of its focus handler when the event is prevented, so nothing gets scheduled:

```tsx
const dismissingRef = useRef(false);

// TODO: Remove once https://github.com/ariakit/ariakit/issues/7024 is fixed.
const dismiss = () => {
  dismissingRef.current = true;
  panelRef.current?.focus();
  dismissingRef.current = false;
  flushSync(() => setOpen(false));
};

<Ariakit.Composite
  ref={panelRef}
  onFocus={(event) => {
    // TODO: Remove once https://github.com/ariakit/ariakit/issues/7024 is fixed.
    if (dismissingRef.current) event.preventDefault();
  }}
/>;
```

When the composite dismisses itself from its own `onFocus` handler, prevent the event there directly instead of flagging it. That covers focus you never initiated too, such as the user tabbing in.

### Assumptions and limitations

This is narrower than the fix, so apply it only where it fits:

- Prevent the event only for the focus events you are discarding. `Composite` bails out of its whole focus handler when the event is prevented, so on any other focus event it will not focus its active item or scroll it into view.
- The snippet is written for a [`virtualFocus`](https://ariakit.com/reference/composite-provider#virtualfocus) composite, which is the composition with the reported symptom. In a roving tabindex composite, preventing the event also skips the `setActiveId(null)` that focusing the container performs.
- It only helps when you can tell, while the focus event is still running, that the focus is being discarded. An unmount committed synchronously after your handler returns, but before the composite's queued microtask runs, strands the presentation anyway.
- Preventing the event is the composite's current escape hatch rather than a documented API, and Ariakit reads the prevented state as an opt-out in more than one handler, so prevent narrowly.

Scoping the store to the composite closes it too, since a presentation subscribes to the store it was handed and a store discarded with the component can never be reached again. That trades away any state the store was meant to keep across mounts.

## Review gate reassessment

<details>
<summary>Cycle 3: Continue the workaround direction, simplify its documentation</summary>

**Assessment**

Issue severity: moderate and accessibility visible. DOM focus is taken off whatever the user is on and the active item changes, with nothing having asked for either. Nothing is corrupted and the user can move focus back.

Expected frequency: low. The strand needs a `virtualFocus` composite, a composite store that outlives it (a popup backed store latches on a truthy read, so it retires a parked request at its next open then close cycle rather than at the close that unmounted the composite), a dismissal committed synchronously in the task that focused the composite, and later a remount under that store with focus back inside it.

Supported scope: `virtualFocus` composites reached through `@ariakit/react`. Only the virtual focus branch asks for `focus: true`, so only it can produce the reported symptom of DOM focus moving on its own; the roving tabindex branch asks only for the scroll.

Implementation and maintenance complexity of the reviewed direction: minimal and disposable. It is one boolean ref, one `onFocus` handler, one three line helper and two `TODO` comments, all inside the sandbox fixture. No library code, no new state in library code, no new tests, no public contract. Stage 5 reverts the file outright, so the only durable artifact is the `## Workaround` prose.

What produced the finding bearing rounds: round 1 reviewed a different direction, deferring each dismissal by a task, and replaced it with this one, which is smaller and keeps all four dismissal timings distinct. Rounds 2 and 3 returned no findings against the code at all. Round 2 required the workaround's assumptions and limitations in this description, which the issue fix workflow mandates. Round 3 corrected two consequences in that prose that were not real: the scheduled presentation passes no `id` and resolves the active item, so preventing it costs neither the `activeId` sync nor `data-active-item`, which derives from `activeId` alone.

The pattern is that the limitations list enumerated internal mechanisms, and every mechanism named is a separate factual claim a reviewer can disprove. That is a documentation surface, not implementation complexity.

**Decision**

Continue. There is no machinery to simplify or remove, and the earlier direction was both larger and less faithful, so reverting to it is not on the table. The ref flag is load bearing, because the dismissal happens in the click handler after `focus()` returns while the prevention has to happen inside the focus event.

Round 3's finding is resolved in the prose only, and the limitations were rewritten to state the workaround's shape rather than enumerate the internals behind it: which focus events to prevent and what preventing costs, that only `virtualFocus` composites need it, and that it covers dismissals predictable while the focus event is still running.

No disposition changed. Round 1's findings 1, 2 and 4 remain obsolete because they describe costs of the abandoned deferral, and round 2's finding remains addressed by this section.

Intentionally left unsupported by the workaround, since the fix covers them: a composite dismissed synchronously by something other than the focus handler in the same task, and everything issue #7024 already declares unsupported, namely swapping the `store` prop of a mounted `Composite`, `CompositeItem` or `Popover` while a presentation is parked.

Registered follow ups: none. The adjacent mechanisms are already owned elsewhere. `composite-item.tsx`'s `cancelPresentationRef` is inside this PR's scope, and the `unstable_placing` publication window is tracked in https://github.com/ariakit/ariakit/issues/7019.

</details>

<details>
<summary>Cycle 6: Continue, and restate the workaround's limitations at handler scope</summary>

**Assessment**

Severity, expected frequency, supported scope and user impact are unchanged from cycle 3.

Complexity is unchanged too: 30 insertions and 7 deletions in one sandbox fixture, reverted when the fix lands. That code has now drawn no finding for four consecutive rounds.

Rounds 4, 5 and 6 each produced one finding, all against the pull request prose. Sorting them by surface gives a sharper diagnosis than cycle 3 reached: claims scoped to the focus handler the workaround guards have never been disproved, while claims that reason past it, into `presentItem`, `composite-item.tsx`, `focusable.tsx` or the roving tabindex branch, have been disproved or disputed three times. Round 4 is the clearest symptom, since its disposition deleted a clause that round 5 then confirmed was true. Two of the findings came from a different source entirely: the reviewed surface grew to the whole description, which is where the stale `## Solution` section and the wrong `virtualFocus` default in the motivation snippet were caught.

**Decision**

Continue. Cutting the limitations down to statements that name no internals at all was considered and rejected, because the issue fix workflow requires a workaround narrower than normal behavior to state what it costs, and that text is reused when the workaround is posted to the issue. Dropping it would under document rather than simplify.

The limitations are instead restated at the scope of the guard itself, so no claim reaches past the handler being prevented: what the composite skips when the event is prevented, the composition the snippet is written for, when the workaround cannot help at all, and its support status. The `data-focus-visible` clause stays deleted. It is technically true, but it has no observable cost in any documented use of the workaround, and naming it already cost two rounds and a discarded browser probe.

No disposition changed, and no supported behavior was narrowed.

Left intentionally unasserted: whether the roving tabindex branch can strand a scroll only request. Two throwaway probes failed to settle it, so neither direction is claimed.

Registered follow ups: none. `composite-item.tsx`'s `cancelPresentationRef` is inside this pull request's own scope, and the `unstable_placing` publication window is tracked in https://github.com/ariakit/ariakit/issues/7019.

</details>

<details>
<summary>Library fix, cycle 4: Continue the store owner design, including in CompositeItem</summary>

**Assessment**

Severity, expected frequency, supported scope and user impact are unchanged from the entries above.

The shipped direction is small. One shared hook replaces the bookkeeping two call sites carried, and `presentItem` stops being exported. The hook adds one layout effect and a few slots to each `CompositeItem`, a component that already runs around nine effects, with stable dependencies so nothing re-runs on an ordinary render.

Across four rounds this gate produced seven findings: six against prose, one against a single `export` keyword, and none against the ownership model, which the first round validated across mount, remount, strict mode, a store swap and a discarded render. Two of the prose findings were against the reassessment records themselves. That is the same diagnosis as the entry above: the audit trail is itself a finding surface, so this entry avoids line anchors and internal mechanism detail.

**Decision**

Continue. An instance scoped mounted flag would close the reported symptom at the same cost, but it would leave the cross store cancellation hazard this issue also reports, so recording the store is the cheaper correct choice rather than extra scope.

`CompositeItem` keeps the hook. The issue names that call site directly and asks for cancellation to stop being reimplemented per call site, so reverting it would leave the stated scope unaddressed, and it would also force `presentItem` back onto a published subpath.

The performance workflow has since run against this change and reports no significant changes and no candidate rows, on Chrome and on Node, so the per item cost is not measurable and the fallback below was not needed. Had it regressed, the retreat would have been to keep the hook for `Composite` alone and move `presentItem` into a module that is not in the package's export map, rather than to reopen the ownership model.

No disposition changed and no supported behavior was narrowed.

Intentionally left uncovered: swapping the `store` prop of a mounted composite while a presentation is parked, which this issue declares unsupported; the `unstable_placing` publication window, which the triage established is unreachable today and whose adjacent work is owned by https://github.com/ariakit/ariakit/issues/7019; and the `CompositeItem` half of this change, which has no user verifiable symptom on its own and so no feasible regression test.

Accepted knowingly: the item's presentation now has an unmount cleanup while the focus redirect subscription beside it deliberately has none. The difference is real, because the presentation is created only once the item is registered, so the strict mode window the redirect guards against is not reachable for it.

Registered follow ups: none.

</details>

