### PR TITLE
Fix Menu label after disclosure replacement

### DIFF
--- a/.changeset/300-menu-disclosure-label.md
+++ b/.changeset/300-menu-disclosure-label.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Menu`](https://ariakit.com/reference/menu) to remove `aria-labelledby` when its disclosure is replaced by an element without an `id`.

--- a/app/src/sandbox/menu-7315/index.react.tsx
+++ b/app/src/sandbox/menu-7315/index.react.tsx
@@ -14,6 +14,7 @@ export default function Example() {
         Initial disclosure
       </Ariakit.MenuButton>
       <button
+        id="replacement-disclosure"
         type="button"
         className="ak-button"
         onClick={(event) => menu.setDisclosureElement(event.currentTarget)}

--- a/app/src/sandbox/menu-7315/index.react.tsx
+++ b/app/src/sandbox/menu-7315/index.react.tsx
@@ -1,0 +1,35 @@
+import * as Ariakit from "@ariakit/react";
+
+export default function Example() {
+  const menu = Ariakit.useMenuStore();
+  const disclosureElement = Ariakit.useStoreState(menu, "disclosureElement");
+
+  return (
+    <>
+      <Ariakit.MenuButton
+        id="initial-disclosure"
+        store={menu}
+        className="ak-button"
+      >
+        Initial disclosure
+      </Ariakit.MenuButton>
+      <button
+        type="button"
+        className="ak-button"
+        onClick={(event) => menu.setDisclosureElement(event.currentTarget)}
+      >
+        Replacement disclosure
+      </button>
+      <Ariakit.Menu
+        store={menu}
+        hideOnInteractOutside={false}
+        className="ak-menu"
+      >
+        <Ariakit.MenuItem className="ak-menu-item">Edit</Ariakit.MenuItem>
+      </Ariakit.Menu>
+      <output aria-label="Current disclosure">
+        {disclosureElement?.textContent}
+      </output>
+    </>
+  );
+}

--- a/app/src/sandbox/menu-7315/index.react.tsx
+++ b/app/src/sandbox/menu-7315/index.react.tsx
@@ -14,7 +14,6 @@ export default function Example() {
         Initial disclosure
       </Ariakit.MenuButton>
       <button
-        id="replacement-disclosure"
         type="button"
         className="ak-button"
         onClick={(event) => menu.setDisclosureElement(event.currentTarget)}

--- a/app/src/sandbox/menu-7315/test-chrome.ts
+++ b/app/src/sandbox/menu-7315/test-chrome.ts
@@ -1,0 +1,23 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/7315
+  test("does not keep the previous disclosure label", async ({ q }) => {
+    await q.button("Initial disclosure").click();
+
+    const menu = q.menu();
+    await test.expect(menu).toBeVisible();
+    await test
+      .expect(menu)
+      .toHaveAttribute("aria-labelledby", "initial-disclosure");
+
+    await q.button("Replacement disclosure").click();
+
+    await test
+      .expect(q.status("Current disclosure"))
+      .toHaveText("Replacement disclosure");
+    await test
+      .expect(menu)
+      .not.toHaveAttribute("aria-labelledby", "initial-disclosure");
+  });
+});

--- a/app/src/sandbox/menu-7315/test-chrome.ts
+++ b/app/src/sandbox/menu-7315/test-chrome.ts
@@ -16,8 +16,6 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test
       .expect(q.status("Current disclosure"))
       .toHaveText("Replacement disclosure");
-    await test
-      .expect(menu)
-      .not.toHaveAttribute("aria-labelledby", "initial-disclosure");
+    await test.expect(menu).not.toHaveAttribute("aria-labelledby");
   });
 });

--- a/app/src/sandbox/menu-7315/test.ts
+++ b/app/src/sandbox/menu-7315/test.ts
@@ -14,5 +14,5 @@ test("does not keep the previous disclosure label", async () => {
   expect(q.status("Current disclosure")).toHaveTextContent(
     "Replacement disclosure",
   );
-  expect(menu).not.toHaveAttribute("aria-labelledby", "initial-disclosure");
+  expect(menu).not.toHaveAttribute("aria-labelledby");
 });

--- a/app/src/sandbox/menu-7315/test.ts
+++ b/app/src/sandbox/menu-7315/test.ts
@@ -1,0 +1,18 @@
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// https://github.com/ariakit/ariakit/issues/7315
+test("does not keep the previous disclosure label", async () => {
+  await click(q.button("Initial disclosure"));
+
+  const menu = q.menu();
+  expect(menu).toBeVisible();
+  expect(menu).toHaveAttribute("aria-labelledby", "initial-disclosure");
+
+  await click(q.button("Replacement disclosure"));
+
+  expect(q.status("Current disclosure")).toHaveTextContent(
+    "Replacement disclosure",
+  );
+  expect(menu).not.toHaveAttribute("aria-labelledby", "initial-disclosure");
+});

--- a/packages/ariakit-react-components/src/menu/menu-list.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-list.tsx
@@ -38,18 +38,13 @@ function useAriaLabelledBy({ store, ...props }: MenuListProps) {
   const contentElement = useStoreState(store, "contentElement");
 
   useEffect(() => {
-    const disclosure = disclosureElement;
-    if (!disclosure) return;
     const menu = contentElement;
     if (!menu) return;
     const menuLabel = label || menu.hasAttribute("aria-label");
-    if (menuLabel) {
-      // The label depends on attributes of the rendered menu and disclosure.
-      // oxlint-disable-next-line react/set-state-in-effect
-      setId(undefined);
-    } else if (disclosure.id) {
-      setId(disclosure.id);
-    }
+    const nextId = menuLabel ? undefined : disclosureElement?.id || undefined;
+    // The label depends on attributes of the rendered menu and disclosure.
+    // oxlint-disable-next-line react/set-state-in-effect
+    setId(nextId);
   }, [label, disclosureElement, contentElement]);
 
   return id;


### PR DESCRIPTION
## Motivation

When an application replaces a menu disclosure with an element that has no `id`, the menu keeps its previous `aria-labelledby` value. The menu then names itself after an element that is no longer its disclosure.

Fixes #7315

## Solution

Add a focused `menu-7315` sandbox with matching Chromium and happy-dom regression tests. The sandbox confirms that the store has moved to the id-less replacement before each final test requires `aria-labelledby` to be absent.

Update `useAriaLabelledBy` to synchronize its stored default on every relevant effect. An explicit menu label still clears the disclosure-derived label, a disclosure with an ID supplies the new value, and an id-less or missing disclosure clears the old value.

The change includes patch changesets for `@ariakit/react-components` and `@ariakit/react`.

## Workaround

Give the replacement disclosure a stable, unique `id` before you pass the element to `setDisclosureElement`:

```tsx
{/* TODO: Remove this ID after https://github.com/ariakit/ariakit/issues/7315 is fixed. */}
<button
  id="replacement-disclosure"
  onClick={(event) => menu.setDisclosureElement(event.currentTarget)}
>
  Replacement disclosure
</button>
```

This workaround requires the replacement element to keep the same unique `id` while it labels the menu. If the application cannot provide a stable ID, set an explicit `aria-label` on `Menu` instead.

## Preview

The current-main investigation in [issue #7315](https://github.com/ariakit/ariakit/issues/7315#issuecomment-5460019835) shows the store pointing at the id-less replacement while the menu keeps the old label.

<img width="900" height="620" alt="Current main shows an id-less replacement disclosure while the menu keeps aria-labelledby initial-disclosure and Chromium keeps the Initial disclosure accessible name" src="https://github.com/user-attachments/assets/fa04a41d-7c66-4694-9393-c2a16f353883" />

The linked investigation also includes a short recording of the disclosure replacement and stale `aria-labelledby` value.
