### PR TITLE
Abandon the composite item presentation handoff on focus escape

### DIFF
--- a/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
@@ -41,6 +41,14 @@ const fruits = [
 ];
 
 interface FixtureProps {
+  /**
+   * Whether the popup takes focus once it is placed. Turning it off keeps a
+   * focus escape from being undone by the popup pulling focus back in, which is
+   * a separate defect. Once that one is fixed, the fixture that turns this off
+   * can go back to the default and cover the same escape there.
+   * See https://github.com/ariakit/ariakit/issues/7033
+   */
+  autoFocusOnShow?: boolean;
   defaultSelectedValue: string | string[];
   focusTarget?: boolean;
   input?: boolean;
@@ -53,8 +61,7 @@ interface FixtureProps {
   /**
    * Drops the popup's own scrollport so the nearest scrollport for its items is
    * the page, which is what makes a stale presentation move the page rather
-   * than the popup's list. It also turns on the temporary workaround below,
-   * which takes the page back out of that request's reach.
+   * than the popup's list.
    */
   pageScrollport?: boolean;
   unmountOnHide?: boolean;
@@ -62,6 +69,7 @@ interface FixtureProps {
 }
 
 function Fixture({
+  autoFocusOnShow,
   defaultSelectedValue,
   focusTarget,
   input,
@@ -85,21 +93,16 @@ function Fixture({
       <Ariakit.ComboboxSelectLabel>{label}</Ariakit.ComboboxSelectLabel>
       <Ariakit.ComboboxSelect style={{ display: "block" }} />
       <Ariakit.ComboboxPopover
+        // Spread rather than passed, because an explicitly undefined prop wins
+        // over the default `ComboboxPopover` computes for itself, which would
+        // retune every fixture that leaves this alone.
+        // See https://github.com/ariakit/ariakit/issues/7028
+        {...(autoFocusOnShow === undefined ? null : { autoFocusOnShow })}
         unmountOnHide={unmountOnHide}
         hideOnInteractOutside={!keepOpen}
         // A popup that is taller than the viewport would otherwise be flipped
         // above the select, which puts the last items back in view.
         flip={!pageScrollport}
-        // TODO: Remove once https://github.com/ariakit/ariakit/issues/7020 is
-        // fixed. With no transformed or contained ancestor to capture it, a
-        // fixed popup is outside the document's scroll flow, so a presentation
-        // that outlives a focus escape can no longer move the page on its way
-        // out.
-        // The mitigation to recommend to users is an internally scrolling
-        // popup, but that is the very precondition this fixture removes, so
-        // it takes the page out of reach instead. The cost is that options
-        // past the fold lose the page scroll that used to reach them.
-        fixed={pageScrollport}
         gutter={4}
         sameWidth
         style={{
@@ -217,6 +220,7 @@ export default function Example() {
       presentation that outlives the escape is visible as a page jump. */}
       <div style={{ marginTop: 200 }}>
         <Fixture
+          autoFocusOnShow={false}
           defaultSelectedValue="Watermelon"
           focusTarget
           input

--- a/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
@@ -53,7 +53,8 @@ interface FixtureProps {
   /**
    * Drops the popup's own scrollport so the nearest scrollport for its items is
    * the page, which is what makes a stale presentation move the page rather
-   * than the popup's list.
+   * than the popup's list. It also turns on the temporary workaround below,
+   * which takes the page back out of that request's reach.
    */
   pageScrollport?: boolean;
   unmountOnHide?: boolean;
@@ -89,6 +90,16 @@ function Fixture({
         // A popup that is taller than the viewport would otherwise be flipped
         // above the select, which puts the last items back in view.
         flip={!pageScrollport}
+        // TODO: Remove once https://github.com/ariakit/ariakit/issues/7020 is
+        // fixed. With no transformed or contained ancestor to capture it, a
+        // fixed popup is outside the document's scroll flow, so a presentation
+        // that outlives a focus escape can no longer move the page on its way
+        // out.
+        // The mitigation to recommend to users is an internally scrolling
+        // popup, but that is the very precondition this fixture removes, so
+        // it takes the page out of reach instead. The cost is that options
+        // past the fold lose the page scroll that used to reach them.
+        fixed={pageScrollport}
         gutter={4}
         sameWidth
         style={{

--- a/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
@@ -44,10 +44,18 @@ interface FixtureProps {
   defaultSelectedValue: string | string[];
   focusTarget?: boolean;
   input?: boolean;
+  /** Keeps the popup open while focus leaves it. */
+  keepOpen?: boolean;
   label: string;
   moveFocusOnOpen?: boolean;
   /** Puts the element focus moves to outside the popup instead of inside it. */
   outsideFocusTarget?: boolean;
+  /**
+   * Drops the popup's own scrollport so the nearest scrollport for its items is
+   * the page, which is what makes a stale presentation move the page rather
+   * than the popup's list.
+   */
+  pageScrollport?: boolean;
   unmountOnHide?: boolean;
   virtualFocus?: boolean;
 }
@@ -56,9 +64,11 @@ function Fixture({
   defaultSelectedValue,
   focusTarget,
   input,
+  keepOpen,
   label,
   moveFocusOnOpen,
   outsideFocusTarget,
+  pageScrollport,
   unmountOnHide,
   virtualFocus,
 }: FixtureProps) {
@@ -75,13 +85,16 @@ function Fixture({
       <Ariakit.ComboboxSelect style={{ display: "block" }} />
       <Ariakit.ComboboxPopover
         unmountOnHide={unmountOnHide}
+        hideOnInteractOutside={!keepOpen}
+        // A popup that is taller than the viewport would otherwise be flipped
+        // above the select, which puts the last items back in view.
+        flip={!pageScrollport}
         gutter={4}
         sameWidth
         style={{
           background: "white",
           border: "1px solid gray",
-          maxHeight: 120,
-          overflow: "auto",
+          ...(pageScrollport ? null : { maxHeight: 120, overflow: "auto" }),
         }}
       >
         {input && (
@@ -185,6 +198,22 @@ export default function Example() {
           label="Escaping fruit"
           moveFocusOnOpen
           outsideFocusTarget
+          unmountOnHide
+        />
+      </div>
+      {/* The same escape, against a popup that keeps itself open and has no
+      scrollport of its own. Nothing left to scroll but the page, so a
+      presentation that outlives the escape is visible as a page jump. */}
+      <div style={{ marginTop: 200 }}>
+        <Fixture
+          defaultSelectedValue="Watermelon"
+          focusTarget
+          input
+          keepOpen
+          label="Page escaping fruit"
+          moveFocusOnOpen
+          outsideFocusTarget
+          pageScrollport
           unmountOnHide
         />
       </div>

--- a/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
@@ -94,6 +94,44 @@ withFramework(import.meta.dirname, async ({ test }) => {
     test.expect(await scroll.events()).not.toContain("document");
   });
 
+  // https://github.com/ariakit/ariakit/issues/7020
+  test("cancels the item handoff presentation when focus leaves an open popup", async ({
+    page,
+    q,
+  }) => {
+    const select = q.combobox("Page escaping fruit");
+    const escapeTarget = q.button("Page escaping fruit focus target");
+
+    // Clicking a select that isn't fully visible would scroll the page to reach
+    // it, and that scroll would land inside the measurement below.
+    await select.scrollIntoViewIfNeeded();
+    await test.expect(select).toBeInViewport({ ratio: 1 });
+    const scrollY = await page.evaluate(() => window.scrollY);
+    const scroll = await recordScrollEvents(page);
+
+    await select.click();
+
+    // The popup stays open, so the presentation the item handoff scheduled is
+    // only abandoned if it sees the escape.
+    await test.expect(escapeTarget).toBeFocused();
+    // Placement is the gate a surviving request parks behind, so pin it rather
+    // than trusting a frame flush to have covered it.
+    await test.expect(q.listbox()).not.toHaveAttribute("data-placing");
+    await test.expect(escapeTarget).toBeFocused();
+    // The popup is still open and the marked item is still the active one, so
+    // none of the three abandon reasons the request already honours can be what
+    // stopped it.
+    await test.expect(q.listbox()).toBeVisible();
+    await test
+      .expect(q.option("Watermelon"))
+      .toHaveAttribute("data-active-item");
+    test.expect(await page.evaluate(() => window.scrollY)).toBe(scrollY);
+    test.expect(await scroll.events()).not.toContain("document");
+    // And the marked item is still out of view, so the page really was the only
+    // thing a surviving presentation could have scrolled.
+    await test.expect(q.option("Watermelon")).not.toBeInViewport();
+  });
+
   // This case originated in the unmerged PR below. It covers the same
   // focus-move cancellation invariant when the popup remounts on open and the
   // select element briefly becomes the composite again.

--- a/packages/ariakit-react-components/src/composite/composite-item.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-item.tsx
@@ -345,18 +345,16 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
         // where it is.
         // An item that opts out of registering itself can't be resolved from
         // the store, so there would be nothing to wait for.
-        // This is the one presentation that deliberately doesn't watch for
-        // focus escaping: it exists to finish a handoff that moves focus twice
-        // on its own, so a focus check would abandon it every time. The other
-        // three abandon reasons still apply, and the handoff is short, but a
-        // focus escape during it does leave the request running.
-        // See https://github.com/ariakit/ariakit/issues/7020
+        // The handoff below moves focus a second time, from this item to the
+        // composite element, but both are inside the composite, so the request
+        // survives it and only focus leaving the composite abandons it.
         if (store.item(id)) {
           cancelPresentationRef.current?.();
           cancelPresentationRef.current = presentItem({
             store,
             id,
             markedOnly: true,
+            requireFocus: true,
           });
         }
         hasFocusedComposite.current = true;

--- a/packages/ariakit-react-components/src/composite/utils.ts
+++ b/packages/ariakit-react-components/src/composite/utils.ts
@@ -115,12 +115,18 @@ export function presentItem({
     const activeElement = getActiveElement(owner);
     // Whoever asked for this still has focus.
     if (activeElement === owner) return true;
-    // A presentation that only scrolls has no reason to see focus move, so
-    // anything else taking it abandons the presentation. One that moves focus
-    // does: it hands focus to the item and the item hands it back, and the
-    // composite element it comes back to isn't always the one that asked,
-    // because that element can change identity while a popup opens.
-    if (!focus) return false;
+    // Focus moving inside the composite is the presentation's own doing, not
+    // the user moving on. A request that moves focus hands it to the item and
+    // the item hands it back, and the composite element it comes back to isn't
+    // always the one that asked, because that element can change identity while
+    // a popup opens. The item's handoff request is the same shape seen from the
+    // other side: it doesn't move focus itself, but it's created midway through
+    // a handoff that does. So the question is whether the composite still has
+    // focus, not whether the element that asked still does.
+    // How wide "the composite" should be is still open: `ownsFocus` counts any
+    // popup descendant, which can't tell a mid-flight handoff apart from the
+    // user moving to another control in the popup.
+    // See https://github.com/ariakit/ariakit/issues/7018
     if (activeElement === target) return true;
     return ownsFocus(store);
   };


### PR DESCRIPTION
## Motivation

`CompositeItem` creates a presentation request when it hands DOM focus back to the composite element. That request passed neither `focus` nor `requireFocus`, so `presentItem` never captured an owner and `stillOwnsFocus` returned `true` unconditionally. Of the four abandon reasons the presentation has, it honoured three (popup closed, active item changed, item disconnected) and missed focus escape.

The consequence is only user-visible when the item's nearest scrollport is the page rather than the popup. Then a request that outlives a focus escape moves the page after the user has already left:

```jsx
// A popup that keeps itself open and scrolls the page, not its own list.
<Ariakit.ComboboxPopover hideOnInteractOutside={false}>
```

## Solution

The request now passes `requireFocus: true`, and `stillOwnsFocus` stops treating a scroll-only request as one that may never see focus move.

The reason it could not simply pass `requireFocus` before is that this request exists to finish a handoff that moves focus a second time, from the item to the composite element. `stillOwnsFocus` had a fast path for a request that moves focus itself, falling back to `ownsFocus(store)`, and an early `return false` for one that does not. That split is what made the handoff unrepresentable: it does not move focus itself, but it is created midway through a handoff that does.

Removing the early return makes the question uniform for every request that asks for it: not whether the element that asked still has focus, but whether the composite still does. Focus moving between an item and the composite element, in either direction, is the presentation's own doing rather than the user moving on. Only focus leaving the composite abandons the request.

That is what `requireFocus` already claimed to mean. Its own documentation reads "Whether to abandon the presentation if the composite loses DOM focus", which the early return contradicted for every request that did not move focus itself. The change deletes a branch and closes the gap between the option's documented contract and its behavior, rather than introducing a new rule.

```diff
   if (activeElement === owner) return true;
-  if (!focus) return false;
   if (activeElement === target) return true;
   return ownsFocus(store);
```

The owner fast path stays. It is what lets a request survive the composite element changing identity while a popup opens, which is exactly what happens when a `ComboboxSelect` hands off from its select button to the input inside the popover. An earlier attempt that dropped it abandoned the ordinary open instead, so the marked item was never presented at all, which `combobox-select-open-page-scroll` catches.

Two of the three pre-existing call sites pass `focus: true`, so they are untouched. The third, the roving-tabindex request in `Composite`'s `onFocus`, changes with this: it used to abandon as soon as anything but the composite element took focus, and now abandons only when focus leaves the composite. Reaching that difference takes roving tabindex, a marked item, a focusable inside the popup that is not an item, and a focus move inside the placing window. Whether popup containment should count as ownership at all is the open contract question in #7018, and this change widens the set of requests that question applies to, which is [recorded there](https://github.com/ariakit/ariakit/issues/7018#issuecomment-5164159455) along with the fact that the zero-hit instrumentation on that issue predates the widening.

Instrumenting `presentItem` in Firefox shows the intended sequence, in milliseconds from one run:

```
t=1319  the composite presentation focuses the marked item
t=1320  the item's handoff request is created and parks on placement
t=1323  the app moves focus to a button outside the widget
t=1326  both requests abandon, ownsFocus=false, and nothing scrolls
```

### Reproduction

The new `Page escaping fruit` fixture in the existing `combobox-select-selected-value-presentation` sandbox keeps its popup open with `hideOnInteractOutside={false}`, gives it no scrollport of its own, and stops it from flipping above the select with `flip={false}`, since flipping would put the trailing items back in view and hide the symptom. Reverting only the two library files while keeping the fixture makes the test fail in Chrome, Firefox and WebKit alike, each with the page scrolling the same 953px to bring `Watermelon` into view after focus has already left.

The fixture also sets `autoFocusOnShow={false}`. That is not part of the reproduction; it isolates it. With auto focus on show active, the popup pulls focus back in after the escape and restarts the whole presentation chain, which is a separate defect now tracked in #7033.

That isolation has a consequence worth stating plainly: this fix closes the request #7020 is about, but it does not on its own make the page jump disappear in the default configuration. A `ComboboxSelect` with an input in its popover has `autoFocusOnShow` active by default, so the recording attached to the issue still needs #7033 before the symptom is fully gone. What lands here is the abandon reason the request was missing, verified in isolation.

The pre-existing `cancels presentation when virtual focus leaves the popup` test does not cover this. It pins the composite-owned request, which did pass `requireFocus: true`, and its popup scrolls internally, so a surviving item-owned request moves that list instead of the page.

### Preview

The `Page escaping fruit` fixture, side by side, with only the two library files differing. One click opens the popup, the app moves focus to the button beside the select while the popover is still being placed, and on the left the page still scrolls away from the widget the user is now on. On the right it stays put and the popup opens where it belongs.

[preview-7020.webm](https://github.com/user-attachments/assets/6f02c5be-2bc0-4ac5-923d-f10c20c49f5a)

### No changeset

`presentItem` and this call site were both introduced by #7009, whose changeset is still pending, so this bug has never been released. There is no shipped behavior to describe in the changelog.

Fixes #7020

## Workaround

For anyone on a build that carries the bug, give the popup its own scrollport, which is what Ariakit's own popup styling already does:

```jsx
<Ariakit.ComboboxPopover
  hideOnInteractOutside={false}
  // TODO: Remove once https://github.com/ariakit/ariakit/issues/7020 is fixed.
  style={{ maxHeight: 200, overflow: "auto" }}
>
```

The stale request then scrolls that list instead of the page, which is the behavior the popup wanted anyway. This is a mitigation rather than a cancellation: the request still runs and still moves something, it just no longer has the page in reach. Leaving `hideOnInteractOutside` at its default avoids the bug outright, because the escape then closes the popup and the request is abandoned by state.

The intermediate commit on this branch used `fixed` on the popover instead, because the sandbox cannot use the scrollport: an internally scrolling popup is precisely the precondition the reproduction removes. **Do not copy that.** For a popup taller than the viewport with no scrollport of its own, a fixed wrapper contributes nothing to the document's scrollable overflow, so options past the fold lose the page scroll that used to reach them, and arrow-key navigation can move the active option off-screen with no scrolling box for `scrollIntoView` to act on.

## Review gate reassessment

<details>
<summary>Cycle 3: Continue the shared-sandbox reproduction</summary>

**Assessment**

Issue severity is high per occurrence and low in frequency. It is a confirmed bug in a stable API that jumps the page several hundred pixels after the user has already left the widget, it is reachable through public API, and it reproduces in Chrome, Firefox and WebKit. It also requires four conditions to coincide, with an escape that lands inside a roughly 4ms placing window unless the app supplies an async `updatePosition`.

Complexity added is 69 lines and no library files at that point. The two new fixture props resolve to the components' own defaults for the seven pre-existing fixtures, so the eight pre-existing tests that consume them, across `test-browser.ts`, `test-ios.ts` and `test.ts`, are behavior-identical. The file already carried six optional variant props, so two more are its own idiom rather than a new abstraction. `pageScrollport` folding "no internal scrollport" and "no flip" together is intrinsic: the page jump only exists when the item's nearest scrollport is the page, which forces the popup to be taller than the viewport, which is exactly when flipping would put the trailing items back in view.

The fixture halves of the first and current reviewed snapshots carry identical blob hashes, so the fixture never changed across the three rounds; only the test's assertion set grew. Every substantive finding was the same class, namely whether a "nothing moved" test can pass vacuously. No round questioned the design.

**Decision**

Continue. Rejected alternatives: keeping the popup's internal scrollport and asserting its own scroll instead, because that scrollport is the documented workaround, so asserting it would encode as a regression the behavior the issue calls acceptable and would pre-empt the cancellation-policy design call; a separate self-contained sandbox, because it duplicates the fruit list and the `Fixture` component against the fixture-lifecycle rule to extend a coherent semantic fixture; and narrowing the assertions, because each one closes a route already dispositioned Address now.

The anti-vacuity coverage is now complete for this invariant, so further hardening is declined unless a reviewer names a concrete escape route.

Carried forward as out of scope: the two neighbouring pre-existing tests use `flushFrames` without pinning placement. The pattern does not transfer, because the popup in one of them closes on the escape and leaves nothing to pin, while the other runs with `virtualFocus` disabled and therefore pins the composite-owned request behind its own retrying viewport assertions.

</details>

<details>
<summary>Cycle 3: Continue with `fixed` as the sandbox workaround</summary>

**Assessment**

The workaround is eleven lines in one dev-only sandbox file, reverted in full at the next commit, with no library change, no public contract change, and no test change. The seven pre-existing fixtures receive `fixed={undefined}`, so the eight pre-existing tests are behavior-identical.

The repeated rounds were about describing `fixed` accurately, not about the change growing. Two findings were real factual errors about how a fixed Ariakit popover behaves, one was a real guidance error that would otherwise have shipped harmful advice, and the rest were wording alignment. The count converged across rounds.

The structural constraint is entailment, not preference. The recommended user workaround operates by adding a scrollport, and the reproduction's `not.toBeInViewport()` guard exists to pin that the page is the item's only scrollport, so no correct guard on that precondition can survive the recommended workaround. That leaves the family of levers that keep the page as the item's one scrollport and put the item out of the page's reach, whose other members were rejected for practical reasons: clipping the document's own overflow breaks the sibling tests that scroll the page, relying on the document already sitting at maximum scroll is contrived and placement-fragile, and patching `scrollIntoView` is more fragile without being more honest. Everything outside that family stops the page by firing one of the three abandon reasons the request already honours, which is exactly what the test asserts did not happen. Two such levers were constructed and rejected on principle: blipping the active item to another one and back, and disconnecting and reconnecting the marked item. Both would pass every assertion while making those assertions false.

**Decision**

Continue with `fixed`. Rejected alternatives: using the scrollport in the sandbox and dropping the `not.toBeInViewport()` guard, because that trades a permanent weakening of the regression test for tidiness in a commit that is reverted one commit later, and the drop would have to be permanent; and skipping the sandbox workaround, because a workaround never validated against the repro tests is not a workaround.

`fixed` is the only viable lever that mitigates without either falsifying the reproduction's precondition or faking an abandon reason, which is why the section above states plainly that it is not the advice to follow.

Process gap recorded: no first-round snapshot was preserved for this track, so the claim that the fixture code did not change across the rounds rests on the disposition record rather than on a diff. Snapshots are preserved eagerly for the fix commit.

</details>

<details>
<summary>Cycle 3: Continue the branch-deleting fix</summary>

**Assessment**

The library delta is one deleted conditional and one added argument. It removes a coupling that was never coherent: `focus` describes what a request does, `requireFocus` describes when it stops, and the deleted branch let the first decide the second. `requireFocus` was already documented as "abandon the presentation if the composite loses DOM focus", so the change closes a gap between the option's contract and its behavior instead of inventing a rule. The complexity ledger is negative.

The widening at the roving-tabindex call site only keeps a request alive while focus is inside the composite. Focus leaving still abandons through `ownsFocus`, and focus landing on a different item still abandons through the active-item check, so it cannot produce a new "the page moves after the user left" defect, which is the class this issue is about. The residual is exactly the popup-descendant clause already owned by #7018.

Across four rounds, no finding touched the library logic, which is unchanged since the second iteration. One was a real sandbox-fixture bug, two were source comments, and the rest were description, follow-up-record or process accuracy. That is convergence rather than thrash.

**Decision**

Continue. Rejected alternatives: scoping the change so no pre-existing call site moves, by exempting the request an item created about itself, because it preserves a branch to protect unreleased and untested behavior, turns the documented contract into a two-case rule, and silently reverts to the bug in the node-replacement shape reported in #7021; and moving the `presentItem` call after the focus redirect so the captured owner becomes the composite element, because the store publishes that element in a later commit than the one that mounts it, so there is a real window in which the ordinary open would silently lose its presentation, which is what `combobox-select-6623` and `combobox-select-open-page-scroll` exist to pin. Also considered and rejected: normalizing the owner to the composite element, matching the owner by item id instead of identity, passing `focus: true` at the handoff, and deduplicating the two requests, which is tracked separately in #7024.

Stopping rule adopted for this track, from round 5 on: decline a finding that neither changes library behavior, nor corrects a factual error, nor fixes a broken asset. Rounds 3 and 4 produced findings entirely about artifacts around the change, and a gate reviewing prose does not converge without one.

Process gap recorded honestly: the file kept as this track's first-round snapshot was written after the fact and is byte-identical to the current one, so it does not attest what a first-round snapshot should. The claim that the logic did not change is instead attested by the second-iteration snapshot taken before round 1. The stage-2 entry recorded the same gap and said it would be closed here; it was not.

</details>
