### PR TITLE
Adopt React hook contract lint rules

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -15,13 +15,11 @@ export default defineConfig({
     // Adopt these React Compiler checks separately from this update.
     // https://github.com/ariakit/ariakit/issues/7240
     "react/exhaustive-effect-dependencies": "off",
-    "react/hooks": "off",
     "react/immutability": "off",
     "react/memo-dependencies": "off",
     "react/purity": "off",
     "react/refs": "off",
     "react/set-state-in-effect": "off",
-    "react/use-memo": "off",
     // Type-only exports are incorrectly reported as missing.
     // https://github.com/oxc-project/oxc/issues/13258
     "import/namespace": "off",

--- a/packages/ariakit-react-components/src/dialog/utils/use-prevent-body-scroll.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/use-prevent-body-scroll.ts
@@ -8,6 +8,12 @@ import { useRootDialog } from "./use-root-dialog.ts";
 // Only iOS doesn't respect `overflow: hidden` on document.body.
 const isIOS = isApple() && !isMac();
 
+// Use layout timing to measure and lock before paint. Keep iOS passive
+// because its scroll capture/restore depends on dialog focus timing. isIOS
+// is session-stable, so the hook choice cannot change between renders.
+// https://github.com/ariakit/ariakit/pull/6288
+const useLockEffect = isIOS ? useEffect : useSafeLayoutEffect;
+
 // The CSS global isn't part of the Window type, even though browsers expose
 // it on every window object.
 interface WindowWithCSS extends Window {
@@ -37,12 +43,6 @@ export function usePreventBodyScroll(
     contentId,
     enabled,
   });
-
-  // Use layout timing to measure and lock before paint. Keep iOS passive
-  // because its scroll capture/restore depends on dialog focus timing. isIOS
-  // is session-stable, so the hook choice cannot change between renders.
-  // https://github.com/ariakit/ariakit/pull/6288
-  const useLockEffect = isIOS ? useEffect : useSafeLayoutEffect;
 
   useLockEffect(() => {
     if (!isRootDialog()) return;

--- a/packages/ariakit-react-components/src/form/form-store.ts
+++ b/packages/ariakit-react-components/src/form/form-store.ts
@@ -105,12 +105,14 @@ export function useFormStoreProps<T extends FormStoreHookStore>(
   useStoreProps(collectionStore, props, "touched", "setTouched");
 
   const useValue = useCallback<FormStore["useValue"]>(
+    // oxlint-disable-next-line react/hooks -- public hook method
     (name) => useFormValue(collectionStore, name),
     [collectionStore],
   );
 
   const useValidate = useCallback<FormStore["useValidate"]>(
     (callback) => {
+      // oxlint-disable-next-line react/hooks -- public hook method
       useFormValidate(collectionStore, callback);
     },
     [collectionStore],
@@ -118,6 +120,7 @@ export function useFormStoreProps<T extends FormStoreHookStore>(
 
   const useSubmit = useCallback<FormStore["useSubmit"]>(
     (callback) => {
+      // oxlint-disable-next-line react/hooks -- public hook method
       useFormSubmit(collectionStore, callback);
     },
     [collectionStore],

--- a/packages/ariakit-react-store/src/index.tsx
+++ b/packages/ariakit-react-store/src/index.tsx
@@ -447,6 +447,7 @@ export function useStore<T extends CoreStore, P>(
   useSafeLayoutEffect(() => init(store), [store]);
 
   const useState: UseState<StoreState<T>> = React.useCallback<AnyFunction>(
+    // oxlint-disable-next-line react/hooks -- public hook method
     (keyOrSelector) => useStoreState(store, keyOrSelector),
     [store],
   );

--- a/packages/ariakit-react-utils/src/hooks.ts
+++ b/packages/ariakit-react-utils/src/hooks.ts
@@ -29,11 +29,24 @@ import {
 import { setRef } from "./misc.ts";
 import type { WrapElement } from "./types.ts";
 
+interface ReactWithOptionalHooks {
+  useId?: () => string;
+  useDeferredValue?: <T>(value: T) => T;
+  useInsertionEffect?: (
+    effect: EffectCallback,
+    dependencies?: DependencyList,
+  ) => void;
+}
+
 // See https://github.com/webpack/webpack/issues/14814
-const _React = { ...React };
+const _React: ReactWithOptionalHooks = { ...React };
 const useReactId = _React.useId;
 const useReactDeferredValue = _React.useDeferredValue;
 const useReactInsertionEffect = _React.useInsertionEffect;
+
+// Select once per loaded React version so every render uses the same hook.
+const useEventUpdate =
+  useReactInsertionEffect ?? ((callback: () => void) => callback());
 
 interface MergedRefEffect {
   ref: Ref<any>;
@@ -87,13 +100,9 @@ export function useEvent<T extends AnyFunction>(callback?: T) {
   const ref = useRef<AnyFunction | undefined>(() => {
     throw new Error("Cannot call an event handler while rendering.");
   });
-  if (useReactInsertionEffect) {
-    useReactInsertionEffect(() => {
-      ref.current = callback;
-    });
-  } else {
+  useEventUpdate(() => {
     ref.current = callback;
-  }
+  });
   return useCallback<AnyFunction>((...args) => ref.current?.(...args), []) as T;
 }
 
@@ -161,19 +170,12 @@ export function useMergeRefs(...refs: Array<Ref<any> | undefined>) {
         }
       };
     };
-    // oxlint-disable-next-line exhaustive-deps
+    // Variadic refs prevent using an array literal for the dependencies.
+    // oxlint-disable-next-line exhaustive-deps, react/use-memo -- variadic refs
   }, refs);
 }
 
-/**
- * Generates a unique ID. Uses React's useId if available.
- */
-export function useId(defaultId?: string): string | undefined {
-  if (useReactId) {
-    const reactId = useReactId();
-    if (defaultId) return defaultId;
-    return reactId;
-  }
+function useIdPolyfill(defaultId?: string): string | undefined {
   const [id, setId] = useState(defaultId);
   useSafeLayoutEffect(() => {
     if (defaultId || id) return;
@@ -183,19 +185,40 @@ export function useId(defaultId?: string): string | undefined {
   return defaultId || id;
 }
 
+function useReactIdWithDefault(defaultId?: string): string | undefined {
+  // This implementation is selected only when React provides useId.
+  const id = useReactId!();
+  return defaultId || id;
+}
+
+// Select once per loaded React version so every render uses the same hook.
+const useCompatibleId = useReactId ? useReactIdWithDefault : useIdPolyfill;
+
 /**
- * Uses React's useDeferredValue if available.
+ * Generates a unique ID. Uses React's useId if available.
  */
-export function useDeferredValue<T>(value: T): T {
-  if (useReactDeferredValue) {
-    return useReactDeferredValue(value);
-  }
+export function useId(defaultId?: string): string | undefined {
+  return useCompatibleId(defaultId);
+}
+
+function useDeferredValuePolyfill<T>(value: T): T {
   const [deferredValue, setDeferredValue] = useState(value);
   useEffect(() => {
     const raf = requestAnimationFrame(() => setDeferredValue(value));
     return () => cancelAnimationFrame(raf);
   }, [value]);
   return deferredValue;
+}
+
+// Select once per loaded React version so every render uses the same hook.
+const useCompatibleDeferredValue =
+  useReactDeferredValue ?? useDeferredValuePolyfill;
+
+/**
+ * Uses React's useDeferredValue if available.
+ */
+export function useDeferredValue<T>(value: T): T {
+  return useCompatibleDeferredValue(value);
 }
 
 /**
@@ -353,7 +376,8 @@ export function useWrapElement<P>(
       }
       return callback(element);
     },
-    // oxlint-disable-next-line exhaustive-deps
+    // Caller-provided dependencies prevent using an array literal here.
+    // oxlint-disable-next-line exhaustive-deps, react/use-memo -- public deps API
     [...deps, props.wrapElement],
   );
 


### PR DESCRIPTION
## Motivation

Oxlint 1.79 exposes React Compiler hook-contract diagnostics in shipped Ariakit packages. Ariakit currently disables `react/hooks` and `react/use-memo` globally, which prevents these checks from protecting otherwise clean source.

This is the hook-contract portion of #7240. It must preserve the public API and compatibility with React 17, React 18, and React 19.

## Solution

Select platform-specific and React-version-specific hook implementations once at module load, so each loaded environment uses one stable hook contract.

```ts
const useLockEffect = isIOS ? useEffect : useSafeLayoutEffect;
const useCompatibleDeferredValue =
  useReactDeferredValue ?? useDeferredValuePolyfill;
```

Keep the deprecated store hook methods with narrow `react/hooks` suppressions because their public object-method API intentionally calls hooks but cannot be modeled by the compiler rule. Keep the variadic dependency APIs with narrow, documented `react/use-memo` suppressions because their dependency lists cannot be array literals.

Remove only the `react/hooks` and `react/use-memo` global `off` entries. The other rules tracked by #7240 remain disabled.

No changeset is included because this change preserves shipped behavior, public signatures, and public types.

## Testing

- `pnpm lint`
- `pnpm tsc`
- `pnpm test` (1,917 tests)
- `pnpm test-react18` (1,039 tests)
- Focused React 19 and React 18 form and store tests
- `pnpm build`

Refs #7240