### PR TITLE
Fix clipboard event support in @ariakit/test

### DIFF
--- a/.changeset/300-test-clipboard-events.md
+++ b/.changeset/300-test-clipboard-events.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/test": patch
+---
+
+Fixed `@ariakit/test` clipboard event dispatch so caller-supplied `clipboardData` is preserved by named dispatchers and caller-built events in environments without native clipboard event support.

--- a/packages/ariakit-test/src/__init-event.ts
+++ b/packages/ariakit-test/src/__init-event.ts
@@ -49,9 +49,7 @@ function assignProps<T extends object>(
 ) {
   for (const [key, value] of Object.entries(props)) {
     // Configurable, matching the descriptors browsers and jsdom give these
-    // members, so a member assigned here can be replaced afterwards. It cannot
-    // rescue a redefine of a member `createEvent` already installed as
-    // non-configurable, which is what #7179 tracks.
+    // members, so a member assigned here can be replaced afterwards.
     Object.defineProperty(obj, key, {
       configurable: true,
       get: () => value ?? null,
@@ -87,6 +85,11 @@ function initClipboardEvent(
   event: ClipboardEvent,
   { clipboardData }: ClipboardEventInit,
 ) {
+  // `@testing-library/dom` may have already installed the requested value as a
+  // non-configurable property when the environment has no `DataTransfer`.
+  // https://github.com/ariakit/ariakit/issues/7179
+  const descriptor = Object.getOwnPropertyDescriptor(event, "clipboardData");
+  if (descriptor?.configurable === false) return;
   assignProps(event, {
     clipboardData,
   });

--- a/packages/ariakit-test/src/dispatch.jsdom.test.ts
+++ b/packages/ariakit-test/src/dispatch.jsdom.test.ts
@@ -141,6 +141,29 @@ test.each([
   },
 );
 
+test.each([
+  ["copy", "copy"],
+  ["cut", "cut"],
+  ["paste", "paste"],
+] as const)(
+  "dispatch.%s delivers caller-supplied clipboardData",
+  async (dispatcher, type) => {
+    const input = document.createElement("input");
+    document.body.append(input);
+    const clipboardData = { getData: () => "a,b" };
+    let receivedClipboardData: DataTransfer | null | undefined;
+    input.addEventListener(type, (event) => {
+      receivedClipboardData = event.clipboardData;
+    });
+    try {
+      expect(await dispatch[dispatcher](input, { clipboardData })).toBe(true);
+      expect(receivedClipboardData).toBe(clipboardData);
+    } finally {
+      input.remove();
+    }
+  },
+);
+
 // jsdom reaches the same gap for a different reason: it ships no `DragEvent`,
 // so `createEvent` falls back to `Event`. Its `WheelEvent` already derives from
 // `MouseEvent`, and is pinned here so fixing drag can't stop initializing it.

--- a/packages/ariakit-test/src/shims.jsdom.test.ts
+++ b/packages/ariakit-test/src/shims.jsdom.test.ts
@@ -3,6 +3,16 @@
 import { expect, test } from "vitest";
 import "./shims.ts";
 
+test("constructs clipboard events from ClipboardEventInit", () => {
+  const clipboardData = { getData: () => "a,b" };
+  // jsdom has no `DataTransfer` constructor, so use the smallest test double
+  // that can prove the fallback preserves the caller's object.
+  // @ts-expect-error
+  const event = new ClipboardEvent("paste", { clipboardData });
+  expect(event.clipboardData).toBe(clipboardData);
+  expect(new ClipboardEvent("paste").clipboardData).toBeNull();
+});
+
 test("leaves an environment that already implements mouse event members alone", () => {
   // jsdom implements the full `getModifierState`, including the `modifier*`
   // init members the happy-dom fallback cannot see, so replacing it would

--- a/packages/ariakit-test/src/shims.jsdom.test.ts
+++ b/packages/ariakit-test/src/shims.jsdom.test.ts
@@ -11,6 +11,10 @@ test("constructs clipboard events from ClipboardEventInit", () => {
   const event = new ClipboardEvent("paste", { clipboardData });
   expect(event.clipboardData).toBe(clipboardData);
   expect(new ClipboardEvent("paste").clipboardData).toBeNull();
+  // Web IDL converts a null dictionary to an empty dictionary.
+  // https://webidl.spec.whatwg.org/#es-dictionary
+  // @ts-expect-error
+  expect(new ClipboardEvent("paste", null).clipboardData).toBeNull();
 });
 
 test("leaves an environment that already implements mouse event members alone", () => {

--- a/packages/ariakit-test/src/shims.ts
+++ b/packages/ariakit-test/src/shims.ts
@@ -60,8 +60,18 @@ function applyBrowserShims() {
     typeof window.ClipboardEvent === "undefined" &&
     typeof Event !== "undefined"
   ) {
-    // @ts-expect-error
-    window.ClipboardEvent = class ClipboardEvent extends Event {};
+    window.ClipboardEvent = class ClipboardEvent extends Event {
+      #clipboardData: DataTransfer | null;
+
+      constructor(type: string, eventInitDict: ClipboardEventInit = {}) {
+        super(type, eventInitDict);
+        this.#clipboardData = eventInitDict.clipboardData ?? null;
+      }
+
+      get clipboardData() {
+        return this.#clipboardData;
+      }
+    };
   }
 
   polyfillMouseEventMembers();

--- a/packages/ariakit-test/src/shims.ts
+++ b/packages/ariakit-test/src/shims.ts
@@ -63,9 +63,10 @@ function applyBrowserShims() {
     window.ClipboardEvent = class ClipboardEvent extends Event {
       #clipboardData: DataTransfer | null;
 
-      constructor(type: string, eventInitDict: ClipboardEventInit = {}) {
-        super(type, eventInitDict);
-        this.#clipboardData = eventInitDict.clipboardData ?? null;
+      constructor(type: string, eventInitDict: ClipboardEventInit | null = {}) {
+        const eventInit = eventInitDict ?? {};
+        super(type, eventInit);
+        this.#clipboardData = eventInit.clipboardData ?? null;
       }
 
       get clipboardData() {


### PR DESCRIPTION
## Motivation

In jsdom and other environments without `DataTransfer`, named clipboard dispatchers throw when Testing Library has already installed `clipboardData` as a non-configurable property. The existing `ClipboardEvent` fallback also ignores `ClipboardEventInit`, so caller-built events lose supplied data and report `undefined` instead of the specified `null` default.

Fixes #7179.
Fixes #7180.

## Solution

Leave an existing non-configurable `clipboardData` property intact because Testing Library already populated it from the caller's options:

```ts
const descriptor = Object.getOwnPropertyDescriptor(event, "clipboardData");
if (descriptor?.configurable === false) return;
```

Implement the fallback constructor's `clipboardData` slot, including Web IDL's explicit `null` dictionary conversion:

```ts
const eventInit = eventInitDict ?? {};
this.#clipboardData = eventInit.clipboardData ?? null;
```

Focused jsdom regressions cover all three named dispatchers, the caller-built constructor path, the default value, and an explicit `null` initializer.

## Testing

- `pnpm test packages/ariakit-test/src`
- `pnpm tsc`
- `pnpm build`
