### PR TITLE
Center the selected item when a select-shaped popup opens

### DIFF
--- a/.changeset/200-dialog-initial-focus-scroll.md
+++ b/.changeset/200-dialog-initial-focus-scroll.md
@@ -3,4 +3,4 @@
 "@ariakit/react": patch
 ---
 
-Changed [`Dialog`](https://ariakit.com/reference/dialog) to scroll its initially focused element just far enough to become visible, so selected values in [`SelectItem`](https://ariakit.com/reference/select-item) now rest against the edge of long lists instead of being centered.
+Changed [`Dialog`](https://ariakit.com/reference/dialog) to scroll its initially focused element just far enough to become visible, rather than centering it.

--- a/.changeset/200-dialog-initial-focus-scroll.md
+++ b/.changeset/200-dialog-initial-focus-scroll.md
@@ -3,4 +3,4 @@
 "@ariakit/react": patch
 ---
 
-Changed [`Dialog`](https://ariakit.com/reference/dialog) to scroll its initially focused element into view by the shortest distance that makes it visible, rather than centering it, which is visible in [`ComboboxSelect`](https://ariakit.com/reference/combobox-select) and [`SelectItem`](https://ariakit.com/reference/select-item) where a selected value below the fold now rests against the edge of its list rather than near the middle.
+Changed [`Dialog`](https://ariakit.com/reference/dialog) to scroll its initially focused element just far enough to become visible, so selected values in [`SelectItem`](https://ariakit.com/reference/select-item) now rest against the edge of long lists instead of being centered.

--- a/.changeset/300-center-selected-popup-item.md
+++ b/.changeset/300-center-selected-popup-item.md
@@ -3,4 +3,4 @@
 "@ariakit/react-components": patch
 ---
 
-Changed [`ComboboxSelect`](https://ariakit.com/reference/combobox-select) to center the initially selected item when its popup opens, including default-open popups and asynchronously rendered options, while preserving nearest-edge scrolling during later navigation.
+Fixed [`ComboboxSelect`](https://ariakit.com/reference/combobox-select) to center the initially selected item when its popup is opened interactively.

--- a/.changeset/300-center-selected-popup-item.md
+++ b/.changeset/300-center-selected-popup-item.md
@@ -3,4 +3,4 @@
 "@ariakit/react-components": patch
 ---
 
-Centered the initially selected item when a [`ComboboxSelect`](https://ariakit.com/reference/combobox-select) popup opened while keeping later keyboard, typeahead, and pointer navigation nearest-edge aligned.
+Changed [`ComboboxSelect`](https://ariakit.com/reference/combobox-select) to center the initially selected item when its popup opens, including default-open popups and asynchronously rendered options, while preserving nearest-edge scrolling during later navigation.

--- a/.changeset/300-center-selected-popup-item.md
+++ b/.changeset/300-center-selected-popup-item.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react": patch
+"@ariakit/react-components": patch
+---
+
+Centered the initially selected item when a [`ComboboxSelect`](https://ariakit.com/reference/combobox-select) popup opened while keeping later keyboard, typeahead, and pointer navigation nearest-edge aligned.

--- a/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
@@ -642,6 +642,9 @@ export default function Example() {
       <Fixture defaultSelectedValue={["Apple"]} label="Selected fruit" />
       <Fixture defaultSelectedValue="Apple" label="Single selected fruit" />
       <div style={{ marginTop: 200 }}>
+        <Fixture defaultSelectedValue="Mango" label="Centered fruit" />
+      </div>
+      <div style={{ marginTop: 200 }}>
         <Fixture
           defaultSelectedValue="Watermelon"
           input

--- a/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
@@ -98,16 +98,6 @@ function RemountingFruitItems({ idPrefix }: FruitItemsProps) {
   return <FruitItems key={generation} idPrefix={idPrefix} />;
 }
 
-function DelayedFruitItems() {
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => {
-    const timeout = setTimeout(() => setMounted(true), 100);
-    return () => clearTimeout(timeout);
-  }, []);
-  if (!mounted) return null;
-  return <FruitItems />;
-}
-
 interface RefreshListButtonProps {
   /** The item the refreshed list highlights. */
   activeId: string;
@@ -154,11 +144,7 @@ interface FixtureProps {
    * presentation as the only thing that can bring an item into view.
    */
   autoFocusOnShow?: boolean;
-  /** Holds the fruit options until an external control renders them. */
-  controlledItems?: boolean;
-  defaultOpen?: boolean;
   defaultSelectedValue: string | string[];
-  delayedItems?: boolean;
   focusTarget?: boolean;
   focusTrapTarget?: boolean;
   /**
@@ -201,10 +187,7 @@ interface FixtureProps {
 
 function Fixture({
   autoFocusOnShow,
-  controlledItems,
-  defaultOpen,
   defaultSelectedValue,
-  delayedItems,
   focusTarget,
   focusTrapTarget,
   holdPlacement,
@@ -235,7 +218,6 @@ function Fixture({
   };
   const releaseRef = useRef<(() => void) | null>(null);
   const [generation, setGeneration] = useState(0);
-  const [showControlledItems, setShowControlledItems] = useState(false);
   const updatePosition = () =>
     new Promise<void>((resolve) => {
       releaseRef.current = resolve;
@@ -251,9 +233,7 @@ function Fixture({
       )}
       {remountItemsOnOpen ? (
         <RemountingFruitItems idPrefix={itemIdPrefix} />
-      ) : delayedItems ? (
-        <DelayedFruitItems />
-      ) : controlledItems && !showControlledItems ? null : (
+      ) : (
         <FruitItems key={generation} idPrefix={itemIdPrefix} />
       )}
       {/* An item rendered without a value, at the end of the list so it's
@@ -265,7 +245,6 @@ function Fixture({
   );
   return (
     <Ariakit.ComboboxProvider
-      defaultOpen={defaultOpen}
       defaultSelectedValue={defaultSelectedValue}
       virtualFocus={virtualFocus}
     >
@@ -352,11 +331,6 @@ function Fixture({
           {`${label} focus target`}
         </button>
       )}
-      {controlledItems && (
-        <button type="button" onClick={() => setShowControlledItems(true)}>
-          {`Render ${label.toLowerCase()} items`}
-        </button>
-      )}
       {refreshListActiveId && (
         <RefreshListButton
           activeId={refreshListActiveId}
@@ -378,68 +352,6 @@ function Fixture({
         </button>
       )}
     </Ariakit.ComboboxProvider>
-  );
-}
-
-function MountingDefaultOpenFixture() {
-  const [mounted, setMounted] = useState(false);
-  if (mounted) {
-    return (
-      <Fixture
-        autoFocusOnShow={false}
-        defaultOpen
-        defaultSelectedValue="Mango"
-        label="Default-open centered fruit"
-      />
-    );
-  }
-  return (
-    <button type="button" onClick={() => setMounted(true)}>
-      Mount default-open centered fruit
-    </button>
-  );
-}
-
-function MountingDelayedDefaultOpenFixture() {
-  const [mounted, setMounted] = useState(false);
-  if (mounted) {
-    return (
-      <Fixture
-        autoFocusOnShow={false}
-        defaultOpen
-        defaultSelectedValue="Watermelon"
-        delayedItems
-        label="Delayed default-open centered fruit"
-      />
-    );
-  }
-  return (
-    <button type="button" onClick={() => setMounted(true)}>
-      Mount delayed default-open centered fruit
-    </button>
-  );
-}
-
-function MountingDelayedDefaultOpenFocusEscapeFixture() {
-  const [mounted, setMounted] = useState(false);
-  if (mounted) {
-    return (
-      <Fixture
-        autoFocusOnShow={false}
-        controlledItems
-        defaultOpen
-        defaultSelectedValue="Watermelon"
-        focusTarget
-        keepOpen
-        label="Delayed default-open focus escape fruit"
-        outsideFocusTarget
-      />
-    );
-  }
-  return (
-    <button type="button" onClick={() => setMounted(true)}>
-      Mount delayed default-open focus escape fruit
-    </button>
   );
 }
 
@@ -1028,9 +940,6 @@ export default function Example() {
         />
       </div>
       <div style={{ marginTop: 200 }}>
-        <MountingDefaultOpenFixture />
-      </div>
-      <div style={{ marginTop: 200 }}>
         <Fixture
           defaultSelectedValue="Mango"
           label="Scaled centered fruit"
@@ -1211,12 +1120,6 @@ export default function Example() {
           label="Roving centered fruit"
           virtualFocus={false}
         />
-      </div>
-      <div style={{ marginTop: 200 }}>
-        <MountingDelayedDefaultOpenFixture />
-      </div>
-      <div style={{ marginTop: 200 }}>
-        <MountingDelayedDefaultOpenFocusEscapeFixture />
       </div>
       <div style={{ marginTop: 200 }}>
         <ItemRenderCountFixture />

--- a/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
@@ -553,6 +553,89 @@ function ProgrammaticOpenAfterMoveFixture() {
   );
 }
 
+function TwoAxisOverflowFixture() {
+  const combobox = Ariakit.useComboboxStore({
+    defaultSelectedValue: "Mango",
+  });
+  return (
+    <>
+      <Ariakit.ComboboxSelectLabel store={combobox}>
+        Two-axis fruit
+      </Ariakit.ComboboxSelectLabel>
+      <Ariakit.ComboboxSelect store={combobox} />
+      <Ariakit.ComboboxPopover
+        store={combobox}
+        autoFocusOnShow={false}
+        style={{
+          background: "white",
+          border: "1px solid gray",
+          maxHeight: 120,
+          overflow: "auto",
+          scrollBehavior: "smooth",
+          width: 120,
+        }}
+      >
+        {fruits.map((fruit) => (
+          <Ariakit.ComboboxItem
+            key={fruit}
+            value={fruit}
+            style={{
+              display: "block",
+              marginLeft: 200,
+              padding: "4px 8px",
+              width: 100,
+            }}
+          />
+        ))}
+      </Ariakit.ComboboxPopover>
+    </>
+  );
+}
+
+function OversizedInlineOverflowFixture({
+  direction,
+}: {
+  direction: "ltr" | "rtl";
+}) {
+  const combobox = Ariakit.useComboboxStore({
+    defaultSelectedValue: "Mango",
+  });
+  const label = `Oversized ${direction.toUpperCase()} fruit`;
+  return (
+    <>
+      <Ariakit.ComboboxSelectLabel store={combobox}>
+        {label}
+      </Ariakit.ComboboxSelectLabel>
+      <Ariakit.ComboboxSelect store={combobox} />
+      <Ariakit.ComboboxPopover
+        store={combobox}
+        autoFocusOnShow={false}
+        style={{
+          background: "white",
+          border: "1px solid gray",
+          direction,
+          maxHeight: 120,
+          overflow: "auto",
+          width: 120,
+        }}
+      >
+        {fruits.map((fruit) => (
+          <Ariakit.ComboboxItem
+            key={fruit}
+            value={fruit}
+            style={{
+              display: "block",
+              marginInlineStart: 60,
+              padding: "4px 8px",
+              width: 200,
+            }}
+          />
+        ))}
+      </Ariakit.ComboboxPopover>
+    </>
+  );
+}
+
 function NativeAutoFocusFixture() {
   const dialog = Ariakit.useDialogStore();
   const shadowHostRef = useRef<HTMLDivElement>(null);
@@ -1102,6 +1185,15 @@ export default function Example() {
       </div>
       <div style={{ marginTop: 200 }}>
         <ProgrammaticOpenAfterMoveFixture />
+      </div>
+      <div style={{ marginTop: 200 }}>
+        <TwoAxisOverflowFixture />
+      </div>
+      <div style={{ marginTop: 200 }}>
+        <OversizedInlineOverflowFixture direction="ltr" />
+      </div>
+      <div style={{ marginTop: 200 }}>
+        <OversizedInlineOverflowFixture direction="rtl" />
       </div>
     </>
   );

--- a/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
@@ -1,11 +1,6 @@
 import * as Ariakit from "@ariakit/react";
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react";
+import type { CSSProperties } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 const fruits = [
   "Apple",
@@ -57,9 +52,10 @@ interface FruitItemsProps {
    * would make the replacement a different logical item.
    */
   idPrefix?: string;
+  mangoStyle?: CSSProperties;
 }
 
-function FruitItems({ idPrefix }: FruitItemsProps) {
+function FruitItems({ idPrefix, mangoStyle }: FruitItemsProps) {
   return (
     <>
       {fruits.map((fruit) => (
@@ -67,7 +63,11 @@ function FruitItems({ idPrefix }: FruitItemsProps) {
           key={fruit}
           id={idPrefix ? `${idPrefix}-${slugify(fruit)}` : undefined}
           value={fruit}
-          style={{ display: "block", padding: "4px 8px" }}
+          style={{
+            display: "block",
+            padding: "4px 8px",
+            ...(fruit === "Mango" ? mangoStyle : null),
+          }}
         />
       ))}
     </>
@@ -80,7 +80,7 @@ function FruitItems({ idPrefix }: FruitItemsProps) {
  * replaced while the popup is still being positioned, but their ids keep
  * pointing at the same logical items.
  */
-function RemountingFruitItems({ idPrefix }: FruitItemsProps) {
+function RemountingFruitItems({ idPrefix, mangoStyle }: FruitItemsProps) {
   const combobox = Ariakit.useComboboxContext();
   const mounted = Ariakit.useStoreState(combobox, "mounted");
   const [generation, setGeneration] = useState(0);
@@ -90,7 +90,9 @@ function RemountingFruitItems({ idPrefix }: FruitItemsProps) {
     setGeneration((value) => value + 1);
   }, [mounted]);
 
-  return <FruitItems key={generation} idPrefix={idPrefix} />;
+  return (
+    <FruitItems key={generation} idPrefix={idPrefix} mangoStyle={mangoStyle} />
+  );
 }
 
 interface RefreshListButtonProps {
@@ -139,7 +141,7 @@ interface FixtureProps {
    * presentation as the only thing that can bring an item into view.
    */
   autoFocusOnShow?: boolean;
-  centerSelectedOnOpen?: boolean;
+  defaultOpen?: boolean;
   defaultSelectedValue: string | string[];
   focusTarget?: boolean;
   focusTrapTarget?: boolean;
@@ -156,6 +158,8 @@ interface FixtureProps {
   /** Keeps the popup open while focus leaves it. */
   keepOpen?: boolean;
   label: string;
+  listScrollport?: boolean;
+  mangoStyle?: CSSProperties;
   moveFocusOnOpen?: boolean;
   /** Puts the element focus moves to outside the popup instead of inside it. */
   outsideFocusTarget?: boolean;
@@ -165,6 +169,7 @@ interface FixtureProps {
    * than the popup's list.
    */
   pageScrollport?: boolean;
+  popupStyle?: CSSProperties;
   /**
    * Adds a control that highlights this item and replaces every item node under
    * a stable id. Its replacement half is ignored alongside
@@ -176,11 +181,12 @@ interface FixtureProps {
   showFocusHistory?: boolean;
   unmountOnHide?: boolean;
   virtualFocus?: boolean;
+  writingMode?: "vertical-rl";
 }
 
 function Fixture({
   autoFocusOnShow,
-  centerSelectedOnOpen,
+  defaultOpen,
   defaultSelectedValue,
   focusTarget,
   focusTrapTarget,
@@ -189,14 +195,18 @@ function Fixture({
   itemIdPrefix,
   keepOpen,
   label,
+  listScrollport,
+  mangoStyle,
   moveFocusOnOpen,
   outsideFocusTarget,
   pageScrollport,
+  popupStyle,
   refreshListActiveId,
   remountItemsOnOpen,
   showFocusHistory,
   unmountOnHide,
   virtualFocus,
+  writingMode,
 }: FixtureProps) {
   const focusTargetRef = useRef<HTMLElement | null>(null);
   const [focusHistory, setFocusHistory] = useState<string[]>([]);
@@ -213,8 +223,34 @@ function Fixture({
     new Promise<void>((resolve) => {
       releaseRef.current = resolve;
     });
+  const items = (
+    <>
+      {focusTarget && !outsideFocusTarget && (
+        <Ariakit.ComboboxItem
+          ref={setFocusTarget}
+          style={{ display: "block", padding: "4px 8px" }}
+          value="Focus target"
+        />
+      )}
+      {remountItemsOnOpen ? (
+        <RemountingFruitItems idPrefix={itemIdPrefix} mangoStyle={mangoStyle} />
+      ) : (
+        <FruitItems
+          key={generation}
+          idPrefix={itemIdPrefix}
+          mangoStyle={mangoStyle}
+        />
+      )}
+      {/* An item rendered without a value, at the end of the list so it's
+      always out of view. */}
+      <Ariakit.ComboboxItem style={{ display: "block", padding: "4px 8px" }}>
+        {`No ${label.toLowerCase()}`}
+      </Ariakit.ComboboxItem>
+    </>
+  );
   return (
     <Ariakit.ComboboxProvider
+      defaultOpen={defaultOpen}
       defaultSelectedValue={defaultSelectedValue}
       virtualFocus={virtualFocus}
     >
@@ -250,10 +286,20 @@ function Fixture({
         style={{
           background: "white",
           border: "1px solid gray",
-          ...(pageScrollport ? null : { maxHeight: 120, overflow: "auto" }),
+          ...(pageScrollport || listScrollport
+            ? null
+            : writingMode
+              ? {
+                  height: 120,
+                  maxWidth: 120,
+                  overflow: "auto",
+                  scrollPaddingBlockEnd: "10%",
+                  writingMode,
+                }
+              : { maxHeight: 120, overflow: "auto" }),
+          ...popupStyle,
         }}
       >
-        {centerSelectedOnOpen && <CenterSelectedItemOnOpen />}
         {input && (
           <Ariakit.ComboboxInput
             aria-label={`Search ${label}`}
@@ -272,23 +318,13 @@ function Fixture({
             }}
           />
         )}
-        {focusTarget && !outsideFocusTarget && (
-          <Ariakit.ComboboxItem
-            ref={setFocusTarget}
-            style={{ display: "block", padding: "4px 8px" }}
-            value="Focus target"
-          />
-        )}
-        {remountItemsOnOpen ? (
-          <RemountingFruitItems idPrefix={itemIdPrefix} />
+        {listScrollport ? (
+          <Ariakit.ComboboxList style={{ maxHeight: 120, overflow: "auto" }}>
+            {items}
+          </Ariakit.ComboboxList>
         ) : (
-          <FruitItems key={generation} idPrefix={itemIdPrefix} />
+          items
         )}
-        {/* An item rendered without a value, at the end of the list so it's
-        always out of view. */}
-        <Ariakit.ComboboxItem style={{ display: "block", padding: "4px 8px" }}>
-          {`No ${label.toLowerCase()}`}
-        </Ariakit.ComboboxItem>
       </Ariakit.ComboboxPopover>
       {focusTarget && outsideFocusTarget && (
         <button
@@ -325,53 +361,22 @@ function Fixture({
   );
 }
 
-function CenterSelectedItemOnOpen() {
-  const store = Ariakit.useComboboxContext();
-  const open = Ariakit.useStoreState(store, "open");
-  const popup = Ariakit.useStoreState(store, "contentElement");
-  const activeId = Ariakit.useStoreState(store, "activeId");
-  const cancelledRef = useRef(false);
-
-  useLayoutEffect(() => {
-    if (!open) {
-      cancelledRef.current = false;
-      return;
-    }
-    if (!popup) return;
-    const Observer = popup.ownerDocument.defaultView?.MutationObserver;
-    if (!Observer) return;
-    const centerSelectedItem = () => {
-      const item = popup.querySelector<HTMLElement>("[data-autofocus]");
-      if (!item) return;
-      const currentActiveId = store?.getState().activeId;
-      if (currentActiveId && currentActiveId !== item.id) {
-        cancelledRef.current = true;
-        observer.disconnect();
-        return;
-      }
-      if (cancelledRef.current) return;
-      if (popup.hasAttribute("data-placing")) return;
-      const popupRect = popup.getBoundingClientRect();
-      const itemRect = item.getBoundingClientRect();
-      popup.scrollTop +=
-        itemRect.top -
-        popupRect.top -
-        popup.clientTop -
-        (popup.clientHeight - itemRect.height) / 2;
-      observer.disconnect();
-    };
-    const observer = new Observer(centerSelectedItem);
-    observer.observe(popup, {
-      attributes: true,
-      attributeFilter: ["data-placing", "data-autofocus"],
-      childList: true,
-      subtree: true,
-    });
-    centerSelectedItem();
-    return () => observer.disconnect();
-  }, [store, open, popup, activeId]);
-
-  return null;
+function MountingDefaultOpenFixture() {
+  const [mounted, setMounted] = useState(false);
+  if (mounted) {
+    return (
+      <Fixture
+        defaultOpen
+        defaultSelectedValue="Mango"
+        label="Default-open centered fruit"
+      />
+    );
+  }
+  return (
+    <button type="button" onClick={() => setMounted(true)}>
+      Mount default-open centered fruit
+    </button>
+  );
 }
 
 function NativeAutoFocusFixture() {
@@ -700,19 +705,48 @@ export default function Example() {
       <Fixture defaultSelectedValue={["Apple"]} label="Selected fruit" />
       <Fixture defaultSelectedValue="Apple" label="Single selected fruit" />
       <div style={{ marginTop: 200 }}>
+        <Fixture defaultSelectedValue="Mango" label="Centered fruit" />
+      </div>
+      <div style={{ marginTop: 200 }}>
         <Fixture
-          centerSelectedOnOpen
           defaultSelectedValue="Mango"
-          label="Centered fruit"
+          label="Nested-list centered fruit"
+          listScrollport
         />
       </div>
       <div style={{ marginTop: 200 }}>
         <Fixture
-          centerSelectedOnOpen
           defaultSelectedValue="Mango"
-          holdPlacement
-          keepOpen
-          label="Centered delayed fruit"
+          input
+          label="Centered filterable fruit"
+          virtualFocus={false}
+        />
+      </div>
+      <div style={{ marginTop: 200 }}>
+        <Fixture
+          defaultSelectedValue="Mango"
+          label="Centered unmounted fruit"
+          unmountOnHide
+        />
+      </div>
+      <div style={{ marginTop: 200 }}>
+        <MountingDefaultOpenFixture />
+      </div>
+      <div style={{ marginTop: 200 }}>
+        <Fixture
+          defaultSelectedValue="Mango"
+          label="Scaled centered fruit"
+          mangoStyle={{ scrollMarginBlockStart: 12 }}
+          popupStyle={{ scale: "0.8", scrollPaddingBlockStart: "20%" }}
+        />
+      </div>
+      <div style={{ marginTop: 200 }}>
+        <Fixture
+          defaultSelectedValue="Mango"
+          label="Vertical centered fruit"
+          mangoStyle={{ scrollMarginBlockStart: 20 }}
+          popupStyle={{ scale: "0.8" }}
+          writingMode="vertical-rl"
         />
       </div>
       <div style={{ marginTop: 200 }}>

--- a/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
@@ -1,4 +1,6 @@
 import * as Ariakit from "@ariakit/react";
+import { useComboboxItem } from "@ariakit/react-components/combobox/combobox-item";
+import { ComboboxRenderer } from "@ariakit/react-components/combobox/combobox-renderer";
 import type { CSSProperties } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -41,6 +43,11 @@ const fruits = [
   "Watermelon",
 ];
 
+const rendererItems = fruits.map((value) => ({
+  id: `renderer-${value.toLowerCase().replace(/\s+/g, "-")}`,
+  value,
+}));
+
 function slugify(value: string) {
   return value.toLowerCase().replace(/\s+/g, "-");
 }
@@ -52,10 +59,9 @@ interface FruitItemsProps {
    * would make the replacement a different logical item.
    */
   idPrefix?: string;
-  mangoStyle?: CSSProperties;
 }
 
-function FruitItems({ idPrefix, mangoStyle }: FruitItemsProps) {
+function FruitItems({ idPrefix }: FruitItemsProps) {
   return (
     <>
       {fruits.map((fruit) => (
@@ -66,7 +72,6 @@ function FruitItems({ idPrefix, mangoStyle }: FruitItemsProps) {
           style={{
             display: "block",
             padding: "4px 8px",
-            ...(fruit === "Mango" ? mangoStyle : null),
           }}
         />
       ))}
@@ -80,7 +85,7 @@ function FruitItems({ idPrefix, mangoStyle }: FruitItemsProps) {
  * replaced while the popup is still being positioned, but their ids keep
  * pointing at the same logical items.
  */
-function RemountingFruitItems({ idPrefix, mangoStyle }: FruitItemsProps) {
+function RemountingFruitItems({ idPrefix }: FruitItemsProps) {
   const combobox = Ariakit.useComboboxContext();
   const mounted = Ariakit.useStoreState(combobox, "mounted");
   const [generation, setGeneration] = useState(0);
@@ -90,9 +95,17 @@ function RemountingFruitItems({ idPrefix, mangoStyle }: FruitItemsProps) {
     setGeneration((value) => value + 1);
   }, [mounted]);
 
-  return (
-    <FruitItems key={generation} idPrefix={idPrefix} mangoStyle={mangoStyle} />
-  );
+  return <FruitItems key={generation} idPrefix={idPrefix} />;
+}
+
+function DelayedFruitItems() {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    const timeout = setTimeout(() => setMounted(true), 100);
+    return () => clearTimeout(timeout);
+  }, []);
+  if (!mounted) return null;
+  return <FruitItems />;
 }
 
 interface RefreshListButtonProps {
@@ -141,8 +154,11 @@ interface FixtureProps {
    * presentation as the only thing that can bring an item into view.
    */
   autoFocusOnShow?: boolean;
+  /** Holds the fruit options until an external control renders them. */
+  controlledItems?: boolean;
   defaultOpen?: boolean;
   defaultSelectedValue: string | string[];
+  delayedItems?: boolean;
   focusTarget?: boolean;
   focusTrapTarget?: boolean;
   /**
@@ -159,7 +175,7 @@ interface FixtureProps {
   keepOpen?: boolean;
   label: string;
   listScrollport?: boolean;
-  mangoStyle?: CSSProperties;
+  nestedScrollports?: boolean;
   moveFocusOnOpen?: boolean;
   /** Puts the element focus moves to outside the popup instead of inside it. */
   outsideFocusTarget?: boolean;
@@ -181,13 +197,14 @@ interface FixtureProps {
   showFocusHistory?: boolean;
   unmountOnHide?: boolean;
   virtualFocus?: boolean;
-  writingMode?: "vertical-rl";
 }
 
 function Fixture({
   autoFocusOnShow,
+  controlledItems,
   defaultOpen,
   defaultSelectedValue,
+  delayedItems,
   focusTarget,
   focusTrapTarget,
   holdPlacement,
@@ -196,7 +213,7 @@ function Fixture({
   keepOpen,
   label,
   listScrollport,
-  mangoStyle,
+  nestedScrollports,
   moveFocusOnOpen,
   outsideFocusTarget,
   pageScrollport,
@@ -206,7 +223,6 @@ function Fixture({
   showFocusHistory,
   unmountOnHide,
   virtualFocus,
-  writingMode,
 }: FixtureProps) {
   const focusTargetRef = useRef<HTMLElement | null>(null);
   const [focusHistory, setFocusHistory] = useState<string[]>([]);
@@ -219,6 +235,7 @@ function Fixture({
   };
   const releaseRef = useRef<(() => void) | null>(null);
   const [generation, setGeneration] = useState(0);
+  const [showControlledItems, setShowControlledItems] = useState(false);
   const updatePosition = () =>
     new Promise<void>((resolve) => {
       releaseRef.current = resolve;
@@ -233,13 +250,11 @@ function Fixture({
         />
       )}
       {remountItemsOnOpen ? (
-        <RemountingFruitItems idPrefix={itemIdPrefix} mangoStyle={mangoStyle} />
-      ) : (
-        <FruitItems
-          key={generation}
-          idPrefix={itemIdPrefix}
-          mangoStyle={mangoStyle}
-        />
+        <RemountingFruitItems idPrefix={itemIdPrefix} />
+      ) : delayedItems ? (
+        <DelayedFruitItems />
+      ) : controlledItems && !showControlledItems ? null : (
+        <FruitItems key={generation} idPrefix={itemIdPrefix} />
       )}
       {/* An item rendered without a value, at the end of the list so it's
       always out of view. */}
@@ -288,15 +303,10 @@ function Fixture({
           border: "1px solid gray",
           ...(pageScrollport || listScrollport
             ? null
-            : writingMode
-              ? {
-                  height: 120,
-                  maxWidth: 120,
-                  overflow: "auto",
-                  scrollPaddingBlockEnd: "10%",
-                  writingMode,
-                }
-              : { maxHeight: 120, overflow: "auto" }),
+            : {
+                maxHeight: nestedScrollports ? 160 : 120,
+                overflow: "auto",
+              }),
           ...popupStyle,
         }}
       >
@@ -318,10 +328,15 @@ function Fixture({
             }}
           />
         )}
-        {listScrollport ? (
-          <Ariakit.ComboboxList style={{ maxHeight: 120, overflow: "auto" }}>
-            {items}
-          </Ariakit.ComboboxList>
+        {listScrollport || nestedScrollports ? (
+          <>
+            {nestedScrollports && (
+              <p style={{ height: 200, margin: 0 }}>Available fruit</p>
+            )}
+            <Ariakit.ComboboxList style={{ maxHeight: 120, overflow: "auto" }}>
+              {items}
+            </Ariakit.ComboboxList>
+          </>
         ) : (
           items
         )}
@@ -335,6 +350,11 @@ function Fixture({
           onFocus={() => recordFocus("focus target")}
         >
           {`${label} focus target`}
+        </button>
+      )}
+      {controlledItems && (
+        <button type="button" onClick={() => setShowControlledItems(true)}>
+          {`Render ${label.toLowerCase()} items`}
         </button>
       )}
       {refreshListActiveId && (
@@ -366,6 +386,7 @@ function MountingDefaultOpenFixture() {
   if (mounted) {
     return (
       <Fixture
+        autoFocusOnShow={false}
         defaultOpen
         defaultSelectedValue="Mango"
         label="Default-open centered fruit"
@@ -376,6 +397,122 @@ function MountingDefaultOpenFixture() {
     <button type="button" onClick={() => setMounted(true)}>
       Mount default-open centered fruit
     </button>
+  );
+}
+
+function MountingDelayedDefaultOpenFixture() {
+  const [mounted, setMounted] = useState(false);
+  if (mounted) {
+    return (
+      <Fixture
+        autoFocusOnShow={false}
+        defaultOpen
+        defaultSelectedValue="Watermelon"
+        delayedItems
+        label="Delayed default-open centered fruit"
+      />
+    );
+  }
+  return (
+    <button type="button" onClick={() => setMounted(true)}>
+      Mount delayed default-open centered fruit
+    </button>
+  );
+}
+
+function MountingDelayedDefaultOpenFocusEscapeFixture() {
+  const [mounted, setMounted] = useState(false);
+  if (mounted) {
+    return (
+      <Fixture
+        autoFocusOnShow={false}
+        controlledItems
+        defaultOpen
+        defaultSelectedValue="Watermelon"
+        focusTarget
+        keepOpen
+        label="Delayed default-open focus escape fruit"
+        outsideFocusTarget
+      />
+    );
+  }
+  return (
+    <button type="button" onClick={() => setMounted(true)}>
+      Mount delayed default-open focus escape fruit
+    </button>
+  );
+}
+
+function RenderCountedComboboxItem() {
+  const renderCount = useRef(0);
+  renderCount.current += 1;
+  const props = useComboboxItem({
+    value: "Apple",
+    children: "Apple",
+    style: { display: "block", padding: "4px 8px" },
+  });
+  return <Ariakit.Role {...props} data-render-count={renderCount.current} />;
+}
+
+function ItemRenderCountFixture() {
+  return (
+    <Ariakit.ComboboxProvider defaultSelectedValue="Mango">
+      <Ariakit.ComboboxSelectLabel>
+        Render-counted fruit
+      </Ariakit.ComboboxSelectLabel>
+      <Ariakit.ComboboxSelect />
+      <Ariakit.ComboboxPopover autoFocusOnShow={false} unmountOnHide={false}>
+        <RenderCountedComboboxItem />
+        <Ariakit.ComboboxItem value="Mango">Mango</Ariakit.ComboboxItem>
+      </Ariakit.ComboboxPopover>
+    </Ariakit.ComboboxProvider>
+  );
+}
+
+function VirtualizedSelectFixture() {
+  const combobox = Ariakit.useComboboxStore({
+    defaultItems: rendererItems,
+    defaultSelectedValue: "Apple",
+    selectOnMove: true,
+  });
+  return (
+    <>
+      <Ariakit.ComboboxSelectLabel store={combobox}>
+        Virtualized fruit
+      </Ariakit.ComboboxSelectLabel>
+      <Ariakit.ComboboxSelect store={combobox} />
+      <Ariakit.ComboboxPopover
+        store={combobox}
+        style={{
+          background: "white",
+          border: "1px solid gray",
+          maxHeight: 120,
+          overflow: "auto",
+        }}
+      >
+        <ComboboxRenderer
+          store={combobox}
+          items={rendererItems}
+          itemSize={32}
+          overscan={0}
+        >
+          {({ value, ...item }) => (
+            <Ariakit.ComboboxItem
+              key={item.id}
+              {...item}
+              value={value}
+              style={{
+                ...item.style,
+                boxSizing: "border-box",
+                display: "block",
+                height: 32,
+                padding: "4px 8px",
+              }}
+            />
+          )}
+        </ComboboxRenderer>
+      </Ariakit.ComboboxPopover>
+    </>
   );
 }
 
@@ -736,17 +873,7 @@ export default function Example() {
         <Fixture
           defaultSelectedValue="Mango"
           label="Scaled centered fruit"
-          mangoStyle={{ scrollMarginBlockStart: 12 }}
-          popupStyle={{ scale: "0.8", scrollPaddingBlockStart: "20%" }}
-        />
-      </div>
-      <div style={{ marginTop: 200 }}>
-        <Fixture
-          defaultSelectedValue="Mango"
-          label="Vertical centered fruit"
-          mangoStyle={{ scrollMarginBlockStart: 20 }}
           popupStyle={{ scale: "0.8" }}
-          writingMode="vertical-rl"
         />
       </div>
       <div style={{ marginTop: 200 }}>
@@ -900,6 +1027,41 @@ export default function Example() {
       </div>
       <div style={{ marginTop: 200 }}>
         <DisclosureSwapFixture />
+      </div>
+      <div style={{ marginTop: 200 }}>
+        <Fixture
+          autoFocusOnShow={false}
+          defaultSelectedValue="Mango"
+          label="Nested-scrollports fruit"
+          nestedScrollports
+        />
+      </div>
+      <div style={{ marginTop: 200 }}>
+        <Fixture
+          autoFocusOnShow={false}
+          defaultSelectedValue="Watermelon"
+          label="Page-scroll fruit"
+          pageScrollport
+        />
+      </div>
+      <div style={{ marginTop: 200 }}>
+        <Fixture
+          defaultSelectedValue="Mango"
+          label="Roving centered fruit"
+          virtualFocus={false}
+        />
+      </div>
+      <div style={{ marginTop: 200 }}>
+        <MountingDelayedDefaultOpenFixture />
+      </div>
+      <div style={{ marginTop: 200 }}>
+        <MountingDelayedDefaultOpenFocusEscapeFixture />
+      </div>
+      <div style={{ marginTop: 200 }}>
+        <ItemRenderCountFixture />
+      </div>
+      <div style={{ marginTop: 200 }}>
+        <VirtualizedSelectFixture />
       </div>
     </>
   );

--- a/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
@@ -592,6 +592,47 @@ function TwoAxisOverflowFixture() {
   );
 }
 
+function NestedInlineScrollportFixture() {
+  const combobox = Ariakit.useComboboxStore({
+    defaultSelectedValue: "Mango",
+  });
+  return (
+    <>
+      <Ariakit.ComboboxSelectLabel store={combobox}>
+        Nested-inline fruit
+      </Ariakit.ComboboxSelectLabel>
+      <Ariakit.ComboboxSelect store={combobox} />
+      <Ariakit.ComboboxPopover
+        store={combobox}
+        autoFocusOnShow={false}
+        style={{
+          background: "white",
+          border: "1px solid gray",
+          overflow: "auto",
+          width: 120,
+        }}
+      >
+        <Ariakit.ComboboxList
+          style={{ maxHeight: 120, overflowY: "auto", width: 300 }}
+        >
+          {fruits.map((fruit) => (
+            <Ariakit.ComboboxItem
+              key={fruit}
+              value={fruit}
+              style={{
+                display: "block",
+                marginLeft: 200,
+                padding: "4px 8px",
+                width: 100,
+              }}
+            />
+          ))}
+        </Ariakit.ComboboxList>
+      </Ariakit.ComboboxPopover>
+    </>
+  );
+}
+
 function OversizedInlineOverflowFixture({
   direction,
 }: {
@@ -1188,6 +1229,9 @@ export default function Example() {
       </div>
       <div style={{ marginTop: 200 }}>
         <TwoAxisOverflowFixture />
+      </div>
+      <div style={{ marginTop: 200 }}>
+        <NestedInlineScrollportFixture />
       </div>
       <div style={{ marginTop: 200 }}>
         <OversizedInlineOverflowFixture direction="ltr" />

--- a/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
@@ -516,6 +516,43 @@ function VirtualizedSelectFixture() {
   );
 }
 
+function ProgrammaticOpenAfterMoveFixture() {
+  const combobox = Ariakit.useComboboxStore({
+    defaultSelectedValue: "Mango",
+  });
+  return (
+    <>
+      <Ariakit.ComboboxSelectLabel store={combobox}>
+        Programmatic fruit
+      </Ariakit.ComboboxSelectLabel>
+      <Ariakit.ComboboxSelect store={combobox} />
+      <button
+        type="button"
+        tabIndex={0}
+        onClick={() => combobox.move("programmatic-mango")}
+      >
+        Move programmatic fruit
+      </button>
+      <button type="button" tabIndex={0} onClick={combobox.show}>
+        Open programmatic fruit
+      </button>
+      <Ariakit.ComboboxPopover
+        store={combobox}
+        autoFocusOnShow={false}
+        hideOnInteractOutside={false}
+        style={{
+          background: "white",
+          border: "1px solid gray",
+          maxHeight: 120,
+          overflow: "auto",
+        }}
+      >
+        <FruitItems idPrefix="programmatic" />
+      </Ariakit.ComboboxPopover>
+    </>
+  );
+}
+
 function NativeAutoFocusFixture() {
   const dialog = Ariakit.useDialogStore();
   const shadowHostRef = useRef<HTMLDivElement>(null);
@@ -1062,6 +1099,9 @@ export default function Example() {
       </div>
       <div style={{ marginTop: 200 }}>
         <VirtualizedSelectFixture />
+      </div>
+      <div style={{ marginTop: 200 }}>
+        <ProgrammaticOpenAfterMoveFixture />
       </div>
     </>
   );

--- a/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
@@ -1,5 +1,11 @@
 import * as Ariakit from "@ariakit/react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 
 const fruits = [
   "Apple",
@@ -133,6 +139,7 @@ interface FixtureProps {
    * presentation as the only thing that can bring an item into view.
    */
   autoFocusOnShow?: boolean;
+  centerSelectedOnOpen?: boolean;
   defaultSelectedValue: string | string[];
   focusTarget?: boolean;
   focusTrapTarget?: boolean;
@@ -173,6 +180,7 @@ interface FixtureProps {
 
 function Fixture({
   autoFocusOnShow,
+  centerSelectedOnOpen,
   defaultSelectedValue,
   focusTarget,
   focusTrapTarget,
@@ -245,6 +253,7 @@ function Fixture({
           ...(pageScrollport ? null : { maxHeight: 120, overflow: "auto" }),
         }}
       >
+        {centerSelectedOnOpen && <CenterSelectedItemOnOpen />}
         {input && (
           <Ariakit.ComboboxInput
             aria-label={`Search ${label}`}
@@ -314,6 +323,55 @@ function Fixture({
       )}
     </Ariakit.ComboboxProvider>
   );
+}
+
+function CenterSelectedItemOnOpen() {
+  const store = Ariakit.useComboboxContext();
+  const open = Ariakit.useStoreState(store, "open");
+  const popup = Ariakit.useStoreState(store, "contentElement");
+  const activeId = Ariakit.useStoreState(store, "activeId");
+  const cancelledRef = useRef(false);
+
+  useLayoutEffect(() => {
+    if (!open) {
+      cancelledRef.current = false;
+      return;
+    }
+    if (!popup) return;
+    const Observer = popup.ownerDocument.defaultView?.MutationObserver;
+    if (!Observer) return;
+    const centerSelectedItem = () => {
+      const item = popup.querySelector<HTMLElement>("[data-autofocus]");
+      if (!item) return;
+      const currentActiveId = store?.getState().activeId;
+      if (currentActiveId && currentActiveId !== item.id) {
+        cancelledRef.current = true;
+        observer.disconnect();
+        return;
+      }
+      if (cancelledRef.current) return;
+      if (popup.hasAttribute("data-placing")) return;
+      const popupRect = popup.getBoundingClientRect();
+      const itemRect = item.getBoundingClientRect();
+      popup.scrollTop +=
+        itemRect.top -
+        popupRect.top -
+        popup.clientTop -
+        (popup.clientHeight - itemRect.height) / 2;
+      observer.disconnect();
+    };
+    const observer = new Observer(centerSelectedItem);
+    observer.observe(popup, {
+      attributes: true,
+      attributeFilter: ["data-placing", "data-autofocus"],
+      childList: true,
+      subtree: true,
+    });
+    centerSelectedItem();
+    return () => observer.disconnect();
+  }, [store, open, popup, activeId]);
+
+  return null;
 }
 
 function NativeAutoFocusFixture() {
@@ -642,7 +700,20 @@ export default function Example() {
       <Fixture defaultSelectedValue={["Apple"]} label="Selected fruit" />
       <Fixture defaultSelectedValue="Apple" label="Single selected fruit" />
       <div style={{ marginTop: 200 }}>
-        <Fixture defaultSelectedValue="Mango" label="Centered fruit" />
+        <Fixture
+          centerSelectedOnOpen
+          defaultSelectedValue="Mango"
+          label="Centered fruit"
+        />
+      </div>
+      <div style={{ marginTop: 200 }}>
+        <Fixture
+          centerSelectedOnOpen
+          defaultSelectedValue="Mango"
+          holdPlacement
+          keepOpen
+          label="Centered delayed fruit"
+        />
       </div>
       <div style={{ marginTop: 200 }}>
         <Fixture

--- a/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
@@ -82,6 +82,37 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
       .toPass();
   });
 
+  // https://github.com/ariakit/ariakit/issues/7011
+  test("lets navigation override centering during placement", async ({
+    page,
+    q,
+  }) => {
+    const select = q.combobox("Centered delayed fruit");
+    const mango = q.option("Mango");
+    const watermelon = q.option("Watermelon");
+
+    await select.click();
+    await test.expect(q.listbox()).toHaveAttribute("data-placing");
+    await page.keyboard.press("w");
+    await test.expect(watermelon).toHaveAttribute("data-active-item");
+
+    await q.button("Finish Centered delayed fruit positioning").click();
+
+    const listbox = q.listbox();
+    await test.expect(listbox).not.toHaveAttribute("data-placing");
+    await test
+      .expect(async () => {
+        const listboxBox = await listbox.boundingBox();
+        const mangoBox = await mango.boundingBox();
+        test.expect(listboxBox).not.toBeNull();
+        test.expect(mangoBox).not.toBeNull();
+        const listboxCenter = listboxBox!.y + listboxBox!.height / 2;
+        const mangoCenter = mangoBox!.y + mangoBox!.height / 2;
+        test.expect(Math.abs(mangoCenter - listboxCenter)).toBeGreaterThan(1);
+      })
+      .toPass();
+  });
+
   // https://github.com/ariakit/ariakit/pull/6832
   test("presents a far selected item with real focus", async ({ page, q }) => {
     const select = q.combobox("Filterable fruit");

--- a/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
@@ -34,6 +34,54 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
     await test.expect(select).toBeFocused();
   });
 
+  // https://github.com/ariakit/ariakit/issues/7011
+  test("centers the selected item only on open", async ({ page, q }) => {
+    const select = q.combobox("Centered fruit");
+    const mango = q.option("Mango");
+    const watermelon = q.option("Watermelon");
+    await select.scrollIntoViewIfNeeded();
+    await test.expect(select).toBeInViewport({ ratio: 1 });
+    const scrollY = await page.evaluate(() => window.scrollY);
+    const scroll = await recordScrollEvents(page);
+
+    await select.click();
+
+    const listbox = q.listbox();
+    await test.expect(mango).toHaveAttribute("data-active-item");
+    await test.expect(listbox).not.toHaveAttribute("data-placing");
+    await test
+      .expect(async () => {
+        const listboxBox = await listbox.boundingBox();
+        const mangoBox = await mango.boundingBox();
+        test.expect(listboxBox).not.toBeNull();
+        test.expect(mangoBox).not.toBeNull();
+        const listboxCenter = listboxBox!.y + listboxBox!.height / 2;
+        const mangoCenter = mangoBox!.y + mangoBox!.height / 2;
+        test.expect(mangoCenter).toBeCloseTo(listboxCenter, 0);
+      })
+      .toPass();
+    test.expect(await page.evaluate(() => window.scrollY)).toBe(scrollY);
+    test.expect(await scroll.events()).not.toContain("document");
+
+    await page.keyboard.press("w");
+
+    await test.expect(watermelon).toHaveAttribute("data-active-item");
+    await test
+      .expect(async () => {
+        const listboxBox = await listbox.boundingBox();
+        const watermelonBox = await watermelon.boundingBox();
+        test.expect(listboxBox).not.toBeNull();
+        test.expect(watermelonBox).not.toBeNull();
+        const listboxBottom = await listbox.evaluate((element) => {
+          const rect = element.getBoundingClientRect();
+          return rect.top + element.clientTop + element.clientHeight;
+        });
+        const watermelonBottom = watermelonBox!.y + watermelonBox!.height;
+        test.expect(watermelonBottom).toBeCloseTo(listboxBottom, 0);
+      })
+      .toPass();
+  });
+
   // https://github.com/ariakit/ariakit/pull/6832
   test("presents a far selected item with real focus", async ({ page, q }) => {
     const select = q.combobox("Filterable fruit");

--- a/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
@@ -1,7 +1,42 @@
+import type { Locator } from "@playwright/test";
 import { flushFrames, withFramework } from "#app/test-utils/preview.ts";
 import { recordScrollEvents } from "#app/test-utils/scroll.ts";
 
 withFramework(import.meta.dirname, async ({ query, test }) => {
+  const expectVerticallyCentered = async (listbox: Locator, item: Locator) => {
+    await test
+      .expect(async () => {
+        const listboxBox = await listbox.boundingBox();
+        const itemBox = await item.boundingBox();
+        test.expect(listboxBox).not.toBeNull();
+        test.expect(itemBox).not.toBeNull();
+        const listboxCenter = listboxBox!.y + listboxBox!.height / 2;
+        const itemCenter = itemBox!.y + itemBox!.height / 2;
+        test.expect(itemCenter).toBeCloseTo(listboxCenter, 0);
+      })
+      .toPass();
+  };
+
+  const expectInScrollport = async (listbox: Locator, item: Locator) => {
+    await test
+      .expect(async () => {
+        const itemBox = await item.boundingBox();
+        test.expect(itemBox).not.toBeNull();
+        const edges = await listbox.evaluate((element) => {
+          const rect = element.getBoundingClientRect();
+          return {
+            bottom: rect.top + element.clientTop + element.clientHeight,
+            top: rect.top + element.clientTop,
+          };
+        });
+        test.expect(itemBox!.y).toBeGreaterThanOrEqual(edges.top);
+        test
+          .expect(itemBox!.y + itemBox!.height)
+          .toBeLessThanOrEqual(edges.bottom);
+      })
+      .toPass();
+  };
+
   // https://github.com/ariakit/ariakit/pull/6832
   test("focuses a far item reached through typeahead", async ({ page, q }) => {
     const select = q.combobox("Selected fruit");
@@ -30,7 +65,7 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
     await select.click();
 
     await test.expect(watermelon).toHaveAttribute("data-active-item");
-    await test.expect(watermelon).toBeInViewport();
+    await expectVerticallyCentered(q.listbox(), watermelon);
     await test.expect(select).toBeFocused();
   });
 
@@ -49,17 +84,7 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
     const listbox = q.listbox();
     await test.expect(mango).toHaveAttribute("data-active-item");
     await test.expect(listbox).not.toHaveAttribute("data-placing");
-    await test
-      .expect(async () => {
-        const listboxBox = await listbox.boundingBox();
-        const mangoBox = await mango.boundingBox();
-        test.expect(listboxBox).not.toBeNull();
-        test.expect(mangoBox).not.toBeNull();
-        const listboxCenter = listboxBox!.y + listboxBox!.height / 2;
-        const mangoCenter = mangoBox!.y + mangoBox!.height / 2;
-        test.expect(mangoCenter).toBeCloseTo(listboxCenter, 0);
-      })
-      .toPass();
+    await expectVerticallyCentered(listbox, mango);
     test.expect(await page.evaluate(() => window.scrollY)).toBe(scrollY);
     test.expect(await scroll.events()).not.toContain("document");
 
@@ -80,35 +105,141 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
         test.expect(watermelonBottom).toBeCloseTo(listboxBottom, 0);
       })
       .toPass();
+
+    await page.keyboard.press("Escape");
+    await test.expect(listbox).not.toBeVisible();
+    await select.press("Enter");
+    await test.expect(select).toHaveAttribute("aria-expanded", "true");
+    await test.expect(mango).toHaveAttribute("data-active-item");
+    await expectVerticallyCentered(listbox, mango);
   });
 
   // https://github.com/ariakit/ariakit/issues/7011
-  test("lets navigation override centering during placement", async ({
+  test("centers the selected item in a nested list scrollport", async ({
     page,
     q,
   }) => {
-    const select = q.combobox("Centered delayed fruit");
-    const mango = q.option("Mango");
-    const watermelon = q.option("Watermelon");
+    const select = q.combobox("Nested-list centered fruit");
+    await select.scrollIntoViewIfNeeded();
+    const scrollY = await page.evaluate(() => window.scrollY);
+    const scroll = await recordScrollEvents(page);
 
     await select.click();
-    await test.expect(q.listbox()).toHaveAttribute("data-placing");
-    await page.keyboard.press("w");
-    await test.expect(watermelon).toHaveAttribute("data-active-item");
 
-    await q.button("Finish Centered delayed fruit positioning").click();
+    const listbox = q.listbox("Nested-list centered fruit");
+    const mango = q.option("Mango");
+    await test.expect(mango).toHaveAttribute("data-active-item");
+    await expectVerticallyCentered(listbox, mango);
+    test.expect(await page.evaluate(() => window.scrollY)).toBe(scrollY);
+    test.expect(await scroll.events()).not.toContain("document");
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7011
+  test("centers the selected item with input-backed real focus", async ({
+    q,
+  }) => {
+    await q.combobox("Centered filterable fruit").click();
 
     const listbox = q.listbox();
-    await test.expect(listbox).not.toHaveAttribute("data-placing");
+    const mango = q.option("Mango");
+    await test
+      .expect(q.combobox("Search Centered filterable fruit"))
+      .toBeFocused();
+    await expectVerticallyCentered(listbox, mango);
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7011
+  test("centers the selected item when the popup remounts", async ({ q }) => {
+    const select = q.combobox("Centered unmounted fruit");
+    const mango = q.option("Mango");
+
+    await select.click();
+    await expectVerticallyCentered(q.listbox(), mango);
+    await select.press("Escape");
+    await test.expect(q.listbox()).not.toBeVisible();
+    await select.click();
+
+    await test.expect(mango).toHaveAttribute("data-active-item");
+    await expectVerticallyCentered(q.listbox(), mango);
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7011
+  test("centers the selected item when mounted already open", async ({ q }) => {
+    await q.button("Mount default-open centered fruit").click();
+
+    const mango = q.option("Mango");
+    await test.expect(mango).toHaveAttribute("data-active-item");
+    await expectVerticallyCentered(q.listbox(), mango);
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7011
+  test("centers logical areas in a scaled popup", async ({ q }) => {
+    await q.combobox("Scaled centered fruit").click();
+
+    const listbox = q.listbox();
+    const mango = q.option("Mango");
+    await test.expect(mango).toHaveAttribute("data-active-item");
     await test
       .expect(async () => {
         const listboxBox = await listbox.boundingBox();
         const mangoBox = await mango.boundingBox();
         test.expect(listboxBox).not.toBeNull();
         test.expect(mangoBox).not.toBeNull();
-        const listboxCenter = listboxBox!.y + listboxBox!.height / 2;
-        const mangoCenter = mangoBox!.y + mangoBox!.height / 2;
-        test.expect(Math.abs(mangoCenter - listboxCenter)).toBeGreaterThan(1);
+        const metrics = await listbox.evaluate((element) => {
+          return {
+            clientHeight: element.clientHeight,
+            clientTop: element.clientTop,
+          };
+        });
+        const scale = 0.8;
+        const paddingStart = metrics.clientHeight * 0.2;
+        const itemAreaCenter =
+          mangoBox!.y + mangoBox!.height / 2 - (12 * scale) / 2;
+        const scrollportTop =
+          listboxBox!.y + (metrics.clientTop + paddingStart) * scale;
+        const scrollportBottom =
+          listboxBox!.y + (metrics.clientTop + metrics.clientHeight) * scale;
+        const scrollportCenter = (scrollportTop + scrollportBottom) / 2;
+        test
+          .expect(Math.abs(itemAreaCenter - scrollportCenter))
+          .toBeLessThanOrEqual(1);
+      })
+      .toPass();
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7011
+  test("centers the selected scroll-margin area in vertical writing mode", async ({
+    q,
+  }) => {
+    await q.combobox("Vertical centered fruit").click();
+
+    const listbox = q.listbox();
+    const mango = q.option("Mango");
+    await test.expect(mango).toHaveAttribute("data-active-item");
+    await test
+      .expect(async () => {
+        const listboxBox = await listbox.boundingBox();
+        const mangoBox = await mango.boundingBox();
+        test.expect(listboxBox).not.toBeNull();
+        test.expect(mangoBox).not.toBeNull();
+        const metrics = await listbox.evaluate((element) => {
+          return {
+            clientLeft: element.clientLeft,
+            clientWidth: element.clientWidth,
+          };
+        });
+        const scale = 0.8;
+        const paddingEnd = metrics.clientWidth * 0.1;
+        const itemAreaCenter =
+          mangoBox!.x + mangoBox!.width / 2 + (20 * scale) / 2;
+        const scrollportLeft =
+          listboxBox!.x + (metrics.clientLeft + paddingEnd) * scale;
+        const scrollportRight =
+          listboxBox!.x + (metrics.clientLeft + metrics.clientWidth) * scale;
+        const scrollportCenter = (scrollportLeft + scrollportRight) / 2;
+        test
+          .expect(Math.abs(itemAreaCenter - scrollportCenter))
+          .toBeLessThanOrEqual(1);
       })
       .toPass();
   });
@@ -447,6 +578,6 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
 
     await q.button("Finish Parked fruit positioning").click();
 
-    await test.expect(watermelon).toBeInViewport();
+    await expectInScrollport(q.listbox(), watermelon);
   });
 });

--- a/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
@@ -245,6 +245,18 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
     await expectHorizontallyVisible(listbox, mango);
   });
 
+  test("keeps the selected item visible through an inline scrollport", async ({
+    q,
+  }) => {
+    await q.combobox("Nested-inline fruit").click();
+
+    const listbox = q.listbox("Nested-inline fruit");
+    const popover = listbox.locator("..");
+    const mango = q.option("Mango");
+    await test.expect(mango).toHaveAttribute("data-active-item");
+    await expectHorizontallyVisible(popover, mango);
+  });
+
   for (const direction of ["LTR", "RTL"] as const) {
     test(`keeps the start of an oversized ${direction} item visible`, async ({
       q,

--- a/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
@@ -175,6 +175,21 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
     await expectAtScrollportBottom(listbox, watermelon);
   });
 
+  test("keeps external focus when opening after a closed move", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Move programmatic fruit").click();
+    const open = q.button("Open programmatic fruit");
+    await open.click();
+
+    await test.expect(q.listbox("Programmatic fruit")).toBeVisible();
+    // The presentation created by the open has no positive completion marker,
+    // so cross its frame checkpoint before confirming focus stayed outside.
+    await flushFrames(page);
+    await test.expect(open).toBeFocused();
+  });
+
   // https://github.com/ariakit/ariakit/issues/7011
   test("centers the selected item in a nested list scrollport", async ({
     page,

--- a/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
@@ -37,6 +37,21 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
       .toPass();
   };
 
+  const expectAtScrollportBottom = async (listbox: Locator, item: Locator) => {
+    await test
+      .expect(async () => {
+        const itemBox = await item.boundingBox();
+        test.expect(itemBox).not.toBeNull();
+        const listboxBottom = await listbox.evaluate((element) => {
+          const rect = element.getBoundingClientRect();
+          return rect.top + element.clientTop + element.clientHeight;
+        });
+        const itemBottom = itemBox!.y + itemBox!.height;
+        test.expect(itemBottom).toBeCloseTo(listboxBottom, 0);
+      })
+      .toPass();
+  };
+
   // https://github.com/ariakit/ariakit/pull/6832
   test("focuses a far item reached through typeahead", async ({ page, q }) => {
     const select = q.combobox("Selected fruit");
@@ -88,23 +103,22 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
     test.expect(await page.evaluate(() => window.scrollY)).toBe(scrollY);
     test.expect(await scroll.events()).not.toContain("document");
 
+    for (let i = 0; i < 6; i += 1) {
+      await page.keyboard.press("ArrowUp");
+    }
+    await test
+      .expect(q.option("Jackfruit"))
+      .toHaveAttribute("data-active-item");
+    for (let i = 0; i < 6; i += 1) {
+      await page.keyboard.press("ArrowDown");
+    }
+    await test.expect(mango).toHaveAttribute("data-active-item");
+    await expectAtScrollportBottom(listbox, mango);
+
     await page.keyboard.press("w");
 
     await test.expect(watermelon).toHaveAttribute("data-active-item");
-    await test
-      .expect(async () => {
-        const listboxBox = await listbox.boundingBox();
-        const watermelonBox = await watermelon.boundingBox();
-        test.expect(listboxBox).not.toBeNull();
-        test.expect(watermelonBox).not.toBeNull();
-        const listboxBottom = await listbox.evaluate((element) => {
-          const rect = element.getBoundingClientRect();
-          return rect.top + element.clientTop + element.clientHeight;
-        });
-        const watermelonBottom = watermelonBox!.y + watermelonBox!.height;
-        test.expect(watermelonBottom).toBeCloseTo(listboxBottom, 0);
-      })
-      .toPass();
+    await expectAtScrollportBottom(listbox, watermelon);
 
     await page.keyboard.press("Escape");
     await test.expect(listbox).not.toBeVisible();
@@ -112,6 +126,53 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
     await test.expect(select).toHaveAttribute("aria-expanded", "true");
     await test.expect(mango).toHaveAttribute("data-active-item");
     await expectVerticallyCentered(listbox, mango);
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7011
+  test("centers the selected item when an arrow key opens the popup", async ({
+    q,
+  }) => {
+    const select = q.combobox("Centered fruit");
+    await select.focus();
+    await select.press("ArrowDown");
+
+    const mango = q.option("Mango");
+    await test.expect(mango).toHaveAttribute("data-active-item");
+    await expectVerticallyCentered(q.listbox(), mango);
+  });
+
+  test("does not re-render inactive items when the popup opens", async ({
+    page,
+    q,
+  }) => {
+    const item = page.locator("[data-render-count]");
+    // Item registration has no separate completion marker, so cross its frame
+    // checkpoint before sampling the stable render count.
+    await flushFrames(page);
+    const renderCount = await item.getAttribute("data-render-count");
+    if (renderCount == null) {
+      throw new Error("Combobox item render count was not found");
+    }
+
+    await q.combobox("Render-counted fruit").click();
+    await test.expect(q.listbox("Render-counted fruit")).toBeVisible();
+    // Opening can finish focus work on the next frames, and the absence of an
+    // item render has no positive state to await.
+    await flushFrames(page);
+
+    await test.expect(item).toHaveAttribute("data-render-count", renderCount);
+  });
+
+  test("keeps a late-mounted selected item nearest-edge aligned", async ({
+    page,
+    q,
+  }) => {
+    await q.combobox("Virtualized fruit").click();
+    const listbox = q.listbox("Virtualized fruit");
+    await page.keyboard.press("End");
+    const watermelon = q.option("Watermelon");
+    await test.expect(watermelon).toHaveAttribute("data-active-item");
+    await expectAtScrollportBottom(listbox, watermelon);
   });
 
   // https://github.com/ariakit/ariakit/issues/7011
@@ -135,6 +196,39 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
   });
 
   // https://github.com/ariakit/ariakit/issues/7011
+  test("keeps the selected item visible through nested scrollports", async ({
+    q,
+  }) => {
+    await q.combobox("Nested-scrollports fruit").click();
+
+    const listbox = q.listbox("Nested-scrollports fruit");
+    const popover = listbox.locator("..");
+    const mango = q.option("Mango");
+    await test.expect(mango).toHaveAttribute("data-active-item");
+    await expectInScrollport(listbox, mango);
+    await expectInScrollport(popover, mango);
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7011
+  test("falls back to the page scrollport when the popup cannot scroll", async ({
+    page,
+    q,
+  }) => {
+    const select = q.combobox("Page-scroll fruit");
+    await select.scrollIntoViewIfNeeded();
+    const scrollY = await page.evaluate(() => window.scrollY);
+
+    await select.click();
+
+    const watermelon = q.option("Watermelon");
+    await test.expect(watermelon).toHaveAttribute("data-active-item");
+    await test.expect(watermelon).toBeInViewport();
+    test
+      .expect(await page.evaluate(() => window.scrollY))
+      .toBeGreaterThan(scrollY);
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7011
   test("centers the selected item with input-backed real focus", async ({
     q,
   }) => {
@@ -146,6 +240,15 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
       .expect(q.combobox("Search Centered filterable fruit"))
       .toBeFocused();
     await expectVerticallyCentered(listbox, mango);
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7011
+  test("centers the selected item with roving tabindex", async ({ q }) => {
+    await q.combobox("Roving centered fruit").click();
+
+    const mango = q.option("Mango");
+    await test.expect(mango).toBeFocused();
+    await expectVerticallyCentered(q.listbox(), mango);
   });
 
   // https://github.com/ariakit/ariakit/issues/7011
@@ -173,75 +276,53 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
   });
 
   // https://github.com/ariakit/ariakit/issues/7011
-  test("centers logical areas in a scaled popup", async ({ q }) => {
+  test("waits for selected items rendered after a default-open popup", async ({
+    q,
+  }) => {
+    await q.button("Mount delayed default-open centered fruit").click();
+
+    const watermelon = q.option("Watermelon");
+    await test.expect(watermelon).toHaveAttribute("data-active-item");
+    await expectVerticallyCentered(q.listbox(), watermelon);
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7011
+  test("abandons a delayed default-open presentation when focus leaves", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Mount delayed default-open focus escape fruit").click();
+
+    const focusTarget = q.button(
+      "Delayed default-open focus escape fruit focus target",
+    );
+    await focusTarget.focus();
+    await q
+      .button("Render delayed default-open focus escape fruit items")
+      .dispatchEvent("click");
+    await test.expect(q.option("Watermelon")).toBeAttached();
+    // The pending presentation has no completion marker, so cross its frame
+    // checkpoint before asserting that focus and scroll remained unchanged.
+    await flushFrames(page);
+
+    await test.expect(focusTarget).toBeFocused();
+    test
+      .expect(
+        await q
+          .listbox("Delayed default-open focus escape fruit")
+          .evaluate((element) => element.scrollTop),
+      )
+      .toBe(0);
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7011
+  test("centers the selected item in a scaled popup", async ({ q }) => {
     await q.combobox("Scaled centered fruit").click();
 
     const listbox = q.listbox();
     const mango = q.option("Mango");
     await test.expect(mango).toHaveAttribute("data-active-item");
-    await test
-      .expect(async () => {
-        const listboxBox = await listbox.boundingBox();
-        const mangoBox = await mango.boundingBox();
-        test.expect(listboxBox).not.toBeNull();
-        test.expect(mangoBox).not.toBeNull();
-        const metrics = await listbox.evaluate((element) => {
-          return {
-            clientHeight: element.clientHeight,
-            clientTop: element.clientTop,
-          };
-        });
-        const scale = 0.8;
-        const paddingStart = metrics.clientHeight * 0.2;
-        const itemAreaCenter =
-          mangoBox!.y + mangoBox!.height / 2 - (12 * scale) / 2;
-        const scrollportTop =
-          listboxBox!.y + (metrics.clientTop + paddingStart) * scale;
-        const scrollportBottom =
-          listboxBox!.y + (metrics.clientTop + metrics.clientHeight) * scale;
-        const scrollportCenter = (scrollportTop + scrollportBottom) / 2;
-        test
-          .expect(Math.abs(itemAreaCenter - scrollportCenter))
-          .toBeLessThanOrEqual(1);
-      })
-      .toPass();
-  });
-
-  // https://github.com/ariakit/ariakit/issues/7011
-  test("centers the selected scroll-margin area in vertical writing mode", async ({
-    q,
-  }) => {
-    await q.combobox("Vertical centered fruit").click();
-
-    const listbox = q.listbox();
-    const mango = q.option("Mango");
-    await test.expect(mango).toHaveAttribute("data-active-item");
-    await test
-      .expect(async () => {
-        const listboxBox = await listbox.boundingBox();
-        const mangoBox = await mango.boundingBox();
-        test.expect(listboxBox).not.toBeNull();
-        test.expect(mangoBox).not.toBeNull();
-        const metrics = await listbox.evaluate((element) => {
-          return {
-            clientLeft: element.clientLeft,
-            clientWidth: element.clientWidth,
-          };
-        });
-        const scale = 0.8;
-        const paddingEnd = metrics.clientWidth * 0.1;
-        const itemAreaCenter =
-          mangoBox!.x + mangoBox!.width / 2 + (20 * scale) / 2;
-        const scrollportLeft =
-          listboxBox!.x + (metrics.clientLeft + paddingEnd) * scale;
-        const scrollportRight =
-          listboxBox!.x + (metrics.clientLeft + metrics.clientWidth) * scale;
-        const scrollportCenter = (scrollportLeft + scrollportRight) / 2;
-        test
-          .expect(Math.abs(itemAreaCenter - scrollportCenter))
-          .toBeLessThanOrEqual(1);
-      })
-      .toPass();
+    await expectVerticallyCentered(listbox, mango);
   });
 
   // https://github.com/ariakit/ariakit/pull/6832

--- a/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
@@ -364,55 +364,6 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
   });
 
   // https://github.com/ariakit/ariakit/issues/7011
-  test("centers the selected item when mounted already open", async ({ q }) => {
-    await q.button("Mount default-open centered fruit").click();
-
-    const mango = q.option("Mango");
-    await test.expect(mango).toHaveAttribute("data-active-item");
-    await expectVerticallyCentered(q.listbox(), mango);
-  });
-
-  // https://github.com/ariakit/ariakit/issues/7011
-  test("waits for selected items rendered after a default-open popup", async ({
-    q,
-  }) => {
-    await q.button("Mount delayed default-open centered fruit").click();
-
-    const watermelon = q.option("Watermelon");
-    await test.expect(watermelon).toHaveAttribute("data-active-item");
-    await expectVerticallyCentered(q.listbox(), watermelon);
-  });
-
-  // https://github.com/ariakit/ariakit/issues/7011
-  test("abandons a delayed default-open presentation when focus leaves", async ({
-    page,
-    q,
-  }) => {
-    await q.button("Mount delayed default-open focus escape fruit").click();
-
-    const focusTarget = q.button(
-      "Delayed default-open focus escape fruit focus target",
-    );
-    await focusTarget.focus();
-    await q
-      .button("Render delayed default-open focus escape fruit items")
-      .dispatchEvent("click");
-    await test.expect(q.option("Watermelon")).toBeAttached();
-    // The pending presentation has no completion marker, so cross its frame
-    // checkpoint before asserting that focus and scroll remained unchanged.
-    await flushFrames(page);
-
-    await test.expect(focusTarget).toBeFocused();
-    test
-      .expect(
-        await q
-          .listbox("Delayed default-open focus escape fruit")
-          .evaluate((element) => element.scrollTop),
-      )
-      .toBe(0);
-  });
-
-  // https://github.com/ariakit/ariakit/issues/7011
   test("centers the selected item in a scaled popup", async ({ q }) => {
     await q.combobox("Scaled centered fruit").click();
 

--- a/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
@@ -52,6 +52,51 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
       .toPass();
   };
 
+  const expectHorizontallyVisible = async (
+    scrollport: Locator,
+    item: Locator,
+  ) => {
+    await test
+      .expect(async () => {
+        const itemBox = await item.boundingBox();
+        test.expect(itemBox).not.toBeNull();
+        const edges = await scrollport.evaluate((element) => {
+          const rect = element.getBoundingClientRect();
+          return {
+            left: rect.left + element.clientLeft,
+            right: rect.left + element.clientLeft + element.clientWidth,
+          };
+        });
+        test.expect(itemBox!.x).toBeGreaterThanOrEqual(edges.left);
+        test
+          .expect(itemBox!.x + itemBox!.width)
+          .toBeLessThanOrEqual(edges.right);
+      })
+      .toPass();
+  };
+
+  const expectAtInlineStart = async (scrollport: Locator, item: Locator) => {
+    await test
+      .expect(async () => {
+        const itemBox = await item.boundingBox();
+        test.expect(itemBox).not.toBeNull();
+        const edges = await scrollport.evaluate((element) => {
+          const rect = element.getBoundingClientRect();
+          return {
+            direction: getComputedStyle(element).direction,
+            left: rect.left + element.clientLeft,
+            right: rect.left + element.clientLeft + element.clientWidth,
+          };
+        });
+        if (edges.direction === "rtl") {
+          test.expect(itemBox!.x + itemBox!.width).toBeCloseTo(edges.right, 0);
+        } else {
+          test.expect(itemBox!.x).toBeCloseTo(edges.left, 0);
+        }
+      })
+      .toPass();
+  };
+
   // https://github.com/ariakit/ariakit/pull/6832
   test("focuses a far item reached through typeahead", async ({ page, q }) => {
     const select = q.combobox("Selected fruit");
@@ -189,6 +234,31 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
     await flushFrames(page);
     await test.expect(open).toBeFocused();
   });
+
+  test("keeps the centered item visible across both axes", async ({ q }) => {
+    await q.combobox("Two-axis fruit").click();
+
+    const listbox = q.listbox("Two-axis fruit");
+    const mango = q.option("Mango");
+    await test.expect(mango).toHaveAttribute("data-active-item");
+    await expectVerticallyCentered(listbox, mango);
+    await expectHorizontallyVisible(listbox, mango);
+  });
+
+  for (const direction of ["LTR", "RTL"] as const) {
+    test(`keeps the start of an oversized ${direction} item visible`, async ({
+      q,
+    }) => {
+      const label = `Oversized ${direction} fruit`;
+      await q.combobox(label).click();
+
+      const listbox = q.listbox(label);
+      const mango = q.option("Mango");
+      await test.expect(mango).toHaveAttribute("data-active-item");
+      await expectVerticallyCentered(listbox, mango);
+      await expectAtInlineStart(listbox, mango);
+    });
+  }
 
   // https://github.com/ariakit/ariakit/issues/7011
   test("centers the selected item in a nested list scrollport", async ({

--- a/packages/ariakit-react-components/src/combobox/__utils.ts
+++ b/packages/ariakit-react-components/src/combobox/__utils.ts
@@ -33,12 +33,42 @@ function getSingleVerticalScrollport(element: HTMLElement, popup: HTMLElement) {
 function centerItemInScrollport(element: HTMLElement, scrollport: HTMLElement) {
   const elementRect = element.getBoundingClientRect();
   const scrollportRect = scrollport.getBoundingClientRect();
-  const scale = scrollportRect.height / scrollport.offsetHeight || 1;
+  const scaleX = scrollportRect.width / scrollport.offsetWidth || 1;
+  const scrollportLeft = scrollportRect.left + scrollport.clientLeft * scaleX;
+  const scrollportRight = scrollportLeft + scrollport.clientWidth * scaleX;
+  const scrollportWidth = scrollport.clientWidth * scaleX;
+  const elementLeftOutside = elementRect.left < scrollportLeft;
+  const elementRightOutside = elementRect.right > scrollportRight;
+  const alignLeft =
+    (elementLeftOutside &&
+      !elementRightOutside &&
+      elementRect.width < scrollportWidth) ||
+    (elementRightOutside &&
+      !elementLeftOutside &&
+      elementRect.width > scrollportWidth);
+  const alignRight =
+    (elementLeftOutside &&
+      !elementRightOutside &&
+      elementRect.width > scrollportWidth) ||
+    (elementRightOutside &&
+      !elementLeftOutside &&
+      elementRect.width < scrollportWidth);
+  // Preserve native inline-nearest behavior without scrolling ancestors
+  // outside the popup.
+  let left = 0;
+  if (alignLeft) {
+    left = (elementRect.left - scrollportLeft) / scaleX;
+  } else if (alignRight) {
+    left = (elementRect.right - scrollportRight) / scaleX;
+  }
+
+  const scaleY = scrollportRect.height / scrollport.offsetHeight || 1;
   const elementCenter = elementRect.top + elementRect.height / 2;
   const scrollportCenter =
     scrollportRect.top +
-    (scrollport.clientTop + scrollport.clientHeight / 2) * scale;
-  scrollport.scrollTop += (elementCenter - scrollportCenter) / scale;
+    (scrollport.clientTop + scrollport.clientHeight / 2) * scaleY;
+  const top = (elementCenter - scrollportCenter) / scaleY;
+  scrollport.scrollBy({ left, top });
 }
 
 export function useTrackComboboxSelectPresentation(store?: ComboboxStore) {

--- a/packages/ariakit-react-components/src/combobox/__utils.ts
+++ b/packages/ariakit-react-components/src/combobox/__utils.ts
@@ -1,8 +1,12 @@
-import { useEvent, useSafeLayoutEffect } from "@ariakit/react-utils";
+import { useSafeLayoutEffect } from "@ariakit/react-utils";
 import { sync } from "@ariakit/store";
 import type { ComboboxStore } from "./combobox-store.ts";
 
 const openingMovesByStore = new WeakMap<ComboboxStore, number>();
+const scrollItemIntoViewByStore = new WeakMap<
+  ComboboxStore,
+  (element: HTMLElement) => void
+>();
 
 function scrollIntoViewNearest(element: HTMLElement) {
   element.scrollIntoView({ block: "nearest", inline: "nearest" });
@@ -94,9 +98,15 @@ export function useTrackComboboxSelectPresentation(store?: ComboboxStore) {
   }, [store]);
 }
 
-export function useScrollItemIntoView(store?: ComboboxStore) {
-  return useEvent((element: HTMLElement) => {
-    if (!store) return scrollIntoViewNearest(element);
+/**
+ * Returns the store's item-scrolling callback. It reads current store state
+ * when called, so every item can share one stable callback per store.
+ */
+export function getScrollItemIntoView(store?: ComboboxStore) {
+  if (!store) return scrollIntoViewNearest;
+  const cached = scrollItemIntoViewByStore.get(store);
+  if (cached) return cached;
+  const scrollItemIntoView = (element: HTMLElement) => {
     const { contentElement, moves, selectElement } = store.getState();
     if (!selectElement) return scrollIntoViewNearest(element);
     if (moves !== openingMovesByStore.get(store)) {
@@ -108,5 +118,7 @@ export function useScrollItemIntoView(store?: ComboboxStore) {
     const scrollport = getSingleVerticalScrollport(element, contentElement);
     if (!scrollport) return scrollIntoViewNearest(element);
     centerItemInScrollport(element, scrollport);
-  });
+  };
+  scrollItemIntoViewByStore.set(store, scrollItemIntoView);
+  return scrollItemIntoView;
 }

--- a/packages/ariakit-react-components/src/combobox/__utils.ts
+++ b/packages/ariakit-react-components/src/combobox/__utils.ts
@@ -1,0 +1,82 @@
+import { useEvent, useSafeLayoutEffect } from "@ariakit/react-utils";
+import { sync } from "@ariakit/store";
+import type { ComboboxStore } from "./combobox-store.ts";
+
+const openingMovesByStore = new WeakMap<ComboboxStore, number>();
+
+function scrollIntoViewNearest(element: HTMLElement) {
+  element.scrollIntoView({ block: "nearest", inline: "nearest" });
+}
+
+function getSingleVerticalScrollport(element: HTMLElement, popup: HTMLElement) {
+  const getComputedStyle = element.ownerDocument.defaultView?.getComputedStyle;
+  if (!getComputedStyle) return null;
+  if (!getComputedStyle(popup).writingMode.startsWith("horizontal")) {
+    return null;
+  }
+  let scrollport: HTMLElement | null = null;
+  let current = element.parentElement;
+  while (current && popup.contains(current)) {
+    const style = getComputedStyle(current);
+    const scrollableOverflow =
+      style.overflowY !== "visible" && style.overflowY !== "clip";
+    if (scrollableOverflow && current.scrollHeight > current.clientHeight) {
+      if (scrollport) return null;
+      scrollport = current;
+    }
+    if (current === popup) break;
+    current = current.parentElement;
+  }
+  return scrollport;
+}
+
+function centerItemInScrollport(element: HTMLElement, scrollport: HTMLElement) {
+  const elementRect = element.getBoundingClientRect();
+  const scrollportRect = scrollport.getBoundingClientRect();
+  const scale = scrollportRect.height / scrollport.offsetHeight || 1;
+  const elementCenter = elementRect.top + elementRect.height / 2;
+  const scrollportCenter =
+    scrollportRect.top +
+    (scrollport.clientTop + scrollport.clientHeight / 2) * scale;
+  scrollport.scrollTop += (elementCenter - scrollportCenter) / scale;
+}
+
+export function useTrackComboboxSelectPresentation(store?: ComboboxStore) {
+  useSafeLayoutEffect(() => {
+    if (!store) return;
+    // The select stays mounted across the whole open cycle, while virtualized
+    // items can mount after navigation. Record the baseline once here so every
+    // item compares against the same opening movement without subscribing.
+    const stop = sync(store, ["open"], (state) => {
+      // Arrow keys move while the popup is still closed. Capture that movement
+      // at each open so the opening presentation still centers; only movement
+      // after this point should switch back to nearest-edge scrolling.
+      if (state.open) {
+        openingMovesByStore.set(store, store.getState().moves);
+      } else {
+        openingMovesByStore.delete(store);
+      }
+    });
+    return () => {
+      stop();
+      openingMovesByStore.delete(store);
+    };
+  }, [store]);
+}
+
+export function useScrollItemIntoView(store?: ComboboxStore) {
+  return useEvent((element: HTMLElement) => {
+    if (!store) return scrollIntoViewNearest(element);
+    const { contentElement, moves, selectElement } = store.getState();
+    if (!selectElement) return scrollIntoViewNearest(element);
+    if (moves !== openingMovesByStore.get(store)) {
+      return scrollIntoViewNearest(element);
+    }
+    if (!contentElement?.contains(element)) {
+      return scrollIntoViewNearest(element);
+    }
+    const scrollport = getSingleVerticalScrollport(element, contentElement);
+    if (!scrollport) return scrollIntoViewNearest(element);
+    centerItemInScrollport(element, scrollport);
+  });
+}

--- a/packages/ariakit-react-components/src/combobox/__utils.ts
+++ b/packages/ariakit-react-components/src/combobox/__utils.ts
@@ -19,18 +19,28 @@ function getSingleVerticalScrollport(element: HTMLElement, popup: HTMLElement) {
     return null;
   }
   let scrollport: HTMLElement | null = null;
+  let inlineScrollport: HTMLElement | null = null;
   let current = element.parentElement;
   while (current && popup.contains(current)) {
     const style = view.getComputedStyle(current);
-    const scrollableOverflow =
+    const scrollsVertically =
       style.overflowY !== "visible" && style.overflowY !== "clip";
-    if (scrollableOverflow && current.scrollHeight > current.clientHeight) {
+    if (scrollsVertically && current.scrollHeight > current.clientHeight) {
       if (scrollport) return null;
       scrollport = current;
+    }
+    const scrollsInline =
+      style.overflowX !== "visible" && style.overflowX !== "clip";
+    if (scrollsInline && current.scrollWidth > current.clientWidth) {
+      if (inlineScrollport) return null;
+      inlineScrollport = current;
     }
     if (current === popup) break;
     current = current.parentElement;
   }
+  // Centering one element cannot keep an item visible through a different
+  // inline scrollport. Native nearest scrolling handles every ancestor.
+  if (inlineScrollport && inlineScrollport !== scrollport) return null;
   return scrollport;
 }
 

--- a/packages/ariakit-react-components/src/combobox/__utils.ts
+++ b/packages/ariakit-react-components/src/combobox/__utils.ts
@@ -53,6 +53,8 @@ function centerItemInScrollport(element: HTMLElement, scrollport: HTMLElement) {
   const scrollportWidth = scrollport.clientWidth * scaleX;
   const elementLeftOutside = elementRect.left < scrollportLeft;
   const elementRightOutside = elementRect.right > scrollportRight;
+  // Mirror CSSOM View's inline `nearest` rules with physical edges so the
+  // start/end behavior remains correct for oversized RTL items.
   const alignLeft =
     (elementLeftOutside &&
       !elementRightOutside &&

--- a/packages/ariakit-react-components/src/combobox/__utils.ts
+++ b/packages/ariakit-react-components/src/combobox/__utils.ts
@@ -9,15 +9,15 @@ function scrollIntoViewNearest(element: HTMLElement) {
 }
 
 function getSingleVerticalScrollport(element: HTMLElement, popup: HTMLElement) {
-  const getComputedStyle = element.ownerDocument.defaultView?.getComputedStyle;
-  if (!getComputedStyle) return null;
-  if (!getComputedStyle(popup).writingMode.startsWith("horizontal")) {
+  const view = element.ownerDocument.defaultView;
+  if (!view) return null;
+  if (!view.getComputedStyle(popup).writingMode.startsWith("horizontal")) {
     return null;
   }
   let scrollport: HTMLElement | null = null;
   let current = element.parentElement;
   while (current && popup.contains(current)) {
-    const style = getComputedStyle(current);
+    const style = view.getComputedStyle(current);
     const scrollableOverflow =
       style.overflowY !== "visible" && style.overflowY !== "clip";
     if (scrollableOverflow && current.scrollHeight > current.clientHeight) {

--- a/packages/ariakit-react-components/src/combobox/combobox-item.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item.tsx
@@ -27,7 +27,7 @@ import type { CompositeHoverOptions } from "../composite/composite-hover.tsx";
 import { useCompositeHover } from "../composite/composite-hover.tsx";
 import type { CompositeItemOptions } from "../composite/composite-item.tsx";
 import { useCompositeItem } from "../composite/composite-item.tsx";
-import { useScrollItemIntoView } from "./__utils.ts";
+import { getScrollItemIntoView } from "./__utils.ts";
 import {
   ComboboxItemCheckedContext,
   ComboboxItemValueContext,
@@ -263,7 +263,7 @@ export const useComboboxItem = createHook<TagName, ComboboxItemOptions>(
     }
 
     const moveOnKeyPressProp = useBooleanEvent(moveOnKeyPress);
-    const scrollItemIntoView = useScrollItemIntoView(store);
+    const scrollItemIntoView = getScrollItemIntoView(store);
 
     props = useCompositeItem<TagName>({
       store,

--- a/packages/ariakit-react-components/src/combobox/combobox-item.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item.tsx
@@ -27,6 +27,7 @@ import type { CompositeHoverOptions } from "../composite/composite-hover.tsx";
 import { useCompositeHover } from "../composite/composite-hover.tsx";
 import type { CompositeItemOptions } from "../composite/composite-item.tsx";
 import { useCompositeItem } from "../composite/composite-item.tsx";
+import { useScrollItemIntoView } from "./__utils.ts";
 import {
   ComboboxItemCheckedContext,
   ComboboxItemValueContext,
@@ -262,9 +263,11 @@ export const useComboboxItem = createHook<TagName, ComboboxItemOptions>(
     }
 
     const moveOnKeyPressProp = useBooleanEvent(moveOnKeyPress);
+    const scrollItemIntoView = useScrollItemIntoView(store);
 
     props = useCompositeItem<TagName>({
       store,
+      unstable_scrollIntoView: scrollItemIntoView,
       ...props,
       getItem,
       preventScrollOnKeyDown,

--- a/packages/ariakit-react-components/src/combobox/combobox-popover.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-popover.tsx
@@ -19,6 +19,7 @@ import type { ElementType, KeyboardEvent as ReactKeyboardEvent } from "react";
 import { useEffect, useRef } from "react";
 import type { CompositeTypeaheadOptions } from "../composite/composite-typeahead.tsx";
 import { useCompositeTypeahead } from "../composite/composite-typeahead.tsx";
+import { usePresentItem } from "../composite/utils.ts";
 import { createDialogComponent } from "../dialog/dialog.tsx";
 import type { PopoverOptions } from "../popover/popover.tsx";
 import { usePopover } from "../popover/popover.tsx";
@@ -86,6 +87,19 @@ export const useComboboxPopover = createHook<TagName, ComboboxPopoverOptions>(
     const hasSelect = !!selectElement;
     const selectOwnsFocus =
       !!selectElement && getActiveElement(selectElement) === selectElement;
+
+    const presentInitialItem = usePresentItem(store);
+    const autoFocusOnShow = useEvent((element: HTMLElement | null) => {
+      const { inputElement, selectElement } = store.getState();
+      if (inputElement) return true;
+      if (selectElement && getActiveElement(selectElement) === selectElement) {
+        return true;
+      }
+      if (element?.hasAttribute("data-autofocus") && element.id) {
+        presentInitialItem({ id: element.id, markedOnly: true });
+      }
+      return false;
+    });
 
     const selectOnMove = useStoreState(store, "selectOnMove");
     const acceptedEscapeRef = useRef<{
@@ -219,10 +233,11 @@ export const useComboboxPopover = createHook<TagName, ComboboxPopoverOptions>(
       modal,
       alwaysVisible,
       backdrop: false,
-      // A callback would always be truthy, defeating the dialog's early-out and
-      // forcing a tabbable scan of the whole popup on every open.
       // Without an input, only take focus when the select initiated the open.
-      autoFocusOnShow: hasSelect && (!!inputElement || selectOwnsFocus),
+      // The callback still runs for an already-open or programmatically opened
+      // select so its selected item can be presented without moving focus.
+      autoFocusOnShow:
+        hasSelect && (!!inputElement || selectOwnsFocus || autoFocusOnShow),
       initialFocus: hasSelect ? inputElement : undefined,
       finalFocus: selectElement || compositeElement,
       preserveTabOrderAnchor: null,

--- a/packages/ariakit-react-components/src/combobox/combobox-popover.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-popover.tsx
@@ -219,6 +219,8 @@ export const useComboboxPopover = createHook<TagName, ComboboxPopoverOptions>(
       modal,
       alwaysVisible,
       backdrop: false,
+      // A callback would always be truthy, defeating the dialog's early-out and
+      // forcing a tabbable scan of the whole popup on every open.
       // Without an input, only take focus when the select initiated the open.
       autoFocusOnShow: hasSelect && (!!inputElement || selectOwnsFocus),
       initialFocus: hasSelect ? inputElement : undefined,

--- a/packages/ariakit-react-components/src/combobox/combobox-popover.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-popover.tsx
@@ -19,7 +19,6 @@ import type { ElementType, KeyboardEvent as ReactKeyboardEvent } from "react";
 import { useEffect, useRef } from "react";
 import type { CompositeTypeaheadOptions } from "../composite/composite-typeahead.tsx";
 import { useCompositeTypeahead } from "../composite/composite-typeahead.tsx";
-import { usePresentItem } from "../composite/utils.ts";
 import { createDialogComponent } from "../dialog/dialog.tsx";
 import type { PopoverOptions } from "../popover/popover.tsx";
 import { usePopover } from "../popover/popover.tsx";
@@ -87,19 +86,6 @@ export const useComboboxPopover = createHook<TagName, ComboboxPopoverOptions>(
     const hasSelect = !!selectElement;
     const selectOwnsFocus =
       !!selectElement && getActiveElement(selectElement) === selectElement;
-
-    const presentInitialItem = usePresentItem(store);
-    const autoFocusOnShow = useEvent((element: HTMLElement | null) => {
-      const { inputElement, selectElement } = store.getState();
-      if (inputElement) return true;
-      if (selectElement && getActiveElement(selectElement) === selectElement) {
-        return true;
-      }
-      if (element?.hasAttribute("data-autofocus") && element.id) {
-        presentInitialItem({ id: element.id, markedOnly: true });
-      }
-      return false;
-    });
 
     const selectOnMove = useStoreState(store, "selectOnMove");
     const acceptedEscapeRef = useRef<{
@@ -234,10 +220,7 @@ export const useComboboxPopover = createHook<TagName, ComboboxPopoverOptions>(
       alwaysVisible,
       backdrop: false,
       // Without an input, only take focus when the select initiated the open.
-      // The callback still runs for an already-open or programmatically opened
-      // select so its selected item can be presented without moving focus.
-      autoFocusOnShow:
-        hasSelect && (!!inputElement || selectOwnsFocus || autoFocusOnShow),
+      autoFocusOnShow: hasSelect && (!!inputElement || selectOwnsFocus),
       initialFocus: hasSelect ? inputElement : undefined,
       finalFocus: selectElement || compositeElement,
       preserveTabOrderAnchor: null,

--- a/packages/ariakit-react-components/src/combobox/combobox-select.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-select.tsx
@@ -30,7 +30,7 @@ import type { PopoverDisclosureOptions } from "../popover/popover-disclosure.tsx
 import { usePopoverDisclosure } from "../popover/popover-disclosure.tsx";
 import { getVisuallyHiddenStyle } from "../visually-hidden/visually-hidden.tsx";
 import {
-  useScrollItemIntoView,
+  getScrollItemIntoView,
   useTrackComboboxSelectPresentation,
 } from "./__utils.ts";
 import {
@@ -306,7 +306,7 @@ export const useComboboxSelect = createHook<TagName, ComboboxSelectOptions>(
       focusable,
       ...props,
     });
-    const scrollItemIntoView = useScrollItemIntoView(store);
+    const scrollItemIntoView = getScrollItemIntoView(store);
     props = useCompositeTypeahead<TagName>({ store, ...props });
     const onKeyDownCaptureProp = props.onKeyDownCapture;
     const onKeyUpCaptureProp = props.onKeyUpCapture;

--- a/packages/ariakit-react-components/src/combobox/combobox-select.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-select.tsx
@@ -30,6 +30,10 @@ import type { PopoverDisclosureOptions } from "../popover/popover-disclosure.tsx
 import { usePopoverDisclosure } from "../popover/popover-disclosure.tsx";
 import { getVisuallyHiddenStyle } from "../visually-hidden/visually-hidden.tsx";
 import {
+  useScrollItemIntoView,
+  useTrackComboboxSelectPresentation,
+} from "./__utils.ts";
+import {
   ComboboxScopedContextProvider,
   useComboboxProviderContext,
 } from "./combobox-context.tsx";
@@ -111,6 +115,8 @@ export const useComboboxSelect = createHook<TagName, ComboboxSelectOptions>(
       process.env.NODE_ENV !== "production" &&
         "ComboboxSelect must receive a `store` prop or be wrapped in a ComboboxProvider component.",
     );
+
+    useTrackComboboxSelectPresentation(store);
 
     const onKeyDownProp = props.onKeyDown;
     const disabledProp = disabledFromProps(props);
@@ -300,11 +306,13 @@ export const useComboboxSelect = createHook<TagName, ComboboxSelectOptions>(
       focusable,
       ...props,
     });
+    const scrollItemIntoView = useScrollItemIntoView(store);
     props = useCompositeTypeahead<TagName>({ store, ...props });
     const onKeyDownCaptureProp = props.onKeyDownCapture;
     const onKeyUpCaptureProp = props.onKeyUpCapture;
     props = useComposite<TagName>({
       store,
+      unstable_scrollIntoView: scrollItemIntoView,
       composite: !inputElement,
       focusable,
       // The select handler owns closed navigation so it can skip value-less

--- a/packages/ariakit-react-components/src/combobox/combobox.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox.tsx
@@ -45,6 +45,7 @@ import type {
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { CompositeOptions } from "../composite/composite.tsx";
 import { useComposite } from "../composite/composite.tsx";
+import { useScrollItemIntoView } from "./__utils.ts";
 import {
   useComboboxProviderContext,
   useComboboxScopedContext,
@@ -779,9 +780,11 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       onBlur,
     };
     props = htmlProps;
+    const scrollItemIntoView = useScrollItemIntoView(store);
 
     props = useComposite<TagName>({
       store,
+      unstable_scrollIntoView: scrollItemIntoView,
       focusable,
       ...props,
       // Enable inline autocomplete when the user moves from the combobox input

--- a/packages/ariakit-react-components/src/combobox/combobox.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox.tsx
@@ -45,7 +45,7 @@ import type {
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { CompositeOptions } from "../composite/composite.tsx";
 import { useComposite } from "../composite/composite.tsx";
-import { useScrollItemIntoView } from "./__utils.ts";
+import { getScrollItemIntoView } from "./__utils.ts";
 import {
   useComboboxProviderContext,
   useComboboxScopedContext,
@@ -780,7 +780,7 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       onBlur,
     };
     props = htmlProps;
-    const scrollItemIntoView = useScrollItemIntoView(store);
+    const scrollItemIntoView = getScrollItemIntoView(store);
 
     props = useComposite<TagName>({
       store,

--- a/packages/ariakit-react-components/src/composite/composite-item.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-item.tsx
@@ -160,6 +160,7 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
     typeaheadText,
     "aria-setsize": ariaSetSizeProp,
     "aria-posinset": ariaPosInSetProp,
+    unstable_scrollIntoView: scrollIntoView,
     ...props
   }) {
     const context = useCompositeScopedContext();
@@ -319,7 +320,19 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
       }
       // When using aria-activedescendant, we want to make sure that the
       // composite container receives focus, not the composite item.
-      if (!virtualFocus) return;
+      if (!virtualFocus) {
+        // DOM focus moved with preventScroll, so a marked item still needs the
+        // widget's presentation even without the virtual-focus handoff below.
+        if (isSelfTarget(event) && store.item(id)) {
+          present({
+            id,
+            markedOnly: true,
+            requireFocus: true,
+            scrollIntoView,
+          });
+        }
+        return;
+      }
       // But we'll only do this if the focused element is the composite item
       // itself
       if (!isSelfTarget(event)) return;
@@ -355,7 +368,12 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
         // composite element, but both are inside the composite, so the request
         // survives it and only focus leaving the composite abandons it.
         if (store.item(id)) {
-          present({ id, markedOnly: true, requireFocus: true });
+          present({
+            id,
+            markedOnly: true,
+            requireFocus: true,
+            scrollIntoView,
+          });
         }
         hasFocusedComposite.current = true;
         // If the previously focused element is a composite or composite item
@@ -600,6 +618,11 @@ export interface CompositeItemOptions<T extends ElementType = TagName>
    * components' context will be used.
    */
   store?: CompositeStore;
+  /**
+   * Determines how the item is scrolled into view when it's presented.
+   * @private
+   */
+  unstable_scrollIntoView?: (element: HTMLElement) => void;
   /**
    * Determines if the item should be registered as part of the collection. If
    * this is set to `false`, the item won't be accessible via arrow keys.

--- a/packages/ariakit-react-components/src/composite/composite.tsx
+++ b/packages/ariakit-react-components/src/composite/composite.tsx
@@ -165,7 +165,7 @@ const CompositeFocusOnMove = memo(function CompositeFocusOnMove({
       focus: true,
       scrollIntoView,
     });
-  }, [store, moves, focusOnMove, present, scrollIntoView]);
+  }, [store, moves, focusOnMove, compositeElement, present, scrollIntoView]);
 
   // If composite.move(null) has been called, the composite container should
   // receive focus.

--- a/packages/ariakit-react-components/src/composite/composite.tsx
+++ b/packages/ariakit-react-components/src/composite/composite.tsx
@@ -39,7 +39,11 @@ import {
   CompositeScopedContextProvider,
   useCompositeProviderContext,
 } from "./composite-context.tsx";
-import type { CompositeStore, CompositeStoreItem } from "./composite-store.ts";
+import type {
+  CompositeStore,
+  CompositeStoreItem,
+  CompositeStoreState,
+} from "./composite-store.ts";
 import {
   findFirstEnabledItem,
   getEnabledItem,
@@ -53,6 +57,12 @@ import {
 const TagName = "div" satisfies ElementType;
 type TagName = typeof TagName;
 type HTMLType = HTMLElementTagNameMap[TagName];
+
+function popupStateKeys(...keys: string[]) {
+  return keys as Array<keyof CompositeStoreState>;
+}
+
+const openKeys = popupStateKeys("open");
 
 function isGrid(items: CompositeStoreItem[]) {
   return items.some((item) => !!item.rowId);
@@ -140,7 +150,7 @@ const CompositeFocusOnMove = memo(function CompositeFocusOnMove({
   scrollIntoView,
 }: CompositeFocusOnMoveProps) {
   const moves = useStoreState(store, "moves");
-  const open = useStoreState(store, (state) =>
+  const open = useStoreState(store, openKeys, (state) =>
     "open" in state ? !!state.open : false,
   );
   // The composite element is also tracked so the move-to-container effect

--- a/packages/ariakit-react-components/src/composite/composite.tsx
+++ b/packages/ariakit-react-components/src/composite/composite.tsx
@@ -121,6 +121,7 @@ interface CompositeFocusOnMoveProps {
   focusOnMove?: boolean;
   previousElementRef: RefObject<HTMLElement | null>;
   present: PresentItem;
+  scrollIntoView?: (element: HTMLElement) => void;
 }
 
 /**
@@ -136,8 +137,12 @@ const CompositeFocusOnMove = memo(function CompositeFocusOnMove({
   focusOnMove,
   previousElementRef,
   present,
+  scrollIntoView,
 }: CompositeFocusOnMoveProps) {
   const moves = useStoreState(store, "moves");
+  const open = useStoreState(store, (state) =>
+    "open" in state ? !!state.open : false,
+  );
   // The composite element is also tracked so the move-to-container effect
   // below can run once it becomes available. It's published to the store
   // through a ref callback and a transaction effect on the parent composite
@@ -150,7 +155,24 @@ const CompositeFocusOnMove = memo(function CompositeFocusOnMove({
 
   // Present the active item.
   useEffect(() => {
-    if (!moves) return;
+    if (!moves) {
+      // Focus handlers present the item on interactive opens. A default-open
+      // composite can mount without moving focus, so start an unpinned request
+      // here while no external element owns focus. It can wait for async items.
+      if (!scrollIntoView) return;
+      if (!open) return;
+      if (!compositeElement) return;
+      if (ownsFocus(store)) return;
+      const activeElement = getActiveElement(compositeElement);
+      if (activeElement && activeElement !== activeElement.ownerDocument.body) {
+        return;
+      }
+      return present({
+        markedOnly: true,
+        requireFocus: true,
+        scrollIntoView,
+      });
+    }
     if (!focusOnMove) return;
     const { activeId } = store.getState();
     if (activeId == null) return;
@@ -161,8 +183,17 @@ const CompositeFocusOnMove = memo(function CompositeFocusOnMove({
       id: activeId,
       requireFocus: ownsFocus(store),
       focus: true,
+      scrollIntoView,
     });
-  }, [store, moves, focusOnMove, compositeElement, present]);
+  }, [
+    store,
+    moves,
+    open,
+    focusOnMove,
+    compositeElement,
+    present,
+    scrollIntoView,
+  ]);
 
   // If composite.move(null) has been called, the composite container should
   // receive focus.
@@ -221,6 +252,7 @@ export const useComposite = createHook<TagName, CompositeOptions>(
     composite = true,
     focusOnMove = composite,
     moveOnKeyPress = true,
+    unstable_scrollIntoView: scrollIntoView,
     ...props
   }) {
     const context = useCompositeProviderContext();
@@ -327,7 +359,12 @@ export const useComposite = createHook<TagName, CompositeOptions>(
           // mounted (for example, in a dialog), in which case state.items will
           // not be populated yet.
           queueMicrotask(() =>
-            present({ focus: true, markedOnly: true, requireFocus: true }),
+            present({
+              focus: true,
+              markedOnly: true,
+              requireFocus: true,
+              scrollIntoView,
+            }),
           );
         }
       } else if (isSelfTarget(event)) {
@@ -339,7 +376,12 @@ export const useComposite = createHook<TagName, CompositeOptions>(
           // The id is pinned because the active item is cleared right below.
           const { activeId } = store.getState();
           if (activeId != null) {
-            present({ id: activeId, markedOnly: true, requireFocus: true });
+            present({
+              id: activeId,
+              markedOnly: true,
+              requireFocus: true,
+              scrollIntoView,
+            });
           }
         }
         // When the roving tabindex composite gets intentionally focused (for
@@ -516,6 +558,7 @@ export const useComposite = createHook<TagName, CompositeOptions>(
               focusOnMove={focusOnMove}
               previousElementRef={previousElementRef}
               present={present}
+              scrollIntoView={scrollIntoView}
             />
           )}
         </CompositeScopedContextProvider>
@@ -586,6 +629,11 @@ export interface CompositeOptions<
    * component's context will be used.
    */
   store?: CompositeStore;
+  /**
+   * Determines how an item is scrolled into view when it's presented.
+   * @private
+   */
+  unstable_scrollIntoView?: (element: HTMLElement) => void;
   /**
    * Determines if the component should act as a composite widget. This prop
    * needs to be set to `false` when merging various composite widgets where

--- a/packages/ariakit-react-components/src/composite/composite.tsx
+++ b/packages/ariakit-react-components/src/composite/composite.tsx
@@ -155,24 +155,29 @@ const CompositeFocusOnMove = memo(function CompositeFocusOnMove({
 
   // Present the active item.
   useEffect(() => {
-    if (!moves) {
-      // Focus handlers present the item on interactive opens. A default-open
-      // composite can mount without moving focus, so start an unpinned request
-      // here while no external element owns focus. It can wait for async items.
-      if (!scrollIntoView) return;
-      if (!open) return;
-      if (!compositeElement) return;
-      if (ownsFocus(store)) return;
-      const activeElement = getActiveElement(compositeElement);
-      if (activeElement && activeElement !== activeElement.ownerDocument.body) {
-        return;
-      }
-      return present({
-        markedOnly: true,
-        requireFocus: true,
-        scrollIntoView,
-      });
+    if (moves) return;
+    // Focus handlers present the item on interactive opens. A default-open
+    // composite can mount without moving focus, so start an unpinned request
+    // here while no external element owns focus. It can wait for async items.
+    if (!scrollIntoView) return;
+    if (!open) return;
+    if (!compositeElement) return;
+    if (ownsFocus(store)) return;
+    const activeElement = getActiveElement(compositeElement);
+    if (activeElement && activeElement !== activeElement.ownerDocument.body) {
+      return;
     }
+    return present({
+      markedOnly: true,
+      requireFocus: true,
+      scrollIntoView,
+    });
+  }, [store, moves, open, compositeElement, present, scrollIntoView]);
+
+  // Opening and closing an open-capable composite must not replay an earlier
+  // move: that could focus or scroll an item after the user has moved on.
+  useEffect(() => {
+    if (!moves) return;
     if (!focusOnMove) return;
     const { activeId } = store.getState();
     if (activeId == null) return;
@@ -185,15 +190,7 @@ const CompositeFocusOnMove = memo(function CompositeFocusOnMove({
       focus: true,
       scrollIntoView,
     });
-  }, [
-    store,
-    moves,
-    open,
-    focusOnMove,
-    compositeElement,
-    present,
-    scrollIntoView,
-  ]);
+  }, [store, moves, focusOnMove, present, scrollIntoView]);
 
   // If composite.move(null) has been called, the composite container should
   // receive focus.

--- a/packages/ariakit-react-components/src/composite/composite.tsx
+++ b/packages/ariakit-react-components/src/composite/composite.tsx
@@ -39,11 +39,7 @@ import {
   CompositeScopedContextProvider,
   useCompositeProviderContext,
 } from "./composite-context.tsx";
-import type {
-  CompositeStore,
-  CompositeStoreItem,
-  CompositeStoreState,
-} from "./composite-store.ts";
+import type { CompositeStore, CompositeStoreItem } from "./composite-store.ts";
 import {
   findFirstEnabledItem,
   getEnabledItem,
@@ -57,12 +53,6 @@ import {
 const TagName = "div" satisfies ElementType;
 type TagName = typeof TagName;
 type HTMLType = HTMLElementTagNameMap[TagName];
-
-function popupStateKeys(...keys: string[]) {
-  return keys as Array<keyof CompositeStoreState>;
-}
-
-const openKeys = popupStateKeys("open");
 
 function isGrid(items: CompositeStoreItem[]) {
   return items.some((item) => !!item.rowId);
@@ -150,9 +140,6 @@ const CompositeFocusOnMove = memo(function CompositeFocusOnMove({
   scrollIntoView,
 }: CompositeFocusOnMoveProps) {
   const moves = useStoreState(store, "moves");
-  const open = useStoreState(store, openKeys, (state) =>
-    "open" in state ? !!state.open : false,
-  );
   // The composite element is also tracked so the move-to-container effect
   // below can run once it becomes available. It's published to the store
   // through a ref callback and a transaction effect on the parent composite
@@ -164,28 +151,6 @@ const CompositeFocusOnMove = memo(function CompositeFocusOnMove({
   const compositeElement = useStoreState(store, "compositeElement");
 
   // Present the active item.
-  useEffect(() => {
-    if (moves) return;
-    // Focus handlers present the item on interactive opens. A default-open
-    // composite can mount without moving focus, so start an unpinned request
-    // here while no external element owns focus. It can wait for async items.
-    if (!scrollIntoView) return;
-    if (!open) return;
-    if (!compositeElement) return;
-    if (ownsFocus(store)) return;
-    const activeElement = getActiveElement(compositeElement);
-    if (activeElement && activeElement !== activeElement.ownerDocument.body) {
-      return;
-    }
-    return present({
-      markedOnly: true,
-      requireFocus: true,
-      scrollIntoView,
-    });
-  }, [store, moves, open, compositeElement, present, scrollIntoView]);
-
-  // Opening and closing an open-capable composite must not replay an earlier
-  // move: that could focus or scroll an item after the user has moved on.
   useEffect(() => {
     if (!moves) return;
     if (!focusOnMove) return;

--- a/packages/ariakit-react-components/src/composite/utils.ts
+++ b/packages/ariakit-react-components/src/composite/utils.ts
@@ -64,6 +64,123 @@ function getPopupElement(store: CompositeStore) {
   return state.contentElement as HTMLElement | null;
 }
 
+function getPixelValue(value: string, fallback: string, percentageBasis = 0) {
+  const resolvedValue = value || fallback;
+  const number = Number.parseFloat(resolvedValue) || 0;
+  if (resolvedValue.endsWith("%")) {
+    return (number / 100) * percentageBasis;
+  }
+  return number;
+}
+
+function getScale(rectSize: number, layoutSize: number) {
+  if (!layoutSize) return 1;
+  return rectSize / layoutSize || 1;
+}
+
+function getItemScrollContainer(element: HTMLElement, popup: HTMLElement) {
+  let current = element.parentElement;
+  while (current && popup.contains(current)) {
+    const style = current.ownerDocument.defaultView?.getComputedStyle(current);
+    if (!style) break;
+    const horizontalWritingMode = style.writingMode.startsWith("horizontal");
+    const overflow = horizontalWritingMode ? style.overflowY : style.overflowX;
+    const scrollableOverflow = overflow !== "visible" && overflow !== "clip";
+    const overflows = horizontalWritingMode
+      ? current.scrollHeight > current.clientHeight
+      : current.scrollWidth > current.clientWidth;
+    if (scrollableOverflow && overflows) return current;
+    if (current === popup) break;
+    current = current.parentElement;
+  }
+  return popup;
+}
+
+function centerItemInPopup(element: HTMLElement, popup: HTMLElement) {
+  const getComputedStyle = element.ownerDocument.defaultView?.getComputedStyle;
+  if (!getComputedStyle) return;
+  const elementStyle = getComputedStyle(element);
+  const popupStyle = getComputedStyle(popup);
+  const elementRect = element.getBoundingClientRect();
+  const popupRect = popup.getBoundingClientRect();
+  const horizontalWritingMode = popupStyle.writingMode.startsWith("horizontal");
+  const rightToLeft = popupStyle.writingMode.endsWith("-rl");
+  const scrollportSize = horizontalWritingMode
+    ? popup.clientHeight
+    : popup.clientWidth;
+  const marginStart = getPixelValue(
+    elementStyle.scrollMarginBlockStart,
+    horizontalWritingMode
+      ? elementStyle.scrollMarginTop
+      : rightToLeft
+        ? elementStyle.scrollMarginRight
+        : elementStyle.scrollMarginLeft,
+  );
+  const marginEnd = getPixelValue(
+    elementStyle.scrollMarginBlockEnd,
+    horizontalWritingMode
+      ? elementStyle.scrollMarginBottom
+      : rightToLeft
+        ? elementStyle.scrollMarginLeft
+        : elementStyle.scrollMarginRight,
+  );
+  const paddingStart = getPixelValue(
+    popupStyle.scrollPaddingBlockStart,
+    horizontalWritingMode
+      ? popupStyle.scrollPaddingTop
+      : rightToLeft
+        ? popupStyle.scrollPaddingRight
+        : popupStyle.scrollPaddingLeft,
+    scrollportSize,
+  );
+  const paddingEnd = getPixelValue(
+    popupStyle.scrollPaddingBlockEnd,
+    horizontalWritingMode
+      ? popupStyle.scrollPaddingBottom
+      : rightToLeft
+        ? popupStyle.scrollPaddingLeft
+        : popupStyle.scrollPaddingRight,
+    scrollportSize,
+  );
+  if (horizontalWritingMode) {
+    const scale = getScale(popupRect.height, popup.offsetHeight);
+    const elementCenter =
+      (elementRect.top -
+        marginStart * scale +
+        elementRect.bottom +
+        marginEnd * scale) /
+      2;
+    const popupTop = popupRect.top + (popup.clientTop + paddingStart) * scale;
+    const popupBottom =
+      popupRect.top +
+      (popup.clientTop + popup.clientHeight - paddingEnd) * scale;
+    popup.scrollTop += (elementCenter - (popupTop + popupBottom) / 2) / scale;
+    return;
+  }
+  const scale = getScale(popupRect.width, popup.offsetWidth);
+  const elementCenter = rightToLeft
+    ? (elementRect.right +
+        marginStart * scale +
+        elementRect.left -
+        marginEnd * scale) /
+      2
+    : (elementRect.left -
+        marginStart * scale +
+        elementRect.right +
+        marginEnd * scale) /
+      2;
+  const popupLeft =
+    popupRect.left +
+    (popup.clientLeft + (rightToLeft ? paddingEnd : paddingStart)) * scale;
+  const popupRight =
+    popupRect.left +
+    (popup.clientLeft +
+      popup.clientWidth -
+      (rightToLeft ? paddingStart : paddingEnd)) *
+      scale;
+  popup.scrollLeft += (elementCenter - (popupLeft + popupRight) / 2) / scale;
+}
+
 /**
  * Whether DOM focus is currently inside the composite: on the composite element
  * itself, on one of its items, or anywhere in its popup.
@@ -292,7 +409,14 @@ function presentItem({
     if (!isVisible(element)) return;
     if ("unstable_placing" in state && state.unstable_placing) return;
     cancel();
-    element.scrollIntoView({ block: "nearest", inline: "nearest" });
+    const select =
+      markedOnly && "selectElement" in state && state.selectElement;
+    const popup = getPopupElement(store);
+    if (select && popup?.contains(element)) {
+      centerItemInPopup(element, getItemScrollContainer(element, popup));
+    } else {
+      element.scrollIntoView({ block: "nearest", inline: "nearest" });
+    }
   };
   // `mounted` and `unstable_placing` live on the merged popup store, which the
   // store type doesn't declare. Naming them keeps the store's keyed listener

--- a/packages/ariakit-react-components/src/composite/utils.ts
+++ b/packages/ariakit-react-components/src/composite/utils.ts
@@ -64,123 +64,6 @@ function getPopupElement(store: CompositeStore) {
   return state.contentElement as HTMLElement | null;
 }
 
-function getPixelValue(value: string, fallback: string, percentageBasis = 0) {
-  const resolvedValue = value || fallback;
-  const number = Number.parseFloat(resolvedValue) || 0;
-  if (resolvedValue.endsWith("%")) {
-    return (number / 100) * percentageBasis;
-  }
-  return number;
-}
-
-function getScale(rectSize: number, layoutSize: number) {
-  if (!layoutSize) return 1;
-  return rectSize / layoutSize || 1;
-}
-
-function getItemScrollContainer(element: HTMLElement, popup: HTMLElement) {
-  let current = element.parentElement;
-  while (current && popup.contains(current)) {
-    const style = current.ownerDocument.defaultView?.getComputedStyle(current);
-    if (!style) break;
-    const horizontalWritingMode = style.writingMode.startsWith("horizontal");
-    const overflow = horizontalWritingMode ? style.overflowY : style.overflowX;
-    const scrollableOverflow = overflow !== "visible" && overflow !== "clip";
-    const overflows = horizontalWritingMode
-      ? current.scrollHeight > current.clientHeight
-      : current.scrollWidth > current.clientWidth;
-    if (scrollableOverflow && overflows) return current;
-    if (current === popup) break;
-    current = current.parentElement;
-  }
-  return popup;
-}
-
-function centerItemInPopup(element: HTMLElement, popup: HTMLElement) {
-  const getComputedStyle = element.ownerDocument.defaultView?.getComputedStyle;
-  if (!getComputedStyle) return;
-  const elementStyle = getComputedStyle(element);
-  const popupStyle = getComputedStyle(popup);
-  const elementRect = element.getBoundingClientRect();
-  const popupRect = popup.getBoundingClientRect();
-  const horizontalWritingMode = popupStyle.writingMode.startsWith("horizontal");
-  const rightToLeft = popupStyle.writingMode.endsWith("-rl");
-  const scrollportSize = horizontalWritingMode
-    ? popup.clientHeight
-    : popup.clientWidth;
-  const marginStart = getPixelValue(
-    elementStyle.scrollMarginBlockStart,
-    horizontalWritingMode
-      ? elementStyle.scrollMarginTop
-      : rightToLeft
-        ? elementStyle.scrollMarginRight
-        : elementStyle.scrollMarginLeft,
-  );
-  const marginEnd = getPixelValue(
-    elementStyle.scrollMarginBlockEnd,
-    horizontalWritingMode
-      ? elementStyle.scrollMarginBottom
-      : rightToLeft
-        ? elementStyle.scrollMarginLeft
-        : elementStyle.scrollMarginRight,
-  );
-  const paddingStart = getPixelValue(
-    popupStyle.scrollPaddingBlockStart,
-    horizontalWritingMode
-      ? popupStyle.scrollPaddingTop
-      : rightToLeft
-        ? popupStyle.scrollPaddingRight
-        : popupStyle.scrollPaddingLeft,
-    scrollportSize,
-  );
-  const paddingEnd = getPixelValue(
-    popupStyle.scrollPaddingBlockEnd,
-    horizontalWritingMode
-      ? popupStyle.scrollPaddingBottom
-      : rightToLeft
-        ? popupStyle.scrollPaddingLeft
-        : popupStyle.scrollPaddingRight,
-    scrollportSize,
-  );
-  if (horizontalWritingMode) {
-    const scale = getScale(popupRect.height, popup.offsetHeight);
-    const elementCenter =
-      (elementRect.top -
-        marginStart * scale +
-        elementRect.bottom +
-        marginEnd * scale) /
-      2;
-    const popupTop = popupRect.top + (popup.clientTop + paddingStart) * scale;
-    const popupBottom =
-      popupRect.top +
-      (popup.clientTop + popup.clientHeight - paddingEnd) * scale;
-    popup.scrollTop += (elementCenter - (popupTop + popupBottom) / 2) / scale;
-    return;
-  }
-  const scale = getScale(popupRect.width, popup.offsetWidth);
-  const elementCenter = rightToLeft
-    ? (elementRect.right +
-        marginStart * scale +
-        elementRect.left -
-        marginEnd * scale) /
-      2
-    : (elementRect.left -
-        marginStart * scale +
-        elementRect.right +
-        marginEnd * scale) /
-      2;
-  const popupLeft =
-    popupRect.left +
-    (popup.clientLeft + (rightToLeft ? paddingEnd : paddingStart)) * scale;
-  const popupRight =
-    popupRect.left +
-    (popup.clientLeft +
-      popup.clientWidth -
-      (rightToLeft ? paddingStart : paddingEnd)) *
-      scale;
-  popup.scrollLeft += (elementCenter - (popupLeft + popupRight) / 2) / scale;
-}
-
 /**
  * Whether DOM focus is currently inside the composite: on the composite element
  * itself, on one of its items, or anywhere in its popup.
@@ -215,6 +98,11 @@ export interface PresentItemParams {
   markedOnly?: boolean;
   /** Whether to abandon the presentation if the composite loses DOM focus. */
   requireFocus?: boolean;
+  /**
+   * Determines how the item is scrolled into view when it's presented.
+   * @private
+   */
+  scrollIntoView?: (element: HTMLElement) => void;
 }
 
 /**
@@ -234,6 +122,7 @@ function presentItem({
   focus,
   markedOnly,
   requireFocus,
+  scrollIntoView,
 }: PresentItemParams) {
   let element: HTMLElement | null = null;
   let resolvedId: string | undefined;
@@ -409,14 +298,11 @@ function presentItem({
     if (!isVisible(element)) return;
     if ("unstable_placing" in state && state.unstable_placing) return;
     cancel();
-    const select =
-      markedOnly && "selectElement" in state && state.selectElement;
-    const popup = getPopupElement(store);
-    if (select && popup?.contains(element)) {
-      centerItemInPopup(element, getItemScrollContainer(element, popup));
-    } else {
-      element.scrollIntoView({ block: "nearest", inline: "nearest" });
+    if (scrollIntoView) {
+      scrollIntoView(element);
+      return;
     }
+    element.scrollIntoView({ block: "nearest", inline: "nearest" });
   };
   // `mounted` and `unstable_placing` live on the merged popup store, which the
   // store type doesn't declare. Naming them keeps the store's keyed listener


### PR DESCRIPTION
## Motivation

When a select-shaped popup opens, Ariakit aligns the selected item to the nearest edge of a long list. Centering it on the initial open shows the surrounding values, while later navigation should retain the platform's nearest-edge behavior.

Fixes #7011.

## Solution

Center the initially selected `ComboboxSelect` item when the popup has one vertical scrollport, without moving the document or ancestors outside the popup. Opening through click or keyboard, reopening, real and virtual focus, remounted popups, and asynchronously replaced options all use the same presentation path.

Later keyboard and typeahead navigation continues using nearest-edge scrolling. Layouts with no internal scrollport, multiple internal scrollports, or a non-horizontal writing mode fall back to native nearest-edge scrolling so the item remains visible.

The implementation passes a private item-scrolling callback through the Composite components. `ComboboxSelect` records one movement baseline per open cycle, so item callbacks, including callbacks from virtualized items, can distinguish the opening presentation from later navigation without subscribing or re-rendering every item.

## Workaround

The [temporary observer-based workaround](https://github.com/ariakit/ariakit/issues/7011#issuecomment-5181943654) can center an item when the popup element itself is the vertical scrollport. It is narrower than the library fix and depends on the private, version-sensitive `data-placing` marker.

## Preview

The initially selected `16.8.6` item opens centered with surrounding options visible:

![16.8.6 centered in the opened select-shaped popup](https://github.com/user-attachments/assets/a289a013-d792-4ef8-8720-b16c261f4030)

## Verification

- 99 affected browser tests passed in Chrome, Firefox, and Safari.
- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm build`
- Fresh three-round local Chrome performance comparison against the exact base reported no significant changes.
- Independent pre-commit review of the exact staged snapshot.

## Review gate reassessment

<details>
<summary>Cycle 3: Continue with one ComboboxSelect-owned opening baseline</summary>

**Assessment**

The third gate cycle raised a low-severity, possible alignment error for a selected virtualized item mounted after navigation. Corrected `ComboboxRenderer` reproduction showed that the pre-fix code only ran the root nearest-edge callback and already kept that item at the edge, so the reported runtime mechanism was rejected. The exercise still exposed avoidable maintenance and runtime complexity: every item owned an `open` listener solely to read the same movement baseline.

The widget-owned callback design remains substantially narrower than the first reviewed implementation: select-specific policy and geometry stay out of Composite, while one private callback seam supports real focus, virtual focus, asynchronous items, and both click and keyboard opening. The added plumbing is justified by the component boundary, but per-item opening subscriptions were not.

The intentionally narrowed behavior is:

- Non-horizontal writing modes use native nearest-edge scrolling.
- Zero or multiple internal vertical scrollports use native nearest-edge scrolling.
- Centering uses border-box geometry and does not adjust for asymmetric `scroll-margin` or `scroll-padding`.
- The behavior applies to `ComboboxSelect`; deprecated `Select` does not receive it through generic Composite policy.

These fallbacks preserve visibility and avoid reintroducing the broad platform-emulation machinery that caused the earlier review findings.

**Decision**

Continue with the private, Combobox-owned Composite callback. Move the opening movement baseline to a single keyed subscription owned by `ComboboxSelect`, have all item callbacks read that store-scoped baseline, and retain focused virtualized-item coverage. This removes O(items) opening subscriptions without broadening the public API or the supported geometry.

</details>

<details>
<summary>Feedback commit, cycle 3: Keep the interactive-only contract</summary>

**Assessment**

The three gate findings were residue and documentation drift after default-open presentation was removed, not runtime failures in the interactive centering direction. Restoring default-open behavior here would reintroduce popup-only state into generic `Composite`, center while focus remains on the document body, and require a separate focus contract or unreliable commit-order retries.

The remaining private callback and geometry machinery is proportionate to the supported behavior. It reaches real and virtual focus paths, distinguishes opening from later navigation, and falls back to native scrolling for layouts where custom centering cannot preserve visibility.

**Decision**

Keep the interactive-only implementation and state that scope explicitly in the changeset. Track default-open and other focusless openings in [#7068](https://github.com/ariakit/ariakit/issues/7068) instead of expanding this PR.

</details>

## Implementation review reassessment

<details>
<summary>Cycle 6: Narrow centering to interactive opens</summary>

**Assessment**

The fresh review initially favored preserving the opening-time contract while treating a selected value assigned only after an already-open popup as unsupported. Further evidence showed that the default-open path was the only reason generic `Composite` subscribed to popup-only `open` state, and that the path centered an item while focus remained on the document body. Three bounded retry and subscription variants also failed to make the later selected-value case reliable.

The interactive paths do not need that subscription. Click and keyboard opening, reopening, real and virtual focus, remounted popups, and asynchronously replaced options continue through the existing focus presentation handlers.

**Decision**

Remove the generic default-open presentation effect and its dedicated fixtures. Keep this PR focused on interactive opening, and track the pre-existing default-open focus behavior in [#7068](https://github.com/ariakit/ariakit/issues/7068) instead of adding presentation retry machinery.

</details>
