### PR TITLE
Document isHappyDOM iframe behavior

### DIFF
--- a/packages/ariakit-test/src/__utils.ts
+++ b/packages/ariakit-test/src/__utils.ts
@@ -6,6 +6,12 @@ export type TextField = HTMLInputElement | HTMLTextAreaElement;
 
 const preventMouseEvents = new WeakMap<Document, boolean>();
 
+/**
+ * The happy-dom marker is per-window. A same-origin iframe window created in
+ * happy-dom does not expose it, so this returns `false` for that window. Callers
+ * that must cover iframe realms must resolve the environment another way.
+ * https://github.com/ariakit/ariakit/issues/7283
+ */
 export function isHappyDOM(
   win: Window | null | undefined = typeof window !== "undefined"
     ? window


### PR DESCRIPTION
## Motivation

`isHappyDOM` checks a marker on the window that it receives. A same-origin iframe window created in happy-dom does not expose this marker, so the helper does not identify the complete test environment through an iframe-owned window.

Ariakit does not support iframes in Vitest tests. This change documents the limitation and does not add iframe support.

## Solution

Document that the marker is per-window, that `isHappyDOM` returns `false` for a happy-dom iframe window, and that callers which must cover iframe realms must resolve the environment another way.

Closes #7283
