### PR TITLE
Update @clerk/astro to v4.0.5

### DIFF
--- a/app/astro.config.ts
+++ b/app/astro.config.ts
@@ -128,24 +128,11 @@ export default defineConfig({
       : clerk({
           signInUrl: getPlusAccountPath({ path: "login" }),
           signUpUrl: getPlusCheckoutPath({ step: "login" }),
-          // @clerk/astro 3.4.2 migrated its build to tsdown and inlined a
-          // newer `@clerk/ui` `Appearance<Ui<any>>` type into its bundled
-          // declarations. That type keeps only per-component overrides (plus
-          // the `Ui` brand and `cssLayerName`) and drops the top-level theme
-          // props (`variables`, `layout`), so this config no longer
-          // type-checks — even though the 3.4.2 changelog reports no runtime
-          // or public API change and the legacy appearance options still work
-          // at runtime. Because excess-property checks stop at the first
-          // unknown key, the `@ts-expect-error` below disables property/value
-          // checking for the whole `appearance` object, not just `variables`;
-          // edits here go unchecked until Clerk ships a fixed type and the
-          // directive can be removed.
           appearance: {
-            // @ts-expect-error -- see the note above (upstream type regression).
             variables: {
               fontSize: "1rem",
             },
-            layout: {
+            options: {
               logoPlacement: "none",
               showOptionalFields: false,
             },

--- a/app/package.json
+++ b/app/package.json
@@ -65,7 +65,7 @@
     "@astrojs/mdx": "7.0.5",
     "@astrojs/react": "6.0.2",
     "@astrojs/solid-js": "7.0.1",
-    "@clerk/astro": "4.0.4",
+    "@clerk/astro": "4.0.5",
     "@fontsource-variable/inter": "5.3.0",
     "@radix-ui/react-popover": "1.1.23",
     "@radix-ui/react-select": "2.3.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,8 +204,8 @@ importers:
         specifier: 7.0.1
         version: 7.0.1(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(solid-js@1.9.14)(supports-color@10.2.2)(terser@5.46.0)(yaml@2.9.0)
       '@clerk/astro':
-        specifier: 4.0.4
-        version: 4.0.4(astro@7.1.6(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@24.13.3)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.59.0)(terser@5.46.0)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: 4.0.5
+        version: 4.0.5(astro@7.1.6(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@24.13.3)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.59.0)(terser@5.46.0)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@fontsource-variable/inter':
         specifier: 5.3.0
         version: 5.3.0
@@ -2290,8 +2290,8 @@ packages:
     resolution: {integrity: sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA==}
     engines: {node: '>= 20.12.0'}
 
-  '@clerk/astro@4.0.4':
-    resolution: {integrity: sha512-RDc/9zkV0I4MideK0/3Bv2k1ILGU3+fhBIUSZY8deku216wqtqZRFFACAvLnP0UdvdxEUzd8WLT2hSjR+cCxMw==}
+  '@clerk/astro@4.0.5':
+    resolution: {integrity: sha512-+wG1hk6dKIH2ikbDoSoUNUvoqxGW2VayXN50g4fG4NodkQkc+GlKim3Tllgsz+0xE/RcCf0bnbHYuN5rrVkE9g==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       astro: ^5.0.0 || ^6.0.0 || ^7.0.0
@@ -2300,8 +2300,8 @@ packages:
     resolution: {integrity: sha512-zmd0jPyb1iALlmyzyRbgujQXrGqw8sf+VpFjm5GkndpBeq5+9+oH7QgMaFEmWi9oxvTd2sZ+EN+QT4+OXPUnGA==}
     engines: {node: '>=14'}
 
-  '@clerk/backend@3.14.0':
-    resolution: {integrity: sha512-WsphTvDFHDuQilKI7dyVE5qmt7USu8qSrujAq6SqpEHbVFfNBfINDNuzxlF9M2skOTfHFfgiTE8Jjb1egIBGLg==}
+  '@clerk/backend@3.15.0':
+    resolution: {integrity: sha512-m8/X0hAjX9HyBD0IdfIFIxP1fbbSvnq5DB6mPLeIc53Ya9XCLn/hlQkaIM8pobKsM/jquRt9DQLT9IvV6z6bFQ==}
     engines: {node: '>=20.9.0'}
 
   '@clerk/clerk-react@4.32.5':
@@ -2331,8 +2331,8 @@ packages:
       react:
         optional: true
 
-  '@clerk/shared@4.25.9':
-    resolution: {integrity: sha512-nw3maGzqPrwmUKjGffOM9Zvw24IyOllq0TkQGzsTfQX312WLu2u5CNvjKntMb6Ok6kXa1Zdc77zmPLn1/EAIFA==}
+  '@clerk/shared@4.25.10':
+    resolution: {integrity: sha512-Vjqk74nQGJ8y+cm+eSshoBzRvBhIzuKLOs3Gt13gEHdyQ6yV798Dl2SrBKt0jw2u6I1tOcD3s8/i9P4yJYo0dw==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
@@ -12702,10 +12702,10 @@ snapshots:
       fast-wrap-ansi: 0.2.0
       sisteransi: 1.0.5
 
-  '@clerk/astro@4.0.4(astro@7.1.6(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@24.13.3)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.59.0)(terser@5.46.0)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@clerk/astro@4.0.5(astro@7.1.6(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@24.13.3)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.59.0)(terser@5.46.0)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@clerk/backend': 3.14.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@clerk/shared': 4.25.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@clerk/backend': 3.15.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@clerk/shared': 4.25.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       astro: 7.1.6(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@24.13.3)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.59.0)(terser@5.46.0)(yaml@2.9.0)
       nanoid: 5.1.6
       nanostores: 1.0.1
@@ -12727,9 +12727,9 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  '@clerk/backend@3.14.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@clerk/backend@3.15.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@clerk/shared': 4.25.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@clerk/shared': 4.25.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       standardwebhooks: 1.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -12777,7 +12777,7 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
 
-  '@clerk/shared@4.25.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@clerk/shared@4.25.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@tanstack/query-core': 5.101.4
       dequal: 2.0.3


### PR DESCRIPTION
## Motivation

`@clerk/astro` 4.0.5 fixes the Astro integration's appearance type resolution so supported `variables` and `options` fields are checked correctly again. Ariakit's app is on 4.0.4 and carries a broad `@ts-expect-error` workaround for the prior type regression.

## Solution

Update `@clerk/astro` to 4.0.5, regenerate and deduplicate the pnpm lockfile, and migrate the legacy `appearance.layout` key to Clerk's current `appearance.options` key. This preserves the existing appearance settings while removing the workaround and restoring type checking for the complete object.

```ts
appearance: {
  variables: { fontSize: "1rem" },
  options: {
    logoPlacement: "none",
    showOptionalFields: false,
  },
}
```

## Dependencies

| Package | Workspace | Old | New | Source |
| --- | --- | --- | --- | --- |
| `@clerk/astro` | `app` | `4.0.4` | `4.0.5` | [Release](https://github.com/clerk/javascript/releases/tag/%40clerk/astro%404.0.5), [upstream fix](https://github.com/clerk/javascript/pull/9281) |
| `@clerk/backend` | lockfile (transitive) | `3.14.0` | `3.15.0` | [Release](https://github.com/clerk/javascript/releases/tag/%40clerk/backend%403.15.0) |
| `@clerk/shared` | lockfile (transitive) | `4.25.9` | `4.25.10` | [Release](https://github.com/clerk/javascript/releases/tag/%40clerk/shared%404.25.10) |

## Acknowledgments

Thanks to [Bobby Lin](https://github.com/BobbyLin23) for fixing and documenting the upstream appearance type regression in [clerk/javascript#9281](https://github.com/clerk/javascript/pull/9281).
