### PR TITLE
Fix width, height, pressure, and isPrimary on the pointer events @ariakit/test fires

### DIFF
--- a/.changeset/300-test-pointer-contact-defaults.md
+++ b/.changeset/300-test-pointer-contact-defaults.md
@@ -1,0 +1,23 @@
+---
+"@ariakit/test": patch
+---
+
+Pointer events report the contact, pressure, and pointer a real device reports
+
+A listener on the pointer events that `hover`, `mouseDown`, `mouseUp`, and the `click`, `tap`, `rightClick`, and `select` gestures fire read `width: 0`, `height: 0`, `isPrimary: false`, and whatever transducer angle the environment happened to pick, a combination no pointing device produces. Pointer Events sizes the contact of a device that reports no geometry of its own, like a mouse, as 1 by 1, requires the altitude of a transducer perpendicular to the screen from a device that reports no tilt, and treats a lone pointer as the primary pointer of its type.
+
+Those events now report the values Chromium, Firefox, and WebKit all report for one ordinary click, including the pressure Pointer Events defines for a device with no pressure sensor: `0.5` while a button is held down and `0` otherwise. A chorded release keeps `0.5` while another button stays held, because the pointer is still in the active buttons state, which is what Firefox and WebKit report. Chromium derives that one from the button being released and reports `0`.
+
+```ts
+q.button.ensure("Resize").addEventListener("pointerdown", (event) => {
+  event.width; // 1
+  event.height; // 1
+  event.pressure; // 0.5
+  event.isPrimary; // true
+  event.altitudeAngle; // Math.PI / 2
+});
+
+await mouseDown(q.button("Resize"));
+```
+
+Values passed to a helper still win. `dispatch` sizes and angles a pointer event it builds by name the same way, because those describe a pointer at rest, and leaves the pressure and the primary pointer to the helper that knows which gesture fires the event.

--- a/packages/ariakit-test/readme.md
+++ b/packages/ariakit-test/readme.md
@@ -119,6 +119,8 @@ Creates and fires a DOM event on an element, then waits for the resulting microt
 
 Unlike higher-level helpers such as `click` and `type`, this fires a single event without simulating the surrounding interaction sequence. Pointer and mouse events fired on an element with `pointer-events: none` are re-dispatched on the nearest ancestor that has pointer events enabled, matching how browsers route those events.
 
+A pointer event built by name reports the contact size and transducer angle browsers report for a device with neither, so `width` and `height` are `1` and `altitudeAngle` is a right angle. The members describing a gesture, such as `pressure` and `isPrimary`, keep their defaults here; the higher-level helpers fill those in. An event you construct yourself keeps whatever its constructor gave it.
+
 Returns: A promise that resolves to `false` when the event's default action was prevented with `event.preventDefault()`, and `true` otherwise.
 
 Example:
@@ -164,7 +166,7 @@ function hover(
 
 Moves the pointer over an element, simulating a real user hovering it. Fires the relevant `pointer`/`mouse` enter, over, and move events, and dispatches the matching leave events on the previously hovered element.
 
-Hidden elements and elements with `pointer-events: none` are handled the way a browser would. Pass `options` to set event properties such as modifier keys.
+Hidden elements and elements with `pointer-events: none` are handled the way a browser would. Pass `options` to set event properties such as modifier keys. The pointer events report `pressure: 0`, or `0.5` when you pass `buttons` to describe a move with a button held down, as during a drag.
 
 Example:
 
@@ -188,7 +190,7 @@ function mouseDown(
 
 Presses a pointer button down on an element, firing `pointerdown` and `mousedown` and moving focus the way a browser would. Disabled elements still receive the pointer event but not `mousedown`, and focus falls back to the closest focusable ancestor when the target itself isn't focusable.
 
-This is one step of a full `click`; use it directly to test press-and-hold behavior. Pass `options` to set event properties such as modifier keys, or `button` to press another mouse button. The events report the pressed button in `buttons`, like a browser does, unless you pass `buttons` yourself to describe a chorded gesture. When that value shows another button was already held down, the press fires `pointermove` instead of `pointerdown`, the way Pointer Events routes a chorded press, and the compatibility `mousedown` still fires.
+This is one step of a full `click`; use it directly to test press-and-hold behavior. Pass `options` to set event properties such as modifier keys, or `button` to press another mouse button. The events report the pressed button in `buttons`, like a browser does, unless you pass `buttons` yourself to describe a chorded gesture. When that value shows another button was already held down, the press fires `pointermove` instead of `pointerdown`, the way Pointer Events routes a chorded press, and the compatibility `mousedown` still fires. The pointer event reports `pressure: 0.5`, the value Pointer Events defines while a device with no pressure sensor holds a button down.
 
 Example:
 
@@ -213,7 +215,7 @@ function mouseUp(
 
 Releases a pointer button on an element, firing `pointerup` and `mouseup`. Disabled elements still receive the pointer event but not `mouseup`.
 
-This is the counterpart to `mouseDown` and one step of a full `click`. Pass `options` to set event properties such as modifier keys, or `button` to release another mouse button. The events report no button still held down in `buttons`, like a browser does, unless you pass `buttons` yourself to describe the buttons a chorded gesture keeps held. When that value shows another button stays held down, the release fires `pointermove` instead of `pointerup`, the way Pointer Events routes a chorded release, and the compatibility `mouseup` still fires.
+This is the counterpart to `mouseDown` and one step of a full `click`. Pass `options` to set event properties such as modifier keys, or `button` to release another mouse button. The events report no button still held down in `buttons`, like a browser does, unless you pass `buttons` yourself to describe the buttons a chorded gesture keeps held. When that value shows another button stays held down, the release fires `pointermove` instead of `pointerup`, the way Pointer Events routes a chorded release, and the compatibility `mouseup` still fires. The pointer event reports `pressure: 0`, or `0.5` while a chorded gesture keeps a button held.
 
 Example:
 

--- a/packages/ariakit-test/src/__mouse.test.ts
+++ b/packages/ariakit-test/src/__mouse.test.ts
@@ -1,0 +1,201 @@
+// Covers the pointer members a gesture reports: the contact size and transducer
+// angle `dispatch.ts` defaults, and the pressure and primary pointer `__mouse.ts`
+// derives per phase. Both are exercised through the public helpers that fire the
+// events.
+import { afterEach, expect, test } from "vitest";
+import { click, hover, mouseDown, mouseUp, q } from "./index.ts";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+// Records each pointer event as `type width height pressure isPrimary`, the
+// shape the expectations below were recorded in from Chromium 151, Firefox 153,
+// and WebKit 26.5 through Playwright.
+// https://github.com/ariakit/ariakit/issues/7172
+function recordPointerEvents(element: Element, types: string[]) {
+  const events: string[] = [];
+  for (const type of types) {
+    element.addEventListener(type, (event) => {
+      const { width, height, pressure, isPrimary } = event as PointerEvent;
+      events.push(`${event.type} ${width} ${height} ${pressure} ${isPrimary}`);
+    });
+  }
+  return events;
+}
+
+const enterEventTypes = ["pointerover", "pointerenter", "pointermove"];
+
+test("hover reports the contact and pointer a mouse reports", async () => {
+  document.body.innerHTML = `<button type="button">Save</button>`;
+
+  const button = q.button.ensure("Save");
+  const events = recordPointerEvents(button, enterEventTypes);
+
+  await hover(button);
+
+  expect(events).toEqual([
+    "pointerover 1 1 0 true",
+    "pointerenter 1 1 0 true",
+    "pointermove 1 1 0 true",
+  ]);
+});
+
+test("hover reports the same values on the events leaving an element", async () => {
+  document.body.innerHTML = `
+    <button type="button">Save</button>
+    <button type="button">Cancel</button>
+  `;
+
+  const save = q.button.ensure("Save");
+  const events = recordPointerEvents(save, [
+    "pointermove",
+    "pointerout",
+    "pointerleave",
+  ]);
+
+  await hover(save);
+  await hover(q.button("Cancel"));
+
+  expect(events).toEqual([
+    "pointermove 1 1 0 true",
+    "pointermove 1 1 0 true",
+    "pointerout 1 1 0 true",
+    "pointerleave 1 1 0 true",
+  ]);
+});
+
+// A caller passing `buttons` describes a pointer moving with a button held, like
+// a drag, which is in the active buttons state.
+test("hover reports pressure while a button stays held", async () => {
+  document.body.innerHTML = `<button type="button">Resize</button>`;
+
+  const button = q.button.ensure("Resize");
+  const events = recordPointerEvents(button, ["pointermove"]);
+
+  await hover(button, { buttons: 1 });
+
+  expect(events).toEqual(["pointermove 1 1 0.5 true"]);
+});
+
+test("mouseDown and mouseUp report the pressure of the button they press", async () => {
+  document.body.innerHTML = `<button type="button">Resize</button>`;
+
+  const button = q.button.ensure("Resize");
+  const events = recordPointerEvents(button, ["pointerdown", "pointerup"]);
+
+  await mouseDown(button);
+  await mouseUp(button);
+
+  expect(events).toEqual(["pointerdown 1 1 0.5 true", "pointerup 1 1 0 true"]);
+});
+
+// A chorded release ends one button while the pointer stays in the active
+// buttons state, so the pressure holds. Firefox and WebKit report it that way;
+// Chromium derives it from the button being released and reports 0.
+test("a chorded release keeps the pressure of the button still held", async () => {
+  document.body.innerHTML = `<button type="button">Resize</button>`;
+
+  const button = q.button.ensure("Resize");
+  const events = recordPointerEvents(button, [
+    "pointerdown",
+    "pointermove",
+    "pointerup",
+  ]);
+
+  // The primary button stays held while the secondary one is pressed and
+  // released.
+  await mouseDown(button);
+  await mouseDown(button, { button: 2, buttons: 3 });
+  await mouseUp(button, { button: 2, buttons: 1 });
+  await mouseUp(button);
+
+  expect(events).toEqual([
+    "pointerdown 1 1 0.5 true",
+    "pointermove 1 1 0.5 true",
+    "pointermove 1 1 0.5 true",
+    "pointerup 1 1 0 true",
+  ]);
+});
+
+// This is the pointer sequence all three engines produce for one ordinary click.
+test("click reports the values a browser reports through the gesture", async () => {
+  document.body.innerHTML = `<button type="button">Submit</button>`;
+
+  const button = q.button.ensure("Submit");
+  const events = recordPointerEvents(button, [
+    ...enterEventTypes,
+    "pointerdown",
+    "pointerup",
+  ]);
+
+  await click(button);
+
+  expect(events).toEqual([
+    "pointerover 1 1 0 true",
+    "pointerenter 1 1 0 true",
+    "pointermove 1 1 0 true",
+    "pointerdown 1 1 0.5 true",
+    "pointerup 1 1 0 true",
+  ]);
+});
+
+// The transducer angle reaches a gesture from the dispatch layer, so one press
+// covers it for every helper. Every engine reports a perpendicular transducer for
+// a mouse.
+test("a press reports the transducer angle of a perpendicular pointer", async () => {
+  document.body.innerHTML = `<button type="button">Resize</button>`;
+
+  const button = q.button.ensure("Resize");
+  let angles: string | undefined;
+  button.addEventListener("pointerdown", (event) => {
+    angles = `${event.altitudeAngle} ${event.azimuthAngle}`;
+  });
+
+  await mouseDown(button);
+
+  expect(angles).toBe(`${Math.PI / 2} 0`);
+});
+
+test("explicit pointer values win over the simulated ones", async () => {
+  document.body.innerHTML = `<button type="button">Draw</button>`;
+
+  const button = q.button.ensure("Draw");
+  const events = recordPointerEvents(button, [
+    "pointermove",
+    "pointerdown",
+    "pointerup",
+  ]);
+
+  // A second pen touching a digitizer that reports its own contact geometry.
+  const options: PointerEventInit = {
+    pointerType: "pen",
+    width: 12,
+    height: 14,
+    pressure: 0.75,
+    isPrimary: false,
+  };
+
+  await hover(button, options);
+  await mouseDown(button, options);
+  await mouseUp(button, options);
+
+  expect(events).toEqual([
+    "pointermove 12 14 0.75 false",
+    "pointerdown 12 14 0.75 false",
+    "pointerup 12 14 0.75 false",
+  ]);
+});
+
+// Zero is a value a pressure-sensitive device reports, so it has to win over the
+// 0.5 the press would otherwise derive.
+test("an explicit zero pressure wins over the pressure a press derives", async () => {
+  document.body.innerHTML = `<button type="button">Draw</button>`;
+
+  const button = q.button.ensure("Draw");
+  const events = recordPointerEvents(button, ["pointerdown"]);
+
+  await mouseDown(button, { pressure: 0 });
+
+  expect(events).toEqual(["pointerdown 1 1 0 true"]);
+});

--- a/packages/ariakit-test/src/__mouse.ts
+++ b/packages/ariakit-test/src/__mouse.ts
@@ -35,6 +35,38 @@ export function omitButtons(options?: PointerEventInit): PointerEventInit {
   return stepOptions;
 }
 
+// A pointing device with no pressure sensor, which is what these helpers
+// simulate, reports 0.5 while it is in the active buttons state and 0 otherwise.
+// https://w3c.github.io/pointerevents/#dom-pointerevent-pressure
+function getPressure(buttons: number) {
+  return buttons === 0 ? 0 : 0.5;
+}
+
+// Neither `dispatch` nor the phase builders below can own these, because
+// `click.ts` and `select.ts` build `click`, `auxclick`, and `contextmenu` from
+// `getPressOptions` and `getReleaseOptions` directly, and Pointer Events resets
+// every pointer attribute on those three except `pointerId` and `pointerType`.
+// Unlike the contact size and transducer angle `dispatch` defaults, these two
+// reset to something other than what a gesture derives. Only the helpers that
+// fire pointer events apply them.
+// https://www.w3.org/TR/pointerevents/#the-click-auxclick-and-contextmenu-events
+
+/**
+ * Fills in the members describing the pointer a phase simulates: these helpers
+ * drive one pointer, which is the primary pointer of its type, and the pressure
+ * follows the `buttons` the phase options already describe.
+ * https://w3c.github.io/pointerevents/#dom-pointerevent-isprimary
+ */
+export function getPointerOptions(
+  options?: PointerEventInit,
+): PointerEventInit {
+  return {
+    ...options,
+    pressure: options?.pressure ?? getPressure(options?.buttons ?? 0),
+    isPrimary: options?.isPrimary ?? true,
+  };
+}
+
 /**
  * Returns the event properties for moving the pointer onto the element, before
  * any button is pressed. One init feeds both the pointer and the mouse events,

--- a/packages/ariakit-test/src/dispatch.test.ts
+++ b/packages/ariakit-test/src/dispatch.test.ts
@@ -194,3 +194,104 @@ test("dispatch(element, event) reports the same modifiers as the named form for 
     input.remove();
   }
 });
+
+function readPointerMembers(event: PointerEvent) {
+  const { width, height, pressure, isPrimary } = event;
+  return `${width} ${height} ${pressure} ${isPrimary}`;
+}
+
+// Pointer Events defaults `width` and `height` to 1, and requires 1 from any
+// device with no contact geometry to report, like a mouse. The pressure and the
+// primary pointer stay at their dictionary defaults, because a lone event carries
+// no gesture to derive them from.
+// https://w3c.github.io/pointerevents/#dom-pointerevent-width
+test("dispatch.pointerDown reports the PointerEventInit defaults for the contact, pressure, and primary pointer", async () => {
+  const button = document.createElement("button");
+  document.body.append(button);
+  let members: string | undefined;
+  button.addEventListener("pointerdown", (event) => {
+    members = readPointerMembers(event);
+  });
+  try {
+    await dispatch.pointerDown(button);
+    expect(members).toBe("1 1 0 false");
+  } finally {
+    button.remove();
+  }
+});
+
+test("dispatch.pointerDown preserves provided pointer values", async () => {
+  const button = document.createElement("button");
+  document.body.append(button);
+  let members: string | undefined;
+  button.addEventListener("pointerdown", (event) => {
+    members = readPointerMembers(event);
+  });
+  try {
+    await dispatch.pointerDown(button, {
+      width: 12,
+      height: 14,
+      pressure: 0.75,
+      isPrimary: true,
+    });
+    expect(members).toBe("12 14 0.75 true");
+  } finally {
+    button.remove();
+  }
+});
+
+// Zero is a contact size a digitizer can report, so it has to survive instead of
+// falling back to the default.
+test("dispatch.pointerDown preserves a zero contact size", async () => {
+  const button = document.createElement("button");
+  document.body.append(button);
+  let members: string | undefined;
+  button.addEventListener("pointerdown", (event) => {
+    members = readPointerMembers(event);
+  });
+  try {
+    await dispatch.pointerDown(button, { width: 0, height: 0 });
+    expect(members).toBe("0 0 0 false");
+  } finally {
+    button.remove();
+  }
+});
+
+function readTransducerAngles(event: PointerEvent) {
+  return `${event.altitudeAngle} ${event.azimuthAngle}`;
+}
+
+// `initPointerEvent` used to leave these two alone, so they reached the event
+// only through the constructor and took happy-dom's default of 0. Chromium,
+// Firefox, and WebKit all report π/2 and 0 for a mouse, on every pointer event
+// including `click`.
+// https://github.com/ariakit/ariakit/issues/7172
+test("dispatch.pointerDown reports the transducer angles of a perpendicular pointer", async () => {
+  const button = document.createElement("button");
+  document.body.append(button);
+  let angles: string | undefined;
+  button.addEventListener("pointerdown", (event) => {
+    angles = readTransducerAngles(event);
+  });
+  try {
+    await dispatch.pointerDown(button);
+    expect(angles).toBe(`${Math.PI / 2} 0`);
+  } finally {
+    button.remove();
+  }
+});
+
+test("dispatch.pointerDown preserves provided transducer angles", async () => {
+  const button = document.createElement("button");
+  document.body.append(button);
+  let angles: string | undefined;
+  button.addEventListener("pointerdown", (event) => {
+    angles = readTransducerAngles(event);
+  });
+  try {
+    await dispatch.pointerDown(button, { altitudeAngle: 0, azimuthAngle: 1 });
+    expect(angles).toBe("0 1");
+  } finally {
+    button.remove();
+  }
+});

--- a/packages/ariakit-test/src/dispatch.ts
+++ b/packages/ariakit-test/src/dispatch.ts
@@ -48,6 +48,22 @@ function sanitizeString(value: string | undefined) {
   return value ?? "";
 }
 
+// `PointerEventInit` defaults the contact geometry to 1x1, and Pointer Events
+// requires 1 from a device that doesn't report geometry of its own, like a mouse.
+// https://w3c.github.io/pointerevents/#dom-pointerevent-width
+function sanitizeContactSize(size: number | undefined) {
+  return size ?? 1;
+}
+
+// Pointer Events requires π/2, a transducer perpendicular to the screen, from a
+// device that reports no tilt. It has no dictionary default, and happy-dom's
+// constructor uses 0, an angle no engine produces for a mouse. The tilt pair is
+// left unconverted, tracked in https://github.com/ariakit/ariakit/issues/7185.
+// https://w3c.github.io/pointerevents/#dom-pointerevent-altitudeangle
+function sanitizeAltitudeAngle(angle: number | undefined) {
+  return angle ?? Math.PI / 2;
+}
+
 function initClipboardEvent(
   event: ClipboardEvent,
   { clipboardData }: ClipboardEventInit,
@@ -174,19 +190,23 @@ function initPointerEvent(
     tiltX,
     tiltY,
     twist,
+    altitudeAngle,
+    azimuthAngle,
     isPrimary,
     pointerType = "mouse",
   }: PointerEventInit,
 ) {
   assignProps(event, {
     pointerId: sanitizeNumber(pointerId),
-    width: sanitizeNumber(width),
-    height: sanitizeNumber(height),
+    width: sanitizeContactSize(width),
+    height: sanitizeContactSize(height),
     pressure: sanitizeNumber(pressure),
     tangentialPressure: sanitizeNumber(tangentialPressure),
     tiltX: sanitizeNumber(tiltX),
     tiltY: sanitizeNumber(tiltY),
     twist: sanitizeNumber(twist),
+    altitudeAngle: sanitizeAltitudeAngle(altitudeAngle),
+    azimuthAngle: sanitizeNumber(azimuthAngle),
     isPrimary: !!isPrimary,
     pointerType: pointerType,
   });
@@ -384,6 +404,13 @@ const events = getKeys(fireEvent).reduce((events, eventName) => {
  * mouse events fired on an element with `pointer-events: none` are re-dispatched
  * on the nearest ancestor that has pointer events enabled, matching how browsers
  * route those events.
+ *
+ * A pointer event built by name reports the contact size and transducer angle
+ * browsers report for a device with neither, so `width` and `height` are `1` and
+ * `altitudeAngle` is a right angle. The members describing a gesture, such as
+ * `pressure` and `isPrimary`, keep their defaults here; the higher-level helpers
+ * fill those in. An event you construct yourself keeps whatever its constructor
+ * gave it.
  * @returns A promise that resolves to `false` when the event's default action was
  * prevented with `event.preventDefault()`, and `true` otherwise.
  * @example

--- a/packages/ariakit-test/src/hover.ts
+++ b/packages/ariakit-test/src/hover.ts
@@ -1,4 +1,5 @@
 import { isVisible, invariant } from "@ariakit/utils";
+import { getPointerOptions } from "./__mouse.ts";
 import { settle, wrapAsync } from "./__utils.ts";
 import { dispatch } from "./dispatch.ts";
 import { sleep } from "./sleep.ts";
@@ -18,6 +19,8 @@ function isPointerEventsEnabled(element: Element) {
  *
  * Hidden elements and elements with `pointer-events: none` are handled the way a
  * browser would. Pass `options` to set event properties such as modifier keys.
+ * The pointer events report `pressure: 0`, or `0.5` when you pass `buttons` to
+ * describe a move with a button held down, as during a drag.
  * @example
  * ```ts
  * await hover(q.button("More options"));
@@ -34,15 +37,18 @@ export function hover(element: Element | null, options?: PointerEventInit) {
     const { lastHovered } = document;
     const { disabled } = element as HTMLButtonElement;
     const pointerEventsEnabled = isPointerEventsEnabled(element);
+    // A move changes no button, so the caller's `buttons` already describes the
+    // pointer, and every event below reports the same one.
+    const moveOptions = getPointerOptions(options);
 
     if (lastHovered && lastHovered !== element && isVisible(lastHovered)) {
-      await dispatch.pointerMove(lastHovered, options);
-      await dispatch.mouseMove(lastHovered, options);
+      await dispatch.pointerMove(lastHovered, moveOptions);
+      await dispatch.mouseMove(lastHovered, moveOptions);
 
       if (isPointerEventsEnabled(lastHovered)) {
         const isElementWithinLastHovered = lastHovered.contains(element);
         const relatedTarget = pointerEventsEnabled ? element : null;
-        const leaveOptions = { ...options, relatedTarget };
+        const leaveOptions = { ...moveOptions, relatedTarget };
 
         await dispatch.pointerOut(lastHovered, leaveOptions);
 
@@ -64,8 +70,8 @@ export function hover(element: Element | null, options?: PointerEventInit) {
 
     if (pointerEventsEnabled) {
       const enterOptions = lastHovered
-        ? { relatedTarget: lastHovered, ...options }
-        : options;
+        ? { relatedTarget: lastHovered, ...moveOptions }
+        : moveOptions;
 
       await dispatch.pointerOver(element, enterOptions);
       await dispatch.pointerEnter(element, enterOptions);
@@ -75,9 +81,9 @@ export function hover(element: Element | null, options?: PointerEventInit) {
       }
     }
 
-    await dispatch.pointerMove(element, options);
+    await dispatch.pointerMove(element, moveOptions);
     if (!disabled) {
-      await dispatch.mouseMove(element, options);
+      await dispatch.mouseMove(element, moveOptions);
     }
 
     document.lastHovered = element;

--- a/packages/ariakit-test/src/mouse-down.ts
+++ b/packages/ariakit-test/src/mouse-down.ts
@@ -6,7 +6,11 @@ import {
   isTextbox,
   invariant,
 } from "@ariakit/utils";
-import { getPressOptions, isChordedPress } from "./__mouse.ts";
+import {
+  getPointerOptions,
+  getPressOptions,
+  isChordedPress,
+} from "./__mouse.ts";
 import {
   getPreventMouseEvents,
   setPreventMouseEvents,
@@ -62,7 +66,8 @@ function shouldClearSelection(element: Element) {
  * describe a chorded gesture. When that value shows another button was already
  * held down, the press fires `pointermove` instead of `pointerdown`, the way
  * Pointer Events routes a chorded press, and the compatibility `mousedown`
- * still fires.
+ * still fires. The pointer event reports `pressure: 0.5`, the value Pointer
+ * Events defines while a device with no pressure sensor holds a button down.
  * @example
  * ```ts
  * await mouseDown(q.button("Resize"));
@@ -77,7 +82,7 @@ export function mouseDown(element: Element | null, options?: PointerEventInit) {
     if (!isVisible(element)) return;
 
     const { disabled } = element as HTMLButtonElement;
-    const pressOptions = getPressOptions(options);
+    const pressOptions = getPointerOptions(getPressOptions(options));
     const document = getDocument(element);
 
     // A chorded press has no `pointerdown` of its own to cancel, so it leaves

--- a/packages/ariakit-test/src/mouse-up.ts
+++ b/packages/ariakit-test/src/mouse-up.ts
@@ -1,5 +1,9 @@
 import { getDocument, isVisible, invariant } from "@ariakit/utils";
-import { getReleaseOptions, isChordedRelease } from "./__mouse.ts";
+import {
+  getPointerOptions,
+  getReleaseOptions,
+  isChordedRelease,
+} from "./__mouse.ts";
 import {
   getPreventMouseEvents,
   setPreventMouseEvents,
@@ -18,7 +22,8 @@ import { dispatch } from "./dispatch.ts";
  * the buttons a chorded gesture keeps held. When that value shows another button
  * stays held down, the release fires `pointermove` instead of `pointerup`, the
  * way Pointer Events routes a chorded release, and the compatibility `mouseup`
- * still fires.
+ * still fires. The pointer event reports `pressure: 0`, or `0.5` while a chorded
+ * gesture keeps a button held.
  * @example
  * ```ts
  * await mouseDown(q.button("Resize"));
@@ -32,7 +37,7 @@ export function mouseUp(element: Element | null, options?: PointerEventInit) {
     if (!isVisible(element)) return;
 
     const { disabled } = element as HTMLButtonElement;
-    const releaseOptions = getReleaseOptions(options);
+    const releaseOptions = getPointerOptions(getReleaseOptions(options));
     const chorded = isChordedRelease(releaseOptions);
 
     if (chorded) {


### PR DESCRIPTION
## Motivation

`initPointerEvent` in `packages/ariakit-test/src/dispatch.ts` sanitized every unset pointer member to zero and `isPrimary` to `false`, and never touched `altitudeAngle` or `azimuthAngle` at all, leaving them at whatever the environment's constructor picked, which is `0` under happy-dom. Pointer Events sizes the contact of a device that reports no geometry of its own, such as a mouse, as 1 by 1, requires the altitude of a transducer perpendicular to the screen from a device that reports no tilt, and treats a lone pointer as the primary pointer of its type.

So `hover`, `mouseDown`, `mouseUp`, and the `click`, `tap`, `rightClick`, and `select` gestures built on them reported a state no pointing device produces, and a test asserting `event.isPrimary` or `event.width` against real browser behavior could not pass.

Measured with Playwright on Chromium 151, Firefox 153, and WebKit 26.5, all three engines report `width: 1`, `height: 1`, `isPrimary: true`, `altitudeAngle: π/2`, and `azimuthAngle: 0` on the pointer events of an ordinary primary-button click, from `pointerover` through `pointerup`, with `pressure: 0.5` on `pointerdown` and `0` on `pointerup`. On the `click` event itself they agree on all of those except `isPrimary`, which is `false` in Chromium and `true` in Firefox and WebKit.

Fixes #7172.

## Solution

The fix splits by which layer owns the value.

`dispatch` owns the members describing a pointer at rest, because they do not depend on a gesture. `initPointerEvent` now returns `1` for the contact geometry rather than `0`, and assigns `altitudeAngle` and `azimuthAngle` for the first time, defaulting the altitude to a right angle. All three engines report these on every pointer event, `click`, `auxclick`, and `contextmenu` included, so this layer is the right home for them.

`pressure` and `isPrimary` describe the gesture, so `hover`, `mouseDown`, and `mouseUp` each apply a new `getPointerOptions` to their own phase options. `pressure` follows the resolved `buttons`, which is the specification rule for a device with no pressure sensor, and which makes a chorded release that leaves another button held keep `0.5`.

That placement is what keeps those two members off `click`, `auxclick`, and `contextmenu`, which Pointer Events requires to reset every pointer attribute except `pointerId` and `pointerType`. `click.ts` and `select.ts` build all three of those events from `getPressOptions` and `getReleaseOptions` directly, so those builders stay pure `button`/`buttons` normalizers, and only the three helpers that fire pointer events fill in the pointer behind them.

### Evidence gap

That boundary cannot be tested on `main`, where `click`, `auxclick`, and `contextmenu` are still `MouseEvent` and carry no pointer members at all. It becomes testable with #7177.

### Not included

The conversion between the `tiltX`/`tiltY` pair and the `altitudeAngle`/`azimuthAngle` pair is not implemented, so `dispatch.pointerDown(element, { tiltX: 30 })` reports a right angle rather than the roughly `1.047` that Chromium and Firefox derive. Pointer Events requires that conversion, but scopes the requirement to the values a user agent receives from hardware rather than to the `PointerEvent` constructor, which is why WebKit performs none on a constructed event and the engines disagree. This is pre-existing on `main`, where the same call reports `0`, and it is tracked in #7185.

Issue #7172 also notes that its second channel reaches `click`, `auxclick`, and `contextmenu`. On `main` those are `MouseEvent` and carry no `altitudeAngle` to correct, so that half arrives with #7177, whose reset list already drops both angles, which lets this change's defaults apply there.

## Overlapping pull requests

This change and two open pull requests touch `packages/ariakit-test/src/dispatch.ts`, so whichever merges last needs a mechanical reconciliation:

- #7177 makes `click`, `auxclick`, and `contextmenu` be `PointerEvent`. Five expectations in its `click.test.ts` assert `altitudeAngle: 0` on those events, which this change makes obsolete.
- #7183 moves `initPointerEvent` out of `dispatch.ts` into a new `__init-event.ts`, so this change's edits move with it.

## Review gate reassessment

<details>
<summary>Cycle 3: Simplify the machinery instead of repairing it</summary>

**Assessment**

The bug is low severity and low frequency: no code in this repository reads `width`, `height`, `pressure`, `isPrimary`, or the angles, and every caller can pass explicit values. Its weight comes from the failure mode rather than the frequency. A test author who asserts a measured browser value cannot make the assertion pass at all, and browser fidelity is this package's entire product.

The implementation is small: two one-line sanitizers and two new assigned members in `dispatch.ts`, one private `getPressure` helper and one `getPointerOptions` helper in `__mouse.ts`, and one call each in `hover`, `mouseDown`, and `mouseUp`. No new public API, since both `__`-prefixed modules are private.

Most findings across the three gate cycles concerned documentation accuracy, scope, or test coverage. Three were the same finding restated with increasing precision: `getPointerOptions` was applied inside `getHoverOptions`, `getPressOptions`, and `getReleaseOptions`. Cycle 1 found the `getHoverOptions` call inert. Cycle 2 found the stated rationale did not apply to `isPrimary`, which is phase-independent. Cycle 3 found that the placement reaches `click`, `auxclick`, and `contextmenu` through `click.ts` and `select.ts`, which is the exact boundary the rationale claimed to protect, and that after #7177 it would pin `isPrimary: true` on the click family and make #7177's own explicit-value test vacuous.

**Decision**

Simplify rather than repair. `getPointerOptions` moved out of the three option builders and into the three public helpers that fire pointer events, next to the call `hover` already made. The builders return to their previous bodies.

This makes the exception structural instead of asserted, on `main` and after #7177, with no dependence on a sibling pull request's reset list. It gives one statable rule: the option builders normalize `button` and `buttons`, and each helper fills in the pointer it simulates. It resolves the cycle 1 finding as a side effect and shrinks the diff.

Both halves of cycle 1's declined non-goal are now addressed. The inert wrapper was declined because `getHoverOptions` already forces `button: 0, buttons: 0` and so describes its phase completely, and the structural move was declined because #7177 deliberately carries `isPrimary` to the click family to match Firefox and WebKit. Neither reason addressed what cycle 3 found, that `click.ts` and `select.ts` call the builders directly, so the derivation never kept anything off the click family. Pointer Events also resets `isPrimary` on those three events, which makes Chromium the conformant engine, so the second reason did not hold either.

One edge case stays intentionally unsupported: the tilt and spherical angle pairs are not derived from each other, registered as https://github.com/ariakit/ariakit/issues/7185.

</details>
