### PR TITLE
Keep focus on a collapsed ComboboxSelect

### DIFF
--- a/.changeset/300-combobox-select-collapsed-focus.md
+++ b/.changeset/300-combobox-select-collapsed-focus.md
@@ -1,0 +1,10 @@
+---
+"@ariakit/react": patch
+"@ariakit/react-components": patch
+---
+
+Collapsed combobox controls keep focus
+
+[`ComboboxSelect`](https://ariakit.com/reference/combobox-select) and [`Combobox`](https://ariakit.com/reference/combobox) no longer move DOM focus into their popup while it is closed. This was visible whenever the options stayed on screen next to the collapsed control, such as with an [`alwaysVisible`](https://ariakit.com/reference/combobox-list#alwaysvisible) [`ComboboxList`](https://ariakit.com/reference/combobox-list), where focusing either control, or typing a letter on the select, moved DOM focus onto an option of a listbox that still reported `aria-expanded="false"`, firing focus and blur on it and, without virtual focus, leaving focus there.
+
+The list still scrolls to the active option, and opening the popup still presents the option that was made active while it was closed.

--- a/.changeset/300-combobox-select-collapsed-focus.md
+++ b/.changeset/300-combobox-select-collapsed-focus.md
@@ -3,8 +3,4 @@
 "@ariakit/react-components": patch
 ---
 
-Collapsed combobox controls keep focus
-
-[`ComboboxSelect`](https://ariakit.com/reference/combobox-select) and [`Combobox`](https://ariakit.com/reference/combobox) no longer move DOM focus into their popup while it is closed. This was visible whenever the options stayed on screen next to the collapsed control, such as with an [`alwaysVisible`](https://ariakit.com/reference/combobox-list#alwaysvisible) [`ComboboxList`](https://ariakit.com/reference/combobox-list), where focusing either control, or typing a letter on the select, moved DOM focus onto an option of a listbox that still reported `aria-expanded="false"`, firing focus and blur on it and, without virtual focus, leaving focus there.
-
-The list still scrolls to the active option, and opening the popup still presents the option that was made active while it was closed.
+Fixed [`ComboboxSelect`](https://ariakit.com/reference/combobox-select) and [`Combobox`](https://ariakit.com/reference/combobox) moving DOM focus off the collapsed control and into their popup, which was visible when the options stayed on screen next to it, such as with an [`alwaysVisible`](https://ariakit.com/reference/combobox-list#alwaysvisible) [`ComboboxList`](https://ariakit.com/reference/combobox-list).

--- a/app/src/sandbox/combobox-select-collapsed-focus/index.react.tsx
+++ b/app/src/sandbox/combobox-select-collapsed-focus/index.react.tsx
@@ -3,6 +3,22 @@ import { useState } from "react";
 
 const fruits = ["Apple", "Banana", "Grape", "Orange"];
 
+interface FocusedOptionsProps {
+  label: string;
+  items: string[];
+}
+
+function FocusedOptions({ label, items }: FocusedOptionsProps) {
+  return (
+    <p>
+      Focused options:{" "}
+      <output aria-label={`${label} focused options`}>
+        {items.join(", ") || "none"}
+      </output>
+    </p>
+  );
+}
+
 interface FruitSelectProps {
   label: string;
   virtualFocus?: boolean;
@@ -10,35 +26,14 @@ interface FruitSelectProps {
 
 function FruitSelect({ label, virtualFocus }: FruitSelectProps) {
   const [focusedItems, setFocusedItems] = useState<string[]>([]);
-  const store = Ariakit.useComboboxStore({
-    defaultSelectedValue: "Apple",
-    virtualFocus,
-  });
-  const open = Ariakit.useStoreState(store, "open");
-  // `ComboboxSelect` forwards composite options to `useComposite`, but it
-  // doesn't list them in its own props type, so they are spread in.
-  const focusOnMoveProps = {
-    focusOnMove: open,
-  } satisfies Ariakit.CompositeOptions;
 
   return (
     <div>
-      <Ariakit.ComboboxProvider store={store}>
-        <Ariakit.ComboboxSelect
-          aria-label={label}
-          // TODO: remove both workarounds once
-          // https://github.com/ariakit/ariakit/issues/7093 is fixed. The prop
-          // stops the closed moves from presenting an item, and the handler
-          // stops the presentation that virtual focus queues when the
-          // collapsed select itself is focused.
-          {...focusOnMoveProps}
-          onFocus={(event) => {
-            const state = store.getState();
-            if (state.open) return;
-            if (!state.virtualFocus) return;
-            event.preventDefault();
-          }}
-        />
+      <Ariakit.ComboboxProvider
+        defaultSelectedValue="Apple"
+        virtualFocus={virtualFocus}
+      >
+        <Ariakit.ComboboxSelect aria-label={label} />
         {/* The list stays visible while the select is collapsed, which is
             also what an exit transition leaves behind while it runs. */}
         <Ariakit.ComboboxList alwaysVisible aria-label={`${label} options`}>
@@ -55,12 +50,57 @@ function FruitSelect({ label, virtualFocus }: FruitSelectProps) {
           ))}
         </Ariakit.ComboboxList>
       </Ariakit.ComboboxProvider>
-      <p>
-        Focused options:{" "}
-        <output aria-label={`${label} focused options`}>
-          {focusedItems.join(", ") || "none"}
-        </output>
-      </p>
+      <FocusedOptions label={label} items={focusedItems} />
+    </div>
+  );
+}
+
+// Enough options that the typeahead target starts outside the scrollport, so
+// the list has somewhere to scroll while the select is collapsed.
+const codes = [
+  ...Array.from({ length: 29 }, (_, index) => `Alpha ${index + 1}`),
+  "Zulu",
+];
+
+function CodeSelect() {
+  return (
+    <Ariakit.ComboboxProvider defaultSelectedValue="Alpha 1">
+      <Ariakit.ComboboxSelect aria-label="Code" />
+      <Ariakit.ComboboxList
+        alwaysVisible
+        aria-label="Code options"
+        style={{ maxHeight: 80, overflowY: "auto" }}
+      >
+        {codes.map((value) => (
+          <Ariakit.ComboboxItem key={value} value={value} />
+        ))}
+      </Ariakit.ComboboxList>
+    </Ariakit.ComboboxProvider>
+  );
+}
+
+// The same contract without a select: the input is the composite element and
+// the options live in a list outside it, so a collapsed input must not focus
+// them either.
+function FilterCombobox() {
+  const [focusedItems, setFocusedItems] = useState<string[]>([]);
+
+  return (
+    <div>
+      <Ariakit.ComboboxProvider defaultActiveId="filter-banana">
+        <Ariakit.Combobox aria-label="Filter" />
+        <Ariakit.ComboboxList alwaysVisible aria-label="Filter options">
+          {fruits.map((value) => (
+            <Ariakit.ComboboxItem
+              key={value}
+              id={`filter-${value.toLowerCase()}`}
+              value={value}
+              onFocus={() => setFocusedItems((items) => [...items, value])}
+            />
+          ))}
+        </Ariakit.ComboboxList>
+      </Ariakit.ComboboxProvider>
+      <FocusedOptions label="Filter" items={focusedItems} />
     </div>
   );
 }
@@ -70,6 +110,8 @@ export default function Example() {
     <>
       <FruitSelect label="Fruit" />
       <FruitSelect label="Fruit without virtual focus" virtualFocus={false} />
+      <CodeSelect />
+      <FilterCombobox />
     </>
   );
 }

--- a/app/src/sandbox/combobox-select-collapsed-focus/index.react.tsx
+++ b/app/src/sandbox/combobox-select-collapsed-focus/index.react.tsx
@@ -79,6 +79,42 @@ function CodeSelect() {
   );
 }
 
+const stages = ["Draft", "Review", "Final"];
+
+// Driven from outside the widget, the way an "apply preset" button or a router
+// effect would, so the move happens while focus is elsewhere on the page.
+function StageSelect() {
+  const store = Ariakit.useComboboxStore({
+    defaultSelectedValue: "Draft",
+    virtualFocus: false,
+  });
+
+  return (
+    <div>
+      <Ariakit.ComboboxProvider store={store}>
+        <Ariakit.ComboboxSelect aria-label="Stage" />
+        <Ariakit.ComboboxList alwaysVisible aria-label="Stage options">
+          {stages.map((value) => (
+            <Ariakit.ComboboxItem key={value} value={value} />
+          ))}
+        </Ariakit.ComboboxList>
+      </Ariakit.ComboboxProvider>
+      {/* Safari only focuses a clicked button when it has an explicit
+          tabindex, and these tests assert where the click left focus. */}
+      <button
+        type="button"
+        tabIndex={0}
+        onClick={() => store.move(store.last())}
+      >
+        Apply stage preset
+      </button>
+      <button type="button" tabIndex={0} onClick={() => store.show()}>
+        Open stage list
+      </button>
+    </div>
+  );
+}
+
 // The same contract without a select: the input is the composite element and
 // the options live in a list outside it, so a collapsed input must not focus
 // them either.
@@ -111,6 +147,7 @@ export default function Example() {
       <FruitSelect label="Fruit" />
       <FruitSelect label="Fruit without virtual focus" virtualFocus={false} />
       <CodeSelect />
+      <StageSelect />
       <FilterCombobox />
     </>
   );

--- a/app/src/sandbox/combobox-select-collapsed-focus/index.react.tsx
+++ b/app/src/sandbox/combobox-select-collapsed-focus/index.react.tsx
@@ -1,0 +1,54 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+
+const fruits = ["Apple", "Banana", "Grape", "Orange"];
+
+interface FruitSelectProps {
+  label: string;
+  virtualFocus?: boolean;
+}
+
+function FruitSelect({ label, virtualFocus }: FruitSelectProps) {
+  const [focusedItems, setFocusedItems] = useState<string[]>([]);
+
+  return (
+    <div>
+      <Ariakit.ComboboxProvider
+        defaultSelectedValue="Apple"
+        virtualFocus={virtualFocus}
+      >
+        <Ariakit.ComboboxSelect aria-label={label} />
+        {/* The list stays visible while the select is collapsed, which is
+            also what an exit transition leaves behind while it runs. */}
+        <Ariakit.ComboboxList alwaysVisible aria-label={`${label} options`}>
+          {fruits.map((value) => (
+            // With virtual focus, DOM focus lands on the item and is handed
+            // straight back to the select, and the select's own blur event is
+            // stopped on the way out. Recording it here is the only way to
+            // observe that an item was focused at all.
+            <Ariakit.ComboboxItem
+              key={value}
+              value={value}
+              onFocus={() => setFocusedItems((items) => [...items, value])}
+            />
+          ))}
+        </Ariakit.ComboboxList>
+      </Ariakit.ComboboxProvider>
+      <p>
+        Focused options:{" "}
+        <output aria-label={`${label} focused options`}>
+          {focusedItems.join(", ") || "none"}
+        </output>
+      </p>
+    </div>
+  );
+}
+
+export default function Example() {
+  return (
+    <>
+      <FruitSelect label="Fruit" />
+      <FruitSelect label="Fruit without virtual focus" virtualFocus={false} />
+    </>
+  );
+}

--- a/app/src/sandbox/combobox-select-collapsed-focus/index.react.tsx
+++ b/app/src/sandbox/combobox-select-collapsed-focus/index.react.tsx
@@ -10,14 +10,35 @@ interface FruitSelectProps {
 
 function FruitSelect({ label, virtualFocus }: FruitSelectProps) {
   const [focusedItems, setFocusedItems] = useState<string[]>([]);
+  const store = Ariakit.useComboboxStore({
+    defaultSelectedValue: "Apple",
+    virtualFocus,
+  });
+  const open = Ariakit.useStoreState(store, "open");
+  // `ComboboxSelect` forwards composite options to `useComposite`, but it
+  // doesn't list them in its own props type, so they are spread in.
+  const focusOnMoveProps = {
+    focusOnMove: open,
+  } satisfies Ariakit.CompositeOptions;
 
   return (
     <div>
-      <Ariakit.ComboboxProvider
-        defaultSelectedValue="Apple"
-        virtualFocus={virtualFocus}
-      >
-        <Ariakit.ComboboxSelect aria-label={label} />
+      <Ariakit.ComboboxProvider store={store}>
+        <Ariakit.ComboboxSelect
+          aria-label={label}
+          // TODO: remove both workarounds once
+          // https://github.com/ariakit/ariakit/issues/7093 is fixed. The prop
+          // stops the closed moves from presenting an item, and the handler
+          // stops the presentation that virtual focus queues when the
+          // collapsed select itself is focused.
+          {...focusOnMoveProps}
+          onFocus={(event) => {
+            const state = store.getState();
+            if (state.open) return;
+            if (!state.virtualFocus) return;
+            event.preventDefault();
+          }}
+        />
         {/* The list stays visible while the select is collapsed, which is
             also what an exit transition leaves behind while it runs. */}
         <Ariakit.ComboboxList alwaysVisible aria-label={`${label} options`}>

--- a/app/src/sandbox/combobox-select-collapsed-focus/test-browser.ts
+++ b/app/src/sandbox/combobox-select-collapsed-focus/test-browser.ts
@@ -105,6 +105,58 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(q.option("Alpha 25")).toHaveAttribute("data-active-item");
   });
 
+  // https://github.com/ariakit/ariakit/pull/7098#discussion_r3742291859
+  // Withholding belongs to the widget that owns focus. A move made from
+  // outside keeps presenting immediately, so the focus it moves is
+  // attributable to that call instead of landing on whoever is focused when
+  // the list next opens.
+  test("a move from outside the widget still presents immediately", async ({
+    page,
+    q,
+  }) => {
+    const openList = q.button("Open stage list");
+
+    await q.button("Apply stage preset").click();
+
+    await test.expect(q.option("Final")).toBeFocused();
+    await test
+      .expect(q.combobox("Stage"))
+      .toHaveAttribute("aria-expanded", "false");
+
+    await openList.click();
+
+    await test
+      .expect(q.combobox("Stage"))
+      .toHaveAttribute("aria-expanded", "true");
+    // Opening is observable above, but a presentation left over from the move
+    // would arrive from a passive effect after paint, so cross those frames
+    // before asserting that the click kept its focus.
+    await flushFrames(page);
+    await test.expect(openList).toBeFocused();
+  });
+
+  // https://github.com/ariakit/ariakit/pull/7098#discussion_r3742291859
+  // Once focus is on an option, moving between options is navigation inside
+  // the list, not focus leaving the control, so the focus ring has to keep up
+  // with the active item even though the list is collapsed.
+  test("arrow keys keep moving focus between options in a collapsed list", async ({
+    page,
+    q,
+  }) => {
+    const list = q.listbox("Stage options");
+    await query(list).option("Draft").click();
+    await test.expect(query(list).option("Draft")).toBeFocused();
+    await test
+      .expect(q.combobox("Stage"))
+      .toHaveAttribute("aria-expanded", "false");
+
+    await page.keyboard.press("ArrowDown");
+
+    const review = query(list).option("Review");
+    await test.expect(review).toHaveAttribute("data-active-item");
+    await test.expect(review).toBeFocused();
+  });
+
   // https://github.com/ariakit/ariakit/issues/7093
   test("a collapsed combobox input never focuses its list", async ({
     page,

--- a/app/src/sandbox/combobox-select-collapsed-focus/test-browser.ts
+++ b/app/src/sandbox/combobox-select-collapsed-focus/test-browser.ts
@@ -44,7 +44,82 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
       await test
         .expect(query(list).option("Grape"))
         .toHaveAttribute("data-active-item");
-      await test.expect(focusedOptions).toContainText("Grape");
+      await test.expect(focusedOptions).toHaveText("Grape");
     });
   }
+
+  // https://github.com/ariakit/ariakit/issues/7093
+  // Only virtual focus asks for the active item when the select itself is
+  // focused, which happens while the list is still closed. That request is the
+  // one that has to survive until the list opens, so a pointer open with no
+  // move before it still presents the item.
+  test("opening the collapsed select with a pointer presents its item", async ({
+    q,
+  }) => {
+    const select = q.combobox("Fruit");
+    const focusedOptions = q.status("Fruit focused options");
+
+    await select.click();
+
+    await test.expect(select).toHaveAttribute("aria-expanded", "true");
+    await test.expect(focusedOptions).toHaveText("Apple");
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7093
+  // Withholding focus must not also withhold the rest of the presentation: a
+  // list that is already on screen still belongs at the active item.
+  test("typeahead scrolls a collapsed list to the active item", async ({
+    q,
+  }) => {
+    const select = q.combobox("Code");
+    const list = q.listbox("Code options");
+    const scrollTop = () => list.evaluate((element) => element.scrollTop);
+
+    await select.focus();
+    test.expect(await scrollTop()).toBe(0);
+
+    await select.press("z");
+
+    const zulu = q.option("Zulu");
+    await test.expect(zulu).toHaveAttribute("data-active-item");
+    await test.expect.poll(scrollTop).toBeGreaterThan(0);
+    await test.expect(zulu).toBeInViewport();
+    await test.expect(select).toBeFocused();
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7093
+  // Focusing the collapsed select leaves a presentation waiting for the list to
+  // open. Picking another option before that happens has to retire it, or
+  // opening the list would present the option that was active on focus.
+  test("picking an option before opening retires the pending presentation", async ({
+    q,
+  }) => {
+    const select = q.combobox("Code");
+    await select.focus();
+    await q.option("Alpha 25").click();
+    await test.expect(select).toHaveText("Alpha 25");
+
+    await select.click();
+
+    await test.expect(select).toHaveAttribute("aria-expanded", "true");
+    await test.expect(q.option("Alpha 25")).toHaveAttribute("data-active-item");
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7093
+  test("a collapsed combobox input never focuses its list", async ({
+    page,
+    q,
+  }) => {
+    const combobox = q.combobox("Filter");
+
+    await combobox.focus();
+
+    await test.expect(combobox).toHaveAttribute("aria-expanded", "false");
+    // The composite can present its active item from a queued microtask or
+    // from a passive effect that runs after paint, so cross those frames
+    // before asserting that focus never reached the list.
+    await flushFrames(page);
+    await test.expect(combobox).toBeFocused();
+    await test.expect(q.status("Filter focused options")).toHaveText("none");
+  });
 });

--- a/app/src/sandbox/combobox-select-collapsed-focus/test-browser.ts
+++ b/app/src/sandbox/combobox-select-collapsed-focus/test-browser.ts
@@ -1,0 +1,50 @@
+import { flushFrames, withFramework } from "#app/test-utils/preview.ts";
+
+const labels = ["Fruit", "Fruit without virtual focus"];
+
+withFramework(import.meta.dirname, async ({ test, query }) => {
+  for (const label of labels) {
+    // https://github.com/ariakit/ariakit/issues/7093
+    test(`${label}: a collapsed select never focuses its list`, async ({
+      page,
+      q,
+    }) => {
+      const select = q.combobox(label);
+      const list = q.listbox(`${label} options`);
+      const focusedOptions = q.status(`${label} focused options`);
+
+      await select.focus();
+
+      await test.expect(select).toHaveAttribute("aria-expanded", "false");
+      // The composite can present its active item from a queued microtask or
+      // from a passive effect that runs after paint, so cross those frames
+      // before asserting that focus never reached the list.
+      await flushFrames(page);
+      await test.expect(select).toBeFocused();
+      await test.expect(focusedOptions).toHaveText("none");
+
+      await select.press("g");
+
+      await test.expect(select).toHaveText("Grape");
+      await test
+        .expect(query(list).option("Grape"))
+        .toHaveAttribute("data-active-item");
+      // The move is committed by the assertions above, but the presentation
+      // effect it schedules still runs after paint.
+      await flushFrames(page);
+      await test.expect(select).toBeFocused();
+      await test.expect(select).toHaveAttribute("aria-expanded", "false");
+      await test.expect(focusedOptions).toHaveText("none");
+
+      // Opening the list is what turns its items into focus targets, so this
+      // also shows that the recorder fires when an item really is focused.
+      await select.press("ArrowDown");
+
+      await test.expect(select).toHaveAttribute("aria-expanded", "true");
+      await test
+        .expect(query(list).option("Grape"))
+        .toHaveAttribute("data-active-item");
+      await test.expect(focusedOptions).toContainText("Grape");
+    });
+  }
+});

--- a/app/src/sandbox/combobox-select-collapsed-focus/test.ts
+++ b/app/src/sandbox/combobox-select-collapsed-focus/test.ts
@@ -1,0 +1,40 @@
+import { focus, press, q, sleep } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+const labels = ["Fruit", "Fruit without virtual focus"];
+
+for (const label of labels) {
+  // https://github.com/ariakit/ariakit/issues/7093
+  test(`${label}: a collapsed select never focuses its list`, async () => {
+    const select = q.combobox.ensure(label);
+    const list = q.listbox(`${label} options`);
+    const focusedOptions = q.status(`${label} focused options`);
+
+    await focus(select);
+
+    expect(select).toHaveAttribute("aria-expanded", "false");
+    // The composite can present its active item from a queued microtask or
+    // from a passive effect, and `focus` only flushes microtasks. Cross a
+    // macrotask so a presentation has a chance to run before asserting that
+    // nothing focused an item.
+    await sleep();
+    expect(select).toHaveFocus();
+    expect(focusedOptions).toHaveTextContent(/^none$/);
+
+    await press("g", select);
+
+    expect(select).toHaveTextContent("Grape");
+    expect(q.within(list).option("Grape")).toHaveAttribute("data-active-item");
+    expect(select).toHaveFocus();
+    expect(select).toHaveAttribute("aria-expanded", "false");
+    expect(focusedOptions).toHaveTextContent(/^none$/);
+
+    // Opening the list is what turns its items into focus targets, so this
+    // also shows that the recorder fires when an item really is focused.
+    await press("ArrowDown", select);
+
+    expect(select).toHaveAttribute("aria-expanded", "true");
+    expect(q.within(list).option("Grape")).toHaveAttribute("data-active-item");
+    expect(focusedOptions).toHaveTextContent("Grape");
+  });
+}

--- a/app/src/sandbox/combobox-select-collapsed-focus/test.ts
+++ b/app/src/sandbox/combobox-select-collapsed-focus/test.ts
@@ -1,4 +1,4 @@
-import { focus, press, q, sleep } from "@ariakit/test";
+import { click, focus, press, q, sleep } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 const labels = ["Fruit", "Fruit without virtual focus"];
@@ -35,6 +35,50 @@ for (const label of labels) {
 
     expect(select).toHaveAttribute("aria-expanded", "true");
     expect(q.within(list).option("Grape")).toHaveAttribute("data-active-item");
-    expect(focusedOptions).toHaveTextContent("Grape");
+    expect(focusedOptions).toHaveTextContent(/^Grape$/);
   });
 }
+
+// https://github.com/ariakit/ariakit/issues/7093
+// Only virtual focus asks for the active item when the select itself is
+// focused, which happens while the list is still closed. That request is the
+// one that has to survive until the list opens, so a pointer open with no move
+// before it still presents the item.
+test("opening the collapsed select with a pointer presents its item", async () => {
+  const select = q.combobox.ensure("Fruit");
+
+  await click(select);
+
+  expect(select).toHaveAttribute("aria-expanded", "true");
+  expect(q.status("Fruit focused options")).toHaveTextContent(/^Apple$/);
+});
+
+// https://github.com/ariakit/ariakit/issues/7093
+// Focusing the collapsed select leaves a presentation waiting for the list to
+// open. Picking another option before that happens has to retire it, or
+// opening the list would present the option that was active on focus.
+test("picking an option before opening retires the pending presentation", async () => {
+  const select = q.combobox.ensure("Code");
+  await focus(select);
+  await click(q.option("Alpha 25"));
+  expect(select).toHaveTextContent("Alpha 25");
+
+  await click(select);
+
+  expect(select).toHaveAttribute("aria-expanded", "true");
+  expect(q.option("Alpha 25")).toHaveAttribute("data-active-item");
+});
+
+// https://github.com/ariakit/ariakit/issues/7093
+test("a collapsed combobox input never focuses its list", async () => {
+  const combobox = q.combobox.ensure("Filter");
+
+  await focus(combobox);
+  // The presentation is queued in a microtask, so cross a macrotask before
+  // asserting that nothing focused an item.
+  await sleep();
+
+  expect(combobox).toHaveFocus();
+  expect(combobox).toHaveAttribute("aria-expanded", "false");
+  expect(q.status("Filter focused options")).toHaveTextContent(/^none$/);
+});

--- a/app/src/sandbox/combobox-select-collapsed-focus/test.ts
+++ b/app/src/sandbox/combobox-select-collapsed-focus/test.ts
@@ -69,6 +69,42 @@ test("picking an option before opening retires the pending presentation", async 
   expect(q.option("Alpha 25")).toHaveAttribute("data-active-item");
 });
 
+// https://github.com/ariakit/ariakit/pull/7098#discussion_r3742291859
+// Withholding belongs to the widget that owns focus. A move made from outside
+// keeps presenting immediately, so the focus it moves is attributable to that
+// call instead of landing on whoever is focused when the list next opens.
+test("a move from outside the widget still presents immediately", async () => {
+  const openList = q.button("Open stage list");
+
+  await click(q.button("Apply stage preset"));
+
+  expect(q.option("Final")).toHaveFocus();
+  expect(q.combobox("Stage")).toHaveAttribute("aria-expanded", "false");
+
+  await click(openList);
+
+  expect(q.combobox("Stage")).toHaveAttribute("aria-expanded", "true");
+  expect(openList).toHaveFocus();
+});
+
+// https://github.com/ariakit/ariakit/pull/7098#discussion_r3742291859
+// Once focus is on an option, moving between options is navigation inside the
+// list, not focus leaving the control, so the focus ring has to keep up with
+// the active item even though the list is collapsed.
+test("arrow keys keep moving focus between options in a collapsed list", async () => {
+  const list = q.listbox("Stage options");
+  const draft = q.within(list).option("Draft");
+  await click(draft);
+  expect(draft).toHaveFocus();
+  expect(q.combobox("Stage")).toHaveAttribute("aria-expanded", "false");
+
+  await press.ArrowDown();
+
+  const review = q.within(list).option("Review");
+  expect(review).toHaveAttribute("data-active-item");
+  expect(review).toHaveFocus();
+});
+
 // https://github.com/ariakit/ariakit/issues/7093
 test("a collapsed combobox input never focuses its list", async () => {
   const combobox = q.combobox.ensure("Filter");

--- a/packages/ariakit-react-components/src/composite/utils.ts
+++ b/packages/ariakit-react-components/src/composite/utils.ts
@@ -125,9 +125,13 @@ function presentItem({
   let done = false;
   let wasMounted = false;
   let wasOpen = false;
-  const owner = requireFocus
-    ? getActiveElement(store.getState().compositeElement)
-    : null;
+  const compositeAtStart = store.getState().compositeElement;
+  const activeAtStart = getActiveElement(compositeAtStart);
+  const owner = requireFocus ? activeAtStart : null;
+  // Only focus that would leave the control itself is this widget's to
+  // withhold, and that is decided once rather than per pass.
+  // https://github.com/ariakit/ariakit/pull/7098#discussion_r3742291859
+  const startedOnComposite = !!compositeAtStart?.contains(activeAtStart);
   const stillOwnsFocus = (target: HTMLElement) => {
     if (!owner) return true;
     const activeElement = getActiveElement(owner);
@@ -239,7 +243,8 @@ function presentItem({
     }
     // Only the focus half is withheld: a list that is already on screen still
     // scrolls to the item the user just made active.
-    const focusWithheld = focus && entersClosedPopup(state, element);
+    const focusWithheld =
+      focus && startedOnComposite && entersClosedPopup(state, element);
     // A request parked on positioning keeps presenting the item it resolved,
     // because the popup is open and the wait is short. This one waits for the
     // popup to open at all, so the user has time to pick another item, and the

--- a/packages/ariakit-react-components/src/composite/utils.ts
+++ b/packages/ariakit-react-components/src/composite/utils.ts
@@ -166,6 +166,31 @@ function presentItem({
     return id != null && state.activeId != null && state.activeId !== id;
   };
 
+  // Whether focusing the item would take DOM focus out of a composite element
+  // that isn't in the popup and put it inside a popup that hasn't opened. A
+  // collapsed widget keeps focus on itself, the way a native select does while
+  // typeahead changes its value. Containment is what separates this from an
+  // `alwaysVisible` popup that is its own composite, such as a Menu, where DOM
+  // focus is the accessibility cursor and has to follow the active item.
+  // https://github.com/ariakit/ariakit/issues/7093
+  const entersClosedPopup = (
+    state: ReturnType<typeof store.getState>,
+    target: HTMLElement,
+  ) => {
+    if (!("open" in state)) return false;
+    if (state.open) return false;
+    const popup = getPopupElement(store);
+    if (!popup?.contains(target)) return false;
+    const { compositeElement } = state;
+    if (!compositeElement) return false;
+    if (popup.contains(compositeElement)) return false;
+    // Focus only reaches a closed popup that is still on screen. Focusing a
+    // hidden one is already a no-op, the same reason the scroll below skips it,
+    // so withholding there would only keep a request alive for no gain. This
+    // reads style, so it goes last.
+    return isVisible(target);
+  };
+
   // Follow the active item only until one resolves, then pin its logical id so
   // a replacement node can be found without presenting a different item.
   const resolveElement = (state: ReturnType<typeof store.getState>) => {
@@ -212,7 +237,18 @@ function presentItem({
     } else if (!stillOwnsFocus(element)) {
       return cancel();
     }
-    if (focus && !focused) {
+    // Only the focus half is withheld: a list that is already on screen still
+    // scrolls to the item the user just made active.
+    const focusWithheld = focus && entersClosedPopup(state, element);
+    // A request parked on positioning keeps presenting the item it resolved,
+    // because the popup is open and the wait is short. This one waits for the
+    // popup to open at all, so the user has time to pick another item, and the
+    // focus it still owes would land on the wrong one.
+    if (focusWithheld) {
+      const { activeId } = state;
+      if (activeId != null && activeId !== resolvedId) return cancel();
+    }
+    if (focus && !focused && !focusWithheld) {
       focused = true;
       focusLeftElement = false;
       const itemElement = element;
@@ -238,13 +274,24 @@ function presentItem({
     }
     // Focus may move immediately, but scrolling is reserved for an explicit
     // presentation target; hover and stale active ids must not move the page.
-    if (markedOnly && !element.hasAttribute("data-autofocus")) return cancel();
+    if (markedOnly && !element.hasAttribute("data-autofocus")) {
+      // A withheld request still owes focus, so keep it pending. Only a
+      // request with nothing left to give is finished here.
+      if (focusWithheld) return;
+      return cancel();
+    }
     // The item can't be shown yet: a popup that is still hidden while closed,
     // or one that hasn't been positioned yet, would be scrolled to no visible
     // effect or to the wrong place.
     if (!isVisible(element)) return;
     if ("unstable_placing" in state && state.unstable_placing) return;
-    cancel();
+    // Withheld focus keeps the request alive, so opening the popup still gives
+    // the item the focus this pass skipped. Scrolling again while it waits only
+    // repeats a nearest-edge scroll, since a closed popup never takes the
+    // centering branch, so it settles unless something else moved the list.
+    if (!focusWithheld) {
+      cancel();
+    }
     if (scrollIntoView) {
       scrollIntoView(element);
       return;


### PR DESCRIPTION
## Motivation

[`ComboboxSelect`](https://ariakit.com/reference/combobox-select) becomes the composite widget when its popup has no [`ComboboxInput`](https://ariakit.com/reference/combobox), and it never narrows `focusOnMove`. `useComposite` defaults `focusOnMove` to `composite`, so the collapsed select keeps asking for its active item to be focused.

That is invisible while the popup is `display: none`, because `element.focus()` on a hidden element is a no-op. It stops being invisible as soon as the options stay on screen while the select is collapsed, which is what [`alwaysVisible`](https://ariakit.com/reference/combobox-list#alwaysvisible) does.

```jsx
<Ariakit.ComboboxProvider defaultSelectedValue="Apple" virtualFocus={false}>
  <Ariakit.ComboboxSelect aria-label="Fruit" />
  <Ariakit.ComboboxList alwaysVisible aria-label="Fruit options">
    {["Apple", "Banana", "Grape", "Orange"].map((value) => (
      <Ariakit.ComboboxItem key={value} value={value} />
    ))}
  </Ariakit.ComboboxList>
</Ariakit.ComboboxProvider>
```

Focusing the collapsed select and pressing `g` selects `Grape` as expected, but `document.activeElement` becomes the `Grape` option while the select still reports `aria-expanded="false"`.

Typeahead is not the only trigger. With the default `virtualFocus`, `Composite`'s own focus handler queues a presentation whenever the container is focused, so simply tabbing into the collapsed select focuses the selected option and hands focus straight back, firing `focusin` and `focusout` on an option of a listbox that never opened. Handlers on the items see both. The same happens to a plain [`Combobox`](https://ariakit.com/reference/combobox) input that has an active item and a standalone `alwaysVisible` list.

## Solution

`presentItem` now withholds DOM focus when giving it would take focus off the control the user is on and put it inside a popup that has not opened. Two conditions have to hold: focus started on the composite element, and the item is inside a popup that the composite element is not in.

The second condition is containment rather than open state. An `alwaysVisible` popup that is its own composite, such as a [`Menu`](https://ariakit.com/reference/menu), navigates with DOM focus while its store is closed, and [#6986](https://github.com/ariakit/ariakit/issues/6986) settled that its items have to keep receiving focus. A `ComboboxSelect` is the opposite shape: the control sits outside the popup, so focus moving into the popup takes it away from the widget the user is on.

The first condition is latched once, when the request is created, and it is what keeps a closed popup receiving focus in the two cases where that is still right. A move made from outside the widget presents immediately, the way `focusOnMove` documents, instead of leaving a request whose focus lands on whoever is focused when the popup next opens. And once focus is already on an option, arrow keys keep moving it between options of a collapsed list, because that is navigation inside the popup rather than focus leaving the control. So the composite being its own popup is not the only reason a closed popup keeps receiving focus; being where the user already is counts too.

Only the focus half is withheld. The list still scrolls to the active option, and the request stays pending rather than being cancelled, so opening the popup still presents the option that was made active while it was closed. That pending lifetime is load-bearing: opening with `ArrowDown` moves the active item while the popup is still closed and only calls `show` on `keyup`.

A withheld request is retired once the active item moves away from the one it resolved. Unlike a request parked on positioning, which the popup is about to finish opening for, this one can wait indefinitely, so the user has time to pick another option and the focus it still owes would otherwise land on the wrong one.

## Testing

- `pnpm test` (1721 tests), `pnpm tsc`, `pnpm lint-fix`
- `pnpm -F app test` for chrome (753), firefox (612) and safari (501)
- Every new assertion was red-checked against the behavior it protects, including the ownership latch in both directions, the withheld-request guard, and the preserved scroll
- `pnpm test-react18` could not be run locally: it fails in its temp-workspace `prepare` step with a husky `MODULE_NOT_FOUND` before any test loads, and reproduces on a clean checkout, so it is environmental. The `Main / Test React 18` CI job covers it.

## Preview

Focusing the collapsed select and pressing `g` in `app/src/sandbox/combobox-select-collapsed-focus/`, with `virtualFocus={false}` so the lost focus is visible. Before, focus lands on the `Grape` option of a listbox that is still collapsed; after, it stays on the select.

Before:

<img width="182" height="160" alt="Collapsed select showing Grape, with the focus ring on the Grape option in the list below and the readout Focused options: Grape" src="https://github.com/user-attachments/assets/c1466083-0eaa-4181-8b87-27cd0f6a0ac9" />

After:

<img width="173" height="160" alt="Collapsed select showing Grape with the focus ring on the select itself and the readout Focused options: none" src="https://github.com/user-attachments/assets/f0be9689-6f10-4597-b780-c9e646761e46" />

## Workaround

Until this is released, a collapsed select can be kept out of its own list with two userland levers, applied to the sandbox in [`b4f64fc`](https://github.com/ariakit/ariakit/commit/b4f64fc53) and reverted by the fix commit.

```jsx
function FruitSelect() {
  const store = Ariakit.useComboboxStore({ defaultSelectedValue: "Apple" });
  const open = Ariakit.useStoreState(store, "open");
  // `ComboboxSelect` forwards composite options to `useComposite`, but it
  // doesn't list them in its own props type, so they are spread in.
  const focusOnMoveProps = {
    focusOnMove: open,
  } satisfies Ariakit.CompositeOptions;

  return (
    <Ariakit.ComboboxProvider store={store}>
      <Ariakit.ComboboxSelect
        aria-label="Fruit"
        // TODO: remove both workarounds once
        // https://github.com/ariakit/ariakit/issues/7093 is fixed.
        {...focusOnMoveProps}
        onFocus={(event) => {
          const state = store.getState();
          if (state.open) return;
          if (!state.virtualFocus) return;
          event.preventDefault();
        }}
      />
      <Ariakit.ComboboxList alwaysVisible aria-label="Fruit options">
        {/* ... */}
      </Ariakit.ComboboxList>
    </Ariakit.ComboboxProvider>
  );
}
```

`focusOnMove` covers the move trigger and the `onFocus` handler covers the virtual-focus trigger. This is narrower than the fix, so it comes with limitations:

- `focusOnMove` is not declared on `ComboboxSelectOptions`, even though `useComboboxSelect` forwards it to `useComposite`. Passing it directly as a JSX attribute is a TypeScript excess-property error, hence the `satisfies`-guarded spread.
- The `onFocus` guard is deliberately limited to virtual focus, so the roving-tabindex branch keeps clearing `activeId` when the select itself is focused.
- Preventing the default focus handling also drops the legitimate presentation that would have run when the popup opens from a pointer click with no prior move. With a bare `ComboboxList`, clicking to open then leaves the list scrolled where it was instead of at the selected item. A `ComboboxPopover` is unaffected. The fix does not share this limitation, because it keeps the request pending instead of dropping it.
- `preventDefault` on a focus event propagates, so an ancestor Ariakit component that bails on `defaultPrevented` in its own `onFocus`, such as `Hovercard` or `CompositeContainer`, is skipped too. There is no userland way to scope it.

## Review gate reassessment

<details>
<summary>Cycle 3: Narrow the contract to popup containment</summary>

**Assessment**

The bug is a real but narrow a11y defect: DOM focus lands on an option of a listbox reporting `aria-expanded="false"`. It is only observable when the options are rendered and visible while the control is collapsed, so `alwaysVisible` or an exit transition. A documented userland workaround exists.

The direction under review was "DOM focus must not reach an item whose popup has not opened". Review found that `app/src/sandbox/menu-always-visible/` (added for [#6986](https://github.com/ariakit/ariakit/issues/6986)) asserts the opposite for a composite whose element is the popup: "DOM focus is the accessibility cursor for a roving tabindex composite like this one, so it has to follow the active item." That contract would have gone red.

Review also found a second trigger of the same defect that `focusOnMove: open` does not reach, because `Composite`'s own focus handler queues a presentation under virtual focus.

**Decision**

Narrow the contract to popup containment: a composite element that sits outside its own popup must not hand DOM focus to items inside that popup while the popup is closed. That covers both triggers, keeps `#6986` green, and removes the need for the `focusOnMove` replay guard that the issue anticipated. Legacy `Select` stays uncovered because its composite element is inside its popup; that is a separate defect, and it was declined as a non-goal.

</details>

<details>
<summary>Cycle 4: Remove the scroll-once latch</summary>

**Assessment**

Withholding focus while keeping the request pending meant the scroll could run again on later store notifications, and a `scrolled` latch was added for it. The next round found that latch could never reset, because its reset site is guarded by a flag the withheld path never sets. Two consecutive rounds of findings clustered on machinery that existed only to defend one edge case.

That edge case is negligible. While the popup is closed, `openingMovesByStore` holds no entry, so the scroll always takes the nearest-edge branch, and bringing an already-visible item into view does nothing. Observing a difference requires manually scrolling a closed, always-visible list between two item registrations.

**Decision**

Remove the latch and decline the edge case. Keep the gate and the pending lifetime: the pending lifetime is load-bearing, because opening with `ArrowDown` moves the active item while the popup is still closed and only calls `show` on `keyup`, and the scroll itself is existing behavior that a plain early return would have regressed.

</details>

<details>
<summary>Cycle 3 (second count): Narrow the gate to visible popups</summary>

**Assessment**

Reassessment found that a bare `ComboboxList` keeps `contentElement` assigned and only adds `hidden` and `display: none` when closed, so the gate also applied to ordinary hidden popups where the defect is provably invisible. There, a focus that used to be a harmless no-op followed by a cancel became a request that survived and delivered a real focus at the next open, in a composition no fixture covers.

The rest of the direction is converging: this round's other findings were all comments and changelog copy, and the library diff was unchanged by them.

**Decision**

Narrow the predicate with a visibility check, positioned last because it reads style. This makes the focus half share the precondition the scroll half already applies, restores the previous behavior for every hidden closed popup, and confines the change to the shape the issue describes.

Intentionally unsupported: a withheld request survives an explicit `activeId` clear and still presents its pinned item when the popup opens. Tightening the retirement guard to cover that would cancel the request when a `virtualFocus={false}` select is clicked, because focusing it clears the active item, and nothing else would present it on open.

</details>

Fixes #7093

