### PR TITLE
Update TagList sandboxes for display: contents

### DIFF
--- a/app/src/sandbox/aria-labelledby-aria-label/index.react.tsx
+++ b/app/src/sandbox/aria-labelledby-aria-label/index.react.tsx
@@ -73,7 +73,10 @@ export default function Example() {
 
       <TagProvider>
         <TagLabel>Tag label</TagLabel>
-        <TagList aria-label="Custom tag list label" />
+        <TagList
+          aria-label="Custom tag list label"
+          style={{ display: "contents" }}
+        />
       </TagProvider>
 
       <TagProvider>

--- a/app/src/sandbox/aria-labelledby-aria-label/test-chrome.ts
+++ b/app/src/sandbox/aria-labelledby-aria-label/test-chrome.ts
@@ -69,7 +69,12 @@ withFramework(import.meta.dirname, async ({ test }) => {
   });
 
   test("tag list with aria-label has no aria-labelledby", async ({ q }) => {
-    const listbox = q.listbox("Custom tag list label");
+    // Playwright filters an initially empty display: contents list from
+    // default role queries.
+    // https://github.com/ariakit/ariakit/issues/7164
+    const listbox = q.listbox("Custom tag list label", {
+      includeHidden: true,
+    });
     await test.expect(listbox).toBeAttached();
     await test
       .expect(listbox)

--- a/app/src/sandbox/combobox-select-tag-tooltip-element-id/index.react.tsx
+++ b/app/src/sandbox/combobox-select-tag-tooltip-element-id/index.react.tsx
@@ -86,7 +86,7 @@ function TagExample() {
       <TagProvider>
         <DynamicTagLabel />
         <TagControl>
-          <TagList />
+          <TagList style={{ display: "contents" }} />
           <DynamicTagInput />
         </TagControl>
       </TagProvider>

--- a/app/src/sandbox/combobox-select-tag-tooltip-element-id/test-chrome.ts
+++ b/app/src/sandbox/combobox-select-tag-tooltip-element-id/test-chrome.ts
@@ -51,7 +51,10 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     const section = query(q.region("Tag"));
     const label = section.text("Tag label");
     const input = section.textbox("Tag label");
-    const list = section.listbox("Tag label");
+    // Playwright filters an initially empty display: contents list from
+    // default role queries.
+    // https://github.com/ariakit/ariakit/issues/7164
+    const list = section.listbox("Tag label", { includeHidden: true });
     // The label names the control too, which groups the tag list and the input.
     const control = section.group("Tag label");
 

--- a/app/src/sandbox/tag-input-6294/index.react.tsx
+++ b/app/src/sandbox/tag-input-6294/index.react.tsx
@@ -14,7 +14,7 @@ export default function Example() {
     <TagProvider values={values} setValues={setValues}>
       <TagLabel>Tags</TagLabel>
       <TagControl>
-        <TagList>
+        <TagList style={{ display: "contents" }}>
           {values.map((value) => (
             <Tag key={value} value={value}>
               {value}

--- a/app/src/sandbox/tag-input-6333/index.react.tsx
+++ b/app/src/sandbox/tag-input-6333/index.react.tsx
@@ -19,7 +19,7 @@ function TagField({ label, delimiter }: TagFieldProps) {
     <TagProvider values={values} setValues={setValues}>
       <TagLabel>{label}</TagLabel>
       <TagControl>
-        <TagList aria-describedby={statusId}>
+        <TagList aria-describedby={statusId} style={{ display: "contents" }}>
           {values.map((value) => (
             <Tag key={value} value={value}>
               {value}


### PR DESCRIPTION
## Motivation

The documented Tag layout uses `TagList` with `display: contents` so the tags and `TagInput` share the `TagControl` layout, but four sandboxes still omitted that style. Applying the documented layout makes Playwright's default role query filter an initially empty boxless list even though the browser accessibility tree retains the named listbox.

## Solution

Apply `style={{ display: "contents" }}` to the four TagList fixtures and make only the two intentionally empty boxless-list queries explicit:

```ts
const listbox = q.listbox("Custom tag list label", {
  includeHidden: true,
});
```

Keep the populated Tag list query on the default role-query behavior, and leave production Tag roles and live-region ownership unchanged.

## Preview

<img width="188" height="104" alt="TagControl with Alpha and Beta tags sharing the field with the input" src="https://github.com/user-attachments/assets/ec37ccf6-6a3e-41c2-b987-f7f38d50a733" />

## Verification

- Confirmed the two existing empty-list queries fail after applying `display: contents`, while the other 13 focused Chrome tests pass.
- Passed 55 affected browser tests across Chrome, Firefox, and Safari, including the unchanged populated Tag list query.
- Passed 5 focused happy-dom tests on React 19 and React 18.
- Passed `pnpm tsc`, `pnpm lint-fix`, and `git diff --check`.

Fixes #7164
