### PR TITLE
Experiment: Add the Link component

### DIFF
--- a/.changeset/200-link-experiment.md
+++ b/.changeset/200-link-experiment.md
@@ -1,0 +1,17 @@
+---
+"@ariakit/react-components": patch
+---
+
+Experimental `Link` and `useLink`
+
+The experimental `Link` component renders a native anchor. When disabled, it omits native destination and anchor microdata attributes during render and exposes link semantics in server HTML.
+
+```tsx
+import { Link } from "@ariakit/react-components/link/link";
+
+<Link href="/articles/2" disabled accessibleWhenDisabled>
+  Next article
+</Link>;
+```
+
+Pass the destination to `Link` so it can withhold it while disabled.

--- a/.changeset/300-disabled-anchor-semantics.md
+++ b/.changeset/300-disabled-anchor-semantics.md
@@ -1,0 +1,16 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Disabled anchors keep link semantics
+
+Disabled [`Focusable`](https://ariakit.com/reference/focusable) anchors now expose link semantics when no `href` is present. Anchors using [`accessibleWhenDisabled`](https://ariakit.com/reference/focusable#accessiblewhendisabled) also receive the explicit tab stop needed to remain keyboard reachable.
+
+This behavior also applies to [`Button`](https://ariakit.com/reference/button) and other Ariakit components when they render an anchor.
+
+```tsx
+<Focusable disabled accessibleWhenDisabled render={<a />}>
+  Unavailable report
+</Focusable>
+```

--- a/.changeset/300-disabled-anchor-semantics.md
+++ b/.changeset/300-disabled-anchor-semantics.md
@@ -5,9 +5,9 @@
 
 Disabled anchors keep link semantics
 
-Disabled [`Focusable`](https://ariakit.com/reference/focusable) anchors now expose link semantics when no `href` is present. Anchors using [`accessibleWhenDisabled`](https://ariakit.com/reference/focusable#accessiblewhendisabled) also receive the explicit tab stop needed to remain keyboard reachable.
+Disabled [`Focusable`](https://ariakit.com/reference/focusable) anchors with a statically supplied intrinsic `render={<a />}` now expose link semantics when no `href` is present. Anchors using [`accessibleWhenDisabled`](https://ariakit.com/reference/focusable#accessiblewhendisabled) also receive the explicit tab stop needed to remain keyboard reachable.
 
-This behavior also applies to [`Button`](https://ariakit.com/reference/button) and other Ariakit components when they render an anchor.
+This behavior also applies to [`Button`](https://ariakit.com/reference/button) and other Ariakit components when they statically render an intrinsic anchor. Function render callbacks and custom render components keep the existing mount-time element detection because their native element type is not available during server rendering.
 
 ```tsx
 <Focusable disabled accessibleWhenDisabled render={<a />}>

--- a/app/package.json
+++ b/app/package.json
@@ -99,6 +99,7 @@
     "react": "19.2.8",
     "react-aria-components": "1.20.0",
     "react-dom": "19.2.8",
+    "react-router-dom": "6.30.4",
     "read-package-up": "12.0.0",
     "rehype-autolink-headings": "7.1.0",
     "rehype-parse": "9.0.1",

--- a/app/src/sandbox/link-disabled/index.react.tsx
+++ b/app/src/sandbox/link-disabled/index.react.tsx
@@ -1,0 +1,468 @@
+import * as Ariakit from "@ariakit/react";
+import { Link, useLink } from "@ariakit/react-components/link/link";
+import { useRef, useState } from "react";
+
+const destinationAttributes = {
+  href: "#destination-contract",
+  itemProp: "url",
+  target: "_blank",
+  download: "contract.html",
+  ping: "/analytics/link",
+  rel: "next",
+  hrefLang: "en",
+  referrerPolicy: "no-referrer" as const,
+  type: "text/html",
+};
+
+function getChapter(page: number) {
+  if (page === 2) {
+    return {
+      eyebrow: "Field note 02",
+      title: "A path through the cloud forest",
+      description:
+        "The trail rises past tree ferns and quiet pools before opening onto the ridge.",
+    };
+  }
+  if (page === 3) {
+    return {
+      eyebrow: "Field note 03",
+      title: "Where the river meets the basalt",
+      description:
+        "Black rock, silver water, and a final crossing before the road returns.",
+    };
+  }
+  return {
+    eyebrow: "Field note 01",
+    title: "Before the valley wakes",
+    description:
+      "A native link keeps every browser gesture available while the next page exists.",
+  };
+}
+
+export function ServerLinks() {
+  return (
+    <>
+      <Link href="#server-enabled">Server-enabled link</Link>
+      <Link {...destinationAttributes} disabled>
+        Server-skipped link
+      </Link>
+      <Link {...destinationAttributes} disabled accessibleWhenDisabled>
+        Server-reachable link
+      </Link>
+      <Link href="#conflicting-state" disabled aria-disabled={false}>
+        Disabled wins conflicting ARIA
+      </Link>
+    </>
+  );
+}
+
+export function WarningLinks() {
+  return (
+    <>
+      <Link disabled render={<a href="#render-owned" />}>
+        Render-owned destination
+      </Link>
+      <Link render={<div />}>Non-anchor action</Link>
+    </>
+  );
+}
+
+function PaginationDemo() {
+  const [page, setPage] = useState(1);
+  const chapter = getChapter(page);
+  const previousPage = page > 1 ? page - 1 : undefined;
+  const nextPage = page < 3 ? page + 1 : undefined;
+
+  return (
+    <section className="overflow-hidden rounded-[2rem] border border-white/10 bg-white/[0.06] shadow-2xl shadow-black/30 backdrop-blur-xl">
+      <div className="relative min-h-80 overflow-hidden border-b border-white/10 bg-[radial-gradient(circle_at_top_right,rgba(129,140,248,0.38),transparent_42%),linear-gradient(145deg,#182039,#090d18_72%)] p-8 sm:p-10">
+        <div className="absolute -right-16 -top-20 size-64 rounded-full border border-white/10" />
+        <div className="absolute -right-4 top-8 size-28 rounded-full border border-white/10" />
+        <div className="relative flex min-h-60 max-w-xl flex-col justify-end">
+          <p className="mb-3 text-xs font-semibold uppercase tracking-[0.24em] text-indigo-200">
+            {chapter.eyebrow}
+          </p>
+          <h2 className="text-balance text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+            {chapter.title}
+          </h2>
+          <p className="mt-4 max-w-lg text-pretty leading-7 text-slate-300">
+            {chapter.description}
+          </p>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-5 p-6 sm:flex-row sm:items-center sm:justify-between sm:p-8">
+        <div aria-live="polite">
+          <p className="text-sm font-medium text-white">Chapter {page} of 3</p>
+          <p className="mt-1 text-xs text-slate-400">
+            Disabled destinations disappear from the anchor.
+          </p>
+        </div>
+        <nav aria-label="Field note pages" className="flex items-center gap-3">
+          <Link
+            href={previousPage ? `#chapter-${previousPage}` : undefined}
+            disabled={!previousPage}
+            className="inline-flex min-h-11 items-center gap-2 rounded-full border border-white/10 bg-white/[0.07] px-5 text-sm font-semibold text-white transition hover:border-white/20 hover:bg-white/[0.12] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-300 aria-disabled:cursor-not-allowed aria-disabled:text-slate-500"
+            onClick={() => {
+              if (previousPage) {
+                setPage(previousPage);
+              }
+            }}
+          >
+            <span aria-hidden="true">←</span>
+            Previous page
+          </Link>
+          <Link
+            href={nextPage ? `#chapter-${nextPage}` : "#chapter-4"}
+            disabled={!nextPage}
+            className="inline-flex min-h-11 items-center gap-2 rounded-full bg-indigo-400 px-5 text-sm font-semibold text-slate-950 shadow-lg shadow-indigo-950/30 transition hover:bg-indigo-300 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-300 aria-disabled:bg-slate-800 aria-disabled:text-slate-500"
+            onClick={() => {
+              if (nextPage) {
+                setPage(nextPage);
+              }
+            }}
+          >
+            Next page
+            <span aria-hidden="true">→</span>
+          </Link>
+        </nav>
+      </div>
+    </section>
+  );
+}
+
+function DestinationAttributeDemo() {
+  const [disabled, setDisabled] = useState(true);
+
+  return (
+    <div className="mt-6 grid gap-4 rounded-2xl border border-white/10 bg-slate-950/50 p-4 sm:grid-cols-[1fr_auto] sm:items-center">
+      <div>
+        <h3 className="text-sm font-semibold text-white">
+          Destination attribute probe
+        </h3>
+        <p className="mt-1 max-w-2xl text-xs leading-5 text-slate-400">
+          Use the button to inspect omission and restoration without activating
+          a download, ping, or new browsing context.
+        </p>
+        <Link
+          {...destinationAttributes}
+          disabled={disabled}
+          tabIndex={-1}
+          className="pointer-events-none mt-3 inline-flex rounded-full border border-white/10 px-3 py-1 font-mono text-xs text-indigo-200 aria-disabled:text-slate-500"
+        >
+          Raw destination attribute probe
+        </Link>
+      </div>
+      <button
+        type="button"
+        className="min-h-11 rounded-xl border border-white/10 bg-white/[0.07] px-4 text-sm font-medium text-white transition hover:bg-white/[0.12] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-300"
+        onClick={() => setDisabled((value) => !value)}
+      >
+        {disabled
+          ? "Restore destination attributes"
+          : "Withhold destination attributes"}
+      </button>
+    </div>
+  );
+}
+
+function KeyboardDemo() {
+  return (
+    <section className="rounded-3xl border border-white/10 bg-white/[0.04] p-6 sm:p-7">
+      <div className="flex items-start gap-4">
+        <span className="grid size-10 shrink-0 place-items-center rounded-2xl bg-emerald-300/10 text-lg text-emerald-200">
+          ⌨
+        </span>
+        <div>
+          <h2 className="font-semibold text-white">One deliberate tab stop</h2>
+          <p className="mt-1 text-sm leading-6 text-slate-400">
+            Start here and press Tab. The ordinary disabled link is skipped,
+            while the explainable link stays reachable.
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-6 grid gap-3 sm:grid-cols-2">
+        <button
+          type="button"
+          className="min-h-11 rounded-xl border border-white/10 bg-slate-950/50 px-4 text-left text-sm font-medium text-slate-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300"
+        >
+          Before links
+        </button>
+        <Link
+          href="#unavailable-report"
+          disabled
+          className="flex min-h-20 flex-col justify-center rounded-2xl border border-white/10 bg-slate-950/50 px-4 text-sm text-slate-500"
+        >
+          Skipped disabled link
+          <span className="mt-1 text-xs">No keyboard stop</span>
+        </Link>
+
+        <Ariakit.TooltipProvider timeout={0}>
+          <Ariakit.TooltipAnchor
+            render={
+              <Link
+                href="#analytics"
+                disabled
+                accessibleWhenDisabled
+                className="flex min-h-20 flex-col justify-center rounded-2xl border border-emerald-300/20 bg-emerald-300/[0.06] px-4 text-sm font-medium text-emerald-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300"
+              />
+            }
+          >
+            Reachable disabled link
+            <span
+              aria-hidden="true"
+              className="mt-1 text-xs font-normal text-emerald-200/60"
+            >
+              Focus for the reason
+            </span>
+          </Ariakit.TooltipAnchor>
+          <Ariakit.Tooltip className="z-50 max-w-64 rounded-xl border border-white/10 bg-slate-900 px-3 py-2 text-sm text-white shadow-xl">
+            Analytics unlocks after the first published report.
+          </Ariakit.Tooltip>
+        </Ariakit.TooltipProvider>
+        <button
+          type="button"
+          className="min-h-11 rounded-xl border border-white/10 bg-slate-950/50 px-4 text-left text-sm font-medium text-slate-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300"
+        >
+          After links
+        </button>
+      </div>
+    </section>
+  );
+}
+
+function StateTransitionDemo() {
+  const [disabled, setDisabled] = useState(false);
+  const linkRef = useRef<HTMLAnchorElement>(null);
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-white/[0.04] p-6 sm:p-7">
+      <div className="flex items-start gap-4">
+        <span className="grid size-10 shrink-0 place-items-center rounded-2xl bg-indigo-300/10 text-indigo-200">
+          ↻
+        </span>
+        <div>
+          <h2 className="font-semibold text-white">Stable through change</h2>
+          <p className="mt-1 text-sm leading-6 text-slate-400">
+            Link owns the destination, so disabling it updates one anchor
+            instead of remounting the element.
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-6 rounded-2xl border border-white/10 bg-slate-950/50 p-4">
+        <Link
+          ref={linkRef}
+          href="#release-notes"
+          disabled={disabled}
+          accessibleWhenDisabled
+          className="inline-flex min-h-11 items-center rounded-full bg-white px-5 text-sm font-semibold text-slate-950 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-300 aria-disabled:bg-slate-800 aria-disabled:text-slate-400"
+        >
+          Release notes
+        </Link>
+        <p className="mt-3 text-xs text-slate-400" aria-live="polite">
+          {disabled
+            ? "Destination withheld; focus remains on the same anchor."
+            : "Destination available as a native link."}
+        </p>
+      </div>
+
+      <button
+        type="button"
+        className="mt-4 min-h-11 rounded-xl border border-white/10 bg-white/[0.07] px-4 text-sm font-medium text-white transition hover:bg-white/[0.12] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-300"
+        onClick={() => {
+          linkRef.current?.focus();
+          setDisabled((value) => !value);
+        }}
+      >
+        {disabled ? "Enable while focused" : "Disable while focused"}
+      </button>
+    </section>
+  );
+}
+
+function CompositionDemo() {
+  const enterpriseDisabled = true;
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-white/[0.04] p-6 sm:p-7">
+      <div className="flex items-start gap-4">
+        <span className="grid size-10 shrink-0 place-items-center rounded-2xl bg-amber-300/10 text-amber-200">
+          ◫
+        </span>
+        <div>
+          <h2 className="font-semibold text-white">
+            Composition keeps context
+          </h2>
+          <p className="mt-1 text-sm leading-6 text-slate-400">
+            Inside a menu, the outer component keeps its menu item role. Both
+            owners receive the same disabled state so the store and link agree.
+          </p>
+        </div>
+      </div>
+
+      <Ariakit.MenuProvider>
+        <Ariakit.MenuButton className="mt-6 inline-flex min-h-11 items-center gap-3 rounded-xl border border-white/10 bg-slate-950/50 px-4 text-sm font-medium text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-300">
+          Workspace menu <span aria-hidden="true">•••</span>
+        </Ariakit.MenuButton>
+        <Ariakit.Menu
+          gutter={8}
+          className="z-50 min-w-64 rounded-2xl border border-white/10 bg-slate-900 p-2 text-sm text-white shadow-2xl outline-none"
+        >
+          <Ariakit.MenuItem className="flex min-h-10 cursor-default items-center rounded-xl px-3 data-active-item:bg-white/10">
+            Overview
+          </Ariakit.MenuItem>
+          <Ariakit.MenuItem
+            disabled={enterpriseDisabled}
+            render={
+              <Link
+                href="#enterprise-settings"
+                disabled={enterpriseDisabled}
+                accessibleWhenDisabled
+                className="flex min-h-10 cursor-default items-center justify-between rounded-xl px-3 text-slate-400 data-active-item:bg-white/10"
+              />
+            }
+          >
+            Enterprise settings <span aria-hidden="true">🔒</span>
+          </Ariakit.MenuItem>
+        </Ariakit.Menu>
+      </Ariakit.MenuProvider>
+
+      <div className="mt-5 rounded-2xl border border-white/10 bg-slate-950/50 p-4">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+          Consumer ARIA parity
+        </p>
+        <Link
+          href="#billing"
+          aria-disabled="true"
+          className="mt-3 inline-flex text-sm font-medium text-amber-100 underline decoration-amber-300/40 underline-offset-4"
+        >
+          Billing portal
+        </Link>
+      </div>
+    </section>
+  );
+}
+
+const contractLinkClass =
+  "inline-flex min-h-11 items-center rounded-full border border-white/10 bg-white/[0.05] px-4 text-sm font-medium text-slate-200 underline decoration-white/20 underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-300 aria-disabled:no-underline aria-disabled:text-slate-500";
+
+function HookLink() {
+  const props = useLink({
+    href: "#contract-hook",
+    className: contractLinkClass,
+  });
+  return <Ariakit.Role.a {...props}>Hook-generated anchor</Ariakit.Role.a>;
+}
+
+function ContractMatrix() {
+  return (
+    <section className="mt-6 rounded-3xl border border-white/10 bg-white/[0.04] p-6 sm:p-7">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-indigo-200">
+            Contract matrix
+          </p>
+          <h2 className="mt-2 text-xl font-semibold text-white">
+            One anchor, every supported state
+          </h2>
+        </div>
+        <p className="max-w-md text-sm leading-6 text-slate-400">
+          These small cases make the API edges available for direct inspection
+          in browser developer tools.
+        </p>
+      </div>
+
+      <div className="mt-6 flex flex-wrap gap-3">
+        <Link href="#contract-enabled" className={contractLinkClass}>
+          Enabled native
+        </Link>
+        <Link href="#contract-disabled" disabled className={contractLinkClass}>
+          Disabled skipped
+        </Link>
+        <Link
+          href="#contract-reachable"
+          disabled
+          accessibleWhenDisabled
+          className={contractLinkClass}
+        >
+          Disabled reachable
+        </Link>
+        <Link
+          href="#contract-aria"
+          aria-disabled="true"
+          className={contractLinkClass}
+        >
+          ARIA-disabled
+        </Link>
+        <Link
+          href="#contract-focusable-off"
+          disabled
+          focusable={false}
+          className={contractLinkClass}
+        >
+          Focusable behavior off
+        </Link>
+        <Link className={contractLinkClass}>Placeholder anchor</Link>
+        <Link
+          href="#contract-composed"
+          render={<a data-composed />}
+          className={contractLinkClass}
+        >
+          Composed native anchor
+        </Link>
+        <Link
+          href="#contract-function"
+          render={(props) => <a {...props} data-function-render />}
+          className={contractLinkClass}
+        >
+          Function-rendered anchor
+        </Link>
+        <HookLink />
+      </div>
+      <DestinationAttributeDemo />
+    </section>
+  );
+}
+
+export default function Example() {
+  return (
+    <main className="relative min-h-dvh overflow-hidden bg-[#070a12] px-4 py-12 text-slate-200 sm:px-6 sm:py-16">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_12%_8%,rgba(99,102,241,0.18),transparent_32%),radial-gradient(circle_at_88%_76%,rgba(16,185,129,0.12),transparent_28%)]" />
+      <div className="relative mx-auto max-w-6xl">
+        <header className="mb-10 max-w-3xl sm:mb-14">
+          <p className="inline-flex items-center gap-2 rounded-full border border-indigo-300/20 bg-indigo-300/[0.08] px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-indigo-200">
+            <span aria-hidden="true">✦</span> Link API experiment
+          </p>
+          <h1 className="mt-5 text-balance text-4xl font-semibold tracking-[-0.04em] text-white sm:text-6xl">
+            Native links, honest states.
+          </h1>
+          <p className="mt-5 max-w-2xl text-pretty text-base leading-7 text-slate-400 sm:text-lg">
+            Enabled links stay native. Disabled links lose their destinations
+            without losing the semantics that people and assistive technology
+            rely on.
+          </p>
+          <Link
+            href="#field-notes"
+            className="mt-6 inline-flex text-sm font-semibold text-indigo-200 underline decoration-indigo-300/40 underline-offset-4 hover:text-indigo-100"
+          >
+            Read field notes
+          </Link>
+        </header>
+
+        <div id="field-notes">
+          <PaginationDemo />
+        </div>
+
+        <div className="mt-6 grid gap-6 lg:grid-cols-3">
+          <KeyboardDemo />
+          <StateTransitionDemo />
+          <CompositionDemo />
+        </div>
+
+        <ContractMatrix />
+      </div>
+    </main>
+  );
+}

--- a/app/src/sandbox/link-disabled/index.react.tsx
+++ b/app/src/sandbox/link-disabled/index.react.tsx
@@ -52,6 +52,21 @@ export function ServerLinks() {
       <Link href="#conflicting-state" disabled aria-disabled={false}>
         Disabled wins conflicting ARIA
       </Link>
+      <Link
+        href="#server-function-skipped"
+        disabled
+        render={(props) => <a {...props} data-server-function-skipped />}
+      >
+        Server function-skipped link
+      </Link>
+      <Link
+        href="#server-function-reachable"
+        disabled
+        accessibleWhenDisabled
+        render={(props) => <a {...props} data-server-function-reachable />}
+      >
+        Server function-reachable link
+      </Link>
     </>
   );
 }
@@ -419,6 +434,15 @@ function ContractMatrix() {
           className={contractLinkClass}
         >
           Function-rendered anchor
+        </Link>
+        <Link
+          href="#contract-function-disabled"
+          disabled
+          accessibleWhenDisabled
+          render={(props) => <a {...props} data-function-render-disabled />}
+          className={contractLinkClass}
+        >
+          Function-rendered disabled
         </Link>
         <HookLink />
       </div>

--- a/app/src/sandbox/link-disabled/index.react.tsx
+++ b/app/src/sandbox/link-disabled/index.react.tsx
@@ -176,7 +176,8 @@ function KeyboardDemo() {
         <div>
           <h2 className="font-semibold text-white">One deliberate tab stop</h2>
           <p className="mt-1 text-sm leading-6 text-slate-400">
-            Start here and press Tab. The ordinary disabled link is skipped,
+            Start here and press Tab. In Safari on macOS, use Option+Tab if Tab
+            skips links and buttons. The ordinary disabled link is skipped,
             while the explainable link stays reachable.
           </p>
         </div>

--- a/app/src/sandbox/link-disabled/preview.json
+++ b/app/src/sandbox/link-disabled/preview.json
@@ -1,0 +1,3 @@
+{
+  "fullscreen": true
+}

--- a/app/src/sandbox/link-disabled/test-browser.ts
+++ b/app/src/sandbox/link-disabled/test-browser.ts
@@ -1,0 +1,15 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("keeps only the explainable disabled link in the tab order", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Before links").focus();
+    await page.keyboard.press("Tab");
+    await test.expect(q.link("Reachable disabled link")).toBeFocused();
+
+    await page.keyboard.press("Tab");
+    await test.expect(q.button("After links")).toBeFocused();
+  });
+});

--- a/app/src/sandbox/link-disabled/test-browser.ts
+++ b/app/src/sandbox/link-disabled/test-browser.ts
@@ -1,15 +1,22 @@
+import type { Page } from "@ariakit/test/playwright";
 import { withFramework } from "#app/test-utils/preview.ts";
+
+function pressTab(page: Page, browserName: string) {
+  const key = browserName === "webkit" ? "Alt+Tab" : "Tab";
+  return page.keyboard.press(key);
+}
 
 withFramework(import.meta.dirname, async ({ test }) => {
   test("keeps only the explainable disabled link in the tab order", async ({
+    browserName,
     page,
     q,
   }) => {
     await q.button("Before links").focus();
-    await page.keyboard.press("Tab");
+    await pressTab(page, browserName);
     await test.expect(q.link("Reachable disabled link")).toBeFocused();
 
-    await page.keyboard.press("Tab");
+    await pressTab(page, browserName);
     await test.expect(q.button("After links")).toBeFocused();
   });
 });

--- a/app/src/sandbox/link-disabled/test-chrome-js-disabled.ts
+++ b/app/src/sandbox/link-disabled/test-chrome-js-disabled.ts
@@ -1,0 +1,50 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+const destinationAttributes = [
+  "href",
+  "itemprop",
+  "target",
+  "download",
+  "ping",
+  "rel",
+  "hreflang",
+  "referrerpolicy",
+  "type",
+];
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test.use({ javaScriptEnabled: false });
+
+  test("serves complete disabled semantics before hydration", async ({
+    page,
+    q,
+  }) => {
+    const skipped = q.link("Previous page");
+    for (const attribute of destinationAttributes) {
+      await test.expect(skipped).not.toHaveAttribute(attribute);
+    }
+    await test.expect(skipped).toHaveAttribute("role", "link");
+    await test.expect(skipped).toHaveAttribute("aria-disabled", "true");
+    await test.expect(skipped).toHaveAttribute("tabindex", "-1");
+
+    const probe = q.link("Raw destination attribute probe");
+    for (const attribute of destinationAttributes) {
+      await test.expect(probe).not.toHaveAttribute(attribute);
+    }
+    await test.expect(probe).toHaveAttribute("role", "link");
+    await test.expect(probe).toHaveAttribute("aria-disabled", "true");
+
+    const reachable = q.link("Reachable disabled link");
+    await test.expect(reachable).not.toHaveAttribute("href");
+    await test.expect(reachable).toHaveAttribute("role", "link");
+    await test.expect(reachable).toHaveAttribute("aria-disabled", "true");
+    await test.expect(reachable).toHaveAttribute("tabindex", "0");
+
+    await q.button("Before links").focus();
+    await page.keyboard.press("Tab");
+    await test.expect(reachable).toBeFocused();
+
+    await page.keyboard.press("Tab");
+    await test.expect(q.button("After links")).toBeFocused();
+  });
+});

--- a/app/src/sandbox/link-disabled/test-chrome-js-disabled.ts
+++ b/app/src/sandbox/link-disabled/test-chrome-js-disabled.ts
@@ -15,6 +15,7 @@ const destinationAttributes = [
 withFramework(import.meta.dirname, async ({ test }) => {
   test.use({ javaScriptEnabled: false });
 
+  // https://github.com/ariakit/ariakit/issues/7112
   test("serves complete disabled semantics before hydration", async ({
     page,
     q,
@@ -39,6 +40,20 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(reachable).toHaveAttribute("role", "link");
     await test.expect(reachable).toHaveAttribute("aria-disabled", "true");
     await test.expect(reachable).toHaveAttribute("tabindex", "0");
+
+    const functionRendered = q.link("Function-rendered disabled");
+    for (const attribute of destinationAttributes) {
+      await test.expect(functionRendered).not.toHaveAttribute(attribute);
+    }
+    await test
+      .expect(functionRendered)
+      .toHaveAttribute("data-function-render-disabled");
+    await test.expect(functionRendered).toHaveAttribute("role", "link");
+    await test
+      .expect(functionRendered)
+      .toHaveAttribute("aria-disabled", "true");
+    await test.expect(functionRendered).toHaveAttribute("tabindex", "0");
+    await test.expect(functionRendered).not.toHaveAttribute("disabled");
 
     await q.button("Before links").focus();
     await page.keyboard.press("Tab");

--- a/app/src/sandbox/link-disabled/test-chrome.ts
+++ b/app/src/sandbox/link-disabled/test-chrome.ts
@@ -1,0 +1,125 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+const destinationAttributes = [
+  "href",
+  "itemprop",
+  "target",
+  "download",
+  "ping",
+  "rel",
+  "hreflang",
+  "referrerpolicy",
+  "type",
+];
+
+const restoredDestination = {
+  href: "#destination-contract",
+  itemprop: "url",
+  target: "_blank",
+  download: "contract.html",
+  ping: "/analytics/link",
+  rel: "next",
+  hreflang: "en",
+  referrerpolicy: "no-referrer",
+  type: "text/html",
+};
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("renders native enabled and complete disabled contracts", async ({
+    q,
+  }) => {
+    const enabled = q.link("Read field notes");
+    await test.expect(enabled).toHaveAttribute("href", "#field-notes");
+    await test.expect(enabled).not.toHaveAttribute("role");
+    await test.expect(enabled).not.toHaveAttribute("aria-disabled");
+    await test.expect(enabled).not.toHaveAttribute("tabindex");
+
+    const disabled = q.link("Raw destination attribute probe");
+    for (const attribute of destinationAttributes) {
+      await test.expect(disabled).not.toHaveAttribute(attribute);
+    }
+    await test.expect(disabled).toHaveAttribute("role", "link");
+    await test.expect(disabled).toHaveAttribute("aria-disabled", "true");
+    await test.expect(disabled).toHaveAttribute("tabindex", "-1");
+
+    const accessible = q.link("Disabled reachable");
+    await test.expect(accessible).not.toHaveAttribute("href");
+    await test.expect(accessible).toHaveAttribute("tabindex", "0");
+    await test.expect(accessible).toHaveAttribute("aria-disabled", "true");
+    await test.expect(accessible).toMatchAriaSnapshot(`
+      - link "Disabled reachable" [disabled]
+    `);
+  });
+
+  test("restores every destination attribute declaratively", async ({ q }) => {
+    const probe = q.link("Raw destination attribute probe");
+    await q.button("Restore destination attributes").click();
+    for (const [attribute, value] of Object.entries(restoredDestination)) {
+      await test.expect(probe).toHaveAttribute(attribute, value);
+    }
+  });
+
+  test("keeps interactive pagination destinations realistic", async ({ q }) => {
+    await q.link("Next page").click();
+    await test.expect(q.text("Chapter 2 of 3")).toBeVisible();
+    const previous = q.link("Previous page");
+    await test.expect(previous).toHaveAttribute("href", "#chapter-1");
+    await test.expect(previous).not.toHaveAttribute("target");
+    await test.expect(previous).not.toHaveAttribute("download");
+    await test.expect(previous).not.toHaveAttribute("ping");
+  });
+
+  test("preserves node identity and focus through both transitions", async ({
+    q,
+  }) => {
+    const link = q.link("Release notes");
+    const before = await link.elementHandle();
+    if (!before) {
+      throw new Error("Release notes link was not rendered");
+    }
+
+    await q.button("Disable while focused").click();
+    let after = await q.link("Release notes").elementHandle();
+    if (!after) {
+      throw new Error("Release notes link was removed");
+    }
+    test
+      .expect(
+        await before.evaluate(
+          (element, nextElement) => element === nextElement,
+          after,
+        ),
+      )
+      .toBe(true);
+    await test.expect(q.link("Release notes")).toBeFocused();
+    await test.expect(q.link("Release notes")).not.toHaveAttribute("href");
+
+    await q.button("Enable while focused").click();
+    after = await q.link("Release notes").elementHandle();
+    if (!after) {
+      throw new Error("Release notes link was removed after re-enabling");
+    }
+    test
+      .expect(
+        await before.evaluate(
+          (element, nextElement) => element === nextElement,
+          after,
+        ),
+      )
+      .toBe(true);
+    await test.expect(q.link("Release notes")).toBeFocused();
+    await test
+      .expect(q.link("Release notes"))
+      .toHaveAttribute("href", "#release-notes");
+  });
+
+  test("preserves the outer menu item role and disabled state", async ({
+    q,
+  }) => {
+    await q.button("Workspace menu").click();
+    const item = q.menuitem("Enterprise settings");
+    await test.expect(item).toHaveAttribute("role", "menuitem");
+    await test.expect(item).toHaveAttribute("aria-disabled", "true");
+    await test.expect(item).not.toHaveAttribute("href");
+  });
+});

--- a/app/src/sandbox/link-disabled/test.ts
+++ b/app/src/sandbox/link-disabled/test.ts
@@ -106,6 +106,14 @@ test("supports accessible, ARIA, and inactive Focusable states", () => {
   expect(focusableOff).toHaveAttribute("href", "#contract-focusable-off");
   expect(focusableOff).not.toHaveAttribute("aria-disabled");
   expect(focusableOff).not.toHaveAttribute("tabindex");
+
+  const functionRendered = q.link("Function-rendered disabled");
+  expectNoDestination(functionRendered);
+  expect(functionRendered).toHaveAttribute("data-function-render-disabled");
+  expect(functionRendered).toHaveAttribute("role", "link");
+  expect(functionRendered).toHaveAttribute("aria-disabled", "true");
+  expect(functionRendered).toHaveAttribute("tabindex", "0");
+  expect(functionRendered).not.toHaveAttribute("disabled");
 });
 
 test("keeps only the explainable disabled link in the tab order", async () => {
@@ -141,6 +149,7 @@ test("preserves an outer menu item role", async () => {
   await press.Escape();
 });
 
+// https://github.com/ariakit/ariakit/issues/7112
 test("renders final disabled semantics before hydration", async () => {
   const scope = globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean };
   const previousActEnvironment = scope.IS_REACT_ACT_ENVIRONMENT;
@@ -187,6 +196,22 @@ test("renders final disabled semantics before hydration", async () => {
     expect(conflict).toHaveAttribute("tabindex", "-1");
     expect(conflict).not.toHaveAttribute("disabled");
 
+    const functionSkipped = query.link("Server function-skipped link");
+    expectNoDestination(functionSkipped);
+    expect(functionSkipped).toHaveAttribute("data-server-function-skipped");
+    expect(functionSkipped).toHaveAttribute("role", "link");
+    expect(functionSkipped).toHaveAttribute("aria-disabled", "true");
+    expect(functionSkipped).toHaveAttribute("tabindex", "-1");
+    expect(functionSkipped).not.toHaveAttribute("disabled");
+
+    const functionReachable = query.link("Server function-reachable link");
+    expectNoDestination(functionReachable);
+    expect(functionReachable).toHaveAttribute("data-server-function-reachable");
+    expect(functionReachable).toHaveAttribute("role", "link");
+    expect(functionReachable).toHaveAttribute("aria-disabled", "true");
+    expect(functionReachable).toHaveAttribute("tabindex", "0");
+    expect(functionReachable).not.toHaveAttribute("disabled");
+
     await act(async () => {
       root = hydrateRoot(container, element);
     });
@@ -199,6 +224,20 @@ test("renders final disabled semantics before hydration", async () => {
     expect(query.link("Server-skipped link")).toHaveAttribute("tabindex", "-1");
     expectNoDestination(query.link("Server-reachable link"));
     expect(query.link("Server-reachable link")).toHaveAttribute(
+      "tabindex",
+      "0",
+    );
+    expect(query.link("Server function-skipped link")).toBe(functionSkipped);
+    expectNoDestination(query.link("Server function-skipped link"));
+    expect(query.link("Server function-skipped link")).toHaveAttribute(
+      "tabindex",
+      "-1",
+    );
+    expect(query.link("Server function-reachable link")).toBe(
+      functionReachable,
+    );
+    expectNoDestination(query.link("Server function-reachable link"));
+    expect(query.link("Server function-reachable link")).toHaveAttribute(
       "tabindex",
       "0",
     );

--- a/app/src/sandbox/link-disabled/test.ts
+++ b/app/src/sandbox/link-disabled/test.ts
@@ -1,0 +1,240 @@
+import { click, focus, press, q } from "@ariakit/test";
+import { render } from "@ariakit/test/react";
+import { act, createElement } from "react";
+import { hydrateRoot } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { expect, test, vi } from "vitest";
+import { ServerLinks, WarningLinks } from "./index.react.tsx";
+
+const destinationAttributes = [
+  "href",
+  "itemprop",
+  "target",
+  "download",
+  "ping",
+  "rel",
+  "hreflang",
+  "referrerpolicy",
+  "type",
+];
+
+const restoredDestination = {
+  href: "#destination-contract",
+  itemprop: "url",
+  target: "_blank",
+  download: "contract.html",
+  ping: "/analytics/link",
+  rel: "next",
+  hreflang: "en",
+  referrerpolicy: "no-referrer",
+  type: "text/html",
+};
+
+function expectNoDestination(element: Element) {
+  for (const attribute of destinationAttributes) {
+    expect(element).not.toHaveAttribute(attribute);
+  }
+}
+
+test("keeps enabled and placeholder anchors native", () => {
+  const enabled = q.link("Read field notes");
+  expect(enabled).toHaveAttribute("href", "#field-notes");
+  expect(enabled).not.toHaveAttribute("role");
+  expect(enabled).not.toHaveAttribute("aria-disabled");
+  expect(enabled).not.toHaveAttribute("tabindex");
+  expect(enabled).not.toHaveAttribute("disabled");
+
+  const placeholder = q.text("Placeholder anchor");
+  expect(placeholder).toHaveProperty("tagName", "A");
+  expect(placeholder).not.toHaveAttribute("href");
+  expect(placeholder).not.toHaveAttribute("role");
+
+  const composed = q.link("Composed native anchor");
+  expect(composed).toHaveAttribute("href", "#contract-composed");
+  expect(composed).toHaveAttribute("data-composed");
+
+  const functionRendered = q.link("Function-rendered anchor");
+  expect(functionRendered).toHaveAttribute("href", "#contract-function");
+  expect(functionRendered).toHaveAttribute("data-function-render");
+
+  expect(q.link("Hook-generated anchor")).toHaveAttribute(
+    "href",
+    "#contract-hook",
+  );
+});
+
+test("withholds every destination attribute while disabled", () => {
+  const link = q.link("Raw destination attribute probe");
+  expectNoDestination(link);
+  expect(link).toHaveAttribute("role", "link");
+  expect(link).toHaveAttribute("aria-disabled", "true");
+  expect(link).toHaveAttribute("tabindex", "-1");
+  expect(link).not.toHaveAttribute("disabled");
+});
+
+test("restores every destination attribute declaratively", async () => {
+  const probe = q.link("Raw destination attribute probe");
+  await click(q.button("Restore destination attributes"));
+  expect(q.link("Raw destination attribute probe")).toBe(probe);
+  for (const [attribute, value] of Object.entries(restoredDestination)) {
+    expect(probe).toHaveAttribute(attribute, value);
+  }
+});
+
+test("keeps interactive pagination destinations realistic", async () => {
+  await click(q.link("Next page"));
+  expect(q.text("Chapter 2 of 3")).toBeVisible();
+  const previous = q.link("Previous page");
+  expect(previous).toHaveAttribute("href", "#chapter-1");
+  expect(previous).not.toHaveAttribute("target");
+  expect(previous).not.toHaveAttribute("download");
+  expect(previous).not.toHaveAttribute("ping");
+});
+
+test("supports accessible, ARIA, and inactive Focusable states", () => {
+  const accessible = q.link("Disabled reachable");
+  expectNoDestination(accessible);
+  expect(accessible).toHaveAttribute("aria-disabled", "true");
+  expect(accessible).toHaveAttribute("tabindex", "0");
+
+  const ariaDisabled = q.link("ARIA-disabled");
+  expectNoDestination(ariaDisabled);
+  expect(ariaDisabled).toHaveAttribute("aria-disabled", "true");
+  expect(ariaDisabled).toHaveAttribute("tabindex", "-1");
+
+  const focusableOff = q.link("Focusable behavior off");
+  expect(focusableOff).toHaveAttribute("href", "#contract-focusable-off");
+  expect(focusableOff).not.toHaveAttribute("aria-disabled");
+  expect(focusableOff).not.toHaveAttribute("tabindex");
+});
+
+test("keeps only the explainable disabled link in the tab order", async () => {
+  await focus(q.button("Before links"));
+  await press.Tab();
+  expect(q.link("Reachable disabled link")).toHaveFocus();
+
+  await press.Tab();
+  expect(q.button("After links")).toHaveFocus();
+});
+
+test("keeps the same anchor focused across disabled transitions", async () => {
+  const link = q.link("Release notes");
+
+  await click(q.button("Disable while focused"));
+  expect(q.link("Release notes")).toBe(link);
+  expect(link).toHaveFocus();
+  expectNoDestination(link);
+  expect(link).toHaveAttribute("aria-disabled", "true");
+
+  await click(q.button("Enable while focused"));
+  expect(q.link("Release notes")).toBe(link);
+  expect(link).toHaveFocus();
+  expect(link).toHaveAttribute("href", "#release-notes");
+});
+
+test("preserves an outer menu item role", async () => {
+  await click(q.button("Workspace menu"));
+  const item = q.menuitem("Enterprise settings");
+  expect(item).toHaveAttribute("role", "menuitem");
+  expect(item).toHaveAttribute("aria-disabled", "true");
+  expectNoDestination(item);
+  await press.Escape();
+});
+
+test("renders final disabled semantics before hydration", async () => {
+  const scope = globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean };
+  const previousActEnvironment = scope.IS_REACT_ACT_ENVIRONMENT;
+  scope.IS_REACT_ACT_ENVIRONMENT = true;
+  const element = createElement(ServerLinks, {});
+  const container = document.createElement("div");
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  let root: ReturnType<typeof hydrateRoot> | undefined;
+
+  try {
+    container.innerHTML = renderToString(element);
+    const unexpectedServerErrors = consoleError.mock.calls.filter(
+      ([message]) =>
+        !String(message).includes("useLayoutEffect does nothing on the server"),
+    );
+    expect(unexpectedServerErrors).toEqual([]);
+    consoleError.mockClear();
+    document.body.appendChild(container);
+
+    const query = q.within(container);
+    const enabled = query.link("Server-enabled link");
+    expect(enabled.outerHTML).toBe(
+      '<a href="#server-enabled">Server-enabled link</a>',
+    );
+
+    const skipped = query.link("Server-skipped link");
+    expectNoDestination(skipped);
+    expect(skipped).toHaveAttribute("role", "link");
+    expect(skipped).toHaveAttribute("aria-disabled", "true");
+    expect(skipped).toHaveAttribute("tabindex", "-1");
+    expect(skipped).not.toHaveAttribute("disabled");
+
+    const reachable = query.link("Server-reachable link");
+    expectNoDestination(reachable);
+    expect(reachable).toHaveAttribute("role", "link");
+    expect(reachable).toHaveAttribute("aria-disabled", "true");
+    expect(reachable).toHaveAttribute("tabindex", "0");
+    expect(reachable).not.toHaveAttribute("disabled");
+
+    const conflict = query.link("Disabled wins conflicting ARIA");
+    expectNoDestination(conflict);
+    expect(conflict).toHaveAttribute("role", "link");
+    expect(conflict).toHaveAttribute("aria-disabled", "true");
+    expect(conflict).toHaveAttribute("tabindex", "-1");
+    expect(conflict).not.toHaveAttribute("disabled");
+
+    await act(async () => {
+      root = hydrateRoot(container, element);
+    });
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(query.link("Server-enabled link")).toBe(enabled);
+    expect(query.link("Server-skipped link")).toBe(skipped);
+    expect(query.link("Server-reachable link")).toBe(reachable);
+    expect(query.link("Disabled wins conflicting ARIA")).toBe(conflict);
+    expectNoDestination(query.link("Server-skipped link"));
+    expect(query.link("Server-skipped link")).toHaveAttribute("tabindex", "-1");
+    expectNoDestination(query.link("Server-reachable link"));
+    expect(query.link("Server-reachable link")).toHaveAttribute(
+      "tabindex",
+      "0",
+    );
+  } finally {
+    consoleError.mockRestore();
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    container.remove();
+    scope.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+  }
+});
+
+test("warns about render props that cannot honor the contract", async () => {
+  using consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const { unmount } = await render(createElement(WarningLinks, {}), {
+    strictMode: true,
+  });
+
+  try {
+    expect(consoleWarn.mock.calls).toEqual([
+      [
+        "This disabled Link still has an `href`. A component can add props " +
+          "to the element in the `render` prop, but it can't take one " +
+          "away, so the link can still be opened in a new tab, copied " +
+          "from the context menu, and listed as a link by assistive " +
+          "technology. Pass the URL to `Link` and it withholds it while " +
+          "the link is disabled.",
+      ],
+      [
+        "Link renders an anchor element. The `render` prop received a <div> " +
+          "element, which can't be a link. Use Command or Button for elements " +
+          "that perform an action instead.",
+      ],
+    ]);
+  } finally {
+    unmount();
+  }
+});

--- a/app/src/sandbox/link-nextjs-app-router/preview.json
+++ b/app/src/sandbox/link-nextjs-app-router/preview.json
@@ -1,0 +1,3 @@
+{
+  "frameworks": ["react"]
+}

--- a/app/src/sandbox/link-nextjs-app-router/test-chrome-js-disabled.ts
+++ b/app/src/sandbox/link-nextjs-app-router/test-chrome-js-disabled.ts
@@ -1,0 +1,45 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ id, test }) => {
+  test.use({ javaScriptEnabled: false });
+
+  test("serves every disabled boundary in fresh server HTML", async ({
+    page,
+    q,
+  }) => {
+    const previous = q.link("Previous dispatch");
+    await test.expect(previous).not.toHaveAttribute("href");
+    await test.expect(previous).toHaveAttribute("role", "link");
+    await test.expect(previous).toHaveAttribute("aria-disabled", "true");
+    await test.expect(previous).toHaveAttribute("tabindex", "0");
+    await test.expect(previous).not.toHaveAttribute("disabled");
+
+    const ariaDisabled = q.link("ARIA-disabled adapter");
+    await test.expect(ariaDisabled).not.toHaveAttribute("href");
+    await test.expect(ariaDisabled).toHaveAttribute("aria-disabled", "true");
+    await test.expect(ariaDisabled).toHaveAttribute("tabindex", "0");
+
+    const skipped = q.link("Skipped disabled adapter");
+    await test.expect(skipped).not.toHaveAttribute("href");
+    await test.expect(skipped).toHaveAttribute("tabindex", "-1");
+
+    await test
+      .expect(q.link("Disabled handling off"))
+      .toHaveAttribute("href", `/${id}/2`);
+
+    await test
+      .expect(q.link("Next dispatch"))
+      .toHaveAttribute("href", `/${id}/2`);
+    await q.link("Next dispatch").click();
+    await test.expect(page).toHaveURL(new RegExp(`/${id}/2$`));
+    await page.goto(new URL(`/${id}/3`, page.url()).href);
+    await test.expect(page).toHaveURL(new RegExp(`/${id}/3$`));
+
+    const next = q.link("Next dispatch");
+    await test.expect(next).not.toHaveAttribute("href");
+    await test.expect(next).toHaveAttribute("role", "link");
+    await test.expect(next).toHaveAttribute("aria-disabled", "true");
+    await test.expect(next).toHaveAttribute("tabindex", "0");
+    await test.expect(next).not.toHaveAttribute("disabled");
+  });
+});

--- a/app/src/sandbox/link-nextjs-app-router/test-chrome.ts
+++ b/app/src/sandbox/link-nextjs-app-router/test-chrome.ts
@@ -1,0 +1,82 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ id, test }) => {
+  test("navigates with conditional Next Link render elements", async ({
+    page,
+    q,
+  }) => {
+    const previous = q.link("Previous dispatch");
+    await test.expect(previous).not.toHaveAttribute("href");
+    await test.expect(previous).toHaveAttribute("role", "link");
+    await test.expect(previous).toHaveAttribute("aria-disabled", "true");
+    await test.expect(previous).toHaveAttribute("tabindex", "0");
+    await test.expect(previous).not.toHaveAttribute("disabled");
+
+    await test
+      .expect(q.link("Next dispatch"))
+      .toHaveAttribute("href", `/${id}/2`);
+    await q.link("Next dispatch").click();
+    await test.expect(page).toHaveURL(new RegExp(`/${id}/2$`));
+    await test
+      .expect(q.heading("A signal across the plateau", { level: 2 }))
+      .toBeVisible();
+    await test
+      .expect(q.link("Previous dispatch"))
+      .toHaveAttribute("href", `/${id}`);
+    await test
+      .expect(q.link("Next dispatch"))
+      .toHaveAttribute("href", `/${id}/3`);
+  });
+
+  test("exposes focus loss at the conditional render boundary", async ({
+    page,
+    q,
+  }) => {
+    await q.link("Next dispatch").click();
+    await test.expect(page).toHaveURL(new RegExp(`/${id}/2$`));
+    await test
+      .expect(q.heading("A signal across the plateau", { level: 2 }))
+      .toBeVisible();
+
+    const before = await q.link("Next dispatch").elementHandle();
+    if (!before) {
+      throw new Error("Next dispatch link was not rendered");
+    }
+    await q.link("Next dispatch").click();
+    await test.expect(page).toHaveURL(new RegExp(`/${id}/3$`));
+
+    const next = q.link("Next dispatch");
+    const after = await next.elementHandle();
+    if (!after) {
+      throw new Error("Next dispatch link was removed");
+    }
+    const sameElement = await before.evaluate(
+      (element, nextElement) => element === nextElement,
+      after,
+    );
+    test.expect(sameElement).toBe(false);
+    await test.expect(next).not.toBeFocused();
+    await test.expect(next).not.toHaveAttribute("href");
+    await test.expect(next).toHaveAttribute("role", "link");
+    await test.expect(next).toHaveAttribute("aria-disabled", "true");
+    await test.expect(next).toHaveAttribute("tabindex", "0");
+  });
+
+  test("resolves adapter state before choosing the render element", async ({
+    q,
+  }) => {
+    const ariaDisabled = q.link("ARIA-disabled adapter");
+    await test.expect(ariaDisabled).not.toHaveAttribute("href");
+    await test.expect(ariaDisabled).toHaveAttribute("aria-disabled", "true");
+    await test.expect(ariaDisabled).toHaveAttribute("tabindex", "0");
+
+    const skipped = q.link("Skipped disabled adapter");
+    await test.expect(skipped).not.toHaveAttribute("href");
+    await test.expect(skipped).toHaveAttribute("aria-disabled", "true");
+    await test.expect(skipped).toHaveAttribute("tabindex", "-1");
+
+    const inactive = q.link("Disabled handling off");
+    await test.expect(inactive).toHaveAttribute("href", `/${id}/2`);
+    await test.expect(inactive).not.toHaveAttribute("aria-disabled");
+  });
+});

--- a/app/src/sandbox/link-react-router/index.react.tsx
+++ b/app/src/sandbox/link-react-router/index.react.tsx
@@ -1,0 +1,230 @@
+import { Link as AriakitLink } from "@ariakit/react-components/link/link";
+import type { LinkProps as AriakitLinkProps } from "@ariakit/react-components/link/link";
+import { forwardRef, useEffect, useRef, useState } from "react";
+import type { MouseEventHandler } from "react";
+import {
+  HashRouter,
+  useHref,
+  useLinkClickHandler,
+  useLocation,
+  useNavigate,
+} from "react-router-dom";
+
+interface RouterLinkProps extends Omit<AriakitLinkProps, "href"> {
+  to: string;
+}
+
+const RouterLink = forwardRef<HTMLAnchorElement, RouterLinkProps>(
+  function RouterLink({ to, onClick, target, ...props }, ref) {
+    const href = useHref(to);
+    const handleClick = useLinkClickHandler(to, { target });
+    const handleLinkClick: MouseEventHandler<HTMLAnchorElement> = (event) => {
+      onClick?.(event);
+      if (event.defaultPrevented) return;
+      handleClick(event);
+    };
+
+    return (
+      <AriakitLink
+        ref={ref}
+        {...props}
+        href={href}
+        target={target}
+        onClick={handleLinkClick}
+      />
+    );
+  },
+);
+
+const entries = [
+  {
+    eyebrow: "Entry one · Atlantic edge",
+    title: "The lighthouse after rain",
+    description:
+      "Salt hangs in the air while the final cloud bank moves beyond the headland.",
+    readingTime: "4 minute read",
+  },
+  {
+    eyebrow: "Entry two · Inland road",
+    title: "A market under striped awnings",
+    description:
+      "Peaches, paper maps, and a narrow street that keeps turning toward the hills.",
+    readingTime: "6 minute read",
+  },
+  {
+    eyebrow: "Entry three · Night train",
+    title: "Last light from the dining car",
+    description:
+      "Fields become silhouettes as the carriage settles into its evening rhythm.",
+    readingTime: "5 minute read",
+  },
+];
+
+const pageLinkClass =
+  "inline-flex min-h-12 items-center justify-center gap-2 whitespace-nowrap rounded-full border border-stone-900/10 bg-white/70 px-3 text-sm font-semibold text-stone-900 shadow-sm transition hover:-translate-y-0.5 hover:bg-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-700 aria-disabled:translate-y-0 aria-disabled:cursor-not-allowed aria-disabled:bg-stone-200/60 aria-disabled:text-stone-400 aria-disabled:shadow-none sm:px-5";
+
+function RouteJournal() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const previousRef = useRef<HTMLAnchorElement>(null);
+  const [guardMessage, setGuardMessage] = useState(
+    "No navigation was intercepted.",
+  );
+  const routePage = Number(location.pathname.match(/\d+$/)?.[0] || 1);
+  const page = Math.min(Math.max(routePage, 1), entries.length);
+  const entry = entries[page - 1];
+  if (!entry) {
+    throw new Error(`Journal entry ${page} was not found`);
+  }
+  const previousPage = page > 1 ? page - 1 : undefined;
+  const nextPage = page < entries.length ? page + 1 : undefined;
+
+  return (
+    <main className="relative min-h-dvh overflow-hidden bg-[#efe9dc] px-4 py-10 text-stone-900 sm:px-6 sm:py-16">
+      <div className="pointer-events-none absolute inset-0 opacity-40 [background-image:radial-gradient(#7c5b3e_0.7px,transparent_0.7px)] [background-size:14px_14px]" />
+      <div className="relative mx-auto max-w-5xl">
+        <header className="mb-8 flex flex-col gap-5 border-b border-stone-900/15 pb-7 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="text-xs font-bold uppercase tracking-[0.24em] text-orange-800">
+              React Router field journal
+            </p>
+            <h1 className="mt-3 max-w-2xl font-serif text-4xl leading-none tracking-tight sm:text-6xl">
+              A route can change without replacing its anchor.
+            </h1>
+          </div>
+          <output
+            aria-label="Current route"
+            className="w-fit rounded-full border border-stone-900/10 bg-white/50 px-4 py-2 font-mono text-xs text-stone-600"
+          >
+            {location.pathname}
+          </output>
+        </header>
+
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1.5fr)_minmax(18rem,0.8fr)]">
+          <article className="overflow-hidden rounded-[2rem] border border-stone-900/10 bg-[#fbf8f1] shadow-2xl shadow-stone-900/10">
+            <div className="relative min-h-80 overflow-hidden bg-[linear-gradient(145deg,#292524,#7c2d12)] p-8 text-white sm:p-10">
+              <div className="absolute -right-16 -top-16 size-64 rounded-full border border-white/15" />
+              <div className="absolute right-10 top-12 size-24 rounded-full bg-orange-200/20 blur-sm" />
+              <div className="relative flex min-h-60 max-w-xl flex-col justify-end">
+                <p className="text-xs font-bold uppercase tracking-[0.22em] text-orange-200">
+                  {entry.eyebrow}
+                </p>
+                <h2 className="mt-3 text-balance font-serif text-4xl leading-tight">
+                  {entry.title}
+                </h2>
+                <p className="mt-4 max-w-lg text-pretty leading-7 text-stone-200">
+                  {entry.description}
+                </p>
+              </div>
+            </div>
+
+            <div className="p-6 sm:p-8">
+              <div className="mb-6 flex items-center justify-between text-xs font-semibold uppercase tracking-[0.16em] text-stone-500">
+                <span>
+                  Page {page} of {entries.length}
+                </span>
+                <span>{entry.readingTime}</span>
+              </div>
+              <nav
+                aria-label="Journal pages"
+                className="grid grid-cols-2 gap-3"
+              >
+                <RouterLink
+                  ref={previousRef}
+                  to={`/page/${previousPage || 1}`}
+                  disabled={!previousPage}
+                  accessibleWhenDisabled
+                  className={pageLinkClass}
+                >
+                  <span aria-hidden="true">←</span> Previous entry
+                </RouterLink>
+                <RouterLink
+                  to={`/page/${nextPage || entries.length}`}
+                  disabled={!nextPage}
+                  className={pageLinkClass}
+                >
+                  Next entry <span aria-hidden="true">→</span>
+                </RouterLink>
+              </nav>
+            </div>
+          </article>
+
+          <aside className="flex flex-col gap-6">
+            <section className="rounded-[2rem] bg-stone-900 p-6 text-stone-100 shadow-xl shadow-stone-900/10">
+              <p className="text-xs font-bold uppercase tracking-[0.2em] text-orange-300">
+                Stable node check
+              </p>
+              <h2 className="mt-3 text-xl font-semibold">
+                Move the route while focus stays put.
+              </h2>
+              <p className="mt-3 text-sm leading-6 text-stone-400">
+                The router supplies a changing href to Ariakit. Link owns that
+                href, so one native anchor survives the state transition.
+              </p>
+              <button
+                type="button"
+                className="mt-5 min-h-11 w-full rounded-xl bg-orange-300 px-4 text-sm font-bold text-stone-950 transition hover:bg-orange-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-200"
+                onClick={() => {
+                  previousRef.current?.focus();
+                  navigate(page === 1 ? "/page/2" : "/page/1");
+                }}
+              >
+                Move route with previous focused
+              </button>
+            </section>
+
+            <section className="rounded-[2rem] border border-stone-900/10 bg-white/55 p-6 backdrop-blur-sm">
+              <p className="text-xs font-bold uppercase tracking-[0.2em] text-orange-800">
+                Consumer control
+              </p>
+              <p className="mt-3 text-sm leading-6 text-stone-600">
+                The adapter calls the consumer first and respects a prevented
+                event before it hands navigation to React Router.
+              </p>
+              <RouterLink
+                to="/page/3"
+                className="mt-5 inline-flex min-h-11 items-center rounded-full border border-stone-900/15 px-4 text-sm font-semibold underline decoration-orange-700/30 underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-700"
+                onClick={(event) => {
+                  event.preventDefault();
+                  setGuardMessage("The consumer kept this route in place.");
+                }}
+              >
+                Try guarded navigation
+              </RouterLink>
+              <output
+                aria-label="Navigation guard"
+                className="mt-4 block rounded-xl bg-stone-900/5 px-3 py-2 text-xs text-stone-600"
+              >
+                {guardMessage}
+              </output>
+            </section>
+          </aside>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+export default function Example() {
+  const [mounted, setMounted] = useState(false);
+  // HashRouter reads document while it creates its history, so wait until the
+  // Astro preview is mounted in the browser.
+  // oxlint-disable-next-line react/set-state-in-effect
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) {
+    return (
+      <main className="grid min-h-dvh place-items-center bg-[#efe9dc] text-sm font-semibold text-stone-600">
+        Preparing the route journal…
+      </main>
+    );
+  }
+
+  return (
+    <HashRouter
+      future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+    >
+      <RouteJournal />
+    </HashRouter>
+  );
+}

--- a/app/src/sandbox/link-react-router/preview.json
+++ b/app/src/sandbox/link-react-router/preview.json
@@ -1,0 +1,4 @@
+{
+  "title": "Link with React Router",
+  "fullscreen": true
+}

--- a/app/src/sandbox/link-react-router/test-chrome.ts
+++ b/app/src/sandbox/link-react-router/test-chrome.ts
@@ -1,0 +1,49 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("navigates through a Link-owned router href", async ({ page, q }) => {
+    const previous = q.link("Previous entry");
+    await test.expect(previous).not.toHaveAttribute("href");
+    await test.expect(previous).toHaveAttribute("aria-disabled", "true");
+    await test.expect(previous).toHaveAttribute("tabindex", "0");
+
+    await q.link("Next entry").click();
+    await test.expect(q.status("Current route")).toHaveText("/page/2");
+    await test.expect(page).toHaveURL(/#\/page\/2$/);
+    await test.expect(previous).toHaveAttribute("href", "#/page/1");
+  });
+
+  test("keeps the focused anchor mounted across route changes", async ({
+    q,
+  }) => {
+    const previous = q.link("Previous entry");
+    const before = await previous.elementHandle();
+    if (!before) {
+      throw new Error("Previous entry link was not rendered");
+    }
+
+    await q.button("Move route with previous focused").click();
+    const after = await q.link("Previous entry").elementHandle();
+    if (!after) {
+      throw new Error("Previous entry link was removed");
+    }
+    const sameElement = await before.evaluate(
+      (element, nextElement) => element === nextElement,
+      after,
+    );
+    test.expect(sameElement).toBe(true);
+    await test.expect(q.link("Previous entry")).toBeFocused();
+    await test
+      .expect(q.link("Previous entry"))
+      .toHaveAttribute("href", "#/page/1");
+  });
+
+  test("respects consumer preventDefault", async ({ page, q }) => {
+    const url = page.url();
+    await q.link("Try guarded navigation").click();
+    await test
+      .expect(q.status("Navigation guard"))
+      .toHaveText("The consumer kept this route in place.");
+    test.expect(page.url()).toBe(url);
+  });
+});

--- a/app/src/sandbox/link-react-router/test.ts
+++ b/app/src/sandbox/link-react-router/test.ts
@@ -1,0 +1,36 @@
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+test("routes through a Link-owned native href", async () => {
+  const previous = q.link("Previous entry");
+  expect(previous).not.toHaveAttribute("href");
+  expect(previous).toHaveAttribute("aria-disabled", "true");
+  expect(previous).toHaveAttribute("tabindex", "0");
+
+  await click(q.link("Next entry"));
+  expect(q.status("Current route")).toHaveTextContent("/page/2");
+  expect(previous).toHaveAttribute("href", "#/page/1");
+  expect(q.link("Next entry")).toHaveAttribute("href", "#/page/3");
+});
+
+test("keeps the focused anchor mounted across route changes", async () => {
+  const previous = q.link("Previous entry");
+  const wasDisabled = !previous.hasAttribute("href");
+  await click(q.button("Move route with previous focused"));
+  expect(q.link("Previous entry")).toBe(previous);
+  expect(previous).toHaveFocus();
+  if (wasDisabled) {
+    expect(previous).toHaveAttribute("href", "#/page/1");
+  } else {
+    expect(previous).not.toHaveAttribute("href");
+  }
+});
+
+test("respects a consumer that prevents navigation", async () => {
+  const route = q.status("Current route").textContent;
+  await click(q.link("Try guarded navigation"));
+  expect(q.status("Navigation guard")).toHaveTextContent(
+    "The consumer kept this route in place.",
+  );
+  expect(q.status("Current route")).toHaveTextContent(route || "");
+});

--- a/app/src/sandbox/native-button-semantics/index.react.tsx
+++ b/app/src/sandbox/native-button-semantics/index.react.tsx
@@ -27,7 +27,9 @@ interface CapabilityFixtureProps {
   focusable?: boolean;
 }
 
-function CapabilityFixture({ focusable = true }: CapabilityFixtureProps) {
+export function CapabilityFixture({
+  focusable = true,
+}: CapabilityFixtureProps) {
   return (
     <div>
       <Ariakit.Focusable focusable={focusable} render={<div />}>

--- a/app/src/sandbox/native-button-semantics/index.react.tsx
+++ b/app/src/sandbox/native-button-semantics/index.react.tsx
@@ -36,6 +36,12 @@ function CapabilityFixture({ focusable = true }: CapabilityFixtureProps) {
       <Ariakit.Focusable disabled render={<a href="#disabled-anchor" />}>
         Disabled anchor
       </Ariakit.Focusable>
+      <Ariakit.Focusable disabled accessibleWhenDisabled render={<a />}>
+        Disabled accessible anchor
+      </Ariakit.Focusable>
+      <Ariakit.Button disabled render={<a href="#disabled-link-button" />}>
+        Disabled link button
+      </Ariakit.Button>
       <Ariakit.Focusable disabled render={<button />}>
         Disabled button
       </Ariakit.Focusable>

--- a/app/src/sandbox/native-button-semantics/test-browser.ts
+++ b/app/src/sandbox/native-button-semantics/test-browser.ts
@@ -50,17 +50,48 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
   test("preserves custom element semantics", async ({ q }) => {
     await test.expect(q.text("Focusable div")).toHaveAttribute("tabindex", "0");
+    await test.expect(q.button("Disabled button")).toBeDisabled();
+
+    const nestedMenuButton = q.menuitem("Nested menu");
+    await test.expect(nestedMenuButton).toHaveJSProperty("tagName", "DIV");
+    await test.expect(nestedMenuButton).not.toHaveAttribute("type");
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7112
+  test("preserves disabled anchor semantics", async ({ q }) => {
     await test
       .expect(q.link("Disabled anchor"))
       .toHaveAttribute("tabindex", "-1");
     await test
       .expect(q.link("Disabled anchor"))
       .not.toHaveAttribute("disabled");
-    await test.expect(q.button("Disabled button")).toBeDisabled();
-
-    const nestedMenuButton = q.menuitem("Nested menu");
-    await test.expect(nestedMenuButton).toHaveJSProperty("tagName", "DIV");
-    await test.expect(nestedMenuButton).not.toHaveAttribute("type");
+    await test
+      .expect(q.link("Disabled accessible anchor"))
+      .toHaveAttribute("tabindex", "0");
+    await test
+      .expect(q.link("Disabled accessible anchor"))
+      .toHaveAttribute("aria-disabled", "true");
+    await test
+      .expect(q.link("Disabled accessible anchor"))
+      .toHaveAttribute("role", "link");
+    await test
+      .expect(q.link("Disabled accessible anchor"))
+      .not.toHaveAttribute("disabled");
+    await test
+      .expect(q.link("Disabled link button"))
+      .toHaveAttribute("role", "link");
+    await test
+      .expect(q.link("Disabled link button"))
+      .toHaveAttribute("href", "#disabled-link-button");
+    await test
+      .expect(q.link("Disabled link button"))
+      .toHaveAttribute("aria-disabled", "true");
+    await test
+      .expect(q.link("Disabled link button"))
+      .toHaveAttribute("tabindex", "-1");
+    await test
+      .expect(q.link("Disabled link button"))
+      .not.toHaveAttribute("disabled");
   });
 
   test("updates custom focusability", async ({ q }) => {

--- a/app/src/sandbox/native-button-semantics/test-chrome-js-disabled.ts
+++ b/app/src/sandbox/native-button-semantics/test-chrome-js-disabled.ts
@@ -1,0 +1,18 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test.use({ javaScriptEnabled: false });
+
+  // https://github.com/ariakit/ariakit/issues/7112
+  test("serves disabled anchor semantics before hydration", async ({ q }) => {
+    const disabled = q.text("Disabled anchor");
+    await test.expect(disabled).toHaveAttribute("role", "link");
+    await test.expect(disabled).toHaveAttribute("tabindex", "-1");
+    await test.expect(disabled).not.toHaveAttribute("disabled");
+
+    const accessible = q.text("Disabled accessible anchor");
+    await test.expect(accessible).toHaveAttribute("role", "link");
+    await test.expect(accessible).toHaveAttribute("tabindex", "0");
+    await test.expect(accessible).not.toHaveAttribute("disabled");
+  });
+});

--- a/app/src/sandbox/native-button-semantics/test.ts
+++ b/app/src/sandbox/native-button-semantics/test.ts
@@ -49,9 +49,31 @@ test("declares native button types before refs run", () => {
 
 test("preserves custom element semantics", () => {
   expect(q.text("Focusable div")).toHaveAttribute("tabindex", "0");
+  expect(q.button("Disabled button")).toHaveAttribute("disabled");
+});
+
+// https://github.com/ariakit/ariakit/issues/7112
+test("preserves disabled anchor semantics", () => {
   expect(q.link("Disabled anchor")).toHaveAttribute("tabindex", "-1");
   expect(q.link("Disabled anchor")).not.toHaveAttribute("disabled");
-  expect(q.button("Disabled button")).toHaveAttribute("disabled");
+  expect(q.link("Disabled accessible anchor")).toHaveAttribute("tabindex", "0");
+  expect(q.link("Disabled accessible anchor")).toHaveAttribute(
+    "aria-disabled",
+    "true",
+  );
+  expect(q.link("Disabled accessible anchor")).toHaveAttribute("role", "link");
+  expect(q.link("Disabled accessible anchor")).not.toHaveAttribute("disabled");
+  expect(q.link("Disabled link button")).toHaveAttribute("role", "link");
+  expect(q.link("Disabled link button")).toHaveAttribute(
+    "href",
+    "#disabled-link-button",
+  );
+  expect(q.link("Disabled link button")).toHaveAttribute(
+    "aria-disabled",
+    "true",
+  );
+  expect(q.link("Disabled link button")).toHaveAttribute("tabindex", "-1");
+  expect(q.link("Disabled link button")).not.toHaveAttribute("disabled");
 });
 
 test("updates custom focusability", async () => {

--- a/app/src/sandbox/native-button-semantics/test.ts
+++ b/app/src/sandbox/native-button-semantics/test.ts
@@ -1,9 +1,9 @@
 import { click, focus, press, q } from "@ariakit/test";
-import { act, createElement } from "react";
+import { act, createElement, Fragment } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { renderToString } from "react-dom/server";
 import { expect, test, vi } from "vitest";
-import { TypeFixture } from "./index.react.tsx";
+import { CapabilityFixture, TypeFixture } from "./index.react.tsx";
 
 function expectSharedButtonTypes(query: ReturnType<typeof q.within>) {
   expect(query.tab("Default tab")).toHaveAttribute("type", "button");
@@ -24,13 +24,23 @@ function expectSharedButtonTypes(query: ReturnType<typeof q.within>) {
   expect(nestedMenuButton).not.toHaveAttribute("type");
 }
 
-function expectServerButtonTypes(query: ReturnType<typeof q.within>) {
+function expectServerElementSemantics(query: ReturnType<typeof q.within>) {
   expectSharedButtonTypes(query);
   const divButton = query.text("Div button");
   expect(divButton).not.toHaveAttribute("type");
+
+  const disabledAnchor = query.link("Disabled anchor");
+  expect(disabledAnchor).toHaveAttribute("role", "link");
+  expect(disabledAnchor).toHaveAttribute("tabindex", "-1");
+  expect(disabledAnchor).not.toHaveAttribute("disabled");
+
+  const accessibleAnchor = query.link("Disabled accessible anchor");
+  expect(accessibleAnchor).toHaveAttribute("role", "link");
+  expect(accessibleAnchor).toHaveAttribute("tabindex", "0");
+  expect(accessibleAnchor).not.toHaveAttribute("disabled");
 }
 
-function expectNativeButtonTypes(query: ReturnType<typeof q.within>) {
+function expectNativeElementSemantics(query: ReturnType<typeof q.within>) {
   expectSharedButtonTypes(query);
   expect(query.tab("Button tab")).toHaveAttribute("type", "button");
   const divButton = query.button("Div button");
@@ -40,7 +50,7 @@ function expectNativeButtonTypes(query: ReturnType<typeof q.within>) {
 }
 
 test("declares native button types before refs run", () => {
-  expectNativeButtonTypes(q);
+  expectNativeElementSemantics(q);
   expect(q.status("Default button ref type")).toHaveTextContent("button");
   expect(q.status("Default command ref type")).toHaveTextContent("button");
   expect(q.status("Default tab ref type")).toHaveTextContent("button");
@@ -97,11 +107,17 @@ test("clears submit focus visibility when focusable is disabled", async () => {
   expect(button).not.toHaveAttribute("data-focus-visible");
 });
 
-test("server markup and hydration use the same native button type", async () => {
+// https://github.com/ariakit/ariakit/issues/7112
+test("server markup and hydration preserve native element semantics", async () => {
   const scope = globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean };
   const previousActEnvironment = scope.IS_REACT_ACT_ENVIRONMENT;
   scope.IS_REACT_ACT_ENVIRONMENT = true;
-  const element = createElement(TypeFixture, {});
+  const element = createElement(
+    Fragment,
+    {},
+    createElement(TypeFixture, {}),
+    createElement(CapabilityFixture, {}),
+  );
   const container = document.createElement("div");
   const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
   let root: ReturnType<typeof hydrateRoot> | undefined;
@@ -116,14 +132,14 @@ test("server markup and hydration use the same native button type", async () => 
     document.body.appendChild(container);
 
     const containerQuery = q.within(container);
-    expectServerButtonTypes(containerQuery);
+    expectServerElementSemantics(containerQuery);
 
     await act(async () => {
       root = hydrateRoot(container, element);
     });
     expect(consoleError).not.toHaveBeenCalled();
 
-    expectNativeButtonTypes(containerQuery);
+    expectNativeElementSemantics(containerQuery);
   } finally {
     consoleError.mockRestore();
     if (root) {

--- a/app/src/sandbox/native-button-semantics/test.ts
+++ b/app/src/sandbox/native-button-semantics/test.ts
@@ -24,11 +24,7 @@ function expectSharedButtonTypes(query: ReturnType<typeof q.within>) {
   expect(nestedMenuButton).not.toHaveAttribute("type");
 }
 
-function expectServerElementSemantics(query: ReturnType<typeof q.within>) {
-  expectSharedButtonTypes(query);
-  const divButton = query.text("Div button");
-  expect(divButton).not.toHaveAttribute("type");
-
+function expectDisabledAnchorSemantics(query: ReturnType<typeof q.within>) {
   const disabledAnchor = query.link("Disabled anchor");
   expect(disabledAnchor).toHaveAttribute("role", "link");
   expect(disabledAnchor).toHaveAttribute("tabindex", "-1");
@@ -40,6 +36,13 @@ function expectServerElementSemantics(query: ReturnType<typeof q.within>) {
   expect(accessibleAnchor).not.toHaveAttribute("disabled");
 }
 
+function expectServerElementSemantics(query: ReturnType<typeof q.within>) {
+  expectSharedButtonTypes(query);
+  const divButton = query.text("Div button");
+  expect(divButton).not.toHaveAttribute("type");
+  expectDisabledAnchorSemantics(query);
+}
+
 function expectNativeElementSemantics(query: ReturnType<typeof q.within>) {
   expectSharedButtonTypes(query);
   expect(query.tab("Button tab")).toHaveAttribute("type", "button");
@@ -47,6 +50,7 @@ function expectNativeElementSemantics(query: ReturnType<typeof q.within>) {
   expect(divButton).not.toHaveAttribute("type");
   expect(divButton).toHaveAttribute("role", "button");
   expect(divButton).toHaveAttribute("tabindex", "0");
+  expectDisabledAnchorSemantics(query);
 }
 
 test("declares native button types before refs run", () => {

--- a/nextjs/app/link-nextjs-app-router/2/page.tsx
+++ b/nextjs/app/link-nextjs-app-router/2/page.tsx
@@ -1,0 +1,5 @@
+import { Pagination } from "../pagination.tsx";
+
+export default function Page() {
+  return <Pagination page={2} />;
+}

--- a/nextjs/app/link-nextjs-app-router/3/page.tsx
+++ b/nextjs/app/link-nextjs-app-router/3/page.tsx
@@ -1,0 +1,5 @@
+import { Pagination } from "../pagination.tsx";
+
+export default function Page() {
+  return <Pagination page={3} />;
+}

--- a/nextjs/app/link-nextjs-app-router/page.tsx
+++ b/nextjs/app/link-nextjs-app-router/page.tsx
@@ -1,0 +1,5 @@
+import { Pagination } from "./pagination.tsx";
+
+export default function Page() {
+  return <Pagination page={1} />;
+}

--- a/nextjs/app/link-nextjs-app-router/pagination.tsx
+++ b/nextjs/app/link-nextjs-app-router/pagination.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { Link } from "@ariakit/react-components/link/link";
+import type { LinkProps } from "@ariakit/react-components/link/link";
+import NextLink from "next/link";
+import type { ComponentPropsWithoutRef } from "react";
+
+type PageNumber = 1 | 2 | 3;
+
+const dispatches = [
+  {
+    page: 1,
+    eyebrow: "Dispatch 01 · Server boundary",
+    title: "The observatory at first light",
+    description:
+      "The first route arrives as complete HTML, including its destination-free previous link.",
+    signal: "Morning signal",
+  },
+  {
+    page: 2,
+    eyebrow: "Dispatch 02 · Open channel",
+    title: "A signal across the plateau",
+    description:
+      "Both directions are active Next.js links, while Ariakit keeps the native anchor contract.",
+    signal: "Midday signal",
+  },
+  {
+    page: 3,
+    eyebrow: "Dispatch 03 · Route edge",
+    title: "The last transmission",
+    description:
+      "At the boundary, the framework link gives way to a plain anchor with no destination.",
+    signal: "Evening signal",
+  },
+] as const;
+
+const pagePaths = {
+  1: "/link-nextjs-app-router",
+  2: "/link-nextjs-app-router/2",
+  3: "/link-nextjs-app-router/3",
+} as const;
+
+const pageLinkClassName =
+  "inline-flex min-h-12 items-center justify-center gap-2 rounded-full border border-white/15 bg-white/[0.08] px-5 text-sm font-semibold text-white transition hover:-translate-y-0.5 hover:bg-white/[0.14] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-300 aria-disabled:translate-y-0 aria-disabled:cursor-not-allowed aria-disabled:text-white/35";
+
+interface AppLinkProps extends Omit<LinkProps, "href" | "render"> {
+  href: ComponentPropsWithoutRef<typeof NextLink>["href"];
+  prefetch?: ComponentPropsWithoutRef<typeof NextLink>["prefetch"];
+}
+
+function AppLink({
+  href,
+  prefetch,
+  disabled,
+  "aria-disabled": ariaDisabled,
+  focusable,
+  accessibleWhenDisabled = true,
+  ...props
+}: AppLinkProps) {
+  const linkDisabled =
+    focusable !== false &&
+    (disabled || ariaDisabled === true || ariaDisabled === "true");
+
+  return (
+    <Link
+      {...props}
+      disabled={disabled}
+      aria-disabled={ariaDisabled}
+      focusable={focusable}
+      accessibleWhenDisabled={accessibleWhenDisabled}
+      render={
+        linkDisabled ? <a /> : <NextLink href={href} prefetch={prefetch} />
+      }
+    />
+  );
+}
+
+function getPreviousPage(page: PageNumber): PageNumber {
+  if (page === 3) return 2;
+  return 1;
+}
+
+function getNextPage(page: PageNumber): PageNumber {
+  if (page === 1) return 2;
+  return 3;
+}
+
+interface PaginationProps {
+  page: PageNumber;
+}
+
+export function Pagination({ page }: PaginationProps) {
+  const dispatch =
+    dispatches.find((entry) => entry.page === page) ?? dispatches[0];
+  const previousPage = getPreviousPage(page);
+  const nextPage = getNextPage(page);
+
+  return (
+    <main className="relative min-h-dvh overflow-hidden bg-[#0f0b12] px-4 py-12 text-white sm:px-6 sm:py-16">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_20%_10%,rgba(244,63,94,0.22),transparent_32%),radial-gradient(circle_at_86%_80%,rgba(251,146,60,0.14),transparent_30%)]" />
+      <div className="relative mx-auto max-w-5xl">
+        <header className="max-w-3xl">
+          <p className="text-xs font-bold uppercase tracking-[0.24em] text-rose-300">
+            Next.js App Router
+          </p>
+          <h1 className="mt-4 text-balance text-4xl font-semibold tracking-[-0.04em] sm:text-6xl">
+            Server-correct links, with a visible router trade-off.
+          </h1>
+          <p className="mt-5 max-w-2xl text-pretty text-base leading-7 text-white/55 sm:text-lg">
+            Enabled controls use Next Link. At a disabled boundary, the render
+            prop swaps it for a destination-free anchor in the server HTML.
+          </p>
+        </header>
+
+        <div className="mt-10 grid gap-6 lg:grid-cols-[minmax(0,1.35fr)_minmax(18rem,0.75fr)]">
+          <section className="overflow-hidden rounded-[2rem] border border-white/10 bg-white/[0.06] shadow-2xl shadow-black/30 backdrop-blur-xl">
+            <div className="relative min-h-80 overflow-hidden bg-[linear-gradient(145deg,#4c0519,#18181b_72%)] p-8 sm:p-10">
+              <div className="absolute -right-20 -top-24 size-72 rounded-full border border-rose-200/20" />
+              <div className="absolute right-12 top-10 size-24 rounded-full bg-orange-300/20 blur-md" />
+              <div className="relative flex min-h-60 flex-col justify-end">
+                <p className="text-xs font-bold uppercase tracking-[0.2em] text-rose-200">
+                  {dispatch.eyebrow}
+                </p>
+                <h2 className="mt-3 max-w-xl text-balance text-3xl font-semibold sm:text-4xl">
+                  {dispatch.title}
+                </h2>
+                <p className="mt-4 max-w-xl leading-7 text-white/60">
+                  {dispatch.description}
+                </p>
+                <p className="mt-7 w-fit rounded-full border border-orange-200/15 bg-orange-200/10 px-3 py-1 text-xs font-semibold text-orange-100">
+                  {dispatch.signal}
+                </p>
+              </div>
+            </div>
+
+            <nav
+              aria-label="Transmission pages"
+              className="grid gap-3 p-6 sm:grid-cols-[1fr_auto_1fr] sm:items-center sm:p-8"
+            >
+              <AppLink
+                href={pagePaths[previousPage]}
+                disabled={page === 1}
+                className={pageLinkClassName}
+              >
+                <span aria-hidden="true">←</span> Previous dispatch
+              </AppLink>
+              <p className="text-center text-sm text-white/45">
+                <span className="block font-semibold text-white">
+                  Page {page} of {dispatches.length}
+                </span>
+                <span className="mt-1 block text-xs">Server-served route</span>
+              </p>
+              <AppLink
+                href={pagePaths[nextPage]}
+                disabled={page === 3}
+                className={pageLinkClassName}
+              >
+                Next dispatch <span aria-hidden="true">→</span>
+              </AppLink>
+            </nav>
+          </section>
+
+          <aside className="flex flex-col gap-6">
+            <section className="rounded-[2rem] border border-rose-300/15 bg-rose-300/[0.07] p-6">
+              <p className="text-xs font-bold uppercase tracking-[0.2em] text-rose-300">
+                Conditional recipe
+              </p>
+              <h2 className="mt-3 text-xl font-semibold">
+                Correct HTML, unstable focus.
+              </h2>
+              <p className="mt-3 text-sm leading-6 text-white/55">
+                The safe disabled branch has no router-owned href. The cost is a
+                remount when the render element changes between a and Next Link,
+                so focus can be lost at the boundary.
+              </p>
+              <div className="mt-5 rounded-xl bg-black/20 px-4 py-3 font-mono text-xs leading-6 text-rose-100/70">
+                disabled ? &lt;a /&gt; : &lt;NextLink /&gt;
+              </div>
+            </section>
+
+            <section className="rounded-[2rem] border border-white/10 bg-white/[0.04] p-6">
+              <p className="text-xs font-bold uppercase tracking-[0.2em] text-orange-300">
+                Adapter state parity
+              </p>
+              <p className="mt-3 text-sm leading-6 text-white/55">
+                The adapter resolves every Link disabled state before it chooses
+                the framework element. Disable JavaScript and these contracts
+                remain visible in fresh server HTML.
+              </p>
+              <div className="mt-5 flex flex-col items-start gap-3 text-sm">
+                <AppLink
+                  href={pagePaths[2]}
+                  aria-disabled="true"
+                  className="font-semibold text-orange-100 underline decoration-orange-300/30 underline-offset-4 aria-disabled:no-underline aria-disabled:text-white/35"
+                >
+                  ARIA-disabled adapter
+                </AppLink>
+                <AppLink
+                  href={pagePaths[2]}
+                  disabled
+                  accessibleWhenDisabled={false}
+                  className="font-semibold text-orange-100 underline decoration-orange-300/30 underline-offset-4 aria-disabled:no-underline aria-disabled:text-white/35"
+                >
+                  Skipped disabled adapter
+                </AppLink>
+                <AppLink
+                  href={pagePaths[2]}
+                  disabled
+                  focusable={false}
+                  prefetch={false}
+                  className="font-semibold text-orange-100 underline decoration-orange-300/30 underline-offset-4"
+                >
+                  Disabled handling off
+                </AppLink>
+              </div>
+            </section>
+          </aside>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@ariakit/react": "workspace:*",
+    "@ariakit/react-components": "workspace:*",
     "next": "16.2.12",
     "react": "19.2.8",
     "react-dom": "19.2.8"

--- a/packages/ariakit-react-components/package.json
+++ b/packages/ariakit-react-components/package.json
@@ -179,6 +179,7 @@
     "./hovercard/hovercard-store": "./src/hovercard/hovercard-store.ts",
     "./hovercard/utils/debug-polygon": "./src/hovercard/utils/debug-polygon.ts",
     "./hovercard/utils/polygon": "./src/hovercard/utils/polygon.ts",
+    "./link/link": "./src/link/link.tsx",
     "./menu/menu": "./src/menu/menu.tsx",
     "./menu/menu-anchor": "./src/menu/menu-anchor.tsx",
     "./menu/menu-arrow": "./src/menu/menu-arrow.tsx",

--- a/packages/ariakit-react-components/src/focusable/focusable.tsx
+++ b/packages/ariakit-react-components/src/focusable/focusable.tsx
@@ -43,6 +43,7 @@ const isSafariBrowser = isSafari();
 
 const nativeTabbableMask = 1;
 const supportsDisabledMask = 2;
+const anchorMask = 4;
 const defaultElementCapabilities = nativeTabbableMask | supportsDisabledMask;
 
 const alwaysFocusVisibleInputTypes = [
@@ -107,14 +108,19 @@ function getElementCapabilities(tagName?: string) {
   if (supportsDisabledAttribute(tagName)) {
     capabilities |= supportsDisabledMask;
   }
+  if (tagName === "a") {
+    capabilities |= anchorMask;
+  }
   return capabilities;
 }
 
 interface GetTabIndexParams {
   focusable: boolean;
+  disabled: boolean;
   trulyDisabled: boolean;
   nativeTabbable: boolean;
   supportsDisabled: boolean;
+  anchor: boolean;
   safariTabIndex: boolean;
   tabIndexProp?: number;
 }
@@ -133,9 +139,11 @@ function isNativeSubmitControl(element: HTMLElement) {
 
 function getTabIndex({
   focusable,
+  disabled,
   trulyDisabled,
   nativeTabbable,
   supportsDisabled,
+  anchor,
   safariTabIndex,
   tabIndexProp,
 }: GetTabIndexParams) {
@@ -150,6 +158,11 @@ function getTabIndex({
     return;
   }
   if (nativeTabbable) {
+    // An anchor without an href needs an explicit tab stop when it remains
+    // accessible. This value is redundant but harmless if the href remains.
+    if (anchor && disabled) {
+      return tabIndexProp ?? 0;
+    }
     // On Safari, buttons and button-like inputs (checkboxes, radios, submit,
     // reset, etc.) require an explicit tabIndex to receive focus on mousedown.
     if (safariTabIndex && tabIndexProp == null) {
@@ -449,6 +462,7 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
       focusable && !!(elementCapabilities & nativeTabbableMask);
     const supportsDisabled =
       focusable && !!(elementCapabilities & supportsDisabledMask);
+    const anchor = focusable && !!(elementCapabilities & anchorMask);
 
     // On Safari, buttons and button-like inputs don't receive focus on
     // mousedown. We detect this from the DOM element (not props) so it works
@@ -475,6 +489,8 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
       }
       return styleProp;
     }, [trulyDisabled, styleProp]);
+    const role =
+      props.role === undefined && disabled && anchor ? "link" : props.role;
 
     props = {
       "data-focus-visible": (focusable && focusVisible) || undefined,
@@ -484,11 +500,14 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
       ...metadataProps,
       ref: useMergeRefs(ref, autoFocusRef, props.ref),
       style,
+      role,
       tabIndex: getTabIndex({
         focusable,
+        disabled,
         trulyDisabled,
         nativeTabbable,
         supportsDisabled,
+        anchor,
         safariTabIndex,
         tabIndexProp: props.tabIndex,
       }),

--- a/packages/ariakit-react-components/src/focusable/focusable.tsx
+++ b/packages/ariakit-react-components/src/focusable/focusable.tsx
@@ -29,7 +29,14 @@ import type {
   KeyboardEvent as ReactKeyboardEvent,
   SyntheticEvent,
 } from "react";
-import { useContext, useEffect, useMemo, useRef, useState } from "react";
+import {
+  isValidElement,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { isCompositeMoveKey, trulyDisabledAttribute } from "./__utils.ts";
 import { FocusableContext } from "./focusable-context.tsx";
 
@@ -445,9 +452,12 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
     });
 
     // Track only the element capabilities that affect the returned props so
-    // resolving the default native element doesn't require another render.
-    const [elementCapabilities, setElementCapabilities] = useState(
-      defaultElementCapabilities,
+    // resolving the default native element doesn't require another render. A
+    // statically rendered anchor can expose disabled semantics on the server.
+    const [elementCapabilities, setElementCapabilities] = useState(() =>
+      isValidElement(props.render) && props.render.type === "a"
+        ? getElementCapabilities("a")
+        : defaultElementCapabilities,
     );
     useSafeLayoutEffect(() => {
       const element = ref.current;

--- a/packages/ariakit-react-components/src/link/link.tsx
+++ b/packages/ariakit-react-components/src/link/link.tsx
@@ -1,0 +1,124 @@
+import {
+  useMergeRefs,
+  createElement,
+  createHook,
+  forwardRef,
+} from "@ariakit/react-utils";
+import type { Props } from "@ariakit/react-utils";
+import { disabledFromProps, warnOnce } from "@ariakit/utils";
+import type { AnchorHTMLAttributes, ElementType } from "react";
+import { useEffect, useRef } from "react";
+import { trulyDisabledAttribute } from "../focusable/__utils.ts";
+import type { FocusableOptions } from "../focusable/focusable.tsx";
+import { useFocusable } from "../focusable/focusable.tsx";
+
+const TagName = "a" satisfies ElementType;
+type TagName = typeof TagName;
+type HTMLType = HTMLElementTagNameMap[TagName];
+
+// An anchor without an href is a placeholder, so every attribute that
+// describes its destination must be omitted too.
+// https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element
+const withoutDestination = {
+  href: undefined,
+  itemProp: undefined,
+  target: undefined,
+  download: undefined,
+  ping: undefined,
+  rel: undefined,
+  hrefLang: undefined,
+  referrerPolicy: undefined,
+  type: undefined,
+} satisfies AnchorHTMLAttributes<HTMLType>;
+
+/**
+ * Returns props to create a `Link` component.
+ */
+export const useLink = createHook<TagName, LinkOptions>(
+  function useLink(props) {
+    const { focusable = true } = props;
+    const disabled = focusable && disabledFromProps(props);
+
+    if (process.env.NODE_ENV !== "production") {
+      const ref = useRef<HTMLType>(null);
+      useEffect(() => {
+        const element = ref.current;
+        if (!element) return;
+        if (element.tagName !== "A") {
+          warnOnce(
+            `Link renders an anchor element. The \`render\` prop received a <${element.localName}> element, which can't be a link. Use Command or Button for elements that perform an action instead.`,
+            element,
+          );
+        }
+        if (disabled && element.hasAttribute("href")) {
+          warnOnce(
+            "This disabled Link still has an `href`. A component can add props " +
+              "to the element in the `render` prop, but it can't take one " +
+              "away, so the link can still be opened in a new tab, copied " +
+              "from the context menu, and listed as a link by assistive " +
+              "technology. Pass the URL to `Link` and it withholds it while " +
+              "the link is disabled.",
+            element,
+          );
+        }
+      });
+      props = { ...props, ref: useMergeRefs(ref, props.ref) };
+    }
+
+    if (disabled) {
+      props = { ...props, ...withoutDestination };
+    }
+
+    props = useFocusable<TagName>(props);
+
+    if (disabled) {
+      // Link knows its native element before Focusable resolves it from the
+      // DOM, so disabled server markup can already expose the right semantics
+      // and tab order.
+      const tabIndex =
+        props.tabIndex ?? (props[trulyDisabledAttribute] ? -1 : 0);
+      props = {
+        role: "link",
+        ...props,
+        "aria-disabled": true,
+        tabIndex,
+        disabled: undefined,
+      };
+    }
+
+    return props;
+  },
+);
+
+/**
+ * Renders a native link that preserves link semantics while disabled.
+ *
+ * A disabled link omits its destination so native browser navigation features
+ * cannot activate it. Use `accessibleWhenDisabled` to keep it in the tab order.
+ * @example
+ * ```jsx
+ * <Link href={nextPage} disabled={!nextPage}>
+ *   Next page
+ * </Link>
+ * ```
+ */
+export const Link = forwardRef(function Link(props: LinkProps) {
+  const htmlProps = useLink(props);
+  return createElement(TagName, htmlProps);
+});
+
+export interface LinkOptions<
+  T extends ElementType = TagName,
+> extends FocusableOptions<T> {
+  /**
+   * The URL the link points to. When the link is disabled, this URL, related
+   * destination attributes, and anchor microdata are omitted from the rendered
+   * anchor.
+   */
+  href?: AnchorHTMLAttributes<HTMLType>["href"];
+}
+
+export type LinkProps<T extends ElementType = TagName> = Props<
+  T,
+  LinkOptions<T>
+>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -305,6 +305,9 @@ importers:
       react-dom:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
+      react-router-dom:
+        specifier: 6.30.4
+        version: 6.30.4(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       read-package-up:
         specifier: 12.0.0
         version: 12.0.0
@@ -488,6 +491,9 @@ importers:
       '@ariakit/react':
         specifier: workspace:*
         version: link:../packages/ariakit-react
+      '@ariakit/react-components':
+        specifier: workspace:*
+        version: link:../packages/ariakit-react-components
       next:
         specifier: 16.2.12
         version: 16.2.12(@babel/core@7.29.0(supports-color@10.2.2))(@playwright/test@1.62.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -4235,6 +4241,10 @@ packages:
     resolution: {integrity: sha512-AzsuD9OfxTOZMMvTRhlN3oHBwOmFN7tDh27LzqmHt4+uOgPhJT7ZM7/kVs/8/o0WxayMUIk3hBmCFRHv1FUoag==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@remix-run/router@1.23.3':
+    resolution: {integrity: sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==}
+    engines: {node: '>=14.0.0'}
 
   '@rolldown/binding-android-arm-eabi@1.2.5':
     resolution: {integrity: sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==}
@@ -9027,6 +9037,19 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-router-dom@6.30.4:
+    resolution: {integrity: sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  react-router@6.30.4:
+    resolution: {integrity: sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
 
   react-router@8.3.0:
     resolution: {integrity: sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==}
@@ -14129,6 +14152,8 @@ snapshots:
   '@react-types/shared@3.36.1(react@19.2.8)':
     dependencies:
       react: 19.2.8
+
+  '@remix-run/router@1.23.3': {}
 
   '@rolldown/binding-android-arm-eabi@1.2.5':
     optional: true
@@ -19488,6 +19513,18 @@ snapshots:
       use-sidecar: 1.1.3(@types/react@19.2.18)(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.18
+
+  react-router-dom@6.30.4(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      '@remix-run/router': 1.23.3
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-router: 6.30.4(react@19.2.8)
+
+  react-router@6.30.4(react@19.2.8):
+    dependencies:
+      '@remix-run/router': 1.23.3
+      react: 19.2.8
 
   react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:


### PR DESCRIPTION
## Motivation

Related to #7112.

> [!IMPORTANT]
> This pull request is an implementation experiment. It is not intended to merge, and #7112 stays open.

Native links support modifier clicks, new tabs, context menus, copying, dragging, mobile previews, and other browser behaviors that button-driven router navigation cannot reproduce. HTML anchors have no native `disabled` state. Removing `href` stops navigation, but it also removes implicit link semantics.

This experiment puts the proposed `Link` API into practice so we can evaluate the design against native anchors, server rendering, React Router, and the Next.js App Router.

## Solution

This pull request adds experimental `Link` and `useLink` exports at `@ariakit/react-components/link/link`. It does not add an `@ariakit/react` re-export, a reference page, `LinkLabel`, or `LinkDescription`.

`Link` owns its native destination. When disabled, it omits `href`, `target`, `download`, `ping`, `rel`, `hrefLang`, `referrerPolicy`, `type`, and anchor `itemProp` during render. The server HTML already has `role="link"`, `aria-disabled="true"`, the correct tab stop, and no native `disabled` attribute.

```tsx
import { Link } from "@ariakit/react-components/link/link";

<Link href={nextPage} disabled={!nextPage}>
  Next page
</Link>;
```

The patch also teaches `Focusable` about disabled anchors. An href-less disabled anchor keeps link semantics, and `accessibleWhenDisabled` can keep it in the tab order. This affects stable disabled-anchor behavior, including an explicit redundant `role="link"` on disabled `a[href]` elements.

Development warnings report non-anchor render elements and render-owned destinations that `Link` cannot remove. A downstream production build removes the warning-only code and strings.

## Integration recipes

### Native link

Pass the destination directly to `Link`. This keeps one anchor mounted when the state changes.

```tsx
<Link href="/reports" disabled={reportCount === 0} accessibleWhenDisabled>
  Reports
</Link>
```

### React Router DOM 6.30.4

React Router exposes the low-level pieces needed for a minimal stable-node adapter. This is not a drop-in replacement for every React Router `Link` option.

```tsx
function RouterLink({ to, onClick, target, ...props }) {
  const href = useHref(to);
  const handleClick = useLinkClickHandler(to, { target });

  return (
    <Link
      {...props}
      href={href}
      target={target}
      onClick={(event) => {
        onClick?.(event);
        if (event.defaultPrevented) return;
        handleClick(event);
      }}
    />
  );
}
```

### Next.js 16.2.12 App Router

`NextLink` owns and requires its `href`. The safe adapter must resolve the disabled state before it selects the render element.

```tsx
const linkDisabled =
  focusable !== false &&
  (disabled || ariaDisabled === true || ariaDisabled === "true");

<Link
  disabled={disabled}
  aria-disabled={ariaDisabled}
  focusable={focusable}
  render={linkDisabled ? <a /> : <NextLink href={href} />}
/>;
```

This conditional element is server-correct, but React remounts the anchor at the boundary. Focus is lost when `accessibleWhenDisabled` keeps the new disabled anchor reachable.

## Preview sandboxes

| Use case | Uploaded preview |
| --- | --- |
| Native `Link` contract, SSR, tab order, composition, and attribute restoration | [Open the native Link sandbox](https://link-7112-experiment-ariakit-preview.ariakit.workers.dev/react/previews/link-disabled/) |
| Stable React Router adapter and consumer event control | [Open the React Router sandbox](https://link-7112-experiment-ariakit-preview.ariakit.workers.dev/react/previews/link-react-router/) |
| Next App Router conditional adapter and focus-loss limitation | [Open the Next.js sandbox](https://link-7112-experiment-ariakit-nextjs.ariakit.workers.dev/link-nextjs-app-router) |

### Native `Link`

[Open the native `Link` sandbox](https://link-7112-experiment-ariakit-preview.ariakit.workers.dev/react/previews/link-disabled/)

The page-3 boundary renders a disabled Next anchor without a destination, while the surrounding pagination remains native:

<img width="1152" height="431" alt="Native Link pagination sandbox at page 3 with the Next link disabled" src="https://github.com/user-attachments/assets/f17dbc0f-45e9-41dc-9b93-6af5e37222a4" />

The same focused anchor withholds and restores its destination without losing node identity or focus:

[Watch the native `Link` focus and destination recording](https://github.com/user-attachments/assets/b7c93803-1ff9-4834-901b-03fa8144495f)

### React Router

[Open the React Router sandbox](https://link-7112-experiment-ariakit-preview.ariakit.workers.dev/react/previews/link-react-router/)

The stable adapter keeps the Previous anchor focused after the route changes:

<img width="1440" height="963" alt="React Router Link sandbox with the Previous page anchor focused after navigation" src="https://github.com/user-attachments/assets/dc929be6-2f51-4af8-bdf0-c42c7f7a9d00" />

The recording also shows that consumer `preventDefault()` wins before router navigation:

[Watch the React Router stable-node and event-guard recording](https://github.com/user-attachments/assets/9c69dd96-309a-4c1d-9de1-daed87fa3c05)

### Next.js App Router

[Open the Next.js App Router sandbox](https://link-7112-experiment-ariakit-nextjs.ariakit.workers.dev/link-nextjs-app-router)

The page-3 route produces the correct destination-free disabled anchor on the server:

<img width="1440" height="900" alt="Next.js App Router Link sandbox at page 3 with destination-free disabled output" src="https://github.com/user-attachments/assets/48d52ad6-2b92-495c-826a-147414816399" />

Keyboard navigation across the `NextLink` to anchor render boundary demonstrates the focus-loss limitation:

[Watch the Next.js render-boundary focus recording](https://github.com/user-attachments/assets/f61ff18a-c495-413e-8502-82f685093e3a)

## What worked well

- Link-owned destination props make disabled output correct during render, SSR, hydration, and JavaScript-disabled use. Attributes restore declaratively when the link becomes enabled.
- The native adapter keeps one anchor mounted, so node identity and focus survive enabled and disabled transitions.
- Existing `Focusable` behavior supplies disabled interaction guards, pointer behavior, ARIA state, and optional keyboard reachability.
- Outer components keep their more specific role. The sandbox verifies a disabled `MenuItem` rendered with `Link`.
- React Router DOM 6.30.4 exposes enough low-level hooks for a stable native anchor adapter. The adapter can also call the consumer first and respect `preventDefault()`.
- Development warnings catch the two important composition mistakes, and a downstream production bundle removes them.

## What did not work well

- Render-element props win Ariakit composition. `Link` cannot remove an `href` owned or derived by `NextLink` or another render component. Before hydration, that destination is still active. After hydration, `NextLink` can also prefetch it. The warning is best-effort because it requires a forwarded ref and a mounted element.
- The safe Next adapter swaps `NextLink` for `<a>`. That produces correct server HTML but remounts the node and loses focus at the disabled boundary.
- The Next adapter must duplicate `Link` disabled-state resolution before choosing its render element. Checking only the boolean `disabled` prop leaves an ARIA-disabled link live on the server.
- `focusable={false}` intentionally turns off the inherited `Focusable` layer, including disabled resolution. Therefore, `<Link disabled focusable={false} href="/target">` stays live. This matches the proposed design and existing `Focusable` semantics, but it is a sharp edge. Decoupling destination removal from focusability would require an explicit API redesign for ARIA and tab-order behavior.
- Server correctness required initial capability hints for a statically supplied `<a />` render target. Function render callbacks and custom render components do not expose their intrinsic element type to `useFocusable` during server render, so they keep mount-time capability resolution. Solving that generally would require an explicit native-element hint or a render-pipeline redesign. Experimental `Link` remains server-correct for callback renders because it knows its anchor contract and owns the destination.
- Implementing the API exposed a broader stable disabled-anchor change in `Focusable` and components built on it. Disabled `a[href]` elements now receive an explicit `role="link"`; ARIA in HTML allows this but does not recommend the redundant role.
- HTML conformance also required withholding anchor microdata `itemProp`, which was not in the original destination-attribute list.
- React does not repair an initial server/client disabled-state hydration mismatch. Stale attributes can persist until a remount or a later value-changing render forces a DOM write.
- Safari on macOS can require Option+Tab to traverse all controls when full keyboard navigation is off. The sandbox and browser test must present this as a fallback because Safari can swap the Tab and Option+Tab behaviors in its Advanced settings; this platform policy is outside `Link`'s `tabIndex` contract.
- Real screen-reader announcement and Safari click-focus behavior still need manual research before any merge proposal.

## Implementation review reassessment

<details>
<summary>Cycle 3: Narrow stable disabled-anchor SSR support</summary>

**Assessment**

- Issue severity: Moderate. Ariakit does not currently ship this `Link` API, and consumers have a small manual workaround. However, incorrect disabled-link output can expose the wrong semantics to assistive technology or leave navigation available during server-only use.
- Expected frequency: Disabled pagination and unavailable navigation links are common. The repeated generic `Focusable` edge requires a callback or opaque custom render target, a disabled anchor, and interaction before hydration or without JavaScript. That narrower combination should be uncommon, although its impact can be substantial when it occurs.
- Supported scope: Experimental `Link` supports destinations that it owns, boolean and ARIA disabled states, destination-attribute omission and restoration, SSR, hydration, JavaScript-disabled output, `accessibleWhenDisabled`, outer-role composition, and callback render anchors that forward the supplied props. The stable `Focusable` improvement supports SSR capability seeding only for a statically supplied intrinsic `render={<a />}`. Opaque targets keep the existing mount-time capability resolution.
- Likely user impact: The primary `Link` path produces correct inert and accessible markup from the initial server response. Static disabled `Focusable` anchors also gain correct role and tab-order output before hydration. Unsupported generic callback anchors can still retain an ineffective `disabled` attribute or an active destination before capability resolution.
- Implementation and maintenance complexity: The runtime design remains localized and adds no new effect, context, render pass, or public capability-hint API. The public-contract cost is moderate because the `Focusable` behavior also changes stable packages and must remain precisely described. Most of the larger evidence footprint comes from the three styled sandboxes and their SSR, hydration, JavaScript-disabled, router, and browser coverage.

**Decision**

Keep the statically supplied intrinsic-anchor optimization and narrow the stable `Focusable` guarantee. Generic callback and custom-component intrinsic types remain runtime-resolved. `Link` keeps callback SSR support and targeted coverage because it owns the anchor contract and destination.

Intentionally unsupported: generic `Focusable` SSR inference for function renders and custom render components without an explicit native-element hint.

</details>

## Verification

Checks run on the final reviewed content:

- `pnpm lint-fix`
- focused Vitest: 3 files, 19 tests
- root TypeScript and Astro checks: 0 diagnostics
- Next.js route type generation and TypeScript
- `pnpm build-app-lite`: Next.js production build, React Compiler, OpenNext worker bundle, and Astro production preview
- affected Chrome sandbox tests: 11 tests in normal parallel mode
- corrected tab-order test in Chrome, Firefox, and Safari: 3 tests

Broader checks ran on the same implementation before review-only cleanup and the final edge-case additions:

- current React suite: 270 files, 1,930 tests
- React 18 suite: 198 files, 1,052 tests
- three-browser sandbox matrix: 18 tests
- reference tests: 13 tests
- package build, package-condition resolution, and `npm pack --dry-run` contents
- downstream production bundle warning-string exclusion
- reference-free website build: 450 pages

CI on this pull request is the broad final-snapshot verification.

## Remaining scope

`LinkLabel` and `LinkDescription` remain deferred as described in #7112. This experiment also does not add a stable root export or reference page. Screen-reader behavior in NVDA, JAWS, and VoiceOver remains a manual pre-merge gate for any future proposal.
