### PR TITLE
Document store subscription key contract

### DIFF
--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -24,7 +24,9 @@ type StoreInit = () => () => void;
 // change; sync fires immediately on registration and synchronously on every
 // change; batch fires immediately on registration, then microtask-coalesced
 // on subsequent changes. See the storeSubscribe/storeSync/storeBatch
-// implementations in createStore.
+// implementations in createStore. The keys also narrow the listener state.
+// Include a key only when its changes should trigger the listener. Read other
+// state with store.getState() inside the listener.
 type StoreSubscribe<S = State, K extends keyof S = keyof S> = Sync<S, K>;
 type StoreSync<S = State, K extends keyof S = keyof S> = Sync<S, K>;
 type StoreBatch<S = State, K extends keyof S = keyof S> = Sync<S, K>;


### PR DESCRIPTION
## Motivation

The `keys` passed to `subscribe`, `sync`, and `batch` control which state changes notify the listener and also narrow both listener state arguments. The nearby comment explains only timing, so a caller can add a key to satisfy TypeScript and unintentionally subscribe to its changes.

## Solution

Extend the comment on the shared `Sync<S, K>` aliases to say that callers should include only keys that must trigger the listener and use `store.getState()` to read other state without subscribing to it.

```ts
subscribe(store, ["open"], () => {
  const { mounted } = store.getState();
});
```

## Verification

- `pnpm lint-fix`
- `pnpm tsc`

Fixes #7280
