### PR TITLE
Use one type for the styles JSON import

### DIFF
--- a/app/env.d.ts
+++ b/app/env.d.ts
@@ -17,11 +17,6 @@ declare module "*?source" {
   export default source;
 }
 
-declare module "#app/styles/styles.json" {
-  const styles: import("./src/lib/styles-json-types.ts").StylesJson;
-  export default styles;
-}
-
 type PlusType = import("./src/lib/schemas.ts").PlusType;
 type Framework = import("./src/lib/schemas.ts").Framework;
 type User = import("@clerk/astro/server").User;

--- a/app/src/lib/styles-json-types.ts
+++ b/app/src/lib/styles-json-types.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: UNLICENSED
  */
 
-/** JSON shape for `#app/styles/styles.json` (shared by `env.d.ts` and `styles.ts`). */
+/** JSON shape for `#app/styles/styles.json`. */
 
 export type StyleType = "utility" | "variant" | "at-property";
 

--- a/app/src/lib/styles-json.d.ts
+++ b/app/src/lib/styles-json.d.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright 2025-present Ariakit FZ-LLC. All Rights Reserved.
+ *
+ * This software is proprietary. See the license.md file in the root of this
+ * package for licensing terms.
+ *
+ * SPDX-License-Identifier: UNLICENSED
+ */
+
+declare module "#app/styles/styles.json" {
+  const styles: import("./styles-json-types.ts").StylesJson;
+  export default styles;
+}

--- a/app/src/lib/styles.ts
+++ b/app/src/lib/styles.ts
@@ -8,7 +8,9 @@
  * SPDX-License-Identifier: UNLICENSED
  */
 
-import stylesRaw from "#app/styles/styles.json" with { type: "json" };
+/// <reference path="./styles-json.d.ts" />
+
+import styles from "#app/styles/styles.json" with { type: "json" };
 import type {
   AtPropertyDef,
   ModuleJson,
@@ -16,7 +18,6 @@ import type {
   StyleDef,
   StyleDependency,
   StyleType,
-  StylesJson,
   UtilityDef,
   VariantDef,
 } from "./styles-json-types.ts";
@@ -25,12 +26,6 @@ import {
   splitVariantSegments,
   toRegexFromWildcard,
 } from "./styles-shared.ts";
-
-// `tsconfig.node.json` reaches this file through `vitest.config.ts`, without
-// `app/env.d.ts`, so the JSON import keeps its inferred literal type there and
-// is not assignable to `StylesJson`. The app projects type it as `StylesJson`.
-// oxlint-disable-next-line no-unnecessary-type-assertion
-const styles = stylesRaw as unknown as StylesJson;
 
 export type {
   AtPropertyDef,

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -89,5 +89,14 @@ export default defineConfig({
         "react/immutability": "off",
       },
     },
+    {
+      // The reference keeps the ambient JSON schema visible to TypeScript
+      // programs that exclude the app directory.
+      // https://github.com/ariakit/ariakit/issues/7254
+      files: ["app/src/lib/styles.ts"],
+      rules: {
+        "triple-slash-reference": ["error", { path: "always" }],
+      },
+    },
   ],
 });


### PR DESCRIPTION
## Motivation

`app/src/lib/styles.ts` is loaded by the app TypeScript projects and by the root Node project through `vitest.config.ts`. Only the app projects loaded the ambient JSON declaration from `app/env.d.ts`, so the same import had two types and required a laundering cast:

```ts
const styles = stylesRaw as unknown as StylesJson;
```

Closes #7254.

## Solution

Move the `#app/styles/styles.json` declaration into `app/src/lib/styles-json.d.ts` and reference it directly from `styles.ts`, so every TypeScript program that includes the source loads the shared `StylesJson` schema:

```ts
/// <reference path="./styles-json.d.ts" />

import styles from "#app/styles/styles.json" with { type: "json" };
```

Remove the duplicate declaration from `app/env.d.ts`, along with the cast, suppression, and workaround comment. A file-specific lint override permits this deliberate path reference only in `styles.ts`.

No changeset is included because this changes internal app type wiring without changing runtime or published-package behavior.

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm test app/src/lib/styles.test.ts` (21 tests)
- Root/app regression proof: the cast-free assignment failed the root program with `TS2322` before the declaration move, while both focused programs passed afterward.
