### PR TITLE
Fix ComboboxPopover role when a nested ComboboxList has a different popup role

### DIFF
--- a/.changeset/300-combobox-list-popup-role.md
+++ b/.changeset/300-combobox-list-popup-role.md
@@ -3,19 +3,4 @@
 "@ariakit/react": patch
 ---
 
-Nested `ComboboxList` can own any popup role
-
-[`ComboboxPopover`](https://ariakit.com/reference/combobox-popover) drops its own `listbox` role when it contains a nested [`ComboboxList`](https://ariakit.com/reference/combobox-list), so the two elements never produce nested popup roles. This now happens whichever popup role the nested list carries, not only `listbox`.
-
-```tsx
-<Ariakit.ComboboxPopover>
-  <div role="status">{matches.length} files</div>
-  <Ariakit.ComboboxList role="tree" aria-label="Files">
-    <Ariakit.ComboboxItem value="app.tsx" />
-  </Ariakit.ComboboxList>
-</Ariakit.ComboboxPopover>
-```
-
-The popover above used to render `role="listbox"` around the tree, which is invalid, and [`Combobox`](https://ariakit.com/reference/combobox) reported `aria-haspopup="listbox"`. It now renders as a dialog and reports `aria-haspopup="dialog"`.
-
-[`ComboboxPopover`](https://ariakit.com/reference/combobox-popover) also keeps its own popup role when an unrelated element with `role="listbox"` renders inside it. Only a real nested [`ComboboxList`](https://ariakit.com/reference/combobox-list) takes over the popup role now.
+Fixed [`ComboboxPopover`](https://ariakit.com/reference/combobox-popover) rendering an invalid `listbox` role around a nested [`ComboboxList`](https://ariakit.com/reference/combobox-list) that carries a different popup role, and dropping its own role when an unrelated element with `role="listbox"` renders inside it.

--- a/.changeset/300-combobox-list-popup-role.md
+++ b/.changeset/300-combobox-list-popup-role.md
@@ -1,0 +1,21 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Nested `ComboboxList` can own any popup role
+
+[`ComboboxPopover`](https://ariakit.com/reference/combobox-popover) drops its own `listbox` role when it contains a nested [`ComboboxList`](https://ariakit.com/reference/combobox-list), so the two elements never produce nested popup roles. This now happens whichever popup role the nested list carries, not only `listbox`.
+
+```tsx
+<Ariakit.ComboboxPopover>
+  <div role="status">{matches.length} files</div>
+  <Ariakit.ComboboxList role="tree" aria-label="Files">
+    <Ariakit.ComboboxItem value="app.tsx" />
+  </Ariakit.ComboboxList>
+</Ariakit.ComboboxPopover>
+```
+
+The popover above used to render `role="listbox"` around the tree, which is invalid, and [`Combobox`](https://ariakit.com/reference/combobox) reported `aria-haspopup="listbox"`. It now renders as a dialog and reports `aria-haspopup="dialog"`.
+
+[`ComboboxPopover`](https://ariakit.com/reference/combobox-popover) also keeps its own popup role when an unrelated element with `role="listbox"` renders inside it. Only a real nested [`ComboboxList`](https://ariakit.com/reference/combobox-list) takes over the popup role now.

--- a/app/src/sandbox/combobox-list-7302/index.react.tsx
+++ b/app/src/sandbox/combobox-list-7302/index.react.tsx
@@ -28,7 +28,14 @@ function GoToFile() {
   return (
     <Ariakit.ComboboxProvider inputValue={value} setInputValue={setValue}>
       <Ariakit.Combobox aria-label="Go to file" />
-      <Ariakit.ComboboxPopover gutter={4} aria-label="Go to file results">
+      {/* TODO: ComboboxList injects role="listbox" here, so the popup role has
+          to be set explicitly. Remove once the nested list can take over the
+          popup role. https://github.com/ariakit/ariakit/issues/7302 */}
+      <Ariakit.ComboboxPopover
+        role="dialog"
+        gutter={4}
+        aria-label="Go to file results"
+      >
         {/* A tree may only own treeitem and group children, so the live count
             has to stay outside the nested list. */}
         <div role="status">
@@ -53,7 +60,14 @@ function RunCommand() {
   return (
     <Ariakit.ComboboxProvider>
       <Ariakit.Combobox aria-label="Run command" />
-      <Ariakit.ComboboxPopover gutter={4} aria-label="Command results">
+      {/* TODO: ComboboxList injects role="listbox" here, so the popup role has
+          to be set explicitly. Remove once the nested list can take over the
+          popup role. https://github.com/ariakit/ariakit/issues/7302 */}
+      <Ariakit.ComboboxPopover
+        role="dialog"
+        gutter={4}
+        aria-label="Command results"
+      >
         <Ariakit.ComboboxList role="menu" aria-label="Commands">
           {commands.map((command) => (
             <Ariakit.ComboboxItem key={command} value={command} />
@@ -84,7 +98,15 @@ function FruitSearch() {
   return (
     <Ariakit.ComboboxProvider>
       <Ariakit.Combobox aria-label="Search fruits" />
-      <Ariakit.ComboboxPopover gutter={4} aria-label="Fruit results">
+      {/* TODO: The unrelated listbox below makes ComboboxList drop its own
+          role, so the popup role has to be set explicitly. Remove once that
+          listbox stops taking over the popup role.
+          https://github.com/ariakit/ariakit/issues/7302 */}
+      <Ariakit.ComboboxPopover
+        role="listbox"
+        gutter={4}
+        aria-label="Fruit results"
+      >
         {fruits.map((fruit) => (
           <Ariakit.ComboboxItem key={fruit} value={fruit} />
         ))}

--- a/app/src/sandbox/combobox-list-7302/index.react.tsx
+++ b/app/src/sandbox/combobox-list-7302/index.react.tsx
@@ -1,0 +1,105 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+
+interface FileEntry {
+  id: string;
+  label: string;
+  folder?: boolean;
+  parent?: string;
+}
+
+const files: FileEntry[] = [
+  { id: "src", label: "src", folder: true },
+  { id: "src/app.tsx", label: "app.tsx", parent: "src" },
+  { id: "src/main.tsx", label: "main.tsx", parent: "src" },
+  { id: "readme.md", label: "readme.md" },
+];
+
+const commands = ["Reload window", "Toggle sidebar", "Split editor"];
+
+const fruits = ["Apple", "Banana", "Cherry"];
+
+function GoToFile() {
+  const [value, setValue] = useState("");
+  const matches = files.filter((file) =>
+    file.label.toLowerCase().includes(value.toLowerCase()),
+  );
+
+  return (
+    <Ariakit.ComboboxProvider inputValue={value} setInputValue={setValue}>
+      <Ariakit.Combobox aria-label="Go to file" />
+      <Ariakit.ComboboxPopover gutter={4} aria-label="Go to file results">
+        {/* A tree may only own treeitem and group children, so the live count
+            has to stay outside the nested list. */}
+        <div role="status">
+          {matches.length} of {files.length} files
+        </div>
+        <Ariakit.ComboboxList role="tree" aria-label="Files">
+          {matches.map((file) => (
+            <Ariakit.ComboboxItem
+              key={file.id}
+              value={file.label}
+              aria-level={file.parent ? 2 : 1}
+              aria-expanded={file.folder || undefined}
+            />
+          ))}
+        </Ariakit.ComboboxList>
+      </Ariakit.ComboboxPopover>
+    </Ariakit.ComboboxProvider>
+  );
+}
+
+function RunCommand() {
+  return (
+    <Ariakit.ComboboxProvider>
+      <Ariakit.Combobox aria-label="Run command" />
+      <Ariakit.ComboboxPopover gutter={4} aria-label="Command results">
+        <Ariakit.ComboboxList role="menu" aria-label="Commands">
+          {commands.map((command) => (
+            <Ariakit.ComboboxItem key={command} value={command} />
+          ))}
+        </Ariakit.ComboboxList>
+        {/* A menu may only own menuitem, menuitemcheckbox, menuitemradio,
+            group and separator children, so the footer hint has to stay
+            outside the nested list. */}
+        <div>Press Enter to run</div>
+      </Ariakit.ComboboxPopover>
+    </Ariakit.ComboboxProvider>
+  );
+}
+
+// Stands in for a third-party widget that ships its own listbox. The combobox
+// does not own this markup and must not hand its popup role over to it.
+function RecentlyUsed() {
+  return (
+    <div role="listbox" aria-label="Recently used">
+      <div role="option" aria-selected={false}>
+        Papaya
+      </div>
+    </div>
+  );
+}
+
+function FruitSearch() {
+  return (
+    <Ariakit.ComboboxProvider>
+      <Ariakit.Combobox aria-label="Search fruits" />
+      <Ariakit.ComboboxPopover gutter={4} aria-label="Fruit results">
+        {fruits.map((fruit) => (
+          <Ariakit.ComboboxItem key={fruit} value={fruit} />
+        ))}
+        <RecentlyUsed />
+      </Ariakit.ComboboxPopover>
+    </Ariakit.ComboboxProvider>
+  );
+}
+
+export default function Example() {
+  return (
+    <>
+      <GoToFile />
+      <RunCommand />
+      <FruitSearch />
+    </>
+  );
+}

--- a/app/src/sandbox/combobox-list-7302/index.react.tsx
+++ b/app/src/sandbox/combobox-list-7302/index.react.tsx
@@ -1,5 +1,6 @@
 import * as Ariakit from "@ariakit/react";
 import { useState } from "react";
+import { createPortal } from "react-dom";
 
 interface FileEntry {
   id: string;
@@ -134,6 +135,31 @@ function SearchIssues() {
   );
 }
 
+// A list for the same store can be rendered outside the popup, for example
+// into a side panel. It is not inside the popup, so it does not take the popup
+// role and the popover keeps owning its own items.
+function SearchDocs() {
+  const [panel, setPanel] = useState<HTMLElement | null>(null);
+
+  return (
+    <Ariakit.ComboboxProvider>
+      <Ariakit.Combobox aria-label="Search docs" />
+      <Ariakit.ComboboxPopover gutter={4} aria-label="Doc results">
+        <Ariakit.ComboboxItem value="Getting started" />
+        <Ariakit.ComboboxItem value="Styling" />
+        {panel &&
+          createPortal(
+            <Ariakit.ComboboxList aria-label="Pinned docs">
+              <Ariakit.ComboboxItem value="Changelog" />
+            </Ariakit.ComboboxList>,
+            panel,
+          )}
+      </Ariakit.ComboboxPopover>
+      <div ref={setPanel} />
+    </Ariakit.ComboboxProvider>
+  );
+}
+
 export default function Example() {
   return (
     <>
@@ -142,6 +168,7 @@ export default function Example() {
       <FruitSearch />
       <SearchTags />
       <SearchIssues />
+      <SearchDocs />
     </>
   );
 }

--- a/app/src/sandbox/combobox-list-7302/index.react.tsx
+++ b/app/src/sandbox/combobox-list-7302/index.react.tsx
@@ -28,14 +28,7 @@ function GoToFile() {
   return (
     <Ariakit.ComboboxProvider inputValue={value} setInputValue={setValue}>
       <Ariakit.Combobox aria-label="Go to file" />
-      {/* TODO: ComboboxList injects role="listbox" here, so the popup role has
-          to be set explicitly. Remove once the nested list can take over the
-          popup role. https://github.com/ariakit/ariakit/issues/7302 */}
-      <Ariakit.ComboboxPopover
-        role="dialog"
-        gutter={4}
-        aria-label="Go to file results"
-      >
+      <Ariakit.ComboboxPopover gutter={4} aria-label="Go to file results">
         {/* A tree may only own treeitem and group children, so the live count
             has to stay outside the nested list. */}
         <div role="status">
@@ -60,14 +53,7 @@ function RunCommand() {
   return (
     <Ariakit.ComboboxProvider>
       <Ariakit.Combobox aria-label="Run command" />
-      {/* TODO: ComboboxList injects role="listbox" here, so the popup role has
-          to be set explicitly. Remove once the nested list can take over the
-          popup role. https://github.com/ariakit/ariakit/issues/7302 */}
-      <Ariakit.ComboboxPopover
-        role="dialog"
-        gutter={4}
-        aria-label="Command results"
-      >
+      <Ariakit.ComboboxPopover gutter={4} aria-label="Command results">
         <Ariakit.ComboboxList role="menu" aria-label="Commands">
           {commands.map((command) => (
             <Ariakit.ComboboxItem key={command} value={command} />
@@ -98,19 +84,51 @@ function FruitSearch() {
   return (
     <Ariakit.ComboboxProvider>
       <Ariakit.Combobox aria-label="Search fruits" />
-      {/* TODO: The unrelated listbox below makes ComboboxList drop its own
-          role, so the popup role has to be set explicitly. Remove once that
-          listbox stops taking over the popup role.
-          https://github.com/ariakit/ariakit/issues/7302 */}
-      <Ariakit.ComboboxPopover
-        role="listbox"
-        gutter={4}
-        aria-label="Fruit results"
-      >
+      <Ariakit.ComboboxPopover gutter={4} aria-label="Fruit results">
         {fruits.map((fruit) => (
           <Ariakit.ComboboxItem key={fruit} value={fruit} />
         ))}
         <RecentlyUsed />
+      </Ariakit.ComboboxPopover>
+    </Ariakit.ComboboxProvider>
+  );
+}
+
+// A wrapper that fixes the popover composition usually renders the list through
+// the popover, so both share one element and only one of them may carry the
+// popup role.
+function SearchTags() {
+  return (
+    <Ariakit.ComboboxProvider>
+      <Ariakit.Combobox aria-label="Search tags" />
+      <Ariakit.ComboboxPopover
+        gutter={4}
+        aria-label="Tag results"
+        render={<Ariakit.ComboboxList />}
+      >
+        <Ariakit.ComboboxItem value="Design" />
+        <Ariakit.ComboboxItem value="Docs" />
+      </Ariakit.ComboboxPopover>
+    </Ariakit.ComboboxProvider>
+  );
+}
+
+// The same shared element, but with a real nested list inside it. That list
+// must take the popup role from both hooks that share the outer element.
+function SearchIssues() {
+  return (
+    <Ariakit.ComboboxProvider>
+      <Ariakit.Combobox aria-label="Search issues" />
+      <Ariakit.ComboboxPopover
+        gutter={4}
+        aria-label="Issue results"
+        render={<Ariakit.ComboboxList />}
+      >
+        <div role="status">2 issues</div>
+        <Ariakit.ComboboxList aria-label="Issues">
+          <Ariakit.ComboboxItem value="Bug report" />
+          <Ariakit.ComboboxItem value="Feature request" />
+        </Ariakit.ComboboxList>
       </Ariakit.ComboboxPopover>
     </Ariakit.ComboboxProvider>
   );
@@ -122,6 +140,8 @@ export default function Example() {
       <GoToFile />
       <RunCommand />
       <FruitSearch />
+      <SearchTags />
+      <SearchIssues />
     </>
   );
 }

--- a/app/src/sandbox/combobox-list-7302/test-chrome.ts
+++ b/app/src/sandbox/combobox-list-7302/test-chrome.ts
@@ -51,4 +51,30 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(query(popover).option("Apple")).toBeVisible();
     await test.expect(query(popover).listbox("Recently used")).toBeVisible();
   });
+
+  // https://github.com/ariakit/ariakit/issues/7302
+  test("popover sharing an element with a list keeps the popup role", async ({
+    q,
+  }) => {
+    const combobox = q.combobox("Search tags");
+    await combobox.click();
+
+    const popover = q.listbox("Tag results");
+    await test.expect(popover).toBeVisible();
+    await test.expect(combobox).toHaveAttribute("aria-haspopup", "listbox");
+    await test.expect(query(popover).option("Design")).toBeVisible();
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7302
+  test("nested list owns the popup role on a shared element", async ({ q }) => {
+    const combobox = q.combobox("Search issues");
+    await combobox.click();
+
+    const popover = q.dialog("Issue results");
+    await test.expect(popover).toBeVisible();
+    await test.expect(combobox).toHaveAttribute("aria-haspopup", "dialog");
+
+    const list = query(popover).listbox("Issues");
+    await test.expect(query(list).option("Bug report")).toBeVisible();
+  });
 });

--- a/app/src/sandbox/combobox-list-7302/test-chrome.ts
+++ b/app/src/sandbox/combobox-list-7302/test-chrome.ts
@@ -1,0 +1,54 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test, query }) => {
+  // https://github.com/ariakit/ariakit/issues/7302
+  test("nested tree list owns the popup role", async ({ q }) => {
+    const combobox = q.combobox("Go to file");
+    await combobox.click();
+
+    const popover = q.dialog("Go to file results");
+    await test.expect(popover).toBeVisible();
+    await test.expect(combobox).toHaveAttribute("aria-haspopup", "dialog");
+
+    const tree = query(popover).tree("Files");
+    await test.expect(query(tree).treeitem()).toHaveCount(4);
+    await test.expect(query(popover).status()).toHaveText("4 of 4 files");
+
+    // The nested list re-renders on every keystroke, so the popup role must
+    // survive both a filtered and an empty result set.
+    await combobox.fill("app");
+    await test.expect(query(popover).status()).toHaveText("1 of 4 files");
+    await test.expect(query(tree).treeitem("app.tsx")).toBeVisible();
+    await test.expect(combobox).toHaveAttribute("aria-haspopup", "dialog");
+
+    await combobox.fill("appzzz");
+    await test.expect(query(popover).status()).toHaveText("0 of 4 files");
+    await test.expect(query(tree).treeitem()).toHaveCount(0);
+    await test.expect(combobox).toHaveAttribute("aria-haspopup", "dialog");
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7302
+  test("nested menu list owns the popup role", async ({ q }) => {
+    const combobox = q.combobox("Run command");
+    await combobox.click();
+
+    const popover = q.dialog("Command results");
+    await test.expect(popover).toBeVisible();
+    await test.expect(combobox).toHaveAttribute("aria-haspopup", "dialog");
+
+    const menu = query(popover).menu("Commands");
+    await test.expect(query(menu).menuitem()).toHaveCount(3);
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7302
+  test("unrelated listbox does not take the popup role", async ({ q }) => {
+    const combobox = q.combobox("Search fruits");
+    await combobox.click();
+
+    const popover = q.listbox("Fruit results");
+    await test.expect(popover).toBeVisible();
+    await test.expect(combobox).toHaveAttribute("aria-haspopup", "listbox");
+    await test.expect(query(popover).option("Apple")).toBeVisible();
+    await test.expect(query(popover).listbox("Recently used")).toBeVisible();
+  });
+});

--- a/app/src/sandbox/combobox-list-7302/test-chrome.ts
+++ b/app/src/sandbox/combobox-list-7302/test-chrome.ts
@@ -77,4 +77,23 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     const list = query(popover).listbox("Issues");
     await test.expect(query(list).option("Bug report")).toBeVisible();
   });
+
+  // https://github.com/ariakit/ariakit/issues/7302
+  // https://github.com/ariakit/ariakit/pull/7304#discussion_r3884213906
+  test("portaled list for the same store does not take the popup role", async ({
+    q,
+  }) => {
+    const combobox = q.combobox("Search docs");
+    await combobox.click();
+
+    const popover = q.listbox("Doc results");
+    await test.expect(popover).toBeVisible();
+    await test.expect(combobox).toHaveAttribute("aria-haspopup", "listbox");
+    await test.expect(query(popover).option("Getting started")).toBeVisible();
+
+    // The pinned list reaches this store through context, but it renders
+    // outside the popup, so it must not take the popup role from it.
+    await test.expect(q.listbox("Pinned docs")).toBeVisible();
+    await test.expect(query(popover).listbox("Pinned docs")).toHaveCount(0);
+  });
 });

--- a/app/src/sandbox/combobox-list-7302/test.ts
+++ b/app/src/sandbox/combobox-list-7302/test.ts
@@ -1,0 +1,60 @@
+import { click, q, type } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// https://github.com/ariakit/ariakit/issues/7302
+test("nested tree list owns the popup role", async () => {
+  const combobox = q.combobox("Go to file");
+  await click(combobox);
+
+  const popover = q.dialog("Go to file results");
+  // ComboboxList resolves the popup role asynchronously, so aria-haspopup can
+  // still be catching up when the popover opens.
+  await expect
+    .poll(() => combobox.getAttribute("aria-haspopup"))
+    .toBe("dialog");
+
+  const tree = q.tree("Files");
+  expect(popover).toContainElement(tree);
+  expect(q.within(tree).treeitem.all()).toHaveLength(4);
+  expect(q.within(popover).status()).toHaveTextContent("4 of 4 files");
+
+  // The nested list re-renders on every keystroke, so the popup role must
+  // survive both a filtered and an empty result set.
+  await type("app", combobox);
+  expect(q.dialog("Go to file results")).toBe(popover);
+  expect(combobox).toHaveAttribute("aria-haspopup", "dialog");
+  expect(q.within(popover).status()).toHaveTextContent("1 of 4 files");
+  expect(q.within(tree).treeitem.all()).toHaveLength(1);
+
+  await type("zzz", combobox);
+  expect(q.dialog("Go to file results")).toBe(popover);
+  expect(combobox).toHaveAttribute("aria-haspopup", "dialog");
+  expect(q.within(popover).status()).toHaveTextContent("0 of 4 files");
+  expect(q.within(tree).treeitem.all()).toHaveLength(0);
+});
+
+// https://github.com/ariakit/ariakit/issues/7302
+test("nested menu list owns the popup role", async () => {
+  const combobox = q.combobox("Run command");
+  await click(combobox);
+
+  const popover = q.dialog("Command results");
+  await expect
+    .poll(() => combobox.getAttribute("aria-haspopup"))
+    .toBe("dialog");
+
+  const menu = q.menu("Commands");
+  expect(popover).toContainElement(menu);
+  expect(q.within(menu).menuitem.all()).toHaveLength(3);
+});
+
+// https://github.com/ariakit/ariakit/issues/7302
+test("unrelated listbox does not take the popup role", async () => {
+  const combobox = q.combobox("Search fruits");
+  await click(combobox);
+
+  const popover = q.listbox("Fruit results");
+  expect(combobox).toHaveAttribute("aria-haspopup", "listbox");
+  expect(popover).toContainElement(q.option("Apple"));
+  expect(popover).toContainElement(q.listbox("Recently used"));
+});

--- a/app/src/sandbox/combobox-list-7302/test.ts
+++ b/app/src/sandbox/combobox-list-7302/test.ts
@@ -58,3 +58,28 @@ test("unrelated listbox does not take the popup role", async () => {
   expect(popover).toContainElement(q.option("Apple"));
   expect(popover).toContainElement(q.listbox("Recently used"));
 });
+
+// https://github.com/ariakit/ariakit/issues/7302
+test("popover sharing an element with a list keeps the popup role", async () => {
+  const combobox = q.combobox("Search tags");
+  await click(combobox);
+
+  const popover = q.listbox("Tag results");
+  expect(combobox).toHaveAttribute("aria-haspopup", "listbox");
+  expect(popover).toContainElement(q.option("Design"));
+});
+
+// https://github.com/ariakit/ariakit/issues/7302
+test("nested list owns the popup role on a shared element", async () => {
+  const combobox = q.combobox("Search issues");
+  await click(combobox);
+
+  const popover = q.dialog("Issue results");
+  await expect
+    .poll(() => combobox.getAttribute("aria-haspopup"))
+    .toBe("dialog");
+
+  const list = q.listbox("Issues");
+  expect(popover).toContainElement(list);
+  expect(list).toContainElement(q.option("Bug report"));
+});

--- a/app/src/sandbox/combobox-list-7302/test.ts
+++ b/app/src/sandbox/combobox-list-7302/test.ts
@@ -7,11 +7,7 @@ test("nested tree list owns the popup role", async () => {
   await click(combobox);
 
   const popover = q.dialog("Go to file results");
-  // ComboboxList resolves the popup role asynchronously, so aria-haspopup can
-  // still be catching up when the popover opens.
-  await expect
-    .poll(() => combobox.getAttribute("aria-haspopup"))
-    .toBe("dialog");
+  expect(combobox).toHaveAttribute("aria-haspopup", "dialog");
 
   const tree = q.tree("Files");
   expect(popover).toContainElement(tree);
@@ -39,9 +35,7 @@ test("nested menu list owns the popup role", async () => {
   await click(combobox);
 
   const popover = q.dialog("Command results");
-  await expect
-    .poll(() => combobox.getAttribute("aria-haspopup"))
-    .toBe("dialog");
+  expect(combobox).toHaveAttribute("aria-haspopup", "dialog");
 
   const menu = q.menu("Commands");
   expect(popover).toContainElement(menu);
@@ -75,11 +69,26 @@ test("nested list owns the popup role on a shared element", async () => {
   await click(combobox);
 
   const popover = q.dialog("Issue results");
-  await expect
-    .poll(() => combobox.getAttribute("aria-haspopup"))
-    .toBe("dialog");
+  expect(combobox).toHaveAttribute("aria-haspopup", "dialog");
 
   const list = q.listbox("Issues");
   expect(popover).toContainElement(list);
   expect(list).toContainElement(q.option("Bug report"));
+});
+
+// https://github.com/ariakit/ariakit/issues/7302
+// https://github.com/ariakit/ariakit/pull/7304#discussion_r3884213906
+test("portaled list for the same store does not take the popup role", async () => {
+  const combobox = q.combobox("Search docs");
+  await click(combobox);
+
+  const popover = q.listbox("Doc results");
+  expect(combobox).toHaveAttribute("aria-haspopup", "listbox");
+  expect(popover).toContainElement(q.option("Getting started"));
+
+  // The pinned list reaches this store through context, but it renders outside
+  // the popup, so it must not take the popup role from it.
+  const pinned = q.listbox("Pinned docs");
+  expect(popover).not.toContainElement(pinned);
+  expect(pinned).toContainElement(q.option("Changelog"));
 });

--- a/packages/ariakit-react-components/src/combobox/combobox-context.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-context.tsx
@@ -15,6 +15,17 @@ export const ComboboxListRoleContext = createContext<string | undefined>(
   undefined,
 );
 
+/**
+ * Lets a nested combobox list register itself with the nearest list above it,
+ * so that list can tell whether it contains another one that owns the popup
+ * role. The registration is forwarded up the chain, so lists that share an
+ * element learn about it too. Registering returns a cleanup function, or
+ * nothing when the element is the receiving list's own element.
+ */
+export const ComboboxNestedListContext = createContext<
+  ((element: Element) => (() => void) | undefined) | null
+>(null);
+
 const ctx = createStoreContext<ComboboxStore>(
   [PopoverContextProvider, CompositeContextProvider],
   [PopoverScopedContextProvider, CompositeScopedContextProvider],

--- a/packages/ariakit-react-components/src/combobox/combobox-context.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-context.tsx
@@ -15,17 +15,6 @@ export const ComboboxListRoleContext = createContext<string | undefined>(
   undefined,
 );
 
-/**
- * Lets a nested combobox list register itself with the nearest list above it,
- * so that list can tell whether it contains another one that owns the popup
- * role. The registration is forwarded up the chain, so lists that share an
- * element learn about it too. Registering returns a cleanup function, or
- * nothing when the element is the receiving list's own element.
- */
-export const ComboboxNestedListContext = createContext<
-  ((element: Element) => (() => void) | undefined) | null
->(null);
-
 const ctx = createStoreContext<ComboboxStore>(
   [PopoverContextProvider, CompositeContextProvider],
   [PopoverScopedContextProvider, CompositeScopedContextProvider],

--- a/packages/ariakit-react-components/src/combobox/combobox-list.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-list.tsx
@@ -25,7 +25,6 @@ import { isHidden } from "../disclosure/disclosure-content.tsx";
 import {
   ComboboxHeadingContext,
   ComboboxListRoleContext,
-  ComboboxNestedListContext,
   ComboboxScopedContextProvider,
   useComboboxContext,
   useComboboxScopedContext,
@@ -101,11 +100,8 @@ export const useComboboxList = createHook<TagName, ComboboxListOptions>(
       ? multiSelectable || undefined
       : undefined;
 
-    const parentList = useContext(ComboboxNestedListContext);
-    // A list for another store is a separate popup that happens to render
-    // inside this one, so it does not own the outer list's popup role.
-    const registerInParentList = scopedContextSameStore ? parentList : null;
-    const [nestedListCount, setNestedListCount] = useState(0);
+    const [hasNestedList, setHasNestedList] = useState(false);
+    const contentElement = useStoreState(store, "contentElement");
     const parentHeadingContext = useContext(ComboboxHeadingContext);
     const headingState = useState<string>();
     const [headingId, setHeadingId] = parentHeadingContext || headingState;
@@ -116,31 +112,22 @@ export const useComboboxList = createHook<TagName, ComboboxListOptions>(
     // We support nested <ComboboxList> elements (usually in the form of
     // ComboboxPopover>ComboboxList). The innermost list owns the popup role,
     // whichever role that is, so an outer list must not render one of its own.
-    // Nested lists register through context so that only a real ComboboxList
-    // suppresses the role, not any descendant with a popup role attribute.
-    const registerNestedList = useEvent((element: Element) => {
-      // ComboboxPopover is built on this same hook, so a ComboboxList passed to
-      // its render prop shares this element rather than nesting inside it.
-      if (element === ref.current) return;
-      setNestedListCount((count) => count + 1);
-      // Both hooks install their own context, so a nested list only reaches the
-      // inner one. Forwarding stops the outer hook from rendering a popup role
-      // on the shared element.
-      const unregisterFromParentList = registerInParentList?.(element);
-      return () => {
-        setNestedListCount((count) => count - 1);
-        unregisterFromParentList?.();
-      };
-    });
-
     useSafeLayoutEffect(() => {
-      if (!registerInParentList) return;
+      if (!mounted) return;
       const element = ref.current;
       if (!element) return;
-      return registerInParentList(element);
-    }, [registerInParentList]);
+      if (contentElement !== element) return;
+      const update = () => {
+        setHasNestedList(!!element.querySelector("[data-combobox-list]"));
+      };
+      // The marker is static, so it can only come and go with its element.
+      const observer = new MutationObserver(update);
+      observer.observe(element, { subtree: true, childList: true });
+      update();
+      return () => observer.disconnect();
+    }, [mounted, contentElement]);
 
-    if (!nestedListCount) {
+    if (!hasNestedList) {
       props = {
         role: "listbox",
         "aria-multiselectable": ariaMultiSelectable,
@@ -156,18 +143,16 @@ export const useComboboxList = createHook<TagName, ComboboxListOptions>(
       props,
       (element) => (
         <ComboboxScopedContextProvider value={store}>
-          <ComboboxNestedListContext.Provider value={registerNestedList}>
-            <ComboboxHeadingContext.Provider value={headingContext}>
-              <DialogHeadingContext.Provider value={setHeadingId}>
-                <ComboboxListRoleContext.Provider value={role}>
-                  {element}
-                </ComboboxListRoleContext.Provider>
-              </DialogHeadingContext.Provider>
-            </ComboboxHeadingContext.Provider>
-          </ComboboxNestedListContext.Provider>
+          <ComboboxHeadingContext.Provider value={headingContext}>
+            <DialogHeadingContext.Provider value={setHeadingId}>
+              <ComboboxListRoleContext.Provider value={role}>
+                {element}
+              </ComboboxListRoleContext.Provider>
+            </DialogHeadingContext.Provider>
+          </ComboboxHeadingContext.Provider>
         </ComboboxScopedContextProvider>
       ),
-      [store, role, headingContext, registerNestedList],
+      [store, role, headingContext],
     );
 
     // When nesting ComboboxList elements, the content element should be
@@ -188,6 +173,9 @@ export const useComboboxList = createHook<TagName, ComboboxListOptions>(
     const labelId = headingId || labelElement?.id;
 
     props = {
+      // Marks a real ComboboxList, so the query above matches only these and
+      // not any other descendant that happens to carry a popup role.
+      "data-combobox-list": "",
       "aria-labelledby": props["aria-label"] != null ? undefined : labelId,
       hidden,
       ...props,

--- a/packages/ariakit-react-components/src/combobox/combobox-list.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-list.tsx
@@ -25,6 +25,7 @@ import { isHidden } from "../disclosure/disclosure-content.tsx";
 import {
   ComboboxHeadingContext,
   ComboboxListRoleContext,
+  ComboboxNestedListContext,
   ComboboxScopedContextProvider,
   useComboboxContext,
   useComboboxScopedContext,
@@ -100,8 +101,11 @@ export const useComboboxList = createHook<TagName, ComboboxListOptions>(
       ? multiSelectable || undefined
       : undefined;
 
-    const [hasListboxInside, setHasListboxInside] = useState(false);
-    const contentElement = useStoreState(store, "contentElement");
+    const parentList = useContext(ComboboxNestedListContext);
+    // A list for another store is a separate popup that happens to render
+    // inside this one, so it does not own the outer list's popup role.
+    const registerInParentList = scopedContextSameStore ? parentList : null;
+    const [nestedListCount, setNestedListCount] = useState(0);
     const parentHeadingContext = useContext(ComboboxHeadingContext);
     const headingState = useState<string>();
     const [headingId, setHeadingId] = parentHeadingContext || headingState;
@@ -110,28 +114,33 @@ export const useComboboxList = createHook<TagName, ComboboxListOptions>(
       [headingId, setHeadingId],
     );
     // We support nested <ComboboxList> elements (usually in the form of
-    // ComboboxPopover>ComboboxList), but we can't have nested listbox roles, so
-    // we check here if there's already a listbox element inside the current
-    // element.
+    // ComboboxPopover>ComboboxList). The innermost list owns the popup role,
+    // whichever role that is, so an outer list must not render one of its own.
+    // Nested lists register through context so that only a real ComboboxList
+    // suppresses the role, not any descendant with a popup role attribute.
+    const registerNestedList = useEvent((element: Element) => {
+      // ComboboxPopover is built on this same hook, so a ComboboxList passed to
+      // its render prop shares this element rather than nesting inside it.
+      if (element === ref.current) return;
+      setNestedListCount((count) => count + 1);
+      // Both hooks install their own context, so a nested list only reaches the
+      // inner one. Forwarding stops the outer hook from rendering a popup role
+      // on the shared element.
+      const unregisterFromParentList = registerInParentList?.(element);
+      return () => {
+        setNestedListCount((count) => count - 1);
+        unregisterFromParentList?.();
+      };
+    });
+
     useSafeLayoutEffect(() => {
-      if (!mounted) return;
+      if (!registerInParentList) return;
       const element = ref.current;
       if (!element) return;
-      if (contentElement !== element) return;
-      const callback = () => {
-        setHasListboxInside(!!element.querySelector("[role='listbox']"));
-      };
-      const observer = new MutationObserver(callback);
-      observer.observe(element, {
-        subtree: true,
-        childList: true,
-        attributeFilter: ["role"],
-      });
-      callback();
-      return () => observer.disconnect();
-    }, [mounted, contentElement]);
+      return registerInParentList(element);
+    }, [registerInParentList]);
 
-    if (!hasListboxInside) {
+    if (!nestedListCount) {
       props = {
         role: "listbox",
         "aria-multiselectable": ariaMultiSelectable,
@@ -147,16 +156,18 @@ export const useComboboxList = createHook<TagName, ComboboxListOptions>(
       props,
       (element) => (
         <ComboboxScopedContextProvider value={store}>
-          <ComboboxHeadingContext.Provider value={headingContext}>
-            <DialogHeadingContext.Provider value={setHeadingId}>
-              <ComboboxListRoleContext.Provider value={role}>
-                {element}
-              </ComboboxListRoleContext.Provider>
-            </DialogHeadingContext.Provider>
-          </ComboboxHeadingContext.Provider>
+          <ComboboxNestedListContext.Provider value={registerNestedList}>
+            <ComboboxHeadingContext.Provider value={headingContext}>
+              <DialogHeadingContext.Provider value={setHeadingId}>
+                <ComboboxListRoleContext.Provider value={role}>
+                  {element}
+                </ComboboxListRoleContext.Provider>
+              </DialogHeadingContext.Provider>
+            </ComboboxHeadingContext.Provider>
+          </ComboboxNestedListContext.Provider>
         </ComboboxScopedContextProvider>
       ),
-      [store, role, headingContext],
+      [store, role, headingContext, registerNestedList],
     );
 
     // When nesting ComboboxList elements, the content element should be


### PR DESCRIPTION
## Motivation

`ComboboxList` documents that its `role` prop accepts any valid combobox popup role (`listbox`, `menu`, `tree`, `grid` or `dialog`). It also drops its own default `role="listbox"` when it already contains a nested list, so `ComboboxPopover > ComboboxList` does not produce nested listboxes.

That detection only looks for one role:

```ts
setHasListboxInside(!!element.querySelector("[role='listbox']"));
```

So the two behaviors disagree. A nested list with any role other than `listbox` is never detected, the popover keeps `role="listbox"`, and the rendered DOM is invalid:

```html
<!-- nested ComboboxList, default role -->
<div role="dialog"><div role="listbox"><div role="option">Apple</div></div></div>

<!-- nested ComboboxList role="tree" -->
<div role="listbox"><div role="tree"><div role="treeitem">Apple</div></div></div>
```

The same component tree, one role string apart. One is auto-corrected, the other is not. axe-core reports the second shape as a critical `aria-required-children` violation. The combobox input also derives `aria-haspopup` from that element, so it advertises `listbox` while the popup is a tree, menu or grid.

The nested form is needed whenever the popover must hold content that the popup role may not own, such as a live result count, a header or a toolbar. A `tree` may only own `treeitem` and `group` children, so that content cannot live inside the list.

The same query has a second problem. It matches any `[role='listbox']` descendant, including markup the combobox does not own:

```jsx
<Ariakit.ComboboxPopover>
  <Ariakit.ComboboxItem value="Apple" />
  <div role="listbox"><div role="option">unrelated</div></div>
</Ariakit.ComboboxPopover>
```

This renders `<div role="dialog"><div role="option">Apple</div><div role="listbox">…</div></div>`, leaving the real `ComboboxItem` outside any listbox.

Fixes #7302

## Solution

Both problems come from asking the DOM the wrong question. `[role='listbox']` is neither necessary nor sufficient: it misses the four other roles a nested list may carry, and it matches elements that are not `ComboboxList` at all.

So the query now asks for component identity instead of a role. `useComboboxList` renders a `data-combobox-list` marker on every list host, and detection looks for that:

```diff
-setHasListboxInside(!!element.querySelector("[role='listbox']"));
+setHasNestedList(!!element.querySelector("[data-combobox-list]"));
```

Everything else about the existing effect is unchanged, including its `[mounted, contentElement]` dependencies and its `contentElement !== element` guard. The net change to the library is one file.

This is role-agnostic by construction, so it covers every popup role the prop accepts rather than enumerating them, and it is scoped to real `ComboboxList` elements, so unrelated markup can no longer take the popup role away from the popover.

Two properties fall out of using a DOM query rather than a React one, and both are load-bearing:

- `Element.querySelector` never matches the element it is called on, so `<ComboboxPopover render={<ComboboxList />}>`, which runs the hook twice on a single element, needs no special case.
- Only DOM descendants match, so a list rendered elsewhere through a portal cannot claim the popup role, and a list portaled *into* the popup from another part of the React tree is still found.

The observer also watches less than before. `main` passed `attributeFilter: ["role"]`, which implies `attributes: true`, so it woke on every `role` mutation anywhere in the popup subtree. The marker is static and can only enter or leave the subtree with its element, so `childList` alone is enough:

```diff
 observer.observe(element, {
   subtree: true,
   childList: true,
-  attributeFilter: ["role"],
 });
```

Per-list role reactivity is unaffected, because `useAttribute` already installs its own `role` observer on each list host.

### Notes

- `ComboboxPopover` composes `useComboboxList`, so the popover element carries `data-combobox-list` too. This matches how `data-dialog` works on `Dialog` and its derived components.
- Legacy `SelectList` renders `role="listbox"` by default only when it has no combobox store and its child store differs, and it carries no marker either way. Such an element nested inside a combobox popup no longer strips that popup's role, which is the same correction as the unrelated-listbox case above.

### Scope

- Middle lists, meaning `ComboboxPopover > ComboboxList > ComboboxList`, are not a supported composition. The supported shape is `ComboboxPopover > ComboboxList`.
- Detection is not scoped to the combobox store. A `ComboboxList` that is a DOM descendant of the popup takes the popup role regardless of which store it belongs to. For the default role this matches `main` exactly. It differs from `main` only when a foreign inline list carries a non-`listbox` role, where `main` produced invalid `listbox > tree` anyway.
- A popover whose only listbox-role content is markup the combobox does not own now keeps `role="listbox"`, so that foreign listbox becomes an invalid child of a listbox. On `main` the popover demoted itself to `dialog` and the foreign listbox was valid. That demotion is exactly what left a popover's own `ComboboxItem` children with no owning listbox, which is the second symptom this fixes, so the two cannot both be satisfied. Consumers who hit this should nest their own items in a `ComboboxList` and pass no `role` to the popover, which then renders as a `dialog`, or move the foreign widget out of the popup.

### Not covered here

- `ComboboxRow` and `ComboboxGroup` read the popup role from the popover rather than the nearest list, so a nested `ComboboxList role="grid"` loses `row` and `rowgroup`. Confirmed pre-existing on `main` and unchanged by this pull request. Tracked in #7305 and fixed in #7314, which is now merged. This branch and that change touch the same file but not the same regions; applying both and running the suites gives 1927 vitest tests and 837 Chrome tests passing.
- Before a popup is opened for the first time, the popover still renders `role="listbox"` and the input still reports `aria-haspopup="listbox"`, because detection is gated on `mounted`. Confirmed pre-existing on `main` by reverting `combobox-list.tsx` to `a8a5181` and re-measuring. Tracked in #7317.

`aria-haspopup` settles one task after the popup role resolves. Measured in Chrome, the popup element's `role` changes at `t=10434.5ms` and the input's `aria-haspopup` at `t=10444.5ms`, in separate mutation batches. `ComboboxSelect` synchronizes this with `useAttribute(contentElement, "role")`; `Combobox` does not, and #7306 declined to add it.

## Workaround

Until the fix is released, pass the popup role explicitly to `ComboboxPopover`.

When the real popup role lives on a nested `ComboboxList`, set the popover to `dialog`:

```jsx
{/* TODO: Remove once released. https://github.com/ariakit/ariakit/issues/7302 */}
<Ariakit.ComboboxPopover role="dialog" aria-label="Go to file results">
  <div role="status">{matches.length} files</div>
  <Ariakit.ComboboxList role="tree" aria-label="Files">
    ...
  </Ariakit.ComboboxList>
</Ariakit.ComboboxPopover>
```

When the popover renders its own items and an unrelated listbox strips its role, set it back to `listbox`:

```jsx
{/* TODO: Remove once released. https://github.com/ariakit/ariakit/issues/7302 */}
<Ariakit.ComboboxPopover role="listbox" aria-label="Fruit results">
  <Ariakit.ComboboxItem value="Apple" />
  <div role="listbox" aria-label="Recently used">...</div>
</Ariakit.ComboboxPopover>
```

Setting the popover to `dialog` also changes `aria-haspopup` from `listbox` to `dialog`. That is intended, and it is what the fix produces too.

This workaround is narrower than the fix:

- The popup role has to be known when the element is written. A popover that renders a nested list in one mode and direct items in another has to compute the prop, because a fixed `role="dialog"` leaves direct items outside any listbox.
- A nested `ComboboxList role="grid"` is not covered, for the reason in #7305 above.
- In the second case the popover owns its own options again, but the unrelated listbox stays an invalid child of a `listbox`. Consumers who need a clean axe run should nest their items in a `ComboboxList` and pass no `role` to the popover, which then renders as a `dialog`, or move the unrelated widget out of the popup.
- In the second case `aria-multiselectable` is not restored, because the popover's `ComboboxList` logic skips the whole block that carries it. Multi-selectable comboboxes have to pass `aria-multiselectable` explicitly. The fix restores it automatically.

## Tests

`app/src/sandbox/combobox-list-7302` covers six scenarios through the rendered accessibility tree:

- A "Go to file" combobox whose popover holds a live result count and a nested `ComboboxList role="tree"`. The popover must be a `dialog` that contains the tree, `aria-haspopup` must be `dialog`, and the role must survive a filtered and an empty result set.
- A "Run command" combobox with a nested `ComboboxList role="menu"` and a footer hint outside it, proving the behavior is not specific to `tree`.
- A fruit search whose popover renders its own options directly and also embeds a third-party widget that ships its own listbox. The popover must keep `role="listbox"` for its own options.
- A tag search whose popover shares its element with a `ComboboxList` through the `render` prop. The shared element must keep `role="listbox"`.
- An issue search with the same shared element plus a real nested `ComboboxList`. The shared element must become a `dialog` and the nested list must own the popup role.
- A docs search whose popover renders its own options and also portals a `ComboboxList` for the same store into a side panel outside the popup. The popover must keep `role="listbox"` and the pinned list must stay outside it.

The first three failed on [`b6edb36`](https://github.com/ariakit/ariakit/commit/b6edb36f52648c1a9c4c340ce600044d980ede55), where CI recorded `Main / Test`, `Main / Test React 18` and `App / Test Chrome` red.

Both properties of the final query were red-checked against the shipped code:

- Reverting the selector to `element.querySelector("[role='listbox']")` fails exactly the three scenarios that define the bug: the tree search, the menu search and the fruit search.
- Broadening the scan to `document.querySelector("[data-combobox-list]")` fails the fruit search, the tag search and the docs search, which is what pins detection to the popup's own subtree.

The issue search passes on `main` as well; it is a behavior-preservation guard for the shared-element composition rather than a regression guard.

## Evidence

There is nothing to screenshot: the popup renders identically and keyboard navigation is unchanged, as the issue notes. The observable difference is in the accessibility tree, so the evidence is a measurement rather than an image. Both runs below instrument the `combobox-list-7302` preview in Chrome with a `MutationObserver` over `role` and `aria-haspopup`, then click the "Go to file" combobox.

On `main` the popup never demotes itself. The observer recorded **zero** mutations, leaving `listbox > tree`:

| | input `aria-haspopup` | popup `role` |
| --- | --- | --- |
| before open | `listbox` | `listbox` |
| after open | `listbox` | `listbox` |

On this branch the popup demotes as it opens:

| | input `aria-haspopup` | popup `role` |
| --- | --- | --- |
| before open | `listbox` | `listbox` |
| after open | `dialog` | `dialog` |

```
t=10434.5  popup  role           listbox -> dialog
t=10444.5  input  aria-haspopup  listbox -> dialog
```

The two land in separate mutation batches, which is the `aria-haspopup` lag described above. The identical `before open` row on both sides is the pre-existing behavior tracked in #7317.

## Implementation review reassessment

<details>
<summary>Direction change: React-context registration replaced by a component marker</summary>

**Assessment**

The first implementation replaced the DOM query with a React context (`ComboboxNestedListContext`) that nested lists registered through. It needed five separate conditions to stay correct: upward forwarding, a same-element guard, a containment check, a same-store gate, and element state to re-run registration after refs attach. Four of the five produced their own review findings: stale forwarding when a parent's registrar changed, a portaled list wrongly suppressing the role, an accidental public export on the published `./combobox/combobox-context` subpath, and an untested store gate.

Role ownership is a DOM containment property, so a React-tree mechanism had to reconstruct DOM-ness by hand. Once the maintainer removed the same-store requirement, the only property the context provided that a DOM query could not was gone.

**Decision**

Return to `main`'s query structure and change what it looks for, from a role to a `data-combobox-list` component marker. The library change went from roughly +50/−28 across two files to one file, `combobox-context.tsx` returned to its `main` state, and four of the five conditions disappeared rather than being repaired. Two findings against the context version, the portal-in case and the accidental export, were resolved for free rather than fixed.

**Intentionally unsupported**

Middle lists, and cross-store DOM descendants as described under Scope.

**Registered follow-ups**

#7305 (fixed by #7314), #7317.

</details>

## Review gate reassessment

<details>
<summary>Round 3: continue the marker design</summary>

**Assessment**

Issue severity is moderate and accessibility-only: invalid ARIA with no visual or keyboard symptom, reported by axe as a critical `aria-required-children` violation, plus a `aria-haspopup` value that does not match the popup. Expected frequency is low, because no pre-existing example or sandbox in the repository puts a non-`listbox` role on a nested `ComboboxList`; every non-default popup role in the repo sits on `ComboboxPopover` itself. The supported scope is one composition, `ComboboxPopover > ComboboxList`, in `@ariakit/react` only; there is no equivalent detection in the Solid or vanilla packages. Likely user impact is limited to screen-reader users of the affected shapes, and both workarounds above are confirmed.

Implementation complexity is now zero added branches, zero added state, zero added helpers, zero added abstractions and zero added exports. The public surface added is one internal DOM attribute, matching `data-dialog`, `data-dialog-dismiss` and `data-composite-container`, none of which are documented. The observer watches strictly less than `main`.

The three round-3 findings were a false claim in this description, a pre-existing defect now tracked in #7317, and comment verbosity. None concerned the mechanism.

**Decision**

Continue. No further simplification is available: a React context cannot express DOM containment without reconstructing it, and a widened role selector regresses inline `Popover` and `Menu` descendants, which was measured.

</details>
