### PR TITLE
Sync the Astro types before linting in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Set up environment
         uses: ./.github/workflows/setup
 
+      - name: Sync Astro types
+        # `pnpm run lint` is type-aware and `app/.astro` is gitignored, so
+        # without this step `astro:content` resolves `CollectionEntry` to `any`
+        # and CI lints a weaker type graph than a synced checkout.
+        run: pnpm --fail-if-no-match -F app exec astro sync
+
       - name: Lint
         run: pnpm run lint
 

--- a/app/src/lib/reference-tokenizer.test.ts
+++ b/app/src/lib/reference-tokenizer.test.ts
@@ -88,8 +88,7 @@ function createRefData(
 }
 
 function makeRef(id: string, data: RefData): CollectionEntry<"references"> {
-  // Partial fixture: only the members the tokenizer reads are populated.
-  return { id, data } as unknown as CollectionEntry<"references">;
+  return { id, collection: "references", data };
 }
 
 function refs(): CollectionEntry<"references">[] {

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -6,6 +6,9 @@ export default defineConfig({
   // `react/jsx-key` and `react/no-children-prop`.
   plugins: ["typescript", "react", "import"],
   options: {
+    // Type-aware rules resolve `astro:content` through the gitignored
+    // `app/.astro`, so the Lint job runs `astro sync` before linting.
+    // https://github.com/ariakit/ariakit/issues/7255
     typeAware: true,
     // A suppression that stops matching is how lint coverage disappears
     // unnoticed, so treat an unused directive as an error rather than as
@@ -66,24 +69,6 @@ export default defineConfig({
       files: ["packages/ariakit-react-components/src/**/*.{ts,tsx}"],
       rules: {
         "forward-ref-uses-ref": "off",
-      },
-    },
-    {
-      // Astro generates these types into the gitignored `app/.astro`, so CI
-      // lints without them and `astro:content` resolves `CollectionEntry` to
-      // `any`, which widens every union built from it.
-      files: ["app/src/lib/**/*.ts"],
-      rules: {
-        "no-redundant-type-constituents": "off",
-      },
-    },
-    {
-      // Same missing types, but here they make a narrowing assertion look
-      // unnecessary. This cannot be a directive because the assertion is
-      // needed once the types exist, so the directive would then be unused.
-      files: ["app/src/lib/reference-tokenizer.test.ts"],
-      rules: {
-        "no-unnecessary-type-assertion": "off",
       },
     },
     {


### PR DESCRIPTION
## Motivation

The Lint job lints without the Astro-generated types, while a synced checkout has them, so the two disagree about type-aware rules.

`app/.astro` is gitignored and produced by `astro sync`, which runs as part of `astro dev`, `astro build`, and `astro check`. The Lint job is checkout, then `.github/workflows/setup`, then `pnpm run lint`, and nothing in that path generates the types. Without them, `astro:content` falls back to `export type CollectionEntry<C> = any` from the `astro` package, while anyone who has run `pnpm dev-app` or `pnpm tsc` lints against the real types.

That divergence nearly shipped a red Lint job in #7248, where a suppression that looked unused locally was load-bearing in CI, and the failure would have appeared on a file nobody touched.

It also costs two config exceptions, both of which exist only because `CollectionEntry` degrades to `any`:

```ts
{
  files: ["app/src/lib/**/*.ts"],
  rules: { "no-redundant-type-constituents": "off" },
},
{
  files: ["app/src/lib/reference-tokenizer.test.ts"],
  rules: { "no-unnecessary-type-assertion": "off" },
},
```

Closes #7255.

## Solution

Run `astro sync` in the Lint job before `pnpm run lint`, and delete both overrides.

With them gone, a Lint job that stops generating the types fails loudly instead of quietly linting a weaker type graph, so the new step cannot be dropped or silently broken:

```
app/src/lib/reference-tokenizer.ts:34:27: error typescript(no-redundant-type-constituents): 'any' overrides all other types in this union type.
```

The step passes `--fail-if-no-match` because `pnpm -F app exec` exits 0 when the filter matches nothing. Verified: `pnpm -F nonexistent-pkg-xyz exec astro sync` exits 0, and the same command with the flag exits 1. Without it, renaming the `app` workspace would leave the sync step green and surface as eight unrelated type errors at the Lint step instead.

`Main / Type check` already generates the same types through `pnpm -F app run check`, using the same setup action, so this needs no secrets and works on pull requests from forks. `astro sync` is the narrow part of that command: it syncs content and writes `app/.astro` without type-checking the app, which the Type check job already owns.

No changeset is included because shipped runtime behavior does not change.

## The second override needed a fixture fix, not a suppression

`no-unnecessary-type-assertion` is auto-fixable and its verdict flips with the generated types, so the override could not simply be deleted: in an unsynced checkout `oxlint --fix` silently deletes the fixture's assertion, exiting 0 with no output, and `pnpm lint-fix` and the `lint-staged` pre-commit hook both invoke it directly. Moving the suppression inline does not work either, because once the types exist the directive is unused and `reportUnusedDisableDirectives: "error"` fails on that.

The assertion turned out to be unnecessary. `CollectionEntry<"references">` requires only `id`, `collection`, and `data`, and every other member is optional, so supplying `collection` makes the fixture valid on its own:

```ts
function makeRef(id: string, data: RefData): CollectionEntry<"references"> {
  return { id, collection: "references", data };
}
```

This lints clean with and without the generated types, under no override at all, and `oxlint --fix` leaves it byte-identical. It also strengthens the fixture: the old `as unknown as` bypassed checking entirely, so `data` was never verified against the collection schema, and it now is. `findCodeReferenceAnchors` never reads `collection`, so behavior is unchanged and the file's 34 tests still pass.

`no-redundant-type-constituents` needed no such care, because it is not auto-fixable: with the types absent it reports all eight errors and leaves the file byte-identical.

## Verification

Reproduced the Lint job's state in a fresh worktree, installed with `pnpm install --frozen-lockfile --no-runtime` and with no `app/.astro`:

| State | `pnpm run lint` |
| --- | --- |
| No `app/.astro` | 8 `no-redundant-type-constituents` errors, all in `app/src/lib/reference-tokenizer.ts` |
| After `astro sync` | Clean |

From that same clean state the full Lint job sequence passes: the sync step, then `pnpm run lint`, then `pnpm run lint-css`. `pnpm tsc` passes, and so does `pnpm test app/src/lib/reference-tokenizer.test.ts`.

On the added runtime the issue asked about, now measured on a real runner rather than estimated: in [this PR's Lint job](https://github.com/ariakit/ariakit/actions/runs/32624279540), the `Sync Astro types` step took **8s** and the whole job took 66s, against 57s for the `Lint` job on `main` at [`8db095d`](https://github.com/ariakit/ariakit/commit/8db095dcdf384efa9ea36cdae49da0f4aed7480b). No package build is needed, and `Type check` already performs the same content sync through `astro check` on an equally cold runner.

That green Lint job is also the proof the step works: with both overrides removed, it can only pass if `astro sync` actually generated the types, since the unsynced state fails with the eight errors above.

On secrets: `astro sync` ran with no environment or secret files present anywhere in the repository, and it needs no `wrangler types` either. Verified by deleting the gitignored `app/worker-configuration.d.ts` along with `app/.astro`, which is the state a fresh CI checkout is in: the step still exits 0.

## Known follow-up

`pnpm run lint` now fails in a checkout that has never run the Astro app, with eight errors in a file the author did not touch. The `lint-staged` pre-commit hook fails the same way, so staging `app/src/lib/reference-tokenizer.ts` in such a checkout also blocks `git commit`. Both failures are loud and non-destructive, and they are the intended consequence of no longer linting against `any`, but there is nothing to read about them: `contributing.md` documents no local lint command and delegates lint to CI.

Verified as introduced here rather than pre-existing: on unmodified `main` at [`59ab242`](https://github.com/ariakit/ariakit/commit/59ab242090b6cd65f8454aecc738268fd6cd8780), the same fresh-worktree lint exits 0, because the overrides absorb exactly these diagnostics.

Closing that gap is a separate decision, either making `pnpm run lint` and `pnpm lint-fix` generate the types themselves, which would make this CI step redundant, or documenting the local lint commands and the `astro sync` prerequisite. Tracked in #7262, which also records that a bare `astro sync` writes the default `app/node_modules/.vite` and so needs `cross-env APP_VITE_CACHE_DIR=node_modules/.vite-check` like `app/package.json`'s `check` script, or it will invalidate a running `pnpm dev-app` server's SSR modules.

## Review gate reassessment

<details>
<summary>Cycle 3: Continue, removing the assertion instead of suppressing it</summary>

**Assessment**

Issue severity is moderate and entirely developer-facing: CI and local lint resolve different types, which already nearly shipped a red Lint job on an untouched file in #7248. Expected frequency is every pull request, since the Lint job runs on all of them. Supported scope is the repository's own lint pipeline; no shipped runtime behavior and no public contract are involved.

Implementation and maintenance complexity is net negative. The final diff is three files, `+10 / −20`, removing two config overrides and one `as unknown as` cast while adding one CI step and one object property. It introduces no branches, state, helpers, abstractions, tests, documentation, or platform policy.

Of eleven findings across three cycles, three trace to PR #7248 merging mid-task and invalidating the base, four were prose or flag corrections, one was blocked by tooling permissions, one registered a separable follow-up, and two formed the single design thread. That thread produced the only wrong turn: cycle 2 concluded that the auto-fixable rule should be suppressed, without asking why it fired, and cycle 3 asked and measured that the assertion was never needed. The cycles reflect external churn and one incomplete root-cause analysis, not a design that resists implementation.

**Decision**

Continue the direction established in cycle 1, which is verbatim what #7255 asks for: sync the Astro types in the Lint job and delete the suppressions that only existed because it did not. Adopt cycle 3's simplification, removing the fixture's assertion rather than keeping an override to shield it, because it deletes the auto-fix hazard's cause rather than muting its detector and completes the issue's stated outcome that both overrides go. Keep `--fail-if-no-match`, which was measured to change behavior. Reverse cycle 2's disposition to retain the `no-unnecessary-type-assertion` override; its measurement stands and is recorded above, only its remedy was wrong.

Splitting the fixture change into its own pull request was considered and rejected: it would either leave the second override in place, failing the issue, or open a window between merges in which `oxlint --fix` silently deletes the assertion.

Making `pnpm run lint` generate the types itself was considered and deliberately excluded as scope drift. It is registered as #7262.

</details>
