### PR TITLE
Fix defaultView collisions in Portal and Combobox

### DIFF
--- a/.changeset/300-default-view-collisions.md
+++ b/.changeset/300-default-view-collisions.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Portal`](https://ariakit.com/reference/portal) and components built on it, such as [`Tooltip`](https://ariakit.com/reference/tooltip), as well as [`Combobox`](https://ariakit.com/reference/combobox), when the document contains a form named `defaultView`.

--- a/app/src/sandbox/portal-combobox-7218/index.react.tsx
+++ b/app/src/sandbox/portal-combobox-7218/index.react.tsx
@@ -1,80 +1,53 @@
 import * as Ariakit from "@ariakit/react";
-import type { MouseEvent, MutableRefObject } from "react";
-import { useCallback, useLayoutEffect, useRef, useState } from "react";
-import {
-  getScrollItemIntoView,
-  useTrackComboboxSelectPresentation,
-} from "../../../../packages/ariakit-react-components/src/combobox/__utils.ts";
+import type { RefObject } from "react";
+import { useRef } from "react";
 
 const items = Array.from({ length: 30 }, (_, index) => `Item ${index + 1}`);
+const formName = "preferences";
 
-interface CollisionProps {
-  formRef: MutableRefObject<HTMLFormElement | null>;
+// React 19 reads the same named property during commits. Scope the collision
+// to native browser work so its failure does not hide Ariakit's behavior.
+function setFormName(formRef: RefObject<HTMLFormElement | null>, name: string) {
+  const form = formRef.current;
+  if (!form) return;
+  form.name = name;
 }
 
-function createDefaultViewForm() {
-  const form = document.createElement("form");
-  form.name = "defaultView";
-  form.setAttribute("aria-label", "Preferences");
-  const label = document.createElement("label");
-  label.textContent = "Theme";
-  const input = document.createElement("input");
-  input.name = "theme";
-  input.defaultValue = "System";
-  label.appendChild(input);
-  form.appendChild(label);
-  return form;
-}
-
-function AddDefaultViewCollision({ formRef }: CollisionProps) {
-  useLayoutEffect(() => {
-    // Keep the real named form across the target layout effects only. React 19
-    // has its own direct lookup that would otherwise mask the Ariakit result.
-    const form = createDefaultViewForm();
-    document.body.appendChild(form);
-    formRef.current = form;
-    return () => form.remove();
-  }, [formRef]);
-
-  return null;
-}
-
-interface RemoveCollisionProps extends CollisionProps {
-  recordResult: () => void;
-}
-
-function RemoveDefaultViewCollision({
+function PreferencesForm({
   formRef,
-  recordResult,
-}: RemoveCollisionProps) {
-  useLayoutEffect(() => {
-    recordResult();
-    formRef.current?.remove();
-    formRef.current = null;
-  }, [formRef, recordResult]);
-
-  return null;
+}: {
+  formRef: RefObject<HTMLFormElement | null>;
+}) {
+  return (
+    <form ref={formRef} name={formName}>
+      <label>
+        Theme
+        <input name="theme" defaultValue="System" />
+      </label>
+    </form>
+  );
 }
 
-function FullscreenPortal() {
+function FullscreenPortal({
+  formRef,
+}: {
+  formRef: RefObject<HTMLFormElement | null>;
+}) {
   const fullscreenHostRef = useRef<HTMLDivElement>(null);
-  const formRef = useRef<HTMLFormElement>(null);
-  const [mounted, setMounted] = useState(false);
 
   const enterFullscreen = () => {
-    void fullscreenHostRef.current?.requestFullscreen();
+    const form = formRef.current;
+    const host = fullscreenHostRef.current;
+    if (!form || !host) return;
+    setFormName(formRef, "defaultView");
+    const restoreName = () => {
+      setFormName(formRef, formName);
+    };
+    host.ownerDocument.addEventListener("fullscreenchange", restoreName, {
+      once: true,
+    });
+    void host.requestFullscreen().catch(restoreName);
   };
-
-  const recordResult = useCallback(() => {
-    const portal = document.querySelector('[id="portal/fullscreen-content"]');
-    const result = document.getElementById("portal-result");
-    if (!result) return;
-    const insideFullscreen =
-      portal?.parentElement === fullscreenHostRef.current;
-    result.textContent = insideFullscreen
-      ? "Portal parent: fullscreen"
-      : "Portal parent: body";
-  }, []);
 
   return (
     <section aria-label="Fullscreen portal">
@@ -85,95 +58,38 @@ function FullscreenPortal() {
         <button type="button" onClick={enterFullscreen}>
           Enter portal fullscreen
         </button>
-        <button type="button" onClick={() => setMounted(true)}>
-          Mount named form and portal
-        </button>
-        <div id="portal-result" role="status" aria-label="Portal result">
-          Portal parent: pending
-        </div>
-        {mounted && (
-          <>
-            <AddDefaultViewCollision formRef={formRef} />
-            <Ariakit.Portal id="fullscreen-content">
-              Fullscreen portal content
-            </Ariakit.Portal>
-            <RemoveDefaultViewCollision
-              formRef={formRef}
-              recordResult={recordResult}
-            />
-          </>
-        )}
+        <Ariakit.Portal>Fullscreen portal content</Ariakit.Portal>
       </div>
     </section>
   );
 }
 
-function ComboboxScroll() {
-  const store = Ariakit.useComboboxStore({
-    defaultSelectedValue: "Item 24",
-    virtualFocus: false,
-  });
-  // Use the same module instance as the callback invoked below so the
-  // user-triggered scroll follows the normal select-presentation branch.
-  useTrackComboboxSelectPresentation(store);
-
-  const recordResult = useCallback(() => {
-    const listbox = document.getElementById("combobox-listbox");
-    const item = document.getElementById("combobox-item-24");
-    const result = document.getElementById("combobox-result");
-    if (!listbox || !item || !result) return;
-    const listboxRect = listbox.getBoundingClientRect();
-    const itemRect = item.getBoundingClientRect();
-    const visible =
-      itemRect.top >= listboxRect.top && itemRect.bottom <= listboxRect.bottom;
-    result.textContent = visible
-      ? "Selected item: visible"
-      : "Selected item: hidden";
-  }, []);
-
-  const testScroll = () => {
-    const listbox = document.getElementById("combobox-listbox");
-    const item = document.getElementById("combobox-item-24");
-    if (!listbox || !item) return;
-    listbox.scrollTop = 0;
-    const form = createDefaultViewForm();
-    document.body.appendChild(form);
-    try {
-      getScrollItemIntoView(store)(item);
-    } finally {
-      recordResult();
-      form.remove();
-    }
+function ComboboxScroll({
+  formRef,
+}: {
+  formRef: RefObject<HTMLFormElement | null>;
+}) {
+  const setLegacyFormName = () => {
+    setFormName(formRef, "defaultView");
   };
-
-  const keepPopupOpen = (event: MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault();
+  const restoreFormName = () => {
+    setFormName(formRef, formName);
   };
 
   return (
     <section aria-label="Combobox scroll">
-      <div id="combobox-result" role="status" aria-label="Combobox result">
-        Selected item: pending
-      </div>
-      <Ariakit.ComboboxProvider store={store}>
+      <Ariakit.ComboboxProvider defaultSelectedValue="Item 24">
         <Ariakit.ComboboxSelectLabel>Favorite item</Ariakit.ComboboxSelectLabel>
         <Ariakit.ComboboxSelect />
         <Ariakit.ComboboxPopover
-          id="combobox-listbox"
           aria-label="Favorite item options"
+          onPointerDownCapture={setLegacyFormName}
+          onFocus={restoreFormName}
+          onPointerUp={restoreFormName}
           style={{ maxHeight: 120, overflow: "auto" }}
         >
-          <button
-            type="button"
-            tabIndex={0}
-            onMouseDown={keepPopupOpen}
-            onClick={testScroll}
-          >
-            Scroll selected item with named form
-          </button>
-          {items.map((item, index) => (
+          {items.map((item) => (
             <Ariakit.ComboboxItem
-              id={`combobox-item-${index + 1}`}
               key={item}
               value={item}
               style={{ display: "block", padding: "4px 8px" }}
@@ -186,10 +102,14 @@ function ComboboxScroll() {
 }
 
 export default function Example() {
+  const formRef = useRef<HTMLFormElement>(null);
+
   return (
     <main>
-      <FullscreenPortal />
-      <ComboboxScroll />
+      <h1>Preferences</h1>
+      <PreferencesForm formRef={formRef} />
+      <FullscreenPortal formRef={formRef} />
+      <ComboboxScroll formRef={formRef} />
     </main>
   );
 }

--- a/app/src/sandbox/portal-combobox-7218/index.react.tsx
+++ b/app/src/sandbox/portal-combobox-7218/index.react.tsx
@@ -1,0 +1,195 @@
+import * as Ariakit from "@ariakit/react";
+import type { MouseEvent, MutableRefObject } from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import {
+  getScrollItemIntoView,
+  useTrackComboboxSelectPresentation,
+} from "../../../../packages/ariakit-react-components/src/combobox/__utils.ts";
+
+const items = Array.from({ length: 30 }, (_, index) => `Item ${index + 1}`);
+
+interface CollisionProps {
+  formRef: MutableRefObject<HTMLFormElement | null>;
+}
+
+function createDefaultViewForm() {
+  const form = document.createElement("form");
+  form.name = "defaultView";
+  form.setAttribute("aria-label", "Preferences");
+  const label = document.createElement("label");
+  label.textContent = "Theme";
+  const input = document.createElement("input");
+  input.name = "theme";
+  input.defaultValue = "System";
+  label.appendChild(input);
+  form.appendChild(label);
+  return form;
+}
+
+function AddDefaultViewCollision({ formRef }: CollisionProps) {
+  useLayoutEffect(() => {
+    // Keep the real named form across the target layout effects only. React 19
+    // has its own direct lookup that would otherwise mask the Ariakit result.
+    const form = createDefaultViewForm();
+    document.body.appendChild(form);
+    formRef.current = form;
+    return () => form.remove();
+  }, [formRef]);
+
+  return null;
+}
+
+interface RemoveCollisionProps extends CollisionProps {
+  recordResult: () => void;
+}
+
+function RemoveDefaultViewCollision({
+  formRef,
+  recordResult,
+}: RemoveCollisionProps) {
+  useLayoutEffect(() => {
+    recordResult();
+    formRef.current?.remove();
+    formRef.current = null;
+  }, [formRef, recordResult]);
+
+  return null;
+}
+
+function FullscreenPortal() {
+  const fullscreenHostRef = useRef<HTMLDivElement>(null);
+  const formRef = useRef<HTMLFormElement>(null);
+  const [mounted, setMounted] = useState(false);
+
+  const enterFullscreen = () => {
+    void fullscreenHostRef.current?.requestFullscreen();
+  };
+
+  const recordResult = useCallback(() => {
+    const portal = document.querySelector('[id="portal/fullscreen-content"]');
+    const result = document.getElementById("portal-result");
+    if (!result) return;
+    const insideFullscreen =
+      portal?.parentElement === fullscreenHostRef.current;
+    result.textContent = insideFullscreen
+      ? "Portal parent: fullscreen"
+      : "Portal parent: body";
+  }, []);
+
+  return (
+    <section aria-label="Fullscreen portal">
+      <div
+        ref={fullscreenHostRef}
+        style={{ background: "white", color: "black", minHeight: 200 }}
+      >
+        <button type="button" onClick={enterFullscreen}>
+          Enter portal fullscreen
+        </button>
+        <button type="button" onClick={() => setMounted(true)}>
+          Mount named form and portal
+        </button>
+        <div id="portal-result" role="status" aria-label="Portal result">
+          Portal parent: pending
+        </div>
+        {mounted && (
+          <>
+            <AddDefaultViewCollision formRef={formRef} />
+            <Ariakit.Portal id="fullscreen-content">
+              Fullscreen portal content
+            </Ariakit.Portal>
+            <RemoveDefaultViewCollision
+              formRef={formRef}
+              recordResult={recordResult}
+            />
+          </>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function ComboboxScroll() {
+  const store = Ariakit.useComboboxStore({
+    defaultSelectedValue: "Item 24",
+    virtualFocus: false,
+  });
+  // Use the same module instance as the callback invoked below so the
+  // user-triggered scroll follows the normal select-presentation branch.
+  useTrackComboboxSelectPresentation(store);
+
+  const recordResult = useCallback(() => {
+    const listbox = document.getElementById("combobox-listbox");
+    const item = document.getElementById("combobox-item-24");
+    const result = document.getElementById("combobox-result");
+    if (!listbox || !item || !result) return;
+    const listboxRect = listbox.getBoundingClientRect();
+    const itemRect = item.getBoundingClientRect();
+    const visible =
+      itemRect.top >= listboxRect.top && itemRect.bottom <= listboxRect.bottom;
+    result.textContent = visible
+      ? "Selected item: visible"
+      : "Selected item: hidden";
+  }, []);
+
+  const testScroll = () => {
+    const listbox = document.getElementById("combobox-listbox");
+    const item = document.getElementById("combobox-item-24");
+    if (!listbox || !item) return;
+    listbox.scrollTop = 0;
+    const form = createDefaultViewForm();
+    document.body.appendChild(form);
+    try {
+      getScrollItemIntoView(store)(item);
+    } finally {
+      recordResult();
+      form.remove();
+    }
+  };
+
+  const keepPopupOpen = (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+  };
+
+  return (
+    <section aria-label="Combobox scroll">
+      <div id="combobox-result" role="status" aria-label="Combobox result">
+        Selected item: pending
+      </div>
+      <Ariakit.ComboboxProvider store={store}>
+        <Ariakit.ComboboxSelectLabel>Favorite item</Ariakit.ComboboxSelectLabel>
+        <Ariakit.ComboboxSelect />
+        <Ariakit.ComboboxPopover
+          id="combobox-listbox"
+          aria-label="Favorite item options"
+          style={{ maxHeight: 120, overflow: "auto" }}
+        >
+          <button
+            type="button"
+            tabIndex={0}
+            onMouseDown={keepPopupOpen}
+            onClick={testScroll}
+          >
+            Scroll selected item with named form
+          </button>
+          {items.map((item, index) => (
+            <Ariakit.ComboboxItem
+              id={`combobox-item-${index + 1}`}
+              key={item}
+              value={item}
+              style={{ display: "block", padding: "4px 8px" }}
+            />
+          ))}
+        </Ariakit.ComboboxPopover>
+      </Ariakit.ComboboxProvider>
+    </section>
+  );
+}
+
+export default function Example() {
+  return (
+    <main>
+      <FullscreenPortal />
+      <ComboboxScroll />
+    </main>
+  );
+}

--- a/app/src/sandbox/portal-combobox-7218/index.react.tsx
+++ b/app/src/sandbox/portal-combobox-7218/index.react.tsx
@@ -14,7 +14,8 @@ interface CollisionProps {
 
 function createDefaultViewForm() {
   const form = document.createElement("form");
-  form.name = "defaultView";
+  // TODO: Restore the name after https://github.com/ariakit/ariakit/issues/7218
+  form.name = "settingsForm";
   form.setAttribute("aria-label", "Preferences");
   const label = document.createElement("label");
   label.textContent = "Theme";

--- a/app/src/sandbox/portal-combobox-7218/index.react.tsx
+++ b/app/src/sandbox/portal-combobox-7218/index.react.tsx
@@ -14,8 +14,7 @@ interface CollisionProps {
 
 function createDefaultViewForm() {
   const form = document.createElement("form");
-  // TODO: Restore the name after https://github.com/ariakit/ariakit/issues/7218
-  form.name = "settingsForm";
+  form.name = "defaultView";
   form.setAttribute("aria-label", "Preferences");
   const label = document.createElement("label");
   label.textContent = "Theme";

--- a/app/src/sandbox/portal-combobox-7218/test-browser.ts
+++ b/app/src/sandbox/portal-combobox-7218/test-browser.ts
@@ -1,0 +1,36 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/7218
+  test("renders a portal inside fullscreen when defaultView is named", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Enter portal fullscreen").click();
+    await page.waitForFunction(() => document.fullscreenElement != null);
+    await q.button("Mount named form and portal").click();
+
+    await test
+      .expect(q.status("Portal result"))
+      .toHaveText("Portal parent: fullscreen");
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7218
+  test("scrolls a selected combobox item when defaultView is named", async ({
+    page,
+    q,
+  }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (error) => errors.push(error.message));
+    await q.combobox("Favorite item").click();
+    await test.expect(q.option("Item 24")).toBeInViewport();
+    await q.button("Scroll selected item with named form").click();
+
+    await test.expect
+      .poll(async () => ({
+        errors,
+        result: await q.status("Combobox result").textContent(),
+      }))
+      .toEqual({ errors: [], result: "Selected item: visible" });
+  });
+});

--- a/app/src/sandbox/portal-combobox-7218/test-browser.ts
+++ b/app/src/sandbox/portal-combobox-7218/test-browser.ts
@@ -3,34 +3,32 @@ import { withFramework } from "#app/test-utils/preview.ts";
 withFramework(import.meta.dirname, async ({ test }) => {
   // https://github.com/ariakit/ariakit/issues/7218
   test("renders a portal inside fullscreen when defaultView is named", async ({
-    page,
     q,
   }) => {
     await q.button("Enter portal fullscreen").click();
-    await page.waitForFunction(() => document.fullscreenElement != null);
-    await q.button("Mount named form and portal").click();
 
-    await test
-      .expect(q.status("Portal result"))
-      .toHaveText("Portal parent: fullscreen");
+    const content = q.text("Fullscreen portal content");
+    await test.expect(content).toBeVisible();
+    await test.expect
+      .poll(() =>
+        content.evaluate((element) =>
+          Boolean(element.ownerDocument.fullscreenElement?.contains(element)),
+        ),
+      )
+      .toBe(true);
   });
 
   // https://github.com/ariakit/ariakit/issues/7218
-  test("scrolls a selected combobox item when defaultView is named", async ({
+  test("selects a combobox item when defaultView is named", async ({
     page,
     q,
   }) => {
     const errors: string[] = [];
     page.on("pageerror", (error) => errors.push(error.message));
     await q.combobox("Favorite item").click();
-    await test.expect(q.option("Item 24")).toBeInViewport();
-    await q.button("Scroll selected item with named form").click();
+    await q.option("Item 24").click();
 
-    await test.expect
-      .poll(async () => ({
-        errors,
-        result: await q.status("Combobox result").textContent(),
-      }))
-      .toEqual({ errors: [], result: "Selected item: visible" });
+    await test.expect(q.combobox("Favorite item")).toHaveText("Item 24");
+    test.expect(errors).toEqual([]);
   });
 });

--- a/packages/ariakit-react-components/src/combobox/__utils.ts
+++ b/packages/ariakit-react-components/src/combobox/__utils.ts
@@ -1,5 +1,6 @@
 import { useSafeLayoutEffect } from "@ariakit/react-utils";
 import { sync } from "@ariakit/store";
+import { getWindow } from "@ariakit/utils";
 import type { ComboboxStore } from "./combobox-store.ts";
 
 const openingMovesByStore = new WeakMap<ComboboxStore, number>();
@@ -13,8 +14,7 @@ function scrollIntoViewNearest(element: HTMLElement) {
 }
 
 function getSingleVerticalScrollport(element: HTMLElement, popup: HTMLElement) {
-  const view = element.ownerDocument.defaultView;
-  if (!view) return null;
+  const view = getWindow(element);
   if (!view.getComputedStyle(popup).writingMode.startsWith("horizontal")) {
     return null;
   }

--- a/packages/ariakit-react-components/src/portal/portal.tsx
+++ b/packages/ariakit-react-components/src/portal/portal.tsx
@@ -11,6 +11,7 @@ import {
 import type { Options, Props } from "@ariakit/react-utils";
 import {
   getDocument,
+  getWindow,
   isFocusEventOutside,
   disableFocusIn,
   getNextTabbable,
@@ -33,7 +34,7 @@ type HTMLType = HTMLElementTagNameMap[TagName];
 function getRootElement(element?: Element | null) {
   const doc = getDocument(element);
   const { fullscreenElement } = doc;
-  const HTMLElementClass = doc.defaultView?.HTMLElement;
+  const HTMLElementClass = getWindow(element).HTMLElement;
   if (HTMLElementClass && fullscreenElement instanceof HTMLElementClass) {
     return fullscreenElement;
   }


### PR DESCRIPTION
## Motivation

A form named `defaultView` can replace the document property lookup in named-access browsers. This breaks fullscreen portals and Combobox item presentation.

Fixes #7218.

## Solution

Route both affected document-window reads through the hardened `getWindow(element)` helper.

The regression sandbox now renders its form with React and exercises ordinary public `Portal`, `ComboboxSelect`, `ComboboxPopover`, and `ComboboxItem` interactions. React 19 has its own direct `ownerDocument.defaultView` read during commits, so the fixture scopes the real form name collision to the native fullscreen and selected-option focus events, then restores the normal name before React flushes an update.

A separate commit proves the userland workaround before the library fix is applied.

## Workaround

Use a different form name until the fix is available:

```html
<!-- TODO: Restore name="defaultView" after https://github.com/ariakit/ariakit/issues/7218 is fixed. -->
<form name="settingsForm">
  <!-- fields -->
</form>
```

## Testing

- `pnpm test-browser portal-combobox-7218`: six passing cases across Chrome, Firefox, and Safari.
- Temporarily restoring the old production reads makes both Chrome regressions fail. The Portal stays outside fullscreen, and Combobox emits `view.getComputedStyle is not a function`.

## Preview

[Browser evidence](https://github.com/ariakit/ariakit/pull/7227#issuecomment-5357515920) captures the fixed fullscreen Portal containment and selected Combobox item visibility. The final review-response commit changes only the regression fixture, so the production implementation shown in that evidence is unchanged.