### PR TITLE
Fix middle click on disabled elements rendered as links

### DIFF
--- a/.changeset/300-focusable-disabled-middle-click.md
+++ b/.changeset/300-focusable-disabled-middle-click.md
@@ -3,4 +3,4 @@
 "@ariakit/react": patch
 ---
 
-Fixed [`Focusable`](https://ariakit.com/reference/focusable) and components built on it, such as [`Tab`](https://ariakit.com/reference/tab) and [`Button`](https://ariakit.com/reference/button), so a middle click no longer opens the destination of a [`disabled`](https://ariakit.com/reference/focusable#disabled) element rendered as a link. This affects elements that stay reachable through [`accessibleWhenDisabled`](https://ariakit.com/reference/focusable#accessiblewhendisabled), which [`Tab`](https://ariakit.com/reference/tab) enables by default.
+Fixed [`Focusable`](https://ariakit.com/reference/focusable) and components built on it, such as [`Tab`](https://ariakit.com/reference/tab) and [`Button`](https://ariakit.com/reference/button), so a middle click no longer opens the destination of a [`disabled`](https://ariakit.com/reference/focusable#disabled) element rendered as a link, including one kept reachable by [`accessibleWhenDisabled`](https://ariakit.com/reference/focusable#accessiblewhendisabled), which [`Tab`](https://ariakit.com/reference/tab) enables by default.

--- a/.changeset/300-focusable-disabled-middle-click.md
+++ b/.changeset/300-focusable-disabled-middle-click.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Focusable`](https://ariakit.com/reference/focusable) and components built on it, such as [`Tab`](https://ariakit.com/reference/tab) and [`Button`](https://ariakit.com/reference/button), so a middle click no longer opens the destination of a [`disabled`](https://ariakit.com/reference/focusable#disabled) element rendered as a link. This affects elements that stay reachable through [`accessibleWhenDisabled`](https://ariakit.com/reference/focusable#accessiblewhendisabled), which [`Tab`](https://ariakit.com/reference/tab) enables by default.

--- a/app/src/sandbox/focusable-tab-7153/index.react.tsx
+++ b/app/src/sandbox/focusable-tab-7153/index.react.tsx
@@ -1,14 +1,4 @@
 import * as Ariakit from "@ariakit/react";
-import type { MouseEvent } from "react";
-
-// `Focusable` disables click, mousedown, and keypress while the element is
-// disabled, but not the auxclick a middle click fires, so a disabled link still
-// opens its destination.
-// TODO: Remove once https://github.com/ariakit/ariakit/issues/7153 is fixed.
-function blockAuxClick(event: MouseEvent) {
-  event.stopPropagation();
-  event.preventDefault();
-}
 
 // The tab list has no tab panels because routed tabs render their panel from
 // the destination page.
@@ -18,17 +8,12 @@ export default function Example() {
       <Ariakit.Focusable render={<a href="?link=enabled" />}>
         Enabled link
       </Ariakit.Focusable>
-      <Ariakit.Focusable
-        disabled
-        onAuxClickCapture={blockAuxClick}
-        render={<a href="?link=disabled" />}
-      >
+      <Ariakit.Focusable disabled render={<a href="?link=disabled" />}>
         Disabled link
       </Ariakit.Focusable>
       <Ariakit.Focusable
         disabled
         accessibleWhenDisabled
-        onAuxClickCapture={blockAuxClick}
         render={<a href="?link=accessible" />}
       >
         Accessible disabled link
@@ -38,12 +23,7 @@ export default function Example() {
           <Ariakit.Tab id="overview" render={<a href="?tab=overview" />}>
             Overview
           </Ariakit.Tab>
-          <Ariakit.Tab
-            id="billing"
-            disabled
-            onAuxClickCapture={blockAuxClick}
-            render={<a href="?tab=billing" />}
-          >
+          <Ariakit.Tab id="billing" disabled render={<a href="?tab=billing" />}>
             Billing
           </Ariakit.Tab>
         </Ariakit.TabList>

--- a/app/src/sandbox/focusable-tab-7153/index.react.tsx
+++ b/app/src/sandbox/focusable-tab-7153/index.react.tsx
@@ -1,4 +1,14 @@
 import * as Ariakit from "@ariakit/react";
+import type { MouseEvent } from "react";
+
+// `Focusable` disables click, mousedown, and keypress while the element is
+// disabled, but not the auxclick a middle click fires, so a disabled link still
+// opens its destination.
+// TODO: Remove once https://github.com/ariakit/ariakit/issues/7153 is fixed.
+function blockAuxClick(event: MouseEvent) {
+  event.stopPropagation();
+  event.preventDefault();
+}
 
 // The tab list has no tab panels because routed tabs render their panel from
 // the destination page.
@@ -8,12 +18,17 @@ export default function Example() {
       <Ariakit.Focusable render={<a href="?link=enabled" />}>
         Enabled link
       </Ariakit.Focusable>
-      <Ariakit.Focusable disabled render={<a href="?link=disabled" />}>
+      <Ariakit.Focusable
+        disabled
+        onAuxClickCapture={blockAuxClick}
+        render={<a href="?link=disabled" />}
+      >
         Disabled link
       </Ariakit.Focusable>
       <Ariakit.Focusable
         disabled
         accessibleWhenDisabled
+        onAuxClickCapture={blockAuxClick}
         render={<a href="?link=accessible" />}
       >
         Accessible disabled link
@@ -23,7 +38,12 @@ export default function Example() {
           <Ariakit.Tab id="overview" render={<a href="?tab=overview" />}>
             Overview
           </Ariakit.Tab>
-          <Ariakit.Tab id="billing" disabled render={<a href="?tab=billing" />}>
+          <Ariakit.Tab
+            id="billing"
+            disabled
+            onAuxClickCapture={blockAuxClick}
+            render={<a href="?tab=billing" />}
+          >
             Billing
           </Ariakit.Tab>
         </Ariakit.TabList>

--- a/app/src/sandbox/focusable-tab-7153/index.react.tsx
+++ b/app/src/sandbox/focusable-tab-7153/index.react.tsx
@@ -1,0 +1,33 @@
+import * as Ariakit from "@ariakit/react";
+
+// The tab list has no tab panels because routed tabs render their panel from
+// the destination page.
+export default function Example() {
+  return (
+    <div className="flex flex-col items-start gap-4">
+      <Ariakit.Focusable render={<a href="?link=enabled" />}>
+        Enabled link
+      </Ariakit.Focusable>
+      <Ariakit.Focusable disabled render={<a href="?link=disabled" />}>
+        Disabled link
+      </Ariakit.Focusable>
+      <Ariakit.Focusable
+        disabled
+        accessibleWhenDisabled
+        render={<a href="?link=accessible" />}
+      >
+        Accessible disabled link
+      </Ariakit.Focusable>
+      <Ariakit.TabProvider defaultSelectedId="overview">
+        <Ariakit.TabList aria-label="Sections">
+          <Ariakit.Tab id="overview" render={<a href="?tab=overview" />}>
+            Overview
+          </Ariakit.Tab>
+          <Ariakit.Tab id="billing" disabled render={<a href="?tab=billing" />}>
+            Billing
+          </Ariakit.Tab>
+        </Ariakit.TabList>
+      </Ariakit.TabProvider>
+    </div>
+  );
+}

--- a/app/src/sandbox/focusable-tab-7153/test-browser.ts
+++ b/app/src/sandbox/focusable-tab-7153/test-browser.ts
@@ -1,0 +1,94 @@
+import type { Locator } from "@ariakit/test/playwright";
+import { errors, expect } from "@ariakit/test/playwright";
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// Playwright's actionability check treats `aria-disabled` as not enabled and
+// refuses to click, so the gesture has to be forced. Forcing skips Playwright's
+// own checks, not the browser's hit testing, which is what blocks the truly
+// disabled link through `pointer-events: none`.
+function middleClick(locator: Locator) {
+  return locator.click({ button: "middle", force: true });
+}
+
+async function expectNavigation(locator: Locator, destination: RegExp) {
+  const page = locator.page();
+  const url = page.url();
+  // Chromium and Firefox open the destination in a new tab, while WebKit
+  // follows the middle click in the current one. Race both so neither engine
+  // needs its own branch.
+  const newTab = page
+    .context()
+    .waitForEvent("page")
+    .catch(() => null);
+  const sameTab = page
+    .waitForURL(destination)
+    .then(() => null)
+    .catch(() => null);
+  await middleClick(locator);
+  const opened = await Promise.race([newTab, sameTab]);
+  await expect(opened ?? page).toHaveURL(destination);
+  if (!opened) return;
+  await expect(page).toHaveURL(url);
+}
+
+async function expectNoNavigation(locator: Locator) {
+  const page = locator.page();
+  const url = page.url();
+  // A blocked gesture leaves nothing behind to assert on, so wait out the
+  // window in which the browser would have delivered the destination. The
+  // slowest delivery measured across the three engines was 1.4s, so this
+  // budget leaves room for a loaded runner without waiting on the clock for
+  // longer than the gesture can plausibly take.
+  const newTab = page
+    .context()
+    .waitForEvent("page", { timeout: 5_000 })
+    .catch((error) => {
+      if (!(error instanceof errors.TimeoutError)) throw error;
+      return null;
+    });
+  const [opened] = await Promise.all([newTab, middleClick(locator)]);
+  expect(opened, "the link opened in a new tab").toBeNull();
+  await expect(page).toHaveURL(url);
+}
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("middle click opens an enabled link", async ({ q }) => {
+    await expectNavigation(q.link("Enabled link"), /\?link=enabled$/);
+  });
+
+  test("middle click opens an enabled tab rendered as a link", async ({
+    q,
+  }) => {
+    await expectNavigation(q.tab("Overview"), /\?tab=overview$/);
+  });
+
+  // Truly disabled elements get `pointer-events: none`, so the pointer lands on
+  // the wrapper and never reaches this link. That also makes the link
+  // impossible to hover, which is why this case alone has no hit-target pin.
+  // https://github.com/ariakit/ariakit/issues/7153
+  test("middle click does not open a disabled link", async ({ q }) => {
+    await expectNoNavigation(q.link("Disabled link"));
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7153
+  test("middle click does not open an accessible disabled link", async ({
+    q,
+  }) => {
+    const link = q.link("Accessible disabled link");
+    // Forcing the click skips Playwright's hit-target check, so hover first to
+    // keep it. Without that pin, a later fixture change could move the gesture
+    // off this link and leave the test passing for the wrong reason.
+    await link.hover();
+    await expectNoNavigation(link);
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7153
+  test("middle click does not open a disabled tab rendered as a link", async ({
+    q,
+  }) => {
+    const tab = q.tab("Billing");
+    // Same hit-target pin as above.
+    await tab.hover();
+    await expectNoNavigation(tab);
+  });
+});

--- a/app/src/sandbox/focusable-tab-7153/test.ts
+++ b/app/src/sandbox/focusable-tab-7153/test.ts
@@ -1,0 +1,38 @@
+import { dispatch, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// A middle click activates a link through `auxclick`, and `@ariakit/test` has
+// no middle-click utility, so dispatch the single event that carries the
+// activation. `dispatch` resolves to `false` when it was prevented.
+function middleClick(element: Element | null) {
+  const event = new MouseEvent("auxclick", {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    detail: 1,
+    button: 1,
+  });
+  return dispatch(element, event);
+}
+
+// Only the browser test covers the truly disabled link: `dispatch` routes
+// around `pointer-events: none` the way a browser does, so its result would
+// describe the ancestor that received the event, not the link.
+
+test("middle click activates an enabled link", async () => {
+  expect(await middleClick(q.link("Enabled link"))).toBe(true);
+});
+
+test("middle click activates an enabled tab rendered as a link", async () => {
+  expect(await middleClick(q.tab("Overview"))).toBe(true);
+});
+
+// https://github.com/ariakit/ariakit/issues/7153
+test("middle click does not activate an accessible disabled link", async () => {
+  expect(await middleClick(q.link("Accessible disabled link"))).toBe(false);
+});
+
+// https://github.com/ariakit/ariakit/issues/7153
+test("middle click does not activate a disabled tab rendered as a link", async () => {
+  expect(await middleClick(q.tab("Billing"))).toBe(false);
+});

--- a/packages/ariakit-react-components/src/focusable/focusable.tsx
+++ b/packages/ariakit-react-components/src/focusable/focusable.tsx
@@ -305,6 +305,13 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
       disabled,
     );
     const onClickCapture = useDisableEvent(props.onClickCapture, disabled);
+    // A middle click fires auxclick instead of click, and preventing mousedown
+    // doesn't stop it, so a disabled element rendered as a link would still
+    // open its destination. See https://github.com/ariakit/ariakit/issues/7153
+    const onAuxClickCapture = useDisableEvent(
+      props.onAuxClickCapture,
+      disabled,
+    );
 
     const handleFocusVisible = (
       event: SyntheticEvent<HTMLType>,
@@ -496,6 +503,7 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
       contentEditable: disabled ? undefined : props.contentEditable,
       onKeyPressCapture,
       onClickCapture,
+      onAuxClickCapture,
       onMouseDownCapture,
       onKeyDownCapture,
       onFocusCapture,


### PR DESCRIPTION
## Motivation

A disabled element rendered as a link still opens its destination on a middle click.

[`Focusable`](https://ariakit.com/reference/focusable) blocks activation by disabling `click`, `mousedown`, and `keypress` in the capture phase. A middle click does not fire `click`, it fires `auxclick`, and nothing in the library listens for it. Calling `preventDefault()` on `mousedown` does not stop it either.

When the element is truly disabled, [`Focusable`](https://ariakit.com/reference/focusable) also applies `pointer-events: none`, so the pointer never reaches it and the gesture is blocked by accident rather than by design. [`accessibleWhenDisabled`](https://ariakit.com/reference/focusable#accessiblewhendisabled) removes `pointer-events: none` to keep the element reachable, and the middle click goes through. That makes [`Tab`](https://ariakit.com/reference/tab) affected at its default settings, because it defaults [`accessibleWhenDisabled`](https://ariakit.com/reference/focusable#accessiblewhendisabled) to `true`.

```tsx
<Ariakit.Tab disabled render={<a href="https://ariakit.org" />}>
  Disabled tab
</Ariakit.Tab>
```

Middle clicking that tab opens the destination in a new tab in Chromium and Firefox, and navigates in place in WebKit. Every other gesture is already blocked: left click, <kbd>Enter</kbd>, and modifier clicks.

Fixes #7153

## Solution

A fourth capture guard covers `auxclick`, beside the three that already cover `click`, `mousedown`, and `keypress`:

```ts
const onAuxClickCapture = useDisableEvent(props.onAuxClickCapture, disabled);
```

It reuses the existing `useDisableEvent` helper, so it behaves exactly like its siblings: the consumer's own handler runs first, and the event is cancelled only when the element is disabled and that handler has not already prevented it. Every component built on [`Focusable`](https://ariakit.com/reference/focusable) inherits the guard, not only links.

The guard is not restricted to the middle button, which matches the unconditional form of the three guards beside it. Back and forward mouse buttons are unaffected: driving them through CDP over a disabled element showed that Chromium dispatches no `auxclick` for them at all, and history navigation still happened.

Like its siblings, the guard stops the event as well as preventing it, so on a disabled element an `auxclick` no longer reaches the handlers that would have run after the guard. This mirrors how the existing `click` guard already suppresses `onClick` on a disabled element, and it is the only behavior change here that a consumer can notice without having hit the bug.

Two gestures stay open by design, because neither fires `auxclick`: the context menu (`Open link in new tab`, `Copy link address`) and dragging the link to the address bar. Removing the destination is the only thing that closes those, and the issue puts both out of scope.

### Tests

The failing tests landed first, in [`2296063a4`](https://github.com/ariakit/ariakit/commit/2296063a4221bddefa0cb648c205a3814b358433), so CI showed the reproduction red before any fix, then a userland workaround in [`f2389b838`](https://github.com/ariakit/ariakit/commit/f2389b838) turned them green from consumer code alone. The workaround is reverted in this commit, so they now pass because of the library change.

`app/src/sandbox/focusable-tab-7153` renders the affected shapes as real links: a [`Focusable`](https://ariakit.com/reference/focusable) that is only [`disabled`](https://ariakit.com/reference/focusable#disabled), one that is also [`accessibleWhenDisabled`](https://ariakit.com/reference/focusable#accessiblewhendisabled), and a routed tab list with an enabled and a disabled [`Tab`](https://ariakit.com/reference/tab).

The browser test delivers the gesture with `click({ button: "middle", force: true })`. Forcing is required because Playwright's actionability check treats `aria-disabled` as not enabled, so an unforced click waits for the element to become enabled and then fails with `element is not enabled`, never dispatching the gesture. Forcing skips Playwright's own checks and not the browser's hit testing, so the truly disabled link is still blocked by `pointer-events: none`, exactly as a real user would experience it.

Two enabled controls, a link and a tab, assert that the same gesture still navigates. Without them a fix that blocked middle click on every tab, enabled or not, would leave the suite green.

## Workaround

Until this ships, [`Focusable`](https://ariakit.com/reference/focusable) forwards `onAuxClickCapture` to the element, so the guard can be passed from userland:

```tsx
// TODO: Remove once https://github.com/ariakit/ariakit/issues/7153 is fixed.
<Ariakit.Tab
  disabled={disabled}
  onAuxClickCapture={
    disabled
      ? (event) => {
          event.stopPropagation();
          event.preventDefault();
        }
      : undefined
  }
  render={<a href="/billing" />}
>
  Billing
</Ariakit.Tab>
```

Assumptions and limitations:

- Attach the handler only while the element is disabled. The library's own guards check [`disabled`](https://ariakit.com/reference/focusable#disabled) before they cancel anything, but a handler passed from userland runs whenever it is attached.
- Apply it to every disabled link, not only the ones that set [`accessibleWhenDisabled`](https://ariakit.com/reference/focusable#accessiblewhendisabled). The default case is blocked by `pointer-events: none` rather than by design, and that protection disappears as soon as the element has to stay reachable, or the consumer sets `pointerEvents` in its own `style`, which [`Focusable`](https://ariakit.com/reference/focusable) merges over its own.
- The handler cancels `auxclick` for every non-primary button, not only the middle one, so a right-button aux click on the element stops reaching ancestor handlers too.
- It does not close the two gestures that never fire `auxclick`: the context menu (`Open link in new tab`, `Copy link address`) and dragging the link to the address bar. Withholding `href` while the element is disabled closes those too, but on a plain [`Focusable`](https://ariakit.com/reference/focusable) it also costs the element its link role and its place in the tab order, because [`Focusable`](https://ariakit.com/reference/focusable) decides native tabbability from the tag name alone.

## Review gate reassessment

<details>
<summary>Cycle 3: Continue the current test design</summary>

**Assessment**

Issue severity is moderate: `disabled` should block activation through every gesture, and middle click is the only remaining hole. Expected frequency is low per session but on a default configuration, since [`Tab`](https://ariakit.com/reference/tab) supplies `accessibleWhenDisabled` by default and middle click is common on link-shaped navigation. Supported scope is narrow: `@ariakit/react` `Focusable` and its descendants, desktop pointer only. Likely user impact is a visible but recoverable navigation to a destination the app deliberately blocked.

All three rounds circled one root decision: the observable under test is the absence of a browser-process side effect that no DOM state records. Nothing in the page changes when the gesture is correctly blocked. That forces a timed window, a timed window makes the failure direction a false green, and a window implemented as a promise created before the gesture has a fragile lifetime. The alternative would be surfacing fixture state for the test to watch, which both test skills explicitly forbid.

Implementation complexity fell rather than rose across the three rounds. `test-browser.ts` went from 91 to 94 lines and `test.ts` from 35 to 38, while a 12-line hand-rolled `page.mouse` driver, a `browserName` branch, and `page`/`context` threaded through four call sites were all removed, and two enabled controls plus two hit-target pins were added. Maintenance complexity is low: no production code, no public API, no CI configuration, all inside one sandbox directory.

**Decision**

Continue the current design. Reverting to the round 1 approach would restore an underived window, the hand-rolled driver, and the missing enabled-tab control. No machinery can be removed without losing coverage: dropping the `sameTab` race hangs the WebKit path to a test timeout, and dropping either hit-target pin or either enabled control reopens an earlier finding.

Two proposals are recorded as declined non-goals so later reviews do not re-raise them. Replacing the `Promise.race` in `expectNavigation` with a `browserName === "webkit"` branch is preferential; the current form is verified green on all three engines. Extending the hit-target pin to the truly disabled case is impossible by construction, since `pointer-events: none` is what that case asserts.

The absence budget stays at 5s. The repository's 60s new-tab waits are presence waits, where a large budget is free because the event arrives early; an absence budget is a hard wall-clock floor paid on every run. The local measurement behind the 5s value is corroborated by CI on the reproduction commit: while the bug was live, every delivery that actually occurred was caught inside the window on chrome, firefox, and safari.

</details>

<details>
<summary>Cycle 6: Simplify the workaround documentation by deletion</summary>

**Assessment**

The workaround commit changed one file and drew no finding in three consecutive gate rounds. Every finding in cycles 4 to 6 landed on the pull request description instead, and each one was a genuine inaccuracy about `Focusable` internals: a snippet that attached the guard unconditionally, an alternative that silently removed keyboard reachability, and a style-merge claim that is key-wise rather than wholesale.

The generator was not the design but added prose specificity. Each correction introduced a new claim, and each new claim became the next round's target. Cycle 6's two findings were direct descendants of cycle 3 and cycle 5 fixes: an evidentiary sentence about retries and flake status, and an accessibility caveat that had drifted away from the example it described.

**Decision**

Continue the implementation unchanged and simplify the prose by deletion rather than correction.

The duplicate `href`-withholding snippet is removed. It restated the alternative already in the issue body, and the accessibility cost stated after it applies to a plain [`Focusable`](https://ariakit.com/reference/focusable) rather than to the [`Tab`](https://ariakit.com/reference/tab) it was illustrated with, since `CompositeItem` pins a non-active item's `tabIndex` before `Focusable` computes one. One scoped sentence carries the cost instead.

The CI corroboration above is reduced to the claim that carries the argument. Attempt counts, per-project retry counts, and flake status were not load-bearing and were expensive to keep accurate.

The remaining limitations stay. Stage 4 of the issue-fix workflow requires them whenever the workaround is narrower than normal component behavior, and they are republished on the issue, where users act on them without this pull request for context. They are now a bulleted list so each limitation stays bound to its own scope.

</details>
