### PR TITLE
Fix Dialog backdrop missing the hidden attribute

### DIFF
--- a/.changeset/300-dialog-backdrop-hidden.md
+++ b/.changeset/300-dialog-backdrop-hidden.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed the element rendered by the [`backdrop`](https://ariakit.com/reference/dialog#backdrop) prop on [`Dialog`](https://ariakit.com/reference/dialog), and every component built on it such as [`Popover`](https://ariakit.com/reference/popover) and [`Menu`](https://ariakit.com/reference/menu), never receiving the `hidden` attribute while it was hidden.

--- a/app/src/sandbox/dialog-backdrop-7344/index.react.tsx
+++ b/app/src/sandbox/dialog-backdrop-7344/index.react.tsx
@@ -1,0 +1,49 @@
+import * as Ariakit from "@ariakit/react";
+
+// Regression fixture for https://github.com/ariakit/ariakit/issues/7344. The
+// backdrop is fixed and covers the viewport, so the dialog has to be
+// positioned as well. Otherwise it stays in flow behind the backdrop and the
+// browser test cannot click the dismiss button.
+const css = `
+  .backdrop {
+    background: rgb(0 0 0 / 0.4);
+  }
+  .dialog {
+    position: fixed;
+    inset: 0.75rem;
+    z-index: 50;
+    margin: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    width: 24rem;
+    height: fit-content;
+    max-width: calc(100vw - 1.5rem);
+    border-radius: 1rem;
+    background: white;
+    color: black;
+    padding: 1.5rem;
+  }
+`;
+
+export default function Example() {
+  const dialog = Ariakit.useDialogStore();
+  return (
+    <>
+      <style>{css}</style>
+      <Ariakit.Button onClick={dialog.show}>Show dialog</Ariakit.Button>
+      <Ariakit.Dialog
+        store={dialog}
+        backdrop={<div className="backdrop" />}
+        className="dialog"
+      >
+        <Ariakit.DialogHeading>Success</Ariakit.DialogHeading>
+        <p>
+          While this dialog is closed, the backdrop must carry the{" "}
+          <code>hidden</code> attribute, like the dialog itself.
+        </p>
+        <Ariakit.DialogDismiss>Close</Ariakit.DialogDismiss>
+      </Ariakit.Dialog>
+    </>
+  );
+}

--- a/app/src/sandbox/dialog-backdrop-7344/index.react.tsx
+++ b/app/src/sandbox/dialog-backdrop-7344/index.react.tsx
@@ -1,6 +1,4 @@
 import * as Ariakit from "@ariakit/react";
-import { forwardRef } from "react";
-import type { ComponentPropsWithoutRef } from "react";
 
 // Regression fixture for https://github.com/ariakit/ariakit/issues/7344. The
 // backdrop is fixed and covers the viewport, so the dialog has to be
@@ -28,23 +26,6 @@ const css = `
   }
 `;
 
-// TODO: Remove this workaround once the backdrop applies the attribute on its
-// own. https://github.com/ariakit/ariakit/issues/7344
-// The dialog still hides the backdrop through the inline `display: none` style
-// it computes, so mirror that decision into the attribute. Keep the component
-// outside `Example` so its identity stays stable across renders.
-const Backdrop = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<"div">>(
-  function Backdrop({ hidden, ...props }, ref) {
-    return (
-      <div
-        {...props}
-        ref={ref}
-        hidden={hidden ?? props.style?.display === "none"}
-      />
-    );
-  },
-);
-
 export default function Example() {
   const dialog = Ariakit.useDialogStore();
   return (
@@ -53,7 +34,7 @@ export default function Example() {
       <Ariakit.Button onClick={dialog.show}>Show dialog</Ariakit.Button>
       <Ariakit.Dialog
         store={dialog}
-        backdrop={<Backdrop className="backdrop" />}
+        backdrop={<div className="backdrop" />}
         className="dialog"
       >
         <Ariakit.DialogHeading>Success</Ariakit.DialogHeading>

--- a/app/src/sandbox/dialog-backdrop-7344/index.react.tsx
+++ b/app/src/sandbox/dialog-backdrop-7344/index.react.tsx
@@ -1,4 +1,6 @@
 import * as Ariakit from "@ariakit/react";
+import { forwardRef } from "react";
+import type { ComponentPropsWithoutRef } from "react";
 
 // Regression fixture for https://github.com/ariakit/ariakit/issues/7344. The
 // backdrop is fixed and covers the viewport, so the dialog has to be
@@ -26,6 +28,23 @@ const css = `
   }
 `;
 
+// TODO: Remove this workaround once the backdrop applies the attribute on its
+// own. https://github.com/ariakit/ariakit/issues/7344
+// The dialog still hides the backdrop through the inline `display: none` style
+// it computes, so mirror that decision into the attribute. Keep the component
+// outside `Example` so its identity stays stable across renders.
+const Backdrop = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<"div">>(
+  function Backdrop({ hidden, ...props }, ref) {
+    return (
+      <div
+        {...props}
+        ref={ref}
+        hidden={hidden ?? props.style?.display === "none"}
+      />
+    );
+  },
+);
+
 export default function Example() {
   const dialog = Ariakit.useDialogStore();
   return (
@@ -34,7 +53,7 @@ export default function Example() {
       <Ariakit.Button onClick={dialog.show}>Show dialog</Ariakit.Button>
       <Ariakit.Dialog
         store={dialog}
-        backdrop={<div className="backdrop" />}
+        backdrop={<Backdrop className="backdrop" />}
         className="dialog"
       >
         <Ariakit.DialogHeading>Success</Ariakit.DialogHeading>

--- a/app/src/sandbox/dialog-backdrop-7344/test-chrome.ts
+++ b/app/src/sandbox/dialog-backdrop-7344/test-chrome.ts
@@ -1,0 +1,25 @@
+// See https://github.com/ariakit/ariakit/issues/7344
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  test("backdrop carries the hidden attribute along with the dialog", async ({
+    q,
+  }) => {
+    // Role queries skip hidden elements by default, but this test is about the
+    // attribute a hidden element must carry.
+    const dialog = q.dialog(undefined, { includeHidden: true });
+    const backdrop = q.presentation(undefined, { includeHidden: true });
+
+    await test.expect(dialog).toHaveAttribute("hidden");
+    await test.expect(backdrop).toHaveAttribute("hidden");
+
+    await q.button("Show dialog").click();
+    await test.expect(dialog).not.toHaveAttribute("hidden");
+    await test.expect(backdrop).not.toHaveAttribute("hidden");
+    await test.expect(backdrop).toBeVisible();
+
+    await q.button("Close").click();
+    await test.expect(dialog).toHaveAttribute("hidden");
+    await test.expect(backdrop).toHaveAttribute("hidden");
+  });
+});

--- a/app/src/sandbox/dialog-backdrop-7344/test.ts
+++ b/app/src/sandbox/dialog-backdrop-7344/test.ts
@@ -1,0 +1,16 @@
+// See https://github.com/ariakit/ariakit/issues/7344
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+test("backdrop carries the hidden attribute along with the dialog", async () => {
+  expect(q.dialog.hidden()).toHaveAttribute("hidden");
+  expect(q.presentation.hidden()).toHaveAttribute("hidden");
+
+  await click(q.button("Show dialog"));
+  expect(q.dialog()).not.toHaveAttribute("hidden");
+  expect(q.presentation()).not.toHaveAttribute("hidden");
+
+  await click(q.button("Close"));
+  expect(q.dialog.hidden()).toHaveAttribute("hidden");
+  expect(q.presentation.hidden()).toHaveAttribute("hidden");
+});

--- a/packages/ariakit-react-components/src/dialog/dialog-backdrop.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog-backdrop.tsx
@@ -57,7 +57,13 @@ export function DialogBackdrop({
     role: "presentation",
     "data-backdrop": contentElement?.id || "",
     alwaysVisible,
-    hidden: hidden != null ? hidden : undefined,
+    // Omit the key when the dialog didn't receive `hidden`. An own key holding
+    // `undefined` would win the spread over the hidden state that the hook
+    // computes, and then get dropped, leaving the backdrop with `display: none`
+    // and no `hidden` attribute. Component boundaries drop undefined props for
+    // this reason, but this hook call isn't one.
+    // https://github.com/ariakit/ariakit/issues/7344
+    ...(hidden != null && { hidden }),
     style: {
       position: "fixed",
       top: 0,


### PR DESCRIPTION
## Motivation

Closes #7344.

The backdrop rendered by the [`backdrop`](https://ariakit.com/reference/dialog#backdrop) prop never received the `hidden` attribute, not even while it was hidden. The dialog element received it normally, so a closed dialog rendered two inconsistent elements:

```html
<div class="backdrop" role="presentation" data-backdrop="_r_0_" style="position: fixed; inset: 0px; display: none; z-index: 50;"></div>
<div hidden data-dialog role="dialog" style="display: none;">…</div>
```

There is no visual change to show, because `display: none` already removed the backdrop from rendering and from the accessibility tree. What broke was everything that reads the attribute: `[hidden]` and `:not([hidden])` selectors, and tooling that treats the attribute as the source of truth for disclosure state.

`DialogBackdrop` passed the dialog's own `hidden` prop to `useDisclosureContent`, using `undefined` to mean "not provided":

```tsx
const props = useDisclosureContent({
  // …
  hidden: hidden != null ? hidden : undefined,
});
```

In `useDisclosureContent`, the computed `hidden` sits before the incoming props, so the spread put the sentinel back and `removeUndefinedValues` then dropped the key. `style` is assigned after the spread, so `display: none` survived. The sentinel that was meant to say "let the hook decide" suppressed the hook's decision instead.

## Solution

`DialogBackdrop` now omits the key instead of passing the sentinel, so the hook's own decision survives:

```tsx
const props = useDisclosureContent({
  // …
  ...(hidden != null && { hidden }),
});
```

This matches what the library already does everywhere else. Ariakit's `forwardRef` drops props holding `undefined` at every component boundary, for this exact reason, which is why `<Dialog hidden={undefined}>` was never affected. `DialogBackdrop` renders through `useDisclosureContent` directly rather than through a component boundary, so it has to drop the sentinel itself. It is the only internal component in the package that does this, so this is the only call site that needs the change.

Keeping the fix at the call site also leaves `useDisclosureContent`'s prop ordering alone. That hook is the innermost one for every disclosure content element, including [`Popover`](https://ariakit.com/reference/popover), [`Menu`](https://ariakit.com/reference/menu), [`Select`](https://ariakit.com/reference/select) and [`DisclosureContent`](https://ariakit.com/reference/disclosure-content). Its ordering is also what implements the documented escape hatch on [`alwaysVisible`](https://ariakit.com/reference/dialog#alwaysvisible), where an explicit `hidden` prop still applies. Reordering the hook to fix the backdrop would have changed that combination for every one of those components at once.

The backdrop and the dialog element now agree in every state: both carry `hidden` while closed, both drop it while open, and both keep it off during an exit transition until the transition ends. `hidden={true}`, `hidden={false}` and `alwaysVisible` are unchanged.

The regression is covered by `app/src/sandbox/dialog-backdrop-7344/`, in both a Chrome browser test and a happy-dom duplicate. Both were committed failing first, so CI records the red state on `58a655b74` and the green state here.

## Workaround

Until this fix is released, render the backdrop through your own component and mirror the `display: none` style that the dialog already computes into the attribute:

```tsx
import * as Ariakit from "@ariakit/react";
import { forwardRef } from "react";
import type { ComponentPropsWithoutRef } from "react";

// TODO: Remove once the backdrop applies the attribute on its own.
// https://github.com/ariakit/ariakit/issues/7344
const Backdrop = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<"div">>(
  function Backdrop({ hidden, ...props }, ref) {
    return (
      <div
        {...props}
        ref={ref}
        hidden={hidden ?? props.style?.display === "none"}
      />
    );
  },
);

<Ariakit.Dialog backdrop={<Backdrop className="backdrop" />}>
  {/* Dialog content */}
</Ariakit.Dialog>;
```

The component keeps working after the fix ships, because the dialog then passes a real boolean and `??` defers to it.

Assumptions and limitations:

- Keep `forwardRef`. The dialog uses the backdrop ref to synchronize the backdrop's `z-index` with the dialog's and to mark the backdrop as an ancestor of the dialog. A plain function component swallows the ref on React 18, which leaves the backdrop on the wrong layer and stops a click on the backdrop from dismissing a portaled dialog.
- Define the component outside the component that renders the dialog. A component created during render changes identity on every render, which remounts the backdrop.
- The attribute comes from the inline `display: none` style that the dialog computes, so the workaround depends on that detail.
- Do not pass your own `display` through the backdrop's `style` prop. The element then reports the visibility you set rather than the dialog's.
- Do not use `hidden={!open}` instead. That hides the backdrop before its exit transition finishes.
