### PR TITLE
Fix focus loss when the active composite item becomes disabled

### DIFF
--- a/.changeset/300-composite-item-disabled-focus.md
+++ b/.changeset/300-composite-item-disabled-focus.md
@@ -1,0 +1,20 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Focus preserved when a composite item becomes disabled
+
+A [`CompositeItem`](https://ariakit.com/reference/composite-item) that becomes [`disabled`](https://ariakit.com/reference/focusable#disabled) while it holds focus now stays focusable until focus moves elsewhere. Previously the focused element was removed from the focus order right away, through the native `disabled` attribute on elements that support it, such as a button or input, and through the loss of `tabindex` on elements that support neither native disabling nor native tabbing, such as a `div`. The browser then moved focus to the body and arrow keys stopped navigating the composite.
+
+```tsx
+<CompositeItem disabled={read} onClick={() => setRead(true)}>
+  Mark as read
+</CompositeItem>
+```
+
+The item is still exposed as disabled through `aria-disabled` and still cannot be activated. Once focus moves away it becomes fully disabled again and arrow keys skip it.
+
+This applies to all components built on [`CompositeItem`](https://ariakit.com/reference/composite-item) that use roving focus, including [`ToolbarItem`](https://ariakit.com/reference/toolbar-item), [`ToolbarContainer`](https://ariakit.com/reference/toolbar-container), [`MenuItem`](https://ariakit.com/reference/menu-item), [`MenuItemCheckbox`](https://ariakit.com/reference/menu-item-checkbox), [`MenuItemRadio`](https://ariakit.com/reference/menu-item-radio), [`Radio`](https://ariakit.com/reference/radio), and [`FormRadio`](https://ariakit.com/reference/form-radio).
+
+[`ComboboxItem`](https://ariakit.com/reference/combobox-item) and [`SelectItem`](https://ariakit.com/reference/select-item) are affected only when the composite opts out of [`virtualFocus`](https://ariakit.com/reference/composite-provider#virtualfocus), which they enable by default, since virtual focus keeps DOM focus on the composite element rather than the item. [`Tab`](https://ariakit.com/reference/tab) is unaffected, since it already keeps disabled tabs focusable by default. To opt out and keep the previous behavior, set [`accessibleWhenDisabled`](https://ariakit.com/reference/focusable#accessiblewhendisabled) to `false`.

--- a/app/src/sandbox/composite-item-disabled-active/index.react.tsx
+++ b/app/src/sandbox/composite-item-disabled-active/index.react.tsx
@@ -1,15 +1,47 @@
 import * as Ariakit from "@ariakit/react";
 import { useId, useState } from "react";
 
+// TODO: Remove this workaround once
+// https://github.com/ariakit/ariakit/issues/7359 is fixed. Keeping the item
+// accessible while it holds DOM focus stops the native `disabled` attribute
+// from moving focus to the body. It is deliberately not applied to the virtual
+// focus, opt out, and initially disabled sections, which must keep their
+// current behavior.
+function SelfDisablingItem(props: Ariakit.CompositeItemProps) {
+  const [focused, setFocused] = useState(false);
+  return (
+    <Ariakit.CompositeItem
+      {...props}
+      accessibleWhenDisabled={focused}
+      onFocus={(event) => {
+        props.onFocus?.(event);
+        setFocused(true);
+      }}
+      onBlur={(event) => {
+        props.onBlur?.(event);
+        const { currentTarget } = event;
+        // Firefox fires focusout when the window loses focus while the element
+        // still holds DOM focus. Releasing the workaround then would apply the
+        // native attribute to the focused element and drop focus to the body
+        // once the window comes back.
+        if (currentTarget.contains(currentTarget.ownerDocument.activeElement)) {
+          return;
+        }
+        setFocused(false);
+      }}
+    />
+  );
+}
+
 function RovingComposite() {
   const [read, setRead] = useState(false);
   return (
     <Ariakit.CompositeProvider>
       <Ariakit.Composite role="toolbar" aria-label="Roving message actions">
         <Ariakit.CompositeItem>Roving reply</Ariakit.CompositeItem>
-        <Ariakit.CompositeItem disabled={read} onClick={() => setRead(true)}>
+        <SelfDisablingItem disabled={read} onClick={() => setRead(true)}>
           Roving mark as read
-        </Ariakit.CompositeItem>
+        </SelfDisablingItem>
         <Ariakit.CompositeItem>Roving archive</Ariakit.CompositeItem>
       </Ariakit.Composite>
     </Ariakit.CompositeProvider>
@@ -38,9 +70,9 @@ function ControlledComposite() {
     <Ariakit.CompositeProvider activeId={activeId} setActiveId={setActiveId}>
       <Ariakit.Composite role="toolbar" aria-label="Controlled message actions">
         <Ariakit.CompositeItem>Controlled reply</Ariakit.CompositeItem>
-        <Ariakit.CompositeItem disabled={read} onClick={() => setRead(true)}>
+        <SelfDisablingItem disabled={read} onClick={() => setRead(true)}>
           Controlled mark as read
-        </Ariakit.CompositeItem>
+        </SelfDisablingItem>
         <Ariakit.CompositeItem>Controlled archive</Ariakit.CompositeItem>
       </Ariakit.Composite>
     </Ariakit.CompositeProvider>
@@ -53,7 +85,7 @@ function NativeControlComposite() {
     <Ariakit.CompositeProvider>
       <Ariakit.Composite role="toolbar" aria-label="Native message actions">
         <Ariakit.CompositeItem>Native reply</Ariakit.CompositeItem>
-        <Ariakit.CompositeItem
+        <SelfDisablingItem
           render={<input type="checkbox" />}
           aria-label="Native mark as read"
           disabled={locked}

--- a/app/src/sandbox/composite-item-disabled-active/index.react.tsx
+++ b/app/src/sandbox/composite-item-disabled-active/index.react.tsx
@@ -1,0 +1,131 @@
+import * as Ariakit from "@ariakit/react";
+import { useId, useState } from "react";
+
+function RovingComposite() {
+  const [read, setRead] = useState(false);
+  return (
+    <Ariakit.CompositeProvider>
+      <Ariakit.Composite role="toolbar" aria-label="Roving message actions">
+        <Ariakit.CompositeItem>Roving reply</Ariakit.CompositeItem>
+        <Ariakit.CompositeItem disabled={read} onClick={() => setRead(true)}>
+          Roving mark as read
+        </Ariakit.CompositeItem>
+        <Ariakit.CompositeItem>Roving archive</Ariakit.CompositeItem>
+      </Ariakit.Composite>
+    </Ariakit.CompositeProvider>
+  );
+}
+
+function VirtualFocusComposite() {
+  const [read, setRead] = useState(false);
+  return (
+    <Ariakit.CompositeProvider virtualFocus>
+      <Ariakit.Composite role="toolbar" aria-label="Virtual message actions">
+        <Ariakit.CompositeItem>Virtual reply</Ariakit.CompositeItem>
+        <Ariakit.CompositeItem disabled={read} onClick={() => setRead(true)}>
+          Virtual mark as read
+        </Ariakit.CompositeItem>
+        <Ariakit.CompositeItem>Virtual archive</Ariakit.CompositeItem>
+      </Ariakit.Composite>
+    </Ariakit.CompositeProvider>
+  );
+}
+
+function ControlledComposite() {
+  const [activeId, setActiveId] = useState<string | null | undefined>();
+  const [read, setRead] = useState(false);
+  return (
+    <Ariakit.CompositeProvider activeId={activeId} setActiveId={setActiveId}>
+      <Ariakit.Composite role="toolbar" aria-label="Controlled message actions">
+        <Ariakit.CompositeItem>Controlled reply</Ariakit.CompositeItem>
+        <Ariakit.CompositeItem disabled={read} onClick={() => setRead(true)}>
+          Controlled mark as read
+        </Ariakit.CompositeItem>
+        <Ariakit.CompositeItem>Controlled archive</Ariakit.CompositeItem>
+      </Ariakit.Composite>
+    </Ariakit.CompositeProvider>
+  );
+}
+
+function NativeControlComposite() {
+  const [locked, setLocked] = useState(false);
+  return (
+    <Ariakit.CompositeProvider>
+      <Ariakit.Composite role="toolbar" aria-label="Native message actions">
+        <Ariakit.CompositeItem>Native reply</Ariakit.CompositeItem>
+        <Ariakit.CompositeItem
+          render={<input type="checkbox" />}
+          aria-label="Native mark as read"
+          disabled={locked}
+          onChange={() => setLocked(true)}
+        />
+        <Ariakit.CompositeItem>Native archive</Ariakit.CompositeItem>
+      </Ariakit.Composite>
+    </Ariakit.CompositeProvider>
+  );
+}
+
+// An explicit `accessibleWhenDisabled={false}` opts out of keeping the item
+// reachable, so this item becomes natively disabled even while it holds focus.
+function OptOutComposite() {
+  const [read, setRead] = useState(false);
+  return (
+    <>
+      <button type="button" tabIndex={0}>
+        Before opt out
+      </button>
+      <Ariakit.CompositeProvider>
+        <Ariakit.Composite role="toolbar" aria-label="Opt out message actions">
+          <Ariakit.CompositeItem>Opt out reply</Ariakit.CompositeItem>
+          <Ariakit.CompositeItem
+            disabled={read}
+            accessibleWhenDisabled={false}
+            onClick={() => setRead(true)}
+          >
+            Opt out mark as read
+          </Ariakit.CompositeItem>
+          <Ariakit.CompositeItem>Opt out archive</Ariakit.CompositeItem>
+        </Ariakit.Composite>
+      </Ariakit.CompositeProvider>
+    </>
+  );
+}
+
+// The active item is disabled before it ever receives focus, so the composite
+// must keep skipping it. https://github.com/ariakit/ariakit/issues/3232
+function InitiallyDisabledComposite() {
+  const disabledId = useId();
+  return (
+    <>
+      <button type="button" tabIndex={0}>
+        Before initially disabled
+      </button>
+      <Ariakit.CompositeProvider defaultActiveId={disabledId}>
+        <Ariakit.Composite role="toolbar" aria-label="Initially disabled">
+          <Ariakit.CompositeItem id={disabledId} disabled>
+            Initially disabled reply
+          </Ariakit.CompositeItem>
+          <Ariakit.CompositeItem>
+            Initially disabled archive
+          </Ariakit.CompositeItem>
+        </Ariakit.Composite>
+      </Ariakit.CompositeProvider>
+      <button type="button" tabIndex={0}>
+        After initially disabled
+      </button>
+    </>
+  );
+}
+
+export default function Example() {
+  return (
+    <main>
+      <RovingComposite />
+      <VirtualFocusComposite />
+      <ControlledComposite />
+      <NativeControlComposite />
+      <OptOutComposite />
+      <InitiallyDisabledComposite />
+    </main>
+  );
+}

--- a/app/src/sandbox/composite-item-disabled-active/index.react.tsx
+++ b/app/src/sandbox/composite-item-disabled-active/index.react.tsx
@@ -1,47 +1,15 @@
 import * as Ariakit from "@ariakit/react";
 import { useId, useState } from "react";
 
-// TODO: Remove this workaround once
-// https://github.com/ariakit/ariakit/issues/7359 is fixed. Keeping the item
-// accessible while it holds DOM focus stops the native `disabled` attribute
-// from moving focus to the body. It is deliberately not applied to the virtual
-// focus, opt out, and initially disabled sections, which must keep their
-// current behavior.
-function SelfDisablingItem(props: Ariakit.CompositeItemProps) {
-  const [focused, setFocused] = useState(false);
-  return (
-    <Ariakit.CompositeItem
-      {...props}
-      accessibleWhenDisabled={focused}
-      onFocus={(event) => {
-        props.onFocus?.(event);
-        setFocused(true);
-      }}
-      onBlur={(event) => {
-        props.onBlur?.(event);
-        const { currentTarget } = event;
-        // Firefox fires focusout when the window loses focus while the element
-        // still holds DOM focus. Releasing the workaround then would apply the
-        // native attribute to the focused element and drop focus to the body
-        // once the window comes back.
-        if (currentTarget.contains(currentTarget.ownerDocument.activeElement)) {
-          return;
-        }
-        setFocused(false);
-      }}
-    />
-  );
-}
-
 function RovingComposite() {
   const [read, setRead] = useState(false);
   return (
     <Ariakit.CompositeProvider>
       <Ariakit.Composite role="toolbar" aria-label="Roving message actions">
         <Ariakit.CompositeItem>Roving reply</Ariakit.CompositeItem>
-        <SelfDisablingItem disabled={read} onClick={() => setRead(true)}>
+        <Ariakit.CompositeItem disabled={read} onClick={() => setRead(true)}>
           Roving mark as read
-        </SelfDisablingItem>
+        </Ariakit.CompositeItem>
         <Ariakit.CompositeItem>Roving archive</Ariakit.CompositeItem>
       </Ariakit.Composite>
     </Ariakit.CompositeProvider>
@@ -70,9 +38,9 @@ function ControlledComposite() {
     <Ariakit.CompositeProvider activeId={activeId} setActiveId={setActiveId}>
       <Ariakit.Composite role="toolbar" aria-label="Controlled message actions">
         <Ariakit.CompositeItem>Controlled reply</Ariakit.CompositeItem>
-        <SelfDisablingItem disabled={read} onClick={() => setRead(true)}>
+        <Ariakit.CompositeItem disabled={read} onClick={() => setRead(true)}>
           Controlled mark as read
-        </SelfDisablingItem>
+        </Ariakit.CompositeItem>
         <Ariakit.CompositeItem>Controlled archive</Ariakit.CompositeItem>
       </Ariakit.Composite>
     </Ariakit.CompositeProvider>
@@ -85,13 +53,61 @@ function NativeControlComposite() {
     <Ariakit.CompositeProvider>
       <Ariakit.Composite role="toolbar" aria-label="Native message actions">
         <Ariakit.CompositeItem>Native reply</Ariakit.CompositeItem>
-        <SelfDisablingItem
+        <Ariakit.CompositeItem
           render={<input type="checkbox" />}
           aria-label="Native mark as read"
           disabled={locked}
           onChange={() => setLocked(true)}
         />
         <Ariakit.CompositeItem>Native archive</Ariakit.CompositeItem>
+      </Ariakit.Composite>
+    </Ariakit.CompositeProvider>
+  );
+}
+
+// An item that is not natively focusable loses its `tabindex` instead of
+// gaining the native `disabled` attribute, which drops focus the same way. This
+// is the shape components like MenuItem and ComboboxItem render.
+function NonNativeComposite() {
+  const [read, setRead] = useState(false);
+  return (
+    <Ariakit.CompositeProvider>
+      <Ariakit.Composite role="toolbar" aria-label="Non-native message actions">
+        <Ariakit.CompositeItem render={<div />} role="button">
+          Non-native reply
+        </Ariakit.CompositeItem>
+        <Ariakit.CompositeItem
+          render={<div />}
+          role="button"
+          disabled={read}
+          onClick={() => setRead(true)}
+        >
+          Non-native mark as read
+        </Ariakit.CompositeItem>
+        <Ariakit.CompositeItem render={<div />} role="button">
+          Non-native archive
+        </Ariakit.CompositeItem>
+      </Ariakit.Composite>
+    </Ariakit.CompositeProvider>
+  );
+}
+
+// A composing Focusable can supply `accessibleWhenDisabled` through context, so
+// the item must not resolve the option to `false` on its own and block it.
+function InheritedComposite() {
+  return (
+    <Ariakit.CompositeProvider>
+      <Ariakit.Composite role="toolbar" aria-label="Inherited message actions">
+        <Ariakit.CompositeItem>Inherited reply</Ariakit.CompositeItem>
+        <Ariakit.Focusable
+          accessibleWhenDisabled
+          render={
+            <Ariakit.CompositeItem disabled>
+              Inherited mark as read
+            </Ariakit.CompositeItem>
+          }
+        />
+        <Ariakit.CompositeItem>Inherited archive</Ariakit.CompositeItem>
       </Ariakit.Composite>
     </Ariakit.CompositeProvider>
   );
@@ -156,6 +172,8 @@ export default function Example() {
       <VirtualFocusComposite />
       <ControlledComposite />
       <NativeControlComposite />
+      <NonNativeComposite />
+      <InheritedComposite />
       <OptOutComposite />
       <InitiallyDisabledComposite />
     </main>

--- a/app/src/sandbox/composite-item-disabled-active/test-browser.ts
+++ b/app/src/sandbox/composite-item-disabled-active/test-browser.ts
@@ -127,6 +127,36 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.button("Native archive")).toBeFocused();
   });
 
+  // An item that is not natively focusable keeps its focus through the item's
+  // `tabindex` rather than through the absence of a native `disabled`
+  // attribute, so it loses focus by a different mechanism.
+  // https://github.com/ariakit/ariakit/issues/7359
+  test("keeps roving focus on a non-native item that disables itself", async ({
+    page,
+    q,
+  }) => {
+    const markAsRead = q.button("Non-native mark as read");
+    const archive = q.button("Non-native archive");
+
+    await q.button("Non-native reply").click();
+    await page.keyboard.press("ArrowRight");
+    await test.expect(markAsRead).toBeFocused();
+
+    await page.keyboard.press("Enter");
+    await test.expect(markAsRead).toHaveAttribute("aria-disabled", "true");
+    // Same engine blur frame as the roving test above, crossed because focus
+    // here is state that must not change.
+    await flushFrames(page);
+    await test.expect(markAsRead).toBeFocused();
+    await test.expect(markAsRead).toHaveAttribute("tabindex", "0");
+
+    await page.keyboard.press("ArrowRight");
+    await test.expect(archive).toBeFocused();
+
+    // Once the item no longer holds focus, it drops out of the focus order.
+    await test.expect(markAsRead).not.toHaveAttribute("tabindex");
+  });
+
   // https://github.com/ariakit/ariakit/issues/7359
   test("honors an explicit accessibleWhenDisabled opt out", async ({
     page,

--- a/app/src/sandbox/composite-item-disabled-active/test-browser.ts
+++ b/app/src/sandbox/composite-item-disabled-active/test-browser.ts
@@ -1,0 +1,171 @@
+import { flushFrames, withFramework } from "#app/test-utils/preview.ts";
+
+// The native `disabled` attribute decides whether the browser keeps DOM focus
+// on the element, and the engines disagree about when they run that blur, so
+// this runs in every desktop project. The native checkbox below is also a
+// native form control.
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/7359
+  test("keeps roving focus on the item that disables itself", async ({
+    page,
+    q,
+  }) => {
+    const reply = q.button("Roving reply");
+    const markAsRead = q.button("Roving mark as read");
+    const archive = q.button("Roving archive");
+
+    await reply.click();
+    await page.keyboard.press("ArrowRight");
+    await test.expect(markAsRead).toBeFocused();
+
+    await page.keyboard.press("Enter");
+    // The commit that reacts to the click resolves aria-disabled and the
+    // native disabled decision together, so aria-disabled gates on that commit
+    // in both the broken and the fixed shapes.
+    await test.expect(markAsRead).toHaveAttribute("aria-disabled", "true");
+    // The blur that a native disabled attribute triggers runs on the engine's
+    // own task and no state tracks it, so cross that frame before asserting
+    // focus, which must not change here.
+    await flushFrames(page);
+    await test.expect(markAsRead).toBeFocused();
+    // Focusable derives the native attribute, data-truly-disabled and the
+    // pointer-events style from one `trulyDisabled` value, and Hovercard reads
+    // data-truly-disabled to decide whether a tooltip may open. An item that
+    // holds focus is reachable, so all three must follow together rather than
+    // leaving it marked unreachable.
+    await test.expect(markAsRead).not.toHaveAttribute("disabled");
+    await test.expect(markAsRead).not.toHaveAttribute("data-truly-disabled");
+    await test.expect(markAsRead).not.toHaveCSS("pointer-events", "none");
+
+    await page.keyboard.press("ArrowRight");
+    await test.expect(archive).toBeFocused();
+
+    // Once the item no longer holds focus, it goes back to being skipped.
+    await test.expect(markAsRead).toHaveAttribute("disabled");
+    await page.keyboard.press("ArrowLeft");
+    await test.expect(reply).toBeFocused();
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7359
+  test("keeps virtual focus on the item that disables itself", async ({
+    page,
+    q,
+  }) => {
+    const composite = q.toolbar("Virtual message actions");
+    const markAsRead = q.button("Virtual mark as read");
+
+    await q.button("Virtual reply").click();
+    await page.keyboard.press("ArrowRight");
+    await test.expect(markAsRead).toHaveAttribute("data-active-item");
+
+    await page.keyboard.press("Enter");
+    // Virtual focus never puts DOM focus on the item, so it must stay natively
+    // disabled and keep being skipped.
+    await test.expect(markAsRead).toHaveAttribute("disabled");
+    await test.expect(markAsRead).toHaveAttribute("aria-disabled", "true");
+    // The composite keeps DOM focus here, so cross the engine's blur frame
+    // before asserting that nothing moved it.
+    await flushFrames(page);
+    await test.expect(composite).toBeFocused();
+
+    await page.keyboard.press("ArrowRight");
+    await test
+      .expect(q.button("Virtual archive"))
+      .toHaveAttribute("data-active-item");
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7359
+  test("keeps focus on a controlled active item that disables itself", async ({
+    page,
+    q,
+  }) => {
+    const markAsRead = q.button("Controlled mark as read");
+
+    await q.button("Controlled reply").click();
+    await page.keyboard.press("ArrowRight");
+    await test.expect(markAsRead).toBeFocused();
+
+    await page.keyboard.press("Enter");
+    await test.expect(markAsRead).toHaveAttribute("aria-disabled", "true");
+    // Same engine blur frame as the roving test above, crossed because focus
+    // here is state that must not change.
+    await flushFrames(page);
+    await test.expect(markAsRead).toBeFocused();
+    await test.expect(markAsRead).toHaveAttribute("data-active-item");
+
+    await page.keyboard.press("ArrowRight");
+    await test.expect(q.button("Controlled archive")).toBeFocused();
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7359
+  test("keeps focus on a native control that disables itself", async ({
+    page,
+    q,
+  }) => {
+    const markAsRead = q.checkbox("Native mark as read");
+
+    await q.button("Native reply").click();
+    await page.keyboard.press("ArrowRight");
+    await test.expect(markAsRead).toBeFocused();
+
+    await page.keyboard.press("Space");
+    await test.expect(markAsRead).toBeChecked();
+    await test.expect(markAsRead).toHaveAttribute("aria-disabled", "true");
+    // Same engine blur frame as the roving test above, crossed because focus
+    // here is state that must not change. A native checkbox is disabled the
+    // same way a button is.
+    await flushFrames(page);
+    await test.expect(markAsRead).toBeFocused();
+
+    // The item stays focusable, but it must not activate anymore. The native
+    // checkbox toggles synchronously with the key event, so no later state
+    // could still flip it.
+    await page.keyboard.press("Space");
+    await test.expect(markAsRead).toBeChecked();
+
+    await page.keyboard.press("ArrowRight");
+    await test.expect(q.button("Native archive")).toBeFocused();
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7359
+  test("honors an explicit accessibleWhenDisabled opt out", async ({
+    page,
+    q,
+  }) => {
+    const reply = q.button("Opt out reply");
+    const markAsRead = q.button("Opt out mark as read");
+
+    await reply.click();
+    await page.keyboard.press("ArrowRight");
+    await test.expect(markAsRead).toBeFocused();
+
+    await page.keyboard.press("Enter");
+    await test.expect(markAsRead).toHaveAttribute("disabled");
+    await test.expect(markAsRead).not.toBeFocused();
+
+    // The opt out accepts the focus loss, so the composite must stay reachable
+    // while activeId still points at the disabled item.
+    await test.expect(markAsRead).toHaveAttribute("data-active-item");
+    await q.button("Before opt out").click();
+    await page.keyboard.press("Tab");
+    await test.expect(reply).toBeFocused();
+  });
+
+  // Guards the fix above against regressing the composite entry behavior at the
+  // Composite layer. https://github.com/ariakit/ariakit/issues/3232 also covers
+  // this through Toolbar in app/src/sandbox/toolbar-keyboard-navigation.
+  test("skips an active item that is disabled before it receives focus", async ({
+    page,
+    q,
+  }) => {
+    await q.button("Before initially disabled").click();
+    await page.keyboard.press("Tab");
+    await test.expect(q.button("Initially disabled archive")).toBeFocused();
+    await test
+      .expect(q.button("Initially disabled reply"))
+      .toHaveAttribute("disabled");
+
+    await page.keyboard.press("Tab");
+    await test.expect(q.button("After initially disabled")).toBeFocused();
+  });
+});

--- a/app/src/sandbox/composite-item-disabled-active/test-firefox.ts
+++ b/app/src/sandbox/composite-item-disabled-active/test-firefox.ts
@@ -1,0 +1,48 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+// Firefox is the only desktop engine that fires focusout when the window loses
+// focus while the element still holds DOM focus. Releasing the item then would
+// apply the native disabled attribute to the focused element and drop focus to
+// the body once the window comes back.
+withFramework(import.meta.dirname, async ({ test }) => {
+  // https://github.com/ariakit/ariakit/issues/7359
+  test("keeps the item accessible across a window focus change", async ({
+    context,
+    page,
+    q,
+  }) => {
+    const markAsRead = q.button("Roving mark as read");
+
+    await q.button("Roving reply").click();
+    await page.keyboard.press("ArrowRight");
+    await page.keyboard.press("Enter");
+    await test.expect(markAsRead).toHaveAttribute("aria-disabled", "true");
+    await test.expect(markAsRead).toBeFocused();
+
+    // Take window focus away with a real popup, then give it back.
+    const [popup] = await Promise.all([
+      context.waitForEvent("page"),
+      page.evaluate(() => {
+        window.open("about:blank", "_blank", "width=200,height=200");
+      }),
+    ]);
+    await popup.bringToFront();
+    // The popup has to actually take window focus before it is closed,
+    // otherwise the page never loses it and the focusout below never fires.
+    // Nothing on the page tracks the window's focus, so no assertion can carry
+    // either of these waits.
+    await page.waitForTimeout(500);
+    await popup.close();
+    await page.bringToFront();
+    // Firefox delivers the window focusout only once the page is fronted
+    // again, and the release it would trigger commits on the following render.
+    await page.waitForTimeout(500);
+
+    await test.expect(markAsRead).not.toHaveAttribute("disabled");
+    await test.expect(markAsRead).toBeFocused();
+
+    // Arrow navigation still works, which is the behavior the user would lose.
+    await page.keyboard.press("ArrowRight");
+    await test.expect(q.button("Roving archive")).toBeFocused();
+  });
+});

--- a/app/src/sandbox/composite-item-disabled-active/test.ts
+++ b/app/src/sandbox/composite-item-disabled-active/test.ts
@@ -86,6 +86,45 @@ test("keeps focus on a native control that disables itself", async () => {
   expect(q.button("Native archive")).toHaveFocus();
 });
 
+// An item that is not natively focusable loses its `tabindex` rather than
+// gaining the native `disabled` attribute, so it drops out of the focus order
+// by a different mechanism.
+// https://github.com/ariakit/ariakit/issues/7359
+test("keeps roving focus on a non-native item that disables itself", async () => {
+  const markAsRead = q.button("Non-native mark as read");
+  const archive = q.button("Non-native archive");
+
+  await click(q.button("Non-native reply"));
+  await press.ArrowRight();
+  expect(markAsRead).toHaveFocus();
+
+  await press.Enter();
+  expect(markAsRead).toHaveFocus();
+  expect(markAsRead).toHaveAttribute("aria-disabled", "true");
+  expect(markAsRead).toHaveAttribute("tabindex", "0");
+
+  await press.ArrowRight();
+  expect(archive).toHaveFocus();
+
+  // Once the item no longer holds focus, it drops out of the focus order.
+  expect(markAsRead).not.toHaveAttribute("tabindex");
+});
+
+// The item derives the option only when it is disabled and focused, and falls
+// back to undefined rather than false so a composing Focusable can still supply
+// it through context.
+// https://github.com/ariakit/ariakit/issues/7359
+test("keeps an inherited accessibleWhenDisabled working", async () => {
+  const markAsRead = q.button("Inherited mark as read");
+
+  // The item is never focused here, so the derivation contributes nothing and
+  // the inherited value is the only thing that can keep it out of the native
+  // disabled state. Arrow navigation still skips it, because the collection is
+  // registered from the raw prop: https://github.com/ariakit/ariakit/issues/7364
+  expect(markAsRead).toHaveAttribute("aria-disabled", "true");
+  expect(markAsRead).not.toBeDisabled();
+});
+
 // https://github.com/ariakit/ariakit/issues/7359
 test("honors an explicit accessibleWhenDisabled opt out", async () => {
   const reply = q.button("Opt out reply");

--- a/app/src/sandbox/composite-item-disabled-active/test.ts
+++ b/app/src/sandbox/composite-item-disabled-active/test.ts
@@ -1,0 +1,120 @@
+import { click, press, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// happy-dom keeps DOM focus on a natively disabled element, so these duplicates
+// pin the navigation break rather than the focus loss: `press` refuses to
+// dispatch keys on a disabled control, the same way browsers do. Focus
+// retention through the transition is covered by the browser test.
+
+// https://github.com/ariakit/ariakit/issues/7359
+test("keeps roving focus on the item that disables itself", async () => {
+  const reply = q.button("Roving reply");
+  const markAsRead = q.button("Roving mark as read");
+  const archive = q.button("Roving archive");
+
+  await click(reply);
+  await press.ArrowRight();
+  expect(markAsRead).toHaveFocus();
+
+  await press.Enter();
+  expect(markAsRead).toHaveFocus();
+  expect(markAsRead).toHaveAttribute("aria-disabled", "true");
+
+  await press.ArrowRight();
+  expect(archive).toHaveFocus();
+
+  // Once the item no longer holds focus, it goes back to being skipped.
+  expect(markAsRead).toBeDisabled();
+  await press.ArrowLeft();
+  expect(reply).toHaveFocus();
+});
+
+// https://github.com/ariakit/ariakit/issues/7359
+test("keeps virtual focus on the item that disables itself", async () => {
+  const composite = q.toolbar("Virtual message actions");
+  const markAsRead = q.button("Virtual mark as read");
+
+  await click(q.button("Virtual reply"));
+  await press.ArrowRight();
+  expect(markAsRead).toHaveAttribute("data-active-item");
+
+  await press.Enter();
+  expect(composite).toHaveFocus();
+  // Virtual focus never puts DOM focus on the item, so it must stay natively
+  // disabled and keep being skipped.
+  expect(markAsRead).toBeDisabled();
+  expect(markAsRead).toHaveAttribute("aria-disabled", "true");
+
+  await press.ArrowRight();
+  expect(q.button("Virtual archive")).toHaveAttribute("data-active-item");
+});
+
+// https://github.com/ariakit/ariakit/issues/7359
+test("keeps focus on a controlled active item that disables itself", async () => {
+  const markAsRead = q.button("Controlled mark as read");
+
+  await click(q.button("Controlled reply"));
+  await press.ArrowRight();
+  expect(markAsRead).toHaveFocus();
+
+  await press.Enter();
+  expect(markAsRead).toHaveFocus();
+  expect(markAsRead).toHaveAttribute("data-active-item");
+
+  await press.ArrowRight();
+  expect(q.button("Controlled archive")).toHaveFocus();
+});
+
+// https://github.com/ariakit/ariakit/issues/7359
+test("keeps focus on a native control that disables itself", async () => {
+  const markAsRead = q.checkbox("Native mark as read");
+
+  await click(q.button("Native reply"));
+  await press.ArrowRight();
+  expect(markAsRead).toHaveFocus();
+
+  await press.Space();
+  expect(markAsRead).toBeChecked();
+  expect(markAsRead).toHaveFocus();
+  expect(markAsRead).toHaveAttribute("aria-disabled", "true");
+
+  // The item stays focusable, but it must not activate anymore.
+  await press.Space();
+  expect(markAsRead).toBeChecked();
+
+  await press.ArrowRight();
+  expect(q.button("Native archive")).toHaveFocus();
+});
+
+// https://github.com/ariakit/ariakit/issues/7359
+test("honors an explicit accessibleWhenDisabled opt out", async () => {
+  const reply = q.button("Opt out reply");
+  const markAsRead = q.button("Opt out mark as read");
+
+  await click(reply);
+  await press.ArrowRight();
+  expect(markAsRead).toHaveFocus();
+
+  await press.Enter();
+  expect(markAsRead).toBeDisabled();
+
+  // The opt out accepts the focus loss, so the composite must stay reachable
+  // while activeId still points at the disabled item.
+  expect(markAsRead).toHaveAttribute("data-active-item");
+  await click(q.button("Before opt out"));
+  await press.Tab();
+  expect(reply).toHaveFocus();
+});
+
+// Guards the fix above against regressing the composite entry behavior at the
+// Composite layer. https://github.com/ariakit/ariakit/issues/3232 also covers
+// this through Toolbar in app/src/sandbox/toolbar-keyboard-navigation.
+test("skips an active item that is disabled before it receives focus", async () => {
+  await click(q.button("Before initially disabled"));
+  await press.Tab();
+  expect(q.button("Initially disabled archive")).toHaveFocus();
+  expect(q.button("Initially disabled reply")).toBeDisabled();
+
+  await press.Tab();
+  expect(q.button("After initially disabled")).toHaveFocus();
+});

--- a/packages/ariakit-react-components/src/composite/composite-item.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-item.tsx
@@ -33,7 +33,7 @@ import type {
   KeyboardEvent,
   SyntheticEvent,
 } from "react";
-import { useCallback, useContext, useMemo, useRef } from "react";
+import { useCallback, useContext, useMemo, useRef, useState } from "react";
 import { withDefaultButtonType } from "../button/utils.ts";
 import type { CollectionItemOptions } from "../collection/collection-item.tsx";
 import { useCollectionItem } from "../collection/collection-item.tsx";
@@ -177,7 +177,17 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
     }, []);
     const row = useContext(CompositeRowContext);
     const disabled = disabledFromProps(props);
-    const trulyDisabled = disabled && !props.accessibleWhenDisabled;
+    // Marking a focused item truly disabled removes it from the focus order,
+    // through the native `disabled` attribute on a button or input and through
+    // the `tabindex` on anything else, and the browser then moves focus to the
+    // body, which stops arrow keys from reaching the composite. Keep the item
+    // accessible while it holds focus, and let it become truly disabled once
+    // focus moves away. An explicit `accessibleWhenDisabled={false}` opts out.
+    // https://github.com/ariakit/ariakit/issues/7359
+    const [focused, setFocused] = useState(false);
+    const accessibleWhenDisabled =
+      props.accessibleWhenDisabled ?? (disabled && focused ? true : undefined);
+    const trulyDisabled = disabled && !accessibleWhenDisabled;
     // Snapshot before the props object is replaced below (useCollectionItem
     // consumes this prop), so the onFocus handler can read it at event time.
     const shouldRegisterItem = props.shouldRegisterItem;
@@ -314,15 +324,23 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
       // When using aria-activedescendant, we want to make sure that the
       // composite container receives focus, not the composite item.
       if (!virtualFocus) {
-        // DOM focus moved with preventScroll, so a marked item still needs the
-        // widget's presentation even without the virtual-focus handoff below.
-        if (isSelfTarget(event) && store.item(id)) {
-          present({
-            id,
-            markedOnly: true,
-            requireFocus: true,
-            scrollIntoView,
-          });
+        if (isSelfTarget(event)) {
+          // Only roving focus leaves DOM focus on the item itself. With virtual
+          // focus the composite element holds it, so the item never needs to
+          // stay accessible while disabled.
+          // https://github.com/ariakit/ariakit/issues/7359
+          setFocused(true);
+          // DOM focus moved with preventScroll, so a marked item still needs
+          // the widget's presentation even without the virtual-focus handoff
+          // below.
+          if (store.item(id)) {
+            present({
+              id,
+              markedOnly: true,
+              requireFocus: true,
+              scrollIntoView,
+            });
+          }
         }
         return;
       }
@@ -418,6 +436,19 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
         if (!state.virtualFocus) return;
         redirectFocusToCompositeElement(relatedTarget, nextCompositeElement);
       });
+    });
+
+    const onBlurProp = props.onBlur;
+
+    const onBlur = useEvent((event: FocusEvent<HTMLType>) => {
+      onBlurProp?.(event);
+      // Firefox fires focusout when the window loses focus, while the element
+      // still holds DOM focus. Releasing the item then would apply the native
+      // attribute to the focused element and drop focus to the body once the
+      // window comes back.
+      // https://github.com/ariakit/ariakit/issues/7359
+      if (getActiveElement(event.currentTarget) === event.currentTarget) return;
+      setFocused(false);
     });
 
     const onBlurCaptureProp = props.onBlurCapture;
@@ -534,7 +565,9 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
       id,
       ref: useMergeRefs(ref, markUnmountingRef, props.ref),
       tabIndex: isTabbable ? props.tabIndex : -1,
+      accessibleWhenDisabled,
       onFocus,
+      onBlur,
       onBlurCapture,
       onKeyDown,
     };
@@ -597,6 +630,26 @@ export interface CompositeItemOptions<T extends ElementType = TagName>
    * components' context will be used.
    */
   store?: CompositeStore;
+  /**
+   * Indicates whether the item should be focusable even when it is
+   * [`disabled`](https://ariakit.com/reference/focusable#disabled). See
+   * [`accessibleWhenDisabled`](https://ariakit.com/reference/focusable#accessiblewhendisabled)
+   * for why this matters for discoverability.
+   *
+   * An item that becomes disabled while it holds focus behaves as if this prop
+   * were enabled, until focus moves elsewhere. This keeps focus on the item
+   * instead of letting it fall back to the body, which would stop arrow keys
+   * from reaching the composite widget. Set this prop to `false` to opt out.
+   *
+   * Learn more on [Focusability of disabled
+   * controls](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#focusabilityofdisabledcontrols).
+   *
+   * Live examples:
+   * - [Combobox with Tabs](https://ariakit.com/examples/combobox-tabs)
+   * - [Command Menu with
+   *   Tabs](https://ariakit.com/examples/dialog-combobox-tab-command-menu)
+   */
+  accessibleWhenDisabled?: CommandOptions<T>["accessibleWhenDisabled"];
   /**
    * Determines how the item is scrolled into view when it's presented.
    * @private

--- a/packages/ariakit-react-components/src/tab/tab.tsx
+++ b/packages/ariakit-react-components/src/tab/tab.tsx
@@ -205,6 +205,17 @@ export interface TabOptions<
    */
   store?: TabStore;
   /**
+   * Indicates whether the tab should be focusable even when it is
+   * [`disabled`](https://ariakit.com/reference/focusable#disabled). A disabled
+   * tab stays focusable by default, and a selected tab always does.
+   *
+   * Learn more on [Focusability of disabled
+   * controls](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#focusabilityofdisabledcontrols).
+   *
+   * Live examples:
+   * - [Combobox with Tabs](https://ariakit.com/examples/combobox-tabs)
+   * - [Command Menu with
+   *   Tabs](https://ariakit.com/examples/dialog-combobox-tab-command-menu)
    * @default true
    */
   accessibleWhenDisabled?: CompositeItemOptions["accessibleWhenDisabled"];


### PR DESCRIPTION
## Motivation

When a focused [`CompositeItem`](https://ariakit.com/reference/composite-item) becomes disabled, it is removed from the focus order right away: through the native `disabled` attribute when it renders a button or input, and through its `tabindex` when it renders anything else. The browser then moves focus to `document.body`, while the composite store still points [`activeId`](https://ariakit.com/reference/composite-provider#activeid) at that item. Arrow keys no longer reach the composite, so keyboard navigation stops until the user presses Tab to get back in.

This is the essential trigger, an item that disables itself while it has focus:

```jsx
<Ariakit.CompositeItem
  disabled={disabled}
  onClick={() => setDisabled(true)}
>
  Disable me
</Ariakit.CompositeItem>
```

Fixes #7359.

## Solution

This pull request lands in stages so CI records the failing reproduction first.

The first commit adds the `composite-item-disabled-active` sandbox with Playwright and happy-dom coverage. Three tests fail on `main`: roving focus, a controlled [`activeId`](https://ariakit.com/reference/composite-provider#activeid), and a native form control. Three more are guards that must stay green: virtual focus, an explicit `accessibleWhenDisabled={false}` opt out, and an active item that is disabled before it ever receives focus (#3232). The final commit adds two more: one for an item that is not natively focusable and therefore loses its `tabindex` rather than gaining the native attribute, and one happy-dom test pinning that the option stays inheritable from a composing [`Focusable`](https://ariakit.com/reference/focusable).

The final commit keeps a composite item accessible while it holds DOM focus, so the native `disabled` attribute is only applied once focus has moved elsewhere. The item stays exposed as disabled through `aria-disabled` and still refuses to activate.

`useCompositeItem` now tracks whether the item holds DOM focus and derives the option from it:

```ts
const accessibleWhenDisabled =
  props.accessibleWhenDisabled ?? (disabled && focused ? true : undefined);
```

Keying on DOM focus rather than on the active item is what preserves #3232: an item that is the active item but was never focused stays natively disabled and keeps being skipped. Falling back to `undefined` rather than `false` keeps the option inheritable from a composing [`Focusable`](https://ariakit.com/reference/focusable), and an explicit `accessibleWhenDisabled={false}` still wins.

The flag is set only under roving focus, since [`virtualFocus`](https://ariakit.com/reference/composite-provider#virtualfocus) leaves DOM focus on the composite element, and only when the item itself is the focus target. It is released on blur unless the item still holds DOM focus, because Firefox fires `focusout` when the window loses focus while the element is still focused. Without that guard the native attribute would land on the focused element and drop focus to the body once the window came back. `test-firefox.ts` covers it, and fails without the guard.

## Workaround

Until this ships, keep the item accessible while it holds DOM focus, so the native `disabled` attribute is never applied to the element the user is currently on.

```tsx
// TODO: Remove once https://github.com/ariakit/ariakit/issues/7359 is fixed.
function SelfDisablingItem(props: Ariakit.CompositeItemProps) {
  const [focused, setFocused] = useState(false);
  return (
    <Ariakit.CompositeItem
      {...props}
      accessibleWhenDisabled={focused}
      onFocus={(event) => {
        props.onFocus?.(event);
        setFocused(true);
      }}
      onBlur={(event) => {
        props.onBlur?.(event);
        const { currentTarget } = event;
        // Firefox fires focusout when the window loses focus while the element
        // still holds DOM focus. Releasing the workaround then would drop focus
        // to the body once the window comes back.
        if (currentTarget.contains(currentTarget.ownerDocument.activeElement)) {
          return;
        }
        setFocused(false);
      }}
    />
  );
}
```

The item keeps DOM focus, stays exposed as disabled through `aria-disabled`, and still refuses to activate. Once focus moves away it becomes natively disabled again, arrow keys skip it, and the composite stays reachable with Tab.

This workaround is narrower than the fix in this pull request, in three ways.

Apply it only under roving focus. Under [`virtualFocus`](https://ariakit.com/reference/composite-provider#virtualfocus) the composite element keeps DOM focus, so nothing is lost. Applying it there would also latch the flag on, because [`CompositeItem`](https://ariakit.com/reference/composite-item) cancels the intermediate blur that follows the virtual focus handoff.

Do not apply it to components that already default `accessibleWhenDisabled` to `true`, such as [`Tab`](https://ariakit.com/reference/tab) and [`FormSubmit`](https://ariakit.com/reference/form-submit). Passing an explicit `false` while the item is unfocused would override that default and make their disabled items natively disabled.

Do not key it on [`activeId`](https://ariakit.com/reference/composite-provider#activeid) instead of DOM focus. `activeId` keeps pointing at the item after focus leaves the composite, so the item would stay natively enabled and become the composite's only tab stop, which is the #3232 behavior this pull request preserves.

The helper owns `accessibleWhenDisabled`, `onFocus` and `onBlur`. It forwards a caller's `onFocus` and `onBlur`, but a caller cannot pass its own `accessibleWhenDisabled` through it.

The Firefox behavior above is reproducible with Playwright: focus the item, disable it, then open a real popup with `window.open`, bring the popup to front, close it, and bring the page back to front. Firefox logs exactly one `focusout` on the item with `relatedTarget === null` while `document.activeElement` is still that item; Chromium logs none. Note that `document.hasFocus()` stays `true` in Playwright, so it cannot be used to detect this.

## Review gate reassessment

<details>
<summary>Library fix cycle 3: Narrow the contract to items that themselves hold focus</summary>

**Assessment**

The core of the fix is small and proportionate: one state flag, one derived option, one release handler. Layered on it was a separable capability, support for items that hold focusable descendants, consisting of an acquire-side hoist, an `isFocusEventOutside` release guard, a `contains` generalization, a fixture section and three tests.

Four of the nine findings on this track concerned only that capability. The two open ones were decisive. The first: the `contains` generalization had no regression coverage, and the evidence originally recorded for it was overstated, since a later measurement showed a self-correcting transient rather than a persistent state. The second, and more serious: Firefox fires no `focusout` when a focused element is removed from the DOM, so a container item whose focused descendant unmounts latched the flag on with no event able to clear it, leaving a disabled item registered as enabled and permanently in the arrow key rotation. That is a regression this pull request would have introduced, and repairing it needed a document level listener or an observer.

**Decision**

Narrow the supported contract to items that themselves hold DOM focus. The acquire side is back under the self target check, the release keeps only the guard that covers Firefox's window blur, and the descendant machinery, its fixture section and its three tests are removed.

This introduces no regression: a disabled container behaves exactly as it does on `main`. It removes both open findings by removing their cause rather than repairing it, and the reported bug stays fully fixed.

**Corrections to the record**

An earlier version of this entry justified the narrowing partly on the claim that components rendering a `div` cannot exhibit this issue, because they never receive the native `disabled` attribute. **That claim is false**, and a later review disproved it with browser probes. `getTabIndex` returns `undefined` for a truly disabled element that is not natively tabbable, so React removes the `tabindex` attribute, and a focused `div` then loses focus to the body in Chromium and WebKit. Components such as [`MenuItem`](https://ariakit.com/reference/menu-item) do exhibit this issue, by that second mechanism.

The narrowing still holds, because it removed support for focus held by a *descendant*, which is orthogonal to the element type of the item itself. The fix is element agnostic, so a `div` rendered item that holds focus is fixed exactly as a button is. A `NonNativeComposite` fixture section and a test in each suite now cover that path; the browser test fails in all three engines without the fix.

An earlier entry also described a container "going inert while the user is typing" without the `contains` generalization. A later measurement showed a self-correcting transient of a few milliseconds. Under this decision the point is moot.

**Intentionally unsupported**

- Composite items that hold focusable descendants, such as `CompositeContainer` and [`ToolbarContainer`](https://ariakit.com/reference/toolbar-container). Focus landing on a descendant does not mark the item as holding focus, so such an item becomes truly disabled while its descendant holds focus, exactly as on `main`. An item that holds focus itself is supported regardless of what it renders.
- A focusable descendant inside a `button` shaped item, which is invalid HTML.

</details>

<details>
<summary>Cycle 3: Continue the current test-only reproduction direction</summary>

**Assessment**

Issue severity is medium. Disabling a focused composite item drops DOM focus to `document.body` and stops arrow key navigation, which is a real keyboard and screen reader defect in a core primitive. It is recoverable, because the existing tabbable fallback lets Tab re-enter the composite, so it is not a permanent keyboard trap.

Expected frequency is medium to high. The trigger is the ordinary pattern of an action that disables itself on activation, such as mark as read, apply, submit, or undo becoming unavailable.

Supported scope is a stable public API. The bug requires roving focus. Virtual focus is unaffected, because DOM focus never rests on the item. Corrected: this entry originally added "and an element that supports the native `disabled` attribute", which a later review disproved. See the corrections in the library fix entry above.

Likely user impact is that keyboard and screen reader users lose their place mid widget and are moved to `document.body` without warning. Pointer users are unaffected.

Implementation and maintenance complexity is low. The reviewed state is test only: one sandbox directory, three files, six fixture sections, and no library change, helper, abstraction, public contract, or platform policy. The six sections are not invented scope. They are exactly the six scenarios the issue requires before shipping: roving focus, virtual focus, controlled `activeId`, an initially disabled active item, native form controls, and an explicit `accessibleWhenDisabled={false}`.

Four of the nine findings so far share one root cause: proving a transient, engine scheduled, negative state, namely focus that must not move, across three browser engines plus a DOM shim that does not model the mechanism. That root cause is intrinsic to the bug's surface rather than to the chosen design. The remaining findings are unrelated singletons about coverage completeness, coverage organization, base branch hygiene, and a documentation deferral. No reviewer in any round challenged the fixture set, the sandbox choice, the browser project selection, or the eventual fix shape, and the trend is convergent: four findings, then four, then one, with top severity falling from High to Medium to Low.

**Decision**

Continue the current design. There is no accreted machinery to simplify away, the only simplification finding raised in three rounds removed a single line, and reverting or narrowing would mean deleting coverage the issue explicitly requires before shipping.

Constraint carried into the library fix: the sketch in the issue, `accessibleWhenDisabled || (disabled && isActiveItem)`, would regress #3232. Items register into the collection as `disabled: trulyDisabled`, and `isTabbable` makes every item tabbable only while the active item is registered as disabled. Making a merely active disabled item accessible would turn an initially disabled active item into the only tabbable item, so Tab would land on it instead of skipping it. The fix must therefore key on the item actually holding DOM focus, not on it being the active item. `InitiallyDisabledComposite` polices this.

Also carried into the library fix: an explicit `accessibleWhenDisabled={false}` opts out of the new behavior, and that must be stated in the [`accessibleWhenDisabled`](https://ariakit.com/reference/focusable#accessiblewhendisabled) documentation and in the changeset.

**Intentionally unsupported**

- Items rendered as `a href` or `summary`, where a disabled item receives `tabindex="-1"` rather than losing the attribute, so focus is not lost. Corrected: this entry originally listed `div` here, and a `div` rendered item does lose focus. See the corrections in the library fix entry above.
- Items with `focusable={false}`, which are never treated as disabled by [`Focusable`](https://ariakit.com/reference/focusable).
- Mobile projects. This is a desktop keyboard focus contract.

No follow-up issues were registered, because every finding was dispositioned as Address now within this pull request.

</details>

<details>
<summary>Cycle 6: Continue, and decline further comment-only findings</summary>

**Assessment**

Issue attributes are unchanged from cycle 3, with one correction: [`Tab`](https://ariakit.com/reference/tab) is not affected, because it already defaults `accessibleWhenDisabled` to `true`. The live surface is roving focus composites whose items do not default that prop.

Complexity is unchanged and remains test only. The staged diff grew from 315 to 422 insertions between the first reviewed state and now, and every addition traces to an accepted finding: one fixture section and its sibling button, one test per file, four `flushFrames` gates with their comments, and the assertions that pin the observable outputs of `trulyDisabled`. No abstraction was introduced, and the only simplification finding raised in six rounds removed a single line.

Twelve findings across six rounds split evenly between substantive and editorial. The substantive ones have two root causes, both now closed. The first is assertions of state that must not change, placed without crossing a boundary, which is closed by the uniform `aria-disabled` gate plus `flushFrames` at all four sites. The second is that the reproduction was written before the fix's observable shape was decided, which is closed and provably exhausted: `trulyDisabled` drives exactly four render outputs in `Focusable`, the roving test now pins three, and the fourth is not independently observable for a button because `useCompositeItem` supplies its own tab index. The collection registration is already pinned by the arrow key navigation assertions in the same test.

The cycle 3 prediction that severity would fall monotonically to comments only was wrong: rounds 4 and 5 each produced a medium finding with real power to discriminate between candidate fixes, and those are the second and third most valuable findings in the track. Continuing past cycle 3 was correct. That justification has now expired, because the substantive class is exhausted while the editorial class is self sustaining: the round 6 finding critiques the wording of a comment that the round 1 fix introduced, and every reword creates fresh comment surface.

**Decision**

Continue the current design. There is no machinery to remove, nothing to revert to, and stage 1 adds no contract to narrow.

From round 7 onward, a finding whose entire content is the wording, placement, or completeness of an explanatory comment, where no assertion, fixture section, or coverage dimension changes, is a Declined non-goal. The one carve out is a comment that states something factually false in a way that would steer the library fix wrong. This weakens no correctness, safety, security, acceptance, or supported behavior requirement, since comment phrasing touches none of them.

**Carried into the library fix**

1. The sketch in the issue, `accessibleWhenDisabled || (disabled && isActiveItem)`, would regress #3232, so the fix must key on the item actually holding DOM focus. The virtual focus and initially disabled guards both discriminate this.
2. While an item holds DOM focus it becomes fully accessible when disabled, so the native attribute, `data-truly-disabled` and the injected `pointer-events: none` all follow together. [`Hovercard`](https://ariakit.com/reference/hovercard) reads `data-truly-disabled` to decide whether a tooltip may open.
3. An explicit `accessibleWhenDisabled={false}` opts out, and that must be stated in the prop documentation and in the changeset.
4. Pre-existing on `main`: `useCompositeItem` computes `trulyDisabled` from the raw prop while [`Focusable`](https://ariakit.com/reference/focusable) resolves the same option through its context channel first, so the two can disagree when the value arrives from a parent. Verified pre-existing and triggerable in an isolated worktree on `main`, and registered as #7364. This pull request neither introduces nor worsens it, so it ships separately.
5. During `focusout`, `document.activeElement` is `body` in Chromium, Firefox and WebKit even when focus moves to a descendant, so a `contains(activeElement)` check cannot identify a descendant move. Superseded by the cycle 3 narrowing: focus held by a descendant is no longer supported, so the fix carries only the `activeElement` check that covers the Firefox window blur `focusout`, and `isFocusEventOutside` is not used.

**Also intentionally unsupported**

- [`Tab`](https://ariakit.com/reference/tab), which is immune by default.
- Grid and [`CompositeRow`](https://ariakit.com/reference/composite-row) composites, which the issue does not name.
- Removal of the active item, which the issue scopes out in favor of #1672.

</details>
