### PR TITLE
Extract shared combobox control behavior

### DIFF
--- a/packages/ariakit-react-components/src/combobox/__combobox-control.tsx
+++ b/packages/ariakit-react-components/src/combobox/__combobox-control.tsx
@@ -1,0 +1,55 @@
+import { createHook } from "@ariakit/react-utils";
+import { getPopupRole } from "@ariakit/utils";
+import type { ElementType } from "react";
+import type { CompositeOptions } from "../composite/composite.tsx";
+import { useComposite } from "../composite/composite.tsx";
+import { getScrollItemIntoView } from "./__utils.ts";
+import type { ComboboxStore } from "./combobox-store.ts";
+
+const TagName = "div" satisfies ElementType;
+type TagName = typeof TagName;
+
+/**
+ * Returns the props that identify the combobox control in the accessibility
+ * tree. The popup role falls back to `listbox`, unlike the `dialog` fallback
+ * that generic dialog disclosures apply.
+ */
+export function getComboboxControlProps(contentElement?: HTMLElement | null) {
+  return {
+    role: "combobox",
+    "aria-haspopup": getPopupRole(contentElement, "listbox"),
+  } as const;
+}
+
+/**
+ * Returns props that turn an element into the composite widget for the
+ * combobox items. This is the primary `role="combobox"` element rendered by
+ * either
+ * [`Combobox`](https://ariakit.com/reference/combobox)/[`ComboboxInput`](https://ariakit.com/reference/combobox-input)
+ * or [`ComboboxSelect`](https://ariakit.com/reference/combobox-select). It's
+ * distinct from
+ * [`ComboboxDisclosure`](https://ariakit.com/reference/combobox-disclosure),
+ * which is an auxiliary popup toggle.
+ * @see https://ariakit.com/components/combobox
+ */
+export const useComboboxControl = createHook<TagName, ComboboxControlOptions>(
+  function useComboboxControl({ store, focusable = true, ...props }) {
+    return useComposite<TagName>({
+      store,
+      unstable_scrollIntoView: getScrollItemIntoView(store),
+      focusable,
+      ...props,
+    });
+  },
+);
+
+export interface ComboboxControlOptions<
+  T extends ElementType = TagName,
+> extends CompositeOptions<T> {
+  /**
+   * Object returned by the
+   * [`useComboboxStore`](https://ariakit.com/reference/use-combobox-store)
+   * hook, already resolved by the component rendering the control.
+   */
+  store: ComboboxStore;
+}

--- a/packages/ariakit-react-components/src/combobox/combobox-select.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-select.tsx
@@ -14,7 +14,6 @@ import {
   toArray,
   disabledFromProps,
   getActiveElement,
-  getPopupRole,
   queueBeforeEvent,
   invariant,
 } from "@ariakit/utils";
@@ -24,15 +23,15 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { withDefaultButtonType } from "../button/utils.ts";
 import type { CompositeTypeaheadOptions } from "../composite/composite-typeahead.tsx";
 import { useCompositeTypeahead } from "../composite/composite-typeahead.tsx";
-import { useComposite } from "../composite/composite.tsx";
 import { getBasePlacement } from "../popover/__utils.ts";
 import type { PopoverDisclosureOptions } from "../popover/popover-disclosure.tsx";
 import { usePopoverDisclosure } from "../popover/popover-disclosure.tsx";
 import { getVisuallyHiddenStyle } from "../visually-hidden/visually-hidden.tsx";
 import {
-  getScrollItemIntoView,
-  useTrackComboboxSelectPresentation,
-} from "./__utils.ts";
+  getComboboxControlProps,
+  useComboboxControl,
+} from "./__combobox-control.tsx";
+import { useTrackComboboxSelectPresentation } from "./__utils.ts";
 import {
   ComboboxScopedContextProvider,
   useComboboxProviderContext,
@@ -287,10 +286,9 @@ export const useComboboxSelect = createHook<TagName, ComboboxSelectOptions>(
     useAttribute(contentElement, "role");
 
     props = {
-      role: "combobox",
+      ...getComboboxControlProps(contentElement),
       "aria-autocomplete": "none",
       "aria-labelledby": props["aria-label"] != null ? undefined : labelId,
-      "aria-haspopup": getPopupRole(contentElement, "listbox"),
       "data-autofill": autofill || undefined,
       "data-name": name,
       children,
@@ -305,13 +303,11 @@ export const useComboboxSelect = createHook<TagName, ComboboxSelectOptions>(
       focusable,
       ...props,
     });
-    const scrollItemIntoView = getScrollItemIntoView(store);
     props = useCompositeTypeahead<TagName>({ store, ...props });
     const onKeyDownCaptureProp = props.onKeyDownCapture;
     const onKeyUpCaptureProp = props.onKeyUpCapture;
-    props = useComposite<TagName>({
+    props = useComboboxControl<TagName>({
       store,
-      unstable_scrollIntoView: scrollItemIntoView,
       composite: !inputElement,
       focusable,
       // The select handler owns closed navigation so it can skip value-less

--- a/packages/ariakit-react-components/src/combobox/combobox.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox.tsx
@@ -18,7 +18,6 @@ import type { Props } from "@ariakit/react-utils";
 import { sync } from "@ariakit/store";
 import {
   disabledFromProps,
-  getPopupRole,
   getScrollingElement,
   getTextboxSelection,
   setSelectionRange,
@@ -44,8 +43,10 @@ import type {
 } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { CompositeOptions } from "../composite/composite.tsx";
-import { useComposite } from "../composite/composite.tsx";
-import { getScrollItemIntoView } from "./__utils.ts";
+import {
+  getComboboxControlProps,
+  useComboboxControl,
+} from "./__combobox-control.tsx";
 import {
   useComboboxProviderContext,
   useComboboxScopedContext,
@@ -124,7 +125,6 @@ function getDefaultAutoSelectId(items: ComboboxStoreState["items"]) {
 export const useCombobox = createHook<TagName, ComboboxOptions>(
   function useCombobox({
     store,
-    focusable = true,
     autoSelect: autoSelectProp = false,
     getAutoSelectId,
     setValueOnChange,
@@ -728,9 +728,8 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
     );
 
     const htmlProps = {
-      role: "combobox",
+      ...getComboboxControlProps(contentElement),
       "aria-autocomplete": ariaAutoComplete,
-      "aria-haspopup": getPopupRole(contentElement, "listbox"),
       "aria-expanded": open,
       "aria-controls": contentElement?.id,
       "data-active-item": isActiveItem || undefined,
@@ -754,12 +753,9 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
       onBlur,
     };
     props = htmlProps;
-    const scrollItemIntoView = getScrollItemIntoView(store);
 
-    props = useComposite<TagName>({
+    props = useComboboxControl<TagName>({
       store,
-      unstable_scrollIntoView: scrollItemIntoView,
-      focusable,
       ...props,
       // Enable inline autocomplete when the user moves from the combobox input
       // to an item.


### PR DESCRIPTION
## Motivation

Closes #6830.

`Combobox`/`ComboboxInput` and `ComboboxSelect` both render the primary `role="combobox"` control, and both duplicate the behavior that makes it one: the combobox popup identity in the accessibility tree, and the composite widget composition that owns the combobox items. `ComboboxSelect` was built on its own first, as agreed in #6796, so the two components now describe the same control twice and can drift apart.

`ComboboxDisclosure` is not part of this. It is an auxiliary popup toggle, so it keeps using `PopoverDisclosure` directly.

## Solution

Add an internal `ComboboxControl` module at `packages/ariakit-react-components/src/combobox/__combobox-control.tsx`, with the `__` prefix that keeps a module out of the generated package exports, the same as `__hovercard-trigger.tsx` and `combobox/__utils.ts`.

It owns two pieces:

- `getComboboxControlProps(contentElement)` returns the control's identity in the accessibility tree, which is `role="combobox"` plus `aria-haspopup` resolved with a `listbox` fallback rather than the `dialog` fallback that generic dialog disclosures apply.
- `useComboboxControl` composes `useComposite` with the combobox item scrolling from `getScrollItemIntoView` and the `focusable` default the control needs to own DOM focus and expose `aria-activedescendant`.

Both components now spread the shared props and call the shared hook:

```tsx
const htmlProps = {
  ...getComboboxControlProps(contentElement),
  "aria-autocomplete": ariaAutoComplete,
  // ...
};

props = useComboboxControl<TagName>({ store, ...props });
```

The split between a plain function and a hook is deliberate. `ComboboxSelect` is also a popover disclosure, so `usePopoverDisclosure` runs between its own props and the control. `useButton` always writes a `role` key and `useDialogDisclosure` defaults `aria-haspopup` to the `dialog` popup role, and in Ariakit's layered props each hook does `props = { ...defaults, ...props }`, so an earlier layer wins. A hook-level ARIA default applied last would therefore be silently overridden for `ComboboxSelect` while working for `Combobox`. Returning those props from a plain function lets each component apply them ahead of every intervening hook, which keeps one definition and one behavior for both.

Store resolution stays per-component on purpose: `Combobox` falls back to the scoped context so a `ComboboxInput` nested inside `ComboboxPopover` still finds its store, which `ComboboxSelect` does not need as the trigger. Typeahead, the `aria-activedescendant` gating on `mounted`, and the open-state keyboard proxying remain in `ComboboxSelect`, because moving any of them into the shared control would change `Combobox` behavior.

## Changes

No behavior changes, no public API changes, and no changeset. `ComboboxOptions` still extends `CompositeOptions`, unchanged from `main`.

## Verification

- `pnpm tsc` and `pnpm lint` pass.
- `pnpm test` passes (254 files, 1708 tests) and `pnpm test-react18` passes (187 files, 974 tests).
- Playwright Chrome passes for `src/sandbox/combobox` and `src/examples/combobox` (220 tests), and the full app Chrome suite passes (732 passed, 1 skipped; 5 unrelated tooltip and tab-panel tests were flaky and green on retry).
- Generated public reference metadata was dumped from the app `jsdoc-loader` for all 27 combobox references on `main` and on this branch, and the two are byte-identical.

## Acknowledgments

Thanks to [@georgekaran](https://github.com/georgekaran) for proposing the sequencing in #6796 that built `ComboboxSelect` first and deferred this extraction, and for implementing the `ComboboxSelect` behavior this change factors out.
