### PR TITLE
Prevent menu item hover from scrolling

### DIFF
--- a/.changeset/300-menu-item-hover-scroll.md
+++ b/.changeset/300-menu-item-hover-scroll.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`MenuItem`](https://ariakit.com/reference/menu-item) hover focus so partially visible menubar and submenu items no longer scroll the page or menu under the pointer.

--- a/app/src/sandbox/menu-item-hover-7012/index.react.tsx
+++ b/app/src/sandbox/menu-item-hover-7012/index.react.tsx
@@ -6,6 +6,12 @@ const itemStyle = {
   padding: "12px 16px",
 } as const;
 
+function preventScrollOnFocus(element: HTMLElement | null) {
+  if (!element) return;
+  const focus = element.focus.bind(element);
+  element.focus = (options) => focus({ ...options, preventScroll: true });
+}
+
 function MenuContent({ label }: { label: string }) {
   return (
     <Ariakit.Menu gutter={4} portal>
@@ -24,6 +30,7 @@ function MenubarExample() {
           {["File", "Edit", "View"].map((label) => (
             <Ariakit.MenuProvider key={label}>
               <Ariakit.MenuItem
+                ref={preventScrollOnFocus}
                 render={<Ariakit.MenuButton />}
                 style={itemStyle}
               >
@@ -51,7 +58,11 @@ function ScrollableMenuExample() {
             </Ariakit.MenuItem>
           ))}
           <Ariakit.MenuProvider>
-            <Ariakit.MenuItem render={<Ariakit.MenuButton />} style={itemStyle}>
+            <Ariakit.MenuItem
+              ref={preventScrollOnFocus}
+              render={<Ariakit.MenuButton />}
+              style={itemStyle}
+            >
               Share
             </Ariakit.MenuItem>
             <MenuContent label="Share" />

--- a/app/src/sandbox/menu-item-hover-7012/index.react.tsx
+++ b/app/src/sandbox/menu-item-hover-7012/index.react.tsx
@@ -1,0 +1,72 @@
+import * as Ariakit from "@ariakit/react";
+
+const itemStyle = {
+  border: "1px solid #ddd",
+  height: 56,
+  padding: "12px 16px",
+} as const;
+
+function MenuContent({ label }: { label: string }) {
+  return (
+    <Ariakit.Menu gutter={4} portal>
+      <Ariakit.MenuItem style={itemStyle}>{label} one</Ariakit.MenuItem>
+      <Ariakit.MenuItem style={itemStyle}>{label} two</Ariakit.MenuItem>
+    </Ariakit.Menu>
+  );
+}
+
+function MenubarExample() {
+  return (
+    <section>
+      <h2>Menubar</h2>
+      <Ariakit.MenubarProvider>
+        <Ariakit.Menubar style={{ display: "flex", gap: 8 }}>
+          {["File", "Edit", "View"].map((label) => (
+            <Ariakit.MenuProvider key={label}>
+              <Ariakit.MenuItem
+                render={<Ariakit.MenuButton />}
+                style={itemStyle}
+              >
+                {label}
+              </Ariakit.MenuItem>
+              <MenuContent label={label} />
+            </Ariakit.MenuProvider>
+          ))}
+        </Ariakit.Menubar>
+      </Ariakit.MenubarProvider>
+    </section>
+  );
+}
+
+function ScrollableMenuExample() {
+  return (
+    <section style={{ marginTop: 1200 }}>
+      <h2>Scrollable menu</h2>
+      <Ariakit.MenuProvider>
+        <Ariakit.MenuButton>Actions</Ariakit.MenuButton>
+        <Ariakit.Menu gutter={4} style={{ maxHeight: 180, overflow: "auto" }}>
+          {["Cut", "Copy", "Paste", "Delete", "Duplicate"].map((label) => (
+            <Ariakit.MenuItem key={label} style={itemStyle}>
+              {label}
+            </Ariakit.MenuItem>
+          ))}
+          <Ariakit.MenuProvider>
+            <Ariakit.MenuItem render={<Ariakit.MenuButton />} style={itemStyle}>
+              Share
+            </Ariakit.MenuItem>
+            <MenuContent label="Share" />
+          </Ariakit.MenuProvider>
+        </Ariakit.Menu>
+      </Ariakit.MenuProvider>
+    </section>
+  );
+}
+
+export default function Example() {
+  return (
+    <main>
+      <MenubarExample />
+      <ScrollableMenuExample />
+    </main>
+  );
+}

--- a/app/src/sandbox/menu-item-hover-7012/index.react.tsx
+++ b/app/src/sandbox/menu-item-hover-7012/index.react.tsx
@@ -6,12 +6,6 @@ const itemStyle = {
   padding: "12px 16px",
 } as const;
 
-function preventScrollOnFocus(element: HTMLElement | null) {
-  if (!element) return;
-  const focus = element.focus.bind(element);
-  element.focus = (options) => focus({ ...options, preventScroll: true });
-}
-
 function MenuContent({ label }: { label: string }) {
   return (
     <Ariakit.Menu gutter={4} portal>
@@ -30,7 +24,6 @@ function MenubarExample() {
           {["File", "Edit", "View"].map((label) => (
             <Ariakit.MenuProvider key={label}>
               <Ariakit.MenuItem
-                ref={preventScrollOnFocus}
                 render={<Ariakit.MenuButton />}
                 style={itemStyle}
               >
@@ -58,11 +51,7 @@ function ScrollableMenuExample() {
             </Ariakit.MenuItem>
           ))}
           <Ariakit.MenuProvider>
-            <Ariakit.MenuItem
-              ref={preventScrollOnFocus}
-              render={<Ariakit.MenuButton />}
-              style={itemStyle}
-            >
+            <Ariakit.MenuItem render={<Ariakit.MenuButton />} style={itemStyle}>
               Share
             </Ariakit.MenuItem>
             <MenuContent label="Share" />

--- a/app/src/sandbox/menu-item-hover-7012/test-chrome-safari.ts
+++ b/app/src/sandbox/menu-item-hover-7012/test-chrome-safari.ts
@@ -1,0 +1,26 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/7012
+  test("hovering a partially visible menubar item does not scroll", async ({
+    page,
+    q,
+  }) => {
+    await q.menuitem("File").click();
+    await test.expect(q.menu("File")).toBeVisible();
+
+    await page.mouse.wheel(0, 50);
+    await test.expect.poll(() => page.evaluate(() => scrollY)).toBe(50);
+
+    const edit = q.menuitem("Edit");
+    const box = await edit.boundingBox();
+    if (!box) {
+      throw new Error("Edit menu item is not visible");
+    }
+    await page.mouse.move(box.x + box.width / 2, 8);
+
+    await test.expect(edit).toBeFocused();
+    await test.expect(q.menu("Edit")).toBeVisible();
+    await test.expect.poll(() => page.evaluate(() => scrollY)).toBe(50);
+  });
+});

--- a/app/src/sandbox/menu-item-hover-7012/test-chrome-safari.ts
+++ b/app/src/sandbox/menu-item-hover-7012/test-chrome-safari.ts
@@ -13,11 +13,12 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect.poll(() => page.evaluate(() => scrollY)).toBe(50);
 
     const edit = q.menuitem("Edit");
+    await test.expect(edit).not.toBeInViewport({ ratio: 1 });
     const box = await edit.boundingBox();
     if (!box) {
       throw new Error("Edit menu item is not visible");
     }
-    await page.mouse.move(box.x + box.width / 2, 8);
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height - 8);
 
     await test.expect(edit).toBeFocused();
     await test.expect(q.menu("Edit")).toBeVisible();

--- a/app/src/sandbox/menu-item-hover-7012/test-chrome.ts
+++ b/app/src/sandbox/menu-item-hover-7012/test-chrome.ts
@@ -29,10 +29,10 @@ withFramework(import.meta.dirname, async ({ test }) => {
     if (!shareBox) {
       throw new Error("Share menu item is not visible");
     }
-    await page.mouse.move(
-      shareBox.x + shareBox.width / 2,
-      menuBox.y + menuBox.height - 8,
-    );
+    const menuBottom = menuBox.y + menuBox.height;
+    test.expect(shareBox.y).toBeLessThan(menuBottom);
+    test.expect(shareBox.y + shareBox.height).toBeGreaterThan(menuBottom);
+    await page.mouse.move(shareBox.x + shareBox.width / 2, menuBottom - 8);
 
     await test.expect(share).toBeFocused();
     await test.expect

--- a/app/src/sandbox/menu-item-hover-7012/test-chrome.ts
+++ b/app/src/sandbox/menu-item-hover-7012/test-chrome.ts
@@ -1,0 +1,42 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/7012
+  test("hovering a partially visible submenu button does not scroll", async ({
+    page,
+    q,
+  }) => {
+    const actions = q.button("Actions");
+    await actions.scrollIntoViewIfNeeded();
+    await actions.click();
+
+    const menu = q.menu("Actions");
+    const menuBox = await menu.boundingBox();
+    if (!menuBox) {
+      throw new Error("Actions menu is not visible");
+    }
+    await page.mouse.move(
+      menuBox.x + menuBox.width / 2,
+      menuBox.y + menuBox.height / 2,
+    );
+    await page.mouse.wheel(0, 128);
+    await test.expect
+      .poll(() => menu.evaluate((element) => element.scrollTop))
+      .toBe(128);
+
+    const share = q.menuitem("Share");
+    const shareBox = await share.boundingBox();
+    if (!shareBox) {
+      throw new Error("Share menu item is not visible");
+    }
+    await page.mouse.move(
+      shareBox.x + shareBox.width / 2,
+      menuBox.y + menuBox.height - 8,
+    );
+
+    await test.expect(share).toBeFocused();
+    await test.expect
+      .poll(() => menu.evaluate((element) => element.scrollTop))
+      .toBe(128);
+  });
+});

--- a/packages/ariakit-react-components/src/menu/menu-item.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-item.tsx
@@ -154,6 +154,9 @@ export const useMenuItem = createHook<TagName, MenuItemOptions>(
         if (!store) return false;
         if (!getFocusOnHover()) return false;
         const { compositeElement, items } = store.getState();
+        // Hovering is not a request to move the page or menu; the pointer is
+        // already on what the user cares about. Keyboard navigation presents
+        // items through the composite's own scroll step.
         // If the menu item is also a submenu button, we should move actual DOM
         // focus to it so that the submenu will not close when the user moves
         // the cursor back to the menu button.

--- a/packages/ariakit-react-components/src/menu/menu-item.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-item.tsx
@@ -159,7 +159,7 @@ export const useMenuItem = createHook<TagName, MenuItemOptions>(
         // the cursor back to the menu button.
         if (isWithinMenu) {
           if (event.currentTarget.hasAttribute("aria-expanded")) {
-            event.currentTarget.focus();
+            event.currentTarget.focus({ preventScroll: true });
           }
           return true;
         }
@@ -167,7 +167,7 @@ export const useMenuItem = createHook<TagName, MenuItemOptions>(
         // the menu item if focus is somewhere on the widget. Without this, the
         // open menus in the menu bar wouldn't close.
         if (menuHasFocus(compositeElement, items, event.currentTarget)) {
-          event.currentTarget.focus();
+          event.currentTarget.focus({ preventScroll: true });
           return true;
         }
         return false;


### PR DESCRIPTION
## Motivation

Hovering a partially visible submenu button or an item in an active menubar moves DOM focus without suppressing the browser's implicit focus scroll. The page or scrollable menu can therefore move under a stationary pointer.

Fixes #7012.

## Solution

Pass `preventScroll: true` to the two `MenuItem` focus calls that run when hover moves DOM focus to a submenu button or active menubar item. This keeps the page and scrollable menus stationary under the pointer while preserving focus, active-item state, menu switching, and Ariakit's explicit keyboard presentation.

The seven focus moves triggered by keyboard or click interactions remain unchanged because presenting those destinations is expected behavior.

Real-browser regressions cover both confirmed paths. The menubar case runs in Chromium and WebKit, while the scrollable submenu case runs in Chromium, matching the engines where each defect was reproduced.

## Workaround

Until a release containing this fix is available, wrap the hovered item's own `focus` method so every direct focus call on that element sets `preventScroll`. Ariakit's keyboard presentation still uses its explicit `scrollIntoView` path, so keyboard navigation continues to bring off-screen items into view.

```tsx
// TODO: Remove after https://github.com/ariakit/ariakit/issues/7012 is fixed.
function preventScrollOnFocus(element: HTMLElement | null) {
  if (!element) return;
  const focus = element.focus.bind(element);
  element.focus = (options) => focus({ ...options, preventScroll: true });
}

<Ariakit.MenuItem
  ref={preventScrollOnFocus}
  render={<Ariakit.MenuButton />}
>
  Edit
</Ariakit.MenuItem>;
```

Apply the ref to the submenu and menubar items rendered as `MenuButton` elements that can receive hover focus. This is a temporary element-level override, so it also suppresses implicit scrolling for other direct `focus()` calls on those elements; Ariakit's explicit item presentation remains intact.

## Preview

A focused 800×450 recording was captured from the failing revision and reviewed locally, showing the page move after hover. The available GitHub API cannot upload user attachments and the browser-upload control is unavailable in this execution environment, so the recording could not be attached; the automated tests below provide the exact before-and-after scroll measurements.

## Testing

Without the workaround or library fix, `APP_PORT=4321 pnpm test-browser app/src/sandbox/menu-item-hover-7012` fails on current `main` as expected:

- Menubar hover changes `scrollY` from 50 to 36 in Chromium and WebKit.
- Submenu hover changes `scrollTop` from 128 to 156 in Chromium.

With the sandbox workaround applied, the same command passes all three cases. With the workaround removed and the final library fix applied, it also passes all three cases.

Additional final verification:

- `pnpm build`
- `pnpm tsc`
- `pnpm lint-fix`
