### PR TITLE
Resolve the owning realm for every value the DOM helpers accept

### DIFF
--- a/.changeset/300-composite-event-realm.md
+++ b/.changeset/300-composite-event-realm.md
@@ -3,17 +3,4 @@
 "@ariakit/react": patch
 ---
 
-Events synthesized inside a same-origin iframe belong to that frame
-
-[`Composite`](https://ariakit.com/reference/composite) synthesizes two events on its virtual-focus path, forwarding the keyboard event to the active item and blurring the previous one, and [`Menu`](https://ariakit.com/reference/menu) synthesizes a third when a submenu closes after the pointer leaves it. All three were built with the outer window's constructors, so for an item inside a same-origin iframe a listener registered inside that frame received an event that failed `instanceof` against its own interfaces.
-
-```ts
-frameWindow.document.addEventListener("keydown", (event) => {
-  // For an item inside that frame: was false, now true.
-  event instanceof frameWindow.KeyboardEvent;
-});
-```
-
-Code in the outer document sees the mirror of this. An item is placed inside a frame by portalling it there, so a handler passed as a prop is authored in the outer realm, and testing one of these events with that realm's own `instanceof` used to succeed and now does not. Such a handler should compare against the constructors of the window that owns the element it is attached to, which is what the browser gives a real event dispatched in a frame.
-
-This reaches every component built on [`Composite`](https://ariakit.com/reference/composite): [`Combobox`](https://ariakit.com/reference/combobox), [`ComboboxSelect`](https://ariakit.com/reference/combobox-select), [`Menu`](https://ariakit.com/reference/menu), [`MenuList`](https://ariakit.com/reference/menu-list), [`Menubar`](https://ariakit.com/reference/menubar), [`RadioGroup`](https://ariakit.com/reference/radio-group), [`SelectList`](https://ariakit.com/reference/select-list), [`SelectPopover`](https://ariakit.com/reference/select-popover), [`TabList`](https://ariakit.com/reference/tab-list), and [`Toolbar`](https://ariakit.com/reference/toolbar).
+Fixed [`Composite`](https://ariakit.com/reference/composite) and components built on it, such as [`Menu`](https://ariakit.com/reference/menu) and [`Toolbar`](https://ariakit.com/reference/toolbar), building the events they synthesize with the outer window's constructors, so an item inside a same-origin iframe received events that failed `instanceof` against that frame's own interfaces.

--- a/.changeset/300-composite-event-realm.md
+++ b/.changeset/300-composite-event-realm.md
@@ -1,0 +1,19 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Events synthesized inside a same-origin iframe belong to that frame
+
+[`Composite`](https://ariakit.com/reference/composite) synthesizes two events on its virtual-focus path, forwarding the keyboard event to the active item and blurring the previous one, and [`Menu`](https://ariakit.com/reference/menu) synthesizes a third when a submenu closes after the pointer leaves it. All three were built with the outer window's constructors, so for an item inside a same-origin iframe a listener registered inside that frame received an event that failed `instanceof` against its own interfaces.
+
+```ts
+frameWindow.document.addEventListener("keydown", (event) => {
+  // For an item inside that frame: was false, now true.
+  event instanceof frameWindow.KeyboardEvent;
+});
+```
+
+Code in the outer document sees the mirror of this. An item is placed inside a frame by portalling it there, so a handler passed as a prop is authored in the outer realm, and testing one of these events with that realm's own `instanceof` used to succeed and now does not. Such a handler should compare against the constructors of the window that owns the element it is attached to, which is what the browser gives a real event dispatched in a frame.
+
+This reaches every component built on [`Composite`](https://ariakit.com/reference/composite): [`Combobox`](https://ariakit.com/reference/combobox), [`ComboboxSelect`](https://ariakit.com/reference/combobox-select), [`Menu`](https://ariakit.com/reference/menu), [`MenuList`](https://ariakit.com/reference/menu-list), [`Menubar`](https://ariakit.com/reference/menubar), [`RadioGroup`](https://ariakit.com/reference/radio-group), [`SelectList`](https://ariakit.com/reference/select-list), [`SelectPopover`](https://ariakit.com/reference/select-popover), [`TabList`](https://ariakit.com/reference/tab-list), and [`Toolbar`](https://ariakit.com/reference/toolbar).

--- a/.changeset/300-dialog-form-realm.md
+++ b/.changeset/300-dialog-form-realm.md
@@ -1,0 +1,16 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Dialogs rendered as a form open again when a control shadows a built-in name
+
+A `<form>` exposes its controls as named properties that override built-ins, so a control named `self`, `document`, or `ownerDocument` answers when [`Dialog`](https://ariakit.com/reference/dialog) resolves the document and window that own it. The dialog threw instead of opening, and on Safari it threw while still closed, so the page failed before anyone interacted with it.
+
+```tsx
+<Ariakit.Dialog render={<form />}>
+  <input type="checkbox" name="self" />
+</Ariakit.Dialog>
+```
+
+Names like these are ordinary on a real form, such as a checkbox recording that a benefit covers the person filling it in.

--- a/.changeset/300-dialog-form-realm.md
+++ b/.changeset/300-dialog-form-realm.md
@@ -3,14 +3,4 @@
 "@ariakit/react": patch
 ---
 
-Dialogs rendered as a form open again when a control shadows a built-in name
-
-A `<form>` exposes its controls as named properties that override built-ins, so a control named `self`, `document`, or `ownerDocument` answers when [`Dialog`](https://ariakit.com/reference/dialog) resolves the document and window that own it. The dialog threw instead of opening, and on Safari it threw while still closed, so the page failed before anyone interacted with it.
-
-```tsx
-<Ariakit.Dialog render={<form />}>
-  <input type="checkbox" name="self" />
-</Ariakit.Dialog>
-```
-
-Names like these are ordinary on a real form, such as a checkbox recording that a benefit covers the person filling it in.
+Fixed [`Dialog`](https://ariakit.com/reference/dialog) throwing instead of opening when it renders a form with a control named `self`, `document`, or `ownerDocument`, and on Safari throwing before the dialog was ever opened, so the page failed without anyone interacting with it.

--- a/.changeset/300-utils-cross-realm-document.md
+++ b/.changeset/300-utils-cross-realm-document.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/utils": patch
+---
+
+Fixed `getDocument` and `getWindow` reporting the ambient document and window for a document that belongs to another realm, such as the one inside a same-origin iframe.

--- a/.changeset/300-utils-event-realm.md
+++ b/.changeset/300-utils-event-realm.md
@@ -2,8 +2,4 @@
 "@ariakit/utils": patch
 ---
 
-Synthetic events belong to the realm of the element they are dispatched at
-
-`fireEvent`, `fireBlurEvent`, `fireFocusEvent`, and `fireKeyboardEvent` built their events with the ambient window's constructors. For an element inside a same-origin iframe, the event was built in the parent realm and dispatched into the frame, so a listener registered inside the frame received an event that failed `instanceof` against its own interfaces.
-
-Each of them now takes its constructor from the window that owns the element. `fireClickEvent` already resolved that window directly and now shares the same resolution, so it keeps working when a form or a document answers the lookup with an element of its own.
+Fixed `fireEvent`, `fireBlurEvent`, `fireFocusEvent`, and `fireKeyboardEvent` building their events with the ambient window's constructors rather than those of the window that owns the element, so an event dispatched into a same-origin iframe belongs to that frame.

--- a/.changeset/300-utils-event-realm.md
+++ b/.changeset/300-utils-event-realm.md
@@ -1,0 +1,9 @@
+---
+"@ariakit/utils": patch
+---
+
+Synthetic events belong to the realm of the element they are dispatched at
+
+`fireEvent`, `fireBlurEvent`, `fireFocusEvent`, and `fireKeyboardEvent` built their events with the ambient window's constructors. For an element inside a same-origin iframe, the event was built in the parent realm and dispatched into the frame, so a listener registered inside the frame received an event that failed `instanceof` against its own interfaces.
+
+Each of them now takes its constructor from the window that owns the element. `fireClickEvent` already resolved that window directly and now shares the same resolution, so it keeps working when a form or a document answers the lookup with an element of its own.

--- a/.changeset/300-utils-realm-resolution.md
+++ b/.changeset/300-utils-realm-resolution.md
@@ -2,10 +2,4 @@
 "@ariakit/utils": patch
 ---
 
-Realm helpers report a document and a window for every input
-
-`getDocument` and `getWindow` decided what kind of value they were handed by testing for a member name, then returned whatever that member answered with. A `<form>` defeats both steps, because it exposes its controls as named properties that override built-ins, so a control named `self`, `document`, or `ownerDocument` makes the form answer for the member the helper reads. A document does the same for the elements it names, so a `<form name="defaultView">` answers the lookup that resolves a window, which changes the answer for every element on the page rather than only for the form.
-
-Both helpers now validate what they resolve rather than trusting the member it came from. A window has to be its own `window`, a document has to report a document's node type, and a resolved view has to own the document back, which is what separates a real view from the window of an `<iframe name="defaultView">`.
-
-They also report the document and the window that own a document from another realm, instead of the ambient ones. `getWindow` is now typed the way `document.defaultView` is, so the interfaces a window carries, such as `PointerEvent`, can be read off its result.
+Fixed `getDocument` and `getWindow` resolving a realm from a member name, which a form or a document can answer with one of its own elements, and typed `getWindow`'s result the way `document.defaultView` is so the interfaces a window carries can be read off it.

--- a/.changeset/300-utils-realm-resolution.md
+++ b/.changeset/300-utils-realm-resolution.md
@@ -1,0 +1,11 @@
+---
+"@ariakit/utils": patch
+---
+
+Realm helpers report a document and a window for every input
+
+`getDocument` and `getWindow` decided what kind of value they were handed by testing for a member name, then returned whatever that member answered with. A `<form>` defeats both steps, because it exposes its controls as named properties that override built-ins, so a control named `self`, `document`, or `ownerDocument` makes the form answer for the member the helper reads. A document does the same for the elements it names, so a `<form name="defaultView">` answers the lookup that resolves a window, which changes the answer for every element on the page rather than only for the form.
+
+Both helpers now validate what they resolve rather than trusting the member it came from. A window has to be its own `window`, a document has to report a document's node type, and a resolved view has to own the document back, which is what separates a real view from the window of an `<iframe name="defaultView">`.
+
+They also report the document and the window that own a document from another realm, instead of the ambient ones. `getWindow` is now typed the way `document.defaultView` is, so the interfaces a window carries, such as `PointerEvent`, can be read off its result.

--- a/app/src/sandbox/composite-iframe-event-realm-7193/index.react.tsx
+++ b/app/src/sandbox/composite-iframe-event-realm-7193/index.react.tsx
@@ -60,6 +60,21 @@ export default function Example() {
   const [frameBody, setFrameBody] = useState<HTMLElement | null>(null);
 
   const setFrame = useCallback((element: HTMLIFrameElement | null) => {
+    // TODO: Remove once https://github.com/ariakit/ariakit/issues/7193 is
+    // fixed. `Composite` builds the events it synthesizes with the ambient
+    // window's constructors, so a listener inside the frame receives an event
+    // from the parent realm. Pointing the frame's constructors at the parent's
+    // makes its own `instanceof` checks recognize them again.
+    //
+    // This only covers the interfaces listed here, and it gives up the frame's
+    // ability to tell a parent-built event from one of its own, so code inside
+    // the frame that relies on that distinction needs a different approach.
+    const frameWindow = element?.contentDocument?.defaultView;
+    if (frameWindow) {
+      frameWindow.Event = window.Event;
+      frameWindow.FocusEvent = window.FocusEvent;
+      frameWindow.KeyboardEvent = window.KeyboardEvent;
+    }
     setFrameBody(element?.contentDocument?.body ?? null);
   }, []);
 

--- a/app/src/sandbox/composite-iframe-event-realm-7193/index.react.tsx
+++ b/app/src/sandbox/composite-iframe-event-realm-7193/index.react.tsx
@@ -1,0 +1,98 @@
+import * as Ariakit from "@ariakit/react";
+import type { Dispatch, SetStateAction, SyntheticEvent } from "react";
+import { useCallback, useState } from "react";
+import { createPortal } from "react-dom";
+
+const tools = ["Bold", "Italic", "Underline"];
+
+// `instanceof` is realm-bound, so the realm is read from the element the
+// listener sits on rather than the ambient window, which is the realm the
+// reported bug builds its events in and would hide the difference.
+// https://github.com/ariakit/ariakit/issues/7193
+function describeEvent(event: SyntheticEvent<Element>) {
+  const ownerWindow = event.currentTarget.ownerDocument.defaultView;
+  const realm =
+    ownerWindow && event.nativeEvent instanceof ownerWindow.Event
+      ? "own window"
+      : "other window";
+  return `${event.nativeEvent.constructor.name}, ${realm}`;
+}
+
+interface EmbeddedToolbarProps {
+  setKeyboardEvents: Dispatch<SetStateAction<string[]>>;
+  setBlurEvents: Dispatch<SetStateAction<string[]>>;
+}
+
+function EmbeddedToolbar({
+  setKeyboardEvents,
+  setBlurEvents,
+}: EmbeddedToolbarProps) {
+  // Virtual focus keeps DOM focus on the toolbar, so `Composite` forwards the
+  // keyboard event to the active item and blurs the previous one itself.
+  // Without it neither synthetic event exists and no item listener runs.
+  const composite = Ariakit.useCompositeStore({ virtualFocus: true });
+  return (
+    <Ariakit.Composite store={composite} role="toolbar" aria-label="Formatting">
+      {tools.map((tool) => (
+        <Ariakit.CompositeItem
+          key={tool}
+          // React nulls `currentTarget` once dispatch ends, and a state updater
+          // runs later, so the event has to be described before updating.
+          onKeyDown={(event) => {
+            const description = describeEvent(event);
+            setKeyboardEvents((events) => [...events, description]);
+          }}
+          onBlur={(event) => {
+            const description = describeEvent(event);
+            setBlurEvents((events) => [...events, description]);
+          }}
+        >
+          {tool}
+        </Ariakit.CompositeItem>
+      ))}
+    </Ariakit.Composite>
+  );
+}
+
+export default function Example() {
+  const [keyboardEvents, setKeyboardEvents] = useState<string[]>([]);
+  const [blurEvents, setBlurEvents] = useState<string[]>([]);
+  const [frameBody, setFrameBody] = useState<HTMLElement | null>(null);
+
+  const setFrame = useCallback((element: HTMLIFrameElement | null) => {
+    setFrameBody(element?.contentDocument?.body ?? null);
+  }, []);
+
+  return (
+    <main>
+      <h1>Embedded formatting toolbar</h1>
+
+      {/* A same-origin frame owns its own constructors, so a listener inside it
+          only recognizes events the frame's own window built. */}
+      <iframe title="Editor frame" ref={setFrame} />
+      {frameBody
+        ? createPortal(
+            <EmbeddedToolbar
+              setKeyboardEvents={setKeyboardEvents}
+              setBlurEvents={setBlurEvents}
+            />,
+            frameBody,
+          )
+        : null}
+
+      <h2 id="item-keyboard-events">Item keyboard events</h2>
+      <ul aria-labelledby="item-keyboard-events" aria-live="polite">
+        {keyboardEvents.map((description, index) => (
+          <li key={index}>{description}</li>
+        ))}
+      </ul>
+
+      <h2 id="item-blur-events">Item blur events</h2>
+      <ul aria-labelledby="item-blur-events" aria-live="polite">
+        {blurEvents.map((description, index) => (
+          <li key={index}>{description}</li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/app/src/sandbox/composite-iframe-event-realm-7193/index.react.tsx
+++ b/app/src/sandbox/composite-iframe-event-realm-7193/index.react.tsx
@@ -60,21 +60,6 @@ export default function Example() {
   const [frameBody, setFrameBody] = useState<HTMLElement | null>(null);
 
   const setFrame = useCallback((element: HTMLIFrameElement | null) => {
-    // TODO: Remove once https://github.com/ariakit/ariakit/issues/7193 is
-    // fixed. `Composite` builds the events it synthesizes with the ambient
-    // window's constructors, so a listener inside the frame receives an event
-    // from the parent realm. Pointing the frame's constructors at the parent's
-    // makes its own `instanceof` checks recognize them again.
-    //
-    // This only covers the interfaces listed here, and it gives up the frame's
-    // ability to tell a parent-built event from one of its own, so code inside
-    // the frame that relies on that distinction needs a different approach.
-    const frameWindow = element?.contentDocument?.defaultView;
-    if (frameWindow) {
-      frameWindow.Event = window.Event;
-      frameWindow.FocusEvent = window.FocusEvent;
-      frameWindow.KeyboardEvent = window.KeyboardEvent;
-    }
     setFrameBody(element?.contentDocument?.body ?? null);
   }, []);
 

--- a/app/src/sandbox/composite-iframe-event-realm-7193/test-browser.ts
+++ b/app/src/sandbox/composite-iframe-event-realm-7193/test-browser.ts
@@ -1,0 +1,35 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// This fixture has no happy-dom duplicate: happy-dom shares one set of
+// constructors between a frame and its parent, so both realms answer
+// `instanceof` the same way and the assertions below would pass either way.
+withFramework(import.meta.dirname, async ({ test, query }) => {
+  // https://github.com/ariakit/ariakit/issues/7193
+  test("forwards the keyboard event built by the frame's own window", async ({
+    page,
+    q,
+  }) => {
+    const frame = query(page.frameLocator("iframe[title='Editor frame']"));
+    const events = query(q.list("Item keyboard events")).listitem();
+    await frame.button("Bold").click();
+
+    await page.keyboard.press("ArrowRight");
+    await test.expect(events).toHaveText(["KeyboardEvent, own window"]);
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7193
+  //
+  // Moving the active item blurs the previous one, a separate path from the
+  // keyboard proxy above.
+  test("blurs the previous item with an event built by the frame's own window", async ({
+    page,
+    q,
+  }) => {
+    const frame = query(page.frameLocator("iframe[title='Editor frame']"));
+    const events = query(q.list("Item blur events")).listitem();
+    await frame.button("Bold").click();
+
+    await page.keyboard.press("ArrowRight");
+    await test.expect(events).toHaveText(["FocusEvent, own window"]);
+  });
+});

--- a/app/src/sandbox/dialog-form-7201/index.react.tsx
+++ b/app/src/sandbox/dialog-form-7201/index.react.tsx
@@ -20,24 +20,31 @@ function CoverageDialog({ label, withDocumentField }: CoverageDialogProps) {
       <button tabIndex={0} onClick={() => setOpen(true)}>
         {label}
       </button>
+      {/* TODO: Remove once https://github.com/ariakit/ariakit/issues/7201 is
+          fixed. The dialog resolves its own document and window from the
+          element it renders, and a form answers those lookups with a control
+          named after them. Nesting the form inside the dialog, rather than
+          rendering the dialog as the form, keeps the form out of that lookup
+          while the dialog still holds exactly the same controls. */}
       <Ariakit.Dialog
         open={open}
         onClose={() => setOpen(false)}
-        render={<form />}
         className="fixed inset-x-4 top-20 mx-auto flex max-w-md flex-col gap-3 rounded bg-white p-6"
       >
         <Ariakit.DialogHeading>{label}</Ariakit.DialogHeading>
-        <label>
-          <input type="checkbox" name="self" />
-          This coverage is for me
-        </label>
-        {withDocumentField ? (
+        <form className="flex flex-col gap-3">
           <label>
-            Proof of eligibility
-            <input name="document" />
+            <input type="checkbox" name="self" />
+            This coverage is for me
           </label>
-        ) : null}
-        <Ariakit.DialogDismiss>Cancel</Ariakit.DialogDismiss>
+          {withDocumentField ? (
+            <label>
+              Proof of eligibility
+              <input name="document" />
+            </label>
+          ) : null}
+          <Ariakit.DialogDismiss>Cancel</Ariakit.DialogDismiss>
+        </form>
       </Ariakit.Dialog>
     </div>
   );

--- a/app/src/sandbox/dialog-form-7201/index.react.tsx
+++ b/app/src/sandbox/dialog-form-7201/index.react.tsx
@@ -24,6 +24,7 @@ function CoverageDialog({ label, withDocumentField }: CoverageDialogProps) {
         open={open}
         onClose={() => setOpen(false)}
         render={<form />}
+        className="fixed inset-x-4 top-20 mx-auto flex max-w-md flex-col gap-3 rounded bg-white p-6"
       >
         <Ariakit.DialogHeading>{label}</Ariakit.DialogHeading>
         <label>

--- a/app/src/sandbox/dialog-form-7201/index.react.tsx
+++ b/app/src/sandbox/dialog-form-7201/index.react.tsx
@@ -20,31 +20,24 @@ function CoverageDialog({ label, withDocumentField }: CoverageDialogProps) {
       <button tabIndex={0} onClick={() => setOpen(true)}>
         {label}
       </button>
-      {/* TODO: Remove once https://github.com/ariakit/ariakit/issues/7201 is
-          fixed. The dialog resolves its own document and window from the
-          element it renders, and a form answers those lookups with a control
-          named after them. Nesting the form inside the dialog, rather than
-          rendering the dialog as the form, keeps the form out of that lookup
-          while the dialog still holds exactly the same controls. */}
       <Ariakit.Dialog
         open={open}
         onClose={() => setOpen(false)}
+        render={<form />}
         className="fixed inset-x-4 top-20 mx-auto flex max-w-md flex-col gap-3 rounded bg-white p-6"
       >
         <Ariakit.DialogHeading>{label}</Ariakit.DialogHeading>
-        <form className="flex flex-col gap-3">
+        <label>
+          <input type="checkbox" name="self" />
+          This coverage is for me
+        </label>
+        {withDocumentField ? (
           <label>
-            <input type="checkbox" name="self" />
-            This coverage is for me
+            Proof of eligibility
+            <input name="document" />
           </label>
-          {withDocumentField ? (
-            <label>
-              Proof of eligibility
-              <input name="document" />
-            </label>
-          ) : null}
-          <Ariakit.DialogDismiss>Cancel</Ariakit.DialogDismiss>
-        </form>
+        ) : null}
+        <Ariakit.DialogDismiss>Cancel</Ariakit.DialogDismiss>
       </Ariakit.Dialog>
     </div>
   );

--- a/app/src/sandbox/dialog-form-7201/index.react.tsx
+++ b/app/src/sandbox/dialog-form-7201/index.react.tsx
@@ -1,0 +1,53 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+
+interface CoverageDialogProps {
+  label: string;
+  withDocumentField: boolean;
+}
+
+// A benefits form names its controls after what they collect, and both `self`
+// and `document` below collide with a member the realm helpers read from the
+// form itself.
+// https://github.com/ariakit/ariakit/issues/7201
+function CoverageDialog({ label, withDocumentField }: CoverageDialogProps) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div>
+      {/* A plain button rather than `DialogDisclosure`, so the dialog has to
+          resolve its own disclosure from the active element when it opens.
+          `tabIndex` keeps Safari focusing the button on click. */}
+      <button tabIndex={0} onClick={() => setOpen(true)}>
+        {label}
+      </button>
+      <Ariakit.Dialog
+        open={open}
+        onClose={() => setOpen(false)}
+        render={<form />}
+      >
+        <Ariakit.DialogHeading>{label}</Ariakit.DialogHeading>
+        <label>
+          <input type="checkbox" name="self" />
+          This coverage is for me
+        </label>
+        {withDocumentField ? (
+          <label>
+            Proof of eligibility
+            <input name="document" />
+          </label>
+        ) : null}
+        <Ariakit.DialogDismiss>Cancel</Ariakit.DialogDismiss>
+      </Ariakit.Dialog>
+    </div>
+  );
+}
+
+export default function Example() {
+  return (
+    <main>
+      <h1>Coverage forms</h1>
+      <CoverageDialog label="Add coverage" withDocumentField={false} />
+      <CoverageDialog label="Add coverage with proof" withDocumentField />
+    </main>
+  );
+}

--- a/app/src/sandbox/dialog-form-7201/test-browser.ts
+++ b/app/src/sandbox/dialog-form-7201/test-browser.ts
@@ -1,0 +1,27 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// `Dialog` keeps its element mounted while closed, and the `isSafariBrowser`
+// effect that tracks the last mousedown resolves the document at mount, so
+// Safari reaches the realm helpers before the dialog is ever opened.
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/7201
+  test("opens a form dialog whose control is named self", async ({ q }) => {
+    await q.button("Add coverage").click();
+    await test.expect(q.dialog("Add coverage")).toBeVisible();
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7201
+  //
+  // A second control named `document` makes the form answer the document lookup
+  // with that control instead of leaving it unanswered, which fails inside the
+  // same helpers for a different reason.
+  test("opens a form dialog whose controls are named self and document", async ({
+    q,
+  }) => {
+    await q.button("Add coverage with proof").click();
+    await test.expect(q.dialog("Add coverage with proof")).toBeVisible();
+
+    await q.button("Cancel").click();
+    await test.expect(q.button("Add coverage with proof")).toBeFocused();
+  });
+});

--- a/app/src/sandbox/dialog-form-7201/test.ts
+++ b/app/src/sandbox/dialog-form-7201/test.ts
@@ -1,0 +1,20 @@
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// https://github.com/ariakit/ariakit/issues/7201
+test("opens a form dialog whose control is named self", async () => {
+  await click(q.button("Add coverage"));
+  expect(q.dialog("Add coverage")).toBeVisible();
+});
+
+// https://github.com/ariakit/ariakit/issues/7201
+//
+// A second control named `document` makes the form answer the document lookup
+// with that control instead of leaving it unanswered, which fails inside the
+// same helpers for a different reason.
+test("opens a form dialog whose controls are named self and document", async () => {
+  await click(q.button("Add coverage with proof"));
+  expect(q.dialog("Add coverage with proof")).toBeVisible();
+  await click(q.button("Cancel"));
+  expect(q.button("Add coverage with proof")).toHaveFocus();
+});

--- a/packages/ariakit-test/src/__utils.test.ts
+++ b/packages/ariakit-test/src/__utils.test.ts
@@ -1,5 +1,57 @@
-import { expect, test } from "vitest";
-import { wrapAsync } from "./__utils.ts";
+import { afterEach, expect, test } from "vitest";
+import { getOwnerWindow, wrapAsync } from "./__utils.ts";
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+// Resolving the realm by reading one member is only safe while nothing shadows
+// it. A form exposes its controls as named properties, and browsers let those
+// override built-ins, so a control named `ownerDocument` answers the lookup this
+// helper starts from. Measured on Chromium 151, Firefox 153, and WebKit 26.5;
+// happy-dom defines `ownerDocument` on the prototype chain, so it is emulated.
+// https://github.com/ariakit/ariakit/issues/7209
+test("getOwnerWindow resolves a form whose control answers the owner document", () => {
+  const form = document.createElement("form");
+  const control = document.createElement("input");
+  control.name = "ownerDocument";
+  form.append(control);
+  document.body.append(form);
+  Object.defineProperty(form, "ownerDocument", {
+    configurable: true,
+    value: control,
+  });
+
+  expect(getOwnerWindow(form)).toBe(window);
+});
+
+// Both callers use the absent result to fall back, so it has to stay absent for
+// a target with no view of its own rather than becoming the ambient window.
+test("getOwnerWindow reports no window for a document with no view", () => {
+  const otherDocument = document.implementation.createHTMLDocument("Other");
+  const element = otherDocument.createElement("div");
+  otherDocument.body.append(element);
+
+  expect(getOwnerWindow(element)).toBeNull();
+});
+
+// `Document` exposes named elements as its own properties too, so the view a
+// document answers with has to be checked rather than returned as it comes.
+// https://github.com/ariakit/ariakit/issues/7209
+test("getOwnerWindow reports no window when a document answers its default view with an element", () => {
+  const otherDocument = document.implementation.createHTMLDocument("Other");
+  const element = otherDocument.createElement("div");
+  otherDocument.body.append(element);
+  const form = otherDocument.createElement("form");
+  form.name = "defaultView";
+  otherDocument.body.append(form);
+  Object.defineProperty(otherDocument, "defaultView", {
+    configurable: true,
+    value: form,
+  });
+
+  expect(getOwnerWindow(element)).toBeNull();
+});
 
 test("wrapAsync does not reapply the act environment when nested", async () => {
   const scope = globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean };

--- a/packages/ariakit-test/src/__utils.test.ts
+++ b/packages/ariakit-test/src/__utils.test.ts
@@ -36,8 +36,25 @@ test("getOwnerWindow reports no window for a document with no view", () => {
 });
 
 // `Document` exposes named elements as its own properties too, so the view a
-// document answers with has to be checked rather than returned as it comes.
+// document answers with has to own it back rather than merely be a window: the
+// same getter answers with a real window when the element it names is a frame.
 // https://github.com/ariakit/ariakit/issues/7209
+test("getOwnerWindow reports no window when a document answers its default view with another realm's window", () => {
+  const frame = document.createElement("iframe");
+  document.body.append(frame);
+  const frameWindow = frame.contentDocument?.defaultView;
+  if (!frameWindow) throw new Error("iframe window is not available");
+  const otherDocument = document.implementation.createHTMLDocument("Other");
+  const element = otherDocument.createElement("div");
+  otherDocument.body.append(element);
+  Object.defineProperty(otherDocument, "defaultView", {
+    configurable: true,
+    value: frameWindow,
+  });
+
+  expect(getOwnerWindow(element)).toBeNull();
+});
+
 test("getOwnerWindow reports no window when a document answers its default view with an element", () => {
   const otherDocument = document.implementation.createHTMLDocument("Other");
   const element = otherDocument.createElement("div");

--- a/packages/ariakit-test/src/__utils.ts
+++ b/packages/ariakit-test/src/__utils.ts
@@ -1,4 +1,4 @@
-import { noop } from "@ariakit/utils";
+import { getDocument, getWindow, noop } from "@ariakit/utils";
 
 export type DirtiableElement = Element & { dirty?: boolean };
 
@@ -25,21 +25,15 @@ export type OwnerWindowSource = Window | Document | Node | null | undefined;
  */
 export function getOwnerWindow(target: OwnerWindowSource) {
   if (!target) return null;
-  // `ownerDocument` first, because a form exposes its controls as named
-  // properties and one named `document` would answer the branch below. Neither
-  // happy-dom nor jsdom implements the form's `[LegacyOverrideBuiltIns]`, so
-  // this name still resolves through `Node.prototype` there; a browser does
-  // implement it, but `createEvent` resolves the window just as fragilely then.
-  // A `Document` reports `null` here and falls through to its own view.
-  // https://html.spec.whatwg.org/multipage/forms.html#the-form-element
-  if ("ownerDocument" in target && target.ownerDocument) {
-    return target.ownerDocument.defaultView;
-  }
-  if ("defaultView" in target) return target.defaultView;
-  // Through the document either way, since only `defaultView` is typed with the
-  // constructors a window carries.
-  if ("document" in target) return target.document.defaultView;
-  return null;
+  // `getWindow` resolves the realm defensively, because a form exposes its
+  // controls as named properties that override built-ins and a document does
+  // the same for the elements it names. It falls back to the ambient window
+  // rather than reporting failure, so the target's own view is the one that
+  // owns the target's document back. Everything else reports absent, which is
+  // what both callers fall back on.
+  // https://github.com/ariakit/ariakit/issues/7209
+  const view = getWindow(target);
+  return view.document === getDocument(target) ? view : null;
 }
 
 export const isBrowser =

--- a/packages/ariakit-utils/readme.md
+++ b/packages/ariakit-utils/readme.md
@@ -261,7 +261,7 @@ const title = canUseDOM ? document.title : "";
 function getDocument(node?: Window | Document | Node | null): Document;
 ```
 
-Returns `element.ownerDocument || document`.
+Returns the document `node` belongs to, or the current one when it has none.
 
 <div align="right">
   <a href="#api-reference">&uarr; back to top</a>
@@ -270,10 +270,12 @@ Returns `element.ownerDocument || document`.
 #### `getWindow`
 
 ```ts
-function getWindow(node?: Window | Document | Node | null): Window;
+function getWindow(
+  node?: Window | Document | Node | null,
+): Window & typeof globalThis;
 ```
 
-Returns `element.ownerDocument.defaultView || window`.
+Returns the window `node` belongs to, or the current one when it has none.
 
 <div align="right">
   <a href="#api-reference">&uarr; back to top</a>

--- a/packages/ariakit-utils/src/dom.test.ts
+++ b/packages/ariakit-utils/src/dom.test.ts
@@ -188,6 +188,26 @@ test("getWindow resolves a window to itself", () => {
   expect(getWindow(frameWindow)).toBe(frameWindow);
 });
 
+// A document names its own elements the same way, so one that names an element
+// `nodeType` answers that read with the element. Measured on the three engines
+// above; happy-dom implements no document named getter, so it is emulated here.
+// Validating through that read would reject the document every element in it
+// belongs to. https://github.com/ariakit/ariakit/pull/7213#discussion_r3816584472
+test("getDocument resolves an element whose document answers nodeType with an element", () => {
+  const otherDocument = document.implementation.createHTMLDocument("Other");
+  const element = otherDocument.createElement("div");
+  otherDocument.body.append(element);
+  const form = otherDocument.createElement("form");
+  form.name = "nodeType";
+  otherDocument.body.append(form);
+  Object.defineProperty(otherDocument, "nodeType", {
+    configurable: true,
+    value: form,
+  });
+
+  expect(getDocument(element)).toBe(otherDocument);
+});
+
 test("getDocument falls back when a form answers its owner document with a control", () => {
   const form = document.createElement("form");
   const control = document.createElement("input");

--- a/packages/ariakit-utils/src/dom.test.ts
+++ b/packages/ariakit-utils/src/dom.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, expect, test } from "vitest";
 import {
+  getActiveElement,
+  getDocument,
   getItemRoleByPopupRole,
   getScrollingElement,
   getTextboxSelection,
   getTextboxValue,
+  getWindow,
   isTextField,
   setSelectionRange,
 } from "./dom.ts";
@@ -68,23 +71,175 @@ test("reads selection offsets from contenteditable elements", () => {
   expect(getTextboxSelection(editor)).toEqual({ start: 3, end: 8 });
 });
 
-test("getScrollingElement falls back to the element's own document, not the global one", () => {
+function appendFrame() {
   const iframe = document.createElement("iframe");
   document.body.append(iframe);
-  const frameDoc = iframe.contentDocument;
-  expect(frameDoc).toBeTruthy();
-  if (!frameDoc?.body) {
-    throw new Error("Expected iframe document body");
+  const frameDocument = iframe.contentDocument;
+  if (!frameDocument?.body || !frameDocument.defaultView) {
+    throw new Error("Expected a same-origin frame document");
   }
+  return { frameDocument, frameWindow: frameDocument.defaultView };
+}
+
+test("getScrollingElement falls back to the element's own document, not the global one", () => {
+  const { frameDocument } = appendFrame();
 
   // The element lives inside the iframe with no in-frame overflow container, so
   // the ancestor walk bottoms out at the document fallback. That fallback must
   // resolve against the iframe's own document, not the top-level page's.
-  const item = frameDoc.createElement("div");
-  frameDoc.body.append(item);
+  const item = frameDocument.createElement("div");
+  frameDocument.body.append(item);
 
   const scroller = getScrollingElement(item);
-  expect(scroller?.ownerDocument).toBe(frameDoc);
+  expect(scroller?.ownerDocument).toBe(frameDocument);
+});
+
+// A form's named-element getter overrides built-ins, so a control named after
+// the member a helper reads makes the form answer with that control instead.
+// Measured on Chromium 151, Firefox 153, and WebKit 26.5. happy-dom reproduces
+// it for `self` and `document` but not for members it defines on the prototype
+// chain, so the cases below that need one of those emulate it.
+// https://github.com/ariakit/ariakit/issues/7201
+
+function appendShadowingForm(
+  ownerDocument: Document,
+  ...controlNames: string[]
+) {
+  const form = ownerDocument.createElement("form");
+  for (const name of controlNames) {
+    const control = ownerDocument.createElement("input");
+    control.name = name;
+    form.append(control);
+  }
+  ownerDocument.body.append(form);
+  return form;
+}
+
+// Each helper gets its own case, because a bundled test stops at the first
+// failing assertion. `getDocument` and `getActiveElement` also fail differently
+// per shape, while `getWindow` reads only `self` and fails the same way in both.
+const shadowingForms = [
+  { controlNames: ["self"], label: "a control named self" },
+  {
+    controlNames: ["self", "document"],
+    label: "controls named self and document",
+  },
+];
+
+test.each(shadowingForms)(
+  "getDocument handles a form with $label",
+  ({ controlNames }) => {
+    const form = appendShadowingForm(document, ...controlNames);
+
+    expect(getDocument(form)).toBe(document);
+  },
+);
+
+test.each(shadowingForms)(
+  "getWindow handles a form with $label",
+  ({ controlNames }) => {
+    const form = appendShadowingForm(document, ...controlNames);
+
+    expect(getWindow(form)).toBe(window);
+  },
+);
+
+test.each(shadowingForms)(
+  "getActiveElement handles a form with $label",
+  ({ controlNames }) => {
+    const button = document.createElement("button");
+    document.body.append(button);
+    const form = appendShadowingForm(document, ...controlNames);
+    button.focus();
+
+    expect(getActiveElement(form)).toBe(button);
+  },
+);
+
+// Resolving through the frame is what makes a wrong answer visible: in the
+// ambient realm the fallback happens to be correct, so a helper that resolves
+// the realm from the wrong member still looks right. The `window` control is
+// what a fix that swapped one member name for another would read.
+test("getDocument resolves a shadowing form to its own frame's document", () => {
+  const { frameDocument } = appendFrame();
+  const form = appendShadowingForm(frameDocument, "self", "window");
+
+  expect(getDocument(form)).toBe(frameDocument);
+});
+
+test("getWindow resolves a shadowing form to its own frame's view", () => {
+  const { frameDocument, frameWindow } = appendFrame();
+  const form = appendShadowingForm(frameDocument, "self", "window");
+
+  expect(getWindow(form)).toBe(frameWindow);
+});
+
+// The window branch is the one the discriminator rewrites, so it needs its own
+// case: dropping it entirely would leave every test above passing.
+test("getDocument resolves a window to its own document", () => {
+  const { frameDocument, frameWindow } = appendFrame();
+
+  expect(getDocument(frameWindow)).toBe(frameDocument);
+});
+
+test("getWindow resolves a window to itself", () => {
+  const { frameWindow } = appendFrame();
+
+  expect(getWindow(frameWindow)).toBe(frameWindow);
+});
+
+test("getDocument falls back when a form answers its owner document with a control", () => {
+  const form = document.createElement("form");
+  const control = document.createElement("input");
+  control.name = "ownerDocument";
+  form.append(control);
+  document.body.append(form);
+  // happy-dom overrides only members it does not define on the prototype chain,
+  // so the browsers' answer for the control above is emulated here.
+  Object.defineProperty(form, "ownerDocument", {
+    configurable: true,
+    value: control,
+  });
+
+  expect(getDocument(form)).toBe(document);
+});
+
+test("getWindow falls back when a document answers its default view with an element", () => {
+  const otherDocument = document.implementation.createHTMLDocument("Other");
+  const element = otherDocument.createElement("div");
+  otherDocument.body.append(element);
+  const form = otherDocument.createElement("form");
+  form.name = "defaultView";
+  otherDocument.body.append(form);
+  // `Document` carries the same named-element override, measured on the three
+  // engines above: a form named `defaultView` makes the document answer that
+  // lookup with the form. happy-dom implements no document named getter, so it
+  // is emulated here. This one reaches every caller rather than only the ones
+  // handed a form, because `getWindow` resolves through the document.
+  Object.defineProperty(otherDocument, "defaultView", {
+    configurable: true,
+    value: form,
+  });
+
+  expect(getWindow(element)).toBe(window);
+});
+
+// A `Document` is a `Node` whose `ownerDocument` is `null`, so resolving one
+// through that member falls through to the ambient document. Measured on
+// Chromium 151, Firefox 153, and WebKit 26.5: both helpers report the top-level
+// page for a document that belongs to a frame.
+// https://github.com/ariakit/ariakit/issues/7206
+
+test("getDocument resolves a document from another realm to itself", () => {
+  const { frameDocument } = appendFrame();
+
+  expect(getDocument(frameDocument)).toBe(frameDocument);
+});
+
+test("getWindow resolves a document from another realm to its own view", () => {
+  const { frameDocument, frameWindow } = appendFrame();
+
+  expect(getWindow(frameDocument)).toBe(frameWindow);
 });
 
 test("setSelectionRange skips input types that do not support text selection", () => {

--- a/packages/ariakit-utils/src/dom.test.ts
+++ b/packages/ariakit-utils/src/dom.test.ts
@@ -224,6 +224,45 @@ test("getWindow falls back when a document answers its default view with an elem
   expect(getWindow(element)).toBe(window);
 });
 
+// The same getter answers with a real window when the element it names is a
+// frame, so the resolved view has to own the document back rather than merely
+// be a window. Measured on the three engines above.
+test("getWindow falls back when a document answers its default view with another realm's window", () => {
+  const { frameWindow } = appendFrame();
+  const otherDocument = document.implementation.createHTMLDocument("Other");
+  const element = otherDocument.createElement("div");
+  otherDocument.body.append(element);
+  Object.defineProperty(otherDocument, "defaultView", {
+    configurable: true,
+    value: frameWindow,
+  });
+
+  expect(getWindow(element)).toBe(window);
+});
+
+// Measured on the same three engines: when that frame is cross-origin, its
+// window still answers `window` with itself and throws a `SecurityError` for
+// `document`, so refusing to answer has to count as owning another document.
+// The environment has no cross-origin frames, so the refusal is emulated.
+test("getWindow falls back when the view it resolves refuses to report its document", () => {
+  const refusingView = {
+    window: null as unknown,
+    get document(): Document {
+      throw new Error("SecurityError");
+    },
+  };
+  refusingView.window = refusingView;
+  const otherDocument = document.implementation.createHTMLDocument("Other");
+  const element = otherDocument.createElement("div");
+  otherDocument.body.append(element);
+  Object.defineProperty(otherDocument, "defaultView", {
+    configurable: true,
+    value: refusingView,
+  });
+
+  expect(getWindow(element)).toBe(window);
+});
+
 // A `Document` is a `Node` whose `ownerDocument` is `null`, so resolving one
 // through that member falls through to the ambient document. Measured on
 // Chromium 151, Firefox 153, and WebKit 26.5: both helpers report the top-level

--- a/packages/ariakit-utils/src/dom.ts
+++ b/packages/ariakit-utils/src/dom.ts
@@ -36,10 +36,27 @@ function isWindow(value: unknown): value is Window & typeof globalThis {
   return (value as Window).window === value;
 }
 
+// Taken from the prototype because a document names its own elements too, so
+// one holding an element named `nodeType` answers that read with it. The getter
+// bypasses that lookup and is brand-checked against the interface rather than
+// the realm, so it still answers for a node belonging to a frame.
+// https://github.com/ariakit/ariakit/pull/7213#discussion_r3816584472
+const nodeTypeGetter =
+  typeof Node === "undefined"
+    ? undefined
+    : // oxlint-disable-next-line typescript/unbound-method -- the receiver is supplied explicitly below
+      Object.getOwnPropertyDescriptor(Node.prototype, "nodeType")?.get;
+
 function isDocument(value: unknown): value is Document {
-  // Node.DOCUMENT_NODE === 9. The numeric literal avoids referencing the `Node`
-  // global, the way `isElement` below does.
-  return (value as Node | null | undefined)?.nodeType === 9;
+  if (!value) return false;
+  // Node.DOCUMENT_NODE === 9.
+  if (!nodeTypeGetter) return (value as Node).nodeType === 9;
+  try {
+    return nodeTypeGetter.call(value) === 9;
+  } catch {
+    // The brand check rejects anything that is not a node.
+    return false;
+  }
 }
 
 function ownsDocument(
@@ -158,6 +175,11 @@ export function isElement(
   // Reading `nodeType` on a non-node target yields `undefined`. The numeric
   // literal (Node.ELEMENT_NODE === 1) avoids referencing the `Node` global, so
   // the guard stays safe even if it's ever evaluated during SSR.
+  //
+  // Unlike `isDocument` above, this reads the member directly, so a form
+  // holding a control named `nodeType` answers for it. Left alone until the
+  // cost of the prototype read on this hot path is measured.
+  // https://github.com/ariakit/ariakit/issues/7215
   return (target as Node | null)?.nodeType === 1;
 }
 

--- a/packages/ariakit-utils/src/dom.ts
+++ b/packages/ariakit-utils/src/dom.ts
@@ -18,22 +18,76 @@ function checkIsBrowser() {
   return typeof window !== "undefined" && !!window.document?.createElement;
 }
 
-/**
- * Returns `element.ownerDocument || document`.
- */
-export function getDocument(node?: Window | Document | Node | null): Document {
-  if (!node) return document;
-  if ("self" in node) return node.document;
-  return node.ownerDocument || document;
+// A form exposes its controls as named properties that override built-ins, and
+// a document does the same for the elements it names, so any member read while
+// resolving a realm can answer with one of those instead: a control named
+// `self` makes a form answer the window test, one named `ownerDocument` makes
+// it answer the document lookup, and a form named `defaultView` makes a
+// document answer the window lookup. The two guards below check what came back
+// rather than trusting the member it came from.
+// https://github.com/ariakit/ariakit/issues/7201
+
+// Typed the way `document.defaultView` is, because the interfaces a caller
+// reads off a window, such as `PointerEvent`, are globals rather than members
+// of `Window`.
+function isWindow(value: unknown): value is Window & typeof globalThis {
+  if (!value) return false;
+  // A window is the only object that is its own `window`.
+  return (value as Window).window === value;
+}
+
+function isDocument(value: unknown): value is Document {
+  // Node.DOCUMENT_NODE === 9. The numeric literal avoids referencing the `Node`
+  // global, the way `isElement` below does.
+  return (value as Node | null | undefined)?.nodeType === 9;
+}
+
+function ownsDocument(
+  view: Window & typeof globalThis,
+  ownerDocument: Document,
+) {
+  try {
+    return view.document === ownerDocument;
+  } catch {
+    // A cross-origin window answers only an allowlist, which `document` is not
+    // on, so refusing to answer is itself proof that it owns another document.
+    return false;
+  }
 }
 
 /**
- * Returns `element.ownerDocument.defaultView || window`.
+ * Returns the document `node` belongs to, or the current one when it has none.
  */
-export function getWindow(node?: Window | Document | Node | null): Window {
+export function getDocument(node?: Window | Document | Node | null): Document {
+  if (!node) return document;
+  if (isDocument(node)) return node;
+  // A plain `Window` is not assignable to the intersection `isWindow` asserts,
+  // so it stays in the type of the branch that has already ruled it out.
+  const nodeDocument = isWindow(node)
+    ? node.document
+    : (node as Node).ownerDocument;
+  if (isDocument(nodeDocument)) return nodeDocument;
+  return document;
+}
+
+/**
+ * Returns the window `node` belongs to, or the current one when it has none.
+ */
+export function getWindow(
+  node?: Window | Document | Node | null,
+): Window & typeof globalThis {
   if (!node) return self;
-  if ("self" in node) return node.self;
-  return getDocument(node).defaultView || window;
+  if (isWindow(node)) return node;
+  const nodeDocument = getDocument(node);
+  const { defaultView } = nodeDocument;
+  // Being a window is not enough, because the named getter answers with the
+  // window of an `<iframe name="defaultView">`, which is a real window from
+  // another realm. A window is only this document's view when it owns it back,
+  // and `Window.document` cannot be shadowed the way `Document` members can.
+  if (isWindow(defaultView) && ownsDocument(defaultView, nodeDocument)) {
+    return defaultView;
+  }
+  return window;
 }
 
 /**

--- a/packages/ariakit-utils/src/events.test.ts
+++ b/packages/ariakit-utils/src/events.test.ts
@@ -1,6 +1,10 @@
 import { expect, onTestFinished, test, vi } from "vitest";
 import {
+  fireBlurEvent,
   fireClickEvent,
+  fireEvent,
+  fireFocusEvent,
+  fireKeyboardEvent,
   isFocusEventOutside,
   isInputEvent,
   isPortalEvent,
@@ -263,7 +267,7 @@ test("fireClickEvent forwards the members of a live event passed as the init", (
 // `instanceof` check here. Replacing the constructor on the frame's window
 // alone makes the two distinguishable: only an implementation that reads the
 // element's own window builds the subclass.
-test("fireClickEvent builds the event with the element's own window", () => {
+function appendFrameButton() {
   const frame = document.createElement("iframe");
   document.body.append(frame);
   onTestFinished(() => frame.remove());
@@ -274,6 +278,11 @@ test("fireClickEvent builds the event with the element's own window", () => {
   const button = frameDocument.body.appendChild(
     frameDocument.createElement("button"),
   );
+  return { button, view };
+}
+
+test("fireClickEvent builds the event with the element's own window", () => {
+  const { button, view } = appendFrameButton();
   const ambientPointerEvent = view.PointerEvent;
   class FramePointerEvent extends ambientPointerEvent {}
   view.PointerEvent = FramePointerEvent;
@@ -292,16 +301,7 @@ test("fireClickEvent builds the event with the element's own window", () => {
 // still has none. Activation has to keep working there rather than throwing,
 // dropping only the pointer members.
 test("fireClickEvent falls back to MouseEvent where PointerEvent is missing", () => {
-  const frame = document.createElement("iframe");
-  document.body.append(frame);
-  onTestFinished(() => frame.remove());
-  const frameDocument = frame.contentDocument;
-  if (!frameDocument) throw new Error("iframe document is not available");
-  const view = frameDocument.defaultView;
-  if (!view) throw new Error("iframe window is not available");
-  const button = frameDocument.body.appendChild(
-    frameDocument.createElement("button"),
-  );
+  const { button, view } = appendFrameButton();
   const framePointerEvent = view.PointerEvent;
   Reflect.deleteProperty(view, "PointerEvent");
   onTestFinished(() => {
@@ -313,4 +313,109 @@ test("fireClickEvent falls back to MouseEvent where PointerEvent is missing", ()
   expect(clicked).toBeInstanceOf(view.MouseEvent);
   expect(clicked).not.toBeInstanceOf(framePointerEvent);
   expect(clicked?.ctrlKey).toBe(true);
+});
+
+// The remaining helpers have to read the same window `fireClickEvent` does, or
+// a listener inside a same-origin frame gets an event that fails `instanceof`
+// against its own interfaces. They tell the two realms apart the same way the
+// two tests above do. https://github.com/ariakit/ariakit/issues/7193
+
+function captureEvents(element: Element, ...types: string[]) {
+  const received: Event[] = [];
+  for (const type of types) {
+    element.addEventListener(type, (event) => received.push(event));
+  }
+  return received;
+}
+
+test("fireEvent builds the event with the element's own window", () => {
+  const { button, view } = appendFrameButton();
+  const frameEvent = view.Event;
+  class SubclassedEvent extends frameEvent {}
+  view.Event = SubclassedEvent;
+  onTestFinished(() => {
+    view.Event = frameEvent;
+  });
+  const received = captureEvents(button, "mouseout");
+
+  fireEvent(button, "mouseout");
+
+  expect(received).toHaveLength(1);
+  expect(received[0]).toBeInstanceOf(SubclassedEvent);
+});
+
+test("fireBlurEvent builds both events with the element's own window", () => {
+  const { button, view } = appendFrameButton();
+  const frameFocusEvent = view.FocusEvent;
+  class SubclassedFocusEvent extends frameFocusEvent {}
+  view.FocusEvent = SubclassedFocusEvent;
+  onTestFinished(() => {
+    view.FocusEvent = frameFocusEvent;
+  });
+  const received = captureEvents(button, "blur", "focusout");
+
+  fireBlurEvent(button);
+
+  expect(received.map((event) => event.type)).toEqual(["blur", "focusout"]);
+  for (const event of received) {
+    expect(event).toBeInstanceOf(SubclassedFocusEvent);
+  }
+});
+
+test("fireFocusEvent builds both events with the element's own window", () => {
+  const { button, view } = appendFrameButton();
+  const frameFocusEvent = view.FocusEvent;
+  class SubclassedFocusEvent extends frameFocusEvent {}
+  view.FocusEvent = SubclassedFocusEvent;
+  onTestFinished(() => {
+    view.FocusEvent = frameFocusEvent;
+  });
+  const received = captureEvents(button, "focus", "focusin");
+
+  fireFocusEvent(button);
+
+  expect(received.map((event) => event.type)).toEqual(["focus", "focusin"]);
+  for (const event of received) {
+    expect(event).toBeInstanceOf(SubclassedFocusEvent);
+  }
+});
+
+test("fireKeyboardEvent builds the event with the element's own window", () => {
+  const { button, view } = appendFrameButton();
+  const frameKeyboardEvent = view.KeyboardEvent;
+  class SubclassedKeyboardEvent extends frameKeyboardEvent {}
+  view.KeyboardEvent = SubclassedKeyboardEvent;
+  onTestFinished(() => {
+    view.KeyboardEvent = frameKeyboardEvent;
+  });
+  const received = captureEvents(button, "keydown");
+
+  fireKeyboardEvent(button, "keydown", { key: "ArrowDown" });
+
+  expect(received).toHaveLength(1);
+  expect(received[0]).toBeInstanceOf(SubclassedKeyboardEvent);
+});
+
+// `Document` exposes named elements as its own properties, so a form named
+// `defaultView` answers the lookup that resolves the window. Reading that
+// member without checking what came back leaves no constructor to build the
+// click with. https://github.com/ariakit/ariakit/issues/7201
+test("fireClickEvent falls back when a document answers its default view with an element", () => {
+  const otherDocument = document.implementation.createHTMLDocument("Other");
+  const button = otherDocument.body.appendChild(
+    otherDocument.createElement("button"),
+  );
+  const form = otherDocument.createElement("form");
+  form.name = "defaultView";
+  otherDocument.body.append(form);
+  Object.defineProperty(otherDocument, "defaultView", {
+    configurable: true,
+    value: form,
+  });
+  const received = captureEvents(button, "click");
+
+  fireClickEvent(button);
+
+  expect(received).toHaveLength(1);
+  expect(received[0]).toBeInstanceOf(PointerEvent);
 });

--- a/packages/ariakit-utils/src/events.ts
+++ b/packages/ariakit-utils/src/events.ts
@@ -3,7 +3,7 @@
  * @module Event utilities
  */
 
-import { contains, isElement, isNode } from "./dom.ts";
+import { contains, getWindow, isElement, isNode } from "./dom.ts";
 import { hasOwnProperty } from "./misc.ts";
 import { isApple } from "./platform.ts";
 
@@ -78,6 +78,10 @@ export function fireEvent(
   type: string,
   eventInit?: EventInit,
 ) {
+  // Built by the window that owns the element, so a listener inside a
+  // same-origin frame gets an event that its own interfaces recognize. The
+  // helpers below do the same. https://github.com/ariakit/ariakit/issues/7193
+  const { Event } = getWindow(element);
   const event = new Event(type, eventInit);
   return element.dispatchEvent(event);
 }
@@ -88,6 +92,7 @@ export function fireEvent(
  * fireBlurEvent(document.getElementById("id"));
  */
 export function fireBlurEvent(element: Element, eventInit?: FocusEventInit) {
+  const { FocusEvent } = getWindow(element);
   const event = new FocusEvent("blur", eventInit);
   const defaultAllowed = element.dispatchEvent(event);
   const bubbleInit = { ...eventInit, bubbles: true };
@@ -101,6 +106,7 @@ export function fireBlurEvent(element: Element, eventInit?: FocusEventInit) {
  * fireFocusEvent(document.getElementById("id"));
  */
 export function fireFocusEvent(element: Element, eventInit?: FocusEventInit) {
+  const { FocusEvent } = getWindow(element);
   const event = new FocusEvent("focus", eventInit);
   const defaultAllowed = element.dispatchEvent(event);
   const bubbleInit = { ...eventInit, bubbles: true };
@@ -121,6 +127,7 @@ export function fireKeyboardEvent(
   type: string,
   eventInit?: KeyboardEventInit,
 ) {
+  const { KeyboardEvent } = getWindow(element);
   const event = new KeyboardEvent(type, eventInit);
   return element.dispatchEvent(event);
 }
@@ -209,13 +216,7 @@ export function fireClickEvent(
   element: Element,
   eventInit?: PointerEventInit | null,
 ) {
-  // Read straight from the document rather than through `getWindow`, which
-  // treats any node with a `self` property as a window. A form exposes its
-  // controls as named properties, so a form owning a control named `self` would
-  // resolve to that control. A form can shadow `ownerDocument` the same way,
-  // which the `?? window` fallback below only degrades rather than fixes; that
-  // residue is https://github.com/ariakit/ariakit/issues/7201.
-  const view = element.ownerDocument.defaultView ?? window;
+  const view = getWindow(element);
   // Falls back to `MouseEvent` where `PointerEvent` is missing, so activation
   // keeps working there and only the pointer members are dropped.
   const EventConstructor = view.PointerEvent ?? view.MouseEvent;


### PR DESCRIPTION
## Motivation

Four issues share one cause: a helper decides what realm a DOM value belongs to by reading a single member, and trusts whatever that member answers with.

**[#7201](https://github.com/ariakit/ariakit/issues/7201)**: `getDocument` and `getWindow` in `packages/ariakit-utils/src/dom.ts` identify a window by testing for a member name.

```ts
if ("self" in node) return node.document;
```

A `<form>` defeats that test. Its named-element getter overrides built-ins, so a control named `self` makes the form answer `"self" in form` with `true`, and the helper takes the window branch. Measured on Chromium 151, Firefox 153, and WebKit 26.5, the same getter also answers `document`, `window`, `ownerDocument`, and `nodeType` with a control, and `Document` carries the same override, so a `<form name="defaultView">` makes `document.defaultView` answer with that form. That last one changes the answer for every element on the page, not only for a form handed to a helper.

This reaches applications through the stable [`Dialog`](https://ariakit.com/reference/dialog) component whenever it renders a form:

```tsx
<Ariakit.Dialog render={<form />}>
  <input type="checkbox" name="self" />
</Ariakit.Dialog>
```

`getDocument` returns `undefined` for that form and `getActiveElement` destructures it, so the dialog throws instead of opening. Safari is worse: `Dialog` keeps its element mounted while closed, and the `isSafariBrowser` effect that tracks the last mousedown resolves the document at mount, so the page throws during hydration and renders nothing at all. The issue's own report says no shipped path is proven; that is no longer accurate.

**[#7193](https://github.com/ariakit/ariakit/issues/7193)**: `fireEvent`, `fireBlurEvent`, `fireFocusEvent`, and `fireKeyboardEvent` in `packages/ariakit-utils/src/events.ts` build their events from the ambient global.

```ts
const event = new KeyboardEvent(type, eventInit);
```

For an element inside a same-origin iframe the event is built in the parent realm and dispatched into the frame, so a listener registered inside the frame gets an event that fails `instanceof` against its own interfaces. [`Composite`](https://ariakit.com/reference/composite) reaches two of these on its virtual-focus path, forwarding the keyboard event to the active item and blurring the previous one.

**[#7206](https://github.com/ariakit/ariakit/issues/7206)**: a `Document` is a `Node` whose `ownerDocument` is `null`, so both helpers fall through to the ambient document when handed one. In the same realm that is accidentally correct; for a document that belongs to a frame it is not.

**[#7209](https://github.com/ariakit/ariakit/issues/7209)**: `getOwnerWindow` in `packages/ariakit-test/src/__utils.ts` resolves the same thing a second way, by reading `ownerDocument` first. That member is safe in happy-dom and jsdom but not in a browser, and its comment claims happy-dom implements no form named getter, which is only true of members happy-dom defines on the prototype chain.

## Solution

Both helpers stop trusting the member an answer came from and validate the answer instead.

```ts
function isWindow(value: unknown): value is Window & typeof globalThis {
  if (!value) return false;
  // A window is the only object that is its own `window`.
  return (value as Window).window === value;
}
```

A window also has to own the document back. That second step matters because the document named getter answers with a real window when the element it names is a frame: measured on Chromium 151, Firefox 153, and WebKit 26.5, an `<iframe name="defaultView">` makes `document.defaultView` return that frame's window, which passes the test above. Reading `document` off a cross-origin one throws on all three engines, so refusing to answer counts as owning another document.

A document has to report a document's node type, read through the getter on `Node.prototype` rather than off the value. A document names its own elements too, so one holding an element named `nodeType` answers a direct read with that element; the prototype getter bypasses that lookup and is brand-checked against the interface rather than the realm, so it still answers for a node belonging to a frame.

Three reads in the same module still go through named-property lookup, which [#7215](https://github.com/ariakit/ariakit/issues/7215) records: `isElement` and `isNode`, where the cost of a prototype read on a hot path needs measuring first, and the `ownerDocument` and `defaultView` lookups, which degrade to the ambient realm rather than answering wrongly.

`getWindow` is now typed the way `document.defaultView` is. The interfaces callers read off a window, such as `PointerEvent`, are globals rather than members of `Window`, so the previous `Window` return type could not carry them.

The five event helpers take their constructors from that resolution. `fireClickEvent` is included: [#7189](https://github.com/ariakit/ariakit/pull/7189) landed a hand-rolled resolution in it, reading `element.ownerDocument.defaultView ?? window` under a comment deferring the remaining hazard to #7201, and this pull request closes #7201. The `PointerEvent` shape [#7171](https://github.com/ariakit/ariakit/issues/7171) asks for is already on `main` and is unchanged here.

`getOwnerWindow` in `@ariakit/test` drops its own algorithm and reads the same resolution, keeping the absent result both of its callers fall back on.

### Coverage

`app/src/sandbox/dialog-form-7201/` renders a benefits form as a dialog whose controls carry the colliding names, and asserts that the dialog opens and returns focus to the button that opened it. Before the fix, Safari failed the whole preview at hydration rather than failing to open the dialog, for the mount-time reason above, so the failure there named the opener instead of the dialog.

`app/src/sandbox/composite-iframe-event-realm-7193/` puts a virtual-focus [`Composite`](https://ariakit.com/reference/composite) inside a same-origin frame and reports the realm of every event its items receive. It has no happy-dom duplicate, because happy-dom shares one set of constructors between a frame and its parent and would report both realms as the same.

`packages/ariakit-utils/src/dom.test.ts`, `packages/ariakit-utils/src/events.test.ts`, and `packages/ariakit-test/src/__utils.test.ts` pin the helper contracts directly. The event cases substitute a constructor on the frame's window, the technique the existing `fireClickEvent` realm tests in that file already use to tell the two realms apart under happy-dom. The shapes those environments do not implement, which are a form answering `ownerDocument`, a document answering `defaultView`, and a cross-origin window refusing to answer at all, are emulated from the browser measurements above.

### Behavior change worth noting

An item is placed inside a frame by portalling it there, so a handler passed as a prop is authored in the outer realm. Testing one of these synthesized events with that realm's own `instanceof` used to succeed and now does not, which is the point: the event now belongs to the frame, the way a real one dispatched there does. Such a handler should compare against the constructors of the window that owns the element it is attached to.

Fixes #7201
Fixes #7193
Fixes #7206
Fixes #7209
## Workaround

Both workarounds were applied to the sandboxes in [`052864c34`](https://github.com/ariakit/ariakit/commit/052864c34) so CI showed them passing, then reverted when the library fix landed. They remain useful to anyone who needs a stopgap before the release. Being consumer-side, they never turned the package-level regressions green: those call the helpers directly and only the library fix reaches them.

### #7201: nest the form instead of rendering the dialog as one

The dialog resolves its own document and window from the element it renders, and a form answers those lookups with a control named after them. Nesting the form inside the dialog keeps the form out of that lookup while the dialog still holds the same controls.

```tsx
// TODO: Remove once https://github.com/ariakit/ariakit/issues/7201 is fixed.
<Ariakit.Dialog open={open} onClose={() => setOpen(false)}>
  <Ariakit.DialogHeading>{label}</Ariakit.DialogHeading>
  <form>
    <input type="checkbox" name="self" />
    <Ariakit.DialogDismiss>Cancel</Ariakit.DialogDismiss>
  </form>
</Ariakit.Dialog>
```

The one thing this gives up is the dialog element being the form itself, which is exactly what cannot be kept while the helpers read a member off it. Renaming the colliding controls also avoids the bug, but that discards the field names the application actually needs, which is the case the report is about.

### #7193: align the frame's event constructors with the parent's

`Composite` builds the events it synthesizes with the ambient window's constructors, so a listener inside a same-origin frame receives an event from the parent realm. Pointing the frame's constructors at the parent's makes its own `instanceof` checks recognize them again.

```tsx
// TODO: Remove once https://github.com/ariakit/ariakit/issues/7193 is fixed.
const setFrame = useCallback((element: HTMLIFrameElement | null) => {
  const frameWindow = element?.contentDocument?.defaultView;
  if (frameWindow) {
    frameWindow.Event = window.Event;
    frameWindow.FocusEvent = window.FocusEvent;
    frameWindow.KeyboardEvent = window.KeyboardEvent;
  }
  // ...
}, []);
```

This one is narrower than normal component behavior, so it comes with conditions. It needs the application to own the code that creates the frame. It covers only the three interfaces listed, which are the ones these helpers build. Assigning `Event` alone would satisfy the sandbox's assertions, since the other two inherit from it, but the other two are what a listener checking `instanceof KeyboardEvent` inside the frame needs. Most importantly, it gives up the frame's ability to tell a parent-built event from one of its own, so code inside the frame that relies on that distinction needs a different approach.

### #7206 and #7209

Neither needs a workaround. #7206 has no proven user-facing path, and #7209 concerns a helper in `@ariakit/test` that cannot fail in the environments that package runs in.
## Review gate reassessment

<details>
<summary>Cycle 3: Continue the four-issue direction, without a new public export</summary>

**Assessment**

Issue severity and scope: [#7201](https://github.com/ariakit/ariakit/issues/7201) and [#7193](https://github.com/ariakit/ariakit/issues/7193) are confirmed bugs in stable APIs. #7201 is worse than its own report states: `Dialog` rendered as a form with a control named `self` throws and unmounts the React tree, and on Safari the `isSafariBrowser` effect runs while the dialog is still closed, so the page fails at hydration rather than on open. [#7206](https://github.com/ariakit/ariakit/issues/7206) has no proven user-facing consequence and costs one early return on a rewrite that has to happen anyway. [#7209](https://github.com/ariakit/ariakit/issues/7209) breaks nothing today and cannot fail in happy-dom or jsdom, the only environments `@ariakit/test` runs in.

Expected frequency: low for each, since all four need either a form control named after a member the helpers read, or a same-origin iframe. The exception is the `defaultView` shape, where a single `<form name="defaultView">` anywhere in the document changes the answer of every `getWindow` call on the page rather than only calls that receive the form.

Implementation and maintenance complexity: the library change is roughly 25 lines across two files, plus two module-private guards. The rest of the work is tests, which the repository's staged issue-fix workflow requires.

What drove the repeated cycles: none of the three rounds found a problem with the design. Every finding concerned the reproductions and their fixtures, which is what a stage-1 snapshot contains. Round 1 was coverage breadth and fixture hygiene, round 2 was test-authoring mechanics plus an external event (`main` moved and landed `getOwnerWindow`, which created #7209 and expanded the scope from two issues to four), and round 3 was one evidence-quality defect plus five small completeness and hygiene points. The one self-reinforcing pattern is a coverage ratchet, where each accepted finding enlarges the surface the next reviewer inspects.

**Decision**

Continue the four-issue direction and keep both validations, but drop the planned new public `getOwnerWindow` export from `@ariakit/utils`.

The export existed only so `@ariakit/test` could share one resolution. It is not needed: once `getDocument` validates what it resolves, the private helper in `@ariakit/test` gets the same hardening through the existing public API, and keeps the absent result both of its callers rely on.

```ts
export function getOwnerWindow(target: OwnerWindowSource) {
  if (!target) return null;
  const view = getDocument(target).defaultView;
  return view?.window === view ? view : null;
}
```

That removes a permanent published contract from `@ariakit/utils`, deletes more lines from `@ariakit/test` than it adds, and satisfies #7209's stated outcome more directly. The planned signature was also wrong: `PointerEvent` is a global rather than a `Window` member, so `getOwnerWindow(node): Window | null` would have failed type-checking at `packages/ariakit-test/src/dispatch.ts`, which reads `getOwnerWindow(element)?.PointerEvent`.

Keeping the resolved-value validation is deliberate. #7201 states that no member name is safe on its own, and the `defaultView` half is the widest hazard in the set, so removing it would leave the reported defect class open.

Intentionally unsupported in this pull request:

- No component-level reproduction for #7206. Its own report proves no user-facing consequence, and the fix rides the same rewrite.
- No component-level reproduction for #7209. It cannot fail in happy-dom or jsdom, and `@ariakit/test` never runs in a browser, so its test is a guard on the shared resolution rather than a reproduction.
- `fireClickEvent` was going to stay with [#7171](https://github.com/ariakit/ariakit/issues/7171). That changed after this branch rebased onto [#7189](https://github.com/ariakit/ariakit/pull/7189), which landed a hand-rolled realm resolution inside that helper under a comment deferring the remaining hazard to #7201. Since this pull request closes #7201, the helper now reads the fixed `getWindow` and the comment goes away.
- [#7207](https://github.com/ariakit/ariakit/issues/7207), registered from this work, was closed by [#7211](https://github.com/ariakit/ariakit/pull/7211) before this branch reached it.

</details>
