### PR TITLE
Fix event initialization for composition events and cross-realm targets

### DIFF
--- a/.changeset/300-test-composition-event-members.md
+++ b/.changeset/300-test-composition-event-members.md
@@ -1,0 +1,11 @@
+---
+"@ariakit/test": patch
+---
+
+Composition dispatchers report `data`, `view`, and `detail`
+
+`dispatch.compositionStart`, `dispatch.compositionUpdate`, and `dispatch.compositionEnd` now report the members `CompositionEvent` defines, so a listener reading `data` receives the composed text instead of `undefined`, along with the `view` and `detail` the interface inherits from `UIEvent`.
+
+`type` composes text through `dispatch.compositionUpdate` when you pass `isComposing`, so an IME-aware listener now reads each character it simulates.
+
+This affected happy-dom, whose `CompositionEvent` is an alias for `Event`, and not jsdom or real browsers, which implement the interface themselves.

--- a/.changeset/300-test-cross-realm-event-init.md
+++ b/.changeset/300-test-cross-realm-event-init.md
@@ -1,0 +1,11 @@
+---
+"@ariakit/test": patch
+---
+
+Events dispatched inside a same-origin iframe are initialized
+
+`dispatch` builds an event with the constructors of the window that owns its target, so an event dispatched at an element inside an iframe belongs to that frame. The initialization then tested it against the outer window's constructors, matched none of them, and skipped every member it assigns.
+
+A keyboard or mouse event reached its listeners with the modifier state its own constructor happened to store, rather than the one the dispatch described. The events already recognized by their type, which are the pointer and click families along with the drag events and `wheel`, were unaffected.
+
+This affected any environment that gives a frame its own constructors, including jsdom and real browsers, but not happy-dom, whose frames share the parent's.

--- a/packages/ariakit-test/src/__init-event.ts
+++ b/packages/ariakit-test/src/__init-event.ts
@@ -1,5 +1,7 @@
 // Part of this code is based on https://github.com/testing-library/user-event/blob/d7483f049a1ec2ebf1ca1e2c1f4367849fca5997/src/event/createEvent.ts
 import { getKeys } from "@ariakit/utils";
+import type { OwnerWindowSource } from "./__utils.ts";
+import { getOwnerWindow } from "./__utils.ts";
 
 type SpecificEventInit<E extends Event> = E extends InputEvent
   ? InputEventInit
@@ -11,9 +13,35 @@ type SpecificEventInit<E extends Event> = E extends InputEvent
         ? PointerEventInit
         : E extends MouseEvent
           ? MouseEventInit
-          : E extends UIEvent
-            ? UIEventInit
-            : EventInit;
+          : E extends CompositionEvent
+            ? CompositionEventInit
+            : E extends UIEvent
+              ? UIEventInit
+              : EventInit;
+
+// The realm whose constructors an interface test runs against: the window that
+// owns the target the event was built for, or the ambient globals when that
+// target has no window. `createEvent` resolves the constructor the same way, so
+// an event built for a node inside a same-origin iframe belongs to that frame
+// and matches no ambient `instanceof`.
+// https://github.com/ariakit/ariakit/issues/7195
+type EventRealm = typeof globalThis;
+
+function getEventRealm(target: OwnerWindowSource): EventRealm {
+  return getOwnerWindow(target) ?? globalThis;
+}
+
+// A realm doesn't necessarily implement every interface `initEvent` tests for,
+// so a missing constructor has to answer false rather than throw. jsdom has
+// `PointerEvent` only from v27 on, and `shims.ts` installs `ClipboardEvent` on
+// the ambient realm only, so an iframe realm has none even though the top one
+// does. https://github.com/ariakit/ariakit/issues/7200
+function isInstanceOf<T>(
+  event: Event,
+  constructor: (new (...args: never[]) => T) | undefined,
+): event is Event & T {
+  return typeof constructor === "function" && event instanceof constructor;
+}
 
 function assignProps<T extends object>(
   obj: T,
@@ -35,7 +63,7 @@ function sanitizeNumber(n: number | undefined) {
   return n ?? 0;
 }
 
-function sanitizeString(value: string | undefined) {
+function sanitizeString(value: string | null | undefined) {
   return value ?? "";
 }
 
@@ -79,6 +107,22 @@ function initUIEvent(event: UIEvent, { view, detail }: UIEventInit) {
   assignProps(event, {
     view,
     detail: sanitizeNumber(detail),
+  });
+}
+
+// `CompositionEventInit` defaults `data` to the empty string, which is what
+// Chromium 151, Firefox 153, and WebKit 26.5 report for an event built without
+// it. `data` is also the only member the interface adds to `UIEvent`. The
+// parameter accepts `InputEventInit` too, because `initEvent` hands every
+// initializer the same options object and that interface declares a nullable
+// `data` of its own.
+// https://w3c.github.io/uievents/#idl-compositionevent
+function initCompositionEvent(
+  event: CompositionEvent,
+  { data }: CompositionEventInit | InputEventInit,
+) {
+  assignProps(event, {
+    data: sanitizeString(data),
   });
 }
 
@@ -265,28 +309,44 @@ const pointerEventTypes = new Set([
   "pointerup",
 ]);
 
-function isPointerEvent(event: Event): event is PointerEvent {
-  // `typeof` first, because the bare global throws where it doesn't exist,
-  // which is the very case the name test covers.
-  if (typeof PointerEvent !== "undefined" && event instanceof PointerEvent) {
-    return true;
-  }
+function isPointerEvent(
+  event: Event,
+  realm: EventRealm,
+): event is PointerEvent {
+  if (isInstanceOf(event, realm.PointerEvent)) return true;
   return pointerEventTypes.has(event.type);
 }
 
-function isMouseEvent(event: Event): event is MouseEvent {
-  if (event instanceof MouseEvent) return true;
+function isMouseEvent(event: Event, realm: EventRealm): event is MouseEvent {
+  if (isInstanceOf(event, realm.MouseEvent)) return true;
   // `PointerEvent` derives from `MouseEvent`, so a pointer event carries the
   // mouse members too.
-  if (isPointerEvent(event)) return true;
+  if (isPointerEvent(event, realm)) return true;
   return mouseDerivedEventTypes.has(event.type);
 }
 
-function isUIEvent(event: Event): event is UIEvent {
-  if (event instanceof UIEvent) return true;
-  // `MouseEvent` derives from `UIEvent`, so anything carrying the mouse members
-  // carries the `UIEvent` ones too.
-  return isMouseEvent(event);
+// The three types `CompositionEvent` covers. happy-dom aliases the interface to
+// `Event`, so `instanceof` there answers true for every event rather than these
+// alone, and the type is the only thing that separates them. Any event
+// `initEvent` sees with one of these names was built by the matching named
+// dispatcher, so the name identifies the interface here.
+// https://github.com/ariakit/ariakit/issues/7174
+const compositionEventTypes = new Set([
+  "compositionstart",
+  "compositionupdate",
+  "compositionend",
+]);
+
+function isCompositionEvent(event: Event): event is CompositionEvent {
+  return compositionEventTypes.has(event.type);
+}
+
+function isUIEvent(event: Event, realm: EventRealm): event is UIEvent {
+  if (isInstanceOf(event, realm.UIEvent)) return true;
+  // `MouseEvent` and `CompositionEvent` both derive from `UIEvent`, so anything
+  // carrying either interface's members carries the `UIEvent` ones too.
+  if (isMouseEvent(event, realm)) return true;
+  return isCompositionEvent(event);
 }
 
 /**
@@ -296,29 +356,36 @@ function isUIEvent(event: Event): event is UIEvent {
  * `keyCode` under happy-dom. Only a caller that built the event for a known
  * event name may run this, because it overwrites whatever the constructor did
  * with the values in `options`.
+ * @param target The node, document, or window the event was built for, whose
+ * realm owns the constructors the interface tests run against.
  */
 export function initEvent<T extends Event>(
   event: T,
+  target: OwnerWindowSource,
   options: SpecificEventInit<T> = {} as SpecificEventInit<T>,
 ) {
-  if (event instanceof ClipboardEvent) {
+  const realm = getEventRealm(target);
+  if (isInstanceOf(event, realm.ClipboardEvent)) {
     initClipboardEvent(event, options);
   }
-  if (event instanceof InputEvent) {
+  if (isInstanceOf(event, realm.InputEvent)) {
     initInputEvent(event, options);
   }
-  if (isUIEvent(event)) {
+  if (isUIEvent(event, realm)) {
     initUIEvent(event, options);
   }
-  if (event instanceof KeyboardEvent) {
+  if (isCompositionEvent(event)) {
+    initCompositionEvent(event, options);
+  }
+  if (isInstanceOf(event, realm.KeyboardEvent)) {
     initKeyboardEvent(event, options);
     initUIEventModifiers(event, options);
   }
-  if (isMouseEvent(event)) {
+  if (isMouseEvent(event, realm)) {
     initMouseEvent(event, options);
     initUIEventModifiers(event, options);
   }
-  if (isPointerEvent(event)) {
+  if (isPointerEvent(event, realm)) {
     initPointerEvent(event, options);
   }
 }

--- a/packages/ariakit-test/src/__utils.ts
+++ b/packages/ariakit-test/src/__utils.ts
@@ -14,6 +14,34 @@ export function isHappyDOM(
   return !!win && "happyDOM" in win;
 }
 
+export type OwnerWindowSource = Window | Document | Node | null | undefined;
+
+/**
+ * The window that owns `target`, which is the realm `@testing-library/dom`
+ * builds an event in, or `null` when none can be resolved. Read a constructor
+ * from here rather than from the ambient global whenever the target may live in
+ * a same-origin iframe, because that frame has interfaces of its own.
+ * https://github.com/ariakit/ariakit/issues/7195
+ */
+export function getOwnerWindow(target: OwnerWindowSource) {
+  if (!target) return null;
+  // `ownerDocument` first, because a form exposes its controls as named
+  // properties and one named `document` would answer the branch below. Neither
+  // happy-dom nor jsdom implements the form's `[LegacyOverrideBuiltIns]`, so
+  // this name still resolves through `Node.prototype` there; a browser does
+  // implement it, but `createEvent` resolves the window just as fragilely then.
+  // A `Document` reports `null` here and falls through to its own view.
+  // https://html.spec.whatwg.org/multipage/forms.html#the-form-element
+  if ("ownerDocument" in target && target.ownerDocument) {
+    return target.ownerDocument.defaultView;
+  }
+  if ("defaultView" in target) return target.defaultView;
+  // Through the document either way, since only `defaultView` is typed with the
+  // constructors a window carries.
+  if ("document" in target) return target.document.defaultView;
+  return null;
+}
+
 export const isBrowser =
   typeof navigator !== "undefined" &&
   !navigator.userAgent.includes("jsdom") &&

--- a/packages/ariakit-test/src/dispatch-without-pointer-event.test.ts
+++ b/packages/ariakit-test/src/dispatch-without-pointer-event.test.ts
@@ -17,9 +17,12 @@ afterAll(() => {
 });
 
 test("runs in an environment with no PointerEvent constructor", () => {
-  // `initEvent` reads the ambient binding, so pin that rather than the window
-  // property: they coincide only while the environment makes them the same
-  // object, and the mouse assertions below would pass either way.
+  // `initEvent` and `createNamedEvent` both read the constructor off the window
+  // that owns the target, so the window property is the one that gates the path
+  // below. The ambient binding is pinned too, because they coincide only while
+  // the environment makes them the same object, and the mouse assertions below
+  // would pass either way.
+  expect(typeof window.PointerEvent).toBe("undefined");
   expect(typeof PointerEvent).toBe("undefined");
 });
 

--- a/packages/ariakit-test/src/dispatch.jsdom.test.ts
+++ b/packages/ariakit-test/src/dispatch.jsdom.test.ts
@@ -3,6 +3,144 @@
 import { expect, test } from "vitest";
 import { dispatch } from "./index.ts";
 
+// A same-origin iframe, whose document is a realm of its own. jsdom builds
+// distinct constructors per realm, and happy-dom shares the parent's, so the
+// cross-realm tests below can only run here.
+function createIframeButton() {
+  const iframe = document.createElement("iframe");
+  document.body.append(iframe);
+  // Reached through the document rather than `contentWindow`, which lib.dom
+  // types as a bare `Window` without the constructors this fixture compares.
+  const iframeWindow = iframe.contentDocument?.defaultView;
+  if (!iframeWindow) throw new Error("Unable to reach the iframe window");
+  const button = iframeWindow.document.createElement("button");
+  iframeWindow.document.body.append(button);
+  return {
+    iframeWindow,
+    button,
+    [Symbol.dispose]() {
+      iframe.remove();
+    },
+  };
+}
+
+// `createEvent` resolves the constructor from the target's own window, so an
+// event dispatched at a node inside an iframe is built in that realm and matches
+// none of the ambient `instanceof` tests `initEvent` picked its initializers
+// with. Every member only an initializer assigns was left undefined.
+//
+// These two types prove it because neither is reached by a name. The type
+// fallbacks cover the drag events and `wheel` (`mouseDerivedEventTypes`), the
+// pointer and click families (`pointerEventTypes`), and the three composition
+// names (`compositionEventTypes`), so `keydown` and `mousedown` are reached by
+// the realm-resolved interface test alone. Measured on this fixture, `mouseup`
+// and `mousemove` behave the same way.
+// https://github.com/ariakit/ariakit/issues/7195
+test.each([
+  ["keyDown", "keydown"],
+  ["mouseDown", "mousedown"],
+] as const)(
+  "dispatch.%s initializes an event dispatched inside an iframe",
+  async (dispatcher, type) => {
+    using fixture = createIframeButton();
+    const { button, iframeWindow } = fixture;
+    let event: KeyboardEvent | MouseEvent | undefined;
+    button.addEventListener(type, (receivedEvent) => {
+      event = receivedEvent;
+    });
+    await dispatch[dispatcher](button, {
+      // jsdom is the only environment that reports this modifier, so a false
+      // answer is what separates the `initUIEventModifiers` table from jsdom's
+      // own constructor. https://github.com/ariakit/ariakit/issues/7166
+      modifierHyper: true,
+      modifierCapsLock: true,
+    });
+    expect({
+      // Pinned so the test cannot pass by the event ceasing to be cross-realm.
+      ambientInstance: event instanceof UIEvent,
+      iframeInstance: event instanceof iframeWindow.UIEvent,
+      hyper: event?.getModifierState("Hyper"),
+      capsLock: event?.getModifierState("CapsLock"),
+      view: event?.view,
+      detail: event?.detail,
+    }).toEqual({
+      ambientInstance: false,
+      iframeInstance: true,
+      hyper: false,
+      capsLock: true,
+      view: null,
+      detail: 0,
+    });
+  },
+);
+
+// The other two target shapes `dispatch` accepts. Each resolves the realm
+// through a branch of its own, and a resolution that failed for either would
+// fall back to the ambient globals, which are the wrong realm here.
+test.each(["document", "window"] as const)(
+  "dispatch.keyDown initializes an event dispatched at an iframe %s",
+  async (shape) => {
+    using fixture = createIframeButton();
+    const { iframeWindow } = fixture;
+    const target = shape === "document" ? iframeWindow.document : iframeWindow;
+    let event: KeyboardEvent | undefined;
+    const listener = (receivedEvent: Event) => {
+      event = receivedEvent as KeyboardEvent;
+    };
+    target.addEventListener("keydown", listener);
+    await dispatch.keyDown(target, { modifierHyper: true });
+    expect({
+      ambientInstance: event instanceof KeyboardEvent,
+      iframeInstance: event instanceof iframeWindow.KeyboardEvent,
+      hyper: event?.getModifierState("Hyper"),
+    }).toEqual({
+      ambientInstance: false,
+      iframeInstance: true,
+      hyper: false,
+    });
+  },
+);
+
+// The pointer members reach a cross-realm event through the type fallback
+// `isPointerEvent` already applies, so this pins that the realm-resolved
+// interface test doesn't take them away again.
+test.each([
+  ["pointerDown", "pointerdown"],
+  ["click", "click"],
+] as const)(
+  "dispatch.%s initializes an event dispatched inside an iframe",
+  async (dispatcher, type) => {
+    using fixture = createIframeButton();
+    const { button, iframeWindow } = fixture;
+    let event: PointerEvent | undefined;
+    button.addEventListener(type, (receivedEvent) => {
+      event = receivedEvent;
+    });
+    await dispatch[dispatcher](button, { pointerType: "pen", tiltX: 30 });
+    expect({
+      ambientInstance: event instanceof PointerEvent,
+      iframeInstance: event instanceof iframeWindow.PointerEvent,
+      altitudeAngle: event?.altitudeAngle,
+      azimuthAngle: event?.azimuthAngle,
+      width: event?.width,
+      height: event?.height,
+      pointerType: event?.pointerType,
+      tiltX: event?.tiltX,
+      detail: event?.detail,
+    }).toEqual({
+      ambientInstance: false,
+      iframeInstance: true,
+      altitudeAngle: Math.PI / 2,
+      azimuthAngle: 0,
+      width: 1,
+      height: 1,
+      pointerType: "pen",
+      tiltX: 30,
+      detail: 0,
+    });
+  },
+);
+
 // jsdom reaches the same gap for a different reason: it ships no `DragEvent`,
 // so `createEvent` falls back to `Event`. Its `WheelEvent` already derives from
 // `MouseEvent`, and is pinned here so fixing drag can't stop initializing it.

--- a/packages/ariakit-test/src/dispatch.test.ts
+++ b/packages/ariakit-test/src/dispatch.test.ts
@@ -609,3 +609,65 @@ test("dispatch.pointerDown preserves provided transducer angles", async () => {
     button.remove();
   }
 });
+
+// happy-dom aliases `CompositionEvent` to `Event`, so a composition event is an
+// instance of no interface `initEvent` tests for, and used to reach its
+// listeners with none of the members the interface defines.
+// https://github.com/ariakit/ariakit/issues/7174
+const compositionDispatchers = [
+  ["compositionStart", "compositionstart"],
+  ["compositionUpdate", "compositionupdate"],
+  ["compositionEnd", "compositionend"],
+] as const;
+
+function readCompositionMembers(event: CompositionEvent | undefined) {
+  return { data: event?.data, detail: event?.detail, view: event?.view };
+}
+
+test.each(compositionDispatchers)(
+  "dispatch.%s reports the CompositionEvent defaults",
+  async (dispatcher, type) => {
+    const input = document.createElement("input");
+    document.body.append(input);
+    let event: CompositionEvent | undefined;
+    input.addEventListener(type, (receivedEvent) => {
+      event = receivedEvent;
+    });
+    try {
+      await dispatch[dispatcher](input);
+      expect(readCompositionMembers(event)).toEqual({
+        data: "",
+        detail: 0,
+        view: null,
+      });
+    } finally {
+      input.remove();
+    }
+  },
+);
+
+test.each(compositionDispatchers)(
+  "dispatch.%s preserves the provided CompositionEvent members",
+  async (dispatcher, type) => {
+    const input = document.createElement("input");
+    document.body.append(input);
+    let event: CompositionEvent | undefined;
+    input.addEventListener(type, (receivedEvent) => {
+      event = receivedEvent;
+    });
+    try {
+      await dispatch[dispatcher](input, {
+        data: "ni",
+        detail: 3,
+        view: window,
+      });
+      expect(readCompositionMembers(event)).toEqual({
+        data: "ni",
+        detail: 3,
+        view: window,
+      });
+    } finally {
+      input.remove();
+    }
+  },
+);

--- a/packages/ariakit-test/src/dispatch.ts
+++ b/packages/ariakit-test/src/dispatch.ts
@@ -4,6 +4,7 @@ import { createEvent, fireEvent } from "@testing-library/dom";
 import { initEvent } from "./__init-event.ts";
 import {
   flushMicrotasks,
+  getOwnerWindow,
   isHappyDOM,
   withWindowEvent,
   wrapAsync,
@@ -174,27 +175,6 @@ function baseDispatch(element: Target, event: Event): Promise<boolean> {
 // https://www.w3.org/TR/pointerevents/#the-click-auxclick-and-contextmenu-events
 const clickFamilyInit = { bubbles: true, cancelable: true, composed: true };
 
-// `createEvent` resolves the constructor against the target's own window, so
-// the interface named below has to be probed on that window rather than on the
-// ambient global.
-function getTargetView(target: NonNullable<Target>) {
-  // `ownerDocument` first, because a form exposes its controls as named
-  // properties and one named `document` would answer the branch below. Neither
-  // happy-dom nor jsdom implements the form's `[LegacyOverrideBuiltIns]`, so
-  // this name still resolves through `Node.prototype` there; a browser does
-  // implement it, but `createEvent` resolves the window just as fragilely then.
-  // A `Document` reports `null` here and falls through to its own view.
-  // https://html.spec.whatwg.org/multipage/forms.html#the-form-element
-  if ("ownerDocument" in target && target.ownerDocument) {
-    return target.ownerDocument.defaultView;
-  }
-  if ("defaultView" in target) return target.defaultView;
-  // Through the document either way, since only `defaultView` is typed with the
-  // constructors a window carries.
-  if ("document" in target) return target.document.defaultView;
-  return null;
-}
-
 function createNamedEvent(
   eventName: DispatchEventType,
   element: NonNullable<Target>,
@@ -210,7 +190,7 @@ function createNamedEvent(
       // `PointerEvent` only from v27 on, and falling back to `MouseEvent` there
       // keeps the members it computes rather than dropping to a bare `Event`.
       // https://github.com/ariakit/ariakit/issues/7178
-      EventType: getTargetView(element)?.PointerEvent
+      EventType: getOwnerWindow(element)?.PointerEvent
         ? "PointerEvent"
         : "MouseEvent",
       defaultInit: clickFamilyInit,
@@ -225,7 +205,7 @@ const events = eventNames.reduce((events, eventName) => {
   events[eventName] = (element, options) => {
     invariant(element, `Unable to dispatch ${eventName} on null element`);
     const event = createNamedEvent(eventName, element, options);
-    initEvent(event, options);
+    initEvent(event, element, options);
     return baseDispatch(element, event);
   };
   return events;

--- a/packages/ariakit-test/src/press.ts
+++ b/packages/ariakit-test/src/press.ts
@@ -111,7 +111,7 @@ function createKeyboardClickEvent(
   // Run the same initialization a named dispatcher does, so this click reports
   // the pointer members every other one does instead of whatever the
   // environment's constructor happens to store.
-  initEvent(event, eventOptions);
+  initEvent(event, element, eventOptions);
   return event;
 }
 

--- a/packages/ariakit-test/src/type.test.ts
+++ b/packages/ariakit-test/src/type.test.ts
@@ -106,3 +106,18 @@ test("type marks the text field that receives text after focus moves", async () 
   expect(onFirstInputChange).not.toHaveBeenCalled();
   expect(onSecondInputChange).toHaveBeenCalledOnce();
 });
+
+// Composed text goes out through `dispatch.compositionUpdate`, which is the one
+// path in the repository that already depends on `data` reaching a listener.
+// https://github.com/ariakit/ariakit/issues/7174
+test("type reports each composed character on the composition event", async () => {
+  const input = createInput();
+  const composed: string[] = [];
+  input.addEventListener("compositionupdate", (event) => {
+    composed.push(event.data);
+  });
+
+  await type("ni", input, { isComposing: true });
+
+  expect(composed).toEqual(["n", "i"]);
+});


### PR DESCRIPTION
## Motivation

`initEvent` in `packages/ariakit-test/src/__init-event.ts` picks which initializers to run with ambient `instanceof` checks. Two separate defects follow from that, one for each issue this closes.

Closes #7174. happy-dom aliases `CompositionEvent` to `Event`, so a composition event is an instance of no interface `initEvent` tested for, and no initializer named `data` in the first place. Every member the interface defines reached listeners as `undefined`:

```ts
await dispatch.compositionUpdate(input, { data: "ni", detail: 3 });
// event.data undefined, should be "ni"
// event.detail undefined, should be 3
// event.view undefined, should be null
```

This reaches repository code: `type` composes text through `dispatch.compositionUpdate` when the caller passes `isComposing`, so an IME-aware listener read `undefined` for every character.

Closes #7195. `createEvent` in `@testing-library/dom` resolves the constructor from the target's own window, so an event dispatched at a node inside a same-origin iframe is built in that frame's realm and fails every ambient `instanceof`. No initializer ran, and each member kept whatever that realm's constructor gave it:

```ts
await dispatch.keyDown(button, { modifierHyper: true });
// getModifierState("Hyper") true, should be false
```

## Solution

`initEvent` now takes the node the event was built for and reads its interface constructors from that node's realm.

Resolving that realm is work `dispatch` already did for itself: [#7190](https://github.com/ariakit/ariakit/pull/7190) added `getTargetView` there to name the interface `createEvent` should build. Rather than add a second resolver, that one moves to `__utils.ts` as `getOwnerWindow` and both callers share it, so there is one place that knows how to reach a target's window and one comment explaining why it reads `ownerDocument` first.

A small `isInstanceOf` helper keeps a constructor the realm does not implement answering `false` instead of throwing. That is load-bearing rather than defensive: `shims.ts` installs `ClipboardEvent` on the ambient realm only, and jsdom ships none of its own, so an iframe realm has no such constructor even though the top one does.

Composition events cannot be identified by `instanceof` in any realm, because happy-dom's alias would match every event rather than these alone. They are recognized by type instead, in the same shape as the `mouseDerivedEventTypes` and `pointerEventTypes` fallbacks already there, which is exact here: the interface defines only `compositionstart`, `compositionupdate`, and `compositionend`, and `initEvent` only ever sees an event a named dispatcher built for a known name. `isUIEvent` accepts them too, since `CompositionEvent` derives from `UIEvent` in Chromium 151, Firefox 153, and WebKit 26.5.

The new `initCompositionEvent` assigns `data`, the only member the interface adds to `UIEvent`, defaulting to the empty string. All three engines report `""` for `new CompositionEvent("compositionupdate").data`, matching the `DOMString data = ""` default in the UI Events IDL.

## Regression coverage

Thirteen new test cases. Eleven are red against the pre-fix source with the tests in place, and green with the fix; the other two are pins, described below, and pass either way.

Six cover the composition dispatchers in `packages/ariakit-test/src/dispatch.test.ts`, for the interface defaults and for caller-provided values, where `data`, `detail`, and `view` were all `undefined` before. One covers the `type` path that already depended on `data`, in `packages/ariakit-test/src/type.test.ts`, which reported `[undefined, undefined]` for `"ni"`.

Four cover the cross-realm half in `packages/ariakit-test/src/dispatch.jsdom.test.ts`, dispatching at a node inside a same-origin iframe: `keyDown` and `mouseDown` at a button, and `keyDown` at the frame's own document and window, which are the other two target shapes `getOwnerWindow` resolves through. In each, `getModifierState("Hyper")` answered `true` from jsdom's own constructor before, rather than `false` from the table `initUIEventModifiers` installs.

Those two types are what prove it, because neither is reached by a name. The type fallbacks cover the drag events and `wheel`, the pointer and click families, and the three composition names this PR adds, so `keydown` and `mousedown` are reached by the realm-resolved interface test alone. Measured on the same fixture, `mouseup` and `mousemove` behave the same way; `wheel`, `pointerdown`, and `click` do not, because their names carry them through either way.

The two pins are the remaining `pointerDown` and `click` iframe cases, which hold the realm-resolved interface test to not taking away the pointer members that fallback currently delivers.

happy-dom cannot fail any of the iframe cases, because its frames share the parent realm's constructors, so they run under `// @vitest-environment jsdom`. Each pins that the received event is not an instance of the outer realm's constructor and is an instance of the frame's, so none can pass by the event ceasing to be cross-realm.

## Review gate reassessment

<details>
<summary>Cycle 3: Continue the realm-resolved direction, now at its simplest point</summary>

**Assessment**

Issue severity and scope. #7174 is silent wrong data on happy-dom, the default environment for every DOM suite here and for most consumers: `data` reads `undefined` where the IDL guarantees a string. No component in this repository reads composition `data`, so the impact is on external consumers and on `type` with `isComposing`. #7195 is realm-bound `instanceof` in a shared helper, the class of defect #6316 was, reaching any environment that gives a frame its own constructors.

Complexity now carried. The realm machinery is a three-line `getEventRealm`, a six-line `isInstanceOf`, a `realm` parameter on three predicates, and a `target` parameter on `initEvent` and its two call sites. `dispatch.ts` is net shorter, because its private `getTargetView` moved out to the shared `getOwnerWindow` rather than being duplicated. `isInstanceOf` is load-bearing rather than defensive: `shims.ts` installs `ClipboardEvent` on the ambient realm only, so a jsdom iframe realm has none and a bare `instanceof` against it throws.

What caused three finding-bearing rounds. Eleven items were raised across them, ten of them substantive once the one declined non-goal is set aside. Of those ten: one was a design defect (the round-1 duck-typing), five were inaccurate claims in comments, a changeset, or the description, one was a test that could not fail, one was an import shadowed by local bindings, one was a changeset convention, and one was an out-of-scope discovery. Half of them concerned sentences rather than code, and they share a root: over-generalizing from a measurement that was itself correct. The test that could not fail has a different root: the default project environment is happy-dom, where `globalThis`, `window`, and `document.defaultView` are one object with one set of constructors, so any assertion about realm resolution is vacuous there by construction.

Complexity trended down, not up. Round 1 resolved the realm with a bespoke twelve-line helper; round 2 added a window brand check on top; the current state delegates to a helper that already existed on `main` and deletes the duplicate. The single design finding was closed by removing machinery, which is the opposite of the pattern this cadence exists to catch.

**Decision**

Continue this direction. The alternative #7195 itself names, a `type`-based test in the shape of `isMouseEvent`, would need exhaustive name sets for `KeyboardEvent`, `InputEvent`, `ClipboardEvent`, and `UIEvent` across the whole event map, and every new event name would have to be added to them. It is more machinery and less accurate.

Do not split the two halves. The seam is real, and the composition half needs no `target` parameter at all, since it is recognized purely by type. Splitting there would have been the better initial plan. Splitting at cycle 3, with every finding fixed and the suite green, buys reviewability the review has already delivered, at the cost of restarting the gate. Two changesets already separate the two stories in the changelog.

All three cycle-3 findings are addressed rather than deferred: the false claim about which events were affected, in three places, with a `mouseDown` red case added; the target-shape test that could not fail, relocated to the jsdom iframe fixture where both shapes are red pre-fix; and the precondition comment this branch invalidated in `dispatch-without-pointer-event.test.ts`.

No disposition changed. The dropped window brand check was re-examined and stays dropped: `getWindowFromNode` reads `defaultView` and then `ownerDocument`, so a form whose named getter shadows either breaks `createEvent` one step before `initEvent` runs, and hardening past that protects nothing reachable.

Registered follow-ups: #7200, #7201.

</details>

## Design note

An earlier revision of this branch hardened the realm resolution against a form's named-element getter, which answers `form.window` and `form.self` with a control of that name. That was dropped. `getOwnerWindow` reads `ownerDocument` first, which neither happy-dom nor jsdom lets a form shadow, and in a browser, where a form does shadow it, `createEvent` resolves the window just as fragilely one step earlier, so hardening past it changes nothing that can be demonstrated. The check was measurable in no environment the suites can run.

## Follow-up

One interface is still uninitialized cross-realm after this change, and cannot be fixed from `__init-event.ts`: `shims.ts` installs `ClipboardEvent` on the ambient realm only and jsdom ships none of its own, so `realm.ClipboardEvent` is `undefined` inside a frame and `initClipboardEvent` never runs there. That is unchanged from before, since the ambient test failed too, and it is the same ambient-realm shim install that #7200 tracks.

`press.ts` is the second `initEvent` caller, and it is updated for the new signature, but no cross-realm test can reach it today. Every higher-level helper is a no-op for a node inside an iframe under jsdom for an unrelated reason: the browser shims in `packages/ariakit-test/src/shims.ts` patch the ambient realm's prototypes only, so `isVisible` reports `false` inside the frame and `hover`, `click`, and `press` all return before firing anything. That is pre-existing on `main` and registered as #7200.

The named-getter hazard the design note describes is unguarded in the realm helpers `@ariakit/utils` exposes, where it does bite: `getDocument` and `getWindow` in `packages/ariakit-utils/src/dom.ts` take the `Window` branch for a form with a control named `self`, which makes `getActiveElement` throw or silently report `null`. That is also pre-existing on `main` and untouched here, and is registered as #7201.
