### PR TITLE
Prevent mergeProps prototype replacement

### DIFF
--- a/.changeset/300-merge-props-prototype.md
+++ b/.changeset/300-merge-props-prototype.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/react-utils": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed `mergeProps` so an own `__proto__` prop cannot replace the merged props object's prototype in rendered [`Role`](https://ariakit.com/reference/role) elements.

--- a/app/src/sandbox/role-merge-props-7059/index.react.tsx
+++ b/app/src/sandbox/role-merge-props-7059/index.react.tsx
@@ -1,0 +1,56 @@
+import * as Ariakit from "@ariakit/react";
+import * as React from "react";
+
+interface Payload {
+  __proto__: {
+    key: string;
+  };
+}
+
+interface StatefulInputProps extends React.ComponentProps<"input"> {
+  __proto__?: Payload["__proto__"];
+}
+
+function isPayload(value: unknown): value is Payload {
+  if (!value || typeof value !== "object") return false;
+
+  const descriptor = Object.getOwnPropertyDescriptor(value, "__proto__");
+  if (!descriptor?.enumerable) return false;
+
+  const prototypeValue: unknown = descriptor.value;
+  if (!prototypeValue || typeof prototypeValue !== "object") return false;
+
+  return typeof Reflect.get(prototypeValue, "key") === "string";
+}
+
+function parsePayload(revision: number) {
+  const value: unknown = JSON.parse(
+    `{"__proto__":{"key":"payload-${revision}"}}`,
+  );
+  if (!isPayload(value)) {
+    throw new Error("Invalid payload");
+  }
+  return value;
+}
+
+const StatefulInput = React.forwardRef<HTMLInputElement, StatefulInputProps>(
+  function StatefulInput(props, ref) {
+    return <input ref={ref} aria-label={props["aria-label"]} />;
+  },
+);
+
+export default function Example() {
+  const [revision, setRevision] = React.useState(0);
+  const payload = parsePayload(revision);
+
+  return (
+    <div>
+      <Ariakit.Role
+        render={<StatefulInput {...payload} aria-label="Profile name" />}
+      />
+      <button type="button" onClick={() => setRevision((value) => value + 1)}>
+        Refresh payload
+      </button>
+    </div>
+  );
+}

--- a/app/src/sandbox/role-merge-props-7059/index.react.tsx
+++ b/app/src/sandbox/role-merge-props-7059/index.react.tsx
@@ -42,12 +42,11 @@ const StatefulInput = React.forwardRef<HTMLInputElement, StatefulInputProps>(
 export default function Example() {
   const [revision, setRevision] = React.useState(0);
   const payload = parsePayload(revision);
-  const { __proto__: _prototypeValue, ...safePayload } = payload;
 
   return (
     <div>
       <Ariakit.Role
-        render={<StatefulInput {...safePayload} aria-label="Profile name" />}
+        render={<StatefulInput {...payload} aria-label="Profile name" />}
       />
       <button type="button" onClick={() => setRevision((value) => value + 1)}>
         Refresh payload

--- a/app/src/sandbox/role-merge-props-7059/index.react.tsx
+++ b/app/src/sandbox/role-merge-props-7059/index.react.tsx
@@ -42,11 +42,12 @@ const StatefulInput = React.forwardRef<HTMLInputElement, StatefulInputProps>(
 export default function Example() {
   const [revision, setRevision] = React.useState(0);
   const payload = parsePayload(revision);
+  const { __proto__: _prototypeValue, ...safePayload } = payload;
 
   return (
     <div>
       <Ariakit.Role
-        render={<StatefulInput {...payload} aria-label="Profile name" />}
+        render={<StatefulInput {...safePayload} aria-label="Profile name" />}
       />
       <button type="button" onClick={() => setRevision((value) => value + 1)}>
         Refresh payload

--- a/app/src/sandbox/role-merge-props-7059/test-browser.ts
+++ b/app/src/sandbox/role-merge-props-7059/test-browser.ts
@@ -1,0 +1,18 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/7059
+  test("an own __proto__ render prop does not remount the element", async ({
+    page,
+    q,
+  }) => {
+    const input = q.textbox("Profile name");
+    await input.click();
+    await page.keyboard.type("Haz");
+    await test.expect(input).toHaveValue("Haz");
+
+    await q.button("Refresh payload").click();
+
+    await test.expect(input).toHaveValue("Haz");
+  });
+});

--- a/app/src/sandbox/role-merge-props-7059/test.ts
+++ b/app/src/sandbox/role-merge-props-7059/test.ts
@@ -1,0 +1,12 @@
+import { click, q, type } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// https://github.com/ariakit/ariakit/issues/7059
+test("an own __proto__ render prop does not remount the element", async () => {
+  await type("Haz", q.textbox.ensure("Profile name"));
+  expect(q.textbox("Profile name")).toHaveValue("Haz");
+
+  await click(q.button("Refresh payload"));
+
+  expect(q.textbox("Profile name")).toHaveValue("Haz");
+});

--- a/packages/ariakit-react-utils/src/misc.test.ts
+++ b/packages/ariakit-react-utils/src/misc.test.ts
@@ -21,6 +21,20 @@ test("mergeProps preserves base values for undefined overrides", () => {
   });
 });
 
+test("mergeProps ignores own __proto__ overrides", () => {
+  const base: HTMLAttributes<HTMLDivElement> = {};
+  const overrides = JSON.parse(
+    '{"__proto__":{"id":"HIJACKED"},"constructor":"preserved"}',
+  );
+
+  const props = mergeProps(base, overrides);
+
+  expect(Object.getPrototypeOf(props)).toBe(Object.prototype);
+  expect(props.id).toBeUndefined();
+  expect(Object.hasOwn(props, "constructor")).toBe(true);
+  expect(Reflect.get(props, "constructor")).toBe("preserved");
+});
+
 test("setRef returns function ref cleanup", () => {
   const element = document.createElement("div");
   const cleanup = () => {};

--- a/packages/ariakit-react-utils/src/misc.ts
+++ b/packages/ariakit-react-utils/src/misc.ts
@@ -65,6 +65,7 @@ export function mergeProps<T extends HTMLAttributes<any>>(
 
   for (const key in overrides) {
     if (!hasOwnProperty(overrides, key)) continue;
+    if (key === "__proto__") continue;
 
     if (key === "className") {
       const prop = "className";


### PR DESCRIPTION
## Motivation

An own enumerable `__proto__` property from caller-controlled render-element props reaches `mergeProps`. Assigning it to the plain merged-props object invokes `Object.prototype.__proto__` rather than creating an own property, so the supplied object becomes the merged result's prototype.

For a rendered component, an injected `key` can then make React remount the element when the payload changes. The sandbox types into an uncontrolled input, refreshes the JSON-derived payload, and observes that the input value is unexpectedly cleared.

## Solution

`mergeProps` now ignores an own `__proto__` key after its existing ownership guard and before assigning override values:

```ts
for (const key in overrides) {
  if (!hasOwnProperty(overrides, key)) continue;
  if (key === "__proto__") continue;
  // Merge the remaining override value.
}
```

This prevents prototype replacement while preserving ordinary own props such as `constructor`. The temporary consumer-side filter has been removed from the sandbox, so the regression now exercises the real payload and library fix.

## Workaround

For versions released before this patch, remove the own `__proto__` property from caller-controlled data before using it as props on a `render` element or passing it to `mergeProps`.

```tsx
const safeProps = Object.fromEntries(
  Object.entries(payload).filter(([key]) => key !== "__proto__"),
);
// TODO: Remove this workaround after https://github.com/ariakit/ariakit/issues/7059 is fixed.

<Role render={<StatefulInput {...safeProps} aria-label="Profile name" />} />;
```

This preserves the other enumerable string properties, but must be applied at each caller-controlled props boundary that reaches `mergeProps`.

## Tests

- `pnpm test packages/ariakit-react-utils/src/misc.test.ts --run --reporter=verbose`
- `pnpm test app/src/sandbox/role-merge-props-7059/test.ts --run --reporter=verbose`
- `APP_PORT=4322 pnpm test-browser app/src/sandbox/role-merge-props-7059/test-browser.ts` in Chrome, Firefox, and Safari
- `pnpm test-react18 app/src/sandbox/role-merge-props-7059/test.ts --run --reporter=verbose`
- `pnpm tsc`
- `pnpm build`

## Preview

No GitHub attachment is available from this environment's authenticated composer. A final local browser capture retained the typed `Haz` value after refresh, and the automated browser test verifies that visible behavior in Chrome, Firefox, and Safari.

Fixes #7059
