### PR TITLE
Fix computed pointer and mouse event members

### DIFF
--- a/.changeset/300-test-computed-mouse-members.md
+++ b/.changeset/300-test-computed-mouse-members.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/test": patch
+---
+
+Fixed named mouse and pointer events in `@ariakit/test` to derive `pageX` and `pageY` from the client coordinates and target window scroll, and derive `which` from `button`, matching browser-generated events even when the environment provides no `MouseEvent` base.

--- a/.changeset/300-test-pointer-orientation-conversion.md
+++ b/.changeset/300-test-pointer-orientation-conversion.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/test": patch
+---
+
+Fixed named pointer events in `@ariakit/test` to derive `tiltX` and `tiltY` from `altitudeAngle` and `azimuthAngle`, and vice versa, so listeners no longer receive contradictory orientations when callers provide only one pair.

--- a/packages/ariakit-test/readme.md
+++ b/packages/ariakit-test/readme.md
@@ -36,7 +36,7 @@ The helpers expect a DOM that implements `PointerEvent`, which means happy-dom, 
 
 They still run on jsdom 26, which `jest-environment-jsdom` 30 depends on. Every event the helpers fire there carries the same mouse, modifier, and pointer members it carries anywhere else, so a listener reads the same `clientX`, `button`, `pointerId`, and modifier state it would in a browser. `click`, `auxclick`, and `contextmenu` are built from `MouseEvent` there rather than `PointerEvent`, which also keeps the members a browser computes.
 
-The `pointer*` events are the ones that environment cannot build from an interface of their own, so they come from `Event`: they are not `instanceof MouseEvent` there, and `pageX`, `pageY`, `offsetX`, `offsetY`, and `which` are undefined on them. The `PointerEvent` global is absent altogether, so both `new PointerEvent()` and `event instanceof PointerEvent` throw a `ReferenceError`.
+The `pointer*` events are the ones that environment cannot build from an interface of their own, so they come from `Event` and are not `instanceof MouseEvent`. The dispatch layer still derives `pageX`, `pageY`, and `which`, but leaves the layout-dependent `offsetX` and `offsetY` undefined. The `PointerEvent` global is absent altogether, so both `new PointerEvent()` and `event instanceof PointerEvent` throw a `ReferenceError`.
 
 <!-- ariakit-docs:start -->
 
@@ -129,7 +129,9 @@ Creates and fires a DOM event on an element, then waits for the resulting microt
 
 Unlike higher-level helpers such as `click` and `type`, this fires a single event without simulating the surrounding interaction sequence. Pointer and mouse events fired on an element with `pointer-events: none` are re-dispatched on the nearest ancestor that has pointer events enabled, matching how browsers route those events.
 
-A pointer event built by name reports the contact size and transducer angle browsers report for a device with neither, so `width` and `height` are `1` and `altitudeAngle` is a right angle. The members describing a gesture, such as `pressure` and `isPrimary`, keep their defaults here; the higher-level helpers fill those in. An event you construct yourself keeps whatever its constructor gave it.
+A pointer event built by name reports the contact size and transducer angle browsers report for a device with neither, so `width` and `height` are `1` and `altitudeAngle` is a right angle. Supplying only the tilt or spherical angle pair derives the other pair. The members describing a gesture, such as `pressure` and `isPrimary`, keep their defaults here; the higher-level helpers fill those in. An event you construct yourself keeps whatever its constructor gave it.
+
+Mouse and pointer events built by name derive `pageX` and `pageY` from the client coordinates and target window scroll, and derive `which` from `button`. The layout-dependent `offsetX` and `offsetY` keep the environment's values.
 
 `click`, `auxclick`, and `contextmenu` are built as `PointerEvent`, the way browsers dispatch them, so they accept and report pointer properties such as `pointerType`. An environment with no `PointerEvent` builds them as `MouseEvent` instead, and they report the same properties there.
 

--- a/packages/ariakit-test/src/__init-event.ts
+++ b/packages/ariakit-test/src/__init-event.ts
@@ -80,11 +80,92 @@ function sanitizeContactSize(size: number | undefined) {
 
 // Pointer Events requires π/2, a transducer perpendicular to the screen, from a
 // device that reports no tilt. It has no dictionary default, and happy-dom's
-// constructor uses 0, an angle no engine produces for a mouse. The tilt pair is
-// left unconverted, tracked in https://github.com/ariakit/ariakit/issues/7185.
+// constructor uses 0, an angle no engine produces for a mouse.
 // https://w3c.github.io/pointerevents/#dom-pointerevent-altitudeangle
 function sanitizeAltitudeAngle(angle: number | undefined) {
   return angle ?? Math.PI / 2;
+}
+
+// Convert between the two orientation pairs with the Pointer Events algorithm.
+// https://www.w3.org/TR/pointerevents/#converting-between-tiltx-tilty-and-altitudeangle-azimuthangle
+function sphericalToTilt(altitudeAngle: number, azimuthAngle: number) {
+  let tiltXRadians = 0;
+  let tiltYRadians = 0;
+
+  if (altitudeAngle === 0) {
+    if (azimuthAngle === 0 || azimuthAngle === 2 * Math.PI) {
+      tiltXRadians = Math.PI / 2;
+    } else if (azimuthAngle === Math.PI / 2) {
+      tiltYRadians = Math.PI / 2;
+    } else if (azimuthAngle === Math.PI) {
+      tiltXRadians = -Math.PI / 2;
+    } else if (azimuthAngle === (3 * Math.PI) / 2) {
+      tiltYRadians = -Math.PI / 2;
+    } else if (azimuthAngle > 0 && azimuthAngle < Math.PI / 2) {
+      tiltXRadians = Math.PI / 2;
+      tiltYRadians = Math.PI / 2;
+    } else if (azimuthAngle > Math.PI / 2 && azimuthAngle < Math.PI) {
+      tiltXRadians = -Math.PI / 2;
+      tiltYRadians = Math.PI / 2;
+    } else if (azimuthAngle > Math.PI && azimuthAngle < (3 * Math.PI) / 2) {
+      tiltXRadians = -Math.PI / 2;
+      tiltYRadians = -Math.PI / 2;
+    } else if (azimuthAngle > (3 * Math.PI) / 2 && azimuthAngle < 2 * Math.PI) {
+      tiltXRadians = Math.PI / 2;
+      tiltYRadians = -Math.PI / 2;
+    }
+  } else {
+    const tangent = Math.tan(altitudeAngle);
+    tiltXRadians = Math.atan(Math.cos(azimuthAngle) / tangent);
+    tiltYRadians = Math.atan(Math.sin(azimuthAngle) / tangent);
+  }
+
+  const radiansToDegrees = 180 / Math.PI;
+  const tiltX = Math.round(tiltXRadians * radiansToDegrees);
+  const tiltY = Math.round(tiltYRadians * radiansToDegrees);
+  return {
+    tiltX: tiltX === 0 ? 0 : tiltX,
+    tiltY: tiltY === 0 ? 0 : tiltY,
+  };
+}
+
+function tiltToSpherical(tiltX: number, tiltY: number) {
+  const tiltXRadians = (tiltX * Math.PI) / 180;
+  const tiltYRadians = (tiltY * Math.PI) / 180;
+  const isParallel = Math.abs(tiltX) === 90 || Math.abs(tiltY) === 90;
+
+  let azimuthAngle = 0;
+  if (tiltX === 0) {
+    if (tiltY > 0) {
+      azimuthAngle = Math.PI / 2;
+    } else if (tiltY < 0) {
+      azimuthAngle = (3 * Math.PI) / 2;
+    }
+  } else if (tiltY === 0) {
+    if (tiltX < 0) {
+      azimuthAngle = Math.PI;
+    }
+  } else if (!isParallel) {
+    azimuthAngle = Math.atan2(Math.tan(tiltYRadians), Math.tan(tiltXRadians));
+    if (azimuthAngle < 0) {
+      azimuthAngle += 2 * Math.PI;
+    }
+  }
+
+  let altitudeAngle = 0;
+  if (isParallel) {
+    altitudeAngle = 0;
+  } else if (tiltX === 0) {
+    altitudeAngle = Math.PI / 2 - Math.abs(tiltYRadians);
+  } else if (tiltY === 0) {
+    altitudeAngle = Math.PI / 2 - Math.abs(tiltXRadians);
+  } else {
+    altitudeAngle = Math.atan(
+      1 / Math.sqrt(Math.tan(tiltXRadians) ** 2 + Math.tan(tiltYRadians) ** 2),
+    );
+  }
+
+  return { altitudeAngle, azimuthAngle };
 }
 
 function initClipboardEvent(
@@ -228,18 +309,25 @@ function initMouseEvent(
     buttons,
     relatedTarget,
   }: MouseEventInit & { x?: number; y?: number },
+  realm: EventRealm,
 ) {
+  const sanitizedClientX = sanitizeNumber(clientX);
+  const sanitizedClientY = sanitizeNumber(clientY);
+  const sanitizedButton = sanitizeNumber(button);
   assignProps(event, {
     screenX: sanitizeNumber(screenX),
     screenY: sanitizeNumber(screenY),
-    clientX: sanitizeNumber(clientX),
-    x: sanitizeNumber(clientX),
-    clientY: sanitizeNumber(clientY),
-    y: sanitizeNumber(clientY),
+    clientX: sanitizedClientX,
+    x: sanitizedClientX,
+    pageX: sanitizedClientX + sanitizeNumber(realm.scrollX),
+    clientY: sanitizedClientY,
+    y: sanitizedClientY,
+    pageY: sanitizedClientY + sanitizeNumber(realm.scrollY),
     movementX: sanitizeNumber(movementX),
     movementY: sanitizeNumber(movementY),
-    button: sanitizeNumber(button),
+    button: sanitizedButton,
     buttons: sanitizeNumber(buttons),
+    which: sanitizedButton + 1,
     relatedTarget,
   });
 }
@@ -262,17 +350,34 @@ function initPointerEvent(
     pointerType = "mouse",
   }: PointerEventInitWithPersistentDeviceId,
 ) {
+  let sanitizedTiltX = sanitizeNumber(tiltX);
+  let sanitizedTiltY = sanitizeNumber(tiltY);
+  let sanitizedAltitudeAngle = sanitizeAltitudeAngle(altitudeAngle);
+  let sanitizedAzimuthAngle = sanitizeNumber(azimuthAngle);
+  const hasTilt = tiltX != null || tiltY != null;
+  const hasSphericalAngles = altitudeAngle != null || azimuthAngle != null;
+
+  if (hasTilt && !hasSphericalAngles) {
+    const angles = tiltToSpherical(sanitizedTiltX, sanitizedTiltY);
+    sanitizedAltitudeAngle = angles.altitudeAngle;
+    sanitizedAzimuthAngle = angles.azimuthAngle;
+  } else if (hasSphericalAngles && !hasTilt) {
+    const tilt = sphericalToTilt(sanitizedAltitudeAngle, sanitizedAzimuthAngle);
+    sanitizedTiltX = tilt.tiltX;
+    sanitizedTiltY = tilt.tiltY;
+  }
+
   assignProps(event, {
     pointerId: sanitizeNumber(pointerId),
     width: sanitizeContactSize(width),
     height: sanitizeContactSize(height),
     pressure: sanitizeNumber(pressure),
     tangentialPressure: sanitizeNumber(tangentialPressure),
-    tiltX: sanitizeNumber(tiltX),
-    tiltY: sanitizeNumber(tiltY),
+    tiltX: sanitizedTiltX,
+    tiltY: sanitizedTiltY,
     twist: sanitizeNumber(twist),
-    altitudeAngle: sanitizeAltitudeAngle(altitudeAngle),
-    azimuthAngle: sanitizeNumber(azimuthAngle),
+    altitudeAngle: sanitizedAltitudeAngle,
+    azimuthAngle: sanitizedAzimuthAngle,
     persistentDeviceId: sanitizeNumber(persistentDeviceId),
     isPrimary: !!isPrimary,
     pointerType: pointerType,
@@ -393,7 +498,7 @@ export function initEvent<T extends Event>(
     initUIEventModifiers(event, options);
   }
   if (isMouseEvent(event, realm)) {
-    initMouseEvent(event, options);
+    initMouseEvent(event, options, realm);
     initUIEventModifiers(event, options);
   }
   if (isPointerEvent(event, realm)) {

--- a/packages/ariakit-test/src/dispatch-without-pointer-event.test.ts
+++ b/packages/ariakit-test/src/dispatch-without-pointer-event.test.ts
@@ -116,10 +116,12 @@ test("initializes pointer events built without the constructor", async () => {
     expect(event?.getModifierState("Shift")).toBe(true);
     expect(event?.pointerId).toBe(7);
     expect(event?.pointerType).toBe("pen");
-    // The boundary the readme documents: a member a browser computes rather
-    // than reading from an init came from the `MouseEvent` base, which a bare
-    // `Event` has no equivalent of, so no initializer can supply it.
-    expect(event?.pageX).toBeUndefined();
+    expect(event?.pageX).toBe(11);
+    expect(event?.pageY).toBe(0);
+    expect(event?.which).toBe(1);
+    // The offset pair depends on layout, which this environment cannot report.
+    expect(event?.offsetX).toBeUndefined();
+    expect(event?.offsetY).toBeUndefined();
   } finally {
     button.remove();
   }

--- a/packages/ariakit-test/src/dispatch.jsdom.test.ts
+++ b/packages/ariakit-test/src/dispatch.jsdom.test.ts
@@ -101,9 +101,29 @@ test.each(["document", "window"] as const)(
   },
 );
 
+// https://github.com/ariakit/ariakit/issues/7197
+test("dispatch.mouseDown derives page coordinates from the target window", async () => {
+  using fixture = createIframeButton();
+  const { button, iframeWindow } = fixture;
+  Object.defineProperties(iframeWindow, {
+    scrollX: { configurable: true, value: 40 },
+    scrollY: { configurable: true, value: 50 },
+  });
+  let event: MouseEvent | undefined;
+  button.addEventListener("mousedown", (receivedEvent) => {
+    event = receivedEvent;
+  });
+  await dispatch.mouseDown(button, { clientX: 11, clientY: 12 });
+  expect({ pageX: event?.pageX, pageY: event?.pageY }).toEqual({
+    pageX: 51,
+    pageY: 62,
+  });
+});
+
 // The pointer members reach a cross-realm event through the type fallback
 // `isPointerEvent` already applies, so this pins that the realm-resolved
 // interface test doesn't take them away again.
+// https://github.com/ariakit/ariakit/issues/7185
 test.each([
   ["pointerDown", "pointerdown"],
   ["click", "click"],
@@ -130,7 +150,7 @@ test.each([
     }).toEqual({
       ambientInstance: false,
       iframeInstance: true,
-      altitudeAngle: Math.PI / 2,
+      altitudeAngle: Math.PI / 2 - Math.PI / 6,
       azimuthAngle: 0,
       width: 1,
       height: 1,

--- a/packages/ariakit-test/src/dispatch.test.ts
+++ b/packages/ariakit-test/src/dispatch.test.ts
@@ -481,6 +481,30 @@ test("dispatch.drop keeps the member only DragEvent defines", async () => {
   }
 });
 
+// https://github.com/ariakit/ariakit/issues/7197
+test("dispatch.mouseDown reports the computed mouse members", async () => {
+  const button = document.createElement("button");
+  document.body.append(button);
+  let event: MouseEvent | undefined;
+  button.addEventListener("mousedown", (receivedEvent) => {
+    event = receivedEvent;
+  });
+  try {
+    await dispatch.mouseDown(button, {
+      clientX: 11,
+      clientY: 12,
+      button: 2,
+    });
+    expect({
+      pageX: event?.pageX,
+      pageY: event?.pageY,
+      which: event?.which,
+    }).toEqual({ pageX: 11, pageY: 12, which: 3 });
+  } finally {
+    button.remove();
+  }
+});
+
 // Keyboard parity covers the `modifier*` init members too, because the
 // environment records them for a caller-built event.
 // https://github.com/ariakit/ariakit/issues/7166
@@ -626,6 +650,90 @@ test("dispatch.pointerDown preserves provided transducer angles", async () => {
   } finally {
     button.remove();
   }
+});
+
+async function getPointerDownEvent(options?: PointerEventInit) {
+  const button = document.createElement("button");
+  document.body.append(button);
+  let event: PointerEvent | undefined;
+  button.addEventListener("pointerdown", (receivedEvent) => {
+    event = receivedEvent;
+  });
+  try {
+    await dispatch.pointerDown(button, options);
+    return event;
+  } finally {
+    button.remove();
+  }
+}
+
+// https://github.com/ariakit/ariakit/issues/7185
+test("dispatch.pointerDown derives transducer angles from tilt", async () => {
+  const event = await getPointerDownEvent({ tiltX: 30 });
+  expect(event?.tiltX).toBe(30);
+  expect(event?.tiltY).toBe(0);
+  expect(event?.altitudeAngle).toBeCloseTo(Math.PI / 3);
+  expect(event?.azimuthAngle).toBe(0);
+});
+
+// https://github.com/ariakit/ariakit/issues/7185
+test("dispatch.pointerDown derives tilt from transducer angles", async () => {
+  const event = await getPointerDownEvent({
+    altitudeAngle: 0.5,
+    azimuthAngle: 1,
+  });
+  expect(event?.tiltX).toBe(45);
+  expect(event?.tiltY).toBe(57);
+  expect(event?.altitudeAngle).toBe(0.5);
+  expect(event?.azimuthAngle).toBe(1);
+});
+
+// Web IDL converts signed zero to positive zero when it stores the rounded
+// result as a `long`.
+// https://github.com/ariakit/ariakit/issues/7185
+test("dispatch.pointerDown normalizes rounded tilt to positive zero", async () => {
+  const event = await getPointerDownEvent({
+    altitudeAngle: 0.5,
+    azimuthAngle: 2 * Math.PI,
+  });
+  expect(event?.tiltY).toBe(0);
+});
+
+// At altitude zero, the azimuth selects an axis or quadrant whose tilt is at
+// the corresponding 90-degree boundary.
+// https://github.com/ariakit/ariakit/issues/7185
+test.each([
+  [0, 90, 0],
+  [Math.PI / 2, 0, 90],
+  [Math.PI, -90, 0],
+  [(3 * Math.PI) / 2, 0, -90],
+  [Math.PI / 4, 90, 90],
+  [(3 * Math.PI) / 4, -90, 90],
+  [(5 * Math.PI) / 4, -90, -90],
+  [(7 * Math.PI) / 4, 90, -90],
+] as const)(
+  "dispatch.pointerDown derives boundary tilt at azimuth %s",
+  async (azimuthAngle, tiltX, tiltY) => {
+    const event = await getPointerDownEvent({ altitudeAngle: 0, azimuthAngle });
+    expect([event?.tiltX, event?.tiltY]).toEqual([tiltX, tiltY]);
+  },
+);
+
+// Chromium and Firefox preserve both explicit pairs, so conversion only fills
+// a pair the caller omitted completely.
+test("dispatch.pointerDown preserves both provided orientation pairs", async () => {
+  const event = await getPointerDownEvent({
+    tiltX: 10,
+    tiltY: 20,
+    altitudeAngle: 0.5,
+    azimuthAngle: 1,
+  });
+  expect({
+    tiltX: event?.tiltX,
+    tiltY: event?.tiltY,
+    altitudeAngle: event?.altitudeAngle,
+    azimuthAngle: event?.azimuthAngle,
+  }).toEqual({ tiltX: 10, tiltY: 20, altitudeAngle: 0.5, azimuthAngle: 1 });
 });
 
 // happy-dom aliases `CompositionEvent` to `Event`, so a composition event is an

--- a/packages/ariakit-test/src/dispatch.ts
+++ b/packages/ariakit-test/src/dispatch.ts
@@ -230,10 +230,15 @@ const events = eventNames.reduce((events, eventName) => {
  *
  * A pointer event built by name reports the contact size and transducer angle
  * browsers report for a device with neither, so `width` and `height` are `1` and
- * `altitudeAngle` is a right angle. The members describing a gesture, such as
+ * `altitudeAngle` is a right angle. Supplying only the tilt or spherical angle
+ * pair derives the other pair. The members describing a gesture, such as
  * `pressure` and `isPrimary`, keep their defaults here; the higher-level helpers
  * fill those in. An event you construct yourself keeps whatever its constructor
  * gave it.
+ *
+ * Mouse and pointer events built by name derive `pageX` and `pageY` from the
+ * client coordinates and target window scroll, and derive `which` from `button`.
+ * The layout-dependent `offsetX` and `offsetY` keep the environment's values.
  *
  * `click`, `auxclick`, and `contextmenu` are built as `PointerEvent`, the way
  * browsers dispatch them, so they accept and report pointer properties such as


### PR DESCRIPTION
## Motivation

Named pointer events in `@ariakit/test` can expose contradictory orientation data when callers provide only one orientation pair. Mouse and pointer events can also keep environment-specific `pageX`, `pageY`, and `which` values that do not match browser-generated events.

```ts
await dispatch.pointerDown(element, {
  clientX: 20,
  button: 2,
  tiltX: 30,
});
```

## Solution

Derive the missing tilt or spherical orientation pair with the Pointer Events conversion algorithms. Preserve both pairs when the caller supplies both.

Derive `pageX` and `pageY` from the client coordinates and target window scroll, and derive `which` from `button`. Keep `offsetX` and `offsetY` environment-dependent because these layout values cannot be computed reliably in DOM test environments.

Add regression coverage for happy-dom, jsdom target realms, and the fallback path without `PointerEvent`.

Fixes #7185.
Fixes #7197.