### PR TITLE
Document Cache Components build guard

### DIFF
--- a/nextjs/next.config.ts
+++ b/nextjs/next.config.ts
@@ -5,6 +5,9 @@ import type { NextConfig } from "next";
 const config: NextConfig = {
   reactCompiler: true,
   typedRoutes: true,
+
+  // Keep this enabled. The production build is the regression test for
+  // https://github.com/ariakit/ariakit/issues/5147.
   cacheComponents: true,
 
   // Pin the Turbopack root to the monorepo root (the parent of this workspace).


### PR DESCRIPTION
## Motivation

`cacheComponents: true` was enabled in #5738 so the production build would cover the regression reported in #5147. The option's purpose is not documented at the configuration site, so dependency-update work has repeatedly treated it as removable.

## Solution

Document that Cache Components must remain enabled because the production build is the #5147 regression test.

```ts
// Keep this enabled. The production build is the regression test for
// https://github.com/ariakit/ariakit/issues/5147.
cacheComponents: true,
```

This is a comment-only change. It does not change the Next.js configuration or build output.

## Verification

- `pnpm lint-fix`
- `pnpm -F nextjs run build`, which reports `Cache Components enabled`
