### PR TITLE
Analyze custom effect hooks with exhaustive deps

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -33,6 +33,13 @@ export default defineConfig({
     "iframe-missing-sandbox": "off",
     "consistent-return": "off",
     "no-unnecessary-type-arguments": "off",
+    "exhaustive-deps": [
+      "error",
+      {
+        additionalHooks:
+          "(useSafeLayoutEffect|useUpdateEffect|useUpdateLayoutEffect)",
+      },
+    ],
     "consistent-type-imports": ["error", { fixStyle: "separate-type-imports" }],
     "consistent-type-specifier-style": ["error", "prefer-top-level"],
     "no-unused-vars": [

--- a/packages/ariakit-react-components/src/checkbox/checkbox-store.ts
+++ b/packages/ariakit-react-components/src/checkbox/checkbox-store.ts
@@ -9,7 +9,7 @@ export function useCheckboxStoreProps<T extends Core.CheckboxStore>(
   update: () => void,
   props: CheckboxStoreProps,
 ) {
-  useUpdateEffect(update, [props.store]);
+  useUpdateEffect(update, [props.store, update]);
   useStoreProps(store, props, "value", "setValue");
   return store;
 }

--- a/packages/ariakit-react-components/src/collection/collection-store.ts
+++ b/packages/ariakit-react-components/src/collection/collection-store.ts
@@ -9,7 +9,7 @@ export function useCollectionStoreProps<T extends Core.CollectionStore>(
   update: () => void,
   props: CollectionStoreProps,
 ) {
-  useUpdateEffect(update, [props.store]);
+  useUpdateEffect(update, [props.store, update]);
   useStoreProps(store, props, "items", "setItems");
   return store;
 }

--- a/packages/ariakit-react-components/src/combobox/combobox-store.ts
+++ b/packages/ariakit-react-components/src/combobox/combobox-store.ts
@@ -37,7 +37,7 @@ export function useComboboxStoreProps<T extends Core.ComboboxStore>(
   update: () => void,
   props: ComboboxStoreProps,
 ) {
-  useUpdateEffect(update, [props.tag]);
+  useUpdateEffect(update, [props.tag, update]);
 
   const inputValueProps = {
     inputValue: props.inputValue ?? props.value,

--- a/packages/ariakit-react-components/src/composite/composite.tsx
+++ b/packages/ariakit-react-components/src/composite/composite.tsx
@@ -201,7 +201,7 @@ const CompositeFocusOnMove = memo(function CompositeFocusOnMove({
       }
       compositeElement.focus({ preventScroll: true });
     }
-  }, [store, moves, compositeElement]);
+  }, [store, moves, compositeElement, previousElementRef]);
 
   return null;
 });

--- a/packages/ariakit-react-components/src/dialog/utils/use-hide-on-interact-outside.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/use-hide-on-interact-outside.ts
@@ -202,7 +202,7 @@ export function useHideOnInteractOutside({
     };
     contentElement.addEventListener("focusin", onFocus, true);
     return () => contentElement.removeEventListener("focusin", onFocus, true);
-  }, [open, domReady, contentElement, store]);
+  }, [open, domReady, contentElement, store, focusedStoreRef]);
 
   const props = {
     store,

--- a/packages/ariakit-react-components/src/dialog/utils/use-root-dialog.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/use-root-dialog.ts
@@ -47,7 +47,15 @@ export function useRootDialog({
     const observer = new MutationObserver(() => flushSync(retry));
     observer.observe(body, { attributeFilter: [attribute] });
     return () => observer.disconnect();
-  }, [updated, enabled, contentId, contentElement, isRootDialog, attribute]);
+  }, [
+    updated,
+    enabled,
+    contentId,
+    contentElement,
+    isRootDialog,
+    attribute,
+    retry,
+  ]);
 
   return isRootDialog;
 }

--- a/packages/ariakit-react-components/src/disclosure/disclosure-store.ts
+++ b/packages/ariakit-react-components/src/disclosure/disclosure-store.ts
@@ -8,7 +8,7 @@ export function useDisclosureStoreProps<T extends Core.DisclosureStore>(
   update: () => void,
   props: DisclosureStoreProps,
 ) {
-  useUpdateEffect(update, [props.store, props.disclosure]);
+  useUpdateEffect(update, [props.store, props.disclosure, update]);
   useStoreProps(store, props, "open", "setOpen");
   useStoreProps(store, props, "mounted", "setMounted");
   useStoreProps(store, props, "animated");

--- a/packages/ariakit-react-components/src/hovercard/hovercard.tsx
+++ b/packages/ariakit-react-components/src/hovercard/hovercard.tsx
@@ -350,7 +350,7 @@ export const useHovercard = createHook<TagName, HovercardOptions>(
       const element = ref.current;
       if (!element) return;
       return registerOnParent?.(element);
-    }, [modal, portal, mounted, domReady]);
+    }, [modal, portal, mounted, domReady, registerOnParent]);
 
     const registerNestedHovercard = useCallback(
       (element: HTMLElement) => {

--- a/packages/ariakit-react-components/src/menu/menu-store.ts
+++ b/packages/ariakit-react-components/src/menu/menu-store.ts
@@ -26,7 +26,12 @@ export function useMenuStoreProps<T extends Core.MenuStore>(
   update: () => void,
   props: MenuStoreProps,
 ) {
-  useUpdateEffect(update, [props.combobox, props.parent, props.menubar]);
+  useUpdateEffect(update, [
+    props.combobox,
+    props.parent,
+    props.menubar,
+    update,
+  ]);
   useStoreProps(store, props, "values", "setValues");
   return Object.assign(
     useHovercardStoreProps(

--- a/packages/ariakit-react-components/src/popover/popover-store.ts
+++ b/packages/ariakit-react-components/src/popover/popover-store.ts
@@ -14,7 +14,7 @@ export function usePopoverStoreProps<T extends Core.PopoverStore>(
   update: () => void,
   props: PopoverStoreProps,
 ) {
-  useUpdateEffect(update, [props.popover]);
+  useUpdateEffect(update, [props.popover, update]);
   useStoreProps(store, props, "placement");
   return useDialogStoreProps(store, update, props);
 }

--- a/packages/ariakit-react-components/src/portal/portal.tsx
+++ b/packages/ariakit-react-components/src/portal/portal.tsx
@@ -170,7 +170,7 @@ export const usePortal = createHook<TagName, PortalOptions>(function usePortal({
         portalEl.remove();
       }
     };
-  }, [portal, portalElement, context]);
+  }, [portal, portalElement, context, portalRefProp]);
 
   // Re-fire the portalRef against the same portal node when only its identity
   // changes (e.g. an inline callback on a parent re-render), mirroring how

--- a/packages/ariakit-react-components/src/select/select-store.ts
+++ b/packages/ariakit-react-components/src/select/select-store.ts
@@ -39,7 +39,7 @@ export function useSelectStoreProps<T extends Core.SelectStore>(
   update: () => void,
   props: SelectStoreProps,
 ) {
-  useUpdateEffect(update, [props.combobox]);
+  useUpdateEffect(update, [props.combobox, update]);
   useStoreProps(store, props, "value", "setValue");
   useStoreProps(store, props, "setValueOnMove");
   return Object.assign(

--- a/packages/ariakit-react-components/src/tab/tab-store.ts
+++ b/packages/ariakit-react-components/src/tab/tab-store.ts
@@ -19,7 +19,7 @@ export function useTabStoreProps<T extends Core.TabStore>(
   update: () => void,
   props: TabStoreProps,
 ) {
-  useUpdateEffect(update, [props.composite, props.combobox]);
+  useUpdateEffect(update, [props.composite, props.combobox, update]);
 
   const compositeStore = useCompositeStoreProps(store, update, props);
   useStoreProps(compositeStore, props, "selectedId", "setSelectedId");

--- a/packages/ariakit-react-store/src/index.tsx
+++ b/packages/ariakit-react-store/src/index.tsx
@@ -420,7 +420,7 @@ export function useStoreProps<
       if (isSameValue(state[key], value)) return;
       setValue(state[key]);
     });
-  }, [store, key, hasSetValue]);
+  }, [store, key, hasSetValue, propsRef]);
 
   // If the value prop is provided, we'll always reset the store state to it.
   useSafeLayoutEffect(() => {

--- a/packages/ariakit-react-utils/src/hooks.ts
+++ b/packages/ariakit-react-utils/src/hooks.ts
@@ -303,7 +303,8 @@ export function useUpdateEffect(effect: EffectCallback, deps?: DependencyList) {
       return effect();
     }
     mounted.current = true;
-    // oxlint-disable-next-line exhaustive-deps
+    // Caller-provided dependencies prevent using an array literal here.
+    // oxlint-disable-next-line exhaustive-deps -- public deps API
   }, deps);
 
   useEffect(
@@ -328,6 +329,8 @@ export function useUpdateLayoutEffect(
       return effect();
     }
     mounted.current = true;
+    // Caller-provided dependencies prevent using an array literal here.
+    // oxlint-disable-next-line exhaustive-deps -- public deps API
   }, deps);
 
   useSafeLayoutEffect(


### PR DESCRIPTION
## Motivation

`react/exhaustive-deps` analyzes built-in React effects but did not analyze `useSafeLayoutEffect`, `useUpdateEffect`, or `useUpdateLayoutEffect`. This allowed incomplete dependency lists in custom effect hooks to pass lint silently.

Fixes #7253.

## Solution

Configure the rule's `additionalHooks` option for all three custom effects:

```ts
"exhaustive-deps": [
  "error",
  {
    additionalHooks:
      "(useSafeLayoutEffect|useUpdateEffect|useUpdateLayoutEffect)",
  },
],
```

Add every dependency exposed by the new analysis. Document and suppress the two wrapper implementations whose public dependency-list API cannot use an array literal.

No changeset is included because the production edits preserve existing behavior and the change affects lint enforcement.

## Verification

- `pnpm lint`
- `pnpm tsc`
- `pnpm test` (268 files, 1,918 tests)
- `pnpm test-react18` (196 files, 1,040 tests)
- `pnpm build`