### PR TITLE
Adopt React ref and immutability lint rules

### DIFF
--- a/app/src/lib/reference-tokenizer.test.ts
+++ b/app/src/lib/reference-tokenizer.test.ts
@@ -88,10 +88,7 @@ function createRefData(
 }
 
 function makeRef(id: string, data: RefData): CollectionEntry<"references"> {
-  // Oxlint reports this assertion inconsistently depending on the file set.
-  // https://github.com/oxc-project/oxc/issues/21752
-  // https://github.com/oxc-project/tsgolint/issues/1047
-  // oxlint-disable-next-line typescript/no-unnecessary-type-assertion -- Partial fixture.
+  // Partial fixture: only the members the tokenizer reads are populated.
   return { id, data } as unknown as CollectionEntry<"references">;
 }
 

--- a/app/src/lib/styles.ts
+++ b/app/src/lib/styles.ts
@@ -26,8 +26,10 @@ import {
   toRegexFromWildcard,
 } from "./styles-shared.ts";
 
-// The JSON import keeps its generated literal type, but the resolver needs the
-// public schema shape shared with the build script.
+// `tsconfig.node.json` reaches this file through `vitest.config.ts`, without
+// `app/env.d.ts`, so the JSON import keeps its inferred literal type there and
+// is not assignable to `StylesJson`. The app projects type it as `StylesJson`.
+// oxlint-disable-next-line no-unnecessary-type-assertion
 const styles = stylesRaw as unknown as StylesJson;
 
 export type {

--- a/app/src/lib/styles.ts
+++ b/app/src/lib/styles.ts
@@ -28,7 +28,6 @@ import {
 
 // The JSON import keeps its generated literal type, but the resolver needs the
 // public schema shape shared with the build script.
-// oxlint-disable-next-line no-unnecessary-type-assertion
 const styles = stylesRaw as unknown as StylesJson;
 
 export type {

--- a/app/src/sandbox/combobox-popover-reset-on-escape/index.react.tsx
+++ b/app/src/sandbox/combobox-popover-reset-on-escape/index.react.tsx
@@ -211,7 +211,8 @@ function RenderCounted() {
     selectOnMove: true,
   });
   const renderCount = useRef(0);
-  renderCount.current += 1;
+  // oxlint-disable-next-line react/refs -- render-count instrumentation
+  const currentRenderCount = ++renderCount.current;
 
   const props = useComboboxPopover({
     store,
@@ -228,7 +229,7 @@ function RenderCounted() {
         <Ariakit.ComboboxSelectedValue />
       </Ariakit.ComboboxSelect>
       <output aria-label="Render counted popover renders">
-        {renderCount.current}
+        {currentRenderCount}
       </output>
       <button
         type="button"

--- a/app/src/sandbox/combobox-select-open-page-scroll/index.react.tsx
+++ b/app/src/sandbox/combobox-select-open-page-scroll/index.react.tsx
@@ -1,6 +1,6 @@
 import * as Ariakit from "@ariakit/react";
 import type { CSSProperties } from "react";
-import { useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 
 const branches = [
   "main",
@@ -139,6 +139,10 @@ function SelfFocusingBranchSelect({
   trigger,
 }: SelfFocusingBranchSelectProps) {
   const combobox = Ariakit.useComboboxStore({ virtualFocus: true });
+  const setAnchorElement = useCallback(
+    (element: HTMLElement | null) => combobox.setAnchorElement(element),
+    [combobox],
+  );
   return (
     <Ariakit.ComboboxProvider store={combobox} resetValueOnHide>
       {trigger ? (
@@ -150,7 +154,7 @@ function SelfFocusingBranchSelect({
         <button
           type="button"
           tabIndex={0}
-          ref={combobox.setAnchorElement}
+          ref={setAnchorElement}
           onClick={combobox.show}
         >
           {label}

--- a/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/index.react.tsx
@@ -359,13 +359,14 @@ function Fixture({
 
 function RenderCountedComboboxItem() {
   const renderCount = useRef(0);
-  renderCount.current += 1;
+  // oxlint-disable-next-line react/refs -- render-count instrumentation
+  const currentRenderCount = ++renderCount.current;
   const props = useComboboxItem({
     value: "Apple",
     children: "Apple",
     style: { display: "block", padding: "4px 8px" },
   });
-  return <Ariakit.Role {...props} data-render-count={renderCount.current} />;
+  return <Ariakit.Role {...props} data-render-count={currentRenderCount} />;
 }
 
 function ItemRenderCountFixture() {

--- a/app/src/sandbox/menu-initial-focus-render/index.react.tsx
+++ b/app/src/sandbox/menu-initial-focus-render/index.react.tsx
@@ -8,7 +8,8 @@ interface MenuProps {
 
 function InstrumentedMenu({ store }: MenuProps) {
   const renderCount = useRef(0);
-  renderCount.current += 1;
+  // oxlint-disable-next-line react/refs -- render-count instrumentation
+  const currentRenderCount = ++renderCount.current;
 
   const props = useMenu({
     store,
@@ -22,7 +23,7 @@ function InstrumentedMenu({ store }: MenuProps) {
         <Ariakit.MenuItem>Share</Ariakit.MenuItem>
         <Ariakit.MenuItem>Delete</Ariakit.MenuItem>
       </Ariakit.Role>
-      <output aria-label="Menu renders">{renderCount.current}</output>
+      <output aria-label="Menu renders">{currentRenderCount}</output>
     </>
   );
 }
@@ -30,9 +31,10 @@ function InstrumentedMenu({ store }: MenuProps) {
 function RenderedItemsRenders({ store }: MenuProps) {
   const renderCount = useRef(0);
   Ariakit.useStoreState(store, "renderedItems");
-  renderCount.current += 1;
+  // oxlint-disable-next-line react/refs -- render-count instrumentation
+  const currentRenderCount = ++renderCount.current;
   return (
-    <output aria-label="Rendered items renders">{renderCount.current}</output>
+    <output aria-label="Rendered items renders">{currentRenderCount}</output>
   );
 }
 

--- a/app/src/sandbox/menu-slide-navigation/menu.react.tsx
+++ b/app/src/sandbox/menu-slide-navigation/menu.react.tsx
@@ -126,6 +126,7 @@ export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
           render={renderMenuButton}
         />
       ) : (
+        // oxlint-disable-next-line react/refs -- forwarded ref passed to pure render helper
         renderMenuButton({ ref, ...props })
       )}
       <Ariakit.Menu

--- a/app/src/sandbox/popover-disclosure-render/index.react.tsx
+++ b/app/src/sandbox/popover-disclosure-render/index.react.tsx
@@ -30,7 +30,8 @@ function InstrumentedPopover({
   const renderCount = useRef(0);
   const firstDisclosureRef = useRef<HTMLSpanElement>(null);
   const secondDisclosureRef = useRef<HTMLSpanElement>(null);
-  renderCount.current += 1;
+  // oxlint-disable-next-line react/refs -- render-count instrumentation
+  const currentRenderCount = ++renderCount.current;
 
   const props = usePopover({
     store,
@@ -52,7 +53,7 @@ function InstrumentedPopover({
       </Ariakit.PopoverDisclosure>
       <Ariakit.Role {...props}>
         <output aria-label={`${label} popover renders`}>
-          {renderCount.current}
+          {currentRenderCount}
         </output>
         <DisclosureElementRenders label={label} store={store} />
         <Ariakit.Button
@@ -86,10 +87,11 @@ function DisclosureElementRenders({
 }: DisclosureElementRendersProps) {
   const renderCount = useRef(0);
   Ariakit.useStoreState(store, "disclosureElement");
-  renderCount.current += 1;
+  // oxlint-disable-next-line react/refs -- render-count instrumentation
+  const currentRenderCount = ++renderCount.current;
   return (
     <output aria-label={`${label} disclosure element renders`}>
-      {renderCount.current}
+      {currentRenderCount}
     </output>
   );
 }

--- a/app/src/sandbox/store-keyed-subscriptions/index.react.tsx
+++ b/app/src/sandbox/store-keyed-subscriptions/index.react.tsx
@@ -163,6 +163,23 @@ function EmptyObjectSelector({ store, calls }: SelectorProps) {
   return null;
 }
 
+function SparseKeySelectors({ store }: StoreProps) {
+  const keys = Array<keyof TestState>(1);
+  const value = useStoreState(store, keys, (state) => state.foo);
+  const object = useStoreStateObject(store, keys, {
+    value: (state) => state.foo,
+  });
+
+  return (
+    <p>
+      Sparse selector values:{" "}
+      <output aria-label="Sparse selector values">
+        {value}:{object.value}
+      </output>
+    </p>
+  );
+}
+
 function ConditionalSelector({ store, calls }: SelectorProps) {
   const [enabled, setEnabled] = useState(false);
   const value = useStoreState(store, enabled ? ["foo"] : [], (state) => {
@@ -452,6 +469,7 @@ export default function Example() {
       <UnkeyedSelector store={store} calls={selectorCalls} />
       <EmptySelector store={store} calls={selectorCalls} />
       <EmptyObjectSelector store={store} calls={selectorCalls} />
+      <SparseKeySelectors store={store} />
       <ConditionalSelector store={store} calls={selectorCalls} />
       <DirectValues store={store} />
       <MixedValues store={store} />

--- a/app/src/sandbox/store-keyed-subscriptions/index.react.tsx
+++ b/app/src/sandbox/store-keyed-subscriptions/index.react.tsx
@@ -98,11 +98,13 @@ interface SelectorProps extends StoreProps {
 
 function KeyedSelectors({ store, calls }: SelectorProps) {
   const value = useStoreState(store, ["foo"], (state) => {
+    // oxlint-disable-next-line react/immutability -- selector call counter
     calls.state += 1;
     return state.foo;
   });
   const object = useStoreStateObject(store, ["foo"], {
     value: (state) => {
+      // oxlint-disable-next-line react/immutability -- selector call counter
       calls.object += 1;
       return state.foo;
     },
@@ -134,6 +136,7 @@ function KeyedSelectors({ store, calls }: SelectorProps) {
 
 function EmptySelector({ store, calls }: SelectorProps) {
   useStoreState(store, [], () => {
+    // oxlint-disable-next-line react/immutability -- selector call counter
     calls.empty += 1;
     return null;
   });
@@ -142,6 +145,7 @@ function EmptySelector({ store, calls }: SelectorProps) {
 
 function UnkeyedSelector({ store, calls }: SelectorProps) {
   useStoreState(store, (state) => {
+    // oxlint-disable-next-line react/immutability -- selector call counter
     calls.unkeyed += 1;
     return state.foo;
   });
@@ -151,6 +155,7 @@ function UnkeyedSelector({ store, calls }: SelectorProps) {
 function EmptyObjectSelector({ store, calls }: SelectorProps) {
   useStoreStateObject(store, [], {
     value: () => {
+      // oxlint-disable-next-line react/immutability -- selector call counter
       calls.emptyObject += 1;
       return null;
     },
@@ -161,6 +166,7 @@ function EmptyObjectSelector({ store, calls }: SelectorProps) {
 function ConditionalSelector({ store, calls }: SelectorProps) {
   const [enabled, setEnabled] = useState(false);
   const value = useStoreState(store, enabled ? ["foo"] : [], (state) => {
+    // oxlint-disable-next-line react/immutability -- selector call counter
     calls.conditional += 1;
     return enabled ? state.foo : null;
   });
@@ -437,20 +443,22 @@ export default function Example() {
     emptyObject: 0,
     conditional: 0,
   });
+  // oxlint-disable-next-line react/refs -- selector call instrumentation
+  const selectorCalls = calls.current;
 
   return (
     <>
-      <KeyedSelectors store={store} calls={calls.current} />
-      <UnkeyedSelector store={store} calls={calls.current} />
-      <EmptySelector store={store} calls={calls.current} />
-      <EmptyObjectSelector store={store} calls={calls.current} />
-      <ConditionalSelector store={store} calls={calls.current} />
+      <KeyedSelectors store={store} calls={selectorCalls} />
+      <UnkeyedSelector store={store} calls={selectorCalls} />
+      <EmptySelector store={store} calls={selectorCalls} />
+      <EmptyObjectSelector store={store} calls={selectorCalls} />
+      <ConditionalSelector store={store} calls={selectorCalls} />
       <DirectValues store={store} />
       <MixedValues store={store} />
       <DynamicSelectors store={store} />
       <OptionalSelector store={store} />
       <StorePropsSetter store={store} />
-      <Controls store={store} calls={calls.current} />
+      <Controls store={store} calls={selectorCalls} />
     </>
   );
 }

--- a/app/src/sandbox/store-keyed-subscriptions/test-chrome.ts
+++ b/app/src/sandbox/store-keyed-subscriptions/test-chrome.ts
@@ -17,6 +17,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test
       .expect(q.status("useStoreStateObject calls"))
       .not.toHaveText("0");
+    // https://github.com/ariakit/ariakit/issues/7240
+    await test.expect(q.status("Sparse selector values")).toHaveText("0:0");
     test.expect(hydrationErrors).toEqual([]);
   });
 

--- a/app/src/sandbox/store-keyed-subscriptions/test.ts
+++ b/app/src/sandbox/store-keyed-subscriptions/test.ts
@@ -100,6 +100,11 @@ test("supports keyed selector types", () => {
   >();
 });
 
+// https://github.com/ariakit/ariakit/issues/7240
+test("renders selectors with sparse JavaScript subscription keys", () => {
+  expect(q.status("Sparse selector values")).toHaveTextContent("0:0");
+});
+
 test("runs selectors only for subscribed keys", async () => {
   const stateCalls = q.status("useStoreState calls").textContent;
   const objectCalls = q.status("useStoreStateObject calls").textContent;

--- a/app/src/sandbox/tab-panel-animated/animated-tabs.react.tsx
+++ b/app/src/sandbox/tab-panel-animated/animated-tabs.react.tsx
@@ -56,5 +56,7 @@ function usePrevious<T>(value: T) {
   useEffect(() => {
     ref.current = value;
   }, [value]);
+  // The animation compares the current selection with the last committed one.
+  // oxlint-disable-next-line react/refs
   return ref.current;
 }

--- a/examples/menu-slide/menu.tsx
+++ b/examples/menu-slide/menu.tsx
@@ -124,6 +124,7 @@ export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
           render={renderMenuButton}
         />
       ) : (
+        // oxlint-disable-next-line react/refs -- forwarded ref passed to pure render helper
         renderMenuButton({ ref, ...props })
       )}
       <Ariakit.Menu

--- a/examples/tab-panel-animated/animated-tabs.tsx
+++ b/examples/tab-panel-animated/animated-tabs.tsx
@@ -65,5 +65,7 @@ function usePrevious<T>(value: T) {
   useEffect(() => {
     ref.current = value;
   }, [value]);
+  // The animation compares the current selection with the last committed one.
+  // oxlint-disable-next-line react/refs
   return ref.current;
 }

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1,9 +1,19 @@
 import { defineConfig } from "oxlint";
 
 export default defineConfig({
-  plugins: ["typescript", "import"],
+  // Declaring `react` only in an override would enable just the rules that
+  // the override names, silently disabling every other React rule, including
+  // `react/jsx-key` and `react/no-children-prop`.
+  plugins: ["typescript", "react", "import"],
   options: {
     typeAware: true,
+    // A suppression that stops matching is how lint coverage disappears
+    // unnoticed, so treat an unused directive as an error rather than as
+    // cleanup.
+    reportUnusedDisableDirectives: "error",
+    // Roughly a quarter of the enabled rules are warnings, which would
+    // otherwise never fail CI.
+    denyWarnings: true,
   },
   ignorePatterns: ["website", "**/*.astro"],
   categories: {
@@ -17,8 +27,10 @@ export default defineConfig({
     "import/namespace": "off",
     "no-unsafe-type-assertion": "off",
     "no-unassigned-import": "off",
+    "react-in-jsx-scope": "off",
     "no-shadow": "off",
     "no-underscore-dangle": "off",
+    "iframe-missing-sandbox": "off",
     "consistent-return": "off",
     "no-unnecessary-type-arguments": "off",
     "consistent-type-imports": ["error", { fixStyle: "separate-type-imports" }],
@@ -42,40 +54,32 @@ export default defineConfig({
       },
     },
     {
-      // Disable this rule for the app because some types depend on the app
-      // being built first, and linting may run before the app is built.
+      // We have our own `forwardRef` implementation that doesn't need the `ref`
+      // parameter, which leads to false positives.
+      files: ["packages/ariakit-react-components/src/**/*.{ts,tsx}"],
+      rules: {
+        "forward-ref-uses-ref": "off",
+      },
+    },
+    {
+      // These types are generated into the gitignored `app/.astro` directory,
+      // so CI always lints without them and `astro:content` resolves
+      // `CollectionEntry` to `any`. That widens unions for the first rule and
+      // makes a narrowing assertion look unnecessary for the second.
       files: ["app/src/lib/**/*.ts"],
       rules: {
         "no-redundant-type-constituents": "off",
+        "no-unnecessary-type-assertion": "off",
       },
     },
     {
-      files: [
-        "**/*.react.*",
-        "{examples,nextjs,packages/ariakit-react*,packages/ariakit-test,templates/react}/**/*.{js,jsx,ts,tsx}",
-      ],
-      excludeFiles: ["**/*.solid.*"],
-      plugins: ["typescript", "react", "import"],
+      // Solid reassigns a variable to hold an element reference, which this
+      // rule reads as mutating a value after render. This override disables
+      // nothing else, so add a rule here only once it reports on Solid.
+      // https://github.com/ariakit/ariakit/issues/7250
+      files: ["**/*.solid.*", "packages/ariakit-solid*/**"],
       rules: {
-        "react/exhaustive-effect-dependencies": "warn",
-        "react/hooks": "warn",
-        "react/iframe-missing-sandbox": "off",
-        "react/immutability": "error",
-        "react/memo-dependencies": "warn",
-        "react/purity": "error",
-        "react/react-in-jsx-scope": "off",
-        "react/refs": "error",
-        "react/set-state-in-effect": "error",
-        "react/use-memo": "error",
-      },
-    },
-    {
-      // We have our own `forwardRef` implementation that doesn't need the
-      // `ref` parameter, which leads to false positives.
-      files: ["packages/ariakit-react-components/src/**/*.{ts,tsx}"],
-      plugins: ["typescript", "react", "import"],
-      rules: {
-        "react/forward-ref-uses-ref": "off",
+        "react/immutability": "off",
       },
     },
   ],

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -12,10 +12,6 @@ export default defineConfig({
     pedantic: "off",
   },
   rules: {
-    // Adopt these React Compiler checks separately from this update.
-    // https://github.com/ariakit/ariakit/issues/7240
-    "react/immutability": "off",
-    "react/refs": "off",
     // Type-only exports are incorrectly reported as missing.
     // https://github.com/oxc-project/oxc/issues/13258
     "import/namespace": "off",
@@ -41,6 +37,20 @@ export default defineConfig({
     ],
   },
   overrides: [
+    {
+      // React Compiler rules do not model Solid component semantics.
+      files: ["**/*.solid.*"],
+      rules: {
+        "react/exhaustive-effect-dependencies": "off",
+        "react/hooks": "off",
+        "react/immutability": "off",
+        "react/memo-dependencies": "off",
+        "react/purity": "off",
+        "react/refs": "off",
+        "react/set-state-in-effect": "off",
+        "react/use-memo": "off",
+      },
+    },
     {
       files: ["*.d.ts"],
       rules: {

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "oxlint";
 
 export default defineConfig({
-  plugins: ["typescript", "react", "import"],
+  plugins: ["typescript", "import"],
   options: {
     typeAware: true,
   },
@@ -17,10 +17,8 @@ export default defineConfig({
     "import/namespace": "off",
     "no-unsafe-type-assertion": "off",
     "no-unassigned-import": "off",
-    "react-in-jsx-scope": "off",
     "no-shadow": "off",
     "no-underscore-dangle": "off",
-    "iframe-missing-sandbox": "off",
     "consistent-return": "off",
     "no-unnecessary-type-arguments": "off",
     "consistent-type-imports": ["error", { fixStyle: "separate-type-imports" }],
@@ -38,31 +36,9 @@ export default defineConfig({
   },
   overrides: [
     {
-      // React Compiler rules do not model Solid component semantics.
-      files: ["**/*.solid.*"],
-      rules: {
-        "react/exhaustive-effect-dependencies": "off",
-        "react/hooks": "off",
-        "react/immutability": "off",
-        "react/memo-dependencies": "off",
-        "react/purity": "off",
-        "react/refs": "off",
-        "react/set-state-in-effect": "off",
-        "react/use-memo": "off",
-      },
-    },
-    {
       files: ["*.d.ts"],
       rules: {
         "consistent-type-imports": "off",
-      },
-    },
-    {
-      // We have our own `forwardRef` implementation that doesn't need the `ref`
-      // parameter, which leads to false positives.
-      files: ["packages/ariakit-react-components/src/**/*.{ts,tsx}"],
-      rules: {
-        "forward-ref-uses-ref": "off",
       },
     },
     {
@@ -71,6 +47,35 @@ export default defineConfig({
       files: ["app/src/lib/**/*.ts"],
       rules: {
         "no-redundant-type-constituents": "off",
+      },
+    },
+    {
+      files: [
+        "**/*.react.*",
+        "{examples,nextjs,packages/ariakit-react*,packages/ariakit-test,templates/react}/**/*.{js,jsx,ts,tsx}",
+      ],
+      excludeFiles: ["**/*.solid.*"],
+      plugins: ["typescript", "react", "import"],
+      rules: {
+        "react/exhaustive-effect-dependencies": "warn",
+        "react/hooks": "warn",
+        "react/iframe-missing-sandbox": "off",
+        "react/immutability": "error",
+        "react/memo-dependencies": "warn",
+        "react/purity": "error",
+        "react/react-in-jsx-scope": "off",
+        "react/refs": "error",
+        "react/set-state-in-effect": "error",
+        "react/use-memo": "error",
+      },
+    },
+    {
+      // We have our own `forwardRef` implementation that doesn't need the
+      // `ref` parameter, which leads to false positives.
+      files: ["packages/ariakit-react-components/src/**/*.{ts,tsx}"],
+      plugins: ["typescript", "react", "import"],
+      rules: {
+        "react/forward-ref-uses-ref": "off",
       },
     },
   ],

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -62,13 +62,20 @@ export default defineConfig({
       },
     },
     {
-      // These types are generated into the gitignored `app/.astro` directory,
-      // so CI always lints without them and `astro:content` resolves
-      // `CollectionEntry` to `any`. That widens unions for the first rule and
-      // makes a narrowing assertion look unnecessary for the second.
+      // Astro generates these types into the gitignored `app/.astro`, so CI
+      // lints without them and `astro:content` resolves `CollectionEntry` to
+      // `any`, which widens every union built from it.
       files: ["app/src/lib/**/*.ts"],
       rules: {
         "no-redundant-type-constituents": "off",
+      },
+    },
+    {
+      // Same missing types, but here they make a narrowing assertion look
+      // unnecessary. This cannot be a directive because the assertion is
+      // needed once the types exist, so the directive would then be unused.
+      files: ["app/src/lib/reference-tokenizer.test.ts"],
+      rules: {
         "no-unnecessary-type-assertion": "off",
       },
     },

--- a/packages/ariakit-react-components/src/collection/collection-renderer.tsx
+++ b/packages/ariakit-react-components/src/collection/collection-renderer.tsx
@@ -227,7 +227,6 @@ function getItemSize(
     if (itemObject.itemSize) {
       return initialSize + itemObject.itemSize * items.length;
     }
-    // oxlint-disable-next-line no-unnecessary-type-arguments
     const totalSize = items.reduce<number>(
       (sum, item) => sum + getItemSize(item, horizontal),
       initialSize,
@@ -242,7 +241,6 @@ function getItemSize(
   // The nested items run along the cross axis, so the item's extent along the
   // measured axis is the largest child extent rather than the sum.
   if (items?.length && !hasSameOrientation) {
-    // oxlint-disable-next-line no-unnecessary-type-arguments
     const maxSize = items.reduce<number>(
       (max, item) => Math.max(max, getItemSize(item, horizontal)),
       0,
@@ -401,6 +399,7 @@ function useScroller(
   });
   // Keep state synchronization and automatic ancestor detection off the
   // layout path.
+  // oxlint-disable-next-line exhaustive-deps
   useEffect(() => {
     if (scrollElement === undefined) {
       inheritedController?.revalidate();
@@ -427,8 +426,7 @@ function useScroller(
     if (nextScroller === scroller) return;
     setScroller(nextScroller);
   });
-  const activeController = scrollElement === undefined ? undefined : controller;
-  return [scroller, scrollerRef, activeController] as const;
+  return [scroller, scrollerRef, controller] as const;
 }
 
 function getRendererOffset(
@@ -489,7 +487,6 @@ function getItemsEnd<T extends Item>(props: {
   const lastItemData = props.data.get(lastItemId);
   if (lastItemData?.end) return lastItemData.end + props.paddingEnd;
   if (!Array.isArray(props.items)) return defaultEnd;
-  // oxlint-disable-next-line no-unnecessary-type-arguments
   const end = props.items.reduce<number>(
     (sum, item) => sum + getItemSize(item, props.horizontal, false),
     0,
@@ -720,7 +717,7 @@ export function useCollectionRenderer<T extends Item = any>({
       ? inheritedScrollerController
       : scrollElementProp === null
         ? undefined
-        : (ownScrollerController ?? undefined);
+        : ownScrollerController;
   const offsetsRef = useRef({ start: 0, end: 0 });
 
   const processVisibleIndices = useCallback(() => {
@@ -770,6 +767,7 @@ export function useCollectionRenderer<T extends Item = any>({
       if (shallowEqual(prevIndices, indices)) return prevIndices;
       return indices;
     });
+    // oxlint-disable-next-line exhaustive-deps
   }, [
     // oxlint-disable-next-line react/memo-dependencies -- element registration signal
     elementsUpdated,

--- a/packages/ariakit-react-components/src/collection/collection-renderer.tsx
+++ b/packages/ariakit-react-components/src/collection/collection-renderer.tsx
@@ -324,9 +324,15 @@ function resolveNullScroller() {
 }
 
 interface ScrollerController {
+  disable: () => void;
+  invalidate: () => void;
+  revalidate: () => void;
+  setResolve: (resolve: () => Element | null) => void;
+}
+
+interface ScrollerControllerState {
   revalidated: boolean;
   resolve: () => Element | null;
-  revalidate: () => void;
 }
 
 function useScroller(
@@ -337,52 +343,61 @@ function useScroller(
   const [scroller, setScroller] = useState<Element | null>(null);
   const scrollerRef = useRef<Element | null>(null);
   const publishedScrollerRef = useRef<Element | null>(null);
-  const controllerRef = useRef<ScrollerController | null>(null);
   const autoResolved = useRef(false);
   const previousRendererRef = useRef(rendererRef);
-  const resolveScroller = () => {
-    const renderer = rendererRef?.current;
-    if (!renderer) return null;
-    return getScrollElement(renderer, scrollElement);
-  };
-  let controller = controllerRef.current;
-  if (!controller && scrollElement !== undefined) {
-    const nextController: ScrollerController = {
-      revalidated: false,
-      resolve: resolveNullScroller,
+  const controllerStateRef = useRef<ScrollerControllerState>({
+    revalidated: false,
+    resolve: resolveNullScroller,
+  });
+  const controller = useMemo<ScrollerController>(() => {
+    return {
+      disable: () => {
+        controllerStateRef.current = {
+          revalidated: true,
+          resolve: resolveNullScroller,
+        };
+      },
+      invalidate: () => {
+        controllerStateRef.current = {
+          ...controllerStateRef.current,
+          revalidated: false,
+        };
+      },
       revalidate: () => {
-        if (nextController.revalidated) return;
-        nextController.revalidated = true;
-        const nextScroller = nextController.resolve();
+        const { revalidated, resolve } = controllerStateRef.current;
+        if (revalidated) return;
+        controllerStateRef.current = { revalidated: true, resolve };
+        const nextScroller = resolve();
         scrollerRef.current = nextScroller;
         if (nextScroller === publishedScrollerRef.current) return;
         publishedScrollerRef.current = nextScroller;
         setScroller(nextScroller);
       },
+      setResolve: (nextResolve) => {
+        controllerStateRef.current = {
+          revalidated: false,
+          resolve: nextResolve,
+        };
+      },
     };
-    controllerRef.current = nextController;
-    controller = nextController;
-  }
+  }, []);
+  const resolveScroller = () => {
+    const renderer = rendererRef?.current;
+    if (!renderer) return null;
+    return getScrollElement(renderer, scrollElement);
+  };
   // Explicit refs and resolvers can change without their prop identity
   // changing, so resolve them during each committed layout.
   // oxlint-disable-next-line exhaustive-deps
   useSafeLayoutEffect(() => {
-    if (inheritedController) {
-      inheritedController.revalidated = false;
-    }
+    inheritedController?.invalidate();
     if (scrollElement === undefined) {
-      if (controller) {
-        controller.revalidated = true;
-        controller.resolve = resolveNullScroller;
-      }
+      controller.disable();
       publishedScrollerRef.current = null;
-      controllerRef.current = null;
       return;
     }
-    if (!controller) return;
     publishedScrollerRef.current = scroller;
-    controller.revalidated = false;
-    controller.resolve = resolveScroller;
+    controller.setResolve(resolveScroller);
     scrollerRef.current = resolveScroller();
   });
   // Keep state synchronization and automatic ancestor detection off the
@@ -407,14 +422,15 @@ function useScroller(
       autoResolved.current = false;
       // Ancestor refs attach after descendant layout effects, so resolve the
       // explicit target again once the entire layout phase has completed.
-      controller?.revalidate();
+      controller.revalidate();
       return;
     }
     const nextScroller = scrollerRef.current;
     if (nextScroller === scroller) return;
     setScroller(nextScroller);
   });
-  return [scroller, scrollerRef, controller] as const;
+  const activeController = scrollElement === undefined ? undefined : controller;
+  return [scroller, scrollerRef, activeController] as const;
 }
 
 function getRendererOffset(
@@ -923,6 +939,8 @@ export function useCollectionRenderer<T extends Item = any>({
         elementObserver?.unobserve(prevElement);
       }
       updateElements();
+      // Item refs are an imperative DOM registry coordinated by updateElements.
+      // oxlint-disable-next-line react/immutability
       elements.set(element.id, element);
       elementObserver?.observe(element);
     },
@@ -987,6 +1005,8 @@ export function useCollectionRenderer<T extends Item = any>({
     for (const [id, element] of elements) {
       if (renderedIds.has(id)) continue;
       elementObserver?.unobserve(element);
+      // Item cleanup mutates the same imperative DOM registry after commit.
+      // oxlint-disable-next-line react/immutability
       elements.delete(id);
     }
   }, [itemsProps, itemSize, elements, elementObserver]);

--- a/packages/ariakit-react-components/src/collection/collection-renderer.tsx
+++ b/packages/ariakit-react-components/src/collection/collection-renderer.tsx
@@ -388,7 +388,6 @@ function useScroller(
   };
   // Explicit refs and resolvers can change without their prop identity
   // changing, so resolve them during each committed layout.
-  // oxlint-disable-next-line exhaustive-deps
   useSafeLayoutEffect(() => {
     inheritedController?.invalidate();
     if (scrollElement === undefined) {
@@ -402,7 +401,6 @@ function useScroller(
   });
   // Keep state synchronization and automatic ancestor detection off the
   // layout path.
-  // oxlint-disable-next-line exhaustive-deps
   useEffect(() => {
     if (scrollElement === undefined) {
       inheritedController?.revalidate();
@@ -772,7 +770,6 @@ export function useCollectionRenderer<T extends Item = any>({
       if (shallowEqual(prevIndices, indices)) return prevIndices;
       return indices;
     });
-    // oxlint-disable-next-line exhaustive-deps
   }, [
     // oxlint-disable-next-line react/memo-dependencies -- element registration signal
     elementsUpdated,

--- a/packages/ariakit-react-components/src/dialog/utils/use-root-dialog.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/use-root-dialog.ts
@@ -25,7 +25,7 @@ export function useRootDialog({
     const id = body.getAttribute(attribute);
     return !id || id === contentId;
     // `updated` changes the callback identity after the observer retries.
-    // oxlint-disable-next-line exhaustive-deps, react/memo-dependencies -- invalidation signal
+    // oxlint-disable-next-line react/memo-dependencies -- invalidation signal
   }, [updated, enabled, contentElement, attribute, contentId]);
 
   // Run in the layout phase so consumers that also moved to the layout phase
@@ -47,7 +47,6 @@ export function useRootDialog({
     const observer = new MutationObserver(() => flushSync(retry));
     observer.observe(body, { attributeFilter: [attribute] });
     return () => observer.disconnect();
-    // oxlint-disable-next-line exhaustive-deps
   }, [updated, enabled, contentId, contentElement, isRootDialog, attribute]);
 
   return isRootDialog;

--- a/packages/ariakit-react-components/src/dialog/utils/use-root-dialog.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/use-root-dialog.ts
@@ -25,7 +25,7 @@ export function useRootDialog({
     const id = body.getAttribute(attribute);
     return !id || id === contentId;
     // `updated` changes the callback identity after the observer retries.
-    // oxlint-disable-next-line react/memo-dependencies -- invalidation signal
+    // oxlint-disable-next-line exhaustive-deps, react/memo-dependencies -- invalidation signal
   }, [updated, enabled, contentElement, attribute, contentId]);
 
   // Run in the layout phase so consumers that also moved to the layout phase

--- a/packages/ariakit-react-components/src/form/form-control.tsx
+++ b/packages/ariakit-react-components/src/form/form-control.tsx
@@ -77,6 +77,8 @@ function useControlState(form: FormStore, name: string) {
 
     return (state: Pick<FormStoreState, "items">) => {
       if (state.items !== prevItems) {
+        // These assignments maintain a selector-local cache for item scans.
+        // oxlint-disable-next-line react/immutability
         prevItems = state.items;
         prevIds = getControlItemIds(state.items, name);
       }

--- a/packages/ariakit-react-components/src/form/form.tsx
+++ b/packages/ariakit-react-components/src/form/form.tsx
@@ -110,6 +110,7 @@ export const useForm = createHook<TagName, FormOptions>(function useForm({
     if (isTextField(element)) {
       element.select();
     }
+    // oxlint-disable-next-line exhaustive-deps
   }, [autoFocusOnSubmit, submitFailed, items]);
 
   const onSubmitProp = props.onSubmit;

--- a/packages/ariakit-react-components/src/form/form.tsx
+++ b/packages/ariakit-react-components/src/form/form.tsx
@@ -110,7 +110,6 @@ export const useForm = createHook<TagName, FormOptions>(function useForm({
     if (isTextField(element)) {
       element.select();
     }
-    // oxlint-disable-next-line exhaustive-deps
   }, [autoFocusOnSubmit, submitFailed, items]);
 
   const onSubmitProp = props.onSubmit;

--- a/packages/ariakit-react-components/src/hovercard/hovercard.tsx
+++ b/packages/ariakit-react-components/src/hovercard/hovercard.tsx
@@ -322,12 +322,14 @@ export const useHovercard = createHook<TagName, HovercardOptions>(
     useEffect(() => {
       if (!domReady) return;
       return () => {
+        // oxlint-disable-next-line exhaustive-deps
         if (!openRef.current) {
           store?.setAutoFocusOnShow(false);
         }
       };
       // This cleanup intentionally reads the live ref so it can observe the
       // latest open state at unmount time.
+      // oxlint-disable-next-line exhaustive-deps
     }, [store, domReady]);
 
     const registerOnParent = useContext(NestedHovercardContext);

--- a/packages/ariakit-react-components/src/hovercard/hovercard.tsx
+++ b/packages/ariakit-react-components/src/hovercard/hovercard.tsx
@@ -322,14 +322,12 @@ export const useHovercard = createHook<TagName, HovercardOptions>(
     useEffect(() => {
       if (!domReady) return;
       return () => {
-        // oxlint-disable-next-line exhaustive-deps
         if (!openRef.current) {
           store?.setAutoFocusOnShow(false);
         }
       };
       // This cleanup intentionally reads the live ref so it can observe the
       // latest open state at unmount time.
-      // oxlint-disable-next-line exhaustive-deps
     }, [store, domReady]);
 
     const registerOnParent = useContext(NestedHovercardContext);

--- a/packages/ariakit-react-store/src/index.tsx
+++ b/packages/ariakit-react-store/src/index.tsx
@@ -70,7 +70,6 @@ function hasSameStoreKeys(
   if (keys?.length !== otherKeys.length) return false;
   for (let index = 0; index < keys.length; index += 1) {
     const key = keys[index];
-    if (key === undefined) return false;
     if (isSameValue(key, otherKeys[index])) continue;
     return false;
   }

--- a/packages/ariakit-react-store/src/index.tsx
+++ b/packages/ariakit-react-store/src/index.tsx
@@ -80,20 +80,23 @@ function hasSameStoreKeys(
 function useStableStoreKeys<K extends StoreKey>(
   keys: readonly K[] | null,
 ): K[] | null {
-  const keysRef = React.useRef<K[] | null>(null);
-  const currentKeys = keysRef.current;
+  const [stableKeys, setStableKeys] = React.useState<K[] | null>(() =>
+    keys === null ? null : [...keys],
+  );
 
   if (keys === null) {
-    keysRef.current = null;
+    if (stableKeys !== null) {
+      setStableKeys(null);
+    }
     return null;
   }
 
-  if (hasSameStoreKeys(currentKeys, keys)) {
-    return currentKeys;
+  if (hasSameStoreKeys(stableKeys, keys)) {
+    return stableKeys;
   }
 
   const nextKeys = [...keys];
-  keysRef.current = nextKeys;
+  setStableKeys(nextKeys);
   return nextKeys;
 }
 

--- a/packages/ariakit-react-utils/src/hooks.ts
+++ b/packages/ariakit-react-utils/src/hooks.ts
@@ -171,7 +171,7 @@ export function useMergeRefs(...refs: Array<Ref<any> | undefined>) {
       };
     };
     // Variadic refs prevent using an array literal for the dependencies.
-    // oxlint-disable-next-line exhaustive-deps, react/use-memo -- variadic refs
+    // oxlint-disable-next-line react/use-memo -- variadic refs
   }, refs);
 }
 
@@ -303,7 +303,6 @@ export function useUpdateEffect(effect: EffectCallback, deps?: DependencyList) {
       return effect();
     }
     mounted.current = true;
-    // oxlint-disable-next-line exhaustive-deps
   }, deps);
 
   useEffect(
@@ -328,7 +327,6 @@ export function useUpdateLayoutEffect(
       return effect();
     }
     mounted.current = true;
-    // oxlint-disable-next-line exhaustive-deps
   }, deps);
 
   useSafeLayoutEffect(
@@ -377,7 +375,7 @@ export function useWrapElement<P>(
       return callback(element);
     },
     // Caller-provided dependencies prevent using an array literal here.
-    // oxlint-disable-next-line exhaustive-deps, react/use-memo -- public deps API
+    // oxlint-disable-next-line react/use-memo -- public deps API
     [...deps, props.wrapElement],
   );
 

--- a/packages/ariakit-react-utils/src/hooks.ts
+++ b/packages/ariakit-react-utils/src/hooks.ts
@@ -171,7 +171,7 @@ export function useMergeRefs(...refs: Array<Ref<any> | undefined>) {
       };
     };
     // Variadic refs prevent using an array literal for the dependencies.
-    // oxlint-disable-next-line react/use-memo -- variadic refs
+    // oxlint-disable-next-line exhaustive-deps, react/use-memo -- variadic refs
   }, refs);
 }
 
@@ -303,6 +303,7 @@ export function useUpdateEffect(effect: EffectCallback, deps?: DependencyList) {
       return effect();
     }
     mounted.current = true;
+    // oxlint-disable-next-line exhaustive-deps
   }, deps);
 
   useEffect(
@@ -375,7 +376,7 @@ export function useWrapElement<P>(
       return callback(element);
     },
     // Caller-provided dependencies prevent using an array literal here.
-    // oxlint-disable-next-line react/use-memo -- public deps API
+    // oxlint-disable-next-line exhaustive-deps, react/use-memo -- public deps API
     [...deps, props.wrapElement],
   );
 

--- a/packages/ariakit-test/src/query.ts
+++ b/packages/ariakit-test/src/query.ts
@@ -1,4 +1,3 @@
-// oxlint-disable unbound-method typescript/no-unnecessary-type-parameters
 import { invariant } from "@ariakit/utils";
 import type {
   ByRoleMatcher,

--- a/vitest.setup.framework.ts
+++ b/vitest.setup.framework.ts
@@ -15,7 +15,6 @@ async function loadReact(dir: string) {
   const component = await importDefault(`./${dir}/index.react.tsx`);
   const element = createElement(Suspense, {
     fallback: null,
-    // oxlint-disable-next-line react/no-children-prop -- createElement requires children prop
     children: createElement(component),
   });
   const { unmount } = await render(element, { strictMode: true });

--- a/vitest.setup.framework.ts
+++ b/vitest.setup.framework.ts
@@ -13,10 +13,11 @@ async function loadReact(dir: string) {
   const { render } = await import("@ariakit/test/react");
   const { createElement, Suspense } = await import("react");
   const component = await importDefault(`./${dir}/index.react.tsx`);
-  const element = createElement(Suspense, {
-    fallback: null,
-    children: createElement(component),
-  });
+  const element = createElement(
+    Suspense,
+    { fallback: null },
+    createElement(component),
+  );
   const { unmount } = await render(element, { strictMode: true });
   return unmount;
 }


### PR DESCRIPTION
## Motivation

Oxlint 1.79 split the React Compiler check into individual rules. The earlier work for #7240 adopted the hook-contract, effect-state, dependency, and purity rules. `react/refs` and `react/immutability` remained disabled because they reported valid render-phase hazards together with deliberate test instrumentation and React-only false positives in Solid files.

Closes #7240.

An earlier revision of this pull request scoped the rules by moving the `react` plugin out of the root `plugins` list and declaring it only inside an override. That is not equivalent. In oxlint 1.79 a plugin introduced only by an override contributes nothing beyond the rules that override names, so every React rule that was not listed stopped running everywhere. Measured with `oxlint --print-config`:

| config | enabled `react/*` rules |
| --- | --- |
| before this series | 38 |
| plugin declared only in an override | 0 |
| this pull request | 40 |

The rules that silently stopped running included `react/jsx-key`, `react/no-children-prop` and `react/exhaustive-deps`. That revision removed twelve `exhaustive-deps` directives as stale, but only three of them were genuinely dead. The other nine were suppressing live errors and are restored here.

## Solution

Keep the `react` plugin at the top level, where a declared plugin does activate its category rules, and scope only the individual rule that needs scoping.

Every React rule stays on everywhere by default. Solid gets a single exemption, for the one rule measured misfiring on it: Solid holds an element reference by reassigning a local, which `react/immutability` reads as mutating a value after render.

```ts
overrides: [
  {
    files: ["**/*.solid.*", "packages/ariakit-solid*/**"],
    rules: {
      "react/immutability": "off",
    },
  },
];
```

Against the config before this series the change is: delete the two lines that parked `react/immutability` and `react/refs`, which is the stated goal of #7240, add that one override, and add two `options` entries. The three pre-existing overrides are unchanged.

- `options.reportUnusedDisableDirectives: "error"` makes a suppression that stops matching a build failure. This is the only mechanism that would have caught the regression above at config-change time, before any source line moved. It surfaced five directives that were already dead, which this pull request removes.
- `options.denyWarnings: true` makes warnings fail CI. Roughly a quarter of the enabled rules are warnings, so they could not fail a build before.

`--disable-nested-config` stays. The upstream issue it works around, oxc-project/oxc#20354, is closed but still reproduces on 1.79.0 when a nested directory carries `options.typeAware` and is linted by explicit path from the outer root.

The `createElement` call in `vitest.setup.framework.ts` now passes its child as the third argument instead of a `children` prop, which removes a `react/no-children-prop` suppression rather than restoring it.

No changeset is included because the production changes preserve existing behavior and the remaining changes affect examples, test sandboxes, or lint configuration.

## Known exceptions

- `react/immutability` is off on `**/*.solid.*` and `packages/ariakit-solid*/**`. It was already off repo-wide before this series, so Solid loses nothing relative to `main`.
- Other React rules, including other React Compiler rules and plain rules such as `react/jsx-key`, still run on Solid source and can misfire there. That behavior predates this pull request and is tracked in #7250, which also records that `denyWarnings` now makes the warning-level ones fail CI.
- `react/exhaustive-deps` does not analyze `useSafeLayoutEffect`, so 48 of the library's 132 effect call sites are unchecked by dependency linting. That gap predates this pull request and is tracked in #7253. It is the reason three of the twelve restored directives were dead.
- `no-unnecessary-type-assertion` is disabled for `app/src/lib`. CI lints without the generated `app/.astro` types, so `astro:content` resolves `CollectionEntry` to `any` there and a narrowing assertion looks unnecessary.

## Implementation review reassessment

<details>
<summary>Cycle 3: Keep state-based key stabilization and simplify equality</summary>

**Assessment**

The first review cycles restored the existing form cache and menu render helper, then removed one unused suppression. The third cycle found that sparse or JavaScript-supplied `undefined` subscription keys made the new render-state update retry indefinitely. These keys are outside the typed `PropertyKey[]` contract and should be rare, but the pull request would turn previously non-crashing input into a render failure.

The state-based key cache remains small and removes the production render-time ref hazard. The `undefined` equality guard predates this lint work and became unnecessary when the comparator was generalized to accept unknown values.

**Decision**

Keep the state-based design and remove the obsolete guard so equality is reflexive for sparse entries. Add focused public-hook regression coverage for both keyed hooks. Do not add key validation or filtering, and do not define support for other invalid key values.

</details>

<details>
<summary>Cycle 6: Keep the scoped plugin and close semantic path gaps</summary>

**Assessment**

The sixth finding-bearing cycle showed that a narrow extension pattern missed names such as `*.react.test.tsx`, while JSX-only example scopes missed React hooks in `.ts` files. The production refactors remain contained and well covered; this finding concerns lint path coverage, not their runtime design.

Oxlint 1.79 does not apply top-level category activation to a plugin introduced only by an override. Mirroring every categorized React rule would be version-coupled and was rejected during review.

**Decision**

Keep React out of the root plugin list. Enable the eight rules tracked by #7240 in an override that matches `**/*.react.*` and the repository's React workspaces, while excluding `**/*.solid.*`. Do not restore global suppressions or rewrite Solid semantics.

</details>

## Review gate reassessment

<details>
<summary>Pass 6: Keep the scoped eight-rule design and remove stale suppressions</summary>

**Assessment**

Scoping the React plugin makes older suppressions for React rules outside #7240 inactive. This has no runtime effect, but unused directives would misrepresent lint coverage. The affected shared framework setup also contains Solid code, so applying the React plugin to that whole file would recreate the cross-framework problem.

**Decision**

Remove the stale `react/no-children-prop` and classic `exhaustive-deps` directive entries. Keep active #7240 rule names in mixed directives. Do not add file-specific exceptions, restore the global plugin, mirror all categorized React rules, or change unrelated loader behavior.

</details>

<details>
<summary>Cycle 3 (top-level plugin direction): Narrow the Solid override to the one measured rule</summary>

**Assessment**

Three consecutive gate passes produced findings, and all three landed on the same artifact: the comment above the Solid override and the rule list it described. Each rewrite replaced one false claim with another, which is the signature of a list that has no true description.

The list was the previous revision's React-override allowlist, inverted. The two sets are identical, so it encoded no property of Solid. Measuring it directly: with the Solid override removed, the only React diagnostics on Solid source anywhere in the repository are three `react/immutability` reports in `app/src/sandbox/create-ref-6349/index.solid.tsx`. Nothing from the other seven rules.

Worse, six of the eight were already enforcing on Solid before this series (`react/purity`, `react/set-state-in-effect` and `react/use-memo` as errors; `react/hooks`, `react/memo-dependencies` and `react/exhaustive-effect-dependencies` as warnings), each adopted repo-wide with no Solid exception in #7242, #7243 and #7246. Disabling them for Solid silently reversed three merged decisions and reintroduced the same silent-coverage-loss failure mode this pull request exists to fix.

Severity of the underlying issue is low and its frequency is one file, but the maintenance cost of the wrong shape is permanent: every pre-emptively disabled rule is a silent false negative on Solid, and the list would need re-auditing whenever oxlint adds a React rule. An armed rule that misfires fails loudly on the commit that introduces it.

An independent complexity review, run with no shared context, reached the same conclusion and confirmed the identical-set finding.

**Decision**

Narrow the Solid override to `react/immutability` alone, and state the mechanism rather than a category claim. Keep the reactive policy: a rule joins the list only once it actually reports. Leave the remaining React rules armed on Solid and track the known latent misfires in #7250 rather than pre-emptively disabling them.

Separately, abandon the `react/exhaustive-deps` retirement that this revision had bundled in. Measurement showed the React Compiler rules report none of its ten diagnostics, including two genuine missing dependencies, so the supersession claim did not hold. The rule stays enabled and nine suppressions are restored. Three of the merge base's twelve proved dead under `reportUnusedDisableDirectives`, each having sat on a `useSafeLayoutEffect` call, which the rule does not analyse.

</details>

## Verification

- Full lint, formatting, and TypeScript checks
- Full test suite: 268 files, 1918 tests passed
- `oxlint --print-config` comparison against the config before this series: the only rule severity changes are `react/immutability` and `react/refs` moving from off to on
- Coverage probes confirming React rules reach `packages/ariakit-react*`, `packages/ariakit-test`, framework-agnostic packages, `examples/`, `guide/`, `app/src`, `nextjs/`, `templates/react`, `scripts/`, and the repository root
- Confirmed `react/purity` still reports on Solid source, so the narrowed override loses no enforcement that `main` had
- Confirmed both new options take effect: an unused directive and a warning-only violation each fail the run
