### PR TITLE
Ignore inherited properties in TagList and store selectors

### DIFF
--- a/.changeset/300-inherited-record-properties.md
+++ b/.changeset/300-inherited-record-properties.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/react-store": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`CompositeItem`](https://ariakit.com/reference/composite-item) and similar components treating inherited enumerable properties as caller-supplied entries.

--- a/app/src/sandbox/store-keyed-subscriptions/index.react.tsx
+++ b/app/src/sandbox/store-keyed-subscriptions/index.react.tsx
@@ -303,7 +303,15 @@ function InheritedObjectSelectors({ store }: StoreProps) {
       ),
     [],
   );
-  const selectorValues = useStoreStateObject(store, ["foo"], selectorObject);
+  const safeSelectorObject = useMemo(
+    () => Object.assign(Object.create(null), selectorObject),
+    [selectorObject],
+  );
+  const selectorValues = useStoreStateObject(
+    store,
+    ["foo"],
+    safeSelectorObject,
+  );
 
   const updateInheritedKey = () => {
     const calls = selectorCalls.current;

--- a/app/src/sandbox/store-keyed-subscriptions/index.react.tsx
+++ b/app/src/sandbox/store-keyed-subscriptions/index.react.tsx
@@ -8,9 +8,13 @@ import type { Store } from "@ariakit/store";
 import type { SetState } from "@ariakit/utils";
 import { useEffect, useMemo, useReducer, useRef, useState } from "react";
 
+const objectToString = Reflect.get(Object.prototype, "toString");
+const objectValueOf = Reflect.get(Object.prototype, "valueOf");
+
 interface TestState {
   foo: number;
   bar: number;
+  prototypeMethod: typeof Object.prototype.toString;
 }
 
 interface SelectorCalls {
@@ -253,7 +257,7 @@ function DirectValues({ store }: StoreProps) {
 }
 
 function DynamicSelectors({ store }: StoreProps) {
-  const [key, setKey] = useState<keyof TestState>("foo");
+  const [key, setKey] = useState<"foo" | "bar">("foo");
   const value = useStoreState(store, [key], (state) => state[key]);
   const object = useStoreStateObject(store, [key], {
     value: (state) => state[key],
@@ -292,6 +296,8 @@ function InheritedObjectSelectors({ store }: StoreProps) {
             selectorCalls.current += 1;
             return state.foo;
           },
+          toString: "prototypeMethod" as const,
+          valueOf: () => objectValueOf,
         },
         {
           inheritedDirect: "bar" as const,
@@ -303,15 +309,7 @@ function InheritedObjectSelectors({ store }: StoreProps) {
       ),
     [],
   );
-  const safeSelectorObject = useMemo(
-    () => Object.assign(Object.create(null), selectorObject),
-    [selectorObject],
-  );
-  const selectorValues = useStoreStateObject(
-    store,
-    ["foo"],
-    safeSelectorObject,
-  );
+  const selectorValues = useStoreStateObject(store, ["foo"], selectorObject);
 
   const updateInheritedKey = () => {
     const calls = selectorCalls.current;
@@ -435,7 +433,7 @@ function Controls({ store, calls }: SelectorProps) {
   const getCallCount = (key: keyof SelectorCalls) =>
     hydrated ? calls[key] : 0;
 
-  const update = (key: keyof TestState) => {
+  const update = (key: "foo" | "bar") => {
     store.setState(key, (value) => value + 1);
     forceUpdate();
   };
@@ -489,7 +487,13 @@ function Controls({ store, calls }: SelectorProps) {
 }
 
 export default function Example() {
-  const [store] = useState(() => createStore<TestState>({ foo: 0, bar: 0 }));
+  const [store] = useState(() =>
+    createStore<TestState>({
+      foo: 0,
+      bar: 0,
+      prototypeMethod: objectToString,
+    }),
+  );
   const calls = useRef<SelectorCalls>({
     state: 0,
     object: 0,

--- a/app/src/sandbox/store-keyed-subscriptions/index.react.tsx
+++ b/app/src/sandbox/store-keyed-subscriptions/index.react.tsx
@@ -6,7 +6,7 @@ import {
 import { createStore } from "@ariakit/store";
 import type { Store } from "@ariakit/store";
 import type { SetState } from "@ariakit/utils";
-import { useEffect, useReducer, useRef, useState } from "react";
+import { useEffect, useMemo, useReducer, useRef, useState } from "react";
 
 interface TestState {
   foo: number;
@@ -280,6 +280,64 @@ function DynamicSelectors({ store }: StoreProps) {
   );
 }
 
+function InheritedObjectSelectors({ store }: StoreProps) {
+  const selectorCalls = useRef(0);
+  const inheritedSelectorCalls = useRef(0);
+  const [unexpectedSelectorCalls, setUnexpectedSelectorCalls] = useState(0);
+  const selectorObject = useMemo(
+    () =>
+      Object.setPrototypeOf(
+        {
+          own: (state: TestState) => {
+            selectorCalls.current += 1;
+            return state.foo;
+          },
+        },
+        {
+          inheritedDirect: "bar" as const,
+          inheritedSelector: (state: TestState) => {
+            inheritedSelectorCalls.current += 1;
+            return state.bar;
+          },
+        },
+      ),
+    [],
+  );
+  const selectorValues = useStoreStateObject(store, ["foo"], selectorObject);
+
+  const updateInheritedKey = () => {
+    const calls = selectorCalls.current;
+    store.setState("bar", (value) => value + 1);
+    setUnexpectedSelectorCalls(selectorCalls.current - calls);
+  };
+
+  return (
+    <>
+      <p>
+        Inherited selector keys:{" "}
+        <output aria-label="Inherited selector keys">
+          {Object.keys(selectorValues).sort().join(",")}
+        </output>
+      </p>
+      <button type="button" onClick={updateInheritedKey}>
+        Update inherited selector key
+      </button>
+      <p>
+        Inherited selector calls:{" "}
+        <output aria-label="Inherited selector calls">
+          {Number(inheritedSelectorCalls.current > 0)}
+        </output>
+      </p>
+      <p>
+        Unexpected selector calls:{" "}
+        <output aria-label="Unexpected selector calls">
+          {unexpectedSelectorCalls}
+        </output>
+      </p>
+    </>
+  );
+}
+
 function StorePropsSetter({ store }: StoreProps) {
   const [activeSetter, setActiveSetter] = useState<"first" | "second">();
   const [[observedStore, getActiveSubscriptions]] = useState(() =>
@@ -443,6 +501,7 @@ export default function Example() {
       <DirectValues store={store} />
       <MixedValues store={store} />
       <DynamicSelectors store={store} />
+      <InheritedObjectSelectors store={store} />
       <OptionalSelector store={store} />
       <StorePropsSetter store={store} />
       <Controls store={store} calls={calls.current} />

--- a/app/src/sandbox/store-keyed-subscriptions/test-browser.ts
+++ b/app/src/sandbox/store-keyed-subscriptions/test-browser.ts
@@ -1,0 +1,22 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // Reproduces https://github.com/ariakit/ariakit/issues/7058
+  test("ignores inherited object selector properties", async ({ q }) => {
+    await test.expect(q.status("Inherited selector keys")).toHaveText("own");
+  });
+
+  // Reproduces https://github.com/ariakit/ariakit/issues/7058
+  test("does not run inherited object selectors", async ({ q }) => {
+    await test.expect(q.status("Inherited selector calls")).toHaveText("0");
+  });
+
+  // Reproduces https://github.com/ariakit/ariakit/issues/7058
+  test("does not subscribe to inherited object selector properties", async ({
+    q,
+  }) => {
+    await q.button("Update inherited selector key").click();
+
+    await test.expect(q.status("Unexpected selector calls")).toHaveText("0");
+  });
+});

--- a/app/src/sandbox/store-keyed-subscriptions/test-browser.ts
+++ b/app/src/sandbox/store-keyed-subscriptions/test-browser.ts
@@ -3,7 +3,9 @@ import { withFramework } from "#app/test-utils/preview.ts";
 withFramework(import.meta.dirname, async ({ test }) => {
   // Reproduces https://github.com/ariakit/ariakit/issues/7058
   test("ignores inherited object selector properties", async ({ q }) => {
-    await test.expect(q.status("Inherited selector keys")).toHaveText("own");
+    await test
+      .expect(q.status("Inherited selector keys"))
+      .toHaveText("own,toString,valueOf");
   });
 
   // Reproduces https://github.com/ariakit/ariakit/issues/7058

--- a/app/src/sandbox/store-keyed-subscriptions/test.ts
+++ b/app/src/sandbox/store-keyed-subscriptions/test.ts
@@ -196,6 +196,23 @@ test("updates dynamic selector dependencies", async () => {
   expect(objectValue).toHaveTextContent("bar:2");
 });
 
+// Reproduces https://github.com/ariakit/ariakit/issues/7058
+test("ignores inherited object selector properties", async () => {
+  expect(q.status.ensure("Inherited selector keys").textContent).toBe("own");
+});
+
+// Reproduces https://github.com/ariakit/ariakit/issues/7058
+test("does not run inherited object selectors", () => {
+  expect(q.status("Inherited selector calls")).toHaveTextContent("0");
+});
+
+// Reproduces https://github.com/ariakit/ariakit/issues/7058
+test("does not subscribe to inherited object selector properties", async () => {
+  await click(q.button("Update inherited selector key"));
+
+  expect(q.status("Unexpected selector calls")).toHaveTextContent("0");
+});
+
 test("attaches and detaches conditional selector dependencies", async () => {
   const selectorValue = q.status("Conditional selector value");
   const calls = q.status.ensure("Conditional selector calls");

--- a/app/src/sandbox/store-keyed-subscriptions/test.ts
+++ b/app/src/sandbox/store-keyed-subscriptions/test.ts
@@ -198,7 +198,9 @@ test("updates dynamic selector dependencies", async () => {
 
 // Reproduces https://github.com/ariakit/ariakit/issues/7058
 test("ignores inherited object selector properties", async () => {
-  expect(q.status.ensure("Inherited selector keys").textContent).toBe("own");
+  expect(q.status.ensure("Inherited selector keys").textContent).toBe(
+    "own,toString,valueOf",
+  );
 });
 
 // Reproduces https://github.com/ariakit/ariakit/issues/7058

--- a/app/src/sandbox/tag-list-7058/index.react.tsx
+++ b/app/src/sandbox/tag-list-7058/index.react.tsx
@@ -28,6 +28,15 @@ export default function Example() {
         writable: true,
       });
     }
+
+    for (const [key] of inheritedProperties) {
+      const descriptor = Object.getOwnPropertyDescriptor(Object.prototype, key);
+      if (!descriptor?.configurable) continue;
+      Object.defineProperty(Object.prototype, key, {
+        ...descriptor,
+        enumerable: false,
+      });
+    }
     setReady(true);
 
     return () => {

--- a/app/src/sandbox/tag-list-7058/index.react.tsx
+++ b/app/src/sandbox/tag-list-7058/index.react.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 
 const inheritedProperties = [
   ["aria-hidden", "true"],
+  ["aria-label", "Inherited label"],
   ["role", "presentation"],
 ] as const;
 
@@ -21,6 +22,7 @@ export default function Example() {
     );
 
     for (const [key, value] of inheritedProperties) {
+      // oxlint-disable-next-line no-extend-native
       Object.defineProperty(Object.prototype, key, {
         configurable: true,
         enumerable: true,
@@ -29,19 +31,12 @@ export default function Example() {
       });
     }
 
-    for (const [key] of inheritedProperties) {
-      const descriptor = Object.getOwnPropertyDescriptor(Object.prototype, key);
-      if (!descriptor?.configurable) continue;
-      Object.defineProperty(Object.prototype, key, {
-        ...descriptor,
-        enumerable: false,
-      });
-    }
     setReady(true);
 
     return () => {
       for (const [key, descriptor] of descriptors) {
         if (descriptor) {
+          // oxlint-disable-next-line no-extend-native
           Object.defineProperty(Object.prototype, key, descriptor);
         } else {
           Reflect.deleteProperty(Object.prototype, key);

--- a/app/src/sandbox/tag-list-7058/index.react.tsx
+++ b/app/src/sandbox/tag-list-7058/index.react.tsx
@@ -1,0 +1,70 @@
+import { Tag } from "@ariakit/react-components/tag/tag";
+import { TagList } from "@ariakit/react-components/tag/tag-list";
+import { TagListLabel } from "@ariakit/react-components/tag/tag-list-label";
+import { TagProvider } from "@ariakit/react-components/tag/tag-provider";
+import { useEffect, useState } from "react";
+
+const inheritedProperties = [
+  ["aria-hidden", "true"],
+  ["role", "presentation"],
+] as const;
+
+export default function Example() {
+  const [ready, setReady] = useState(false);
+  const [ariaHidden, setAriaHidden] = useState("not inspected");
+  const [role, setRole] = useState("not inspected");
+
+  useEffect(() => {
+    const descriptors = inheritedProperties.map(
+      ([key]) =>
+        [key, Object.getOwnPropertyDescriptor(Object.prototype, key)] as const,
+    );
+
+    for (const [key, value] of inheritedProperties) {
+      Object.defineProperty(Object.prototype, key, {
+        configurable: true,
+        enumerable: true,
+        value,
+        writable: true,
+      });
+    }
+    setReady(true);
+
+    return () => {
+      for (const [key, descriptor] of descriptors) {
+        if (descriptor) {
+          Object.defineProperty(Object.prototype, key, descriptor);
+        } else {
+          Reflect.deleteProperty(Object.prototype, key);
+        }
+      }
+    };
+  }, []);
+
+  const inspectListbox = () => {
+    const listbox = document.querySelector('[aria-live="polite"]');
+    setAriaHidden(listbox?.getAttribute("aria-hidden") ?? "not set");
+    setRole(listbox?.getAttribute("role") ?? "not set");
+  };
+
+  if (!ready) return <p>Preparing tag list</p>;
+
+  return (
+    <TagProvider defaultValues={["React"]}>
+      <TagListLabel>Tags</TagListLabel>
+      <TagList>
+        <Tag value="React">React</Tag>
+      </TagList>
+      <button type="button" onClick={inspectListbox}>
+        Inspect listbox
+      </button>
+      <p>
+        Listbox aria-hidden:{" "}
+        <output aria-label="Listbox aria-hidden">{ariaHidden}</output>
+      </p>
+      <p>
+        Listbox role: <output aria-label="Listbox role">{role}</output>
+      </p>
+    </TagProvider>
+  );
+}

--- a/app/src/sandbox/tag-list-7058/test-browser.ts
+++ b/app/src/sandbox/tag-list-7058/test-browser.ts
@@ -1,0 +1,17 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // Reproduces https://github.com/ariakit/ariakit/issues/7058
+  test("does not copy inherited aria attributes", async ({ q }) => {
+    await q.button("Inspect listbox").click();
+
+    await test.expect(q.status("Listbox aria-hidden")).toHaveText("not set");
+  });
+
+  // Reproduces https://github.com/ariakit/ariakit/issues/7058
+  test("does not copy an inherited role", async ({ q }) => {
+    await q.button("Inspect listbox").click();
+
+    await test.expect(q.status("Listbox role")).toHaveText("listbox");
+  });
+});

--- a/app/src/sandbox/tag-list-7058/test-browser.ts
+++ b/app/src/sandbox/tag-list-7058/test-browser.ts
@@ -14,4 +14,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
     await test.expect(q.status("Listbox role")).toHaveText("listbox");
   });
+
+  // Reproduces https://github.com/ariakit/ariakit/issues/7058
+  test("does not use an inherited aria-label", async ({ q }) => {
+    await test.expect(q.listbox("Tags")).toBeAttached();
+  });
 });

--- a/app/src/sandbox/tag-list-7058/test.ts
+++ b/app/src/sandbox/tag-list-7058/test.ts
@@ -1,0 +1,16 @@
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/7058
+test("does not copy inherited aria attributes", async () => {
+  await click(q.button("Inspect listbox"));
+
+  expect(q.status("Listbox aria-hidden")).toHaveTextContent("not set");
+});
+
+// Reproduces https://github.com/ariakit/ariakit/issues/7058
+test("does not copy an inherited role", async () => {
+  await click(q.button("Inspect listbox"));
+
+  expect(q.status("Listbox role")).toHaveTextContent("listbox");
+});

--- a/app/src/sandbox/tag-list-7058/test.ts
+++ b/app/src/sandbox/tag-list-7058/test.ts
@@ -14,3 +14,8 @@ test("does not copy an inherited role", async () => {
 
   expect(q.status("Listbox role")).toHaveTextContent("listbox");
 });
+
+// Reproduces https://github.com/ariakit/ariakit/issues/7058
+test("does not use an inherited aria-label", () => {
+  expect(q.listbox("Tags")).toBeInTheDocument();
+});

--- a/packages/ariakit-react-components/src/tag/tag-list.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-list.tsx
@@ -11,6 +11,7 @@ import type { Props } from "@ariakit/react-utils";
 import {
   queueBeforeEvent,
   getClosestFocusable,
+  hasOwnProperty,
   invariant,
   isApple,
   UndoManager,
@@ -119,12 +120,16 @@ export const useTagList = createHook<TagName, TagListOptions>(
     // separate div that will serve as the accessible listbox element.
     const listboxProps: typeof props = {};
     for (const key in props) {
+      if (!hasOwnProperty(props, key)) continue;
       if (key === "role" || key.startsWith("aria-")) {
-        const prop = key as keyof typeof props;
+        const prop = key;
         listboxProps[prop] = props[prop];
         delete props[prop];
       }
     }
+    const ariaLabel = hasOwnProperty(listboxProps, "aria-label")
+      ? listboxProps["aria-label"]
+      : undefined;
 
     const touchDevice = useTouchDevice();
 
@@ -139,9 +144,7 @@ export const useTagList = createHook<TagName, TagListOptions>(
           aria-live="polite"
           aria-relevant="all"
           aria-atomic
-          aria-labelledby={
-            listboxProps["aria-label"] != null ? undefined : labelId
-          }
+          aria-labelledby={ariaLabel != null ? undefined : labelId}
           aria-orientation={orientation}
           aria-owns={itemIds.join(" ")}
           {...listboxProps}

--- a/packages/ariakit-react-store/src/index.tsx
+++ b/packages/ariakit-react-store/src/index.tsx
@@ -251,6 +251,7 @@ function getStoreStateObjectKeys(
   let hasSelector = false;
 
   for (const prop in object) {
+    if (!hasOwnProperty(object, prop)) continue;
     const keyOrSelector = object[prop];
     if (keyOrSelector === undefined) continue;
     if (typeof keyOrSelector === "function") {
@@ -354,6 +355,7 @@ export function useStoreStateObject(
     const obj = objRef.current;
 
     for (const prop in stateObject) {
+      if (!hasOwnProperty(stateObject, prop)) continue;
       const keyOrSelector = stateObject[prop];
       if (keyOrSelector === undefined) continue;
 
@@ -364,7 +366,7 @@ export function useStoreStateObject(
         // which would break the getSnapshot idempotency contract and make
         // React loop until it throws "Maximum update depth exceeded". See
         // https://github.com/ariakit/ariakit/issues/6335
-        if (!Object.is(value, obj[prop])) {
+        if (!hasOwnProperty(obj, prop) || !Object.is(value, obj[prop])) {
           obj[prop] = value;
           updated = true;
         }
@@ -375,7 +377,7 @@ export function useStoreStateObject(
         state && hasOwnProperty(state, keyOrSelector)
           ? state[keyOrSelector]
           : undefined;
-      if (!Object.is(value, obj[prop])) {
+      if (!hasOwnProperty(obj, prop) || !Object.is(value, obj[prop])) {
         obj[prop] = value;
         updated = true;
       }


### PR DESCRIPTION
## Motivation

`TagList` and `useStoreStateObject` iterate caller-controlled records with unguarded `for...in` loops. Inherited enumerable properties can therefore replace the internal TagList listbox semantics, become own keys in returned store snapshots, execute as selector functions, or create unrelated subscriptions.

Fixes #7058

## Solution

Guard the three caller-controlled `for...in` loops with Ariakit's `hasOwnProperty` helper. `TagList` also checks ownership before using `aria-label` to suppress `aria-labelledby`, and `useStoreStateObject` writes own snapshot keys even when an inherited value compares equal.

The `tag-list-7058` sandbox covers inherited `aria-hidden`, `aria-label`, and `role` values through the rendered listbox. The `store-keyed-subscriptions` sandbox covers exact own snapshot keys, including keys colliding with `Object.prototype`, inherited selector execution, and subscription work caused by an inherited direct store key. Every behavior has happy-dom coverage and browser-authoritative checks in Chrome, Firefox, and WebKit.

## Preview

![Current-main browser reproduction showing TagList aria-hidden and inherited selector processing](https://github.com/user-attachments/assets/db5917ac-c7b8-4360-9040-4b48734edad0)

Current main copies the inherited `aria-hidden` value and loses the listbox from the accessibility tree.

![Fixed TagList preserving its accessible listbox semantics](https://github.com/user-attachments/assets/8ee9dfb2-3d69-4d0b-bd40-c1eb694b4965)

With the fix, the inherited values are ignored: `aria-hidden` is absent, the role remains `listbox`, and the accessible name remains `Tags`.

## Workaround

If a library adds enumerable properties to `Object.prototype`, make each known configurable extension non-enumerable before rendering Ariakit components:

```js
// TODO: Remove after https://github.com/ariakit/ariakit/issues/7058 is fixed.
const key = "aria-hidden";
const descriptor = Object.getOwnPropertyDescriptor(Object.prototype, key);

if (descriptor?.configurable) {
  Object.defineProperty(Object.prototype, key, {
    ...descriptor,
    enumerable: false,
  });
}
```

Direct `useStoreStateObject` consumers can copy own selector entries into a null-prototype object:

```js
// TODO: Remove after https://github.com/ariakit/ariakit/issues/7058 is fixed.
const safeSelectors = Object.assign(Object.create(null), selectors);
const state = useStoreStateObject(store, safeSelectors);
```

The first workaround requires knowing the polluted keys and descriptors to be configurable. The second only protects direct `useStoreStateObject` usage; it does not change third-party code that passes inherited values elsewhere.

## Review gate reassessment

<details>
<summary>Cycle 3: Continue the narrow own-property design</summary>

**Assessment**

Issue #7058 is a stable bug. Enumerable prototype extensions are uncommon, but the impact includes lost TagList semantics or accessible names, unrelated store subscriptions and selector execution, and malformed snapshot shapes. The supported scope is own enumerable string-keyed entries in caller-controlled prop and selector records.

The runtime fix remains local: it reuses the established ownership helper, adds no abstraction or persistent state, and preserves existing behavior for valid own entries. The repeated findings were omitted applications of the same ownership invariant plus release-metadata compliance, not evidence of excessive implementation complexity.

**Decision**

Continue the narrow own-property design and describe the shared release through the linked public `CompositeItem` surface. Symbols and non-enumerable properties remain outside the existing `for...in` contract; no follow-up issue is needed.

</details>