### PR TITLE
Remove the PointerEvent fallback from @ariakit/test

### DIFF
--- a/.changeset/100-test-remove-pointer-event-fallback.md
+++ b/.changeset/100-test-remove-pointer-event-fallback.md
@@ -1,0 +1,25 @@
+---
+"@ariakit/test": minor
+---
+
+Removed the `PointerEvent` fallback
+
+**BREAKING** if your tests, or the code they exercise, reference the `PointerEvent` global, narrow a `pointer*` event with `instanceof MouseEvent`, or read `pageX`, `pageY`, `offsetX`, `offsetY`, or `which` from one, on jsdom below v27, such as the jsdom 26 that `jest-environment-jsdom` 30 depends on.
+
+Importing `@ariakit/test` used to install a `PointerEvent` constructor when the environment had none, which it had done since a time when jsdom implemented no such constructor. jsdom implements it from v27 on, and happy-dom implements it too, so the fallback no longer served the environments it was written for. Environments that implement `PointerEvent` are unaffected.
+
+Where the constructor is missing, the global is now absent again, so building one by hand throws. Dispatch the event by name instead, which reports the same members and works in every environment.
+
+Before:
+
+```ts
+await dispatch(q.button(), new PointerEvent("pointerdown", { pointerId: 7 }));
+```
+
+After:
+
+```ts
+await dispatch.pointerDown(q.button(), { pointerId: 7 });
+```
+
+The helpers themselves keep working there, and every event they fire carries the same mouse, modifier, and pointer members it carries anywhere else. `click`, `auxclick`, and `contextmenu` are built from `MouseEvent` there rather than `PointerEvent`, so they keep the computed members too. The `pointer*` events come from `Event`, so `pageX`, `pageY`, `offsetX`, `offsetY`, and `which` are undefined on those. The [readme](https://github.com/ariakit/ariakit/blob/main/packages/ariakit-test/readme.md#test-environment) documents the expected environment.

--- a/packages/ariakit-test/readme.md
+++ b/packages/ariakit-test/readme.md
@@ -30,6 +30,14 @@ import { click, press, type } from "@ariakit/test";
 
 The `@ariakit/test/react` entry point renders React components for testing, and the `@ariakit/test/playwright` entry point provides query helpers for Playwright tests.
 
+### Test environment
+
+The helpers expect a DOM that implements `PointerEvent`, which means happy-dom, jsdom v27 or later, or a real browser.
+
+They still run on jsdom 26, which `jest-environment-jsdom` 30 depends on. Every event the helpers fire there carries the same mouse, modifier, and pointer members it carries anywhere else, so a listener reads the same `clientX`, `button`, `pointerId`, and modifier state it would in a browser. `click`, `auxclick`, and `contextmenu` are built from `MouseEvent` there rather than `PointerEvent`, which also keeps the members a browser computes.
+
+The `pointer*` events are the ones that environment cannot build from an interface of their own, so they come from `Event`: they are not `instanceof MouseEvent` there, and `pageX`, `pageY`, `offsetX`, `offsetY`, and `which` are undefined on them. The `PointerEvent` global is absent altogether, so both `new PointerEvent()` and `event instanceof PointerEvent` throw a `ReferenceError`.
+
 <!-- ariakit-docs:start -->
 
 ## API reference
@@ -123,7 +131,7 @@ Unlike higher-level helpers such as `click` and `type`, this fires a single even
 
 A pointer event built by name reports the contact size and transducer angle browsers report for a device with neither, so `width` and `height` are `1` and `altitudeAngle` is a right angle. The members describing a gesture, such as `pressure` and `isPrimary`, keep their defaults here; the higher-level helpers fill those in. An event you construct yourself keeps whatever its constructor gave it.
 
-`click`, `auxclick`, and `contextmenu` are built as `PointerEvent`, the way browsers dispatch them, so they accept and report pointer properties such as `pointerType`.
+`click`, `auxclick`, and `contextmenu` are built as `PointerEvent`, the way browsers dispatch them, so they accept and report pointer properties such as `pointerType`. An environment with no `PointerEvent` builds them as `MouseEvent` instead, and they report the same properties there.
 
 Returns: A promise that resolves to `false` when the event's default action was prevented with `event.preventDefault()`, and `true` otherwise.
 

--- a/packages/ariakit-test/src/__init-event.ts
+++ b/packages/ariakit-test/src/__init-event.ts
@@ -242,8 +242,43 @@ const mouseDerivedEventTypes = new Set([
   "wheel",
 ]);
 
+// The same gap one interface further down: jsdom implements `PointerEvent` only
+// from v27 on, so an older environment cannot build these from an interface of
+// their own, and testing the name as well keeps them initialized there. The
+// click family belongs here because Pointer Events defines those three as
+// `PointerEvent` too, so they carry the pointer members even where the
+// dispatchers build them from `MouseEvent` instead.
+// https://github.com/ariakit/ariakit/issues/7178
+const pointerEventTypes = new Set([
+  "auxclick",
+  "click",
+  "contextmenu",
+  "gotpointercapture",
+  "lostpointercapture",
+  "pointercancel",
+  "pointerdown",
+  "pointerenter",
+  "pointerleave",
+  "pointermove",
+  "pointerout",
+  "pointerover",
+  "pointerup",
+]);
+
+function isPointerEvent(event: Event): event is PointerEvent {
+  // `typeof` first, because the bare global throws where it doesn't exist,
+  // which is the very case the name test covers.
+  if (typeof PointerEvent !== "undefined" && event instanceof PointerEvent) {
+    return true;
+  }
+  return pointerEventTypes.has(event.type);
+}
+
 function isMouseEvent(event: Event): event is MouseEvent {
   if (event instanceof MouseEvent) return true;
+  // `PointerEvent` derives from `MouseEvent`, so a pointer event carries the
+  // mouse members too.
+  if (isPointerEvent(event)) return true;
   return mouseDerivedEventTypes.has(event.type);
 }
 
@@ -283,7 +318,7 @@ export function initEvent<T extends Event>(
     initMouseEvent(event, options);
     initUIEventModifiers(event, options);
   }
-  if (event instanceof PointerEvent) {
+  if (isPointerEvent(event)) {
     initPointerEvent(event, options);
   }
 }

--- a/packages/ariakit-test/src/dispatch-without-pointer-event.test.ts
+++ b/packages/ariakit-test/src/dispatch-without-pointer-event.test.ts
@@ -1,0 +1,123 @@
+import { afterAll, expect, test } from "vitest";
+
+// Both environments this repository runs on implement `PointerEvent`, so the
+// only way to reach the path an older jsdom takes is to remove the constructor
+// before the package loads. The import is deferred past the deletion, and goes
+// through the entry point rather than the module, because the entry point
+// applies the shims: a fallback reintroduced there would reinstall the global
+// and fail the precondition below.
+// https://github.com/ariakit/ariakit/issues/7178
+const nativePointerEvent = window.PointerEvent;
+Reflect.deleteProperty(window, "PointerEvent");
+
+const { dispatch, press } = await import("./index.ts");
+
+afterAll(() => {
+  window.PointerEvent = nativePointerEvent;
+});
+
+test("runs in an environment with no PointerEvent constructor", () => {
+  // `initEvent` reads the ambient binding, so pin that rather than the window
+  // property: they coincide only while the environment makes them the same
+  // object, and the mouse assertions below would pass either way.
+  expect(typeof PointerEvent).toBe("undefined");
+});
+
+test("keeps the click family on the closest interface available", async () => {
+  const button = document.createElement("button");
+  document.body.append(button);
+  const received: PointerEvent[] = [];
+  button.addEventListener("click", (event) => {
+    received.push(event);
+  });
+  try {
+    // The dispatchers build `click`, `auxclick`, and `contextmenu` as
+    // `PointerEvent`, the way browsers do, so these are the events an absent
+    // constructor would otherwise strip down to a bare `Event`. Reaching a
+    // listener at all is also what proves it no longer throws.
+    await dispatch.click(button, {
+      clientX: 11,
+      button: 0,
+      shiftKey: true,
+      pointerType: "mouse",
+    });
+    const event = received[0];
+    // Named with the closest interface the environment has, so this one keeps
+    // the members `MouseEvent` computes as well.
+    expect(event).toBeInstanceOf(MouseEvent);
+    expect(event?.clientX).toBe(11);
+    expect(event?.button).toBe(0);
+    expect(event?.getModifierState("Shift")).toBe(true);
+    expect(event?.pointerType).toBe("mouse");
+    // The positive side of the boundary the `pointer*` test pins below, where
+    // a bare `Event` carries no `pageX` at all.
+    expect(event?.pageX).toBeDefined();
+  } finally {
+    button.remove();
+  }
+});
+
+test("submits a form implicitly, which builds its click by hand", async () => {
+  const form = document.createElement("form");
+  form.innerHTML = "<input><button type='submit'>Save</button>";
+  document.body.append(form);
+  const input = form.querySelector("input");
+  const submitted: Event[] = [];
+  const clicks: PointerEvent[] = [];
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    submitted.push(event);
+  });
+  form.addEventListener("click", (event) => {
+    clicks.push(event);
+  });
+  try {
+    // `press` constructs this click itself rather than going through the
+    // dispatchers, so it resolves the constructor separately.
+    await press.Enter(input);
+    expect(submitted).toHaveLength(1);
+    const click = clicks[0];
+    // Resolved to the closest interface available, and initialized with the
+    // members a keyboard activation reports for the pointer that didn't cause
+    // it, the same ones it reports where `PointerEvent` exists.
+    expect(click).toBeInstanceOf(MouseEvent);
+    expect(click?.pointerId).toBe(-1);
+    expect(click?.pointerType).toBe("");
+  } finally {
+    form.remove();
+  }
+});
+
+test("initializes pointer events built without the constructor", async () => {
+  const button = document.createElement("button");
+  document.body.append(button);
+  const received: PointerEvent[] = [];
+  button.addEventListener("pointerdown", (event) => {
+    received.push(event);
+  });
+  try {
+    await dispatch.pointerDown(button, {
+      clientX: 11,
+      button: 0,
+      shiftKey: true,
+      pointerId: 7,
+      pointerType: "pen",
+    });
+    const event = received[0];
+    // `createEvent` fell back to `window.Event`, so the class is not
+    // `MouseEvent` here, but every member the init dictionaries define is
+    // assigned by name, the way drag and wheel events already are.
+    expect(event).not.toBeInstanceOf(MouseEvent);
+    expect(event?.clientX).toBe(11);
+    expect(event?.button).toBe(0);
+    expect(event?.getModifierState("Shift")).toBe(true);
+    expect(event?.pointerId).toBe(7);
+    expect(event?.pointerType).toBe("pen");
+    // The boundary the readme documents: a member a browser computes rather
+    // than reading from an init came from the `MouseEvent` base, which a bare
+    // `Event` has no equivalent of, so no initializer can supply it.
+    expect(event?.pageX).toBeUndefined();
+  } finally {
+    button.remove();
+  }
+});

--- a/packages/ariakit-test/src/dispatch.test.ts
+++ b/packages/ariakit-test/src/dispatch.test.ts
@@ -126,6 +126,29 @@ test("dispatch builds the click-family events as PointerEvent", async () => {
   }
 });
 
+// The interface above is named after probing the target's own window, and a
+// form exposes its controls as named properties, so one named `document`
+// answers `"document" in form`. Probing through that name would find the
+// control instead and fall back to the weaker interface.
+// https://github.com/ariakit/ariakit/issues/7178
+// https://webidl.spec.whatwg.org/#legacy-platform-object
+test("dispatch.click builds a PointerEvent for a form with a control named document", async () => {
+  const form = document.createElement("form");
+  form.innerHTML = "<input name='document'>";
+  document.body.append(form);
+  const received: Event[] = [];
+  form.addEventListener("click", (event) => {
+    received.push(event);
+  });
+  try {
+    await dispatch.click(form, { pointerType: "pen" });
+    expect(received[0]).toBeInstanceOf(PointerEvent);
+    expect((received[0] as PointerEvent).pointerType).toBe("pen");
+  } finally {
+    form.remove();
+  }
+});
+
 // `dispatch` fires the event the caller describes. Dropping the attributes a
 // browser resets on a click is the job of the gesture helpers, which know the
 // press those attributes came from.

--- a/packages/ariakit-test/src/dispatch.ts
+++ b/packages/ariakit-test/src/dispatch.ts
@@ -174,6 +174,27 @@ function baseDispatch(element: Target, event: Event): Promise<boolean> {
 // https://www.w3.org/TR/pointerevents/#the-click-auxclick-and-contextmenu-events
 const clickFamilyInit = { bubbles: true, cancelable: true, composed: true };
 
+// `createEvent` resolves the constructor against the target's own window, so
+// the interface named below has to be probed on that window rather than on the
+// ambient global.
+function getTargetView(target: NonNullable<Target>) {
+  // `ownerDocument` first, because a form exposes its controls as named
+  // properties and one named `document` would answer the branch below. Neither
+  // happy-dom nor jsdom implements the form's `[LegacyOverrideBuiltIns]`, so
+  // this name still resolves through `Node.prototype` there; a browser does
+  // implement it, but `createEvent` resolves the window just as fragilely then.
+  // A `Document` reports `null` here and falls through to its own view.
+  // https://html.spec.whatwg.org/multipage/forms.html#the-form-element
+  if ("ownerDocument" in target && target.ownerDocument) {
+    return target.ownerDocument.defaultView;
+  }
+  if ("defaultView" in target) return target.defaultView;
+  // Through the document either way, since only `defaultView` is typed with the
+  // constructors a window carries.
+  if ("document" in target) return target.document.defaultView;
+  return null;
+}
+
 function createNamedEvent(
   eventName: DispatchEventType,
   element: NonNullable<Target>,
@@ -185,7 +206,13 @@ function createNamedEvent(
     eventName === "contextMenu"
   ) {
     return createEvent(eventName.toLowerCase(), element, options, {
-      EventType: "PointerEvent",
+      // Name the closest interface the environment implements. jsdom has
+      // `PointerEvent` only from v27 on, and falling back to `MouseEvent` there
+      // keeps the members it computes rather than dropping to a bare `Event`.
+      // https://github.com/ariakit/ariakit/issues/7178
+      EventType: getTargetView(element)?.PointerEvent
+        ? "PointerEvent"
+        : "MouseEvent",
       defaultInit: clickFamilyInit,
     });
   }
@@ -226,7 +253,8 @@ const events = eventNames.reduce((events, eventName) => {
  *
  * `click`, `auxclick`, and `contextmenu` are built as `PointerEvent`, the way
  * browsers dispatch them, so they accept and report pointer properties such as
- * `pointerType`.
+ * `pointerType`. An environment with no `PointerEvent` builds them as
+ * `MouseEvent` instead, and they report the same properties there.
  * @returns A promise that resolves to `false` when the event's default action was
  * prevented with `event.preventDefault()`, and `true` otherwise.
  * @example

--- a/packages/ariakit-test/src/press.ts
+++ b/packages/ariakit-test/src/press.ts
@@ -91,7 +91,12 @@ function createKeyboardClickEvent(
   options: KeyboardEventInit,
 ) {
   const { defaultView } = element.ownerDocument;
-  const PointerEventConstructor = defaultView?.PointerEvent ?? PointerEvent;
+  // jsdom has `PointerEvent` only from v27 on, and the bare global throws where
+  // it doesn't exist, so fall back to the closest interface the environment
+  // implements. `initEvent` below assigns the members either way.
+  // https://github.com/ariakit/ariakit/issues/7178
+  const PointerEventConstructor =
+    defaultView?.PointerEvent ?? defaultView?.MouseEvent ?? MouseEvent;
   const eventOptions: PointerEventInit = {
     bubbles: true,
     cancelable: true,

--- a/packages/ariakit-test/src/shims.ts
+++ b/packages/ariakit-test/src/shims.ts
@@ -64,14 +64,6 @@ function applyBrowserShims() {
     window.ClipboardEvent = class ClipboardEvent extends Event {};
   }
 
-  if (
-    typeof window.PointerEvent === "undefined" &&
-    typeof MouseEvent !== "undefined"
-  ) {
-    // @ts-expect-error
-    window.PointerEvent = class PointerEvent extends MouseEvent {};
-  }
-
   polyfillMouseEventMembers();
   patchKeyboardEventModifierState();
 


### PR DESCRIPTION
## Motivation

`@ariakit/test` installed a `PointerEvent` constructor whenever the environment had none:

```ts
window.PointerEvent = class PointerEvent extends MouseEvent {};
```

That fallback dates to [`1188a99`](https://github.com/ariakit/ariakit/commit/1188a9961) in December 2023, when this repository ran jsdom 23, which implemented no such constructor. jsdom implements it from [v27](https://github.com/jsdom/jsdom/releases/tag/v27.0.0) on and happy-dom implements it too, so the upstream gap it covered is closed and the block is stale compatibility code by the rule in `ariakit-ariakit-test-workflow`.

Issue #7178 asked for a decision rather than a patch: either keep the fallback and make it reproduce the constructor's `PointerEventInit` handling, or remove it and document the minimum environment. This takes the second option.

## Solution

Remove the fallback, and stop the rest of the package from assuming the constructor exists.

`initEvent` used to evaluate a bare `event instanceof PointerEvent`, which throws `ReferenceError` where the global is absent, on **every** named dispatch rather than only the pointer ones. It now recognizes those events by name as well, the same way `mouseDerivedEventTypes` already covers drag and wheel for interfaces the environment builds from a weaker class.

The click family needed the same treatment from the other side. Since #7177, `dispatch` builds `click`, `auxclick`, and `contextmenu` as `PointerEvent`, so without a constructor `createEvent` would have dropped them to a bare `Event` and lost the mouse members too, exactly as #7178 predicted. Both construction sites, in `dispatch.ts` and in `press.ts`, now name the closest interface the environment implements, resolved from the target's own window rather than the ambient global.

The net effect on an environment without `PointerEvent`: every event the helpers fire still carries the mouse, modifier, and pointer members it carries anywhere else. What is lost is the class, and the members a browser computes rather than reads from an init.

## Tests

`dispatch-without-pointer-event.test.ts` deletes `window.PointerEvent` before importing the package, which is what makes these paths reachable in a suite whose environment implements the constructor. It covers the three call sites that would otherwise break: the click family, the caller-built click behind implicit form submission, and the `pointer*` events, which are the ones that keep the documented residual difference.

`dispatch.test.ts` gains one case for the window lookup: a form exposes its controls as named properties, so a form containing `<input name="document">` answers `"document" in form`, and probing through that name would find the control and build the weaker interface.

Each of these is red against the change it guards. Reverting the two construction sites fails the click-family and implicit-submission cases, one with a bare `Event` and one with the `ReferenceError`; reverting the name-based path fails the `pointer*` case; reverting the window lookup's branch order fails the form case.

## Verification

Measured on jsdom 26.1.0, the version `jest-environment-jsdom` 30 depends on, since no installed environment here lacks the constructor:

```
native PointerEvent: undefined
createEvent resolves pointerdown to: Event
initEvent's bare instanceof: ReferenceError: PointerEvent is not defined
```

The same measurement is what ruled out removing the fallback on its own.

## Review gate reassessment

<details>
<summary>Direction change: remove the fallback rather than reproduce it</summary>

**Assessment**

An earlier revision of this branch implemented the faithful fallback instead, and the review rounds on it were spent almost entirely on documenting a code path that no environment in this repository executes. The decisive question was not how faithful the reimplementation could be, but whether the package should still carry a polyfill for a gap upstream had closed.

Measured for that decision: jsdom 26 has no `PointerEvent`; `jest-environment-jsdom` 30 still depends on `jsdom@^26.1.0`; no Ariakit component listens to pointer events, so component behavior under an older jsdom is unaffected either way; and the fallback was itself the reason a caller could write `new PointerEvent(...)` there at all, which is the surface the issue reported as defective.

**Decision**

Remove it, and keep the package working through the call sites instead of a global. The residual difference is documented in the readme under Test environment and pinned by tests rather than narrated.

Registered follow-ups, both pre-existing and independent of this change: #7180 for the sibling `ClipboardEvent` fallback, which stays because jsdom ships no `ClipboardEvent` at any version, and #7197 for the computed mouse members that no initializer assigns in any environment.

</details>

Closes #7178.
