### PR TITLE
Fix Dialog remounting its contents when the backdrop prop changes

### DIFF
--- a/.changeset/300-dialog-backdrop-remount.md
+++ b/.changeset/300-dialog-backdrop-remount.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Dialog`](https://ariakit.com/reference/dialog), and every component built on it such as [`Popover`](https://ariakit.com/reference/popover) and [`Menu`](https://ariakit.com/reference/menu), recreating its contents when the [`backdrop`](https://ariakit.com/reference/dialog#backdrop) prop changed between a falsy and a truthy value.

--- a/app/src/sandbox/dialog-backdrop-7335/index.react.tsx
+++ b/app/src/sandbox/dialog-backdrop-7335/index.react.tsx
@@ -42,9 +42,7 @@ export default function Example() {
       */}
       <ComposeDialog />
       {/*
-        The same setting on a dialog that renders inline rather than in a
-        portal, so the dialog element is reconciled among its own parent's
-        children instead of the portal's.
+        The same setting on an inline, non-modal dialog.
         https://github.com/ariakit/ariakit/issues/7335
       */}
       <QuickNoteDialog />
@@ -60,17 +58,14 @@ function ComposeDialog() {
       <Ariakit.DialogDisclosure>Compose</Ariakit.DialogDisclosure>
       <Ariakit.Dialog
         className="dialog"
-        // TODO: Remove this workaround once the fix ships. The sandbox stops
-        // reproducing the bug while it is applied.
-        // https://github.com/ariakit/ariakit/issues/7335
         backdrop={
-          <div
-            className={highContrast ? "backdrop backdrop-high" : "backdrop"}
-            // Leave the property out while the backdrop is on. An explicit
-            // `display: undefined` would override the `display: none` Ariakit
-            // sets while the dialog is closed.
-            style={dimmed ? undefined : { display: "none" }}
-          />
+          dimmed ? (
+            <div
+              className={highContrast ? "backdrop backdrop-high" : "backdrop"}
+            />
+          ) : (
+            false
+          )
         }
       >
         <Ariakit.DialogHeading>Compose</Ariakit.DialogHeading>
@@ -80,10 +75,8 @@ function ComposeDialog() {
         <Attachments />
         <DimBackground checked={dimmed} onChange={setDimmed} />
         {/*
-          Turning this on re-renders the dialog with a new backdrop element
-          while the backdrop stays truthy, so the wrapper's shape doesn't
-          change. It's the control that tells the falsy/truthy boundary apart
-          from an ordinary re-render.
+          Turning this on keeps the backdrop truthy, which is the control that
+          separates the falsy/truthy boundary from an ordinary re-render.
         */}
         <label>
           <input
@@ -108,14 +101,7 @@ function QuickNoteDialog() {
         modal={false}
         portal={false}
         className="dialog"
-        // TODO: Remove this workaround once the fix ships.
-        // https://github.com/ariakit/ariakit/issues/7335
-        backdrop={
-          <div
-            className="backdrop"
-            style={dimmed ? undefined : { display: "none" }}
-          />
-        }
+        backdrop={dimmed ? <div className="backdrop" /> : false}
       >
         <Ariakit.DialogHeading>Quick note</Ariakit.DialogHeading>
         <label>

--- a/app/src/sandbox/dialog-backdrop-7335/index.react.tsx
+++ b/app/src/sandbox/dialog-backdrop-7335/index.react.tsx
@@ -1,0 +1,154 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+
+// The backdrop covers the viewport, so the dialogs need a stacking context of
+// their own to stay above it. Keep these styles inline because Vitest does not
+// process this sandbox's CSS imports in happy-dom.
+const css = `
+  .backdrop {
+    background: rgb(0 0 0 / 0.4);
+  }
+  .backdrop-high {
+    background: rgb(0 0 0 / 0.8);
+  }
+  .dialog {
+    position: fixed;
+    inset: 0.75rem;
+    z-index: 50;
+    margin: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: start;
+    gap: 0.75rem;
+    width: 20rem;
+    height: fit-content;
+    max-width: calc(100vw - 1.5rem);
+    border-radius: 1rem;
+    background: white;
+    color: black;
+    padding: 1.5rem;
+  }
+`;
+
+export default function Example() {
+  return (
+    <div>
+      <style>{css}</style>
+      {/*
+        Dimming the background is an appearance setting the user changes while
+        the dialog stays open, so the draft they typed and the state their
+        attachments hold have to survive it.
+        https://github.com/ariakit/ariakit/issues/7335
+      */}
+      <ComposeDialog />
+      {/*
+        The same setting on a dialog that renders inline rather than in a
+        portal, so the dialog element is reconciled among its own parent's
+        children instead of the portal's.
+        https://github.com/ariakit/ariakit/issues/7335
+      */}
+      <QuickNoteDialog />
+    </div>
+  );
+}
+
+function ComposeDialog() {
+  const [dimmed, setDimmed] = useState(true);
+  const [highContrast, setHighContrast] = useState(false);
+  return (
+    <Ariakit.DialogProvider>
+      <Ariakit.DialogDisclosure>Compose</Ariakit.DialogDisclosure>
+      <Ariakit.Dialog
+        className="dialog"
+        backdrop={
+          dimmed ? (
+            <div
+              className={highContrast ? "backdrop backdrop-high" : "backdrop"}
+            />
+          ) : (
+            false
+          )
+        }
+      >
+        <Ariakit.DialogHeading>Compose</Ariakit.DialogHeading>
+        <label>
+          Message <input type="text" />
+        </label>
+        <Attachments />
+        <DimBackground checked={dimmed} onChange={setDimmed} />
+        {/*
+          Turning this on re-renders the dialog with a new backdrop element
+          while the backdrop stays truthy, so the number of children never
+          changes. It's the control that tells the falsy/truthy boundary apart
+          from an ordinary re-render.
+        */}
+        <label>
+          <input
+            type="checkbox"
+            checked={highContrast}
+            onChange={(event) => setHighContrast(event.target.checked)}
+          />{" "}
+          High contrast backdrop
+        </label>
+        <Ariakit.DialogDismiss>Send</Ariakit.DialogDismiss>
+      </Ariakit.Dialog>
+    </Ariakit.DialogProvider>
+  );
+}
+
+function QuickNoteDialog() {
+  const [dimmed, setDimmed] = useState(true);
+  return (
+    <Ariakit.DialogProvider>
+      <Ariakit.DialogDisclosure>Quick note</Ariakit.DialogDisclosure>
+      <Ariakit.Dialog
+        modal={false}
+        portal={false}
+        className="dialog"
+        backdrop={dimmed ? <div className="backdrop" /> : false}
+      >
+        <Ariakit.DialogHeading>Quick note</Ariakit.DialogHeading>
+        <label>
+          Note <input type="text" />
+        </label>
+        <Attachments />
+        <DimBackground checked={dimmed} onChange={setDimmed} />
+        <Ariakit.DialogDismiss>Save</Ariakit.DialogDismiss>
+      </Ariakit.Dialog>
+    </Ariakit.DialogProvider>
+  );
+}
+
+interface DimBackgroundProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+// The setting lives above the dialog, the way an application preference does,
+// so it outlives the dialog's subtree and can't be what the assertions measure.
+function DimBackground({ checked, onChange }: DimBackgroundProps) {
+  return (
+    <label>
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onChange(event.target.checked)}
+      />{" "}
+      Dim the background
+    </label>
+  );
+}
+
+// The count lives in a child of the dialog, so it survives only when the
+// dialog's subtree is preserved rather than recreated.
+function Attachments() {
+  const [count, setCount] = useState(0);
+  return (
+    <div>
+      <button type="button" onClick={() => setCount((value) => value + 1)}>
+        Add attachment
+      </button>{" "}
+      <span role="status">Attachments: {count}</span>
+    </div>
+  );
+}

--- a/app/src/sandbox/dialog-backdrop-7335/index.react.tsx
+++ b/app/src/sandbox/dialog-backdrop-7335/index.react.tsx
@@ -60,14 +60,17 @@ function ComposeDialog() {
       <Ariakit.DialogDisclosure>Compose</Ariakit.DialogDisclosure>
       <Ariakit.Dialog
         className="dialog"
+        // TODO: Remove this workaround once the fix ships. The sandbox stops
+        // reproducing the bug while it is applied.
+        // https://github.com/ariakit/ariakit/issues/7335
         backdrop={
-          dimmed ? (
-            <div
-              className={highContrast ? "backdrop backdrop-high" : "backdrop"}
-            />
-          ) : (
-            false
-          )
+          <div
+            className={highContrast ? "backdrop backdrop-high" : "backdrop"}
+            // Leave the property out while the backdrop is on. An explicit
+            // `display: undefined` would override the `display: none` Ariakit
+            // sets while the dialog is closed.
+            style={dimmed ? undefined : { display: "none" }}
+          />
         }
       >
         <Ariakit.DialogHeading>Compose</Ariakit.DialogHeading>
@@ -78,8 +81,8 @@ function ComposeDialog() {
         <DimBackground checked={dimmed} onChange={setDimmed} />
         {/*
           Turning this on re-renders the dialog with a new backdrop element
-          while the backdrop stays truthy, so the number of children never
-          changes. It's the control that tells the falsy/truthy boundary apart
+          while the backdrop stays truthy, so the wrapper's shape doesn't
+          change. It's the control that tells the falsy/truthy boundary apart
           from an ordinary re-render.
         */}
         <label>
@@ -105,7 +108,14 @@ function QuickNoteDialog() {
         modal={false}
         portal={false}
         className="dialog"
-        backdrop={dimmed ? <div className="backdrop" /> : false}
+        // TODO: Remove this workaround once the fix ships.
+        // https://github.com/ariakit/ariakit/issues/7335
+        backdrop={
+          <div
+            className="backdrop"
+            style={dimmed ? undefined : { display: "none" }}
+          />
+        }
       >
         <Ariakit.DialogHeading>Quick note</Ariakit.DialogHeading>
         <label>

--- a/app/src/sandbox/dialog-backdrop-7335/test-chrome.ts
+++ b/app/src/sandbox/dialog-backdrop-7335/test-chrome.ts
@@ -2,11 +2,9 @@ import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test, query }) => {
   // Gaining or losing the backdrop must only mount or unmount the backdrop.
-  // The backdrop renders as a sibling before the dialog, so rendering that
-  // sibling only while the prop is truthy moves the dialog to another position
-  // among its parent's children, and React remounts everything inside it.
   // https://github.com/ariakit/ariakit/issues/7335
   test("backdrop toggle keeps the contents of a modal dialog", async ({
+    page,
     q,
   }) => {
     await q.button("Compose").click();
@@ -18,10 +16,19 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(query(dialog).status()).toHaveText("Attachments: 2");
     await test.expect(q.presentation()).toBeVisible();
 
+    const dialogId = await dialog.getAttribute("id");
+    // Guards the selector below against a missing id.
+    test.expect(dialogId).toBeTruthy();
     await query(dialog).checkbox("Dim the background").click();
     // Role queries skip elements hidden from the accessibility tree, so this
     // asserts that no backdrop is shown, not that no element is mounted.
     await test.expect(q.presentation()).toHaveCount(0);
+    // Losing the backdrop has to unmount it, not just hide it. This passes
+    // before the fix too, and rules out the userland workaround's shape, which
+    // keeps a hidden backdrop mounted.
+    await test
+      .expect(page.locator(`[data-backdrop="${dialogId}"]`))
+      .toHaveCount(0);
     await test.expect(query(dialog).textbox("Message")).toHaveValue("Ship it");
     await test.expect(query(dialog).status()).toHaveText("Attachments: 2");
 
@@ -31,10 +38,9 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(query(dialog).status()).toHaveText("Attachments: 2");
   });
 
-  // Changing the backdrop's own appearance re-renders the dialog with a new
-  // backdrop element while the backdrop stays truthy, so the number of children
-  // never changes. This passes today: it's the control that tells the
-  // falsy/truthy boundary apart from an ordinary re-render.
+  // Keeps the backdrop truthy, so this passes before the fix too: it's the
+  // control that separates the falsy/truthy boundary from an ordinary
+  // re-render.
   // https://github.com/ariakit/ariakit/issues/7335
   test("changing the backdrop's appearance keeps the contents", async ({
     q,
@@ -52,8 +58,7 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(query(dialog).status()).toHaveText("Attachments: 1");
   });
 
-  // A dialog that renders inline is reconciled among its own parent's children
-  // rather than the portal's, so it needs the same stable position.
+  // The same toggle on an inline, non-modal dialog.
   // https://github.com/ariakit/ariakit/issues/7335
   test("backdrop toggle keeps the contents of an inline dialog", async ({
     q,

--- a/app/src/sandbox/dialog-backdrop-7335/test-chrome.ts
+++ b/app/src/sandbox/dialog-backdrop-7335/test-chrome.ts
@@ -1,0 +1,79 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test, query }) => {
+  // Gaining or losing the backdrop must only mount or unmount the backdrop.
+  // The backdrop renders as a sibling before the dialog, so rendering that
+  // sibling only while the prop is truthy moves the dialog to another position
+  // among its parent's children, and React remounts everything inside it.
+  // https://github.com/ariakit/ariakit/issues/7335
+  test("backdrop toggle keeps the contents of a modal dialog", async ({
+    q,
+  }) => {
+    await q.button("Compose").click();
+    const dialog = q.dialog("Compose");
+    await test.expect(dialog).toBeVisible();
+    await query(dialog).textbox("Message").fill("Ship it");
+    await query(dialog).button("Add attachment").click();
+    await query(dialog).button("Add attachment").click();
+    await test.expect(query(dialog).status()).toHaveText("Attachments: 2");
+    await test.expect(q.presentation()).toBeVisible();
+
+    await query(dialog).checkbox("Dim the background").click();
+    // Role queries skip elements hidden from the accessibility tree, so this
+    // asserts that no backdrop is shown, not that no element is mounted.
+    await test.expect(q.presentation()).toHaveCount(0);
+    await test.expect(query(dialog).textbox("Message")).toHaveValue("Ship it");
+    await test.expect(query(dialog).status()).toHaveText("Attachments: 2");
+
+    await query(dialog).checkbox("Dim the background").click();
+    await test.expect(q.presentation()).toBeVisible();
+    await test.expect(query(dialog).textbox("Message")).toHaveValue("Ship it");
+    await test.expect(query(dialog).status()).toHaveText("Attachments: 2");
+  });
+
+  // Changing the backdrop's own appearance re-renders the dialog with a new
+  // backdrop element while the backdrop stays truthy, so the number of children
+  // never changes. This passes today: it's the control that tells the
+  // falsy/truthy boundary apart from an ordinary re-render.
+  // https://github.com/ariakit/ariakit/issues/7335
+  test("changing the backdrop's appearance keeps the contents", async ({
+    q,
+  }) => {
+    await q.button("Compose").click();
+    const dialog = q.dialog("Compose");
+    await test.expect(dialog).toBeVisible();
+    await query(dialog).textbox("Message").fill("Ship it");
+    await query(dialog).button("Add attachment").click();
+    await test.expect(q.presentation()).not.toHaveClass(/backdrop-high/);
+
+    await query(dialog).checkbox("High contrast backdrop").click();
+    await test.expect(q.presentation()).toHaveClass(/backdrop-high/);
+    await test.expect(query(dialog).textbox("Message")).toHaveValue("Ship it");
+    await test.expect(query(dialog).status()).toHaveText("Attachments: 1");
+  });
+
+  // A dialog that renders inline is reconciled among its own parent's children
+  // rather than the portal's, so it needs the same stable position.
+  // https://github.com/ariakit/ariakit/issues/7335
+  test("backdrop toggle keeps the contents of an inline dialog", async ({
+    q,
+  }) => {
+    await q.button("Quick note").click();
+    const dialog = q.dialog("Quick note");
+    await test.expect(dialog).toBeVisible();
+    await query(dialog).textbox("Note").fill("Buy milk");
+    await query(dialog).button("Add attachment").click();
+    await test.expect(query(dialog).status()).toHaveText("Attachments: 1");
+    await test.expect(q.presentation()).toBeVisible();
+
+    await query(dialog).checkbox("Dim the background").click();
+    await test.expect(q.presentation()).toHaveCount(0);
+    await test.expect(query(dialog).textbox("Note")).toHaveValue("Buy milk");
+    await test.expect(query(dialog).status()).toHaveText("Attachments: 1");
+
+    await query(dialog).checkbox("Dim the background").click();
+    await test.expect(q.presentation()).toBeVisible();
+    await test.expect(query(dialog).textbox("Note")).toHaveValue("Buy milk");
+    await test.expect(query(dialog).status()).toHaveText("Attachments: 1");
+  });
+});

--- a/app/src/sandbox/dialog-backdrop-7335/test.ts
+++ b/app/src/sandbox/dialog-backdrop-7335/test.ts
@@ -1,0 +1,77 @@
+import { click, q, type } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// Gaining or losing the backdrop must only mount or unmount the backdrop. The
+// backdrop renders as a sibling before the dialog, so rendering that sibling
+// only while the prop is truthy moves the dialog to another position among its
+// parent's children, and React remounts everything inside it.
+// https://github.com/ariakit/ariakit/issues/7335
+test("backdrop toggle keeps the contents of a modal dialog", async () => {
+  await click(q.button("Compose"));
+  const dialog = q.dialog("Compose");
+  expect(dialog).toBeVisible();
+  await type("Ship it", q.textbox("Message"));
+  await click(q.button("Add attachment"));
+  await click(q.button("Add attachment"));
+  expect(q.status()).toHaveTextContent("Attachments: 2");
+  expect(q.presentation()).toBeVisible();
+
+  await click(q.checkbox("Dim the background"));
+  // Role queries skip elements hidden from the accessibility tree, so this
+  // asserts that no backdrop is shown, not that no element is mounted.
+  expect(q.presentation.maybe()).not.toBeInTheDocument();
+  expect(q.textbox("Message")).toHaveValue("Ship it");
+  expect(q.status()).toHaveTextContent("Attachments: 2");
+  expect(q.dialog("Compose")).toBe(dialog);
+
+  await click(q.checkbox("Dim the background"));
+  expect(q.presentation()).toBeVisible();
+  expect(q.textbox("Message")).toHaveValue("Ship it");
+  expect(q.status()).toHaveTextContent("Attachments: 2");
+  expect(q.dialog("Compose")).toBe(dialog);
+});
+
+// Changing the backdrop's own appearance re-renders the dialog with a new
+// backdrop element while the backdrop stays truthy, so the number of children
+// never changes. This passes today: it's the control that tells the
+// falsy/truthy boundary apart from an ordinary re-render.
+// https://github.com/ariakit/ariakit/issues/7335
+test("changing the backdrop's appearance keeps the contents", async () => {
+  await click(q.button("Compose"));
+  const dialog = q.dialog("Compose");
+  expect(dialog).toBeVisible();
+  await type("Ship it", q.textbox("Message"));
+  await click(q.button("Add attachment"));
+  expect(q.presentation()).not.toHaveClass("backdrop-high");
+
+  await click(q.checkbox("High contrast backdrop"));
+  expect(q.presentation()).toHaveClass("backdrop-high");
+  expect(q.textbox("Message")).toHaveValue("Ship it");
+  expect(q.status()).toHaveTextContent("Attachments: 1");
+  expect(q.dialog("Compose")).toBe(dialog);
+});
+
+// A dialog that renders inline is reconciled among its own parent's children
+// rather than the portal's, so it needs the same stable position.
+// https://github.com/ariakit/ariakit/issues/7335
+test("backdrop toggle keeps the contents of an inline dialog", async () => {
+  await click(q.button("Quick note"));
+  const dialog = q.dialog("Quick note");
+  expect(dialog).toBeVisible();
+  await type("Buy milk", q.textbox("Note"));
+  await click(q.button("Add attachment"));
+  expect(q.status()).toHaveTextContent("Attachments: 1");
+  expect(q.presentation()).toBeVisible();
+
+  await click(q.checkbox("Dim the background"));
+  expect(q.presentation.maybe()).not.toBeInTheDocument();
+  expect(q.textbox("Note")).toHaveValue("Buy milk");
+  expect(q.status()).toHaveTextContent("Attachments: 1");
+  expect(q.dialog("Quick note")).toBe(dialog);
+
+  await click(q.checkbox("Dim the background"));
+  expect(q.presentation()).toBeVisible();
+  expect(q.textbox("Note")).toHaveValue("Buy milk");
+  expect(q.status()).toHaveTextContent("Attachments: 1");
+  expect(q.dialog("Quick note")).toBe(dialog);
+});

--- a/app/src/sandbox/dialog-backdrop-7335/test.ts
+++ b/app/src/sandbox/dialog-backdrop-7335/test.ts
@@ -1,10 +1,7 @@
 import { click, q, type } from "@ariakit/test";
 import { expect, test } from "vitest";
 
-// Gaining or losing the backdrop must only mount or unmount the backdrop. The
-// backdrop renders as a sibling before the dialog, so rendering that sibling
-// only while the prop is truthy moves the dialog to another position among its
-// parent's children, and React remounts everything inside it.
+// Gaining or losing the backdrop must only mount or unmount the backdrop.
 // https://github.com/ariakit/ariakit/issues/7335
 test("backdrop toggle keeps the contents of a modal dialog", async () => {
   await click(q.button("Compose"));
@@ -20,6 +17,14 @@ test("backdrop toggle keeps the contents of a modal dialog", async () => {
   // Role queries skip elements hidden from the accessibility tree, so this
   // asserts that no backdrop is shown, not that no element is mounted.
   expect(q.presentation.maybe()).not.toBeInTheDocument();
+  // Guards the selector below against a missing id.
+  expect(dialog.id).toBeTruthy();
+  // Losing the backdrop has to unmount it, not just hide it. This passes before
+  // the fix too, and rules out the userland workaround's shape, which keeps a
+  // hidden backdrop mounted.
+  expect(
+    document.querySelectorAll(`[data-backdrop="${dialog.id}"]`),
+  ).toHaveLength(0);
   expect(q.textbox("Message")).toHaveValue("Ship it");
   expect(q.status()).toHaveTextContent("Attachments: 2");
   expect(q.dialog("Compose")).toBe(dialog);
@@ -31,10 +36,8 @@ test("backdrop toggle keeps the contents of a modal dialog", async () => {
   expect(q.dialog("Compose")).toBe(dialog);
 });
 
-// Changing the backdrop's own appearance re-renders the dialog with a new
-// backdrop element while the backdrop stays truthy, so the number of children
-// never changes. This passes today: it's the control that tells the
-// falsy/truthy boundary apart from an ordinary re-render.
+// Keeps the backdrop truthy, so this passes before the fix too: it's the
+// control that separates the falsy/truthy boundary from an ordinary re-render.
 // https://github.com/ariakit/ariakit/issues/7335
 test("changing the backdrop's appearance keeps the contents", async () => {
   await click(q.button("Compose"));
@@ -51,8 +54,7 @@ test("changing the backdrop's appearance keeps the contents", async () => {
   expect(q.dialog("Compose")).toBe(dialog);
 });
 
-// A dialog that renders inline is reconciled among its own parent's children
-// rather than the portal's, so it needs the same stable position.
+// The same toggle on an inline, non-modal dialog.
 // https://github.com/ariakit/ariakit/issues/7335
 test("backdrop toggle keeps the contents of an inline dialog", async () => {
   await click(q.button("Quick note"));

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -848,8 +848,8 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
   props = useWrapElement(
     props,
     // The button toggles inside a wrapper that's always rendered, rather than
-    // by swapping the returned element, so gaining or losing it doesn't shift
-    // the dialog's index and remount everything inside it.
+    // by swapping the returned element, so gaining or losing it doesn't remount
+    // the dialog.
     // https://github.com/ariakit/ariakit/issues/7335
     (element) => (
       <>
@@ -873,10 +873,13 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
   // Wraps the dialog with a backdrop element if the backdrop prop is truthy.
   props = useWrapElement(
     props,
-    (element) => {
-      if (!backdrop) return element;
-      return (
-        <>
+    // The backdrop toggles inside a wrapper that's always rendered. Returning
+    // the bare element in one branch and a fragment in the other would change
+    // the element type in the dialog's slot and remount everything inside it.
+    // https://github.com/ariakit/ariakit/issues/7335
+    (element) => (
+      <>
+        {!!backdrop && (
           <DialogBackdrop
             store={store}
             backdrop={backdrop}
@@ -884,10 +887,10 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
             hidden={hiddenProp}
             alwaysVisible={alwaysVisible}
           />
-          {element}
-        </>
-      );
-    },
+        )}
+        {element}
+      </>
+    ),
     [store, backdrop, hiddenProp, alwaysVisible],
   );
 


### PR DESCRIPTION
## Motivation

`Dialog` renders its backdrop as a sibling right before the dialog element, but it did so only while the `backdrop` prop was truthy. The wrapper returned the bare element otherwise:

```tsx
(element) => {
  if (!backdrop) return element;
  return (
    <>
      <DialogBackdrop ... />
      {element}
    </>
  );
},
```

React unwraps an unkeyed fragment when it is a parent's only child, so the two branches handed that parent different children. With the backdrop off they were `[hidden dismiss slot, dialog]`, whatever the wrapper nested directly inside this one returns. With the backdrop on they became `[backdrop, <>[hidden dismiss slot, dialog]</>]`, because that inner fragment was then an array item rather than an only child. The slot holding the dialog changed element type, so React deleted its fiber and built a new one, and everything the application had rendered inside the dialog was discarded with it.

An application that turns the backdrop on or off therefore lost the draft the user typed, the scroll position, and the state of every child component. That was not limited to an open dialog: `unmountOnHide` is off by default, so a closed dialog keeps rendering its subtree, and flipping the prop while it was closed discarded the contents it was preserving for the next open. It is also not limited to `Dialog`: `Popover`, `Menu`, and every other component built on it accept the same prop.

## Solution

Always return the wrapper fragment and toggle the backdrop inside a fixed slot, so both branches hand the parent the same shape and the dialog's slot keeps its element type. Gaining or losing the backdrop then only mounts or unmounts the backdrop itself:

```tsx
(element) => (
  <>
    {!!backdrop && <DialogBackdrop ... />}
    {element}
  </>
),
```

This is the treatment #7333 applied to the neighbouring hidden dismiss wrapper in the same file. Rendering `DialogBackdrop` unconditionally and letting it return `null` would also hold that slot's element type stable, but it would run a disclosure store, its store subscriptions, and its layout effects for every dialog that has no backdrop, which is every non-modal popup.

## Reproduction

`app/src/sandbox/dialog-backdrop-7335/` toggles the backdrop from a "Dim the background" appearance setting while the dialog stays open. The tests assert that an uncontrolled input's draft and a child component's counter both survive, in a portalled modal dialog and in an inline non-modal one. Both dialogs render their own `DialogDismiss` and hold `modal` and `portal` constant, which isolates the backdrop wrapper from the hidden dismiss wrapper and from `usePortal`.

A third test changes the backdrop's own appearance instead, keeping the prop truthy. It passes before the fix and separates the falsy/truthy boundary from an ordinary re-render.

## Workaround

On a released version that predates this fix, keep the `backdrop` prop truthy and hide the backdrop element with CSS. The wrapper's shape then never changes, so the slot holding the dialog keeps its element type and its contents survive.

The "Work around Dialog backdrop remounts in the sandbox" commit applied this to the sandbox, which made all three of its tests pass with no library change. The "Fix Dialog remounting its contents when the backdrop prop changes" commit reverted it, so the fixture now exercises the library fix directly.

```tsx
// TODO: Remove this workaround after upgrading to a version with the fix.
// https://github.com/ariakit/ariakit/issues/7335
<Ariakit.Dialog
  backdrop={
    <div
      className="backdrop"
      // Leave the property out while the backdrop is on. An explicit
      // `display: undefined` would override the `display: none` Ariakit sets
      // while the dialog is closed, leaving the backdrop covering the page.
      style={dimmed ? undefined : { display: "none" }}
    />
  }
>
  {/* Your dialog content */}
</Ariakit.Dialog>
```

It is narrower than the fix:

- The backdrop element stays mounted and hidden instead of unmounting, so it keeps matching selectors such as `[data-backdrop]` and keeps its `data-open` and `data-enter` attributes. A transition declared on it also keeps counting toward the dialog's own close timing, because the dialog measures the backdrop alongside itself. It also keeps running `DialogBackdrop`'s store and layout effects while the backdrop is off, which is the cost the fix avoids by not rendering it at all.
- The `backdrop` prop has to be a JSX element to carry the `style`. A `boolean` has to become one, and a custom component has to spread `style` onto its underlying element.
- It covers the `backdrop` prop alone. Changing `portal` while the dialog is open still remounts it, through `usePortal`, and so does changing `modal` unless `portal` is pinned, since `portal` defaults to `modal`. That is expected: `portal` changes which DOM parent the element lives under, and React cannot carry a fiber across that move. It was raised as #7343 and closed as working as expected, so this limitation is permanent rather than something a later fix removes.

## Follow-ups

Both were found while working on this and verified pre-existing on `main`:

- #7346 is still open: `select.tsx` and `combobox-select.tsx` render their hidden native select as a sibling before the element and only while `name` is truthy, which is the same wrapper shape this fixes.
- #7344, the backdrop never receiving the `hidden` attribute, has since been fixed by #7345, which this branch has merged in.

Fixes #7335

## Review gate reassessment

<details>
<summary>Cycle 3, workaround commit: continue</summary>

Severity medium to high, since crossing the boundary silently discards everything inside the dialog. Frequency low to medium, since it needs a consumer that changes `backdrop` while the dialog is mounted. Scope wide, since `backdrop` is public on `Dialog` and on every component built on it. User impact is loss of user entered data.

Complexity is very low. The fix changes the shape of one `useWrapElement` callback and removes an early return, matching what #7333 did to the neighbouring wrapper. The commit under review is about twenty lines in one sandbox file, which the next commit reverts.

Continue. Nothing to simplify or remove, and no disposition changed. Every finding so far has been about comments and prose rather than code, behavior, or test validity.

Intentionally unsupported: changing `portal` while the dialog is open still remounts it, and so does changing `modal` unless `portal` is pinned. See https://github.com/ariakit/ariakit/issues/7343.

Registered follow-up: https://github.com/ariakit/ariakit/issues/7344.

</details>

<details>
<summary>Cycle 6, workaround commit: continue, and narrow what counts as a finding</summary>

Severity, frequency, scope, user impact and complexity are unchanged from cycle 3.

Continue. No finding has required a change to the workaround's code or behavior, and the staged code has been clean since the first round. The cycles came from one stale sentence with several copies: this issue was written before #7333, which then became the merge base and changed the mechanism, and the superseded model had already been copied into the issue body, the description, the commit message, the fixture and both test files.

A statement in this description is a finding when it asserts something false about the code, the behavior, the tests or the CI state. Emphasis, ordering, length and optional caveats are preferential and declined.

Two corrections were deferred at this point: the reproduction's comments, which sat outside that commit's snapshot and are rewritten by the fix commit, and this issue's own `## Problem` section, which is corrected when the workaround guidance is reconciled after the fix.

Intentionally unsupported and registered follow-ups are unchanged from cycle 3.

</details>

<details>
<summary>Cycle 3, library fix commit: continue</summary>

Severity, frequency, scope and user impact are unchanged.

Complexity is very low. The library change is one `useWrapElement` callback: an early return replaced by a conditional slot inside a fragment that is now always returned. It adds no branches, state, helpers, abstractions, dependency entries or public contract, and it removes an early return. There is no DOM, SSR or hydration difference. Maintenance cost is negative, because both wrappers in the file now share one shape.

Continue. The operative cause is the wrapper's return shape, a bare element in one branch and a fragment in the other. Rendering the backdrop conditionally is not the hazard, and the fix still does it. Rendering `DialogBackdrop` unconditionally was compared again and rejected, because it would run a disclosure store, a store subscription and several layout effects for every non-modal popup.

That component's unreachable `if (!backdrop) return null;` stays. Removing it is not a one line deletion: it also narrows `backdrop` for the two statements below it, which would otherwise be able to pass `undefined` as a component type.

Registered follow-up added: https://github.com/ariakit/ariakit/issues/7346.

</details>

<details>
<summary>Cycle 6, library fix commit: continue the change, cut the prose</summary>

Severity, frequency, scope, user impact and complexity are unchanged from the cycle 3 entry above.

Continue the library change, which no round has found a defect in. Three further rounds changed comment text only.

Change one thing about the review target. Rounds 4, 5 and 6 each found a different false claim rather than another copy of one, and the round 6 correction was itself inaccurate. That is the signature of too much React internals commentary spread across too many artifacts, so an inaccurate explanatory claim in a non-normative artifact is now deleted rather than corrected. The mechanism is stated once in `dialog.tsx` and once in `## Motivation`; the test and fixture comments name what each case covers and let the issue link carry the derivation.

Intentionally unsupported and registered follow-ups are unchanged.

</details>
