### PR TITLE
Dispatch click, auxclick, and contextmenu as PointerEvent

### DIFF
--- a/.changeset/200-test-dispatch-aux-click.md
+++ b/.changeset/200-test-dispatch-aux-click.md
@@ -1,0 +1,11 @@
+---
+"@ariakit/test": patch
+---
+
+Added `dispatch.auxClick`
+
+`dispatch` now fires `auxclick` by name, like every other event it builds. `@testing-library/dom` has no `auxclick` entry in its event map, so firing that event previously meant building it by hand and passing it to `dispatch(element, event)`.
+
+```ts
+await dispatch.auxClick(q.link("Ariakit"), { button: 1 });
+```

--- a/.changeset/300-test-pointer-event-click-family.md
+++ b/.changeset/300-test-pointer-event-click-family.md
@@ -1,0 +1,21 @@
+---
+"@ariakit/test": patch
+---
+
+`click`, `auxclick`, and `contextmenu` are dispatched as `PointerEvent`
+
+Pointer Events defines these three events as `PointerEvent`, and Chromium, Firefox, and WebKit all dispatch them that way, but the test environment built them as `MouseEvent`. A listener could not check `event instanceof PointerEvent`, and pointer properties such as `pointerType` were missing even though the `pointerdown` and `pointerup` of the same gesture reported them. TypeScript types all three events as `PointerEvent`, so reading `pointerType` in a listener type-checked and then returned `undefined`.
+
+`click`, `tap`, `rightClick`, and `select` now carry the `pointerId` and `pointerType` they simulate through to the event that ends the gesture, including the click a label forwards to its control. The attributes describing the contact itself, such as `pressure` and `tiltX`, stay at their default values there, the way browsers reset them, so a pen press reporting `tiltX: 30` still ends in a `click` reporting `tiltX: 0`.
+
+```ts
+q.link.ensure("Ariakit").addEventListener("auxclick", (event) => {
+  event.pointerType; // "pen"
+});
+
+await click(q.link("Ariakit"), { button: 1, pointerType: "pen" });
+```
+
+`press.Enter` and `press.Space` fire the same `PointerEvent`, but report no pointer behind it, with `pointerId: -1` and an empty `pointerType`. That is what every engine reports for a click no pointer caused.
+
+`button` and `buttons` keep their mouse-event semantics on these three events, as Pointer Events requires, so assertions on them are unaffected.

--- a/app/src/sandbox/focusable-tab-7153/test.ts
+++ b/app/src/sandbox/focusable-tab-7153/test.ts
@@ -1,18 +1,11 @@
 import { dispatch, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
-// A middle click activates a link through `auxclick`, and `@ariakit/test` has
-// no middle-click utility, so dispatch the single event that carries the
-// activation. `dispatch` resolves to `false` when it was prevented.
+// A middle click activates a link through `auxclick`, so fire the single event
+// that carries the activation rather than the whole `click` sequence.
+// `dispatch` resolves to `false` when it was prevented.
 function middleClick(element: Element | null) {
-  const event = new MouseEvent("auxclick", {
-    bubbles: true,
-    cancelable: true,
-    composed: true,
-    detail: 1,
-    button: 1,
-  });
-  return dispatch(element, event);
+  return dispatch.auxClick(element, { detail: 1, button: 1 });
 }
 
 // Only the browser test covers the truly disabled link: `dispatch` routes

--- a/app/src/sandbox/focusable-tab-7153/test.ts
+++ b/app/src/sandbox/focusable-tab-7153/test.ts
@@ -1,31 +1,48 @@
-import { dispatch, q } from "@ariakit/test";
+import { click, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
-// A middle click activates a link through `auxclick`, so fire the single event
-// that carries the activation rather than the whole `click` sequence.
-// `dispatch` resolves to `false` when it was prevented.
-function middleClick(element: Element | null) {
-  return dispatch.auxClick(element, { detail: 1, button: 1 });
+// A middle click activates a link through `auxclick`, and happy-dom doesn't
+// follow the destination, so the event's own `defaultPrevented` flag is what
+// says whether the activation would have run. A disabled element stops the
+// event before it bubbles back up, so the listener runs in the capture phase,
+// ahead of the handler that prevents it, and the flag is read afterwards.
+async function middleClickActivates(element: Element) {
+  const auxClicks: Event[] = [];
+  const record = (event: Event) => {
+    // `click` routes around `pointer-events: none` the way a browser does, so
+    // an event that landed elsewhere says nothing about this element.
+    if (event.target !== element) return;
+    auxClicks.push(event);
+  };
+  const { ownerDocument } = element;
+  ownerDocument.addEventListener("auxclick", record, true);
+  try {
+    await click(element, { button: 1 });
+  } finally {
+    ownerDocument.removeEventListener("auxclick", record, true);
+  }
+  expect(auxClicks, "no auxclick landed on the element").toHaveLength(1);
+  return auxClicks.every((event) => !event.defaultPrevented);
 }
 
-// Only the browser test covers the truly disabled link: `dispatch` routes
-// around `pointer-events: none` the way a browser does, so its result would
-// describe the ancestor that received the event, not the link.
+// Only the browser test covers the truly disabled link: `pointer-events: none`
+// keeps the gesture away from it, so the `auxclick` never lands on the link.
 
 test("middle click activates an enabled link", async () => {
-  expect(await middleClick(q.link("Enabled link"))).toBe(true);
+  expect(await middleClickActivates(q.link.ensure("Enabled link"))).toBe(true);
 });
 
 test("middle click activates an enabled tab rendered as a link", async () => {
-  expect(await middleClick(q.tab("Overview"))).toBe(true);
+  expect(await middleClickActivates(q.tab.ensure("Overview"))).toBe(true);
 });
 
 // https://github.com/ariakit/ariakit/issues/7153
 test("middle click does not activate an accessible disabled link", async () => {
-  expect(await middleClick(q.link("Accessible disabled link"))).toBe(false);
+  const link = q.link.ensure("Accessible disabled link");
+  expect(await middleClickActivates(link)).toBe(false);
 });
 
 // https://github.com/ariakit/ariakit/issues/7153
 test("middle click does not activate a disabled tab rendered as a link", async () => {
-  expect(await middleClick(q.tab("Billing"))).toBe(false);
+  expect(await middleClickActivates(q.tab.ensure("Billing"))).toBe(false);
 });

--- a/packages/ariakit-test/readme.md
+++ b/packages/ariakit-test/readme.md
@@ -108,8 +108,10 @@ type Target = Document | Window | Node | Element | null;
 
 type EventFunction = (element: Target, options?: object) => Promise<boolean>;
 
+type DispatchEventType = EventType | "auxClick";
+
 type EventsObject = {
-  [K in EventType]: EventFunction;
+  [K in DispatchEventType]: EventFunction;
 };
 
 const dispatch: typeof baseDispatch & EventsObject;
@@ -119,6 +121,8 @@ Creates and fires a DOM event on an element, then waits for the resulting microt
 
 Unlike higher-level helpers such as `click` and `type`, this fires a single event without simulating the surrounding interaction sequence. Pointer and mouse events fired on an element with `pointer-events: none` are re-dispatched on the nearest ancestor that has pointer events enabled, matching how browsers route those events.
 
+`click`, `auxclick`, and `contextmenu` are built as `PointerEvent`, the way browsers dispatch them, so they accept and report pointer properties such as `pointerType`.
+
 Returns: A promise that resolves to `false` when the event's default action was prevented with `event.preventDefault()`, and `true` otherwise.
 
 Example:
@@ -126,6 +130,7 @@ Example:
 ```ts
 await dispatch.keyDown(q.textbox(), { key: "Enter" });
 await dispatch.click(q.button());
+await dispatch.auxClick(q.link("Ariakit"), { button: 1 });
 // Fire a custom event instance directly:
 await dispatch(q.textbox(), new Event("selectstart", { bubbles: true }));
 ```

--- a/packages/ariakit-test/src/__mouse.ts
+++ b/packages/ariakit-test/src/__mouse.ts
@@ -1,5 +1,3 @@
-import { dispatch } from "./dispatch.ts";
-
 // `MouseEvent.buttons` is a bitmask of the buttons currently held down, and its
 // bits are not ordered like `MouseEvent.button`: the secondary button is bit 1
 // while the auxiliary button is bit 2. Pointer Events defines the whole mapping,
@@ -18,6 +16,17 @@ export function getMouseButton(options?: MouseEventInit) {
   return options?.button ?? 0;
 }
 
+function omit(
+  options: PointerEventInit | undefined,
+  keys: ReadonlyArray<keyof PointerEventInit>,
+): PointerEventInit {
+  const remaining = { ...options };
+  for (const key of keys) {
+    delete remaining[key];
+  }
+  return remaining;
+}
+
 // Each phase derives `buttons` from the button it simulates. `mouseDown` and
 // `mouseUp` run a single phase, so an explicit value describes a chord there and
 // wins. A multi-step helper runs every phase from one init, where no single
@@ -30,9 +39,48 @@ export function getMouseButton(options?: MouseEventInit) {
  * device can be in.
  */
 export function omitButtons(options?: PointerEventInit): PointerEventInit {
-  const stepOptions = { ...options };
-  delete stepOptions.buttons;
-  return stepOptions;
+  return omit(options, ["buttons"]);
+}
+
+// The attributes that describe the contact itself rather than the pointer that
+// made it. `isPrimary` is left out because it describes the pointer, and
+// Firefox and WebKit do carry it through (Chromium reports `false`).
+const contactAttributes = [
+  "width",
+  "height",
+  "pressure",
+  "tangentialPressure",
+  "tiltX",
+  "tiltY",
+  "twist",
+] as const;
+
+/**
+ * Drops the contact attributes, which don't survive into `click`, `auxclick`,
+ * and `contextmenu`, keeping the members that identify the pointer behind them.
+ * Browsers reset the contact there: a pen press reporting `tiltX: 30` still ends
+ * in a `click` reporting `tiltX: 0`.
+ * https://www.w3.org/TR/pointerevents/#the-click-auxclick-and-contextmenu-events
+ */
+export function omitContactAttributes(
+  options?: PointerEventInit,
+): PointerEventInit {
+  return omit(options, contactAttributes);
+}
+
+/**
+ * Returns only the members that identify the pointer behind a gesture, for an
+ * event a browser derives from another one, like the `click` a label forwards to
+ * its control.
+ */
+export function getPointerIdentity(
+  options?: PointerEventInit,
+): PointerEventInit {
+  return {
+    pointerId: options?.pointerId,
+    pointerType: options?.pointerType,
+    isPrimary: options?.isPrimary,
+  };
 }
 
 /**
@@ -73,6 +121,14 @@ export function getReleaseOptions(
   };
 }
 
+/**
+ * Returns the event properties for the `click` or `auxclick` that ends the
+ * gesture, which a browser fires on the release with the contact reset.
+ */
+export function getClickOptions(options?: PointerEventInit): PointerEventInit {
+  return { detail: 1, ...omitContactAttributes(getReleaseOptions(options)) };
+}
+
 // Pointer Events fires no `pointerdown` or `pointerup` for a chorded button
 // change, where a button changes state while another one stays held down. The
 // change rides on `pointermove` instead, and only the compatibility mouse
@@ -95,19 +151,4 @@ export function isChordedPress(options: PointerEventInit) {
  */
 export function isChordedRelease(options: PointerEventInit) {
   return (options.buttons ?? 0) !== 0;
-}
-
-// `@testing-library/dom` has no `auxclick` in its event map, so `dispatch` can't
-// build this one by name.
-export function dispatchAuxClick(element: Element, options?: MouseEventInit) {
-  const { defaultView } = element.ownerDocument;
-  const MouseEventConstructor = defaultView?.MouseEvent ?? MouseEvent;
-  const event = new MouseEventConstructor("auxclick", {
-    bubbles: true,
-    cancelable: true,
-    composed: true,
-    detail: 1,
-    ...options,
-  });
-  return dispatch(element, event);
 }

--- a/packages/ariakit-test/src/__mouse.ts
+++ b/packages/ariakit-test/src/__mouse.ts
@@ -1,3 +1,5 @@
+import { getKeys } from "@ariakit/utils";
+
 // `MouseEvent.buttons` is a bitmask of the buttons currently held down, and its
 // bits are not ordered like `MouseEvent.button`: the secondary button is bit 1
 // while the auxiliary button is bit 2. Pointer Events defines the whole mapping,
@@ -42,18 +44,37 @@ export function omitButtons(options?: PointerEventInit): PointerEventInit {
   return omit(options, ["buttons"]);
 }
 
+type PointerIdentityAttribute = "pointerId" | "pointerType" | "isPrimary";
+
+type ContactAttribute = Exclude<
+  keyof PointerEventInit,
+  keyof MouseEventInit | PointerIdentityAttribute
+>;
+
 // The attributes that describe the contact itself rather than the pointer that
-// made it. `isPrimary` is left out because it describes the pointer, and
-// Firefox and WebKit do carry it through (Chromium reports `false`).
-const contactAttributes = [
-  "width",
-  "height",
-  "pressure",
-  "tangentialPressure",
-  "tiltX",
-  "tiltY",
-  "twist",
-] as const;
+// made it. `isPrimary` is left out deliberately, not by that rule: the
+// specification resets every pointer attribute here except `pointerId` and
+// `pointerType`, and Chromium follows it, but Firefox and WebKit carry
+// `isPrimary` over, so a value the caller passes explicitly is kept.
+//
+// Keyed rather than listed so TypeScript requires every non-identity member. A
+// list silently missed the four below, and `PointerEventInit` keeps growing.
+// https://github.com/ariakit/ariakit/pull/7177#discussion_r3811185510
+const contactAttributes: Record<ContactAttribute, true> = {
+  width: true,
+  height: true,
+  pressure: true,
+  tangentialPressure: true,
+  tiltX: true,
+  tiltY: true,
+  twist: true,
+  altitudeAngle: true,
+  azimuthAngle: true,
+  coalescedEvents: true,
+  predictedEvents: true,
+};
+
+const contactAttributeKeys = getKeys(contactAttributes);
 
 /**
  * Drops the contact attributes, which don't survive into `click`, `auxclick`,
@@ -65,7 +86,7 @@ const contactAttributes = [
 export function omitContactAttributes(
   options?: PointerEventInit,
 ): PointerEventInit {
-  return omit(options, contactAttributes);
+  return omit(options, contactAttributeKeys);
 }
 
 /**

--- a/packages/ariakit-test/src/click.test.ts
+++ b/packages/ariakit-test/src/click.test.ts
@@ -257,3 +257,117 @@ test("click with the auxiliary button doesn't run activation behavior", async ()
     "Banana",
   ]);
 });
+
+// Records the pointer members that separate the press from the event ending the
+// gesture, in the shape the expectations below were recorded in from Chromium,
+// Firefox, and WebKit through Playwright.
+// https://github.com/ariakit/ariakit/issues/7162
+function recordPointerMembers(element: Element, types: string[]) {
+  const events: string[] = [];
+  for (const type of types) {
+    element.addEventListener(type, (event) => {
+      const { pointerId, pointerType, isPrimary, pressure, tiltX } =
+        event as PointerEvent;
+      const isPointerEvent = event instanceof PointerEvent;
+      events.push(
+        `${event.type} ${isPointerEvent} ${pointerId} ${pointerType} ${isPrimary} ${pressure} ${tiltX}`,
+      );
+    });
+  }
+  return events;
+}
+
+// Browsers carry only the causal pointer's identity onto the event that ends
+// the gesture: a pen press reporting `tiltX: 30` still produces a `click` with
+// `tiltX: 0`. `isPrimary` describes the pointer, so it carries over, the way
+// Firefox and WebKit report it (Chromium resets it).
+test("click carries only the pointer identity to the click event", async () => {
+  document.body.innerHTML = `<button type="button">Submit</button>`;
+
+  const button = q.button.ensure("Submit");
+  const events = recordPointerMembers(button, ["pointerdown", "click"]);
+
+  await click(button, {
+    pointerId: 7,
+    pointerType: "pen",
+    isPrimary: true,
+    pressure: 0.5,
+    tiltX: 30,
+  });
+
+  expect(events).toEqual([
+    "pointerdown true 7 pen true 0.5 30",
+    "click true 7 pen true 0 0",
+  ]);
+});
+
+test("click with the auxiliary button carries the pointer identity to auxclick", async () => {
+  document.body.innerHTML = `<button type="button">Paste</button>`;
+
+  const button = q.button.ensure("Paste");
+  const events = recordPointerMembers(button, ["pointerdown", "auxclick"]);
+
+  await click(button, {
+    button: 1,
+    pointerId: 7,
+    pointerType: "pen",
+    isPrimary: true,
+    pressure: 0.5,
+    tiltX: 30,
+  });
+
+  expect(events).toEqual([
+    "pointerdown true 7 pen true 0.5 30",
+    "auxclick true 7 pen true 0 0",
+  ]);
+});
+
+// Activating a label forwards a click to its control, and Chromium and Firefox
+// give that forwarded event the pointer that caused it. WebKit reports an unset
+// pointer there instead.
+test("click forwards the pointer identity from a label to its control", async () => {
+  document.body.innerHTML = `
+    <label for="agree">Agree</label>
+    <input id="agree" type="checkbox">
+  `;
+
+  const label = q.text.ensure("Agree");
+  const checkbox = q.checkbox.ensure("Agree");
+  const events = recordPointerMembers(checkbox, ["click"]);
+
+  await click(label, {
+    pointerId: 7,
+    pointerType: "pen",
+    isPrimary: true,
+    pressure: 0.5,
+    tiltX: 30,
+  });
+
+  expect(events).toEqual(["click true 7 pen true 0 0"]);
+  expect((checkbox as HTMLInputElement).checked).toBe(true);
+});
+
+test("rightClick carries the pointer identity to contextmenu and auxclick", async () => {
+  document.body.innerHTML = `<button type="button">Open menu</button>`;
+
+  const button = q.button.ensure("Open menu");
+  const events = recordPointerMembers(button, [
+    "pointerdown",
+    "contextmenu",
+    "auxclick",
+  ]);
+
+  await rightClick(button, {
+    pointerId: 7,
+    pointerType: "pen",
+    isPrimary: true,
+    pressure: 0.5,
+    tiltX: 30,
+  });
+
+  expect(events).toEqual([
+    "pointerdown true 7 pen true 0.5 30",
+    "contextmenu true 7 pen true 0 0",
+    "auxclick true 7 pen true 0 0",
+  ]);
+});

--- a/packages/ariakit-test/src/click.test.ts
+++ b/packages/ariakit-test/src/click.test.ts
@@ -260,17 +260,28 @@ test("click with the auxiliary button doesn't run activation behavior", async ()
 
 // Records the pointer members that separate the press from the event ending the
 // gesture, in the shape the expectations below were recorded in from Chromium,
-// Firefox, and WebKit through Playwright.
+// Firefox, and WebKit through Playwright. `altitudeAngle` is the exception:
+// `initPointerEvent` never touches it, so it only resets when the options
+// reaching the constructor drop it, and it then lands on happy-dom's default of
+// `0` where browsers report π/2. What the expectations pin is that it stops
+// reporting the press's value, not the value it resets to.
 // https://github.com/ariakit/ariakit/issues/7162
+// https://github.com/ariakit/ariakit/issues/7172
 function recordPointerMembers(element: Element, types: string[]) {
   const events: string[] = [];
   for (const type of types) {
     element.addEventListener(type, (event) => {
-      const { pointerId, pointerType, isPrimary, pressure, tiltX } =
-        event as PointerEvent;
+      const {
+        pointerId,
+        pointerType,
+        isPrimary,
+        pressure,
+        tiltX,
+        altitudeAngle,
+      } = event as PointerEvent;
       const isPointerEvent = event instanceof PointerEvent;
       events.push(
-        `${event.type} ${isPointerEvent} ${pointerId} ${pointerType} ${isPrimary} ${pressure} ${tiltX}`,
+        `${event.type} ${isPointerEvent} ${pointerId} ${pointerType} ${isPrimary} ${pressure} ${tiltX} ${altitudeAngle}`,
       );
     });
   }
@@ -279,8 +290,8 @@ function recordPointerMembers(element: Element, types: string[]) {
 
 // Browsers carry only the causal pointer's identity onto the event that ends
 // the gesture: a pen press reporting `tiltX: 30` still produces a `click` with
-// `tiltX: 0`. `isPrimary` describes the pointer, so it carries over, the way
-// Firefox and WebKit report it (Chromium resets it).
+// `tiltX: 0`. `isPrimary` is the deliberate exception, kept because Firefox and
+// WebKit carry it over, while Chromium resets it as the specification requires.
 test("click carries only the pointer identity to the click event", async () => {
   document.body.innerHTML = `<button type="button">Submit</button>`;
 
@@ -292,12 +303,13 @@ test("click carries only the pointer identity to the click event", async () => {
     pointerType: "pen",
     isPrimary: true,
     pressure: 0.5,
+    altitudeAngle: 0.3,
     tiltX: 30,
   });
 
   expect(events).toEqual([
-    "pointerdown true 7 pen true 0.5 30",
-    "click true 7 pen true 0 0",
+    "pointerdown true 7 pen true 0.5 30 0.3",
+    "click true 7 pen true 0 0 0",
   ]);
 });
 
@@ -313,12 +325,13 @@ test("click with the auxiliary button carries the pointer identity to auxclick",
     pointerType: "pen",
     isPrimary: true,
     pressure: 0.5,
+    altitudeAngle: 0.3,
     tiltX: 30,
   });
 
   expect(events).toEqual([
-    "pointerdown true 7 pen true 0.5 30",
-    "auxclick true 7 pen true 0 0",
+    "pointerdown true 7 pen true 0.5 30 0.3",
+    "auxclick true 7 pen true 0 0 0",
   ]);
 });
 
@@ -340,10 +353,11 @@ test("click forwards the pointer identity from a label to its control", async ()
     pointerType: "pen",
     isPrimary: true,
     pressure: 0.5,
+    altitudeAngle: 0.3,
     tiltX: 30,
   });
 
-  expect(events).toEqual(["click true 7 pen true 0 0"]);
+  expect(events).toEqual(["click true 7 pen true 0 0 0"]);
   expect((checkbox as HTMLInputElement).checked).toBe(true);
 });
 
@@ -362,12 +376,13 @@ test("rightClick carries the pointer identity to contextmenu and auxclick", asyn
     pointerType: "pen",
     isPrimary: true,
     pressure: 0.5,
+    altitudeAngle: 0.3,
     tiltX: 30,
   });
 
   expect(events).toEqual([
-    "pointerdown true 7 pen true 0.5 30",
-    "contextmenu true 7 pen true 0 0",
-    "auxclick true 7 pen true 0 0",
+    "pointerdown true 7 pen true 0.5 30 0.3",
+    "contextmenu true 7 pen true 0 0 0",
+    "auxclick true 7 pen true 0 0 0",
   ]);
 });

--- a/packages/ariakit-test/src/click.ts
+++ b/packages/ariakit-test/src/click.ts
@@ -1,11 +1,12 @@
 import { isVisible, isFocusable, invariant } from "@ariakit/utils";
 import {
-  dispatchAuxClick,
+  getClickOptions,
   getHoverOptions,
   getMouseButton,
+  getPointerIdentity,
   getPressOptions,
-  getReleaseOptions,
   omitButtons,
+  omitContactAttributes,
 } from "./__mouse.ts";
 import { isHappyDOM, settle, wrapAsync } from "./__utils.ts";
 import { dispatch } from "./dispatch.ts";
@@ -35,7 +36,10 @@ function getInputFromLabel(element: HTMLLabelElement) {
     | undefined;
 }
 
-async function clickLabel(element: HTMLLabelElement, options?: MouseEventInit) {
+async function clickLabel(
+  element: HTMLLabelElement,
+  options?: PointerEventInit,
+) {
   const input = getInputFromLabel(element);
   const isInputDisabled = Boolean(input?.disabled);
 
@@ -53,8 +57,10 @@ async function clickLabel(element: HTMLLabelElement, options?: MouseEventInit) {
     if (defaultAllowed && isFocusable(input)) {
       await focus(input);
       // Only "click" is fired! Browsers don't go over the whole event stack in
-      // this case (mousedown, mouseup etc.).
-      await dispatch.click(input);
+      // this case (mousedown, mouseup etc.). The forwarded click still reports
+      // the pointer that caused it, as it does in Chromium and Firefox (WebKit
+      // reports an unset pointer instead).
+      await dispatch.click(input, getPointerIdentity(options));
     }
   }
 }
@@ -90,7 +96,7 @@ function clearHappyDOMSelectCache(element: HTMLSelectElement) {
 
 async function clickOption(
   element: HTMLOptionElement,
-  eventOptions?: MouseEventInit,
+  eventOptions?: PointerEventInit,
 ) {
   // https://stackoverflow.com/a/16530782/5513909
   const select = element.closest("select") as HTMLSelectElement & {
@@ -205,7 +211,10 @@ export function click(
 
     // The secondary button opens the context menu while it's still held down.
     if (button === 2) {
-      await dispatch.contextMenu(element, getPressOptions(stepOptions));
+      await dispatch.contextMenu(
+        element,
+        omitContactAttributes(getPressOptions(stepOptions)),
+      );
     }
 
     if (!tap) {
@@ -218,18 +227,18 @@ export function click(
     await mouseUp(element, stepOptions);
 
     const { disabled } = element as HTMLButtonElement;
+    const clickOptions = getClickOptions(stepOptions);
 
     if (button !== 0) {
       // Non-primary buttons fire `auxclick` instead of `click`, and never run
       // activation behavior, so labels and options aren't forwarded. Chromium
       // and WebKit still fire it on disabled controls, so it isn't suppressed
       // here (Firefox doesn't fire it).
-      await dispatchAuxClick(element, getReleaseOptions(stepOptions));
+      await dispatch.auxClick(element, clickOptions);
     } else if (disabled) {
       // Disabled controls suppress the final user-generated click.
       return;
     } else {
-      const clickOptions = { detail: 1, ...getReleaseOptions(stepOptions) };
       const label = getClosestLabel(element);
 
       if (label) {

--- a/packages/ariakit-test/src/dispatch.test.ts
+++ b/packages/ariakit-test/src/dispatch.test.ts
@@ -92,8 +92,9 @@ test("dispatch.input preserves provided inputType", async () => {
   }
 });
 
-// `auxclick` has no `@testing-library/dom` event map entry, so it can only be
-// dispatched through the direct form, which is how the gap below surfaced.
+// `auxclick` has no `@testing-library/dom` event map entry, so the direct form
+// was the only way to fire it before `dispatch.auxClick`, which is how the gap
+// below surfaced. This keeps covering that caller-built form.
 // https://github.com/ariakit/ariakit/issues/7156
 test("dispatch(element, event) reads modifier state on a caller-built mouse event", async () => {
   const button = document.createElement("button");
@@ -148,6 +149,89 @@ test("dispatch(element, event) reports the same standard modifiers and x/y as th
       x: 7,
       y: 9,
     });
+  } finally {
+    button.remove();
+  }
+});
+
+// Pointer Events defines `click`, `auxclick`, and `contextmenu` as
+// `PointerEvent`, which is what Chromium, Firefox, and WebKit dispatch for all
+// three. `@testing-library/dom` declares `MouseEvent` for `click` and
+// `contextMenu`, and has no `auxclick` entry at all.
+// https://github.com/ariakit/ariakit/issues/7162
+// https://www.w3.org/TR/pointerevents/#the-click-auxclick-and-contextmenu-events
+test("dispatch builds the click-family events as PointerEvent", async () => {
+  const button = document.createElement("button");
+  document.body.append(button);
+  const events: string[] = [];
+  for (const type of ["click", "auxclick", "contextmenu"]) {
+    button.addEventListener(type, (event) => {
+      const { pointerId, pointerType } = event as PointerEvent;
+      const isPointerEvent = event instanceof PointerEvent;
+      events.push(
+        `${event.type} ${isPointerEvent} ${pointerId} ${pointerType}`,
+      );
+    });
+  }
+  const options: PointerEventInit = { pointerId: 7, pointerType: "pen" };
+  try {
+    await dispatch.click(button, options);
+    await dispatch.auxClick(button, options);
+    await dispatch.contextMenu(button, options);
+    expect(events).toEqual([
+      "click true 7 pen",
+      "auxclick true 7 pen",
+      "contextmenu true 7 pen",
+    ]);
+  } finally {
+    button.remove();
+  }
+});
+
+// `dispatch` fires the event the caller describes. Dropping the attributes a
+// browser resets on a click is the job of the gesture helpers, which know the
+// press those attributes came from.
+test("dispatch.click keeps the contact attributes the caller passes", async () => {
+  const button = document.createElement("button");
+  document.body.append(button);
+  let event: PointerEvent | undefined;
+  button.addEventListener("click", (clickEvent) => {
+    event = clickEvent;
+  });
+  try {
+    await dispatch.click(button, { pressure: 0.5, tiltX: 30 });
+    expect(event?.pressure).toBe(0.5);
+    expect(event?.tiltX).toBe(30);
+  } finally {
+    button.remove();
+  }
+});
+
+// The named dispatchers report a default mouse pointer when the caller names
+// none, the same default every other pointer event uses.
+test("dispatch.click defaults to a mouse pointer", async () => {
+  const button = document.createElement("button");
+  document.body.append(button);
+  let event: PointerEvent | undefined;
+  button.addEventListener("click", (clickEvent) => {
+    event = clickEvent;
+  });
+  try {
+    await dispatch.click(button);
+    expect(event?.pointerId).toBe(0);
+    expect(event?.pointerType).toBe("mouse");
+  } finally {
+    button.remove();
+  }
+});
+
+test("dispatch.auxClick reports a prevented default", async () => {
+  const button = document.createElement("button");
+  document.body.append(button);
+  try {
+    expect(await dispatch.auxClick(button)).toBe(true);
+    button.addEventListener("auxclick", (event) => event.preventDefault());
+    expect(await dispatch.auxClick(button)).toBe(false);
   } finally {
     button.remove();
   }

--- a/packages/ariakit-test/src/dispatch.test.ts
+++ b/packages/ariakit-test/src/dispatch.test.ts
@@ -92,68 +92,6 @@ test("dispatch.input preserves provided inputType", async () => {
   }
 });
 
-// `auxclick` has no `@testing-library/dom` event map entry, so the direct form
-// was the only way to fire it before `dispatch.auxClick`, which is how the gap
-// below surfaced. This keeps covering that caller-built form.
-// https://github.com/ariakit/ariakit/issues/7156
-test("dispatch(element, event) reads modifier state on a caller-built mouse event", async () => {
-  const button = document.createElement("button");
-  document.body.append(button);
-  const modifiers: boolean[] = [];
-  button.addEventListener("auxclick", (event) => {
-    // A plain DOM listener calls this unguarded, the way a browser allows.
-    modifiers.push(
-      event.getModifierState("Shift"),
-      event.getModifierState("Control"),
-    );
-  });
-  try {
-    await dispatch(
-      button,
-      new MouseEvent("auxclick", { bubbles: true, shiftKey: true }),
-    );
-    expect(modifiers).toEqual([true, false]);
-  } finally {
-    button.remove();
-  }
-});
-
-// Parity covers the standard modifiers and `x`/`y`. happy-dom's constructor
-// discards the `modifier*` init members, so a caller-built event cannot report
-// those the way a named dispatcher does.
-test("dispatch(element, event) reports the same standard modifiers and x/y as the named form", async () => {
-  const button = document.createElement("button");
-  document.body.append(button);
-  const options: MouseEventInit = { shiftKey: true, clientX: 7, clientY: 9 };
-  let direct: MouseEvent | undefined;
-  let named: MouseEvent | undefined;
-  button.addEventListener("auxclick", (event) => {
-    direct = event;
-  });
-  button.addEventListener("click", (event) => {
-    named = event;
-  });
-  try {
-    await dispatch(button, new MouseEvent("auxclick", options));
-    await dispatch.click(button, options);
-    const readMembers = (event: MouseEvent | undefined) => ({
-      shift: event?.getModifierState("Shift"),
-      control: event?.getModifierState("Control"),
-      x: event?.x,
-      y: event?.y,
-    });
-    expect(readMembers(direct)).toEqual(readMembers(named));
-    expect(readMembers(direct)).toEqual({
-      shift: true,
-      control: false,
-      x: 7,
-      y: 9,
-    });
-  } finally {
-    button.remove();
-  }
-});
-
 // Pointer Events defines `click`, `auxclick`, and `contextmenu` as
 // `PointerEvent`, which is what Chromium, Firefox, and WebKit dispatch for all
 // three. `@testing-library/dom` declares `MouseEvent` for `click` and
@@ -232,6 +170,68 @@ test("dispatch.auxClick reports a prevented default", async () => {
     expect(await dispatch.auxClick(button)).toBe(true);
     button.addEventListener("auxclick", (event) => event.preventDefault());
     expect(await dispatch.auxClick(button)).toBe(false);
+  } finally {
+    button.remove();
+  }
+});
+
+// `auxclick` has no `@testing-library/dom` event map entry, so the direct form
+// was the only way to fire it before `dispatch.auxClick`, which is how the gap
+// below surfaced. This keeps covering that caller-built form.
+// https://github.com/ariakit/ariakit/issues/7156
+test("dispatch(element, event) reads modifier state on a caller-built mouse event", async () => {
+  const button = document.createElement("button");
+  document.body.append(button);
+  const modifiers: boolean[] = [];
+  button.addEventListener("auxclick", (event) => {
+    // A plain DOM listener calls this unguarded, the way a browser allows.
+    modifiers.push(
+      event.getModifierState("Shift"),
+      event.getModifierState("Control"),
+    );
+  });
+  try {
+    await dispatch(
+      button,
+      new MouseEvent("auxclick", { bubbles: true, shiftKey: true }),
+    );
+    expect(modifiers).toEqual([true, false]);
+  } finally {
+    button.remove();
+  }
+});
+
+// Parity covers the standard modifiers and `x`/`y`. happy-dom's constructor
+// discards the `modifier*` init members, so a caller-built event cannot report
+// those the way a named dispatcher does.
+test("dispatch(element, event) reports the same standard modifiers and x/y as the named form", async () => {
+  const button = document.createElement("button");
+  document.body.append(button);
+  const options: MouseEventInit = { shiftKey: true, clientX: 7, clientY: 9 };
+  let direct: MouseEvent | undefined;
+  let named: MouseEvent | undefined;
+  button.addEventListener("auxclick", (event) => {
+    direct = event;
+  });
+  button.addEventListener("click", (event) => {
+    named = event;
+  });
+  try {
+    await dispatch(button, new MouseEvent("auxclick", options));
+    await dispatch.click(button, options);
+    const readMembers = (event: MouseEvent | undefined) => ({
+      shift: event?.getModifierState("Shift"),
+      control: event?.getModifierState("Control"),
+      x: event?.x,
+      y: event?.y,
+    });
+    expect(readMembers(direct)).toEqual(readMembers(named));
+    expect(readMembers(direct)).toEqual({
+      shift: true,
+      control: false,
+      x: 7,
+      y: 9,
+    });
   } finally {
     button.remove();
   }

--- a/packages/ariakit-test/src/dispatch.ts
+++ b/packages/ariakit-test/src/dispatch.ts
@@ -27,8 +27,12 @@ type Target = Document | Window | Node | Element | null;
 
 type EventFunction = (element: Target, options?: object) => Promise<boolean>;
 
+// `@testing-library/dom` has no `auxclick` in its event map, so `dispatch` adds
+// it to the events it can build by name.
+type DispatchEventType = EventType | "auxClick";
+
 type EventsObject = {
-  [K in EventType]: EventFunction;
+  [K in DispatchEventType]: EventFunction;
 };
 
 function assignProps<T extends object>(
@@ -362,10 +366,39 @@ function baseDispatch(element: Target, event: Event): Promise<boolean> {
   });
 }
 
-const events = getKeys(fireEvent).reduce((events, eventName) => {
+// The `@testing-library/dom` event map builds `click` and `contextmenu` from
+// `MouseEvent` and has no `auxclick` entry, but Pointer Events defines all three
+// as `PointerEvent`, which is what Chromium, Firefox, and WebKit dispatch. Only
+// the interface and the pointer members change; `button` and `buttons` keep
+// their mouse-event semantics. Replacing the map's `click` entry also drops its
+// `button: 0`, which `initMouseEvent` assigns anyway.
+// https://www.w3.org/TR/pointerevents/#the-click-auxclick-and-contextmenu-events
+const clickFamilyInit = { bubbles: true, cancelable: true, composed: true };
+
+function createNamedEvent(
+  eventName: DispatchEventType,
+  element: NonNullable<Target>,
+  options?: object,
+) {
+  if (
+    eventName === "click" ||
+    eventName === "auxClick" ||
+    eventName === "contextMenu"
+  ) {
+    return createEvent(eventName.toLowerCase(), element, options, {
+      EventType: "PointerEvent",
+      defaultInit: clickFamilyInit,
+    });
+  }
+  return createEvent[eventName](element, options);
+}
+
+const eventNames: DispatchEventType[] = [...getKeys(fireEvent), "auxClick"];
+
+const events = eventNames.reduce((events, eventName) => {
   events[eventName] = (element, options) => {
     invariant(element, `Unable to dispatch ${eventName} on null element`);
-    const event = createEvent[eventName](element, options);
+    const event = createNamedEvent(eventName, element, options);
     initEvent(event, options);
     return baseDispatch(element, event);
   };
@@ -384,12 +417,17 @@ const events = getKeys(fireEvent).reduce((events, eventName) => {
  * mouse events fired on an element with `pointer-events: none` are re-dispatched
  * on the nearest ancestor that has pointer events enabled, matching how browsers
  * route those events.
+ *
+ * `click`, `auxclick`, and `contextmenu` are built as `PointerEvent`, the way
+ * browsers dispatch them, so they accept and report pointer properties such as
+ * `pointerType`.
  * @returns A promise that resolves to `false` when the event's default action was
  * prevented with `event.preventDefault()`, and `true` otherwise.
  * @example
  * ```ts
  * await dispatch.keyDown(q.textbox(), { key: "Enter" });
  * await dispatch.click(q.button());
+ * await dispatch.auxClick(q.link("Ariakit"), { button: 1 });
  * // Fire a custom event instance directly:
  * await dispatch(q.textbox(), new Event("selectstart", { bubbles: true }));
  * ```

--- a/packages/ariakit-test/src/press.jsdom.test.ts
+++ b/packages/ariakit-test/src/press.jsdom.test.ts
@@ -25,6 +25,31 @@ test("press.Enter activates a default button in jsdom", async () => {
   expect(onSubmit).toHaveBeenCalledOnce();
 });
 
+// This click is built and dispatched synchronously rather than through a named
+// dispatcher, so it's the one place the shared initialization can be skipped.
+// jsdom leaves the members it doesn't construct absent, where happy-dom stores
+// its own defaults, and only the initializer makes the two agree.
+test("press.Enter submits with the same pointer members every click reports", async () => {
+  const form = document.createElement("form");
+  const input = document.createElement("input");
+  const button = document.createElement("button");
+  const members: Array<Record<string, unknown>> = [];
+  button.type = "submit";
+  button.addEventListener("click", (event) => {
+    event.preventDefault();
+    const { altitudeAngle, azimuthAngle, tiltX, width } = event;
+    members.push({ altitudeAngle, azimuthAngle, tiltX, width });
+  });
+  form.append(input, button);
+  document.body.append(form);
+
+  await press.Enter(input);
+
+  expect(members).toEqual([
+    { altitudeAngle: Math.PI / 2, azimuthAngle: 0, tiltX: 0, width: 1 },
+  ]);
+});
+
 test("press.Enter does not resubmit an image submitter after external validation", async () => {
   const form = document.createElement("form");
   const input = document.createElement("input");

--- a/packages/ariakit-test/src/press.test.ts
+++ b/packages/ariakit-test/src/press.test.ts
@@ -318,3 +318,54 @@ test("press.Enter on a textarea emits an Enter keypress charCode", async () => {
     expect.objectContaining({ charCode: 13 }),
   );
 });
+
+// Keyboard activation still fires a `PointerEvent`, but Chromium, Firefox, and
+// WebKit all report an unset pointer on it, so the click must not claim a mouse
+// pressed the control.
+// https://github.com/ariakit/ariakit/issues/7162
+test("press activates a button with no pointer behind the click", async () => {
+  const button = document.createElement("button");
+  document.body.append(button);
+  const events: Array<Record<string, unknown>> = [];
+  button.addEventListener("click", (event) => {
+    const { pointerId, pointerType } = event;
+    events.push({
+      isPointerEvent: event instanceof PointerEvent,
+      pointerId,
+      pointerType,
+    });
+  });
+
+  await press.Enter(button);
+  await press.Space(button);
+
+  expect(events).toEqual([
+    { isPointerEvent: true, pointerId: -1, pointerType: "" },
+    { isPointerEvent: true, pointerId: -1, pointerType: "" },
+  ]);
+});
+
+test("press.Enter submits with no pointer behind the default button click", async () => {
+  const form = document.createElement("form");
+  const input = document.createElement("input");
+  const button = document.createElement("button");
+  const events: Array<Record<string, unknown>> = [];
+  button.type = "submit";
+  button.addEventListener("click", (event) => {
+    event.preventDefault();
+    const { pointerId, pointerType } = event;
+    events.push({
+      isPointerEvent: event instanceof PointerEvent,
+      pointerId,
+      pointerType,
+    });
+  });
+  form.append(input, button);
+  document.body.append(form);
+
+  await press.Enter(input);
+
+  expect(events).toEqual([
+    { isPointerEvent: true, pointerId: -1, pointerType: "" },
+  ]);
+});

--- a/packages/ariakit-test/src/press.test.ts
+++ b/packages/ariakit-test/src/press.test.ts
@@ -353,11 +353,14 @@ test("press.Enter submits with no pointer behind the default button click", asyn
   button.type = "submit";
   button.addEventListener("click", (event) => {
     event.preventDefault();
-    const { pointerId, pointerType } = event;
+    const { pointerId, pointerType, altitudeAngle } = event;
     events.push({
       isPointerEvent: event instanceof PointerEvent,
       pointerId,
       pointerType,
+      // The constructor supplies the two members above, so only one it doesn't
+      // supply can catch this click skipping the shared initialization.
+      altitudeAngle,
     });
   });
   form.append(input, button);
@@ -366,6 +369,11 @@ test("press.Enter submits with no pointer behind the default button click", asyn
   await press.Enter(input);
 
   expect(events).toEqual([
-    { isPointerEvent: true, pointerId: -1, pointerType: "" },
+    {
+      isPointerEvent: true,
+      pointerId: -1,
+      pointerType: "",
+      altitudeAngle: Math.PI / 2,
+    },
   ]);
 });

--- a/packages/ariakit-test/src/press.ts
+++ b/packages/ariakit-test/src/press.ts
@@ -23,6 +23,15 @@ type KeyActionMap = Record<
   (element: Element, options: KeyboardEventInit) => Promise<void>
 >;
 
+// A keyboard activation still fires a `PointerEvent`, but no pointer caused it.
+// Chromium, Firefox, and WebKit all report an unset pointer there, so the click
+// doesn't claim a mouse pressed the control.
+// https://www.w3.org/TR/pointerevents/#the-click-auxclick-and-contextmenu-events
+const noPointerOptions: PointerEventInit = {
+  pointerId: -1,
+  pointerType: "",
+};
+
 const clickableInputTypes = [
   "button",
   "color",
@@ -74,13 +83,15 @@ function getSubmitButton(form: HTMLFormElement) {
   );
 }
 
+// Built here rather than through `dispatch.click` because implicit submission
+// needs the click dispatched synchronously, before `requestSubmit` runs.
 function createKeyboardClickEvent(
   element: Element,
   options: KeyboardEventInit,
 ) {
   const { defaultView } = element.ownerDocument;
-  const MouseEventConstructor = defaultView?.MouseEvent ?? MouseEvent;
-  return new MouseEventConstructor("click", {
+  const PointerEventConstructor = defaultView?.PointerEvent ?? PointerEvent;
+  return new PointerEventConstructor("click", {
     bubbles: true,
     cancelable: true,
     composed: true,
@@ -88,6 +99,7 @@ function createKeyboardClickEvent(
     ctrlKey: options.ctrlKey,
     metaKey: options.metaKey,
     shiftKey: options.shiftKey,
+    ...noPointerOptions,
   });
 }
 
@@ -238,7 +250,7 @@ const keyDownMap: KeyActionMap = {
       !nonSubmittableTypes.includes(element.type);
 
     if (isClickable) {
-      await dispatch.click(element, options);
+      await dispatch.click(element, { ...options, ...noPointerOptions });
     } else if (isSubmittable) {
       await submitFormByPressingEnterOn(element, options);
     }
@@ -361,7 +373,7 @@ const keyUpMap: KeyActionMap = {
     // (the DOM test environments don't blur it the way a real browser does, and
     // jsdom would otherwise fire the click).
     if (isSpaceable && !isDisabled(element)) {
-      await dispatch.click(element, options);
+      await dispatch.click(element, { ...options, ...noPointerOptions });
     }
   },
 };

--- a/packages/ariakit-test/src/press.ts
+++ b/packages/ariakit-test/src/press.ts
@@ -5,6 +5,7 @@ import {
   getPreviousTabbable,
   isFocusable,
 } from "@ariakit/utils";
+import { initEvent } from "./__init-event.ts";
 import {
   flushMicrotasks,
   isHappyDOM,
@@ -91,7 +92,7 @@ function createKeyboardClickEvent(
 ) {
   const { defaultView } = element.ownerDocument;
   const PointerEventConstructor = defaultView?.PointerEvent ?? PointerEvent;
-  return new PointerEventConstructor("click", {
+  const eventOptions: PointerEventInit = {
     bubbles: true,
     cancelable: true,
     composed: true,
@@ -100,7 +101,13 @@ function createKeyboardClickEvent(
     metaKey: options.metaKey,
     shiftKey: options.shiftKey,
     ...noPointerOptions,
-  });
+  };
+  const event = new PointerEventConstructor("click", eventOptions);
+  // Run the same initialization a named dispatcher does, so this click reports
+  // the pointer members every other one does instead of whatever the
+  // environment's constructor happens to store.
+  initEvent(event, eventOptions);
+  return event;
 }
 
 function dispatchKeyboardClick(element: Element, options: KeyboardEventInit) {

--- a/packages/ariakit-test/src/select.test.ts
+++ b/packages/ariakit-test/src/select.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, expect, test } from "vitest";
+import { q, select } from "./index.ts";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+// Dragging across text ends the gesture with a `click`, so it reports the same
+// pointer as the press and resets the contact, like the other helpers.
+// https://github.com/ariakit/ariakit/issues/7162
+test("select carries only the pointer identity to the click event", async () => {
+  document.body.innerHTML = `<div>first second third</div>`;
+
+  const element = q.text.ensure("first second third");
+  const events: string[] = [];
+  element.addEventListener("click", (event) => {
+    const isPointerEvent = event instanceof PointerEvent;
+    events.push(
+      `${event.type} ${isPointerEvent} ${event.pointerId} ${event.pointerType} ${event.pressure}`,
+    );
+  });
+
+  await select("second", element, {
+    pointerId: 7,
+    pointerType: "pen",
+    pressure: 0.5,
+  });
+
+  expect(document.getSelection()?.toString()).toBe("second");
+  expect(events).toEqual(["click true 7 pen 0"]);
+});

--- a/packages/ariakit-test/src/select.ts
+++ b/packages/ariakit-test/src/select.ts
@@ -1,5 +1,5 @@
 import { isVisible, invariant } from "@ariakit/utils";
-import { getHoverOptions, getReleaseOptions, omitButtons } from "./__mouse.ts";
+import { getClickOptions, getHoverOptions, omitButtons } from "./__mouse.ts";
 import { settle, wrapAsync } from "./__utils.ts";
 import { dispatch } from "./dispatch.ts";
 import { hover } from "./hover.ts";
@@ -91,10 +91,7 @@ export function select(
 
     await mouseUp(element, stepOptions);
 
-    await dispatch.click(element, {
-      detail: 1,
-      ...getReleaseOptions(stepOptions),
-    });
+    await dispatch.click(element, getClickOptions(stepOptions));
 
     await sleep();
   });


### PR DESCRIPTION
## Motivation

`@ariakit/test` dispatches `click`, `auxclick`, and `contextmenu` as `MouseEvent`, but Pointer Events defines all three as `PointerEvent`, which is what browsers dispatch.

`dispatch` builds named events from the `@testing-library/dom` event map, which declares `MouseEvent` for `click` and `contextMenu` and has no `auxclick` entry at all, so `auxclick` was hand-built as a `MouseEvent` as well. A listener could not check `event instanceof PointerEvent`, and the pointer properties were missing even when the caller passed them and the press phase of the same gesture reported them.

```ts
await click(button, { pointerId: 7, pointerType: "pen" });
// pointerdown: PointerEvent, pointerId 7,         pointerType "pen"
// click:       MouseEvent,   pointerId undefined, pointerType undefined
```

TypeScript types all three events as `PointerEvent` in `lib.dom`, so reading `event.pointerType` in a listener type-checked and then returned `undefined`.

## Browser behavior

Measured with Playwright on Chromium 151, Firefox 153, and WebKit 26.5:

| Events | Interface | `pointerId` and `pointerType` | Contact attributes |
| --- | --- | --- | --- |
| `pointerdown`, `pointerup` | `PointerEvent` | the causal pointer | the causal pointer |
| `mousedown`, `mouseup` | `MouseEvent` | absent | absent |
| `click`, `auxclick`, `contextmenu` | `PointerEvent` | the causal pointer | default values |

Only the pointer's identity carries over to the last three. In every engine a mouse press reports `pressure: 0.5` while the button is held and the resulting `click` reports `0`, and in Chromium a pen press reporting `tiltX: 30` ends in a `click` reporting `tiltX: 0`, while a touch press reporting `width: 3.92` ends in a `click` reporting `width: 1`. The identity itself does follow the causal pointer, including a pen or touch `pointerType`.

The engines disagree on `isPrimary`. Pointer Events resets every pointer attribute on these events except `pointerId` and `pointerType`, and Chromium follows it, reporting `false`, while Firefox and WebKit carry the pointer's value through. This PR keeps a value the caller passes explicitly, matching those two, and records the divergence where the decision lives.

For a click no pointer caused, which covers keyboard activation and `element.click()`, all three engines report `pointerId: -1` and an empty `pointerType`. `dblclick` stays a plain `MouseEvent` in every engine, so it is left alone.

## Solution

`dispatch` now builds `click`, `auxclick`, and `contextmenu` from `PointerEvent`, overriding the interface the `@testing-library/dom` event map declares, and `auxclick` joins the events it can fire by name as `dispatch.auxClick`. Routing all three through the same named path initializes the pointer members the same way in every environment, instead of depending on what each DOM implementation's `PointerEvent` constructor keeps.

`click`, `tap`, `rightClick`, and `select` pass the `pointerId` and `pointerType` they simulate to that event and drop the contact attributes, matching the engines. The click a label forwards to its control carries the same identity, the way Chromium and Firefox forward it. `press.Enter` and `press.Space` pass `pointerId: -1` with an empty `pointerType`, so a click no pointer caused does not claim a mouse pressed the control. The implicit form-submission click in `press` becomes a `PointerEvent` too, and stays hand-built there because submission needs it dispatched synchronously.

`button` and `buttons` keep their mouse-event semantics, which Pointer Events requires for exactly these three events, so existing assertions on them are unaffected.

## Follow-ups

Related gaps found while working on this are tracked separately, because none is introduced by this change and none has to be resolved for the events to carry the right interface:

- #7171: `fireClickEvent` in `@ariakit/utils` dispatches the synthetic click behind `Enter` and `Space` activation as a `MouseEvent`. That one ships to real applications rather than tests.
- #7176: the click a label forwards to its control still drops the gesture's modifiers, coordinates, and `detail`.

#7172, the pointer members reporting values no browser produces, was fixed on `main` by #7188 while this was open. The two changes compose: `dispatch` now gives a reset `altitudeAngle` the right angle browsers report instead of zero, and this branch is what drops the press's value so that default applies to the click family at all.

## Review gate reassessment

<details>
<summary>Cycle 3: Continue the dispatch-layer direction, with no removals</summary>

**Assessment**

Issue severity is moderate and structural rather than cosmetic. `@ariakit/test` exists to reproduce browser event sequences faithfully, and it built the three most-used events in the library on the wrong interface, against all three engines and the Pointer Events specification, while TypeScript types those same handlers as `PointerEvent`. Reading `event.pointerType` in a listener type-checked and returned `undefined`, which is a silent-wrong-answer defect in a test library.

Expected frequency is low today, since nothing in this repository reads these members, but structurally rising: the surrounding area is under active development, and every helper already accepts `PointerEventInit` and forwards it to the press phase.

Supported scope is three event types across the `dispatch` primitive and six public helpers. The `pointerId`/`pointerType`-follow-the-pointer versus contact-attributes-at-defaults distinction is not gold-plating; the issue's triage comment required it.

Implementation complexity is proportionate and partly negative. Of 462 added lines, 324 are tests, changesets, and the generated readme, leaving 138 added and 41 removed lines of source across five files. That includes deleting the hand-built `dispatchAuxClick`, and `select.ts` is now smaller than on `main`. Public API grows by one method, `dispatch.auxClick`, which replaced a private special case. The dispatch-layer change rides a documented, typed extension point in `@testing-library/dom` rather than a monkey-patch, and the new option builders join the `getHoverOptions`/`getPressOptions`/`getReleaseOptions` family that already lives in the same private module.

The three gate rounds converge rather than thrash: findings went 3, 3, 2, severity never exceeded Low, priority never exceeded P2, and no round produced a P0 or P1. The kind of finding degraded monotonically, from a wrong value that would reach consumers, to internal consistency and duplication, to one missing test and one stale comment. The one genuine thrash thread is `isPrimary`, which produced a finding in all three rounds in three different forms. Its cause is an engine disagreement, where Chromium resets the attribute and Firefox and WebKit carry it through, chased through the three places the code touches it with no executable record of the decision.

**Decision**

Continue the current direction with no removals, no revert, and no narrowing, and address both round 3 findings before committing.

The competing design, moving the contact-attribute drop into `dispatch` itself, was re-evaluated on its merits and rejected again on stronger grounds than the original rejection: the gesture helpers would still need a `getClickOptions`-shaped function for `detail` and the release `buttons`, so it saves little, and it would make `dispatch.click(element, { pressure: 0.5 })` silently discard a caller's explicit value. A red check during this cycle confirmed the drop would have to happen inside `initEvent`, deeper in the primitive than the alternative implies. That rejection is now pinned by a test.

The `isPrimary` thread is terminated by converting the decision from prose into an enforced invariant: the pointer-identity tests now pass `isPrimary` and assert it, which red-checks in both regression directions. No accepted disposition was reversed. No intentionally unsupported edge cases beyond the registered follow-ups above.

</details>

Fixes #7162
