### PR TITLE
Make test queries ensure matches by default

### DIFF
--- a/.changeset/100-test-queries-ensure-by-default.md
+++ b/.changeset/100-test-queries-ensure-by-default.md
@@ -1,0 +1,23 @@
+---
+"@ariakit/test": minor
+---
+
+Test queries ensure matches by default
+
+**BREAKING** if you use `q` or `query` methods that may not find an element, or if you use their `.ensure` variants.
+
+Single-element queries now throw when no matching element is found. The `.ensure` variant has been removed, and the new `.maybe` variant returns `null` when no element is found. Collection queries such as `.all()` continue to return an empty array when there are no matches.
+
+Before:
+
+```ts
+const saveButton = q.button.ensure("Save");
+const optionalDialog = q.dialog("Settings");
+```
+
+After:
+
+```ts
+const saveButton = q.button("Save");
+const optionalDialog = q.dialog.maybe("Settings");
+```

--- a/.changeset/300-test-pointer-contact-defaults.md
+++ b/.changeset/300-test-pointer-contact-defaults.md
@@ -9,7 +9,7 @@ A listener on the pointer events that `hover`, `mouseDown`, `mouseUp`, and the `
 Those events now report the values Chromium, Firefox, and WebKit all report for one ordinary click, including the pressure Pointer Events defines for a device with no pressure sensor: `0.5` while a button is held down and `0` otherwise. A chorded release keeps `0.5` while another button stays held, because the pointer is still in the active buttons state, which is what Firefox and WebKit report. Chromium derives that one from the button being released and reports `0`.
 
 ```ts
-q.button.ensure("Resize").addEventListener("pointerdown", (event) => {
+q.button("Resize").addEventListener("pointerdown", (event) => {
   event.width; // 1
   event.height; // 1
   event.pressure; // 0.5

--- a/.changeset/300-test-pointer-event-click-family.md
+++ b/.changeset/300-test-pointer-event-click-family.md
@@ -9,7 +9,7 @@ Pointer Events defines these three events as `PointerEvent`, and Chromium, Firef
 `click`, `tap`, `rightClick`, and `select` now carry the `pointerId` and `pointerType` they simulate through to the event that ends the gesture, including the click a label forwards to its control. The attributes describing the contact itself, such as `pressure` and `tiltX`, stay at their default values there, the way browsers reset them, so a pen press reporting `tiltX: 30` still ends in a `click` reporting `tiltX: 0`.
 
 ```ts
-q.link.ensure("Ariakit").addEventListener("auxclick", (event) => {
+q.link("Ariakit").addEventListener("auxclick", (event) => {
   event.pointerType; // "pen"
 });
 

--- a/app/src/examples/combobox-group/test.ts
+++ b/app/src/examples/combobox-group/test.ts
@@ -109,7 +109,7 @@ test("composition text", async () => {
   // TODO: Add a composition helper to @ariakit/test.
   await dispatch.compositionStart(q.combobox());
   await type("'", q.combobox(), { isComposing: true });
-  expect(q.option("John Smith")).not.toBeInTheDocument();
+  expect(q.option.maybe("John Smith")).not.toBeInTheDocument();
   await type("á", q.combobox(), { isComposing: true });
   await dispatch.compositionEnd(q.combobox());
   await sleep();

--- a/app/src/examples/dialog-framer-motion/test.ts
+++ b/app/src/examples/dialog-framer-motion/test.ts
@@ -2,14 +2,14 @@ import { click, press, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 test("show/hide on click", async () => {
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   await click(q.button("Show modal"));
   expect(q.dialog()).toBeVisible();
   expect(q.button("OK")).toHaveFocus();
   await click(q.button("OK"));
   expect(q.dialog()).toBeVisible();
   expect(q.button("Show modal")).toHaveFocus();
-  await expect.poll(q.dialog).not.toBeInTheDocument();
+  await expect.poll(q.dialog.maybe).not.toBeInTheDocument();
   expect(q.button("Show modal")).toHaveFocus();
 });
 
@@ -28,6 +28,6 @@ test("prevent body scroll", async () => {
   await press.Enter();
   expect(q.dialog()).toBeVisible();
   expect(documentElement).toHaveStyle(lockStyle);
-  await expect.poll(q.dialog).not.toBeInTheDocument();
+  await expect.poll(q.dialog.maybe).not.toBeInTheDocument();
   expect(documentElement).not.toHaveStyle({ overflowY: "hidden" });
 });

--- a/app/src/examples/disclosure/_component/test.ts
+++ b/app/src/examples/disclosure/_component/test.ts
@@ -4,7 +4,7 @@ import { expect, test } from "vitest";
 test("show/hide when clicking on disclosure", async () => {
   expect(q.text(/Create an account/)).toBeVisible();
   await click(q.button("How do I get started?"));
-  expect(q.text(/Create an account/)).not.toBeVisible();
+  expect(q.text.maybe(/Create an account/)).not.toBeVisible();
   await click(q.button("How do I get started?"));
   expect(q.text(/Create an account/)).toBeVisible();
 });
@@ -12,11 +12,11 @@ test("show/hide when clicking on disclosure", async () => {
 test("show/hide with keyboard", async () => {
   await press.Tab();
   await press.Enter();
-  expect(q.text(/Create an account/)).not.toBeVisible();
+  expect(q.text.maybe(/Create an account/)).not.toBeVisible();
   await press.Enter();
   expect(q.text(/Create an account/)).toBeVisible();
   await press.Space();
-  expect(q.text(/Create an account/)).not.toBeVisible();
+  expect(q.text.maybe(/Create an account/)).not.toBeVisible();
   await press.Space();
   expect(q.text(/Create an account/)).toBeVisible();
 });

--- a/app/src/examples/popover/_component/test.ts
+++ b/app/src/examples/popover/_component/test.ts
@@ -2,12 +2,12 @@ import { click, press, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 test("show/hide when clicking on disclosure", async () => {
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   await click(q.button("Accept invite"));
   expect(q.dialog()).toBeVisible();
   expect(q.button("Accept")).toHaveFocus();
   await click(q.button("Accept invite"));
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   expect(q.button("Accept invite")).toHaveFocus();
 });
 
@@ -18,7 +18,7 @@ test("show/hide when pressing enter on disclosure", async () => {
   expect(q.button("Accept")).toHaveFocus();
   await press.ShiftTab();
   await press.Enter();
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
 });
 
 test("show/hide when pressing space on disclosure", async () => {
@@ -28,7 +28,7 @@ test("show/hide when pressing space on disclosure", async () => {
   expect(q.button("Accept")).toHaveFocus();
   await press.ShiftTab();
   await press.Space();
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
 });
 
 test("hide when pressing escape on disclosure", async () => {
@@ -36,13 +36,13 @@ test("hide when pressing escape on disclosure", async () => {
   await press.ShiftTab();
   expect(q.dialog()).toBeVisible();
   await press.Escape();
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
 });
 
 test("hide when pressing escape on popover", async () => {
   await click(q.button("Accept invite"));
   expect(q.dialog()).toBeVisible();
   await press.Escape();
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   expect(q.button("Accept invite")).toHaveFocus();
 });

--- a/app/src/sandbox/combobox-5058/test.ts
+++ b/app/src/sandbox/combobox-5058/test.ts
@@ -26,7 +26,7 @@ test("mirrors selected values when composite is false", () => {
 
 // https://github.com/ariakit/ariakit/pull/6795#discussion_r3625787623
 test("omits aria-disabled selected values", () => {
-  const form = q.form.ensure("Disabled fruits") as HTMLFormElement;
+  const form = q.form("Disabled fruits") as HTMLFormElement;
 
   expect(q.combobox("Disabled fruits")).toBeDisabled();
   expect(new FormData(form).getAll("disabled-fruits")).toEqual([]);

--- a/app/src/sandbox/combobox-6315/test.ts
+++ b/app/src/sandbox/combobox-6315/test.ts
@@ -19,7 +19,7 @@ function getInputValue(element: HTMLElement) {
 
 // https://github.com/ariakit/ariakit/issues/6315
 test("does not corrupt decomposed inline completion", async () => {
-  const combobox = q.combobox.ensure("Your favorite drink");
+  const combobox = q.combobox("Your favorite drink");
 
   await click(combobox);
   await type(decomposedCafe);
@@ -30,7 +30,7 @@ test("does not corrupt decomposed inline completion", async () => {
   ]);
 
   await click(q.button("Save"));
-  expectSafeValue(q.status.ensure().textContent ?? "", [
+  expectSafeValue(q.status().textContent ?? "", [
     decomposedCafe,
     decomposedCafeteria,
     composedCafeteria,
@@ -38,7 +38,7 @@ test("does not corrupt decomposed inline completion", async () => {
 });
 
 test("does not drop completion characters after decomposed input", async () => {
-  const combobox = q.combobox.ensure("Your favorite drink");
+  const combobox = q.combobox("Your favorite drink");
 
   await click(combobox);
   await type(decomposedCafet);
@@ -49,7 +49,7 @@ test("does not drop completion characters after decomposed input", async () => {
   ]);
 
   await click(q.button("Save"));
-  expectSafeValue(q.status.ensure().textContent ?? "", [
+  expectSafeValue(q.status().textContent ?? "", [
     decomposedCafet,
     decomposedCafeteria,
     composedCafeteria,
@@ -57,7 +57,7 @@ test("does not drop completion characters after decomposed input", async () => {
 });
 
 test("completes unaccented input against accented items", async () => {
-  const combobox = q.combobox.ensure("Your favorite drink");
+  const combobox = q.combobox("Your favorite drink");
 
   await click(combobox);
   await type("cafe ");

--- a/app/src/sandbox/combobox-disclosure/test.ts
+++ b/app/src/sandbox/combobox-disclosure/test.ts
@@ -8,7 +8,7 @@ test("show and hide popup with disclosure button", async () => {
   expect(q.listbox()).toBeVisible();
   await click(q.button("Hide popup"));
   expect(q.button("Show popup")).toHaveAttribute("aria-expanded", "false");
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
 });
 
 test("show and hide popup with combobox", async () => {
@@ -18,7 +18,7 @@ test("show and hide popup with combobox", async () => {
   expect(q.listbox()).toBeVisible();
   await press.Escape();
   expect(q.button("Show popup")).toHaveAttribute("aria-expanded", "false");
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
 });
 
 test("keep focus on combobox if disclosure button pressed", async () => {

--- a/app/src/sandbox/combobox-filtering-integrated/test.ts
+++ b/app/src/sandbox/combobox-filtering-integrated/test.ts
@@ -6,20 +6,20 @@ test("show/hide popover with click", async () => {
   expect(q.listbox()).toBeVisible();
   expect(q.option("Apple")).not.toHaveFocus();
   await click(document.body);
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   expect(q.combobox()).not.toHaveFocus();
 });
 
 test("show/hide popover with keyboard", async () => {
   await press.Tab();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   await press.ArrowDown();
   expect(q.listbox()).toBeVisible();
   expect(q.option("Apple")).not.toHaveFocus();
   await press.PageDown();
   expect(q.option("Yogurt")).toHaveFocus();
   await press.Escape();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   expect(q.combobox()).toHaveFocus();
 });
 

--- a/app/src/sandbox/combobox-group-basic/test.ts
+++ b/app/src/sandbox/combobox-group-basic/test.ts
@@ -105,7 +105,7 @@ test("composition text", async () => {
   // TODO: Add a composition helper to @ariakit/test.
   await dispatch.compositionStart(q.combobox());
   await type("'", q.combobox(), { isComposing: true });
-  expect(q.option("Apple")).not.toBeInTheDocument();
+  expect(q.option.maybe("Apple")).not.toBeInTheDocument();
   await type("á", q.combobox(), { isComposing: true });
   await dispatch.compositionEnd(q.combobox());
   await sleep();

--- a/app/src/sandbox/combobox-ime-6663/test.ts
+++ b/app/src/sandbox/combobox-ime-6663/test.ts
@@ -3,7 +3,7 @@ import { expect, test } from "vitest";
 
 // Reproduces https://github.com/ariakit/ariakit/issues/6663
 test("keeps focus in the combobox between IME composition sessions", async () => {
-  const combobox = q.combobox.ensure("Fruit");
+  const combobox = q.combobox("Fruit");
 
   combobox.focus();
   await type("사", combobox, { isComposing: true });

--- a/app/src/sandbox/combobox-inline-autocomplete/test.ts
+++ b/app/src/sandbox/combobox-inline-autocomplete/test.ts
@@ -3,7 +3,7 @@ import { expect, test } from "vitest";
 
 test("autocomplete on arrow down key", async () => {
   await press.Tab();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   expect(q.combobox("Your favorite fruit")).toHaveFocus();
   await type("a");
   expect(q.listbox()).toBeVisible();
@@ -13,7 +13,7 @@ test("autocomplete on arrow down key", async () => {
 
 test("autocomplete on arrow up key", async () => {
   await press.Tab();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   expect(q.combobox("Your favorite fruit")).toHaveFocus();
   await type("w");
   expect(q.listbox()).toBeVisible();

--- a/app/src/sandbox/combobox-item-value/test.ts
+++ b/app/src/sandbox/combobox-item-value/test.ts
@@ -14,31 +14,31 @@ function getPartTexts(element: HTMLElement, selector: string) {
 
 // Reproduces https://github.com/ariakit/ariakit/issues/6298
 test("renders overlapping matches without duplicated text", async () => {
-  await type("ana", q.combobox.ensure("Search files"));
+  await type("ana", q.combobox("Search files"));
 
-  const option = q.option.ensure("Banana.txt");
+  const option = q.option("Banana.txt");
   expect(option.textContent).toBe("Banana.txt");
   expect(getPartTexts(option, "[data-user-value]")).toEqual(["anana"]);
 
-  const normalizedEmptyValue = q.status.ensure("Normalized empty value");
+  const normalizedEmptyValue = q.status("Normalized empty value");
   expect(normalizedEmptyValue.textContent).toBe("Cafe");
   expect(getPartTexts(normalizedEmptyValue, "[data-user-value]")).toEqual([]);
 });
 
 // Reproduces https://github.com/ariakit/ariakit/issues/6329
 test("highlights only the typed syllable in Hangul item values", async () => {
-  await type("사", q.combobox.ensure("Search files"));
+  await type("사", q.combobox("Search files"));
 
-  const option = q.option.ensure("사과.txt");
+  const option = q.option("사과.txt");
   expect(option.textContent).toBe("사과.txt");
   expect(getPartTexts(option, "[data-user-value]")).toEqual(["사"]);
   expect(getPartTexts(option, "[data-autocomplete-value]")).toEqual(["과.txt"]);
 });
 
 test("highlights only the typed kana in item values with dakuten", async () => {
-  await type("ガ", q.combobox.ensure("Search files"));
+  await type("ガ", q.combobox("Search files"));
 
-  const option = q.option.ensure("ガラス.txt");
+  const option = q.option("ガラス.txt");
   expect(option.textContent).toBe("ガラス.txt");
   expect(getPartTexts(option, "[data-user-value]")).toEqual(["ガ"]);
   expect(getPartTexts(option, "[data-autocomplete-value]")).toEqual([
@@ -47,9 +47,9 @@ test("highlights only the typed kana in item values with dakuten", async () => {
 });
 
 test("keeps combining marks attached in decomposed item values", async () => {
-  await type("sum", q.combobox.ensure("Search files"));
+  await type("sum", q.combobox("Search files"));
 
-  const option = q.option.ensure(decomposedResume);
+  const option = q.option(decomposedResume);
   expect(option.textContent).toBe(decomposedResume);
   expect(getPartTexts(option, "[data-user-value]")).toEqual(["sum"]);
   expect(getPartTexts(option, "[data-autocomplete-value]")).toEqual([
@@ -61,9 +61,9 @@ test("keeps combining marks attached in decomposed item values", async () => {
 test("renders a single autocomplete span for normalized-empty input", async () => {
   // A lone combining mark normalizes to an empty string, which must not
   // produce highlights but must keep the autocomplete span structure.
-  await type("\u0301", q.combobox.ensure("Search files"));
+  await type("\u0301", q.combobox("Search files"));
 
-  const option = q.option.ensure("notes.txt");
+  const option = q.option("notes.txt");
   expect(option.textContent).toBe("notes.txt");
   expect(getPartTexts(option, "[data-user-value]")).toEqual([]);
   expect(getPartTexts(option, "[data-autocomplete-value]")).toEqual([
@@ -74,9 +74,9 @@ test("renders a single autocomplete span for normalized-empty input", async () =
 test("does not highlight characters the input only partially matches", async () => {
   // A lone medial jamo matches only a fragment of the decomposed 사 syllable,
   // which must not highlight the whole character.
-  await type("\u1161", q.combobox.ensure("Search files"));
+  await type("\u1161", q.combobox("Search files"));
 
-  const option = q.option.ensure("사과.txt");
+  const option = q.option("사과.txt");
   expect(option.textContent).toBe("사과.txt");
   expect(getPartTexts(option, "[data-user-value]")).toEqual([]);
   expect(getPartTexts(option, "[data-autocomplete-value]")).toEqual([
@@ -86,7 +86,7 @@ test("does not highlight characters the input only partially matches", async () 
 
 test("collapses partial matches next to removed combining marks", async () => {
   const markedApple = "사\u0301과.txt";
-  const output = q.status.ensure("Partial match with combining mark");
+  const output = q.status("Partial match with combining mark");
   expect(output.textContent).toBe(markedApple);
   expect(getPartTexts(output, "[data-user-value]")).toEqual([]);
   expect(getPartTexts(output, "[data-autocomplete-value]")).toEqual([
@@ -95,16 +95,16 @@ test("collapses partial matches next to removed combining marks", async () => {
 });
 
 test("highlights a character fully covered by overlapping partial matches", async () => {
-  const output = q.status.ensure("Union of partial matches");
+  const output = q.status("Union of partial matches");
   expect(output.textContent).toBe("각");
   expect(getPartTexts(output, "[data-user-value]")).toEqual(["각"]);
   expect(getPartTexts(output, "[data-autocomplete-value]")).toEqual([]);
 });
 
 test("highlights diacritic-insensitive matches in decomposed item values", async () => {
-  await type("resume", q.combobox.ensure("Search files"));
+  await type("resume", q.combobox("Search files"));
 
-  const option = q.option.ensure(decomposedResume);
+  const option = q.option(decomposedResume);
   expect(option.textContent).toBe(decomposedResume);
   expect(getPartTexts(option, "[data-user-value]")).toEqual([
     "Re\u0301sume\u0301",

--- a/app/src/sandbox/combobox-list-6868/test.ts
+++ b/app/src/sandbox/combobox-list-6868/test.ts
@@ -5,7 +5,7 @@ import { expect, test } from "vitest";
 test("skips the list by default", async () => {
   await click(q.combobox("Default fruit"));
   expect(q.combobox("Search Default fruit")).toHaveFocus();
-  const list = q.listbox.ensure("Default fruit options");
+  const list = q.listbox("Default fruit options");
   expect(list).toHaveAttribute("tabindex", "-1");
 
   await press.Tab();
@@ -18,10 +18,10 @@ test("skips the list by default", async () => {
 // https://github.com/ariakit/ariakit/issues/6868
 test("skips an empty list by default", async () => {
   await click(q.combobox("Default fruit"));
-  const input = q.combobox.ensure("Search Default fruit");
+  const input = q.combobox("Search Default fruit");
   await type("zzzz", input);
   expect(q.status()).toHaveTextContent("No results");
-  const list = q.listbox.ensure("Default fruit options");
+  const list = q.listbox("Default fruit options");
   expect(list).toHaveAttribute("tabindex", "-1");
 
   await press.Tab();
@@ -32,7 +32,7 @@ test("skips an empty list by default", async () => {
 test("ignores an authored tabIndex", async () => {
   await click(q.combobox("Authored tab index fruit"));
   expect(q.combobox("Search Authored tab index fruit")).toHaveFocus();
-  const list = q.listbox.ensure("Authored tab index fruit options");
+  const list = q.listbox("Authored tab index fruit options");
 
   await press.Tab();
   expect(q.button("After Authored tab index fruit options")).toHaveFocus();
@@ -40,8 +40,8 @@ test("ignores an authored tabIndex", async () => {
 });
 
 test("moves focus from a standalone list to the combobox", async () => {
-  const combobox = q.combobox.ensure("Standalone fruit");
-  const list = q.listbox.ensure("Standalone fruit options");
+  const combobox = q.combobox("Standalone fruit");
+  const list = q.listbox("Standalone fruit options");
 
   await click(list);
   expect(combobox).toHaveFocus();

--- a/app/src/sandbox/combobox-min-length/test.ts
+++ b/app/src/sandbox/combobox-min-length/test.ts
@@ -2,16 +2,16 @@ import { click, press, q, type } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 test("popover is not shown on click when combobox is pristine", async () => {
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   await click(q.combobox());
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
 });
 
 test("popover is not shown on arrow down key when combobox is pristine", async () => {
   await press.Tab();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   await press.ArrowDown();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
 });
 
 test("show popover after typing", async () => {
@@ -24,7 +24,7 @@ test("popover is shown on click when combobox is dirty", async () => {
   await press.Tab();
   await type("a");
   await press.Escape();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   await click(q.combobox());
   expect(q.listbox()).toBeVisible();
   expect(q.option(/Apple/)).not.toHaveFocus();
@@ -34,7 +34,7 @@ test("popover is shown on arrow down key when combobox is dirty", async () => {
   await press.Tab();
   await type("a");
   await press.Escape();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   await press.ArrowDown();
   expect(q.listbox()).toBeVisible();
   expect(q.option(/Apple/)).not.toHaveFocus();

--- a/app/src/sandbox/combobox-multiple/test.ts
+++ b/app/src/sandbox/combobox-multiple/test.ts
@@ -34,7 +34,7 @@ test("check/uncheck with enter", async () => {
 test("check/uncheck item after filtering", async () => {
   await press.Tab();
   await type("b");
-  await expect.poll(q.option.lazy("Apple")).not.toBeInTheDocument();
+  await expect.poll(q.option.maybe.lazy("Apple")).not.toBeInTheDocument();
   expect(q.option("Bacon")).toHaveAttribute("aria-selected", "true");
   await press.ArrowDown();
   await press.Enter();
@@ -62,7 +62,7 @@ test("open with keyboard, then try to open again", async () => {
   await press.ArrowDown();
   expect(q.option("Apple")).toHaveFocus();
   await press.Escape();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   expect(q.combobox()).toHaveFocus();
   await press.ArrowDown();
   expect(q.listbox()).toBeVisible();

--- a/app/src/sandbox/combobox-overflow-padding-5696/test.ts
+++ b/app/src/sandbox/combobox-overflow-padding-5696/test.ts
@@ -13,7 +13,7 @@ function expectOverflowPadding(popover: HTMLElement, value = "32px") {
 }
 
 test("uses the greatest horizontal overflow padding for CSS sizing", async () => {
-  const popover = q.listbox.ensure();
+  const popover = q.listbox();
   expectOverflowPadding(popover);
 
   const combobox = q.combobox("Favorite fruit");
@@ -27,7 +27,7 @@ test("uses the greatest horizontal overflow padding for CSS sizing", async () =>
 
 test("does not reposition when inline padding values are unchanged", async () => {
   const popover = q.listbox();
-  const positionUpdates = q.status.ensure("Position updates");
+  const positionUpdates = q.status("Position updates");
   const initialPositionUpdates = positionUpdates.textContent;
   expect(Number(initialPositionUpdates)).toBeGreaterThan(0);
 
@@ -38,8 +38,8 @@ test("does not reposition when inline padding values are unchanged", async () =>
 });
 
 test("repositions when an inline padding value changes", async () => {
-  const popover = q.listbox.ensure();
-  const positionUpdates = q.status.ensure("Position updates");
+  const popover = q.listbox();
+  const positionUpdates = q.status("Position updates");
   const initialPositionUpdates = positionUpdates.textContent;
   expect(Number(initialPositionUpdates)).toBeGreaterThan(0);
 

--- a/app/src/sandbox/combobox-popover-modal-input/test.ts
+++ b/app/src/sandbox/combobox-popover-modal-input/test.ts
@@ -3,7 +3,7 @@ import { expect, test } from "vitest";
 
 // https://github.com/ariakit/ariakit/pull/6832#discussion_r3649287442
 test("closes the modal popover with Escape from the input inside it", async () => {
-  await click(q.combobox.ensure("Favorite fruit"));
+  await click(q.combobox("Favorite fruit"));
   expect(q.combobox("Search fruits")).toHaveFocus();
   await press.Escape();
   expect(q.combobox("Favorite fruit")).toHaveAttribute(
@@ -14,7 +14,7 @@ test("closes the modal popover with Escape from the input inside it", async () =
 });
 
 test("keeps the combobox select interactive while the rest is inert", async () => {
-  await click(q.combobox.ensure("Favorite fruit"));
-  expect(q.button("Outside")).not.toBeInTheDocument();
+  await click(q.combobox("Favorite fruit"));
+  expect(q.button.maybe("Outside")).not.toBeInTheDocument();
   expect(q.combobox("Favorite fruit")).toBeInTheDocument();
 });

--- a/app/src/sandbox/combobox-popover-reset-on-escape/test.ts
+++ b/app/src/sandbox/combobox-popover-reset-on-escape/test.ts
@@ -53,7 +53,7 @@ test("still restores when the descendant is out of the event path", async () => 
   await press.ArrowDown();
   expect(q.combobox("Descendant")).toHaveTextContent("Banana");
   await press.Escape();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   expect(q.combobox("Descendant")).toHaveTextContent("Apple");
 });
 
@@ -64,7 +64,7 @@ test("keeps the previewed value when clicking outside after a consumed Escape", 
   await click(q.button("Handles escape"));
   await press.Escape();
   await click(document.body);
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   expect(q.combobox("Descendant")).toHaveTextContent("Banana");
 });
 
@@ -86,7 +86,7 @@ test("still restores when hideOnEscape prevents the default", async () => {
   await press.ArrowDown();
   expect(q.combobox("Prevented")).toHaveTextContent("Banana");
   await press.Escape();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   expect(q.combobox("Prevented")).toHaveTextContent("Apple");
 });
 
@@ -96,7 +96,7 @@ test("keeps the previewed value when the popover is toggled closed after a consu
   await click(q.button("Handles escape"));
   await press.Escape();
   await click(q.combobox("Descendant"));
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   expect(q.combobox("Descendant")).toHaveTextContent("Banana");
 });
 
@@ -107,7 +107,7 @@ test("reports one closing Escape per keypress", async () => {
     "reset:0 close:0 events:",
   );
   await press.Escape();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   expect(q.status("Counted counts")).toHaveTextContent(
     "reset:1 close:1 events:close,reset",
   );
@@ -154,7 +154,7 @@ test("preserves the original baseline after a prevented close", async () => {
   expect(q.combobox("Vetoed once")).toHaveTextContent("Banana");
   expect(q.status("Vetoed once ready")).toHaveTextContent("ready");
   await press.Escape();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   expect(q.combobox("Vetoed once")).toHaveTextContent("Apple");
 });
 
@@ -165,11 +165,11 @@ test("keeps tracking the baseline after a close is prevented before moving", asy
   expect(q.status("Vetoed before move ready")).toHaveTextContent("ready");
   await click(q.button("Set selection after veto"));
   expect(q.combobox("Vetoed before move")).toHaveTextContent("Banana");
-  q.combobox.ensure("Vetoed before move").focus();
+  q.combobox("Vetoed before move").focus();
   await press.End();
   expect(q.combobox("Vetoed before move")).toHaveTextContent("Grape");
   await press.Escape();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   expect(q.combobox("Vetoed before move")).toHaveTextContent("Banana");
 });
 
@@ -179,11 +179,11 @@ test("keeps tracking a synchronous selection update from a vetoing onClose", asy
   expect(q.listbox()).toBeVisible();
   expect(q.combobox("Vetoed with selection")).toHaveTextContent("Banana");
   expect(q.status("Vetoed with selection ready")).toHaveTextContent("ready");
-  q.combobox.ensure("Vetoed with selection").focus();
+  q.combobox("Vetoed with selection").focus();
   await press.End();
   expect(q.combobox("Vetoed with selection")).toHaveTextContent("Grape");
   await press.Escape();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   expect(q.combobox("Vetoed with selection")).toHaveTextContent("Banana");
 });
 
@@ -193,7 +193,7 @@ test("doesn't reset for a different close from a consumed Escape", async () => {
   expect(q.combobox("Descendant close")).toHaveTextContent("Banana");
   await click(q.button("Consumes Escape and closes"));
   await press.Escape();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   expect(q.combobox("Descendant close")).toHaveTextContent("Banana");
 });
 
@@ -213,7 +213,7 @@ test("doesn't reuse a consumed Escape for a later close", async () => {
   await click(q.button("Swallows escape"));
   await press.Escape();
   await click(q.combobox("Counted"));
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   expect(q.combobox("Counted")).toHaveTextContent("Banana");
   expect(q.status("Counted counts")).toHaveTextContent(
     "reset:0 close:1 events:close",
@@ -237,7 +237,7 @@ test("restores independently across open sessions", async () => {
 // https://github.com/ariakit/ariakit/pull/6832#discussion_r3650305278
 test("doesn't render the popover when the selected value changes", async () => {
   await click(q.combobox("Render counted"));
-  const renderCount = q.status.ensure("Render counted popover renders");
+  const renderCount = q.status("Render counted popover renders");
   const countBeforeChange = renderCount.textContent;
   await dispatch.click(q.button("Set render counted selection"));
   expect(q.combobox("Render counted")).toHaveTextContent("Banana");
@@ -248,7 +248,7 @@ test("tracks selection changes before the first move", async () => {
   await click(q.combobox("Render counted"));
   await click(q.button("Set render counted selection"));
   expect(q.combobox("Render counted")).toHaveTextContent("Banana");
-  q.combobox.ensure("Render counted").focus();
+  q.combobox("Render counted").focus();
   await press.ArrowDown();
   expect(q.combobox("Render counted")).toHaveTextContent("Banana");
   await press.ArrowDown();
@@ -274,7 +274,7 @@ test("captures the baseline when an already-open store replaces the store", asyn
   expect(q.combobox("Store replacement")).toHaveTextContent("Banana");
   await click(q.button("Replace open store"));
   expect(q.listbox()).toBeVisible();
-  q.combobox.ensure("Store replacement").focus();
+  q.combobox("Store replacement").focus();
   await press.End();
   expect(q.combobox("Store replacement")).toHaveTextContent("Grape");
   await press.Escape();
@@ -284,8 +284,8 @@ test("captures the baseline when an already-open store replaces the store", asyn
 // https://github.com/ariakit/ariakit/pull/6832#discussion_r3650306657
 test("doesn't steal focus after focus leaves the popover", async () => {
   await click(q.combobox("Render counted"));
-  const popover = q.listbox.ensure();
-  const target = q.button.ensure("External focus target");
+  const popover = q.listbox();
+  const target = q.button("External focus target");
   popover.focus();
   target.focus();
   await Promise.resolve();

--- a/app/src/sandbox/combobox-radix-select/test.ts
+++ b/app/src/sandbox/combobox-radix-select/test.ts
@@ -2,24 +2,24 @@ import { click, hover, press, q, type } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 test("open/close select with the mouse", async () => {
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   await click(q.combobox("Language"));
   expect(q.dialog()).toBeInTheDocument();
   expect(q.combobox("Search languages")).toHaveFocus();
   await click(document.body);
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   expect(q.combobox()).toHaveFocus();
   expect(q.combobox()).toHaveTextContent("Select a language");
 });
 
 test("open/close select with the keyboard", async () => {
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   await press.Tab();
   await press.Enter();
   expect(q.dialog()).toBeInTheDocument();
   expect(q.combobox("Search languages")).toHaveFocus();
   await press.Escape();
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   expect(q.combobox()).toHaveFocus();
   expect(q.combobox()).toHaveTextContent("Select a language");
 });
@@ -29,7 +29,7 @@ test("select an option with the mouse", async () => {
   expect(q.dialog()).toBeInTheDocument();
   expect(q.combobox("Search languages")).toHaveFocus();
   await click(q.option("Thai"));
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   expect(q.combobox()).toHaveFocus();
   expect(q.combobox()).toHaveTextContent("Thai");
 });
@@ -43,7 +43,7 @@ test("select an option with the keyboard", async () => {
   await press.ArrowDown();
   await press.ArrowDown();
   await press.Enter();
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   expect(q.combobox()).toHaveFocus();
   expect(q.combobox()).toHaveTextContent("Spanish");
 });
@@ -59,7 +59,7 @@ test("search and select", async () => {
   expect(q.option("Polish")).not.toHaveAttribute("data-active-item");
   expect(q.option("Portuguese")).toHaveAttribute("data-active-item");
   await press.Enter();
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   expect(q.combobox()).toHaveFocus();
   expect(q.combobox()).toHaveTextContent("Portuguese");
 });

--- a/app/src/sandbox/combobox-select-collapsed-focus/test.ts
+++ b/app/src/sandbox/combobox-select-collapsed-focus/test.ts
@@ -7,7 +7,7 @@ const hoverLabels = ["Hover fruit", "Callback hover fruit"];
 for (const label of labels) {
   // https://github.com/ariakit/ariakit/issues/7093
   test(`${label}: a collapsed select never focuses its list`, async () => {
-    const select = q.combobox.ensure(label);
+    const select = q.combobox(label);
     const list = q.listbox(`${label} options`);
     const focusedOptions = q.status(`${label} focused options`);
 
@@ -46,7 +46,7 @@ for (const label of labels) {
 // one that has to survive until the list opens, so a pointer open with no move
 // before it still presents the item.
 test("opening the collapsed select with a pointer presents its item", async () => {
-  const select = q.combobox.ensure("Fruit");
+  const select = q.combobox("Fruit");
 
   await click(select);
 
@@ -59,7 +59,7 @@ test("opening the collapsed select with a pointer presents its item", async () =
 // open. Picking another option before that happens has to retire it, or
 // opening the list would present the option that was active on focus.
 test("picking an option before opening retires the pending presentation", async () => {
-  const select = q.combobox.ensure("Code");
+  const select = q.combobox("Code");
   await focus(select);
   await click(q.option("Alpha 25"));
   expect(select).toHaveTextContent("Alpha 25");
@@ -273,7 +273,7 @@ test("default hover in an open plain combobox activates nothing", async () => {
 
 // https://github.com/ariakit/ariakit/issues/7093
 test("a collapsed combobox input never focuses its list", async () => {
-  const combobox = q.combobox.ensure("Filter");
+  const combobox = q.combobox("Filter");
 
   await focus(combobox);
   // The presentation is queued in a microtask, so cross a macrotask before

--- a/app/src/sandbox/combobox-select-controlled-open/test.ts
+++ b/app/src/sandbox/combobox-select-controlled-open/test.ts
@@ -4,7 +4,7 @@ import { expect, test } from "vitest";
 test("popover can be toggled", async () => {
   expect(q.listbox()).toBeVisible();
   await click(q.combobox());
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   await click(q.combobox());
   expect(q.listbox()).toBeVisible();
 });

--- a/app/src/sandbox/combobox-select-focus-within/test.ts
+++ b/app/src/sandbox/combobox-select-focus-within/test.ts
@@ -5,7 +5,7 @@ import { expect, test } from "vitest";
 test("shows and hides the cancel button with popover focus", async () => {
   const select = q.combobox("Favorite fruit");
   await click(select);
-  const search = q.combobox.ensure("Search...");
+  const search = q.combobox("Search...");
   const cancel = q.button("Clear input");
   expect(search).toHaveFocus();
   expect(cancel).toHaveAttribute("data-visible");
@@ -37,7 +37,7 @@ test("shows and hides the cancel button with popover focus", async () => {
   await press.Tab();
   expect(cancel).toHaveFocus();
   await press.Tab();
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
 });
 
 // examples/select-combobox-focus-within/test.ts

--- a/app/src/sandbox/combobox-select-form-disabled/test.ts
+++ b/app/src/sandbox/combobox-select-form-disabled/test.ts
@@ -12,7 +12,7 @@ test("disabled select is visually and semantically disabled", () => {
 
 test("disabled select cannot be opened with click", async () => {
   await click(q.combobox("Favorite fruit"));
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
 });
 
 test("disabled select cannot be opened with keyboard", async () => {
@@ -22,7 +22,7 @@ test("disabled select cannot be opened with keyboard", async () => {
   expect(q.button("Submit")).toHaveFocus();
 
   await press.ArrowDown();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
 });
 
 test("disabled select does not submit value", async () => {

--- a/app/src/sandbox/combobox-select-form/test.ts
+++ b/app/src/sandbox/combobox-select-form/test.ts
@@ -18,7 +18,7 @@ test("select another value", async () => {
   using alert = spyOnAlert();
   await click(q.combobox());
   await click(q.option("Orange"));
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   expect(q.combobox()).toHaveTextContent("Orange");
   await click(q.button("Submit"));
   expect(alert).toHaveBeenCalledWith("Orange");

--- a/app/src/sandbox/combobox-select-grid/test.ts
+++ b/app/src/sandbox/combobox-select-grid/test.ts
@@ -28,7 +28,7 @@ test("changes an expanded value with the keyboard", async () => {
   await type("tt");
   expect(q.gridcell("Top Right")).toHaveFocus();
   await press.Escape();
-  expect(q.grid()).not.toBeInTheDocument();
+  expect(q.grid.maybe()).not.toBeInTheDocument();
   expect(q.combobox("Position")).toHaveTextContent("Center");
   await press.Space();
   await type("top right");
@@ -40,7 +40,7 @@ test("changes an expanded value with the keyboard", async () => {
 test("changes a collapsed value with the keyboard", async () => {
   await press.Tab();
   await press.ArrowDown();
-  expect(q.grid()).not.toBeInTheDocument();
+  expect(q.grid.maybe()).not.toBeInTheDocument();
   expect(q.combobox("Position")).toHaveTextContent("Bottom Center");
   await press.ArrowLeft();
   expect(q.combobox("Position")).toHaveTextContent("Bottom Left");
@@ -70,7 +70,7 @@ test("changes the value on hover", async () => {
   await hover(document.body);
   expect(q.gridcell("Top Center")).toHaveFocus();
   await click(document.body);
-  expect(q.grid()).not.toBeInTheDocument();
+  expect(q.grid.maybe()).not.toBeInTheDocument();
   expect(q.combobox("Position")).toHaveTextContent("Top Center");
 });
 
@@ -83,7 +83,7 @@ test("keeps the moved value when tabbing out", async () => {
   await click(q.combobox("Position"));
   await press.ArrowDown();
   await press.Tab();
-  expect(q.grid()).not.toBeInTheDocument();
+  expect(q.grid.maybe()).not.toBeInTheDocument();
   expect(q.combobox("Position")).toHaveTextContent("Bottom Center");
 
   target.remove();

--- a/app/src/sandbox/combobox-select-item-custom/test.ts
+++ b/app/src/sandbox/combobox-select-item-custom/test.ts
@@ -20,7 +20,7 @@ test("set value on move", async () => {
   expect(q.option(/Sonia Poe/)).toHaveFocus();
   expect(q.combobox("Account")).toHaveTextContent(/Sonia Poe/);
   await press.Escape();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   expect(q.combobox("Account")).toHaveTextContent(/Jane Doe/);
 });
 

--- a/app/src/sandbox/combobox-select-items-unmount/select-tests.test-helper.ts
+++ b/app/src/sandbox/combobox-select-items-unmount/select-tests.test-helper.ts
@@ -16,11 +16,11 @@ export function testSelect(focusTarget: "combobox" | "listbox") {
     expect(q.combobox()).not.toHaveFocus();
     await click(q.text("Favorite fruit"));
     expect(q.combobox()).toHaveFocus();
-    expect(q.listbox()).not.toBeInTheDocument();
+    expect(q.listbox.maybe()).not.toBeInTheDocument();
   });
 
   test("show/hide on click", async () => {
-    expect(q.listbox()).not.toBeInTheDocument();
+    expect(q.listbox.maybe()).not.toBeInTheDocument();
     await click(q.combobox());
     expect(q.listbox()).toBeVisible();
     expectFocusTarget();
@@ -28,7 +28,7 @@ export function testSelect(focusTarget: "combobox" | "listbox") {
     expect(q.option("Apple")).toHaveAttribute("aria-selected", "true");
     expect(q.combobox()).toHaveTextContent("Apple");
     await click(q.combobox());
-    expect(q.listbox()).not.toBeInTheDocument();
+    expect(q.listbox.maybe()).not.toBeInTheDocument();
     expect(q.combobox()).toHaveFocus();
     expect(q.combobox()).toHaveTextContent("Apple");
     expect(q.combobox()).not.toHaveAttribute("aria-activedescendant");
@@ -43,7 +43,7 @@ export function testSelect(focusTarget: "combobox" | "listbox") {
     expect(q.combobox()).toHaveTextContent("Apple");
     await press.ShiftTab();
     await press.Enter();
-    expect(q.listbox()).not.toBeInTheDocument();
+    expect(q.listbox.maybe()).not.toBeInTheDocument();
     expect(q.combobox()).toHaveTextContent("Apple");
   });
 
@@ -56,7 +56,7 @@ export function testSelect(focusTarget: "combobox" | "listbox") {
     expect(q.combobox()).toHaveTextContent("Apple");
     await press.ShiftTab();
     await press.Space();
-    expect(q.listbox()).not.toBeInTheDocument();
+    expect(q.listbox.maybe()).not.toBeInTheDocument();
     expect(q.combobox()).toHaveTextContent("Apple");
   });
 
@@ -69,7 +69,7 @@ export function testSelect(focusTarget: "combobox" | "listbox") {
     await press.ShiftTab();
     expect(document.activeElement).toBe(q.combobox());
     await press.Escape();
-    expect(q.listbox()).not.toBeInTheDocument();
+    expect(q.listbox.maybe()).not.toBeInTheDocument();
     expect(q.combobox()).toHaveFocus();
     await press.ArrowUp();
     expect(q.listbox()).toBeVisible();
@@ -81,14 +81,14 @@ export function testSelect(focusTarget: "combobox" | "listbox") {
     await click(q.combobox());
     expect(q.listbox()).toBeVisible();
     await press.Escape();
-    expect(q.listbox()).not.toBeInTheDocument();
+    expect(q.listbox.maybe()).not.toBeInTheDocument();
   });
 
   test("hide on click outside", async () => {
     await click(q.combobox());
     expect(q.listbox()).toBeVisible();
     await click(document.body);
-    expect(q.listbox()).not.toBeInTheDocument();
+    expect(q.listbox.maybe()).not.toBeInTheDocument();
   });
 
   test("hide on click on label", async () => {
@@ -96,7 +96,7 @@ export function testSelect(focusTarget: "combobox" | "listbox") {
     expect(q.listbox()).toBeVisible();
     await click(q.text("Favorite fruit"));
     expect(q.combobox()).toHaveFocus();
-    expect(q.listbox()).not.toBeInTheDocument();
+    expect(q.listbox.maybe()).not.toBeInTheDocument();
   });
 
   test("navigate through items with keyboard", async () => {
@@ -146,11 +146,11 @@ export function testSelect(focusTarget: "combobox" | "listbox") {
     await press.Tab();
     await type("g");
     expect(q.combobox()).toHaveTextContent("Apple");
-    expect(q.listbox()).not.toBeInTheDocument();
+    expect(q.listbox.maybe()).not.toBeInTheDocument();
     await sleep(600);
     await type("ora");
     expect(q.combobox()).toHaveTextContent("Orange");
-    expect(q.listbox()).not.toBeInTheDocument();
+    expect(q.listbox.maybe()).not.toBeInTheDocument();
   });
 
   test("select with enter", async () => {
@@ -159,7 +159,7 @@ export function testSelect(focusTarget: "combobox" | "listbox") {
     await press.ArrowDown();
     await press.Enter();
     expect(q.combobox()).toHaveTextContent("Banana");
-    expect(q.listbox()).not.toBeInTheDocument();
+    expect(q.listbox.maybe()).not.toBeInTheDocument();
     await press.Enter();
     expect(q.listbox()).toBeVisible();
     expect(q.option("Banana")).toHaveFocus();
@@ -174,7 +174,7 @@ export function testSelect(focusTarget: "combobox" | "listbox") {
     await press.ArrowDown();
     await press.Space();
     expect(q.combobox()).toHaveTextContent("Orange");
-    expect(q.listbox()).not.toBeInTheDocument();
+    expect(q.listbox.maybe()).not.toBeInTheDocument();
     await press.Space();
     expect(q.listbox()).toBeVisible();
     expect(q.option("Orange")).toHaveFocus();
@@ -186,7 +186,7 @@ export function testSelect(focusTarget: "combobox" | "listbox") {
     await click(q.combobox());
     await click(q.option("Banana"));
     expect(q.combobox()).toHaveTextContent("Banana");
-    expect(q.listbox()).not.toBeInTheDocument();
+    expect(q.listbox.maybe()).not.toBeInTheDocument();
     await click(q.combobox());
     expect(q.option("Apple")).toHaveAttribute("aria-selected", "false");
     expect(q.option("Banana")).toHaveAttribute("aria-selected", "true");
@@ -195,7 +195,7 @@ export function testSelect(focusTarget: "combobox" | "listbox") {
     expect(q.listbox()).toBeVisible();
     await click(q.option("Orange"));
     expect(q.combobox()).toHaveTextContent("Orange");
-    expect(q.listbox()).not.toBeInTheDocument();
+    expect(q.listbox.maybe()).not.toBeInTheDocument();
   });
 
   test("hover on item", async () => {

--- a/app/src/sandbox/combobox-select-menu-filters/test.ts
+++ b/app/src/sandbox/combobox-select-menu-filters/test.ts
@@ -16,10 +16,10 @@ test("checkbox menu adds an open filter and commits its value", async () => {
   await click(filters.button("Filters (0)"));
   await click(filters.menuitemcheckbox("Language"));
 
-  const select = filters.combobox.ensure("Language:");
+  const select = filters.combobox("Language:");
   expect(select).toHaveAttribute("aria-expanded", "true");
   expect(select).toHaveTextContent("Language: Choose one");
-  const listbox = filters.listbox.ensure("Language:");
+  const listbox = filters.listbox("Language:");
   const listboxQuery = q.within(listbox);
   await type("fr", select);
   expect(listboxQuery.option("French")).toHaveFocus();
@@ -40,7 +40,7 @@ test("click menu removes an uncommitted filter on outside click", async () => {
   );
   await click(document.body);
   expect(filters.button("Filters (0)")).toBeVisible();
-  expect(filters.combobox("Language:")).not.toBeInTheDocument();
+  expect(filters.combobox.maybe("Language:")).not.toBeInTheDocument();
 });
 
 for (const mode of ["Checkbox", "Click"]) {
@@ -54,7 +54,7 @@ for (const mode of ["Checkbox", "Click"]) {
     expect(filters.combobox("Status:")).toHaveFocus();
     await press.Tab();
     await expect
-      .poll(() => filters.combobox("Status:"))
+      .poll(() => filters.combobox.maybe("Status:"))
       .not.toBeInTheDocument();
     expect(filters.button("Filters (0)")).toBeVisible();
   });
@@ -78,7 +78,7 @@ test("click menu manages multiple filters", async () => {
   expect(filters.button("Filters (2)")).toBeVisible();
 
   await click(filters.button("Remove Language filter"));
-  expect(filters.combobox("Language:")).not.toBeInTheDocument();
+  expect(filters.combobox.maybe("Language:")).not.toBeInTheDocument();
   await click(filters.button("Filters (1)"));
   await click(q.menuitem("Clear all"));
   expect(filters.button("Filters (0)")).toHaveFocus();

--- a/app/src/sandbox/combobox-select-multiple/test.ts
+++ b/app/src/sandbox/combobox-select-multiple/test.ts
@@ -6,7 +6,7 @@ test("default value", () => {
 });
 
 test("show/hide on click", async () => {
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   await click(q.combobox("Favorite food"));
   expect(q.listbox()).toBeVisible();
   expect(q.combobox("Favorite food")).toHaveFocus();
@@ -14,13 +14,13 @@ test("show/hide on click", async () => {
   expect(q.option("Apple")).toHaveAttribute("aria-selected", "true");
   expect(q.option("Cake")).toHaveAttribute("aria-selected", "true");
   await click(q.combobox("Favorite food"));
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   expect(q.combobox("Favorite food")).toHaveFocus();
   expect(q.combobox("Favorite food")).toHaveTextContent("2 food selected");
 });
 
 test("show/hide on enter", async () => {
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   await press.Tab();
   await press.Enter();
   expect(q.listbox()).toBeVisible();
@@ -29,12 +29,12 @@ test("show/hide on enter", async () => {
   expect(q.option("Apple")).toHaveAttribute("aria-selected", "true");
   expect(q.option("Cake")).toHaveAttribute("aria-selected", "true");
   await press.Escape();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   expect(q.combobox("Favorite food")).toHaveFocus();
 });
 
 test("show/hide on space", async () => {
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   await press.Tab();
   await press.Space();
   expect(q.listbox()).toBeVisible();
@@ -43,7 +43,7 @@ test("show/hide on space", async () => {
   expect(q.option("Apple")).toHaveAttribute("aria-selected", "true");
   expect(q.option("Cake")).toHaveAttribute("aria-selected", "true");
   await press.Escape();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   expect(q.combobox("Favorite food")).toHaveFocus();
 });
 
@@ -58,7 +58,7 @@ test("select with keyboard", async () => {
   expect(q.combobox("Favorite food")).toHaveTextContent("3 food selected");
   await press.ArrowDown();
   await press.Escape();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   expect(q.combobox("Favorite food")).toHaveFocus();
   expect(q.combobox("Favorite food")).toHaveTextContent("3 food selected");
   await press.ArrowUp();

--- a/app/src/sandbox/combobox-select-open-active-item/test.ts
+++ b/app/src/sandbox/combobox-select-open-active-item/test.ts
@@ -9,26 +9,26 @@ function activeText(label: string) {
 for (const label of ["Mounted fruit", "Unmounted fruit"]) {
   describe(label, () => {
     test("click", async () => {
-      await click(q.combobox.ensure(label));
+      await click(q.combobox(label));
       expect(activeText(label)).toBe("Orange");
     });
     test("Enter", async () => {
-      await focus(q.combobox.ensure(label));
+      await focus(q.combobox(label));
       await press.Enter();
       expect(activeText(label)).toBe("Orange");
     });
     test("Space", async () => {
-      await focus(q.combobox.ensure(label));
+      await focus(q.combobox(label));
       await press.Space();
       expect(activeText(label)).toBe("Orange");
     });
     test("ArrowDown", async () => {
-      await focus(q.combobox.ensure(label));
+      await focus(q.combobox(label));
       await press.ArrowDown();
       expect(activeText(label)).toBe("Orange");
     });
     test("ArrowUp", async () => {
-      await focus(q.combobox.ensure(label));
+      await focus(q.combobox(label));
       await press.ArrowUp();
       expect(activeText(label)).toBe("Orange");
     });
@@ -38,7 +38,7 @@ for (const label of ["Mounted fruit", "Unmounted fruit"]) {
 describe("Status", () => {
   // https://github.com/ariakit/ariakit/pull/6832#discussion_r3648996674
   test("ArrowDown moves through the items after clicking to open", async () => {
-    await click(q.combobox.ensure("Status"));
+    await click(q.combobox("Status"));
     expect(activeText("Status")).toBeUndefined();
 
     await press.ArrowDown();
@@ -57,7 +57,7 @@ describe("Status", () => {
 
   // https://github.com/ariakit/ariakit/pull/6832#discussion_r3648996674
   test("ArrowDown moves through the items after opening with Enter", async () => {
-    await focus(q.combobox.ensure("Status"));
+    await focus(q.combobox("Status"));
     await press.Enter();
     expect(activeText("Status")).toBeUndefined();
 
@@ -75,11 +75,11 @@ describe("Status", () => {
 for (const label of ["No-autofocus status", "Real-focus status"]) {
   // https://github.com/ariakit/ariakit/pull/6832
   test(`${label} moves from the focused select`, async () => {
-    const select = q.combobox.ensure(label);
+    const select = q.combobox(label);
     await click(select);
     expect(select).toHaveFocus();
 
-    const listbox = q.listbox.ensure(`${label} options`);
+    const listbox = q.listbox(`${label} options`);
     expect(q.within(listbox).option("Draft")).toHaveAttribute(
       "data-active-item",
     );

--- a/app/src/sandbox/combobox-select-programmatic-open/test.ts
+++ b/app/src/sandbox/combobox-select-programmatic-open/test.ts
@@ -22,7 +22,7 @@ test("keeps focus while options arrive after the open", async () => {
   expect(q.listbox()).toBeVisible();
   // Pins that Onion registers after the open instead of being there all along,
   // which is the whole point of this test.
-  expect(q.option("Onion")).not.toBeInTheDocument();
+  expect(q.option.maybe("Onion")).not.toBeInTheDocument();
 
   await click(q.button("Load all vegetables"));
 
@@ -66,7 +66,7 @@ test("abandons the presentation when focus leaves before the options arrive", as
   expect(q.combobox("Vegetable")).toHaveFocus();
   // The presentation is still waiting for its target, which is what makes the
   // focus move below an abandonment rather than a no-op.
-  expect(q.option("Onion")).not.toBeInTheDocument();
+  expect(q.option.maybe("Onion")).not.toBeInTheDocument();
 
   const note = q.textbox("Note");
   await click(note);

--- a/app/src/sandbox/combobox-select-renderer/test.ts
+++ b/app/src/sandbox/combobox-select-renderer/test.ts
@@ -43,6 +43,6 @@ test("renders every selected value when options share a value", () => {
   const listbox = q.listbox("Duplicate selected values");
   expect(q.within(listbox).option("Selected Banana")).toBeInTheDocument();
   expect(
-    q.within(listbox).option("Later duplicate Banana"),
+    q.within(listbox).option.maybe("Later duplicate Banana"),
   ).not.toBeInTheDocument();
 });

--- a/app/src/sandbox/combobox-select-scroll-into-view/test.ts
+++ b/app/src/sandbox/combobox-select-scroll-into-view/test.ts
@@ -12,7 +12,7 @@ test("keeps the keyboard position when the selection registers late", async () =
   // The absence is asserted after the move so it also proves the move won the
   // race against the fixture's late registration.
   await press.ArrowDown();
-  expect(q.option("Item 24")).not.toBeInTheDocument();
+  expect(q.option.maybe("Item 24")).not.toBeInTheDocument();
   expect(q.option("Item 1")).toHaveAttribute("data-active-item");
 
   await expect

--- a/app/src/sandbox/combobox-select-tabs/test.ts
+++ b/app/src/sandbox/combobox-select-tabs/test.ts
@@ -17,7 +17,7 @@ describe.each(cases)("%s", (label, searchable, manual) => {
     expect(q.option("main")).toHaveAttribute("aria-selected", "true");
 
     await click(q.option("leg"));
-    expect(q.dialog()).not.toBeInTheDocument();
+    expect(q.dialog.maybe()).not.toBeInTheDocument();
     expect(select).toHaveTextContent("leg");
 
     await focus(select);
@@ -35,7 +35,7 @@ describe.each(cases)("%s", (label, searchable, manual) => {
       manual ? "false" : "true",
     );
     if (manual) {
-      expect(q.tabpanel("Tags")).not.toBeInTheDocument();
+      expect(q.tabpanel.maybe("Tags")).not.toBeInTheDocument();
       await press.Enter();
     }
     expect(q.tab("Tags")).toHaveAttribute("aria-selected", "true");
@@ -53,7 +53,7 @@ describe.each(cases)("%s", (label, searchable, manual) => {
     await press.ArrowRight();
     expect(q.tab("Tags")).toHaveFocus();
     await press.Tab();
-    expect(q.dialog()).not.toBeInTheDocument();
+    expect(q.dialog.maybe()).not.toBeInTheDocument();
 
     target.remove();
   });
@@ -70,7 +70,7 @@ describe.each(cases)("%s", (label, searchable, manual) => {
       const custom = q.option("Create branch custom from main");
       expect(custom).toHaveFocus();
       await press.Enter();
-      expect(q.dialog()).not.toBeInTheDocument();
+      expect(q.dialog.maybe()).not.toBeInTheDocument();
       expect(select).toHaveTextContent("custom");
 
       await press.Space();

--- a/app/src/sandbox/combobox-select-tag-tooltip-element-id/test.ts
+++ b/app/src/sandbox/combobox-select-tag-tooltip-element-id/test.ts
@@ -3,7 +3,7 @@ import { expect, test } from "vitest";
 
 test("updates combobox relationships when the input id changes", async () => {
   const section = q.within(q.region("Combobox"));
-  const label = section.text.ensure("Combobox label");
+  const label = section.text("Combobox label");
   const combobox = section.combobox("Combobox label");
   const cancel = section.button("Clear input");
 
@@ -19,7 +19,7 @@ test("updates combobox relationships when the input id changes", async () => {
 
 test("updates the tooltip anchor when the content id changes", async () => {
   const section = q.within(q.region("Tooltip"));
-  const anchor = section.button.ensure("Tooltip label");
+  const anchor = section.button("Tooltip label");
 
   expect(anchor).toHaveAttribute("aria-labelledby", "tooltip-before");
 

--- a/app/src/sandbox/combobox-select-typeahead/test.ts
+++ b/app/src/sandbox/combobox-select-typeahead/test.ts
@@ -41,12 +41,12 @@ for (const [name, labels] of Object.entries(fixtures)) {
 
     // https://github.com/ariakit/ariakit/issues/2699
     test("matches custom item content while closed", async () => {
-      const select = q.combobox.ensure(labels.country);
+      const select = q.combobox(labels.country);
       await focus(select);
       await press("c", select);
 
       expect(select).toHaveTextContent("Canada");
-      expect(q.listbox()).not.toBeInTheDocument();
+      expect(q.listbox.maybe()).not.toBeInTheDocument();
     });
 
     // https://github.com/ariakit/ariakit/issues/2699
@@ -63,9 +63,9 @@ for (const [name, labels] of Object.entries(fixtures)) {
     test("typeahead updates the value for late unmounted items", async () => {
       await click(q.button(labels.loadFruitOptions));
 
-      const select = q.combobox.ensure(labels.fruit);
+      const select = q.combobox(labels.fruit);
       expect(select).toHaveFocus();
-      expect(q.option("Apple")).not.toBeInTheDocument();
+      expect(q.option.maybe("Apple")).not.toBeInTheDocument();
       expect(q.status(`${labels.fruit} active item`)).toHaveTextContent(
         "orange",
       );
@@ -83,9 +83,9 @@ for (const [name, labels] of Object.entries(fixtures)) {
     test("typeahead updates the value for late renderer items", async () => {
       await click(q.button(labels.loadRenderedFruitOptions));
 
-      const select = q.combobox.ensure(labels.renderedFruit);
+      const select = q.combobox(labels.renderedFruit);
       expect(select).toHaveFocus();
-      expect(q.option("Apple")).not.toBeInTheDocument();
+      expect(q.option.maybe("Apple")).not.toBeInTheDocument();
       expect(q.status(`${labels.renderedFruit} active item`)).toHaveTextContent(
         "orange",
       );

--- a/app/src/sandbox/combobox-select/test.ts
+++ b/app/src/sandbox/combobox-select/test.ts
@@ -9,7 +9,7 @@ const cases = [
 describe.each(cases)("%s", (label, searchLabel) => {
   test("opens and closes with the pointer and keyboard", async () => {
     const select = q.combobox(label);
-    expect(q.dialog(label)).not.toBeInTheDocument();
+    expect(q.dialog.maybe(label)).not.toBeInTheDocument();
 
     await click(select);
     expect(q.dialog(label)).toBeVisible();
@@ -18,7 +18,7 @@ describe.each(cases)("%s", (label, searchLabel) => {
     expect(q.option("Apple")).toHaveFocus();
 
     await click(select);
-    expect(q.dialog(label)).not.toBeInTheDocument();
+    expect(q.dialog.maybe(label)).not.toBeInTheDocument();
     expect(select).toHaveFocus();
 
     await press.Enter();
@@ -27,7 +27,7 @@ describe.each(cases)("%s", (label, searchLabel) => {
     await press.ShiftTab();
     expect(select).toHaveFocus();
     await press.Enter();
-    expect(q.dialog(label)).not.toBeInTheDocument();
+    expect(q.dialog.maybe(label)).not.toBeInTheDocument();
   });
 
   test("filters, commits, and restores the selected item", async () => {

--- a/app/src/sandbox/combobox-selected-value/test.ts
+++ b/app/src/sandbox/combobox-selected-value/test.ts
@@ -12,7 +12,7 @@ test("renders fallback, selected value, and item state", async () => {
   expect(q.option("Apple")).toHaveTextContent("✓");
   expect(q.option("Banana")).not.toHaveTextContent("✓");
   expect(
-    q.option.ensure("Apple").querySelector("[data-selected]"),
+    q.option("Apple").querySelector("[data-selected]"),
   ).toBeInTheDocument();
 
   await click(q.option("Banana"));
@@ -39,7 +39,7 @@ test("heading labels the popover and nested list", async () => {
 
   await click(q.button("Dismiss fruit options"));
 
-  expect(q.dialog("Fruit options")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Fruit options")).not.toBeInTheDocument();
 });
 
 test("restores the selected value on Escape", async () => {
@@ -66,7 +66,7 @@ test("keeps a disabled filterable select out of the tab order", async () => {
 
 // https://github.com/ariakit/ariakit/pull/6832#discussion_r3647555511
 test("preserves the input value when resetValueOnSelect is false", async () => {
-  const input = q.combobox.ensure("Persistent fruit filter");
+  const input = q.combobox("Persistent fruit filter");
   await type("ap", input);
   await click(q.option("Apple"));
 
@@ -76,7 +76,7 @@ test("preserves the input value when resetValueOnSelect is false", async () => {
 // https://github.com/ariakit/ariakit/pull/6832
 test("preserves a select input value when resetValueOnSelect is false", async () => {
   await click(q.combobox("Persistent select fruit"));
-  const input = q.combobox.ensure("Persistent select fruit filter");
+  const input = q.combobox("Persistent select fruit filter");
   await type("ap", input);
   await click(q.option("Apple"));
 

--- a/app/src/sandbox/combobox-tabs-animated/test.ts
+++ b/app/src/sandbox/combobox-tabs-animated/test.ts
@@ -16,7 +16,9 @@ test("selected tab is restored only after the animation ends", async () => {
   expect(examplesTab).not.toHaveFocus();
   expect(examplesTab).not.toHaveAttribute("data-active-item");
   expect(examplesTab).toHaveAttribute("aria-selected", "true");
-  await expect.poll(q.dialog.hidden.lazy("Pages")).not.toBeInTheDocument();
+  await expect
+    .poll(q.dialog.maybe.hidden.lazy("Pages"))
+    .not.toBeInTheDocument();
   await press.ArrowDown();
   await press.ArrowDown();
   expect(q.tab("Components 16")).toHaveFocus();

--- a/app/src/sandbox/combobox-tabs/test.ts
+++ b/app/src/sandbox/combobox-tabs/test.ts
@@ -15,9 +15,9 @@ test("open popover with components tab initially selected, but not active", asyn
   expect(q.tab("Components 16")).toHaveAttribute("aria-selected", "true");
   expect(q.tab("Components 16")).not.toHaveFocus();
   expect(q.tab("Components 16")).not.toHaveAttribute("data-active-item");
-  expect(q.tabpanel("All 53")).not.toBeInTheDocument();
-  expect(q.tabpanel("Guide 6")).not.toBeInTheDocument();
-  expect(q.tabpanel("Examples 31")).not.toBeInTheDocument();
+  expect(q.tabpanel.maybe("All 53")).not.toBeInTheDocument();
+  expect(q.tabpanel.maybe("Guide 6")).not.toBeInTheDocument();
+  expect(q.tabpanel.maybe("Examples 31")).not.toBeInTheDocument();
   expect(q.tabpanel("Components 16")).toBeVisible();
   expect(q.option("Button")).toBeVisible();
   expect(q.option("Button")).not.toHaveFocus();
@@ -26,7 +26,7 @@ test("open popover with components tab initially selected, but not active", asyn
 
 test("move through items and tabs with the keyboard", async () => {
   await press.Tab();
-  expect(q.dialog("Pages")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Pages")).not.toBeInTheDocument();
   await press.ArrowDown();
   expect(await q.dialog.wait("Pages")).toBeVisible();
   expect(q.combobox()).toHaveAttribute("data-active-item");
@@ -71,7 +71,7 @@ test("move through items and tabs with a mouse", async () => {
   expect(q.option("Button")).toHaveFocus();
   await click(q.tab("Guide 6"));
   expect(q.tab("Guide 6")).toHaveAttribute("aria-selected", "true");
-  expect(q.option("Button")).not.toBeInTheDocument();
+  expect(q.option.maybe("Button")).not.toBeInTheDocument();
 });
 
 test("filter items and change tabs", async () => {
@@ -141,7 +141,7 @@ test("open the popover with arrow down after switching tabs", async () => {
   await expect.poll(q.tab.lazy("Examples 31")).toHaveFocus();
   await press.Escape();
   await expect.poll(q.combobox).toHaveAttribute("data-active-item");
-  expect(q.dialog("Pages")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Pages")).not.toBeInTheDocument();
   await press.ArrowDown();
   await expect.poll(q.dialog.lazy("Pages")).toBeVisible();
   expect(q.tabpanel("Components 16")).toBeVisible();

--- a/app/src/sandbox/combobox-textarea/test.ts
+++ b/app/src/sandbox/combobox-textarea/test.ts
@@ -3,7 +3,7 @@ import { expect, test } from "vitest";
 
 test("@ at the beginning", async () => {
   await press.Tab();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   await type("@");
   expect(q.combobox()).toHaveValue("@");
   expect(q.combobox()).toHaveFocus();
@@ -43,9 +43,9 @@ test("typing on the textarea", async () => {
   expect(q.combobox()).toHaveValue("Hi @tcodes0 @matheus1lva ");
   await type("\b\n\n#lat");
   await press.ArrowLeft();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   await type("\b");
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   await type("\b");
   expect(q.listbox()).toBeVisible();
   await press.Enter();

--- a/app/src/sandbox/combobox/test.ts
+++ b/app/src/sandbox/combobox/test.ts
@@ -6,21 +6,21 @@ function getSelectionStart(element: Element | HTMLInputElement | null) {
 }
 
 test("show on click", async () => {
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   await click(q.combobox());
   expect(q.listbox()).toBeVisible();
   expect(q.option("🍎 Apple")).not.toHaveFocus();
 });
 
 test("label click", async () => {
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   await click(q.text("Your favorite fruit"));
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
 });
 
 test("show on arrow down key", async () => {
   await press.Tab();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   await press.ArrowDown();
   expect(q.listbox()).toBeVisible();
   expect(q.option("🍎 Apple")).not.toHaveFocus();
@@ -28,7 +28,7 @@ test("show on arrow down key", async () => {
 
 test("show on arrow up key", async () => {
   await press.Tab();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   await press.ArrowUp();
   expect(q.listbox()).toBeVisible();
   expect(q.option("🍉 Watermelon")).not.toHaveFocus();
@@ -36,7 +36,7 @@ test("show on arrow up key", async () => {
 
 test("show on change", async () => {
   await press.Tab();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   await type("a");
   expect(q.listbox()).toBeVisible();
   expect(q.option("🍎 Apple")).not.toHaveFocus();
@@ -71,7 +71,7 @@ test("set value and hide on item click with mouse", async () => {
   await click(q.option("🍊 Orange"));
   expect(q.combobox()).toHaveFocus();
   expect(q.combobox()).toHaveValue("Orange");
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
 });
 
 test("set value and hide on item click with keyboard", async () => {
@@ -83,7 +83,7 @@ test("set value and hide on item click with keyboard", async () => {
   await press.Enter();
   expect(q.combobox()).toHaveFocus();
   expect(q.combobox()).toHaveValue("Grape");
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
 });
 
 test("do not set value and hide by pressing space", async () => {
@@ -103,7 +103,7 @@ test("hide listbox by pressing escape", async () => {
   await click(q.combobox());
   expect(q.listbox()).toBeVisible();
   await press.Escape();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   expect(q.combobox()).toHaveFocus();
 });
 
@@ -111,7 +111,7 @@ test("hide listbox by clicking outside", async () => {
   await click(q.combobox());
   expect(q.listbox()).toBeVisible();
   await click(document.body);
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   expect(q.combobox()).not.toHaveFocus();
 });
 
@@ -120,7 +120,7 @@ test("re-open listbox when deleting content", async () => {
   await type("a");
   expect(q.listbox()).toBeVisible();
   await press.Escape();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
   await type("\b");
   expect(q.listbox()).toBeVisible();
 });

--- a/app/src/sandbox/composite-6335/test.ts
+++ b/app/src/sandbox/composite-6335/test.ts
@@ -12,7 +12,7 @@ async function setValue(input: HTMLElement, value: string) {
 // Reproduces https://github.com/ariakit/ariakit/issues/6335
 test("clearing the page field does not crash the app", async () => {
   expect(q.option("Item 1")).toBeInTheDocument();
-  const input = q.spinbutton.ensure("Page");
+  const input = q.spinbutton("Page");
   await click(input);
   // Clearing the field makes the page number NaN, a transient state while the
   // user types another page number

--- a/app/src/sandbox/composite-late-item-focus/test.ts
+++ b/app/src/sandbox/composite-late-item-focus/test.ts
@@ -6,7 +6,7 @@ test("does not refocus a late item after focus leaves the composite", async () =
   await focus(q.button("First"));
   await press.ArrowDown();
 
-  const mount = q.button.ensure("Mount late items");
+  const mount = q.button("Mount late items");
   await click(mount);
 
   expect(mount).toHaveFocus();
@@ -15,11 +15,11 @@ test("does not refocus a late item after focus leaves the composite", async () =
 
 // https://github.com/ariakit/ariakit/issues/6986
 test("does not refocus a late item after focus leaves a virtual focus composite", async () => {
-  const composite = q.listbox.ensure("Virtual actions");
+  const composite = q.listbox("Virtual actions");
   await focus(composite);
   expect(composite).toHaveFocus();
 
-  const mount = q.button.ensure("Mount virtual late item");
+  const mount = q.button("Mount virtual late item");
   await click(mount);
 
   expect(q.option("Virtual late item")).toBeVisible();
@@ -34,7 +34,7 @@ test("only focuses the latest item after rapid unresolved moves", async () => {
 
   // Mount without moving focus out of the composite so the pending retry can
   // still focus the latest unresolved item.
-  q.button.ensure("Mount late items").click();
+  q.button("Mount late items").click();
   await sleep();
 
   expect(q.button("Late")).not.toHaveFocus();

--- a/app/src/sandbox/composite-presentation-cancel-on-unmount/test.ts
+++ b/app/src/sandbox/composite-presentation-cancel-on-unmount/test.ts
@@ -19,10 +19,10 @@ import { expect, test } from "vitest";
  */
 async function loadRecentFilesWithFocusInside() {
   await click(q.button("Show shortcuts"));
-  const editShortcuts = q.button.ensure("Edit shortcuts");
+  const editShortcuts = q.button("Edit shortcuts");
   await focus(editShortcuts);
   // Clicked through the DOM so the click doesn't move focus out of the panel.
-  q.button.ensure("Load recent files").click();
+  q.button("Load recent files").click();
   await sleep();
   expect(q.button("Recent files")).toBeVisible();
   return editShortcuts;
@@ -48,11 +48,11 @@ test("keeps focus after the panel is hidden synchronously", async () => {
 });
 
 test("keeps focus after tabbing into a panel that hides itself", async () => {
-  const arm = q.button.ensure("Hide shortcuts on focus");
+  const arm = q.button("Hide shortcuts on focus");
   await click(arm);
   expect(arm).toHaveFocus();
   await press.Tab();
-  expect(q.toolbar("Shortcuts")).not.toBeInTheDocument();
+  expect(q.toolbar.maybe("Shortcuts")).not.toBeInTheDocument();
 
   expect(await loadRecentFilesWithFocusInside()).toHaveFocus();
 });

--- a/app/src/sandbox/composite-typeahead-buffer/test.ts
+++ b/app/src/sandbox/composite-typeahead-buffer/test.ts
@@ -31,7 +31,7 @@ test("keeps typeahead characters scoped to each composite instance", async () =>
 
     // Cherry must not start with "b", otherwise same-initial looping would
     // reset a leaked buffer and hide the regression.
-    q.button.ensure("Cherry").focus();
+    q.button("Cherry").focus();
     expect(q.button("Cherry")).toHaveFocus();
 
     await typeahead("b");

--- a/app/src/sandbox/dialog-4345/test.ts
+++ b/app/src/sandbox/dialog-4345/test.ts
@@ -14,7 +14,7 @@ test("scroll lock preserves the html element's inline overflow-y", async () => {
   expect(documentElement).toHaveStyle("overflow-x: hidden");
   expect(documentElement).toHaveStyle("overflow-y: hidden");
   await press.Escape();
-  expect(q.dialog("Dialog")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Dialog")).not.toBeInTheDocument();
   expect(documentElement).toHaveStyle("overflow-y: scroll");
   expect(documentElement).not.toHaveStyle("scrollbar-gutter: stable");
   expect(documentElement).not.toHaveStyle("overflow-x: hidden");
@@ -40,7 +40,7 @@ test("fallback scroll lock also hides the html overflow", async () => {
   expect(body).toHaveStyle("overflow: hidden");
   expect(body).toHaveStyle("padding-right: 1024px");
   await press.Escape();
-  expect(q.dialog("Dialog")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Dialog")).not.toBeInTheDocument();
   expect(documentElement).toHaveStyle("overflow-y: scroll");
   expect(documentElement).not.toHaveStyle("--scrollbar-width: 1024px");
   expect(body).not.toHaveStyle("overflow: hidden");

--- a/app/src/sandbox/dialog-5179/test.ts
+++ b/app/src/sandbox/dialog-5179/test.ts
@@ -43,12 +43,12 @@ test.each(["capture", "bubble"] as const)(
     await withDocumentRoot(async (q) => {
       const name = `Document root own ${phase} dialog`;
       await click(q.button(`Open ${name.toLowerCase()}`));
-      const input = q.combobox.ensure("Search");
+      const input = q.combobox("Search");
       expect(q.dialog(name)).toBeVisible();
 
       if (phase === "bubble") {
         await press.Escape(input);
-        expect(q.listbox("Suggestions")).not.toBeInTheDocument();
+        expect(q.listbox.maybe("Suggestions")).not.toBeInTheDocument();
       }
 
       await press.Escape(input);
@@ -67,12 +67,12 @@ test("lets a child handle Escape before the dialog", async () => {
 
   await press.Escape();
 
-  expect(q.listbox("Suggestions")).not.toBeInTheDocument();
+  expect(q.listbox.maybe("Suggestions")).not.toBeInTheDocument();
   expect(q.dialog("Dialog")).toBeVisible();
 
   await press.Escape();
 
-  expect(q.dialog("Dialog")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Dialog")).not.toBeInTheDocument();
 });
 
 test.each(["Ariakit Portal", "React portal"])(
@@ -80,7 +80,7 @@ test.each(["Ariakit Portal", "React portal"])(
   async (portal) => {
     const dialogName = `${portal} child dialog`;
     await click(q.button(`Open ${dialogName.toLowerCase()}`));
-    const input = q.combobox.ensure("Search");
+    const input = q.combobox("Search");
     expect(q.dialog(dialogName)).toBeVisible();
     expect(q.listbox("Suggestions")).toBeVisible();
 
@@ -90,19 +90,19 @@ test.each(["Ariakit Portal", "React portal"])(
 
     await press.Escape(input);
 
-    expect(q.listbox("Suggestions")).not.toBeInTheDocument();
+    expect(q.listbox.maybe("Suggestions")).not.toBeInTheDocument();
     expect(q.dialog(dialogName)).toBeVisible();
 
     await press.Escape(input);
 
-    expect(q.dialog(dialogName)).not.toBeInTheDocument();
+    expect(q.dialog.maybe(dialogName)).not.toBeInTheDocument();
   },
 );
 
 test("lets an ancestor capture handler own Escape", async () => {
   await click(q.button("Open outer capture dialog"));
   const dialog = q.dialog("Outer capture dialog");
-  const input = q.within(dialog).combobox.ensure("Search");
+  const input = q.within(dialog).combobox("Search");
   const listbox = q.within(dialog).listbox("Suggestions");
 
   expect(dialog).toBeVisible();
@@ -123,7 +123,7 @@ test("closes on an unclaimed Escape outside the dialog", async () => {
   await focus(disclosure);
   await press.Escape(disclosure);
 
-  expect(q.dialog("Outside dialog")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Outside dialog")).not.toBeInTheDocument();
 });
 
 test("lets an ancestor capture handler own Escape outside the dialog", async () => {
@@ -143,21 +143,21 @@ test("hides after its own bubble handler stops Escape", async () => {
 
   await press.Escape();
 
-  expect(q.listbox("Suggestions")).not.toBeInTheDocument();
+  expect(q.listbox.maybe("Suggestions")).not.toBeInTheDocument();
   expect(q.dialog("Own bubble dialog")).toBeVisible();
 
   await press.Escape();
 
-  expect(q.dialog("Own bubble dialog")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Own bubble dialog")).not.toBeInTheDocument();
 });
 
 test("hides after its own capture handler stops Escape", async () => {
   await click(q.button("Open own capture dialog"));
   expect(q.dialog("Own capture dialog")).toBeVisible();
 
-  await press.Escape(q.combobox.ensure("Search"));
+  await press.Escape(q.combobox("Search"));
 
-  expect(q.dialog("Own capture dialog")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Own capture dialog")).not.toBeInTheDocument();
 });
 
 test("stops Escape before a third-party dialog bubble handler", async () => {
@@ -168,7 +168,7 @@ test("stops Escape before a third-party dialog bubble handler", async () => {
 
   await press.Escape(q.button("Inside nested ariakit dialog"));
 
-  expect(q.dialog("Nested Ariakit dialog")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Nested Ariakit dialog")).not.toBeInTheDocument();
   expect(q.dialog("Third-party dialog")).toBeVisible();
 });
 
@@ -180,14 +180,14 @@ test("can stop Escape before a third-party dialog capture handler", async () => 
 
   await press.Escape(q.button("Inside shielded ariakit dialog"));
 
-  expect(q.dialog("Shielded Ariakit dialog")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Shielded Ariakit dialog")).not.toBeInTheDocument();
   expect(q.dialog("Capture third-party dialog")).toBeVisible();
 });
 
 test("calls a rejected hideOnEscape callback once", async () => {
   await click(q.button("Open rejected callback dialog"));
   const dialog = q.dialog("Rejected callback dialog");
-  const button = q.within(dialog).button.ensure("Callback calls: 0");
+  const button = q.within(dialog).button("Callback calls: 0");
   expect(dialog).toBeVisible();
 
   await press.Escape(button);
@@ -200,7 +200,7 @@ test("calls an accepted hideOnEscape callback once", async () => {
   const disclosure = q.button("Open accepted callback dialog");
   await click(disclosure);
   const dialog = q.dialog("Accepted callback dialog");
-  const button = q.within(dialog).button.ensure("Callback calls: 0");
+  const button = q.within(dialog).button("Callback calls: 0");
   expect(dialog).toBeVisible();
 
   await press.Escape(button);
@@ -213,7 +213,7 @@ test("calls an accepted hideOnEscape callback once", async () => {
 test("accepts default prevention from hideOnEscape", async () => {
   await click(q.button("Open prevented callback dialog"));
   const dialog = q.dialog("Prevented callback dialog");
-  const button = q.within(dialog).button.ensure("Callback calls: 0");
+  const button = q.within(dialog).button("Callback calls: 0");
   expect(dialog).toBeVisible();
 
   await press.Escape(button);
@@ -224,7 +224,7 @@ test("accepts default prevention from hideOnEscape", async () => {
 test("hides when hideOnEscape stops Escape from a React portal", async () => {
   await click(q.button("Open react portal callback dialog"));
   const dialog = q.dialog("React portal callback dialog");
-  const button = q.button.ensure("Callback calls: 0");
+  const button = q.button("Callback calls: 0");
   expect(dialog).toBeVisible();
 
   await focus(button);
@@ -236,85 +236,91 @@ test("hides when hideOnEscape stops Escape from a React portal", async () => {
 test("lets a child capture Escape in a document root", async () => {
   await withDocumentRoot(async (q) => {
     await click(q.button("Open document root capture dialog"));
-    const input = q.combobox.ensure("Search");
+    const input = q.combobox("Search");
     expect(q.dialog("Document root capture dialog")).toBeVisible();
     expect(q.listbox("Suggestions")).toBeVisible();
 
     await press.Escape(input);
 
-    expect(q.listbox("Suggestions")).not.toBeInTheDocument();
+    expect(q.listbox.maybe("Suggestions")).not.toBeInTheDocument();
     expect(q.dialog("Document root capture dialog")).toBeVisible();
 
     await press.Escape(input);
 
-    expect(q.dialog("Document root capture dialog")).not.toBeInTheDocument();
+    expect(
+      q.dialog.maybe("Document root capture dialog"),
+    ).not.toBeInTheDocument();
   });
 });
 
 test("lets a child handle Escape in a document root", async () => {
   await withDocumentRoot(async (q) => {
     await click(q.button("Open document root dialog"));
-    const input = q.combobox.ensure("Search");
+    const input = q.combobox("Search");
     expect(q.dialog("Document root dialog")).toBeVisible();
     expect(q.listbox("Suggestions")).toBeVisible();
 
     await press.Escape(input);
 
-    expect(q.listbox("Suggestions")).not.toBeInTheDocument();
+    expect(q.listbox.maybe("Suggestions")).not.toBeInTheDocument();
     expect(q.dialog("Document root dialog")).toBeVisible();
 
     await press.Escape(input);
 
-    expect(q.dialog("Document root dialog")).not.toBeInTheDocument();
+    expect(q.dialog.maybe("Document root dialog")).not.toBeInTheDocument();
   });
 });
 
 test("respects default prevention in a document root", async () => {
   await withDocumentRoot(async (q) => {
     await click(q.button("Open document root prevented dialog"));
-    const input = q.combobox.ensure("Search");
+    const input = q.combobox("Search");
     expect(q.dialog("Document root prevented dialog")).toBeVisible();
     expect(q.listbox("Suggestions")).toBeVisible();
 
     await press.Escape(input);
 
-    expect(q.listbox("Suggestions")).not.toBeInTheDocument();
+    expect(q.listbox.maybe("Suggestions")).not.toBeInTheDocument();
     expect(q.dialog("Document root prevented dialog")).toBeVisible();
 
     await press.Escape(input);
 
-    expect(q.dialog("Document root prevented dialog")).not.toBeInTheDocument();
+    expect(
+      q.dialog.maybe("Document root prevented dialog"),
+    ).not.toBeInTheDocument();
   });
 });
 
 test("hides after its own bubble handler in a document root", async () => {
   await withDocumentRoot(async (q) => {
     await click(q.button("Open document root own bubble dialog"));
-    const input = q.combobox.ensure("Search");
+    const input = q.combobox("Search");
     expect(q.dialog("Document root own bubble dialog")).toBeVisible();
     expect(q.listbox("Suggestions")).toBeVisible();
 
     await press.Escape(input);
 
-    expect(q.listbox("Suggestions")).not.toBeInTheDocument();
+    expect(q.listbox.maybe("Suggestions")).not.toBeInTheDocument();
     expect(q.dialog("Document root own bubble dialog")).toBeVisible();
 
     await press.Escape(input);
 
-    expect(q.dialog("Document root own bubble dialog")).not.toBeInTheDocument();
+    expect(
+      q.dialog.maybe("Document root own bubble dialog"),
+    ).not.toBeInTheDocument();
   });
 });
 
 test("hides after its own capture handler in a document root", async () => {
   await withDocumentRoot(async (q) => {
     await click(q.button("Open document root own capture dialog"));
-    const input = q.combobox.ensure("Search");
+    const input = q.combobox("Search");
     expect(q.dialog("Document root own capture dialog")).toBeVisible();
 
     await press.Escape(input);
 
     expect(
-      q.dialog("Document root own capture dialog"),
+      q.dialog.maybe("Document root own capture dialog"),
     ).not.toBeInTheDocument();
   });
 });
@@ -323,7 +329,7 @@ test("hides when hideOnEscape stops Escape in a document root", async () => {
   await withDocumentRoot(async (q) => {
     await click(q.button("Open document root callback dialog"));
     const dialog = q.dialog("Document root callback dialog");
-    const button = q.within(dialog).button.ensure("Callback calls: 0");
+    const button = q.within(dialog).button("Callback calls: 0");
     expect(dialog).toBeVisible();
 
     await press.Escape(button);
@@ -340,7 +346,9 @@ test("closes on global Escape outside a document-root dialog", async () => {
 
     await press.Escape(disclosure);
 
-    expect(q.dialog("Document root global dialog")).not.toBeInTheDocument();
+    expect(
+      q.dialog.maybe("Document root global dialog"),
+    ).not.toBeInTheDocument();
   });
 });
 
@@ -360,7 +368,7 @@ test("lets an ancestor capture handler own Escape in a document root", async () 
   await withDocumentRoot(async (q) => {
     await click(q.button("Open document root outside dialog"));
     const dialog = q.dialog("Document root outside dialog");
-    const input = q.within(dialog).combobox.ensure("Search");
+    const input = q.within(dialog).combobox("Search");
     const listbox = q.within(dialog).listbox("Suggestions");
 
     expect(dialog).toBeVisible();

--- a/app/src/sandbox/dialog-5238/test.ts
+++ b/app/src/sandbox/dialog-5238/test.ts
@@ -6,16 +6,16 @@ test("keeps the frontmost initially open sibling dialog interactive", async () =
   expect(q.dialog.all.hidden()).toHaveLength(2);
   expect(q.dialog.hidden("Apples")).toBeVisible();
   expect(q.dialog.hidden("Oranges")).toBeVisible();
-  expect(q.dialog("Oranges")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Oranges")).not.toBeInTheDocument();
   expect(q.dialog("Apples")).toBeVisible();
 
   await click(q.button("Eat apple"));
   expect(q.status("Apple count")).toHaveTextContent("Apples eaten: 1");
-  expect(q.dialog("Oranges")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Oranges")).not.toBeInTheDocument();
   expect(q.dialog("Apples")).toBeVisible();
 
   await rightClick(document.querySelector("[data-testid=apples-backdrop]"));
-  expect(q.dialog("Apples")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Apples")).not.toBeInTheDocument();
   expect(q.dialog("Oranges")).toBeVisible();
   await click(q.button("Eat orange"));
   expect(q.status("Orange count")).toHaveTextContent("Oranges eaten: 1");
@@ -32,8 +32,8 @@ test("keeps initially open sibling dialogs interactive in a shadow root", async 
     "[data-dialog-shadow-portal]",
   );
   const shadowQ = q.within(portal);
-  const orangesDialog = shadowQ.dialog.ensure.hidden("Oranges");
-  const applesDialog = shadowQ.dialog.ensure.hidden("Apples");
+  const orangesDialog = shadowQ.dialog.hidden("Oranges");
+  const applesDialog = shadowQ.dialog.hidden("Apples");
 
   expect(applesDialog.getRootNode()).toBe(host?.shadowRoot);
   expect(shadowQ.dialog.all.hidden()).toHaveLength(2);
@@ -46,7 +46,7 @@ test("keeps initially open sibling dialogs interactive in a shadow root", async 
   await rightClick(
     portal?.querySelector("[data-testid=apples-backdrop]") || null,
   );
-  expect(shadowQ.dialog("Apples")).not.toBeInTheDocument();
+  expect(shadowQ.dialog.maybe("Apples")).not.toBeInTheDocument();
   expect(orangesDialog.closest("[inert]")).toBeNull();
 
   await click(shadowQ.button("Eat orange"));

--- a/app/src/sandbox/dialog-animated-variants/test.ts
+++ b/app/src/sandbox/dialog-animated-variants/test.ts
@@ -36,5 +36,5 @@ test.each([
     expect(q.dialog.hidden(name)).not.toHaveStyle("display: none");
   }
 
-  await expect.poll(q.dialog.lazy(name)).not.toBeInTheDocument();
+  await expect.poll(q.dialog.maybe.lazy(name)).not.toBeInTheDocument();
 });

--- a/app/src/sandbox/dialog-backdrop-6339/test.ts
+++ b/app/src/sandbox/dialog-backdrop-6339/test.ts
@@ -5,7 +5,7 @@ import { expect, test } from "vitest";
 test("backdrop fades out on close when only the backdrop is animated", async () => {
   await click(q.button("Show dialog"));
   expect(q.dialog()).toBeVisible();
-  const backdrop = q.presentation.ensure();
+  const backdrop = q.presentation();
   // The enter state is applied after a couple of frames.
   await expect.poll(() => backdrop.getAttribute("data-enter")).toBe("true");
   expect(q.button("Close")).toHaveFocus();
@@ -24,7 +24,7 @@ test("backdrop fades out on close when only the backdrop is animated", async () 
 test("backdrop finishes its longer fade out when the panel has a shorter transition", async () => {
   await click(q.button("Show fast dialog"));
   expect(q.dialog()).toBeVisible();
-  const backdrop = q.presentation.ensure();
+  const backdrop = q.presentation();
   // The enter state is applied after a couple of frames.
   await expect.poll(() => backdrop.getAttribute("data-enter")).toBe("true");
   expect(q.button("Close")).toHaveFocus();

--- a/app/src/sandbox/dialog-combobox-command-menu/test.ts
+++ b/app/src/sandbox/dialog-combobox-command-menu/test.ts
@@ -7,7 +7,7 @@ async function hoverOutside() {
 }
 
 test("open dialog with click and hide with esc", async () => {
-  expect(q.dialog("Command Menu")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Command Menu")).not.toBeInTheDocument();
   await click(q.button("Open Command Menu"));
   expect(q.dialog("Command Menu")).toBeVisible();
   expect(q.combobox("Search for apps and commands...")).toHaveFocus();
@@ -15,7 +15,7 @@ test("open dialog with click and hide with esc", async () => {
   expect(q.group("Suggestions")).toBeVisible();
   await press.Escape();
   expect(q.button("Open Command Menu")).toHaveFocus();
-  await expect.poll(q.dialog).not.toBeInTheDocument();
+  await expect.poll(q.dialog.maybe).not.toBeInTheDocument();
 });
 
 test("open dialog with click and hide by clicking outside", async () => {
@@ -24,7 +24,7 @@ test("open dialog with click and hide by clicking outside", async () => {
   expect(q.combobox("Search for apps and commands...")).toHaveFocus();
   await click(document.body);
   expect(q.button("Open Command Menu")).not.toHaveFocus();
-  await expect.poll(q.dialog).not.toBeInTheDocument();
+  await expect.poll(q.dialog.maybe).not.toBeInTheDocument();
 });
 
 test("open dialog with enter and hide by pressing enter on esc button", async () => {
@@ -35,7 +35,7 @@ test("open dialog with enter and hide by pressing enter on esc button", async ()
   await press.Tab();
   expect(q.button("Esc")).toHaveFocus();
   await press.Enter();
-  await expect.poll(q.dialog).not.toBeInTheDocument();
+  await expect.poll(q.dialog.maybe).not.toBeInTheDocument();
 });
 
 test("navigate through items with keyboard", async () => {

--- a/app/src/sandbox/dialog-combobox-tab-command-menu/test.ts
+++ b/app/src/sandbox/dialog-combobox-tab-command-menu/test.ts
@@ -27,17 +27,17 @@ describe.each(LABELS)("%s", (label) => {
 
   test("close command menu when Escape key is pressed", async () => {
     await press.Escape();
-    expect(q.dialog("Command Menu")).not.toBeInTheDocument();
+    expect(q.dialog.maybe("Command Menu")).not.toBeInTheDocument();
   });
 
   test("close command menu when clicking outside", async () => {
     await click(document.body);
-    expect(q.dialog("Command Menu")).not.toBeInTheDocument();
+    expect(q.dialog.maybe("Command Menu")).not.toBeInTheDocument();
   });
 
   test("close command menu when clicking on the esc button", async () => {
     await click(q.button("Esc"));
-    expect(q.dialog("Command Menu")).not.toBeInTheDocument();
+    expect(q.dialog.maybe("Command Menu")).not.toBeInTheDocument();
   });
 
   test("filter options when typing", async () => {
@@ -75,21 +75,21 @@ describe.each(TABS)("Tabs - %s", (label) => {
   test("pressing Tab key should select tabs", async () => {
     await press.Tab();
     expect(q.tab(/^All/)).toHaveAttribute("aria-selected", "false");
-    expect(q.tabpanel(/^All/)).not.toBeInTheDocument();
+    expect(q.tabpanel.maybe(/^All/)).not.toBeInTheDocument();
     expect(q.tab(/^Guide/)).toHaveAttribute("aria-selected", "true");
     expect(q.tab(/^Guide/)).toHaveAttribute("data-active-item");
     expect(q.tabpanel(/^Guide/)).toBeVisible();
 
     await press.Tab();
     expect(q.tab(/^Guide/)).toHaveAttribute("aria-selected", "false");
-    expect(q.tabpanel(/^Guide/)).not.toBeInTheDocument();
+    expect(q.tabpanel.maybe(/^Guide/)).not.toBeInTheDocument();
     expect(q.tab(/^Components/)).toHaveAttribute("aria-selected", "true");
     expect(q.tab(/^Components/)).toHaveAttribute("data-active-item");
     expect(q.tabpanel(/^Components/)).toBeVisible();
 
     await press.ShiftTab();
     expect(q.tab(/^Components/)).toHaveAttribute("aria-selected", "false");
-    expect(q.tabpanel(/^Components/)).not.toBeInTheDocument();
+    expect(q.tabpanel.maybe(/^Components/)).not.toBeInTheDocument();
     expect(q.tab(/^Guide/)).toHaveAttribute("aria-selected", "true");
     expect(q.tab(/^Guide/)).toHaveAttribute("data-active-item");
     expect(q.tabpanel(/^Guide/)).toBeVisible();
@@ -122,13 +122,13 @@ describe.each(TABS)("Tabs - %s", (label) => {
     await press.Tab();
     await press.ArrowRight();
     expect(q.tab(/^Guide/)).toHaveAttribute("aria-selected", "false");
-    expect(q.tabpanel(/^Guide/)).not.toBeInTheDocument();
+    expect(q.tabpanel.maybe(/^Guide/)).not.toBeInTheDocument();
     expect(q.tab(/^Components/)).toHaveAttribute("aria-selected", "true");
     expect(q.tab(/^Components/)).toHaveAttribute("data-active-item");
     expect(q.tabpanel(/^Components/)).toBeVisible();
     await press.ArrowLeft();
     expect(q.tab(/^Components/)).toHaveAttribute("aria-selected", "false");
-    expect(q.tabpanel(/^Components/)).not.toBeInTheDocument();
+    expect(q.tabpanel.maybe(/^Components/)).not.toBeInTheDocument();
     expect(q.tab(/^Guide/)).toHaveAttribute("aria-selected", "true");
     expect(q.tab(/^Guide/)).toHaveAttribute("data-active-item");
     expect(q.tabpanel(/^Guide/)).toBeVisible();

--- a/app/src/sandbox/dialog-core-interactions/test.ts
+++ b/app/src/sandbox/dialog-core-interactions/test.ts
@@ -32,7 +32,7 @@ test("closes with Escape and restores disclosure focus", async () => {
   await click(disclosure);
   await press.Escape();
 
-  expect(q.dialog("Success")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Success")).not.toBeInTheDocument();
   expect(disclosure).toHaveFocus();
 });
 
@@ -42,7 +42,7 @@ test("closes on outside click without restoring disclosure focus", async () => {
   await click(disclosure);
   await click(outside);
 
-  expect(q.dialog("Success")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Success")).not.toBeInTheDocument();
   expect(disclosure).not.toHaveFocus();
 });
 
@@ -60,7 +60,7 @@ for (const trigger of ["click", "Enter", "Space"] as const) {
       await press.Space(dismiss);
     }
 
-    expect(q.dialog("Success")).not.toBeInTheDocument();
+    expect(q.dialog.maybe("Success")).not.toBeInTheDocument();
     expect(disclosure).toHaveFocus();
   });
 }

--- a/app/src/sandbox/dialog-details-enhancement/test.ts
+++ b/app/src/sandbox/dialog-details-enhancement/test.ts
@@ -2,14 +2,14 @@ import { click, press, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 test("show on disclosure click", async () => {
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   await click(q.button("Show modal"));
   expect(q.dialog()).toBeVisible();
   expect(q.button("OK")).toHaveFocus();
 });
 
 test("show on disclosure enter", async () => {
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   await press.Tab();
   await press.Enter();
   expect(q.dialog()).toBeVisible();
@@ -17,7 +17,7 @@ test("show on disclosure enter", async () => {
 });
 
 test("show on disclosure space", async () => {
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   await press.Tab();
   await press.Space();
   expect(q.dialog()).toBeVisible();
@@ -37,7 +37,7 @@ test("hide on escape", async () => {
   await click(q.button("Show modal"));
   expect(q.dialog()).toBeVisible();
   await press.Escape();
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   expect(q.button("Show modal")).toHaveFocus();
 });
 
@@ -45,7 +45,7 @@ test("hide on click outside", async () => {
   await click(q.button("Show modal"));
   expect(q.dialog()).toBeVisible();
   await click(document.body);
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   expect(q.button("Show modal")).not.toHaveFocus();
 });
 
@@ -53,7 +53,7 @@ test("hide on dismiss button click", async () => {
   await click(q.button("Show modal"));
   expect(q.dialog()).toBeVisible();
   await click(q.button("OK"));
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   expect(q.button("Show modal")).toHaveFocus();
 });
 
@@ -61,7 +61,7 @@ test("hide on dismiss button enter", async () => {
   await click(q.button("Show modal"));
   expect(q.dialog()).toBeVisible();
   await press.Enter();
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   expect(q.button("Show modal")).toHaveFocus();
 });
 
@@ -69,6 +69,6 @@ test("hide on dismiss button space", async () => {
   await click(q.button("Show modal"));
   expect(q.dialog()).toBeVisible();
   await press.Space();
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   expect(q.button("Show modal")).toHaveFocus();
 });

--- a/app/src/sandbox/dialog-hide-warning/test.ts
+++ b/app/src/sandbox/dialog-hide-warning/test.ts
@@ -14,7 +14,7 @@ test("open/hide dialog without filling in the form", async () => {
   expect(q.dialog("Post")).toBeVisible();
   expect(q.textbox()).toHaveFocus();
   await click(q.button("Dismiss popup"));
-  expect(q.dialog("Post")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Post")).not.toBeInTheDocument();
 });
 
 test("try to hide the dialog with Escape after filling in the form", async () => {
@@ -22,21 +22,21 @@ test("try to hide the dialog with Escape after filling in the form", async () =>
   await type("Hello");
   await press.Escape();
   expect(q.dialog.hidden("Post")).toBeVisible();
-  expect(q.dialog("Post")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Post")).not.toBeInTheDocument();
   expect(q.dialog("Save post?")).toBeVisible();
   expect(q.button("Save")).toHaveFocus();
   await press.Escape();
-  expect(q.dialog("Save post?")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Save post?")).not.toBeInTheDocument();
   expect(q.dialog("Post")).toBeVisible();
   expect(q.textbox()).toHaveFocus();
   await press.Escape();
   expect(q.dialog.hidden("Post")).toBeVisible();
-  expect(q.dialog("Post")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Post")).not.toBeInTheDocument();
   expect(q.dialog("Save post?")).toBeVisible();
   expect(q.button("Save")).toHaveFocus();
   await press.Enter();
-  expect(q.dialog("Post")).not.toBeInTheDocument();
-  expect(q.dialog("Save post?")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Post")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Save post?")).not.toBeInTheDocument();
   expect(q.button("Post")).toHaveFocus();
 });
 
@@ -45,21 +45,21 @@ test("try to hide the dialog by clicking outside after filling in the form", asy
   await type("Hello");
   await click(backdrop());
   expect(q.dialog.hidden("Post")).toBeVisible();
-  expect(q.dialog("Post")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Post")).not.toBeInTheDocument();
   expect(q.dialog("Save post?")).toBeVisible();
   expect(q.button("Save")).toHaveFocus();
   await click(backdrop());
-  expect(q.dialog("Save post?")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Save post?")).not.toBeInTheDocument();
   expect(q.dialog("Post")).toBeVisible();
   expect(q.textbox()).toHaveFocus();
   await click(backdrop());
   expect(q.dialog.hidden("Post")).toBeVisible();
-  expect(q.dialog("Post")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Post")).not.toBeInTheDocument();
   expect(q.dialog("Save post?")).toBeVisible();
   expect(q.button("Save")).toHaveFocus();
   await click(q.button("Save"));
-  expect(q.dialog("Post")).not.toBeInTheDocument();
-  expect(q.dialog("Save post?")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Post")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Save post?")).not.toBeInTheDocument();
   expect(q.button("Post")).toHaveFocus();
 });
 
@@ -68,12 +68,12 @@ test("try to hide the dialog by clicking on the dismiss button after filling in 
   await type("Hello");
   await click(q.button("Dismiss popup"));
   expect(q.dialog.hidden("Post")).toBeVisible();
-  expect(q.dialog("Post")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Post")).not.toBeInTheDocument();
   expect(q.dialog("Save post?")).toBeVisible();
   expect(q.button("Save")).toHaveFocus();
   await click(backdrop());
   expect(q.textbox()).toHaveFocus();
   await click(q.button("Post"));
-  expect(q.dialog("Post")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Post")).not.toBeInTheDocument();
   expect(q.button("Post")).toHaveFocus();
 });

--- a/app/src/sandbox/dialog-menu-interactions/test.ts
+++ b/app/src/sandbox/dialog-menu-interactions/test.ts
@@ -10,19 +10,19 @@ const backdrop = () => {
 };
 
 test("show dialog", async () => {
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   await click(q.button("View recipe"));
   expect(q.dialog()).toBeVisible();
 });
 
 test("show/hide menu", async () => {
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
   await click(q.button("View recipe"));
   await click(q.button("Share"));
   expect(q.menu()).toBeVisible();
   expect(q.menu()).toHaveFocus();
   await click(q.button("Share"));
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
   await click(q.button("Share"));
   expect(q.menu()).toBeVisible();
   expect(q.menu()).toHaveFocus();
@@ -35,10 +35,10 @@ test("hide menu and dialog with esc", async () => {
   expect(q.menu()).toBeVisible();
   await press.Escape();
   expect(q.dialog()).toBeVisible();
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
   expect(q.button("Share")).toHaveFocus();
   await press.Escape();
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   expect(q.button("View recipe")).toHaveFocus();
 });
 
@@ -49,7 +49,7 @@ test("hide menu by clicking on dialog", async () => {
   expect(q.menu()).toBeVisible();
   await click(q.dialog());
   expect(q.dialog()).toBeVisible();
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
   expect(q.dialog()).toHaveFocus();
 });
 
@@ -59,8 +59,8 @@ test("hide both menu and dialog by clicking outside dialog", async () => {
   expect(q.dialog()).toBeVisible();
   expect(q.menu()).toBeVisible();
   await click(backdrop());
-  expect(q.dialog()).not.toBeInTheDocument();
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
   expect(q.button("View recipe")).not.toHaveFocus();
 });
 

--- a/app/src/sandbox/dialog-nested-cart/test.ts
+++ b/app/src/sandbox/dialog-nested-cart/test.ts
@@ -2,7 +2,7 @@ import { click, press, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 function backdrop(name: string) {
-  const dialog = q.dialog.ensure(name);
+  const dialog = q.dialog(name);
   const id = dialog.id;
   const backdrop = document.querySelector(`[data-backdrop="${id}"]`);
   expect(backdrop).toBeInTheDocument();
@@ -10,7 +10,7 @@ function backdrop(name: string) {
 }
 
 test("show cart dialog", async () => {
-  expect(q.dialog("Your Shopping Cart")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Your Shopping Cart")).not.toBeInTheDocument();
   await click(q.button("View Cart"));
   expect(q.dialog("Your Shopping Cart")).toBeVisible();
   expect(q.button("Dismiss popup")).toHaveFocus();
@@ -21,7 +21,7 @@ test("hide cart dialog with escape", async () => {
   expect(q.dialog("Your Shopping Cart")).toBeVisible();
   expect(q.button("Dismiss popup")).toHaveFocus();
   await press.Escape();
-  expect(q.dialog("Your Shopping Cart")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Your Shopping Cart")).not.toBeInTheDocument();
   expect(q.button("View Cart")).toHaveFocus();
 });
 
@@ -30,20 +30,20 @@ test("hide cart dialog by clicking outside", async () => {
   expect(q.dialog("Your Shopping Cart")).toBeVisible();
   expect(q.button("Dismiss popup")).toHaveFocus();
   await click(backdrop("Your Shopping Cart"));
-  expect(q.dialog("Your Shopping Cart")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Your Shopping Cart")).not.toBeInTheDocument();
   expect(q.button("View Cart")).not.toHaveFocus();
 });
 
 test("show confirm dialog", async () => {
   await click(q.button("View Cart"));
-  expect(q.dialog("Remove product")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Remove product")).not.toBeInTheDocument();
   await click(q.button("Remove Warm Jacket"));
   expect(q.dialog.hidden("Your Shopping Cart")).toBeVisible();
-  expect(q.dialog("Your Shopping Cart")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Your Shopping Cart")).not.toBeInTheDocument();
   expect(q.dialog("Remove product")).toBeVisible();
   expect(q.button("Cancel")).toHaveFocus();
   await press.Enter();
-  expect(q.dialog("Remove product")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Remove product")).not.toBeInTheDocument();
   expect(q.dialog("Your Shopping Cart")).toBeVisible();
   expect(q.button("Remove Warm Jacket")).toHaveFocus();
 });
@@ -53,7 +53,7 @@ test("hide confirm dialog by pressing escape", async () => {
   await click(q.button("Remove Warm Jacket"));
   expect(q.dialog("Remove product")).toBeVisible();
   await press.Escape();
-  expect(q.dialog("Remove product")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Remove product")).not.toBeInTheDocument();
   expect(q.dialog("Your Shopping Cart")).toBeVisible();
   expect(q.button("Remove Warm Jacket")).toHaveFocus();
 });
@@ -63,7 +63,7 @@ test("hide confirm dialog by clicking outside", async () => {
   await click(q.button("Remove Warm Jacket"));
   expect(q.dialog("Remove product")).toBeVisible();
   await click(backdrop("Remove product"));
-  expect(q.dialog("Remove product")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Remove product")).not.toBeInTheDocument();
   expect(q.dialog("Your Shopping Cart")).toBeVisible();
   expect(q.button("Remove Warm Jacket")).not.toHaveFocus();
 });

--- a/app/src/sandbox/dialog-nested-variants/test.ts
+++ b/app/src/sandbox/dialog-nested-variants/test.ts
@@ -21,14 +21,14 @@ function expectModalStyle(toHaveStyle: boolean) {
 }
 
 test("show dialog and hide with escape", async () => {
-  expect(q.dialog("Dialog")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Dialog")).not.toBeInTheDocument();
   expectModalStyle(false);
   await click(q.button("Open dialog"));
   expect(q.dialog("Dialog")).toBeVisible();
   expect(q.button("Close")).toHaveFocus();
   expectModalStyle(true);
   await press.Escape();
-  expect(q.dialog("Dialog")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Dialog")).not.toBeInTheDocument();
   expect(q.button("Open dialog")).toHaveFocus();
   expectModalStyle(false);
 });
@@ -53,7 +53,7 @@ test("fall back to body padding without scrollbar-gutter support", async () => {
   expect(body).toHaveStyle("overflow: hidden");
   expect(body).toHaveStyle("padding-right: 1024px");
   await press.Escape();
-  expect(q.dialog("Dialog")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Dialog")).not.toBeInTheDocument();
   expect(documentElement).not.toHaveStyle("--scrollbar-width: 1024px");
   expect(body).not.toHaveStyle("overflow: hidden");
   expect(body).not.toHaveStyle("padding-right: 1024px");
@@ -65,7 +65,7 @@ test.each(["nested", "sibling"])(
     await click(q.button("Open dialog"));
     await click(q.button(name));
     expect(q.dialog.hidden("Dialog")).toBeVisible();
-    expect(q.dialog("Dialog")).not.toBeInTheDocument();
+    expect(q.dialog.maybe("Dialog")).not.toBeInTheDocument();
     expect(q.button("Close")).toHaveFocus();
     expect(q.dialog(name)).toBeVisible();
     expectModalStyle(true);
@@ -73,24 +73,24 @@ test.each(["nested", "sibling"])(
     expect(q.dialog.hidden("Dialog")).toBeVisible();
     expect(q.dialog.hidden(name)).toBeVisible();
     expect(q.button("Close")).toHaveFocus();
-    expect(q.dialog("Dialog")).not.toBeInTheDocument();
-    expect(q.dialog(name)).not.toBeInTheDocument();
+    expect(q.dialog.maybe("Dialog")).not.toBeInTheDocument();
+    expect(q.dialog.maybe(name)).not.toBeInTheDocument();
     expect(q.dialog(`${name} ${name}`)).toBeVisible();
     expectModalStyle(true);
     await press.Escape();
-    expect(q.dialog.hidden(`${name} ${name}`)).not.toBeVisible();
+    expect(q.dialog.maybe.hidden(`${name} ${name}`)).not.toBeVisible();
     expect(q.dialog.hidden("Dialog")).toBeVisible();
     expect(q.button(`${name} ${name}`)).toHaveFocus();
-    expect(q.dialog("Dialog")).not.toBeInTheDocument();
+    expect(q.dialog.maybe("Dialog")).not.toBeInTheDocument();
     expect(q.dialog(name)).toBeVisible();
     expectModalStyle(true);
     await press.Escape();
-    expect(q.dialog.hidden(name)).not.toBeVisible();
+    expect(q.dialog.maybe.hidden(name)).not.toBeVisible();
     expect(q.button(name)).toHaveFocus();
     expect(q.dialog("Dialog")).toBeVisible();
     expectModalStyle(true);
     await press.Escape();
-    expect(q.dialog("Dialog")).not.toBeInTheDocument();
+    expect(q.dialog.maybe("Dialog")).not.toBeInTheDocument();
     expect(q.button("Open dialog")).toHaveFocus();
     expectModalStyle(false);
   },
@@ -104,31 +104,33 @@ test.each(["nested", "sibling"])(
     await click(q.button(`${name} unmount`));
     expect(q.dialog.hidden("Dialog")).toBeVisible();
     expect(q.button("Close")).toHaveFocus();
-    expect(q.dialog("Dialog")).not.toBeInTheDocument();
+    expect(q.dialog.maybe("Dialog")).not.toBeInTheDocument();
     expect(q.dialog(`${name} unmount`)).toBeVisible();
     expectModalStyle(true);
     await click(q.button(`${name} unmount ${name}`));
     expect(q.dialog.hidden("Dialog")).toBeVisible();
     expect(q.dialog.hidden(`${name} unmount`)).toBeVisible();
     expect(q.button("Close")).toHaveFocus();
-    expect(q.dialog("Dialog")).not.toBeInTheDocument();
-    expect(q.dialog(`${name} unmount`)).not.toBeInTheDocument();
+    expect(q.dialog.maybe("Dialog")).not.toBeInTheDocument();
+    expect(q.dialog.maybe(`${name} unmount`)).not.toBeInTheDocument();
     expect(q.dialog(`${name} unmount ${name}`)).toBeVisible();
     expectModalStyle(true);
     await press.Escape();
-    expect(q.dialog.hidden(`${name} unmount ${name}`)).not.toBeInTheDocument();
+    expect(
+      q.dialog.maybe.hidden(`${name} unmount ${name}`),
+    ).not.toBeInTheDocument();
     expect(q.button(`${name} unmount ${name}`)).toHaveFocus();
     expect(q.dialog.hidden("Dialog")).toBeVisible();
-    expect(q.dialog("Dialog")).not.toBeInTheDocument();
+    expect(q.dialog.maybe("Dialog")).not.toBeInTheDocument();
     expect(q.dialog(`${name} unmount`)).toBeVisible();
     expectModalStyle(true);
     await press.Escape();
-    expect(q.dialog.hidden(`${name} unmount`)).not.toBeInTheDocument();
+    expect(q.dialog.maybe.hidden(`${name} unmount`)).not.toBeInTheDocument();
     expect(q.button(`${name} unmount`)).toHaveFocus();
     expect(q.dialog("Dialog")).toBeVisible();
     expectModalStyle(true);
     await press.Escape();
-    expect(q.dialog.hidden("Dialog")).not.toBeInTheDocument();
+    expect(q.dialog.maybe.hidden("Dialog")).not.toBeInTheDocument();
     expect(q.button("Open dialog")).toHaveFocus();
     expectModalStyle(false);
   },
@@ -161,20 +163,22 @@ test.each(["nested", "sibling"])(
     expect(q.dialog(`${name} no portal ${name}`)).toBeVisible();
     expectModalStyle(true);
     await press.Escape();
-    expect(q.dialog.hidden(`${name} no portal ${name}`)).not.toBeVisible();
+    expect(
+      q.dialog.maybe.hidden(`${name} no portal ${name}`),
+    ).not.toBeVisible();
     expect(q.button(`${name} no portal ${name}`)).toHaveFocus();
     expect(getBackdrop(`${name} no portal ${name}`)).not.toBeVisible();
     expect(maybeNoRole("Dialog")).toBeVisible();
     expect(q.dialog(`${name} no portal`)).toBeVisible();
     expectModalStyle(true);
     await press.Escape();
-    expect(q.dialog.hidden(`${name} no portal`)).not.toBeVisible();
+    expect(q.dialog.maybe.hidden(`${name} no portal`)).not.toBeVisible();
     expect(q.button(`${name} no portal`)).toHaveFocus();
     expect(getBackdrop(`${name} no portal`)).not.toBeVisible();
     expect(q.dialog("Dialog")).toBeVisible();
     expectModalStyle(true);
     await press.Escape();
-    expect(q.dialog("Dialog")).not.toBeInTheDocument();
+    expect(q.dialog.maybe("Dialog")).not.toBeInTheDocument();
     expect(q.button("Open dialog")).toHaveFocus();
     expectModalStyle(false);
   },
@@ -184,32 +188,34 @@ test.each(["nested", "sibling"])(
 test.each(["nested", "sibling"])(
   "show %s no portal portal dialog and hide with escape",
   async (name) => {
-    const maybeNoRole = name === "nested" ? q.none.hidden : q.dialog.hidden;
+    const noRole = name === "nested" ? q.none.hidden : q.dialog.hidden;
+    const maybeNoRole =
+      name === "nested" ? q.none.maybe.hidden : q.dialog.maybe.hidden;
     await click(q.button("Open dialog"));
     await click(q.button(`${name} no portal portal`));
     expect(q.button("Close")).toHaveFocus();
     await press.ShiftTab();
     await press.ShiftTab();
     expect(q.button("Close")).toHaveFocus();
-    expect(maybeNoRole("Dialog")).toBeVisible();
+    expect(noRole("Dialog")).toBeVisible();
     expect(q.dialog(`${name} no portal portal`)).toBeVisible();
     expectModalStyle(true);
     await click(q.button(`${name} no portal portal ${name}`));
-    expect(maybeNoRole("Dialog")).toBeVisible();
+    expect(noRole("Dialog")).toBeVisible();
     expect(q.dialog.hidden(`${name} no portal portal`)).toBeVisible();
     expect(q.button("Close")).toHaveFocus();
     expect(q.dialog(`${name} no portal portal ${name}`)).toBeVisible();
     expectModalStyle(true);
     await press.Escape();
     expect(
-      q.dialog.hidden(`${name} no portal portal ${name}`),
+      q.dialog.maybe.hidden(`${name} no portal portal ${name}`),
     ).not.toBeVisible();
     expect(q.button(`${name} no portal portal ${name}`)).toHaveFocus();
-    expect(maybeNoRole("Dialog")).toBeVisible();
+    expect(noRole("Dialog")).toBeVisible();
     expect(q.dialog(`${name} no portal portal`)).toBeVisible();
     expectModalStyle(true);
     await press.Escape();
-    expect(q.dialog.hidden(`${name} no portal portal`)).not.toBeVisible();
+    expect(q.dialog.maybe.hidden(`${name} no portal portal`)).not.toBeVisible();
     expect(q.button(`${name} no portal portal`)).toHaveFocus();
     expect(q.dialog("Dialog")).toBeVisible();
     expectModalStyle(true);
@@ -228,22 +234,24 @@ test.each(["nested", "sibling"])(
     await click(q.button(`${name} no backdrop`));
     expect(q.dialog.hidden("Dialog")).toBeVisible();
     expect(q.button("Close")).toHaveFocus();
-    expect(q.dialog("Dialog")).not.toBeInTheDocument();
+    expect(q.dialog.maybe("Dialog")).not.toBeInTheDocument();
     expect(q.dialog(`${name} no backdrop`)).toBeVisible();
     expectModalStyle(true);
     await click(q.button(`${name} no backdrop ${name}`));
     expect(q.dialog.hidden("Dialog")).toBeVisible();
     expect(q.dialog.hidden(`${name} no backdrop`)).toBeVisible();
     expect(q.button("Close")).toHaveFocus();
-    expect(q.dialog("Dialog")).not.toBeInTheDocument();
-    expect(q.dialog(`${name} no backdrop`)).not.toBeInTheDocument();
+    expect(q.dialog.maybe("Dialog")).not.toBeInTheDocument();
+    expect(q.dialog.maybe(`${name} no backdrop`)).not.toBeInTheDocument();
     expect(q.dialog(`${name} no backdrop ${name}`)).toBeVisible();
     expectModalStyle(true);
     await click(document.body);
-    expect(q.dialog.hidden("Dialog")).not.toBeInTheDocument();
+    expect(q.dialog.maybe.hidden("Dialog")).not.toBeInTheDocument();
     expect(q.button("Open dialog")).not.toHaveFocus();
-    expect(q.dialog(`${name} no backdrop ${name}`)).not.toBeInTheDocument();
-    expect(q.dialog(`${name} no backdrop`)).not.toBeInTheDocument();
+    expect(
+      q.dialog.maybe(`${name} no backdrop ${name}`),
+    ).not.toBeInTheDocument();
+    expect(q.dialog.maybe(`${name} no backdrop`)).not.toBeInTheDocument();
     expectModalStyle(false);
   },
 );
@@ -255,7 +263,7 @@ test.each(["nested", "sibling"])(
     await click(q.button(`${name} dismiss`));
     await expect.poll(q.button.lazy("Close")).toHaveFocus();
     expect(q.dialog(`${name} dismiss`)).toBeVisible();
-    expect(q.dialog("Dialog")).not.toBeInTheDocument();
+    expect(q.dialog.maybe("Dialog")).not.toBeInTheDocument();
     expectModalStyle(true);
     await click(q.button(`${name} dismiss ${name}`));
     await expect
@@ -266,7 +274,7 @@ test.each(["nested", "sibling"])(
     expectModalStyle(true);
     await press.Escape();
     expect(q.button("Open dialog")).toHaveFocus();
-    expect(q.dialog(`${name} dismiss ${name}`)).not.toBeInTheDocument();
+    expect(q.dialog.maybe(`${name} dismiss ${name}`)).not.toBeInTheDocument();
     expectModalStyle(false);
   },
 );
@@ -276,18 +284,20 @@ test.each(["sibling"])(
   async (name) => {
     await click(q.button("Open dialog"));
     await click(q.button(`${name} dismiss unmount`));
-    expect(q.dialog.hidden("Dialog")).not.toBeInTheDocument();
+    expect(q.dialog.maybe.hidden("Dialog")).not.toBeInTheDocument();
     expect(q.button("Close")).toHaveFocus();
     expect(q.dialog(`${name} dismiss unmount`)).toBeVisible();
     expectModalStyle(true);
     await click(q.button(`${name} dismiss unmount ${name}`));
-    expect(q.dialog.hidden(`${name} dismiss unmount`)).not.toBeInTheDocument();
+    expect(
+      q.dialog.maybe.hidden(`${name} dismiss unmount`),
+    ).not.toBeInTheDocument();
     expect(q.button("Close")).toHaveFocus();
     expect(q.dialog(`${name} dismiss unmount ${name}`)).toBeVisible();
     expectModalStyle(true);
     await press.Escape();
     expect(
-      q.dialog.hidden(`${name} dismiss unmount ${name}`),
+      q.dialog.maybe.hidden(`${name} dismiss unmount ${name}`),
     ).not.toBeInTheDocument();
     expect(q.button("Open dialog")).toHaveFocus();
     expectModalStyle(false);

--- a/app/src/sandbox/dialog-notifications/test.ts
+++ b/app/src/sandbox/dialog-notifications/test.ts
@@ -21,6 +21,6 @@ test("notifications remain interactive while the dialog is modal", async () => {
   expect(q.alert.all()).toHaveLength(0);
   expect(q.dialog("Notification")).toBeVisible();
   await press.Escape();
-  expect(q.dialog("Notification")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Notification")).not.toBeInTheDocument();
   expect(q.button("Show modal")).toHaveFocus();
 });

--- a/app/src/sandbox/dialog-persistent-elements/test.ts
+++ b/app/src/sandbox/dialog-persistent-elements/test.ts
@@ -80,7 +80,7 @@ test("closes on a newly inserted outside element after replacing the dialog", as
   await click(q.button("Add late outside field"));
   await click(q.textbox("Late outside field"));
 
-  await expect.poll(q.dialog.hidden.lazy("Dialog")).not.toBeVisible();
+  await expect.poll(q.dialog.maybe.hidden.lazy("Dialog")).not.toBeVisible();
 });
 
 test("stays open when interacting with a persistent shadow element", async () => {
@@ -131,7 +131,7 @@ test("still closes when interacting outside before the dialog is focused", async
   expect(q.dialog("Dialog")).toBeVisible();
 
   await click(q.textbox("Outside field"));
-  await expect.poll(q.dialog.hidden.lazy("Dialog")).not.toBeVisible();
+  await expect.poll(q.dialog.maybe.hidden.lazy("Dialog")).not.toBeVisible();
 });
 
 test("closes when interacting inside an unrelated shadow root", async () => {
@@ -144,7 +144,7 @@ test("closes when interacting inside an unrelated shadow root", async () => {
     "[data-outside-shadow-field]",
   );
   await click(outsideShadowField || null);
-  await expect.poll(q.dialog.hidden.lazy("Dialog")).not.toBeVisible();
+  await expect.poll(q.dialog.maybe.hidden.lazy("Dialog")).not.toBeVisible();
 });
 
 // Regression for https://github.com/ariakit/ariakit/pull/6810#discussion_r3635034591
@@ -159,7 +159,7 @@ test("closes when interacting with a same-id dialog in another root", async () =
       "[aria-label='Shadow dialog field']",
     );
   await click(shadowDialogField || null);
-  await expect.poll(q.dialog.hidden.lazy("Dialog")).not.toBeVisible();
+  await expect.poll(q.dialog.maybe.hidden.lazy("Dialog")).not.toBeVisible();
 });
 
 // Regression for https://github.com/ariakit/ariakit/pull/6810#discussion_r3635035742
@@ -173,7 +173,7 @@ test("closes on a no-focus outside shadow click", async () => {
       "[data-outside-shadow-button]",
     );
   await click(outsideButton || null);
-  await expect.poll(q.dialog.hidden.lazy("Dialog")).not.toBeVisible();
+  await expect.poll(q.dialog.maybe.hidden.lazy("Dialog")).not.toBeVisible();
 });
 
 // Regression for https://github.com/ariakit/ariakit/pull/6810#discussion_r3635035742

--- a/app/src/sandbox/dialog-reopen-focus-state/test.ts
+++ b/app/src/sandbox/dialog-reopen-focus-state/test.ts
@@ -10,7 +10,7 @@ test("resets outside-interaction focus tracking when reopened", async () => {
   await click(q.textbox("Inside field"));
   expect(q.textbox("Inside field")).toHaveFocus();
   await click(q.button("Close dialog"));
-  await expect.poll(q.dialog.hidden.lazy("Dialog")).not.toBeVisible();
+  await expect.poll(q.dialog.maybe.hidden.lazy("Dialog")).not.toBeVisible();
 
   await click(q.button("Open dialog"));
   expect(q.dialog("Dialog")).toBeVisible();
@@ -20,5 +20,5 @@ test("resets outside-interaction focus tracking when reopened", async () => {
   // as interacting outside and closes the dialog.
   await click(q.button("Reveal outside field"));
   expect(q.textbox("Dynamic outside field")).toHaveFocus();
-  await expect.poll(q.dialog.hidden.lazy("Dialog")).not.toBeVisible();
+  await expect.poll(q.dialog.maybe.hidden.lazy("Dialog")).not.toBeVisible();
 });

--- a/app/src/sandbox/dialog-route-state/test.ts
+++ b/app/src/sandbox/dialog-route-state/test.ts
@@ -2,24 +2,24 @@ import { click, press, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 test("show/hide on disclosure click with mouse", async () => {
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   await click(q.link());
   expect(q.dialog()).toBeVisible();
   expect(q.textbox()).toHaveFocus();
   await click(q.link("Dismiss popup"));
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   expect(q.link()).toHaveFocus();
 });
 
 test("show/hide on disclosure click with keyboard", async () => {
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   await click(q.link());
   expect(q.dialog()).toBeVisible();
   expect(q.textbox()).toHaveFocus();
   await press.ShiftTab();
   expect(q.link()).toHaveFocus();
   await press.Enter();
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   expect(q.link()).toHaveFocus();
 });
 
@@ -27,7 +27,7 @@ test("hide on escape", async () => {
   await click(q.link());
   expect(q.dialog()).toBeVisible();
   await press.Escape();
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   expect(q.link()).toHaveFocus();
 });
 
@@ -39,15 +39,15 @@ test("hide on escape with a persistent nested hovercard", async () => {
 
   await press.Escape();
 
-  expect(q.dialog()).not.toBeInTheDocument();
-  expect(q.text("Feature preview")).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
+  expect(q.text.maybe("Feature preview")).not.toBeInTheDocument();
 });
 
 test("hide on click outside", async () => {
   await click(q.link());
   expect(q.dialog()).toBeVisible();
   await click(document.body);
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   expect(q.link()).toHaveFocus();
 });
 
@@ -56,6 +56,6 @@ test("hide on submit", async () => {
   expect(q.dialog()).toBeVisible();
   await press.Tab();
   await press.Enter();
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   expect(q.link()).toHaveFocus();
 });

--- a/app/src/sandbox/focusable-tab-7153/test.ts
+++ b/app/src/sandbox/focusable-tab-7153/test.ts
@@ -29,20 +29,20 @@ async function middleClickActivates(element: Element) {
 // keeps the gesture away from it, so the `auxclick` never lands on the link.
 
 test("middle click activates an enabled link", async () => {
-  expect(await middleClickActivates(q.link.ensure("Enabled link"))).toBe(true);
+  expect(await middleClickActivates(q.link("Enabled link"))).toBe(true);
 });
 
 test("middle click activates an enabled tab rendered as a link", async () => {
-  expect(await middleClickActivates(q.tab.ensure("Overview"))).toBe(true);
+  expect(await middleClickActivates(q.tab("Overview"))).toBe(true);
 });
 
 // https://github.com/ariakit/ariakit/issues/7153
 test("middle click does not activate an accessible disabled link", async () => {
-  const link = q.link.ensure("Accessible disabled link");
+  const link = q.link("Accessible disabled link");
   expect(await middleClickActivates(link)).toBe(false);
 });
 
 // https://github.com/ariakit/ariakit/issues/7153
 test("middle click does not activate a disabled tab rendered as a link", async () => {
-  expect(await middleClickActivates(q.tab.ensure("Billing"))).toBe(false);
+  expect(await middleClickActivates(q.tab("Billing"))).toBe(false);
 });

--- a/app/src/sandbox/form-6307/test.ts
+++ b/app/src/sandbox/form-6307/test.ts
@@ -4,7 +4,7 @@ import { expect, test } from "vitest";
 // Reproduces https://github.com/ariakit/ariakit/issues/6307
 
 test("a successful submit does not steal focus on later items changes", async () => {
-  const email = q.textbox.ensure("Email");
+  const email = q.textbox("Email");
 
   // 1. Submit with the email empty: the submission fails and the invalid email
   //    field is focused (correct autoFocusOnSubmit behavior).

--- a/app/src/sandbox/form-callback-queue/test.ts
+++ b/app/src/sandbox/form-callback-queue/test.ts
@@ -5,6 +5,10 @@ const validationError = () =>
   q.text(
     "Constraints not satisfied - Field 1 - Field 2 - Abstract Form - Form",
   );
+const maybeValidationError = () =>
+  q.text.maybe(
+    "Constraints not satisfied - Field 1 - Field 2 - Abstract Form - Form",
+  );
 const submitErrors = () =>
   q.text.all("Field - Abstract Form 1 - Abstract Form 2 - Form 1 - Form 2");
 
@@ -12,7 +16,7 @@ test("validation on sync input", async () => {
   const input = q.textbox.all().at(0);
   if (!input) throw new Error("Missing textbox");
   await click(input);
-  expect(validationError()).not.toBeInTheDocument();
+  expect(maybeValidationError()).not.toBeInTheDocument();
   await click(document.body);
   expect(validationError()).toBeInTheDocument();
 });
@@ -21,7 +25,7 @@ test("validation on async input", async () => {
   const input = q.textbox.all().at(1);
   if (!input) throw new Error("Missing textbox");
   await click(input);
-  expect(validationError()).not.toBeInTheDocument();
+  expect(maybeValidationError()).not.toBeInTheDocument();
   await click(document.body);
   expect(validationError()).toBeInTheDocument();
 });

--- a/app/src/sandbox/form-radio/test.ts
+++ b/app/src/sandbox/form-radio/test.ts
@@ -13,14 +13,14 @@ test("focus on the first radio button by tabbing", async () => {
 
 test("show error on blur", async () => {
   await press.Tab();
-  expect(q.text("Please select a color.")).not.toBeInTheDocument();
+  expect(q.text.maybe("Please select a color.")).not.toBeInTheDocument();
   await press.Tab();
   expect(q.button("Submit")).toHaveFocus();
   expect(q.text("Please select a color.")).toBeInTheDocument();
 });
 
 test("show error on submit", async () => {
-  expect(q.text("Please select a color.")).not.toBeInTheDocument();
+  expect(q.text.maybe("Please select a color.")).not.toBeInTheDocument();
   await click(q.button("Submit"));
   expect(q.text("Please select a color.")).toBeInTheDocument();
 });
@@ -39,7 +39,7 @@ test("fix error on change", async () => {
   expect(q.radio("Blue")).toHaveFocus();
   expect(q.text("Please select a color.")).toBeInTheDocument();
   await press.Space();
-  expect(q.text("Please select a color.")).not.toBeInTheDocument();
+  expect(q.text.maybe("Please select a color.")).not.toBeInTheDocument();
 });
 
 test("submit form", async () => {

--- a/app/src/sandbox/form-select/test.ts
+++ b/app/src/sandbox/form-select/test.ts
@@ -8,7 +8,7 @@ test("click on label", async () => {
   await click(q.text("Favorite fruit"));
   expect(q.combobox()).toHaveFocus();
   expect(q.combobox()).toHaveAttribute("data-focus-visible");
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
 });
 
 test("show error on tabbing through select button", async () => {
@@ -43,7 +43,7 @@ test("submit failed", async () => {
   await click(q.button("Submit"));
   expect(errors()).toHaveLength(1);
   expect(q.combobox()).toHaveFocus();
-  expect(q.listbox()).not.toBeInTheDocument();
+  expect(q.listbox.maybe()).not.toBeInTheDocument();
 });
 
 test("submit succeed", async () => {

--- a/app/src/sandbox/hovercard-disclosure-interactions/test.ts
+++ b/app/src/sandbox/hovercard-disclosure-interactions/test.ts
@@ -41,7 +41,7 @@ for (const trigger of ["click", "Enter", "Space"] as const) {
     } else {
       await press.Space(disclosure());
     }
-    expect(q.dialog("Ariakit")).not.toBeInTheDocument();
+    expect(q.dialog.maybe("Ariakit")).not.toBeInTheDocument();
     expect(disclosure()).toHaveFocus();
   });
 }
@@ -51,7 +51,7 @@ test("Escape restores focus to the anchor", async () => {
   await press.Tab();
   await press.Enter();
   await press.Escape();
-  expect(q.dialog("Ariakit")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Ariakit")).not.toBeInTheDocument();
   expect(q.link("@ariakit.com")).toHaveFocus();
 });
 

--- a/app/src/sandbox/hovercard-interactions/test.ts
+++ b/app/src/sandbox/hovercard-interactions/test.ts
@@ -2,6 +2,7 @@ import { click, dispatch, hover, press, q, sleep } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 const hovercard = () => q.dialog("Ariakit profile");
+const maybeHovercard = () => q.dialog.maybe("Ariakit profile");
 
 const hoverOutside = async () => {
   await hover(document.body);
@@ -10,17 +11,17 @@ const hoverOutside = async () => {
 
 // https://github.com/ariakit/ariakit/issues/7043
 test("shows after hovering and hides after hovering outside", async () => {
-  expect(hovercard()).not.toBeInTheDocument();
+  expect(maybeHovercard()).not.toBeInTheDocument();
 
   // Dispatch directly so the assertions run before the timeout can expire
   // when the full suite delays the interaction helper.
   await dispatch.mouseMove(q.link("@ariakit.com"));
-  expect(hovercard()).not.toBeInTheDocument();
+  expect(maybeHovercard()).not.toBeInTheDocument();
   await expect.poll(hovercard).toBeVisible();
 
   await dispatch.mouseMove(document.body);
   expect(hovercard()).toBeVisible();
-  await expect.poll(hovercard).not.toBeInTheDocument();
+  await expect.poll(maybeHovercard).not.toBeInTheDocument();
 });
 
 test("stays open while focused", async () => {
@@ -57,7 +58,7 @@ test("Escape closes an unfocused hovercard without moving focus", async () => {
   await expect.poll(hovercard).toBeVisible();
 
   await press.Escape();
-  expect(hovercard()).not.toBeInTheDocument();
+  expect(maybeHovercard()).not.toBeInTheDocument();
   expect(anchor).not.toHaveFocus();
 });
 
@@ -68,6 +69,6 @@ test("Escape closes a focused hovercard and restores the anchor", async () => {
   await click(q.button("Follow"));
 
   await press.Escape();
-  expect(hovercard()).not.toBeInTheDocument();
+  expect(maybeHovercard()).not.toBeInTheDocument();
   expect(anchor).toHaveFocus();
 });

--- a/app/src/sandbox/hovercard-nested-listener/test.ts
+++ b/app/src/sandbox/hovercard-nested-listener/test.ts
@@ -3,7 +3,7 @@ import { expect, test } from "vitest";
 
 // See https://github.com/ariakit/ariakit/pull/6143
 const installCount = () =>
-  q.status.ensure("Parent hovercard mousemove listener installs").textContent;
+  q.status("Parent hovercard mousemove listener installs").textContent;
 
 test("toggling a nested hovercard does not reinstall the parent mousemove listener", async () => {
   expect(q.dialog("Parent hovercard")).toBeVisible();
@@ -16,7 +16,9 @@ test("toggling a nested hovercard does not reinstall the parent mousemove listen
 
   // Unmounting the nested hovercard must not reinstall it either.
   await click(q.button("Toggle nested"));
-  await expect.poll(q.dialog.lazy("Nested hovercard")).not.toBeInTheDocument();
+  await expect
+    .poll(q.dialog.maybe.lazy("Nested hovercard"))
+    .not.toBeInTheDocument();
   expect(installCount()).toBe(initialInstalls);
 });
 
@@ -31,6 +33,8 @@ test("closes nested hovercard on Escape when focus is outside", async () => {
   expect(q.dialog("Nested hovercard")).toBeVisible();
 
   await press.Escape();
-  await expect.poll(q.dialog.lazy("Nested hovercard")).not.toBeInTheDocument();
+  await expect
+    .poll(q.dialog.maybe.lazy("Nested hovercard"))
+    .not.toBeInTheDocument();
   expect(q.dialog("Parent hovercard")).toBeVisible();
 });

--- a/app/src/sandbox/menu-always-visible/test.ts
+++ b/app/src/sandbox/menu-always-visible/test.ts
@@ -3,8 +3,8 @@ import { expect, test } from "vitest";
 
 // https://github.com/ariakit/ariakit/issues/6986
 test("moves focus through the menu while its store is closed", async () => {
-  const save = q.menuitem.ensure("Save");
-  const close = q.menuitem.ensure("Close");
+  const save = q.menuitem("Save");
+  const close = q.menuitem("Close");
 
   await click(save);
   expect(save).toHaveFocus();

--- a/app/src/sandbox/menu-button-disabled/test.ts
+++ b/app/src/sandbox/menu-button-disabled/test.ts
@@ -16,7 +16,7 @@ test("disabled menu button does not open its menu on hover", async () => {
   // its portal mounts, which is the wait the test above measures. Cross it to
   // give the assertion below a chance to fail.
   await sleep();
-  expect(q.menu("Hover MenuButton props")).not.toBeInTheDocument();
+  expect(q.menu.maybe("Hover MenuButton props")).not.toBeInTheDocument();
 });
 
 // https://github.com/ariakit/ariakit/issues/7115
@@ -24,14 +24,14 @@ test("disabled rendered button does not open its menu on hover", async () => {
   await hover(q.button("Hover render props"));
   // Same portal-mount wait as the test above.
   await sleep();
-  expect(q.menu("Hover render props")).not.toBeInTheDocument();
+  expect(q.menu.maybe("Hover render props")).not.toBeInTheDocument();
 });
 
 test("public hook keeps the false default when the option is an own undefined value", async () => {
   await hover(q.button("Hover hook undefined"));
   // Same portal-mount wait as the tests above.
   await sleep();
-  expect(q.menu("Hover hook undefined")).not.toBeInTheDocument();
+  expect(q.menu.maybe("Hover hook undefined")).not.toBeInTheDocument();
 });
 
 test("disabled menu button opens its menu on hover when the consumer opts in", async () => {
@@ -49,5 +49,5 @@ test("opting in does not open the menu on hover for a truly disabled button", as
   await hover(q.button("Hover opted in truly disabled"));
   // Same portal-mount wait as the tests above.
   await sleep();
-  expect(q.menu("Hover opted in truly disabled")).not.toBeInTheDocument();
+  expect(q.menu.maybe("Hover opted in truly disabled")).not.toBeInTheDocument();
 });

--- a/app/src/sandbox/menu-combobox-interactions/test.ts
+++ b/app/src/sandbox/menu-combobox-interactions/test.ts
@@ -9,21 +9,21 @@ const cases = [
 describe.each(cases)("%s", (buttonLabel, searchLabel) => {
   test("show/hide on click", async () => {
     const button = q.button(buttonLabel);
-    expect(q.dialog(buttonLabel)).not.toBeInTheDocument();
+    expect(q.dialog.maybe(buttonLabel)).not.toBeInTheDocument();
     await click(button);
     expect(q.dialog(buttonLabel)).toBeVisible();
     expect(q.dialog(buttonLabel)).not.toHaveFocus();
     expect(q.combobox(searchLabel)).toHaveFocus();
     expect(q.option("Paragraph")).not.toHaveFocus();
     await click(button);
-    expect(q.dialog(buttonLabel)).not.toBeInTheDocument();
+    expect(q.dialog.maybe(buttonLabel)).not.toBeInTheDocument();
     expect(button).toHaveFocus();
   });
 
   test("show/hide on enter", async () => {
     const button = q.button(buttonLabel);
     await focus(button);
-    expect(q.dialog(buttonLabel)).not.toBeInTheDocument();
+    expect(q.dialog.maybe(buttonLabel)).not.toBeInTheDocument();
     await press.Enter();
     expect(q.dialog(buttonLabel)).toBeVisible();
     expect(q.dialog(buttonLabel)).not.toHaveFocus();
@@ -32,7 +32,7 @@ describe.each(cases)("%s", (buttonLabel, searchLabel) => {
     await press.ShiftTab();
     expect(button).toHaveFocus();
     await press.Enter();
-    expect(q.dialog(buttonLabel)).not.toBeInTheDocument();
+    expect(q.dialog.maybe(buttonLabel)).not.toBeInTheDocument();
     expect(button).toHaveFocus();
   });
 
@@ -47,7 +47,7 @@ describe.each(cases)("%s", (buttonLabel, searchLabel) => {
     await press.ShiftTab();
     expect(button).toHaveFocus();
     await press.Space();
-    expect(q.dialog(buttonLabel)).not.toBeInTheDocument();
+    expect(q.dialog.maybe(buttonLabel)).not.toBeInTheDocument();
     expect(button).toHaveFocus();
   });
 
@@ -77,11 +77,11 @@ describe.each(cases)("%s", (buttonLabel, searchLabel) => {
     await type("c");
     expect(q.option("Classic")).toHaveFocus();
     await type("o");
-    expect(q.option("Classic")).not.toBeInTheDocument();
+    expect(q.option.maybe("Classic")).not.toBeInTheDocument();
     expect(q.option("Code")).toHaveFocus();
     await type("ver");
     expect(q.combobox(searchLabel)).toHaveValue("cover");
-    expect(q.option("Code")).not.toBeInTheDocument();
+    expect(q.option.maybe("Code")).not.toBeInTheDocument();
     expect(q.option("Cover")).toHaveFocus();
     await press.Escape();
     expect(button).toHaveFocus();

--- a/app/src/sandbox/menu-context-interactions/test.ts
+++ b/app/src/sandbox/menu-context-interactions/test.ts
@@ -2,21 +2,21 @@ import { click, press, q, rightClick } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 test("show context menu and hide it with escape", async () => {
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
   await rightClick(q.text("Right click here"));
   await expect.poll(q.menu).toHaveFocus();
   expect(q.menu()).toBeVisible();
   await rightClick(q.text("Right click here"));
   await expect.poll(q.menu).toBeVisible();
   await press.Escape();
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
 });
 
 test("show context menu and hide it by clicking outside", async () => {
   await rightClick(q.text("Right click here"));
   await expect.poll(q.menu).toBeVisible();
   await click(document.body);
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
 });
 
 test("navigate through context menu with keyboard", async () => {

--- a/app/src/sandbox/menu-core-interactions/test.ts
+++ b/app/src/sandbox/menu-core-interactions/test.ts
@@ -4,13 +4,13 @@ import { expect, test, vi } from "vitest";
 const spyOnAlert = () => vi.spyOn(window, "alert").mockImplementation(() => {});
 
 test("show/hide on click", async () => {
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
   await click(q.button("Actions"));
   expect(q.menu()).toBeVisible();
   expect(q.menu()).toHaveFocus();
   expect(q.menuitem("Edit")).not.toHaveFocus();
   await click(q.button("Actions"));
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
   expect(q.button("Actions")).toHaveFocus();
 });
 
@@ -23,7 +23,7 @@ test("show/hide on enter", async () => {
   await press.ShiftTab();
   expect(q.menu()).toBeVisible();
   await press.Enter();
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
 });
 
 test("show/hide on space", async () => {
@@ -37,7 +37,7 @@ test("show/hide on space", async () => {
   await press.ShiftTab();
   expect(q.menu()).toBeVisible();
   await press.Space();
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
 });
 
 test("show on arrow down", async () => {
@@ -58,27 +58,27 @@ test("hide on escape", async () => {
   await click(q.button("Actions"));
   expect(q.menu()).toBeVisible();
   await press.Escape();
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
   expect(q.button("Actions")).toHaveFocus();
   await press.Enter();
   expect(q.menu()).toBeVisible();
   await press.Escape();
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
   expect(q.button("Actions")).toHaveFocus();
   await press.Space();
   expect(q.menu()).toBeVisible();
   await press.Escape();
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
   expect(q.button("Actions")).toHaveFocus();
   await press.ArrowDown();
   expect(q.menu()).toBeVisible();
   await press.Escape();
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
   expect(q.button("Actions")).toHaveFocus();
   await press.ArrowUp();
   expect(q.menu()).toBeVisible();
   await press.Escape();
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
   expect(q.button("Actions")).toHaveFocus();
 });
 
@@ -86,7 +86,7 @@ test("hide on click outside", async () => {
   await click(q.button("Actions"));
   expect(q.menu()).toBeVisible();
   await click(document.body);
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
   expect(q.button("Actions")).not.toHaveFocus();
 });
 
@@ -98,7 +98,7 @@ test("hide on click on outside element", async () => {
   await click(q.button("Actions"));
   expect(q.menu()).toBeVisible();
   await click(q.text("Outside"));
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
   expect(q.text("Outside")).toHaveFocus();
 
   buttonOutside.remove();
@@ -112,7 +112,7 @@ test("hide on tab", async () => {
   await click(q.button("Actions"));
   expect(q.menu()).toBeVisible();
   await press.Tab();
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
   expect(q.text("Outside")).toHaveFocus();
 
   buttonOutside.remove();
@@ -172,7 +172,7 @@ test("menu item click", async () => {
   expect(alert).toHaveBeenCalledTimes(0);
   await click(q.menuitem("Edit"));
   expect(alert).toHaveBeenCalledTimes(1);
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
   expect(q.button("Actions")).toHaveFocus();
 });
 
@@ -183,7 +183,7 @@ test("menu item enter", async () => {
   expect(alert).toHaveBeenCalledTimes(0);
   await press.Enter();
   expect(alert).toHaveBeenCalledTimes(1);
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
   expect(q.button("Actions")).toHaveFocus();
 });
 
@@ -194,7 +194,7 @@ test("menu item space", async () => {
   expect(alert).toHaveBeenCalledTimes(0);
   await press.Space();
   expect(alert).toHaveBeenCalledTimes(1);
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
   expect(q.button("Actions")).toHaveFocus();
 });
 
@@ -207,7 +207,7 @@ test("menu item hover enter", async () => {
   await hover(q.menuitem("Edit"));
   await press.Enter();
   expect(alert).toHaveBeenCalledTimes(1);
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
   expect(q.button("Actions")).toHaveFocus();
 });
 
@@ -220,7 +220,7 @@ test("menu item hover space", async () => {
   await hover(q.menuitem("Edit"));
   await press.Space();
   expect(alert).toHaveBeenCalledTimes(1);
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
   expect(q.button("Actions")).toHaveFocus();
 });
 
@@ -234,7 +234,7 @@ test("typeahead", async () => {
 });
 
 test("https://github.com/ariakit/ariakit/issues/3342", async () => {
-  const button = q.button.ensure("Actions");
+  const button = q.button("Actions");
   await click(button);
   const nextSibling = button.nextElementSibling;
   expect(nextSibling).toBe(q.menu()?.parentElement);

--- a/app/src/sandbox/menu-motion-transitions/test.ts
+++ b/app/src/sandbox/menu-motion-transitions/test.ts
@@ -2,18 +2,18 @@ import { click, press, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 test("show/hide on click", async () => {
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
   await click(q.button("Options"));
   expect(q.menu()).toBeVisible();
   expect(q.menu()).toHaveFocus();
   await click(q.button("Options"));
   expect(q.button("Options")).toHaveFocus();
   expect(q.menu.hidden()).toBeVisible();
-  await expect.poll(q.menu).not.toBeInTheDocument();
+  await expect.poll(q.menu.maybe).not.toBeInTheDocument();
 });
 
 test("show/hide on enter", async () => {
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
   await press.Tab();
   await press.Enter();
   expect(q.menu()).toBeVisible();
@@ -22,11 +22,11 @@ test("show/hide on enter", async () => {
   await press.Enter();
   expect(q.button("Options")).toHaveFocus();
   expect(q.menu()).toBeVisible();
-  await expect.poll(q.menu).not.toBeInTheDocument();
+  await expect.poll(q.menu.maybe).not.toBeInTheDocument();
 });
 
 test("show/hide on space", { retry: 2 }, async () => {
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
   await press.Tab();
   await press.Space();
   expect(q.menu()).toBeVisible();
@@ -35,23 +35,23 @@ test("show/hide on space", { retry: 2 }, async () => {
   await press.Space();
   expect(q.button("Options")).toHaveFocus();
   expect(q.menu.hidden()).toBeVisible();
-  await expect.poll(q.menu).not.toBeInTheDocument();
+  await expect.poll(q.menu.maybe).not.toBeInTheDocument();
 });
 
 test("hide on esc", async () => {
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
   await click(q.button("Options"));
   await press.Escape();
   expect(q.button("Options")).toHaveFocus();
   expect(q.menu()).toBeVisible();
-  await expect.poll(q.menu).not.toBeInTheDocument();
+  await expect.poll(q.menu.maybe).not.toBeInTheDocument();
 });
 
 test("hide on click outside", async () => {
-  expect(q.menu()).not.toBeInTheDocument();
+  expect(q.menu.maybe()).not.toBeInTheDocument();
   await click(q.button("Options"));
   await click(document.body);
   expect(q.button("Options")).not.toHaveFocus();
   expect(q.menu.hidden()).toBeVisible();
-  await expect.poll(q.menu).not.toBeInTheDocument();
+  await expect.poll(q.menu.maybe).not.toBeInTheDocument();
 });

--- a/app/src/sandbox/menu-nested-interactions/test.ts
+++ b/app/src/sandbox/menu-nested-interactions/test.ts
@@ -2,10 +2,10 @@ import { click, hover, press, q, sleep, type } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 test("show/hide submenu on click", async () => {
-  expect(q.menu("Edit")).not.toBeInTheDocument();
+  expect(q.menu.maybe("Edit")).not.toBeInTheDocument();
   await click(q.button("Edit"));
   expect(q.menu("Edit")).toBeVisible();
-  expect(q.menu("Find")).not.toBeInTheDocument();
+  expect(q.menu.maybe("Find")).not.toBeInTheDocument();
   await click(q.menuitem("Find"));
   expect(q.menu("Find")).toBeVisible();
   expect(q.menuitem("Find")).toHaveFocus();
@@ -13,7 +13,7 @@ test("show/hide submenu on click", async () => {
   expect(q.menu("Find")).toBeVisible();
   expect(q.menuitem("Find")).toHaveFocus();
   await click(q.menuitem("Find Next"));
-  expect(q.menu("Edit")).not.toBeInTheDocument();
+  expect(q.menu.maybe("Edit")).not.toBeInTheDocument();
   expect(q.button("Edit")).toHaveFocus();
 });
 
@@ -22,13 +22,13 @@ test("show/hide submenu on enter", async () => {
   await press.Enter();
   await type("f");
   expect(q.menuitem("Find")).toHaveFocus();
-  expect(q.menu("Find")).not.toBeInTheDocument();
+  expect(q.menu.maybe("Find")).not.toBeInTheDocument();
   await press.Enter();
   expect(q.menu("Find")).toBeVisible();
   expect(q.menuitem("Search the Web...")).toHaveFocus();
   await press.Enter();
-  expect(q.menu("Edit")).not.toBeInTheDocument();
-  expect(q.menu("Find")).not.toBeInTheDocument();
+  expect(q.menu.maybe("Edit")).not.toBeInTheDocument();
+  expect(q.menu.maybe("Find")).not.toBeInTheDocument();
   expect(q.button("Edit")).toHaveFocus();
 });
 
@@ -38,15 +38,15 @@ test("show/hide submenu on space", async () => {
   await sleep();
   await type("s");
   expect(q.menuitem("Speech")).toHaveFocus();
-  expect(q.menu("Speech")).not.toBeInTheDocument();
+  expect(q.menu.maybe("Speech")).not.toBeInTheDocument();
   // Wait for typeahead delay
   await sleep(600);
   await press.Space();
   expect(q.menu("Speech")).toBeVisible();
   expect(q.menuitem("Start Speaking")).toHaveFocus();
   await press.Space();
-  expect(q.menu("Edit")).not.toBeInTheDocument();
-  expect(q.menu("Speech")).not.toBeInTheDocument();
+  expect(q.menu.maybe("Edit")).not.toBeInTheDocument();
+  expect(q.menu.maybe("Speech")).not.toBeInTheDocument();
   expect(q.button("Edit")).toHaveFocus();
 });
 
@@ -55,7 +55,7 @@ test("show/hide submenu on arrow keys", async () => {
   await press.Enter();
   await type("f");
   await press.ArrowLeft();
-  expect(q.menu("Find")).not.toBeInTheDocument();
+  expect(q.menu.maybe("Find")).not.toBeInTheDocument();
   await press.ArrowRight();
   expect(q.menu("Find")).toBeVisible();
   expect(q.menuitem("Search the Web...")).toHaveFocus();
@@ -72,14 +72,14 @@ test("show/hide submenu on arrow keys", async () => {
   expect(q.menuitem("Find Previous")).toHaveFocus();
   await press.ArrowLeft();
   expect(q.menuitem("Find")).toHaveFocus();
-  expect(q.menu("Find")).not.toBeInTheDocument();
+  expect(q.menu.maybe("Find")).not.toBeInTheDocument();
 });
 
 test("show/hide submenu on mouse hover", async () => {
   await click(q.button("Edit"));
   await hover(q.menuitem("Find"));
   expect(q.menuitem("Find")).toHaveFocus();
-  expect(q.menu("Find")).not.toBeInTheDocument();
+  expect(q.menu.maybe("Find")).not.toBeInTheDocument();
   await expect.poll(q.menu.lazy("Find")).toBeVisible();
   expect(q.menuitem("Find")).toHaveFocus();
   await hover(q.menuitem("Find Next"));
@@ -88,8 +88,8 @@ test("show/hide submenu on mouse hover", async () => {
   expect(q.menuitem("Find Next")).toHaveAttribute("data-active-item");
   await hover(q.menuitem("Speech"));
   expect(q.menuitem("Speech")).toHaveFocus();
-  expect(q.menu("Find")).not.toBeInTheDocument();
-  expect(q.menu("Speech")).not.toBeInTheDocument();
+  expect(q.menu.maybe("Find")).not.toBeInTheDocument();
+  expect(q.menu.maybe("Speech")).not.toBeInTheDocument();
   await expect.poll(q.menu.lazy("Speech")).toBeVisible();
 });
 
@@ -98,8 +98,8 @@ test("hide submenu on escape", async () => {
   await click(q.menuitem("Find"));
   await hover(q.menuitem("Find Next"));
   await press.Escape();
-  expect(q.menu("Find")).not.toBeInTheDocument();
-  expect(q.menu("Edit")).not.toBeInTheDocument();
+  expect(q.menu.maybe("Find")).not.toBeInTheDocument();
+  expect(q.menu.maybe("Edit")).not.toBeInTheDocument();
   expect(q.button("Edit")).toHaveFocus();
 });
 
@@ -119,6 +119,6 @@ test("blur submenu button on mouse leave after hovering over disabled submenu it
   await hover(q.menuitem("Speech"));
   await hover(await q.menuitem.wait("Stop Speaking"));
   await hover(document.body);
-  expect(q.menu("Speech")).not.toBeInTheDocument();
+  expect(q.menu.maybe("Speech")).not.toBeInTheDocument();
   expect(q.menuitem("Speech")).not.toHaveAttribute("data-active-item");
 });

--- a/app/src/sandbox/menu-nested-search-interactions/test.ts
+++ b/app/src/sandbox/menu-nested-search-interactions/test.ts
@@ -6,7 +6,7 @@ test("open/hide menu", async () => {
   expect(q.dialog("Actions")).toBeVisible();
   expect(q.combobox("Search actions...")).toHaveFocus();
   await click(q.button("Actions"));
-  expect(q.dialog("Actions")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Actions")).not.toBeInTheDocument();
   expect(q.button("Actions")).toHaveFocus();
 });
 
@@ -17,7 +17,7 @@ test("open/hide menu with keyboard", async () => {
   expect(q.combobox("Search actions...")).toHaveFocus();
   expect(q.option("Ask AI")).toHaveFocus();
   await press.Escape();
-  expect(q.dialog("Actions")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Actions")).not.toBeInTheDocument();
   expect(q.button("Actions")).toHaveFocus();
 });
 
@@ -43,7 +43,7 @@ test("reset filter on hide", async () => {
   await type("a");
   expect(q.combobox("Search actions...")).toHaveValue("a");
   await click(document.body);
-  expect(q.dialog("Actions")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Actions")).not.toBeInTheDocument();
   expect(q.button("Actions")).not.toHaveFocus();
   await click(q.button("Actions"));
   expect(q.combobox("Search actions...")).toHaveValue("");
@@ -55,7 +55,7 @@ test("open/hide with search submenu", async () => {
   await hover(option);
   expect(option).toHaveFocus();
   expect(option).toHaveAttribute("aria-expanded", "false");
-  expect(q.dialog("Turn into page in")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Turn into page in")).not.toBeInTheDocument();
   expect(await q.dialog.wait("Turn into page in")).toBeVisible();
   // Testing blurOnHoverEnd={false}
   await hover(document.body);
@@ -67,7 +67,7 @@ test("open/hide with search submenu", async () => {
   expect(q.combobox("Search pages to add in...")).toHaveFocus();
   expect(q.option("Private pages")).toHaveFocus();
   await press.ArrowLeft();
-  expect(q.dialog("Turn into page in")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Turn into page in")).not.toBeInTheDocument();
   expect(option).toHaveFocus();
   expect(option).toHaveAttribute("aria-expanded", "false");
   expect(q.combobox("Search actions...")).toHaveFocus();
@@ -80,8 +80,8 @@ test("open/hide with search submenu", async () => {
   await hover(q.option("Private pages"));
   await press.Escape();
   expect(q.button("Actions")).toHaveFocus();
-  expect(q.dialog("Actions")).not.toBeInTheDocument();
-  expect(q.dialog("Turn into page in")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Actions")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Turn into page in")).not.toBeInTheDocument();
 });
 
 test("tab in/out search menu", async () => {
@@ -110,13 +110,13 @@ test("set block type", async () => {
   expect(q.menuitemradio("Text")).toHaveAttribute("aria-checked", "true");
   await type("cc");
   await press.Enter();
-  expect(q.dialog("Actions")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Actions")).not.toBeInTheDocument();
   expect(q.text("Callout")).toBeInTheDocument();
   await press.Enter();
   await type("Turn into");
   expect(q.option("Text not checked")).toHaveFocus();
   expect(q.option("Callout checked")).toBeInTheDocument();
   await press.Enter();
-  expect(q.dialog("Actions")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Actions")).not.toBeInTheDocument();
   expect(q.text("Text")).toBeInTheDocument();
 });

--- a/app/src/sandbox/menu-placing-pass/test.ts
+++ b/app/src/sandbox/menu-placing-pass/test.ts
@@ -24,7 +24,7 @@ test("leaves focus outside after a focused item is replaced", async () => {
   const withinMenu = q.within(q.menu("Replacement actions"));
   await focus(withinMenu.menuitem("Action 1"));
   await press.End();
-  const item = withinMenu.menuitem.ensure("Action 30");
+  const item = withinMenu.menuitem("Action 30");
   expect(item).toHaveFocus();
 
   await blur(item);
@@ -44,7 +44,7 @@ test("restores focus when a refocused item is replaced", async () => {
   const withinMenu = q.within(menu);
   await focus(withinMenu.menuitem("Action 1"));
   await press.End();
-  const item = withinMenu.menuitem.ensure("Action 30");
+  const item = withinMenu.menuitem("Action 30");
   expect(item).toHaveFocus();
   expect(menu).toHaveAttribute("data-placing");
   await blur(item);

--- a/app/src/sandbox/menu-tooltip-variants/test.ts
+++ b/app/src/sandbox/menu-tooltip-variants/test.ts
@@ -25,7 +25,7 @@ describe.each(labels)("%s", (label) => {
     await hover(q.button(label));
     expect(await q.tooltip.wait(label)).toBeVisible();
     await hoverOutside();
-    expect(q.tooltip(label)).not.toBeInTheDocument();
+    expect(q.tooltip.maybe(label)).not.toBeInTheDocument();
   });
 
   test("hide tooltip by clicking on menu button", async () => {
@@ -34,7 +34,7 @@ describe.each(labels)("%s", (label) => {
     await click(q.button(label));
     expect(q.menu(label)).toBeVisible();
     expect(q.menu(label)).toHaveFocus();
-    expect(q.tooltip(label)).not.toBeInTheDocument();
+    expect(q.tooltip.maybe(label)).not.toBeInTheDocument();
   });
 
   test("do not show tooltip on hover after clicking on menu button", async () => {
@@ -42,10 +42,10 @@ describe.each(labels)("%s", (label) => {
     expect(await q.tooltip.wait(label)).toBeVisible();
     await click(q.button(label));
     expect(q.menu(label)).toBeVisible();
-    expect(q.tooltip(label)).not.toBeInTheDocument();
+    expect(q.tooltip.maybe(label)).not.toBeInTheDocument();
     await hover(q.button.hidden(label));
     await hover(q.button.hidden(label));
-    expect(q.tooltip(label)).not.toBeInTheDocument();
+    expect(q.tooltip.maybe(label)).not.toBeInTheDocument();
   });
 
   test("but show tooltip on hover after clicking on menu button and then hovering outside unless it's modal", async () => {
@@ -53,12 +53,12 @@ describe.each(labels)("%s", (label) => {
     expect(await q.tooltip.wait(label)).toBeVisible();
     await click(q.button(label));
     expect(q.menu(label)).toBeVisible();
-    expect(q.tooltip(label)).not.toBeInTheDocument();
+    expect(q.tooltip.maybe(label)).not.toBeInTheDocument();
     await hoverOutside();
     await hover(q.button.hidden(label));
     await hover(q.button.hidden(label));
     if (label.includes("modal")) {
-      expect(q.tooltip(label)).not.toBeInTheDocument();
+      expect(q.tooltip.maybe(label)).not.toBeInTheDocument();
     } else {
       expect(await q.tooltip.wait(label)).toBeVisible();
     }
@@ -68,7 +68,7 @@ describe.each(labels)("%s", (label) => {
     await click(q.button(label));
     expect(q.menu(label)).toBeVisible();
     await press.Escape();
-    expect(q.menu(label)).not.toBeInTheDocument();
+    expect(q.menu.maybe(label)).not.toBeInTheDocument();
     expect(await q.tooltip.wait(label)).toBeVisible();
   });
 });
@@ -79,14 +79,14 @@ describe.each(nonModalLabels)("%s", (label) => {
     expect(await q.tooltip.wait(label)).toBeVisible();
     await click(q.button(label));
     expect(q.menu(label)).toBeVisible();
-    expect(q.tooltip(label)).not.toBeInTheDocument();
+    expect(q.tooltip.maybe(label)).not.toBeInTheDocument();
     await hoverOutside();
     await hover(q.button(label));
     expect(await q.tooltip.wait(label)).toBeVisible();
     await click(q.button(label));
     await click(q.button(label));
     expect(q.menu(label)).toBeVisible();
-    expect(q.tooltip(label)).not.toBeInTheDocument();
+    expect(q.tooltip.maybe(label)).not.toBeInTheDocument();
   });
 
   describe("with timeout", () => {
@@ -98,17 +98,17 @@ describe.each(nonModalLabels)("%s", (label) => {
 
     test("do not show tooltip with timeout after clicking on menu button before the tooltip is shown", async () => {
       await hover(q.button(label));
-      expect(q.tooltip(label)).not.toBeInTheDocument();
+      expect(q.tooltip.maybe(label)).not.toBeInTheDocument();
       await click(q.button(label));
       expect(q.menu(label)).toBeVisible();
-      expect(q.tooltip(label)).not.toBeInTheDocument();
+      expect(q.tooltip.maybe(label)).not.toBeInTheDocument();
       await hover(q.button(label), { movementX: 10, movementY: 10 });
       await sleep(200);
-      expect(q.tooltip(label)).not.toBeInTheDocument();
+      expect(q.tooltip.maybe(label)).not.toBeInTheDocument();
       // Can show tooltip after the mouse re-enters the anchor.
       await hoverOutside();
       await hover(q.button(label));
-      expect(q.tooltip(label)).not.toBeInTheDocument();
+      expect(q.tooltip.maybe(label)).not.toBeInTheDocument();
       expect(await q.tooltip.wait(label)).toBeVisible();
     });
   });
@@ -124,11 +124,11 @@ test("compose VisuallyHidden, TooltipAnchor, and MenuButton", async () => {
   await hover(button);
   expect(await q.tooltip.wait("Accessibility Shortcuts")).toBeVisible();
   await hoverOutside();
-  expect(q.tooltip("Accessibility Shortcuts")).not.toBeInTheDocument();
+  expect(q.tooltip.maybe("Accessibility Shortcuts")).not.toBeInTheDocument();
 
   await hover(button);
   await click(button);
   expect(q.menu("Accessibility Shortcuts")).toBeVisible();
   expect(q.menu("Accessibility Shortcuts")).toHaveFocus();
-  expect(q.tooltip("Accessibility Shortcuts")).not.toBeInTheDocument();
+  expect(q.tooltip.maybe("Accessibility Shortcuts")).not.toBeInTheDocument();
 });

--- a/app/src/sandbox/menu-values-interactions/test.ts
+++ b/app/src/sandbox/menu-values-interactions/test.ts
@@ -191,7 +191,7 @@ test("navigate with keyboard ignoring disabled items", async () => {
 
 test("reset radioControlled externally", async () => {
   await click(q.button("Menu"));
-  const orange = q.menuitemradio.ensure("Orange (radioControlled)");
+  const orange = q.menuitemradio("Orange (radioControlled)");
   expect(orange).toHaveAttribute("aria-checked", "false");
   expect(orange.querySelector("svg")).toBeNull();
   await click(orange);
@@ -202,7 +202,7 @@ test("reset radioControlled externally", async () => {
     document.querySelector("[data-radio-controlled-value]")?.textContent,
   ).toBe("");
   await click(q.button("Menu"));
-  const resetOrange = q.menuitemradio.ensure("Orange (radioControlled)");
+  const resetOrange = q.menuitemradio("Orange (radioControlled)");
   expect(resetOrange).toHaveAttribute("aria-checked", "false");
   expect(resetOrange.querySelector("svg")).toBeNull();
 });

--- a/app/src/sandbox/menubar-interactions/test.ts
+++ b/app/src/sandbox/menubar-interactions/test.ts
@@ -2,17 +2,17 @@ import { click, hover, press, q, sleep, type } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 test("show/hide on click", async () => {
-  expect(q.menu("File")).not.toBeInTheDocument();
+  expect(q.menu.maybe("File")).not.toBeInTheDocument();
   await click(q.menuitem("File"));
   expect(q.menu("File")).toBeVisible();
   expect(q.menu("File")).toHaveFocus();
   expect(q.menuitem("New Tab")).not.toHaveFocus();
   await click(q.menuitem("New Tab"));
-  expect(q.menu("File")).not.toBeInTheDocument();
+  expect(q.menu.maybe("File")).not.toBeInTheDocument();
   expect(q.menuitem("File")).toHaveFocus();
   await click(q.menuitem("File"));
   await click(q.menuitem("File"));
-  expect(q.menu("File")).not.toBeInTheDocument();
+  expect(q.menu.maybe("File")).not.toBeInTheDocument();
   expect(q.menuitem("File")).toHaveFocus();
 });
 
@@ -22,14 +22,14 @@ test("show/hide on enter", async () => {
   expect(q.menu("File")).toBeVisible();
   expect(q.menuitem("New Tab")).toHaveFocus();
   await press.Enter();
-  expect(q.menu("File")).not.toBeInTheDocument();
+  expect(q.menu.maybe("File")).not.toBeInTheDocument();
   expect(q.menuitem("File")).toHaveFocus();
   await press.Enter();
   await press.ShiftTab();
   expect(q.menu("File")).toBeVisible();
   expect(q.menuitem("File")).toHaveFocus();
   await press.Enter();
-  expect(q.menu("File")).not.toBeInTheDocument();
+  expect(q.menu.maybe("File")).not.toBeInTheDocument();
   expect(q.menuitem("File")).toHaveFocus();
 });
 
@@ -39,14 +39,14 @@ test("show/hide on space", async () => {
   expect(q.menu("File")).toBeVisible();
   await expect.poll(q.menuitem.lazy("New Tab")).toHaveFocus();
   await press.Space();
-  expect(q.menu("File")).not.toBeInTheDocument();
+  expect(q.menu.maybe("File")).not.toBeInTheDocument();
   expect(q.menuitem("File")).toHaveFocus();
   await press.Space();
   await press.ShiftTab();
   expect(q.menu("File")).toBeVisible();
   expect(q.menuitem("File")).toHaveFocus();
   await press.Space();
-  expect(q.menu("File")).not.toBeInTheDocument();
+  expect(q.menu.maybe("File")).not.toBeInTheDocument();
   expect(q.menuitem("File")).toHaveFocus();
 });
 
@@ -56,7 +56,7 @@ test("show/hide on key down", async () => {
   expect(q.menu("File")).toBeVisible();
   expect(q.menuitem("New Tab")).toHaveFocus();
   await press.ArrowRight();
-  expect(q.menu("File")).not.toBeInTheDocument();
+  expect(q.menu.maybe("File")).not.toBeInTheDocument();
   expect(q.menu("Edit")).toBeInTheDocument();
   expect(q.menu("Edit")).toBeVisible();
   expect(q.menuitem("Edit")).toHaveFocus();
@@ -68,14 +68,14 @@ test("show/hide on key down", async () => {
   expect(q.menuitem("Emoji & Symbols")).toHaveFocus();
   await type("f");
   expect(q.menuitem("Find")).toHaveFocus();
-  expect(q.menu("Find")).not.toBeInTheDocument();
+  expect(q.menu.maybe("Find")).not.toBeInTheDocument();
   await press.ArrowRight();
   expect(q.menu("Find")).toBeInTheDocument();
   expect(q.menu("Find")).toBeVisible();
   expect(q.menuitem("Search the Web")).toHaveFocus();
   await press.ArrowLeft();
   expect(q.menuitem("Find")).toHaveFocus();
-  expect(q.menu("Find")).not.toBeInTheDocument();
+  expect(q.menu.maybe("Find")).not.toBeInTheDocument();
   await press.ArrowRight();
   await press.ArrowRight();
   expect(q.menuitem("View")).toHaveFocus();
@@ -105,20 +105,20 @@ test("typeahead from menu button continues after focus moves to menu", async () 
 
 test("show/hide on hover", async () => {
   await hover(q.menuitem("File"));
-  expect(q.menu("File")).not.toBeInTheDocument();
+  expect(q.menu.maybe("File")).not.toBeInTheDocument();
   await click(q.menuitem("File"));
   expect(q.menu("File")).toBeVisible();
   await hover(q.menuitem("New Window"));
   expect(q.menu("File")).toHaveFocus();
   await hover(q.menuitem("View"));
   expect(q.menuitem("View")).toHaveFocus();
-  expect(q.menu("File")).not.toBeInTheDocument();
+  expect(q.menu.maybe("File")).not.toBeInTheDocument();
   expect(q.menu("View")).toBeVisible();
   await hover(q.menuitem("Developer"));
   await hover(await q.menuitem.wait("View Source"));
   await hover(q.menuitem("File"));
   expect(q.menu("File")).toBeVisible();
-  expect(q.menu("View")).not.toBeInTheDocument();
+  expect(q.menu.maybe("View")).not.toBeInTheDocument();
 });
 
 test("hide on escape", async () => {
@@ -131,12 +131,12 @@ test("hide on escape", async () => {
   await expect.poll(q.menuitem.lazy("Email Link")).toHaveFocus();
   await press.Escape();
   expect(q.menuitem("File")).toHaveFocus();
-  expect(q.menu("Share")).not.toBeInTheDocument();
-  expect(q.menu("File")).not.toBeInTheDocument();
+  expect(q.menu.maybe("Share")).not.toBeInTheDocument();
+  expect(q.menu.maybe("File")).not.toBeInTheDocument();
   await press.ArrowRight();
   expect(q.menuitem("Edit")).toHaveFocus();
-  expect(q.menu("Edit")).not.toBeInTheDocument();
+  expect(q.menu.maybe("Edit")).not.toBeInTheDocument();
   await press.Escape();
   await hover(q.menuitem("View"));
-  expect(q.menu("View")).not.toBeInTheDocument();
+  expect(q.menu.maybe("View")).not.toBeInTheDocument();
 });

--- a/app/src/sandbox/popover-anchor-3729/test.ts
+++ b/app/src/sandbox/popover-anchor-3729/test.ts
@@ -5,7 +5,7 @@ import { expect, test } from "vitest";
 test.each(["Disclosure first", "Anchor first"])(
   "keeps the explicit anchor when the %s disclosure is clicked",
   async (label) => {
-    const anchor = q.status.ensure(`${label} current anchor`);
+    const anchor = q.status(`${label} current anchor`);
     expect(anchor).toHaveTextContent("explicit");
 
     await click(q.button(`Open ${label}`));
@@ -17,7 +17,7 @@ test.each(["Disclosure first", "Anchor first"])(
 
 test("falls back to the disclosure when the explicit anchor unmounts", async () => {
   const label = "Disclosure first";
-  const anchor = q.status.ensure(`${label} current anchor`);
+  const anchor = q.status(`${label} current anchor`);
 
   await click(q.button(`Open ${label}`));
   await click(q.button(`Remove ${label} anchor`));
@@ -86,7 +86,7 @@ test.each([
   );
 
   await press("Escape");
-  expect(q.listbox(`${label} Combobox items`)).not.toBeInTheDocument();
+  expect(q.listbox.maybe(`${label} Combobox items`)).not.toBeInTheDocument();
 });
 
 test("uses ComboboxDisclosure when the combobox input unmounts", async () => {

--- a/app/src/sandbox/popover-arrow/test.ts
+++ b/app/src/sandbox/popover-arrow/test.ts
@@ -33,7 +33,7 @@ const cases = [
 // See https://github.com/ariakit/ariakit/issues/6320
 test("clears the arrow's stale static-side inset after a placement change", async () => {
   await click(q.button("Accept invite"));
-  const dialog = q.dialog.ensure("Team meeting");
+  const dialog = q.dialog("Team meeting");
   const arrow = dialog.querySelector<HTMLElement>(".arrow");
   expect(arrow).toBeInTheDocument();
   if (!arrow) return;
@@ -61,7 +61,7 @@ test("clears the arrow's stale static-side inset after a placement change", asyn
 for (const { label, strokeWidth, stroke } of cases) {
   test(`arrow stroke matches the ${label.toLowerCase()} box-shadow`, async () => {
     await click(q.button(label));
-    const dialog = q.dialog.ensure(label);
+    const dialog = q.dialog(label);
     // The arrow SVG paths inherit the stroke and stroke-width set on the
     // arrow element, so the values on the arrow are what the user sees drawn
     // around the arrow notch.

--- a/app/src/sandbox/popover-core-interactions/test.ts
+++ b/app/src/sandbox/popover-core-interactions/test.ts
@@ -4,25 +4,25 @@ import { expect, test } from "vitest";
 test("toggles provider popover with click, Enter, and Space", async () => {
   const disclosure = q.button("Accept invite");
 
-  expect(q.dialog("Team meeting")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Team meeting")).not.toBeInTheDocument();
   await click(disclosure);
   expect(q.dialog("Team meeting")).toBeVisible();
   expect(q.button("Accept")).toHaveFocus();
   await click(disclosure);
-  expect(q.dialog("Team meeting")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Team meeting")).not.toBeInTheDocument();
   expect(disclosure).toHaveFocus();
 
   await press.Enter(disclosure);
   expect(q.dialog("Team meeting")).toBeVisible();
   await press.ShiftTab();
   await press.Enter();
-  expect(q.dialog("Team meeting")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Team meeting")).not.toBeInTheDocument();
 
   await press.Space(disclosure);
   expect(q.dialog("Team meeting")).toBeVisible();
   await press.ShiftTab();
   await press.Space();
-  expect(q.dialog("Team meeting")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Team meeting")).not.toBeInTheDocument();
 });
 
 test("hides provider popover with Escape from disclosure and content", async () => {
@@ -32,12 +32,12 @@ test("hides provider popover with Escape from disclosure and content", async () 
   await press.ShiftTab();
   expect(q.dialog("Team meeting")).toBeVisible();
   await press.Escape();
-  expect(q.dialog("Team meeting")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Team meeting")).not.toBeInTheDocument();
 
   await click(disclosure);
   expect(q.button("Accept")).toHaveFocus();
   await press.Escape();
-  expect(q.dialog("Team meeting")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Team meeting")).not.toBeInTheDocument();
   expect(disclosure).toHaveFocus();
 });
 
@@ -47,7 +47,7 @@ test("controlled standalone popover closes through onClose", async () => {
   await click(disclosure);
   expect(q.dialog("Review meeting")).toBeVisible();
   await press.Escape();
-  expect(q.dialog("Review meeting")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Review meeting")).not.toBeInTheDocument();
   expect(disclosure).toHaveFocus();
 });
 
@@ -71,7 +71,7 @@ for (const trigger of ["click", "Enter", "Space"] as const) {
     } else {
       await press.Space(disclosure);
     }
-    expect(q.dialog("Review meeting")).not.toBeInTheDocument();
+    expect(q.dialog.maybe("Review meeting")).not.toBeInTheDocument();
   });
 }
 
@@ -79,5 +79,5 @@ test("hides controlled standalone popover with Escape from disclosure", async ()
   await click(q.button("Review invite"));
   await press.ShiftTab();
   await press.Escape();
-  expect(q.dialog("Review meeting")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Review meeting")).not.toBeInTheDocument();
 });

--- a/app/src/sandbox/popover-disclosure-7087/test.ts
+++ b/app/src/sandbox/popover-disclosure-7087/test.ts
@@ -12,14 +12,14 @@ async function openFromQuickFormatAndClose() {
   // below starts, so naming "Formatting" there is a real change.
   expect(q.button("Quick format")).toHaveAttribute("aria-expanded", "true");
   await click(q.button("Quick format"));
-  await expect.poll(q.dialog.lazy("Formatting")).not.toBeInTheDocument();
+  await expect.poll(q.dialog.maybe.lazy("Formatting")).not.toBeInTheDocument();
 }
 
 // https://github.com/ariakit/ariakit/issues/7087
 test("names the Formatting button as the opener of a programmatic open", async () => {
   await openFromQuickFormatAndClose();
 
-  const note = q.textbox.ensure("Note");
+  const note = q.textbox("Note");
   await click(note);
   await press("*", note);
 
@@ -31,20 +31,20 @@ test("names the Formatting button as the opener of a programmatic open", async (
   // The popup takes its outside state from the named button, so the note the
   // caret sits in is outside and clicking it dismisses the popup.
   await click(note);
-  await expect.poll(q.dialog.lazy("Formatting")).not.toBeInTheDocument();
+  await expect.poll(q.dialog.maybe.lazy("Formatting")).not.toBeInTheDocument();
 });
 
 // https://github.com/ariakit/ariakit/issues/7087
 test("returns focus to the named button when dismissed from inside", async () => {
   await openFromQuickFormatAndClose();
 
-  const note = q.textbox.ensure("Note");
+  const note = q.textbox("Note");
   await click(note);
   await press("*", note);
   expect(q.dialog("Formatting")).toBeVisible();
 
   await click(q.button("Done"));
-  await expect.poll(q.dialog.lazy("Formatting")).not.toBeInTheDocument();
+  await expect.poll(q.dialog.maybe.lazy("Formatting")).not.toBeInTheDocument();
   expect(q.button("Formatting")).toHaveFocus();
 });
 
@@ -56,13 +56,13 @@ test("returns focus to the named button when dismissed from inside", async () =>
 test("dismisses with Escape from the field the caret is in", async () => {
   await openFromQuickFormatAndClose();
 
-  const note = q.textbox.ensure("Note");
+  const note = q.textbox("Note");
   await click(note);
   await press("*", note);
   expect(q.dialog("Formatting")).toBeVisible();
 
   await press.Escape(note);
-  await expect.poll(q.dialog.lazy("Formatting")).not.toBeInTheDocument();
+  await expect.poll(q.dialog.maybe.lazy("Formatting")).not.toBeInTheDocument();
 });
 
 // A mounted button already claims the store, and the store can't tell that
@@ -84,19 +84,19 @@ test("keeps a mounted button as the opener when the open names none", async () =
 // still treat it as a stale fallback rather than as somebody's choice.
 // https://github.com/ariakit/ariakit/issues/7087
 test("replaces the fallback after an open that captured nothing", async () => {
-  const note = q.textbox.ensure("Note");
-  const title = q.textbox.ensure("Title");
+  const note = q.textbox("Note");
+  const title = q.textbox("Title");
   await click(note);
   await press("/", note);
   expect(q.dialog("Suggestions")).toBeVisible();
   await press.Escape(note);
-  await expect.poll(q.dialog.lazy("Suggestions")).not.toBeInTheDocument();
+  await expect.poll(q.dialog.maybe.lazy("Suggestions")).not.toBeInTheDocument();
 
   await click(q.button("Summarize note"));
   expect(q.dialog("Suggestions")).toBeVisible();
   // The button dropped focus, so this Escape comes from the body.
   await press.Escape();
-  await expect.poll(q.dialog.lazy("Suggestions")).not.toBeInTheDocument();
+  await expect.poll(q.dialog.maybe.lazy("Suggestions")).not.toBeInTheDocument();
 
   await click(title);
   await press("/", title);
@@ -114,13 +114,13 @@ test("replaces the fallback after an open that captured nothing", async () => {
 // opener forever.
 // https://github.com/ariakit/ariakit/issues/7087
 test("replaces the fallback after the popup's own store is replaced", async () => {
-  const note = q.textbox.ensure("Note");
-  const title = q.textbox.ensure("Title");
+  const note = q.textbox("Note");
+  const title = q.textbox("Title");
   await click(note);
   await press("/", note);
   expect(q.dialog("Suggestions")).toBeVisible();
   await press.Escape(note);
-  await expect.poll(q.dialog.lazy("Suggestions")).not.toBeInTheDocument();
+  await expect.poll(q.dialog.maybe.lazy("Suggestions")).not.toBeInTheDocument();
 
   await click(q.button("Reload suggestions"));
 
@@ -135,8 +135,8 @@ test("replaces the fallback after the popup's own store is replaced", async () =
 });
 
 test("falls back to the focused field when no button is mounted", async () => {
-  const note = q.textbox.ensure("Note");
-  const title = q.textbox.ensure("Title");
+  const note = q.textbox("Note");
+  const title = q.textbox("Title");
   await click(note);
   await press("/", note);
   expect(q.dialog("Suggestions")).toBeVisible();
@@ -149,7 +149,7 @@ test("falls back to the focused field when no button is mounted", async () => {
   expect(q.dialog("Suggestions")).toBeVisible();
 
   await click(title);
-  await expect.poll(q.dialog.lazy("Suggestions")).not.toBeInTheDocument();
+  await expect.poll(q.dialog.maybe.lazy("Suggestions")).not.toBeInTheDocument();
 
   // Reopening from the title hands the popup a new opener, so now it's the
   // title that no longer counts as outside. A fix that simply kept any opener

--- a/app/src/sandbox/popover-disclosure-render/test.ts
+++ b/app/src/sandbox/popover-disclosure-render/test.ts
@@ -23,8 +23,8 @@ test.each([
   await click(q.button(`Toggle ${label} popover`));
   expect(q.dialog()).toBeVisible();
 
-  const popoverRenders = q.status.ensure(`${label} popover renders`);
-  const disclosureElementRenders = q.status.ensure(
+  const popoverRenders = q.status(`${label} popover renders`);
+  const disclosureElementRenders = q.status(
     `${label} disclosure element renders`,
   );
 
@@ -48,7 +48,7 @@ test("re-renders when the disclosure positioning fallback changes", async () => 
   await click(q.button("Toggle Fallback popover"));
   expect(q.dialog()).toBeVisible();
 
-  const popoverRenders = q.status.ensure("Fallback popover renders");
+  const popoverRenders = q.status("Fallback popover renders");
   await click(q.button("Set Fallback disclosure element"));
   const previousPopoverRenders = popoverRenders.textContent;
 

--- a/app/src/sandbox/popover-lazy-loading/test.ts
+++ b/app/src/sandbox/popover-lazy-loading/test.ts
@@ -21,7 +21,7 @@ for (const trigger of ["click", "Enter", "Space"] as const) {
     } else {
       await press.Enter(disclosure);
     }
-    expect(q.dialog("Team meeting")).not.toBeInTheDocument();
+    expect(q.dialog.maybe("Team meeting")).not.toBeInTheDocument();
   });
 }
 
@@ -29,13 +29,13 @@ test("hides a lazy popover with Escape from disclosure", async () => {
   await click(q.button("Accept invite"));
   await press.ShiftTab();
   await press.Escape();
-  expect(q.dialog("Team meeting")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Team meeting")).not.toBeInTheDocument();
 });
 
 test("hides a lazy popover with Escape from content", async () => {
   const disclosure = q.button("Accept invite");
   await click(disclosure);
   await press.Escape();
-  expect(q.dialog("Team meeting")).not.toBeInTheDocument();
+  expect(q.dialog.maybe("Team meeting")).not.toBeInTheDocument();
   expect(disclosure).toHaveFocus();
 });

--- a/app/src/sandbox/popover-selection/test.ts
+++ b/app/src/sandbox/popover-selection/test.ts
@@ -14,11 +14,11 @@ Range.prototype.getBoundingClientRect = () => ({
 });
 
 test("shows and hides on text selection", async () => {
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
   await select("dolor, sit");
   expect(q.dialog()).toBeVisible();
   await click(q.text(/^Lorem ipsum/));
-  expect(q.dialog()).not.toBeInTheDocument();
+  expect(q.dialog.maybe()).not.toBeInTheDocument();
 });
 
 test("tabs backward into the selection popover", async () => {

--- a/app/src/sandbox/portal-core-rendering/test.ts
+++ b/app/src/sandbox/portal-core-rendering/test.ts
@@ -5,7 +5,7 @@ test("renders detached content and removes it when unmounted", async () => {
   expect(q.text("Detached portal content")).toBeInTheDocument();
 
   await click(q.button("Toggle portal"));
-  expect(q.text("Detached portal content")).not.toBeInTheDocument();
+  expect(q.text.maybe("Detached portal content")).not.toBeInTheDocument();
 
   await click(q.button("Toggle portal"));
   expect(q.text("Detached portal content")).toBeInTheDocument();

--- a/app/src/sandbox/radio-shift-tab-focus/test.ts
+++ b/app/src/sandbox/radio-shift-tab-focus/test.ts
@@ -4,7 +4,7 @@ import { expect, test } from "vitest";
 test("Shift+Tab moves focus back to the checked radio", async () => {
   const option1 = q.radio("Option 1");
   const option2 = q.radio("Option 2");
-  const option3 = q.radio.ensure("Option 3");
+  const option3 = q.radio("Option 3");
 
   await press.Tab();
   expect(option1).toHaveFocus();

--- a/app/src/sandbox/react-components-undefined-props/test.ts
+++ b/app/src/sandbox/react-components-undefined-props/test.ts
@@ -18,7 +18,7 @@ test("forwarded undefined focusable keeps the tab panel out of the tab order", a
 
 // https://github.com/ariakit/ariakit/issues/7028
 test("forwarded undefined clickOnEnter keeps Enter inert on a native checkbox", async () => {
-  const checkbox = q.checkbox.ensure("Subscribe");
+  const checkbox = q.checkbox("Subscribe");
   await click(checkbox);
   expect(checkbox).toBeChecked();
   await press.Enter(checkbox);
@@ -40,7 +40,7 @@ test("explicit focusable still overrides the computed default", async () => {
 
 // https://github.com/ariakit/ariakit/issues/7028
 test("explicit clickOnEnter still overrides the computed default", async () => {
-  const checkbox = q.checkbox.ensure("Notify");
+  const checkbox = q.checkbox("Notify");
   await click(checkbox);
   expect(checkbox).toBeChecked();
   await press.Enter(checkbox);
@@ -49,7 +49,7 @@ test("explicit clickOnEnter still overrides the computed default", async () => {
 
 // https://github.com/ariakit/ariakit/issues/7037
 test("a composed hook preserves a later computed default", async () => {
-  const combobox = q.combobox.ensure("Direct hook");
+  const combobox = q.combobox("Direct hook");
   await type("a", combobox);
   await expect.poll(q.listbox.lazy()).toBeVisible();
   // The assertion is about focus not moving, so wait for the popover's

--- a/app/src/sandbox/role-merge-props-7059/test.ts
+++ b/app/src/sandbox/role-merge-props-7059/test.ts
@@ -3,7 +3,7 @@ import { expect, test } from "vitest";
 
 // https://github.com/ariakit/ariakit/issues/7059
 test("an own __proto__ render prop does not remount the element", async () => {
-  await type("Haz", q.textbox.ensure("Profile name"));
+  await type("Haz", q.textbox("Profile name"));
   expect(q.textbox("Profile name")).toHaveValue("Haz");
 
   await click(q.button("Refresh payload"));

--- a/app/src/sandbox/select-legacy/public-tests/basic.react.test-helper.ts
+++ b/app/src/sandbox/select-legacy/public-tests/basic.react.test-helper.ts
@@ -14,7 +14,7 @@ describe("public-select", () => {
     expect(q.option("Apple")).toHaveFocus();
     expect(q.option("Apple")).toHaveAttribute("aria-selected", "true");
     await click(q.option("Banana"));
-    expect(q.listbox()).not.toBeInTheDocument();
+    expect(q.listbox.maybe()).not.toBeInTheDocument();
     expect(select).toHaveTextContent("Banana");
   });
 });
@@ -84,7 +84,7 @@ describe("public-select-form-disabled", () => {
     expect(select).toBeDisabled();
     expect(select).toHaveAttribute("aria-disabled", "true");
     await click(select);
-    expect(q.listbox()).not.toBeInTheDocument();
+    expect(q.listbox.maybe()).not.toBeInTheDocument();
     await click(q.button("Submit disabled legacy select"));
     expect(alert).toHaveBeenCalledWith(null);
   });
@@ -100,7 +100,7 @@ describe("public-select-items-unmount", () => {
     const select = q.combobox("Unmounting favorite fruit");
     await click(select);
     await click(q.option("Banana"));
-    expect(q.listbox()).not.toBeInTheDocument();
+    expect(q.listbox.maybe()).not.toBeInTheDocument();
     await click(select);
     expect(q.option("Banana")).toHaveAttribute("aria-selected", "true");
   });
@@ -116,7 +116,7 @@ describe("public-select-default-open-controlled", () => {
     const select = q.combobox("Default-open favorite fruit");
     expect(q.listbox()).toBeVisible();
     await click(select);
-    expect(q.listbox()).not.toBeInTheDocument();
+    expect(q.listbox.maybe()).not.toBeInTheDocument();
     await click(select);
     expect(q.listbox()).toBeVisible();
   });

--- a/app/src/sandbox/select-legacy/public-tests/combobox.react.test-helper.ts
+++ b/app/src/sandbox/select-legacy/public-tests/combobox.react.test-helper.ts
@@ -27,7 +27,7 @@ describe.each([
     expect(q.option("Grape")).toHaveFocus();
     await press.Enter();
     expect(select).toHaveTextContent("Grape");
-    expect(q.dialog()).not.toBeInTheDocument();
+    expect(q.dialog.maybe()).not.toBeInTheDocument();
   });
 });
 

--- a/app/src/sandbox/store-init-6314/test.ts
+++ b/app/src/sandbox/store-init-6314/test.ts
@@ -18,7 +18,7 @@ test("keeps sibling setup teardowns active after a stale init disposer runs", as
   expect(q.text("B count: 2")).toBeVisible();
 
   await click(q.button("Hide panel A"));
-  expect(q.text("A count:")).not.toBeInTheDocument();
+  expect(q.text.maybe("A count:")).not.toBeInTheDocument();
 
   await press("b");
   expect(q.text("B count: 3")).toBeVisible();

--- a/app/src/sandbox/store-keyed-subscriptions/test.ts
+++ b/app/src/sandbox/store-keyed-subscriptions/test.ts
@@ -97,13 +97,11 @@ test("supports keyed selector types", () => {
 });
 
 test("runs selectors only for subscribed keys", async () => {
-  const stateCalls = q.status.ensure("useStoreState calls").textContent;
-  const objectCalls = q.status.ensure("useStoreStateObject calls").textContent;
-  const unkeyedCalls = q.status.ensure("Unkeyed selector calls").textContent;
-  const emptyCalls = q.status.ensure("Empty selector calls").textContent;
-  const emptyObjectCalls = q.status.ensure(
-    "Empty object selector calls",
-  ).textContent;
+  const stateCalls = q.status("useStoreState calls").textContent;
+  const objectCalls = q.status("useStoreStateObject calls").textContent;
+  const unkeyedCalls = q.status("Unkeyed selector calls").textContent;
+  const emptyCalls = q.status("Empty selector calls").textContent;
+  const emptyObjectCalls = q.status("Empty object selector calls").textContent;
 
   expect(q.status("Optional value")).toHaveTextContent("none");
   expect(q.status("Optional object direct bar")).toHaveTextContent("none");
@@ -111,17 +109,13 @@ test("runs selectors only for subscribed keys", async () => {
 
   await click(q.button("Update bar"));
 
-  expect(q.status.ensure("useStoreState calls").textContent).toBe(stateCalls);
-  expect(q.status.ensure("useStoreStateObject calls").textContent).toBe(
-    objectCalls,
-  );
-  expect(q.status.ensure("Empty selector calls").textContent).toBe(emptyCalls);
-  expect(q.status.ensure("Empty object selector calls").textContent).toBe(
+  expect(q.status("useStoreState calls").textContent).toBe(stateCalls);
+  expect(q.status("useStoreStateObject calls").textContent).toBe(objectCalls);
+  expect(q.status("Empty selector calls").textContent).toBe(emptyCalls);
+  expect(q.status("Empty object selector calls").textContent).toBe(
     emptyObjectCalls,
   );
-  expect(q.status.ensure("Unkeyed selector calls").textContent).not.toBe(
-    unkeyedCalls,
-  );
+  expect(q.status("Unkeyed selector calls").textContent).not.toBe(unkeyedCalls);
   expect(q.status("Direct bar")).toHaveTextContent("1");
   expect(q.status("Mixed direct bar")).toHaveTextContent("1");
   expect(q.status("Mixed doubled foo")).toHaveTextContent("0");
@@ -130,14 +124,12 @@ test("runs selectors only for subscribed keys", async () => {
 
   await click(q.button("Update foo"));
 
-  expect(q.status.ensure("useStoreState calls").textContent).not.toBe(
-    stateCalls,
-  );
-  expect(q.status.ensure("useStoreStateObject calls").textContent).not.toBe(
+  expect(q.status("useStoreState calls").textContent).not.toBe(stateCalls);
+  expect(q.status("useStoreStateObject calls").textContent).not.toBe(
     objectCalls,
   );
-  expect(q.status.ensure("Empty selector calls").textContent).toBe(emptyCalls);
-  expect(q.status.ensure("Empty object selector calls").textContent).toBe(
+  expect(q.status("Empty selector calls").textContent).toBe(emptyCalls);
+  expect(q.status("Empty object selector calls").textContent).toBe(
     emptyObjectCalls,
   );
   expect(q.status("Selector value")).toHaveTextContent("1");
@@ -198,7 +190,7 @@ test("updates dynamic selector dependencies", async () => {
 
 test("attaches and detaches conditional selector dependencies", async () => {
   const selectorValue = q.status("Conditional selector value");
-  const calls = q.status.ensure("Conditional selector calls");
+  const calls = q.status("Conditional selector calls");
   const pausedCalls = calls.textContent;
 
   expect(selectorValue).toHaveTextContent("paused");

--- a/app/src/sandbox/tab-disabled/test.ts
+++ b/app/src/sandbox/tab-disabled/test.ts
@@ -10,7 +10,7 @@ test("navigate through tabs with keyboard", async () => {
   await press.ArrowRight();
   expect(q.tab("Meat")).toHaveFocus();
   expect(q.tab("Meat")).toHaveAttribute("aria-selected", "false");
-  expect(q.tabpanel.hidden("Meat")).not.toBeVisible();
+  expect(q.tabpanel.maybe.hidden("Meat")).not.toBeVisible();
   expect(q.tab("Vegetables")).toHaveAttribute("aria-selected", "true");
   expect(q.tabpanel("Vegetables")).toBeVisible();
 

--- a/app/src/sandbox/tag-input-6333/test.ts
+++ b/app/src/sandbox/tag-input-6333/test.ts
@@ -3,16 +3,16 @@ import { expect, test } from "vitest";
 
 // Reproduces https://github.com/ariakit/ariakit/issues/6333
 test("splits string delimiters with regex metacharacters literally", async () => {
-  await type("one.two.", q.textbox.ensure("Dot tags"));
+  await type("one.two.", q.textbox("Dot tags"));
   expect(q.text("Dot tags values: one, two")).toBeVisible();
 });
 
 test("does not throw on string delimiters that are invalid regex patterns", async () => {
-  await type("one+two+", q.textbox.ensure("Plus tags"));
+  await type("one+two+", q.textbox("Plus tags"));
   expect(q.text("Plus tags values: one, two")).toBeVisible();
 });
 
 test("does not freeze on string delimiters that match empty regexes", async () => {
-  await type("one|two|", q.textbox.ensure("Pipe tags"));
+  await type("one|two|", q.textbox("Pipe tags"));
   expect(q.text("Pipe tags values: one, two")).toBeVisible();
 });

--- a/app/src/sandbox/tag-remove-6330/test.ts
+++ b/app/src/sandbox/tag-remove-6330/test.ts
@@ -11,7 +11,7 @@ test("exposes standalone TagRemove with visible text as a named button", () => {
   );
   expect(tagRemove).toHaveAttribute("aria-hidden", "true");
   expect(tagRemove?.querySelector("svg")).toBeInTheDocument();
-  expect(q.button("Remove React")).not.toBeInTheDocument();
+  expect(q.button.maybe("Remove React")).not.toBeInTheDocument();
 });
 
 test("exposes standalone TagRemove with an aria-label", () => {
@@ -19,11 +19,11 @@ test("exposes standalone TagRemove with an aria-label", () => {
   expect(removeButton).not.toHaveAttribute("aria-hidden", "true");
   expect(removeButton).toHaveAttribute("aria-label", "Remove Vue filter");
   expect(removeButton).toHaveTextContent("x");
-  expect(q.button("Remove Vue")).not.toBeInTheDocument();
+  expect(q.button.maybe("Remove Vue")).not.toBeInTheDocument();
 });
 
 test("does not render a default icon outside a Tag", () => {
-  const removeButton = q.button.ensure("Remove Angular filter");
+  const removeButton = q.button("Remove Angular filter");
   expect(removeButton).not.toHaveAttribute("aria-hidden", "true");
   expect(removeButton).toHaveAttribute("aria-label", "Remove Angular filter");
   expect(removeButton.querySelector("svg")).not.toBeInTheDocument();
@@ -33,7 +33,7 @@ test("preserves a standalone render element name", () => {
   const removeButton = q.button("Remove Svelte filter");
   expect(removeButton).not.toHaveAttribute("aria-hidden", "true");
   expect(removeButton).not.toHaveAttribute("aria-label");
-  expect(q.button("Remove Svelte")).not.toBeInTheDocument();
+  expect(q.button.maybe("Remove Svelte")).not.toBeInTheDocument();
 });
 
 test("preserves a standalone root labelledby name", () => {
@@ -42,5 +42,5 @@ test("preserves a standalone root labelledby name", () => {
   expect(removeButton).not.toHaveAttribute("aria-label");
   expect(removeButton).toHaveAttribute("aria-labelledby", "solid-label");
   expect(removeButton).toHaveTextContent("x");
-  expect(q.button("Remove Solid")).not.toBeInTheDocument();
+  expect(q.button.maybe("Remove Solid")).not.toBeInTheDocument();
 });

--- a/app/src/sandbox/tag/test.ts
+++ b/app/src/sandbox/tag/test.ts
@@ -38,7 +38,7 @@ test("renders the tags inside the listbox and the input outside it", async () =>
   expect(tagList).not.toHaveAttribute("aria-owns");
   // The listbox role accepts only options as children, so the input must be a
   // sibling of the tag list rather than a descendant of it.
-  expect(tagList).not.toContainElement(q.textbox.ensure("Tags"));
+  expect(tagList).not.toContainElement(q.textbox("Tags"));
 });
 
 test("labels the control, the tag list and the input", async () => {
@@ -55,24 +55,24 @@ test("click on tag", async () => {
 });
 
 test("remove tag by clicking on remove button", async () => {
-  const tag = q.option.ensure("JavaScript");
+  const tag = q.option("JavaScript");
   await click(tag.querySelector("[aria-label^=Press]"));
   expect(q.textbox()).toHaveFocus();
-  expect(q.option("JavaScript")).not.toBeInTheDocument();
+  expect(q.option.maybe("JavaScript")).not.toBeInTheDocument();
 });
 
 test("remove tag by pressing Delete", async () => {
   await click(q.option("JavaScript"));
   await press.Delete();
   expect(q.option("React")).toHaveFocus();
-  expect(q.option("JavaScript")).not.toBeInTheDocument();
+  expect(q.option.maybe("JavaScript")).not.toBeInTheDocument();
 });
 
 test("remove tag by pressing Backspace on the tag", async () => {
   await click(q.option("React"));
   await press.Backspace();
   expect(q.option("JavaScript")).toHaveFocus();
-  expect(q.option("React")).not.toBeInTheDocument();
+  expect(q.option.maybe("React")).not.toBeInTheDocument();
 });
 
 test("remove tag by pressing Backspace on the textbox", async () => {
@@ -80,7 +80,7 @@ test("remove tag by pressing Backspace on the textbox", async () => {
   expect(q.option.all()).toHaveLength(2);
   await press.Backspace();
   expect(q.textbox()).toHaveFocus();
-  expect(q.option("React")).not.toBeInTheDocument();
+  expect(q.option.maybe("React")).not.toBeInTheDocument();
   expect(q.option("JavaScript")).toBeInTheDocument();
 });
 
@@ -154,7 +154,7 @@ test("move focus between tag list elements", async () => {
 });
 
 test("undo/redo removing tags", async () => {
-  const tag = q.option.ensure("React");
+  const tag = q.option("React");
   await click(tag.querySelector("[aria-label^=Press]"));
   expect(options()).toEqual(["JavaScript"]);
   expect(q.textbox("Tags")).toHaveFocus();

--- a/app/src/sandbox/toolbar-container-focus/test.ts
+++ b/app/src/sandbox/toolbar-container-focus/test.ts
@@ -14,7 +14,7 @@ async function pressSafariComposingEnter(input: HTMLElement) {
 
 // Reproduces https://github.com/ariakit/ariakit/issues/6579
 test("keeps focus in the field on composing Enter", async () => {
-  const input = q.textbox.ensure("Message");
+  const input = q.textbox("Message");
 
   input.focus();
   expect(input).toHaveFocus();
@@ -27,7 +27,7 @@ test("keeps focus in the field on composing Enter", async () => {
 });
 
 test("keeps focus in the field on Safari composing Enter", async () => {
-  const input = q.textbox.ensure("Message");
+  const input = q.textbox("Message");
 
   input.focus();
   expect(input).toHaveFocus();

--- a/app/src/sandbox/tooltip-4894/test.ts
+++ b/app/src/sandbox/tooltip-4894/test.ts
@@ -16,10 +16,10 @@ test("keeps multiple forced tooltips visible", async () => {
 test("hides controlled tooltips that accept setOpen updates", async () => {
   await click(q.button("Open managed one"));
   expect(q.tooltip("MANAGED ONE")).toBeVisible();
-  expect(q.tooltip("MANAGED TWO")).not.toBeInTheDocument();
+  expect(q.tooltip.maybe("MANAGED TWO")).not.toBeInTheDocument();
 
   await click(q.button("Open managed two"));
-  expect(q.tooltip("MANAGED ONE")).not.toBeInTheDocument();
+  expect(q.tooltip.maybe("MANAGED ONE")).not.toBeInTheDocument();
   expect(q.tooltip("MANAGED TWO")).toBeVisible();
 });
 
@@ -29,7 +29,7 @@ test("keeps managed tooltips active after forced tooltips reopen", async () => {
   expect(q.tooltip("MANAGED ONE")).toBeVisible();
 
   await click(q.button("Open managed two"));
-  expect(q.tooltip("MANAGED ONE")).not.toBeInTheDocument();
+  expect(q.tooltip.maybe("MANAGED ONE")).not.toBeInTheDocument();
   expect(q.tooltip("MANAGED TWO")).toBeVisible();
   expect(q.tooltip("FORCED ONE")).toBeVisible();
   expect(q.tooltip("FORCED TWO")).toBeVisible();

--- a/app/src/sandbox/tooltip-button-disabled/test.ts
+++ b/app/src/sandbox/tooltip-button-disabled/test.ts
@@ -32,7 +32,7 @@ test("shows the tooltip on keyboard focus in both composition orders", async () 
 test("does not show the tooltip on hover when the consumer opts out for disabled anchors", async () => {
   await hover(q.button("Archive file"));
   expect(
-    q.tooltip("You need permission to archive files"),
+    q.tooltip.maybe("You need permission to archive files"),
   ).not.toBeInTheDocument();
 });
 
@@ -53,7 +53,7 @@ test("lets a callback decide whether a disabled anchor shows on hover", async ()
   // the tooltip here.
   await hover(q.button("Restore file"));
   expect(
-    q.tooltip("You need permission to restore files"),
+    q.tooltip.maybe("You need permission to restore files"),
   ).not.toBeInTheDocument();
 });
 
@@ -98,14 +98,14 @@ test("does not show the tooltip on hover for a truly disabled anchor that keeps 
   // keep the tooltip closed.
   expect(q.button("Duplicate file")).toHaveStyle("pointer-events: auto");
   await hover(q.button("Duplicate file"));
-  expect(q.tooltip("Duplicating is unavailable")).not.toBeInTheDocument();
+  expect(q.tooltip.maybe("Duplicating is unavailable")).not.toBeInTheDocument();
 });
 
 // https://github.com/ariakit/ariakit/issues/7116
 test("does not show the tooltip on hover when the truly disabled state is below the anchor", async () => {
   expect(q.button("Print file")).toHaveStyle("pointer-events: auto");
   await hover(q.button("Print file"));
-  expect(q.tooltip("Printing is unavailable")).not.toBeInTheDocument();
+  expect(q.tooltip.maybe("Printing is unavailable")).not.toBeInTheDocument();
 });
 
 test("opens a delayed tooltip on hover", async () => {
@@ -125,7 +125,7 @@ test("does not open a delayed tooltip when the anchor turns truly disabled while
   // Same 150ms show timeout as the control above, and still nothing observable
   // to poll, so cross it before asserting the tooltip stayed closed.
   await sleep(250);
-  expect(q.tooltip("Syncing needs access")).not.toBeInTheDocument();
+  expect(q.tooltip.maybe("Syncing needs access")).not.toBeInTheDocument();
 });
 
 test("shows the tooltip on hover when the rendered button is disabled with focusable false", async () => {
@@ -150,7 +150,7 @@ test("does not show the tooltip on hover when the anchor is disabled with focusa
   // shield applies here, so the hover decision itself is what this asserts.
   expect(q.text("Encrypt file")).not.toHaveAttribute("tabindex");
   await hover(q.text("Encrypt file"));
-  expect(q.tooltip("Encryption is unavailable")).not.toBeInTheDocument();
+  expect(q.tooltip.maybe("Encryption is unavailable")).not.toBeInTheDocument();
 });
 
 test("does not open a delayed tooltip when the anchor loses focusable while it is pending", async () => {
@@ -162,7 +162,9 @@ test("does not open a delayed tooltip when the anchor loses focusable while it i
   // nothing observable to poll, so cross it before asserting the tooltip
   // stayed closed.
   await sleep(250);
-  expect(q.tooltip("Uploading needs a connection")).not.toBeInTheDocument();
+  expect(
+    q.tooltip.maybe("Uploading needs a connection"),
+  ).not.toBeInTheDocument();
 });
 
 test("shows the tooltip on hover when the rendered element carries the attribute with a false value", async () => {

--- a/app/src/sandbox/tooltip-fullscreen-portal/test.ts
+++ b/app/src/sandbox/tooltip-fullscreen-portal/test.ts
@@ -15,7 +15,7 @@ test("does not leak duplicate tooltip portal containers in StrictMode", async ()
   );
 
   await click(q.button("Unmount tooltip"));
-  expect(q.tooltip("Tooltip content")).not.toBeInTheDocument();
+  expect(q.tooltip.maybe("Tooltip content")).not.toBeInTheDocument();
   expect(q.status("Portal containers")).toHaveTextContent(
     "Portal containers: 0",
   );

--- a/app/src/sandbox/tooltip-interactions/test.ts
+++ b/app/src/sandbox/tooltip-interactions/test.ts
@@ -10,11 +10,11 @@ const hoverOutside = async () => {
 test("shows on hover, hides outside, and immediately reopens", async () => {
   const anchor = q.link("Tooltip anchor");
 
-  expect(q.tooltip("Tooltip content")).not.toBeInTheDocument();
+  expect(q.tooltip.maybe("Tooltip content")).not.toBeInTheDocument();
   await hover(anchor);
   expect(await q.tooltip.wait("Tooltip content")).toBeVisible();
   await hoverOutside();
-  await expect.poll(q.tooltip).not.toBeInTheDocument();
+  await expect.poll(q.tooltip.maybe).not.toBeInTheDocument();
 
   await hover(anchor);
   expect(q.tooltip("Tooltip content")).toBeVisible();
@@ -34,7 +34,7 @@ test("shows on focus and hides after focus moves", async () => {
   expect(await q.tooltip.wait("Tooltip content")).toBeVisible();
   await press.Tab();
   expect(q.button("After tooltip")).toHaveFocus();
-  expect(q.tooltip("Tooltip content")).not.toBeInTheDocument();
+  expect(q.tooltip.maybe("Tooltip content")).not.toBeInTheDocument();
 });
 
 test("stays open after focus-visible and pointer movement", async () => {
@@ -57,7 +57,7 @@ test("waits again after keyboard focus is lost", async () => {
   await press.Tab();
   await press.Tab();
   expect(q.button("After tooltip")).toHaveFocus();
-  expect(q.tooltip("Tooltip content")).not.toBeInTheDocument();
+  expect(q.tooltip.maybe("Tooltip content")).not.toBeInTheDocument();
 
   await hoverOutside();
   // Dispatch directly so the assertion runs before the timeout can expire
@@ -65,7 +65,7 @@ test("waits again after keyboard focus is lost", async () => {
   await dispatch.mouseOver(anchor);
   await dispatch.mouseEnter(anchor);
   await dispatch.mouseMove(anchor);
-  expect(q.tooltip("Tooltip content")).not.toBeInTheDocument();
+  expect(q.tooltip.maybe("Tooltip content")).not.toBeInTheDocument();
   expect(await q.tooltip.wait("Tooltip content")).toBeVisible();
 });
 
@@ -76,6 +76,6 @@ test("Escape from tooltip content restores its anchor", async () => {
   await click(q.tooltip("Tooltip content"));
 
   await press.Escape();
-  expect(q.tooltip("Tooltip content")).not.toBeInTheDocument();
+  expect(q.tooltip.maybe("Tooltip content")).not.toBeInTheDocument();
   expect(anchor).toHaveFocus();
 });

--- a/app/src/sandbox/tooltip-variants/test.ts
+++ b/app/src/sandbox/tooltip-variants/test.ts
@@ -11,7 +11,7 @@ test("shows the instant tooltip on hover and focus", async () => {
   await hover(anchor);
   expect(q.tooltip("Instant tooltip")).toBeVisible();
   await hoverOutside();
-  expect(q.tooltip("Instant tooltip")).not.toBeInTheDocument();
+  expect(q.tooltip.maybe("Instant tooltip")).not.toBeInTheDocument();
   await press.Tab();
   expect(anchor).toHaveFocus();
   expect(q.tooltip("Instant tooltip")).toBeVisible();
@@ -24,7 +24,7 @@ test("keeps the label tooltip open when its anchor is clicked", async () => {
   await click(anchor);
   expect(q.tooltip("Bold label")).toBeVisible();
   await hoverOutside();
-  expect(q.tooltip("Bold label")).not.toBeInTheDocument();
+  expect(q.tooltip.maybe("Bold label")).not.toBeInTheDocument();
 });
 
 test("keeps the hover-triggered tooltip mounted during leave", async () => {
@@ -33,7 +33,9 @@ test("keeps the hover-triggered tooltip mounted during leave", async () => {
   expect(await q.tooltip.wait("Animated tooltip")).toBeVisible();
   await hoverOutside();
   expect(q.tooltip.hidden("Animated tooltip")).toBeVisible();
-  await expect.poll(q.tooltip.lazy("Animated tooltip")).not.toBeInTheDocument();
+  await expect
+    .poll(q.tooltip.maybe.lazy("Animated tooltip"))
+    .not.toBeInTheDocument();
 });
 
 test("keeps the focus-triggered tooltip mounted during leave", async () => {
@@ -45,7 +47,9 @@ test("keeps the focus-triggered tooltip mounted during leave", async () => {
   expect(q.tooltip("Animated tooltip")).toBeVisible();
   await click(q.button("Bold"));
   expect(q.tooltip.hidden("Animated tooltip")).toBeVisible();
-  await expect.poll(q.tooltip.lazy("Animated tooltip")).not.toBeInTheDocument();
+  await expect
+    .poll(q.tooltip.maybe.lazy("Animated tooltip"))
+    .not.toBeInTheDocument();
 });
 
 test("Escape from animated tooltip content restores the anchor", async () => {
@@ -55,5 +59,7 @@ test("Escape from animated tooltip content restores the anchor", async () => {
   await click(q.tooltip("Animated tooltip"));
   await press.Escape();
   expect(anchor).toHaveFocus();
-  await expect.poll(q.tooltip.lazy("Animated tooltip")).not.toBeInTheDocument();
+  await expect
+    .poll(q.tooltip.maybe.lazy("Animated tooltip"))
+    .not.toBeInTheDocument();
 });

--- a/packages/ariakit-test/readme.md
+++ b/packages/ariakit-test/readme.md
@@ -283,14 +283,14 @@ interface QueryObject extends RoleQueries {
 const query: QueryObject;
 ```
 
-Queries the DOM by ARIA role, accessible name, text, or label, built on top of Testing Library. Call a role method such as `query.button(name)` or `query.dialog()` to get the matching element (or `null`), passing a string or `RegExp` to match its accessible name. Use `query.text()` and `query.labeled()` to query by text content or associated label, and `query.within(element)` to scope queries to a subtree.
+Queries the DOM by ARIA role, accessible name, text, or label, built on top of Testing Library. Call a role method such as `query.button(name)` or `query.dialog()` to get the matching element, passing a string or `RegExp` to match its accessible name. Queries throw when no matching element is found. Use `query.text()` and `query.labeled()` to query by text content or associated label, and `query.within(element)` to scope queries to a subtree.
 
-Every query also exposes `.lazy` (return a reusable function that runs the query when called), `.all` (return all matches), `.wait` (resolve once the element appears), and `.ensure` (throw when it's missing) variants, and role queries additionally expose `.hidden` to include otherwise-hidden elements.
+Every query also exposes `.lazy` (return a reusable function that runs the query when called), `.all` (return all matches, including an empty array), `.wait` (resolve once the element appears), and `.maybe` (return `null` when it's missing) variants. Role queries additionally expose `.hidden` to include otherwise-hidden elements.
 
 Example:
 
 ```ts
-const dialog = query.dialog.lazy("Settings");
+const dialog = query.dialog.maybe.lazy("Settings");
 expect(dialog()).not.toBeInTheDocument();
 await click(query.button("Open settings"));
 expect(dialog()).toBeVisible();
@@ -326,7 +326,7 @@ Short alias for `query`. Queries the DOM by ARIA role, accessible name, text, or
 Example:
 
 ```ts
-const dialog = q.dialog.lazy("Settings");
+const dialog = q.dialog.maybe.lazy("Settings");
 expect(dialog()).not.toBeInTheDocument();
 await click(q.button("Open settings"));
 expect(dialog()).toBeVisible();
@@ -468,7 +468,7 @@ Example:
 
 ```ts
 await click(q.button("Close"));
-await waitFor(() => expect(q.dialog()).not.toBeInTheDocument());
+await waitFor(() => expect(q.dialog.maybe()).not.toBeInTheDocument());
 ```
 
 <div align="right">

--- a/packages/ariakit-test/src/__mouse.test.ts
+++ b/packages/ariakit-test/src/__mouse.test.ts
@@ -29,7 +29,7 @@ const enterEventTypes = ["pointerover", "pointerenter", "pointermove"];
 test("hover reports the contact and pointer a mouse reports", async () => {
   document.body.innerHTML = `<button type="button">Save</button>`;
 
-  const button = q.button.ensure("Save");
+  const button = q.button("Save");
   const events = recordPointerEvents(button, enterEventTypes);
 
   await hover(button);
@@ -47,7 +47,7 @@ test("hover reports the same values on the events leaving an element", async () 
     <button type="button">Cancel</button>
   `;
 
-  const save = q.button.ensure("Save");
+  const save = q.button("Save");
   const events = recordPointerEvents(save, [
     "pointermove",
     "pointerout",
@@ -70,7 +70,7 @@ test("hover reports the same values on the events leaving an element", async () 
 test("hover reports pressure while a button stays held", async () => {
   document.body.innerHTML = `<button type="button">Resize</button>`;
 
-  const button = q.button.ensure("Resize");
+  const button = q.button("Resize");
   const events = recordPointerEvents(button, ["pointermove"]);
 
   await hover(button, { buttons: 1 });
@@ -81,7 +81,7 @@ test("hover reports pressure while a button stays held", async () => {
 test("mouseDown and mouseUp report the pressure of the button they press", async () => {
   document.body.innerHTML = `<button type="button">Resize</button>`;
 
-  const button = q.button.ensure("Resize");
+  const button = q.button("Resize");
   const events = recordPointerEvents(button, ["pointerdown", "pointerup"]);
 
   await mouseDown(button);
@@ -96,7 +96,7 @@ test("mouseDown and mouseUp report the pressure of the button they press", async
 test("a chorded release keeps the pressure of the button still held", async () => {
   document.body.innerHTML = `<button type="button">Resize</button>`;
 
-  const button = q.button.ensure("Resize");
+  const button = q.button("Resize");
   const events = recordPointerEvents(button, [
     "pointerdown",
     "pointermove",
@@ -122,7 +122,7 @@ test("a chorded release keeps the pressure of the button still held", async () =
 test("click reports the values a browser reports through the gesture", async () => {
   document.body.innerHTML = `<button type="button">Submit</button>`;
 
-  const button = q.button.ensure("Submit");
+  const button = q.button("Submit");
   const events = recordPointerEvents(button, [
     ...enterEventTypes,
     "pointerdown",
@@ -146,7 +146,7 @@ test("click reports the values a browser reports through the gesture", async () 
 test("a press reports the transducer angle of a perpendicular pointer", async () => {
   document.body.innerHTML = `<button type="button">Resize</button>`;
 
-  const button = q.button.ensure("Resize");
+  const button = q.button("Resize");
   let angles: string | undefined;
   button.addEventListener("pointerdown", (event) => {
     angles = `${event.altitudeAngle} ${event.azimuthAngle}`;
@@ -160,7 +160,7 @@ test("a press reports the transducer angle of a perpendicular pointer", async ()
 test("explicit pointer values win over the simulated ones", async () => {
   document.body.innerHTML = `<button type="button">Draw</button>`;
 
-  const button = q.button.ensure("Draw");
+  const button = q.button("Draw");
   const events = recordPointerEvents(button, [
     "pointermove",
     "pointerdown",
@@ -192,7 +192,7 @@ test("explicit pointer values win over the simulated ones", async () => {
 test("an explicit zero pressure wins over the pressure a press derives", async () => {
   document.body.innerHTML = `<button type="button">Draw</button>`;
 
-  const button = q.button.ensure("Draw");
+  const button = q.button("Draw");
   const events = recordPointerEvents(button, ["pointerdown"]);
 
   await mouseDown(button, { pressure: 0 });

--- a/packages/ariakit-test/src/click.jsdom.test.ts
+++ b/packages/ariakit-test/src/click.jsdom.test.ts
@@ -19,7 +19,7 @@ function setupMultiSelect() {
 }
 
 function getSelect() {
-  return q.listbox.ensure("Fruits") as HTMLSelectElement;
+  return q.listbox("Fruits") as HTMLSelectElement;
 }
 
 function getSelectedValues() {

--- a/packages/ariakit-test/src/click.test.ts
+++ b/packages/ariakit-test/src/click.test.ts
@@ -43,7 +43,7 @@ test("shift-click exposes updated selectedOptions on change", async () => {
     </select>
   `;
 
-  const select = q.listbox.ensure("Fruits") as HTMLSelectElement;
+  const select = q.listbox("Fruits") as HTMLSelectElement;
   const date = q.option("Date");
   let changedSelection: string[] = [];
   let mouseUpSelection: string[] = [];
@@ -75,7 +75,7 @@ test("shift-click exposes updated selectedOptions on change", async () => {
 test("click with the auxiliary button dispatches auxclick instead of click", async () => {
   document.body.innerHTML = `<button type="button">Paste</button>`;
 
-  const button = q.button.ensure("Paste");
+  const button = q.button("Paste");
   const events = recordEvents(button);
 
   await click(button, { button: 1 });
@@ -95,7 +95,7 @@ test("click with the auxiliary button dispatches auxclick instead of click", asy
 test("click moves the pointer onto the element with no button held", async () => {
   document.body.innerHTML = `<button type="button">Paste</button>`;
 
-  const button = q.button.ensure("Paste");
+  const button = q.button("Paste");
   const events: string[] = [];
 
   const types = [
@@ -134,8 +134,8 @@ test("click and rightClick derive buttons from the button they press", async () 
     <button type="button">Open menu</button>
   `;
 
-  const paste = q.button.ensure("Paste");
-  const menu = q.button.ensure("Open menu");
+  const paste = q.button("Paste");
+  const menu = q.button("Open menu");
   const pasteEvents = recordEvents(paste);
   const menuEvents = recordEvents(menu);
 
@@ -164,7 +164,7 @@ test("click and rightClick derive buttons from the button they press", async () 
 test("click with the primary button keeps dispatching click", async () => {
   document.body.innerHTML = `<button type="button">Submit</button>`;
 
-  const button = q.button.ensure("Submit");
+  const button = q.button("Submit");
   const events = recordEvents(button);
 
   await click(button);
@@ -182,7 +182,7 @@ test("click with the primary button keeps dispatching click", async () => {
 test("click with the secondary button matches rightClick", async () => {
   document.body.innerHTML = `<button type="button">Open menu</button>`;
 
-  const button = q.button.ensure("Open menu");
+  const button = q.button("Open menu");
   const events = recordEvents(button);
 
   await click(button, { button: 2 });
@@ -204,7 +204,7 @@ test("click with the secondary button matches rightClick", async () => {
 test("click with the auxiliary button dispatches auxclick on disabled controls", async () => {
   document.body.innerHTML = `<button type="button" disabled>Paste</button>`;
 
-  const button = q.button.ensure("Paste");
+  const button = q.button("Paste");
   const events = recordEvents(button);
 
   await click(button, { button: 1 });
@@ -231,10 +231,10 @@ test("click with the auxiliary button doesn't run activation behavior", async ()
     </select>
   `;
 
-  const select = q.listbox.ensure("Fruits") as HTMLSelectElement;
-  const checkbox = q.checkbox.ensure("Agree") as HTMLInputElement;
-  const label = q.text.ensure("Agree");
-  const cherry = q.option.ensure("Cherry");
+  const select = q.listbox("Fruits") as HTMLSelectElement;
+  const checkbox = q.checkbox("Agree") as HTMLInputElement;
+  const label = q.text("Agree");
+  const cherry = q.option("Cherry");
   const checkboxEvents = recordEvents(checkbox);
   const labelEvents = recordEvents(label);
   const optionEvents = recordEvents(cherry);
@@ -291,7 +291,7 @@ function recordPointerMembers(element: Element, types: string[]) {
 test("click carries only the pointer identity to the click event", async () => {
   document.body.innerHTML = `<button type="button">Submit</button>`;
 
-  const button = q.button.ensure("Submit");
+  const button = q.button("Submit");
   const events = recordPointerMembers(button, ["pointerdown", "click"]);
 
   await click(button, {
@@ -312,7 +312,7 @@ test("click carries only the pointer identity to the click event", async () => {
 test("click with the auxiliary button carries the pointer identity to auxclick", async () => {
   document.body.innerHTML = `<button type="button">Paste</button>`;
 
-  const button = q.button.ensure("Paste");
+  const button = q.button("Paste");
   const events = recordPointerMembers(button, ["pointerdown", "auxclick"]);
 
   await click(button, {
@@ -340,8 +340,8 @@ test("click forwards the pointer identity from a label to its control", async ()
     <input id="agree" type="checkbox">
   `;
 
-  const label = q.text.ensure("Agree");
-  const checkbox = q.checkbox.ensure("Agree");
+  const label = q.text("Agree");
+  const checkbox = q.checkbox("Agree");
   const events = recordPointerMembers(checkbox, ["click"]);
 
   await click(label, {
@@ -360,7 +360,7 @@ test("click forwards the pointer identity from a label to its control", async ()
 test("rightClick carries the pointer identity to contextmenu and auxclick", async () => {
   document.body.innerHTML = `<button type="button">Open menu</button>`;
 
-  const button = q.button.ensure("Open menu");
+  const button = q.button("Open menu");
   const events = recordPointerMembers(button, [
     "pointerdown",
     "contextmenu",
@@ -402,7 +402,7 @@ function recordModifiers(element: Element, modifier: string) {
 test("click with the auxiliary button reports its modifier state on auxclick", async () => {
   document.body.innerHTML = `<button type="button">Paste</button>`;
 
-  const button = q.button.ensure("Paste");
+  const button = q.button("Paste");
   const states = recordModifiers(button, "CapsLock");
 
   await click(button, { button: 1, modifierCapsLock: true });
@@ -413,7 +413,7 @@ test("click with the auxiliary button reports its modifier state on auxclick", a
 test("rightClick reports its modifier state on auxclick", async () => {
   document.body.innerHTML = `<button type="button">Open menu</button>`;
 
-  const button = q.button.ensure("Open menu");
+  const button = q.button("Open menu");
   const states = recordModifiers(button, "AltGraph");
 
   await rightClick(button, { modifierAltGraph: true });

--- a/packages/ariakit-test/src/mouse-down.test.ts
+++ b/packages/ariakit-test/src/mouse-down.test.ts
@@ -125,8 +125,8 @@ test("click suppresses mouse events when pointerdown is prevented", async () => 
     <button type="button">Press me</button>
   `;
 
-  const input = q.textbox.ensure("Before");
-  const button = q.button.ensure("Press me");
+  const input = q.textbox("Before");
+  const button = q.button("Press me");
   const events: string[] = [];
   let preventPointerDown = true;
 
@@ -168,7 +168,7 @@ test("click suppresses mouse events when pointerdown is prevented", async () => 
 test("mouseUp suppresses mouseup after a prevented pointerdown", async () => {
   document.body.innerHTML = `<button type="button">Press me</button>`;
 
-  const button = q.button.ensure("Press me");
+  const button = q.button("Press me");
   const events: string[] = [];
   let preventPointerDown = true;
 
@@ -203,7 +203,7 @@ test("mouseUp suppresses mouseup after a prevented pointerdown", async () => {
 test("mouseDown and mouseUp report the held button", async () => {
   document.body.innerHTML = `<button type="button">Resize</button>`;
 
-  const button = q.button.ensure("Resize");
+  const button = q.button("Resize");
   const events = recordPressEvents(button);
 
   const heldButtons = [
@@ -240,7 +240,7 @@ test("mouseDown and mouseUp report the held button", async () => {
 test("mouseDown and mouseUp fire pointermove for a chorded button change", async () => {
   document.body.innerHTML = `<button type="button">Resize</button>`;
 
-  const button = q.button.ensure("Resize");
+  const button = q.button("Resize");
   const events = recordPressEvents(button, chordEventTypes);
 
   // The primary button stays held while the secondary one is pressed and
@@ -269,7 +269,7 @@ test("mouseDown and mouseUp fire pointermove for a chorded button change", async
 test("a canceled pointermove keeps the mouse events of a chorded gesture", async () => {
   document.body.innerHTML = `<button type="button">Resize</button>`;
 
-  const button = q.button.ensure("Resize");
+  const button = q.button("Resize");
   const events = recordPressEvents(button, chordEventTypes);
   button.addEventListener("pointermove", (event) => event.preventDefault());
 
@@ -296,7 +296,7 @@ test("a canceled pointermove keeps the mouse events of a chorded gesture", async
 test("a canceled pointerdown suppresses the mouse events of a chorded gesture", async () => {
   document.body.innerHTML = `<button type="button">Resize</button>`;
 
-  const button = q.button.ensure("Resize");
+  const button = q.button("Resize");
   const events = recordPressEvents(button, chordEventTypes);
   button.addEventListener("pointerdown", (event) => event.preventDefault());
 
@@ -316,7 +316,7 @@ test("a canceled pointerdown suppresses the mouse events of a chorded gesture", 
 // `select` runs every step from one init like `click` does, so it derives each
 // step and ignores an explicit `buttons`.
 test("select derives buttons from the button it presses", async () => {
-  const paragraph = q.text.ensure(/Keep this/);
+  const paragraph = q.text(/Keep this/);
   const events = recordPressEvents(paragraph);
 
   await select(selectionText, paragraph, { buttons: 3 });

--- a/packages/ariakit-test/src/query.test.ts
+++ b/packages/ariakit-test/src/query.test.ts
@@ -7,7 +7,7 @@ afterEach(() => {
 });
 
 test("lazy role queries run when called", () => {
-  const dialog = q.dialog.lazy("Name");
+  const dialog = q.dialog.maybe.lazy("Name");
 
   expect(dialog()).toBeNull();
 
@@ -23,7 +23,7 @@ test("lazy role queries run when called", () => {
 });
 
 test("lazy role query variants run the matching variant", () => {
-  const dialog = q.dialog.ensure.lazy("Visible");
+  const dialog = q.dialog.lazy("Visible");
   const hiddenDialog = q.dialog.hidden.lazy("Hidden");
   const dialogs = q.dialog.all.lazy("Visible");
 
@@ -43,8 +43,8 @@ test("lazy role queries can be scoped with within", () => {
     <div role="dialog" aria-label="Scoped">Outside</div>
   `;
 
-  const region = q.region.ensure("Wrapper");
-  const dialog = q.within(region).dialog.lazy("Scoped");
+  const region = q.region("Wrapper");
+  const dialog = q.within(region).dialog.maybe.lazy("Scoped");
 
   expect(dialog()).toBeNull();
 
@@ -54,8 +54,8 @@ test("lazy role queries can be scoped with within", () => {
 });
 
 test("lazy text and label queries run when called", () => {
-  const text = q.text.lazy<HTMLButtonElement>("Submit");
-  const input = q.labeled.lazy<HTMLInputElement>("Email");
+  const text = q.text.maybe.lazy<HTMLButtonElement>("Submit");
+  const input = q.labeled.maybe.lazy<HTMLInputElement>("Email");
 
   expect(text()).toBeNull();
   expect(input()).toBeNull();
@@ -71,18 +71,14 @@ test("lazy text and label queries run when called", () => {
 });
 
 test("lazy text and label query variants run the matching variant", async () => {
-  const text = q.text.ensure.lazy("Ready");
+  const text = q.text.lazy("Ready");
   const texts = q.text.all.lazy("Submit");
   const waitedTexts = q.text.wait.all.lazy("Submit");
   const allWaitedTexts = q.text.all.wait.lazy("Submit");
-  const ensuredTexts = q.text.ensure.all.lazy("Submit");
-  const allEnsuredTexts = q.text.all.ensure.lazy("Submit");
-  const label = q.labeled.ensure.lazy<HTMLInputElement>("Name");
+  const label = q.labeled.lazy<HTMLInputElement>("Name");
   const labels = q.labeled.all.lazy<HTMLInputElement>("Email");
   const waitedLabels = q.labeled.wait.all.lazy<HTMLInputElement>("Email");
   const allWaitedLabels = q.labeled.all.wait.lazy<HTMLInputElement>("Email");
-  const ensuredLabels = q.labeled.ensure.all.lazy<HTMLInputElement>("Email");
-  const allEnsuredLabels = q.labeled.all.ensure.lazy<HTMLInputElement>("Email");
 
   document.body.innerHTML = `
     <button>Submit</button>
@@ -97,12 +93,21 @@ test("lazy text and label query variants run the matching variant", async () => 
   expect(texts()).toHaveLength(2);
   await expect(waitedTexts()).resolves.toHaveLength(2);
   await expect(allWaitedTexts()).resolves.toHaveLength(2);
-  expect(ensuredTexts()).toHaveLength(2);
-  expect(allEnsuredTexts()).toHaveLength(2);
   expect(label()).toBeInstanceOf(HTMLInputElement);
   expect(labels()).toHaveLength(2);
   await expect(waitedLabels()).resolves.toHaveLength(2);
   await expect(allWaitedLabels()).resolves.toHaveLength(2);
-  expect(ensuredLabels()).toHaveLength(2);
-  expect(allEnsuredLabels()).toHaveLength(2);
+});
+
+test("queries ensure matches by default", () => {
+  expect(() => q.button("Save")).toThrow();
+  expect(() => q.text("Ready")).toThrow();
+  expect(() => q.labeled("Name")).toThrow();
+
+  expect(q.button.maybe("Save")).toBeNull();
+  expect(q.button.all("Save")).toHaveLength(0);
+  expect(q.text.maybe("Ready")).toBeNull();
+  expect(q.text.all("Ready")).toHaveLength(0);
+  expect(q.labeled.maybe("Name")).toBeNull();
+  expect(q.labeled.all("Name")).toHaveLength(0);
 });

--- a/packages/ariakit-test/src/query.ts
+++ b/packages/ariakit-test/src/query.ts
@@ -93,8 +93,7 @@ interface TextQueryParams {
   all: TextMethod<"array", TextQueryArgs>;
   wait: TextMethod<"waitValue", TextWaitQueryArgs>;
   waitAll: TextMethod<"waitArray", TextWaitQueryArgs>;
-  ensure: TextMethod<"value", TextQueryArgs>;
-  ensureAll: TextMethod<"array", TextQueryArgs>;
+  maybe: TextMethod<"nullable", TextQueryArgs>;
 }
 
 interface QueryObject extends RoleQueries {
@@ -188,20 +187,16 @@ function createRoleQuery(role: AriaRole, queries = documentQueries) {
         query(name, { hidden: true, ...options }),
     );
 
-  const query = assignLazy(createQuery(queries.queryByRole));
+  const query = assignLazy(createQuery(queries.getByRole));
   const allQuery = assignLazy(createQuery(queries.queryAllByRole));
   const waitQuery = assignLazy(createQuery(queries.findByRole));
   const waitAllQuery = assignLazy(createQuery(queries.findAllByRole));
-  const ensureQuery = assignLazy(createQuery(queries.getByRole));
-  const ensureAllQuery = assignLazy(createQuery(queries.getAllByRole));
+  const maybeQuery = assignLazy(createQuery(queries.queryByRole));
 
   const all = Object.assign(allQuery, {
     hidden: createHiddenQuery(allQuery),
     wait: Object.assign(waitAllQuery, {
       hidden: createHiddenQuery(waitAllQuery),
-    }),
-    ensure: Object.assign(ensureAllQuery, {
-      hidden: createHiddenQuery(ensureAllQuery),
     }),
   });
 
@@ -212,18 +207,15 @@ function createRoleQuery(role: AriaRole, queries = documentQueries) {
     }),
   });
 
-  const ensure = Object.assign(ensureQuery, {
-    hidden: createHiddenQuery(ensureQuery),
-    all: Object.assign(ensureAllQuery, {
-      hidden: createHiddenQuery(ensureAllQuery),
-    }),
+  const maybe = Object.assign(maybeQuery, {
+    hidden: createHiddenQuery(maybeQuery),
   });
 
   return Object.assign(query, {
     hidden: createHiddenQuery(query),
     all,
     wait,
-    ensure,
+    maybe,
   });
 }
 
@@ -235,7 +227,7 @@ function createRoleQueries(queries = documentQueries) {
 }
 
 function createTextQuery(
-  defaultQuery: TextMethod<"nullable", TextQueryArgs>,
+  defaultQuery: TextMethod<"value", TextQueryArgs>,
   params: TextQueryParams,
 ) {
   const query = assignTextLazy(defaultQuery);
@@ -245,35 +237,30 @@ function createTextQuery(
     all: assignTextLazy(params.waitAll),
   });
 
-  const ensure = Object.assign(assignTextLazy(params.ensure), {
-    all: assignTextLazy(params.ensureAll),
-  });
+  const maybe = assignTextLazy(params.maybe);
 
   const all = Object.assign(allQuery, {
     wait: wait.all,
-    ensure: ensure.all,
   });
 
-  return Object.assign(query, { all, wait, ensure });
+  return Object.assign(query, { all, wait, maybe });
 }
 
 function createTextQueryObject(queries = documentQueries) {
-  return createTextQuery(queries.queryByText, {
+  return createTextQuery(queries.getByText, {
     all: queries.queryAllByText,
     wait: queries.findByText,
     waitAll: queries.findAllByText,
-    ensure: queries.getByText,
-    ensureAll: queries.getAllByText,
+    maybe: queries.queryByText,
   });
 }
 
 function createLabeledQuery(queries = documentQueries) {
-  return createTextQuery(queries.queryByLabelText, {
+  return createTextQuery(queries.getByLabelText, {
     all: queries.queryAllByLabelText,
     wait: queries.findByLabelText,
     waitAll: queries.findAllByLabelText,
-    ensure: queries.getByLabelText,
-    ensureAll: queries.getAllByLabelText,
+    maybe: queries.queryByLabelText,
   });
 }
 
@@ -292,18 +279,19 @@ function createQueryObject(queries = documentQueries): QueryObject {
 /**
  * Queries the DOM by ARIA role, accessible name, text, or label, built on top of
  * Testing Library. Call a role method such as `query.button(name)` or
- * `query.dialog()` to get the matching element (or `null`), passing a string or
- * `RegExp` to match its accessible name. Use `query.text()` and `query.labeled()`
- * to query by text content or associated label, and `query.within(element)` to
- * scope queries to a subtree.
+ * `query.dialog()` to get the matching element, passing a string or `RegExp` to
+ * match its accessible name. Queries throw when no matching element is found.
+ * Use `query.text()` and `query.labeled()` to query by text content or associated
+ * label, and `query.within(element)` to scope queries to a subtree.
  *
  * Every query also exposes `.lazy` (return a reusable function that runs the
- * query when called), `.all` (return all matches), `.wait` (resolve once the
- * element appears), and `.ensure` (throw when it's missing) variants, and role
- * queries additionally expose `.hidden` to include otherwise-hidden elements.
+ * query when called), `.all` (return all matches, including an empty array),
+ * `.wait` (resolve once the element appears), and `.maybe` (return `null` when
+ * it's missing) variants. Role queries additionally expose `.hidden` to include
+ * otherwise-hidden elements.
  * @example
  * ```ts
- * const dialog = query.dialog.lazy("Settings");
+ * const dialog = query.dialog.maybe.lazy("Settings");
  * expect(dialog()).not.toBeInTheDocument();
  * await click(query.button("Open settings"));
  * expect(dialog()).toBeVisible();
@@ -319,7 +307,7 @@ export const query = createQueryObject();
  * label.
  * @example
  * ```ts
- * const dialog = q.dialog.lazy("Settings");
+ * const dialog = q.dialog.maybe.lazy("Settings");
  * expect(dialog()).not.toBeInTheDocument();
  * await click(q.button("Open settings"));
  * expect(dialog()).toBeVisible();

--- a/packages/ariakit-test/src/right-click.test.ts
+++ b/packages/ariakit-test/src/right-click.test.ts
@@ -8,7 +8,7 @@ afterEach(() => {
 test("rightClick dispatches a secondary click sequence", async () => {
   document.body.innerHTML = `<button type="button">Open menu</button>`;
 
-  const button = q.button.ensure("Open menu");
+  const button = q.button("Open menu");
   const events: string[] = [];
   const mouseEvents: Array<{
     button: number;
@@ -64,7 +64,7 @@ test("rightClick dispatches a secondary click sequence", async () => {
 test("rightClick dispatches contextmenu and auxclick after prevented pointerdown", async () => {
   document.body.innerHTML = `<button type="button">Open menu</button>`;
 
-  const button = q.button.ensure("Open menu");
+  const button = q.button("Open menu");
   const events: string[] = [];
 
   for (const type of [
@@ -103,7 +103,7 @@ test("rightClick retargets pointer events on pointer-events none", async () => {
   `;
 
   const parent = document.querySelector("[data-testid='parent']");
-  const button = q.button.ensure("Open menu");
+  const button = q.button("Open menu");
   const events: string[] = [];
 
   parent?.addEventListener("pointerdown", (event) => {

--- a/packages/ariakit-test/src/select.test.ts
+++ b/packages/ariakit-test/src/select.test.ts
@@ -11,7 +11,7 @@ afterEach(() => {
 test("select carries only the pointer identity to the click event", async () => {
   document.body.innerHTML = `<div>first second third</div>`;
 
-  const element = q.text.ensure("first second third");
+  const element = q.text("first second third");
   const events: string[] = [];
   element.addEventListener("click", (event) => {
     const isPointerEvent = event instanceof PointerEvent;

--- a/packages/ariakit-test/src/wait-for.ts
+++ b/packages/ariakit-test/src/wait-for.ts
@@ -9,7 +9,7 @@ import { wrapAsync } from "./__utils.ts";
  * @example
  * ```ts
  * await click(q.button("Close"));
- * await waitFor(() => expect(q.dialog()).not.toBeInTheDocument());
+ * await waitFor(() => expect(q.dialog.maybe()).not.toBeInTheDocument());
  * ```
  */
 export function waitFor<T>(


### PR DESCRIPTION
## Motivation

`@ariakit/test` queries currently return nullable elements by default even though most tests expect a match and fail later when it is missing. Consumers must add `.ensure` to get an immediate Testing Library error and a non-null return type.

```ts
const button = q.button.ensure("Save");
```

## Solution

Make single-element role, text, and label queries use ensure semantics by default, remove `.ensure`, and add `.maybe` for queries that intentionally accept a missing element. Keep `.all()` non-throwing so empty collections remain valid.

```ts
const button = q.button("Save");
const dialog = q.dialog.maybe("Settings");
const options = q.option.all();
```

The repository test call sites are migrated so ordinary lookups stay bare and only negative presence checks or absence-tolerant polling use `.maybe`.
