### PR TITLE
Fix Select and ComboboxSelect remounts when name changes

### DIFF
--- a/.changeset/300-select-name-remount.md
+++ b/.changeset/300-select-name-remount.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react": patch
+"@ariakit/react-components": patch
+---
+
+Fixed [`Select`](https://ariakit.com/reference/select) and [`ComboboxSelect`](https://ariakit.com/reference/combobox-select) losing descendant state when the `name` prop changes between empty and nonempty.

--- a/app/src/sandbox/select-combobox-name-7346/index.react.tsx
+++ b/app/src/sandbox/select-combobox-name-7346/index.react.tsx
@@ -32,9 +32,6 @@ function Field({ combobox = false, initiallyNamed = false }: FieldProps) {
   const [submitted, setSubmitted] = useState("Not submitted");
   const label = `${combobox ? "Combobox" : "Select"} ${initiallyNamed ? "named" : "unnamed"}`;
   const name = included ? "fruit" : undefined;
-  const selectValue = Ariakit.useStoreState(select, "value");
-  const comboboxValue = Ariakit.useStoreState(comboboxStore, "selectedValue");
-  const value = combobox ? comboboxValue : selectValue;
   const popupProps = {
     "aria-label": label,
     role: "dialog",
@@ -65,12 +62,9 @@ function Field({ combobox = false, initiallyNamed = false }: FieldProps) {
         />
         Include {label}
       </label>
-      {/* TODO: Remove after upgrading to the fixed version.
-      https://github.com/ariakit/ariakit/issues/7346 */}
-      <input type="hidden" name={name} value={value} />
       {combobox ? (
         <Ariakit.ComboboxProvider store={comboboxStore}>
-          <Ariakit.ComboboxSelect aria-label={label}>
+          <Ariakit.ComboboxSelect name={name} aria-label={label}>
             <Ariakit.ComboboxSelectedValue />
             {/* The portal keeps the popup outside the button in the DOM,
             while its React state belongs to the select's rendered subtree. */}
@@ -85,7 +79,7 @@ function Field({ combobox = false, initiallyNamed = false }: FieldProps) {
         </Ariakit.ComboboxProvider>
       ) : (
         <Ariakit.SelectProvider store={select}>
-          <Ariakit.Select aria-label={label}>
+          <Ariakit.Select name={name} aria-label={label}>
             <Ariakit.SelectValue />
             <Ariakit.SelectPopover store={select} {...popupProps}>
               <Ariakit.SelectList>

--- a/app/src/sandbox/select-combobox-name-7346/index.react.tsx
+++ b/app/src/sandbox/select-combobox-name-7346/index.react.tsx
@@ -29,9 +29,10 @@ function Field({ combobox = false, initiallyNamed = false }: FieldProps) {
     defaultSelectedValue: "Apple",
   });
   const [included, setIncluded] = useState(initiallyNamed);
+  const [fieldName, setFieldName] = useState("fruit");
   const [submitted, setSubmitted] = useState("Not submitted");
   const label = `${combobox ? "Combobox" : "Select"} ${initiallyNamed ? "named" : "unnamed"}`;
-  const name = included ? "fruit" : undefined;
+  const name = included ? fieldName : undefined;
   const popupProps = {
     "aria-label": label,
     role: "dialog",
@@ -49,7 +50,7 @@ function Field({ combobox = false, initiallyNamed = false }: FieldProps) {
       onSubmit={(event) => {
         event.preventDefault();
         const data = new FormData(event.currentTarget);
-        const fruit = data.get("fruit");
+        const fruit = data.get(fieldName);
         setSubmitted(typeof fruit === "string" ? fruit : "Omitted");
       }}
     >
@@ -91,6 +92,9 @@ function Field({ combobox = false, initiallyNamed = false }: FieldProps) {
           </Ariakit.Select>
         </Ariakit.SelectProvider>
       )}
+      <Ariakit.Button onClick={() => setFieldName("produce")}>
+        Rename {label}
+      </Ariakit.Button>
       <Ariakit.Button type="submit">Submit {label}</Ariakit.Button>
       <output aria-label={`${label} submission`}>{submitted}</output>
     </form>

--- a/app/src/sandbox/select-combobox-name-7346/index.react.tsx
+++ b/app/src/sandbox/select-combobox-name-7346/index.react.tsx
@@ -32,6 +32,9 @@ function Field({ combobox = false, initiallyNamed = false }: FieldProps) {
   const [submitted, setSubmitted] = useState("Not submitted");
   const label = `${combobox ? "Combobox" : "Select"} ${initiallyNamed ? "named" : "unnamed"}`;
   const name = included ? "fruit" : undefined;
+  const selectValue = Ariakit.useStoreState(select, "value");
+  const comboboxValue = Ariakit.useStoreState(comboboxStore, "selectedValue");
+  const value = combobox ? comboboxValue : selectValue;
   const popupProps = {
     "aria-label": label,
     role: "dialog",
@@ -45,7 +48,7 @@ function Field({ combobox = false, initiallyNamed = false }: FieldProps) {
   return (
     <form
       aria-label={label}
-      style={{ margin: 24 }}
+      style={{ margin: 24, display: "flex", gap: 12, alignItems: "center" }}
       onSubmit={(event) => {
         event.preventDefault();
         const data = new FormData(event.currentTarget);
@@ -62,9 +65,12 @@ function Field({ combobox = false, initiallyNamed = false }: FieldProps) {
         />
         Include {label}
       </label>
+      {/* TODO: Remove after upgrading to the fixed version.
+      https://github.com/ariakit/ariakit/issues/7346 */}
+      <input type="hidden" name={name} value={value} />
       {combobox ? (
         <Ariakit.ComboboxProvider store={comboboxStore}>
-          <Ariakit.ComboboxSelect name={name} aria-label={label}>
+          <Ariakit.ComboboxSelect aria-label={label}>
             <Ariakit.ComboboxSelectedValue />
             {/* The portal keeps the popup outside the button in the DOM,
             while its React state belongs to the select's rendered subtree. */}
@@ -79,7 +85,7 @@ function Field({ combobox = false, initiallyNamed = false }: FieldProps) {
         </Ariakit.ComboboxProvider>
       ) : (
         <Ariakit.SelectProvider store={select}>
-          <Ariakit.Select name={name} aria-label={label}>
+          <Ariakit.Select aria-label={label}>
             <Ariakit.SelectValue />
             <Ariakit.SelectPopover store={select} {...popupProps}>
               <Ariakit.SelectList>
@@ -99,11 +105,11 @@ function Field({ combobox = false, initiallyNamed = false }: FieldProps) {
 
 export default function Example() {
   return (
-    <>
+    <div>
       <Field />
       <Field initiallyNamed />
       <Field combobox />
       <Field combobox initiallyNamed />
-    </>
+    </div>
   );
 }

--- a/app/src/sandbox/select-combobox-name-7346/index.react.tsx
+++ b/app/src/sandbox/select-combobox-name-7346/index.react.tsx
@@ -1,0 +1,109 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+import type { MouseEvent } from "react";
+
+function Notes() {
+  const [attachments, setAttachments] = useState(0);
+  return (
+    <>
+      <label>
+        Note
+        <input defaultValue="" />
+      </label>
+      <Ariakit.Button onClick={() => setAttachments((count) => count + 1)}>
+        Add attachment
+      </Ariakit.Button>
+      <output aria-label="Attachments">Attachments: {attachments}</output>
+    </>
+  );
+}
+
+interface FieldProps {
+  combobox?: boolean;
+  initiallyNamed?: boolean;
+}
+
+function Field({ combobox = false, initiallyNamed = false }: FieldProps) {
+  const select = Ariakit.useSelectStore({ defaultValue: "Apple" });
+  const comboboxStore = Ariakit.useComboboxStore({
+    defaultSelectedValue: "Apple",
+  });
+  const [included, setIncluded] = useState(initiallyNamed);
+  const [submitted, setSubmitted] = useState("Not submitted");
+  const label = `${combobox ? "Combobox" : "Select"} ${initiallyNamed ? "named" : "unnamed"}`;
+  const name = included ? "fruit" : undefined;
+  const popupProps = {
+    "aria-label": label,
+    role: "dialog",
+    portal: true,
+    modal: false,
+    hideOnInteractOutside: false,
+    // Portal events still bubble through the trigger in the React tree.
+    onClick: (event: MouseEvent) => event.stopPropagation(),
+    style: { background: "white", padding: 16, border: "1px solid" },
+  };
+  return (
+    <form
+      aria-label={label}
+      style={{ margin: 24 }}
+      onSubmit={(event) => {
+        event.preventDefault();
+        const data = new FormData(event.currentTarget);
+        const fruit = data.get("fruit");
+        setSubmitted(typeof fruit === "string" ? fruit : "Omitted");
+      }}
+    >
+      <label>
+        <input
+          type="checkbox"
+          aria-label={`Include ${label}`}
+          checked={included}
+          onChange={(event) => setIncluded(event.target.checked)}
+        />
+        Include {label}
+      </label>
+      {combobox ? (
+        <Ariakit.ComboboxProvider store={comboboxStore}>
+          <Ariakit.ComboboxSelect name={name} aria-label={label}>
+            <Ariakit.ComboboxSelectedValue />
+            {/* The portal keeps the popup outside the button in the DOM,
+            while its React state belongs to the select's rendered subtree. */}
+            <Ariakit.ComboboxPopover store={comboboxStore} {...popupProps}>
+              <Ariakit.ComboboxList>
+                <Ariakit.ComboboxItem value="Apple" />
+                <Ariakit.ComboboxItem value="Orange" />
+              </Ariakit.ComboboxList>
+              <Notes />
+            </Ariakit.ComboboxPopover>
+          </Ariakit.ComboboxSelect>
+        </Ariakit.ComboboxProvider>
+      ) : (
+        <Ariakit.SelectProvider store={select}>
+          <Ariakit.Select name={name} aria-label={label}>
+            <Ariakit.SelectValue />
+            <Ariakit.SelectPopover store={select} {...popupProps}>
+              <Ariakit.SelectList>
+                <Ariakit.SelectItem value="Apple" />
+                <Ariakit.SelectItem value="Orange" />
+              </Ariakit.SelectList>
+              <Notes />
+            </Ariakit.SelectPopover>
+          </Ariakit.Select>
+        </Ariakit.SelectProvider>
+      )}
+      <Ariakit.Button type="submit">Submit {label}</Ariakit.Button>
+      <output aria-label={`${label} submission`}>{submitted}</output>
+    </form>
+  );
+}
+
+export default function Example() {
+  return (
+    <>
+      <Field />
+      <Field initiallyNamed />
+      <Field combobox />
+      <Field combobox initiallyNamed />
+    </>
+  );
+}

--- a/app/src/sandbox/select-combobox-name-7346/test-chrome.ts
+++ b/app/src/sandbox/select-combobox-name-7346/test-chrome.ts
@@ -38,4 +38,32 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
       }
     });
   }
+  for (const label of ["Select named", "Combobox named"]) {
+    // Keeps name nonempty, so this passes before the fix too. It distinguishes
+    // a rename from the empty/nonempty boundary that caused the remount.
+    // https://github.com/ariakit/ariakit/issues/7346
+    test(`${label} keeps popup state when name stays nonempty`, async ({
+      q,
+    }) => {
+      await q.combobox(label).click();
+      const dialog = q.dialog(label);
+      await test.expect(dialog).toBeVisible();
+      await query(dialog).textbox("Note").fill("Buy ripe fruit");
+      await query(dialog).button("Add attachment").click();
+      await test
+        .expect(q.form(label).locator("select"))
+        .toHaveAttribute("name", "fruit");
+
+      await q.button(`Rename ${label}`).click();
+      await test
+        .expect(q.form(label).locator("select"))
+        .toHaveAttribute("name", "produce");
+      await test
+        .expect(query(dialog).textbox("Note"))
+        .toHaveValue("Buy ripe fruit");
+      await test.expect(query(dialog).status()).toHaveText("Attachments: 1");
+      await q.button(`Submit ${label}`).click();
+      await test.expect(q.status(`${label} submission`)).toHaveText("Apple");
+    });
+  }
 });

--- a/app/src/sandbox/select-combobox-name-7346/test-chrome.ts
+++ b/app/src/sandbox/select-combobox-name-7346/test-chrome.ts
@@ -28,6 +28,9 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
           .expect(query(dialog).textbox("Note"))
           .toHaveValue("Buy ripe fruit");
         await test.expect(query(dialog).status()).toHaveText("Attachments: 1");
+        await test
+          .expect(q.form(label).locator("select"))
+          .toHaveCount(included ? 1 : 0);
         await q.button(`Submit ${label}`).click();
         await test
           .expect(q.status(`${label} submission`))

--- a/app/src/sandbox/select-combobox-name-7346/test-chrome.ts
+++ b/app/src/sandbox/select-combobox-name-7346/test-chrome.ts
@@ -1,0 +1,38 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test, query }) => {
+  for (const label of [
+    "Select unnamed",
+    "Select named",
+    "Combobox unnamed",
+    "Combobox named",
+  ]) {
+    // https://github.com/ariakit/ariakit/issues/7346
+    test(`${label} keeps popup state when name changes`, async ({ q }) => {
+      await q.combobox(label).click();
+      const dialog = q.dialog(label);
+      await test.expect(dialog).toBeVisible();
+      await query(dialog).textbox("Note").fill("Buy ripe fruit");
+      await query(dialog).button("Add attachment").click();
+      await test.expect(query(dialog).status()).toHaveText("Attachments: 1");
+
+      for (const included of [
+        label.endsWith(" unnamed"),
+        !label.endsWith(" unnamed"),
+      ]) {
+        await q.checkbox(`Include ${label}`).click();
+        await test
+          .expect(q.checkbox(`Include ${label}`))
+          .toBeChecked({ checked: included });
+        await test
+          .expect(query(dialog).textbox("Note"))
+          .toHaveValue("Buy ripe fruit");
+        await test.expect(query(dialog).status()).toHaveText("Attachments: 1");
+        await q.button(`Submit ${label}`).click();
+        await test
+          .expect(q.status(`${label} submission`))
+          .toHaveText(included ? "Apple" : "Omitted");
+      }
+    });
+  }
+});

--- a/app/src/sandbox/select-combobox-name-7346/test.ts
+++ b/app/src/sandbox/select-combobox-name-7346/test.ts
@@ -38,3 +38,31 @@ for (const label of [
     }
   });
 }
+
+for (const label of ["Select named", "Combobox named"]) {
+  // Keeps name nonempty, so this passes before the fix too. It distinguishes
+  // a rename from the empty/nonempty boundary that caused the remount.
+  // https://github.com/ariakit/ariakit/issues/7346
+  test(`${label} keeps popup state when name stays nonempty`, async () => {
+    await click(q.combobox(label));
+    const dialog = q.dialog(label);
+    expect(dialog).toBeVisible();
+    await type("Buy ripe fruit", q.textbox("Note"));
+    await click(q.button("Add attachment"));
+    expect(q.form(label).querySelector("select")).toHaveAttribute(
+      "name",
+      "fruit",
+    );
+
+    await click(q.button(`Rename ${label}`));
+    expect(q.form(label).querySelector("select")).toHaveAttribute(
+      "name",
+      "produce",
+    );
+    expect(q.textbox("Note")).toHaveValue("Buy ripe fruit");
+    expect(q.status("Attachments")).toHaveTextContent("Attachments: 1");
+    expect(q.dialog(label)).toBe(dialog);
+    await click(q.button(`Submit ${label}`));
+    expect(q.status(`${label} submission`)).toHaveTextContent("Apple");
+  });
+}

--- a/app/src/sandbox/select-combobox-name-7346/test.ts
+++ b/app/src/sandbox/select-combobox-name-7346/test.ts
@@ -28,6 +28,9 @@ for (const label of [
       expect(q.textbox("Note")).toHaveValue("Buy ripe fruit");
       expect(q.status("Attachments")).toHaveTextContent("Attachments: 1");
       expect(q.dialog(label)).toBe(dialog);
+      expect(q.form(label).querySelectorAll("select")).toHaveLength(
+        included ? 1 : 0,
+      );
       await click(q.button(`Submit ${label}`));
       expect(q.status(`${label} submission`)).toHaveTextContent(
         included ? "Apple" : "Omitted",

--- a/app/src/sandbox/select-combobox-name-7346/test.ts
+++ b/app/src/sandbox/select-combobox-name-7346/test.ts
@@ -1,0 +1,37 @@
+import { click, q, type } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+for (const label of [
+  "Select unnamed",
+  "Select named",
+  "Combobox unnamed",
+  "Combobox named",
+]) {
+  // https://github.com/ariakit/ariakit/issues/7346
+  test(`${label} keeps popup state when name changes`, async () => {
+    await click(q.combobox(label));
+    const dialog = q.dialog(label);
+    expect(dialog).toBeVisible();
+    await type("Buy ripe fruit", q.textbox("Note"));
+    await click(q.button("Add attachment"));
+    expect(q.status("Attachments")).toHaveTextContent("Attachments: 1");
+
+    for (const included of [
+      label.endsWith(" unnamed"),
+      !label.endsWith(" unnamed"),
+    ]) {
+      await click(q.checkbox(`Include ${label}`));
+      expect(q.checkbox(`Include ${label}`)).toHaveProperty(
+        "checked",
+        included,
+      );
+      expect(q.textbox("Note")).toHaveValue("Buy ripe fruit");
+      expect(q.status("Attachments")).toHaveTextContent("Attachments: 1");
+      expect(q.dialog(label)).toBe(dialog);
+      await click(q.button(`Submit ${label}`));
+      expect(q.status(`${label} submission`)).toHaveTextContent(
+        included ? "Apple" : "Omitted",
+      );
+    }
+  });
+}

--- a/packages/ariakit-react-components/src/combobox/combobox-select.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-select.tsx
@@ -201,7 +201,10 @@ export const useComboboxSelect = createHook<TagName, ComboboxSelectOptions>(
     // update the combobox store.
     props = useWrapElement(
       props,
-      // Keep the control in the same slot when the native select toggles.
+      // The native select toggles inside a wrapper that's always rendered.
+      // Returning the bare element in one branch and a fragment in the other
+      // would remount the control and everything inside it.
+      // https://github.com/ariakit/ariakit/issues/7346
       (element) => (
         <>
           {!!name && (

--- a/packages/ariakit-react-components/src/combobox/combobox-select.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-select.tsx
@@ -201,10 +201,10 @@ export const useComboboxSelect = createHook<TagName, ComboboxSelectOptions>(
     // update the combobox store.
     props = useWrapElement(
       props,
-      (element) => {
-        if (!name) return element;
-        return (
-          <>
+      // Keep the control in the same slot when the native select toggles.
+      (element) => (
+        <>
+          {!!name && (
             <select
               style={getVisuallyHiddenStyle()}
               tabIndex={-1}
@@ -246,10 +246,10 @@ export const useComboboxSelect = createHook<TagName, ComboboxSelectOptions>(
                 </option>
               ))}
             </select>
-            {element}
-          </>
-        );
-      },
+          )}
+          {element}
+        </>
+      ),
       [
         store,
         label,

--- a/packages/ariakit-react-components/src/select/select.tsx
+++ b/packages/ariakit-react-components/src/select/select.tsx
@@ -198,10 +198,10 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
   // onChange event is triggered and we set the autofill state to true.
   props = useWrapElement(
     props,
-    (element) => {
-      if (!name) return element;
-      return (
-        <>
+    // Keep the control in the same slot when the native select toggles.
+    (element) => (
+      <>
+        {!!name && (
           <select
             style={getVisuallyHiddenStyle()}
             tabIndex={-1}
@@ -245,10 +245,10 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
               </option>
             ))}
           </select>
-          {element}
-        </>
-      );
-    },
+        )}
+        {element}
+      </>
+    ),
     [
       store,
       label,

--- a/packages/ariakit-react-components/src/select/select.tsx
+++ b/packages/ariakit-react-components/src/select/select.tsx
@@ -198,7 +198,10 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
   // onChange event is triggered and we set the autofill state to true.
   props = useWrapElement(
     props,
-    // Keep the control in the same slot when the native select toggles.
+    // The native select toggles inside a wrapper that's always rendered.
+    // Returning the bare element in one branch and a fragment in the other
+    // would remount the control and everything inside it.
+    // https://github.com/ariakit/ariakit/issues/7346
     (element) => (
       <>
         {!!name && (


### PR DESCRIPTION
## Motivation

Changing `name` between empty and nonempty remounts the rendered subtree of `Select` and `ComboboxSelect`. Local state and uncontrolled input values are lost. This also affects a popover composed inside the control through a portal. A popover rendered as a separate sibling is outside this subtree.

## Solution

Keep the wrapper fragment stable and render the hidden native select in a fixed conditional slot before the control. Changing `name` now mounts or unmounts only the native select, while preserving the control and its descendants.

```tsx
<>
  {!!name && <select /* native form and autofill control */ />}
  {element}
</>
```

The fix retains native form submission and autofill behavior. It adds no DOM wrapper, public API, or extra native select when `name` is empty.

## Tests

Four regressions cover both controls, initially named and unnamed. Each toggles `name` in both directions and checks an uncontrolled draft, child component state, native-select presence, and form submission. The same cases run in Chromium, React 19, and React 18.

Two additional proof cases keep `name` nonempty (`"fruit"` to `"produce"`) and check the native field name, draft, child state, and submission. All six cases pass locally in Chromium, React 19, and React 18. The two new cases also pass with the pre-fix source and fail at the draft assertion when the wrapper is temporarily keyed by `name`. Lint and type checks pass.

Local verification passed: `pnpm test` (1,956 tests), `pnpm test-react18` (1,078 tests), `pnpm tsc`, `pnpm lint-fix`, `pnpm build`, and 34 targeted browser checks across Chromium, Firefox, and Safari.

The reproduction, userland workaround, and library fix are separate commits. The final fixture uses the library fix without the workaround. CI recorded the four expected reproduction failures in `Main / Test`, `Main / Test React 18`, and `App / Test Chrome`. The workaround then passed those complete suites (1,956, 1,078, and 854 tests respectively).

Fixes #7346

## Workaround

Until the fix is released, leave `name` off the Ariakit control and submit its selected value through a separate hidden input. The control then keeps the same wrapper shape. The sandbox verifies this workaround without a library change.

```tsx
const combobox = Ariakit.useComboboxStore({ defaultSelectedValue: "Apple" });
const value = Ariakit.useStoreState(combobox, "selectedValue");

// TODO: Remove after upgrading to the fixed version.
// https://github.com/ariakit/ariakit/issues/7346
<input type="hidden" name={included ? "fruit" : undefined} value={value} />
<Ariakit.ComboboxSelect store={combobox} />
```

For `Select`, use `useSelectStore` and its `value` state. This example covers a single selected value and an enabled control inside a form. For multiple values, render one hidden input per value. Forward `form` and `disabled` to those inputs when needed. Hidden inputs do not provide the native select's autofill or `required` validation behavior; handle validation separately if the application needs it. The library fix retains those native-select features.

## Preview

Local before-and-after recordings show the draft clearing before the fix and surviving both name transitions after it. They are not attached yet because the browser upload requires explicit permission.
