### PR TITLE
Document the getItem composition channel and the unmergeItem restore direction

### DIFF
--- a/packages/ariakit-components/src/collection/collection-store.ts
+++ b/packages/ariakit-components/src/collection/collection-store.ts
@@ -291,6 +291,8 @@ export function createCollectionStore<
         }
         return nextItems;
       });
+      // Unregistering reverses this merge: it restores the previous item, or
+      // removes the item when this registration introduced it.
       const unmergeItem = () => {
         if (registeredItems) {
           if (previousRegisteredItem) {

--- a/packages/ariakit-components/src/collection/collection-store.ts
+++ b/packages/ariakit-components/src/collection/collection-store.ts
@@ -291,8 +291,9 @@ export function createCollectionStore<
         }
         return nextItems;
       });
-      // Unregistering reverses this merge: it restores the previous item, or
-      // removes the item when this registration introduced it.
+      // Same-ID registrations must clean up in reverse order: each cleanup
+      // restores the item it replaced or removes the item it introduced.
+      // https://github.com/ariakit/ariakit/pull/7286#discussion_r3853776498
       const unmergeItem = () => {
         if (registeredItems) {
           if (previousRegisteredItem) {

--- a/packages/ariakit-react-components/src/collection/collection-item.tsx
+++ b/packages/ariakit-react-components/src/collection/collection-item.tsx
@@ -50,6 +50,8 @@ export const useCollectionItem = createHook<TagName, CollectionItemOptions>(
       if (!id) return;
       if (!element) return;
       if (!shouldRegisterItem) return;
+      // With render composition, outer components register after rendered ones.
+      // Their item fields take precedence when the store merges registrations.
       const item = getItem({ id, element });
       return store?.renderItem(item);
     }, [id, shouldRegisterItem, getItem, store]);

--- a/packages/ariakit-react-components/src/collection/collection-item.tsx
+++ b/packages/ariakit-react-components/src/collection/collection-item.tsx
@@ -50,8 +50,9 @@ export const useCollectionItem = createHook<TagName, CollectionItemOptions>(
       if (!id) return;
       if (!element) return;
       if (!shouldRegisterItem) return;
-      // With render composition, outer components register after rendered ones.
-      // Their item fields take precedence when the store merges registrations.
+      // When composed items mount together, outer registrations run last. Their
+      // fields take precedence over rendered components in the initial merge.
+      // https://github.com/ariakit/ariakit/pull/7286#discussion_r3853776494
       const item = getItem({ id, element });
       return store?.renderItem(item);
     }, [id, shouldRegisterItem, getItem, store]);


### PR DESCRIPTION
## Motivation

Collection registration relies on two non-obvious behaviors: on an initial shared mount, render composition determines item-field precedence; layered same-ID registrations must clean up in reverse order so unregistering can restore a previous item. These invariants are not explained in source and are easy to infer incorrectly.

## Solution

Add focused implementation comments at the `getItem` call and `unmergeItem` cleanup:

```ts
const item = getItem({ id, element });
const unmergeItem = () => {
```

The comments document initial shared-mount outer-registration precedence and the reverse-order cleanup requirement for same-ID registrations without changing public JSDoc or generated reference metadata. A temporary composition fixture confirmed that, on the initial shared mount, both registrations can contribute distinct fields and the outer registration wins conflicting fields.

## Verification

- `pnpm lint-fix`

Closes #7281
