### PR TITLE
Fix dispatch event name derivation

### DIFF
--- a/.changeset/300-test-double-click-dispatch.md
+++ b/.changeset/300-test-double-click-dispatch.md
@@ -2,4 +2,4 @@
 "@ariakit/test": patch
 ---
 
-Fixed `dispatch` to expose only event names it can build, preventing the unsupported `doubleClick` alias from throwing at runtime.
+Fixed `dispatch` to expose only event names it can build, preventing the unsupported `doubleClick` alias from being typed or installed at runtime.

--- a/.changeset/300-test-double-click-dispatch.md
+++ b/.changeset/300-test-double-click-dispatch.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/test": patch
+---
+
+Fixed `dispatch` to expose only event names it can build, preventing the unsupported `doubleClick` alias from throwing at runtime.

--- a/packages/ariakit-test/readme.md
+++ b/packages/ariakit-test/readme.md
@@ -116,7 +116,7 @@ type Target = Document | Window | Node | Element | null;
 
 type EventFunction = (element: Target, options?: object) => Promise<boolean>;
 
-type DispatchEventType = EventType | "auxClick";
+type DispatchEventType = Exclude<EventType, "doubleClick"> | "auxClick";
 
 type EventsObject = {
   [K in DispatchEventType]: EventFunction;

--- a/packages/ariakit-test/src/dispatch.test.ts
+++ b/packages/ariakit-test/src/dispatch.test.ts
@@ -92,6 +92,22 @@ test("dispatch.input preserves provided inputType", async () => {
   }
 });
 
+test("dispatch exposes only buildable double-click events", async () => {
+  const button = document.createElement("button");
+  document.body.append(button);
+  let calls = 0;
+  button.addEventListener("dblclick", () => {
+    calls += 1;
+  });
+  try {
+    await dispatch.dblClick(button);
+    expect(calls).toBe(1);
+    expect(dispatch).not.toHaveProperty("doubleClick");
+  } finally {
+    button.remove();
+  }
+});
+
 // Pointer Events defines `click`, `auxclick`, and `contextmenu` as
 // `PointerEvent`, which is what Chromium, Firefox, and WebKit dispatch for all
 // three. `@testing-library/dom` declares `MouseEvent` for `click` and

--- a/packages/ariakit-test/src/dispatch.test.ts
+++ b/packages/ariakit-test/src/dispatch.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+import { expect, expectTypeOf, test } from "vitest";
 import { dispatch, press } from "./index.ts";
 
 test("dispatch.keyDown uses empty strings for omitted keyboard strings", async () => {
@@ -93,6 +93,8 @@ test("dispatch.input preserves provided inputType", async () => {
 });
 
 test("dispatch exposes only buildable double-click events", async () => {
+  expectTypeOf(dispatch).toHaveProperty("dblClick");
+  expectTypeOf(dispatch).not.toHaveProperty("doubleClick");
   const button = document.createElement("button");
   document.body.append(button);
   let calls = 0;

--- a/packages/ariakit-test/src/dispatch.ts
+++ b/packages/ariakit-test/src/dispatch.ts
@@ -199,7 +199,7 @@ function createNamedEvent(
   return createEvent[eventName](element, options);
 }
 
-const eventNames: DispatchEventType[] = [...getKeys(fireEvent), "auxClick"];
+const eventNames: DispatchEventType[] = [...getKeys(createEvent), "auxClick"];
 
 const events = eventNames.reduce((events, eventName) => {
   events[eventName] = (element, options) => {

--- a/packages/ariakit-test/src/dispatch.ts
+++ b/packages/ariakit-test/src/dispatch.ts
@@ -15,8 +15,9 @@ type Target = Document | Window | Node | Element | null;
 type EventFunction = (element: Target, options?: object) => Promise<boolean>;
 
 // `@testing-library/dom` has no `auxclick` in its event map, so `dispatch` adds
-// it to the events it can build by name.
-type DispatchEventType = EventType | "auxClick";
+// it to the events it can build by name. Its `doubleClick` alias has no matching
+// `createEvent` method, so only the buildable `dblClick` name is exposed.
+type DispatchEventType = Exclude<EventType, "doubleClick"> | "auxClick";
 
 type EventsObject = {
   [K in DispatchEventType]: EventFunction;
@@ -199,7 +200,10 @@ function createNamedEvent(
   return createEvent[eventName](element, options);
 }
 
-const eventNames: DispatchEventType[] = [...getKeys(createEvent), "auxClick"];
+const eventNames: DispatchEventType[] = [
+  ...getKeys(createEvent).filter((eventName) => eventName !== "doubleClick"),
+  "auxClick",
+];
 
 const events = eventNames.reduce((events, eventName) => {
   events[eventName] = (element, options) => {


### PR DESCRIPTION
## Motivation

`@testing-library/dom` adds `doubleClick` to `fireEvent` and its public `EventType`, but not to the runtime `createEvent` object. `dispatch` used `fireEvent` to create its named methods and `createEvent` to build events. JavaScript consumers therefore received a `dispatch.doubleClick` method that threw, while TypeScript consumers were told the unsupported alias existed.

The supported double-click method works:

```ts
await dispatch.dblClick(button);
```

## Solution

Build the named method list from `createEvent`, which is the event-construction surface that `dispatch` uses. Exclude the unsupported `doubleClick` alias from the public dispatch type while keeping Ariakit's `auxClick` extension. Regenerate the API reference and add type-level and runtime regressions that verify `dblClick` dispatches once and `doubleClick` is absent.

Fixes #7194

## Verification

- `pnpm test packages/ariakit-test/src`
- `pnpm tsc`
- `pnpm build`
- `pnpm clean`
- `pnpm --filter @ariakit/test run docs`
- `pnpm lint-fix`
