### PR TITLE
Limit cached DOM accessors to nodeType and activeElement

### DIFF
--- a/.changeset/300-focusable-named-node-type.md
+++ b/.changeset/300-focusable-named-node-type.md
@@ -1,6 +1,0 @@
----
-"@ariakit/react-components": patch
-"@ariakit/react": patch
----
-
-Fixed [`Focusable`](https://ariakit.com/reference/focusable) retaining keyboard focus styling when a pointer focuses a form that contains a control named `nodeType`.

--- a/.changeset/300-react-named-active-element.md
+++ b/.changeset/300-react-named-active-element.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Dialog`](https://ariakit.com/reference/dialog) and components built on it, such as [`Popover`](https://ariakit.com/reference/popover) and [`Menu`](https://ariakit.com/reference/menu), failing to return focus to the element that opened it when the document contains a form named `activeElement`.

--- a/.changeset/300-utils-named-active-element.md
+++ b/.changeset/300-utils-named-active-element.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/utils": patch
+---
+
+Fixed `getActiveElement` reporting a form instead of the focused element when the document contains a form named `activeElement`.

--- a/.changeset/300-utils-named-dom-members.md
+++ b/.changeset/300-utils-named-dom-members.md
@@ -1,5 +1,0 @@
----
-"@ariakit/utils": patch
----
-
-Fixed `isElement` and `isNode` rejecting a form that contains a control named `nodeType`, and fixed `getDocument` and `getWindow` falling back to the ambient realm when named elements shadow `ownerDocument` or `defaultView` inside a frame.

--- a/.changeset/300-utils-realm-resolution.md
+++ b/.changeset/300-utils-realm-resolution.md
@@ -2,4 +2,4 @@
 "@ariakit/utils": patch
 ---
 
-Fixed `getDocument` and `getWindow` resolving a realm from a member name, which a form or a document can answer with one of its own elements, and typed `getWindow`'s result the way `document.defaultView` is so the interfaces a window carries can be read off it.
+Fixed `getDocument` and `getWindow` trusting a member that a form or a document can answer with one of its own elements, so they now check what came back and fall back instead of returning a value of the wrong type, and typed `getWindow`'s result the way `document.defaultView` is so the interfaces a window carries can be read off it.

--- a/app/src/sandbox/dialog-form-named-active-element/index.react.tsx
+++ b/app/src/sandbox/dialog-form-named-active-element/index.react.tsx
@@ -1,0 +1,52 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+
+// A saved-views form on the page carries a name that collides with the member
+// `getActiveElement` reads, so the document answers `activeElement` with the
+// form instead of the focused control. `Dialog` remembers the element that
+// opened it through that read, so focus has nowhere correct to return to.
+export default function Example() {
+  const dialog = Ariakit.useDialogStore();
+  const [focusedElement, setFocusedElement] = useState("None");
+
+  return (
+    <main>
+      <h1>Reports</h1>
+
+      <form name="activeElement" aria-label="Saved views">
+        <label>
+          View name
+          <input name="view" defaultValue="Last quarter" />
+        </label>
+      </form>
+
+      {/* The named form makes `document.activeElement` answer with itself, so
+          Playwright's `toBeFocused` can never pass on this page: it compares
+          `getRootNode().activeElement` against the node. Focus is reported
+          through the output below instead. `tabIndex` keeps Safari focusing the
+          button on click, so all three projects exercise the same path. */}
+      <button
+        type="button"
+        tabIndex={0}
+        onClick={dialog.show}
+        onFocus={() => setFocusedElement("Edit report")}
+      >
+        Edit report
+      </button>
+
+      <Ariakit.Dialog store={dialog} modal={false} aria-label="Edit report">
+        <Ariakit.DialogHeading>Edit report</Ariakit.DialogHeading>
+        <button
+          type="button"
+          tabIndex={0}
+          onClick={dialog.hide}
+          onFocus={() => setFocusedElement("Done")}
+        >
+          Done
+        </button>
+      </Ariakit.Dialog>
+
+      <output aria-label="Focused element">{focusedElement}</output>
+    </main>
+  );
+}

--- a/app/src/sandbox/dialog-form-named-active-element/test-browser.ts
+++ b/app/src/sandbox/dialog-form-named-active-element/test-browser.ts
@@ -1,0 +1,18 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// happy-dom implements no document named getter, so only a real browser makes
+// the form answer the `activeElement` read. The three desktop projects all
+// reproduce it.
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/7225
+  test("restores dialog focus past a named activeElement form", async ({
+    q,
+  }) => {
+    await q.button("Edit report").click();
+    await test.expect(q.status("Focused element")).toHaveText("Done");
+
+    await q.button("Done").click();
+
+    await test.expect(q.status("Focused element")).toHaveText("Edit report");
+  });
+});

--- a/app/src/sandbox/focusable-click-focus/index.react.tsx
+++ b/app/src/sandbox/focusable-click-focus/index.react.tsx
@@ -37,13 +37,6 @@ export default function Example() {
         />{" "}
         Wrapped
       </label>
-      {/* https://github.com/ariakit/ariakit/issues/7215 */}
-      <Ariakit.Focusable
-        render={<form aria-label="Node editor" style={{ padding: 16 }} />}
-        tabIndex={0}
-      >
-        <input aria-label="Node type" name="nodeType" />
-      </Ariakit.Focusable>
     </div>
   );
 }

--- a/app/src/sandbox/focusable-click-focus/test-browser.ts
+++ b/app/src/sandbox/focusable-click-focus/test-browser.ts
@@ -28,27 +28,6 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(button).toHaveAttribute("data-focus-visible", "true");
   });
 
-  // https://github.com/ariakit/ariakit/issues/7215
-  // happy-dom defines `nodeType` on the form's prototype, so only real browsers
-  // reproduce the named-property override this interaction exercises.
-  test("uses pointer focus on a form that names a nodeType field", async ({
-    page,
-    q,
-  }) => {
-    const button = q.button("Button");
-    await button.focus();
-    await button.press("Enter");
-
-    const form = q.form("Node editor");
-    await form.click({ position: { x: 4, y: 4 } });
-    await test.expect(form).toBeFocused();
-
-    // data-focus-visible is applied from a queued callback a frame later, so
-    // cross those frames before asserting it never arrives.
-    await flushFrames(page);
-    await test.expect(form).not.toHaveAttribute("data-focus-visible");
-  });
-
   test("checkbox receives focus on click", async ({ q }) => {
     const checkbox = q.checkbox("Checkbox");
     await checkbox.click();

--- a/packages/ariakit-utils/src/dom.test.ts
+++ b/packages/ariakit-utils/src/dom.test.ts
@@ -7,8 +7,6 @@ import {
   getTextboxSelection,
   getTextboxValue,
   getWindow,
-  isElement,
-  isNode,
   isTextField,
   setSelectionRange,
 } from "./dom.ts";
@@ -98,9 +96,9 @@ test("getScrollingElement falls back to the element's own document, not the glob
 
 // A form's named-element getter overrides built-ins, so a control named after
 // the member a helper reads makes the form answer with that control instead.
-// Measured on Chromium 151, Firefox 153, and WebKit 26.5. happy-dom reproduces
-// it for `self` and `document` but not for members it defines on the prototype
-// chain, so the cases below that need one of those emulate it.
+// happy-dom reproduces that for some names and not others, and implements no
+// document named getter, so the cases it cannot produce use `defineProperty` to
+// stand in for the own property a browser exposes.
 // https://github.com/ariakit/ariakit/issues/7201
 
 function appendShadowingForm(
@@ -128,25 +126,24 @@ function shadowFormMember(form: HTMLFormElement, name: string) {
   });
 }
 
-// https://github.com/ariakit/ariakit/issues/7215
-test("isElement handles a form that answers nodeType with a control", () => {
-  const form = appendShadowingForm(document, "nodeType");
-  shadowFormMember(form, "nodeType");
+// The realm is no longer resolved through a prototype read, so a form whose
+// control is named `ownerDocument` resolves to the ambient document rather than
+// its own. What still has to hold is that the control never stands in for a
+// document, because callers destructure `documentElement` off the result.
+// happy-dom defines `ownerDocument` on the prototype chain, so the browsers'
+// answer for the control is emulated here.
+test("getDocument falls back when a form answers ownerDocument with a control", () => {
+  const form = appendShadowingForm(document, "ownerDocument");
+  shadowFormMember(form, "ownerDocument");
 
-  expect(isElement(form)).toBe(true);
-});
-
-// https://github.com/ariakit/ariakit/issues/7215
-test("isNode handles a form that answers nodeType with a control", () => {
-  const form = appendShadowingForm(document, "nodeType");
-  shadowFormMember(form, "nodeType");
-
-  expect(isNode(form)).toBe(true);
+  expect(getDocument(form)).toBe(document);
 });
 
 // Each helper gets its own case, because a bundled test stops at the first
-// failing assertion. `getDocument` and `getActiveElement` also fail differently
-// per shape, while `getWindow` reads only `self` and fails the same way in both.
+// failing assertion. No helper reads `self` or `document` off the value it is
+// handed, since `isWindow` compares identity through `window`, and `.document`
+// is only read once a value is known to be a window; these names guard against
+// a regression to the member reads they replaced.
 const shadowingForms = [
   { controlNames: ["self"], label: "a control named self" },
   {
@@ -217,61 +214,9 @@ test("getWindow resolves a window to itself", () => {
   expect(getWindow(frameWindow)).toBe(frameWindow);
 });
 
-// A document names its own elements the same way, so one that names an element
-// `nodeType` answers that read with the element. Measured on the three engines
-// above; happy-dom implements no document named getter, so it is emulated here.
-// Validating through that read would reject the document every element in it
-// belongs to. https://github.com/ariakit/ariakit/pull/7213#discussion_r3816584472
-test("getDocument resolves an element whose document answers nodeType with an element", () => {
-  const otherDocument = document.implementation.createHTMLDocument("Other");
-  const element = otherDocument.createElement("div");
-  otherDocument.body.append(element);
-  const form = otherDocument.createElement("form");
-  form.name = "nodeType";
-  otherDocument.body.append(form);
-  Object.defineProperty(otherDocument, "nodeType", {
-    configurable: true,
-    value: form,
-  });
-
-  expect(getDocument(element)).toBe(otherDocument);
-});
-
-// https://github.com/ariakit/ariakit/issues/7215
-test("getDocument ignores a form's named ownerDocument control", () => {
-  const { frameDocument } = appendFrame();
-  const form = appendShadowingForm(frameDocument, "ownerDocument");
-  // happy-dom overrides only members it does not define on the prototype chain,
-  // so the browsers' answer for the control above is emulated here.
-  shadowFormMember(form, "ownerDocument");
-
-  expect(getDocument(form)).toBe(frameDocument);
-});
-
-// https://github.com/ariakit/ariakit/issues/7215
-test("getWindow ignores a document's named defaultView form", () => {
-  const { frameDocument, frameWindow } = appendFrame();
-  const element = frameDocument.createElement("div");
-  frameDocument.body.append(element);
-  const form = frameDocument.createElement("form");
-  form.name = "defaultView";
-  frameDocument.body.append(form);
-  // `Document` carries the same named-element override, measured on the three
-  // engines above: a form named `defaultView` makes the document answer that
-  // lookup with the form. happy-dom implements no document named getter, so it
-  // is emulated here. This one reaches every caller rather than only the ones
-  // handed a form, because `getWindow` resolves through the document.
-  Object.defineProperty(frameDocument, "defaultView", {
-    configurable: true,
-    value: form,
-  });
-
-  expect(getWindow(element)).toBe(frameWindow);
-});
-
-// The same getter answers with a real window when the element it names is a
-// frame, so the resolved view has to own the document back rather than merely
-// be a window. Measured on the three engines above.
+// A document's named getter answers with a real window when the element it
+// names is a frame, so the resolved view has to own the document back rather
+// than merely be a window.
 test("getWindow falls back when a document answers its default view with another realm's window", () => {
   const { frameWindow } = appendFrame();
   const otherDocument = document.implementation.createHTMLDocument("Other");
@@ -285,9 +230,9 @@ test("getWindow falls back when a document answers its default view with another
   expect(getWindow(element)).toBe(window);
 });
 
-// Measured on the same three engines: when that frame is cross-origin, its
-// window still answers `window` with itself and throws a `SecurityError` for
-// `document`, so refusing to answer has to count as owning another document.
+// When that frame is cross-origin, its window still answers `window` with
+// itself and throws a `SecurityError` for `document`, so refusing to answer has
+// to count as owning another document.
 // The environment has no cross-origin frames, so the refusal is emulated.
 test("getWindow falls back when the view it resolves refuses to report its document", () => {
   const refusingView = {
@@ -308,6 +253,24 @@ test("getWindow falls back when the view it resolves refuses to report its docum
   expect(getWindow(element)).toBe(window);
 });
 
+// Validating through the read a named element answers would reject the document
+// every element in it belongs to, which is why `isDocument` takes the accessor.
+// https://github.com/ariakit/ariakit/pull/7213#discussion_r3816584472
+test("getDocument resolves an element whose document answers nodeType with an element", () => {
+  const otherDocument = document.implementation.createHTMLDocument("Other");
+  const element = otherDocument.createElement("div");
+  otherDocument.body.append(element);
+  const form = otherDocument.createElement("form");
+  form.name = "nodeType";
+  otherDocument.body.append(form);
+  Object.defineProperty(otherDocument, "nodeType", {
+    configurable: true,
+    value: form,
+  });
+
+  expect(getDocument(element)).toBe(otherDocument);
+});
+
 // A `Document` is a `Node` whose `ownerDocument` is `null`, so resolving one
 // through that member falls through to the ambient document. Measured on
 // Chromium 151, Firefox 153, and WebKit 26.5: both helpers report the top-level
@@ -324,6 +287,25 @@ test("getWindow resolves a document from another realm to its own view", () => {
   const { frameDocument, frameWindow } = appendFrame();
 
   expect(getWindow(frameDocument)).toBe(frameWindow);
+});
+
+// A named form and the focused element are both elements, so no value tells
+// them apart and `getActiveElement` reads the accessor instead.
+// https://github.com/ariakit/ariakit/issues/7228#issuecomment-5359605589
+test("getActiveElement ignores a document's named activeElement form", () => {
+  const { frameDocument } = appendFrame();
+  const button = frameDocument.createElement("button");
+  frameDocument.body.append(button);
+  const form = frameDocument.createElement("form");
+  form.name = "activeElement";
+  frameDocument.body.append(form);
+  button.focus();
+  Object.defineProperty(frameDocument, "activeElement", {
+    configurable: true,
+    value: form,
+  });
+
+  expect(getActiveElement(button)).toBe(button);
 });
 
 test("setSelectionRange skips input types that do not support text selection", () => {

--- a/packages/ariakit-utils/src/dom.ts
+++ b/packages/ariakit-utils/src/dom.ts
@@ -18,15 +18,45 @@ function checkIsBrowser() {
   return typeof window !== "undefined" && !!window.document?.createElement;
 }
 
-// A form exposes its controls as named properties that override built-ins, and
-// a document does the same for the elements it names, so any member read while
-// resolving a realm can answer with one of those instead: a control named
-// `self` makes a form answer the window test, one named `ownerDocument` makes
-// it answer the document lookup, and a form named `defaultView` makes a
-// document answer the window lookup. The two guards below check what came back
-// rather than trusting the member it came from.
+// A form exposes its listed controls as named properties that override
+// built-ins, and a document does the same for the elements it names, so a
+// member read on either can answer with an element instead of the value the
+// interface declares. Where the helper can tell from the value that it got an
+// element, it does, and answers safely rather than accurately. An accessor is
+// reserved for the reads where that is impossible.
 // https://github.com/ariakit/ariakit/issues/7201
-// https://github.com/ariakit/ariakit/issues/7215
+
+// The two accessors below sit at different prototype depths, and the depths
+// differ per DOM implementation, so walk the chain rather than read one
+// prototype. Resolved from the live document because `canUseDOM` does not prove
+// the `Node` and `Document` globals exist.
+function lookupGetter(prototype: object, name: string) {
+  let target: object | null = prototype;
+  while (target) {
+    const descriptor = Object.getOwnPropertyDescriptor(target, name);
+    // oxlint-disable-next-line typescript/unbound-method -- the receiver is supplied explicitly at every call site
+    if (descriptor?.get) return descriptor.get;
+    target = Object.getPrototypeOf(target);
+  }
+  return undefined;
+}
+
+// The read that would do the checking is the one a named element answers, so a
+// document naming an element `nodeType` would be rejected as a document and
+// every element in that frame would resolve to the ambient realm.
+// https://github.com/ariakit/ariakit/pull/7213#discussion_r3816584472
+const nodeTypeGetter = canUseDOM
+  ? lookupGetter(Object.getPrototypeOf(window.document), "nodeType")
+  : undefined;
+
+// A named form and the focused element are both elements, so no value tells
+// them apart, and the wrong answer is silent rather than a throw the developer
+// can act on. Other collisions are the application's to fix, by giving the
+// control a different `name` and `id`, since a form matches on either.
+// https://github.com/ariakit/ariakit/issues/7228#issuecomment-5359605589
+const activeElementGetter = canUseDOM
+  ? lookupGetter(Object.getPrototypeOf(window.document), "activeElement")
+  : undefined;
 
 // Typed the way `document.defaultView` is, because the interfaces a caller
 // reads off a window, such as `PointerEvent`, are globals rather than members
@@ -36,17 +66,6 @@ function isWindow(value: unknown): value is Window & typeof globalThis {
   // A window is the only object that is its own `window`.
   return (value as Window).window === value;
 }
-
-// Taken from the prototype because a document names its own elements too, so
-// one holding an element named `nodeType` answers that read with it. The getter
-// bypasses that lookup and is brand-checked against the interface rather than
-// the realm, so it still answers for a node belonging to a frame.
-// https://github.com/ariakit/ariakit/pull/7213#discussion_r3816584472
-const nodeTypeGetter =
-  typeof Node === "undefined"
-    ? undefined
-    : // oxlint-disable-next-line typescript/unbound-method -- the receiver is supplied explicitly below
-      Object.getOwnPropertyDescriptor(Node.prototype, "nodeType")?.get;
 
 function isDocument(value: unknown): value is Document {
   if (!value) return false;
@@ -58,12 +77,6 @@ function isDocument(value: unknown): value is Document {
     // The brand check rejects anything that is not a node.
     return false;
   }
-}
-
-// Start at the prototype to bypass named properties while keeping `value` as
-// the getter receiver, including for values from another realm.
-function getDOMProperty(value: object, name: string) {
-  return Reflect.get(Object.getPrototypeOf(value), name, value);
 }
 
 function ownsDocument(
@@ -88,8 +101,6 @@ export function getDocument(node?: Window | Document | Node | null): Document {
   if (isWindow(node)) return node.document;
   const nodeDocument = (node as Node).ownerDocument;
   if (isDocument(nodeDocument)) return nodeDocument;
-  const unshadowedDocument = getDOMProperty(node, "ownerDocument");
-  if (isDocument(unshadowedDocument)) return unshadowedDocument;
   return document;
 }
 
@@ -106,12 +117,10 @@ export function getWindow(
   // Being a window is not enough, because the named getter answers with the
   // window of an `<iframe name="defaultView">`, which is a real window from
   // another realm. A window is only this document's view when it owns it back,
-  // and `Window.document` cannot be shadowed the way `Document` members can.
+  // and that check reads no member a named element can answer.
   if (isWindow(defaultView) && ownsDocument(defaultView, nodeDocument)) {
     return defaultView;
   }
-  const unshadowedView = getDOMProperty(nodeDocument, "defaultView");
-  if (isWindow(unshadowedView)) return unshadowedView;
   return window;
 }
 
@@ -122,7 +131,10 @@ export function getActiveElement(
   node?: Node | null,
   activeDescendant = false,
 ): HTMLElement | null {
-  const { activeElement } = getDocument(node);
+  const ownerDocument = getDocument(node);
+  const activeElement = activeElementGetter
+    ? (activeElementGetter.call(ownerDocument) as Element | null)
+    : ownerDocument.activeElement;
   if (!activeElement?.nodeName) {
     // In IE11, activeElement might be an empty object if we're interacting
     // with elements inside of an iframe.
@@ -180,14 +192,10 @@ export function contains(parent: Node, child: Node): boolean {
 export function isElement(
   target: EventTarget | null | undefined,
 ): target is Element {
-  // Node.ELEMENT_NODE === 1.
-  // Named-property collisions are objects, so numeric reads stay genuine.
-  const nodeType = (target as Node | null)?.nodeType;
-  return (
-    nodeType === 1 ||
-    (typeof nodeType === "object" &&
-      getDOMProperty(target as object, "nodeType") === 1)
-  );
+  // Reading `nodeType` on a non-node target yields `undefined`. The numeric
+  // literal (Node.ELEMENT_NODE === 1) avoids referencing the `Node` global, so
+  // the guard stays safe even if it's ever evaluated during SSR.
+  return (target as Node | null)?.nodeType === 1;
 }
 
 /**
@@ -203,13 +211,7 @@ export function isElement(
  * }
  */
 export function isNode(target: EventTarget | null | undefined): target is Node {
-  // Named-property collisions are objects, so numeric reads stay genuine.
-  const nodeType = (target as Node | null)?.nodeType;
-  return (
-    typeof nodeType === "number" ||
-    (typeof nodeType === "object" &&
-      typeof getDOMProperty(target as object, "nodeType") === "number")
-  );
+  return typeof (target as Node | null)?.nodeType === "number";
 }
 
 /**


### PR DESCRIPTION
## Motivation

HTML exposes named properties on `HTMLFormElement` and `Document` through WebIDL's [`[LegacyOverrideBuiltIns]`](https://webidl.spec.whatwg.org/#LegacyOverrideBuiltIns), so a control named after a DOM member makes the form answer with that control. The behavior is deliberate and permanent: in [whatwg/html#4112](https://github.com/whatwg/html/issues/4112) it is described as "entirely a product of web compatibility, and cannot be changed".

[#7213](https://github.com/ariakit/ariakit/pull/7213), [#7217](https://github.com/ariakit/ariakit/pull/7217), and [#7227](https://github.com/ariakit/ariakit/pull/7227) grew a prototype-read defense around that behavior. Weighing it again, most of it is not worth carrying.

Where a collision makes Ariakit throw, the developer gets a stack trace naming the read, and renaming the field fixes it. The members being defended are also implausible field names: nobody calls a form control `checkVisibility`, `getClientRects`, or `nodeType`. Full coverage would mean auditing roughly 250 DOM member reads across the packages, and every new read would reopen the question.

Almost no comparable library defends against this. `tabbable`, `focus-trap`, Floating UI, Radix UI, Headless UI, Testing Library, Lit, Vue, and React DOM all read these members directly. jQuery [closed their report](https://github.com/jquery/jquery/issues/3691) as out of scope.

## Solution

Remove `getDOMProperty`, the per-call prototype read, and with it the `ownerDocument` and `defaultView` fallbacks and the `isElement` and `isNode` fallbacks.

Keep the two cached accessors, because each covers a read the helper cannot check by value:

- `nodeType`, because the read that would do the checking is the one a named element answers. A document naming an element `nodeType` would be rejected as a document, and every element in that frame would resolve to the ambient realm. This is `main`'s existing `nodeTypeGetter`, resolved through the same walk as the new one.
- `activeElement`, because a named form and the focused element are both elements, so no value tells them apart, and the wrong answer is silent rather than a throw.

Keep the value guards from [#7213](https://github.com/ariakit/ariakit/pull/7213) too. `isWindow` compares identity and `ownsDocument` compares documents, so both reject a named element without reading through a prototype.

## Contract

`@ariakit/utils` DOM helpers defend against a named-property collision only where the helper cannot detect the wrong answer from the value and the failure would be silent. Every other collision, whether it throws or degrades to a safe `false`, is the application's to fix by renaming the control. A form matches its controls by `name` **or** `id`, and the past names map keeps answering after the attribute is removed, so both have to change in the markup.

The retained guards are what still resolve a form whose control is named `self` or `document`, and what keeps the [`Portal`](https://ariakit.com/reference/portal) and [`Combobox`](https://ariakit.com/reference/combobox) fix from [#7227](https://github.com/ariakit/ariakit/pull/7227) working, so `app/src/sandbox/dialog-form-7201/` and `app/src/sandbox/portal-combobox-7218/` stay green unchanged.

## Verification

`pnpm tsc`, `pnpm lint`, and `pnpm test` are clean, with 1915 tests passing across 268 files.

The new `app/src/sandbox/dialog-form-named-active-element/` sandbox is a red check: with the accessor reverted to `ownerDocument.activeElement`, focus fails to return to the opener in Chrome, Firefox, and Safari; with it in place all three pass. The unit cases for `activeElement` and for `nodeType` are red the same way. `dialog-form-7201`, `portal-combobox-7218`, and `focusable-click-focus` were rerun in all three desktop projects to confirm the retained behavior survives the revert.

## Review gate reassessment

<details>
<summary>Cycle 3: Continue, with the boundary written into the code</summary>

**Assessment**

Severity and scope: the retained read fixes one silent, page-wide wrong answer. `getActiveElement` backs focus tracking for `Composite`, `Dialog`, `Menu`, and `Tab`, so a document holding `<form name="activeElement">` loses focus restoration with no error. Every other collision in this family either throws, which names the offending field for the developer, or degrades to a safe fallback.

Frequency: low. It needs an `embed`, `form`, `iframe`, `img`, or `object` element whose `name` is literally `activeElement`.

Complexity: `packages/ariakit-utils/src/dom.ts` is net `-10` lines and its test file net `-33`. The new machinery is `lookupGetter`, one module constant, and one ternary, with no public API added. The expensive parts, a per-call `Reflect.get` through the prototype and an untested `typeof === "object"` fallback in `isElement` that ran for every observed event, are what the revert removes.

Cause of the repeated cycles: implementation findings went 2, then 0, then 0. Rounds 2 and 3 landed entirely on comments, changeset wording, and two claims that did not survive verification. Reverting heavily annotated code rewrites factual claims rather than deleting them, and that prose is where the cycles concentrated, not the design.

**Decision**

Continue. Reverting the accessor as well would discard a three-engine red check to save roughly twenty lines, and would leave a demonstrated `Dialog` focus bug unfixed.

The justification is narrowed and now stated in the code, because "defend the silent cases" is too broad to hold: `<form name="body">` is silent too, and `document.body` is read unguarded in about a dozen places. The rule that survives is that a value check is preferred because it costs nothing, and an accessor is reserved for a member where no value check can work. `isWindow` and `isDocument` reject a named control by what came back, and a named `body` would answer with a form rather than a `BODY` element. Only `activeElement` admits no such test, since any element can legitimately be focused.

Intentionally unsupported: `isElement` and `isNode` answer `false` for a form whose control is named `nodeType`; `getDocument` and `getWindow` resolve to the ambient realm rather than the frame's when `ownerDocument` or `defaultView` is shadowed; `isButton` and `isVisible` throw. Renaming the control is the supported fix in each case.

Registered follow-up: https://github.com/ariakit/ariakit/issues/7230.

</details>

<details>
<summary>Cycle 6: Continue, and stop asserting platform facts in comments</summary>

**Assessment**

Findings by round: code 2, 0, 0, 0, 1, 0; prose 4, 3, 3, 2, 2, 2. The design has been stable since round 1. Round 5 found the one real defect, a regression below the pre-hardening baseline, and it is fixed and covered.

What keeps producing findings is the comment surface. This change carried roughly a dozen falsifiable platform assertions in comments, engine version pins, per-implementation prototype depths, and which member happy-dom does or does not clobber. None of them is covered by a test, and several were wrong. The `lookupGetter` comment was the serious case: it claimed browsers alias `HTMLDocument` to `Document` so a single read would find both accessors, which measurement contradicts in all three engines. Acting on that comment would have collapsed the walk and silently restored exactly the regression round 5 caught.

**Decision**

Continue the implementation, and narrow the comments to intent plus a permalink. Engine versions and prototype depths are dated evidence and now live in this description and in the linked threads, where they carry a date, rather than in source that outlives them. The rationale a reader needs, why an accessor instead of a value check, stays in the code.

The contract above is now stated once, so the boundary can be cited rather than relitigated.

Registered follow-up: https://github.com/ariakit/ariakit/issues/7230, kept open because those three reads are the same member on the same silent-failure path, and closing that gap is bounded work rather than an open-ended audit.

</details>

## Notes

`getElementId` was built for `element.id` and then removed. `id` is the one genuinely ordinary field name Ariakit reads, and `form.id` is measurably clobbered on a live mounted Ariakit form, but no component-level failure could be demonstrated: `Portal` reads it in a layout effect before the form's controls mount, and the remaining reads need an exotic composition such as a nested composite item rendered as a form. By the standard applied to the rest of this revert it does not ship.

On the alternative of reading `element.getAttribute("id")`, measured in Chromium: it is the worst of the three options. It does not close the class, because `getAttribute` is itself clobberable, so it converts a silent wrong value into a `TypeError` for a form whose control is named `getAttribute`. It is around 2.7 times slower than either `element.id` or a cached getter. And it returns `null` rather than `""` for a missing id, which changes the type at every call site. If `id` is ever defended, the shape is a cached `Element.prototype` getter.

[#7225](https://github.com/ariakit/ariakit/issues/7225) and [#7228](https://github.com/ariakit/ariakit/issues/7228) are closed as not planned alongside this change, and [#7226](https://github.com/ariakit/ariakit/pull/7226) is closed unmerged.
