### PR TITLE
Fix ComboboxItem roles with explicit stores

### DIFF
--- a/.changeset/300-combobox-item-store-role.md
+++ b/.changeset/300-combobox-item-store-role.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`ComboboxItem`](https://ariakit.com/reference/combobox-item) to resolve its automatic role from its own explicit combobox store.

--- a/app/src/sandbox/combobox-item-7316/index.react.tsx
+++ b/app/src/sandbox/combobox-item-7316/index.react.tsx
@@ -1,0 +1,52 @@
+import * as Ariakit from "@ariakit/react";
+import { useComboboxItem } from "@ariakit/react-components/combobox/combobox-item";
+
+function NestedListbox() {
+  const store = Ariakit.useComboboxStore({ defaultOpen: true });
+  const itemProps = useComboboxItem({ store, value: "Inner item" });
+
+  return (
+    <>
+      <Ariakit.Combobox store={store} aria-label="Inner combobox" />
+      <Ariakit.ComboboxPopover
+        store={store}
+        role="listbox"
+        aria-label="Inner list"
+      >
+        <Ariakit.Role {...itemProps} />
+      </Ariakit.ComboboxPopover>
+    </>
+  );
+}
+
+function StandaloneMenu() {
+  const store = Ariakit.useComboboxStore({ defaultOpen: true });
+  const itemProps = useComboboxItem({ store, value: "Standalone item" });
+
+  return (
+    <>
+      <Ariakit.Combobox store={store} aria-label="Standalone combobox" />
+      <Ariakit.ComboboxPopover
+        store={store}
+        role="menu"
+        aria-label="Standalone menu"
+      >
+        <Ariakit.Role {...itemProps} />
+      </Ariakit.ComboboxPopover>
+    </>
+  );
+}
+
+export default function Example() {
+  return (
+    <>
+      <Ariakit.ComboboxProvider defaultOpen>
+        <Ariakit.Combobox aria-label="Outer combobox" />
+        <Ariakit.ComboboxPopover role="menu" aria-label="Outer menu">
+          <NestedListbox />
+        </Ariakit.ComboboxPopover>
+      </Ariakit.ComboboxProvider>
+      <StandaloneMenu />
+    </>
+  );
+}

--- a/app/src/sandbox/combobox-item-7316/index.react.tsx
+++ b/app/src/sandbox/combobox-item-7316/index.react.tsx
@@ -13,7 +13,7 @@ function NestedListbox() {
         role="listbox"
         aria-label="Inner list"
       >
-        <Ariakit.Role {...itemProps} />
+        <Ariakit.Role {...itemProps} role="option" />
       </Ariakit.ComboboxPopover>
     </>
   );
@@ -31,7 +31,7 @@ function StandaloneMenu() {
         role="menu"
         aria-label="Standalone menu"
       >
-        <Ariakit.Role {...itemProps} />
+        <Ariakit.Role {...itemProps} role="menuitem" />
       </Ariakit.ComboboxPopover>
     </>
   );

--- a/app/src/sandbox/combobox-item-7316/index.react.tsx
+++ b/app/src/sandbox/combobox-item-7316/index.react.tsx
@@ -13,7 +13,7 @@ function NestedListbox() {
         role="listbox"
         aria-label="Inner list"
       >
-        <Ariakit.Role {...itemProps} role="option" />
+        <Ariakit.Role {...itemProps} />
       </Ariakit.ComboboxPopover>
     </>
   );
@@ -31,7 +31,7 @@ function StandaloneMenu() {
         role="menu"
         aria-label="Standalone menu"
       >
-        <Ariakit.Role {...itemProps} role="menuitem" />
+        <Ariakit.Role {...itemProps} />
       </Ariakit.ComboboxPopover>
     </>
   );

--- a/app/src/sandbox/combobox-item-7316/test-chrome.ts
+++ b/app/src/sandbox/combobox-item-7316/test-chrome.ts
@@ -1,0 +1,15 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test, query }) => {
+  // Reproduces https://github.com/ariakit/ariakit/issues/7316
+  test("uses the explicit store role under another popup", async ({ q }) => {
+    const listbox = q.listbox("Inner list");
+    await test.expect(query(listbox).option("Inner item")).toBeVisible();
+  });
+
+  // Reproduces https://github.com/ariakit/ariakit/issues/7316
+  test("uses the explicit store role without a provider", async ({ q }) => {
+    const menu = q.menu("Standalone menu");
+    await test.expect(query(menu).menuitem("Standalone item")).toBeVisible();
+  });
+});

--- a/app/src/sandbox/combobox-item-7316/test.ts
+++ b/app/src/sandbox/combobox-item-7316/test.ts
@@ -1,0 +1,14 @@
+import { q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// Reproduces https://github.com/ariakit/ariakit/issues/7316
+test("uses the explicit store role under another popup", () => {
+  const listbox = q.listbox("Inner list");
+  expect(q.within(listbox).option("Inner item")).toBeInTheDocument();
+});
+
+// Reproduces https://github.com/ariakit/ariakit/issues/7316
+test("uses the explicit store role without a provider", () => {
+  const menu = q.menu("Standalone menu");
+  expect(q.within(menu).menuitem("Standalone item")).toBeInTheDocument();
+});

--- a/packages/ariakit-react-components/src/combobox/combobox-item.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item.tsx
@@ -13,6 +13,7 @@ import type { Props } from "@ariakit/react-utils";
 import {
   disabledFromProps,
   getItemRoleByPopupRole,
+  getPopupRole,
   hasFocus,
   isTextField,
   isDownloading,
@@ -93,6 +94,8 @@ export const useComboboxItem = createHook<TagName, ComboboxItemOptions>(
     );
 
     const id = useId(props.id);
+    const listRole = useContext(ComboboxListRoleContext);
+    const listRoleMatchesStore = listRole?.store === store;
 
     const {
       resetValueOnSelectState,
@@ -100,6 +103,7 @@ export const useComboboxItem = createHook<TagName, ComboboxItemOptions>(
       selected,
       autoFocusSelected,
       selectElement,
+      contentElement,
     } = useStoreStateObject(store, ["selectedValue"], {
       resetValueOnSelectState: "resetValueOnSelect",
       multiSelectable(state) {
@@ -116,6 +120,7 @@ export const useComboboxItem = createHook<TagName, ComboboxItemOptions>(
         return state.selectedValue[state.selectedValue.length - 1] === value;
       },
       selectElement: "selectElement",
+      contentElement: "contentElement",
     });
 
     // The selected item marks the initial presentation target. Derive the
@@ -142,8 +147,12 @@ export const useComboboxItem = createHook<TagName, ComboboxItemOptions>(
     setValueOnClick = setValueOnClick ?? (!selectMode && !multiSelectable);
     hideOnClick = hideOnClick ?? (value != null && !multiSelectable);
     preventScrollOnKeyDown = preventScrollOnKeyDown ?? selectMode;
-    const listRole = useContext(ComboboxListRoleContext);
-    const role = getItemRole(listRole?.role);
+    const popupRole = listRoleMatchesStore
+      ? listRole?.role
+      : getPopupRole(contentElement);
+    const role = getItemRole(
+      typeof popupRole === "string" ? popupRole : undefined,
+    );
 
     const onClickProp = props.onClick;
     const setValueOnClickProp = useBooleanEvent(setValueOnClick);


### PR DESCRIPTION
## Motivation

`useComboboxItem` can inherit an outer combobox popup role when it receives an explicit store. The rendered item then exposes a role that conflicts with its own popup.

Fixes #7316

## Solution

Resolve the role from `ComboboxListRoleContext` only when that context belongs to the item's store. Otherwise, derive the popup role from the explicit store's content element. The content element joins the existing store subscription, so this does not add a second subscription.

Add happy-dom, React 18, and Chrome regression coverage for an explicit store nested under another popup and for an explicit store without a provider. Add patch release notes for `@ariakit/react-components` and `@ariakit/react`.

## Workaround

Pass the item role explicitly after spreading the props returned by `useComboboxItem`.

```tsx
const itemProps = useComboboxItem({ store, value: "Inner item" });

{/* TODO: Remove after https://github.com/ariakit/ariakit/issues/7316 is fixed. */}
<Ariakit.Role {...itemProps} role="option" />
```

The explicit role must match the popup: use `option` for a listbox, `menuitem` for a menu, `treeitem` for a tree, or `gridcell` for a grid. This workaround preserves the reported composition and ARIA semantics, but consumers must keep the role synchronized if the popup role changes.

## Preview

No visual artifact is included because the broken and corrected states render identically. The difference exists only in the DOM and accessibility roles, which the browser assertions cover.
