### PR TITLE
Define focus for default-open menus

### DIFF
--- a/.changeset/300-menu-default-open-focus.md
+++ b/.changeset/300-menu-default-open-focus.md
@@ -1,0 +1,24 @@
+---
+"@ariakit/components": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Menus that mount already open take focus
+
+A [`Menu`](https://ariakit.com/reference/menu) that is already open when it mounts, through [`defaultOpen`](https://ariakit.com/reference/menu-provider#defaultopen) or a controlled open state, now moves focus into the menu. Previously focus stayed where it was while the first item still appeared highlighted, leaving keyboard and screen reader users outside an open menu with no way to navigate it.
+
+```tsx
+<MenuProvider defaultOpen>
+  <MenuButton>Actions</MenuButton>
+  {/* The menu now takes focus, and no item is highlighted. */}
+  <Menu>
+    <MenuItem>Rename</MenuItem>
+    <MenuItem>Duplicate</MenuItem>
+  </Menu>
+</MenuProvider>
+```
+
+Focus lands on the menu itself, which is where clicking [`MenuButton`](https://ariakit.com/reference/menu-button) with a mouse already puts it. Modal menus opened this way used to focus the first item instead, so both now behave the same. Menus opened by hovering a [`MenuButton`](https://ariakit.com/reference/menu-button), such as submenus and menubar menus, still leave focus alone. To open a menu without moving focus, for example one restored from saved state on page load, pass [`autoFocusOnShow={false}`](https://ariakit.com/reference/menu#autofocusonshow).
+
+Thanks to [@ciampo](https://github.com/ciampo) for reporting the issue and providing the workaround that informed this solution.

--- a/.changeset/300-menu-default-open-focus.md
+++ b/.changeset/300-menu-default-open-focus.md
@@ -4,21 +4,4 @@
 "@ariakit/react": patch
 ---
 
-Menus that mount already open take focus
-
-A [`Menu`](https://ariakit.com/reference/menu) that is already open when it mounts, through [`defaultOpen`](https://ariakit.com/reference/menu-provider#defaultopen) or a controlled open state, now moves focus into the menu. Previously focus stayed where it was while the first item still appeared highlighted, leaving keyboard and screen reader users outside an open menu with no way to navigate it.
-
-```tsx
-<MenuProvider defaultOpen>
-  <MenuButton>Actions</MenuButton>
-  {/* The menu now takes focus, and no item is highlighted. */}
-  <Menu>
-    <MenuItem>Rename</MenuItem>
-    <MenuItem>Duplicate</MenuItem>
-  </Menu>
-</MenuProvider>
-```
-
-Focus lands on the menu itself, which is where clicking [`MenuButton`](https://ariakit.com/reference/menu-button) with a mouse already puts it. Modal menus opened this way used to focus the first item instead, so both now behave the same. Menus opened by hovering a [`MenuButton`](https://ariakit.com/reference/menu-button), such as submenus and menubar menus, still leave focus alone. To open a menu without moving focus, for example one restored from saved state on page load, pass [`autoFocusOnShow={false}`](https://ariakit.com/reference/menu#autofocusonshow).
-
-Thanks to [@ciampo](https://github.com/ciampo) for reporting the issue and providing the workaround that informed this solution.
+Fixed the focus behavior of [`Menu`](https://ariakit.com/reference/menu) when it's rendered already open, for example with [`defaultOpen`](https://ariakit.com/reference/menu-provider#defaultopen): focus now moves to the menu container with no item highlighted, in both non-modal menus, which previously left focus alone, and modal menus, which previously focused the first item. Thanks to [@ciampo](https://github.com/ciampo).

--- a/app/src/sandbox/menu-conditional-mount/index.react.tsx
+++ b/app/src/sandbox/menu-conditional-mount/index.react.tsx
@@ -1,0 +1,73 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+
+interface NewItemActionsProps {
+  modal?: boolean;
+  autoFocusOnShow?: boolean;
+  onClose: () => void;
+}
+
+function NewItemActions({
+  modal,
+  autoFocusOnShow,
+  onClose,
+}: NewItemActionsProps) {
+  return (
+    <Ariakit.MenuProvider
+      defaultOpen
+      // Unmounting on close lets the preview be replayed by hand without
+      // reloading the page.
+      setOpen={(open) => {
+        if (open) return;
+        onClose();
+      }}
+    >
+      <Ariakit.MenuButton className="button">Actions</Ariakit.MenuButton>
+      <Ariakit.Menu
+        modal={modal}
+        autoFocusOnShow={autoFocusOnShow}
+        gutter={8}
+        className="menu"
+      >
+        <Ariakit.MenuItem className="menu-item">Rename</Ariakit.MenuItem>
+        <Ariakit.MenuItem className="menu-item">Duplicate</Ariakit.MenuItem>
+      </Ariakit.Menu>
+    </Ariakit.MenuProvider>
+  );
+}
+
+type Variant = "default" | "modal" | "quiet";
+
+// Adding an item mounts its actions already open, the way a real flow reveals
+// the next available actions without a second click. The button that was
+// clicked keeps focus, so the menu has to take focus away from a live element
+// rather than from a blank body.
+export default function Example() {
+  const [added, setAdded] = useState<Variant | null>(null);
+  const close = () => setAdded(null);
+
+  return (
+    <div>
+      <div>
+        <Ariakit.Button className="button" onClick={() => setAdded("default")}>
+          Add item
+        </Ariakit.Button>
+        {added === "default" && <NewItemActions onClose={close} />}
+      </div>
+      <div>
+        <Ariakit.Button className="button" onClick={() => setAdded("modal")}>
+          Add modal item
+        </Ariakit.Button>
+        {added === "modal" && <NewItemActions modal onClose={close} />}
+      </div>
+      <div>
+        <Ariakit.Button className="button" onClick={() => setAdded("quiet")}>
+          Add quiet item
+        </Ariakit.Button>
+        {added === "quiet" && (
+          <NewItemActions autoFocusOnShow={false} onClose={close} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/src/sandbox/menu-conditional-mount/index.react.tsx
+++ b/app/src/sandbox/menu-conditional-mount/index.react.tsx
@@ -1,5 +1,5 @@
 import * as Ariakit from "@ariakit/react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 interface NewItemActionsProps {
   modal?: boolean;
@@ -12,27 +12,16 @@ function NewItemActions({
   autoFocusOnShow,
   onClose,
 }: NewItemActionsProps) {
-  const menu = Ariakit.useMenuStore({
-    defaultOpen: true,
-    // Unmounting on close lets the preview be replayed by hand without
-    // reloading the page.
-    setOpen: (open) => {
-      if (open) return;
-      onClose();
-    },
-  });
-
-  useEffect(() => {
-    // Menu inherits Hovercard's `autoFocusOnShow: false`, and only a MenuButton
-    // gesture flips it, so a menu that mounts already open never focuses its
-    // container.
-    // TODO: Remove this, and the store hoist it needs, once
-    // https://github.com/ariakit/ariakit/issues/2946 is fixed.
-    menu.setAutoFocusOnShow(true);
-  }, [menu]);
-
   return (
-    <Ariakit.MenuProvider store={menu}>
+    <Ariakit.MenuProvider
+      defaultOpen
+      // Unmounting on close lets the preview be replayed by hand without
+      // reloading the page.
+      setOpen={(open) => {
+        if (open) return;
+        onClose();
+      }}
+    >
       <Ariakit.MenuButton className="button">Actions</Ariakit.MenuButton>
       <Ariakit.Menu
         modal={modal}

--- a/app/src/sandbox/menu-conditional-mount/index.react.tsx
+++ b/app/src/sandbox/menu-conditional-mount/index.react.tsx
@@ -1,5 +1,5 @@
 import * as Ariakit from "@ariakit/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 interface NewItemActionsProps {
   modal?: boolean;
@@ -12,16 +12,27 @@ function NewItemActions({
   autoFocusOnShow,
   onClose,
 }: NewItemActionsProps) {
+  const menu = Ariakit.useMenuStore({
+    defaultOpen: true,
+    // Unmounting on close lets the preview be replayed by hand without
+    // reloading the page.
+    setOpen: (open) => {
+      if (open) return;
+      onClose();
+    },
+  });
+
+  useEffect(() => {
+    // Menu inherits Hovercard's `autoFocusOnShow: false`, and only a MenuButton
+    // gesture flips it, so a menu that mounts already open never focuses its
+    // container.
+    // TODO: Remove this, and the store hoist it needs, once
+    // https://github.com/ariakit/ariakit/issues/2946 is fixed.
+    menu.setAutoFocusOnShow(true);
+  }, [menu]);
+
   return (
-    <Ariakit.MenuProvider
-      defaultOpen
-      // Unmounting on close lets the preview be replayed by hand without
-      // reloading the page.
-      setOpen={(open) => {
-        if (open) return;
-        onClose();
-      }}
-    >
+    <Ariakit.MenuProvider store={menu}>
       <Ariakit.MenuButton className="button">Actions</Ariakit.MenuButton>
       <Ariakit.Menu
         modal={modal}

--- a/app/src/sandbox/menu-conditional-mount/test-browser.ts
+++ b/app/src/sandbox/menu-conditional-mount/test-browser.ts
@@ -1,0 +1,47 @@
+import { flushFrames, withFramework } from "#app/test-utils/preview.ts";
+
+// menu-default-open covers the page-load opening, where no element owns focus.
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/2946
+  test("takes focus when the menu mounts already open", async ({ q }) => {
+    await q.button("Add item").click();
+
+    await test.expect(q.menu()).toBeVisible();
+    await test.expect(q.menu()).toBeFocused();
+    await test
+      .expect(q.menuitem("Rename"))
+      .not.toHaveAttribute("data-active-item");
+  });
+
+  // A modal menu already takes focus today, but onto the first item.
+  // https://github.com/ariakit/ariakit/issues/2946#issuecomment-4977621514
+  // #2946 redefines that for both modal modes: the container takes focus and
+  // nothing is highlighted.
+  // https://github.com/ariakit/ariakit/issues/2946
+  test("focuses the container when a modal menu mounts already open", async ({
+    q,
+  }) => {
+    await q.button("Add modal item").click();
+
+    await test.expect(q.menu()).toBeVisible();
+    await test.expect(q.menu()).toBeFocused();
+    await test
+      .expect(q.menuitem("Rename"))
+      .not.toHaveAttribute("data-active-item");
+  });
+
+  // Whether an item stays highlighted while focus is declined is deliberately
+  // not pinned here, because nothing has decided that yet.
+  // https://github.com/ariakit/ariakit/issues/2946
+  test("leaves focus alone when the menu opts out", async ({ page, q }) => {
+    const add = q.button("Add quiet item");
+    await add.click();
+
+    await test.expect(q.menu()).toBeVisible();
+    // The dialog schedules its focus in an effect and a microtask, so let those
+    // frames pass before asserting that focus never moved.
+    await flushFrames(page);
+    await test.expect(add).toBeFocused();
+  });
+});

--- a/app/src/sandbox/menu-conditional-mount/test.ts
+++ b/app/src/sandbox/menu-conditional-mount/test.ts
@@ -1,0 +1,39 @@
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// menu-default-open covers the page-load opening, where no element owns focus.
+
+// https://github.com/ariakit/ariakit/issues/2946
+test("takes focus when the menu mounts already open", async () => {
+  await click(q.button("Add item"));
+
+  expect(q.menu()).toBeVisible();
+  expect(q.menu()).toHaveFocus();
+  expect(q.menuitem("Rename")).not.toHaveAttribute("data-active-item");
+});
+
+// A modal menu already takes focus today, but onto the first item.
+// https://github.com/ariakit/ariakit/issues/2946#issuecomment-4977621514
+// #2946 redefines that for both modal modes: the container takes focus and
+// nothing is highlighted.
+// https://github.com/ariakit/ariakit/issues/2946
+test("focuses the container when a modal menu mounts already open", async () => {
+  await click(q.button("Add modal item"));
+
+  expect(q.menu()).toBeVisible();
+  expect(q.menu()).toHaveFocus();
+  expect(q.menuitem("Rename")).not.toHaveAttribute("data-active-item");
+});
+
+// Whether an item stays highlighted while focus is declined is deliberately not
+// pinned here, because nothing has decided that yet.
+// https://github.com/ariakit/ariakit/issues/2946
+test("leaves focus alone when the menu opts out", async () => {
+  const add = q.button("Add quiet item");
+  await click(add);
+
+  expect(q.menu()).toBeVisible();
+  // `click` already settles the dialog's focus effect and microtask, so focus
+  // has had its chance to move by now.
+  expect(add).toHaveFocus();
+});

--- a/app/src/sandbox/menu-default-open/index.react.tsx
+++ b/app/src/sandbox/menu-default-open/index.react.tsx
@@ -1,0 +1,15 @@
+import * as Ariakit from "@ariakit/react";
+
+// The menu is open from the first render, so it has to define its own focus
+// without a user gesture and without a prior focus owner to return to.
+export default function Example() {
+  return (
+    <Ariakit.MenuProvider defaultOpen>
+      <Ariakit.MenuButton className="button">Actions</Ariakit.MenuButton>
+      <Ariakit.Menu gutter={8} className="menu">
+        <Ariakit.MenuItem className="menu-item">Rename</Ariakit.MenuItem>
+        <Ariakit.MenuItem className="menu-item">Duplicate</Ariakit.MenuItem>
+      </Ariakit.Menu>
+    </Ariakit.MenuProvider>
+  );
+}

--- a/app/src/sandbox/menu-default-open/index.react.tsx
+++ b/app/src/sandbox/menu-default-open/index.react.tsx
@@ -1,22 +1,10 @@
 import * as Ariakit from "@ariakit/react";
-import { useEffect } from "react";
 
 // The menu is open from the first render, so it has to define its own focus
 // without a user gesture and without a prior focus owner to return to.
 export default function Example() {
-  const menu = Ariakit.useMenuStore({ defaultOpen: true });
-
-  useEffect(() => {
-    // Menu inherits Hovercard's `autoFocusOnShow: false`, and only a MenuButton
-    // gesture flips it, so a menu that mounts already open never focuses its
-    // container.
-    // TODO: Remove this, and the store hoist it needs, once
-    // https://github.com/ariakit/ariakit/issues/2946 is fixed.
-    menu.setAutoFocusOnShow(true);
-  }, [menu]);
-
   return (
-    <Ariakit.MenuProvider store={menu}>
+    <Ariakit.MenuProvider defaultOpen>
       <Ariakit.MenuButton className="button">Actions</Ariakit.MenuButton>
       <Ariakit.Menu gutter={8} className="menu">
         <Ariakit.MenuItem className="menu-item">Rename</Ariakit.MenuItem>

--- a/app/src/sandbox/menu-default-open/index.react.tsx
+++ b/app/src/sandbox/menu-default-open/index.react.tsx
@@ -1,10 +1,22 @@
 import * as Ariakit from "@ariakit/react";
+import { useEffect } from "react";
 
 // The menu is open from the first render, so it has to define its own focus
 // without a user gesture and without a prior focus owner to return to.
 export default function Example() {
+  const menu = Ariakit.useMenuStore({ defaultOpen: true });
+
+  useEffect(() => {
+    // Menu inherits Hovercard's `autoFocusOnShow: false`, and only a MenuButton
+    // gesture flips it, so a menu that mounts already open never focuses its
+    // container.
+    // TODO: Remove this, and the store hoist it needs, once
+    // https://github.com/ariakit/ariakit/issues/2946 is fixed.
+    menu.setAutoFocusOnShow(true);
+  }, [menu]);
+
   return (
-    <Ariakit.MenuProvider defaultOpen>
+    <Ariakit.MenuProvider store={menu}>
       <Ariakit.MenuButton className="button">Actions</Ariakit.MenuButton>
       <Ariakit.Menu gutter={8} className="menu">
         <Ariakit.MenuItem className="menu-item">Rename</Ariakit.MenuItem>

--- a/app/src/sandbox/menu-default-open/test-browser.ts
+++ b/app/src/sandbox/menu-default-open/test-browser.ts
@@ -1,0 +1,29 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// menu-conditional-mount covers the modal, opt-out, and mount-after-load
+// openings, which need a page where nothing is open yet.
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/2946
+  test("takes focus when the menu starts open", async ({ q }) => {
+    await test.expect(q.menu()).toBeVisible();
+    await test.expect(q.menu()).toBeFocused();
+    await test
+      .expect(q.menuitem("Rename"))
+      .not.toHaveAttribute("data-active-item");
+  });
+
+  // The menu is only usable if the composite can still start roving from the
+  // container it just focused.
+  // https://github.com/ariakit/ariakit/issues/2946
+  test("navigates from the container when the menu starts open", async ({
+    page,
+    q,
+  }) => {
+    await test.expect(q.menu()).toBeFocused();
+
+    await page.keyboard.press("ArrowDown");
+
+    await test.expect(q.menuitem("Rename")).toBeFocused();
+  });
+});

--- a/app/src/sandbox/menu-default-open/test.ts
+++ b/app/src/sandbox/menu-default-open/test.ts
@@ -1,0 +1,25 @@
+import { press, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// menu-conditional-mount covers the modal, opt-out, and mount-after-load
+// openings, which need a page where nothing is open yet.
+
+// https://github.com/ariakit/ariakit/issues/2946
+test("takes focus when the menu starts open", async () => {
+  await expect.poll(q.menu.lazy()).toBeVisible();
+
+  expect(q.menu()).toHaveFocus();
+  expect(q.menuitem("Rename")).not.toHaveAttribute("data-active-item");
+});
+
+// The menu is only usable if the composite can still start roving from the
+// container it just focused.
+// https://github.com/ariakit/ariakit/issues/2946
+test("navigates from the container when the menu starts open", async () => {
+  await expect.poll(q.menu.lazy()).toBeVisible();
+  expect(q.menu()).toHaveFocus();
+
+  await press.ArrowDown();
+
+  expect(q.menuitem("Rename")).toHaveFocus();
+});

--- a/packages/ariakit-components/src/menu/menu-store.ts
+++ b/packages/ariakit-components/src/menu/menu-store.ts
@@ -86,13 +86,13 @@ export function createMenuStore({
     hideTimeout: defaultValue(props.hideTimeout, syncState.hideTimeout, 0),
   });
 
-  // Hovercard opens on hover, so it leaves focus alone by default. A menu that
-  // starts open has no gesture to speak for it, and rendering it open is still
-  // a request to interact with it, so it takes focus instead.
+  // Hovercard leaves focus alone by default and its disclosure opts in. Menus
+  // do the opposite: they arm here and the hover trigger opts out. It has to be
+  // the hovercard store, whose value wins when the menu store initializes.
   // https://github.com/ariakit/ariakit/issues/2946
   hovercard.setState(
     "autoFocusOnShow",
-    defaultValue(syncState.autoFocusOnShow, hovercard.getState().open),
+    defaultValue(syncState.autoFocusOnShow, true),
   );
 
   const initialState: MenuStoreState = {
@@ -169,6 +169,8 @@ export interface MenuStoreState<T extends MenuStoreValues = MenuStoreValues>
   placement: HovercardStoreState["placement"];
   /** @default 0 */
   hideTimeout?: HovercardStoreState["hideTimeout"];
+  /** @default true */
+  autoFocusOnShow: HovercardStoreState["autoFocusOnShow"];
   /**
    * Determines the element that should be focused when the menu is opened.
    */

--- a/packages/ariakit-components/src/menu/menu-store.ts
+++ b/packages/ariakit-components/src/menu/menu-store.ts
@@ -86,6 +86,15 @@ export function createMenuStore({
     hideTimeout: defaultValue(props.hideTimeout, syncState.hideTimeout, 0),
   });
 
+  // Hovercard opens on hover, so it leaves focus alone by default. A menu that
+  // starts open has no gesture to speak for it, and rendering it open is still
+  // a request to interact with it, so it takes focus instead.
+  // https://github.com/ariakit/ariakit/issues/2946
+  hovercard.setState(
+    "autoFocusOnShow",
+    defaultValue(syncState.autoFocusOnShow, hovercard.getState().open),
+  );
+
   const initialState: MenuStoreState = {
     ...composite.getState(),
     ...hovercard.getState(),

--- a/packages/ariakit-react-components/src/menu/menu-button.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-button.tsx
@@ -253,6 +253,9 @@ export const useMenuButton = createHook<TagName, MenuButtonOptions>(
         };
         const canShowOnHover = getShowOnHover();
         if (!canShowOnHover) return false;
+        // Menus take focus when they open, but a hover is the passive way to
+        // get there, so this one opts out.
+        store?.setAutoFocusOnShow(false);
         const parent = parentIsMenubar ? parentMenubar : parentMenu;
         if (!parent) return true;
         // When hovering over a menu button shows a menu and the menu button is


### PR DESCRIPTION
## Motivation

A `Menu` that is already open when it mounts never receives focus. Focus stays wherever it was, while the first item is highlighted as if it were the active one.

```jsx
// Focus stays on the body. Arrow keys do nothing. "Rename" looks active anyway.
<Ariakit.MenuProvider defaultOpen>
  <Ariakit.MenuButton>Actions</Ariakit.MenuButton>
  <Ariakit.Menu>
    <Ariakit.MenuItem>Rename</Ariakit.MenuItem>
    <Ariakit.MenuItem>Duplicate</Ariakit.MenuItem>
  </Ariakit.Menu>
</Ariakit.MenuProvider>
```

`Menu` builds on `Hovercard`, so it inherits an [`autoFocusOnShow` state that starts as `false`](https://github.com/ariakit/ariakit/blob/897182fbb250a656e8821a3c1ca7f479bd3670ff/packages/ariakit-components/src/hovercard/hovercard-store.ts#L36). That default is right for a hovercard, which opens on hover and must not steal focus. Only [`MenuButton`'s click and keydown handlers](https://github.com/ariakit/ariakit/blob/897182fbb250a656e8821a3c1ca7f479bd3670ff/packages/ariakit-react-components/src/menu/menu-button.tsx#L153) ever flip it to `true`, so a menu that mounts already open never runs them and [`useMenu` bails before resolving a focus target](https://github.com/ariakit/ariakit/blob/897182fbb250a656e8821a3c1ca7f479bd3670ff/packages/ariakit-react-components/src/menu/menu.tsx#L98).

The state is overloaded. `false` means both "a hover opened this, leave focus alone" and "nobody has said anything yet". A menu that mounts open lands in the second bucket and is treated as the first. `Select` and `ComboboxSelect` are `Popover`-based and never inherit that default, which is why #7079 had to answer the same question for a different composition.

## Solution

The two components want opposite defaults, so each one states its own and the exceptions opt out.

A hovercard opens on hover, so it keeps leaving focus alone and its disclosure opts in. A menu is the other way around: showing one is a request to interact with it, so the menu store arms itself and the hover trigger opts out.

```diff
  // in createMenuStore, after the hovercard store is created
+ hovercard.setState(
+   "autoFocusOnShow",
+   defaultValue(syncState.autoFocusOnShow, true),
+ );
```

```diff
  // in MenuButton's showOnHover, once the hover is known to open the menu
+ store?.setAutoFocusOnShow(false);
```

The value is written onto the hovercard store rather than the menu's own `initialState` because `createStore` pushes each parent store's value for shared keys into the child at init, so an `initialState` entry would be overwritten. `MenuButton` is the only menu hover trigger, so the opt-out is complete: `MenuAnchor` only positions.

Three alternatives were tried and rejected:

- **Removing the two reset-on-close effects in `Hovercard`.** Breaks `menu-placing-pass`: with the flag left `true` while a menu is open, the container stays an armed focus target, so replacing a focused item's DOM node lands focus on the container instead of restoring it to the item.
- **Disarming on close from the store, with a `sync` on `open`.** Breaks `menu-motion-transitions`. That fixture is a controlled menu, and a controlled round trip briefly writes the stale `open: false` back into the store, so the flag was disarmed before the menu actually opened.
- **Making `autoFocusOnShow` a store creation option.** Wiring it through `useStoreProps` turned it into a permanent controlled pin that reverted every internal write within a microtask, which silently disabled `HovercardDisclosure`'s opt-in. The escape hatch stays the existing [`autoFocusOnShow={false}`](https://ariakit.com/reference/menu#autofocusonshow) prop on `Menu`, matching #7079.

Focus lands on the menu container, which is where the store's own `initialFocus: "container"` default points and where a mouse click on `MenuButton` already puts it. Modal menus that mount open previously landed on the first item, through `Dialog`'s generic first-tabbable fallback rather than any menu decision, so this redefines that case to match. The issue body's claim that modal already focuses the container is inaccurate and was corrected in [this comment](https://github.com/ariakit/ariakit/issues/2946#issuecomment-4977621514).

## Coverage

Two sandboxes, because a menu that is open at page load already owns focus and cannot share a page with click-driven variants.

`app/src/sandbox/menu-default-open` is the reported scenario: a menu open from the first render, with no user gesture and no prior focus owner. It asserts that focus lands on the menu container with no item highlighted, and that ArrowDown still starts roving from there, so the menu is operable and not merely focused.

`app/src/sandbox/menu-conditional-mount` is the flow that motivates the pattern in practice: clicking **Add item** reveals the next available actions without a second click. Here the menu takes focus away from a live, focused button rather than from a blank body, which is a different branch in `Dialog`. It covers the non-modal case, the modal case, and the `autoFocusOnShow={false}` opt-out.

The reproduction landed first, before any library change, so CI recorded the red state: 4 failing and 1 passing, in happy-dom, React 18, Chrome, Firefox, and Safari.

| Scenario | Before | After |
| --- | --- | --- |
| Non-modal, open at page load | Focus on `body`, ArrowDown does nothing | Container focused, ArrowDown reaches the first item |
| Non-modal, mounted open after a click | Focus stays on the clicked button | Container focused |
| Modal, mounted open after a click | First item focused | Container focused |
| `autoFocusOnShow={false}` | Focus stays put | Unchanged |

The opt-out test deliberately does not pin whether an item stays highlighted while focus is declined. Nothing has decided that, and asserting it would freeze the exact half-state the issue calls wrong.

`menubar-navigation` is the red check for the hover opt-out: those menus render with `unmountOnHide`, so they are still armed at their first open, and the test asserts focus stays on `body` while hovering. It fails without the `MenuButton` hunk. `menu-placing-pass` and `menu-motion-transitions` guard the two rejected alternatives.

## Verification

- Full happy-dom suite: 257 files, 1718 tests. React 18: 190 files, 984 tests.
- Chrome `menu hovercard tooltip menubar`: 749 passed. Firefox: 607. Safari: 497.
- `pnpm tsc` and `pnpm lint` clean.
- Both reference generators checked. The only generated metadata change repo-wide is `use-menu-store`'s `autoFocusOnShow` default flipping from `false` to `true`, which the new `/** @default true */` override on `MenuStoreState` makes truthful.
- A store-replacement focus steal was suspected during review and disproved with an A/B probe: with and without the fix, replacing an open menu's store closes the menu and leaves focus on the clicking button, identically.

## Known gap

Menus that render while closed are disarmed by `Hovercard`'s reset-on-close effect, so a later bare `store.show()` on them does not move focus. A `<Menu unmountOnHide>` that has never opened does not render at all, so that effect never runs and its **first** non-gesture open does take focus, while later opens do not. Every `MenuButton` path is unaffected, since click and keydown arm, and focus and hover opt out.

Closing that window means moving where the reset runs relative to the `unmountOnHide` unmount gate, in shared `Hovercard` code that `menu-placing-pass` and `menu-motion-transitions` are sensitive to. It is left as is rather than fixed here.

## Workaround

Until the fix ships, a menu that intentionally mounts already open can enable the state itself after mount. `setAutoFocusOnShow` is only reachable from a store reference, and `useMenuStore` has no equivalent option, so the store has to be hoisted out of the provider.

```jsx
const menu = Ariakit.useMenuStore({ defaultOpen: true });

useEffect(() => {
  // Menu inherits Hovercard's `autoFocusOnShow: false`, and only a MenuButton
  // gesture flips it, so a menu that mounts already open never focuses its
  // container.
  // TODO: Remove this, and the store hoist it needs, once
  // https://github.com/ariakit/ariakit/issues/2946 is fixed.
  menu.setAutoFocusOnShow(true);
}, [menu]);

return (
  <Ariakit.MenuProvider store={menu}>
    <Ariakit.MenuButton>Actions</Ariakit.MenuButton>
    <Ariakit.Menu>{/* items */}</Ariakit.Menu>
  </Ariakit.MenuProvider>
);
```

Assumptions and limitations:

- It assumes this menu should take focus. A default-open menu meant to stay passive, such as one restored from persisted state on page load, should use `<Ariakit.Menu autoFocusOnShow={false}>` instead.
- It only covers the initial mount-open. The effect runs once, and `Hovercard` resets the state to `false` on close. Ordinary open and close cycles keep working because `MenuButton` sets it again on click and keydown, but a later programmatic `store.show()` with no button gesture opens without focus again and needs its own `setAutoFocusOnShow(true)`.
- Focus lands on the menu container with no item highlighted, because the store's `initialFocus` stays at its `"container"` default. Add `store.setInitialFocus("first")` to highlight the first item instead. For a modal menu this changes today's behavior, which focuses the first item.
- An explicit `autoFocusOnShow={false}` on `Menu` still wins over the store state, so the workaround does not override a deliberate opt-out.
- Focus moves in an effect, one commit after mount, so it settles slightly later than the fix does.

## Review gate reassessment

<details>
<summary>Cycle 3: Continue the current direction</summary>

**Assessment**

The bug is a real WAI-ARIA menu-pattern violation: keyboard and assistive-technology users are stranded outside an open menu with no navigable focus. Impact is high per occurrence and low in aggregate, since `defaultOpen` menus are not the dominant pattern, and a documented workaround exists. The affected surface is public and supported.

Complexity at the boundary was 2 fixtures, 6 files, 5 scenarios, 226 lines, no library code, no helpers, no shared utilities, and no public contract. The merged precedent for the structurally identical `ComboboxSelect` problem, #7079, shipped 424 lines, 2 fixtures, 14 test bodies, a new shared helper, and 2 changesets. Measured against that precedent, this snapshot is under-built rather than over-built. Each scenario maps to a distinct branch of `canAutoFocusOnShow`: page load with no prior focus owner, mount while a live button holds focus, modal, explicit opt-out, and post-focus operability.

Finding severity across the three cycles was strictly decreasing: cycle 1 found a scope defect (the reported page-load scenario was never exercised), cycle 2 found a false-green defect (an unasserted premise), and cycle 3 found only comments and one test title. No finding in any cycle challenged the contract being encoded. #6737's closure reason does not transfer, since that concerned accumulating workarounds in library code and this snapshot contains none.

**Decision**

Continue. Two removals were applied at the boundary: a redundant `tabIndex={0}` on three `Ariakit.Button`s, which `Focusable` already supplies on Safari through `safariTabIndex`, verified by a green Safari run of the opt-out guard; and a dead `label` prop on the fixture's menu component. One proposed assertion was declined as a non-goal rather than applied, as described above.

</details>

## Acknowledgments

Thanks to [@ciampo](https://github.com/ciampo) for reporting the issue with a reproduction and for the original workaround.
