### PR TITLE
Stabilize hovercard interaction timing test

### DIFF
--- a/app/src/sandbox/hovercard-interactions/test.ts
+++ b/app/src/sandbox/hovercard-interactions/test.ts
@@ -1,4 +1,4 @@
-import { click, hover, press, q, sleep } from "@ariakit/test";
+import { click, dispatch, hover, press, q, sleep } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 const hovercard = () => q.dialog("Ariakit profile");
@@ -12,10 +12,14 @@ const hoverOutside = async () => {
 test("shows after hovering and hides after hovering outside", async () => {
   expect(hovercard()).not.toBeInTheDocument();
 
-  await hover(q.link("@ariakit.com"));
+  // Dispatch directly so the assertions run before the timeout can expire
+  // when the full suite delays the interaction helper.
+  await dispatch.mouseMove(q.link("@ariakit.com"));
+  expect(hovercard()).not.toBeInTheDocument();
   await expect.poll(hovercard).toBeVisible();
 
-  await hoverOutside();
+  await dispatch.mouseMove(document.body);
+  expect(hovercard()).toBeVisible();
   await expect.poll(hovercard).not.toBeInTheDocument();
 });
 

--- a/app/src/sandbox/hovercard-interactions/test.ts
+++ b/app/src/sandbox/hovercard-interactions/test.ts
@@ -8,6 +8,7 @@ const hoverOutside = async () => {
   await hover(document.body, { clientX: 10, clientY: 10 });
 };
 
+// https://github.com/ariakit/ariakit/issues/7043
 test("shows after hovering and hides after hovering outside", async () => {
   expect(hovercard()).not.toBeInTheDocument();
 

--- a/app/src/sandbox/hovercard-interactions/test.ts
+++ b/app/src/sandbox/hovercard-interactions/test.ts
@@ -13,11 +13,9 @@ test("shows after hovering and hides after hovering outside", async () => {
   expect(hovercard()).not.toBeInTheDocument();
 
   await hover(q.link("@ariakit.com"));
-  expect(hovercard()).not.toBeInTheDocument();
   await expect.poll(hovercard).toBeVisible();
 
   await hoverOutside();
-  expect(hovercard()).toBeVisible();
   await expect.poll(hovercard).not.toBeInTheDocument();
 });
 

--- a/app/src/sandbox/tooltip-interactions/test.ts
+++ b/app/src/sandbox/tooltip-interactions/test.ts
@@ -1,4 +1,4 @@
-import { click, focus, hover, press, q } from "@ariakit/test";
+import { click, dispatch, focus, hover, press, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 const hoverOutside = async () => {
@@ -60,7 +60,12 @@ test("waits again after keyboard focus is lost", async () => {
   expect(q.tooltip("Tooltip content")).not.toBeInTheDocument();
 
   await hoverOutside();
-  await hover(anchor);
+  // Dispatch directly so the assertion runs before the timeout can expire
+  // when the full suite delays the interaction helper.
+  await dispatch.mouseOver(anchor);
+  await dispatch.mouseEnter(anchor);
+  await dispatch.mouseMove(anchor);
+  expect(q.tooltip("Tooltip content")).not.toBeInTheDocument();
   expect(await q.tooltip.wait("Tooltip content")).toBeVisible();
 });
 

--- a/app/src/sandbox/tooltip-interactions/test.ts
+++ b/app/src/sandbox/tooltip-interactions/test.ts
@@ -49,6 +49,7 @@ test("stays open after focus-visible and pointer movement", async () => {
   expect(q.tooltip("Tooltip content")).toBeVisible();
 });
 
+// https://github.com/ariakit/ariakit/issues/7043
 test("waits again after keyboard focus is lost", async () => {
   const anchor = q.link("Tooltip anchor");
   await hover(anchor);
@@ -60,7 +61,6 @@ test("waits again after keyboard focus is lost", async () => {
 
   await hoverOutside();
   await hover(anchor);
-  expect(q.tooltip("Tooltip content")).not.toBeInTheDocument();
   expect(await q.tooltip.wait("Tooltip content")).toBeVisible();
 });
 


### PR DESCRIPTION
## Motivation

The `hovercard-interactions` and `tooltip-interactions` sandbox tests use `hover()` around short show/hide timeouts. The helper's final settle can let a timeout expire before a synchronous assertion runs under full Vitest-suite load. The regression is tracked in [#7043](https://github.com/ariakit/ariakit/issues/7043).

## Solution

The affected assertions now dispatch only the mouse events needed to trigger each component, avoiding the helper's wall-clock settle while preserving the immediate timing checks and existing eventual visibility checks. The tooltip sequence includes `mouseOver`, `mouseEnter`, and `mouseMove` because `TooltipAnchor` uses the entry events to arm hover behavior. This is test infrastructure only; no library behavior changed and no changeset is needed.

## Workaround

Before this fix, the timing assertions could be omitted while retaining the eventual behavior checks:

```ts
await hover(q.link("@ariakit.com"));
// TODO: Remove once https://github.com/ariakit/ariakit/issues/7043 is fixed.
await expect.poll(hovercard).toBeVisible();
await hoverOutside();
await expect.poll(hovercard).not.toBeInTheDocument();
```

```ts
await hoverOutside();
await hover(anchor);
// TODO: Remove once https://github.com/ariakit/ariakit/issues/7043 is fixed.
await expect(await q.tooltip.wait("Tooltip content")).toBeVisible();
```

This workaround preserves eventual show/hide behavior but does not verify the asynchronous timing contract. The final tests restore that coverage without changing library code.

## Verification

- Focused hovercard test: 5/5 passed.
- Focused tooltip test: 6/6 passed.
- React project: 184 files and 948 tests passed.
- `pnpm lint-fix` passed.
- `pnpm tsc` passed with 0 Astro errors, warnings, or hints.

Fixes #7043