### PR TITLE
Preserve click gesture initialization

### DIFF
--- a/.changeset/300-test-forwarded-click-init.md
+++ b/.changeset/300-test-forwarded-click-init.md
@@ -2,4 +2,4 @@
 "@ariakit/test": patch
 ---
 
-Fixed `click` to carry modifiers, coordinates, and `detail` to the click a label forwards to its control, and fixed `press.Enter` to carry `modifier*` values such as `modifierCapsLock` to a form's implicit submit-button click.
+Fixed click-family gesture helpers to reset `isPrimary` on their terminal events, fixed `click` to carry modifiers, coordinates, and `detail` to the click a label forwards to its control, and fixed `press.Enter` to carry `modifier*` values such as `modifierCapsLock` to a form's implicit submit-button click.

--- a/.changeset/300-test-forwarded-click-init.md
+++ b/.changeset/300-test-forwarded-click-init.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/test": patch
+---
+
+Fixed `click` to carry modifiers, coordinates, and `detail` to the click a label forwards to its control, and fixed `press.Enter` to carry `modifier*` values such as `modifierCapsLock` to a form's implicit submit-button click.

--- a/packages/ariakit-test/src/__init-event.ts
+++ b/packages/ariakit-test/src/__init-event.ts
@@ -3,6 +3,12 @@ import { getKeys } from "@ariakit/utils";
 import type { OwnerWindowSource } from "./__utils.ts";
 import { getOwnerWindow } from "./__utils.ts";
 
+// Pointer Events Level 4 includes this member in its initializer, but TypeScript
+// 6.0 declares it only on the resulting event.
+export type PointerEventInitWithPersistentDeviceId = PointerEventInit & {
+  persistentDeviceId?: PointerEvent["persistentDeviceId"];
+};
+
 type SpecificEventInit<E extends Event> = E extends InputEvent
   ? InputEventInit
   : E extends ClipboardEvent
@@ -10,7 +16,7 @@ type SpecificEventInit<E extends Event> = E extends InputEvent
     : E extends KeyboardEvent
       ? KeyboardEventInit
       : E extends PointerEvent
-        ? PointerEventInit
+        ? PointerEventInitWithPersistentDeviceId
         : E extends MouseEvent
           ? MouseEventInit
           : E extends CompositionEvent
@@ -248,9 +254,10 @@ function initPointerEvent(
     twist,
     altitudeAngle,
     azimuthAngle,
+    persistentDeviceId,
     isPrimary,
     pointerType = "mouse",
-  }: PointerEventInit,
+  }: PointerEventInitWithPersistentDeviceId,
 ) {
   assignProps(event, {
     pointerId: sanitizeNumber(pointerId),
@@ -263,6 +270,7 @@ function initPointerEvent(
     twist: sanitizeNumber(twist),
     altitudeAngle: sanitizeAltitudeAngle(altitudeAngle),
     azimuthAngle: sanitizeNumber(azimuthAngle),
+    persistentDeviceId: sanitizeNumber(persistentDeviceId),
     isPrimary: !!isPrimary,
     pointerType: pointerType,
   });

--- a/packages/ariakit-test/src/__mouse.ts
+++ b/packages/ariakit-test/src/__mouse.ts
@@ -1,4 +1,5 @@
 import { getKeys } from "@ariakit/utils";
+import type { PointerEventInitWithPersistentDeviceId } from "./__init-event.ts";
 
 // `MouseEvent.buttons` is a bitmask of the buttons currently held down, and its
 // bits are not ordered like `MouseEvent.button`: the secondary button is bit 1
@@ -19,9 +20,9 @@ export function getMouseButton(options?: MouseEventInit) {
 }
 
 function omit(
-  options: PointerEventInit | undefined,
-  keys: ReadonlyArray<keyof PointerEventInit>,
-): PointerEventInit {
+  options: PointerEventInitWithPersistentDeviceId | undefined,
+  keys: ReadonlyArray<keyof PointerEventInitWithPersistentDeviceId>,
+): PointerEventInitWithPersistentDeviceId {
   const remaining = { ...options };
   for (const key of keys) {
     delete remaining[key];
@@ -114,25 +115,24 @@ export function getReleaseOptions(
   };
 }
 
-type PointerIdentityAttribute = "pointerId" | "pointerType" | "isPrimary";
+type PointerIdentityAttribute = "pointerId" | "pointerType";
 
-type ContactAttribute = Exclude<
-  keyof PointerEventInit,
+type ClickResetAttribute = Exclude<
+  keyof PointerEventInitWithPersistentDeviceId,
   keyof MouseEventInit | PointerIdentityAttribute
 >;
 
-// The contact a caller described for the press, which browsers reset on the
-// click-family events so each member falls back to the value `dispatch` gives a
-// device that reports none. `isPrimary` stays out on purpose: nothing derives it
-// for these events, and Firefox and WebKit carry a caller's value over where
-// Chromium resets it. So a caller's `pressure` is dropped here while their
-// `isPrimary` reaches the click.
+// The pointer-specific values a caller described for the press, which the
+// click-family events reset so each member falls back to the value `dispatch`
+// gives a device that reports none. Only the causal pointer's ID and type carry
+// over.
 //
 // Keyed rather than listed so TypeScript requires every non-identity member. A
 // list silently missed `altitudeAngle`, `azimuthAngle`, `coalescedEvents`, and
 // `predictedEvents`, and `PointerEventInit` keeps growing.
 // https://github.com/ariakit/ariakit/pull/7177#discussion_r3811185510
-const contactAttributes: Record<ContactAttribute, true> = {
+const clickResetAttributes: Record<ClickResetAttribute, true> = {
+  isPrimary: true,
   width: true,
   height: true,
   pressure: true,
@@ -142,31 +142,32 @@ const contactAttributes: Record<ContactAttribute, true> = {
   twist: true,
   altitudeAngle: true,
   azimuthAngle: true,
+  persistentDeviceId: true,
   coalescedEvents: true,
   predictedEvents: true,
 };
 
-const contactAttributeKeys = getKeys(contactAttributes);
+const clickResetAttributeKeys = getKeys(clickResetAttributes);
 
 /**
  * Returns the event properties for the `click` or `auxclick` that ends the
- * gesture, which a browser fires on the release with the contact reset.
+ * gesture, with every pointer-specific member except the ID and type reset.
  */
 export function getClickOptions(options?: PointerEventInit): PointerEventInit {
   return {
     detail: 1,
-    ...omit(getReleaseOptions(options), contactAttributeKeys),
+    ...omit(getReleaseOptions(options), clickResetAttributeKeys),
   };
 }
 
 /**
  * Returns the event properties for the `contextmenu` the secondary button opens
- * while it is still held down, with the same contact reset.
+ * while it is still held down, with the same pointer-specific reset.
  */
 export function getContextMenuOptions(
   options?: PointerEventInit,
 ): PointerEventInit {
-  return omit(getPressOptions(options), contactAttributeKeys);
+  return omit(getPressOptions(options), clickResetAttributeKeys);
 }
 
 // Pointer Events fires no `pointerdown` or `pointerup` for a chorded button

--- a/packages/ariakit-test/src/__mouse.ts
+++ b/packages/ariakit-test/src/__mouse.ts
@@ -149,21 +149,6 @@ const contactAttributes: Record<ContactAttribute, true> = {
 const contactAttributeKeys = getKeys(contactAttributes);
 
 /**
- * Returns only the members that identify the pointer behind a gesture, for an
- * event a browser derives from another one, like the `click` a label forwards to
- * its control.
- */
-export function getPointerIdentity(
-  options?: PointerEventInit,
-): PointerEventInit {
-  return {
-    pointerId: options?.pointerId,
-    pointerType: options?.pointerType,
-    isPrimary: options?.isPrimary,
-  };
-}
-
-/**
  * Returns the event properties for the `click` or `auxclick` that ends the
  * gesture, which a browser fires on the release with the contact reset.
  */

--- a/packages/ariakit-test/src/click.test.ts
+++ b/packages/ariakit-test/src/click.test.ts
@@ -284,29 +284,38 @@ function recordPointerMembers(element: Element, types: string[]) {
   return events;
 }
 
-// Browsers carry only the causal pointer's identity onto the event that ends
-// the gesture: a pen press reporting `tiltX: 30` still produces a `click` with
-// `tiltX: 0`. `isPrimary` is the deliberate exception, kept because Firefox and
-// WebKit carry it over, while Chromium resets it as the specification requires.
+// Pointer Events carries only the causal pointer's ID and type onto the event
+// that ends the gesture. Chromium resets `isPrimary` as required; Firefox and
+// WebKit carry it over instead.
+// https://github.com/ariakit/ariakit/issues/7204
 test("click carries only the pointer identity to the click event", async () => {
   document.body.innerHTML = `<button type="button">Submit</button>`;
 
   const button = q.button("Submit");
   const events = recordPointerMembers(button, ["pointerdown", "click"]);
+  const persistentDeviceIds: Array<number | undefined> = [];
+  for (const type of ["pointerdown", "click"]) {
+    button.addEventListener(type, (event) => {
+      persistentDeviceIds.push((event as PointerEvent).persistentDeviceId);
+    });
+  }
 
-  await click(button, {
+  const options: PointerEventInit & { persistentDeviceId: number } = {
     pointerId: 7,
     pointerType: "pen",
     isPrimary: true,
     pressure: 0.5,
     altitudeAngle: 0.3,
     tiltX: 30,
-  });
+    persistentDeviceId: 91,
+  };
+  await click(button, options);
 
   expect(events).toEqual([
     "pointerdown true 7 pen true 0.5 30 0.3",
-    `click true 7 pen true 0 0 ${Math.PI / 2}`,
+    `click true 7 pen false 0 0 ${Math.PI / 2}`,
   ]);
+  expect(persistentDeviceIds).toEqual([91, 0]);
 });
 
 test("click with the auxiliary button carries the pointer identity to auxclick", async () => {
@@ -327,7 +336,7 @@ test("click with the auxiliary button carries the pointer identity to auxclick",
 
   expect(events).toEqual([
     "pointerdown true 7 pen true 0.5 30 0.3",
-    `auxclick true 7 pen true 0 0 ${Math.PI / 2}`,
+    `auxclick true 7 pen false 0 0 ${Math.PI / 2}`,
   ]);
 });
 
@@ -353,7 +362,7 @@ test("click forwards the pointer identity from a label to its control", async ()
     tiltX: 30,
   });
 
-  expect(events).toEqual([`click true 7 pen true 0 0 ${Math.PI / 2}`]);
+  expect(events).toEqual([`click true 7 pen false 0 0 ${Math.PI / 2}`]);
   expect((checkbox as HTMLInputElement).checked).toBe(true);
 });
 
@@ -430,8 +439,8 @@ test("rightClick carries the pointer identity to contextmenu and auxclick", asyn
 
   expect(events).toEqual([
     "pointerdown true 7 pen true 0.5 30 0.3",
-    `contextmenu true 7 pen true 0 0 ${Math.PI / 2}`,
-    `auxclick true 7 pen true 0 0 ${Math.PI / 2}`,
+    `contextmenu true 7 pen false 0 0 ${Math.PI / 2}`,
+    `auxclick true 7 pen false 0 0 ${Math.PI / 2}`,
   ]);
 });
 

--- a/packages/ariakit-test/src/click.test.ts
+++ b/packages/ariakit-test/src/click.test.ts
@@ -357,6 +357,58 @@ test("click forwards the pointer identity from a label to its control", async ()
   expect((checkbox as HTMLInputElement).checked).toBe(true);
 });
 
+// Chromium and Firefox report `detail: 1` on the forwarded click, while WebKit
+// reports `0`. Keep the gesture's value so both clicks describe one activation.
+// https://github.com/ariakit/ariakit/issues/7176
+test("click forwards the gesture init from a label to its control", async () => {
+  document.body.innerHTML = `
+    <label for="agree">Agree</label>
+    <input id="agree" type="checkbox">
+  `;
+
+  const label = q.text("Agree");
+  const checkbox = q.checkbox("Agree");
+  const events: Array<Record<string, unknown>> = [];
+  const recordEvent = (event: PointerEvent) => {
+    events.push({
+      target: event.currentTarget === label ? "label" : "checkbox",
+      shiftKey: event.shiftKey,
+      capsLock: event.getModifierState("CapsLock"),
+      clientX: event.clientX,
+      clientY: event.clientY,
+      detail: event.detail,
+    });
+  };
+  label.addEventListener("click", recordEvent);
+  checkbox.addEventListener("click", recordEvent);
+
+  await click(label, {
+    shiftKey: true,
+    modifierCapsLock: true,
+    clientX: 17,
+    clientY: 19,
+  });
+
+  expect(events).toEqual([
+    {
+      target: "label",
+      shiftKey: true,
+      capsLock: true,
+      clientX: 17,
+      clientY: 19,
+      detail: 1,
+    },
+    {
+      target: "checkbox",
+      shiftKey: true,
+      capsLock: true,
+      clientX: 17,
+      clientY: 19,
+      detail: 1,
+    },
+  ]);
+});
+
 test("rightClick carries the pointer identity to contextmenu and auxclick", async () => {
   document.body.innerHTML = `<button type="button">Open menu</button>`;
 

--- a/packages/ariakit-test/src/click.ts
+++ b/packages/ariakit-test/src/click.ts
@@ -4,7 +4,6 @@ import {
   getContextMenuOptions,
   getHoverOptions,
   getMouseButton,
-  getPointerIdentity,
   omitButtons,
 } from "./__mouse.ts";
 import { isHappyDOM, settle, wrapAsync } from "./__utils.ts";
@@ -56,10 +55,9 @@ async function clickLabel(
     if (defaultAllowed && isFocusable(input)) {
       await focus(input);
       // Only "click" is fired! Browsers don't go over the whole event stack in
-      // this case (mousedown, mouseup etc.). The forwarded click still reports
-      // the pointer that caused it, as it does in Chromium and Firefox (WebKit
-      // reports an unset pointer instead).
-      await dispatch.click(input, getPointerIdentity(options));
+      // this case (mousedown, mouseup etc.). The forwarded click carries the
+      // terminal event init from the gesture that activated the label.
+      await dispatch.click(input, options);
     }
   }
 }

--- a/packages/ariakit-test/src/press.test.ts
+++ b/packages/ariakit-test/src/press.test.ts
@@ -383,9 +383,17 @@ test("press.Enter keeps modifier state on the default button click", async () =>
   const form = document.createElement("form");
   const input = document.createElement("input");
   const button = document.createElement("button");
-  const states: string[] = [];
+  const states: Array<{
+    type: string;
+    detail: number;
+    capsLock: boolean;
+  }> = [];
   const recordState = (event: KeyboardEvent | MouseEvent) => {
-    states.push(`${event.type} ${event.getModifierState("CapsLock")}`);
+    states.push({
+      type: event.type,
+      detail: event.detail,
+      capsLock: event.getModifierState("CapsLock"),
+    });
   };
   button.type = "submit";
   input.addEventListener("keydown", recordState);
@@ -395,7 +403,11 @@ test("press.Enter keeps modifier state on the default button click", async () =>
   form.append(input, button);
   document.body.append(form);
 
-  await press.Enter(input, { modifierCapsLock: true });
+  await press.Enter(input, { detail: 2, modifierCapsLock: true });
 
-  expect(states).toEqual(["keydown true", "click true", "keyup true"]);
+  expect(states).toEqual([
+    { type: "keydown", detail: 2, capsLock: true },
+    { type: "click", detail: 0, capsLock: true },
+    { type: "keyup", detail: 2, capsLock: true },
+  ]);
 });

--- a/packages/ariakit-test/src/press.test.ts
+++ b/packages/ariakit-test/src/press.test.ts
@@ -377,3 +377,25 @@ test("press.Enter submits with no pointer behind the default button click", asyn
     },
   ]);
 });
+
+// https://github.com/ariakit/ariakit/issues/7181
+test("press.Enter keeps modifier state on the default button click", async () => {
+  const form = document.createElement("form");
+  const input = document.createElement("input");
+  const button = document.createElement("button");
+  const states: string[] = [];
+  const recordState = (event: KeyboardEvent | MouseEvent) => {
+    states.push(`${event.type} ${event.getModifierState("CapsLock")}`);
+  };
+  button.type = "submit";
+  input.addEventListener("keydown", recordState);
+  button.addEventListener("click", recordState);
+  input.addEventListener("keyup", recordState);
+  form.addEventListener("submit", (event) => event.preventDefault());
+  form.append(input, button);
+  document.body.append(form);
+
+  await press.Enter(input, { modifierCapsLock: true });
+
+  expect(states).toEqual(["keydown true", "click true", "keyup true"]);
+});

--- a/packages/ariakit-test/src/press.ts
+++ b/packages/ariakit-test/src/press.ts
@@ -98,13 +98,10 @@ function createKeyboardClickEvent(
   const PointerEventConstructor =
     defaultView?.PointerEvent ?? defaultView?.MouseEvent ?? MouseEvent;
   const eventOptions: PointerEventInit = {
+    ...options,
     bubbles: true,
     cancelable: true,
     composed: true,
-    altKey: options.altKey,
-    ctrlKey: options.ctrlKey,
-    metaKey: options.metaKey,
-    shiftKey: options.shiftKey,
     ...noPointerOptions,
   };
   const event = new PointerEventConstructor("click", eventOptions);

--- a/packages/ariakit-test/src/press.ts
+++ b/packages/ariakit-test/src/press.ts
@@ -97,8 +97,37 @@ function createKeyboardClickEvent(
   // https://github.com/ariakit/ariakit/issues/7178
   const PointerEventConstructor =
     defaultView?.PointerEvent ?? defaultView?.MouseEvent ?? MouseEvent;
+  const {
+    altKey,
+    ctrlKey,
+    metaKey,
+    shiftKey,
+    modifierAltGraph,
+    modifierCapsLock,
+    modifierFn,
+    modifierFnLock,
+    modifierHyper,
+    modifierNumLock,
+    modifierScrollLock,
+    modifierSuper,
+    modifierSymbol,
+    modifierSymbolLock,
+  } = options;
   const eventOptions: PointerEventInit = {
-    ...options,
+    altKey,
+    ctrlKey,
+    metaKey,
+    shiftKey,
+    modifierAltGraph,
+    modifierCapsLock,
+    modifierFn,
+    modifierFnLock,
+    modifierHyper,
+    modifierNumLock,
+    modifierScrollLock,
+    modifierSuper,
+    modifierSymbol,
+    modifierSymbolLock,
     bubbles: true,
     cancelable: true,
     composed: true,


### PR DESCRIPTION
## Motivation

The click a label forwards to its control keeps only the causal pointer identity. It drops the gesture's modifier state, coordinates, and `detail`, so a listener sees different event data depending on whether a test clicks the label or the control directly.

```ts
await click(q.text("Accept terms"), {
  shiftKey: true,
  clientX: 17,
  clientY: 19,
});
```

The synchronous click that `press.Enter` produces for implicit form submission has a related gap. It keeps the four standard modifier properties, but drops `modifier*` init members such as `modifierCapsLock`. The surrounding `keydown` and `keyup` report Caps Lock while the click between them does not.

The click-family gesture helpers also treat `isPrimary` as causal pointer identity. Pointer Events requires `click`, `auxclick`, and `contextmenu` to reset every pointer-specific member except `pointerId` and `pointerType`, so `@ariakit/test` disagrees with both the specification and `@ariakit/utils`.

## Solution

The label path now forwards the complete normalized terminal `PointerEventInit` to the control click. This preserves pointer identity, modifiers, coordinates, and `detail` while keeping reset-only pointer properties at their terminal-event defaults. Chromium and Firefox report `detail: 1` on the forwarded click while WebKit reports `0`; this change deliberately preserves the gesture's `1` so both clicks describe one activation.

The implicit-submission path now explicitly transfers only the standard and `modifier*` members from `KeyboardEventInit` into its synchronous click options. Keyboard-only and UI fields such as `detail` therefore keep their click defaults. The fixed event flags and no-pointer values are applied afterward, so submission remains synchronous and the click still reports `pointerId: -1` with an empty `pointerType`.

The click reset set now includes `isPrimary` and the Level 4 `persistentDeviceId` member. A small internal type bridge covers `persistentDeviceId` until TypeScript declares it on `PointerEventInit`, so pointer phases preserve a caller value while terminal click-family events report the required defaults.

The obsolete pointer-identity-only helper is removed because the label path no longer uses it.

Fixes #7176
Fixes #7181
Fixes #7204

## Verification

- `pnpm test packages/ariakit-test/src` (20 files, 164 tests)
- `pnpm tsc`
- `pnpm build`
- `pnpm clean`
- `pnpm lint-fix`
