### PR TITLE
Skip the Git hooks in CI

### DIFF
--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -20,6 +20,14 @@ runs:
       with:
         node-version-file: package.json
 
+    - name: Disable Git hooks
+      shell: bash
+      # Dedicated jobs lint, format, and test every change, so the pre-commit
+      # hook is not necessary in CI. The jobs that commit generated files
+      # install only part of the workspace. The hook's `lint-staged` tasks need
+      # all of it, so the hook fails the commit.
+      run: echo "HUSKY=0" >> "$GITHUB_ENV"
+
     - name: Allow partial install
       if: inputs.filters != '' || inputs.install != 'true'
       shell: bash


### PR DESCRIPTION
## Motivation

The `release` workflow fails on every push to `main` since #7264. The `Version or publish` job runs `changesets/action`, which commits the version bump. That commit runs the Git `pre-commit` hook, and the hook now fails ([run 32631214739](https://github.com/ariakit/ariakit/actions/runs/32631214739/job/97174220135)):

```text
✖ pnpm run sync-astro-types:
$ cross-env APP_VITE_CACHE_DIR=node_modules/.vite-sync astro sync ...
Error: spawn astro ENOENT
[WARN]  Local package.json exists, but node_modules missing, did you mean to install?
husky - pre-commit script failed (code 1)
```

#7264 added `pnpm run sync-astro-types` to the `lint-staged` tasks:

```json
"lint-staged": {
  "package.json": "pnpm -r run --if-present clean",
  "*.{js,ts,tsx,md,mdx,json}": [
    "pnpm run sync-astro-types",
    "oxlint --disable-nested-config --fix --no-error-on-unmatched-pattern",
    "oxfmt --no-error-on-unmatched-pattern"
  ]
}
```

That script runs `pnpm -F app run sync`, so it needs the `app` workspace. The `release` job installs only `./packages/*...`, so `app/node_modules` does not exist there and the hook fails the commit. Git then exits with code 1, which the job reports as `The process '/usr/bin/git' failed with exit code 1`.

The `docs` job carries the same trap on its `pull_request` path, where `commit-or-pr` runs `git commit`. It also installs only `./packages/*...`, and it commits `packages/*/readme.md`, which the same `lint-staged` glob matches.

## Solution

Set `HUSKY=0` in the job environment from the shared `setup` action, so no CI job runs the repository's Git hooks:

```yaml
- name: Disable Git hooks
  shell: bash
  run: echo "HUSKY=0" >> "$GITHUB_ENV"
```

Dedicated jobs already lint, format, and test every change, so the `pre-commit` hook is not necessary in CI. The jobs that commit generated files install only part of the workspace, while the hook's `lint-staged` tasks need all of it.

The step writes the variable before the install step, because husky skips its own `core.hooksPath` install when `HUSKY=0` is already set. `.husky/_/h` also honors the variable at run time, so both layers are covered.

`.github/workflows/perf.yml` already sets `HUSKY: 0` in three places, so this follows an established pattern. Those entries stay, because they document a distinct hazard at the point of use: husky's `prepare` step rewrites `core.hooksPath` to a relative path under a temporary worktree.

## Verification

The release job was replicated locally with a partial install (`--filter './packages/*...'`, which leaves `app/node_modules` absent) plus `pnpm_config_verify_deps_before_run=false`, which is what the `Allow partial install` step sets in CI.

- Without the fix, committing a simulated `changeset version` bump reproduced the CI failure: `Error: spawn astro ENOENT`, `Local package.json exists, but node_modules missing`, `husky - pre-commit script failed (code 1)`, exit 1.
- With `HUSKY=0`, the same commit succeeds with exit 0 and no hook output.

`changeset version` was also run against the 41 pending changesets, and `oxfmt --check` then passed across the repository on 2080 files. The release output that the hook used to format is already format-clean, so the generated `Publish` pull request stays green without it.
