### PR TITLE
Stabilize tag combobox inline autocomplete test

### DIFF
--- a/app/src/sandbox/tag-combobox/test.ts
+++ b/app/src/sandbox/tag-combobox/test.ts
@@ -80,6 +80,7 @@ test("deselecting a tag should not highlight the input text if it is not the fir
   expect(q.combobox()).toHaveValue("");
   expect(q.option(/Aiden Freeman /)).toHaveAttribute("data-active-item");
   expect(q.option(/Aiden Freeman /)).toHaveAttribute("aria-selected", "false");
+  await q.option.wait(/Abigail Rivera /);
   await press.ArrowUp();
   expect(q.combobox()).toHaveValue("abigailrivera35@email.com");
   expect(q.option(/Abigail Rivera /)).toHaveAttribute("data-active-item");


### PR DESCRIPTION
## Motivation

The tag-combobox integration test can press `ArrowUp` before the fixture's `useDeferredValue` result list commits after deselecting Aiden. Under CI load, Abigail Rivera is not rendered yet, so navigation leaves the input empty and the test flakes.

## Solution

Wait for the Abigail Rivera option through `q.option.wait` before pressing `ArrowUp`. This synchronizes the test with observable UI state instead of a fixed delay while preserving its existing navigation and inline-completion assertions.

```ts
await q.option.wait(/Abigail Rivera /);
await press.ArrowUp();
```

## Testing

- Full tag-combobox Vitest file, 5/5 passed
- Focused React 19 test under the high-frequency CPU throttle that reproduced the failure
- Focused React 18 compatibility test
- Repository oxlint and oxfmt passes

Fixes #7057
