### PR TITLE
Dispatch the synthetic Command click as a PointerEvent

### DIFF
--- a/.changeset/300-command-click-pointer-event.md
+++ b/.changeset/300-command-click-pointer-event.md
@@ -1,0 +1,20 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Keyboard activation dispatches a `PointerEvent`
+
+The click that [`Command`](https://ariakit.com/reference/command) synthesizes for `Enter` and `Space` on an element that isn't natively clickable is now a `PointerEvent` built by the window that owns the element, reporting `pointerId: -1` and an empty `pointerType`. That is what Chromium, Firefox, and WebKit dispatch for a click no pointer caused, so a handler reading `event.pointerType` or checking `event instanceof PointerEvent` now sees the same shape it sees on a native button.
+
+```tsx
+<Ariakit.Button
+  render={<div />}
+  onClick={(event) => {
+    // After Enter or Space: was false, now true.
+    event.nativeEvent instanceof PointerEvent;
+  }}
+/>
+```
+
+This reaches every component built on [`Command`](https://ariakit.com/reference/command): [`Button`](https://ariakit.com/reference/button), [`Checkbox`](https://ariakit.com/reference/checkbox), [`Radio`](https://ariakit.com/reference/radio), [`CompositeItem`](https://ariakit.com/reference/composite-item), [`MenuItem`](https://ariakit.com/reference/menu-item), [`MenuItemCheckbox`](https://ariakit.com/reference/menu-item-checkbox), [`MenuItemRadio`](https://ariakit.com/reference/menu-item-radio), [`ComboboxItem`](https://ariakit.com/reference/combobox-item), [`SelectItem`](https://ariakit.com/reference/select-item), [`Tab`](https://ariakit.com/reference/tab), [`ToolbarItem`](https://ariakit.com/reference/toolbar-item), [`ToolbarContainer`](https://ariakit.com/reference/toolbar-container), [`Disclosure`](https://ariakit.com/reference/disclosure), [`DialogDisclosure`](https://ariakit.com/reference/dialog-disclosure), [`DialogDismiss`](https://ariakit.com/reference/dialog-dismiss), [`PopoverDisclosure`](https://ariakit.com/reference/popover-disclosure), [`PopoverDismiss`](https://ariakit.com/reference/popover-dismiss), [`HovercardDisclosure`](https://ariakit.com/reference/hovercard-disclosure), [`HovercardDismiss`](https://ariakit.com/reference/hovercard-dismiss), [`MenuButton`](https://ariakit.com/reference/menu-button), [`MenuDismiss`](https://ariakit.com/reference/menu-dismiss), [`Select`](https://ariakit.com/reference/select), [`SelectDismiss`](https://ariakit.com/reference/select-dismiss), [`ComboboxSelect`](https://ariakit.com/reference/combobox-select), [`ComboboxCancel`](https://ariakit.com/reference/combobox-cancel), [`ComboboxDisclosure`](https://ariakit.com/reference/combobox-disclosure), [`ComboboxDismiss`](https://ariakit.com/reference/combobox-dismiss), [`FormSubmit`](https://ariakit.com/reference/form-submit), [`FormReset`](https://ariakit.com/reference/form-reset), [`FormPush`](https://ariakit.com/reference/form-push), [`FormRemove`](https://ariakit.com/reference/form-remove), [`FormCheckbox`](https://ariakit.com/reference/form-checkbox), and [`FormRadio`](https://ariakit.com/reference/form-radio).

--- a/.changeset/300-fire-click-event-pointer-event.md
+++ b/.changeset/300-fire-click-event-pointer-event.md
@@ -1,0 +1,9 @@
+---
+"@ariakit/utils": patch
+---
+
+`fireClickEvent` dispatches a `PointerEvent`
+
+`fireClickEvent` now builds a `PointerEvent` from the window that owns the element, the way browsers dispatch a click, and reports `pointerId: -1` with an empty `pointerType` unless the caller passes a pointer. It previously built a `MouseEvent` from the ambient global, which dropped the pointer members its `PointerEventInit` parameter accepted and put the event in the wrong realm for an element inside a same-origin iframe. Where the environment has no `PointerEvent`, it still builds a `MouseEvent`, so activation keeps working and only the pointer members are dropped.
+
+Every pointer attribute other than `pointerId` and `pointerType`, such as `pressure`, `width`, `tiltX`, `isPrimary`, and `persistentDeviceId`, is reported at its default value even when the caller passes it, which is what Pointer Events requires of a click.

--- a/app/src/sandbox/command-7171/index.react.tsx
+++ b/app/src/sandbox/command-7171/index.react.tsx
@@ -3,6 +3,63 @@ import type { Dispatch, MouseEvent, SetStateAction } from "react";
 import { useCallback, useState } from "react";
 import { createPortal } from "react-dom";
 
+// TODO: Remove once https://github.com/ariakit/ariakit/issues/7171 is fixed.
+//
+// `Command` builds the click it synthesizes for Enter and Space as a
+// `MouseEvent` from the ambient window. Swap that event for the `PointerEvent`
+// browsers dispatch, built by the window that owns the element, and copy the
+// members `Command` already passed. Replacing the event instead of the
+// activation leaves every rule `Command` applies to decide whether to click in
+// place, including the disabled, self-target, text-field, `clickOnEnter`, and
+// `clickOnSpace` guards.
+//
+// This belongs on the command element itself. It re-dispatches on
+// `currentTarget`, so delegating it to an ancestor would retarget the click to
+// that ancestor and the command's own `onClick` would never run.
+function replaceSyntheticClick(event: MouseEvent<HTMLElement>) {
+  const click = event.nativeEvent;
+  // A real click already arrives as a `PointerEvent` from the right window, and
+  // a trusted event cannot be re-dispatched as one anyway.
+  if (click.isTrusted) return;
+  // A non-cancelable click cannot be suppressed, so replacing it would run its
+  // default behavior alongside the replacement's.
+  if (!click.cancelable) return;
+  const element = event.currentTarget;
+  const { defaultView } = element.ownerDocument;
+  // Resolve the constructor before canceling anything, so a missing
+  // `PointerEvent` leaves the click alone rather than destroying it.
+  const PointerEventConstructor = defaultView?.PointerEvent;
+  if (!PointerEventConstructor) return;
+  // Skip the replacement this handler already dispatched. Asking the element's
+  // own window survives a `class PointerEvent extends MouseEvent {}` polyfill,
+  // which a `pointerId` probe would not.
+  if (click instanceof PointerEventConstructor) return;
+  const replacement = new PointerEventConstructor("click", {
+    altKey: click.altKey,
+    bubbles: click.bubbles,
+    button: click.button,
+    buttons: click.buttons,
+    cancelable: click.cancelable,
+    clientX: click.clientX,
+    clientY: click.clientY,
+    ctrlKey: click.ctrlKey,
+    detail: click.detail,
+    metaKey: click.metaKey,
+    // A click no pointer caused reports an unset pointer.
+    pointerId: -1,
+    pointerType: "",
+    shiftKey: click.shiftKey,
+  });
+  // Built before anything is canceled, so a constructor that throws leaves the
+  // original click alone rather than destroying the activation. Canceling it
+  // keeps its default behavior, such as following a link, from running twice,
+  // and stopping it keeps the original from continuing alongside the
+  // replacement.
+  event.preventDefault();
+  event.stopPropagation();
+  element.dispatchEvent(replacement);
+}
+
 // An event built in another realm fails `instanceof` against every constructor
 // of the window checking it, so the interface and the realm have to be read
 // separately. The constructor name is comparable across realms, while
@@ -59,6 +116,7 @@ export default function Example() {
         role="button"
         render={<div />}
         onClick={createClickReporter(setClickEvents)}
+        onClickCapture={replaceSyntheticClick}
       >
         Report click
       </Ariakit.Command>
@@ -78,6 +136,7 @@ export default function Example() {
               role="button"
               render={<div />}
               onClick={createClickReporter(setFrameClickEvents)}
+              onClickCapture={replaceSyntheticClick}
             >
               Frame command
             </Ariakit.Command>,

--- a/app/src/sandbox/command-7171/index.react.tsx
+++ b/app/src/sandbox/command-7171/index.react.tsx
@@ -3,63 +3,6 @@ import type { Dispatch, MouseEvent, SetStateAction } from "react";
 import { useCallback, useState } from "react";
 import { createPortal } from "react-dom";
 
-// TODO: Remove once https://github.com/ariakit/ariakit/issues/7171 is fixed.
-//
-// `Command` builds the click it synthesizes for Enter and Space as a
-// `MouseEvent` from the ambient window. Swap that event for the `PointerEvent`
-// browsers dispatch, built by the window that owns the element, and copy the
-// members `Command` already passed. Replacing the event instead of the
-// activation leaves every rule `Command` applies to decide whether to click in
-// place, including the disabled, self-target, text-field, `clickOnEnter`, and
-// `clickOnSpace` guards.
-//
-// This belongs on the command element itself. It re-dispatches on
-// `currentTarget`, so delegating it to an ancestor would retarget the click to
-// that ancestor and the command's own `onClick` would never run.
-function replaceSyntheticClick(event: MouseEvent<HTMLElement>) {
-  const click = event.nativeEvent;
-  // A real click already arrives as a `PointerEvent` from the right window, and
-  // a trusted event cannot be re-dispatched as one anyway.
-  if (click.isTrusted) return;
-  // A non-cancelable click cannot be suppressed, so replacing it would run its
-  // default behavior alongside the replacement's.
-  if (!click.cancelable) return;
-  const element = event.currentTarget;
-  const { defaultView } = element.ownerDocument;
-  // Resolve the constructor before canceling anything, so a missing
-  // `PointerEvent` leaves the click alone rather than destroying it.
-  const PointerEventConstructor = defaultView?.PointerEvent;
-  if (!PointerEventConstructor) return;
-  // Skip the replacement this handler already dispatched. Asking the element's
-  // own window survives a `class PointerEvent extends MouseEvent {}` polyfill,
-  // which a `pointerId` probe would not.
-  if (click instanceof PointerEventConstructor) return;
-  const replacement = new PointerEventConstructor("click", {
-    altKey: click.altKey,
-    bubbles: click.bubbles,
-    button: click.button,
-    buttons: click.buttons,
-    cancelable: click.cancelable,
-    clientX: click.clientX,
-    clientY: click.clientY,
-    ctrlKey: click.ctrlKey,
-    detail: click.detail,
-    metaKey: click.metaKey,
-    // A click no pointer caused reports an unset pointer.
-    pointerId: -1,
-    pointerType: "",
-    shiftKey: click.shiftKey,
-  });
-  // Built before anything is canceled, so a constructor that throws leaves the
-  // original click alone rather than destroying the activation. Canceling it
-  // keeps its default behavior, such as following a link, from running twice,
-  // and stopping it keeps the original from continuing alongside the
-  // replacement.
-  event.preventDefault();
-  event.stopPropagation();
-  element.dispatchEvent(replacement);
-}
-
 // An event built in another realm fails `instanceof` against every constructor
 // of the window checking it, so the interface and the realm have to be read
 // separately. The constructor name is comparable across realms, while
@@ -116,7 +59,6 @@ export default function Example() {
         role="button"
         render={<div />}
         onClick={createClickReporter(setClickEvents)}
-        onClickCapture={replaceSyntheticClick}
       >
         Report click
       </Ariakit.Command>
@@ -136,7 +78,6 @@ export default function Example() {
               role="button"
               render={<div />}
               onClick={createClickReporter(setFrameClickEvents)}
-              onClickCapture={replaceSyntheticClick}
             >
               Frame command
             </Ariakit.Command>,

--- a/app/src/sandbox/command-7171/index.react.tsx
+++ b/app/src/sandbox/command-7171/index.react.tsx
@@ -1,0 +1,95 @@
+import * as Ariakit from "@ariakit/react";
+import type { Dispatch, MouseEvent, SetStateAction } from "react";
+import { useCallback, useState } from "react";
+import { createPortal } from "react-dom";
+
+// An event built in another realm fails `instanceof` against every constructor
+// of the window checking it, so the interface and the realm have to be read
+// separately. The constructor name is comparable across realms, while
+// `instanceof ownerWindow.Event` answers only the realm question.
+function isPointerEvent(event: globalThis.MouseEvent): event is PointerEvent {
+  return "pointerId" in event;
+}
+
+function describeClickEvent(event: globalThis.MouseEvent, element: Element) {
+  // The window that owns the element is the realm a listener sitting next to it
+  // checks against, and the one browsers build the click in. A missing
+  // `defaultView` reports "other window" instead of falling back to the ambient
+  // window, which is the realm the reported bug builds its event in and would
+  // hide the difference this fixture exists to show.
+  const ownerWindow = element.ownerDocument.defaultView;
+  const realm =
+    ownerWindow && event instanceof ownerWindow.Event
+      ? "own window"
+      : "other window";
+  const pointer = isPointerEvent(event)
+    ? `pointerId ${event.pointerId}, pointerType "${event.pointerType}"`
+    : "no pointer members";
+  return `${event.constructor.name}, ${realm}, ${pointer}`;
+}
+
+function createClickReporter(setEvents: Dispatch<SetStateAction<string[]>>) {
+  return (event: MouseEvent<HTMLElement>) => {
+    const description = describeClickEvent(
+      event.nativeEvent,
+      event.currentTarget,
+    );
+    setEvents((events) => [...events, description]);
+  };
+}
+
+export default function Example() {
+  const [clickEvents, setClickEvents] = useState<string[]>([]);
+  const [frameClickEvents, setFrameClickEvents] = useState<string[]>([]);
+  const [frameBody, setFrameBody] = useState<HTMLElement | null>(null);
+
+  const setFrame = useCallback((element: HTMLIFrameElement | null) => {
+    setFrameBody(element?.contentDocument?.body ?? null);
+  }, []);
+
+  return (
+    <main>
+      <h1>Command keyboard click event</h1>
+
+      {/* Both commands render a non-native element on purpose, because that is
+          what makes `Command` synthesize the click for Enter and Space. On a
+          native button the browser dispatches it, and `@ariakit/test` simulates
+          it, so neither would exercise the code under test. */}
+      <Ariakit.Command
+        role="button"
+        render={<div />}
+        onClick={createClickReporter(setClickEvents)}
+      >
+        Report click
+      </Ariakit.Command>
+      <h2 id="document-click-events">Document click events</h2>
+      <ul aria-labelledby="document-click-events" aria-live="polite">
+        {clickEvents.map((description, index) => (
+          <li key={index}>{description}</li>
+        ))}
+      </ul>
+
+      {/* A same-origin frame owns its own constructors, so a listener inside it
+          only recognizes events the frame's own window built. */}
+      <iframe title="Command frame" ref={setFrame} />
+      {frameBody
+        ? createPortal(
+            <Ariakit.Command
+              role="button"
+              render={<div />}
+              onClick={createClickReporter(setFrameClickEvents)}
+            >
+              Frame command
+            </Ariakit.Command>,
+            frameBody,
+          )
+        : null}
+      <h2 id="frame-click-events">Frame click events</h2>
+      <ul aria-labelledby="frame-click-events" aria-live="polite">
+        {frameClickEvents.map((description, index) => (
+          <li key={index}>{description}</li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/app/src/sandbox/command-7171/no-pointer-click.ts
+++ b/app/src/sandbox/command-7171/no-pointer-click.ts
@@ -1,0 +1,9 @@
+// Measured on Chromium 151, Firefox 153, and WebKit 26.5: a click no pointer
+// caused, such as Enter or Space activation, is a `PointerEvent` built by the
+// window that owns the element, reporting `pointerId: -1` and an empty
+// `pointerType`.
+//
+// Shared by both suites so the authoritative browser test and its happy-dom
+// duplicate cannot drift to different expected shapes.
+export const NO_POINTER_CLICK =
+  'PointerEvent, own window, pointerId -1, pointerType ""';

--- a/app/src/sandbox/command-7171/test-browser.ts
+++ b/app/src/sandbox/command-7171/test-browser.ts
@@ -1,0 +1,62 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+import { NO_POINTER_CLICK } from "./no-pointer-click.ts";
+
+withFramework(import.meta.dirname, async ({ test, query }) => {
+  // https://github.com/ariakit/ariakit/issues/7171
+  test("Enter dispatches a PointerEvent with no pointer behind it", async ({
+    page,
+    q,
+  }) => {
+    const events = query(q.list("Document click events")).listitem();
+    await q.button("Report click").focus();
+
+    await page.keyboard.press("Enter");
+    await test.expect(events).toHaveText([NO_POINTER_CLICK]);
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7171
+  //
+  // Space dispatches the click from the keyup handler, a separate path from
+  // Enter's keydown handler in `Command`.
+  test("Space dispatches a PointerEvent with no pointer behind it", async ({
+    page,
+    q,
+  }) => {
+    const events = query(q.list("Document click events")).listitem();
+    await q.button("Report click").focus();
+
+    await page.keyboard.press("Space");
+    await test.expect(events).toHaveText([NO_POINTER_CLICK]);
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7171
+  //
+  // A same-origin frame owns its own constructors, so the click has to be built
+  // by the frame's window for a listener inside it to recognize it. happy-dom
+  // shares one set of constructors between a frame and its parent, so this half
+  // has no duplicate in `test.ts`.
+  test("Enter inside a frame dispatches an event built by the frame's window", async ({
+    page,
+    q,
+  }) => {
+    const frame = query(page.frameLocator("iframe[title='Command frame']"));
+    const events = query(q.list("Frame click events")).listitem();
+    await frame.button("Frame command").focus();
+
+    await page.keyboard.press("Enter");
+    await test.expect(events).toHaveText([NO_POINTER_CLICK]);
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7171
+  test("Space inside a frame dispatches an event built by the frame's window", async ({
+    page,
+    q,
+  }) => {
+    const frame = query(page.frameLocator("iframe[title='Command frame']"));
+    const events = query(q.list("Frame click events")).listitem();
+    await frame.button("Frame command").focus();
+
+    await page.keyboard.press("Space");
+    await test.expect(events).toHaveText([NO_POINTER_CLICK]);
+  });
+});

--- a/app/src/sandbox/command-7171/test.ts
+++ b/app/src/sandbox/command-7171/test.ts
@@ -1,0 +1,30 @@
+import { focus, press, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+import { NO_POINTER_CLICK } from "./no-pointer-click.ts";
+
+function getClickEvents() {
+  return q
+    .within(q.list("Document click events"))
+    .listitem.all()
+    .map((item) => item.textContent);
+}
+
+// https://github.com/ariakit/ariakit/issues/7171
+//
+// The realm half of this behavior is covered only by `test-browser.ts`, because
+// happy-dom shares one set of constructors between a frame and its parent.
+test("Enter dispatches a PointerEvent with no pointer behind it", async () => {
+  await focus(q.button("Report click"));
+  await press.Enter();
+  expect(getClickEvents()).toEqual([NO_POINTER_CLICK]);
+});
+
+// https://github.com/ariakit/ariakit/issues/7171
+//
+// Space dispatches the click from the keyup handler, a separate path from
+// Enter's keydown handler in `Command`.
+test("Space dispatches a PointerEvent with no pointer behind it", async () => {
+  await focus(q.button("Report click"));
+  await press.Space();
+  expect(getClickEvents()).toEqual([NO_POINTER_CLICK]);
+});

--- a/packages/ariakit-utils/readme.md
+++ b/packages/ariakit-utils/readme.md
@@ -728,11 +728,13 @@ fireKeyboardEvent(document.getElementById("id"), "keydown", {
 ```ts
 function fireClickEvent(
   element: Element,
-  eventInit?: PointerEventInit,
+  eventInit?: PointerEventInit | null,
 ): boolean;
 ```
 
 Creates and dispatches a click event.
+
+The event is a `PointerEvent` built by the window that owns the element, the way browsers dispatch it, falling back to a `MouseEvent` where that window has no `PointerEvent`. It reports no pointer behind the click unless the caller passes one, and reports every other pointer attribute at its default value, the way a click always does.
 
 Example:
 

--- a/packages/ariakit-utils/src/events.test.ts
+++ b/packages/ariakit-utils/src/events.test.ts
@@ -1,5 +1,6 @@
-import { expect, test, vi } from "vitest";
+import { expect, onTestFinished, test, vi } from "vitest";
 import {
+  fireClickEvent,
   isFocusEventOutside,
   isInputEvent,
   isPortalEvent,
@@ -74,4 +75,242 @@ test("queueBeforeEvent cancel removes the queued animation frame listener", () =
 
 test("queueBeforeEvent cancel removes the queued timeout listener", () => {
   expectCancelToRemoveQueuedEventListener(1_000);
+});
+
+// https://github.com/ariakit/ariakit/issues/7171
+//
+// Measured on Chromium 151, Firefox 153, and WebKit 26.5: a click no pointer
+// caused, such as the one `Command` synthesizes for Enter and Space, is a
+// `PointerEvent` reporting `pointerId: -1` and an empty `pointerType`.
+
+function captureClick(
+  element: HTMLElement,
+  eventInit?: PointerEventInit | null,
+) {
+  let clicked: PointerEvent | undefined;
+  element.addEventListener("click", (event) => {
+    clicked = event;
+  });
+  fireClickEvent(element, eventInit);
+  return clicked;
+}
+
+test("fireClickEvent dispatches a PointerEvent with no pointer behind it", () => {
+  const clicked = captureClick(document.createElement("button"));
+  expect(clicked).toBeInstanceOf(PointerEvent);
+  expect(clicked?.pointerId).toBe(-1);
+  expect(clicked?.pointerType).toBe("");
+});
+
+test("fireClickEvent keeps the pointer members the caller passes", () => {
+  const clicked = captureClick(document.createElement("button"), {
+    pointerId: 7,
+    pointerType: "pen",
+  });
+  expect(clicked?.pointerId).toBe(7);
+  expect(clicked?.pointerType).toBe("pen");
+});
+
+// https://github.com/ariakit/ariakit/issues/7199
+//
+// Pointer Events resets every pointer attribute other than `pointerId` and
+// `pointerType` on a click, so the contact a press described never reaches it.
+// The expected values come from a default-constructed event rather than
+// literals, because the specification's defaults are not all zero and a DOM
+// implementation may not have caught up with them.
+//
+// `persistentDeviceId` is reset too but cannot be asserted here, because
+// happy-dom doesn't implement it. Chromium 151 and Firefox 153 were measured
+// leaking a caller's value onto the click without the reset.
+test("fireClickEvent resets the pointer contact the caller passes", () => {
+  const defaults = new PointerEvent("click");
+  const clicked = captureClick(document.createElement("button"), {
+    pointerId: 7,
+    pointerType: "pen",
+    pressure: 0.5,
+    tangentialPressure: 0.25,
+    width: 3,
+    height: 4,
+    tiltX: 30,
+    tiltY: 20,
+    twist: 90,
+    altitudeAngle: 1.2,
+    azimuthAngle: 0.5,
+    isPrimary: true,
+    coalescedEvents: [new PointerEvent("pointermove")],
+    predictedEvents: [new PointerEvent("pointermove")],
+  });
+  expect(clicked?.pointerId).toBe(7);
+  expect(clicked?.pointerType).toBe("pen");
+  expect(clicked?.pressure).toBe(defaults.pressure);
+  expect(clicked?.tangentialPressure).toBe(defaults.tangentialPressure);
+  expect(clicked?.width).toBe(defaults.width);
+  expect(clicked?.height).toBe(defaults.height);
+  expect(clicked?.tiltX).toBe(defaults.tiltX);
+  expect(clicked?.tiltY).toBe(defaults.tiltY);
+  expect(clicked?.twist).toBe(defaults.twist);
+  expect(clicked?.altitudeAngle).toBe(defaults.altitudeAngle);
+  expect(clicked?.azimuthAngle).toBe(defaults.azimuthAngle);
+  expect(clicked?.isPrimary).toBe(defaults.isPrimary);
+  expect(clicked?.getCoalescedEvents()).toHaveLength(0);
+  expect(clicked?.getPredictedEvents()).toHaveLength(0);
+});
+
+// The sibling helpers pass a `null` init straight to a constructor, which reads
+// it as an empty dictionary, so this one has to keep accepting it too.
+test("fireClickEvent accepts a null init", () => {
+  const clicked = captureClick(document.createElement("button"), null);
+  expect(clicked).toBeInstanceOf(PointerEvent);
+  expect(clicked?.pointerId).toBe(-1);
+});
+
+// `0` is a valid pointer identity, so the fallback has to distinguish it from a
+// missing member rather than treat it as absent.
+test("fireClickEvent keeps a zero pointerId the caller passes", () => {
+  const clicked = captureClick(document.createElement("button"), {
+    pointerId: 0,
+  });
+  expect(clicked?.pointerId).toBe(0);
+});
+
+// `getWindow` treats any node with a `self` property as a window, and a form
+// exposes its controls as named properties, so the window has to come from the
+// document instead.
+test("fireClickEvent dispatches on a form owning a control named self", () => {
+  const form = document.createElement("form");
+  const control = document.createElement("input");
+  control.name = "self";
+  form.append(control);
+  document.body.append(form);
+  onTestFinished(() => form.remove());
+  // Without the named property there is nothing for the helper to trip over,
+  // and this would pass whichever window it read.
+  expect(Reflect.get(form, "self")).toBe(control);
+
+  const clicked = captureClick(form);
+
+  expect(clicked).toBeInstanceOf(PointerEvent);
+  expect(clicked?.pointerId).toBe(-1);
+});
+
+// The init the constructor reads is layered over a fresh object, because a
+// proxy may not report a value different from a frozen own property of its
+// target, and every layered member could be one.
+test("fireClickEvent accepts a frozen init", () => {
+  const defaults = new PointerEvent("click");
+  const clicked = captureClick(
+    document.createElement("button"),
+    Object.freeze({ ctrlKey: true, pressure: 0.5 }),
+  );
+  expect(clicked?.ctrlKey).toBe(true);
+  expect(clicked?.pressure).toBe(defaults.pressure);
+  expect(clicked?.pointerId).toBe(-1);
+});
+
+test("fireClickEvent reports no pointer for members passed as undefined", () => {
+  const clicked = captureClick(document.createElement("button"), {
+    pointerId: undefined,
+    pointerType: undefined,
+  });
+  expect(clicked?.pointerId).toBe(-1);
+  expect(clicked?.pointerType).toBe("");
+});
+
+// `Command` passes the key event's own members through this helper, so a click
+// handler can tell an open-in-new-tab or download activation from a plain one.
+// This one passes before the fix too. It is here so the new init merge cannot
+// drop those members, not to reproduce the reported bug.
+test("fireClickEvent keeps the event members the caller passes", () => {
+  const clicked = captureClick(document.createElement("button"), {
+    altKey: true,
+    bubbles: true,
+    cancelable: true,
+    ctrlKey: true,
+    detail: 1,
+    metaKey: true,
+    shiftKey: true,
+  });
+  expect(clicked?.altKey).toBe(true);
+  expect(clicked?.ctrlKey).toBe(true);
+  expect(clicked?.metaKey).toBe(true);
+  expect(clicked?.shiftKey).toBe(true);
+  expect(clicked?.bubbles).toBe(true);
+  expect(clicked?.cancelable).toBe(true);
+  expect(clicked?.detail).toBe(1);
+});
+
+// A live event keeps most of its members on a prototype rather than on itself,
+// so the init has to reach the constructor through the prototype chain. Copying
+// it would forward little in a browser and, even here, would lose `bubbles` and
+// `cancelable`.
+test("fireClickEvent forwards the members of a live event passed as the init", () => {
+  const source = new MouseEvent("click", {
+    bubbles: true,
+    cancelable: true,
+    ctrlKey: true,
+    detail: 3,
+  });
+  const clicked = captureClick(document.createElement("button"), source);
+  expect(clicked?.ctrlKey).toBe(true);
+  expect(clicked?.detail).toBe(3);
+  expect(clicked?.bubbles).toBe(true);
+  expect(clicked?.cancelable).toBe(true);
+  expect(clicked?.pointerId).toBe(-1);
+});
+
+// happy-dom gives a frame its own `Window` but the same `PointerEvent` as its
+// parent, so an ambient-global implementation would satisfy a plain
+// `instanceof` check here. Replacing the constructor on the frame's window
+// alone makes the two distinguishable: only an implementation that reads the
+// element's own window builds the subclass.
+test("fireClickEvent builds the event with the element's own window", () => {
+  const frame = document.createElement("iframe");
+  document.body.append(frame);
+  onTestFinished(() => frame.remove());
+  const frameDocument = frame.contentDocument;
+  if (!frameDocument) throw new Error("iframe document is not available");
+  const view = frameDocument.defaultView;
+  if (!view) throw new Error("iframe window is not available");
+  const button = frameDocument.body.appendChild(
+    frameDocument.createElement("button"),
+  );
+  const ambientPointerEvent = view.PointerEvent;
+  class FramePointerEvent extends ambientPointerEvent {}
+  view.PointerEvent = FramePointerEvent;
+  onTestFinished(() => {
+    view.PointerEvent = ambientPointerEvent;
+  });
+
+  const clicked = captureClick(button, { ctrlKey: true });
+
+  expect(clicked).toBeInstanceOf(FramePointerEvent);
+  expect(clicked?.pointerId).toBe(-1);
+  expect(clicked?.ctrlKey).toBe(true);
+});
+
+// jsdom implements `PointerEvent` only from v27, so `jest-environment-jsdom` 30
+// still has none. Activation has to keep working there rather than throwing,
+// dropping only the pointer members.
+test("fireClickEvent falls back to MouseEvent where PointerEvent is missing", () => {
+  const frame = document.createElement("iframe");
+  document.body.append(frame);
+  onTestFinished(() => frame.remove());
+  const frameDocument = frame.contentDocument;
+  if (!frameDocument) throw new Error("iframe document is not available");
+  const view = frameDocument.defaultView;
+  if (!view) throw new Error("iframe window is not available");
+  const button = frameDocument.body.appendChild(
+    frameDocument.createElement("button"),
+  );
+  const framePointerEvent = view.PointerEvent;
+  Reflect.deleteProperty(view, "PointerEvent");
+  onTestFinished(() => {
+    view.PointerEvent = framePointerEvent;
+  });
+
+  const clicked = captureClick(button, { ctrlKey: true });
+
+  expect(clicked).toBeInstanceOf(view.MouseEvent);
+  expect(clicked).not.toBeInstanceOf(framePointerEvent);
+  expect(clicked?.ctrlKey).toBe(true);
 });

--- a/packages/ariakit-utils/src/events.ts
+++ b/packages/ariakit-utils/src/events.ts
@@ -4,6 +4,7 @@
  */
 
 import { contains, isElement, isNode } from "./dom.ts";
+import { hasOwnProperty } from "./misc.ts";
 import { isApple } from "./platform.ts";
 
 /**
@@ -124,13 +125,101 @@ export function fireKeyboardEvent(
   return element.dispatchEvent(event);
 }
 
+type PointerIdentityAttribute = "pointerId" | "pointerType";
+
+type ResetAttribute =
+  | Exclude<
+      keyof PointerEventInit,
+      keyof MouseEventInit | PointerIdentityAttribute
+    >
+  // Chromium and Firefox read this one from the init, but `lib.dom` doesn't
+  // declare it on `PointerEventInit` yet, so `Exclude` can't find it. Measured
+  // leaking a caller's value onto the click in both, where their own click
+  // reports 0.
+  | "persistentDeviceId";
+
+// Pointer Events requires every pointer attribute other than `pointerId` and
+// `pointerType` to have its default value on a click, so the event never
+// reports the contact a press described. `isPrimary` is one of them, even
+// though it identifies the pointer rather than the contact: Firefox and WebKit
+// carry a caller's value over where Chromium resets it, and the specification,
+// not the engine count, decides which is right.
+//
+// Keyed rather than listed so TypeScript requires every non-identity member it
+// knows about, because `PointerEventInit` keeps growing.
+// https://www.w3.org/TR/pointerevents/#the-click-auxclick-and-contextmenu-events
+const resetAttributes: Record<ResetAttribute, true> = {
+  width: true,
+  height: true,
+  pressure: true,
+  tangentialPressure: true,
+  tiltX: true,
+  tiltY: true,
+  twist: true,
+  altitudeAngle: true,
+  azimuthAngle: true,
+  isPrimary: true,
+  coalescedEvents: true,
+  predictedEvents: true,
+  persistentDeviceId: true,
+};
+
+// Chromium, Firefox, and WebKit all report an unset pointer on a click no
+// pointer caused, such as keyboard activation, so the event doesn't claim a
+// mouse pressed the element.
+//
+// The constructor reads the init through the prototype chain, so a caller can
+// pass a live event. Copying it would flatten it to its own properties, which a
+// live event mostly doesn't have, and inheriting from it would break the native
+// getters' brand checks, so the members are layered on with a proxy instead.
+function getClickEventInit(eventInit?: PointerEventInit | null) {
+  const init = eventInit ?? {};
+  // Proxying a fresh object rather than the caller's, because a trap may not
+  // report a value different from a frozen own property of its target, and
+  // every member below is layered over whatever the caller froze. Only the
+  // constructor reads the result, and it reads each member by name, so the
+  // empty target reporting no own keys is not observable.
+  const target: PointerEventInit = {};
+  return new Proxy(target, {
+    get(_target, key) {
+      if (key === "pointerId") return init.pointerId ?? -1;
+      if (key === "pointerType") return init.pointerType ?? "";
+      // Reading one of them as absent leaves the constructor's own default,
+      // which is the value browsers report on a click.
+      if (hasOwnProperty(resetAttributes, key)) return undefined;
+      // Rooted at the caller's init rather than at the empty target, so a
+      // native getter runs against the object that owns it.
+      return Reflect.get(init, key);
+    },
+  });
+}
+
 /**
  * Creates and dispatches a click event.
+ *
+ * The event is a `PointerEvent` built by the window that owns the element, the
+ * way browsers dispatch it, falling back to a `MouseEvent` where that window
+ * has no `PointerEvent`. It reports no pointer behind the click unless the
+ * caller passes one, and reports every other pointer attribute at its default
+ * value, the way a click always does.
  * @example
  * fireClickEvent(document.getElementById("id"));
  */
-export function fireClickEvent(element: Element, eventInit?: PointerEventInit) {
-  const event = new MouseEvent("click", eventInit);
+export function fireClickEvent(
+  element: Element,
+  eventInit?: PointerEventInit | null,
+) {
+  // Read straight from the document rather than through `getWindow`, which
+  // treats any node with a `self` property as a window. A form exposes its
+  // controls as named properties, so a form owning a control named `self` would
+  // resolve to that control. A form can shadow `ownerDocument` the same way,
+  // which the `?? window` fallback below only degrades rather than fixes; that
+  // residue is https://github.com/ariakit/ariakit/issues/7201.
+  const view = element.ownerDocument.defaultView ?? window;
+  // Falls back to `MouseEvent` where `PointerEvent` is missing, so activation
+  // keeps working there and only the pointer members are dropped.
+  const EventConstructor = view.PointerEvent ?? view.MouseEvent;
+  const event = new EventConstructor("click", getClickEventInit(eventInit));
   return element.dispatchEvent(event);
 }
 


### PR DESCRIPTION
## Motivation

When a [`Command`](https://ariakit.com/reference/command) isn't rendered as a natively clickable element, it synthesizes the click behind `Enter` and `Space` activation. `fireClickEvent` in `@ariakit/utils` builds that click as a `MouseEvent` from the ambient global:

```ts
export function fireClickEvent(element: Element, eventInit?: PointerEventInit) {
  const event = new MouseEvent("click", eventInit);
  return element.dispatchEvent(event);
}
```

Browsers dispatch a click as a `PointerEvent` even when no pointer caused it. Measured with Playwright on Chromium 151, Firefox 153, and WebKit 26.5, `Enter`, `Space`, and `element.click()` on a native button all produce a `PointerEvent` reporting `pointerId: -1` and an empty `pointerType`, built by the window that owns the element.

So a consumer checking `event instanceof PointerEvent` or reading `event.pointerType` in a click handler sees a different event shape when a user activates an Ariakit component with the keyboard than when they activate a native `<button>` the same way. `lib.dom` types `click` as `PointerEvent`, so reading `event.pointerType` in that handler type-checks and then returns `undefined`. The parameter is already typed `PointerEventInit`, but `MouseEvent`'s constructor ignores the pointer members, so a caller passing `pointerId` or `pointerType` has them silently dropped.

Taking the constructor from the ambient global also puts the event in the wrong realm for an element inside a same-origin iframe, where a listener in the frame's own realm gets an event its `PointerEvent` doesn't recognize.

This reaches every component built on [`Command`](https://ariakit.com/reference/command), such as [`Button`](https://ariakit.com/reference/button).

## Solution

`fireClickEvent` now builds a `PointerEvent` from the window that owns the element:

```ts
export function fireClickEvent(
  element: Element,
  eventInit?: PointerEventInit | null,
) {
  const view = element.ownerDocument.defaultView ?? window;
  const EventConstructor = view.PointerEvent ?? view.MouseEvent;
  const event = new EventConstructor("click", getClickEventInit(eventInit));
  return element.dispatchEvent(event);
}
```

The window comes from the document rather than from `getWindow`, which treats any node carrying a `self` property as a window. A form exposes its controls as named properties, so a form owning a control named `self` would resolve to that control. `@ariakit/test` avoided the same hazard in #7190. A form can shadow `ownerDocument` the same way, which this only degrades rather than fixes; that residue is #7201.

The `MouseEvent` fallback keeps activation working where `PointerEvent` doesn't exist. jsdom implements it only from v27, so `jest-environment-jsdom` 30 still has none, and throwing there would break keyboard activation for every component built on [`Command`](https://ariakit.com/reference/command). That path drops only the pointer members, which is exactly today's behavior.

`getClickEventInit` layers the click's own members over whatever the caller passed. It reports `pointerId: -1` and an empty `pointerType` unless the caller passes a pointer, and reports every other pointer attribute, such as `pressure`, `width`, `tiltX`, `isPrimary`, and `persistentDeviceId`, at its default value even when the caller passes it, which is what Pointer Events requires of a click. `persistentDeviceId` has to be named explicitly, because `lib.dom` doesn't declare it on `PointerEventInit` yet even though Chromium and Firefox read it, and it was measured leaking a caller's value onto the click in both. Firefox and WebKit carry a caller's `isPrimary` over where Chromium resets it, and the specification, not the engine count, settles that.

`@ariakit/test` draws the line in a different place for most of them, deliberately: its `dispatch.click` primitive fires the event the caller describes, and the reset lives in the gesture helpers, which know the press the contact came from. `fireClickEvent` has no such split, since it is the helper that synthesizes the click, so it enforces the reset itself. `isPrimary` is the one attribute where the two packages disagree at the same layer, because `@ariakit/test`'s gesture helpers still classify it as pointer identity; that is #7204.

Those members are layered with a proxy rather than by copying, because the constructor reads the init through the prototype chain and a caller may pass a live event, whose members mostly live on a prototype. Copying would forward almost nothing, including `bubbles`, and inheriting from the caller's object instead would break the native getters' brand checks. The proxy wraps a fresh object rather than the caller's, because a trap may not report a value different from a frozen own property of its target.

The `app/src/sandbox/command-7171/` fixture renders a non-native [`Command`](https://ariakit.com/reference/command) in the document and another one portaled into a same-origin iframe, and logs the interface, the realm, and the pointer members of each click it receives. Both keys are covered separately, because [`Command`](https://ariakit.com/reference/command) dispatches the `Enter` click from its keydown handler and the `Space` click from its keyup handler. The realm half is covered only in the browser, because happy-dom shares one set of constructors between a frame and its parent.

`packages/ariakit-utils/src/events.test.ts` covers the helper directly, and each behavior above is red-checked against an implementation without it. One test is deliberately green on both sides: it pins the members [`Command`](https://ariakit.com/reference/command) forwards, such as the modifier state that [`MenuItem`](https://ariakit.com/reference/menu-item) reads to tell an open-in-new-tab activation from a plain one, so the rewrite cannot drop behavior that was already correct.

## Preview

Pressing `Enter` and then `Space` on each command, before the fix. The framed command reports `other window`, because the event was built by the parent's `PointerEvent`:

<img width="760" height="880" alt="The sandbox before the fix, with every entry reading MouseEvent and the framed command reading other window" src="https://github.com/user-attachments/assets/1a6d6eca-30bf-417f-bb47-a465bc62c8aa" />

The same interaction after the fix. Every entry is a `PointerEvent` from its own window, reporting `pointerId -1` and an empty `pointerType`:

<img width="760" height="880" alt="The sandbox after the fix, with every entry reading PointerEvent, own window, pointerId -1, pointerType empty" src="https://github.com/user-attachments/assets/1837a432-71f0-489c-bbaf-0b4d50d4998d" />

## Workaround

Where the component can stay on its default native element, that is the whole workaround. The browser dispatches the correct `PointerEvent` itself, and [`Command`](https://ariakit.com/reference/command) never synthesizes one:

```tsx
<Ariakit.Command onClick={handleClick}>Action</Ariakit.Command>
```

For a component that has to render a non-native element, replace the event [`Command`](https://ariakit.com/reference/command) dispatches rather than the activation itself, so every rule it applies to decide whether to click stays in place:

```tsx
// TODO: Remove once https://github.com/ariakit/ariakit/issues/7171 is fixed.
function replaceSyntheticClick(event: React.MouseEvent<HTMLElement>) {
  const click = event.nativeEvent;
  if (click.isTrusted) return;
  // A non-cancelable click cannot be suppressed, so replacing it would run its
  // default behavior alongside the replacement's.
  if (!click.cancelable) return;
  const element = event.currentTarget;
  const { defaultView } = element.ownerDocument;
  // Resolve the constructor and check the click against it before canceling
  // anything, so a missing `PointerEvent` leaves the click alone and the
  // replacement is never re-entered.
  const PointerEventConstructor = defaultView?.PointerEvent;
  if (!PointerEventConstructor) return;
  if (click instanceof PointerEventConstructor) return;
  // Built before the original is canceled, so a constructor that throws cannot
  // destroy the activation.
  const replacement = new PointerEventConstructor("click", {
    altKey: click.altKey,
    bubbles: click.bubbles,
    button: click.button,
    buttons: click.buttons,
    cancelable: click.cancelable,
    clientX: click.clientX,
    clientY: click.clientY,
    ctrlKey: click.ctrlKey,
    detail: click.detail,
    metaKey: click.metaKey,
    pointerId: -1,
    pointerType: "",
    shiftKey: click.shiftKey,
  });
  event.preventDefault();
  event.stopPropagation();
  element.dispatchEvent(replacement);
}

<Ariakit.Command
  render={<div />}
  onClickCapture={replaceSyntheticClick}
  onClick={handleClick}
/>;
```

### Assumptions and limitations

This is narrower than the library fix, so it is worth knowing what it does not cover.

- Some listeners see both events. React runs every `onClickCapture` on the path from its delegation root, so an ancestor's `onClickCapture`, and any native capture listener at or above that root, receive the original `MouseEvent` and then the replacement. A native capture listener between that root and the element, and every target and bubble-phase listener, only ever sees the replacement.
- A listener that cancels the original has no effect on the replacement, which is a fresh event, and `dispatchEvent` for the original returns `false`. A non-cancelable click is left alone instead, because its default behavior could not be suppressed and would run alongside the replacement's.
- It belongs on the command element itself. It re-dispatches on `currentTarget`, so delegating one handler to a wrapper retargets the click to that wrapper and the command's own `onClick` never runs.
- It replaces any untrusted click on the element that isn't already a `PointerEvent`, not only the one [`Command`](https://ariakit.com/reference/command) synthesizes. Measured in happy-dom, `element.click()` is already a `PointerEvent` and is left alone. A simulated click is replaced only where the test environment still builds it as a `MouseEvent`; `@ariakit/test` builds the click family as a `PointerEvent` since #7177, so it is left alone there too. The replacement copies the modifiers, `button`, `buttons`, `detail`, `clientX`, and `clientY`, and leaves `screenX`, `screenY`, `movementX`, `movementY`, `relatedTarget`, and the extended modifier state at their defaults.
- It carries only the members [`Command`](https://ariakit.com/reference/command) already passes, so `view` stays `null` and `composed` stays `false`, exactly as they are today. A `composed: false` click does not cross a shadow boundary. Both members are tracked in #7192.
- It needs a real `PointerEvent`. Under a `class PointerEvent extends MouseEvent {}` polyfill, such as Jest with jsdom 20 or 21, the replacement carries no pointer members.
- It occupies `onClickCapture`, so a consumer already using that prop has to compose the two by hand.
- React types `click` as a mouse event, so the pointer members are read from `event.nativeEvent`.

## Follow-ups

Related gaps found while working on this are tracked separately, because neither is introduced by this change and neither has to be resolved for the click to carry the right interface, pointer members, and realm:

- #7192: the same synthetic click reports `view: null` and `composed: false`, where browsers report the element's own window and `true`.
- #7193: the other event helpers in `@ariakit/utils` still build their events from the ambient global.
- #7204: `@ariakit/test`'s gesture helpers still let a caller's `isPrimary` reach the click they end with, where this now resets it.
- #7201: `getDocument` and `getWindow` mistake a form control named `self` for a window. This fix reads the window from the document instead of through those helpers, so the click is no longer exposed, but their other callers still are, and a form can shadow `ownerDocument` the same way.

## Review gate reassessment

<details>
<summary>Cycle 3: Continue the event-replacement workaround, with the ordering fix</summary>

**Assessment**

Issue severity is low and the fix is a parity correction rather than a repair. `PointerEvent` extends `MouseEvent`, so every property consumers read today is unaffected and `instanceof MouseEvent` still holds. The worst symptom is `undefined` where `lib.dom` promised a value.

Expected frequency is rare. It needs the intersection of two conditions: a [`Command`](https://ariakit.com/reference/command)-derived component rendered as a non-native element, and a consumer branching on `instanceof PointerEvent`, reading `pointerType` or `pointerId`, or depending on realm identity inside a same-origin iframe.

Supported scope of the reassessed direction is one function in one sandbox, deleted in the next commit, plus the same snippet published for consumers to copy.

Implementation complexity in the repository is near zero: one function, one prop per fixture element, no state, no hooks, no library coupling. The complexity that mattered was on the published-snippet side.

Three consecutive cycles produced findings from two distinct causes. The first cycle's eleven findings all came from one cause: the workaround reimplemented the activation policy of [`Command`](https://ariakit.com/reference/command) in userland, so it had to re-derive every guard that component applies, and some of them, such as `clickOnEnter` and `clickOnSpace`, cannot be read from userland at all. The second and third cycles share a different cause, the invariant that a click must never be canceled unless its replacement can be delivered. That one is exhausted once construction is hoisted, because the only statements left between the cancellation and the delivery are `stopPropagation` and `dispatchEvent`, neither of which can fail that way. The finding rate went from eleven to one to one, and cycle 3 confirmed every earlier disposition.

Simpler alternatives were re-evaluated and rejected. Native-element guidance alone is simplest and is now the primary published guidance, but it cannot make the non-native reproduction pass and does not help a consumer who must render a non-native element. Normalizing the members inside the consumer's own `onClick` does not fix `instanceof` or the realm, which are the actual complaints. Replacing the explicit member copy with a rest-spread of the React event is shorter, but passes `nativeEvent`, `target`, and `isTrusted` into a `PointerEventInit`, so it was recorded as an available simplification and deliberately not taken.

**Decision**

Continue the current direction with the cycle 3 ordering fix applied. No revert to the earlier mechanism, no redesign, no narrowing of the supported contract. The cycle 3 finding is addressed on cost grounds: it is a statement reorder that adds no branch and no state, and it restores an invariant the code's own comment already claimed. Its residual risk is narrower than first recorded, because the `instanceof` check already throws for a non-constructible constructor before anything is canceled.

No earlier disposition is reversed. The `view` and `composed` follow-up is discharged as #7192, and the ambient-global follow-up for the other event helpers as #7193.

Intentionally unsupported edge cases, all stated in the `## Workaround` section above: capture-phase listeners observing both events, a capture-phase `preventDefault` on the original being discarded, and environments whose `PointerEvent` is a `MouseEvent` subclass polyfill.

</details>

<details>
<summary>Cycle 6: Continue the same mechanism, with one closing prose pass</summary>

**Assessment**

The mechanism has produced no runtime-behavior defect since cycle 3. Cycles 4, 5, and 6 raised eight findings between them, and every one concerns prose accuracy or test coverage rather than what the code does.

All three of those cycles kept circling one fact: which listeners observe the original event and which observe the replacement. React attaches one delegated capture listener on its root container and runs the whole root-to-target `onClickCapture` queue from it, so an ancestor's capture handler has already seen the original before this handler runs, and sees the replacement too. Three independent reviewers each re-derived that correctly and each found a different compression of it wrong, once in the code comment and once in this description. Keeping the same account in two places is a drift generator, and cycle 6's finding was literally that the two had drifted apart.

The reassessment also corrected a premise behind the cycle 5 disposition. That cycle rewrote the code comment on the grounds that consumers copy it. They do not: the snippet published here carries a single comment, and the sandbox's remaining comments are read by reviewers of a file that the next commit deletes.

Issue severity, expected frequency, and supported scope are unchanged from the cycle 3 entry: a low-severity parity gap, rarely reached, worked around in one function with a one-commit lifetime. The eight limitations read heavy for that, but they replaced four measured high-severity behavioral breaks in the mechanism this one superseded, two of which userland cannot even detect. Documented observation in place of undocumented breakage is the right trade.

**Decision**

Continue with the same mechanism. No revert, no redesign, no narrowing. One closing prose pass: the code comment stops describing propagation at all, because a claim that asserts no boundary cannot drift from this description, and this description becomes the single source of truth with an exhaustive account of the four listener cases and of the members the replacement does not copy. The published snippet also gains two short comments explaining the guard ordering, which cycles 2 and 3 established as load-bearing, so a consumer trimming it cannot reintroduce that bug.

Two commitments are recorded here rather than left in the task record, because a commitment that lives only there is what let this resurface at cycle 6:

- Stage 3 must assert in `packages/ariakit-utils/src/events.test.ts` that a caller's init members, modifier state at minimum, survive `fireClickEvent`. That contract has no coverage anywhere today, and stage 3 rewrites the exact function that carries it. Pinning it in the sandbox instead was declined, since that code is reverted one commit later.
- For the remaining cycles, a finding against this section is addressed only where it identifies a statement that is false. A statement that is merely less complete than it could be is a declined non-goal, because there is always a finer distinction available and cycles 4 through 6 are what chasing them looks like.

No earlier disposition is reversed except cycle 5's, which is superseded: the comment is deleted rather than made more precise.

</details>

<details>
<summary>Library fix, cycle 4: Continue the proxy, with the frozen-init fix</summary>

**Assessment**

This is a different direction from the workaround reassessed above: the subject is `fireClickEvent` itself.

The line count grew from three to about seventy, but the two issues account for it separately. #7171 costs roughly twenty lines: the realm-aware constructor, the pointer identity, and the documentation. The rest is #7199, which the maintainer asked for mid-flight, and which is a deliberate mirror of the record `@ariakit/test` adopted in #7188, including its `isPrimary` exception. Judging the whole mass against #7171's severity would be measuring one issue by another's yardstick.

Four cycles produced findings, from four different causes. The first is an unstated contract question, what shapes of `eventInit` are supported, which each cycle answered a slice of, rewriting the init mechanism three times: a spread, then a spread with derived pointer members, then a proxy. That question is now answered in the source. The second is the hand-maintained list of derived components in the changeset, which produced a finding in three consecutive cycles. The third is the mid-flight arrival of #7199. The fourth is ordinary prose and test polish. Implementation findings per cycle went two, two, two, one.

The mechanism was re-examined rather than assumed. A plain spread silently drops a live event's members, including `bubbles`, which in React means the handler never runs. `Object.create` and `setPrototypeOf` were both measured to throw, because native getters brand-check their receiver. An explicit allowlist of the members to copy would be longer than the eleven-key blocklist and would silently drop future ones. Documenting the narrowing was tried and abandoned once the documented remedy, spreading a live event, was measured to be false in every engine. A layering step is not optional either, because `pointerId` defaults to `0` and this issue requires `-1`.

**Decision**

Continue with the cycle 4 fixes. No revert, no narrowing, and no fourth rewrite of the init mechanism.

The frozen-init finding is addressed because it is cheap and categorical rather than because it is likely: a proxy trap may not report a value different from a frozen own property of its target, and this trap changes thirteen of them, so the target is now a fresh object that the trap reads the caller's init through. That removes the last invariant a get-only trap can violate, and it is red-checked.

The component enumeration is kept rather than replaced with a representative phrase, because the repository's changeset guidance asks a multi-paragraph entry to name every affected component, and two reviewers have now independently recomputed the transitive closure and agreed the list is complete. `ToolbarInput` is removed from it: it renders an `input`, so `Command` returns at its text-field guard before synthesizing any click, and it is deprecated.

The duplication of the contact-attribute record with `@ariakit/test` stays declined, now with the size acknowledged. `@ariakit/utils` exposes a single index entry point and every export is auto-documented, so sharing the record would add public API to a published package to save eleven keys, and the keyed record already compile-guards both copies against a future `PointerEventInit` member.

#7199 moved from a registered follow-up to in scope on the maintainer's instruction and is now fixed here, so it is closed by this pull request rather than listed under follow-ups.

</details>

Fixes #7171
Fixes #7199
