### PR TITLE
Announce a select-shaped Combobox popup as expanded on its select

### DIFF
--- a/.changeset/300-combobox-select-expanded-state.md
+++ b/.changeset/300-combobox-select-expanded-state.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react": patch
+"@ariakit/react-components": patch
+---
+
+Fixed [`ComboboxSelect`](https://ariakit.com/reference/combobox-select) reporting `aria-expanded="false"` while its popup was open.

--- a/app/src/sandbox/combobox-select-programmatic-open/index.react.tsx
+++ b/app/src/sandbox/combobox-select-programmatic-open/index.react.tsx
@@ -50,7 +50,11 @@ export default function Example() {
       <Ariakit.ComboboxSelectLabel store={store}>
         Vegetable
       </Ariakit.ComboboxSelectLabel>
-      <Ariakit.ComboboxSelect store={store} />
+      {/* The select announces the popup it controls, so its expanded state
+      follows the open state rather than whoever owned focus when it opened.
+      TODO: Remove once the select derives this on its own.
+      https://github.com/ariakit/ariakit/issues/7080 */}
+      <Ariakit.ComboboxSelect store={store} aria-expanded={open} />
       {/* Refuses the focus a click would take, so loading the remaining
       options is not itself a focus move out of the picker. */}
       <button

--- a/app/src/sandbox/combobox-select-programmatic-open/index.react.tsx
+++ b/app/src/sandbox/combobox-select-programmatic-open/index.react.tsx
@@ -50,11 +50,7 @@ export default function Example() {
       <Ariakit.ComboboxSelectLabel store={store}>
         Vegetable
       </Ariakit.ComboboxSelectLabel>
-      {/* The select announces the popup it controls, so its expanded state
-      follows the open state rather than whoever owned focus when it opened.
-      TODO: Remove once the select derives this on its own.
-      https://github.com/ariakit/ariakit/issues/7080 */}
-      <Ariakit.ComboboxSelect store={store} aria-expanded={open} />
+      <Ariakit.ComboboxSelect store={store} />
       {/* Refuses the focus a click would take, so loading the remaining
       options is not itself a focus move out of the picker. */}
       <button

--- a/app/src/sandbox/combobox-select-programmatic-open/test-browser.ts
+++ b/app/src/sandbox/combobox-select-programmatic-open/test-browser.ts
@@ -65,6 +65,25 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.combobox("Vegetable")).toBeFocused();
   });
 
+  // The select is the only control for this popup, so it stays the element that
+  // announces the open state no matter who held focus when the open happened.
+  // https://github.com/ariakit/ariakit/issues/7080
+  test("announces the select as expanded when another element owns focus", async ({
+    page,
+    q,
+  }) => {
+    const select = q.combobox("Vegetable");
+    const note = q.textbox("Note");
+    await note.click();
+    await test.expect(note).toBeFocused();
+    await test.expect(select).toHaveAttribute("aria-expanded", "false");
+
+    await page.keyboard.press("F2");
+
+    await test.expect(q.listbox()).toBeVisible();
+    await test.expect(select).toHaveAttribute("aria-expanded", "true");
+  });
+
   // https://github.com/ariakit/ariakit/issues/7068
   test("abandons the presentation when focus leaves before the options arrive", async ({
     page,

--- a/app/src/sandbox/combobox-select-programmatic-open/test.ts
+++ b/app/src/sandbox/combobox-select-programmatic-open/test.ts
@@ -44,6 +44,22 @@ test("takes focus even when another element owns it", async () => {
   expect(q.combobox("Vegetable")).toHaveFocus();
 });
 
+// The select is the only control for this popup, so it stays the element that
+// announces the open state no matter who held focus when the open happened.
+// https://github.com/ariakit/ariakit/issues/7080
+test("announces the select as expanded when another element owns focus", async () => {
+  const select = q.combobox("Vegetable");
+  const note = q.textbox("Note");
+  await click(note);
+  expect(note).toHaveFocus();
+  expect(select).toHaveAttribute("aria-expanded", "false");
+
+  await press("F2");
+
+  expect(q.listbox()).toBeVisible();
+  expect(select).toHaveAttribute("aria-expanded", "true");
+});
+
 // https://github.com/ariakit/ariakit/issues/7068
 test("abandons the presentation when focus leaves before the options arrive", async () => {
   await press("F2");

--- a/packages/ariakit-react-components/src/combobox/combobox-select.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-select.tsx
@@ -128,6 +128,7 @@ export const useComboboxSelect = createHook<TagName, ComboboxSelectOptions>(
     const multiSelectable = Array.isArray(selectedValue);
     const inputElement = useStoreState(store, "inputElement");
     const mounted = useStoreState(store, "mounted");
+    const open = useStoreState(store, "open");
 
     const onKeyDown = useEvent((event: KeyboardEvent<HTMLType>) => {
       onKeyDownProp?.(event);
@@ -291,6 +292,11 @@ export const useComboboxSelect = createHook<TagName, ComboboxSelectOptions>(
       "aria-autocomplete": "none",
       "aria-labelledby": props["aria-label"] != null ? undefined : labelId,
       "aria-haspopup": getPopupRole(contentElement, "listbox"),
+      // The select is the combobox for this popup, so it announces the popup's
+      // state directly, like Combobox and ComboboxDisclosure do, instead of
+      // depending on still owning the store's disclosure element.
+      // https://github.com/ariakit/ariakit/issues/7080
+      "aria-expanded": open,
       "data-autofill": autofill || undefined,
       "data-name": name,
       children,


### PR DESCRIPTION
## Motivation

When a select-shaped Combobox popup is opened programmatically while another element owns focus, the `ComboboxSelect` keeps announcing itself as collapsed for the whole time its listbox is open.

```jsx
// Focus is in the note field, then a shortcut opens the picker.
const combobox = Ariakit.useComboboxStore();

useEffect(() => {
  const onKeyDown = (event) => {
    if (event.key !== "F2") return;
    combobox.show();
  };
  document.addEventListener("keydown", onKeyDown);
  return () => document.removeEventListener("keydown", onKeyDown);
}, [combobox]);
```

The listbox is visible and `aria-controls` points at it, but the select renders `aria-expanded="false"`, so assistive technology describes the control as collapsed while its popup is displayed.

`Dialog` records the element that owns focus when the popup opens as the store's disclosure element, and `Disclosure` reports `aria-expanded="true"` only while its own element still holds that slot. An open that happens while another element owns focus therefore takes the select out of the slot that decides the attribute, and the select keeps announcing itself collapsed for as long as the popup is open.

Fixes #7080

## Solution

`ComboboxSelect` now sets `aria-expanded` from the store's `open` state in its own props object, the way [`Combobox`](https://ariakit.com/reference/combobox) and [`ComboboxDisclosure`](https://ariakit.com/reference/combobox-disclosure) already do for the popup they control. It is written before the consumer's props are spread, so it can still be overridden, and it wins over the ownership-derived value `Disclosure` sets further down the hook chain. The attribute becomes a pure function of the popup's open state, so it is correct on the first render too, and it agrees with the `aria-controls` that `Disclosure` already sets.

The fix does not touch the store's disclosure element, so everything derived from that slot, such as which targets Escape accepts and how an outside interaction is classified, behaves exactly as before. Reclaiming the slot was considered and rejected, because it would take Escape dismissal away from the element that owned focus when the popup opened.

The sandbox workaround from [`a3a41d0`](https://github.com/ariakit/ariakit/commit/a3a41d09f23d772cd7d39535200ab2a982492f32) is reverted in the same commit, so the tests added in [`1b38b77`](https://github.com/ariakit/ariakit/commit/1b38b772bb7af04affa0cf1b7d2e3fe1e11ce64d) now pass against the library.

The same ownership gate still affects other triggers whose popup opens without passing through them, which is tracked separately in #7083.

## Workaround

When the popup opens while another element owns focus, the select keeps reporting `aria-expanded="false"` for as long as the popup is open. Until the fix ships, a consumer can supply the attribute directly.

```tsx
{/* TODO: Remove once the select derives this on its own.
https://github.com/ariakit/ariakit/issues/7080 */}
<Ariakit.ComboboxSelect store={combobox} aria-expanded={open} />
```

Read `open` from the store with `const open = Ariakit.useStoreState(combobox, "open")`. This is the same value [`Combobox`](https://ariakit.com/reference/combobox) and [`ComboboxDisclosure`](https://ariakit.com/reference/combobox-disclosure) already expose for the popup they control, so the select ends up announcing what its siblings do.

### Assumptions and limitations

This corrects the announced state only. The popup still treats the element that owned focus at open time as its disclosure element, so everything else derived from that, such as which targets Escape accepts and how an outside interaction is classified, behaves exactly as it does without the workaround. Those are unchanged rather than fixed.

## Review gate reassessment

<details>
<summary>Cycle 3: Continue the userland workaround, simplified twice</summary>

**Assessment**

Issue severity is low and announcement only. The listbox is visible, `aria-controls` is correct, and focus restoration is unaffected because `ComboboxPopover` pins `finalFocus` to the select. Expected frequency is low but real, since it needs a `ComboboxSelect`, a programmatic or default open, and another element owning focus. Supported scope is one composition: a `ComboboxSelect` that is the sole disclosure for its popup. Likely user impact is a screen reader describing the control as collapsed while its popup is displayed.

Implementation complexity is very low: eleven added lines in one sandbox fixture, no library code, no public API, no new abstraction, and the code is reverted in the next stage. Maintenance complexity in the repository is near zero for the same reason. What persists is the published workaround prose, and that is where the cost sits.

Six of the eleven findings across the three rounds carried a documentation disposition rather than an implementation one, two changed code, and the machinery never grew.

**Decision**

Continue the direction, and simplify twice. Read `selectElement` from the store instead of holding a ref, so the snippet needs no ref and no change to the consumer's JSX. Use a passive effect instead of a layout effect, since React runs every layout effect in a commit before any passive effect in that commit, which removes the placement constraint and the server rendering warning.

Two limitations remain: the single disclosure slot, and losing Escape dismissal from the element that owned focus at open time.

</details>

<details>
<summary>Cycle 6: Replace the store write with a prop override</summary>

**Assessment**

Severity, frequency, scope, and user impact are unchanged from cycle 3. What changed is the reading of the finding stream. Rounds 3, 4, 5, and 6 each produced a finding against a mechanism explanation in the published prose, and the staged code had two consecutive clean passes, which invited the conclusion that only the prose was at fault. That conclusion was wrong, because no round had asked whether the machinery was needed at all. The prose was hard to state correctly because the thing it described was intricate: writing the store's disclosure slot from userland reaches readers inside the popup that the workaround cannot see, and disclosing that reach is what the workflow requires.

**Decision**

Replace the effect that reclaimed the disclosure slot with an explicit prop override, which is the first shape the issue-fix workflow prefers for a workaround.

The attribute is written in one place in the select's hook chain, and every layer between spreads consumer props after its own defaults, so `aria-expanded={open}` reaches the DOM. It is also the value [`Combobox`](https://ariakit.com/reference/combobox) and [`ComboboxDisclosure`](https://ariakit.com/reference/combobox-disclosure) already expose for the popup they control.

The override is strictly smaller and strictly better. It repairs the same attribute, and because it never touches the disclosure slot it introduces none of the collateral the previous shape did. The Escape regression that cycle 3 accepted as intentionally unsupported is gone: a probe that fails under the store write passes under the override. The placement constraint, the server rendering caveat, the null slot guard, and the multiple disclosure assumption are all unreachable rather than better worded.

Most of the accumulated findings are retired as obsolete, because they concern behavior the chosen solution removes.

**Intentionally unsupported**

The workaround corrects the announced state only. The popup still treats the element that owned focus at open time as its disclosure element, so anything else derived from that slot is unchanged rather than fixed.

</details>

<details>
<summary>Cycle 3 of the library fix: Continue, and stop restating Dialog's arbitration</summary>

**Assessment**

The library fix is one store subscription and one property in a props object that is already being built. No new public API, no new store state, no new branch, no new helper, and no change to any shared primitive. It removes a coupling rather than adding one, since the select's announced state stops depending on slot arbitration.

Across three formal rounds the staged code was byte-identical and drew zero findings. Every finding landed on prose describing `Dialog`'s open-time capture, which the fix does not touch. The difficulty was inherited from the code being explained, not produced by the code being added, which is the opposite of the cycle 6 situation on the workaround.

**Decision**

Continue the staged fix. Three alternative shapes were re-derived and rejected: deriving `aria-expanded` from `open` inside `Disclosure` unconditionally, which changes a primitive every disclosure composition inherits and feeds menubar behavior; having the select reclaim the disclosure slot, which this pull request already measured breaking Escape dismissal; and changing `Dialog` instead, which would change the focus restoration contract for every popup opened without passing through its trigger.

Stop restating that arbitration in user-facing copy. The changeset now states the symptom only, and the code comment lost the clause that over-claimed how the slot is assigned.

</details>
