### PR TITLE
Resolve remaining named DOM member collisions

### DIFF
--- a/.changeset/300-react-named-active-element.md
+++ b/.changeset/300-react-named-active-element.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Composite`](https://ariakit.com/reference/composite) and [`Dialog`](https://ariakit.com/reference/dialog) focus tracking when a document exposes a form named `activeElement`.

--- a/.changeset/300-utils-named-active-button-visibility.md
+++ b/.changeset/300-utils-named-active-button-visibility.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/utils": patch
+---
+
+Fixed `getActiveElement` reading a named form instead of the focused element, and fixed `isButton` and `isVisible` throwing when form controls shadow the DOM members they read.

--- a/app/src/sandbox/dom-7225/index.react.tsx
+++ b/app/src/sandbox/dom-7225/index.react.tsx
@@ -28,26 +28,26 @@ export default function Example() {
 
   return (
     <main>
-      <form ref={formRef} name="profileForm" aria-label="Profile">
+      <form ref={formRef} name="activeElement" aria-label="Profile">
         <label>
           Tag name
-          <input name="tagNameField" />
+          <input name="tagName" />
         </label>
         <label>
           Visibility check
-          <input name="checkVisibilityField" />
+          <input name="checkVisibility" />
         </label>
         <label>
           Width
-          <input name="offsetWidthField" />
+          <input name="offsetWidth" />
         </label>
         <label>
           Height
-          <input name="offsetHeightField" />
+          <input name="offsetHeight" />
         </label>
         <label>
           Client rectangles
-          <input name="getClientRectsField" />
+          <input name="getClientRects" />
         </label>
       </form>
 

--- a/app/src/sandbox/dom-7225/index.react.tsx
+++ b/app/src/sandbox/dom-7225/index.react.tsx
@@ -1,0 +1,73 @@
+import { getActiveElement, isButton, isVisible } from "@ariakit/utils";
+import { useRef, useState } from "react";
+
+export default function Example() {
+  const formRef = useRef<HTMLFormElement>(null);
+  const [activeElementResult, setActiveElementResult] = useState("Not checked");
+  const [buttonResult, setButtonResult] = useState("Not checked");
+  const [visibilityResult, setVisibilityResult] = useState("Not checked");
+
+  const checkActiveElement = (button: HTMLButtonElement) => {
+    const activeElement = getActiveElement(button);
+    setActiveElementResult(
+      activeElement === button ? "Focused button" : "Wrong element",
+    );
+  };
+
+  const checkButton = () => {
+    const form = formRef.current;
+    if (!form) return;
+    setButtonResult(isButton(form) ? "Button" : "Not a button");
+  };
+
+  const checkVisibility = () => {
+    const form = formRef.current;
+    if (!form) return;
+    setVisibilityResult(isVisible(form) ? "Visible" : "Hidden");
+  };
+
+  return (
+    <main>
+      <form ref={formRef} name="activeElement" aria-label="Profile">
+        <label>
+          Tag name
+          <input name="tagName" />
+        </label>
+        <label>
+          Visibility check
+          <input name="checkVisibility" />
+        </label>
+        <label>
+          Width
+          <input name="offsetWidth" />
+        </label>
+        <label>
+          Height
+          <input name="offsetHeight" />
+        </label>
+        <label>
+          Client rectangles
+          <input name="getClientRects" />
+        </label>
+      </form>
+
+      <button
+        type="button"
+        onClick={(event) => checkActiveElement(event.currentTarget)}
+      >
+        Check active element
+      </button>
+      <output aria-label="Active element result">{activeElementResult}</output>
+
+      <button type="button" onClick={checkButton}>
+        Check button type
+      </button>
+      <output aria-label="Button result">{buttonResult}</output>
+
+      <button type="button" onClick={checkVisibility}>
+        Check visibility
+      </button>
+      <output aria-label="Visibility result">{visibilityResult}</output>
+    </main>
+  );
+}

--- a/app/src/sandbox/dom-7225/index.react.tsx
+++ b/app/src/sandbox/dom-7225/index.react.tsx
@@ -1,11 +1,14 @@
+import * as Ariakit from "@ariakit/react";
 import { getActiveElement, isButton, isVisible } from "@ariakit/utils";
 import { useRef, useState } from "react";
 
 export default function Example() {
+  const dialog = Ariakit.useDialogStore();
   const formRef = useRef<HTMLFormElement>(null);
   const [activeElementResult, setActiveElementResult] = useState("Not checked");
   const [buttonResult, setButtonResult] = useState("Not checked");
   const [visibilityResult, setVisibilityResult] = useState("Not checked");
+  const [focusedElement, setFocusedElement] = useState("None");
 
   const checkActiveElement = (button: HTMLButtonElement) => {
     const activeElement = getActiveElement(button);
@@ -50,6 +53,24 @@ export default function Example() {
           <input name="getClientRects" />
         </label>
       </form>
+
+      <button
+        type="button"
+        onClick={dialog.show}
+        onFocus={() => setFocusedElement("Open dialog")}
+      >
+        Open dialog
+      </button>
+      <Ariakit.Dialog store={dialog} modal={false} aria-label="Example dialog">
+        <button
+          type="button"
+          onClick={dialog.hide}
+          onFocus={() => setFocusedElement("Close dialog")}
+        >
+          Close dialog
+        </button>
+      </Ariakit.Dialog>
+      <output aria-label="Focused element">{focusedElement}</output>
 
       <button
         type="button"

--- a/app/src/sandbox/dom-7225/index.react.tsx
+++ b/app/src/sandbox/dom-7225/index.react.tsx
@@ -28,26 +28,26 @@ export default function Example() {
 
   return (
     <main>
-      <form ref={formRef} name="activeElement" aria-label="Profile">
+      <form ref={formRef} name="profileForm" aria-label="Profile">
         <label>
           Tag name
-          <input name="tagName" />
+          <input name="tagNameField" />
         </label>
         <label>
           Visibility check
-          <input name="checkVisibility" />
+          <input name="checkVisibilityField" />
         </label>
         <label>
           Width
-          <input name="offsetWidth" />
+          <input name="offsetWidthField" />
         </label>
         <label>
           Height
-          <input name="offsetHeight" />
+          <input name="offsetHeightField" />
         </label>
         <label>
           Client rectangles
-          <input name="getClientRects" />
+          <input name="getClientRectsField" />
         </label>
       </form>
 

--- a/app/src/sandbox/dom-7225/test-browser.ts
+++ b/app/src/sandbox/dom-7225/test-browser.ts
@@ -1,0 +1,30 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/7225
+  test("resolves the focused element past a named form", async ({ q }) => {
+    const button = q.button("Check active element");
+    await button.focus();
+    await button.press("Enter");
+
+    await test
+      .expect(q.status("Active element result"))
+      .toHaveText("Focused button");
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7225
+  test("checks a form with a control named tagName", async ({ q }) => {
+    await q.button("Check button type").click();
+
+    await test.expect(q.status("Button result")).toHaveText("Not a button");
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7225
+  test("checks visibility with controls named after DOM members", async ({
+    q,
+  }) => {
+    await q.button("Check visibility").click();
+
+    await test.expect(q.status("Visibility result")).toHaveText("Visible");
+  });
+});

--- a/app/src/sandbox/dom-7225/test-browser.ts
+++ b/app/src/sandbox/dom-7225/test-browser.ts
@@ -13,6 +13,20 @@ withFramework(import.meta.dirname, async ({ test }) => {
   });
 
   // https://github.com/ariakit/ariakit/issues/7225
+  // happy-dom has no document named getter, so this integration stays in the
+  // browser suite that reproduces the platform behavior.
+  test("restores dialog focus past a named activeElement form", async ({
+    q,
+  }) => {
+    await q.button("Open dialog").click();
+    await test.expect(q.status("Focused element")).toHaveText("Close dialog");
+
+    await q.button("Close dialog").click();
+
+    await test.expect(q.status("Focused element")).toHaveText("Open dialog");
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7225
   test("checks a form with a control named tagName", async ({ q }) => {
     await q.button("Check button type").click();
 

--- a/packages/ariakit-utils/readme.md
+++ b/packages/ariakit-utils/readme.md
@@ -397,7 +397,7 @@ isButton(document.querySelector("div[role='button']")); // false
 #### `isVisible`
 
 ```ts
-function isVisible(element: Element): any;
+function isVisible(element: Element): boolean;
 ```
 
 Checks if the element is visible or not.

--- a/packages/ariakit-utils/readme.md
+++ b/packages/ariakit-utils/readme.md
@@ -397,7 +397,7 @@ isButton(document.querySelector("div[role='button']")); // false
 #### `isVisible`
 
 ```ts
-function isVisible(element: Element): boolean;
+function isVisible(element: Element): any;
 ```
 
 Checks if the element is visible or not.

--- a/packages/ariakit-utils/src/dom.test.ts
+++ b/packages/ariakit-utils/src/dom.test.ts
@@ -204,6 +204,30 @@ test("getActiveElement ignores a document's named activeElement form", () => {
   expect(getActiveElement(button)).toBe(button);
 });
 
+// https://github.com/ariakit/ariakit/pull/7226#discussion_r3822521065
+test("getActiveElement works without Object.hasOwn", () => {
+  const button = document.createElement("button");
+  document.body.append(button);
+  button.focus();
+  const descriptor = Object.getOwnPropertyDescriptor(Object, "hasOwn");
+  Object.defineProperty(Object, "hasOwn", {
+    configurable: true,
+    value: undefined,
+  });
+  let activeElement: HTMLElement | null = null;
+  try {
+    activeElement = getActiveElement(button);
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(Object, "hasOwn", descriptor);
+    } else {
+      Reflect.deleteProperty(Object, "hasOwn");
+    }
+  }
+
+  expect(activeElement).toBe(button);
+});
+
 // https://github.com/ariakit/ariakit/issues/7225
 test("isButton ignores a form's named tagName control", () => {
   const form = appendShadowingForm(document, "tagName");
@@ -226,6 +250,30 @@ test("isVisible ignores controls named after the members it reads", () => {
   }
 
   expect(isVisible(form)).toBe(true);
+});
+
+// https://github.com/ariakit/ariakit/issues/7225
+// Emulate an engine without checkVisibility so the geometry fallbacks run.
+test("isVisible reads geometry past named controls", () => {
+  const descriptor = Object.getOwnPropertyDescriptor(
+    Element.prototype,
+    "checkVisibility",
+  );
+  if (!descriptor) {
+    throw new Error("Expected Element.prototype.checkVisibility");
+  }
+  Reflect.deleteProperty(Element.prototype, "checkVisibility");
+  try {
+    const memberNames = ["offsetWidth", "offsetHeight", "getClientRects"];
+    const form = appendShadowingForm(document, ...memberNames);
+    for (const name of memberNames) {
+      shadowFormMember(form, name);
+    }
+
+    expect(isVisible(form)).toBe(true);
+  } finally {
+    Object.defineProperty(Element.prototype, "checkVisibility", descriptor);
+  }
 });
 
 // Resolving through the frame is what makes a wrong answer visible: in the

--- a/packages/ariakit-utils/src/dom.test.ts
+++ b/packages/ariakit-utils/src/dom.test.ts
@@ -7,9 +7,11 @@ import {
   getTextboxSelection,
   getTextboxValue,
   getWindow,
+  isButton,
   isElement,
   isNode,
   isTextField,
+  isVisible,
   setSelectionRange,
 } from "./dom.ts";
 
@@ -184,6 +186,47 @@ test.each(shadowingForms)(
     expect(getActiveElement(form)).toBe(button);
   },
 );
+
+// https://github.com/ariakit/ariakit/issues/7225
+test("getActiveElement ignores a document's named activeElement form", () => {
+  const { frameDocument } = appendFrame();
+  const button = frameDocument.createElement("button");
+  frameDocument.body.append(button);
+  const form = frameDocument.createElement("form");
+  form.name = "activeElement";
+  frameDocument.body.append(form);
+  button.focus();
+  Object.defineProperty(frameDocument, "activeElement", {
+    configurable: true,
+    value: form,
+  });
+
+  expect(getActiveElement(button)).toBe(button);
+});
+
+// https://github.com/ariakit/ariakit/issues/7225
+test("isButton ignores a form's named tagName control", () => {
+  const form = appendShadowingForm(document, "tagName");
+  shadowFormMember(form, "tagName");
+
+  expect(isButton(form)).toBe(false);
+});
+
+// https://github.com/ariakit/ariakit/issues/7225
+test("isVisible ignores controls named after the members it reads", () => {
+  const memberNames = [
+    "checkVisibility",
+    "offsetWidth",
+    "offsetHeight",
+    "getClientRects",
+  ];
+  const form = appendShadowingForm(document, ...memberNames);
+  for (const name of memberNames) {
+    shadowFormMember(form, name);
+  }
+
+  expect(isVisible(form)).toBe(true);
+});
 
 // Resolving through the frame is what makes a wrong answer visible: in the
 // ambient realm the fallback happens to be correct, so a helper that resolves

--- a/packages/ariakit-utils/src/dom.ts
+++ b/packages/ariakit-utils/src/dom.ts
@@ -122,7 +122,11 @@ export function getActiveElement(
   node?: Node | null,
   activeDescendant = false,
 ): HTMLElement | null {
-  const { activeElement } = getDocument(node);
+  const ownerDocument = getDocument(node);
+  // The native accessor is inherited, so an own answer may be a named element.
+  const activeElement = Object.hasOwn(ownerDocument, "activeElement")
+    ? getDOMProperty(ownerDocument, "activeElement")
+    : ownerDocument.activeElement;
   if (!activeElement?.nodeName) {
     // In IE11, activeElement might be an empty object if we're interacting
     // with elements inside of an iframe.
@@ -229,9 +233,15 @@ export function isFrame(element: Element): element is HTMLIFrameElement {
  * isButton(document.querySelector("div[role='button']")); // false
  */
 export function isButton(element: { tagName: string; type?: string }) {
-  const tagName = element.tagName.toLowerCase();
-  if (tagName === "button") return true;
-  if (tagName === "input" && element.type) {
+  const tagNameProperty = element.tagName;
+  const tagName =
+    typeof tagNameProperty === "string"
+      ? tagNameProperty
+      : getDOMProperty(element, "tagName");
+  if (typeof tagName !== "string") return false;
+  const normalizedTagName = tagName.toLowerCase();
+  if (normalizedTagName === "button") return true;
+  if (normalizedTagName === "input" && element.type) {
     return buttonInputTypes.indexOf(element.type) !== -1;
   }
   return false;
@@ -253,12 +263,29 @@ export function isVisible(element: Element) {
   if (typeof element.checkVisibility === "function") {
     return element.checkVisibility();
   }
+  const unshadowedCheckVisibility = getDOMProperty(element, "checkVisibility");
+  if (typeof unshadowedCheckVisibility === "function") {
+    return unshadowedCheckVisibility.call(element);
+  }
   const htmlElement = element as HTMLElement;
-  return (
-    htmlElement.offsetWidth > 0 ||
-    htmlElement.offsetHeight > 0 ||
-    element.getClientRects().length > 0
-  );
+  const offsetWidthProperty = htmlElement.offsetWidth;
+  const offsetWidth =
+    typeof offsetWidthProperty === "number"
+      ? offsetWidthProperty
+      : getDOMProperty(element, "offsetWidth");
+  if (typeof offsetWidth === "number" && offsetWidth > 0) return true;
+  const offsetHeightProperty = htmlElement.offsetHeight;
+  const offsetHeight =
+    typeof offsetHeightProperty === "number"
+      ? offsetHeightProperty
+      : getDOMProperty(element, "offsetHeight");
+  if (typeof offsetHeight === "number" && offsetHeight > 0) return true;
+  if (typeof element.getClientRects === "function") {
+    return element.getClientRects().length > 0;
+  }
+  const unshadowedGetClientRects = getDOMProperty(element, "getClientRects");
+  if (typeof unshadowedGetClientRects !== "function") return false;
+  return unshadowedGetClientRects.call(element).length > 0;
 }
 
 /**

--- a/packages/ariakit-utils/src/dom.ts
+++ b/packages/ariakit-utils/src/dom.ts
@@ -259,7 +259,7 @@ const buttonInputTypes = [
 /**
  * Checks if the element is visible or not.
  */
-export function isVisible(element: Element) {
+export function isVisible(element: Element): boolean {
   if (typeof element.checkVisibility === "function") {
     return element.checkVisibility();
   }

--- a/packages/ariakit-utils/src/dom.ts
+++ b/packages/ariakit-utils/src/dom.ts
@@ -74,12 +74,12 @@ interface DOMMemberTypes {
   string: string;
 }
 
-function getDOMMember<Type extends keyof DOMMemberTypes>(
-  value: object,
-  name: string,
+function getDOMMember<Value extends object, Type extends keyof DOMMemberTypes>(
+  value: Value,
+  name: Extract<keyof Value, string>,
   type: Type,
 ): DOMMemberTypes[Type] | undefined {
-  const member: unknown = Reflect.get(value, name);
+  const member: unknown = value[name];
   if (typeof member === type) {
     return member as DOMMemberTypes[Type];
   }
@@ -282,9 +282,10 @@ const buttonInputTypes = [
 export function isVisible(element: Element): boolean {
   const checkVisibility = getDOMMember(element, "checkVisibility", "function");
   if (checkVisibility) return checkVisibility.call(element);
-  const offsetWidth = getDOMMember(element, "offsetWidth", "number");
+  const htmlElement = element as HTMLElement;
+  const offsetWidth = getDOMMember(htmlElement, "offsetWidth", "number");
   if (offsetWidth != null && offsetWidth > 0) return true;
-  const offsetHeight = getDOMMember(element, "offsetHeight", "number");
+  const offsetHeight = getDOMMember(htmlElement, "offsetHeight", "number");
   if (offsetHeight != null && offsetHeight > 0) return true;
   const getClientRects = getDOMMember(element, "getClientRects", "function");
   if (!getClientRects) return false;

--- a/packages/ariakit-utils/src/dom.ts
+++ b/packages/ariakit-utils/src/dom.ts
@@ -4,7 +4,7 @@
  */
 
 import { hasOwnProperty } from "./misc.ts";
-import type { AriaHasPopup, AriaRole } from "./types.ts";
+import type { AnyFunction, AriaHasPopup, AriaRole } from "./types.ts";
 
 /**
  * It's `true` if it is running in a browser environment or `false` if it is not
@@ -62,8 +62,32 @@ function isDocument(value: unknown): value is Document {
 
 // Start at the prototype to bypass named properties while keeping `value` as
 // the getter receiver, including for values from another realm.
-function getDOMProperty(value: object, name: string) {
+function getDOMProperty(value: Document, name: "activeElement"): Element | null;
+function getDOMProperty(value: object, name: string): unknown;
+function getDOMProperty(value: object, name: string): unknown {
   return Reflect.get(Object.getPrototypeOf(value), name, value);
+}
+
+interface DOMMemberTypes {
+  function: AnyFunction;
+  number: number;
+  string: string;
+}
+
+function getDOMMember<Type extends keyof DOMMemberTypes>(
+  value: object,
+  name: string,
+  type: Type,
+): DOMMemberTypes[Type] | undefined {
+  const member: unknown = Reflect.get(value, name);
+  if (typeof member === type) {
+    return member as DOMMemberTypes[Type];
+  }
+  const unshadowedMember = getDOMProperty(value, name);
+  if (typeof unshadowedMember === type) {
+    return unshadowedMember as DOMMemberTypes[Type];
+  }
+  return undefined;
 }
 
 function ownsDocument(
@@ -124,7 +148,7 @@ export function getActiveElement(
 ): HTMLElement | null {
   const ownerDocument = getDocument(node);
   // The native accessor is inherited, so an own answer may be a named element.
-  const activeElement = Object.hasOwn(ownerDocument, "activeElement")
+  const activeElement = hasOwnProperty(ownerDocument, "activeElement")
     ? getDOMProperty(ownerDocument, "activeElement")
     : ownerDocument.activeElement;
   if (!activeElement?.nodeName) {
@@ -233,12 +257,8 @@ export function isFrame(element: Element): element is HTMLIFrameElement {
  * isButton(document.querySelector("div[role='button']")); // false
  */
 export function isButton(element: { tagName: string; type?: string }) {
-  const tagNameProperty = element.tagName;
-  const tagName =
-    typeof tagNameProperty === "string"
-      ? tagNameProperty
-      : getDOMProperty(element, "tagName");
-  if (typeof tagName !== "string") return false;
+  const tagName = getDOMMember(element, "tagName", "string");
+  if (!tagName) return false;
   const normalizedTagName = tagName.toLowerCase();
   if (normalizedTagName === "button") return true;
   if (normalizedTagName === "input" && element.type) {
@@ -260,32 +280,15 @@ const buttonInputTypes = [
  * Checks if the element is visible or not.
  */
 export function isVisible(element: Element): boolean {
-  if (typeof element.checkVisibility === "function") {
-    return element.checkVisibility();
-  }
-  const unshadowedCheckVisibility = getDOMProperty(element, "checkVisibility");
-  if (typeof unshadowedCheckVisibility === "function") {
-    return unshadowedCheckVisibility.call(element);
-  }
-  const htmlElement = element as HTMLElement;
-  const offsetWidthProperty = htmlElement.offsetWidth;
-  const offsetWidth =
-    typeof offsetWidthProperty === "number"
-      ? offsetWidthProperty
-      : getDOMProperty(element, "offsetWidth");
-  if (typeof offsetWidth === "number" && offsetWidth > 0) return true;
-  const offsetHeightProperty = htmlElement.offsetHeight;
-  const offsetHeight =
-    typeof offsetHeightProperty === "number"
-      ? offsetHeightProperty
-      : getDOMProperty(element, "offsetHeight");
-  if (typeof offsetHeight === "number" && offsetHeight > 0) return true;
-  if (typeof element.getClientRects === "function") {
-    return element.getClientRects().length > 0;
-  }
-  const unshadowedGetClientRects = getDOMProperty(element, "getClientRects");
-  if (typeof unshadowedGetClientRects !== "function") return false;
-  return unshadowedGetClientRects.call(element).length > 0;
+  const checkVisibility = getDOMMember(element, "checkVisibility", "function");
+  if (checkVisibility) return checkVisibility.call(element);
+  const offsetWidth = getDOMMember(element, "offsetWidth", "number");
+  if (offsetWidth != null && offsetWidth > 0) return true;
+  const offsetHeight = getDOMMember(element, "offsetHeight", "number");
+  if (offsetHeight != null && offsetHeight > 0) return true;
+  const getClientRects = getDOMMember(element, "getClientRects", "function");
+  if (!getClientRects) return false;
+  return getClientRects.call(element).length > 0;
 }
 
 /**


### PR DESCRIPTION
## Motivation

HTML documents and forms expose named elements as properties. Those properties can replace the DOM members that Ariakit reads.

A form named `activeElement` makes `getActiveElement` report the form instead of the focused control. Form controls named `tagName`, `checkVisibility`, `offsetWidth`, `offsetHeight`, and `getClientRects` make `isButton` and `isVisible` throw instead of returning a result.

## Solution

Read a native DOM member from its prototype when a named property shadows the normal value. `Reflect.get` keeps the original document or element as the getter receiver, including for values from another realm.

Use the existing ES2018-safe ownership helper for `activeElement`. Centralize the other direct and prototype reads in a typed `getDOMMember` helper, and keep `.call(element)` at method call sites so the hot path does not allocate bound functions.

Add utility regression tests and a real-browser sandbox with all six colliding names. A focused unit test removes `Element.prototype.checkVisibility` so the legacy geometry fallbacks also run. The sandbox renders an Ariakit `Dialog` and verifies that focus returns to its opener without reading the colliding `document.activeElement` value.

The `tagName` fix in this PR is limited to `@ariakit/utils`. Other direct DOM member reads in the React and event packages can still shadow before `isButton` runs; [#7228](https://github.com/ariakit/ariakit/issues/7228) tracks that broader audit and fix.

## Workaround

Until a release with this fix is available, use collision-free DOM names and remap them when preparing the submitted form data:

```tsx
{/* TODO: Remove this remapping after https://github.com/ariakit/ariakit/issues/7225 is released. */}
<input name="tagNameField" />
```

```ts
const data = new FormData(form);
data.set("tagName", data.get("tagNameField") ?? "");
data.delete("tagNameField");
```

Apply the same suffix-and-remap pattern to `activeElement`, `checkVisibility`, `offsetWidth`, `offsetHeight`, and `getClientRects`. This workaround requires control over both the DOM field names and the point where `FormData` is prepared.

## Preview

The final sandbox reports `Focused button`, `Not a button`, and `Visible` with the collision-prone names present. Its Ariakit `Dialog` also restores focus from `Close dialog` to `Open dialog`. The focused browser suite passes all 12 cases across Chrome, Firefox, and Safari. The utility suite passes all 82 tests, and the production-style app build includes `/react/previews/dom-7225`.

[Dialog focus-restoration recording](https://github.com/user-attachments/assets/8e32ce1c-6b02-401e-befc-c696bbc0917f)

Fixes #7225
