### PR TITLE
Treat Safari Option+Tab as keyboard modality

### DIFF
--- a/.changeset/300-safari-option-tab-focus-visible.md
+++ b/.changeset/300-safari-option-tab-focus-visible.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Focusable`](https://ariakit.com/reference/focusable) treating Safari's `Option+Tab` navigation as a pointer interaction, so components built on it such as [`Button`](https://ariakit.com/reference/button) and [`TooltipAnchor`](https://ariakit.com/reference/tooltip-anchor) now receive [`data-focus-visible`](https://ariakit.com/guide/styling#data-focus-visible) when focus reaches them that way. On macOS, `Option+Tab` is how Safari moves focus between all focusable elements while the system keyboard navigation setting is off.

--- a/app/src/sandbox/focusable-tooltip-7094/index.react.tsx
+++ b/app/src/sandbox/focusable-tooltip-7094/index.react.tsx
@@ -1,6 +1,28 @@
 import * as Ariakit from "@ariakit/react";
+import { useEffect } from "react";
+
+// TODO: Remove once https://github.com/ariakit/ariakit/issues/7094 is released.
+// Safari navigates with Option+Tab when the macOS keyboard navigation setting
+// is off, but Ariakit ignores every Alt-modified key when it records keyboard
+// modality. Re-announcing the gesture without the modifier makes it count.
+function useOptionTabKeyboardModality() {
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!event.isTrusted) return;
+      if (!event.altKey) return;
+      if (event.key !== "Tab") return;
+      // Ariakit reads only the modifier keys here, so the re-announced event
+      // carries no key. Naming it Tab would make other document listeners
+      // handle one gesture twice, which can move focus twice in a focus trap.
+      document.dispatchEvent(new KeyboardEvent("keydown"));
+    };
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => document.removeEventListener("keydown", onKeyDown, true);
+  }, []);
+}
 
 export default function Example() {
+  useOptionTabKeyboardModality();
   return (
     <div>
       <p>Click here, then press Option+Tab to focus the button.</p>

--- a/app/src/sandbox/focusable-tooltip-7094/index.react.tsx
+++ b/app/src/sandbox/focusable-tooltip-7094/index.react.tsx
@@ -2,7 +2,7 @@ import * as Ariakit from "@ariakit/react";
 
 export default function Example() {
   return (
-    <div>
+    <div className="flex flex-col items-center gap-12">
       <p>Click here, then press Option+Tab to focus the button.</p>
       <Ariakit.TooltipProvider>
         <Ariakit.TooltipAnchor render={<Ariakit.Button />}>

--- a/app/src/sandbox/focusable-tooltip-7094/index.react.tsx
+++ b/app/src/sandbox/focusable-tooltip-7094/index.react.tsx
@@ -1,0 +1,15 @@
+import * as Ariakit from "@ariakit/react";
+
+export default function Example() {
+  return (
+    <div>
+      <p>Click here, then press Option+Tab to focus the button.</p>
+      <Ariakit.TooltipProvider>
+        <Ariakit.TooltipAnchor render={<Ariakit.Button />}>
+          Bookmark
+        </Ariakit.TooltipAnchor>
+        <Ariakit.Tooltip>Add to bookmarks</Ariakit.Tooltip>
+      </Ariakit.TooltipProvider>
+    </div>
+  );
+}

--- a/app/src/sandbox/focusable-tooltip-7094/index.react.tsx
+++ b/app/src/sandbox/focusable-tooltip-7094/index.react.tsx
@@ -1,28 +1,6 @@
 import * as Ariakit from "@ariakit/react";
-import { useEffect } from "react";
-
-// TODO: Remove once https://github.com/ariakit/ariakit/issues/7094 is released.
-// Safari navigates with Option+Tab when the macOS keyboard navigation setting
-// is off, but Ariakit ignores every Alt-modified key when it records keyboard
-// modality. Re-announcing the gesture without the modifier makes it count.
-function useOptionTabKeyboardModality() {
-  useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (!event.isTrusted) return;
-      if (!event.altKey) return;
-      if (event.key !== "Tab") return;
-      // Ariakit reads only the modifier keys here, so the re-announced event
-      // carries no key. Naming it Tab would make other document listeners
-      // handle one gesture twice, which can move focus twice in a focus trap.
-      document.dispatchEvent(new KeyboardEvent("keydown"));
-    };
-    document.addEventListener("keydown", onKeyDown, true);
-    return () => document.removeEventListener("keydown", onKeyDown, true);
-  }, []);
-}
 
 export default function Example() {
-  useOptionTabKeyboardModality();
   return (
     <div>
       <p>Click here, then press Option+Tab to focus the button.</p>

--- a/app/src/sandbox/focusable-tooltip-7094/test-safari.ts
+++ b/app/src/sandbox/focusable-tooltip-7094/test-safari.ts
@@ -1,0 +1,47 @@
+import { flushFrames, withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/7094
+  test("Option+Tab focuses the anchor as keyboard navigation", async ({
+    page,
+    q,
+  }) => {
+    const anchor = q.button("Bookmark");
+    // The listener that records pointer modality is installed when the island
+    // hydrates, and Safari's tabindex is applied by a later effect in the same
+    // component, so waiting for it proves the click reaches that listener. It
+    // only proves that while the fixture passes no tabIndex of its own.
+    await test.expect(anchor).toHaveAttribute("tabindex", "0");
+
+    // Safari moves focus with Option+Tab instead of Tab when the macOS keyboard
+    // navigation setting is off. Clicking first is what makes the regression
+    // observable: modality starts as keyboard until a pointer gesture drops it.
+    await q
+      .text("Click here, then press Option+Tab to focus the button.")
+      .click();
+    await page.keyboard.press("Alt+Tab");
+
+    await test.expect(anchor).toBeFocused();
+    await test.expect(anchor).toHaveAttribute("data-focus-visible", "true");
+    await test.expect(q.tooltip("Add to bookmarks")).toBeVisible();
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7094
+  test("clicking the anchor is still pointer navigation", async ({
+    page,
+    q,
+  }) => {
+    const anchor = q.button("Bookmark");
+    // Same hydration gate as above. Without it a pre-hydration click would
+    // leave the attribute absent for the wrong reason.
+    await test.expect(anchor).toHaveAttribute("tabindex", "0");
+
+    await anchor.click();
+    await test.expect(anchor).toBeFocused();
+    // Focus visibility is applied from a queueBeforeEvent callback that falls
+    // back to requestAnimationFrame, so the attribute would also be absent
+    // while it is still pending. Cross those frames to prove it never arrives.
+    await flushFrames(page);
+    await test.expect(anchor).not.toHaveAttribute("data-focus-visible");
+  });
+});

--- a/packages/ariakit-react-components/src/focusable/focusable.tsx
+++ b/packages/ariakit-react-components/src/focusable/focusable.tsx
@@ -192,7 +192,15 @@ function onGlobalMouseDown(event: MouseEvent) {
 function onGlobalKeyDown(event: KeyboardEvent) {
   if (event.metaKey) return;
   if (event.ctrlKey) return;
-  if (event.altKey) return;
+  if (event.altKey) {
+    // Safari moves focus with Option+Tab when the macOS keyboard navigation
+    // setting is off, so that gesture is keyboard navigation rather than a
+    // shortcut. Every other Alt-modified key still keeps the current modality,
+    // since Option types special characters on macOS.
+    // https://github.com/ariakit/ariakit/issues/7094
+    if (!isSafariBrowser) return;
+    if (event.key !== "Tab") return;
+  }
   isKeyboardModality = true;
 }
 


### PR DESCRIPTION
## Motivation

`Focusable` decides between keyboard and pointer modality from a global `keydown` listener that bails out on any `Alt`-modified key:

```ts
function onGlobalKeyDown(event: KeyboardEvent) {
  if (event.metaKey) return;
  if (event.ctrlKey) return;
  if (event.altKey) return;
  isKeyboardModality = true;
}
```

On macOS that discards a real keyboard navigation gesture. When the system-wide keyboard navigation setting (`System Settings` > `Keyboard` > `Keyboard navigation`, exposed in Safari as `Press Tab to highlight each item on a webpage`) is off, which is the default, Safari moves focus between all focusable elements with `Option+Tab` instead of plain `Tab`. Safari delivers that as a `keydown` with `altKey: true` and `key: "Tab"`, so Ariakit never sets `isKeyboardModality`, and the element that receives focus is treated as if it had been clicked.

Because `isKeyboardModality` starts as `true` and only flips to `false` on `mousedown`, this surfaces as soon as the user has touched the mouse once, which is the normal case. Focus lands on the same element either way, so this is not a focus movement problem. Only the modality classification differs, and everything keyed off it is lost: the focus ring components draw from `data-focus-visible`, and focus-driven behavior such as `Tooltip`.

For users who have not enabled full keyboard access, `Option+Tab` is the only way to reach non-form controls, so today those users never get focus-visible styling at all.

## Solution

Keep the `Alt` bail-out, but make an exception for `Option+Tab` on Safari, so the gesture is recorded as keyboard modality exactly like plain `Tab`:

```ts
if (event.altKey) {
  if (!isSafariBrowser) return;
  if (event.key !== "Tab") return;
}
```

The exception stays deliberately narrow in both directions. It is gated on Safari because `Alt+Tab` is the window switcher elsewhere, and restricted to `Tab` because `Option` is the special-character modifier on macOS, so `Option+e` and friends are typing rather than navigating. Every other `Alt`-modified key keeps the current modality, exactly as before.

The second `altKey` guard in `onKeyDownCapture` is intentionally left alone. It covers typing on an element that already has focus, and the `Option+Tab` keydown is delivered to the element focus is leaving, so it is not part of this problem.

## Preview

Safari reaching the tooltip anchor with `Option+Tab` after a mouse click elsewhere on the page. The anchor is focused, draws its focus ring from `data-focus-visible`, and shows its tooltip. Before this change the same gesture produced neither.

![Safari preview showing the Bookmark button focused with a visible focus ring and its "Add to bookmarks" tooltip after pressing Option+Tab](https://github.com/user-attachments/assets/5c6dd15f-8ebf-421b-9c8d-06d17ad15585)

## Workaround

Until this ships, consumers can re-announce the gesture as an unmodified `keydown` so the global listener records keyboard modality:

```jsx
import { useEffect } from "react";

// TODO: Remove once https://github.com/ariakit/ariakit/issues/7094 is released.
function useOptionTabKeyboardModality() {
  useEffect(() => {
    const onKeyDown = (event) => {
      if (!event.isTrusted) return;
      if (!event.altKey) return;
      if (event.key !== "Tab") return;
      // Ariakit reads only the modifier keys here, so the re-announced event
      // carries no key. Naming it Tab would make other document listeners
      // handle one gesture twice, which can move focus twice in a focus trap.
      document.dispatchEvent(new KeyboardEvent("keydown"));
    };
    document.addEventListener("keydown", onKeyDown, true);
    return () => document.removeEventListener("keydown", onKeyDown, true);
  }, []);
}
```

### Assumptions and limitations

This workaround is deliberately narrower and, in one respect, broader than the library fix, so it is not a complete substitute for it.

- **It is not Safari-gated.** The fix applies the exception only on Safari, while the snippet reacts to `Alt+Tab` on any platform. Gating it in userland would mean a user agent sniff, or adding `@ariakit/utils` just to import `isSafari()`, which is not worth it for code you delete after the release. The practical consequence is rare: on macOS Chrome and Firefox, `Option+Tab` reaches the page but does not move focus, so the flag flips with no matching focus event, and a later window blur and refocus can paint a focus ring on an element the user had clicked. On Windows and most Linux window managers the shell consumes `Alt+Tab` before the page sees it.
- **It only covers `Option+Tab`**, including `Option+Shift+Tab`. Any other `Alt`-modified key still leaves modality untouched.
- **It restores only the global modality flag, not per-element keyboard handling.** The synthetic event targets `document`, and propagation only visits the target's ancestors, so it never reaches element handlers. The second `altKey` guard in `onKeyDownCapture` is unaffected, so `Option+Tab` still does not make an already-focused element focus-visible in place. Only the element that subsequently receives focus benefits, which is what this bug needs.
- **It only reacts to trusted events**, so it is a no-op under testing libraries that dispatch synthetic events, such as happy-dom and jsdom. It can only be covered in a real browser.
- **It only covers the top-level document.** Ariakit registers its global listeners on same-origin child frames too, so `Option+Tab` inside an iframe is not re-announced.
- **It should be installed once, near the app root.** Several mounted copies each dispatch one extra event per gesture, which is harmless because the flag is idempotent.
- **Other document-level `keydown` listeners observe one extra untrusted event.** It carries no key, so handlers that branch on `event.key` ignore it.
- **The listener is installed in an effect**, so a gesture that arrives before hydration is not re-announced.

## Regression test

`app/src/sandbox/focusable-tooltip-7094` renders a `TooltipAnchor` as a `Button`, which is the reported scenario. `test-safari.ts` clicks the page text to switch to pointer modality, presses `Option+Tab`, and then asserts that the anchor is focused, carries `data-focus-visible`, and shows its tooltip. A second test clicks the anchor directly and asserts that pointer modality still does not produce `data-focus-visible`, so the first test's failure is attributable to modality classification rather than to the fixture never applying focus visibility at all.

Both tests wait for the `tabindex` that `Focusable` adds on Safari after hydration before interacting. The listener that records pointer modality is installed from an effect, so without that gate a click landing before the island hydrates would leave modality at its `true` default and let the first test pass on broken code.

The test is red on the failing-repro commit and green with the fix. Coverage is Playwright-only. A happy-dom duplicate is not possible here: happy-dom hardcodes `navigator.vendor` to an empty string, so `isSafari()` is always false there, which means such a test would stay red both before and after a Safari-gated fix.

### Evidence gap

The two negative branches of the guard are not covered by automated tests, and both were judged impractical rather than overlooked.

`Alt+Tab` in a non-Safari browser has no observable effect to assert, because no other engine moves focus on that gesture, so there is no focus event to check.

An `Alt`-modified non-`Tab` key is technically observable, since composite widgets move focus on `Alt+ArrowRight`, but asserting today's outcome would pin behavior that is itself questionable. That inconsistency is pre-existing and independent of this change, and is filed separately as #7099.

Fixes #7094
