### PR TITLE
Fix modifier state on caller-built keyboard events

### DIFF
--- a/.changeset/300-test-keyboard-modifier-state.md
+++ b/.changeset/300-test-keyboard-modifier-state.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/test": patch
+---
+
+Fixed keyboard events in the test environment so `getModifierState` matches the exact modifier names in UI Events and reports the `modifier*` members the event was built with, such as `AltGraph` and `CapsLock`, instead of reading `AltGraph` from `Alt` and matching a name like `shift` case-insensitively.

--- a/packages/ariakit-test/src/dispatch.test.ts
+++ b/packages/ariakit-test/src/dispatch.test.ts
@@ -117,9 +117,9 @@ test("dispatch(element, event) reads modifier state on a caller-built mouse even
   }
 });
 
-// Parity covers the standard modifiers and `x`/`y`. happy-dom's constructor
-// discards the `modifier*` init members, so a caller-built event cannot report
-// those the way a named dispatcher does.
+// Parity covers the standard modifiers and `x`/`y`. happy-dom's `MouseEvent`
+// constructor discards the `modifier*` init members, so a caller-built event
+// cannot report those the way a named dispatcher does.
 test("dispatch(element, event) reports the same standard modifiers and x/y as the named form", async () => {
   const button = document.createElement("button");
   document.body.append(button);
@@ -150,5 +150,47 @@ test("dispatch(element, event) reports the same standard modifiers and x/y as th
     });
   } finally {
     button.remove();
+  }
+});
+
+// Keyboard parity covers the `modifier*` init members too, because the
+// environment records them for a caller-built event.
+// https://github.com/ariakit/ariakit/issues/7166
+test("dispatch(element, event) reports the same modifiers as the named form for a keyboard event", async () => {
+  const input = document.createElement("input");
+  document.body.append(input);
+  const options: KeyboardEventInit = {
+    key: "a",
+    altKey: true,
+    modifierCapsLock: true,
+    // No browser engine implements `Super`, so neither path records it here.
+    // Recording it on one side only would break the parity below.
+    modifierSuper: true,
+  };
+  const received: KeyboardEvent[] = [];
+  input.addEventListener("keydown", (event) => {
+    received.push(event);
+  });
+  try {
+    await dispatch(input, new KeyboardEvent("keydown", options));
+    await dispatch.keyDown(input, options);
+    const readModifiers = (event: KeyboardEvent | undefined) => ({
+      alt: event?.getModifierState("Alt"),
+      altGraph: event?.getModifierState("AltGraph"),
+      capsLock: event?.getModifierState("CapsLock"),
+      shift: event?.getModifierState("Shift"),
+      super: event?.getModifierState("Super"),
+    });
+    const [direct, named] = received;
+    expect(readModifiers(direct)).toEqual(readModifiers(named));
+    expect(readModifiers(direct)).toEqual({
+      alt: true,
+      altGraph: false,
+      capsLock: true,
+      shift: false,
+      super: false,
+    });
+  } finally {
+    input.remove();
   }
 });

--- a/packages/ariakit-test/src/shims.jsdom.test.ts
+++ b/packages/ariakit-test/src/shims.jsdom.test.ts
@@ -17,3 +17,23 @@ test("leaves an environment that already implements mouse event members alone", 
   expect(event.getModifierState("CapsLock")).toBe(true);
   expect([event.x, event.y]).toEqual([3, 4]);
 });
+
+test("leaves an environment with a conformant modifier state alone", () => {
+  // jsdom already matches UI Events here, so the shim must leave it alone
+  // rather than record the initializer itself. Pin that guard from jsdom, since
+  // the happy-dom default project makes it look redundant.
+  const event = new KeyboardEvent("keydown", {
+    altKey: true,
+    modifierCapsLock: true,
+  });
+  expect([
+    event.getModifierState("CapsLock"),
+    event.getModifierState("AltGraph"),
+    event.getModifierState("alt"),
+  ]).toEqual([true, false, false]);
+  // Both implementations answer those the same way. `Super` is what separates
+  // them: jsdom reports the spec member that Chrome, Firefox, and Safari all
+  // ignore, so the shim doesn't record it and would report false here.
+  const superEvent = new KeyboardEvent("keydown", { modifierSuper: true });
+  expect(superEvent.getModifierState("Super")).toBe(true);
+});

--- a/packages/ariakit-test/src/shims.test.ts
+++ b/packages/ariakit-test/src/shims.test.ts
@@ -118,6 +118,102 @@ test("gives mouse and pointer events the browser's modifier state and x/y", () =
   }
 });
 
+test("gives keyboard events the browser's exact modifier state", () => {
+  // These hold natively in browsers and jsdom (see shims.jsdom.test.ts), so the
+  // assertions are not guarded by `isBrowser`. Dispatching without going through
+  // `press` or `dispatch.keyDown` reaches only the environment shim.
+  const input = document.createElement("input");
+  document.body.append(input);
+  const received: KeyboardEvent[] = [];
+  input.addEventListener("keydown", (event) => {
+    received.push(event);
+  });
+  try {
+    input.dispatchEvent(new KeyboardEvent("keydown", { altKey: true }));
+    // `AltGraph` is a modifier of its own: `Alt` must not report it, and it
+    // must not report `Alt` back.
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { modifierAltGraph: true }),
+    );
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { shiftKey: true, modifierCapsLock: true }),
+    );
+    expect(
+      received.map((event) => [
+        event.getModifierState("Alt"),
+        event.getModifierState("AltGraph"),
+        event.getModifierState("Shift"),
+        event.getModifierState("CapsLock"),
+        event.altKey,
+        event.shiftKey,
+      ]),
+    ).toEqual([
+      [true, false, false, false, true, false],
+      [false, true, false, false, false, false],
+      [false, false, true, true, false, true],
+    ]);
+    // UI Events lists exact, case-sensitive modifier names.
+    expect(received[0]?.getModifierState("alt")).toBe(false);
+    expect(received[1]?.getModifierState("altgraph")).toBe(false);
+    expect(received[2]?.getModifierState("shift")).toBe(false);
+    // An unrecognized name reports false, the way browsers do. `Object.prototype`
+    // member names are the interesting case: looking them up on a plain object
+    // literal finds an inherited value and reports something other than false.
+    // This event has recorded members, so the name reaches the recorded set
+    // rather than stopping at the standard-flag lookup.
+    expect(received[2]?.getModifierState("constructor")).toBe(false);
+    expect(received[2]?.getModifierState("Nope")).toBe(false);
+  } finally {
+    input.remove();
+  }
+});
+
+test("keeps the keyboard event constructor's contract while patching it", () => {
+  // Recording the modifier initializer replaces `window.KeyboardEvent`, so pin
+  // what the replacement must keep.
+  expect(KeyboardEvent.DOM_KEY_LOCATION_NUMPAD).toBe(3);
+  // A subclass would fail this: the environment builds this event from its own
+  // class, which is not an instance of a class that extends it.
+  expect(document.createEvent("KeyboardEvent")).toBeInstanceOf(KeyboardEvent);
+  // Wrapping the constructor leaves the prototype pointing at the unwrapped
+  // class unless the patch moves it too.
+  expect(new KeyboardEvent("keydown").constructor).toBe(KeyboardEvent);
+  const options = {
+    key: "a",
+    code: "KeyA",
+    location: 3,
+    repeat: true,
+    isComposing: true,
+    bubbles: true,
+    cancelable: true,
+  };
+  const event = new KeyboardEvent("keydown", options);
+  expect(event).toBeInstanceOf(UIEvent);
+  expect({
+    key: event.key,
+    code: event.code,
+    location: event.location,
+    repeat: event.repeat,
+    isComposing: event.isComposing,
+    bubbles: event.bubbles,
+    cancelable: event.cancelable,
+  }).toEqual(options);
+  class CustomKeyboardEvent extends KeyboardEvent {}
+  const custom = new CustomKeyboardEvent("keydown", { modifierCapsLock: true });
+  expect(custom).toBeInstanceOf(CustomKeyboardEvent);
+  expect(custom.getModifierState("CapsLock")).toBe(true);
+  // WebIDL reads each dictionary member with a plain get, so an inherited
+  // member counts, as it does for the flags the environment reads itself.
+  const inherited = new KeyboardEvent(
+    "keydown",
+    Object.create({ modifierCapsLock: true }),
+  );
+  expect(inherited.getModifierState("CapsLock")).toBe(true);
+  // Browsers, jsdom, and happy-dom all throw when the name is missing.
+  const nameless: { getModifierState(key?: string): boolean } = event;
+  expect(() => nameless.getModifierState()).toThrow(TypeError);
+});
+
 test("exposes the dispatched event on window.event while listeners run", async () => {
   if (isBrowser) return;
   const button = document.createElement("button");

--- a/packages/ariakit-test/src/shims.ts
+++ b/packages/ariakit-test/src/shims.ts
@@ -73,6 +73,7 @@ function applyBrowserShims() {
   }
 
   polyfillMouseEventMembers();
+  patchKeyboardEventModifierState();
 
   // happy-dom doesn't implement window.alert (jsdom and real browsers do).
   // Provide a no-op so code that calls or spies on it works under happy-dom.
@@ -101,6 +102,34 @@ function applyBrowserShims() {
   };
 }
 
+// The modifier keys every mouse and keyboard event exposes as a standard flag.
+// A Map, because an object literal would resolve `Object.prototype` key names
+// such as `constructor` to a bogus flag.
+const standardModifierFlags = new Map<
+  string,
+  "altKey" | "ctrlKey" | "metaKey" | "shiftKey"
+>([
+  ["Alt", "altKey"],
+  ["Control", "ctrlKey"],
+  ["Meta", "metaKey"],
+  ["Shift", "shiftKey"],
+]);
+
+// The modifier keys an event carries only as an `EventModifierInit` member.
+// This mirrors `initUIEventModififiers`, which also leaves out UI Events'
+// `modifierHyper` and `modifierSuper`, and no browser engine implements those.
+// https://w3c.github.io/uievents/#event-modifier-initializers
+const initOnlyModifierMembers = new Map<string, keyof EventModifierInit>([
+  ["AltGraph", "modifierAltGraph"],
+  ["CapsLock", "modifierCapsLock"],
+  ["Fn", "modifierFn"],
+  ["FnLock", "modifierFnLock"],
+  ["NumLock", "modifierNumLock"],
+  ["ScrollLock", "modifierScrollLock"],
+  ["Symbol", "modifierSymbol"],
+  ["SymbolLock", "modifierSymbolLock"],
+]);
+
 // happy-dom's MouseEvent implements neither `getModifierState` nor the `x`/`y`
 // aliases of `clientX`/`clientY`, which browsers and jsdom provide. A named
 // dispatcher installs both while initializing the event, so only events the
@@ -114,27 +143,16 @@ function polyfillMouseEventMembers() {
   const prototype = window.MouseEvent.prototype;
 
   if (typeof prototype.getModifierState !== "function") {
-    // happy-dom's constructor keeps only these four flags and drops the
+    // happy-dom's constructor keeps only the standard flags and drops the
     // `modifier*` init members, so this fallback can never report the others.
-    // A Map, because an object literal would resolve `Object.prototype` key
-    // names such as `constructor` to a bogus flag.
     // https://github.com/ariakit/ariakit/issues/7165
-    const flagsByModifier = new Map<
-      string,
-      "altKey" | "ctrlKey" | "metaKey" | "shiftKey"
-    >([
-      ["Alt", "altKey"],
-      ["Control", "ctrlKey"],
-      ["Meta", "metaKey"],
-      ["Shift", "shiftKey"],
-    ]);
     // Plain assignment matches the writable, enumerable, configurable
     // descriptor browsers and jsdom give this method.
     prototype.getModifierState = function getModifierState(
       this: MouseEvent,
       key: string,
     ) {
-      const flag = flagsByModifier.get(key);
+      const flag = standardModifierFlags.get(key);
       if (!flag) return false;
       return this[flag];
     };
@@ -155,6 +173,83 @@ function polyfillMouseEventMembers() {
       },
     });
   }
+}
+
+// happy-dom's KeyboardEvent lowercases the name `getModifierState` is given, so
+// `shift` matches `Shift`, and it answers `AltGraph` from `altKey`. Its
+// constructor also keeps only the standard flags, dropping every `modifier*`
+// init member, which a prototype patch alone can no longer recover. Browsers
+// and jsdom match the exact UI Events names and read `AltGraph` from its own
+// member, so record the initializer as the event is built and answer from it.
+// https://github.com/ariakit/ariakit/issues/7166
+// https://w3c.github.io/uievents/#event-modifier-initializers
+function patchKeyboardEventModifierState() {
+  const OriginalKeyboardEvent = window.KeyboardEvent;
+  if (typeof OriginalKeyboardEvent !== "function") return;
+  const prototype = OriginalKeyboardEvent.prototype;
+
+  if (typeof prototype.getModifierState === "function") {
+    const probe = new OriginalKeyboardEvent("keydown", {
+      altKey: true,
+      modifierCapsLock: true,
+    });
+    // A conformant implementation keeps the `modifier*` members, matches the
+    // exact names, and reads `AltGraph` from its own member. Probing the
+    // behavior rather than the environment retires this shim on its own once
+    // happy-dom conforms.
+    const isConformant =
+      probe.getModifierState("CapsLock") &&
+      !probe.getModifierState("AltGraph") &&
+      !probe.getModifierState("alt");
+    if (isConformant) return;
+  }
+
+  const initModifiers = new WeakMap<KeyboardEvent, Set<string>>();
+
+  // A Proxy rather than a subclass: events the environment builds from its own
+  // class, such as `document.createEvent("KeyboardEvent")`, keep passing
+  // `instanceof`.
+  const PatchedKeyboardEvent = new Proxy(OriginalKeyboardEvent, {
+    construct(target, args, newTarget) {
+      const event: KeyboardEvent = Reflect.construct(target, args, newTarget);
+      const init: EventModifierInit | undefined = args[1];
+      if (!init) return event;
+      const modifiers = new Set<string>();
+      // A plain get, the way WebIDL reads a dictionary member and the way the
+      // environment itself reads the standard flags, so an inherited member
+      // counts.
+      for (const [modifier, member] of initOnlyModifierMembers) {
+        if (init[member]) {
+          modifiers.add(modifier);
+        }
+      }
+      if (modifiers.size) {
+        initModifiers.set(event, modifiers);
+      }
+      return event;
+    },
+  });
+
+  window.KeyboardEvent = PatchedKeyboardEvent;
+  // An event reports the same constructor the global exposes, so move the
+  // prototype's own pointer to the wrapper as well.
+  prototype.constructor = PatchedKeyboardEvent;
+
+  prototype.getModifierState = function getModifierState(
+    this: KeyboardEvent,
+    key: string,
+  ) {
+    if (!arguments.length) {
+      throw new TypeError(
+        "Failed to execute 'getModifierState' on 'KeyboardEvent': 1 argument required, but only 0 present.",
+      );
+    }
+    const flag = standardModifierFlags.get(key);
+    if (flag) return this[flag];
+    // An event the environment built from its own class has no recorded
+    // initializer, leaving only the standard flags above to report.
+    return initModifiers.get(this)?.has(key) ?? false;
+  };
 }
 
 // happy-dom omits built-in constraint messages. Use jsdom's generic text so


### PR DESCRIPTION
## Motivation

`@ariakit/test` normalizes happy-dom into the browser's contract for the whole test environment, and #7170 established that contract for a caller-built `MouseEvent`. happy-dom's `KeyboardEvent` is the remaining gap, and it diverges in three ways at once.

`getModifierState` lowercases the name it is given and answers `AltGraph` from `altKey`, and the constructor stores only `altKey`, `ctrlKey`, `metaKey`, and `shiftKey`, discarding every `modifier*` initializer member:

```ts
new KeyboardEvent("keydown", { altKey: true }).getModifierState("AltGraph");
// true, should be false

new KeyboardEvent("keydown", { modifierAltGraph: true }).getModifierState("AltGraph");
// false, should be true

new KeyboardEvent("keydown", { shiftKey: true }).getModifierState("shift");
// true, should be false
```

I measured `false`, `true`, `false` in Chromium 151, Firefox 153, WebKit 26.5, and jsdom 29.1.1, which is what [UI Events](https://w3c.github.io/uievents/#event-modifier-initializers) specifies: `AltGraph` is a modifier of its own, and the names are exact.

`press`, `type`, and `dispatch.keyDown` are unaffected. They all run the module-private `initEvent`, whose own `getModifierState` shadows happy-dom's while the original options are still in hand. Only an event built straight from the constructor reaches a listener with the environment's implementation.

That is not limited to a test that builds the event itself. `Composite` forwards a keydown to its active item through `fireKeyboardEvent` in `@ariakit/utils`, which constructs the event directly. React's synthetic event carries no `modifier*` member, so the forwarded event kept its standard flags, but an `onKeyDown` handler on the item still saw the case-insensitive names and the `AltGraph` false positive.

Fixes #7166.

## Solution

A prototype-only override is not enough. It can fix the case matching and stop `Alt` from reporting `AltGraph`, but the `modifier*` members are gone by the time any method could read them, so the initializer has to be recorded while the event is being built.

`patchKeyboardEventModifierState` in `shims.ts` wraps `window.KeyboardEvent` in a `Proxy` whose `construct` trap records the `modifier*` members in a `WeakMap`, then replaces `getModifierState` with one that reads the standard flags from the event and every other modifier from that record.

A `Proxy` rather than a subclass, because happy-dom builds `document.createEvent("KeyboardEvent")` from its own class rather than from the global this patch assigns to. With a subclass that event stops satisfying `instanceof KeyboardEvent`, which holds in all three browsers, and `initEvent` would then skip it. The `Proxy` also forwards `new.target`, so a consumer's `class extends KeyboardEvent` still works, and the prototype's own `constructor` moves to the wrapper so an event still reports the constructor the global exposes.

The patch is feature-detected by behavior rather than by environment. It probes one event for the three divergences and returns early when the environment already conforms, so it leaves jsdom and any conformant environment alone, and retires itself once happy-dom conforms, the same way `polyfillMouseEventMembers` does.

The `WeakMap` keeps the recorded state off the event, so the instance shape stays exactly what the environment produced. An event the environment built on its own has no record and reports only the standard flags, which is all happy-dom stores for it anyway. The replacement also keeps happy-dom's missing-argument `TypeError`, which browsers and jsdom throw too.

The recorded set is exactly what `initUIEventModififiers` reports for a named dispatcher, so the two paths agree on every modifier name UI Events defines. They still differ on names it does not: the named form answers `Object.prototype` members such as `constructor` with `true`, which is #7168 and untouched here. UI Events also defines `modifierHyper` and `modifierSuper`, which that helper leaves out and which I measured all three browser engines reporting as false, so recording them would have diverged from both at once. jsdom does report them, which is what the guard below keys on.

The standard flags now come from one shared `standardModifierFlags` map, which the mouse fallback from #7170 also uses.

## Tests

Two happy-dom tests in `shims.test.ts` fail on `main` and pass with the patch. One dispatches three caller-built keyboard events and asserts the full modifier state, the exact names, and unrecognized names. The other pins what replacing the constructor has to preserve: the constants, `instanceof` for `document.createEvent("KeyboardEvent")` and `UIEvent`, the constructor an event reports, the normal keyboard fields, subclassing, inherited initializer members, and the missing-argument `TypeError`.

`dispatch.test.ts` gains the keyboard counterpart of the mouse parity test from #7170. `dispatch(element, event)` and `dispatch.keyDown(element, options)` now report the same modifier state for the same options, which is the invariant the mouse test documents as unreachable. Without the patch the direct form answers `AltGraph` as `true` and `CapsLock` as `false` while the named form answers both correctly, so the parity assertion fails. It also passes `modifierSuper`, which both paths must keep reporting as `false`, so recording that member on one side alone breaks the parity.

`shims.jsdom.test.ts` pins the conformance guard from jsdom, where the happy-dom project makes it look redundant. Both implementations answer the shared assertions the same way, so the test keys on `Super`: jsdom reports the spec member the browsers ignore and the patch therefore does not record, so removing the guard wraps jsdom's constructor and flips it to false.

`pnpm test` (262 files, 1800 tests), `pnpm test-react18` (194 files, 1046 tests), `pnpm tsc`, and `pnpm lint-fix` all pass.

## Review gate reassessment

<details>
<summary>Cycle 3: Continue the constructor-recording direction</summary>

**Assessment**

Issue severity and scope: wrong boolean answers from `getModifierState` in the test environment, with no throw. Triaged `experimental bug`, since `@ariakit/test` is not exposed through `@ariakit/react`. The three divergences differ in reach. Case-insensitive names and `AltGraph` answered from `altKey` reach every keyboard event built from the constructor, including the library's own `Composite` forwarding through `fireKeyboardEvent`. The discarded `modifier*` members reach only hand-built events, because React's synthetic event carries no such member. Expected frequency is low: no repository code outside this package's own tests reads `getModifierState`, and `press`, `type`, and `dispatch.keyDown` were never affected. The dangerous class is the false green, where `getModifierState("shift")` passes under happy-dom and would fail in every browser.

Implementation and maintenance complexity: one feature-detected function of about 55 lines, in a file that already holds six such patches, one of which (`patchHappyDOMFormData`) already replaces a global constructor. No new module, no new public API, no new dependency, and no change to `dispatch.ts` source. The merged sibling #7170 was +199/-0 across the same five files; this is +274/-16 for a strictly harder problem. Of the 16 removed lines, 13 are #7170's inline modifier map lifted to module scope so both fallbacks share it, and 3 are a reworded comment on the mouse parity test.

What drove the cycles: of nine findings across three rounds, one was a real defect in new code (`event.constructor` identity, repaired in one line), one was invalid, three were rationale prose, three were test strategy or value, and one was an external issue's stale text. No finding challenged the design, and none clustered around the machinery. Across two full repair rounds the machinery gained exactly one behavioral line, so the loop was justification prose, not design instability. Two of the prose findings hit the same comment block twice, which is the same failure #7170's cycle-3 entry recorded.

Alternatives: a prototype-only override saves about 90 lines and fixes the two name-matching divergences, but it cannot recover the discarded `modifier*` members, which the issue names and rejects that approach over. It would also leave `dispatch(element, event)` and `dispatch.keyDown` disagreeing, the split the new parity test pins, and it would push the global-constructor change into the larger #7165 PR that must also handle `MouseEvent` and the `auxclick` gesture. A subclass is strictly worse: measured in this environment, `document.createEvent("KeyboardEvent")` then stops satisfying `instanceof KeyboardEvent`, so `initEvent` would silently skip those events. An instance-level method would avoid the `WeakMap` but change the instance shape and leave environment-built events unfixed.

**Decision**

Continue the current direction. There is no machinery to remove, nothing to revert, and no contract to narrow. The standing concern is comment volume rather than code, so this round's repair to the `Proxy`-over-subclass comment removed the clause a subclass also satisfies instead of adding the cross-realm clause that no test pins, and the inherited-initializer assertion moved to `modifierCapsLock`, which all three browser engines honor.

Dispositions at this boundary: the third round's claim that the constructor-contract test fails to discriminate against a subclass was classified invalid, measured against a Vitest `happy-dom` project rather than a directly constructed happy-dom `Window`, where the global assignment lands differently. The suggested iframe assertion was declined, because cross-realm `instanceof` is legitimately false in real browsers and would need a guard the rest of the test does not carry. Intentionally left unsupported: `modifierHyper` and `modifierSuper`, keyboard events built through an iframe realm's constructor, and `MouseEvent` `modifier*` recovery, which #7165 tracks.

</details>

<details>
<summary>Cycle 6: Continue, and sweep the claim family that was generating the cycles</summary>

**Assessment**

The severity, scope, impact, and complexity are unchanged from cycle 3, and I re-verified the two facts the direction rests on. happy-dom's `KeyboardEvent` constructor assigns eleven named fields and no `modifier*` member, so construct-time capture is forced rather than chosen. A subclass on the global fails here because Vitest's `populateGlobal` setter stores into its own override map and never writes the happy-dom window field that `Document.createEvent` reads, so `document.createEvent("KeyboardEvent")` would stop satisfying `instanceof KeyboardEvent` and `initEvent` would silently skip those events.

What drove three more cycles: of eighteen findings across six rounds, exactly one was a defect in new code, and rounds 4 through 6 produced no code defect and no design challenge at all. The machinery gained one behavioral line across all six rounds. The remaining findings did not cluster around the machinery; they clustered around one restated fact, which engine implements which modifier member, phrased with different scope in different files. Rounds 5 and 6 found the same over-broad wording in sibling comments, one round apart.

**Decision**

Continue the current direction, and treat the finding class rather than the instance. Instead of correcting the single comment round 6 named, this round sweeps every remaining engine-scope claim, in the test comment and in this description, to one consistent form that says browser engine and acknowledges that jsdom does report those members. Correcting one instance at a time is what turned a stable implementation into three extra rounds.

No disposition changed in substance, including round 3's invalid classification, which a second independent measurement confirmed. Newly recorded as intentionally unsupported: the `dispatch.test.ts` parity test is coupled to the happy-dom project and would fail under jsdom on `Super`. It reaches only the `dom` project through the Vitest config, and the swept comment is what documents that, so no environment pin is added.

</details>

## Follow-ups

- #7165 states that the general caller-built case is not recoverable. This PR shows that it is: recording the initializer at construction works the same way for `window.MouseEvent`, and that would give `auxclick` the modifier state the rest of its gesture reports without moving `initEvent` into a private module or adding public API. It stays out of this PR because #7166 asks for the global-constructor change to remain separate from the dispatch-initializer work in #7165, #7168, and #7169.
