### PR TITLE
Withhold SelectItem focusOnHover callbacks while the select is collapsed

### DIFF
--- a/.changeset/300-select-item-focus-on-hover-closed.md
+++ b/.changeset/300-select-item-focus-on-hover-closed.md
@@ -3,4 +3,4 @@
 "@ariakit/react": patch
 ---
 
-Fixed [`SelectItem`](https://ariakit.com/reference/select-item) so an authored [`focusOnHover`](https://ariakit.com/reference/select-item#focusonhover) callback no longer runs while the select is closed, keeping its side effects from activating an item, changing the value, or moving focus in a collapsed always-visible [`SelectList`](https://ariakit.com/reference/select-list).
+Fixed [`SelectItem`](https://ariakit.com/reference/select-item) so an authored [`focusOnHover`](https://ariakit.com/reference/select-item#focusonhover) callback no longer runs while the select is closed, keeping its side effects from activating an item, changing the value, or moving focus in a collapsed always-visible [`SelectList`](https://ariakit.com/reference/select-list). Thanks to [@waterWang](https://github.com/waterWang).

--- a/.changeset/300-select-item-focus-on-hover-closed.md
+++ b/.changeset/300-select-item-focus-on-hover-closed.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`SelectItem`](https://ariakit.com/reference/select-item) so an authored [`focusOnHover`](https://ariakit.com/reference/select-item#focusonhover) callback no longer runs while the select is closed, keeping its side effects from activating an item, changing the value, or moving focus in a collapsed always-visible [`SelectList`](https://ariakit.com/reference/select-list).

--- a/app/src/sandbox/select-legacy/public-cases/cases.react.tsx
+++ b/app/src/sandbox/select-legacy/public-cases/cases.react.tsx
@@ -19,6 +19,7 @@ import {
 import {
   LegacyPublicSelectAnimatedCase,
   LegacyPublicSelectAnimatedStoreCase,
+  LegacyPublicSelectCollapsedHoverCase,
   LegacyPublicSelectGridCase,
   LegacyPublicSelectGridStoreCase,
   LegacyPublicSelectGroupCase,
@@ -51,6 +52,7 @@ export const legacyPublicSelectCases = {
   "public-select-group": LegacyPublicSelectGroupCase,
   "public-select-item-custom": LegacyPublicSelectItemCustomCase,
   "public-select-listbox": LegacyPublicSelectListboxCase,
+  "public-select-collapsed-hover": LegacyPublicSelectCollapsedHoverCase,
   "public-select-combobox": LegacyPublicSelectComboboxCase,
   "public-select-combobox-store": LegacyPublicSelectComboboxStoreCase,
   "public-select-combobox-virtualized":

--- a/app/src/sandbox/select-legacy/public-cases/cases.react.tsx
+++ b/app/src/sandbox/select-legacy/public-cases/cases.react.tsx
@@ -23,6 +23,7 @@ import {
   LegacyPublicSelectGridCase,
   LegacyPublicSelectGridStoreCase,
   LegacyPublicSelectGroupCase,
+  LegacyPublicSelectHideOnHoverCase,
   LegacyPublicSelectItemCustomCase,
   LegacyPublicSelectListboxCase,
 } from "./composite.react.tsx";
@@ -53,6 +54,7 @@ export const legacyPublicSelectCases = {
   "public-select-item-custom": LegacyPublicSelectItemCustomCase,
   "public-select-listbox": LegacyPublicSelectListboxCase,
   "public-select-collapsed-hover": LegacyPublicSelectCollapsedHoverCase,
+  "public-select-hide-on-hover": LegacyPublicSelectHideOnHoverCase,
   "public-select-combobox": LegacyPublicSelectComboboxCase,
   "public-select-combobox-store": LegacyPublicSelectComboboxStoreCase,
   "public-select-combobox-virtualized":

--- a/app/src/sandbox/select-legacy/public-cases/composite.react.tsx
+++ b/app/src/sandbox/select-legacy/public-cases/composite.react.tsx
@@ -1,6 +1,6 @@
 import * as Ariakit from "@ariakit/react";
 import { useState } from "react";
-import { FruitItems } from "./shared.react.tsx";
+import { fruits, FruitItems } from "./shared.react.tsx";
 
 function AnimatedPopover() {
   return (
@@ -192,6 +192,40 @@ export function LegacyPublicSelectItemCustomCase() {
         ))}
       </Ariakit.SelectPopover>
     </Ariakit.SelectProvider>
+  );
+}
+
+// An authored focusOnHover callback with a side effect: the consumer moves
+// the composite from inside the predicate, like the select-grid example does.
+// While the select is collapsed, the callback must not run at all, or the
+// move would still activate the item, commit its value, and steal focus.
+// https://github.com/ariakit/ariakit/issues/7120
+export function LegacyPublicSelectCollapsedHoverCase() {
+  const select = Ariakit.useSelectStore({ defaultValue: "Apple" });
+  return (
+    <>
+      {/* Safari needs an explicit tabindex to focus the clicked button. */}
+      <button type="button" tabIndex={0}>
+        Collapsed hover other control
+      </button>
+      <Ariakit.SelectProvider store={select}>
+        <Ariakit.SelectLabel>Collapsed hover fruit</Ariakit.SelectLabel>
+        <Ariakit.Select />
+        <Ariakit.SelectList alwaysVisible aria-label="Collapsed hover options">
+          {fruits.map((value) => (
+            <Ariakit.SelectItem
+              key={value}
+              value={value}
+              focusOnHover={(event) => {
+                if (event.type === "mouseleave") return false;
+                select.move(event.currentTarget.id);
+                return true;
+              }}
+            />
+          ))}
+        </Ariakit.SelectList>
+      </Ariakit.SelectProvider>
+    </>
   );
 }
 

--- a/app/src/sandbox/select-legacy/public-cases/composite.react.tsx
+++ b/app/src/sandbox/select-legacy/public-cases/composite.react.tsx
@@ -217,9 +217,6 @@ export function LegacyPublicSelectCollapsedHoverCase() {
               key={value}
               value={value}
               focusOnHover={(event) => {
-                // TODO: Remove this open check once
-                // https://github.com/ariakit/ariakit/issues/7120 is fixed.
-                if (!select.getState().open) return false;
                 if (event.type === "mouseleave") return false;
                 select.move(event.currentTarget.id);
                 return true;

--- a/app/src/sandbox/select-legacy/public-cases/composite.react.tsx
+++ b/app/src/sandbox/select-legacy/public-cases/composite.react.tsx
@@ -229,6 +229,33 @@ export function LegacyPublicSelectCollapsedHoverCase() {
   );
 }
 
+// An authored focusOnHover callback that closes the select from inside the
+// predicate. Built-in activation must stop when the callback itself collapses
+// the popup, or the hovered item would become active after close.
+// https://github.com/ariakit/ariakit/pull/7121#discussion_r3780074062
+export function LegacyPublicSelectHideOnHoverCase() {
+  const select = Ariakit.useSelectStore({ defaultValue: "Apple" });
+  return (
+    <Ariakit.SelectProvider store={select}>
+      <Ariakit.SelectLabel>Hide-on-hover fruit</Ariakit.SelectLabel>
+      <Ariakit.Select />
+      <Ariakit.SelectList alwaysVisible aria-label="Hide-on-hover options">
+        {fruits.map((value) => (
+          <Ariakit.SelectItem
+            key={value}
+            value={value}
+            focusOnHover={(event) => {
+              if (event.type === "mouseleave") return false;
+              select.hide();
+              return true;
+            }}
+          />
+        ))}
+      </Ariakit.SelectList>
+    </Ariakit.SelectProvider>
+  );
+}
+
 export function LegacyPublicSelectListboxCase() {
   const select = Ariakit.useSelectStore({ open: true });
   return (

--- a/app/src/sandbox/select-legacy/public-cases/composite.react.tsx
+++ b/app/src/sandbox/select-legacy/public-cases/composite.react.tsx
@@ -217,6 +217,9 @@ export function LegacyPublicSelectCollapsedHoverCase() {
               key={value}
               value={value}
               focusOnHover={(event) => {
+                // TODO: Remove this open check once
+                // https://github.com/ariakit/ariakit/issues/7120 is fixed.
+                if (!select.getState().open) return false;
                 if (event.type === "mouseleave") return false;
                 select.move(event.currentTarget.id);
                 return true;

--- a/app/src/sandbox/select-legacy/public-tests/composite.react.test-helper.ts
+++ b/app/src/sandbox/select-legacy/public-tests/composite.react.test-helper.ts
@@ -80,6 +80,50 @@ describe("public-select-item-custom", () => {
   });
 });
 
+describe("public-select-collapsed-hover", () => {
+  beforeEach(async () => {
+    await click(q.button("Show public-select-collapsed-hover"));
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7120
+  // The authored focusOnHover callback moves the composite from inside the
+  // predicate. While the select is collapsed, the callback must not run at
+  // all, or the move would still activate the item, commit its value, and
+  // steal focus from the unrelated control.
+  test("a side-effectful focusOnHover callback does nothing on a collapsed list", async () => {
+    const select = q.combobox("Collapsed hover fruit");
+    const grape = q.option("Grape");
+    const other = q.button("Collapsed hover other control");
+
+    await click(other);
+    expect(other).toHaveFocus();
+
+    // `hover` settles the DOM before resolving, so the assertions below run
+    // after any activation the mousemove handler committed.
+    await hover(grape);
+
+    expect(select).toHaveAttribute("aria-expanded", "false");
+    expect(grape).not.toHaveAttribute("data-active-item");
+    expect(select).toHaveTextContent("Apple");
+    expect(other).toHaveFocus();
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7120
+  // The gate is about the closed list: the same side-effectful callback
+  // keeps working once the select opens.
+  test("the same callback activates the option once the select opens", async () => {
+    const select = q.combobox("Collapsed hover fruit");
+    const grape = q.option("Grape");
+
+    await click(select);
+    expect(select).toHaveAttribute("aria-expanded", "true");
+
+    await hover(grape);
+
+    expect(grape).toHaveAttribute("data-active-item");
+  });
+});
+
 describe("public-select-listbox", () => {
   beforeEach(async () => {
     await click(q.button("Show public-select-listbox"));

--- a/app/src/sandbox/select-legacy/public-tests/composite.react.test-helper.ts
+++ b/app/src/sandbox/select-legacy/public-tests/composite.react.test-helper.ts
@@ -124,6 +124,32 @@ describe("public-select-collapsed-hover", () => {
   });
 });
 
+describe("public-select-hide-on-hover", () => {
+  beforeEach(async () => {
+    await click(q.button("Show public-select-hide-on-hover"));
+  });
+
+  // https://github.com/ariakit/ariakit/pull/7121#discussion_r3780074062
+  // The authored callback closes the select and returns true. Built-in
+  // activation must still stop, or the hovered item would become active in
+  // the just-collapsed list.
+  test("built-in activation stops when the callback closes the select", async () => {
+    const select = q.combobox("Hide-on-hover fruit");
+    const grape = q.option("Grape");
+
+    await click(select);
+    expect(select).toHaveAttribute("aria-expanded", "true");
+
+    // `hover` settles the DOM before resolving, so the assertions below run
+    // after any activation the mousemove handler committed.
+    await hover(grape);
+
+    expect(select).toHaveAttribute("aria-expanded", "false");
+    expect(grape).not.toHaveAttribute("data-active-item");
+    expect(q.option("Apple")).toHaveAttribute("data-active-item");
+  });
+});
+
 describe("public-select-listbox", () => {
   beforeEach(async () => {
     await click(q.button("Show public-select-listbox"));

--- a/app/src/sandbox/select-legacy/test-public-browser.ts
+++ b/app/src/sandbox/select-legacy/test-public-browser.ts
@@ -145,7 +145,6 @@ withFramework(import.meta.dirname, async ({ test }) => {
   // activation must still stop, or the hovered item would become active in
   // the just-collapsed list.
   test("built-in activation stops when the callback closes the select", async ({
-    page,
     q,
   }) => {
     await q.button("Show public-select-hide-on-hover").click();
@@ -158,11 +157,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await grape.hover();
 
     await test.expect(select).toHaveAttribute("aria-expanded", "false");
-    // The stray activation would be committed inside the same mousemove
-    // handler that closed the select, so there is no positive state to wait
-    // for. Cross the frames a presentation would use before asserting that
-    // none did.
-    await flushFrames(page);
+    // The buggy shape would commit the stray activation in the same mousemove
+    // handler that closes the select, so the awaited collapse above is the
+    // settle point for the assertions below.
     await test.expect(grape).not.toHaveAttribute("data-active-item");
     await test.expect(q.option("Apple")).toHaveAttribute("data-active-item");
   });

--- a/app/src/sandbox/select-legacy/test-public-browser.ts
+++ b/app/src/sandbox/select-legacy/test-public-browser.ts
@@ -1,6 +1,6 @@
 import { expect } from "@playwright/test";
 import type { Page } from "@playwright/test";
-import { withFramework } from "#app/test-utils/preview.ts";
+import { flushFrames, withFramework } from "#app/test-utils/preview.ts";
 
 type ShowLegacyPublicCase = (caseName: string) => Promise<void>;
 
@@ -91,5 +91,52 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(select).toContainText("Triangle");
     await page.keyboard.press("ArrowDown");
     await test.expect(select).toContainText("Square");
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7120
+  // The authored focusOnHover callback moves the composite from inside the
+  // predicate. While the select is collapsed, the callback must not run at
+  // all, or the move would still activate the item, commit its value, and
+  // steal focus from the unrelated control.
+  test("a side-effectful focusOnHover callback does nothing on a collapsed list", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Show public-select-collapsed-hover").click();
+    const select = q.combobox("Collapsed hover fruit");
+    const grape = q.option("Grape");
+    const other = q.button("Collapsed hover other control");
+
+    await other.click();
+    await test.expect(other).toBeFocused();
+
+    await grape.hover();
+
+    await test.expect(select).toHaveAttribute("aria-expanded", "false");
+    // Hover activation is committed inside the mousemove handler, so there
+    // is no positive state to wait for. Cross the frames a presentation
+    // would use to reach the item before asserting that none did.
+    await flushFrames(page);
+    await test.expect(grape).not.toHaveAttribute("data-active-item");
+    await test.expect(select).toContainText("Apple");
+    await test.expect(other).toBeFocused();
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7120
+  // The gate is about the closed list: the same side-effectful callback
+  // keeps working once the select opens.
+  test("the same callback activates the option once the select opens", async ({
+    q,
+  }) => {
+    await q.button("Show public-select-collapsed-hover").click();
+    const select = q.combobox("Collapsed hover fruit");
+    const grape = q.option("Grape");
+
+    await select.click();
+    await test.expect(select).toHaveAttribute("aria-expanded", "true");
+
+    await grape.hover();
+
+    await test.expect(grape).toHaveAttribute("data-active-item");
   });
 });

--- a/app/src/sandbox/select-legacy/test-public-browser.ts
+++ b/app/src/sandbox/select-legacy/test-public-browser.ts
@@ -139,4 +139,31 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
     await test.expect(grape).toHaveAttribute("data-active-item");
   });
+
+  // https://github.com/ariakit/ariakit/pull/7121#discussion_r3780074062
+  // The authored callback closes the select and returns true. Built-in
+  // activation must still stop, or the hovered item would become active in
+  // the just-collapsed list.
+  test("built-in activation stops when the callback closes the select", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Show public-select-hide-on-hover").click();
+    const select = q.combobox("Hide-on-hover fruit");
+    const grape = q.option("Grape");
+
+    await select.click();
+    await test.expect(select).toHaveAttribute("aria-expanded", "true");
+
+    await grape.hover();
+
+    await test.expect(select).toHaveAttribute("aria-expanded", "false");
+    // The stray activation would be committed inside the same mousemove
+    // handler that closed the select, so there is no positive state to wait
+    // for. Cross the frames a presentation would use before asserting that
+    // none did.
+    await flushFrames(page);
+    await test.expect(grape).not.toHaveAttribute("data-active-item");
+    await test.expect(q.option("Apple")).toHaveAttribute("data-active-item");
+  });
 });

--- a/packages/ariakit-react-components/src/select/select-item.tsx
+++ b/packages/ariakit-react-components/src/select/select-item.tsx
@@ -184,14 +184,16 @@ export const useSelectItem = createHook<TagName, SelectItemOptions>(
     props = useCompositeHover({
       store,
       ...props,
-      // Disable focusOnHover when the popup is closed, even for authored
-      // values, so pointer hover can't activate an item or move focus while
-      // the select is collapsed. The open check comes first so authored
-      // callbacks with side effects don't run at all while closed.
+      // Withhold focusOnHover while the popup is closed, even for authored
+      // values, so hover can't activate an item or move focus while the
+      // select is collapsed. Check open before the authored callback so its
+      // side effects never run while closed, and again after so built-in
+      // activation stops when the callback itself closes the select.
       // https://github.com/ariakit/ariakit/issues/7120
       focusOnHover(event) {
         if (!store.getState().open) return false;
-        return focusOnHoverProp(event);
+        if (!focusOnHoverProp(event)) return false;
+        return store.getState().open;
       },
     });
 

--- a/packages/ariakit-react-components/src/select/select-item.tsx
+++ b/packages/ariakit-react-components/src/select/select-item.tsx
@@ -184,13 +184,14 @@ export const useSelectItem = createHook<TagName, SelectItemOptions>(
     props = useCompositeHover({
       store,
       ...props,
-      // We have to disable focusOnHover when the popup is closed, otherwise
-      // the active item will change to null (the container) when the popup is
-      // closed by clicking on an item.
+      // Disable focusOnHover when the popup is closed, even for authored
+      // values, so pointer hover can't activate an item or move focus while
+      // the select is collapsed. The open check comes first so authored
+      // callbacks with side effects don't run at all while closed.
+      // https://github.com/ariakit/ariakit/issues/7120
       focusOnHover(event) {
-        if (!focusOnHoverProp(event)) return false;
-        const state = store.getState();
-        return state.open;
+        if (!store.getState().open) return false;
+        return focusOnHoverProp(event);
       },
     });
 


### PR DESCRIPTION
## Motivation

Fixes #7120.

[`useSelectItem`](https://github.com/ariakit/ariakit/blob/a0426ed547d95b84c9d53033053e51baeaca4aaa/packages/ariakit-react-components/src/select/select-item.tsx#L184-L195) gates hover activation on the live `open` state, but it invokes the authored [`focusOnHover`](https://ariakit.com/reference/select-item#focusonhover) predicate before that check:

```ts
focusOnHover(event) {
  if (!focusOnHoverProp(event)) return false;
  const state = store.getState();
  return state.open;
},
```

The later `false` result stops the built-in `useCompositeHover` activation, but it cannot undo callback side effects. A callback that moves the composite from inside the predicate, like the [select-grid example](https://github.com/ariakit/ariakit/blob/a0426ed547d95b84c9d53033053e51baeaca4aaa/examples/select-grid/index.react.tsx#L18-L28) does, therefore still runs while the select popup is closed. On an `alwaysVisible` [`SelectList`](https://ariakit.com/reference/select-list), the `move()` call activates the hovered item, commits its value (the select store commits the value on move while the popup is unmounted), and steals DOM focus from an unrelated control, all while the select stays collapsed.

This is the same defect class as #7118, fixed for `ComboboxItem` by #7119, which checks `open` before invoking the authored predicate.

## Solution

`useSelectItem` now checks the live `open` state before invoking the authored predicate and re-reads it afterward, matching the merged #7119 guard for `ComboboxItem`:

```ts
focusOnHover(event) {
  if (!store.getState().open) return false;
  if (!focusOnHoverProp(event)) return false;
  return store.getState().open;
},
```

While the select is closed, the authored callback no longer runs at all, on hover start or hover end, so consumer side effects cannot activate an item, change the value, or move focus. The final re-read preserves the base branch's guarantee that built-in activation stops when the callback itself closes the select. Once the select is open and stays open, authored callbacks behave exactly as before.

The fix followed the staged bug-fix workflow so CI demonstrates each step:

1. [`2a45f62e6`](https://github.com/ariakit/ariakit/commit/2a45f62e63bf876288e9b3a31780cac4766fa43a) added the failing reproduction: the `select-legacy` sandbox gains a `public-select-collapsed-hover` case, an always-visible legacy `SelectList` whose items use the side-effectful `move()` callback pattern next to an unrelated focusable control. New browser tests and a happy-dom duplicate assert that hovering an option in the collapsed list changes nothing, and that the same callback still activates options once the select opens. The closed-list test failed in Chrome, Firefox, Safari, and happy-dom at that commit.
2. [`750235ab2`](https://github.com/ariakit/ariakit/commit/750235ab25981b3614b135b3d8c7b88866e6f952) demonstrated the userland workaround below in the sandbox, making every repro test pass with the library unchanged.
3. [`28e3335a5`](https://github.com/ariakit/ariakit/commit/28e3335a5239040df50be05823e4a2f0469d5dff) reverted the workaround and applied the library fix, keeping all repro tests green in every environment (Chrome, Firefox, Safari, happy-dom under React 19 and React 18).
4. [`a6ed24a56`](https://github.com/ariakit/ariakit/commit/a6ed24a56d31ef997edc4ceb451c6ba34c23382a) addressed review feedback by restoring the post-callback `open` re-read, with a `public-select-hide-on-hover` regression case whose callback closes the select from inside the predicate. The new test failed on the previous head and passes with the final guard.

## Preview

The recording below shows the fixed behavior in the `select-legacy` sandbox. Active item and DOM focus are outlined via demo-only injected CSS for visibility, since sandboxes ship unstyled: amber marks the active item, blue marks DOM focus. While the select is collapsed, hovering Banana and Grape changes nothing, with focus staying on the unrelated control and Apple remaining the active item. After the select opens, the same hover callback activates the hovered options again.

https://github.com/user-attachments/assets/fe93a043-7f70-4fdc-b88b-17099324b303

## Acknowledgments

Thanks to [@waterWang](https://github.com/waterWang) for preparing an exploratory fix branch for #7120 and offering it for adoption. The final implementation was authored independently and uses a different, two-sided guard, but their branch explored the same fix ahead of this PR.

## Workaround

Until the fix is released, consumers can guard their authored [`focusOnHover`](https://ariakit.com/reference/select-item#focusonhover) callback with the live `open` state before any other logic:

```tsx
const select = Ariakit.useSelectStore();

<Ariakit.SelectItem
  value="Apple"
  focusOnHover={(event) => {
    // TODO: Remove this open check once
    // https://github.com/ariakit/ariakit/issues/7120 is fixed.
    if (!select.getState().open) return false;
    // Existing authored logic starts after the live open check.
    if (event.type === "mouseleave") return false;
    select.move(event.currentTarget.id);
    return true;
  }}
/>;
```

The guard must come before all authored logic so no side effect runs while the select is closed, including on hover end. It needs to be applied to every `SelectItem` with an authored `focusOnHover` callback. Reading `select.getState().open` at event time avoids stale closure state; any side-effectful callback already has the store in scope, or can get it from the context with [`useSelectContext`](https://ariakit.com/reference/use-select-context). Plain boolean `focusOnHover` values do not need the workaround, because the built-in check already withholds activation while the select is closed.


