### PR TITLE
Use the click helper in the middle-click sandbox test

### DIFF
--- a/app/src/sandbox/focusable-tab-7153/test.ts
+++ b/app/src/sandbox/focusable-tab-7153/test.ts
@@ -16,8 +16,11 @@ async function middleClickActivates(element: Element) {
   };
   const { ownerDocument } = element;
   ownerDocument.addEventListener("auxclick", record, true);
-  await click(element, { button: 1 });
-  ownerDocument.removeEventListener("auxclick", record, true);
+  try {
+    await click(element, { button: 1 });
+  } finally {
+    ownerDocument.removeEventListener("auxclick", record, true);
+  }
   expect(auxClicks, "no auxclick landed on the element").toHaveLength(1);
   return auxClicks.every((event) => !event.defaultPrevented);
 }

--- a/app/src/sandbox/focusable-tab-7153/test.ts
+++ b/app/src/sandbox/focusable-tab-7153/test.ts
@@ -1,38 +1,45 @@
-import { dispatch, q } from "@ariakit/test";
+import { click, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
-// A middle click activates a link through `auxclick`, and `@ariakit/test` has
-// no middle-click utility, so dispatch the single event that carries the
-// activation. `dispatch` resolves to `false` when it was prevented.
-function middleClick(element: Element | null) {
-  const event = new MouseEvent("auxclick", {
-    bubbles: true,
-    cancelable: true,
-    composed: true,
-    detail: 1,
-    button: 1,
-  });
-  return dispatch(element, event);
+// A middle click activates a link through `auxclick`, and happy-dom doesn't
+// follow the destination, so the event's own `defaultPrevented` flag is what
+// says whether the activation would have run. A disabled element stops the
+// event before it bubbles back up, so the listener runs in the capture phase,
+// ahead of the handler that prevents it, and the flag is read afterwards.
+async function middleClickActivates(element: Element) {
+  const auxClicks: Event[] = [];
+  const record = (event: Event) => {
+    // `click` routes around `pointer-events: none` the way a browser does, so
+    // an event that landed elsewhere says nothing about this element.
+    if (event.target !== element) return;
+    auxClicks.push(event);
+  };
+  const { ownerDocument } = element;
+  ownerDocument.addEventListener("auxclick", record, true);
+  await click(element, { button: 1 });
+  ownerDocument.removeEventListener("auxclick", record, true);
+  expect(auxClicks, "no auxclick landed on the element").toHaveLength(1);
+  return auxClicks.every((event) => !event.defaultPrevented);
 }
 
-// Only the browser test covers the truly disabled link: `dispatch` routes
-// around `pointer-events: none` the way a browser does, so its result would
-// describe the ancestor that received the event, not the link.
+// Only the browser test covers the truly disabled link: `pointer-events: none`
+// keeps the gesture away from it, so the `auxclick` never lands on the link.
 
 test("middle click activates an enabled link", async () => {
-  expect(await middleClick(q.link("Enabled link"))).toBe(true);
+  expect(await middleClickActivates(q.link.ensure("Enabled link"))).toBe(true);
 });
 
 test("middle click activates an enabled tab rendered as a link", async () => {
-  expect(await middleClick(q.tab("Overview"))).toBe(true);
+  expect(await middleClickActivates(q.tab.ensure("Overview"))).toBe(true);
 });
 
 // https://github.com/ariakit/ariakit/issues/7153
 test("middle click does not activate an accessible disabled link", async () => {
-  expect(await middleClick(q.link("Accessible disabled link"))).toBe(false);
+  const link = q.link.ensure("Accessible disabled link");
+  expect(await middleClickActivates(link)).toBe(false);
 });
 
 // https://github.com/ariakit/ariakit/issues/7153
 test("middle click does not activate a disabled tab rendered as a link", async () => {
-  expect(await middleClick(q.tab("Billing"))).toBe(false);
+  expect(await middleClickActivates(q.tab.ensure("Billing"))).toBe(false);
 });


### PR DESCRIPTION
## Motivation

The happy-dom test for the `focusable-tab-7153` sandbox landed in [`8088d73`](https://github.com/ariakit/ariakit/commit/8088d7355a326ce7b3977d107513804f71a21a84) right after [`de0e76f`](https://github.com/ariakit/ariakit/commit/de0e76f54cd714366d308a3de5dadd59f5be837b) taught the `@ariakit/test` `click` helper to press non-primary mouse buttons, so it was written before that helper existed. It built the activating event by hand and dispatched only that one event:

```ts
function middleClick(element: Element | null) {
  const event = new MouseEvent("auxclick", { /* ... */ button: 1 });
  return dispatch(element, event);
}
```

That skipped everything a real middle click does first, and its comment still claimed that `@ariakit/test` has no middle-click utility.

## Solution

Drive the gesture through the public helper, so the test performs the same sequence a user does (hover, `pointerdown`, `mousedown`, focus, `pointerup`, `mouseup`, `auxclick`):

```ts
await click(element, { button: 1 });
```

`click` resolves to nothing, so the test records the `auxclick` event and reads `defaultPrevented` once the gesture is over. happy-dom does not follow the destination, so that flag is what says whether the activation would have run. The listener runs in the capture phase because `Focusable` calls `stopPropagation()` when it is disabled, which would keep a bubble listener from ever seeing the event.

The recorder also ignores an `auxclick` whose target is not the queried element. `dispatch` re-dispatches pointer events on the nearest ancestor with pointer events enabled, and `click` walks up to the first visible parent, so without that guard a fixture change could leave the two enabled-element tests passing while measuring an ancestor. The Playwright test already pays for the same precaution with an explicit hover before its forced click.

## Verification

`pnpm test` and `pnpm test-react18` pass for the file, and `pnpm tsc` is clean.

Removing `onAuxClickCapture` from `useFocusable` turns exactly the two `does not activate` tests red with `expected true to be false`, while the two enabled-element tests stay green, so the regression coverage still holds.
