### PR TITLE
Update dependency stripe to v22.6.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -102,7 +102,7 @@
     "rehype-parse": "9.0.1",
     "shiki": "4.4.3",
     "solid-js": "1.9.15",
-    "stripe": "22.5.0",
+    "stripe": "22.6.0",
     "tailwindcss": "4.3.3",
     "textarea-caret": "3.1.0",
     "ts-morph": "28.0.0",

--- a/app/src/lib/schemas.ts
+++ b/app/src/lib/schemas.ts
@@ -49,7 +49,11 @@ export const PriceDataSchema = z.object({
   product: z.string(),
   amount: z.number(),
   currency: z.string(),
-  taxBehavior: z.enum(["exclusive", "inclusive", "unspecified"]),
+  // Stripe types `tax_behavior` as an open union so new API values don't break
+  // the build. Nothing matches it against literals: it's only compared with the
+  // live Stripe value in stripe.ts and passed back, so it's carried as-is.
+  // https://github.com/stripe/stripe-node/blob/v22.6.0/src/resources/Prices.ts#L611-L615
+  taxBehavior: z.string(),
 });
 export type PriceData = z.infer<typeof PriceDataSchema>;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,8 +318,8 @@ importers:
         specifier: 1.9.15
         version: 1.9.15
       stripe:
-        specifier: 22.5.0
-        version: 22.5.0(@types/node@24.13.3)
+        specifier: 22.6.0
+        version: 22.6.0(@types/node@24.13.3)
       tailwindcss:
         specifier: 4.3.3
         version: 4.3.3
@@ -9764,8 +9764,8 @@ packages:
     resolution: {integrity: sha512-aT2BU9KkizY9SATf14WhhYVv2uOapBWX0OFWF4xvcj1mPaNotlSc2CsxpS4DS46ZueSppmCF5BX1sNYBtwBvfw==}
     engines: {node: '>=12.*'}
 
-  stripe@22.5.0:
-    resolution: {integrity: sha512-QVwMwriC0bbySx6R4dpsvJ0W//GojC1kwWVS6rPSoVqDUIZX4Hy3TaUrd2AZeXEAaKbfWIjQjvo3vKAReHZ0vQ==}
+  stripe@22.6.0:
+    resolution: {integrity: sha512-Ezk+WYEEwX2DLxFrKfb6coznlCMZvCaCYMNPXNHFSZkBIEzF5Hgm7RLb38q/0h9Ol5jsUJGJRorvhzAvckgfhw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -20631,7 +20631,7 @@ snapshots:
       '@types/node': 24.13.3
       qs: 6.15.0
 
-  stripe@22.5.0(@types/node@24.13.3):
+  stripe@22.6.0(@types/node@24.13.3):
     optionalDependencies:
       '@types/node': 24.13.3
 


### PR DESCRIPTION
## Motivation

Renovate groups `stripe` and `@stripe/*` together in `renovate.json`. In that group, only `stripe` in the `app` workspace has an update available, because `@stripe/stripe-js` is already at its latest version. The `website` workspace is out of scope because `renovate.json` disables `website/package.json`.

## Solution

Bump `stripe` from `22.5.0` to `22.6.0` in `app/package.json`, regenerate the lockfile, and run the configured `pnpmDedupe` post-update operation. The dedupe reported no changes, so the lockfile diff is limited to `stripe` itself.

The update also required one product-code change, described below.

## Tax behavior migration

`stripe@22.6.0` widens many enums with an `OtherString` escape hatch so that new API values do not break builds. Across `cjs/resources/`, `OtherString` occurrences go from 2143 in `22.5.0` to 2712 in `22.6.0`. `Price.TaxBehavior` is one of the widened enums:

```ts
// stripe@22.5.0
type TaxBehavior = 'exclusive' | 'inclusive' | 'unspecified';

// stripe@22.6.0
type TaxBehavior = 'exclusive' | 'inclusive' | 'unspecified' | OtherString;
```

`PriceDataSchema.taxBehavior` was a closed enum, so the four places that copy `price.tax_behavior` into `PriceData` stopped type-checking:

```
app/src/actions/admin.ts:187:9 - error TS2322: Type 'TaxBehavior' is not assignable to type '"exclusive" | "inclusive" | "unspecified"'.
  Type 'OtherString' is not assignable to type '"exclusive" | "inclusive" | "unspecified"'.

Found 4 errors in 2 files.

Errors  Files
     3  app/src/actions/admin.ts:116
     1  app/src/pages/api/stripe-webhook.ts:139
```

This is a deliberate upstream change rather than a regression, so it is adopted instead of worked around. The field now mirrors the type Stripe publishes:

```ts
taxBehavior: z.string(),
```

This keeps every call site unchanged and preserves the existing behavior exactly.

Narrowing the value back to the three documented strings was considered and rejected. `PriceDataSchema` is only a `z.infer` source and is never parsed at runtime, so the closed enum validated nothing. Nothing matches `taxBehavior` against specific values either: `createCheckout` compares it to the live Stripe value to decide whether the cached price is still current, and otherwise passes it straight back to Stripe.

```ts
const isSamePrice =
  price.originalAmount === stripePrice.unit_amount &&
  price.taxBehavior === stripePrice.tax_behavior &&
  compareCurrency(price.currency, stripePrice.currency);
```

Coercing an unrecognized value to a fallback would therefore break that comparison and silently build an inline price with the wrong tax treatment. Carrying the value through as-is keeps the comparison correct for whatever Stripe returns.

## Dependencies

| Declaration | Workspace | Old | New | Links |
| --- | --- | --- | --- | --- |
| `stripe` | `app` | `22.5.0` | `22.6.0` | [source](https://github.com/stripe/stripe-node) / [release](https://github.com/stripe/stripe-node/releases/tag/v22.6.0) / [changelog](https://github.com/stripe/stripe-node/blob/v22.6.0/CHANGELOG.md) |

Notes relevant to this repository:

- The pinned Stripe API version moves from `2026-07-29.dahlia` to `2026-08-26.dahlia`. `app/src/lib/stripe.ts` constructs the client without an `apiVersion`, so it takes the SDK default, as it did for earlier updates. Both versions are `.dahlia`, and webhook payload versions come from the endpoint configuration rather than the SDK, so `constructEvent` is unaffected.
- `Price.tax_behavior` became an open union, which required the migration above. `Event.Type` is not widened, so the `satisfies Record<string, Stripe.Event.Type>` guard in `app/src/pages/api/stripe-webhook.ts` still catches event-name typos. The other newly widened enums that this app could read are not used.
- The SDK now throws a connection error instead of hanging when the server drops the connection while it sends a response body ([#2815](https://github.com/stripe/stripe-node/pull/2815)). This replaces a hang with a thrown error, and the client already sets `maxNetworkRetries: 2`.
- The other flagged changes in the release do not apply here. This repository does not use `PaymentRecord`, `PaymentAttemptRecord`, `allowed_payment_method_types`, V2 discriminated-union parameters, or the new `EventNotificationHandler`.

`@stripe/stripe-js` is left at `9.14.0`, which is the current latest version.
