### PR TITLE
Fix the flaky combobox item render-count browser test

### DIFF
--- a/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
@@ -180,21 +180,20 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
     q,
   }) => {
     const item = page.locator("[data-render-count]");
-    // Item registration has no separate completion marker, so cross its frame
-    // checkpoint before sampling the stable render count.
-    await flushFrames(page);
-    const renderCount = await item.getAttribute("data-render-count");
-    if (renderCount == null) {
-      throw new Error("Combobox item render count was not found");
-    }
+    // Mounting renders the item twice: once on its own, then again when the
+    // composite element is published. `beforeEach` returns when Astro only
+    // schedules hydration, so a frame checkpoint can still sample the first.
+    // https://github.com/ariakit/ariakit/issues/7184
+    await test.expect(item).toHaveAttribute("data-render-count", "2");
 
     await q.combobox("Render-counted fruit").click();
     await test.expect(q.listbox("Render-counted fruit")).toBeVisible();
-    // Opening can finish focus work on the next frames, and the absence of an
-    // item render has no positive state to await.
+    // The open still commits on the next frames, and the absence of an item
+    // render has no positive state to await, so give a stray render a chance
+    // to appear before asserting it never happened.
     await flushFrames(page);
 
-    await test.expect(item).toHaveAttribute("data-render-count", renderCount);
+    await test.expect(item).toHaveAttribute("data-render-count", "2");
   });
 
   test("keeps a late-mounted selected item nearest-edge aligned", async ({


### PR DESCRIPTION
## Motivation

Closes #7184.

The Playwright test `does not re-render inactive items when the popup opens` fails intermittently in the `firefox` project, always on the assertion that compares the item's render count after the popup opens with a count sampled before the click. It exhausts all three attempts, and it has failed on `main` itself on dependency bumps that touch no component code.

The sample is the unstable half. `withFramework`'s `beforeEach` waits for the island's `ssr` attribute to disappear, but `@astrojs/react`'s client entry calls `hydrateRoot` inside `startTransition`, and `astro-island` removes `ssr` and dispatches `astro:hydrate` as soon as that call returns. The attribute therefore marks hydration as scheduled, not committed.

Measured on the preview page with a `MutationObserver`, the item's post-hydration render lands 224 to 374 ms (7 to 16 animation frames) after `ssr` is removed, in Chrome, Firefox and Safari alike. `flushFrames(page)` crosses only 2 frames, so the sampled value can still be the pre-commit `1` while the settled value is `2`, and the assertion after the popup opens then reports that settled `2` as a re-render.

## Solution

Replace the sample with a retrying assertion on the settled render count, which is a signal that actually completes.

```diff
-    await flushFrames(page);
-    const renderCount = await item.getAttribute("data-render-count");
-    if (renderCount == null) {
-      throw new Error("Combobox item render count was not found");
-    }
+    await test.expect(item).toHaveAttribute("data-render-count", "2");

     await q.combobox("Render-counted fruit").click();
     await test.expect(q.listbox("Render-counted fruit")).toBeVisible();
     await flushFrames(page);

-    await test.expect(item).toHaveAttribute("data-render-count", renderCount);
+    await test.expect(item).toHaveAttribute("data-render-count", "2");
```

Mounting renders the item twice, once on its own and once more when the composite element is published in a layout effect, so `2` is its settled count. The assertion after the popup opens keeps its `flushFrames` wait, because the absence of a render still has no positive state to await.

A regression still fails the test: an actual re-render on open moves the attribute to `3`. A change to the mount render count now fails the first assertion loudly, instead of silently rebasing the value the second assertion compares against.

## Verification

The failure was reproduced deterministically by patching `window.MessageChannel` to delay React's scheduler by 100 ms per slice, which simulates CI contention without blocking Playwright's own polling. Under that delay the old code sampled `1` and failed with `Expected: "1" / Received: "2"` in Chrome, Firefox and Safari, the exact CI error. The new code passed in all three engines under the identical delay.

The settled count of `2` was confirmed in all three engines against both the Astro dev server and the built `preview-lite` server that CI uses. This sandbox's browser suite passes 99/99 on Chrome, Firefox and Safari with retries disabled.

## Follow-up

The generic weakness behind this, that the preview hydration wait resolves before the framework commits, is tracked separately in #7186.
