### PR TITLE
Apply browser shims to iframe realms

### DIFF
--- a/.changeset/300-test-iframe-browser-shims.md
+++ b/.changeset/300-test-iframe-browser-shims.md
@@ -2,4 +2,4 @@
 "@ariakit/test": patch
 ---
 
-Fixed `click`, `hover`, `press`, and `dispatch` to apply browser shims in the target element's own realm, so interactions and clipboard events work inside same-origin iframes under jsdom.
+Fixed the test helpers to apply browser shims in the target element's own realm, so pointer, keyboard, and clipboard events reach elements inside same-origin iframes under jsdom instead of being dropped.

--- a/.changeset/300-test-iframe-browser-shims.md
+++ b/.changeset/300-test-iframe-browser-shims.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/test": patch
+---
+
+Fixed `click`, `hover`, `press`, and `dispatch` to apply browser shims in the target element's own realm, so interactions and clipboard events work inside same-origin iframes under jsdom.

--- a/packages/ariakit-test/src/click.ts
+++ b/packages/ariakit-test/src/click.ts
@@ -1,4 +1,4 @@
-import { isVisible, isFocusable, invariant } from "@ariakit/utils";
+import { invariant } from "@ariakit/utils";
 import {
   getClickOptions,
   getContextMenuOptions,
@@ -12,6 +12,7 @@ import { focus } from "./focus.ts";
 import { hover } from "./hover.ts";
 import { mouseDown } from "./mouse-down.ts";
 import { mouseUp } from "./mouse-up.ts";
+import { isFocusable, isVisible } from "./shims.ts";
 import { sleep } from "./sleep.ts";
 
 function getClosestLabel(element: Element) {

--- a/packages/ariakit-test/src/click.ts
+++ b/packages/ariakit-test/src/click.ts
@@ -12,7 +12,11 @@ import { focus } from "./focus.ts";
 import { hover } from "./hover.ts";
 import { mouseDown } from "./mouse-down.ts";
 import { mouseUp } from "./mouse-up.ts";
-import { isFocusable, isVisible } from "./shims.ts";
+import {
+  isFocusable,
+  isFramePointerEventsEnabled,
+  isVisible,
+} from "./shims.ts";
 import { sleep } from "./sleep.ts";
 
 function getClosestLabel(element: Element) {
@@ -193,6 +197,7 @@ export function click(
   return wrapAsync(async () => {
     invariant(element, "Unable to click on null element");
     if (!isVisible(element)) return;
+    if (!isFramePointerEventsEnabled(element)) return;
 
     const button = getMouseButton(options);
     const stepOptions = omitButtons(options);

--- a/packages/ariakit-test/src/dispatch.ts
+++ b/packages/ariakit-test/src/dispatch.ts
@@ -9,6 +9,7 @@ import {
   withWindowEvent,
   wrapAsync,
 } from "./__utils.ts";
+import { ensureBrowserShims, getElementStyle } from "./shims.ts";
 
 type Target = Document | Window | Node | Element | null;
 
@@ -145,11 +146,12 @@ function dispatchDisabledControlClick(
 function baseDispatch(element: Target, event: Event): Promise<boolean> {
   return wrapAsync(async () => {
     invariant(element, `Unable to dispatch ${event.type} on null element`);
+    ensureBrowserShims(element);
 
     const eventName = event.type.toLowerCase();
 
     if (pointerEvents.includes(eventName) && "classList" in element) {
-      const { pointerEvents } = getComputedStyle(element);
+      const pointerEvents = getElementStyle(element)?.pointerEvents;
       if (pointerEvents === "none") {
         if (element.parentElement) {
           // Recursive so we'll repeat the process if the parent element also
@@ -181,6 +183,7 @@ function createNamedEvent(
   element: NonNullable<Target>,
   options?: object,
 ) {
+  ensureBrowserShims(element);
   if (
     eventName === "click" ||
     eventName === "auxClick" ||

--- a/packages/ariakit-test/src/focus.ts
+++ b/packages/ariakit-test/src/focus.ts
@@ -1,7 +1,8 @@
-import { getActiveElement, isFocusable, invariant } from "@ariakit/utils";
+import { getActiveElement, invariant } from "@ariakit/utils";
 import type { DirtiableElement } from "./__utils.ts";
 import { flushMicrotasks, wrapAsync } from "./__utils.ts";
 import { dispatch } from "./dispatch.ts";
+import { isFocusable } from "./shims.ts";
 
 /**
  * Moves focus to an element, simulating a real user focusing it. Elements that

--- a/packages/ariakit-test/src/hover.ts
+++ b/packages/ariakit-test/src/hover.ts
@@ -2,7 +2,11 @@ import { invariant } from "@ariakit/utils";
 import { getPointerOptions } from "./__mouse.ts";
 import { settle, wrapAsync } from "./__utils.ts";
 import { dispatch } from "./dispatch.ts";
-import { getElementStyle, isVisible } from "./shims.ts";
+import {
+  getElementStyle,
+  isFramePointerEventsEnabled,
+  isVisible,
+} from "./shims.ts";
 import { sleep } from "./sleep.ts";
 
 type DocumentWithLastHovered = Document & {
@@ -33,6 +37,7 @@ export function hover(element: Element | null, options?: PointerEventInit) {
     invariant(element, "Unable to hover on null element");
 
     if (!isVisible(element)) return;
+    if (!isFramePointerEventsEnabled(element)) return;
 
     const document = element.ownerDocument as DocumentWithLastHovered;
     const { lastHovered } = document;

--- a/packages/ariakit-test/src/hover.ts
+++ b/packages/ariakit-test/src/hover.ts
@@ -1,7 +1,8 @@
-import { isVisible, invariant } from "@ariakit/utils";
+import { invariant } from "@ariakit/utils";
 import { getPointerOptions } from "./__mouse.ts";
 import { settle, wrapAsync } from "./__utils.ts";
 import { dispatch } from "./dispatch.ts";
+import { getElementStyle, isVisible } from "./shims.ts";
 import { sleep } from "./sleep.ts";
 
 type DocumentWithLastHovered = Document & {
@@ -9,7 +10,7 @@ type DocumentWithLastHovered = Document & {
 };
 
 function isPointerEventsEnabled(element: Element) {
-  return getComputedStyle(element).pointerEvents !== "none";
+  return getElementStyle(element)?.pointerEvents !== "none";
 }
 
 /**

--- a/packages/ariakit-test/src/mouse-down.ts
+++ b/packages/ariakit-test/src/mouse-down.ts
@@ -1,8 +1,6 @@
 import {
   getDocument,
-  isVisible,
   getClosestFocusable,
-  isFocusable,
   isTextbox,
   invariant,
 } from "@ariakit/utils";
@@ -19,6 +17,7 @@ import {
 import { blur } from "./blur.ts";
 import { dispatch } from "./dispatch.ts";
 import { focus } from "./focus.ts";
+import { getElementStyle, isFocusable, isVisible } from "./shims.ts";
 
 const selectionClearingInputTypes = [
   "date",
@@ -122,7 +121,7 @@ export function mouseDown(element: Element | null, options?: PointerEventInit) {
       }
       if (
         isFocusable(element) &&
-        getComputedStyle(element).pointerEvents !== "none"
+        getElementStyle(element)?.pointerEvents !== "none"
       ) {
         await focus(element);
       } else if (element.parentElement) {

--- a/packages/ariakit-test/src/mouse-up.ts
+++ b/packages/ariakit-test/src/mouse-up.ts
@@ -1,4 +1,4 @@
-import { getDocument, isVisible, invariant } from "@ariakit/utils";
+import { getDocument, invariant } from "@ariakit/utils";
 import {
   getPointerOptions,
   getReleaseOptions,
@@ -10,6 +10,7 @@ import {
   wrapAsync,
 } from "./__utils.ts";
 import { dispatch } from "./dispatch.ts";
+import { isVisible } from "./shims.ts";
 
 /**
  * Releases a pointer button on an element, firing `pointerup` and `mouseup`.

--- a/packages/ariakit-test/src/press.ts
+++ b/packages/ariakit-test/src/press.ts
@@ -3,7 +3,6 @@ import {
   setSelectionRange,
   getNextTabbable,
   getPreviousTabbable,
-  isFocusable,
 } from "@ariakit/utils";
 import { initEvent } from "./__init-event.ts";
 import {
@@ -16,6 +15,7 @@ import {
 import { blur } from "./blur.ts";
 import { dispatch } from "./dispatch.ts";
 import { focus } from "./focus.ts";
+import { isFocusable } from "./shims.ts";
 import { sleep } from "./sleep.ts";
 import { type } from "./type.ts";
 

--- a/packages/ariakit-test/src/select.ts
+++ b/packages/ariakit-test/src/select.ts
@@ -1,10 +1,11 @@
-import { isVisible, invariant } from "@ariakit/utils";
+import { invariant } from "@ariakit/utils";
 import { getClickOptions, getHoverOptions, omitButtons } from "./__mouse.ts";
 import { settle, wrapAsync } from "./__utils.ts";
 import { dispatch } from "./dispatch.ts";
 import { hover } from "./hover.ts";
 import { mouseDown } from "./mouse-down.ts";
 import { mouseUp } from "./mouse-up.ts";
+import { isVisible } from "./shims.ts";
 import { sleep } from "./sleep.ts";
 
 /**

--- a/packages/ariakit-test/src/shims.jsdom.test.ts
+++ b/packages/ariakit-test/src/shims.jsdom.test.ts
@@ -4,17 +4,20 @@ import { expect, test } from "vitest";
 import { click, dispatch, hover, press } from "./index.ts";
 
 function createIframeButton() {
+  const container = document.createElement("div");
   const iframe = document.createElement("iframe");
-  document.body.append(iframe);
+  container.append(iframe);
+  document.body.append(container);
   const iframeWindow = iframe.contentDocument?.defaultView;
   if (!iframeWindow) throw new Error("Unable to reach the iframe window");
   const button = iframeWindow.document.createElement("button");
   iframeWindow.document.body.append(button);
   return {
+    container,
     iframeWindow,
     button,
     [Symbol.dispose]() {
-      iframe.remove();
+      container.remove();
     },
   };
 }
@@ -51,6 +54,19 @@ test("applies layout shims in an iframe realm before hovering", async () => {
   expect(received).toEqual(["pointerover"]);
   expect(button.getClientRects()[0]).toMatchObject({ width: 1, height: 1 });
   expect(hiddenButton.getClientRects()).toHaveLength(0);
+});
+
+test("does not hover content inside a hidden iframe ancestor", async () => {
+  using fixture = createIframeButton();
+  const { button, container } = fixture;
+  container.style.display = "none";
+  const received: string[] = [];
+  button.addEventListener("pointerover", (event) => received.push(event.type));
+
+  await hover(button);
+
+  expect(received).toEqual([]);
+  expect(button.getClientRects()).toHaveLength(0);
 });
 
 test("applies focus shims in an iframe realm before clicking", async () => {

--- a/packages/ariakit-test/src/shims.jsdom.test.ts
+++ b/packages/ariakit-test/src/shims.jsdom.test.ts
@@ -1,7 +1,23 @@
 // @vitest-environment jsdom
 
 import { expect, test } from "vitest";
-import "./shims.ts";
+import { click, dispatch, hover, press } from "./index.ts";
+
+function createIframeButton() {
+  const iframe = document.createElement("iframe");
+  document.body.append(iframe);
+  const iframeWindow = iframe.contentDocument?.defaultView;
+  if (!iframeWindow) throw new Error("Unable to reach the iframe window");
+  const button = iframeWindow.document.createElement("button");
+  iframeWindow.document.body.append(button);
+  return {
+    iframeWindow,
+    button,
+    [Symbol.dispose]() {
+      iframe.remove();
+    },
+  };
+}
 
 test("constructs clipboard events from ClipboardEventInit", () => {
   const clipboardData = { getData: () => "a,b" };
@@ -15,6 +31,70 @@ test("constructs clipboard events from ClipboardEventInit", () => {
   // https://webidl.spec.whatwg.org/#es-dictionary
   // @ts-expect-error
   expect(new ClipboardEvent("paste", null).clipboardData).toBeNull();
+});
+
+test("applies layout shims in an iframe realm before hovering", async () => {
+  using fixture = createIframeButton();
+  const { button, iframeWindow } = fixture;
+  const hiddenButton = iframeWindow.document.createElement("button");
+  hiddenButton.style.display = "none";
+  iframeWindow.document.body.append(hiddenButton);
+  const received: string[] = [];
+  button.addEventListener("pointerover", (event) => received.push(event.type));
+  hiddenButton.addEventListener("pointerover", (event) =>
+    received.push(event.type),
+  );
+
+  await hover(button);
+  await hover(hiddenButton);
+
+  expect(received).toEqual(["pointerover"]);
+  expect(button.getClientRects()[0]).toMatchObject({ width: 1, height: 1 });
+  expect(hiddenButton.getClientRects()).toHaveLength(0);
+});
+
+test("applies focus shims in an iframe realm before clicking", async () => {
+  using fixture = createIframeButton();
+  const { button, iframeWindow } = fixture;
+  const received: string[] = [];
+  button.addEventListener("pointerdown", (event) => received.push(event.type));
+  button.addEventListener("click", (event) => received.push(event.type));
+
+  await click(button);
+
+  expect(received).toEqual(["pointerdown", "click"]);
+  expect(iframeWindow.document.activeElement).toBe(button);
+});
+
+test("applies browser shims in an iframe realm before pressing", async () => {
+  using fixture = createIframeButton();
+  const { button } = fixture;
+  const received: string[] = [];
+  button.addEventListener("keydown", (event) => received.push(event.type));
+  button.addEventListener("click", (event) => received.push(event.type));
+  button.addEventListener("keyup", (event) => received.push(event.type));
+
+  await press.Enter(button);
+
+  expect(received).toEqual(["keydown", "click", "keyup"]);
+});
+
+test("installs ClipboardEvent in an iframe realm before dispatching", async () => {
+  using fixture = createIframeButton();
+  const { button, iframeWindow } = fixture;
+  const clipboardData = { getData: () => "a,b" };
+  let received: ClipboardEvent | undefined;
+  button.addEventListener("paste", (event) => {
+    received = event;
+  });
+
+  // jsdom has no `DataTransfer` constructor, so use the smallest test double
+  // that can prove the fallback preserves the caller's object.
+  await dispatch.paste(button, { clipboardData });
+
+  expect(received).toBeInstanceOf(iframeWindow.ClipboardEvent);
+  expect(received).not.toBeInstanceOf(ClipboardEvent);
+  expect(received?.clipboardData).toBe(clipboardData);
 });
 
 test("leaves an environment that already implements mouse event members alone", () => {

--- a/packages/ariakit-test/src/shims.jsdom.test.ts
+++ b/packages/ariakit-test/src/shims.jsdom.test.ts
@@ -14,6 +14,7 @@ function createIframeButton() {
   iframeWindow.document.body.append(button);
   return {
     container,
+    iframe,
     iframeWindow,
     button,
     [Symbol.dispose]() {
@@ -67,6 +68,23 @@ test("does not hover content inside a hidden iframe ancestor", async () => {
 
   expect(received).toEqual([]);
   expect(button.getClientRects()).toHaveLength(0);
+});
+
+test("does not interact with content inside a pointer-inert iframe", async () => {
+  using fixture = createIframeButton();
+  const { button, container, iframe, iframeWindow } = fixture;
+  container.style.pointerEvents = "none";
+  const received: string[] = [];
+  for (const event of ["pointerover", "pointermove", "pointerdown", "click"]) {
+    button.addEventListener(event, () => received.push(event));
+  }
+
+  await hover(button);
+  await click(button);
+
+  expect(received).toEqual([]);
+  expect(iframeWindow.getComputedStyle(button).pointerEvents).toBe("auto");
+  expect(getComputedStyle(iframe).pointerEvents).toBe("none");
 });
 
 test("applies focus shims in an iframe realm before clicking", async () => {

--- a/packages/ariakit-test/src/shims.ts
+++ b/packages/ariakit-test/src/shims.ts
@@ -51,7 +51,15 @@ function applyBrowserShims(
   ElementConstructor.prototype.getClientRects = function getClientRects() {
     const isHidden = (element: Element) => {
       if (!element.isConnected) return true;
-      if (element.parentElement && isHidden(element.parentElement)) return true;
+      const parent = element.parentElement;
+      if (parent && isHidden(parent)) return true;
+      if (!parent) {
+        const frame = element.ownerDocument.defaultView?.frameElement;
+        if (frame) {
+          ensureBrowserShims(frame);
+          if (frame.getClientRects().length === 0) return true;
+        }
+      }
       if (!(element instanceof HTMLElementConstructor)) return false;
       if (element.hidden) return true;
       const style = targetWindow.getComputedStyle(element);

--- a/packages/ariakit-test/src/shims.ts
+++ b/packages/ariakit-test/src/shims.ts
@@ -8,8 +8,10 @@ import type { OwnerWindowSource } from "./__utils.ts";
 import { getOwnerWindow, isBrowser, isHappyDOM } from "./__utils.ts";
 
 // Apply shims at import because components read layout and focusability between
-// interactions. Both public DOM entry points load this side effect.
+// interactions. Frame realms stay unshimmed until a helper first receives one
+// of their nodes. Both public DOM entry points load this side effect.
 // https://github.com/ariakit/ariakit/pull/6256#discussion_r3366022385
+// https://github.com/ariakit/ariakit/pull/7219#discussion_r3819765577
 
 // Key by the prototype because happy-dom frames share their parent's classes;
 // keying by window would wrap the same methods again for every frame.

--- a/packages/ariakit-test/src/shims.ts
+++ b/packages/ariakit-test/src/shims.ts
@@ -1,107 +1,154 @@
 // oxlint-disable unbound-method
-import { isFocusable, noop } from "@ariakit/utils";
-import { isBrowser, isHappyDOM } from "./__utils.ts";
+import {
+  isFocusable as isElementFocusable,
+  isVisible as isElementVisible,
+  noop,
+} from "@ariakit/utils";
+import type { OwnerWindowSource } from "./__utils.ts";
+import { getOwnerWindow, isBrowser, isHappyDOM } from "./__utils.ts";
 
 // Apply shims at import because components read layout and focusability between
 // interactions. Both public DOM entry points load this side effect.
 // https://github.com/ariakit/ariakit/pull/6256#discussion_r3366022385
 
-function applyBrowserShims() {
+// Key by the prototype because happy-dom frames share their parent's classes;
+// keying by window would wrap the same methods again for every frame.
+// https://github.com/ariakit/ariakit/issues/7200
+const appliedBrowserShims = new WeakMap<object, () => void>();
+
+function applyBrowserShims(
+  targetWindow:
+    | (Window & typeof globalThis)
+    | null
+    | undefined = typeof window === "undefined" ? undefined : window,
+) {
   if (isBrowser) return noop;
   // Importing `@ariakit/test` in plain Node must remain a no-op.
   if (
-    typeof window === "undefined" ||
-    typeof HTMLElement === "undefined" ||
-    typeof Element === "undefined"
+    !targetWindow ||
+    typeof targetWindow.HTMLElement === "undefined" ||
+    typeof targetWindow.Element === "undefined"
   ) {
     return noop;
   }
 
-  const originalFocus = HTMLElement.prototype.focus;
+  const { Element: ElementConstructor } = targetWindow;
+  const { HTMLElement: HTMLElementConstructor } = targetWindow;
+  polyfillClipboardEvent(targetWindow);
+  const existingRestore = appliedBrowserShims.get(ElementConstructor.prototype);
+  if (existingRestore) return existingRestore;
 
-  HTMLElement.prototype.focus = function focus(options) {
-    if (!isFocusable(this)) return;
+  const originalFocus = HTMLElementConstructor.prototype.focus;
+
+  HTMLElementConstructor.prototype.focus = function focus(options) {
+    if (!isElementFocusable(this)) return;
     return originalFocus.call(this, options);
   };
 
-  const originalGetClientRects = Element.prototype.getClientRects;
+  const originalGetClientRects = ElementConstructor.prototype.getClientRects;
 
   // @ts-expect-error
-  Element.prototype.getClientRects = function getClientRects() {
+  ElementConstructor.prototype.getClientRects = function getClientRects() {
     const isHidden = (element: Element) => {
       if (!element.isConnected) return true;
       if (element.parentElement && isHidden(element.parentElement)) return true;
-      if (!(element instanceof HTMLElement)) return false;
+      if (!(element instanceof HTMLElementConstructor)) return false;
       if (element.hidden) return true;
-      const style = getComputedStyle(element);
+      const style = targetWindow.getComputedStyle(element);
       return style.display === "none" || style.visibility === "hidden";
     };
     if (isHidden(this)) return [];
     return [{ width: 1, height: 1 }];
   };
 
-  if (!Element.prototype.scrollIntoView) {
-    Element.prototype.scrollIntoView = noop;
+  if (!ElementConstructor.prototype.scrollIntoView) {
+    ElementConstructor.prototype.scrollIntoView = noop;
   }
 
-  if (!Element.prototype.hasPointerCapture) {
-    Element.prototype.hasPointerCapture = noop;
+  if (!ElementConstructor.prototype.hasPointerCapture) {
+    ElementConstructor.prototype.hasPointerCapture = noop;
   }
 
-  if (!Element.prototype.setPointerCapture) {
-    Element.prototype.setPointerCapture = noop;
+  if (!ElementConstructor.prototype.setPointerCapture) {
+    ElementConstructor.prototype.setPointerCapture = noop;
   }
 
-  if (!Element.prototype.releasePointerCapture) {
-    Element.prototype.releasePointerCapture = noop;
+  if (!ElementConstructor.prototype.releasePointerCapture) {
+    ElementConstructor.prototype.releasePointerCapture = noop;
   }
 
-  if (
-    typeof window.ClipboardEvent === "undefined" &&
-    typeof Event !== "undefined"
-  ) {
-    window.ClipboardEvent = class ClipboardEvent extends Event {
-      #clipboardData: DataTransfer | null;
-
-      constructor(type: string, eventInitDict: ClipboardEventInit | null = {}) {
-        const eventInit = eventInitDict ?? {};
-        super(type, eventInit);
-        this.#clipboardData = eventInit.clipboardData ?? null;
-      }
-
-      get clipboardData() {
-        return this.#clipboardData;
-      }
-    };
-  }
-
-  polyfillMouseEventMembers();
-  patchKeyboardEventModifierState();
+  polyfillMouseEventMembers(targetWindow);
+  patchKeyboardEventModifierState(targetWindow);
 
   // happy-dom doesn't implement window.alert (jsdom and real browsers do).
   // Provide a no-op so code that calls or spies on it works under happy-dom.
-  if (isHappyDOM() && typeof window.alert !== "function") {
-    window.alert = () => {};
+  if (isHappyDOM(targetWindow) && typeof targetWindow.alert !== "function") {
+    targetWindow.alert = () => {};
   }
 
   // happy-dom diverges from real browsers in a few spec-conformance areas; these
   // shims patch them for the whole test environment (jsdom already behaves
   // correctly). Each helper returns a function that restores the original
   // behavior.
-  const restoreHappyDOMShims = isHappyDOM()
-    ? [
-        patchHappyDOMValidationMessage(),
-        patchHappyDOMFormData(),
-        patchHappyDOMSelectionChange(),
-        patchHappyDOMAnimationFrame(),
-        patchHappyDOMProxiedParentNode(),
-      ]
-    : [];
+  const restoreHappyDOMShims =
+    isHappyDOM(targetWindow) &&
+    typeof window !== "undefined" &&
+    targetWindow === window
+      ? [
+          patchHappyDOMValidationMessage(),
+          patchHappyDOMFormData(),
+          patchHappyDOMSelectionChange(),
+          patchHappyDOMAnimationFrame(),
+          patchHappyDOMProxiedParentNode(),
+        ]
+      : [];
 
-  return () => {
-    HTMLElement.prototype.focus = originalFocus;
-    Element.prototype.getClientRects = originalGetClientRects;
+  const restore = () => {
+    HTMLElementConstructor.prototype.focus = originalFocus;
+    ElementConstructor.prototype.getClientRects = originalGetClientRects;
     for (const restore of restoreHappyDOMShims) restore();
+    appliedBrowserShims.delete(ElementConstructor.prototype);
+  };
+  appliedBrowserShims.set(ElementConstructor.prototype, restore);
+  return restore;
+}
+
+export function ensureBrowserShims(target: OwnerWindowSource) {
+  const targetWindow = getOwnerWindow(target);
+  applyBrowserShims(targetWindow);
+  return targetWindow;
+}
+
+export function isVisible(element: Element) {
+  ensureBrowserShims(element);
+  return isElementVisible(element);
+}
+
+export function isFocusable(element: Element) {
+  ensureBrowserShims(element);
+  return isElementFocusable(element);
+}
+
+export function getElementStyle(element: Element) {
+  return ensureBrowserShims(element)?.getComputedStyle(element);
+}
+
+function polyfillClipboardEvent(targetWindow: Window & typeof globalThis) {
+  if (typeof targetWindow.ClipboardEvent !== "undefined") return;
+  if (typeof targetWindow.Event === "undefined") return;
+  const { Event: EventConstructor } = targetWindow;
+  targetWindow.ClipboardEvent = class ClipboardEvent extends EventConstructor {
+    #clipboardData: DataTransfer | null;
+
+    constructor(type: string, eventInitDict: ClipboardEventInit | null = {}) {
+      const eventInit = eventInitDict ?? {};
+      super(type, eventInit);
+      this.#clipboardData = eventInit.clipboardData ?? null;
+    }
+
+    get clipboardData() {
+      return this.#clipboardData;
+    }
   };
 }
 
@@ -141,9 +188,9 @@ const initOnlyModifierMembers = new Map<string, keyof EventModifierInit>([
 // https://github.com/ariakit/ariakit/issues/7156
 // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/getModifierState
 // https://drafts.csswg.org/cssom-view/#dom-mouseevent-x
-function polyfillMouseEventMembers() {
-  if (typeof window.MouseEvent === "undefined") return;
-  const prototype = window.MouseEvent.prototype;
+function polyfillMouseEventMembers(targetWindow: Window & typeof globalThis) {
+  if (typeof targetWindow.MouseEvent === "undefined") return;
+  const prototype = targetWindow.MouseEvent.prototype;
 
   if (typeof prototype.getModifierState !== "function") {
     // happy-dom's constructor keeps only the standard flags and drops the
@@ -186,8 +233,10 @@ function polyfillMouseEventMembers() {
 // member, so record the initializer as the event is built and answer from it.
 // https://github.com/ariakit/ariakit/issues/7166
 // https://w3c.github.io/uievents/#event-modifier-initializers
-function patchKeyboardEventModifierState() {
-  const OriginalKeyboardEvent = window.KeyboardEvent;
+function patchKeyboardEventModifierState(
+  targetWindow: Window & typeof globalThis,
+) {
+  const OriginalKeyboardEvent = targetWindow.KeyboardEvent;
   if (typeof OriginalKeyboardEvent !== "function") return;
   const prototype = OriginalKeyboardEvent.prototype;
 
@@ -233,7 +282,7 @@ function patchKeyboardEventModifierState() {
     },
   });
 
-  window.KeyboardEvent = PatchedKeyboardEvent;
+  targetWindow.KeyboardEvent = PatchedKeyboardEvent;
   // An event reports the same constructor the global exposes, so move the
   // prototype's own pointer to the wrapper as well.
   prototype.constructor = PatchedKeyboardEvent;

--- a/packages/ariakit-test/src/shims.ts
+++ b/packages/ariakit-test/src/shims.ts
@@ -143,6 +143,16 @@ export function getElementStyle(element: Element) {
   return ensureBrowserShims(element)?.getComputedStyle(element);
 }
 
+// An iframe's pointer-events value gates inner hit testing but does not inherit
+// into its content document.
+// https://github.com/ariakit/ariakit/pull/7219#discussion_r3820094503
+export function isFramePointerEventsEnabled(element: Element) {
+  const frame = element.ownerDocument.defaultView?.frameElement;
+  if (!frame) return true;
+  if (getElementStyle(frame)?.pointerEvents === "none") return false;
+  return isFramePointerEventsEnabled(frame);
+}
+
 function polyfillClipboardEvent(targetWindow: Window & typeof globalThis) {
   if (typeof targetWindow.ClipboardEvent !== "undefined") return;
   if (typeof targetWindow.Event === "undefined") return;

--- a/packages/ariakit-test/src/type.ts
+++ b/packages/ariakit-test/src/type.ts
@@ -1,8 +1,9 @@
-import { getActiveElement, isTextField, isFocusable } from "@ariakit/utils";
+import { getActiveElement, isTextField } from "@ariakit/utils";
 import type { DirtiableElement, TextField } from "./__utils.ts";
 import { settle, wrapAsync } from "./__utils.ts";
 import { dispatch } from "./dispatch.ts";
 import { focus } from "./focus.ts";
+import { isFocusable } from "./shims.ts";
 import { sleep } from "./sleep.ts";
 
 function getKeyFromChar(key: string) {


### PR DESCRIPTION
## Motivation

`@ariakit/test` applied its layout, focus, and `ClipboardEvent` shims only to the ambient window. In jsdom, a same-origin iframe has separate DOM prototypes, so these supported calls did nothing or lost `clipboardData`:

```ts
await hover(button);
await click(button);
await press.Enter(button);
await dispatch.paste(button, { clipboardData });
```

## Solution

Resolve each target's owning window before visibility, focusability, computed-style, or named-event construction. Lazily apply the existing shims once to that realm's prototypes, and build the clipboard fallback from that realm's `Event` constructor.

## Regression coverage

Focused jsdom tests cover hover and hidden styles, click focus, Enter activation, clipboard dispatch, hidden frame ancestors, and pointer-inert frame ancestors. The core iframe cases were red on `main`. The ancestor regressions were red on earlier PR heads and green with the current changes.

## Follow-ups

This PR restores verified pointer, keyboard, and clipboard event delivery. It does not claim complete iframe interaction parity. [#7220](https://github.com/ariakit/ariakit/issues/7220) tracks ambient realm-sensitive predicates, [#7221](https://github.com/ariakit/ariakit/issues/7221) tracks cross-frame pointer and focus state, and [#7222](https://github.com/ariakit/ariakit/issues/7222) tracks lazy frame-realm shim timing.

## Implementation review reassessment

<details>
<summary>Cycle 3: Continue the narrow event-delivery design</summary>

**Assessment**

The original defect has high impact within its supported scope because pointer and keyboard helpers become complete no-ops for same-origin iframe nodes under jsdom. That setup is less frequent than top-level tests, but it is a documented and realistic fixture pattern. The per-realm prototype cache and owner-window wrappers add moderate maintenance complexity. The repeated findings cluster around hit testing, ambient constructor branches, cross-document state, and lazy shim timing.

**Decision**

Continue the per-realm design because it directly fixes the original no-op failure with focused coverage. Address the iframe-ancestor `pointer-events` gate with one recursive frame check and a targeted regression. Keep the broader parity work in #7220, #7221, and #7222 because those fixes require new interaction branches or shared frame-tree state. Do not expand this PR beyond the directly introduced hit-testing cases.

</details>

Fixes #7200.
