### PR TITLE
Consolidate popover positioned and placing state

### DIFF
--- a/.changeset/300-popover-placing-pass.md
+++ b/.changeset/300-popover-placing-pass.md
@@ -3,18 +3,4 @@
 "@ariakit/react": patch
 ---
 
-Popups now wait for their whole positioning pass
-
-Components that move focus or scroll into a popup, such as [`Menu`](https://ariakit.com/reference/menu), [`Select`](https://ariakit.com/reference/select) and [`Combobox`](https://ariakit.com/reference/combobox) with auto-select, now wait for every positioning pass rather than only the one that follows the popup being shown. Re-anchoring an open popup, by changing its [`placement`](https://ariakit.com/reference/popover-provider#placement) or anchor or by calling [`render`](https://ariakit.com/reference/use-popover-store#render) on its store, no longer lets them act on the position the popup is leaving.
-
-A custom [`updatePosition`](https://ariakit.com/reference/popover#updateposition) that calls the supplied default function and then keeps working now owns the whole pass. Previously the popup counted itself as placed as soon as that inner call finished, so focus could move into it, or the page could scroll to it, while the callback was still deciding where it belongs.
-
-```tsx
-<Menu
-  updatePosition={async ({ updatePosition }) => {
-    await updatePosition();
-    await measureContent();
-    await updatePosition();
-  }}
-/>
-```
+Fixed focus and scroll moving into a popup before a custom [`updatePosition`](https://ariakit.com/reference/popover#updateposition) that calls the supplied default function has finished its own work, which affects [`Popover`](https://ariakit.com/reference/popover) and components built on it such as [`Menu`](https://ariakit.com/reference/menu) and [`Select`](https://ariakit.com/reference/select).

--- a/.changeset/300-popover-placing-pass.md
+++ b/.changeset/300-popover-placing-pass.md
@@ -1,0 +1,20 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Popups now wait for their whole positioning pass
+
+Components that move focus or scroll into a popup, such as [`Menu`](https://ariakit.com/reference/menu), [`Select`](https://ariakit.com/reference/select) and [`Combobox`](https://ariakit.com/reference/combobox) with auto-select, now wait for every positioning pass rather than only the one that follows the popup being shown. Re-anchoring an open popup, by changing its [`placement`](https://ariakit.com/reference/popover-provider#placement) or anchor or by calling [`render`](https://ariakit.com/reference/use-popover-store#render) on its store, no longer lets them act on the position the popup is leaving.
+
+A custom [`updatePosition`](https://ariakit.com/reference/popover#updateposition) that calls the supplied default function and then keeps working now owns the whole pass. Previously the popup counted itself as placed as soon as that inner call finished, so focus could move into it, or the page could scroll to it, while the callback was still deciding where it belongs.
+
+```tsx
+<Menu
+  updatePosition={async ({ updatePosition }) => {
+    await updatePosition();
+    await measureContent();
+    await updatePosition();
+  }}
+/>
+```

--- a/app/src/sandbox/menu-placing-pass/index.react.tsx
+++ b/app/src/sandbox/menu-placing-pass/index.react.tsx
@@ -1,0 +1,120 @@
+import * as Ariakit from "@ariakit/react";
+import type { ComponentProps } from "react";
+import { useRef } from "react";
+
+type MenuProps = ComponentProps<typeof Ariakit.Menu>;
+type UpdatePosition = NonNullable<MenuProps["updatePosition"]>;
+
+// Enough items, at a fixed height, that the last one sits below the fold once
+// the menu opens. Bringing it into view is then a page scroll rather than a
+// no-op.
+const actionCount = 30;
+
+const actions = Array.from(
+  { length: actionCount },
+  (_, index) => `Action ${index + 1}`,
+);
+
+const lastAction = `Action ${actionCount}`;
+
+/**
+ * A menu whose positioning finishes in two steps: it places itself with what it
+ * knows, waits for asynchronous work that can change where it belongs, then
+ * places itself again. `updatePosition` is the public way to express that, and
+ * holding that second step is what keeps a whole positioning pass observable
+ * from a test.
+ *
+ * Everything is driven from buttons outside the menu on purpose. The
+ * presentation that `move` schedules only skips its focus-ownership check when
+ * focus starts outside the composite, and that is the arrangement where the
+ * popup being placed is the only thing left that can release it.
+ */
+export default function Example() {
+  const menu = Ariakit.useMenuStore();
+  const holdRef = useRef<Promise<void> | null>(null);
+  const releaseRef = useRef<(() => void) | null>(null);
+
+  // Armed before the pass starts, so every run `autoUpdate` makes for that pass
+  // waits on the same promise instead of each creating its own and settling on
+  // its own.
+  const holdNextPass = () => {
+    holdRef.current ??= new Promise<void>((resolve) => {
+      releaseRef.current = () => {
+        holdRef.current = null;
+        releaseRef.current = null;
+        resolve();
+      };
+    });
+  };
+
+  const updatePosition: UpdatePosition = async ({ updatePosition }) => {
+    await updatePosition();
+    const held = holdRef.current;
+    if (!held) return;
+    await held;
+    await updatePosition();
+  };
+
+  return (
+    <main style={{ display: "grid", gap: 8, justifyItems: "start" }}>
+      {/* Puts the controls below the fold so the page is scrolled while the
+      menu is open, which is the only way a page jump is observable. */}
+      <div style={{ height: 900 }} />
+      <button
+        type="button"
+        tabIndex={0}
+        onClick={() => {
+          holdNextPass();
+          menu.render();
+        }}
+      >
+        Reposition Actions
+      </button>
+      <button
+        type="button"
+        tabIndex={0}
+        onClick={() => {
+          const item = menu
+            .getState()
+            .items.find((item) => item.element?.textContent === lastAction);
+          if (item) {
+            menu.move(item.id);
+          }
+        }}
+      >
+        Move to last Actions action
+      </button>
+      <button type="button" tabIndex={0} onClick={() => releaseRef.current?.()}>
+        Finish Actions positioning
+      </button>
+      {/* Last of the controls, so the open menu covers only the spacer below
+      instead of the buttons that drive it. */}
+      <Ariakit.MenuButton store={menu} tabIndex={0} onClick={holdNextPass}>
+        Actions
+      </Ariakit.MenuButton>
+      {/* hideOnInteractOutside is off so the buttons above can drive the menu
+      without closing it. flip and slide are off so the menu keeps a predictable
+      geometry: its last item stays below the fold until something scrolls to
+      it. */}
+      <Ariakit.Menu
+        store={menu}
+        updatePosition={updatePosition}
+        hideOnInteractOutside={false}
+        portal={false}
+        flip={false}
+        slide={false}
+        style={{ background: "white", border: "1px solid gray" }}
+      >
+        {actions.map((action) => (
+          <Ariakit.MenuItem
+            key={action}
+            style={{ display: "block", height: 32 }}
+          >
+            {action}
+          </Ariakit.MenuItem>
+        ))}
+      </Ariakit.Menu>
+      <div style={{ height: 1500 }} />
+    </main>
+  );
+}

--- a/app/src/sandbox/menu-placing-pass/index.react.tsx
+++ b/app/src/sandbox/menu-placing-pass/index.react.tsx
@@ -17,6 +17,8 @@ const actions = Array.from(
 
 const lastAction = `Action ${actionCount}`;
 
+const measureError = "Could not measure the Actions menu";
+
 /**
  * A menu whose positioning finishes in two steps: it places itself with what it
  * knows, waits for asynchronous work that can change where it belongs, then
@@ -52,7 +54,7 @@ export default function Example() {
       };
       failRef.current = () => {
         settle();
-        reject(new Error("Could not measure the Actions menu"));
+        reject(new Error(measureError));
       };
     });
   };
@@ -62,6 +64,11 @@ export default function Example() {
       await updatePosition();
     }
     const held = holdRef.current;
+    // Once the supplied default is held back, every later pass fails the same
+    // way. Resolving here instead would report a finished pass that positioned
+    // nothing, which is not a state a real callback sits in, and the popup
+    // would count itself as placed on the next `autoUpdate` run.
+    if (!held && skipRef.current) throw new Error(measureError);
     if (!held) return;
     await held;
     await updatePosition();

--- a/app/src/sandbox/menu-placing-pass/index.react.tsx
+++ b/app/src/sandbox/menu-placing-pass/index.react.tsx
@@ -129,6 +129,11 @@ export default function Example() {
 
   return (
     <main style={{ display: "grid", gap: 8, justifyItems: "start" }}>
+      {/* Its own scenario, above everything the Actions menu uses. Each menu
+      opens into the spacer that follows its own controls, so neither one can
+      cover the buttons that drive the other and both stay drivable in any
+      order. */}
+      <LateMountedMenu />
       {/* Puts the controls below the fold so the page is scrolled while the
       menu is open, which is the only way a page jump is observable. */}
       <div style={{ height: 900 }} />
@@ -177,8 +182,8 @@ export default function Example() {
       >
         Skip Actions positioning
       </button>
-      {/* Last of the controls, so the open menu covers only the spacer below
-      instead of the buttons that drive it. */}
+      {/* Last of the buttons that drive it, and the spacer below is taller than
+      the open menu, so opening it covers no control. */}
       <Ariakit.MenuButton store={menu} tabIndex={0} onClick={holdNextPass}>
         Actions
       </Ariakit.MenuButton>
@@ -204,7 +209,6 @@ export default function Example() {
           </Ariakit.MenuItem>
         ))}
       </Ariakit.Menu>
-      <LateMountedMenu />
       <div style={{ height: 1500 }} />
     </main>
   );

--- a/app/src/sandbox/menu-placing-pass/index.react.tsx
+++ b/app/src/sandbox/menu-placing-pass/index.react.tsx
@@ -1,6 +1,7 @@
 import * as Ariakit from "@ariakit/react";
+import { sync } from "@ariakit/store";
 import type { ComponentProps } from "react";
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 
 type MenuProps = ComponentProps<typeof Ariakit.Menu>;
 type UpdatePosition = NonNullable<MenuProps["updatePosition"]>;
@@ -33,11 +34,39 @@ export default function Example() {
   const menu = Ariakit.useMenuStore();
   const holdRef = useRef<Promise<void> | null>(null);
   const releaseRef = useRef<(() => void) | null>(null);
+  const placing = Ariakit.useStoreState(menu, "unstable_placing");
+
+  // TODO: remove once https://github.com/ariakit/ariakit/issues/7019 is fixed.
+  // Holds the state asserted for the rest of a pass the popup has already
+  // published as finished. A listener rather than a write after the awaited
+  // pass, because the popup notifies its subscribers synchronously, and
+  // registered at mount, so it runs ahead of the subscription a presentation
+  // makes for itself later.
+  useEffect(
+    () =>
+      sync(menu, ["unstable_placing"], (state) => {
+        if (!holdRef.current) return;
+        // Read rather than subscribed: a popup that closed mid-pass is not
+        // placing, and re-asserting here would strand the state with nobody
+        // left to clear it.
+        if (!menu.getState().mounted) return;
+        if (state.unstable_placing) return;
+        menu.setState("unstable_placing", true);
+      }),
+    [menu],
+  );
 
   // Armed before the pass starts, so every run `autoUpdate` makes for that pass
   // waits on the same promise instead of each creating its own and settling on
   // its own.
   const holdNextPass = () => {
+    // TODO: remove once https://github.com/ariakit/ariakit/issues/7019 is
+    // fixed. The popup asserts this only when it is shown, so a pass this app
+    // starts on an already open popup has to say so by hand. A closed popup
+    // starts no pass, and nothing would clear the state again.
+    if (menu.getState().mounted) {
+      menu.setState("unstable_placing", true);
+    }
     holdRef.current ??= new Promise<void>((resolve) => {
       releaseRef.current = () => {
         holdRef.current = null;
@@ -99,6 +128,10 @@ export default function Example() {
       <Ariakit.Menu
         store={menu}
         updatePosition={updatePosition}
+        // TODO: remove once https://github.com/ariakit/ariakit/issues/7019 is
+        // fixed. The popup gates its initial focus on placement state it keeps
+        // to itself, which no store write can reach, so gate it here too.
+        autoFocusOnShow={!placing}
         hideOnInteractOutside={false}
         portal={false}
         flip={false}

--- a/app/src/sandbox/menu-placing-pass/index.react.tsx
+++ b/app/src/sandbox/menu-placing-pass/index.react.tsx
@@ -1,7 +1,6 @@
 import * as Ariakit from "@ariakit/react";
-import { sync } from "@ariakit/store";
 import type { ComponentProps } from "react";
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 
 type MenuProps = ComponentProps<typeof Ariakit.Menu>;
 type UpdatePosition = NonNullable<MenuProps["updatePosition"]>;
@@ -34,39 +33,11 @@ export default function Example() {
   const menu = Ariakit.useMenuStore();
   const holdRef = useRef<Promise<void> | null>(null);
   const releaseRef = useRef<(() => void) | null>(null);
-  const placing = Ariakit.useStoreState(menu, "unstable_placing");
-
-  // TODO: remove once https://github.com/ariakit/ariakit/issues/7019 is fixed.
-  // Holds the state asserted for the rest of a pass the popup has already
-  // published as finished. A listener rather than a write after the awaited
-  // pass, because the popup notifies its subscribers synchronously, and
-  // registered at mount, so it runs ahead of the subscription a presentation
-  // makes for itself later.
-  useEffect(
-    () =>
-      sync(menu, ["unstable_placing"], (state) => {
-        if (!holdRef.current) return;
-        // Read rather than subscribed: a popup that closed mid-pass is not
-        // placing, and re-asserting here would strand the state with nobody
-        // left to clear it.
-        if (!menu.getState().mounted) return;
-        if (state.unstable_placing) return;
-        menu.setState("unstable_placing", true);
-      }),
-    [menu],
-  );
 
   // Armed before the pass starts, so every run `autoUpdate` makes for that pass
   // waits on the same promise instead of each creating its own and settling on
   // its own.
   const holdNextPass = () => {
-    // TODO: remove once https://github.com/ariakit/ariakit/issues/7019 is
-    // fixed. The popup asserts this only when it is shown, so a pass this app
-    // starts on an already open popup has to say so by hand. A closed popup
-    // starts no pass, and nothing would clear the state again.
-    if (menu.getState().mounted) {
-      menu.setState("unstable_placing", true);
-    }
     holdRef.current ??= new Promise<void>((resolve) => {
       releaseRef.current = () => {
         holdRef.current = null;
@@ -128,10 +99,6 @@ export default function Example() {
       <Ariakit.Menu
         store={menu}
         updatePosition={updatePosition}
-        // TODO: remove once https://github.com/ariakit/ariakit/issues/7019 is
-        // fixed. The popup gates its initial focus on placement state it keeps
-        // to itself, which no store write can reach, so gate it here too.
-        autoFocusOnShow={!placing}
         hideOnInteractOutside={false}
         portal={false}
         flip={false}

--- a/app/src/sandbox/menu-placing-pass/index.react.tsx
+++ b/app/src/sandbox/menu-placing-pass/index.react.tsx
@@ -33,22 +33,34 @@ export default function Example() {
   const menu = Ariakit.useMenuStore();
   const holdRef = useRef<Promise<void> | null>(null);
   const releaseRef = useRef<(() => void) | null>(null);
+  const failRef = useRef<(() => void) | null>(null);
+  const skipRef = useRef(false);
 
   // Armed before the pass starts, so every run `autoUpdate` makes for that pass
   // waits on the same promise instead of each creating its own and settling on
   // its own.
   const holdNextPass = () => {
-    holdRef.current ??= new Promise<void>((resolve) => {
-      releaseRef.current = () => {
+    holdRef.current ??= new Promise<void>((resolve, reject) => {
+      const settle = () => {
         holdRef.current = null;
         releaseRef.current = null;
+        failRef.current = null;
+      };
+      releaseRef.current = () => {
+        settle();
         resolve();
+      };
+      failRef.current = () => {
+        settle();
+        reject(new Error("Could not measure the Actions menu"));
       };
     });
   };
 
   const updatePosition: UpdatePosition = async ({ updatePosition }) => {
-    await updatePosition();
+    if (!skipRef.current) {
+      await updatePosition();
+    }
     const held = holdRef.current;
     if (!held) return;
     await held;
@@ -86,6 +98,24 @@ export default function Example() {
       </button>
       <button type="button" tabIndex={0} onClick={() => releaseRef.current?.()}>
         Finish Actions positioning
+      </button>
+      {/* The asynchronous work a real callback awaits can fail. The pass is
+      over either way, and the popup already carries the position the supplied
+      default wrote before the failure. */}
+      <button type="button" tabIndex={0} onClick={() => failRef.current?.()}>
+        Fail Actions positioning
+      </button>
+      {/* Holds the supplied default back, so the next pass fails without ever
+      positioning the popup. That one has nothing to show, so it has to stay
+      unplaced. */}
+      <button
+        type="button"
+        tabIndex={0}
+        onClick={() => {
+          skipRef.current = true;
+        }}
+      >
+        Skip Actions positioning
       </button>
       {/* Last of the controls, so the open menu covers only the spacer below
       instead of the buttons that drive it. */}

--- a/app/src/sandbox/menu-placing-pass/index.react.tsx
+++ b/app/src/sandbox/menu-placing-pass/index.react.tsx
@@ -20,6 +20,59 @@ const lastAction = `Action ${actionCount}`;
 const measureError = "Could not measure the Actions menu";
 
 /**
+ * The same held pass, in a menu that mounts only once its store is already
+ * open. No `Popover` is mounted when the popup shows, so nothing publishes the
+ * show transition and the popup starts out looking placed until its own layout
+ * effect says otherwise. What keeps focus out in the meantime is that no commit
+ * carries a connected content element while the popup still looks placed, and
+ * nothing else covers that flow.
+ */
+function LateMountedMenu() {
+  const menu = Ariakit.useMenuStore();
+  const open = Ariakit.useStoreState(menu, "open");
+  const releaseRef = useRef<(() => void) | null>(null);
+
+  const updatePosition: UpdatePosition = async ({ updatePosition }) => {
+    await updatePosition();
+    await new Promise<void>((resolve) => {
+      releaseRef.current = resolve;
+    });
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        tabIndex={0}
+        onClick={() => {
+          const release = releaseRef.current;
+          releaseRef.current = null;
+          release?.();
+        }}
+      >
+        Finish Late actions positioning
+      </button>
+      <Ariakit.MenuButton store={menu} tabIndex={0}>
+        Late actions
+      </Ariakit.MenuButton>
+      {open && (
+        <Ariakit.Menu
+          store={menu}
+          updatePosition={updatePosition}
+          hideOnInteractOutside={false}
+          portal={false}
+          style={{ background: "white", border: "1px solid gray" }}
+        >
+          <Ariakit.MenuItem style={{ display: "block" }}>
+            Rename
+          </Ariakit.MenuItem>
+        </Ariakit.Menu>
+      )}
+    </>
+  );
+}
+
+/**
  * A menu whose positioning finishes in two steps: it places itself with what it
  * knows, waits for asynchronous work that can change where it belongs, then
  * places itself again. `updatePosition` is the public way to express that, and
@@ -151,6 +204,7 @@ export default function Example() {
           </Ariakit.MenuItem>
         ))}
       </Ariakit.Menu>
+      <LateMountedMenu />
       <div style={{ height: 1500 }} />
     </main>
   );

--- a/app/src/sandbox/menu-placing-pass/test-browser.ts
+++ b/app/src/sandbox/menu-placing-pass/test-browser.ts
@@ -52,6 +52,68 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(lastItem).toBeInViewport();
   });
 
+  // A pass that fails has still ended, and when the supplied default already
+  // wrote a position the popup is somewhere real. Leaving it marked unplaced
+  // strands everything waiting on it: the items keep taking focus but the page
+  // never follows, so navigating past the fold walks focus onto items the user
+  // cannot see.
+  // Browser-only: the popover hands `update` to `autoUpdate`, which never
+  // awaits it, so a rejecting callback also surfaces as an unhandled rejection.
+  // Vitest fails a run on that regardless of what the page does with it, and
+  // the popover rethrows on purpose.
+  // https://github.com/ariakit/ariakit/pull/7032#discussion_r3702887246
+  test("publishes the popup as placed when a custom updatePosition fails after positioning it", async ({
+    page,
+    q,
+  }) => {
+    const menu = q.menu("Actions");
+    const firstItem = q.menuitem("Action 1");
+    const lastItem = q.menuitem("Action 30");
+
+    await page.evaluate(() => window.scrollTo({ top: 700 }));
+    await test.expect.poll(() => page.evaluate(() => window.scrollY)).toBe(700);
+
+    await q.button("Actions").click();
+    await test.expect(menu).toBeVisible();
+    await test.expect(firstItem).toBeInViewport();
+    await test.expect(menu).toHaveAttribute("data-placing");
+
+    await q.button("Move to last Actions action").click();
+    await test.expect(lastItem).toHaveAttribute("data-active-item");
+    // Same checkpoint as the first test: a presentation that is waiting has no
+    // positive state, so wait through where its scroll would have landed.
+    await flushFrames(page);
+    await test.expect(lastItem).not.toBeInViewport();
+
+    await q.button("Fail Actions positioning").click();
+    await test.expect(menu).not.toHaveAttribute("data-placing");
+    await test.expect(lastItem).toBeInViewport();
+  });
+
+  // The other half of the same rule, and the only thing separating it from
+  // clearing the state on any failure: a pass that fails before it positions
+  // anything has nothing to move focus or scroll to, so the popup keeps
+  // waiting.
+  // https://github.com/ariakit/ariakit/pull/7032#discussion_r3702887246
+  test("keeps the popup unplaced when a custom updatePosition fails before positioning it", async ({
+    page,
+    q,
+  }) => {
+    const menu = q.menu("Actions");
+
+    await q.button("Skip Actions positioning").click();
+    await q.button("Actions").click();
+    await test.expect(menu).toBeVisible();
+    await test.expect(menu).toHaveAttribute("data-placing");
+
+    await q.button("Fail Actions positioning").click();
+    // Staying unplaced has no positive state, so wait through the checkpoint
+    // where the release would have landed.
+    await flushFrames(page);
+    await test.expect(menu).toHaveAttribute("data-placing");
+    await test.expect(menu).not.toBeFocused();
+  });
+
   // Re-anchoring an open popup starts a new positioning pass, and the popup is
   // no more placed during that pass than it was during the first one. A
   // presentation that runs anyway acts on the position the popup is leaving.

--- a/app/src/sandbox/menu-placing-pass/test-browser.ts
+++ b/app/src/sandbox/menu-placing-pass/test-browser.ts
@@ -165,4 +165,24 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(menu).not.toHaveAttribute("data-placing");
     await test.expect(lastItem).toBeInViewport();
   });
+
+  // A popup that mounts only once its store is already open has no `Popover`
+  // mounted to publish the show transition, so it starts out looking placed.
+  // Focus must still stay out until its pass finishes.
+  // https://github.com/ariakit/ariakit/pull/7032#discussion_r3703769238
+  test("keeps focus out of a popup that mounts after its store is open", async ({
+    q,
+  }) => {
+    const menu = q.menu("Late actions");
+    const trigger = q.button("Late actions");
+
+    await trigger.click();
+    await test.expect(menu).toBeVisible();
+    await test.expect(menu).toHaveAttribute("data-placing");
+    await test.expect(trigger).toBeFocused();
+
+    await q.button("Finish Late actions positioning").click();
+    await test.expect(menu).not.toHaveAttribute("data-placing");
+    await test.expect(menu).toBeFocused();
+  });
 });

--- a/app/src/sandbox/menu-placing-pass/test-browser.ts
+++ b/app/src/sandbox/menu-placing-pass/test-browser.ts
@@ -1,0 +1,94 @@
+import { flushFrames, withFramework } from "#app/test-utils/preview.ts";
+import { recordScrollEvents } from "#app/test-utils/scroll.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // A custom `updatePosition` that calls the supplied default and then keeps
+  // working owns the whole pass: the popup is only where it belongs once that
+  // callback returns. Publishing readiness when the inner default pass resolves
+  // lets a pending presentation scroll the page to an intermediate position.
+  // `data-placing` is pinned alongside the scroll because it is the state the
+  // presentation waits on, so a green scroll assertion would otherwise not
+  // distinguish "waited" from "had nothing to do".
+  // https://github.com/ariakit/ariakit/issues/7019
+  test("keeps the popup unplaced while a custom updatePosition is still working", async ({
+    page,
+    q,
+  }) => {
+    const menu = q.menu("Actions");
+    const firstItem = q.menuitem("Action 1");
+    const lastItem = q.menuitem("Action 30");
+
+    await page.evaluate(() => window.scrollTo({ top: 700 }));
+    await test.expect.poll(() => page.evaluate(() => window.scrollY)).toBe(700);
+
+    await q.button("Actions").click();
+    await test.expect(menu).toBeVisible();
+    // The default pass has written a transform by now, which is what brings the
+    // menu under its button, so the callback is the only thing left to wait for.
+    await test.expect(firstItem).toBeInViewport();
+    // A popup that isn't placed doesn't take its initial focus, so focus
+    // staying on the button is the user-facing half of the state the attribute
+    // mirrors.
+    await test.expect(q.button("Actions")).toBeFocused();
+    await test.expect(menu).toHaveAttribute("data-placing");
+    await test.expect(lastItem).not.toBeInViewport();
+
+    const scroll = await recordScrollEvents(page);
+    await q.button("Move to last Actions action").click();
+    await test.expect(lastItem).toHaveAttribute("data-active-item");
+
+    // There is no positive state for a presentation that is waiting, so wait
+    // through the checkpoint where its scroll would have landed.
+    await flushFrames(page);
+    await test.expect(lastItem).not.toBeInViewport();
+    test.expect(await scroll.events()).not.toContain("document");
+
+    await q.button("Finish Actions positioning").click();
+    await test.expect(menu).not.toHaveAttribute("data-placing");
+    await test.expect(lastItem).toBeInViewport();
+  });
+
+  // Re-anchoring an open popup starts a new positioning pass, and the popup is
+  // no more placed during that pass than it was during the first one. A
+  // presentation that runs anyway acts on the position the popup is leaving.
+  // Browser-only: an already open popup has no initial focus left to take, and
+  // the focus half of a presentation never waits on placement, so the document
+  // scroll is the only user-facing difference here and happy-dom cannot model
+  // it because it stubs `scrollIntoView`.
+  // https://github.com/ariakit/ariakit/issues/7019
+  test("keeps the popup unplaced while an open popup repositions itself", async ({
+    page,
+    q,
+  }) => {
+    const menu = q.menu("Actions");
+    const firstItem = q.menuitem("Action 1");
+    const lastItem = q.menuitem("Action 30");
+
+    await page.evaluate(() => window.scrollTo({ top: 700 }));
+    await test.expect.poll(() => page.evaluate(() => window.scrollY)).toBe(700);
+
+    await q.button("Actions").click();
+    await test.expect(menu).toBeVisible();
+    await q.button("Finish Actions positioning").click();
+    await test.expect(menu).not.toHaveAttribute("data-placing");
+    await test.expect(firstItem).toBeInViewport();
+    await test.expect(lastItem).not.toBeInViewport();
+
+    await q.button("Reposition Actions").click();
+    await test.expect(menu).toHaveAttribute("data-placing");
+
+    const scroll = await recordScrollEvents(page);
+    await q.button("Move to last Actions action").click();
+    await test.expect(lastItem).toHaveAttribute("data-active-item");
+
+    // Same checkpoint as the first test: a presentation that is waiting has no
+    // positive state, so wait through where its scroll would have landed.
+    await flushFrames(page);
+    await test.expect(lastItem).not.toBeInViewport();
+    test.expect(await scroll.events()).not.toContain("document");
+
+    await q.button("Finish Actions positioning").click();
+    await test.expect(menu).not.toHaveAttribute("data-placing");
+    await test.expect(lastItem).toBeInViewport();
+  });
+});

--- a/app/src/sandbox/menu-placing-pass/test-browser.ts
+++ b/app/src/sandbox/menu-placing-pass/test-browser.ts
@@ -43,6 +43,10 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(lastItem).not.toBeInViewport();
     test.expect(await scroll.events()).not.toContain("document");
 
+    // The scroll the presentation held back lands once the pass is over. This
+    // proves that half was deferred rather than dropped; it does not tell the
+    // two worlds apart, because the unfixed one reaches the same offset
+    // earlier, which is what the assertions before the release cover.
     await q.button("Finish Actions positioning").click();
     await test.expect(menu).not.toHaveAttribute("data-placing");
     await test.expect(lastItem).toBeInViewport();
@@ -71,6 +75,10 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(menu).toBeVisible();
     await q.button("Finish Actions positioning").click();
     await test.expect(menu).not.toHaveAttribute("data-placing");
+    // Focus is on the button that finished the pass, so the popup taking its
+    // show autofocus here is the one place in the suite that separates holding
+    // that half back from removing it.
+    await test.expect(menu).toBeFocused();
     await test.expect(firstItem).toBeInViewport();
     await test.expect(lastItem).not.toBeInViewport();
 
@@ -87,6 +95,10 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(lastItem).not.toBeInViewport();
     test.expect(await scroll.events()).not.toContain("document");
 
+    // The scroll the presentation held back lands once the pass is over. This
+    // proves that half was deferred rather than dropped; it does not tell the
+    // two worlds apart, because the unfixed one reaches the same offset
+    // earlier, which is what the assertions before the release cover.
     await q.button("Finish Actions positioning").click();
     await test.expect(menu).not.toHaveAttribute("data-placing");
     await test.expect(lastItem).toBeInViewport();

--- a/app/src/sandbox/menu-placing-pass/test.ts
+++ b/app/src/sandbox/menu-placing-pass/test.ts
@@ -21,3 +21,21 @@ test("keeps the popup unplaced while a custom updatePosition is still working", 
   await click(q.button("Finish Actions positioning"));
   expect(menu).not.toHaveAttribute("data-placing");
 });
+
+// The same flow in happy-dom, which is where the React 18 suite runs. What it
+// pins is a scheduling property rather than anything the browser decides: a
+// popup that mounts once its store is already open, with no `Popover` mounted
+// to publish the show transition, must not take focus before its own pass
+// finishes.
+// https://github.com/ariakit/ariakit/pull/7032#discussion_r3703769238
+test("keeps focus out of a popup that mounts after its store is open", async () => {
+  const trigger = q.button("Late actions");
+  await click(trigger);
+  const menu = q.menu("Late actions");
+  expect(menu).toHaveAttribute("data-placing");
+  expect(trigger).toHaveFocus();
+
+  await click(q.button("Finish Late actions positioning"));
+  expect(menu).not.toHaveAttribute("data-placing");
+  expect(menu).toHaveFocus();
+});

--- a/app/src/sandbox/menu-placing-pass/test.ts
+++ b/app/src/sandbox/menu-placing-pass/test.ts
@@ -1,0 +1,23 @@
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// The sandbox's other scenario, re-anchoring an already open popup, is covered
+// only by the browser test: an already open popup has no initial focus left to
+// take, and the focus half of a presentation never waits on placement, so its
+// only user-facing effect is a document scroll that happy-dom cannot model.
+// https://github.com/ariakit/ariakit/issues/7019
+test("keeps the popup unplaced while a custom updatePosition is still working", async () => {
+  await click(q.button("Actions"));
+  const menu = q.menu("Actions");
+  // A popup that isn't placed doesn't take its initial focus, so focus staying
+  // on the button is the user-facing half of the state the attribute mirrors.
+  expect(q.button("Actions")).toHaveFocus();
+  expect(menu).toHaveAttribute("data-placing");
+
+  await click(q.button("Move to last Actions action"));
+  expect(q.menuitem("Action 30")).toHaveAttribute("data-active-item");
+  expect(menu).toHaveAttribute("data-placing");
+
+  await click(q.button("Finish Actions positioning"));
+  expect(menu).not.toHaveAttribute("data-placing");
+});

--- a/packages/ariakit-components/src/popover/popover-store.ts
+++ b/packages/ariakit-components/src/popover/popover-store.ts
@@ -144,11 +144,14 @@ export interface PopoverStoreState extends DialogStoreState {
    */
   rendered: symbol;
   /**
-   * Whether the popover is showing but hasn't been positioned yet.
+   * Whether the popover is showing and its current positioning pass hasn't
+   * written a position yet. Every pass asserts it, not just the one that
+   * follows the popover being shown.
    *
    * Components that move focus or scroll into the popup wait for this to become
    * `false`, otherwise they act on an element that's still at its
-   * pre-placement origin and drag the page along with it.
+   * pre-placement origin, or at a position it's about to leave, and drag the
+   * page along with it.
    * @private
    */
   unstable_placing: boolean;

--- a/packages/ariakit-components/src/popover/popover-store.ts
+++ b/packages/ariakit-components/src/popover/popover-store.ts
@@ -144,9 +144,14 @@ export interface PopoverStoreState extends DialogStoreState {
    */
   rendered: symbol;
   /**
-   * Whether the popover is showing and its current positioning pass hasn't
-   * written a position yet. Every pass asserts it, not just the one that
-   * follows the popover being shown.
+   * Whether the popover is showing and hasn't settled at the position its
+   * current positioning pass will leave it at. Every pass a commit starts
+   * asserts it, not just the one that follows the popover being shown: showing
+   * publishes it as soon as the store changes, while every other commit-started
+   * pass publishes it with its commit, so code that re-anchors and reads this
+   * in the same turn still sees the previous value. The `autoUpdate` runs that
+   * follow a scroll or a resize reposition an already placed popover without
+   * asserting it again.
    *
    * Components that move focus or scroll into the popup wait for this to become
    * `false`, otherwise they act on an element that's still at its

--- a/packages/ariakit-react-components/src/popover/popover.tsx
+++ b/packages/ariakit-react-components/src/popover/popover.tsx
@@ -22,7 +22,7 @@ import {
   size,
 } from "@floating-ui/dom";
 import type { ElementType, HTMLAttributes } from "react";
-import { useRef, useState } from "react";
+import { useRef } from "react";
 import type { DialogOptions } from "../dialog/dialog.tsx";
 import { createDialogComponent, useDialog } from "../dialog/dialog.tsx";
 import { isHidden } from "../disclosure/disclosure-content.tsx";
@@ -295,10 +295,11 @@ export const usePopover = createHook<TagName, PopoverOptions>(
 
     const defaultArrowElementRef = useRef<HTMLElement | null>(null);
 
-    // We have to wait for the popover to be positioned for the first time
-    // before we can move focus, otherwise there may be scroll jumps. See
-    // popover-standalone example test-browser file.
-    const [positioned, setPositioned] = useState(false);
+    // Focus can only move into the popover once it has been positioned,
+    // otherwise there may be scroll jumps. See the menu-placing-pass sandbox.
+    // That's the question `unstable_placing` already answers, so it's read from
+    // there rather than tracked a second time.
+    const positioned = !placing;
 
     const { portalRef, domReady } = usePortalRef(portal, props.portalRef);
 
@@ -330,6 +331,16 @@ export const usePopover = createHook<TagName, PopoverOptions>(
       !mounted && isHidden(mounted, props.hidden, props.alwaysVisible);
 
     useSafeLayoutEffect(() => {
+      // Every pass starts unplaced, not just the one that follows the popup
+      // being shown, so a popup that is re-anchored while open stops counting
+      // as placed until the new position has been written. Asserted before the
+      // guards below, because a pass that can't start hasn't placed anything
+      // either. Only while mounted: a popup with nothing to position, such as
+      // an `alwaysVisible` menu that is closed, must never be left waiting.
+      if (mounted) {
+        store?.setState("unstable_placing", true);
+      }
+
       if (!popoverElement?.isConnected) return;
 
       const positioningPadding = {
@@ -413,7 +424,6 @@ export const usePopover = createHook<TagName, PopoverOptions>(
         if (shouldCancelUpdate()) return;
 
         store?.setState("currentPlacement", pos.placement);
-        setPositioned(true);
 
         const x = roundByDPR(pos.x);
         const y = roundByDPR(pos.y);
@@ -424,11 +434,6 @@ export const usePopover = createHook<TagName, PopoverOptions>(
           left: "0",
           transform: `translate3d(${x}px,${y}px,0)`,
         });
-
-        // The popover is placed once its position has been written, not when
-        // computePosition resolves, so anything waiting to move focus or scroll
-        // into it never acts on the pre-placement origin.
-        store?.setState("unstable_placing", false);
 
         // https://floating-ui.com/docs/arrow#usage
         if (arrow && pos.middlewareData.arrow) {
@@ -473,14 +478,18 @@ export const usePopover = createHook<TagName, PopoverOptions>(
 
         if (hasCustomUpdatePosition) {
           await updatePositionProp({ updatePosition });
-          // User callbacks may keep awaiting after updatePosition has run, so
-          // make sure this effect is still current before marking it ready.
-          if (shouldCancelUpdate()) return;
-          setPositioned(true);
-          store?.setState("unstable_placing", false);
         } else {
           await updatePosition();
         }
+
+        // The pass owns the popover until it returns, so this is the only place
+        // that publishes it as placed. A custom updatePosition that calls the
+        // supplied default and then keeps working would otherwise hand
+        // readiness over as soon as that inner pass wrote its transform, and
+        // anything waiting to move focus or scroll into the popup would act on
+        // a position the callback is still about to change.
+        if (shouldCancelUpdate()) return;
+        store?.setState("unstable_placing", false);
       };
 
       // https://floating-ui.com/docs/autoUpdate
@@ -491,7 +500,6 @@ export const usePopover = createHook<TagName, PopoverOptions>(
 
       return () => {
         canceled = true;
-        setPositioned(false);
         cancelAutoUpdate();
       };
     }, [
@@ -542,13 +550,14 @@ export const usePopover = createHook<TagName, PopoverOptions>(
       return () => cancelAnimationFrame(raf);
     }, [mounted, domReady, popoverElement, contentElement]);
 
-    // Showing a popover makes it unplaced by definition, and that has to land
-    // before anything can read it. A layout effect can't publish it, because
-    // effects run children before parents, so the popover's own descendants
-    // would observe the previous value. Subscribing to the store instead means
-    // the transition is seen synchronously, wherever it comes from. Only a
-    // mounted Popover asserts this, so a popup with nothing to position, such
-    // as a combobox inside a plain dialog, is never left waiting.
+    // The positioning effect above asserts this at the start of every pass, but
+    // it can't be what publishes the show transition. Layout effects run
+    // children before parents, so the popover's own descendants would observe
+    // the previous value on the commit that opens the popup. Subscribing to the
+    // store instead means the transition is seen synchronously, wherever it
+    // comes from. Only a mounted Popover asserts this, so a popup with nothing
+    // to position, such as a combobox inside a plain dialog, is never left
+    // waiting.
     // This state must never outlive its writer: it's asserted here and cleared
     // by the positioning effect, both owned by this component, while the store
     // it lives on can be owned by an ancestor. A Popover that unmounts, or that

--- a/packages/ariakit-react-components/src/popover/popover.tsx
+++ b/packages/ariakit-react-components/src/popover/popover.tsx
@@ -371,6 +371,9 @@ export const usePopover = createHook<TagName, PopoverOptions>(
       // Each effect run owns this flag. Cleanup marks stale runs so in-flight
       // async positioning work can skip state and style writes.
       let canceled = false;
+      // Whether this effect run has written a position, which is what makes the
+      // popover somewhere real rather than at its pre-placement origin.
+      let placed = false;
 
       const shouldCancelUpdate = () => {
         if (canceled) return true;
@@ -435,6 +438,8 @@ export const usePopover = createHook<TagName, PopoverOptions>(
           transform: `translate3d(${x}px,${y}px,0)`,
         });
 
+        placed = true;
+
         // https://floating-ui.com/docs/arrow#usage
         if (arrow && pos.middlewareData.arrow) {
           const { x: arrowX, y: arrowY } = pos.middlewareData.arrow;
@@ -476,18 +481,32 @@ export const usePopover = createHook<TagName, PopoverOptions>(
       const update = async () => {
         if (shouldCancelUpdate()) return;
 
-        if (hasCustomUpdatePosition) {
-          await updatePositionProp({ updatePosition });
-        } else {
-          await updatePosition();
+        try {
+          if (hasCustomUpdatePosition) {
+            await updatePositionProp({ updatePosition });
+          } else {
+            await updatePosition();
+          }
+        } catch (error) {
+          // A pass that throws has still ended. Publish the popover as placed
+          // if this run wrote a position before failing, so a custom
+          // updatePosition that positions the popover and then fails doesn't
+          // strand everything waiting on it. A pass that failed before writing
+          // anything keeps waiting, because there's still nothing to move focus
+          // or scroll to. Rethrowing keeps the failure visible to the app.
+          if (placed && !shouldCancelUpdate()) {
+            store?.setState("unstable_placing", false);
+          }
+          throw error;
         }
 
         // The pass owns the popover until it returns, so this is the only place
-        // that publishes it as placed. A custom updatePosition that calls the
-        // supplied default and then keeps working would otherwise hand
-        // readiness over as soon as that inner pass wrote its transform, and
-        // anything waiting to move focus or scroll into the popup would act on
-        // a position the callback is still about to change.
+        // that publishes it as placed on the success path. A custom
+        // updatePosition that calls the supplied default and then keeps working
+        // would otherwise hand readiness over as soon as that inner pass wrote
+        // its transform, and anything waiting to move focus or scroll into the
+        // popover would act on a position the callback is still about to
+        // change.
         if (shouldCancelUpdate()) return;
         store?.setState("unstable_placing", false);
       };


### PR DESCRIPTION
## Motivation

Fixes #7019.

`usePopover` tracks whether the popover has been placed twice: a local `positioned` state and the `unstable_placing` store state that `data-placing` mirrors. They agree on the show transition and disagree everywhere else, and each disagreement is a real behavior difference.

The positioning effect's cleanup resets `positioned`, but nothing re-asserts `unstable_placing`, and its publisher only asserts it on `mounted` changes. So every re-run of that effect on an already open popup, driven by `placement`, `anchorElement`, `rendered`, `gutter`, `sameWidth` and the rest of its dependency list, leaves the popup marked as placed while it is being positioned again. Anything waiting on that state, such as composite item presentation and [`Combobox`](https://ariakit.com/reference/combobox) auto-select, acts on the position the popup is leaving.

A custom [`updatePosition`](https://ariakit.com/reference/popover#updateposition) that calls the supplied default and then keeps working has the same problem earlier: both writes sit inside that default pass, so the popup publishes itself as placed while the callback that owns the pass is still running.

```tsx
<Menu
  updatePosition={async ({ updatePosition }) => {
    // Places the popup with what it has.
    await updatePosition();
    // Everything after this runs against a popup that already counts as placed.
    await measureContent();
    await updatePosition();
  }}
/>
```

## Solution

The positioning effect now asserts `unstable_placing` at the start of every pass, not just the one that follows the popup being shown, and `positioned` is derived from it instead of being tracked in its own `useState`. The two can no longer disagree, `data-placing` means what it did before #7009, and one piece of state plus the re-render it caused are gone.

Only the effect asserts it, so the `autoUpdate` runs that follow a scroll or a resize still reposition without marking the popup unplaced again.

The write that publishes the popup as placed moved out of the default `updatePosition` and into the outer update, after whichever branch ran. That is what makes a custom callback own its whole pass.

## Preview

The same sandbox on both sides: the page is scrolled, the menu opens with its positioning pass held open, and the app moves the active item to the last one in a menu taller than the viewport.

Before, the popup counts itself as placed as soon as the supplied default pass writes a transform, so the page moves twice while the pass is still running. After, it stays put until the pass finishes, then moves once.

[popover-placing-pass.webm](https://github.com/user-attachments/assets/d6eca923-4c04-4520-9319-ef250436aa7e)

## Reproduction

`app/src/sandbox/menu-placing-pass` is a menu whose positioning pass can be held open, which is what makes the window observable. Its browser test covers both halves through the page scroll a pending presentation causes, and its happy-dom test covers the custom callback through the popup taking its initial focus early.

The re-anchoring half is browser-only. An already open popup has no initial focus left to take, and the focus half of a presentation never waits on placement, so its only user-facing effect is a document scroll that happy-dom cannot model.

## Workaround

Until the fix is released, an app can hold the popup's placing state asserted for a whole pass by hand. Three pieces are needed, because the popup leaves three separate gaps.

```tsx
// TODO: remove once https://github.com/ariakit/ariakit/issues/7019 is fixed.
const placing = useStoreState(store, "unstable_placing");

// 1. The popup marks itself as placed as early as the end of the supplied
// default pass. Re-assert it from a listener rather than from after the awaited
// pass: the popup notifies its subscribers synchronously, so a later write is
// already too late, and any `autoUpdate` run during the pass would let a
// waiting presentation through. Registered at mount, so it runs ahead of the
// subscription a presentation makes for itself.
useEffect(
  () =>
    sync(store, ["unstable_placing"], (state) => {
      if (!settlingRef.current) return;
      if (!store.getState().mounted) return;
      if (state.unstable_placing) return;
      store.setState("unstable_placing", true);
    }),
  [store],
);

// 2. The popup asserts the state only when it is shown, so a pass the app
// starts on an already open popup has to say so by hand.
if (store.getState().mounted) {
  store.setState("unstable_placing", true);
}
store.render();

// 3. The popup gates its initial focus on placement state it keeps to itself,
// which no store write can reach.
<Popover store={store} updatePosition={updatePosition} autoFocusOnShow={!placing} />;
```

Assumptions and limitations:

- `unstable_placing` is a private store state with no compatibility guarantee, and this pull request reworks its lifecycle.
- `sync` ships from `@ariakit/store`, which `@ariakit/react` does not re-export, so this needs a direct dependency on that package.
- The listener has to be registered before any presentation subscribes, which mount time satisfies. A presentation left pending across a remount of the component that owns the listener is not covered.
- The `mounted` guards matter. Without the first, closing the popup mid-pass strands the state asserted with nobody left to clear it; without the second, arming a pass while the popup is closed leaves `data-placing` on a hidden element.
- The [`autoFocusOnShow`](https://ariakit.com/reference/dialog#autofocusonshow) gate defers the popup's initial focus rather than removing it, so it has to be derived from state that is asserted before the pass starts.

Apps that can tolerate an unplaced popup while their asynchronous work runs have a simpler option for the custom-callback half alone: do the work first and call the supplied default last, so the popup publishes readiness at the right moment with no store writes at all.

## Review gate reassessment

<details>
<summary>Cycle 3: Narrow the covered layers, keep the fixture</summary>

**Assessment**

Issue #7019 describes one bounded regression and one pre-existing behavior, both P2, neither from a user report. The fix touches the positioning path that gates autofocus for every popover-backed component, so its blast radius is larger than either symptom.

The reproduction itself is inert: three files, no library branches, no public contract, in line with the sibling fixtures `composite-presentation-cancel-on-close` (196 lines) and `popover-stale-position` (149 lines). Every apparently elaborate element is load-bearing: the item count and fixed heights are what put the last item outside the viewport after placement, without which the viewport assertions are vacuous, and `flip={false} slide={false}` is what keeps that precondition stable rather than incidental.

Three of the five findings across the first three rounds targeted the happy-dom duplicate, the one artifact that is optional under repository policy. No round proposed a cut to the sandbox or the browser test. The repeated cycles were circling one removable file rather than converging on a fixture that is too large.

**Decision**

Narrow the covered layers instead of continuing unchanged. The happy-dom duplicate's re-anchoring test was removed, because a reposition pass has no user-facing consequence that happy-dom can model, and covering it there meant pinning `data-placing` with nothing beside it. The browser test now owns that half authoritatively through the page scroll, and both files record why.

Everything else was kept. Extending `composite-presentation-cancel-on-close` was rejected because its held callback deliberately never calls the supplied default, so its tests depend on the popup staying at its pre-placement origin, and extending `popover-stale-position` was rejected because it has no composite and its assertions depend on its own geometry.

Known maintenance property: the fixture's precondition is that the last item sits outside the viewport after placement. It has comfortable margin at the desktop projects' 1280x720, and the `test-browser.ts` filename keeps it off the mobile projects.

</details>

<details>
<summary>Cycle 6: Freeze the workaround code, move its rationale into this description</summary>

**Assessment**

Six finding-bearing rounds on the workaround produced no behavioral defect in it. Two produced verified improvements: a mount-time store listener replacing a write after the awaited pass, which closed a measured escape window, and deleting a piece of component state the listener made unnecessary. Piece count never grew; the app now carries one fewer piece of React state than at the first reviewed state.

Each of the three pieces maps one-to-one onto a distinct gap and none is removable without failing a reproduction test. The shape is dictated by the bug, not by review pressure.

Where the cost landed was prose. The diff carried roughly twice as many comment lines as code lines, on code the next commit deletes, and five of six rounds found a mechanism claim inside those comments that a later round disproved.

**Decision**

Keep all three pieces and freeze the code. In-code comments are held to what a reader can check in the diff; the mechanism narrative moved to the `## Workaround` section above, where it survives the revert instead of being deleted with the code. Comment volume was roughly halved.

The reassessment also found a defect no review round had caught: the mount-time listener outlived the popup's mount, so closing the popup mid-pass re-asserted over the library's own teardown and stranded the state. Both `mounted` guards in the snippet above come from that, and both were verified in a browser.

Rejected alternatives: dropping the sandbox demonstration and documenting the workaround only here, which would ship unverified consumer advice; and reverting the listener to the simpler in-callback write, which saves seven lines but reopens the escape window that an ancestor scroll or a resize during the pass reaches.

</details>


<details>
<summary>Cycle 9: Keep the fixture whole, remove the coupling instead of the tenant</summary>

**Assessment**

The library change has been stable since cycle 6. Cycles 7, 8, and 9 were entirely fixture and prose: a flake in the skip path, a coverage gap for a late-mounted popup, a doc claim about when the state is asserted, and now a layout trap. That split matters, because it says the design is settled and the remaining cost is in the artifact that demonstrates it.

Sized against what it buys: the popover diff is 19 added code lines against 11 removed, a net of 8, seven of which are the error path that hoisting the clear out of the default pass made necessary. It deletes a `useState` and a re-render per positioning pass. The rest of its 82 lines are comments. The parallel advisor also established that `unstable_placing` has never shipped, since the changeset from #7009 is still pending, so the issue's first half is a fix against an unreleased state and only the custom-callback half reaches released users. That argues for less churn here, not more.

The advisor recommended extracting `LateMountedMenu` into its own sandbox, on the grounds that the two scenarios share only a CSS grid and that moving the component merely re-solves the layout puzzle, leaving a third arrangement one `<main>` append away. That last claim is the load-bearing one and it does not survive measurement. In the arrangement adopted here each menu sits immediately above a spacer taller than itself, 962px of menu above a 1500px spacer and 26px above a 900px spacer, so an appended control lands clear of both. Appending one and driving both menus was tested in a browser: nothing is covered. The advisor's other stated extraction cost, a changed visual baseline, does not exist either, because `app/src/lib/preview-index.ts` filters sandboxes out of the visual index and this fixture has no screenshots.

On the substance, `ariakit-ariakit-example-playwright-test` asks that a coherent scenario extend an existing semantic fixture rather than fork a parallel one. The late-mount case asserts the same contract as the other four tests, that focus waits on the positioning pass, reached through a different mounting path. It is coherent with them, and it is the only pin on a guarantee this pull request relocated: before the change `useState(false)` made `positioned` false at mount, and after it safety on those first commits rests entirely on the dialog's `isConnected` guard.

**Decision**

Continue. `LateMountedMenu` stays in `menu-placing-pass`, and the coupling that caused the recurrence is removed instead by moving it above everything the Actions menu uses. Both edited comments now state invariants a reader can check from the file rather than positions in a list, which is the specific failure this cycle started with.

Rejected alternatives: extraction, for the reasons above; the review comment's own suggestion of moving the component just above the `Actions` button, which was measured to trade the bug for its mirror, with the settled late menu covering the `Actions` trigger; placing it last, after the spacer, which would hold only because nothing follows it and so reinstates the positional premise this cycle objected to; and amending the comment to document the overlap, which leaves the trap in place.

Stopping rule for what remains: the last three cycles found real but Low-severity fixture-quality issues, each cheap to fix. Further findings at that level should be declined or registered rather than addressed here unless they would cause a false test result.

</details>
