### PR TITLE
Fix composite presentation when focused item is replaced

### DIFF
--- a/.changeset/300-menu-item-replacement-focus.md
+++ b/.changeset/300-menu-item-replacement-focus.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Menu`](https://ariakit.com/reference/menu) to preserve DOM focus and bring a logical item into view when React replaces its element while the popup is positioning.

--- a/app/src/sandbox/menu-placing-pass/index.react.tsx
+++ b/app/src/sandbox/menu-placing-pass/index.react.tsx
@@ -1,6 +1,6 @@
 import * as Ariakit from "@ariakit/react";
 import type { ComponentProps } from "react";
-import { Fragment, useRef, useState } from "react";
+import { Fragment, useEffect, useRef, useState } from "react";
 
 type MenuProps = ComponentProps<typeof Ariakit.Menu>;
 type UpdatePosition = NonNullable<MenuProps["updatePosition"]>;
@@ -27,6 +27,14 @@ function FocusedReplacementMenu() {
   const menu = Ariakit.useMenuStore();
   const releaseRef = useRef<(() => void) | null>(null);
   const [generation, setGeneration] = useState(0);
+
+  // TODO: Remove once https://github.com/ariakit/ariakit/issues/7042 is fixed.
+  useEffect(() => {
+    const { activeId, open } = menu.getState();
+    if (!open) return;
+    if (activeId == null) return;
+    menu.move(activeId);
+  }, [menu, generation]);
 
   const updatePosition: UpdatePosition = () =>
     new Promise<void>((resolve) => {

--- a/app/src/sandbox/menu-placing-pass/index.react.tsx
+++ b/app/src/sandbox/menu-placing-pass/index.react.tsx
@@ -1,6 +1,6 @@
 import * as Ariakit from "@ariakit/react";
 import type { ComponentProps } from "react";
-import { useRef } from "react";
+import { Fragment, useRef, useState } from "react";
 
 type MenuProps = ComponentProps<typeof Ariakit.Menu>;
 type UpdatePosition = NonNullable<MenuProps["updatePosition"]>;
@@ -18,6 +18,71 @@ const actions = Array.from(
 const lastAction = `Action ${actionCount}`;
 
 const measureError = "Could not measure the Actions menu";
+
+/**
+ * Holds menu positioning open while replacing the focused item's DOM node.
+ * The replacement keeps the same id, so it remains the same logical item.
+ */
+function FocusedReplacementMenu() {
+  const menu = Ariakit.useMenuStore();
+  const releaseRef = useRef<(() => void) | null>(null);
+  const [generation, setGeneration] = useState(0);
+
+  const updatePosition: UpdatePosition = () =>
+    new Promise<void>((resolve) => {
+      releaseRef.current = resolve;
+    });
+
+  return (
+    <section style={{ display: "grid", gap: 8, justifyItems: "start" }}>
+      <button type="button" tabIndex={0} onClick={menu.show}>
+        Show replacement actions
+      </button>
+      <button
+        type="button"
+        tabIndex={0}
+        onClick={() => setGeneration((value) => value + 1)}
+      >
+        Replace focused action
+      </button>
+      <button
+        type="button"
+        tabIndex={0}
+        onClick={() => {
+          releaseRef.current?.();
+          releaseRef.current = null;
+        }}
+      >
+        Finish replacement actions positioning
+      </button>
+      <Ariakit.Menu
+        store={menu}
+        aria-label="Replacement actions"
+        hideOnInteractOutside={false}
+        portal={false}
+        updatePosition={updatePosition}
+        style={{
+          background: "white",
+          border: "1px solid gray",
+          height: 100,
+          overflow: "auto",
+        }}
+      >
+        <Fragment key={generation}>
+          {actions.map((action, index) => (
+            <Ariakit.MenuItem
+              key={action}
+              id={`replacement-action-${index + 1}`}
+              style={{ display: "block", height: 32 }}
+            >
+              {action}
+            </Ariakit.MenuItem>
+          ))}
+        </Fragment>
+      </Ariakit.Menu>
+    </section>
+  );
+}
 
 /**
  * The same held pass, in a menu that mounts only once its store is already
@@ -129,6 +194,7 @@ export default function Example() {
 
   return (
     <main style={{ display: "grid", gap: 8, justifyItems: "start" }}>
+      <FocusedReplacementMenu />
       {/* Its own scenario, above everything the Actions menu uses. Each menu
       opens into the spacer that follows its own controls, so neither one can
       cover the buttons that drive the other and both stay drivable in any

--- a/app/src/sandbox/menu-placing-pass/index.react.tsx
+++ b/app/src/sandbox/menu-placing-pass/index.react.tsx
@@ -1,6 +1,6 @@
 import * as Ariakit from "@ariakit/react";
 import type { ComponentProps } from "react";
-import { Fragment, useEffect, useRef, useState } from "react";
+import { Fragment, useRef, useState } from "react";
 
 type MenuProps = ComponentProps<typeof Ariakit.Menu>;
 type UpdatePosition = NonNullable<MenuProps["updatePosition"]>;
@@ -27,14 +27,6 @@ function FocusedReplacementMenu() {
   const menu = Ariakit.useMenuStore();
   const releaseRef = useRef<(() => void) | null>(null);
   const [generation, setGeneration] = useState(0);
-
-  // TODO: Remove once https://github.com/ariakit/ariakit/issues/7042 is fixed.
-  useEffect(() => {
-    const { activeId, open } = menu.getState();
-    if (!open) return;
-    if (activeId == null) return;
-    menu.move(activeId);
-  }, [menu, generation]);
 
   const updatePosition: UpdatePosition = () =>
     new Promise<void>((resolve) => {

--- a/app/src/sandbox/menu-placing-pass/test-browser.ts
+++ b/app/src/sandbox/menu-placing-pass/test-browser.ts
@@ -23,9 +23,6 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
     await q.button("Replace focused action").dispatchEvent("click");
     const replacement = withinMenu.menuitem("Action 30");
     await test.expect(replacement).toHaveAttribute("data-active-item");
-    await test.expect
-      .poll(() => page.evaluate(() => document.activeElement?.tagName))
-      .toBe("BODY");
 
     await q
       .button("Finish replacement actions positioning")

--- a/app/src/sandbox/menu-placing-pass/test-browser.ts
+++ b/app/src/sandbox/menu-placing-pass/test-browser.ts
@@ -1,7 +1,41 @@
 import { flushFrames, withFramework } from "#app/test-utils/preview.ts";
 import { recordScrollEvents } from "#app/test-utils/scroll.ts";
 
-withFramework(import.meta.dirname, async ({ test }) => {
+withFramework(import.meta.dirname, async ({ query, test }) => {
+  // https://github.com/ariakit/ariakit/issues/7042
+  test("presents a focused item after its node is replaced", async ({
+    page,
+    q,
+  }) => {
+    const menu = q.menu("Replacement actions");
+    const withinMenu = query(menu);
+
+    await q.button("Show replacement actions").click();
+    await test.expect(menu).toBeVisible();
+    await test.expect(menu).toHaveAttribute("data-placing");
+
+    await withinMenu.menuitem("Action 1").focus();
+    await page.keyboard.press("End");
+    await test.expect(withinMenu.menuitem("Action 30")).toBeFocused();
+
+    // Dispatching without a native click preserves the removed item as the
+    // browser's focus provenance while React commits its replacement.
+    await q.button("Replace focused action").dispatchEvent("click");
+    const replacement = withinMenu.menuitem("Action 30");
+    await test.expect(replacement).toHaveAttribute("data-active-item");
+    await test.expect
+      .poll(() => page.evaluate(() => document.activeElement?.tagName))
+      .toBe("BODY");
+
+    await q
+      .button("Finish replacement actions positioning")
+      .dispatchEvent("click");
+    await test.expect(replacement).toBeFocused();
+    await test.expect
+      .poll(() => menu.evaluate((element) => element.scrollTop))
+      .toBeGreaterThan(0);
+  });
+
   // A custom `updatePosition` that calls the supplied default and then keeps
   // working owns the whole pass: the popup is only where it belongs once that
   // callback returns. Publishing readiness when the inner default pass resolves

--- a/app/src/sandbox/menu-placing-pass/test-browser.ts
+++ b/app/src/sandbox/menu-placing-pass/test-browser.ts
@@ -23,6 +23,7 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
     await q.button("Replace focused action").dispatchEvent("click");
     const replacement = withinMenu.menuitem("Action 30");
     await test.expect(replacement).toHaveAttribute("data-active-item");
+    await test.expect(replacement).toBeFocused();
 
     await q
       .button("Finish replacement actions positioning")
@@ -31,6 +32,34 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
     await test.expect
       .poll(() => menu.evaluate((element) => element.scrollTop))
       .toBeGreaterThan(0);
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7042
+  test("abandons a replaced item after focus leaves", async ({ page, q }) => {
+    const menu = q.menu("Replacement actions");
+    const withinMenu = query(menu);
+
+    await q.button("Show replacement actions").click();
+    await withinMenu.menuitem("Action 1").focus();
+    await page.keyboard.press("End");
+    const item = withinMenu.menuitem("Action 30");
+    await test.expect(item).toBeFocused();
+
+    await item.blur();
+    await test.expect
+      .poll(() => page.evaluate(() => document.activeElement?.tagName))
+      .toBe("BODY");
+    await q.button("Replace focused action").dispatchEvent("click");
+    const replacement = withinMenu.menuitem("Action 30");
+    await test.expect(replacement).toHaveAttribute("data-active-item");
+
+    await q
+      .button("Finish replacement actions positioning")
+      .dispatchEvent("click");
+    await test.expect(replacement).not.toBeFocused();
+    await test.expect
+      .poll(() => menu.evaluate((element) => element.scrollTop))
+      .toBe(0);
   });
 
   // A custom `updatePosition` that calls the supplied default and then keeps

--- a/app/src/sandbox/menu-placing-pass/test-browser.ts
+++ b/app/src/sandbox/menu-placing-pass/test-browser.ts
@@ -74,8 +74,14 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
     await withinMenu.menuitem("Action 1").focus();
     await page.keyboard.press("End");
     const item = withinMenu.menuitem("Action 30");
+    await test.expect(item).toBeFocused();
+    await test.expect(menu).toHaveAttribute("data-placing");
     await item.blur();
+    await test.expect
+      .poll(() => page.evaluate(() => document.activeElement?.tagName))
+      .toBe("BODY");
     await item.focus();
+    await test.expect(item).toBeFocused();
 
     await q.button("Replace focused action").dispatchEvent("click");
     const replacement = withinMenu.menuitem("Action 30");
@@ -84,6 +90,9 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
       .button("Finish replacement actions positioning")
       .dispatchEvent("click");
     await test.expect(replacement).toBeFocused();
+    await test.expect
+      .poll(() => menu.evaluate((element) => element.scrollTop))
+      .toBeGreaterThan(0);
   });
 
   // A custom `updatePosition` that calls the supplied default and then keeps

--- a/app/src/sandbox/menu-placing-pass/test-browser.ts
+++ b/app/src/sandbox/menu-placing-pass/test-browser.ts
@@ -62,6 +62,30 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
       .toBe(0);
   });
 
+  // https://github.com/ariakit/ariakit/pull/7065#discussion_r3711847856
+  test("restores focus when a refocused item is replaced", async ({
+    page,
+    q,
+  }) => {
+    const menu = q.menu("Replacement actions");
+    const withinMenu = query(menu);
+
+    await q.button("Show replacement actions").click();
+    await withinMenu.menuitem("Action 1").focus();
+    await page.keyboard.press("End");
+    const item = withinMenu.menuitem("Action 30");
+    await item.blur();
+    await item.focus();
+
+    await q.button("Replace focused action").dispatchEvent("click");
+    const replacement = withinMenu.menuitem("Action 30");
+
+    await q
+      .button("Finish replacement actions positioning")
+      .dispatchEvent("click");
+    await test.expect(replacement).toBeFocused();
+  });
+
   // A custom `updatePosition` that calls the supplied default and then keeps
   // working owns the whole pass: the popup is only where it belongs once that
   // callback returns. Publishing readiness when the inner default pass resolves

--- a/app/src/sandbox/menu-placing-pass/test.ts
+++ b/app/src/sandbox/menu-placing-pass/test.ts
@@ -12,7 +12,6 @@ test("restores focus after a focused item is replaced", async () => {
   await dispatch.click(q.button("Replace focused action"));
   const replacement = withinMenu.menuitem("Action 30");
   expect(replacement).toHaveAttribute("data-active-item");
-  expect(document.activeElement).toBe(document.body);
 
   await dispatch.click(q.button("Finish replacement actions positioning"));
   expect(replacement).toHaveFocus();

--- a/app/src/sandbox/menu-placing-pass/test.ts
+++ b/app/src/sandbox/menu-placing-pass/test.ts
@@ -37,6 +37,23 @@ test("leaves focus outside after a focused item is replaced", async () => {
   expect(replacement).not.toHaveFocus();
 });
 
+// https://github.com/ariakit/ariakit/pull/7065#discussion_r3711847856
+test("restores focus when a refocused item is replaced", async () => {
+  await click(q.button("Show replacement actions"));
+  const withinMenu = q.within(q.menu("Replacement actions"));
+  await focus(withinMenu.menuitem("Action 1"));
+  await press.End();
+  const item = withinMenu.menuitem.ensure("Action 30");
+  await blur(item);
+  await focus(item);
+
+  await dispatch.click(q.button("Replace focused action"));
+  const replacement = withinMenu.menuitem("Action 30");
+
+  await dispatch.click(q.button("Finish replacement actions positioning"));
+  expect(replacement).toHaveFocus();
+});
+
 // The sandbox's other scenario, re-anchoring an already open popup, is covered
 // only by the browser test: an already open popup has no initial focus left to
 // take, and the focus half of a presentation never waits on placement, so its

--- a/app/src/sandbox/menu-placing-pass/test.ts
+++ b/app/src/sandbox/menu-placing-pass/test.ts
@@ -1,4 +1,4 @@
-import { click, dispatch, focus, press, q } from "@ariakit/test";
+import { blur, click, dispatch, focus, press, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 // https://github.com/ariakit/ariakit/issues/7042
@@ -12,9 +12,29 @@ test("restores focus after a focused item is replaced", async () => {
   await dispatch.click(q.button("Replace focused action"));
   const replacement = withinMenu.menuitem("Action 30");
   expect(replacement).toHaveAttribute("data-active-item");
+  expect(replacement).toHaveFocus();
 
   await dispatch.click(q.button("Finish replacement actions positioning"));
   expect(replacement).toHaveFocus();
+});
+
+// https://github.com/ariakit/ariakit/issues/7042
+test("leaves focus outside after a focused item is replaced", async () => {
+  await click(q.button("Show replacement actions"));
+  const withinMenu = q.within(q.menu("Replacement actions"));
+  await focus(withinMenu.menuitem("Action 1"));
+  await press.End();
+  const item = withinMenu.menuitem.ensure("Action 30");
+  expect(item).toHaveFocus();
+
+  await blur(item);
+  expect(document.activeElement).toBe(document.body);
+  await dispatch.click(q.button("Replace focused action"));
+  const replacement = withinMenu.menuitem("Action 30");
+  expect(replacement).toHaveAttribute("data-active-item");
+
+  await dispatch.click(q.button("Finish replacement actions positioning"));
+  expect(replacement).not.toHaveFocus();
 });
 
 // The sandbox's other scenario, re-anchoring an already open popup, is covered

--- a/app/src/sandbox/menu-placing-pass/test.ts
+++ b/app/src/sandbox/menu-placing-pass/test.ts
@@ -40,12 +40,17 @@ test("leaves focus outside after a focused item is replaced", async () => {
 // https://github.com/ariakit/ariakit/pull/7065#discussion_r3711847856
 test("restores focus when a refocused item is replaced", async () => {
   await click(q.button("Show replacement actions"));
-  const withinMenu = q.within(q.menu("Replacement actions"));
+  const menu = q.menu("Replacement actions");
+  const withinMenu = q.within(menu);
   await focus(withinMenu.menuitem("Action 1"));
   await press.End();
   const item = withinMenu.menuitem.ensure("Action 30");
+  expect(item).toHaveFocus();
+  expect(menu).toHaveAttribute("data-placing");
   await blur(item);
+  expect(document.activeElement).toBe(document.body);
   await focus(item);
+  expect(item).toHaveFocus();
 
   await dispatch.click(q.button("Replace focused action"));
   const replacement = withinMenu.menuitem("Action 30");

--- a/app/src/sandbox/menu-placing-pass/test.ts
+++ b/app/src/sandbox/menu-placing-pass/test.ts
@@ -1,5 +1,22 @@
-import { click, q } from "@ariakit/test";
+import { click, dispatch, focus, press, q } from "@ariakit/test";
 import { expect, test } from "vitest";
+
+// https://github.com/ariakit/ariakit/issues/7042
+test("restores focus after a focused item is replaced", async () => {
+  await click(q.button("Show replacement actions"));
+  const withinMenu = q.within(q.menu("Replacement actions"));
+  await focus(withinMenu.menuitem("Action 1"));
+  await press.End();
+  expect(withinMenu.menuitem("Action 30")).toHaveFocus();
+
+  await dispatch.click(q.button("Replace focused action"));
+  const replacement = withinMenu.menuitem("Action 30");
+  expect(replacement).toHaveAttribute("data-active-item");
+  expect(document.activeElement).toBe(document.body);
+
+  await dispatch.click(q.button("Finish replacement actions positioning"));
+  expect(replacement).toHaveFocus();
+});
 
 // The sandbox's other scenario, re-anchoring an already open popup, is covered
 // only by the browser test: an already open popup has no initial focus left to

--- a/packages/ariakit-react-components/src/composite/composite-item.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-item.tsx
@@ -50,6 +50,8 @@ import {
   focusSilently,
   getEnabledItem,
   isItem,
+  markItemMounted,
+  markItemUnmounting,
   selectTextField,
   usePresentItem,
 } from "./utils.ts";
@@ -166,6 +168,13 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
 
     const id = useId(props.id);
     const ref = useRef<HTMLType>(null);
+    const mountedElementRef = useRef<HTMLType>(null);
+    const markUnmountingRef = useCallback((element: HTMLType | null) => {
+      const mountedElement = mountedElementRef.current;
+      if (!element && mountedElement) markItemUnmounting(mountedElement);
+      if (element) markItemMounted(element);
+      mountedElementRef.current = element;
+    }, []);
     const row = useContext(CompositeRowContext);
     const disabled = disabledFromProps(props);
     const trulyDisabled = disabled && !props.accessibleWhenDisabled;
@@ -527,7 +536,7 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
       "data-active-item": isActiveItem || undefined,
       ...props,
       id,
-      ref: useMergeRefs(ref, props.ref),
+      ref: useMergeRefs(ref, markUnmountingRef, props.ref),
       tabIndex: isTabbable ? props.tabIndex : -1,
       onFocus,
       onBlurCapture,

--- a/packages/ariakit-react-components/src/composite/utils.ts
+++ b/packages/ariakit-react-components/src/composite/utils.ts
@@ -14,6 +14,19 @@ export const flipItems = Core.flipItems;
 export const findFirstEnabledItem = Core.findFirstEnabledItem;
 export const groupItemsByRows = Core.groupItemsByRows;
 
+const unmountingItems = new WeakSet<Element>();
+
+/** Marks the brief window between a composite item's ref cleanup and removal. */
+export function markItemUnmounting(element: Element) {
+  unmountingItems.add(element);
+  queueMicrotask(() => unmountingItems.delete(element));
+}
+
+/** Clears a transient ref cleanup when React keeps the same node mounted. */
+export function markItemMounted(element: Element) {
+  unmountingItems.delete(element);
+}
+
 /**
  * Runs a callback while preserving the composite element's own scroll position.
  *
@@ -107,6 +120,7 @@ function presentItem({
   let element: HTMLElement | null = null;
   let resolvedId: string | undefined;
   let focused = false;
+  let focusLeftElement = false;
   let done = false;
   let wasMounted = false;
   let wasOpen = false;
@@ -185,20 +199,27 @@ function presentItem({
     resolvedId = item.id;
     return item.element;
   };
+  let removeBlurListener: (() => void) | undefined;
   let unsubscribe: (() => void) | undefined;
   const cancel = () => {
     done = true;
+    removeBlurListener?.();
     unsubscribe?.();
   };
   const present = () => {
     if (done) return;
     const state = store.getState();
     if (abandonedByState(state)) return cancel();
+    let restoreFocus = false;
     if (!element) {
       // The item may not have rendered yet, so keep waiting for it.
       element = resolveElement(state);
       if (!element) return;
     } else if (!element.isConnected) {
+      restoreFocus =
+        focused &&
+        !focusLeftElement &&
+        getActiveElement(element) === getDocument(element).body;
       // The element left the DOM, but React can replace an item's node while
       // keeping its id, so the logical item can still be there and still be
       // worth presenting. Resolve it again here rather than going back to
@@ -221,27 +242,27 @@ function presentItem({
     // is nothing to compare focus against, and an option that has just focused
     // itself isn't even recognizable as an item yet.
     //
-    // A request whose item still holds DOM focus when that item is replaced
-    // ends here, because the browser parks focus on the body when it removes
-    // the focused node. It only gets that far with an owner to compare against,
-    // and only where the item keeps DOM focus: a virtual-focus item that hands
-    // focus straight back to the composite element moves no focus at all when
-    // its node is replaced. A `Menu` moved while focus is already inside it
-    // therefore keeps the behavior a replaced item had before this, while the
-    // same menu moved from outside has no owner and gets this far. Only as far
-    // as the scroll, though: the focus step below is latched to the element the
-    // request first resolved, so a replacement is brought into view without
-    // being focused in its place.
-    //
-    // Telling a removed focused node apart from focus escaping is deliberately
-    // not attempted here: the signal would have to be carried down from the
-    // re-resolution above, into an ordering that just gained a focus-escape
-    // guarantee.
-    // See https://github.com/ariakit/ariakit/issues/7042
-    if (!stillOwnsFocus(element)) return cancel();
+    // Removing the focused node parks focus on the document body. Restore
+    // focus only when the item's ref cleanup marked that blur as removal. An
+    // explicit blur is latched below, so replacing the item afterward does not
+    // turn a real focus escape into a new focus request.
+    if (restoreFocus) {
+      focused = false;
+    } else if (!stillOwnsFocus(element)) {
+      return cancel();
+    }
     if (focus && !focused) {
       focused = true;
+      focusLeftElement = false;
       const itemElement = element;
+      removeBlurListener?.();
+      const onBlur = () => {
+        focusLeftElement = !unmountingItems.has(itemElement);
+      };
+      itemElement.addEventListener("blur", onBlur, { once: true });
+      removeBlurListener = () => {
+        itemElement.removeEventListener("blur", onBlur);
+      };
       withCompositeScrollPreserved(store, () => {
         itemElement.focus({ preventScroll: true });
       });

--- a/packages/ariakit-react-components/src/composite/utils.ts
+++ b/packages/ariakit-react-components/src/composite/utils.ts
@@ -200,11 +200,11 @@ function presentItem({
     resolvedId = item.id;
     return item.element;
   };
-  let removeBlurListener: (() => void) | undefined;
+  let removeFocusListeners: (() => void) | undefined;
   let unsubscribe: (() => void) | undefined;
   const cancel = () => {
     done = true;
-    removeBlurListener?.();
+    removeFocusListeners?.();
     unsubscribe?.();
   };
   const present = () => {
@@ -256,13 +256,18 @@ function presentItem({
       focused = true;
       focusLeftElement = false;
       const itemElement = element;
-      removeBlurListener?.();
+      removeFocusListeners?.();
       const onBlur = () => {
         focusLeftElement = !unmountingItems.has(itemElement);
       };
-      itemElement.addEventListener("blur", onBlur, { once: true });
-      removeBlurListener = () => {
+      const onFocus = () => {
+        focusLeftElement = false;
+      };
+      itemElement.addEventListener("blur", onBlur);
+      itemElement.addEventListener("focus", onFocus);
+      removeFocusListeners = () => {
         itemElement.removeEventListener("blur", onBlur);
+        itemElement.removeEventListener("focus", onFocus);
       };
       withCompositeScrollPreserved(store, () => {
         itemElement.focus({ preventScroll: true });

--- a/packages/ariakit-react-components/src/composite/utils.ts
+++ b/packages/ariakit-react-components/src/composite/utils.ts
@@ -245,8 +245,9 @@ function presentItem({
     //
     // Removing the focused node parks focus on the document body. Restore
     // focus only when the item's ref cleanup marked that blur as removal. An
-    // explicit blur is latched below, so replacing the item afterward does not
-    // turn a real focus escape into a new focus request.
+    // explicit blur is latched below until the same item takes focus again, so
+    // replacing an item the user left does not turn a real focus escape into a
+    // new focus request, while an item they came back to is still restored.
     if (restoreFocus) {
       focused = false;
     } else if (!stillOwnsFocus(element)) {

--- a/packages/ariakit-react-components/src/composite/utils.ts
+++ b/packages/ariakit-react-components/src/composite/utils.ts
@@ -16,8 +16,9 @@ export const groupItemsByRows = Core.groupItemsByRows;
 
 const unmountingItems = new WeakSet<Element>();
 
-/** Marks the brief window between a composite item's ref cleanup and removal. */
+/** Marks the brief window between a focused item's ref cleanup and removal. */
 export function markItemUnmounting(element: Element) {
+  if (getActiveElement(element) !== element) return;
   unmountingItems.add(element);
   queueMicrotask(() => unmountingItems.delete(element));
 }


### PR DESCRIPTION
## Motivation

When an application replaces the focused DOM node for a menu item under the same logical id while its popup is still positioning, the browser moves focus to the document body. The pending presentation treated that as a real focus escape and stopped, so the replacement kept the active state but received neither focus nor the delayed scroll.

```tsx
<Fragment key={generation}>
  <Ariakit.MenuItem id="stable-action-id">Action</Ariakit.MenuItem>
</Fragment>
```

Fixes #7042

## Solution

Track the brief ref-cleanup window for each composite item and listen for focus changes directly on the element a presentation request focuses. If React disconnects that focused node during its ref cleanup, the request re-resolves the same logical item, restores focus to the replacement, and completes its pending scroll presentation. A blur that occurs outside that replacement window remains terminal, so an explicit focus escape is never turned into a new focus request.

This stays local to the active presentation request: a transient `WeakSet` marker and paired item `blur` and `focus` listeners replace the broader document-level focus state used in the earlier attempt. The focus listener keeps the request's focus-left state current when an item blurs and then regains focus before replacement.

The public `Menu` regression uses stable item ids and a held positioning promise. It verifies the relevant behavior:

- replacing the focused node preserves focus immediately and brings the replacement into view when positioning finishes;
- explicitly blurring before replacement leaves focus outside and does not scroll the replacement into view;
- blurring and refocusing the item before replacement restores focus to the same-id replacement.

Removing the explicit-blur guard or the refocus listener makes the corresponding happy-dom and browser cancellation tests fail, confirming that coverage protects both distinctions.

## Workaround

Prefer keeping item nodes stable while the popup is positioning. If replacement is unavoidable on a version without this fix, reissue the active move after the new nodes render:

```tsx
// TODO: Remove once https://github.com/ariakit/ariakit/issues/7042 is fixed.
useEffect(() => {
  const { activeId, open } = menu.getState();
  if (!open) return;
  if (activeId == null) return;
  menu.move(activeId);
}, [menu, itemsGeneration]);
```

Tie `itemsGeneration` specifically to actual item-node replacement. `menu.move()` schedules a complete presentation and moves DOM focus as well as scrolling, so this workaround is narrower than the final library behavior.

## Verification

- `pnpm lint-fix`
- `pnpm build`
- `pnpm clean`
- `pnpm tsc`
- React 19: 254 files, 1700 tests
- React 18: 187 files, 966 tests
- Focused browser tests: Chrome 8/8, Firefox 8/8, WebKit 8/8
- Focused happy-dom tests: React 19 5/5, React 18 5/5
- `pnpm build-app-lite`

## Preview

[Exact-head browser recording: after the item blurs and regains focus, the same-id replacement receives focus when positioning finishes.](https://github.com/user-attachments/assets/56baba84-3bdb-4259-b47c-61b6ab344bf2)

## Implementation review reassessment

<details>
<summary>Cycle 3: Narrow cleanup-time blur provenance</summary>

**Assessment**

The original issue is a confirmed stable-API `Menu` bug: with a pending public `updatePosition`, replacing the focused same-id item drops focus to the document body and leaves the active item offscreen. This has medium impact for keyboard and assistive-technology users, although the timing is uncommon.

Cycle 1 narrowed the unmount marker to the focused item. Cycle 2 found that the one-shot blur latch stayed terminal after refocus, so the implementation now keeps persistent focus and blur listeners for the active request. A separate direct-ref change attempted to distinguish a callback-ref cleanup that deliberately calls `blur()`, but Cycle 3 showed that this guarantee would not cover the equally public render-element ref path.

The cleanup-time blur scenario is rare, and complete support would require cross-cutting final-ref ordering machinery or a risky global merge-order change.

**Decision**

Keep the focused-only marker and the refocus listener pair. Treat `blur()` invoked from callback-ref teardown as unsupported focus-escape provenance regardless of whether the callback comes from a direct ref or a render-element ref. The partial direct-ref behavior was removed, keeping both public ref surfaces coherent without a cross-cutting abstraction.

</details>
