### PR TITLE
Preserve computed props for undefined render values

### DIFF
--- a/.changeset/300-render-undefined-props.md
+++ b/.changeset/300-render-undefined-props.md
@@ -4,4 +4,4 @@
 "@ariakit/react": patch
 ---
 
-Fixed [`Checkbox`](https://ariakit.com/reference/checkbox) and other components composed with [`render`](https://ariakit.com/reference/checkbox#render) to preserve computed props when a render element receives `undefined`, while still allowing generated IDs to be explicitly removed. Thanks to [@Jackardios](https://github.com/Jackardios).
+Fixed [`Checkbox`](https://ariakit.com/reference/checkbox) and other components composed with [`render`](https://ariakit.com/reference/checkbox#render) to preserve computed props when a render element receives `undefined`. Thanks to [@Jackardios](https://github.com/Jackardios).

--- a/.changeset/300-render-undefined-props.md
+++ b/.changeset/300-render-undefined-props.md
@@ -4,4 +4,4 @@
 "@ariakit/react": patch
 ---
 
-Fixed [`Checkbox`](https://ariakit.com/reference/checkbox) and other components composed with [`render`](https://ariakit.com/reference/checkbox#render) to preserve computed props when a render element explicitly receives `undefined`, while explicit values, including `null`, continue to override computed props. Thanks to [@Jackardios](https://github.com/Jackardios).
+Fixed [`Checkbox`](https://ariakit.com/reference/checkbox) and other components composed with [`render`](https://ariakit.com/reference/checkbox#render) to preserve computed props when a render element receives `undefined`, while still allowing generated IDs to be explicitly removed. Thanks to [@Jackardios](https://github.com/Jackardios).

--- a/.changeset/300-render-undefined-props.md
+++ b/.changeset/300-render-undefined-props.md
@@ -4,6 +4,4 @@
 "@ariakit/react": patch
 ---
 
-Fixed [`Checkbox`](https://ariakit.com/reference/checkbox) and other components that use `render` to preserve computed props when a render element explicitly receives `undefined`. Explicit values, including `null`, continue to override computed props.
-
-Thanks to [@Jackardios](https://github.com/Jackardios) for reporting the related `mergeProps` behavior that informed this fix.
+Fixed [`Checkbox`](https://ariakit.com/reference/checkbox) and other components composed with [`render`](https://ariakit.com/reference/checkbox#render) to preserve computed props when a render element explicitly receives `undefined`, while explicit values, including `null`, continue to override computed props. Thanks to [@Jackardios](https://github.com/Jackardios).

--- a/.changeset/300-render-undefined-props.md
+++ b/.changeset/300-render-undefined-props.md
@@ -1,0 +1,9 @@
+---
+"@ariakit/react-utils": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Checkbox`](https://ariakit.com/reference/checkbox) and other components that use `render` to preserve computed props when a render element explicitly receives `undefined`. Explicit values, including `null`, continue to override computed props.
+
+Thanks to [@Jackardios](https://github.com/Jackardios) for reporting the related `mergeProps` behavior that informed this fix.

--- a/app/src/examples/_lib/react-utils/merge-props.react.ts
+++ b/app/src/examples/_lib/react-utils/merge-props.react.ts
@@ -34,7 +34,7 @@ export function mergeProps<T extends React.HTMLAttributes<any>>(
     }
 
     const overrideValue = overrides[key];
-    if (overrideValue === undefined && key !== "id") continue;
+    if (overrideValue === undefined) continue;
 
     if (key.startsWith("on")) {
       if (typeof overrideValue !== "function") {

--- a/app/src/examples/_lib/react-utils/merge-props.react.ts
+++ b/app/src/examples/_lib/react-utils/merge-props.react.ts
@@ -34,6 +34,7 @@ export function mergeProps<T extends React.HTMLAttributes<any>>(
     }
 
     const overrideValue = overrides[key];
+    if (overrideValue === undefined) continue;
 
     if (key.startsWith("on")) {
       if (typeof overrideValue !== "function") {

--- a/app/src/examples/_lib/react-utils/merge-props.react.ts
+++ b/app/src/examples/_lib/react-utils/merge-props.react.ts
@@ -34,7 +34,7 @@ export function mergeProps<T extends React.HTMLAttributes<any>>(
     }
 
     const overrideValue = overrides[key];
-    if (overrideValue === undefined) continue;
+    if (overrideValue === undefined && key !== "id") continue;
 
     if (key.startsWith("on")) {
       if (typeof overrideValue !== "function") {

--- a/app/src/sandbox/checkbox-interactions/index.react.tsx
+++ b/app/src/sandbox/checkbox-interactions/index.react.tsx
@@ -63,6 +63,20 @@ function ButtonCheckbox() {
   );
 }
 
+function ForwardedUndefinedCheckbox(props: Ariakit.CheckboxProps) {
+  const { role, ...rest } = props;
+  return <Ariakit.Checkbox {...rest} render={<div role={role} />} />;
+}
+
+function RenderPropCheckbox() {
+  return (
+    <section>
+      <h2>Render prop checkbox</h2>
+      <ForwardedUndefinedCheckbox aria-label="Forwarded undefined" />
+    </section>
+  );
+}
+
 function CustomCheckbox() {
   const [checked, setChecked] = useState(true);
   return (
@@ -110,6 +124,7 @@ export default function Example() {
       <BasicCheckboxes />
       <DynamicCheckboxes />
       <ButtonCheckbox />
+      <RenderPropCheckbox />
       <CustomCheckbox />
       <CheckboxGroup />
     </main>

--- a/app/src/sandbox/checkbox-interactions/index.react.tsx
+++ b/app/src/sandbox/checkbox-interactions/index.react.tsx
@@ -65,14 +65,21 @@ function ButtonCheckbox() {
 
 function ForwardedUndefinedCheckbox(props: Ariakit.CheckboxProps) {
   const { role, ...rest } = props;
-  return <Ariakit.Checkbox {...rest} render={<div role={role} />} />;
+  return (
+    <Ariakit.Checkbox
+      {...rest}
+      render={<div {...(role !== undefined && { role })} />}
+    />
+  );
 }
 
 function RenderPropCheckbox() {
   return (
     <section>
       <h2>Render prop checkbox</h2>
-      <ForwardedUndefinedCheckbox aria-label="Forwarded undefined" />
+      <ForwardedUndefinedCheckbox aria-label="Forwarded undefined">
+        Forwarded undefined
+      </ForwardedUndefinedCheckbox>
     </section>
   );
 }

--- a/app/src/sandbox/checkbox-interactions/index.react.tsx
+++ b/app/src/sandbox/checkbox-interactions/index.react.tsx
@@ -65,12 +65,7 @@ function ButtonCheckbox() {
 
 function ForwardedUndefinedCheckbox(props: Ariakit.CheckboxProps) {
   const { role, ...rest } = props;
-  return (
-    <Ariakit.Checkbox
-      {...rest}
-      render={<div {...(role !== undefined && { role })} />}
-    />
-  );
+  return <Ariakit.Checkbox {...rest} render={<div role={role} />} />;
 }
 
 function RenderPropCheckbox() {

--- a/app/src/sandbox/checkbox-interactions/test-browser.ts
+++ b/app/src/sandbox/checkbox-interactions/test-browser.ts
@@ -1,0 +1,16 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/7036
+  test("preserves checkbox semantics when an optional render prop is undefined", async ({
+    q,
+  }) => {
+    const checkbox = q.checkbox("Forwarded undefined");
+    await test.expect(checkbox).toHaveAttribute("aria-checked", "false");
+
+    await checkbox.click();
+    await test
+      .expect(q.checkbox("Forwarded undefined"))
+      .toHaveAttribute("aria-checked", "true");
+  });
+});

--- a/app/src/sandbox/checkbox-interactions/test.ts
+++ b/app/src/sandbox/checkbox-interactions/test.ts
@@ -24,6 +24,7 @@ test("keeps each checkbox implementation in the tab order", async () => {
     "Dynamic 1",
     "Dynamic 2",
     "Button checkbox: Unchecked",
+    "Forwarded undefined",
     "Custom",
     "Apple",
     "Orange",
@@ -135,6 +136,18 @@ test("supports a checkbox rendered as a button", async () => {
 
   await press.Enter();
   expect(q.checkbox("Button checkbox: Checked")).toHaveAttribute(
+    "aria-checked",
+    "true",
+  );
+});
+
+// https://github.com/ariakit/ariakit/issues/7036
+test("preserves checkbox semantics when an optional render prop is undefined", async () => {
+  const checkbox = q.checkbox("Forwarded undefined");
+  expect(checkbox).toHaveAttribute("aria-checked", "false");
+
+  await click(checkbox);
+  expect(q.checkbox("Forwarded undefined")).toHaveAttribute(
     "aria-checked",
     "true",
   );

--- a/app/src/sandbox/dialog-route-state/index.react.tsx
+++ b/app/src/sandbox/dialog-route-state/index.react.tsx
@@ -4,19 +4,32 @@ import { useState } from "react";
 
 export default function Example() {
   const [open, setOpen] = useState(false);
+  const [includePreview, setIncludePreview] = useState(false);
+  const [previewOpen, setPreviewOpen] = useState(false);
 
   const close = (event?: Event | SyntheticEvent) => {
     event?.preventDefault();
     setOpen(false);
+    setPreviewOpen(false);
   };
 
   return (
     <>
+      <label>
+        <input
+          type="checkbox"
+          tabIndex={0}
+          checked={includePreview}
+          onChange={(event) => setIncludePreview(event.currentTarget.checked)}
+        />
+        Include preview
+      </label>
       <a
         href="/post"
         className="button"
         onClick={(event) => {
           event.preventDefault();
+          setPreviewOpen(includePreview);
           setOpen(true);
         }}
       >
@@ -49,6 +62,23 @@ export default function Example() {
             Post
           </Ariakit.Button>
         </form>
+        <Ariakit.HovercardProvider open={previewOpen} setOpen={setPreviewOpen}>
+          <Ariakit.HovercardAnchor render={<Ariakit.Role.div />}>
+            Preview anchor
+          </Ariakit.HovercardAnchor>
+          <Ariakit.Hovercard
+            role="presentation"
+            focusable={false}
+            hideOnEscape={false}
+            hideOnInteractOutside={false}
+            unmountOnHide
+            updatePosition={() => {}}
+            render={<Ariakit.Role.div id={undefined} />}
+            getPersistentElements={() => document.getElementsByTagName("body")}
+          >
+            Feature preview
+          </Ariakit.Hovercard>
+        </Ariakit.HovercardProvider>
       </Ariakit.Dialog>
     </>
   );

--- a/app/src/sandbox/dialog-route-state/index.react.tsx
+++ b/app/src/sandbox/dialog-route-state/index.react.tsx
@@ -73,7 +73,7 @@ export default function Example() {
             hideOnInteractOutside={false}
             unmountOnHide
             updatePosition={() => {}}
-            render={<Ariakit.Role.div id={undefined} />}
+            render={(props) => <Ariakit.Role.div {...props} id={undefined} />}
             getPersistentElements={() => document.getElementsByTagName("body")}
           >
             Feature preview

--- a/app/src/sandbox/dialog-route-state/test-browser.ts
+++ b/app/src/sandbox/dialog-route-state/test-browser.ts
@@ -1,0 +1,18 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/7036
+  test("hide on escape with a persistent nested hovercard", async ({
+    page,
+    q,
+  }) => {
+    await q.checkbox("Include preview").click();
+    await q.link("Post").click();
+    await test.expect(q.text("Feature preview")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+
+    await test.expect(q.dialog("Post")).not.toBeVisible();
+    await test.expect(q.text("Feature preview")).not.toBeVisible();
+  });
+});

--- a/app/src/sandbox/dialog-route-state/test.ts
+++ b/app/src/sandbox/dialog-route-state/test.ts
@@ -31,6 +31,18 @@ test("hide on escape", async () => {
   expect(q.link()).toHaveFocus();
 });
 
+// https://github.com/ariakit/ariakit/issues/7036
+test("hide on escape with a persistent nested hovercard", async () => {
+  await click(q.checkbox("Include preview"));
+  await click(q.link());
+  expect(q.text("Feature preview")).toBeVisible();
+
+  await press.Escape();
+
+  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.text("Feature preview")).not.toBeInTheDocument();
+});
+
 test("hide on click outside", async () => {
   await click(q.link());
   expect(q.dialog()).toBeVisible();

--- a/guide/300-composition/readme.md
+++ b/guide/300-composition/readme.md
@@ -56,7 +56,7 @@ The [Tab with Next.js App Router](/examples/tab-next-router) example uses the `r
 
 ## Merging the rendered element props
 
-When passing an HTML element to the `render` prop, all the HTML props returned by the original component will be passed to the rendered element. The `style`, `className`, `ref` and event props will be automatically merged. In all other cases, the rendered element props will override the original component props.
+When passing an HTML element to the `render` prop, all the HTML props returned by the original component will be passed to the rendered element. The `style`, `className`, `ref` and event props will be automatically merged. In all other cases, defined rendered element props, including `null`, will override the original component props. Props set to `undefined` will be ignored.
 
 - Props coming from the original component will be passed to the rendered element:
 
@@ -76,6 +76,16 @@ When passing an HTML element to the `render` prop, all the HTML props returned b
 
   ```html "id"
   <a id="link">...</a>
+  ```
+
+- To intentionally remove a prop, use a render function and apply `undefined` after spreading the original component props:
+
+  ```jsx "id"
+  <ComboboxItem id="item" render={(props) => <a {...props} id={undefined} />} />
+  ```
+
+  ```html
+  <a>...</a>
   ```
 
 This also applies to the `children` prop. You don't need to nest children within the `render` prop. But if you do, the children passed to the rendered element will override the original component children.

--- a/packages/ariakit-react-utils/src/misc.test.ts
+++ b/packages/ariakit-react-utils/src/misc.test.ts
@@ -4,25 +4,21 @@ import { mergeProps, setRef } from "./misc.ts";
 
 test("mergeProps preserves base values for undefined overrides", () => {
   const base: HTMLAttributes<HTMLDivElement> = {
+    id: "base",
     role: "checkbox",
     children: "base",
   };
   const overrides: HTMLAttributes<HTMLDivElement> = {
+    id: undefined,
     role: undefined,
     children: null,
   };
 
   expect(mergeProps(base, overrides)).toEqual({
+    id: "base",
     role: "checkbox",
     children: null,
   });
-});
-
-test("mergeProps allows an undefined id override", () => {
-  const base: HTMLAttributes<HTMLDivElement> = { id: "base" };
-  const overrides: HTMLAttributes<HTMLDivElement> = { id: undefined };
-
-  expect(mergeProps(base, overrides)).toEqual({ id: undefined });
 });
 
 test("setRef returns function ref cleanup", () => {

--- a/packages/ariakit-react-utils/src/misc.test.ts
+++ b/packages/ariakit-react-utils/src/misc.test.ts
@@ -1,5 +1,22 @@
+import type { HTMLAttributes } from "react";
 import { expect, test } from "vitest";
-import { setRef } from "./misc.ts";
+import { mergeProps, setRef } from "./misc.ts";
+
+test("mergeProps preserves base values for undefined overrides", () => {
+  const base: HTMLAttributes<HTMLDivElement> = {
+    role: "checkbox",
+    children: "base",
+  };
+  const overrides: HTMLAttributes<HTMLDivElement> = {
+    role: undefined,
+    children: null,
+  };
+
+  expect(mergeProps(base, overrides)).toEqual({
+    role: "checkbox",
+    children: null,
+  });
+});
 
 test("setRef returns function ref cleanup", () => {
   const element = document.createElement("div");

--- a/packages/ariakit-react-utils/src/misc.test.ts
+++ b/packages/ariakit-react-utils/src/misc.test.ts
@@ -18,6 +18,13 @@ test("mergeProps preserves base values for undefined overrides", () => {
   });
 });
 
+test("mergeProps allows an undefined id override", () => {
+  const base: HTMLAttributes<HTMLDivElement> = { id: "base" };
+  const overrides: HTMLAttributes<HTMLDivElement> = { id: undefined };
+
+  expect(mergeProps(base, overrides)).toEqual({ id: undefined });
+});
+
 test("setRef returns function ref cleanup", () => {
   const element = document.createElement("div");
   const cleanup = () => {};

--- a/packages/ariakit-react-utils/src/misc.ts
+++ b/packages/ariakit-react-utils/src/misc.ts
@@ -87,7 +87,7 @@ export function mergeProps<T extends HTMLAttributes<any>>(
     }
 
     const overrideValue = overrides[key];
-    if (overrideValue === undefined && key !== "id") continue;
+    if (overrideValue === undefined) continue;
 
     if (key.startsWith("on")) {
       if (typeof overrideValue !== "function") {

--- a/packages/ariakit-react-utils/src/misc.ts
+++ b/packages/ariakit-react-utils/src/misc.ts
@@ -87,6 +87,7 @@ export function mergeProps<T extends HTMLAttributes<any>>(
     }
 
     const overrideValue = overrides[key];
+    if (overrideValue === undefined) continue;
 
     if (key.startsWith("on")) {
       if (typeof overrideValue !== "function") {

--- a/packages/ariakit-react-utils/src/misc.ts
+++ b/packages/ariakit-react-utils/src/misc.ts
@@ -87,7 +87,7 @@ export function mergeProps<T extends HTMLAttributes<any>>(
     }
 
     const overrideValue = overrides[key];
-    if (overrideValue === undefined) continue;
+    if (overrideValue === undefined && key !== "id") continue;
 
     if (key.startsWith("on")) {
       if (typeof overrideValue !== "function") {

--- a/website/components/plus.tsx
+++ b/website/components/plus.tsx
@@ -171,7 +171,9 @@ export const PlusFeaturePreviewContainer = forwardRef<
       hideOnInteractOutside={false}
       updatePosition={() => {}}
       {...props}
-      render={<Role.div id={undefined} render={props.render} />}
+      render={(renderProps) => (
+        <Role.div {...renderProps} id={undefined} render={props.render} />
+      )}
       getPersistentElements={() => document.getElementsByTagName("body")}
       wrapperProps={{
         ...props.wrapperProps,


### PR DESCRIPTION
## Motivation

The `render` composition path let a render element prop with an `undefined` value erase a value computed by the Ariakit component. In the reported `Checkbox` case, a wrapper that forwards an optional `role` prop rendered a `div` without the computed `role="checkbox"`, removing the control's accessible semantics.

Fixes #7036

## Solution

`mergeProps` now ignores `undefined` ordinary render-element overrides, so computed props such as `role="checkbox"` and generated IDs are preserved. Defined ordinary values, including `null`, continue to override computed props, while `className`, `style`, and event handlers retain their existing special merge rules.

The Plus feature preview intentionally removes its nested Hovercard ID through a render callback, keeping that exception local instead of weakening the merge rule:

```tsx
render={(renderProps) => (
  <Role.div {...renderProps} id={undefined} render={props.render} />
)}
```

The published React utility, app mirror, package invariant tests, public `Checkbox` fixture, composition guide, and nested Hovercard with route-state Dialog regression are covered.

## Workaround

Before this fix is available, omit optional render props when they are undefined:

```tsx
function MyCheckbox({ role, ...props }: MyCheckboxProps) {
  // TODO: Remove this workaround once https://github.com/ariakit/ariakit/issues/7036 is fixed.
  return (
    <Ariakit.Checkbox
      {...props}
      render={<div {...(role !== undefined && { role })} />}
    />
  );
}
```

This workaround is limited to optional props forwarded into the `render` element. Defined values continue to override computed values as before.

## Preview

The fixed local preview showed `Forwarded undefined` in the browser accessibility tree, and the nested route-dialog regression passed in Chrome, Firefox, and Safari. A GitHub-hosted screen recording is not included because the available browser session was signed out, so the normal GitHub attachment upload flow was unavailable.

## Test plan

- [x] Replacing the final callback with the old render element makes the nested Hovercard regression fail because Escape leaves the route Dialog open with a generated Hovercard ID.
- [x] Focused route-dialog, Checkbox, and package invariant tests pass 17/17 under the current React version.
- [x] The same focused tests pass 17/17 under React 18.
- [x] The nested route-dialog Playwright regression passes in Chrome, Firefox, and Safari (3/3).
- [x] The full React Vitest project passes 951/951 tests across 184 files.
- [x] `pnpm tsc` passes.
- [x] `pnpm lint-fix` passes.
- [x] `pnpm build` passes, followed by `pnpm clean`.

## Acknowledgments

Thanks to [@Jackardios](https://github.com/Jackardios) for reporting the related `mergeProps` behavior that informed this fix.
