### PR TITLE
Record the modal Dialog native-parity decision in dialog.tsx

### DIFF
--- a/app/src/sandbox/dialog-core-interactions/test.ts
+++ b/app/src/sandbox/dialog-core-interactions/test.ts
@@ -17,7 +17,7 @@ for (const trigger of ["click", "Enter", "Space"] as const) {
   });
 }
 
-test("traps focus inside the dialog", async () => {
+test("keeps focus on the only dialog button with synthetic Tab", async () => {
   await click(q.button("Show modal"));
   expect(q.button("OK")).toHaveFocus();
 

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -221,8 +221,9 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     portal,
     props.portalRef,
   );
-  // Sets preserveTabOrder to true only if the dialog is not a modal and is
-  // open.
+  // Modal dialogs don't use tab-order sentinels to match native <dialog>.
+  // Tab may reach browser UI instead of cycling inside, which is intentional.
+  // https://github.com/ariakit/ariakit/issues/7092#issuecomment-5227754640
   const preserveTabOrderProp = props.preserveTabOrder;
   const preserveTabOrder = useStoreState(
     store,


### PR DESCRIPTION
## Motivation

A modal `Dialog` deliberately omits tab-order sentinels to match native `<dialog>` behavior, but the rationale was not recorded next to the `preserveTabOrder` condition. The happy-dom sandbox test title also described a hard focus-trap contract even though its synthetic Tab helper cannot model focus moving to browser UI.

## Solution

Document the native-parity rationale next to the modal `preserveTabOrder` condition and link the exact closing decision in #7092. Rename the sandbox test to describe its synthetic Tab behavior without asserting a browser focus-trap contract.

A fresh comparison against a native modal `<dialog>` confirmed that Chromium and WebKit can hand focus to browser UI at the dialog boundary, while Firefox keeps focus in the page.

## Verification

- `pnpm lint-fix`
- `pnpm test app/src/sandbox/dialog-core-interactions/test.ts`

Fixes #7282
