### PR TITLE
Match the synthetic Command click view and composition

### DIFF
--- a/.changeset/300-command-click-metadata.md
+++ b/.changeset/300-command-click-metadata.md
@@ -1,0 +1,7 @@
+---
+"@ariakit/utils": patch
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed `fireClickEvent` so clicks expose the target element's owner window through `view` and are composed. This also fixed keyboard activation on non-native [`Command`](https://ariakit.com/reference/command) elements and components built on [`Command`](https://ariakit.com/reference/command), such as [`Button`](https://ariakit.com/reference/button).

--- a/.changeset/300-command-click-metadata.md
+++ b/.changeset/300-command-click-metadata.md
@@ -1,7 +1,6 @@
 ---
-"@ariakit/utils": patch
 "@ariakit/react-components": patch
 "@ariakit/react": patch
 ---
 
-Fixed `fireClickEvent` so clicks expose the target element's owner window through `view` and are composed. This also fixed keyboard activation on non-native [`Command`](https://ariakit.com/reference/command) elements and components built on [`Command`](https://ariakit.com/reference/command), such as [`Button`](https://ariakit.com/reference/button).
+Fixed keyboard activation on non-native [`Command`](https://ariakit.com/reference/command) elements and components built on [`Command`](https://ariakit.com/reference/command), such as [`Button`](https://ariakit.com/reference/button), so their synthetic clicks use the element's owner window for `view` and are composed.

--- a/.changeset/300-fire-click-event-metadata.md
+++ b/.changeset/300-fire-click-event-metadata.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/utils": patch
+---
+
+Fixed `fireClickEvent` so clicks use the target element's owner window for `view` and are composed.

--- a/app/src/sandbox/command-7171/no-pointer-click.ts
+++ b/app/src/sandbox/command-7171/no-pointer-click.ts
@@ -1,9 +1,0 @@
-// Measured on Chromium 151, Firefox 153, and WebKit 26.5: a click no pointer
-// caused, such as Enter or Space activation, is a `PointerEvent` built by the
-// window that owns the element, reporting `pointerId: -1` and an empty
-// `pointerType`.
-//
-// Shared by both suites so the authoritative browser test and its happy-dom
-// duplicate cannot drift to different expected shapes.
-export const NO_POINTER_CLICK =
-  'PointerEvent, own window, pointerId -1, pointerType ""';

--- a/app/src/sandbox/command-keyboard-click/index.react.tsx
+++ b/app/src/sandbox/command-keyboard-click/index.react.tsx
@@ -1,6 +1,6 @@
 import * as Ariakit from "@ariakit/react";
 import type { Dispatch, MouseEvent, SetStateAction } from "react";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 
 // An event built in another realm fails `instanceof` against every constructor
@@ -28,24 +28,65 @@ function describeClickEvent(event: globalThis.MouseEvent, element: Element) {
   return `${event.constructor.name}, ${realm}, ${pointer}`;
 }
 
-function createClickReporter(setEvents: Dispatch<SetStateAction<string[]>>) {
+function describeClickMetadata(event: globalThis.MouseEvent, element: Element) {
+  const ownerWindow = element.ownerDocument.defaultView;
+  const view =
+    event.view === ownerWindow
+      ? "own window"
+      : event.view
+        ? "other window"
+        : "null";
+  return `view ${view}, composed ${event.composed}`;
+}
+
+function createClickReporter(
+  setEvents: Dispatch<SetStateAction<string[]>>,
+  setMetadata: Dispatch<SetStateAction<string[]>>,
+) {
   return (event: MouseEvent<HTMLElement>) => {
     const description = describeClickEvent(
       event.nativeEvent,
       event.currentTarget,
     );
     setEvents((events) => [...events, description]);
+    const metadata = describeClickMetadata(
+      event.nativeEvent,
+      event.currentTarget,
+    );
+    setMetadata((events) => [...events, metadata]);
   };
 }
 
 export default function Example() {
   const [clickEvents, setClickEvents] = useState<string[]>([]);
+  const [clickMetadata, setClickMetadata] = useState<string[]>([]);
   const [frameClickEvents, setFrameClickEvents] = useState<string[]>([]);
+  const [frameClickMetadata, setFrameClickMetadata] = useState<string[]>([]);
   const [frameBody, setFrameBody] = useState<HTMLElement | null>(null);
+  const [shadowRoot, setShadowRoot] = useState<ShadowRoot | null>(null);
+  const [outerShadowClicks, setOuterShadowClicks] = useState(0);
 
   const setFrame = useCallback((element: HTMLIFrameElement | null) => {
     setFrameBody(element?.contentDocument?.body ?? null);
   }, []);
+
+  const setShadowHost = useCallback((element: HTMLDivElement | null) => {
+    setShadowRoot(
+      element?.shadowRoot ?? element?.attachShadow({ mode: "open" }) ?? null,
+    );
+  }, []);
+
+  useEffect(() => {
+    const host = shadowRoot?.host;
+    const ownerDocument = host?.ownerDocument;
+    if (!host || !ownerDocument) return;
+    const onClick = (event: Event) => {
+      if (!event.composedPath().includes(host)) return;
+      setOuterShadowClicks((count) => count + 1);
+    };
+    ownerDocument.addEventListener("click", onClick);
+    return () => ownerDocument.removeEventListener("click", onClick);
+  }, [shadowRoot]);
 
   return (
     <main>
@@ -58,7 +99,7 @@ export default function Example() {
       <Ariakit.Command
         role="button"
         render={<div />}
-        onClick={createClickReporter(setClickEvents)}
+        onClick={createClickReporter(setClickEvents, setClickMetadata)}
       >
         Report click
       </Ariakit.Command>
@@ -66,6 +107,12 @@ export default function Example() {
       <ul aria-labelledby="document-click-events" aria-live="polite">
         {clickEvents.map((description, index) => (
           <li key={index}>{description}</li>
+        ))}
+      </ul>
+      <h2 id="document-click-metadata">Document click metadata</h2>
+      <ul aria-labelledby="document-click-metadata" aria-live="polite">
+        {clickMetadata.map((metadata, index) => (
+          <li key={index}>{metadata}</li>
         ))}
       </ul>
 
@@ -77,7 +124,10 @@ export default function Example() {
             <Ariakit.Command
               role="button"
               render={<div />}
-              onClick={createClickReporter(setFrameClickEvents)}
+              onClick={createClickReporter(
+                setFrameClickEvents,
+                setFrameClickMetadata,
+              )}
             >
               Frame command
             </Ariakit.Command>,
@@ -90,6 +140,24 @@ export default function Example() {
           <li key={index}>{description}</li>
         ))}
       </ul>
+      <h2 id="frame-click-metadata">Frame click metadata</h2>
+      <ul aria-labelledby="frame-click-metadata" aria-live="polite">
+        {frameClickMetadata.map((metadata, index) => (
+          <li key={index}>{metadata}</li>
+        ))}
+      </ul>
+
+      <h2>Shadow boundary</h2>
+      <div data-shadow-host ref={setShadowHost} />
+      {shadowRoot
+        ? createPortal(
+            <Ariakit.Command role="button" render={<div />}>
+              Shadow command
+            </Ariakit.Command>,
+            shadowRoot,
+          )
+        : null}
+      <p role="status">Outer shadow clicks: {outerShadowClicks}</p>
     </main>
   );
 }

--- a/app/src/sandbox/command-keyboard-click/index.react.tsx
+++ b/app/src/sandbox/command-keyboard-click/index.react.tsx
@@ -92,13 +92,9 @@ export default function Example() {
     <main>
       <h1>Command keyboard click event</h1>
 
-      {/* Both commands render a non-native element on purpose, because that is
-          what makes `Command` synthesize the click for Enter and Space. On a
-          native button the browser dispatches it, and `@ariakit/test` simulates
-          it, so neither would exercise the code under test. */}
+      {/* TODO: Remove the native button workaround once
+          https://github.com/ariakit/ariakit/issues/7192 is fixed. */}
       <Ariakit.Command
-        role="button"
-        render={<div />}
         onClick={createClickReporter(setClickEvents, setClickMetadata)}
       >
         Report click
@@ -122,8 +118,6 @@ export default function Example() {
       {frameBody
         ? createPortal(
             <Ariakit.Command
-              role="button"
-              render={<div />}
               onClick={createClickReporter(
                 setFrameClickEvents,
                 setFrameClickMetadata,
@@ -151,9 +145,7 @@ export default function Example() {
       <div data-shadow-host ref={setShadowHost} />
       {shadowRoot
         ? createPortal(
-            <Ariakit.Command role="button" render={<div />}>
-              Shadow command
-            </Ariakit.Command>,
+            <Ariakit.Command>Shadow command</Ariakit.Command>,
             shadowRoot,
           )
         : null}

--- a/app/src/sandbox/command-keyboard-click/index.react.tsx
+++ b/app/src/sandbox/command-keyboard-click/index.react.tsx
@@ -92,9 +92,13 @@ export default function Example() {
     <main>
       <h1>Command keyboard click event</h1>
 
-      {/* TODO: Remove the native button workaround once
-          https://github.com/ariakit/ariakit/issues/7192 is fixed. */}
+      {/* Both commands render a non-native element on purpose, because that is
+          what makes `Command` synthesize the click for Enter and Space. On a
+          native button the browser dispatches it, and `@ariakit/test` simulates
+          it, so neither would exercise the code under test. */}
       <Ariakit.Command
+        role="button"
+        render={<div />}
         onClick={createClickReporter(setClickEvents, setClickMetadata)}
       >
         Report click
@@ -118,6 +122,8 @@ export default function Example() {
       {frameBody
         ? createPortal(
             <Ariakit.Command
+              role="button"
+              render={<div />}
               onClick={createClickReporter(
                 setFrameClickEvents,
                 setFrameClickMetadata,
@@ -145,7 +151,9 @@ export default function Example() {
       <div data-shadow-host ref={setShadowHost} />
       {shadowRoot
         ? createPortal(
-            <Ariakit.Command>Shadow command</Ariakit.Command>,
+            <Ariakit.Command role="button" render={<div />}>
+              Shadow command
+            </Ariakit.Command>,
             shadowRoot,
           )
         : null}

--- a/app/src/sandbox/command-keyboard-click/test-browser.ts
+++ b/app/src/sandbox/command-keyboard-click/test-browser.ts
@@ -1,5 +1,8 @@
 import { withFramework } from "#app/test-utils/preview.ts";
-import { NO_POINTER_CLICK } from "./no-pointer-click.ts";
+
+const NO_POINTER_CLICK =
+  'PointerEvent, own window, pointerId -1, pointerType ""';
+const CLICK_METADATA = "view own window, composed true";
 
 withFramework(import.meta.dirname, async ({ test, query }) => {
   // https://github.com/ariakit/ariakit/issues/7171
@@ -58,5 +61,43 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
 
     await page.keyboard.press("Space");
     await test.expect(events).toHaveText([NO_POINTER_CLICK]);
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7192
+  test("Enter dispatches a click with its own view that is composed", async ({
+    page,
+    q,
+  }) => {
+    const metadata = query(q.list("Document click metadata")).listitem();
+    await q.button("Report click").focus();
+
+    await page.keyboard.press("Enter");
+    await test.expect(metadata).toHaveText([CLICK_METADATA]);
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7192
+  test("Space inside a frame dispatches a click with its own view that is composed", async ({
+    page,
+    q,
+  }) => {
+    const frame = query(page.frameLocator("iframe[title='Command frame']"));
+    const metadata = query(q.list("Frame click metadata")).listitem();
+    await frame.button("Frame command").focus();
+
+    await page.keyboard.press("Space");
+    await test.expect(metadata).toHaveText([CLICK_METADATA]);
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7192
+  test("keyboard clicks cross a shadow boundary", async ({ page, q }) => {
+    const command = q.button("Shadow command");
+    const status = q.status();
+    await command.focus();
+
+    await page.keyboard.press("Enter");
+    await test.expect(status).toHaveText("Outer shadow clicks: 1");
+
+    await page.keyboard.press("Space");
+    await test.expect(status).toHaveText("Outer shadow clicks: 2");
   });
 });

--- a/app/src/sandbox/command-keyboard-click/test-browser.ts
+++ b/app/src/sandbox/command-keyboard-click/test-browser.ts
@@ -89,6 +89,9 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
   });
 
   // https://github.com/ariakit/ariakit/issues/7192
+  //
+  // happy-dom does not reliably reproduce this React portal propagation path,
+  // so this behavior remains browser-only.
   test("keyboard clicks cross a shadow boundary", async ({ page, q }) => {
     const command = q.button("Shadow command");
     const status = q.status();

--- a/app/src/sandbox/command-keyboard-click/test.ts
+++ b/app/src/sandbox/command-keyboard-click/test.ts
@@ -30,17 +30,3 @@ test("Space dispatches a PointerEvent with no pointer behind it", async () => {
   await press.Space();
   expect(getClickEvents()).toEqual([NO_POINTER_CLICK]);
 });
-
-// https://github.com/ariakit/ariakit/issues/7192
-test("keyboard clicks cross a shadow boundary", async () => {
-  const host = document.querySelector("[data-shadow-host]");
-  const command = host?.shadowRoot?.querySelector<HTMLElement>("[role=button]");
-  if (!command) throw new Error("Shadow command is not available");
-  await focus(command);
-
-  await press.Enter(command);
-  expect(q.status()).toHaveTextContent("Outer shadow clicks: 1");
-
-  await press.Space(command);
-  expect(q.status()).toHaveTextContent("Outer shadow clicks: 2");
-});

--- a/app/src/sandbox/command-keyboard-click/test.ts
+++ b/app/src/sandbox/command-keyboard-click/test.ts
@@ -1,6 +1,8 @@
 import { focus, press, q } from "@ariakit/test";
 import { expect, test } from "vitest";
-import { NO_POINTER_CLICK } from "./no-pointer-click.ts";
+
+const NO_POINTER_CLICK =
+  'PointerEvent, own window, pointerId -1, pointerType ""';
 
 function getClickEvents() {
   return q
@@ -27,4 +29,18 @@ test("Space dispatches a PointerEvent with no pointer behind it", async () => {
   await focus(q.button("Report click"));
   await press.Space();
   expect(getClickEvents()).toEqual([NO_POINTER_CLICK]);
+});
+
+// https://github.com/ariakit/ariakit/issues/7192
+test("keyboard clicks cross a shadow boundary", async () => {
+  const host = document.querySelector("[data-shadow-host]");
+  const command = host?.shadowRoot?.querySelector<HTMLElement>("[role=button]");
+  if (!command) throw new Error("Shadow command is not available");
+  await focus(command);
+
+  await press.Enter(command);
+  expect(q.status()).toHaveTextContent("Outer shadow clicks: 1");
+
+  await press.Space(command);
+  expect(q.status()).toHaveTextContent("Outer shadow clicks: 2");
 });

--- a/packages/ariakit-utils/readme.md
+++ b/packages/ariakit-utils/readme.md
@@ -736,7 +736,7 @@ function fireClickEvent(
 
 Creates and dispatches a click event.
 
-The event is a `PointerEvent` built by the window that owns the element, the way browsers dispatch it, falling back to a `MouseEvent` where that window has no `PointerEvent`. It reports no pointer behind the click unless the caller passes one, and reports every other pointer attribute at its default value, the way a click always does.
+The event is a `PointerEvent` built by the window that owns the element, the way browsers dispatch it, falling back to a `MouseEvent` where that window has no `PointerEvent`. Its `view` is that window and it is composed. It reports no pointer behind the click unless the caller passes one, and reports every other pointer attribute at its default value, the way a click always does.
 
 Example:
 

--- a/packages/ariakit-utils/src/events.test.ts
+++ b/packages/ariakit-utils/src/events.test.ts
@@ -297,6 +297,16 @@ test("fireClickEvent builds the event with the element's own window", () => {
   expect(clicked?.ctrlKey).toBe(true);
 });
 
+// https://github.com/ariakit/ariakit/issues/7192
+test("fireClickEvent uses the element's window as the view and composes the click", () => {
+  const { button, view } = appendFrameButton();
+
+  const clicked = captureClick(button, { composed: false, view: window });
+
+  expect(clicked?.view).toBe(view);
+  expect(clicked?.composed).toBe(true);
+});
+
 // jsdom implements `PointerEvent` only from v27, so `jest-environment-jsdom` 30
 // still has none. Activation has to keep working there rather than throwing,
 // dropping only the pointer members.

--- a/packages/ariakit-utils/src/events.ts
+++ b/packages/ariakit-utils/src/events.ts
@@ -179,7 +179,7 @@ const resetAttributes: Record<ResetAttribute, true> = {
 // pass a live event. Copying it would flatten it to its own properties, which a
 // live event mostly doesn't have, and inheriting from it would break the native
 // getters' brand checks, so the members are layered on with a proxy instead.
-function getClickEventInit(eventInit?: PointerEventInit | null) {
+function getClickEventInit(view: Window, eventInit?: PointerEventInit | null) {
   const init = eventInit ?? {};
   // Proxying a fresh object rather than the caller's, because a trap may not
   // report a value different from a frozen own property of its target, and
@@ -189,6 +189,8 @@ function getClickEventInit(eventInit?: PointerEventInit | null) {
   const target: PointerEventInit = {};
   return new Proxy(target, {
     get(_target, key) {
+      if (key === "view") return view;
+      if (key === "composed") return true;
       if (key === "pointerId") return init.pointerId ?? -1;
       if (key === "pointerType") return init.pointerType ?? "";
       // Reading one of them as absent leaves the constructor's own default,
@@ -206,9 +208,10 @@ function getClickEventInit(eventInit?: PointerEventInit | null) {
  *
  * The event is a `PointerEvent` built by the window that owns the element, the
  * way browsers dispatch it, falling back to a `MouseEvent` where that window
- * has no `PointerEvent`. It reports no pointer behind the click unless the
- * caller passes one, and reports every other pointer attribute at its default
- * value, the way a click always does.
+ * has no `PointerEvent`. Its `view` is that window and it is composed. It
+ * reports no pointer behind the click unless the caller passes one, and reports
+ * every other pointer attribute at its default value, the way a click always
+ * does.
  * @example
  * fireClickEvent(document.getElementById("id"));
  */
@@ -220,7 +223,10 @@ export function fireClickEvent(
   // Falls back to `MouseEvent` where `PointerEvent` is missing, so activation
   // keeps working there and only the pointer members are dropped.
   const EventConstructor = view.PointerEvent ?? view.MouseEvent;
-  const event = new EventConstructor("click", getClickEventInit(eventInit));
+  const event = new EventConstructor(
+    "click",
+    getClickEventInit(view, eventInit),
+  );
   return element.dispatchEvent(event);
 }
 


### PR DESCRIPTION
## Motivation

When [`Command`](https://ariakit.com/reference/command) renders a non-native element, keyboard activation dispatches a synthetic click with `view: null` and `composed: false`. Native keyboard clicks use the element's owner window and cross open shadow boundaries.

Closes #7192.

## Solution

`fireClickEvent` now layers the target element's owner window onto `view` and sets `composed: true`. The existing Proxy still preserves caller-provided event members, supports live and frozen init objects, and resets pointer contact data to native click defaults.

The regression coverage verifies document, iframe, and shadow-root activation. It also renames the existing #7171 sandbox to `command-keyboard-click` so the related keyboard-click regressions use one fixture.

The shadow-root propagation assertion runs in the browser suite because happy-dom does not reliably reproduce this React portal path.

## Workaround

Keep `Command` on its default native button so the browser dispatches the keyboard click:

```tsx
<Ariakit.Command onClick={handleClick}>Action</Ariakit.Command>
```

This preserves the native click's owner-window `view` and composed propagation. It does not apply when the interface must render a non-native host.

## Preview

The final non-native `Command` activation reports the owner window, creates a composed click, and lets Enter and Space cross the shadow boundary twice:

![Non-native Command keyboard activation reports the owner window and two clicks cross the shadow boundary](https://github.com/user-attachments/assets/60e231ed-1e6f-41b8-a625-203d336910f8)