### PR TITLE
Withhold ComboboxItem hover activation while the combobox is collapsed

### DIFF
--- a/.changeset/300-combobox-item-focus-on-hover-closed.md
+++ b/.changeset/300-combobox-item-focus-on-hover-closed.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`ComboboxItem`](https://ariakit.com/reference/combobox-item) so an explicit [`focusOnHover`](https://ariakit.com/reference/combobox-item#focusonhover) boolean or callback value neither activates an item on hover nor clears the active item on hover end while the combobox is closed.

--- a/app/src/sandbox/combobox-select-collapsed-focus/index.react.tsx
+++ b/app/src/sandbox/combobox-select-collapsed-focus/index.react.tsx
@@ -151,23 +151,33 @@ interface HoverSelectProps {
 // which the default predicate alone never reaches.
 // https://github.com/ariakit/ariakit/issues/7118
 function HoverSelect({ label, focusOnHover }: HoverSelectProps) {
+  // TODO: Remove this store hoist and the open-state gate in focusOnHover
+  // below once https://github.com/ariakit/ariakit/issues/7118 is fixed.
+  const combobox = Ariakit.useComboboxStore({
+    defaultSelectedValue: "Apple",
+    virtualFocus: false,
+  });
+
   return (
     <div>
       {/* Safari needs an explicit tabindex to focus the clicked button. */}
       <button type="button" tabIndex={0}>
         {label} other control
       </button>
-      <Ariakit.ComboboxProvider
-        defaultSelectedValue="Apple"
-        virtualFocus={false}
-      >
+      <Ariakit.ComboboxProvider store={combobox}>
         <Ariakit.ComboboxSelect aria-label={label} />
         <Ariakit.ComboboxList alwaysVisible aria-label={`${label} options`}>
           {fruits.map((value) => (
             <Ariakit.ComboboxItem
               key={value}
               value={value}
-              focusOnHover={focusOnHover}
+              focusOnHover={(event) => {
+                if (!combobox.getState().open) return false;
+                if (typeof focusOnHover === "function") {
+                  return focusOnHover(event);
+                }
+                return focusOnHover ?? false;
+              }}
             />
           ))}
         </Ariakit.ComboboxList>

--- a/app/src/sandbox/combobox-select-collapsed-focus/index.react.tsx
+++ b/app/src/sandbox/combobox-select-collapsed-focus/index.react.tsx
@@ -141,6 +141,41 @@ function FilterCombobox() {
   );
 }
 
+interface HoverSelectProps {
+  label: string;
+  focusOnHover: Ariakit.ComboboxItemProps["focusOnHover"];
+}
+
+// The pointer side of the same contract. An explicit boolean and a callback
+// are authored here so the collapsed gate is exercised on the authored path,
+// which the default predicate alone never reaches.
+// https://github.com/ariakit/ariakit/issues/7118
+function HoverSelect({ label, focusOnHover }: HoverSelectProps) {
+  return (
+    <div>
+      {/* Safari needs an explicit tabindex to focus the clicked button. */}
+      <button type="button" tabIndex={0}>
+        {label} other control
+      </button>
+      <Ariakit.ComboboxProvider
+        defaultSelectedValue="Apple"
+        virtualFocus={false}
+      >
+        <Ariakit.ComboboxSelect aria-label={label} />
+        <Ariakit.ComboboxList alwaysVisible aria-label={`${label} options`}>
+          {fruits.map((value) => (
+            <Ariakit.ComboboxItem
+              key={value}
+              value={value}
+              focusOnHover={focusOnHover}
+            />
+          ))}
+        </Ariakit.ComboboxList>
+      </Ariakit.ComboboxProvider>
+    </div>
+  );
+}
+
 export default function Example() {
   return (
     <>
@@ -149,6 +184,8 @@ export default function Example() {
       <CodeSelect />
       <StageSelect />
       <FilterCombobox />
+      <HoverSelect label="Hover fruit" focusOnHover />
+      <HoverSelect label="Callback hover fruit" focusOnHover={() => true} />
     </>
   );
 }

--- a/app/src/sandbox/combobox-select-collapsed-focus/index.react.tsx
+++ b/app/src/sandbox/combobox-select-collapsed-focus/index.react.tsx
@@ -216,6 +216,46 @@ function MoveHoverSelect() {
   );
 }
 
+// An authored callback that closes the list from inside the predicate and
+// still returns true. The gate must re-read the live open state after the
+// callback, or the stale pre-check result would activate the item and steal
+// focus right as the list collapses.
+// https://github.com/ariakit/ariakit/issues/7118
+function HideHoverSelect() {
+  const combobox = Ariakit.useComboboxStore({
+    defaultSelectedValue: "Apple",
+    virtualFocus: false,
+  });
+
+  return (
+    <div>
+      {/* Safari needs an explicit tabindex to focus the clicked button. */}
+      <button type="button" tabIndex={0} onClick={() => combobox.show()}>
+        Open hide hover fruit list
+      </button>
+      <Ariakit.ComboboxProvider store={combobox}>
+        <Ariakit.ComboboxSelect aria-label="Hide hover fruit" />
+        <Ariakit.ComboboxList
+          alwaysVisible
+          aria-label="Hide hover fruit options"
+        >
+          {fruits.map((value) => (
+            <Ariakit.ComboboxItem
+              key={value}
+              value={value}
+              focusOnHover={(event) => {
+                if (event.type === "mouseleave") return false;
+                combobox.hide();
+                return true;
+              }}
+            />
+          ))}
+        </Ariakit.ComboboxList>
+      </Ariakit.ComboboxProvider>
+    </div>
+  );
+}
+
 export default function Example() {
   return (
     <>
@@ -227,6 +267,7 @@ export default function Example() {
       <HoverSelect label="Hover fruit" focusOnHover />
       <HoverSelect label="Callback hover fruit" focusOnHover={() => true} />
       <MoveHoverSelect />
+      <HideHoverSelect />
     </>
   );
 }

--- a/app/src/sandbox/combobox-select-collapsed-focus/index.react.tsx
+++ b/app/src/sandbox/combobox-select-collapsed-focus/index.react.tsx
@@ -151,8 +151,37 @@ interface HoverSelectProps {
 // which the default predicate alone never reaches.
 // https://github.com/ariakit/ariakit/issues/7118
 function HoverSelect({ label, focusOnHover }: HoverSelectProps) {
-  // TODO: Remove this store hoist and the open-state gate in focusOnHover
-  // below once https://github.com/ariakit/ariakit/issues/7118 is fixed.
+  return (
+    <div>
+      {/* Safari needs an explicit tabindex to focus the clicked button. */}
+      <button type="button" tabIndex={0}>
+        {label} other control
+      </button>
+      <Ariakit.ComboboxProvider
+        defaultSelectedValue="Apple"
+        virtualFocus={false}
+      >
+        <Ariakit.ComboboxSelect aria-label={label} />
+        <Ariakit.ComboboxList alwaysVisible aria-label={`${label} options`}>
+          {fruits.map((value) => (
+            <Ariakit.ComboboxItem
+              key={value}
+              value={value}
+              focusOnHover={focusOnHover}
+            />
+          ))}
+        </Ariakit.ComboboxList>
+      </Ariakit.ComboboxProvider>
+    </div>
+  );
+}
+
+// An authored callback with a side effect: the consumer moves the composite
+// from inside the predicate, like the select-grid example does. The closed
+// gate must keep the callback from running at all, or the move would still
+// activate the item and steal focus.
+// https://github.com/ariakit/ariakit/issues/7118
+function MoveHoverSelect() {
   const combobox = Ariakit.useComboboxStore({
     defaultSelectedValue: "Apple",
     virtualFocus: false,
@@ -162,21 +191,22 @@ function HoverSelect({ label, focusOnHover }: HoverSelectProps) {
     <div>
       {/* Safari needs an explicit tabindex to focus the clicked button. */}
       <button type="button" tabIndex={0}>
-        {label} other control
+        Move hover fruit other control
       </button>
       <Ariakit.ComboboxProvider store={combobox}>
-        <Ariakit.ComboboxSelect aria-label={label} />
-        <Ariakit.ComboboxList alwaysVisible aria-label={`${label} options`}>
+        <Ariakit.ComboboxSelect aria-label="Move hover fruit" />
+        <Ariakit.ComboboxList
+          alwaysVisible
+          aria-label="Move hover fruit options"
+        >
           {fruits.map((value) => (
             <Ariakit.ComboboxItem
               key={value}
               value={value}
               focusOnHover={(event) => {
-                if (!combobox.getState().open) return false;
-                if (typeof focusOnHover === "function") {
-                  return focusOnHover(event);
-                }
-                return focusOnHover ?? false;
+                if (event.type === "mouseleave") return false;
+                combobox.move(event.currentTarget.id);
+                return true;
               }}
             />
           ))}
@@ -196,6 +226,7 @@ export default function Example() {
       <FilterCombobox />
       <HoverSelect label="Hover fruit" focusOnHover />
       <HoverSelect label="Callback hover fruit" focusOnHover={() => true} />
+      <MoveHoverSelect />
     </>
   );
 }

--- a/app/src/sandbox/combobox-select-collapsed-focus/test-browser.ts
+++ b/app/src/sandbox/combobox-select-collapsed-focus/test-browser.ts
@@ -203,6 +203,92 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
   }
 
   // https://github.com/ariakit/ariakit/issues/7118
+  // The other hover direction: after the list closes by clicking an option,
+  // moving the pointer off that option must not clear the active item or move
+  // focus while the list is collapsed.
+  test("hover end on a collapsed list keeps the active item", async ({
+    page,
+    q,
+  }) => {
+    const select = q.combobox("Hover fruit");
+    const list = q.listbox("Hover fruit options");
+    const grape = query(list).option("Grape");
+    const other = q.button("Hover fruit other control");
+
+    await select.click();
+    await test.expect(select).toHaveAttribute("aria-expanded", "true");
+    await grape.hover();
+    await test.expect(grape).toHaveAttribute("data-active-item");
+
+    await grape.click();
+    await test.expect(select).toHaveAttribute("aria-expanded", "false");
+    await test.expect(grape).toHaveAttribute("data-active-item");
+    // Clicking an option in an always-visible list leaves DOM focus on it
+    // even as the list collapses, so the hover end below starts from the
+    // option.
+    await test.expect(grape).toBeFocused();
+
+    // The click's mouseup resets the mouse-movement tracker, and a hover
+    // teleport fires the boundary events before any mousemove, which would
+    // skip the hover-end handler entirely. Move within the option first the
+    // way a real pointer would, so the tracker is armed when it leaves.
+    await grape.hover({ position: { x: 4, y: 4 } });
+    await other.hover();
+
+    // Retaining the attribute and focus is an absence-of-change assertion,
+    // and the mouseleave clearing would land within a frame, so cross the
+    // frames before asserting that nothing changed.
+    await flushFrames(page);
+    await test.expect(grape).toHaveAttribute("data-active-item");
+    await test.expect(grape).toBeFocused();
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7118
+  // The closed gate must keep the authored callback from running at all: this
+  // one moves the composite from inside the predicate, so merely invoking it
+  // while collapsed would activate the item and steal focus.
+  test("a side-effectful callback does nothing on a collapsed list", async ({
+    page,
+    q,
+  }) => {
+    const select = q.combobox("Move hover fruit");
+    const list = q.listbox("Move hover fruit options");
+    const grape = query(list).option("Grape");
+    const other = q.button("Move hover fruit other control");
+
+    await other.click();
+    await test.expect(other).toBeFocused();
+
+    await grape.hover();
+
+    await test.expect(select).toHaveAttribute("aria-expanded", "false");
+    // Hover activation is committed inside the mousemove handler, so there
+    // is no positive state to wait for. Cross the frames a presentation
+    // would use to reach the item before asserting that none did.
+    await flushFrames(page);
+    await test.expect(grape).not.toHaveAttribute("data-active-item");
+    await test.expect(other).toBeFocused();
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7118
+  // The gate is about the closed list: the same side-effectful callback keeps
+  // working once the select opens.
+  test("a side-effectful callback activates the option once the list opens", async ({
+    q,
+  }) => {
+    const select = q.combobox("Move hover fruit");
+    const list = q.listbox("Move hover fruit options");
+    const grape = query(list).option("Grape");
+
+    await select.click();
+    await test.expect(select).toHaveAttribute("aria-expanded", "true");
+
+    await grape.hover();
+
+    await test.expect(grape).toHaveAttribute("data-active-item");
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7118
   // The default predicate is part of the same contract: with no authored
   // focusOnHover, hovering an option in a collapsed list changes nothing.
   test("default hover on a collapsed list changes nothing", async ({

--- a/app/src/sandbox/combobox-select-collapsed-focus/test-browser.ts
+++ b/app/src/sandbox/combobox-select-collapsed-focus/test-browser.ts
@@ -1,6 +1,7 @@
 import { flushFrames, withFramework } from "#app/test-utils/preview.ts";
 
 const labels = ["Fruit", "Fruit without virtual focus"];
+const hoverLabels = ["Hover fruit", "Callback hover fruit"];
 
 withFramework(import.meta.dirname, async ({ test, query }) => {
   for (const label of labels) {
@@ -155,6 +156,96 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     const review = query(list).option("Review");
     await test.expect(review).toHaveAttribute("data-active-item");
     await test.expect(review).toBeFocused();
+  });
+
+  for (const label of hoverLabels) {
+    // https://github.com/ariakit/ariakit/issues/7118
+    test(`${label}: hovering an option in a collapsed list changes nothing`, async ({
+      page,
+      q,
+    }) => {
+      const select = q.combobox(label);
+      const list = q.listbox(`${label} options`);
+      const grape = query(list).option("Grape");
+      const other = q.button(`${label} other control`);
+
+      await other.click();
+      await test.expect(other).toBeFocused();
+
+      await grape.hover();
+
+      await test.expect(select).toHaveAttribute("aria-expanded", "false");
+      // Hover activation is committed inside the mousemove handler, so there
+      // is no positive state to wait for. Cross the frames a presentation
+      // would use to reach the item before asserting that none did.
+      await flushFrames(page);
+      await test.expect(grape).not.toHaveAttribute("data-active-item");
+      await test.expect(other).toBeFocused();
+    });
+
+    // https://github.com/ariakit/ariakit/issues/7118
+    // The gate is about the closed list, not about the authored value, so the
+    // same item still takes hover once the select opens.
+    test(`${label}: hovering an option activates it once the list opens`, async ({
+      q,
+    }) => {
+      const select = q.combobox(label);
+      const list = q.listbox(`${label} options`);
+      const grape = query(list).option("Grape");
+
+      await select.click();
+      await test.expect(select).toHaveAttribute("aria-expanded", "true");
+
+      await grape.hover();
+
+      await test.expect(grape).toHaveAttribute("data-active-item");
+    });
+  }
+
+  // https://github.com/ariakit/ariakit/issues/7118
+  // The default predicate is part of the same contract: with no authored
+  // focusOnHover, hovering an option in a collapsed list changes nothing.
+  test("default hover on a collapsed list changes nothing", async ({
+    page,
+    q,
+  }) => {
+    const select = q.combobox("Fruit");
+    const list = q.listbox("Fruit options");
+    const grape = query(list).option("Grape");
+
+    await grape.hover();
+
+    await test.expect(select).toHaveAttribute("aria-expanded", "false");
+    // Hover activation is committed inside the mousemove handler, so there
+    // is no positive state to wait for. Cross the frames a presentation
+    // would use to reach the item before asserting that none did.
+    await flushFrames(page);
+    await test.expect(grape).not.toHaveAttribute("data-active-item");
+    await test.expect(q.status("Fruit focused options")).toHaveText("none");
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7118
+  // Without ComboboxSelect the default stays false even while the list is
+  // open, so hover only activates an item when the consumer opts in.
+  test("default hover in an open plain combobox activates nothing", async ({
+    page,
+    q,
+  }) => {
+    const combobox = q.combobox("Filter");
+    const list = q.listbox("Filter options");
+    const grape = query(list).option("Grape");
+
+    await combobox.click();
+    await test.expect(combobox).toHaveAttribute("aria-expanded", "true");
+
+    await grape.hover();
+
+    // Hover activation is committed inside the mousemove handler, so there
+    // is no positive state to wait for. Cross the frames a presentation
+    // would use to reach the item before asserting that none did.
+    await flushFrames(page);
+    await test.expect(grape).not.toHaveAttribute("data-active-item");
+    await test.expect(combobox).toBeFocused();
   });
 
   // https://github.com/ariakit/ariakit/issues/7093

--- a/app/src/sandbox/combobox-select-collapsed-focus/test-browser.ts
+++ b/app/src/sandbox/combobox-select-collapsed-focus/test-browser.ts
@@ -289,6 +289,33 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
   });
 
   // https://github.com/ariakit/ariakit/issues/7118
+  // The open state must be re-read after the authored callback runs: this one
+  // closes the list from inside the predicate and still returns true, so a
+  // stale pre-check result would activate the item and steal focus right as
+  // the list collapses.
+  test("a callback that closes the list on hover activates nothing", async ({
+    q,
+  }) => {
+    const select = q.combobox("Hide hover fruit");
+    const list = q.listbox("Hide hover fruit options");
+    const banana = query(list).option("Banana");
+    const other = q.button("Open hide hover fruit list");
+
+    await other.click();
+    await test.expect(other).toBeFocused();
+    await test.expect(select).toHaveAttribute("aria-expanded", "true");
+
+    await banana.hover();
+
+    await test.expect(select).toHaveAttribute("aria-expanded", "false");
+    // The buggy shape commits the activation and the focus steal in the same
+    // mousemove handler that hides the list, so the awaited collapse above is
+    // the settle point for the assertions below.
+    await test.expect(banana).not.toHaveAttribute("data-active-item");
+    await test.expect(other).toBeFocused();
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7118
   // The default predicate is part of the same contract: with no authored
   // focusOnHover, hovering an option in a collapsed list changes nothing.
   test("default hover on a collapsed list changes nothing", async ({

--- a/app/src/sandbox/combobox-select-collapsed-focus/test.ts
+++ b/app/src/sandbox/combobox-select-collapsed-focus/test.ts
@@ -144,6 +144,74 @@ for (const label of hoverLabels) {
 }
 
 // https://github.com/ariakit/ariakit/issues/7118
+// The other hover direction: after the list closes by clicking an option,
+// moving the pointer off that option must not clear the active item or move
+// focus while the list is collapsed.
+test("hover end on a collapsed list keeps the active item", async () => {
+  const select = q.combobox("Hover fruit");
+  const list = q.listbox("Hover fruit options");
+  const grape = q.within(list).option("Grape");
+  const other = q.button("Hover fruit other control");
+
+  await click(select);
+  expect(select).toHaveAttribute("aria-expanded", "true");
+  await hover(grape);
+  expect(grape).toHaveAttribute("data-active-item");
+
+  await click(grape);
+  expect(select).toHaveAttribute("aria-expanded", "false");
+  expect(grape).toHaveAttribute("data-active-item");
+  // Clicking an option in an always-visible list leaves DOM focus on it even
+  // as the list collapses, so the hover end below starts from the option.
+  expect(grape).toHaveFocus();
+
+  // `hover` settles the DOM before resolving, so the assertions below run
+  // after any clearing the mouseleave handler committed.
+  await hover(other);
+
+  expect(grape).toHaveAttribute("data-active-item");
+  expect(grape).toHaveFocus();
+});
+
+// https://github.com/ariakit/ariakit/issues/7118
+// The closed gate must keep the authored callback from running at all: this
+// one moves the composite from inside the predicate, so merely invoking it
+// while collapsed would activate the item and steal focus.
+test("a side-effectful callback does nothing on a collapsed list", async () => {
+  const select = q.combobox("Move hover fruit");
+  const list = q.listbox("Move hover fruit options");
+  const grape = q.within(list).option("Grape");
+  const other = q.button("Move hover fruit other control");
+
+  await click(other);
+  expect(other).toHaveFocus();
+
+  // `hover` settles the DOM before resolving, so the assertions below run
+  // after any activation the mousemove handler committed.
+  await hover(grape);
+
+  expect(select).toHaveAttribute("aria-expanded", "false");
+  expect(grape).not.toHaveAttribute("data-active-item");
+  expect(other).toHaveFocus();
+});
+
+// https://github.com/ariakit/ariakit/issues/7118
+// The gate is about the closed list: the same side-effectful callback keeps
+// working once the select opens.
+test("a side-effectful callback activates the option once the list opens", async () => {
+  const select = q.combobox("Move hover fruit");
+  const list = q.listbox("Move hover fruit options");
+  const grape = q.within(list).option("Grape");
+
+  await click(select);
+  expect(select).toHaveAttribute("aria-expanded", "true");
+
+  await hover(grape);
+
+  expect(grape).toHaveAttribute("data-active-item");
+});
+
+// https://github.com/ariakit/ariakit/issues/7118
 // The default predicate is part of the same contract: with no authored
 // focusOnHover, hovering an option in a collapsed list changes nothing.
 test("default hover on a collapsed list changes nothing", async () => {

--- a/app/src/sandbox/combobox-select-collapsed-focus/test.ts
+++ b/app/src/sandbox/combobox-select-collapsed-focus/test.ts
@@ -212,6 +212,30 @@ test("a side-effectful callback activates the option once the list opens", async
 });
 
 // https://github.com/ariakit/ariakit/issues/7118
+// The open state must be re-read after the authored callback runs: this one
+// closes the list from inside the predicate and still returns true, so a
+// stale pre-check result would activate the item and steal focus right as
+// the list collapses.
+test("a callback that closes the list on hover activates nothing", async () => {
+  const select = q.combobox("Hide hover fruit");
+  const list = q.listbox("Hide hover fruit options");
+  const banana = q.within(list).option("Banana");
+  const other = q.button("Open hide hover fruit list");
+
+  await click(other);
+  expect(other).toHaveFocus();
+  expect(select).toHaveAttribute("aria-expanded", "true");
+
+  // `hover` settles the DOM before resolving, so the assertions below run
+  // after any activation the mousemove handler committed.
+  await hover(banana);
+
+  expect(select).toHaveAttribute("aria-expanded", "false");
+  expect(banana).not.toHaveAttribute("data-active-item");
+  expect(other).toHaveFocus();
+});
+
+// https://github.com/ariakit/ariakit/issues/7118
 // The default predicate is part of the same contract: with no authored
 // focusOnHover, hovering an option in a collapsed list changes nothing.
 test("default hover on a collapsed list changes nothing", async () => {

--- a/app/src/sandbox/combobox-select-collapsed-focus/test.ts
+++ b/app/src/sandbox/combobox-select-collapsed-focus/test.ts
@@ -1,7 +1,8 @@
-import { click, focus, press, q, sleep } from "@ariakit/test";
+import { click, focus, hover, press, q, sleep } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 const labels = ["Fruit", "Fruit without virtual focus"];
+const hoverLabels = ["Hover fruit", "Callback hover fruit"];
 
 for (const label of labels) {
   // https://github.com/ariakit/ariakit/issues/7093
@@ -103,6 +104,79 @@ test("arrow keys keep moving focus between options in a collapsed list", async (
   const review = q.within(list).option("Review");
   expect(review).toHaveAttribute("data-active-item");
   expect(review).toHaveFocus();
+});
+
+for (const label of hoverLabels) {
+  // https://github.com/ariakit/ariakit/issues/7118
+  test(`${label}: hovering an option in a collapsed list changes nothing`, async () => {
+    const select = q.combobox(label);
+    const list = q.listbox(`${label} options`);
+    const grape = q.within(list).option("Grape");
+    const other = q.button(`${label} other control`);
+
+    await click(other);
+    expect(other).toHaveFocus();
+
+    // `hover` settles the DOM before resolving, so the assertions below run
+    // after any activation the mousemove handler committed.
+    await hover(grape);
+
+    expect(select).toHaveAttribute("aria-expanded", "false");
+    expect(grape).not.toHaveAttribute("data-active-item");
+    expect(other).toHaveFocus();
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7118
+  // The gate is about the closed list, not about the authored value, so the
+  // same item still takes hover once the select opens.
+  test(`${label}: hovering an option activates it once the list opens`, async () => {
+    const select = q.combobox(label);
+    const list = q.listbox(`${label} options`);
+    const grape = q.within(list).option("Grape");
+
+    await click(select);
+    expect(select).toHaveAttribute("aria-expanded", "true");
+
+    await hover(grape);
+
+    expect(grape).toHaveAttribute("data-active-item");
+  });
+}
+
+// https://github.com/ariakit/ariakit/issues/7118
+// The default predicate is part of the same contract: with no authored
+// focusOnHover, hovering an option in a collapsed list changes nothing.
+test("default hover on a collapsed list changes nothing", async () => {
+  const select = q.combobox("Fruit");
+  const list = q.listbox("Fruit options");
+  const grape = q.within(list).option("Grape");
+
+  // `hover` settles the DOM before resolving, so the assertions below run
+  // after any activation the mousemove handler committed.
+  await hover(grape);
+
+  expect(select).toHaveAttribute("aria-expanded", "false");
+  expect(grape).not.toHaveAttribute("data-active-item");
+  expect(q.status("Fruit focused options")).toHaveTextContent(/^none$/);
+});
+
+// https://github.com/ariakit/ariakit/issues/7118
+// Without ComboboxSelect the default stays false even while the list is open,
+// so hover only activates an item when the consumer opts in.
+test("default hover in an open plain combobox activates nothing", async () => {
+  const combobox = q.combobox("Filter");
+  const list = q.listbox("Filter options");
+  const grape = q.within(list).option("Grape");
+
+  await click(combobox);
+  expect(combobox).toHaveAttribute("aria-expanded", "true");
+
+  // `hover` settles the DOM before resolving, so the assertions below run
+  // after any activation the mousemove handler committed.
+  await hover(grape);
+
+  expect(grape).not.toHaveAttribute("data-active-item");
+  expect(combobox).toHaveFocus();
 });
 
 // https://github.com/ariakit/ariakit/issues/7093

--- a/app/src/sandbox/combobox-select-open-active-item/index.react.tsx
+++ b/app/src/sandbox/combobox-select-open-active-item/index.react.tsx
@@ -24,21 +24,6 @@ function Select({ label, values, defaultSelectedValue, unmount }: SelectProps) {
   );
 }
 
-function ClosedAlwaysVisibleSelect() {
-  return (
-    <Ariakit.ComboboxProvider
-      defaultSelectedValue="Explicit hover first"
-      virtualFocus={false}
-    >
-      <Ariakit.ComboboxSelect aria-label="Always-visible hover select" />
-      <Ariakit.ComboboxList alwaysVisible aria-label="Always-visible options">
-        <Ariakit.ComboboxItem focusOnHover value="Explicit hover first" />
-        <Ariakit.ComboboxItem focusOnHover value="Explicit hover second" />
-      </Ariakit.ComboboxList>
-    </Ariakit.ComboboxProvider>
-  );
-}
-
 interface FocusOwnerSelectProps {
   label: string;
   virtualFocus?: boolean;
@@ -88,7 +73,6 @@ export default function Example() {
         defaultSelectedValue={[]}
         unmount={false}
       />
-      <ClosedAlwaysVisibleSelect />
       <FocusOwnerSelect label="No-autofocus status" />
       <FocusOwnerSelect label="Real-focus status" virtualFocus={false} />
     </>

--- a/app/src/sandbox/combobox-select-open-active-item/test-browser.ts
+++ b/app/src/sandbox/combobox-select-open-active-item/test-browser.ts
@@ -125,12 +125,4 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
         .toHaveAttribute("data-active-item");
     });
   }
-
-  // https://github.com/ariakit/ariakit/pull/6832
-  test("honors focusOnHover on a closed always-visible list", async ({ q }) => {
-    const item = q.option("Explicit hover second");
-    await item.hover();
-
-    await test.expect(item).toHaveAttribute("data-active-item");
-  });
 });

--- a/app/src/sandbox/combobox-select-open-active-item/test.ts
+++ b/app/src/sandbox/combobox-select-open-active-item/test.ts
@@ -1,4 +1,4 @@
-import { click, focus, hover, press, q } from "@ariakit/test";
+import { click, focus, press, q } from "@ariakit/test";
 import { describe, expect, test } from "vitest";
 
 function activeText(label: string) {
@@ -95,11 +95,3 @@ for (const label of ["No-autofocus status", "Real-focus status"]) {
     );
   });
 }
-
-// https://github.com/ariakit/ariakit/pull/6832
-test("honors focusOnHover on a closed always-visible list", async () => {
-  const item = q.option.ensure("Explicit hover second");
-  await hover(item);
-
-  expect(item).toHaveAttribute("data-active-item");
-});

--- a/packages/ariakit-react-components/src/combobox/combobox-item.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item.tsx
@@ -283,16 +283,19 @@ export const useComboboxItem = createHook<TagName, ComboboxItemOptions>(
       },
     });
 
-    const focusOnHoverProp = useBooleanEvent(focusOnHover ?? false);
+    const focusOnHoverProp = useBooleanEvent(focusOnHover ?? selectMode);
 
     props = useCompositeHover({
       store,
       ...props,
+      // Disable focusOnHover when the popup is closed, even for authored
+      // values, so pointer hover can't activate an item or move focus while
+      // the combobox is collapsed. The open check comes first so authored
+      // callbacks with side effects don't run at all while closed.
+      // https://github.com/ariakit/ariakit/issues/7118
       focusOnHover(event) {
-        if (focusOnHover !== undefined) {
-          return focusOnHoverProp(event);
-        }
-        return selectMode && store.getState().open;
+        if (!store.getState().open) return false;
+        return focusOnHoverProp(event);
       },
     });
 
@@ -430,6 +433,9 @@ export interface ComboboxItemOptions<T extends ElementType = TagName>
   /**
    * Defaults to `false`, or `true` when the item is used with a
    * [`ComboboxSelect`](https://ariakit.com/reference/combobox-select).
+   *
+   * Regardless of the value, hovering an item never activates it or moves
+   * focus while the combobox is closed.
    */
   focusOnHover?: CompositeHoverOptions["focusOnHover"];
 }

--- a/packages/ariakit-react-components/src/combobox/combobox-item.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item.tsx
@@ -291,11 +291,13 @@ export const useComboboxItem = createHook<TagName, ComboboxItemOptions>(
       // Disable focusOnHover when the popup is closed, even for authored
       // values, so pointer hover can't activate an item or move focus while
       // the combobox is collapsed. The open check comes first so authored
-      // callbacks with side effects don't run at all while closed.
+      // callbacks with side effects don't run at all while closed, and it's
+      // re-read afterwards because the callback itself may close the list.
       // https://github.com/ariakit/ariakit/issues/7118
       focusOnHover(event) {
         if (!store.getState().open) return false;
-        return focusOnHoverProp(event);
+        if (!focusOnHoverProp(event)) return false;
+        return store.getState().open;
       },
     });
 

--- a/packages/ariakit-react-components/src/combobox/combobox-item.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item.tsx
@@ -436,8 +436,10 @@ export interface ComboboxItemOptions<T extends ElementType = TagName>
    * Defaults to `false`, or `true` when the item is used with a
    * [`ComboboxSelect`](https://ariakit.com/reference/combobox-select).
    *
-   * Regardless of the value, hovering an item never activates it or moves
-   * focus while the combobox is closed.
+   * Regardless of the value, hover has no effect while the combobox is
+   * closed: hovering an item never activates it or moves focus, and moving
+   * the pointer off an item never clears the active item or moves focus back
+   * to the combobox.
    */
   focusOnHover?: CompositeHoverOptions["focusOnHover"];
 }


### PR DESCRIPTION
## Motivation

An explicit [`focusOnHover`](https://ariakit.com/reference/combobox-item#focusonhover) value on `ComboboxItem`, either a boolean `true` or a callback that returns `true`, bypasses the combobox open-state check. In an `alwaysVisible` list, pointer hover can activate an item and move DOM focus to the combobox owner while the owner is collapsed with `aria-expanded="false"`:

```tsx
<button type="button">Other control</button>
<Ariakit.ComboboxProvider virtualFocus={false}>
  <Ariakit.ComboboxSelect aria-label="Fruit" />
  <Ariakit.ComboboxList alwaysVisible aria-label="Fruit options">
    <Ariakit.ComboboxItem focusOnHover value="Apple" />
    <Ariakit.ComboboxItem focusOnHover value="Banana" />
  </Ariakit.ComboboxList>
</Ariakit.ComboboxProvider>
```

With focus on `Other control`, merely moving the pointer over `Banana` steals focus from the button and activates the item, even though the `Fruit` combobox is collapsed. The override was introduced by 6f79732407cebf3ffda58d8c74be5fb14e03969e, which honors authored item options unconditionally instead of gating the final hover predicate on the live `open` state the way `SelectItem` does.

Fixes #7118

## Solution

`useComboboxItem` now gates the whole `focusOnHover` predicate on the live combobox `open` state, applying the same closed-state rule that `SelectItem` already enforces: the closed state applies to the default value, an explicit boolean, and a callback in the same way, and hover activates an item once the store opens.

```ts
focusOnHover(event) {
  if (!store.getState().open) return false;
  if (!focusOnHoverProp(event)) return false;
  return store.getState().open;
},
```

The `open` check runs before the authored predicate so callbacks with side effects, such as the `move()` pattern from the [select-grid example](https://ariakit.com/examples/select-grid), don't run at all while the list is collapsed, and it is re-read after the predicate runs so a callback that closes the list from inside the predicate can't activate an item with a stale result. The gate covers both hover directions: hovering an option no longer activates it, and moving the pointer off an option no longer clears the active item or pulls focus back into the widget while the list is closed. The `focusOnHover` reference docs now state both directions of the closed-state rule, and a changeset covers `@ariakit/react-components` and `@ariakit/react`.

The reproduction and its guard rails live in the `combobox-select-collapsed-focus` sandbox, which owns the collapsed-focus contract: failing tests for an authored boolean and an authored callback on a collapsed always-visible list (red in CI on the first commit), a red-checked test proving a side-effectful callback isn't invoked while collapsed, a hover-end test proving leaving an option in a collapsed list keeps the active item and focus, and green guards pinning that both authored forms still take hover once the list opens plus the default predicate on a collapsed select list and an open plain combobox. The sandbox workaround from the second commit is reverted in the final commit.

This change also removes the `ClosedAlwaysVisibleSelect` fixture and its "honors focusOnHover on a closed always-visible list" test from the `combobox-select-open-active-item` sandbox. That previously green test pinned the contract added by 6f79732407cebf3ffda58d8c74be5fb14e03969e (#6832), which this change reverses; its reproduction details and the honored-override intent now live in the `HoverSelect` fixture and the open-list guard tests.

The same predicate-before-open-check exposure exists in the soft-deprecated `SelectItem` and is registered as #7120; it is pre-existing on `main` and independent of this change.

## Preview

The recording below shows the fixed behavior in the `combobox-select-collapsed-focus` sandbox with the fix applied, with only the `Hover fruit` widget visible and helper styles injected for legibility: real DOM focus is outlined in crimson and the active item is painted gold. Hovering the options of the collapsed always-visible list changes nothing while focus sits on the outside button, hovering activates items once the select opens, and after closing the list by clicking Grape, moving the pointer away keeps Grape active and focused. The issue's own [recording](https://github.com/user-attachments/assets/177d1d1a-0c78-42bf-aa9e-8b0f3863230e) shows the pre-fix behavior, where the same hover steals focus from the button.

[Recording of the fixed hover behavior on a collapsed always-visible combobox list](https://github.com/user-attachments/assets/9e8b6c10-9dcf-4975-849a-f74a141c26e8)

## Workaround

Until the fix is released, gate the authored `focusOnHover` value on the live open state from userland. The second commit applies this in the sandbox and all repro tests pass with the library unchanged:

```tsx
// TODO: Remove this store hoist and the open-state gate in focusOnHover
// below once https://github.com/ariakit/ariakit/issues/7118 is fixed.
const combobox = Ariakit.useComboboxStore({ virtualFocus: false });

<Ariakit.ComboboxProvider store={combobox}>
  <Ariakit.ComboboxSelect aria-label="Fruit" />
  <Ariakit.ComboboxList alwaysVisible aria-label="Fruit options">
    <Ariakit.ComboboxItem
      value="Apple"
      focusOnHover={(event) => {
        if (!combobox.getState().open) return false;
        // Defer to whatever value you would otherwise author.
        return true;
      }}
    />
  </Ariakit.ComboboxList>
</Ariakit.ComboboxProvider>;
```

Assumptions and limitations:

- The snippet assumes `focusOnHover` is always authored on the item. If your code sometimes leaves the prop `undefined`, returning `false` from the wrapper in that case is narrower than the component default (`selectMode && open`), which keeps hover activation on while a select-shaped list is open. Only apply the gate where you author the value.
- The gate also suppresses the hover-end blur while the list is collapsed: a pointer leaving an item after the list has closed no longer clears the active item or returns focus to the combobox. This matches the reading that nothing hover-driven should change state while the list is collapsed, and the library fix follows the same rule `SelectItem` already applies to both paths.

## Review gate reassessment

<details>
<summary>Cycle 3: Continue the stage-1 reproduction direction</summary>

**Assessment**

The formal pre-commit gate produced findings in rounds 1 (6), 2 (3), and 3 (1) for one unchanged direction: extend the semantic `combobox-select-collapsed-focus` sandbox with the reproduction and remove the contract-reversing test from `combobox-select-open-active-item`. Every finding was hygiene-grade — redundant waits, query-helper style, comment wording, commit-message provenance, and an unrun verification command — and none questioned the fixture placement, the contract shape, or the deletion decision. The underlying bug is a confirmed, user-visible focus-stealing defect (`bug`, `a11y`) in a stable API, so the reproduction work is required by the issue-fix workflow. The direction adds one small fixture component and six test behaviors duplicated across the two mandated test surfaces, with no new machinery or public contracts.

**Decision**

Continue the current direction. The finding counts are strictly decreasing and converging on hygiene, which indicates reviewer thoroughness rather than a design problem. Alternatives were weighed and rejected: an isolated issue-number sandbox would contradict the fixture lifecycle preference for coherent semantic fixtures, and dropping the default-contract guard tests would leave the fix free to silently flip the default predicate. An independent fresh-context complexity subagent performed the same reassessment in parallel and reached the same recommendation; the assessments were compared before recording.

Intentionally uncovered, recorded so later rounds do not expand scope onto them: a `virtualFocus` (aria-activedescendant) hover variant (same predicate branch; the real-focus variant is the stronger signal and the one the issue demonstrates), an authored `focusOnHover` on a plain combobox with a closed `alwaysVisible` list (identical authored branch to the covered select case), and a Solid duplicate (the sandbox has no Solid entry, so `withFramework` runs React only).

</details>

<details>
<summary>Cycle 6: Continue; close the hover-end coverage gap with one capped test pair</summary>

**Assessment**

Cycles 4 through 6 (workaround pass 1, fix pass 1, fix pass 3) each produced findings for the same unchanged direction: a userland gate in the sandbox, then a `SelectItem`-parity open gate in `useComboboxItem`. Cycle 5 was substantive and improved the fix shape: the open check was hoisted before the authored predicate so side-effectful callbacks (the select-grid `move()` pattern) don't run while collapsed, pinned by a red-checked regression pair. The remaining cycle-6 finding was the last uncovered branch of the same single predicate: the hover-end direction claimed by the changeset had no regression pin. The fix itself stayed three lines plus a JSDoc note and a changeset; the test surface growth is bounded, with every test mapping to a distinct consumer-visible claim in the changeset or JSDoc.

**Decision**

Continue; address the hover-end gap with exactly one test per duplicate against the existing `HoverSelect` fixture (no new fixture), red-checked against the pre-fix predicate (`data-active-item` cleared to `null` on hover-away while collapsed). An independent fresh-context complexity subagent reached the same recommendation and the same scope cap; the assessments were compared before recording. Narrowing the changeset claim instead was rejected because the leave path is genuinely gated, so dropping the clause would misdescribe shipped behavior. Recorded without action in this PR: the fix comment no longer claims literal statement-order parity with `SelectItem` (the reorder is deliberate), and `SelectItem`'s own predicate-before-open-check exposure is registered as #7120 (pre-existing on `main`; that component is soft-deprecated in favor of `useComboboxItem`). The default-predicate guards do not foreclose #6837 (enabling `focusOnHover` by default for plain comboboxes in v0.5); they make any future default flip deliberate rather than accidental.

</details>

<details>
<summary>Cycle 10: Continue the review-response work; delete the disputed wait instead of rewording it</summary>

**Assessment**

The gate cycles responding to this PR's two inline review threads produced one substantive outcome (the `focusOnHover` post-callback re-read with its red-checked `HideHoverSelect` coverage, requested by the review thread) and then two successive comment-accuracy findings on a single `flushFrames` justification in the new browser test. Each proposed wording named a deferral mechanism that source inspection could not locate on this fixture's path: hover activation goes through `setActiveId`, which never bumps `moves`, so no presentation passive effect can fire, and a list-only composition has no post-hide focus restoration. The finding pattern is documentation convergence on one comment, not design churn; severities are monotonically decreasing and no cycle questioned the fix, the fixture, or the response scope. A cycle-count correction is also recorded: an earlier finding-bearing pass was missed in the count, so the prior reassessment ran one cycle later than its nominal boundary; counting continues from the recorded boundaries.

**Decision**

Continue; no revert, fixture removal, or contract narrowing. The cycle disposition changed from rewording the comment to deleting the `flushFrames` call and its comment from that one test: unlike its siblings, the test awaits a positive `aria-expanded` transition as its settle point, and the buggy shape commits the activation and focus steal synchronously in the same handler that hides the list, which the re-run browser red check confirmed (still solidly red without the wait). An independent fresh-context complexity subagent performed the same reassessment in parallel and recommended exactly this disposition change; the assessments were compared and the disagreement investigated against source before recording. Declared out of scope for this PR: refactoring the pre-existing duplicated `flushFrames` comments from the #7093 tests.

</details>
