### PR TITLE
Prevent Dialog delayed auto-focus from reclaiming escaped focus

### DIFF
--- a/.changeset/300-dialog-auto-focus-escape.md
+++ b/.changeset/300-dialog-auto-focus-escape.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Dialog`](https://ariakit.com/reference/dialog) and components built on it, such as [`ComboboxPopover`](https://ariakit.com/reference/combobox-popover), so delayed auto-focus no longer pulls focus back after focus has moved outside the dialog.

--- a/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
@@ -1,5 +1,5 @@
 import * as Ariakit from "@ariakit/react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 const fruits = [
   "Apple",
@@ -216,11 +216,9 @@ function Fixture({
           style={{
             background: "white",
             border: "1px solid gray",
+            boxSizing: "border-box",
             padding: 8,
-            position: "fixed",
-            right: 8,
-            top: 8,
-            zIndex: 1,
+            width: 320,
           }}
         >
           Open the select. Expected focus history: input → focus target. An
@@ -443,6 +441,80 @@ function ShadowRootDialogFixture() {
           </Ariakit.Dialog>
         </Ariakit.Portal>
       )}
+    </>
+  );
+}
+
+function IframeDialogFixture() {
+  const dialog = Ariakit.useDialogStore();
+  const initialFocusRef = useRef<HTMLInputElement>(null);
+  const dialogFocusRef = useRef<HTMLInputElement>(null);
+  const frameRef = useRef<HTMLIFrameElement>(null);
+  const iframeFocusRef = useRef<HTMLInputElement>(null);
+  const [frameBody, setFrameBody] = useState<HTMLElement | null>(null);
+  const [focusHistory, setFocusHistory] = useState<string[]>([]);
+  const setFrame = useCallback((element: HTMLIFrameElement | null) => {
+    frameRef.current = element;
+    setFrameBody(element?.contentDocument?.body ?? null);
+  }, []);
+  const recordFocus = (target: string) => {
+    setFocusHistory((history) => [...history, target]);
+  };
+  return (
+    <>
+      <Ariakit.DialogDisclosure
+        store={dialog}
+        onClick={() => setFocusHistory([])}
+      >
+        Open iframe focus dialog
+      </Ariakit.DialogDisclosure>
+      <p>
+        Open the dialog. Expected focus history: dialog focus → iframe focus →
+        initial focus. If the history stops at iframe focus, the frame hid that
+        focus was still inside the dialog. Current focus history:{" "}
+        <output aria-label="Iframe dialog focus history">
+          {focusHistory.length ? focusHistory.join(" → ") : "none"}
+        </output>
+      </p>
+      <Ariakit.Dialog
+        store={dialog}
+        aria-label="Iframe focus dialog"
+        autoFocusOnShow={() => {
+          // Stage an app-owned handoff before Dialog queues initial focus.
+          dialogFocusRef.current?.focus();
+          // Firefox needs the browsing context activated before its field can
+          // receive focus from the parent document.
+          frameRef.current?.contentWindow?.focus();
+          iframeFocusRef.current?.focus();
+          return true;
+        }}
+        hideOnInteractOutside={false}
+        initialFocus={initialFocusRef}
+        modal={false}
+        portal={false}
+        unmountOnHide={false}
+      >
+        <iframe ref={setFrame} title="Initial focus frame" tabIndex={0} />
+        {frameBody && (
+          <Ariakit.Portal portalElement={frameBody}>
+            <input
+              ref={iframeFocusRef}
+              aria-label="Iframe app focus field"
+              onFocus={() => recordFocus("iframe focus")}
+            />
+          </Ariakit.Portal>
+        )}
+        <input
+          ref={dialogFocusRef}
+          aria-label="Iframe dialog focus field"
+          onFocus={() => recordFocus("dialog focus")}
+        />
+        <input
+          ref={initialFocusRef}
+          aria-label="Iframe initial focus field"
+          onFocus={() => recordFocus("initial focus")}
+        />
+      </Ariakit.Dialog>
     </>
   );
 }
@@ -711,6 +783,9 @@ export default function Example() {
       </div>
       <div style={{ marginTop: 200 }}>
         <ShadowRootDialogFixture />
+      </div>
+      <div style={{ marginTop: 200 }}>
+        <IframeDialogFixture />
       </div>
       <div style={{ marginTop: 200 }}>
         <StoreSwapFixture />

--- a/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
@@ -214,6 +214,25 @@ function Fixture({
       virtualFocus={virtualFocus}
     >
       <Ariakit.ComboboxSelectLabel>{label}</Ariakit.ComboboxSelectLabel>
+      {showFocusHistory && (
+        <p
+          style={{
+            background: "white",
+            border: "1px solid gray",
+            padding: 8,
+            position: "fixed",
+            right: 8,
+            top: 8,
+            zIndex: 1,
+          }}
+        >
+          Open the select. Expected focus history: input → focus target. An
+          extra input means the popup pulled focus back. Current focus history:{" "}
+          <output aria-label={`${label} focus history`}>
+            {focusHistory.length ? focusHistory.join(" → ") : "none"}
+          </output>
+        </p>
+      )}
       <Ariakit.ComboboxSelect style={{ display: "block" }} />
       <Ariakit.ComboboxPopover
         autoFocusOnShow={autoFocusOnShow}
@@ -296,15 +315,6 @@ function Fixture({
         >
           {`Finish ${label} positioning`}
         </button>
-      )}
-      {showFocusHistory && (
-        <p>
-          Open the select. Expected focus history: input → focus target. An
-          extra input means the popup pulled focus back. Current focus history:{" "}
-          <output aria-label={`${label} focus history`}>
-            {focusHistory.length ? focusHistory.join(" → ") : "none"}
-          </output>
-        </p>
       )}
     </Ariakit.ComboboxProvider>
   );

--- a/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
@@ -170,6 +170,7 @@ interface FixtureProps {
   refreshListActiveId?: string;
   /** Replaces every item node under a stable id while the popup opens. */
   remountItemsOnOpen?: boolean;
+  showFocusHistory?: boolean;
   unmountOnHide?: boolean;
   virtualFocus?: boolean;
 }
@@ -188,10 +189,16 @@ function Fixture({
   pageScrollport,
   refreshListActiveId,
   remountItemsOnOpen,
+  showFocusHistory,
   unmountOnHide,
   virtualFocus,
 }: FixtureProps) {
   const focusTargetRef = useRef<HTMLElement | null>(null);
+  const [focusHistory, setFocusHistory] = useState<string[]>([]);
+  const recordFocus = (target: string) => {
+    if (!showFocusHistory) return;
+    setFocusHistory((history) => [...history, target]);
+  };
   const setFocusTarget = (element: HTMLElement | null) => {
     focusTargetRef.current = element;
   };
@@ -228,6 +235,7 @@ function Fixture({
           <Ariakit.ComboboxInput
             aria-label={`Search ${label}`}
             onFocus={() => {
+              recordFocus("input");
               if (!moveFocusOnOpen) return;
               queueMicrotask(() => {
                 // An in-popup target is meant to be scrolled into its popup by
@@ -260,7 +268,12 @@ function Fixture({
         </Ariakit.ComboboxItem>
       </Ariakit.ComboboxPopover>
       {focusTarget && outsideFocusTarget && (
-        <button type="button" tabIndex={0} ref={setFocusTarget}>
+        <button
+          type="button"
+          tabIndex={0}
+          ref={setFocusTarget}
+          onFocus={() => recordFocus("focus target")}
+        >
           {`${label} focus target`}
         </button>
       )}
@@ -283,6 +296,15 @@ function Fixture({
         >
           {`Finish ${label} positioning`}
         </button>
+      )}
+      {showFocusHistory && (
+        <p>
+          Open the select. Expected focus history: input → focus target. An
+          extra input means the popup pulled focus back. Current focus history:{" "}
+          <output aria-label={`${label} focus history`}>
+            {focusHistory.length ? focusHistory.join(" → ") : "none"}
+          </output>
+        </p>
       )}
     </Ariakit.ComboboxProvider>
   );
@@ -398,6 +420,22 @@ export default function Example() {
           keepOpen
           label="Parked fruit"
           refreshListActiveId="parked-apple"
+        />
+      </div>
+      {/* The popup stays open after focus leaves, so Dialog's delayed
+          auto-focus must not pull focus back into it. */}
+      <div style={{ marginTop: 200 }}>
+        <Fixture
+          defaultSelectedValue="Watermelon"
+          focusTarget
+          input
+          keepOpen
+          label="Focus escaping fruit"
+          moveFocusOnOpen
+          outsideFocusTarget
+          pageScrollport
+          showFocusHistory
+          unmountOnHide
         />
       </div>
     </>

--- a/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
@@ -130,12 +130,7 @@ function RefreshListButton({
 interface FixtureProps {
   /**
    * Whether the popup takes focus once it is placed. Turning it off leaves the
-   * presentation as the only thing that can bring an item into view, and keeps
-   * a focus escape from being undone by the popup pulling focus back in, which
-   * is a separate defect. Once that one is fixed, the fixture that turns this
-   * off to hold a focus escape can go back to the default and cover the same
-   * escape there.
-   * See https://github.com/ariakit/ariakit/issues/7033
+   * presentation as the only thing that can bring an item into view.
    */
   autoFocusOnShow?: boolean;
   defaultSelectedValue: string | string[];
@@ -383,7 +378,6 @@ export default function Example() {
       presentation that outlives the escape is visible as a page jump. */}
       <div style={{ marginTop: 200 }}>
         <Fixture
-          autoFocusOnShow={false}
           defaultSelectedValue="Watermelon"
           focusTarget
           input
@@ -436,7 +430,6 @@ export default function Example() {
           auto-focus must not pull focus back into it. */}
       <div style={{ marginTop: 200 }}>
         <Fixture
-          autoFocusOnShow={false}
           defaultSelectedValue="Watermelon"
           focusTarget
           input

--- a/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
@@ -135,6 +135,7 @@ interface FixtureProps {
   autoFocusOnShow?: boolean;
   defaultSelectedValue: string | string[];
   focusTarget?: boolean;
+  focusTrapTarget?: boolean;
   /**
    * Holds the popup in its positioning window until a control releases it, so a
    * presentation stays parked while something else acts on the popup. Releasing
@@ -174,6 +175,7 @@ function Fixture({
   autoFocusOnShow,
   defaultSelectedValue,
   focusTarget,
+  focusTrapTarget,
   holdPlacement,
   input,
   itemIdPrefix,
@@ -283,6 +285,7 @@ function Fixture({
       </Ariakit.ComboboxPopover>
       {focusTarget && outsideFocusTarget && (
         <button
+          data-focus-trap={focusTrapTarget ? "" : undefined}
           type="button"
           tabIndex={0}
           ref={setFocusTarget}
@@ -373,6 +376,73 @@ function NativeAutoFocusFixture() {
           }}
         />
       </Ariakit.Dialog>
+    </>
+  );
+}
+
+function ShadowRootDialogFixture() {
+  const shadowHostRef = useRef<HTMLDivElement>(null);
+  const initialFocusRef = useRef<HTMLInputElement>(null);
+  const [open, setOpen] = useState(false);
+  const [portalElement, setPortalElement] = useState<HTMLElement | null>(null);
+  const [focusHistory, setFocusHistory] = useState<string[]>([]);
+  const recordFocus = (target: string) => {
+    setFocusHistory((history) => [...history, target]);
+  };
+  useEffect(() => {
+    const host = shadowHostRef.current;
+    if (!host) return;
+    const root = host.shadowRoot || host.attachShadow({ mode: "open" });
+    const portal = host.ownerDocument.createElement("div");
+    root.append(portal);
+    setPortalElement(portal);
+    return () => portal.remove();
+  }, []);
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          setFocusHistory([]);
+          setOpen(true);
+        }}
+      >
+        Open shadow-root focus dialog
+      </button>
+      <div ref={shadowHostRef} data-shadow-root-dialog-host />
+      <p>
+        Open the dialog. Expected focus history: app focus → initial focus. If
+        the history stops at app focus, the shadow host hid that focus was still
+        inside the dialog. Current focus history:{" "}
+        <output aria-label="Shadow-root dialog focus history">
+          {focusHistory.length ? focusHistory.join(" → ") : "none"}
+        </output>
+      </p>
+      {portalElement && (
+        <Ariakit.Portal portalElement={portalElement}>
+          <Ariakit.Dialog
+            aria-label="Shadow-root focus dialog"
+            hideOnInteractOutside={false}
+            initialFocus={initialFocusRef}
+            modal={false}
+            onClose={() => setOpen(false)}
+            open={open}
+            portal={false}
+            unmountOnHide
+          >
+            <input
+              aria-label="Shadow-root app focus field"
+              autoFocus
+              onFocus={() => recordFocus("app focus")}
+            />
+            <input
+              ref={initialFocusRef}
+              aria-label="Shadow-root initial focus field"
+              onFocus={() => recordFocus("initial focus")}
+            />
+          </Ariakit.Dialog>
+        </Ariakit.Portal>
+      )}
     </>
   );
 }
@@ -622,7 +692,25 @@ export default function Example() {
         />
       </div>
       <div style={{ marginTop: 200 }}>
+        <Fixture
+          defaultSelectedValue="Watermelon"
+          focusTarget
+          focusTrapTarget
+          input
+          keepOpen
+          label="Focus trap escaping fruit"
+          moveFocusOnOpen
+          outsideFocusTarget
+          pageScrollport
+          showFocusHistory
+          unmountOnHide
+        />
+      </div>
+      <div style={{ marginTop: 200 }}>
         <NativeAutoFocusFixture />
+      </div>
+      <div style={{ marginTop: 200 }}>
+        <ShadowRootDialogFixture />
       </div>
       <div style={{ marginTop: 200 }}>
         <StoreSwapFixture />

--- a/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
@@ -436,6 +436,7 @@ export default function Example() {
           auto-focus must not pull focus back into it. */}
       <div style={{ marginTop: 200 }}>
         <Fixture
+          autoFocusOnShow={false}
           defaultSelectedValue="Watermelon"
           focusTarget
           input

--- a/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
@@ -315,6 +315,185 @@ function Fixture({
   );
 }
 
+function NativeAutoFocusFixture() {
+  const dialog = Ariakit.useDialogStore();
+  const shadowHostRef = useRef<HTMLDivElement>(null);
+  const focusTargetRef = useRef<HTMLInputElement>(null);
+  const [focusHistory, setFocusHistory] = useState<string[]>([]);
+  const recordFocus = (target: string) => {
+    setFocusHistory((history) => [...history, target]);
+  };
+  useEffect(() => {
+    const host = shadowHostRef.current;
+    if (!host) return;
+    const root = host.shadowRoot || host.attachShadow({ mode: "open" });
+    const nestedHost = host.ownerDocument.createElement("div");
+    const nestedRoot = nestedHost.attachShadow({ mode: "open" });
+    const input = host.ownerDocument.createElement("input");
+    input.setAttribute("aria-label", "Native auto-focus shadow target");
+    const onFocus = () => {
+      setFocusHistory((history) => [...history, "shadow target"]);
+    };
+    input.addEventListener("focus", onFocus);
+    nestedRoot.append(input);
+    root.append(nestedHost);
+    focusTargetRef.current = input;
+    return () => {
+      focusTargetRef.current = null;
+      input.removeEventListener("focus", onFocus);
+      nestedHost.remove();
+    };
+  }, []);
+  return (
+    <>
+      <Ariakit.DialogDisclosure store={dialog}>
+        Native auto-focus dialog
+      </Ariakit.DialogDisclosure>
+      <div ref={shadowHostRef} />
+      <p>
+        Open the dialog. Expected focus history: input → shadow target. An extra
+        input means the dialog pulled focus back. Current focus history:{" "}
+        <output aria-label="Native auto-focus history">
+          {focusHistory.length ? focusHistory.join(" → ") : "none"}
+        </output>
+      </p>
+      <Ariakit.Dialog
+        store={dialog}
+        hideOnInteractOutside={false}
+        modal={false}
+        portal={false}
+        unmountOnHide
+      >
+        <input
+          aria-label="Native auto-focus input"
+          autoFocus
+          onFocus={() => {
+            recordFocus("input");
+            focusTargetRef.current?.focus();
+          }}
+        />
+      </Ariakit.Dialog>
+    </>
+  );
+}
+
+function StoreSwapFixture() {
+  const dialogA = Ariakit.useDialogStore();
+  const dialogB = Ariakit.useDialogStore();
+  const [dialog, setDialog] = useState(dialogA);
+  const [dialogName, setDialogName] = useState("A");
+  const [focusHistory, setFocusHistory] = useState<string[]>([]);
+  const initialFocusRef = useRef<HTMLInputElement>(null);
+  const recordFocus = (target: string) => {
+    setFocusHistory((history) => [...history, target]);
+  };
+  const showDialog = (name: string, nextDialog: typeof dialogA) => {
+    setDialogName(name);
+    setDialog(nextDialog);
+    nextDialog.show();
+  };
+  return (
+    <>
+      <button
+        type="button"
+        tabIndex={0}
+        onFocus={() => recordFocus("open store A")}
+        onClick={() => showDialog("A", dialogA)}
+      >
+        Open store A
+      </button>
+      <button
+        type="button"
+        tabIndex={0}
+        onFocus={() => recordFocus("open store B")}
+        onClick={() => showDialog("B", dialogB)}
+      >
+        Open store B
+      </button>
+      <p>
+        Open store A, then store B. Expected focus history: open store A → store
+        A input → open store B → store B input. Current focus history:{" "}
+        <output aria-label="Store swap focus history">
+          {focusHistory.length ? focusHistory.join(" → ") : "none"}
+        </output>
+      </p>
+      <Ariakit.Dialog
+        store={dialog}
+        hideOnInteractOutside={false}
+        initialFocus={initialFocusRef}
+        modal={false}
+        portal={false}
+      >
+        <input
+          ref={initialFocusRef}
+          aria-label={`Store ${dialogName} initial focus`}
+          onFocus={() => recordFocus(`store ${dialogName} input`)}
+        />
+      </Ariakit.Dialog>
+    </>
+  );
+}
+
+function DisclosureSwapFixture() {
+  const dialog = Ariakit.useDialogStore();
+  const previousDisclosureRef = useRef<HTMLButtonElement>(null);
+  const replacementDisclosureRef = useRef<HTMLButtonElement>(null);
+  const initialFocusRef = useRef<HTMLInputElement>(null);
+  const [focusHistory, setFocusHistory] = useState<string[]>([]);
+  const recordFocus = (target: string) => {
+    setFocusHistory((history) => [...history, target]);
+  };
+  return (
+    <>
+      <button
+        ref={previousDisclosureRef}
+        type="button"
+        onFocus={() => recordFocus("previous disclosure")}
+        onClick={(event) => {
+          setFocusHistory([]);
+          dialog.setDisclosureElement(event.currentTarget);
+          dialog.show();
+        }}
+      >
+        Open disclosure swap dialog
+      </button>
+      <button ref={replacementDisclosureRef} type="button">
+        Replacement disclosure
+      </button>
+      <p>
+        Open the dialog. Expected focus history: input → previous disclosure. An
+        extra input means delayed auto-focus used the stale disclosure. Current
+        focus history:{" "}
+        <output aria-label="Disclosure swap focus history">
+          {focusHistory.length ? focusHistory.join(" → ") : "none"}
+        </output>
+      </p>
+      <Ariakit.Dialog
+        store={dialog}
+        autoFocusOnShow={() => {
+          queueMicrotask(() => {
+            dialog.setDisclosureElement(replacementDisclosureRef.current);
+            previousDisclosureRef.current?.focus();
+          });
+          return true;
+        }}
+        hideOnInteractOutside={false}
+        initialFocus={initialFocusRef}
+        modal={false}
+        portal={false}
+        unmountOnHide
+      >
+        <input
+          ref={initialFocusRef}
+          aria-label="Disclosure swap input"
+          autoFocus
+          onFocus={() => recordFocus("input")}
+        />
+      </Ariakit.Dialog>
+    </>
+  );
+}
+
 export default function Example() {
   return (
     <>
@@ -441,6 +620,15 @@ export default function Example() {
           showFocusHistory
           unmountOnHide
         />
+      </div>
+      <div style={{ marginTop: 200 }}>
+        <NativeAutoFocusFixture />
+      </div>
+      <div style={{ marginTop: 200 }}>
+        <StoreSwapFixture />
+      </div>
+      <div style={{ marginTop: 200 }}>
+        <DisclosureSwapFixture />
       </div>
     </>
   );

--- a/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
@@ -152,7 +152,71 @@ withFramework(import.meta.dirname, async ({ test }) => {
     // for focus not being stolen once that microtask has run.
     await flushFrames(page);
     await test.expect(escapeTarget).toBeFocused();
+    await test.expect(q.listbox()).toBeVisible();
     await test.expect(focusHistory).toHaveText("input → focus target");
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7033
+  test("does not refocus after native auto-focus moves focus into a shadow root", async ({
+    page,
+    q,
+  }) => {
+    const disclosure = q.button("Native auto-focus dialog");
+    const escapeTarget = q.textbox("Native auto-focus shadow target");
+    const focusHistory = q.status("Native auto-focus history");
+
+    await test.expect(focusHistory).toHaveText("none");
+
+    await disclosure.click();
+
+    // React runs native auto-focus before layout effects. The input's focus
+    // handler moves focus out synchronously, before Dialog can install a DOM
+    // listener to observe that the dialog had already received focus.
+    await test.expect(escapeTarget).toBeFocused();
+    // Dialog's queued auto-focus has no observable completion marker, so cross
+    // its frame checkpoint before asserting that focus remained outside.
+    await flushFrames(page);
+    await test.expect(escapeTarget).toBeFocused();
+    await test.expect(focusHistory).toHaveText("input → shadow target");
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7033
+  test("focuses a dialog after its store changes", async ({ q }) => {
+    const focusHistory = q.status("Store swap focus history");
+
+    await test.expect(focusHistory).toHaveText("none");
+
+    await q.button("Open store A").click();
+    await test.expect(q.textbox("Store A initial focus")).toBeFocused();
+
+    await q.button("Open store B").click();
+
+    await test.expect(q.textbox("Store B initial focus")).toBeFocused();
+    await test
+      .expect(focusHistory)
+      .toHaveText(
+        "open store A → store A input → open store B → store B input",
+      );
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7033
+  test("uses the current disclosure in delayed auto-focus", async ({
+    page,
+    q,
+  }) => {
+    const previousDisclosure = q.button("Open disclosure swap dialog");
+    const focusHistory = q.status("Disclosure swap focus history");
+
+    await test.expect(focusHistory).toHaveText("none");
+
+    await previousDisclosure.click();
+
+    await test.expect(previousDisclosure).toBeFocused();
+    // Dialog's queued auto-focus has no observable completion marker, so cross
+    // its frame checkpoint before asserting that focus remained outside.
+    await flushFrames(page);
+    await test.expect(previousDisclosure).toBeFocused();
+    await test.expect(focusHistory).toHaveText("input → previous disclosure");
   });
 
   // This case originated in the unmerged PR below. It covers the same

--- a/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
@@ -157,6 +157,26 @@ withFramework(import.meta.dirname, async ({ test }) => {
   });
 
   // https://github.com/ariakit/ariakit/issues/7033
+  test("does not refocus an external focus trap", async ({ page, q }) => {
+    const select = q.combobox("Focus trap escaping fruit");
+    const escapeTarget = q.button("Focus trap escaping fruit focus target");
+    const focusHistory = q.status("Focus trap escaping fruit focus history");
+
+    await test.expect(focusHistory).toHaveText("none");
+
+    await select.click();
+
+    await test.expect(escapeTarget).toBeFocused();
+    await test.expect(q.listbox()).not.toHaveAttribute("data-placing");
+    // Dialog queues auto-focus after placement, and there is no positive state
+    // for focus not being stolen once that microtask has run.
+    await flushFrames(page);
+    await test.expect(escapeTarget).toBeFocused();
+    await test.expect(q.listbox()).toBeVisible();
+    await test.expect(focusHistory).toHaveText("input → focus target");
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7033
   test("does not refocus after native auto-focus moves focus into a shadow root", async ({
     page,
     q,
@@ -178,6 +198,23 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await flushFrames(page);
     await test.expect(escapeTarget).toBeFocused();
     await test.expect(focusHistory).toHaveText("input → shadow target");
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7033
+  test("honors initial focus when the dialog is inside a shadow root", async ({
+    q,
+  }) => {
+    const focusHistory = q.status("Shadow-root dialog focus history");
+
+    await test.expect(focusHistory).toHaveText("none");
+
+    await q.button("Open shadow-root focus dialog").click();
+
+    await test
+      .expect(q.textbox("Shadow-root initial focus field"))
+      .toBeFocused();
+    await test.expect(q.dialog("Shadow-root focus dialog")).toBeVisible();
+    await test.expect(focusHistory).toHaveText("app focus → initial focus");
   });
 
   // https://github.com/ariakit/ariakit/issues/7033

--- a/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
@@ -132,6 +132,29 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.option("Watermelon")).not.toBeInViewport();
   });
 
+  // https://github.com/ariakit/ariakit/issues/7033
+  test("does not refocus after focus leaves an open popup", async ({
+    page,
+    q,
+  }) => {
+    const select = q.combobox("Focus escaping fruit");
+    const escapeTarget = q.button("Focus escaping fruit focus target");
+    const focusHistory = q.status("Focus escaping fruit focus history");
+
+    await test.expect(focusHistory).toHaveText("none");
+
+    await select.click();
+
+    // The app moved focus out of the popup while it was opening.
+    await test.expect(escapeTarget).toBeFocused();
+    await test.expect(q.listbox()).not.toHaveAttribute("data-placing");
+    // Dialog queues auto-focus after placement, and there is no positive state
+    // for focus not being stolen once that microtask has run.
+    await flushFrames(page);
+    await test.expect(escapeTarget).toBeFocused();
+    await test.expect(focusHistory).toHaveText("input → focus target");
+  });
+
   // This case originated in the unmerged PR below. It covers the same
   // focus-move cancellation invariant when the popup remounts on open and the
   // select element briefly becomes the composite again.

--- a/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
@@ -1,7 +1,7 @@
 import { flushFrames, withFramework } from "#app/test-utils/preview.ts";
 import { recordScrollEvents } from "#app/test-utils/scroll.ts";
 
-withFramework(import.meta.dirname, async ({ test }) => {
+withFramework(import.meta.dirname, async ({ query, test }) => {
   // https://github.com/ariakit/ariakit/pull/6832
   test("focuses a far item reached through typeahead", async ({ page, q }) => {
     const select = q.combobox("Selected fruit");
@@ -215,6 +215,28 @@ withFramework(import.meta.dirname, async ({ test }) => {
       .toBeFocused();
     await test.expect(q.dialog("Shadow-root focus dialog")).toBeVisible();
     await test.expect(focusHistory).toHaveText("app focus → initial focus");
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7033
+  test("honors initial focus after focus enters a contained iframe", async ({
+    page,
+    q,
+  }) => {
+    const frame = query(
+      page.frameLocator("iframe[title='Initial focus frame']"),
+    );
+    const focusHistory = q.status("Iframe dialog focus history");
+
+    await test.expect(focusHistory).toHaveText("none");
+
+    await q.button("Open iframe focus dialog").click();
+
+    await test.expect(q.textbox("Iframe initial focus field")).toBeFocused();
+    await test.expect(q.dialog("Iframe focus dialog")).toBeVisible();
+    await test.expect(frame.textbox("Iframe app focus field")).toBeVisible();
+    await test
+      .expect(focusHistory)
+      .toHaveText("dialog focus → iframe focus → initial focus");
   });
 
   // https://github.com/ariakit/ariakit/issues/7033

--- a/app/src/sandbox/combobox-select-selected-value-presentation/test.ts
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/test.ts
@@ -10,3 +10,28 @@ test("activates a far item reached through typeahead", async () => {
   expect(q.option("Lychee")).toHaveAttribute("data-active-item");
   expect(select).toHaveFocus();
 });
+
+// https://github.com/ariakit/ariakit/issues/7033
+test("focuses a dialog after its store changes", async () => {
+  await click(q.button("Open store A"));
+  expect(q.textbox("Store A initial focus")).toHaveFocus();
+
+  await click(q.button("Open store B"));
+
+  expect(q.textbox("Store B initial focus")).toHaveFocus();
+  expect(q.status("Store swap focus history")).toHaveTextContent(
+    "open store A → store A input → open store B → store B input",
+  );
+});
+
+// https://github.com/ariakit/ariakit/issues/7033
+test("uses the current disclosure in delayed auto-focus", async () => {
+  const previousDisclosure = q.button("Open disclosure swap dialog");
+
+  await click(previousDisclosure);
+
+  expect(previousDisclosure).toHaveFocus();
+  expect(q.status("Disclosure swap focus history")).toHaveTextContent(
+    "input → previous disclosure",
+  );
+});

--- a/app/src/sandbox/combobox-select-selected-value-presentation/test.ts
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/test.ts
@@ -12,6 +12,21 @@ test("activates a far item reached through typeahead", async () => {
 });
 
 // https://github.com/ariakit/ariakit/issues/7033
+test("honors initial focus when the dialog is inside a shadow root", async () => {
+  await click(q.button("Open shadow-root focus dialog"));
+
+  const shadowRoot = document.querySelector<HTMLElement>(
+    "[data-shadow-root-dialog-host]",
+  )?.shadowRoot;
+  await expect
+    .poll(() => shadowRoot?.activeElement?.getAttribute("aria-label"))
+    .toBe("Shadow-root initial focus field");
+  expect(q.status("Shadow-root dialog focus history")).toHaveTextContent(
+    "app focus → initial focus",
+  );
+});
+
+// https://github.com/ariakit/ariakit/issues/7033
 test("focuses a dialog after its store changes", async () => {
   await click(q.button("Open store A"));
   expect(q.textbox("Store A initial focus")).toHaveFocus();

--- a/app/src/sandbox/dialog-persistent-elements/index.react.tsx
+++ b/app/src/sandbox/dialog-persistent-elements/index.react.tsx
@@ -48,6 +48,7 @@ function ComboboxPersistentElement() {
 export default function Example() {
   const [open, setOpen] = useState(false);
   const [asSection, setAsSection] = useState(false);
+  const [showLateOutside, setShowLateOutside] = useState(false);
   const [showShadowDialog, setShowShadowDialog] = useState(false);
   const [shadowDialogPortal, setShadowDialogPortal] =
     useState<HTMLElement | null>(null);
@@ -206,6 +207,13 @@ export default function Example() {
         >
           Dismiss notification
         </button>
+        <button
+          type="button"
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={() => setShowLateOutside(true)}
+        >
+          Add late outside field
+        </button>
       </div>
 
       {/* happy-dom proxies forms for named access. Their descendants must still
@@ -225,6 +233,13 @@ export default function Example() {
         placeholder="Outside field"
         className="rounded border border-gray-300 px-3 py-1"
       />
+      {showLateOutside && (
+        <input
+          aria-label="Late outside field"
+          placeholder="Late outside field"
+          className="rounded border border-gray-300 px-3 py-1"
+        />
+      )}
 
       <div ref={setShadowHost} data-testid="shadow-host" />
 

--- a/app/src/sandbox/dialog-persistent-elements/test-browser.ts
+++ b/app/src/sandbox/dialog-persistent-elements/test-browser.ts
@@ -106,6 +106,17 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.dialog("Dialog")).toBeVisible();
   });
 
+  // https://github.com/ariakit/ariakit/issues/7033
+  test("closes on a newly inserted outside element after replacing the dialog", async ({
+    q,
+  }) => {
+    await q.button("Open dialog").click();
+    await q.button("Replace dialog element").click();
+    await q.button("Add late outside field").click();
+    await q.textbox("Late outside field").click();
+    await test.expect(q.dialog("Dialog")).not.toBeVisible();
+  });
+
   test("stays open when interacting with a persistent shadow element", async ({
     page,
     q,

--- a/app/src/sandbox/dialog-persistent-elements/test.ts
+++ b/app/src/sandbox/dialog-persistent-elements/test.ts
@@ -71,6 +71,18 @@ test("keeps persistent elements after replacing an open dialog node", async () =
   expect(q.dialog("Dialog")).toBeVisible();
 });
 
+// https://github.com/ariakit/ariakit/issues/7033
+test("closes on a newly inserted outside element after replacing the dialog", async () => {
+  await click(q.button("Open dialog"));
+  await click(q.button("Replace dialog element"));
+  expect(q.dialog("Dialog")?.tagName).toBe("SECTION");
+
+  await click(q.button("Add late outside field"));
+  await click(q.textbox("Late outside field"));
+
+  await expect.poll(q.dialog.hidden.lazy("Dialog")).not.toBeVisible();
+});
+
 test("stays open when interacting with a persistent shadow element", async () => {
   await click(q.button("Open dialog"));
   expect(q.dialog("Dialog")).toBeVisible();

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -500,7 +500,10 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
       // focusable element outside while the dialog is waiting to be
       // positioned. Preserve that user choice, but allow a dialog that hasn't
       // received focus yet to perform its initial focus move.
-      const activeElement = getActiveElement(element);
+      const documentActiveElement = getDocument(contentElement).activeElement;
+      const activeElement = isElement(documentActiveElement)
+        ? documentActiveElement
+        : null;
       const deepestActiveElement =
         activeElement && getDeepestActiveElement(activeElement);
       if (

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -508,7 +508,12 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
         activeElement &&
         deepestActiveElement &&
         isFocusable(deepestActiveElement) &&
-        !isElementInDialog(activeElement, contentElement, disclosureElement)
+        !isElementInDialog(activeElement, contentElement, disclosureElement) &&
+        !isElementInDialog(
+          deepestActiveElement,
+          contentElement,
+          disclosureElement,
+        )
       ) {
         return;
       }

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -31,6 +31,7 @@ import type {
   ComponentPropsWithRef,
   ElementType,
   FC,
+  FocusEvent as ReactFocusEvent,
   ReactElement,
   KeyboardEvent as ReactKeyboardEvent,
   RefObject,
@@ -87,6 +88,16 @@ function isAlreadyFocusingAnotherElement(dialog?: HTMLElement | null) {
   if (dialog && contains(dialog, activeElement)) return false;
   if (isFocusable(activeElement)) return true;
   return false;
+}
+
+function getDeepestActiveElement(element: Element) {
+  let activeElement = element;
+  while (activeElement.shadowRoot) {
+    const nextElement = activeElement.shadowRoot.activeElement;
+    if (!isElement(nextElement)) break;
+    activeElement = nextElement;
+  }
+  return activeElement;
 }
 
 function isElementInDialog(
@@ -222,18 +233,28 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
   // (e.g., onClose calling event.preventDefault), async closes with
   // animations, or when autoFocusOnHide is disabled.
   const interactedOutsideRef = useRef(false);
+  const focusedStoreRef = useRef<DialogStore | null>(null);
   useSafeLayoutEffect(() => {
     return sync(store, ["open"], (state) => {
-      if (!state.open) return;
+      if (!state.open) {
+        focusedStoreRef.current = null;
+        return;
+      }
       interactedOutsideRef.current = false;
+      // Native auto-focus may run before layout effects on the initial open
+      // render, so preserve focus captured during that commit. Focus history
+      // from another store doesn't belong to this open cycle.
+      if (focusedStoreRef.current === store) return;
+      focusedStoreRef.current = null;
     });
   }, [store]);
-  useHideOnInteractOutside(
+  useHideOnInteractOutside({
     store,
     hideOnInteractOutside,
     domReady,
     interactedOutsideRef,
-  );
+    focusedStoreRef,
+  });
 
   const { wrapElement, nestedDialogs } = useNestedDialogs(store);
   props = useWrapElement(props, wrapElement, [wrapElement]);
@@ -264,6 +285,10 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
   // dialog is opened.
   useSafeLayoutEffect(() => {
     if (!open) return;
+    // Native auto-focus can focus the dialog and synchronously move focus
+    // outside before layout effects run. In that case, the current element is
+    // an escape target rather than the element that disclosed the dialog.
+    if (focusedStoreRef.current === store) return;
     const dialog = ref.current;
     const activeElement = getActiveElement(dialog, true);
     if (!activeElement) return;
@@ -463,21 +488,26 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
       contentElement;
     const isElementFocusable = isFocusable(element);
     if (!autoFocusOnShowProp(isElementFocusable ? element : null)) return;
-    const { disclosureElement } = store.getState();
     setAutoFocusEnabled(true);
     queueMicrotask(() => {
+      const { open, disclosureElement } = store.getState();
       // If the dialog was closed between scheduling and executing this
       // microtask, skip the focus call. Otherwise, focusing a now-hidden
       // element could steal focus from the disclosure that focusOnHide already
       // restored.
-      if (!store.getState().open) return;
-      // Focus may have moved to another focusable element outside the dialog
-      // while it was waiting to be positioned. Preserve that user choice, but
-      // allow focus to remain on the disclosure or another owned element.
+      if (!open) return;
+      // Once the dialog has received focus, focus may move to another
+      // focusable element outside while the dialog is waiting to be
+      // positioned. Preserve that user choice, but allow a dialog that hasn't
+      // received focus yet to perform its initial focus move.
       const activeElement = getActiveElement(element);
+      const deepestActiveElement =
+        activeElement && getDeepestActiveElement(activeElement);
       if (
+        focusedStoreRef.current === store &&
         activeElement &&
-        isFocusable(activeElement) &&
+        deepestActiveElement &&
+        isFocusable(deepestActiveElement) &&
         !isElementInDialog(activeElement, contentElement, disclosureElement)
       ) {
         return;
@@ -506,6 +536,7 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     preserveTabOrder,
     store,
     autoFocusOnShowProp,
+    focusedStoreRef,
   ]);
 
   const mayAutoFocusOnHide = !!autoFocusOnHide;
@@ -612,6 +643,16 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
 
   const onKeyDownProp = props.onKeyDown;
   const onKeyDownCaptureProp = props.onKeyDownCapture;
+  const onFocusCaptureProp = props.onFocusCapture;
+
+  const onFocusCapture = useEvent((event: ReactFocusEvent<HTMLType>) => {
+    onFocusCaptureProp?.(event);
+    if (!store.getState().open) return;
+    const target = event.target;
+    if (!isNode(target)) return;
+    if (!contains(event.currentTarget, target)) return;
+    focusedStoreRef.current = store;
+  });
 
   const acceptEscape = useEvent((event: KeyboardEvent) => {
     if (event.key !== "Escape") return false;
@@ -795,6 +836,7 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     "data-dialog-portal": hasDefaultModalPortal ? portalNode?.id : undefined,
     id,
     ref: useMergeRefs(ref, props.ref),
+    onFocusCapture,
     onKeyDown,
     onKeyDownCapture,
   };

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -62,6 +62,7 @@ import {
   markAndDisableTreeOutside,
 } from "./utils/disable-tree.ts";
 import {
+  isElementInside,
   isElementMarked,
   markTreeInside,
   markTreeOutside,
@@ -86,6 +87,16 @@ function isAlreadyFocusingAnotherElement(dialog?: HTMLElement | null) {
   if (dialog && contains(dialog, activeElement)) return false;
   if (isFocusable(activeElement)) return true;
   return false;
+}
+
+function isElementInDialog(
+  element: Element,
+  dialog: Element,
+  disclosureElement: Element | null,
+) {
+  if (contains(dialog, element)) return true;
+  if (disclosureElement && contains(disclosureElement, element)) return true;
+  return isElementInside(element, dialog);
 }
 
 function getElementFromProp(
@@ -452,6 +463,7 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
       contentElement;
     const isElementFocusable = isFocusable(element);
     if (!autoFocusOnShowProp(isElementFocusable ? element : null)) return;
+    const { disclosureElement } = store.getState();
     setAutoFocusEnabled(true);
     queueMicrotask(() => {
       // If the dialog was closed between scheduling and executing this
@@ -459,6 +471,17 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
       // element could steal focus from the disclosure that focusOnHide already
       // restored.
       if (!store.getState().open) return;
+      // Focus may have moved to another focusable element outside the dialog
+      // while it was waiting to be positioned. Preserve that user choice, but
+      // allow focus to remain on the disclosure or another owned element.
+      const activeElement = getActiveElement(element);
+      if (
+        activeElement &&
+        isFocusable(activeElement) &&
+        !isElementInDialog(activeElement, contentElement, disclosureElement)
+      ) {
+        return;
+      }
       // The browser's own focus scroll is unreliable here: Safari drops it
       // when a focus handler immediately moves focus elsewhere, which is what
       // virtual focus does. Scroll explicitly instead, so every engine behaves

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -500,6 +500,9 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
       // focusable element outside while the dialog is waiting to be
       // positioned. Preserve that user choice, but allow a dialog that hasn't
       // received focus yet to perform its initial focus move.
+      // `getActiveElement` follows same-origin frames into another document.
+      // Ownership must stay in the dialog's document, where focus in a frame is
+      // represented by the frame element inside the dialog.
       const documentActiveElement = getDocument(contentElement).activeElement;
       const activeElement = isElement(documentActiveElement)
         ? documentActiveElement

--- a/packages/ariakit-react-components/src/dialog/utils/use-hide-on-interact-outside.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/use-hide-on-interact-outside.ts
@@ -162,12 +162,21 @@ function shouldHideOnInteractOutside(
   return !!hideOnInteractOutside;
 }
 
-export function useHideOnInteractOutside(
-  store: DialogStore,
-  hideOnInteractOutside: DialogOptions["hideOnInteractOutside"],
-  domReady?: boolean | HTMLElement | null,
-  interactedOutsideRef?: MutableRefObject<boolean>,
-) {
+interface UseHideOnInteractOutsideOptions {
+  store: DialogStore;
+  hideOnInteractOutside: DialogOptions["hideOnInteractOutside"];
+  domReady: boolean | HTMLElement | null | undefined;
+  interactedOutsideRef: MutableRefObject<boolean>;
+  focusedStoreRef: MutableRefObject<DialogStore | null>;
+}
+
+export function useHideOnInteractOutside({
+  store,
+  hideOnInteractOutside,
+  domReady,
+  interactedOutsideRef,
+  focusedStoreRef,
+}: UseHideOnInteractOutsideOptions) {
   const open = useStoreState(store, "open");
   const contentElement = useStoreState(store, "contentElement");
   const eventWindow = contentElement
@@ -179,7 +188,6 @@ export function useHideOnInteractOutside(
     contentElement,
   );
   const focusedRef = useRef(false);
-
   // Tracks whether the content element has been focused at least once since
   // the dialog opened. The event listeners below use this to decide whether
   // the marked-tree check applies. Shared by all event types.
@@ -190,12 +198,19 @@ export function useHideOnInteractOutside(
     focusedRef.current = false;
     const onFocus = () => {
       focusedRef.current = true;
+      focusedStoreRef.current = store;
     };
     contentElement.addEventListener("focusin", onFocus, true);
     return () => contentElement.removeEventListener("focusin", onFocus, true);
-  }, [open, domReady, contentElement]);
+  }, [open, domReady, contentElement, store]);
 
-  const props = { store, capture: true, open, contentElement, focusedRef };
+  const props = {
+    store,
+    capture: true,
+    open,
+    contentElement,
+    focusedRef,
+  };
 
   useEventOutside({
     ...props,
@@ -232,9 +247,7 @@ export function useHideOnInteractOutside(
         return;
       }
       if (!shouldHideOnInteractOutside(hideOnInteractOutside, event)) return;
-      if (interactedOutsideRef) {
-        interactedOutsideRef.current = true;
-      }
+      interactedOutsideRef.current = true;
       store.hide();
     },
   });
@@ -250,7 +263,6 @@ export function useHideOnInteractOutside(
       if (!shouldHideOnInteractOutside(hideOnInteractOutside, event)) return;
       const target = event.target;
       if (
-        interactedOutsideRef &&
         isElement(target) &&
         getDocument(target) !== getDocument(contentElement)
       ) {
@@ -265,9 +277,7 @@ export function useHideOnInteractOutside(
     type: "contextmenu",
     listener: (event) => {
       if (!shouldHideOnInteractOutside(hideOnInteractOutside, event)) return;
-      if (interactedOutsideRef) {
-        interactedOutsideRef.current = true;
-      }
+      interactedOutsideRef.current = true;
       store.hide();
     },
   });


### PR DESCRIPTION
## Motivation

`Dialog` queues its initial auto-focus until the popup has been positioned. If focus leaves an open popup while it is waiting, the delayed callback can reclaim focus and create an unexpected focus loop in components such as `ComboboxPopover`.

Fixes #7033.

## Solution

`Dialog` now records whether the current store's dialog has received focus. React focus capture covers native `autoFocus` before layout effects, while a native `focusin` listener covers later focus moves and non-React descendants. The delayed callback suppresses auto-focus only when that exact store has received focus and focus is now on another focusable destination outside the current dialog, disclosure, and owned tree.

The callback reads the current `open` and `disclosureElement` state when its microtask runs. Active-element ownership starts in the Dialog document, where focus inside a same-origin iframe remains represented by the containing `iframe`. Existing open-shadow traversal then uses the deepest focused node for focusability and checks ownership against both the document's shallow active host and that deepest node. This uses the narrow dialog, disclosure, and owned-tree predicate; unlike outside-interaction handling, it intentionally does not classify arbitrary `data-focus-trap` elements as owned. Outside-interaction behavior keeps a separate content-scoped focus flag because replacing the rendered dialog element must reset that state without erasing the store's auto-focus history.

The `combobox-select-selected-value-presentation` sandbox includes visible histories for the original focus escape, an external focus-trap escape, native auto-focus into a nested open shadow root, a dialog mounted inside an open shadow root, focus entering a contained iframe, store replacement, and disclosure replacement. For `Focus escaping fruit` and `Focus trap escaping fruit`, the broken behavior records `input → focus target → input → focus target`; the fixed behavior ends at `input → focus target` and leaves the popup visible. Their history panels now stay in normal flow at a readable width, so each result remains attributable to its fixture. The contained-iframe dialog separately shows `dialog focus → iframe focus → initial focus`. Browser tests cover placement and browsing-context behavior, while reliable store, disclosure, content-replacement, and shadow-root dialog cases are duplicated in happy-dom for React 18 coverage.

## Implementation review reassessment

<details>
<summary>Cycle 3: Keep store focus history separate from outside-interaction state</summary>

**Assessment**

The original active-element-only guard was too broad and suppressed legitimate initial focus in Menu and Combobox compositions. The required distinction is whether this exact `DialogStore` has already received focus, not merely whether some focusable element is active outside. Outside-interaction listeners have a different content-element reset boundary, so their focused state cannot safely stand in for store history.

**Decision**

Continue with one store-valued history ref for delayed auto-focus and one local content-scoped boolean for outside-interaction behavior. Keep the open-shadow traversal local to `Dialog` because no shared utility needs the broader behavior. This adds no public API and preserves existing content-replacement semantics.

</details>

<details>
<summary>Cycle 9: Continue store-scoped history with document-local ownership</summary>

**Assessment**

The original bug has moderate overall severity and high accessibility impact when it occurs: delayed auto-focus can reclaim focus after an application or user has intentionally left an open popup. Its expected frequency remains timing-dependent, but it affects stable Dialog behavior used by Select and ComboboxSelect and has been reproduced in Chrome and Firefox.

The current implementation has meaningful but bounded private complexity: one exact-store focus-history ref, React and native focus observation paths, and a local ownership check. Removing exact-store history was tested and regressed existing Menu and Combobox behavior, so that state remains load-bearing.

The confirmed same-origin iframe regression is narrower and likely less frequent than the original issue, but it silently drops the documented `initialFocus` behavior and initial scroll relative to the merge base. `getActiveElement` follows same-origin frames, while ownership must be decided in the Dialog's own document. Reading that document's active element leaves a focused frame represented by its containing `iframe`, after which the existing open-shadow traversal and shallow/deep ownership checks remain valid. This replaces an over-broad lookup and adds no state, branch, helper, public API, or shared abstraction.

The test and sandbox footprint is now the larger maintenance concern. The specialized regressions protect distinct decisions, and the two original focus-history panels now stay in normal flow so they cannot overlap during manual verification.

**Decision**

Continue the exact-store design. Address the confirmed iframe regression by resolving the active element from the Dialog's document, retaining both shallow-host and deepest-open-shadow ownership checks, and adding one focused browser regression.

Keep the auto-focus ownership predicate narrow: an arbitrary external `data-focus-trap` remains a legitimate escape. Do not replace exact-store history with an active-element-only guard.

Keep each original focus-history panel in normal flow so a browser user can identify the bug as `input → focus target → input` instead of the expected `input → focus target` without another fixture covering the result.

This is a local completion of the current direction, not a redesign, reversion, or support narrowing, so the implementation-cycle count does not reset.

**Intentionally unsupported**

Closed-shadow internals; null, body, disconnected, or non-focusable active targets; outside focus before the exact current store's dialog has received focus; arbitrary external focus traps as owned elements; and cross-browsing-context focus transitions where the Dialog itself lives in a child frame remain unsupported without a confirmed reproduction. Frame documents are not traversed for ownership; the containing `iframe` in the Dialog's document is the supported boundary.

</details>

## Review gate reassessment

<details>
<summary>Cycle 3: Continue the narrow store-scoped focus design</summary>

**Assessment**

The bug has high accessibility impact when it occurs because focus can be reclaimed after the user or application has intentionally moved it. Its expected frequency is lower because it requires delayed placement to overlap a focus transition. Review rounds identified pre-layout native auto-focus, store replacement, nested open shadow roots, and timing-proof requirements. These are distinct supported focus paths rather than speculative branches.

**Decision**

Continue exact-store focus history and local open-shadow focusability handling. Do not broaden shared DOM or outside-interaction machinery. Closed shadow roots, body or null active targets, disconnected or non-focusable destinations, and outside focus before the current store's dialog receives focus remain intentionally unsupported because they do not provide a reliable user-selected focus destination.

</details>

<details>
<summary>Cycle 6: Continue store-scoped focus history with local shadow handling</summary>

**Assessment**

Overall severity is moderate, with high accessibility disruption per occurrence and timing-dependent frequency. The production change remains private and modest: one store-valued ref, one existing content-scoped boolean with its original reset semantics, and one local shadow traversal helper. No public API or shared DOM abstraction is added. Later review findings focused on browser authority, React 18 duplication, internal call shape, dead guards, and provenance, which shows convergence rather than a failing implementation direction.

**Decision**

Keep the current design. Use an object parameter for the expanded internal hook, assign required refs unconditionally, retain both browser and happy-dom coverage where the behavior is reliable in each environment, and preserve the same intentionally unsupported cases listed above. Reverting to an active-element guard, using a store-independent boolean, or sharing one ref across both reset boundaries would reintroduce confirmed regressions.

</details>

## Workaround

For consumers pinned to a release before this fix, disable the delayed auto-focus for this composition:

```tsx
<ComboboxPopover
  // TODO: Remove after https://github.com/ariakit/ariakit/issues/7033 is fixed.
  autoFocusOnShow={false}
/>
```

This keeps focus on the escape target but opts out of Dialog initial focus behavior for the popup.

## Preview

The [original focus-escape evidence](https://github.com/ariakit/ariakit/pull/7048#issuecomment-5167123335) and [shadow-root follow-up](https://github.com/ariakit/ariakit/pull/7048#issuecomment-5177509096) include screenshots and short recordings of the visible focus-history panels.

The latest sandbox keeps the original focus history in a readable panel next to its own fixture. After opening `Focus escaping fruit`, the fixed history ends at `input → focus target`:

<img width="321" height="768" alt="Focus escaping fruit fixture showing the fixed input to focus target history in its own non-overlapping panel" src="https://github.com/user-attachments/assets/453ba07f-ed45-44fe-b10d-bd7b2e4fd38d" />
