### PR TITLE
Fix missing modifier state on caller-built mouse events

### DIFF
--- a/.changeset/300-test-dispatch-modifier-state.md
+++ b/.changeset/300-test-dispatch-modifier-state.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/test": patch
+---
+
+Fixed mouse events in the test environment to expose `getModifierState` for `Alt`, `Control`, `Meta`, and `Shift`, plus the `x` and `y` aliases of `clientX` and `clientY`, so a listener reading modifier state no longer throws a `TypeError` on an event passed to `dispatch(element, event)` or on the `auxclick` that `rightClick` and `click` with a non-primary `button` fire.

--- a/packages/ariakit-test/src/dispatch.test.ts
+++ b/packages/ariakit-test/src/dispatch.test.ts
@@ -91,3 +91,64 @@ test("dispatch.input preserves provided inputType", async () => {
     input.remove();
   }
 });
+
+// `auxclick` has no `@testing-library/dom` event map entry, so it can only be
+// dispatched through the direct form, which is how the gap below surfaced.
+// https://github.com/ariakit/ariakit/issues/7156
+test("dispatch(element, event) reads modifier state on a caller-built mouse event", async () => {
+  const button = document.createElement("button");
+  document.body.append(button);
+  const modifiers: boolean[] = [];
+  button.addEventListener("auxclick", (event) => {
+    // A plain DOM listener calls this unguarded, the way a browser allows.
+    modifiers.push(
+      event.getModifierState("Shift"),
+      event.getModifierState("Control"),
+    );
+  });
+  try {
+    await dispatch(
+      button,
+      new MouseEvent("auxclick", { bubbles: true, shiftKey: true }),
+    );
+    expect(modifiers).toEqual([true, false]);
+  } finally {
+    button.remove();
+  }
+});
+
+// Parity covers the standard modifiers and `x`/`y`. happy-dom's constructor
+// discards the `modifier*` init members, so a caller-built event cannot report
+// those the way a named dispatcher does.
+test("dispatch(element, event) reports the same standard modifiers and x/y as the named form", async () => {
+  const button = document.createElement("button");
+  document.body.append(button);
+  const options: MouseEventInit = { shiftKey: true, clientX: 7, clientY: 9 };
+  let direct: MouseEvent | undefined;
+  let named: MouseEvent | undefined;
+  button.addEventListener("auxclick", (event) => {
+    direct = event;
+  });
+  button.addEventListener("click", (event) => {
+    named = event;
+  });
+  try {
+    await dispatch(button, new MouseEvent("auxclick", options));
+    await dispatch.click(button, options);
+    const readMembers = (event: MouseEvent | undefined) => ({
+      shift: event?.getModifierState("Shift"),
+      control: event?.getModifierState("Control"),
+      x: event?.x,
+      y: event?.y,
+    });
+    expect(readMembers(direct)).toEqual(readMembers(named));
+    expect(readMembers(direct)).toEqual({
+      shift: true,
+      control: false,
+      x: 7,
+      y: 9,
+    });
+  } finally {
+    button.remove();
+  }
+});

--- a/packages/ariakit-test/src/shims.jsdom.test.ts
+++ b/packages/ariakit-test/src/shims.jsdom.test.ts
@@ -1,0 +1,19 @@
+// @vitest-environment jsdom
+
+import { expect, test } from "vitest";
+import "./shims.ts";
+
+test("leaves an environment that already implements mouse event members alone", () => {
+  // jsdom implements the full `getModifierState`, including the `modifier*`
+  // init members the happy-dom fallback cannot see, so replacing it would
+  // silently downgrade every jsdom suite. Pin that guard from jsdom, since the
+  // happy-dom default project makes it look redundant. Dropping the `x`/`y`
+  // guard installs an equivalent accessor, so it has no such check.
+  const event = new MouseEvent("auxclick", {
+    modifierCapsLock: true,
+    clientX: 3,
+    clientY: 4,
+  });
+  expect(event.getModifierState("CapsLock")).toBe(true);
+  expect([event.x, event.y]).toEqual([3, 4]);
+});

--- a/packages/ariakit-test/src/shims.test.ts
+++ b/packages/ariakit-test/src/shims.test.ts
@@ -62,6 +62,62 @@ test("runs animation frame callbacks as a spec-compliant batch", async () => {
   expect(timestamps[0]).toBe(timestamps[1]);
 });
 
+test("gives mouse and pointer events the browser's modifier state and x/y", () => {
+  // These hold natively in browsers and jsdom (see shims.jsdom.test.ts), so the
+  // assertions are not guarded by `isBrowser`. Dispatching without going through
+  // `dispatch` reaches only the environment shim.
+  const button = document.createElement("button");
+  document.body.append(button);
+  const received: MouseEvent[] = [];
+  button.addEventListener("auxclick", (event) => {
+    received.push(event);
+  });
+  button.addEventListener("pointerdown", (event) => {
+    received.push(event);
+  });
+  try {
+    button.dispatchEvent(
+      new MouseEvent("auxclick", {
+        altKey: true,
+        ctrlKey: true,
+        clientX: 3,
+        clientY: 4,
+      }),
+    );
+    // PointerEvent extends MouseEvent, so it inherits the same members.
+    button.dispatchEvent(
+      new PointerEvent("pointerdown", { metaKey: true, shiftKey: true }),
+    );
+    // A third combination gives every modifier a pattern of its own across the
+    // three events, so no transposed pair in the lookup can pass. TypeScript
+    // can't catch one: every flag name belongs to the same union.
+    button.dispatchEvent(
+      new PointerEvent("pointerdown", { altKey: true, metaKey: true }),
+    );
+    expect(
+      received.map((event) => [
+        event.getModifierState("Alt"),
+        event.getModifierState("Control"),
+        event.getModifierState("Meta"),
+        event.getModifierState("Shift"),
+        event.x,
+        event.y,
+      ]),
+    ).toEqual([
+      [true, true, false, false, 3, 4],
+      [false, false, true, true, 0, 0],
+      [true, false, true, false, 0, 0],
+    ]);
+    // An unrecognized key reports false, the way browsers do. `Object.prototype`
+    // member names are the interesting case: looking them up on a plain object
+    // literal finds an inherited value and reports something other than false.
+    expect(received[0]?.getModifierState("constructor")).toBe(false);
+    expect(received[0]?.getModifierState("Nope")).toBe(false);
+  } finally {
+    button.remove();
+  }
+});
+
 test("exposes the dispatched event on window.event while listeners run", async () => {
   if (isBrowser) return;
   const button = document.createElement("button");

--- a/packages/ariakit-test/src/shims.ts
+++ b/packages/ariakit-test/src/shims.ts
@@ -72,6 +72,8 @@ function applyBrowserShims() {
     window.PointerEvent = class PointerEvent extends MouseEvent {};
   }
 
+  polyfillMouseEventMembers();
+
   // happy-dom doesn't implement window.alert (jsdom and real browsers do).
   // Provide a no-op so code that calls or spies on it works under happy-dom.
   if (isHappyDOM() && typeof window.alert !== "function") {
@@ -97,6 +99,62 @@ function applyBrowserShims() {
     Element.prototype.getClientRects = originalGetClientRects;
     for (const restore of restoreHappyDOMShims) restore();
   };
+}
+
+// happy-dom's MouseEvent implements neither `getModifierState` nor the `x`/`y`
+// aliases of `clientX`/`clientY`, which browsers and jsdom provide. A named
+// dispatcher installs both while initializing the event, so only events the
+// caller built reached listeners without them. PointerEvent extends MouseEvent
+// and inherits this patch.
+// https://github.com/ariakit/ariakit/issues/7156
+// https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/getModifierState
+// https://drafts.csswg.org/cssom-view/#dom-mouseevent-x
+function polyfillMouseEventMembers() {
+  if (typeof window.MouseEvent === "undefined") return;
+  const prototype = window.MouseEvent.prototype;
+
+  if (typeof prototype.getModifierState !== "function") {
+    // happy-dom's constructor keeps only these four flags and drops the
+    // `modifier*` init members, so this fallback can never report the others.
+    // A Map, because an object literal would resolve `Object.prototype` key
+    // names such as `constructor` to a bogus flag.
+    // https://github.com/ariakit/ariakit/issues/7165
+    const flagsByModifier = new Map<
+      string,
+      "altKey" | "ctrlKey" | "metaKey" | "shiftKey"
+    >([
+      ["Alt", "altKey"],
+      ["Control", "ctrlKey"],
+      ["Meta", "metaKey"],
+      ["Shift", "shiftKey"],
+    ]);
+    // Plain assignment matches the writable, enumerable, configurable
+    // descriptor browsers and jsdom give this method.
+    prototype.getModifierState = function getModifierState(
+      this: MouseEvent,
+      key: string,
+    ) {
+      const flag = flagsByModifier.get(key);
+      if (!flag) return false;
+      return this[flag];
+    };
+  }
+
+  const aliases = [
+    ["x", "clientX"],
+    ["y", "clientY"],
+  ] as const;
+
+  for (const [alias, source] of aliases) {
+    if (alias in prototype) continue;
+    Object.defineProperty(prototype, alias, {
+      configurable: true,
+      enumerable: true,
+      get(this: MouseEvent) {
+        return this[source];
+      },
+    });
+  }
 }
 
 // happy-dom omits built-in constraint messages. Use jsdom's generic text so


### PR DESCRIPTION
## Motivation

`@ariakit/test` normalizes the events it creates. Each named dispatcher (`dispatch.click`, `dispatch.keyDown`, and so on) builds the event and then runs a module-private `initEvent`, which installs `getModifierState` along with the other properties a test environment may not implement.

The direct form, `dispatch(element, event)`, takes an event the caller built and never runs that initializer. happy-dom's `MouseEvent` implements no `getModifierState`, so a plain DOM listener threw:

```ts
button.addEventListener("auxclick", (event) => {
  // TypeError: event.getModifierState is not a function
  event.getModifierState("Shift");
});

await dispatch(button, new MouseEvent("auxclick", { shiftKey: true }));
```

Consumers reach this without calling `dispatch` themselves. `auxclick` has no `@testing-library/dom` event map entry, so the direct form is the only way to fire it, which means `rightClick(element)` and `click(element, { button })` both route through it. React consumers are insulated, because React's modifier getter falls back to `nativeEvent.shiftKey` when the native method is absent.

Fixes #7156.

## Solution

Measuring the two forms first showed this is an environment gap rather than a `dispatch` design flaw.

Diffing every reachable property of a named-dispatch `MouseEvent` against a direct-dispatch one built from the same init found exactly two divergences under happy-dom: `getModifierState`, and the `x`/`y` aliases of `clientX`/`clientY`. Everything else already matched. Under jsdom the same diff found no divergences at all, because jsdom implements both natively, the way browsers do.

So the fix goes in `shims.ts`, where the package already normalizes happy-dom's spec divergences, as one feature-detected `polyfillMouseEventMembers`. It fills in the two missing members and is a no-op anywhere they already exist, so it self-removes if happy-dom implements them. happy-dom's `PointerEvent` extends `MouseEvent`, so one prototype patch covers both.

This also covers events that never reach `dispatch` at all, such as a plain `element.dispatchEvent(new MouseEvent(...))` in a consumer's test.

### Why not the two approaches in the issue

The issue asked for the fix at the dispatch layer. Running `initEvent` from `baseDispatch` turns out to be unsafe in two independent ways:

1. `assignProps` defines properties with `configurable: false`, and a named dispatcher already runs `initEvent` before calling `baseDispatch`. Initializing there again throws `TypeError: Cannot redefine property` on every named dispatcher call.
2. `initEvent` derives values from the options that built the event, not from the event, and `initMouseEvent` writes them unconditionally. A caller-built event dispatched through it would have its own values overwritten, so `clientX: 7` would come out as `0`.

`initEvent` needs the `EventInit` that produced the event, which the direct form does not have. The one thing it could add for a caller-built event is `getModifierState`, and the environment patch supplies that without touching the caller's object.

The `modifier*` init members (`modifierAltGraph`, `modifierCapsLock`, and so on) stay out of reach for a caller-built event, because happy-dom's constructor discards them, so the fallback reports the four flags it does keep. That leaves the `auxclick` fired by `click` and `rightClick` reporting less than its sibling events, which is tracked in #7165 along with both approaches the issue proposed. This PR does not close that, but it does remove the throw for every mouse and pointer event.

`select.ts` builds a plain `Event` for `selectstart`, which `initEvent` never touches, so the issue's note about it needs no change.

## Tests

Three tests fail on `main` with `TypeError: event.getModifierState is not a function` and pass with the patch: the issue's reproduction with the listener calling `getModifierState` unguarded, a parity check against the named form, and an environment-level check that dispatches without going through `dispatch`.

`shims.jsdom.test.ts` pins the absence guard from jsdom, where the default happy-dom project makes it look redundant. Removing that guard replaces jsdom's spec-correct method with the four-flag fallback and flips `getModifierState("CapsLock")` from `true` to `false`.

## Follow-ups

- #7165: the `auxclick` in a `click` or `rightClick` gesture drops the `modifier*` init members its sibling events report.
- #7166: happy-dom's `KeyboardEvent.getModifierState` conflates `AltGraph` with `Alt`, ignores the `modifier*` members, and matches key names case-insensitively.
- #7168: `initUIEventModififiers` reports a bogus modifier state for `Object.prototype` key names, the same defect this PR avoided in the new fallback.
- #7169: `initEvent` skips modifier and mouse initialization for wheel, drag, and touch events, because those interfaces don't extend `MouseEvent` under happy-dom the way they do in browsers.

## Review gate reassessment

<details>
<summary>Cycle 3: Continue the environment-patch direction</summary>

**Assessment**

Issue severity and scope: a `TypeError` thrown into any plain DOM listener that reads modifier state under happy-dom. Triaged `experimental bug`, since `@ariakit/test` is not exposed through `@ariakit/react`. Reachable from the public direct form and from `rightClick` and `click` with a non-primary `button`. Expected frequency is low: it has shipped since #6574 without a report, no repository code reads `getModifierState`, and React consumers are insulated.

Implementation and maintenance complexity: one feature-detected function of about 45 lines in a file that already holds several larger happy-dom patches. No new module, no new public API, no new dependency, no change to `dispatch.ts` or any component, and no deletions.

What drove the cycles: of twelve findings across three rounds, one was a real defect in new code (an object-literal lookup resolving `Object.prototype` key names), two were pre-existing defects in untouched code, and nine were comment, test-name, doc-link, and changeset copy. No finding challenged the design, none clustered around the new machinery, and every accepted repair was one to three lines. The machinery shrank rather than grew: round 2 replaced an `Object.defineProperty` call with a plain assignment.

Alternatives: the issue's approach 1 moves about 180 lines into a private module and still only fixes the library's own `auxclick`, not the caller-built case the issue reproduces. Approach 2 adds public `dispatch.auxClick` API and also leaves the caller-built case broken. Running `initEvent` from `baseDispatch` throws `Cannot redefine property` on every named dispatcher call. None is better; both remain live options on #7165.

**Decision**

Continue the current direction. No machinery to remove, nothing to revert, no contract to narrow. The one standing concern was comment volume, since each round's disposition added qualifying prose that became the next round's reviewable surface, so the comment blocks were cut back to the code-style guidance instead of extended again.

Dispositions at this boundary: the `initUIEventModififiers` prototype-key defect was registered as #7168 rather than widening the diff, since it is pre-existing in a module this PR does not touch and no consumer scenario was established. The changeset was rewritten as a single sentence naming the four modifiers it actually covers. Two comment phrasings that overstated their scope were corrected as part of the trim.

</details>
