### PR TITLE
Adopt React dependency and purity lint rules

### DIFF
--- a/app/src/components/code-block.react.tsx
+++ b/app/src/components/code-block.react.tsx
@@ -248,6 +248,7 @@ export function CodeBlockPreviewIframe({
 
   React.useEffect(() => {
     setLoaded(false);
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- iframe lifecycle signal
   }, [previewUrl, setLoaded]);
 
   React.useEffect(() => {
@@ -457,6 +458,7 @@ export function CodeBlockPreviewIframe({
         true,
       );
     };
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- iframe lifecycle signal
   }, [previewUrl, clickAndWait, scrollTop, fullscreen, setLoaded]);
 
   return (

--- a/app/src/sandbox/combobox-textarea/index.react.tsx
+++ b/app/src/sandbox/combobox-textarea/index.react.tsx
@@ -43,6 +43,7 @@ export default function Example() {
   // the textarea value have shifted the trigger character.
   React.useEffect(() => {
     return combobox.render();
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- textarea layout signal
   }, [combobox, value]);
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/app/src/sandbox/store-keyed-subscriptions/index.react.tsx
+++ b/app/src/sandbox/store-keyed-subscriptions/index.react.tsx
@@ -314,6 +314,7 @@ function StorePropsSetter({ store }: StoreProps) {
     // The count is observable only after useStoreProps updates subscriptions.
     // oxlint-disable-next-line react/set-state-in-effect
     setActiveSubscriptions(getActiveSubscriptions());
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- subscription commit signal
   }, [activeSetter, getActiveSubscriptions]);
 
   return (

--- a/app/src/sandbox/store-keyed-subscriptions/test.ts
+++ b/app/src/sandbox/store-keyed-subscriptions/test.ts
@@ -14,7 +14,10 @@ test("supports keyed selector types", () => {
   const countStore = createStore({ kind: "count" as const, count: 0 });
   const labelStore = createStore({ kind: "label" as const, label: "" });
 
-  const useCheckTypes = (optionalStore?: typeof store) => {
+  const useCheckTypes = (
+    optionalStore?: typeof store,
+    unionStore: typeof countStore | typeof labelStore = countStore,
+  ) => {
     expectTypeOf(useStoreState(store, "key")).toEqualTypeOf<string>();
     expectTypeOf(
       useStoreState(store, (state) => state.key),
@@ -62,8 +65,6 @@ test("supports keyed selector types", () => {
       derived: string | undefined;
     }>();
 
-    const unionStore: typeof countStore | typeof labelStore =
-      Math.random() > 0.5 ? countStore : labelStore;
     const unionValue = useStoreState(
       unionStore,
       ["kind", "count", "label"],
@@ -92,7 +93,10 @@ test("supports keyed selector types", () => {
   };
 
   expectTypeOf(useCheckTypes).toEqualTypeOf<
-    (optionalStore?: typeof store) => void
+    (
+      optionalStore?: typeof store,
+      unionStore?: typeof countStore | typeof labelStore,
+    ) => void
   >();
 });
 

--- a/examples/combobox-textarea/index.react.tsx
+++ b/examples/combobox-textarea/index.react.tsx
@@ -44,6 +44,7 @@ export default function Example() {
   // the textarea value have shifted the trigger character.
   React.useEffect(() => {
     return combobox.render();
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- textarea layout signal
   }, [combobox, value]);
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -14,10 +14,7 @@ export default defineConfig({
   rules: {
     // Adopt these React Compiler checks separately from this update.
     // https://github.com/ariakit/ariakit/issues/7240
-    "react/exhaustive-effect-dependencies": "off",
     "react/immutability": "off",
-    "react/memo-dependencies": "off",
-    "react/purity": "off",
     "react/refs": "off",
     // Type-only exports are incorrectly reported as missing.
     // https://github.com/oxc-project/oxc/issues/13258

--- a/packages/ariakit-react-components/src/collection/collection-renderer.tsx
+++ b/packages/ariakit-react-components/src/collection/collection-renderer.tsx
@@ -681,6 +681,7 @@ export function useCollectionRenderer<T extends Item = any>({
       // oxlint-disable-next-line react/set-state-in-effect
       setData(nextData);
     }
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- element registration signal
   }, [elementsUpdated, itemSize, baseId, items, data, computeData]);
 
   const [ownScroller, ownScrollerRef, ownScrollerController] = useScroller(
@@ -757,6 +758,7 @@ export function useCollectionRenderer<T extends Item = any>({
     });
     // oxlint-disable-next-line exhaustive-deps
   }, [
+    // oxlint-disable-next-line react/memo-dependencies -- element registration signal
     elementsUpdated,
     scroller,
     scrollerRef,

--- a/packages/ariakit-react-components/src/composite/composite.tsx
+++ b/packages/ariakit-react-components/src/composite/composite.tsx
@@ -165,6 +165,7 @@ const CompositeFocusOnMove = memo(function CompositeFocusOnMove({
       focus: true,
       scrollIntoView,
     });
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- store invalidation signal
   }, [store, moves, focusOnMove, compositeElement, present, scrollIntoView]);
 
   // If composite.move(null) has been called, the composite container should

--- a/packages/ariakit-react-components/src/dialog/utils/use-root-dialog.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/use-root-dialog.ts
@@ -24,7 +24,8 @@ export function useRootDialog({
     const { body } = getDocument(contentElement);
     const id = body.getAttribute(attribute);
     return !id || id === contentId;
-    // oxlint-disable-next-line exhaustive-deps
+    // `updated` changes the callback identity after the observer retries.
+    // oxlint-disable-next-line exhaustive-deps, react/memo-dependencies -- invalidation signal
   }, [updated, enabled, contentElement, attribute, contentId]);
 
   // Run in the layout phase so consumers that also moved to the layout phase

--- a/packages/ariakit-react-components/src/form/form-store.ts
+++ b/packages/ariakit-react-components/src/form/form-store.ts
@@ -63,6 +63,7 @@ export function useFormValidate<T extends FormStoreValues = FormStoreValues>(
   const items = useStoreState(store, "items");
   useEffect(
     () => store.onValidate(eventCallback),
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- callback order invalidation
     [store, items, eventCallback],
   );
 }
@@ -90,7 +91,11 @@ export function useFormSubmit<T extends FormStoreValues = FormStoreValues>(
   const eventCallback = useEvent(callback);
   // Same logic as useFormValidate.
   const items = useStoreState(store, "items");
-  useEffect(() => store.onSubmit(eventCallback), [store, items, eventCallback]);
+  useEffect(
+    () => store.onSubmit(eventCallback),
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- callback order invalidation
+    [store, items, eventCallback],
+  );
 }
 
 export function useFormStoreProps<T extends FormStoreHookStore>(


### PR DESCRIPTION
## Motivation

Issue #7240 tracks adopting React Compiler lint rules that were previously disabled as a group. After the hook-contract and effect-state work, the dependency and purity rules still reported diagnostics.

These checks should run globally so new dependency mistakes are reported and impure render logic fails lint. Some current dependency entries are deliberate invalidation signals, so removing them would change behavior.

This work follows #7242, which provides the effect-state baseline.

Part of #7240.

## Solution

Enable `react/exhaustive-effect-dependencies`, `react/memo-dependencies`, and `react/purity` globally by removing their `off` overrides. Keep deliberate invalidation dependencies and document each narrow suppression at the affected hook. For example:

```tsx
// oxlint-disable-next-line react/exhaustive-effect-dependencies -- textarea layout signal
}, [combobox, value]);
```

Replace random union selection in the type-oriented fixture with a deterministic optional input:

```tsx
const useCheckTypes = (
  optionalStore?: typeof store,
  unionStore: typeof countStore | typeof labelStore = countStore,
) => {
  // Type assertions.
};
```

This preserves union-store type coverage without calling `Math.random()` from a hook-like function. No changeset is included because shipped runtime behavior does not change.
