### PR TITLE
Update dependency stripe to v22.6.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -102,7 +102,7 @@
     "rehype-parse": "9.0.1",
     "shiki": "4.4.3",
     "solid-js": "1.9.15",
-    "stripe": "22.5.0",
+    "stripe": "22.6.0",
     "tailwindcss": "4.3.3",
     "textarea-caret": "3.1.0",
     "ts-morph": "28.0.0",

--- a/app/src/actions/admin.ts
+++ b/app/src/actions/admin.ts
@@ -25,7 +25,7 @@ import { formatCurrency } from "#app/lib/locale.ts";
 import { createLogger } from "#app/lib/logger.ts";
 import { objectId } from "#app/lib/object.ts";
 import type { PlusType, PriceData } from "#app/lib/schemas.ts";
-import { PlusTypeSchema } from "#app/lib/schemas.ts";
+import { PlusTypeSchema, PriceDataSchema } from "#app/lib/schemas.ts";
 import {
   createSalePromo,
   expanded,
@@ -113,7 +113,9 @@ async function syncPrices() {
       product: price.product.id,
       currency: price.currency,
       amount: price.unit_amount || 0,
-      taxBehavior: price.tax_behavior || "exclusive",
+      taxBehavior: PriceDataSchema.shape.taxBehavior.parse(
+        price.tax_behavior || "exclusive",
+      ),
     });
     const productType = price.product.metadata.plusType;
     if (productType !== priceType) {
@@ -184,7 +186,9 @@ async function syncPrices() {
         product: price.product.id,
         currency: price.currency,
         amount: price.unit_amount || defaultPrice.amount,
-        taxBehavior: price.tax_behavior || "exclusive",
+        taxBehavior: PriceDataSchema.shape.taxBehavior.parse(
+          price.tax_behavior || "exclusive",
+        ),
       });
     }
   }
@@ -338,7 +342,9 @@ async function setPrice(input: SetPriceInput) {
       product: objectId(price.product),
       amount: price.unit_amount ?? amountWithCents,
       currency: price.currency,
-      taxBehavior: price.tax_behavior || taxBehavior,
+      taxBehavior: PriceDataSchema.shape.taxBehavior.parse(
+        price.tax_behavior || taxBehavior,
+      ),
     });
   };
   const deactivatePrice = async (priceId: string) => {

--- a/app/src/pages/api/stripe-webhook.ts
+++ b/app/src/pages/api/stripe-webhook.ts
@@ -20,6 +20,7 @@ import {
 import { createLogger } from "#app/lib/logger.ts";
 import { objectId } from "#app/lib/object.ts";
 import { badRequest, internalServerError, ok } from "#app/lib/response.ts";
+import { PriceDataSchema } from "#app/lib/schemas.ts";
 import {
   getPromotionCoupon,
   getStripeClient,
@@ -136,7 +137,9 @@ export const POST: APIRoute = async (context) => {
       product: objectId(price.product),
       amount: price.unit_amount,
       currency: price.currency,
-      taxBehavior: price.tax_behavior ?? "unspecified",
+      taxBehavior: PriceDataSchema.shape.taxBehavior.parse(
+        price.tax_behavior ?? "unspecified",
+      ),
     });
     logger.info("Price stored in KV store", key);
     return ok();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,8 +318,8 @@ importers:
         specifier: 1.9.15
         version: 1.9.15
       stripe:
-        specifier: 22.5.0
-        version: 22.5.0(@types/node@24.13.3)
+        specifier: 22.6.0
+        version: 22.6.0(@types/node@24.13.3)
       tailwindcss:
         specifier: 4.3.3
         version: 4.3.3
@@ -9764,8 +9764,8 @@ packages:
     resolution: {integrity: sha512-aT2BU9KkizY9SATf14WhhYVv2uOapBWX0OFWF4xvcj1mPaNotlSc2CsxpS4DS46ZueSppmCF5BX1sNYBtwBvfw==}
     engines: {node: '>=12.*'}
 
-  stripe@22.5.0:
-    resolution: {integrity: sha512-QVwMwriC0bbySx6R4dpsvJ0W//GojC1kwWVS6rPSoVqDUIZX4Hy3TaUrd2AZeXEAaKbfWIjQjvo3vKAReHZ0vQ==}
+  stripe@22.6.0:
+    resolution: {integrity: sha512-Ezk+WYEEwX2DLxFrKfb6coznlCMZvCaCYMNPXNHFSZkBIEzF5Hgm7RLb38q/0h9Ol5jsUJGJRorvhzAvckgfhw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -20631,7 +20631,7 @@ snapshots:
       '@types/node': 24.13.3
       qs: 6.15.0
 
-  stripe@22.5.0(@types/node@24.13.3):
+  stripe@22.6.0(@types/node@24.13.3):
     optionalDependencies:
       '@types/node': 24.13.3
 


### PR DESCRIPTION
## Motivation

Update the app to Stripe 22.6.0. This release widens `Price.TaxBehavior` to include unknown strings, so the app's four assignments to its closed tax-behavior enum no longer type-check.

## Solution

Update the exact Stripe pin and regenerate the lockfile with pnpm 11.24.0, including the configured `pnpm dedupe` operation. Keep the website's Stripe dependencies unchanged because Renovate disables updates in that workspace. The app's grouped `@stripe/stripe-js` dependency is already current at 9.14.0.

Validate incoming tax behavior with the existing price schema before caching or storing prices:

```ts
PriceDataSchema.shape.taxBehavior.parse(price.tax_behavior || "exclusive")
```

Keep the existing defaults: `exclusive` for admin operations and `unspecified` for price webhooks. Unknown nonempty values stop the operation before that price is stored. This preserves the app's supported tax values without a type assertion or a guessed tax fallback.

## Dependencies

| Package | Workspace | Old | New | Source |
| --- | --- | --- | --- | --- |
| `stripe` | `app` (`dependencies`) | `22.5.0` | `22.6.0` | [Release notes](https://github.com/stripe/stripe-node/releases/tag/v22.6.0), [source comparison](https://github.com/stripe/stripe-node/compare/v22.5.0...v22.6.0) |

The app does not override Stripe's API version. This update changes its default from `2026-07-29.dahlia` to `2026-08-26.dahlia`. The tax-type migration follows the [updated price types](https://github.com/stripe/stripe-node/blob/v22.6.0/src/resources/Prices.ts).

The registry published 22.6.0 on August 27, 2026. It meets the configured three-day minimum release age. Renovate does not enable automerge for Stripe. This PR also requires human review because it changes app code.

## Verification

- `pnpm install --frozen-lockfile` and `pnpm dedupe` pass.
- On unchanged app source, `pnpm tsc` passes with Stripe 22.5.0 and fails with four `TS2322` errors with 22.6.0.
- `pnpm lint-fix` and `pnpm tsc` pass after the migration.
- `pnpm build-app-lite` passes.
- An offline SDK smoke check passes for the constructor, default API version, and signed `price.updated` webhook parsing. No live Stripe calls were made.
