### PR TITLE
Fix Combobox group and row roles in nested grids

### DIFF
--- a/.changeset/300-combobox-nested-grid-roles.md
+++ b/.changeset/300-combobox-nested-grid-roles.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`ComboboxGroup`](https://ariakit.com/reference/combobox-group) and [`ComboboxRow`](https://ariakit.com/reference/combobox-row) to use `rowgroup` and `row` roles when the nearest [`ComboboxList`](https://ariakit.com/reference/combobox-list) is a grid.

--- a/app/src/sandbox/combobox-grid/index.react.tsx
+++ b/app/src/sandbox/combobox-grid/index.react.tsx
@@ -1,5 +1,4 @@
 import * as Ariakit from "@ariakit/react";
-import { ComboboxListRoleContext } from "@ariakit/react-components/combobox/combobox-context";
 import { useComboboxGroup } from "@ariakit/react-components/combobox/combobox-group";
 import { useComboboxRow } from "@ariakit/react-components/combobox/combobox-row";
 
@@ -40,61 +39,14 @@ function HookGrid() {
   );
 }
 
-function SelectHookRoles({
-  store,
-  testId = "select-hook-roles",
-}: {
-  store: Ariakit.ComboboxStore;
-  testId?: string;
-}) {
-  const groupProps = useComboboxGroup({ store });
-  const rowProps = useComboboxRow({ store });
-
+function NestedHookGrid() {
   return (
-    <span
-      data-testid={testId}
-      data-group-role={groupProps.role}
-      data-row-role={rowProps.role}
-    />
-  );
-}
-
-function SelectHookGrid() {
-  const store = Ariakit.useComboboxStore();
-
-  return (
-    <>
-      <Ariakit.ComboboxLabel store={store} className="label">
-        Select direction
-      </Ariakit.ComboboxLabel>
-      <Ariakit.ComboboxSelect store={store} className="combobox">
-        Choose direction
-        <SelectHookRoles store={store} />
-        <ComboboxListRoleContext.Provider value={undefined}>
-          <SelectHookRoles store={store} testId="pending-list-hook-roles" />
-        </ComboboxListRoleContext.Provider>
-      </Ariakit.ComboboxSelect>
-      <Ariakit.ComboboxPopover
-        store={store}
-        role="grid"
-        aria-label="Select hook directions"
-        gutter={4}
-        className="popover"
-      >
-        <Ariakit.ComboboxRow className="combobox-row">
-          <Ariakit.ComboboxItem
-            role="gridcell"
-            className="combobox-item"
-            value="West"
-          />
-          <Ariakit.ComboboxItem
-            role="gridcell"
-            className="combobox-item"
-            value="East"
-          />
-        </Ariakit.ComboboxRow>
+    <Ariakit.ComboboxProvider defaultOpen>
+      <Ariakit.Combobox aria-label="Outer command" />
+      <Ariakit.ComboboxPopover role="dialog" aria-label="Outer commands">
+        <HookGrid />
       </Ariakit.ComboboxPopover>
-    </>
+    </Ariakit.ComboboxProvider>
   );
 }
 
@@ -190,8 +142,7 @@ export default function Example() {
         </Ariakit.ComboboxPopover>
       </Ariakit.ComboboxProvider>
 
-      <HookGrid />
-      <SelectHookGrid />
+      <NestedHookGrid />
     </>
   );
 }

--- a/app/src/sandbox/combobox-grid/index.react.tsx
+++ b/app/src/sandbox/combobox-grid/index.react.tsx
@@ -1,4 +1,102 @@
 import * as Ariakit from "@ariakit/react";
+import { ComboboxListRoleContext } from "@ariakit/react-components/combobox/combobox-context";
+import { useComboboxGroup } from "@ariakit/react-components/combobox/combobox-group";
+import { useComboboxRow } from "@ariakit/react-components/combobox/combobox-row";
+
+function HookGrid() {
+  const store = Ariakit.useComboboxStore();
+  const groupProps = useComboboxGroup({ store });
+  const rowProps = useComboboxRow({ store });
+
+  return (
+    <>
+      <Ariakit.ComboboxLabel store={store} className="label">
+        Hook direction
+      </Ariakit.ComboboxLabel>
+      <Ariakit.Combobox store={store} className="combobox" />
+      <Ariakit.ComboboxPopover
+        store={store}
+        role="grid"
+        aria-label="Hook directions"
+        gutter={4}
+        className="popover"
+      >
+        <Ariakit.Role {...groupProps}>
+          <Ariakit.Role {...rowProps}>
+            <Ariakit.ComboboxItem
+              role="gridcell"
+              className="combobox-item"
+              value="South West"
+            />
+            <Ariakit.ComboboxItem
+              role="gridcell"
+              className="combobox-item"
+              value="South East"
+            />
+          </Ariakit.Role>
+        </Ariakit.Role>
+      </Ariakit.ComboboxPopover>
+    </>
+  );
+}
+
+function SelectHookRoles({
+  store,
+  testId = "select-hook-roles",
+}: {
+  store: Ariakit.ComboboxStore;
+  testId?: string;
+}) {
+  const groupProps = useComboboxGroup({ store });
+  const rowProps = useComboboxRow({ store });
+
+  return (
+    <span
+      data-testid={testId}
+      data-group-role={groupProps.role}
+      data-row-role={rowProps.role}
+    />
+  );
+}
+
+function SelectHookGrid() {
+  const store = Ariakit.useComboboxStore();
+
+  return (
+    <>
+      <Ariakit.ComboboxLabel store={store} className="label">
+        Select direction
+      </Ariakit.ComboboxLabel>
+      <Ariakit.ComboboxSelect store={store} className="combobox">
+        Choose direction
+        <SelectHookRoles store={store} />
+        <ComboboxListRoleContext.Provider value={undefined}>
+          <SelectHookRoles store={store} testId="pending-list-hook-roles" />
+        </ComboboxListRoleContext.Provider>
+      </Ariakit.ComboboxSelect>
+      <Ariakit.ComboboxPopover
+        store={store}
+        role="grid"
+        aria-label="Select hook directions"
+        gutter={4}
+        className="popover"
+      >
+        <Ariakit.ComboboxRow className="combobox-row">
+          <Ariakit.ComboboxItem
+            role="gridcell"
+            className="combobox-item"
+            value="West"
+          />
+          <Ariakit.ComboboxItem
+            role="gridcell"
+            className="combobox-item"
+            value="East"
+          />
+        </Ariakit.ComboboxRow>
+      </Ariakit.ComboboxPopover>
+    </>
+  );
+}
 
 export default function Example() {
   return (
@@ -71,29 +169,29 @@ export default function Example() {
           Grouped direction
         </Ariakit.ComboboxLabel>
         <Ariakit.Combobox className="combobox" />
-        <div role="status">2 results</div>
-        <Ariakit.ComboboxPopover
-          role="grid"
-          aria-label="Grouped directions"
-          gutter={4}
-          className="popover"
-        >
-          <Ariakit.ComboboxGroup>
-            <Ariakit.ComboboxRow className="combobox-row">
-              <Ariakit.ComboboxItem
-                role="gridcell"
-                className="combobox-item"
-                value="North West"
-              />
-              <Ariakit.ComboboxItem
-                role="gridcell"
-                className="combobox-item"
-                value="North East"
-              />
-            </Ariakit.ComboboxRow>
-          </Ariakit.ComboboxGroup>
+        <Ariakit.ComboboxPopover gutter={4} className="popover">
+          <div role="status">2 results</div>
+          <Ariakit.ComboboxList role="grid" aria-label="Grouped directions">
+            <Ariakit.ComboboxGroup>
+              <Ariakit.ComboboxRow className="combobox-row">
+                <Ariakit.ComboboxItem
+                  role="gridcell"
+                  className="combobox-item"
+                  value="North West"
+                />
+                <Ariakit.ComboboxItem
+                  role="gridcell"
+                  className="combobox-item"
+                  value="North East"
+                />
+              </Ariakit.ComboboxRow>
+            </Ariakit.ComboboxGroup>
+          </Ariakit.ComboboxList>
         </Ariakit.ComboboxPopover>
       </Ariakit.ComboboxProvider>
+
+      <HookGrid />
+      <SelectHookGrid />
     </>
   );
 }

--- a/app/src/sandbox/combobox-grid/index.react.tsx
+++ b/app/src/sandbox/combobox-grid/index.react.tsx
@@ -2,62 +2,95 @@ import * as Ariakit from "@ariakit/react";
 
 export default function Example() {
   return (
-    <Ariakit.ComboboxProvider focusWrap={false} focusLoop={false}>
-      <Ariakit.ComboboxLabel className="label">Direction</Ariakit.ComboboxLabel>
-      <Ariakit.Combobox className="combobox" placeholder="e.g., Top, Center" />
-      <Ariakit.ComboboxPopover role="grid" gutter={4} className="popover">
-        <Ariakit.ComboboxRow className="combobox-row">
-          <Ariakit.ComboboxItem
-            role="gridcell"
-            className="combobox-item"
-            value="Top Left"
-          />
-          <Ariakit.ComboboxItem
-            role="gridcell"
-            className="combobox-item"
-            value="Top Center"
-          />
-          <Ariakit.ComboboxItem
-            role="gridcell"
-            className="combobox-item"
-            value="Top Right"
-          />
-        </Ariakit.ComboboxRow>
-        <Ariakit.ComboboxRow className="combobox-row">
-          <Ariakit.ComboboxItem
-            role="gridcell"
-            className="combobox-item"
-            value="Center Left"
-          />
-          <Ariakit.ComboboxItem
-            role="gridcell"
-            className="combobox-item"
-            value="Center"
-          />
-          <Ariakit.ComboboxItem
-            role="gridcell"
-            className="combobox-item"
-            value="Center Right"
-          />
-        </Ariakit.ComboboxRow>
-        <Ariakit.ComboboxRow className="combobox-row">
-          <Ariakit.ComboboxItem
-            role="gridcell"
-            className="combobox-item"
-            value="Bottom Left"
-          />
-          <Ariakit.ComboboxItem
-            role="gridcell"
-            className="combobox-item"
-            value="Bottom Center"
-          />
-          <Ariakit.ComboboxItem
-            role="gridcell"
-            className="combobox-item"
-            value="Bottom Right"
-          />
-        </Ariakit.ComboboxRow>
-      </Ariakit.ComboboxPopover>
-    </Ariakit.ComboboxProvider>
+    <>
+      <Ariakit.ComboboxProvider focusWrap={false} focusLoop={false}>
+        <Ariakit.ComboboxLabel className="label">
+          Direction
+        </Ariakit.ComboboxLabel>
+        <Ariakit.Combobox
+          className="combobox"
+          placeholder="e.g., Top, Center"
+        />
+        <Ariakit.ComboboxPopover role="grid" gutter={4} className="popover">
+          <Ariakit.ComboboxRow className="combobox-row">
+            <Ariakit.ComboboxItem
+              role="gridcell"
+              className="combobox-item"
+              value="Top Left"
+            />
+            <Ariakit.ComboboxItem
+              role="gridcell"
+              className="combobox-item"
+              value="Top Center"
+            />
+            <Ariakit.ComboboxItem
+              role="gridcell"
+              className="combobox-item"
+              value="Top Right"
+            />
+          </Ariakit.ComboboxRow>
+          <Ariakit.ComboboxRow className="combobox-row">
+            <Ariakit.ComboboxItem
+              role="gridcell"
+              className="combobox-item"
+              value="Center Left"
+            />
+            <Ariakit.ComboboxItem
+              role="gridcell"
+              className="combobox-item"
+              value="Center"
+            />
+            <Ariakit.ComboboxItem
+              role="gridcell"
+              className="combobox-item"
+              value="Center Right"
+            />
+          </Ariakit.ComboboxRow>
+          <Ariakit.ComboboxRow className="combobox-row">
+            <Ariakit.ComboboxItem
+              role="gridcell"
+              className="combobox-item"
+              value="Bottom Left"
+            />
+            <Ariakit.ComboboxItem
+              role="gridcell"
+              className="combobox-item"
+              value="Bottom Center"
+            />
+            <Ariakit.ComboboxItem
+              role="gridcell"
+              className="combobox-item"
+              value="Bottom Right"
+            />
+          </Ariakit.ComboboxRow>
+        </Ariakit.ComboboxPopover>
+      </Ariakit.ComboboxProvider>
+
+      <Ariakit.ComboboxProvider>
+        <Ariakit.ComboboxLabel className="label">
+          Grouped direction
+        </Ariakit.ComboboxLabel>
+        <Ariakit.Combobox className="combobox" />
+        <Ariakit.ComboboxPopover gutter={4} className="popover">
+          <div role="status">2 results</div>
+          <Ariakit.ComboboxList role="grid" aria-label="Grouped directions">
+            <Ariakit.ComboboxGroup>
+              <Ariakit.ComboboxRow className="combobox-row">
+                <Ariakit.ComboboxItem
+                  role="gridcell"
+                  className="combobox-item"
+                  value="North West"
+                />
+                <Ariakit.ComboboxItem
+                  role="gridcell"
+                  className="combobox-item"
+                  value="North East"
+                />
+              </Ariakit.ComboboxRow>
+            </Ariakit.ComboboxGroup>
+          </Ariakit.ComboboxList>
+        </Ariakit.ComboboxPopover>
+      </Ariakit.ComboboxProvider>
+    </>
   );
 }

--- a/app/src/sandbox/combobox-grid/index.react.tsx
+++ b/app/src/sandbox/combobox-grid/index.react.tsx
@@ -71,24 +71,27 @@ export default function Example() {
           Grouped direction
         </Ariakit.ComboboxLabel>
         <Ariakit.Combobox className="combobox" />
-        <Ariakit.ComboboxPopover gutter={4} className="popover">
-          <div role="status">2 results</div>
-          <Ariakit.ComboboxList role="grid" aria-label="Grouped directions">
-            <Ariakit.ComboboxGroup>
-              <Ariakit.ComboboxRow className="combobox-row">
-                <Ariakit.ComboboxItem
-                  role="gridcell"
-                  className="combobox-item"
-                  value="North West"
-                />
-                <Ariakit.ComboboxItem
-                  role="gridcell"
-                  className="combobox-item"
-                  value="North East"
-                />
-              </Ariakit.ComboboxRow>
-            </Ariakit.ComboboxGroup>
-          </Ariakit.ComboboxList>
+        <div role="status">2 results</div>
+        <Ariakit.ComboboxPopover
+          role="grid"
+          aria-label="Grouped directions"
+          gutter={4}
+          className="popover"
+        >
+          <Ariakit.ComboboxGroup>
+            <Ariakit.ComboboxRow className="combobox-row">
+              <Ariakit.ComboboxItem
+                role="gridcell"
+                className="combobox-item"
+                value="North West"
+              />
+              <Ariakit.ComboboxItem
+                role="gridcell"
+                className="combobox-item"
+                value="North East"
+              />
+            </Ariakit.ComboboxRow>
+          </Ariakit.ComboboxGroup>
         </Ariakit.ComboboxPopover>
       </Ariakit.ComboboxProvider>
     </>

--- a/app/src/sandbox/combobox-grid/index.react.tsx
+++ b/app/src/sandbox/combobox-grid/index.react.tsx
@@ -2,7 +2,12 @@ import * as Ariakit from "@ariakit/react";
 import { useComboboxGroup } from "@ariakit/react-components/combobox/combobox-group";
 import { useComboboxRow } from "@ariakit/react-components/combobox/combobox-row";
 
-function HookGrid() {
+interface HookGridProps {
+  label: string;
+  popupLabel: string;
+}
+
+function HookGrid({ label, popupLabel }: HookGridProps) {
   const store = Ariakit.useComboboxStore();
   const groupProps = useComboboxGroup({ store });
   const rowProps = useComboboxRow({ store });
@@ -10,13 +15,13 @@ function HookGrid() {
   return (
     <>
       <Ariakit.ComboboxLabel store={store} className="label">
-        Hook direction
+        {label}
       </Ariakit.ComboboxLabel>
       <Ariakit.Combobox store={store} className="combobox" />
       <Ariakit.ComboboxPopover
         store={store}
         role="grid"
-        aria-label="Hook directions"
+        aria-label={popupLabel}
         gutter={4}
         className="popover"
       >
@@ -44,7 +49,10 @@ function NestedHookGrid() {
     <Ariakit.ComboboxProvider defaultOpen>
       <Ariakit.Combobox aria-label="Outer command" />
       <Ariakit.ComboboxPopover role="dialog" aria-label="Outer commands">
-        <HookGrid />
+        <HookGrid
+          label="Nested hook direction"
+          popupLabel="Nested hook directions"
+        />
       </Ariakit.ComboboxPopover>
     </Ariakit.ComboboxProvider>
   );
@@ -142,6 +150,7 @@ export default function Example() {
         </Ariakit.ComboboxPopover>
       </Ariakit.ComboboxProvider>
 
+      <HookGrid label="Hook direction" popupLabel="Hook directions" />
       <NestedHookGrid />
     </>
   );

--- a/app/src/sandbox/combobox-grid/test-chrome.ts
+++ b/app/src/sandbox/combobox-grid/test-chrome.ts
@@ -11,28 +11,15 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(gridQuery.gridcell()).toHaveCount(2);
   });
 
-  test("preserves grid roles with explicit-store hooks", async ({ q }) => {
+  // Reproduces https://github.com/ariakit/ariakit/issues/7305
+  test("preserves grid roles for explicit-store hooks under another popup", async ({
+    q,
+  }) => {
     await q.combobox("Hook direction").click();
     const grid = q.grid("Hook directions");
     const gridQuery = query(grid);
     await test.expect(gridQuery.rowgroup()).toBeVisible();
     await test.expect(gridQuery.row()).toBeVisible();
     await test.expect(gridQuery.gridcell()).toHaveCount(2);
-  });
-
-  test("preserves grid roles for hooks under select scope", async ({
-    page,
-  }) => {
-    const roles = page.getByTestId("select-hook-roles");
-    await test.expect(roles).toHaveAttribute("data-group-role", "rowgroup");
-    await test.expect(roles).toHaveAttribute("data-row-role", "row");
-  });
-
-  test("does not fall back while a nested list role is pending", async ({
-    page,
-  }) => {
-    const roles = page.getByTestId("pending-list-hook-roles");
-    await test.expect(roles).toHaveAttribute("data-group-role", "group");
-    await test.expect(roles).toHaveAttribute("data-row-role", "presentation");
   });
 });

--- a/app/src/sandbox/combobox-grid/test-chrome.ts
+++ b/app/src/sandbox/combobox-grid/test-chrome.ts
@@ -10,4 +10,29 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(gridQuery.row()).toBeVisible();
     await test.expect(gridQuery.gridcell()).toHaveCount(2);
   });
+
+  test("preserves grid roles with explicit-store hooks", async ({ q }) => {
+    await q.combobox("Hook direction").click();
+    const grid = q.grid("Hook directions");
+    const gridQuery = query(grid);
+    await test.expect(gridQuery.rowgroup()).toBeVisible();
+    await test.expect(gridQuery.row()).toBeVisible();
+    await test.expect(gridQuery.gridcell()).toHaveCount(2);
+  });
+
+  test("preserves grid roles for hooks under select scope", async ({
+    page,
+  }) => {
+    const roles = page.getByTestId("select-hook-roles");
+    await test.expect(roles).toHaveAttribute("data-group-role", "rowgroup");
+    await test.expect(roles).toHaveAttribute("data-row-role", "row");
+  });
+
+  test("does not fall back while a nested list role is pending", async ({
+    page,
+  }) => {
+    const roles = page.getByTestId("pending-list-hook-roles");
+    await test.expect(roles).toHaveAttribute("data-group-role", "group");
+    await test.expect(roles).toHaveAttribute("data-row-role", "presentation");
+  });
 });

--- a/app/src/sandbox/combobox-grid/test-chrome.ts
+++ b/app/src/sandbox/combobox-grid/test-chrome.ts
@@ -1,0 +1,13 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test, query }) => {
+  // Reproduces https://github.com/ariakit/ariakit/issues/7305
+  test("uses the nested grid role for groups and rows", async ({ q }) => {
+    await q.combobox("Grouped direction").click();
+    const grid = q.grid("Grouped directions");
+    const gridQuery = query(grid);
+    await test.expect(gridQuery.rowgroup()).toBeVisible();
+    await test.expect(gridQuery.row()).toBeVisible();
+    await test.expect(gridQuery.gridcell()).toHaveCount(2);
+  });
+});

--- a/app/src/sandbox/combobox-grid/test-chrome.ts
+++ b/app/src/sandbox/combobox-grid/test-chrome.ts
@@ -12,11 +12,21 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
   });
 
   // Reproduces https://github.com/ariakit/ariakit/issues/7305
+  test("preserves grid roles with explicit-store hooks", async ({ q }) => {
+    await q.combobox("Hook direction").click();
+    const grid = q.grid("Hook directions");
+    const gridQuery = query(grid);
+    await test.expect(gridQuery.rowgroup()).toBeVisible();
+    await test.expect(gridQuery.row()).toBeVisible();
+    await test.expect(gridQuery.gridcell()).toHaveCount(2);
+  });
+
+  // Reproduces https://github.com/ariakit/ariakit/issues/7305
   test("preserves grid roles for explicit-store hooks under another popup", async ({
     q,
   }) => {
-    await q.combobox("Hook direction").click();
-    const grid = q.grid("Hook directions");
+    await q.combobox("Nested hook direction").click();
+    const grid = q.grid("Nested hook directions");
     const gridQuery = query(grid);
     await test.expect(gridQuery.rowgroup()).toBeVisible();
     await test.expect(gridQuery.row()).toBeVisible();

--- a/app/src/sandbox/combobox-grid/test.ts
+++ b/app/src/sandbox/combobox-grid/test.ts
@@ -71,3 +71,24 @@ test("uses the nested grid role for groups and rows", async () => {
   expect(gridQuery.row()).toBeInTheDocument();
   expect(gridQuery.gridcell.all()).toHaveLength(2);
 });
+
+test("preserves grid roles with explicit-store hooks", async () => {
+  await click(q.combobox("Hook direction"));
+  const grid = q.grid("Hook directions");
+  const gridQuery = q.within(grid);
+  expect(gridQuery.rowgroup()).toBeInTheDocument();
+  expect(gridQuery.row()).toBeInTheDocument();
+  expect(gridQuery.gridcell.all()).toHaveLength(2);
+});
+
+test("preserves grid roles for hooks under select scope", () => {
+  const roles = document.querySelector("[data-testid=select-hook-roles]");
+  expect(roles).toHaveAttribute("data-group-role", "rowgroup");
+  expect(roles).toHaveAttribute("data-row-role", "row");
+});
+
+test("does not fall back while a nested list role is pending", () => {
+  const roles = document.querySelector("[data-testid=pending-list-hook-roles]");
+  expect(roles).toHaveAttribute("data-group-role", "group");
+  expect(roles).toHaveAttribute("data-row-role", "presentation");
+});

--- a/app/src/sandbox/combobox-grid/test.ts
+++ b/app/src/sandbox/combobox-grid/test.ts
@@ -72,23 +72,12 @@ test("uses the nested grid role for groups and rows", async () => {
   expect(gridQuery.gridcell.all()).toHaveLength(2);
 });
 
-test("preserves grid roles with explicit-store hooks", async () => {
+// Reproduces https://github.com/ariakit/ariakit/issues/7305
+test("preserves grid roles for explicit-store hooks under another popup", async () => {
   await click(q.combobox("Hook direction"));
   const grid = q.grid("Hook directions");
   const gridQuery = q.within(grid);
   expect(gridQuery.rowgroup()).toBeInTheDocument();
   expect(gridQuery.row()).toBeInTheDocument();
   expect(gridQuery.gridcell.all()).toHaveLength(2);
-});
-
-test("preserves grid roles for hooks under select scope", () => {
-  const roles = document.querySelector("[data-testid=select-hook-roles]");
-  expect(roles).toHaveAttribute("data-group-role", "rowgroup");
-  expect(roles).toHaveAttribute("data-row-role", "row");
-});
-
-test("does not fall back while a nested list role is pending", () => {
-  const roles = document.querySelector("[data-testid=pending-list-hook-roles]");
-  expect(roles).toHaveAttribute("data-group-role", "group");
-  expect(roles).toHaveAttribute("data-row-role", "presentation");
 });

--- a/app/src/sandbox/combobox-grid/test.ts
+++ b/app/src/sandbox/combobox-grid/test.ts
@@ -6,37 +6,37 @@ function getSelectionStart(element: Element | HTMLInputElement | null) {
 }
 
 test("move cursor without moving through items", async () => {
-  await click(q.combobox());
+  await click(q.combobox("Direction"));
   await type("abc");
-  expect(getSelectionStart(q.combobox())).toBe(3);
+  expect(getSelectionStart(q.combobox("Direction"))).toBe(3);
   await press.ArrowLeft();
-  expect(getSelectionStart(q.combobox())).toBe(2);
+  expect(getSelectionStart(q.combobox("Direction"))).toBe(2);
   expect(q.gridcell.all(undefined, { selected: true })).toHaveLength(0);
   await press.Home();
-  expect(getSelectionStart(q.combobox())).toBe(0);
+  expect(getSelectionStart(q.combobox("Direction"))).toBe(0);
   expect(q.gridcell.all(undefined, { selected: true })).toHaveLength(0);
 });
 
 test("move through items without moving the cursor", async () => {
-  await click(q.combobox());
+  await click(q.combobox("Direction"));
   await type("abc");
-  expect(getSelectionStart(q.combobox())).toBe(3);
+  expect(getSelectionStart(q.combobox("Direction"))).toBe(3);
   await press.ArrowDown();
   expect(q.gridcell("Top Left")).toHaveFocus();
   await press.End();
   expect(q.gridcell("Top Right")).toHaveFocus();
   await press.ArrowLeft();
   expect(q.gridcell("Top Center")).toHaveFocus();
-  expect(getSelectionStart(q.combobox())).toBe(3);
+  expect(getSelectionStart(q.combobox("Direction"))).toBe(3);
   await press.Home();
   expect(q.gridcell("Top Left")).toHaveFocus();
-  expect(getSelectionStart(q.combobox())).toBe(3);
+  expect(getSelectionStart(q.combobox("Direction"))).toBe(3);
 });
 
 test("move through items moving the cursor", async () => {
-  await click(q.combobox());
+  await click(q.combobox("Direction"));
   await type("abc");
-  expect(getSelectionStart(q.combobox())).toBe(3);
+  expect(getSelectionStart(q.combobox("Direction"))).toBe(3);
   await press.ArrowDown();
   expect(q.gridcell("Top Left")).toHaveFocus();
   await press.End();
@@ -44,20 +44,30 @@ test("move through items moving the cursor", async () => {
   await press.Home();
   await press.Home();
   expect(q.gridcell("Top Left")).toHaveFocus();
-  expect(getSelectionStart(q.combobox())).toBe(0);
+  expect(getSelectionStart(q.combobox("Direction"))).toBe(0);
   await press.End();
   expect(q.gridcell("Top Right")).toHaveFocus();
-  expect(getSelectionStart(q.combobox())).toBe(0);
+  expect(getSelectionStart(q.combobox("Direction"))).toBe(0);
   await press.End();
   expect(q.gridcell("Top Right")).toHaveFocus();
-  expect(getSelectionStart(q.combobox())).toBe(3);
+  expect(getSelectionStart(q.combobox("Direction"))).toBe(3);
   await press.ArrowLeft();
   expect(q.gridcell("Top Center")).toHaveFocus();
-  expect(getSelectionStart(q.combobox())).toBe(3);
+  expect(getSelectionStart(q.combobox("Direction"))).toBe(3);
   await press.ArrowLeft();
   expect(q.gridcell("Top Left")).toHaveFocus();
-  expect(getSelectionStart(q.combobox())).toBe(3);
+  expect(getSelectionStart(q.combobox("Direction"))).toBe(3);
   await press.ArrowLeft();
   expect(q.gridcell("Top Left")).toHaveFocus();
-  expect(getSelectionStart(q.combobox())).toBe(2);
+  expect(getSelectionStart(q.combobox("Direction"))).toBe(2);
+});
+
+// Reproduces https://github.com/ariakit/ariakit/issues/7305
+test("uses the nested grid role for groups and rows", async () => {
+  await click(q.combobox("Grouped direction"));
+  const grid = q.grid("Grouped directions");
+  const gridQuery = q.within(grid);
+  expect(gridQuery.rowgroup()).toBeInTheDocument();
+  expect(gridQuery.row()).toBeInTheDocument();
+  expect(gridQuery.gridcell.all()).toHaveLength(2);
 });

--- a/app/src/sandbox/combobox-grid/test.ts
+++ b/app/src/sandbox/combobox-grid/test.ts
@@ -73,9 +73,19 @@ test("uses the nested grid role for groups and rows", async () => {
 });
 
 // Reproduces https://github.com/ariakit/ariakit/issues/7305
-test("preserves grid roles for explicit-store hooks under another popup", async () => {
+test("preserves grid roles with explicit-store hooks", async () => {
   await click(q.combobox("Hook direction"));
   const grid = q.grid("Hook directions");
+  const gridQuery = q.within(grid);
+  expect(gridQuery.rowgroup()).toBeInTheDocument();
+  expect(gridQuery.row()).toBeInTheDocument();
+  expect(gridQuery.gridcell.all()).toHaveLength(2);
+});
+
+// Reproduces https://github.com/ariakit/ariakit/issues/7305
+test("preserves grid roles for explicit-store hooks under another popup", async () => {
+  await click(q.combobox("Nested hook direction"));
+  const grid = q.grid("Nested hook directions");
   const gridQuery = q.within(grid);
   expect(gridQuery.rowgroup()).toBeInTheDocument();
   expect(gridQuery.row()).toBeInTheDocument();

--- a/packages/ariakit-react-components/src/combobox/combobox-context.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-context.tsx
@@ -11,8 +11,8 @@ import {
 } from "../popover/popover-context.tsx";
 import type { ComboboxStore } from "./combobox-store.ts";
 
-export const ComboboxListRoleContext = createContext<string | undefined>(
-  undefined,
+export const ComboboxListRoleContext = createContext<string | undefined | null>(
+  null,
 );
 
 const ctx = createStoreContext<ComboboxStore>(

--- a/packages/ariakit-react-components/src/combobox/combobox-context.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-context.tsx
@@ -11,7 +11,12 @@ import {
 } from "../popover/popover-context.tsx";
 import type { ComboboxStore } from "./combobox-store.ts";
 
-export const ComboboxListRoleContext = createContext<string | undefined | null>(
+interface ComboboxListRole {
+  store: ComboboxStore;
+  role: string | undefined;
+}
+
+export const ComboboxListRoleContext = createContext<ComboboxListRole | null>(
   null,
 );
 

--- a/packages/ariakit-react-components/src/combobox/combobox-group.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-group.tsx
@@ -44,9 +44,9 @@ export const useComboboxGroup = createHook<TagName, ComboboxGroupOptions>(
     );
 
     const contentElement = useStoreState(store, "contentElement");
-    const contextRole = useContext(ComboboxListRoleContext);
+    const listRole = useContext(ComboboxListRoleContext);
     const popupRole =
-      contextRole === null ? getPopupRole(contentElement) : contextRole;
+      listRole?.store === store ? listRole.role : getPopupRole(contentElement);
 
     if (popupRole === "grid") {
       props = { role: "rowgroup", ...props };

--- a/packages/ariakit-react-components/src/combobox/combobox-group.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-group.tsx
@@ -3,9 +3,13 @@ import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
 import { getPopupRole, invariant } from "@ariakit/utils";
 import type { ElementType } from "react";
+import { useContext } from "react";
 import type { CompositeGroupOptions } from "../composite/composite-group.tsx";
 import { useCompositeGroup } from "../composite/composite-group.tsx";
-import { useComboboxScopedContext } from "./combobox-context.tsx";
+import {
+  ComboboxListRoleContext,
+  useComboboxScopedContext,
+} from "./combobox-context.tsx";
 import type { ComboboxStore } from "./combobox-store.ts";
 
 const TagName = "div" satisfies ElementType;
@@ -40,7 +44,9 @@ export const useComboboxGroup = createHook<TagName, ComboboxGroupOptions>(
     );
 
     const contentElement = useStoreState(store, "contentElement");
-    const popupRole = getPopupRole(contentElement);
+    const contextRole = useContext(ComboboxListRoleContext);
+    const popupRole =
+      contextRole === null ? getPopupRole(contentElement) : contextRole;
 
     if (popupRole === "grid") {
       props = { role: "rowgroup", ...props };

--- a/packages/ariakit-react-components/src/combobox/combobox-item.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item.tsx
@@ -55,7 +55,7 @@ function isSelected(
 /**
  * Returns the role for a combobox item based on the popup role.
  */
-function getItemRole(popupRole?: string) {
+function getItemRole(popupRole?: string | null) {
   return getItemRoleByPopupRole(popupRole) ?? "option";
 }
 

--- a/packages/ariakit-react-components/src/combobox/combobox-item.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item.tsx
@@ -55,7 +55,7 @@ function isSelected(
 /**
  * Returns the role for a combobox item based on the popup role.
  */
-function getItemRole(popupRole?: string | null) {
+function getItemRole(popupRole?: string) {
   return getItemRoleByPopupRole(popupRole) ?? "option";
 }
 
@@ -142,8 +142,8 @@ export const useComboboxItem = createHook<TagName, ComboboxItemOptions>(
     setValueOnClick = setValueOnClick ?? (!selectMode && !multiSelectable);
     hideOnClick = hideOnClick ?? (value != null && !multiSelectable);
     preventScrollOnKeyDown = preventScrollOnKeyDown ?? selectMode;
-    const popupRole = useContext(ComboboxListRoleContext);
-    const role = getItemRole(popupRole);
+    const listRole = useContext(ComboboxListRoleContext);
+    const role = getItemRole(listRole?.role);
 
     const onClickProp = props.onClick;
     const setValueOnClickProp = useBooleanEvent(setValueOnClick);

--- a/packages/ariakit-react-components/src/combobox/combobox-list.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-list.tsx
@@ -94,6 +94,7 @@ export const useComboboxList = createHook<TagName, ComboboxListOptions>(
     );
 
     const role = useAttribute(ref, "role", props.role);
+    const listRole = useMemo(() => ({ store, role }), [store, role]);
     const isCompositeRole =
       role === "listbox" || role === "tree" || role === "grid";
     const ariaMultiSelectable = isCompositeRole
@@ -149,14 +150,14 @@ export const useComboboxList = createHook<TagName, ComboboxListOptions>(
         <ComboboxScopedContextProvider value={store}>
           <ComboboxHeadingContext.Provider value={headingContext}>
             <DialogHeadingContext.Provider value={setHeadingId}>
-              <ComboboxListRoleContext.Provider value={role}>
+              <ComboboxListRoleContext.Provider value={listRole}>
                 {element}
               </ComboboxListRoleContext.Provider>
             </DialogHeadingContext.Provider>
           </ComboboxHeadingContext.Provider>
         </ComboboxScopedContextProvider>
       ),
-      [store, role, headingContext],
+      [store, listRole, headingContext],
     );
 
     // When nesting ComboboxList elements, the content element should be

--- a/packages/ariakit-react-components/src/combobox/combobox-row.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-row.tsx
@@ -3,9 +3,13 @@ import { createElement, createHook, forwardRef } from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
 import { getPopupRole, invariant } from "@ariakit/utils";
 import type { ElementType } from "react";
+import { useContext } from "react";
 import type { CompositeRowOptions } from "../composite/composite-row.tsx";
 import { useCompositeRow } from "../composite/composite-row.tsx";
-import { useComboboxScopedContext } from "./combobox-context.tsx";
+import {
+  ComboboxListRoleContext,
+  useComboboxScopedContext,
+} from "./combobox-context.tsx";
 import type { ComboboxStore } from "./combobox-store.ts";
 
 const TagName = "div" satisfies ElementType;
@@ -39,7 +43,9 @@ export const useComboboxRow = createHook<TagName, ComboboxRowOptions>(
     );
 
     const contentElement = useStoreState(store, "contentElement");
-    const popupRole = getPopupRole(contentElement);
+    const contextRole = useContext(ComboboxListRoleContext);
+    const popupRole =
+      contextRole === null ? getPopupRole(contentElement) : contextRole;
     const role = popupRole === "grid" ? "row" : "presentation";
 
     props = { role, ...props };

--- a/packages/ariakit-react-components/src/combobox/combobox-row.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-row.tsx
@@ -43,9 +43,9 @@ export const useComboboxRow = createHook<TagName, ComboboxRowOptions>(
     );
 
     const contentElement = useStoreState(store, "contentElement");
-    const contextRole = useContext(ComboboxListRoleContext);
+    const listRole = useContext(ComboboxListRoleContext);
     const popupRole =
-      contextRole === null ? getPopupRole(contentElement) : contextRole;
+      listRole?.store === store ? listRole.role : getPopupRole(contentElement);
     const role = popupRole === "grid" ? "row" : "presentation";
 
     props = { role, ...props };


### PR DESCRIPTION
## Motivation

`ComboboxGroup` and `ComboboxRow` resolved their roles from the combobox store's outer `contentElement`. When a nested `ComboboxList` owned `role="grid"`, the group and row ignored that nearest list and rendered as `group` and `presentation`, so assistive technology lost the grid's row structure.

Fixes #7305

## Solution

`ComboboxListRoleContext` now carries the nearest list's store and resolved role. `ComboboxGroup` and `ComboboxRow` use that role only when the context belongs to their store. Otherwise, they read the explicit store's `contentElement`. This preserves nested list roles and prevents an outer combobox popup role from leaking into inner explicit-store hooks. `ComboboxItem` keeps its existing nearest-list behavior; #7316 tracks its pre-existing cross-store automatic-role behavior.

```ts
listRole?.store === store
  ? listRole.role
  : getPopupRole(contentElement);
```

The `combobox-grid` sandbox now covers three public role-resolution paths in happy-dom and Chrome:

- a nested `ComboboxList role="grid"`;
- explicit-store hooks with no list-role provider;
- explicit-store hooks rendered under another combobox popup.

The sandbox no longer imports the private role context or exposes hidden role-probe attributes. A patch changeset covers `@ariakit/react-components` and `@ariakit/react`.

## Workaround

Until the fix is released, put the `grid` role on `ComboboxPopover`, render the group and rows directly inside it, and move content that a grid may not own outside the popup.

```tsx
<div role="status">{results.length} results</div>
{/* TODO: Remove after https://github.com/ariakit/ariakit/issues/7305 is fixed. */}
<ComboboxPopover role="grid" aria-label="Results">
  <ComboboxGroup>
    <ComboboxRow>
      <ComboboxItem role="gridcell" value="North West" />
      <ComboboxItem role="gridcell" value="North East" />
    </ComboboxRow>
  </ComboboxGroup>
</ComboboxPopover>
```

This workaround preserves grid, row-group, row, grid-cell, focus, and keyboard behavior. It is narrower than the final fix because headers, live result counts, toolbars, and other content that a grid may not own cannot remain inside the popup.

## Tests

- `pnpm lint-fix`
- `pnpm build`
- `pnpm clean`
- `pnpm tsc`
- `pnpm test`: 268 files and 1,921 tests passed
- `pnpm test app/src/sandbox/combobox-grid/test.ts`: 6 tests passed
- `pnpm test-react18 app/src/sandbox/combobox-grid/test.ts`: 6 tests passed
- `APP_PORT=4324 pnpm -F app run test --project=chrome src/sandbox/combobox-grid/test-chrome.ts --output test-results/7314-comment-response-no-provider`: 3 tests passed
- Red check (cross-store): the cross-store test failed with `group` and `presentation` after the store-ownership condition was temporarily removed, then all 5 focused tests passed after restoration
- Red check (no provider): the standalone test failed with `group` and `presentation` after only the no-provider fallback was temporarily removed, while the other 5 focused tests passed; all 6 tests passed after restoration

## Evidence

The defect changes DOM and accessibility roles without changing the rendered UI. Automated accessibility-tree assertions provide the relevant evidence, so no visual artifact is attached.

## Implementation review reassessment

<details>
<summary>Cycle 4: Pair list roles with owning stores and remove private probes</summary>

**Assessment**

- **Issue severity:** Medium. An outer combobox role can replace the inner store's grid role and remove row-group and row semantics for assistive technology.
- **Expected frequency:** Low across all comboboxes, but deterministic when explicit-store hooks render under another combobox list or popup.
- **Supported scope:** Nested component composition and documented explicit-store hooks must resolve roles from their own combobox store.
- **Likely user impact:** Assistive technology can receive the wrong structure for an inner grid when an outer combobox provides a nearer role context.
- **Implementation and maintenance complexity:** Low. One memoized context object carries the store and role. Two hooks use the same direct ownership check, and the change removes the three-state scalar sentinel and private test probes.

**Decision**

Change direction from the three-state scalar value to a store-owned context object. This prevents cross-store role leakage, represents a pending same-store role as `role: undefined`, and removes tests coupled to the private context shape. The public nested-combobox fixture covers the reported regression. This direction change resets the implementation review finding count. `ComboboxItem` keeps its pre-existing behavior, which is outside this PR and tracked in #7316.

</details>

## Review gate reassessment

<details>
<summary>Cycle 3: Continue the three-state role-context design</summary>

**Assessment**

- **Issue severity:** Medium. Affected grids lose row-group and row semantics for assistive technology.
- **Expected frequency:** Low across all comboboxes, but deterministic for a grid role on a nested `ComboboxList`.
- **Supported scope:** Nested component composition and documented explicit-store hooks must work. Generic combobox scope must not replace list-role-provider detection, and a pending nearest provider must still take precedence.
- **Likely user impact:** The original bug removes grid position information. Incorrect fallback behavior could also break public hook composition or temporarily apply outer-grid semantics to an inner list.
- **Implementation and maintenance complexity:** Low to moderate. The runtime change adds no store state, observer, helper, or public prop. It adds a three-state context value and the same small precedence branch in two hooks. Each test fixture covers a distinct supported state.

**Decision**

Continue the three-state context design. It is smaller than a second presence context or wrapper object and preserves the required role precedence. Keep direct coverage for the measured role, missing provider, generic select scope, and provider-present pending-role states.

</details>
