### PR TITLE
Fix Composite remount replaying an old focus request

### DIFF
--- a/.changeset/300-composite-remount-focus.md
+++ b/.changeset/300-composite-remount-focus.md
@@ -3,4 +3,4 @@
 "@ariakit/react": patch
 ---
 
-Fixed [`Composite`](https://ariakit.com/reference/composite) taking focus itself or moving focus to the item that was active before, and scrolling the page to it, when it becomes a composite widget anew after being rendered again or after the [`composite`](https://ariakit.com/reference/composite#composite-1) prop switches back on, with no new [`move`](https://ariakit.com/reference/use-composite-store#move) call behind it. This also applies to all components built on it, such as [`Menu`](https://ariakit.com/reference/menu) and [`Toolbar`](https://ariakit.com/reference/toolbar).
+Fixed [`Composite`](https://ariakit.com/reference/composite) replaying an earlier [`move`](https://ariakit.com/reference/use-composite-store#move) call, taking focus and scrolling the page, when it is mounted again or when the [`composite`](https://ariakit.com/reference/composite#composite-1) prop switches back on. This also applies to all components built on it, such as [`Menu`](https://ariakit.com/reference/menu) and [`Toolbar`](https://ariakit.com/reference/toolbar).

--- a/.changeset/300-composite-remount-focus.md
+++ b/.changeset/300-composite-remount-focus.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed [`Composite`](https://ariakit.com/reference/composite) taking focus itself or moving focus to the item that was active before, and scrolling the page to it, when it becomes a composite widget anew after being rendered again or after the [`composite`](https://ariakit.com/reference/composite#composite-1) prop switches back on, with no new [`move`](https://ariakit.com/reference/use-composite-store#move) call behind it. This also applies to all components built on it, such as [`Menu`](https://ariakit.com/reference/menu) and [`Toolbar`](https://ariakit.com/reference/toolbar).

--- a/app/src/sandbox/composite-7360/index.react.tsx
+++ b/app/src/sandbox/composite-7360/index.react.tsx
@@ -1,5 +1,5 @@
 import * as Ariakit from "@ariakit/react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 // Taller than a viewport, so the toolbar after it starts out of view from the
 // controls above.
@@ -24,16 +24,6 @@ export default function Example() {
   const store = Ariakit.useCompositeStore();
   const [expanded, setExpanded] = useState(true);
   const [handedOff, setHandedOff] = useState(false);
-
-  // TODO: Remove once https://github.com/ariakit/ariakit/issues/7360 is fixed.
-  // The recorded move count is what the toolbar carries out again when it comes
-  // back, so clear it once the toolbar goes away. A move issued later, while it
-  // is still away, is pending and has to survive, so `away` stays one dependency.
-  const away = !expanded || handedOff;
-  useEffect(() => {
-    if (!away) return;
-    store.setState("moves", 0);
-  }, [away, store]);
 
   return (
     <main style={{ display: "grid", gap: 16, justifyItems: "start" }}>

--- a/app/src/sandbox/composite-7360/index.react.tsx
+++ b/app/src/sandbox/composite-7360/index.react.tsx
@@ -1,5 +1,5 @@
 import * as Ariakit from "@ariakit/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 // Taller than a viewport, so the toolbar after it starts out of view from the
 // controls above.
@@ -24,6 +24,16 @@ export default function Example() {
   const store = Ariakit.useCompositeStore();
   const [expanded, setExpanded] = useState(true);
   const [handedOff, setHandedOff] = useState(false);
+
+  // TODO: Remove once https://github.com/ariakit/ariakit/issues/7360 is fixed.
+  // The recorded move count is what the toolbar carries out again when it comes
+  // back, so clear it once the toolbar goes away. A move issued later, while it
+  // is still away, is pending and has to survive, so `away` stays one dependency.
+  const away = !expanded || handedOff;
+  useEffect(() => {
+    if (!away) return;
+    store.setState("moves", 0);
+  }, [away, store]);
 
   return (
     <main style={{ display: "grid", gap: 16, justifyItems: "start" }}>

--- a/app/src/sandbox/composite-7360/index.react.tsx
+++ b/app/src/sandbox/composite-7360/index.react.tsx
@@ -19,11 +19,17 @@ const paragraphs = Array.from({ length: 24 }, (_, index) => index + 1);
  * focus and keyboard navigation for it. The toolbar stops moving focus
  * meanwhile, so a focus command issued while it is handed off has to wait until
  * the toolbar is a composite again.
+ *
+ * The highlight tool stands in for a tool the app loads on demand. Asking for
+ * it before it arrives records a move for an item that has not registered yet,
+ * which is the same kind of pending request as a focus command issued while the
+ * toolbar is away: it has to be carried out once its item shows up.
  */
 export default function Example() {
   const store = Ariakit.useCompositeStore();
   const [expanded, setExpanded] = useState(true);
   const [handedOff, setHandedOff] = useState(false);
+  const [highlightLoaded, setHighlightLoaded] = useState(false);
 
   return (
     <main style={{ display: "grid", gap: 16, justifyItems: "start" }}>
@@ -42,6 +48,20 @@ export default function Example() {
         </button>
         <button type="button" tabIndex={0} onClick={() => store.move(null)}>
           Focus toolbar
+        </button>
+        <button
+          type="button"
+          tabIndex={0}
+          onClick={() => store.move("highlight")}
+        >
+          Focus highlight tool
+        </button>
+        <button
+          type="button"
+          tabIndex={0}
+          onClick={() => setHighlightLoaded(true)}
+        >
+          Load highlight tool
         </button>
         <label>
           <input
@@ -74,6 +94,11 @@ export default function Example() {
           <Ariakit.CompositeItem id="underline">
             Underline
           </Ariakit.CompositeItem>
+          {highlightLoaded && (
+            <Ariakit.CompositeItem id="highlight">
+              Highlight
+            </Ariakit.CompositeItem>
+          )}
         </Ariakit.Composite>
       )}
     </main>

--- a/app/src/sandbox/composite-7360/index.react.tsx
+++ b/app/src/sandbox/composite-7360/index.react.tsx
@@ -1,0 +1,81 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+
+// Taller than a viewport, so the toolbar after it starts out of view from the
+// controls above.
+const paragraphs = Array.from({ length: 24 }, (_, index) => index + 1);
+
+/**
+ * A formatting toolbar at the end of a long document, with the store created by
+ * the page so it outlives every mount of the toolbar itself.
+ *
+ * Collapsing the toolbar points the store's active item back at the toolbar
+ * container. That is what an app does for a widget that should come back with
+ * no item of its own selected, and `setActiveId(null)` only records it. Unlike
+ * the `move(null)` behind the focus command, it asks for no focus.
+ *
+ * Handing off composite behavior renders the same toolbar with
+ * `composite={false}`, the way a widget does when another composite takes over
+ * focus and keyboard navigation for it. The toolbar stops moving focus
+ * meanwhile, so a focus command issued while it is handed off has to wait until
+ * the toolbar is a composite again.
+ */
+export default function Example() {
+  const store = Ariakit.useCompositeStore();
+  const [expanded, setExpanded] = useState(true);
+  const [handedOff, setHandedOff] = useState(false);
+
+  return (
+    <main style={{ display: "grid", gap: 16, justifyItems: "start" }}>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+        <button
+          type="button"
+          tabIndex={0}
+          onClick={() => {
+            if (expanded) {
+              store.setActiveId(null);
+            }
+            setExpanded(!expanded);
+          }}
+        >
+          {expanded ? "Collapse toolbar" : "Expand toolbar"}
+        </button>
+        <button type="button" tabIndex={0} onClick={() => store.move(null)}>
+          Focus toolbar
+        </button>
+        <label>
+          <input
+            type="checkbox"
+            tabIndex={0}
+            checked={handedOff}
+            onChange={(event) => setHandedOff(event.currentTarget.checked)}
+          />
+          Hand off composite behavior
+        </label>
+      </div>
+      {paragraphs.map((paragraph) => (
+        <p key={paragraph} style={{ height: 80 }}>
+          Paragraph {paragraph}
+        </p>
+      ))}
+      {/* Last on the page, so removing and adding it changes layout only below
+      the controls. Scroll anchoring then has nothing to compensate for, which
+      leaves the composite itself as the only thing that can move the page. */}
+      {expanded && (
+        <Ariakit.Composite
+          store={store}
+          composite={!handedOff}
+          role="toolbar"
+          aria-label="Formatting"
+          style={{ display: "flex", gap: 8 }}
+        >
+          <Ariakit.CompositeItem id="bold">Bold</Ariakit.CompositeItem>
+          <Ariakit.CompositeItem id="italic">Italic</Ariakit.CompositeItem>
+          <Ariakit.CompositeItem id="underline">
+            Underline
+          </Ariakit.CompositeItem>
+        </Ariakit.Composite>
+      )}
+    </main>
+  );
+}

--- a/app/src/sandbox/composite-7360/test-browser.ts
+++ b/app/src/sandbox/composite-7360/test-browser.ts
@@ -1,0 +1,229 @@
+import type { query } from "@ariakit/test/playwright";
+import type { Page } from "@playwright/test";
+import { flushFrames, withFramework } from "#app/test-utils/preview.ts";
+import { recordScrollEvents } from "#app/test-utils/scroll.ts";
+
+type Query = ReturnType<typeof query>;
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  /**
+   * Moves the active item with the keyboard. The move is what arms the replay:
+   * it leaves a move count behind that a fresh effect instance reads as a focus
+   * request to carry out when the toolbar comes back, whether it comes back by
+   * mounting again or by becoming a composite again.
+   */
+  const moveToSecondItem = async (q: Query, page: Page) => {
+    await q.button("Bold").click();
+    await page.keyboard.press("ArrowRight");
+    await test.expect(q.button("Italic")).toBeFocused();
+  };
+
+  /** Rests the page at its origin, away from the toolbar at the end. */
+  const scrollToTop = async (page: Page) => {
+    await page.evaluate(() => window.scrollTo({ top: 0 }));
+    await test.expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0);
+  };
+
+  const handOffControl = (q: Query) =>
+    q.checkbox("Hand off composite behavior");
+
+  /** Hands composite behavior over and rests the page at its origin. */
+  const handOff = async (q: Query, page: Page) => {
+    await handOffControl(q).click();
+    await test.expect(handOffControl(q)).toBeChecked();
+    await scrollToTop(page);
+  };
+
+  /**
+   * Takes composite behavior back and settles the point where a focus or scroll
+   * request would land.
+   */
+  const takeBackAndSettle = async (q: Query, page: Page) => {
+    await handOffControl(q).click();
+    await test.expect(handOffControl(q)).not.toBeChecked();
+    // Same checkpoint as `expandAndSettle`, reached through the `composite`
+    // prop instead of a mount.
+    await flushFrames(page);
+  };
+
+  /**
+   * Returns to the controls at the top of the document and collapses the
+   * toolbar from there, so the page rests at its origin with the toggle holding
+   * focus and the toolbar unmounted.
+   */
+  const collapseFromTop = async (q: Query, page: Page) => {
+    await scrollToTop(page);
+    await q.button("Collapse toolbar").click();
+    await test.expect(q.toolbar("Formatting")).toBeHidden();
+  };
+
+  /**
+   * Brings the toolbar back and settles the point where a focus or scroll
+   * request would land.
+   */
+  const expandAndSettle = async (q: Query, page: Page) => {
+    await q.button("Expand toolbar").click();
+    await test.expect(q.toolbar("Formatting")).toBeVisible();
+    // Focus staying put and the page not moving have no positive state to wait
+    // on, and the effect that would disturb either runs a commit after the
+    // toolbar appears, once its element reaches the store.
+    await flushFrames(page);
+  };
+
+  // Pins the harness: with no move behind it, nothing in the library asks for
+  // focus or a scroll here, so this fails only if mounting the toolbar moves
+  // focus or the page on its own.
+  test("keeps focus and page position when an untouched toolbar comes back", async ({
+    page,
+    q,
+  }) => {
+    await collapseFromTop(q, page);
+    const scroll = await recordScrollEvents(page);
+
+    await expandAndSettle(q, page);
+
+    await test.expect(q.button("Collapse toolbar")).toBeFocused();
+    test.expect(await page.evaluate(() => window.scrollY)).toBe(0);
+    test.expect(await scroll.events()).not.toContain("document");
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7360
+  test("keeps focus and page position when the toolbar comes back after a move", async ({
+    page,
+    q,
+  }) => {
+    await moveToSecondItem(q, page);
+    await collapseFromTop(q, page);
+    const scroll = await recordScrollEvents(page);
+
+    await expandAndSettle(q, page);
+
+    await test.expect(q.button("Collapse toolbar")).toBeFocused();
+    test.expect(await page.evaluate(() => window.scrollY)).toBe(0);
+    test.expect(await scroll.events()).not.toContain("document");
+  });
+
+  // https://github.com/ariakit/ariakit/issues/7360
+  test("keeps focus and page position through repeated remounts", async ({
+    page,
+    q,
+  }) => {
+    await moveToSecondItem(q, page);
+    await collapseFromTop(q, page);
+    const scroll = await recordScrollEvents(page);
+
+    for (let cycle = 0; cycle < 3; cycle += 1) {
+      await expandAndSettle(q, page);
+      await test.expect(q.button("Collapse toolbar")).toBeFocused();
+      await q.button("Collapse toolbar").click();
+      await test.expect(q.toolbar("Formatting")).toBeHidden();
+    }
+
+    await test.expect(q.button("Expand toolbar")).toBeFocused();
+    test.expect(await page.evaluate(() => window.scrollY)).toBe(0);
+    test.expect(await scroll.events()).not.toContain("document");
+  });
+
+  // The same pin as the control above, for the other way the toolbar comes
+  // back: whatever the `composite` prop switching off and on does on its own,
+  // it isn't what the tests below observe.
+  test("keeps focus and page position when untouched composite behavior comes back", async ({
+    page,
+    q,
+  }) => {
+    await handOff(q, page);
+    const scroll = await recordScrollEvents(page);
+
+    await takeBackAndSettle(q, page);
+
+    await test.expect(handOffControl(q)).toBeFocused();
+    test.expect(await page.evaluate(() => window.scrollY)).toBe(0);
+    test.expect(await scroll.events()).not.toContain("document");
+  });
+
+  // The sibling request: with an item still active, what gets replayed presents
+  // that item instead of the toolbar container. Handing composite behavior over
+  // and taking it back remounts the effect without replacing the toolbar
+  // element, so this also covers a remount the element itself survives.
+  // https://github.com/ariakit/ariakit/issues/7360
+  test("keeps focus and page position when composite behavior comes back", async ({
+    page,
+    q,
+  }) => {
+    await moveToSecondItem(q, page);
+    await handOff(q, page);
+    const scroll = await recordScrollEvents(page);
+
+    await takeBackAndSettle(q, page);
+
+    await test.expect(handOffControl(q)).toBeFocused();
+    test.expect(await page.evaluate(() => window.scrollY)).toBe(0);
+    test.expect(await scroll.events()).not.toContain("document");
+  });
+
+  // The other half of that branch: a move recorded while composite behavior is
+  // handed off has nothing to carry it out, so it stays pending and its item
+  // takes focus once the toolbar is a composite again. The move comes from the
+  // arrow key, which still moves the active item meanwhile; only focus stops
+  // following it.
+  // https://github.com/ariakit/ariakit/issues/7363
+  test("focuses a newly moved item when composite behavior comes back", async ({
+    page,
+    q,
+  }) => {
+    await moveToSecondItem(q, page);
+    await handOffControl(q).click();
+    await test.expect(handOffControl(q)).toBeChecked();
+
+    await q.button("Italic").click();
+    await page.keyboard.press("ArrowRight");
+    await takeBackAndSettle(q, page);
+
+    await test.expect(q.button("Underline")).toBeFocused();
+  });
+
+  test("focuses the toolbar when a focus command runs while it is expanded", async ({
+    q,
+  }) => {
+    // Pins the fixture geometry the two `toBeInViewport` assertions rely on: a
+    // shorter document would leave the toolbar on screen from the start and
+    // make them pass without the library scrolling anything.
+    await test.expect(q.toolbar("Formatting")).not.toBeInViewport();
+
+    await q.button("Focus toolbar").click();
+
+    await test.expect(q.toolbar("Formatting")).toBeFocused();
+    await test.expect(q.toolbar("Formatting")).toBeInViewport();
+  });
+
+  // A move that arrives with no composite element to carry it out stays
+  // pending, so the toolbar takes focus once it is back.
+  test("focuses the toolbar when a focus command runs while it is collapsed", async ({
+    page,
+    q,
+  }) => {
+    await moveToSecondItem(q, page);
+    await collapseFromTop(q, page);
+
+    await q.button("Focus toolbar").click();
+    await q.button("Expand toolbar").click();
+
+    await test.expect(q.toolbar("Formatting")).toBeFocused();
+    await test.expect(q.toolbar("Formatting")).toBeInViewport();
+  });
+
+  // The same pending move, but with the toolbar mounted the whole time and only
+  // its `composite` prop switching off and back on.
+  test("focuses the toolbar when a focus command runs while it is handed off", async ({
+    q,
+  }) => {
+    await handOffControl(q).click();
+    await test.expect(handOffControl(q)).toBeChecked();
+
+    await q.button("Focus toolbar").click();
+    await handOffControl(q).click();
+
+    await test.expect(handOffControl(q)).not.toBeChecked();
+    await test.expect(q.toolbar("Formatting")).toBeFocused();
+  });
+});

--- a/app/src/sandbox/composite-7360/test-browser.ts
+++ b/app/src/sandbox/composite-7360/test-browser.ts
@@ -1,18 +1,16 @@
-import type { query } from "@ariakit/test/playwright";
 import type { Page } from "@playwright/test";
 import { flushFrames, withFramework } from "#app/test-utils/preview.ts";
 import { recordScrollEvents } from "#app/test-utils/scroll.ts";
 
-type Query = ReturnType<typeof query>;
-
-withFramework(import.meta.dirname, async ({ test }) => {
+withFramework(import.meta.dirname, async ({ test, query }) => {
   /**
    * Moves the active item with the keyboard. The move is what arms the replay:
    * it leaves a move count behind that a fresh effect instance reads as a focus
    * request to carry out when the toolbar comes back, whether it comes back by
    * mounting again or by becoming a composite again.
    */
-  const moveToSecondItem = async (q: Query, page: Page) => {
+  const moveToSecondItem = async (page: Page) => {
+    const q = query(page);
     await q.button("Bold").click();
     await page.keyboard.press("ArrowRight");
     await test.expect(q.button("Italic")).toBeFocused();
@@ -24,13 +22,13 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0);
   };
 
-  const handOffControl = (q: Query) =>
-    q.checkbox("Hand off composite behavior");
+  const handOffControl = (page: Page) =>
+    query(page).checkbox("Hand off composite behavior");
 
   /** Hands composite behavior over and rests the page at its origin. */
-  const handOff = async (q: Query, page: Page) => {
-    await handOffControl(q).click();
-    await test.expect(handOffControl(q)).toBeChecked();
+  const handOff = async (page: Page) => {
+    await handOffControl(page).click();
+    await test.expect(handOffControl(page)).toBeChecked();
     await scrollToTop(page);
   };
 
@@ -38,9 +36,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
    * Takes composite behavior back and settles the point where a focus or scroll
    * request would land.
    */
-  const takeBackAndSettle = async (q: Query, page: Page) => {
-    await handOffControl(q).click();
-    await test.expect(handOffControl(q)).not.toBeChecked();
+  const takeBackAndSettle = async (page: Page) => {
+    await handOffControl(page).click();
+    await test.expect(handOffControl(page)).not.toBeChecked();
     // Same checkpoint as `expandAndSettle`, reached through the `composite`
     // prop instead of a mount.
     await flushFrames(page);
@@ -51,7 +49,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
    * toolbar from there, so the page rests at its origin with the toggle holding
    * focus and the toolbar unmounted.
    */
-  const collapseFromTop = async (q: Query, page: Page) => {
+  const collapseFromTop = async (page: Page) => {
+    const q = query(page);
     await scrollToTop(page);
     await q.button("Collapse toolbar").click();
     await test.expect(q.toolbar("Formatting")).toBeHidden();
@@ -61,13 +60,31 @@ withFramework(import.meta.dirname, async ({ test }) => {
    * Brings the toolbar back and settles the point where a focus or scroll
    * request would land.
    */
-  const expandAndSettle = async (q: Query, page: Page) => {
+  const expandAndSettle = async (page: Page) => {
+    const q = query(page);
     await q.button("Expand toolbar").click();
     await test.expect(q.toolbar("Formatting")).toBeVisible();
     // Focus staying put and the page not moving have no positive state to wait
     // on, and the effect that would disturb either runs a commit after the
     // toolbar appears, once its element reaches the store.
     await flushFrames(page);
+  };
+
+  /**
+   * Asks for a tool that has not loaded yet. The move counts as a request like
+   * any other, but nothing can carry it out until the item registers.
+   */
+  const askForHighlight = async (page: Page) => {
+    const q = query(page);
+    await scrollToTop(page);
+    await q.button("Focus highlight tool").click();
+    await test.expect(q.button("Highlight")).toBeHidden();
+  };
+
+  const loadHighlight = async (page: Page) => {
+    const q = query(page);
+    await q.button("Load highlight tool").click();
+    await test.expect(q.button("Highlight")).toBeVisible();
   };
 
   // Pins the harness: with no move behind it, nothing in the library asks for
@@ -77,10 +94,10 @@ withFramework(import.meta.dirname, async ({ test }) => {
     page,
     q,
   }) => {
-    await collapseFromTop(q, page);
+    await collapseFromTop(page);
     const scroll = await recordScrollEvents(page);
 
-    await expandAndSettle(q, page);
+    await expandAndSettle(page);
 
     await test.expect(q.button("Collapse toolbar")).toBeFocused();
     test.expect(await page.evaluate(() => window.scrollY)).toBe(0);
@@ -92,11 +109,11 @@ withFramework(import.meta.dirname, async ({ test }) => {
     page,
     q,
   }) => {
-    await moveToSecondItem(q, page);
-    await collapseFromTop(q, page);
+    await moveToSecondItem(page);
+    await collapseFromTop(page);
     const scroll = await recordScrollEvents(page);
 
-    await expandAndSettle(q, page);
+    await expandAndSettle(page);
 
     await test.expect(q.button("Collapse toolbar")).toBeFocused();
     test.expect(await page.evaluate(() => window.scrollY)).toBe(0);
@@ -108,12 +125,12 @@ withFramework(import.meta.dirname, async ({ test }) => {
     page,
     q,
   }) => {
-    await moveToSecondItem(q, page);
-    await collapseFromTop(q, page);
+    await moveToSecondItem(page);
+    await collapseFromTop(page);
     const scroll = await recordScrollEvents(page);
 
     for (let cycle = 0; cycle < 3; cycle += 1) {
-      await expandAndSettle(q, page);
+      await expandAndSettle(page);
       await test.expect(q.button("Collapse toolbar")).toBeFocused();
       await q.button("Collapse toolbar").click();
       await test.expect(q.toolbar("Formatting")).toBeHidden();
@@ -129,14 +146,13 @@ withFramework(import.meta.dirname, async ({ test }) => {
   // it isn't what the tests below observe.
   test("keeps focus and page position when untouched composite behavior comes back", async ({
     page,
-    q,
   }) => {
-    await handOff(q, page);
+    await handOff(page);
     const scroll = await recordScrollEvents(page);
 
-    await takeBackAndSettle(q, page);
+    await takeBackAndSettle(page);
 
-    await test.expect(handOffControl(q)).toBeFocused();
+    await test.expect(handOffControl(page)).toBeFocused();
     test.expect(await page.evaluate(() => window.scrollY)).toBe(0);
     test.expect(await scroll.events()).not.toContain("document");
   });
@@ -148,15 +164,14 @@ withFramework(import.meta.dirname, async ({ test }) => {
   // https://github.com/ariakit/ariakit/issues/7360
   test("keeps focus and page position when composite behavior comes back", async ({
     page,
-    q,
   }) => {
-    await moveToSecondItem(q, page);
-    await handOff(q, page);
+    await moveToSecondItem(page);
+    await handOff(page);
     const scroll = await recordScrollEvents(page);
 
-    await takeBackAndSettle(q, page);
+    await takeBackAndSettle(page);
 
-    await test.expect(handOffControl(q)).toBeFocused();
+    await test.expect(handOffControl(page)).toBeFocused();
     test.expect(await page.evaluate(() => window.scrollY)).toBe(0);
     test.expect(await scroll.events()).not.toContain("document");
   });
@@ -166,18 +181,18 @@ withFramework(import.meta.dirname, async ({ test }) => {
   // takes focus once the toolbar is a composite again. The move comes from the
   // arrow key, which still moves the active item meanwhile; only focus stops
   // following it.
-  // https://github.com/ariakit/ariakit/issues/7363
+  // Related: https://github.com/ariakit/ariakit/issues/7363
   test("focuses a newly moved item when composite behavior comes back", async ({
     page,
     q,
   }) => {
-    await moveToSecondItem(q, page);
-    await handOffControl(q).click();
-    await test.expect(handOffControl(q)).toBeChecked();
+    await moveToSecondItem(page);
+    await handOffControl(page).click();
+    await test.expect(handOffControl(page)).toBeChecked();
 
     await q.button("Italic").click();
     await page.keyboard.press("ArrowRight");
-    await takeBackAndSettle(q, page);
+    await takeBackAndSettle(page);
 
     await test.expect(q.button("Underline")).toBeFocused();
   });
@@ -202,8 +217,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     page,
     q,
   }) => {
-    await moveToSecondItem(q, page);
-    await collapseFromTop(q, page);
+    await moveToSecondItem(page);
+    await collapseFromTop(page);
 
     await q.button("Focus toolbar").click();
     await q.button("Expand toolbar").click();
@@ -215,15 +230,71 @@ withFramework(import.meta.dirname, async ({ test }) => {
   // The same pending move, but with the toolbar mounted the whole time and only
   // its `composite` prop switching off and back on.
   test("focuses the toolbar when a focus command runs while it is handed off", async ({
+    page,
     q,
   }) => {
-    await handOffControl(q).click();
-    await test.expect(handOffControl(q)).toBeChecked();
+    await handOffControl(page).click();
+    await test.expect(handOffControl(page)).toBeChecked();
 
     await q.button("Focus toolbar").click();
-    await handOffControl(q).click();
+    await handOffControl(page).click();
 
-    await test.expect(handOffControl(q)).not.toBeChecked();
+    await test.expect(handOffControl(page)).not.toBeChecked();
     await test.expect(q.toolbar("Formatting")).toBeFocused();
+  });
+
+  // Pins the third kind of pending move, the one waiting on its item rather
+  // than on the toolbar: with nothing replacing the toolbar meanwhile, the
+  // request is carried out when the tool loads.
+  test("focuses a tool that loads after being asked for", async ({
+    page,
+    q,
+  }) => {
+    await askForHighlight(page);
+
+    await loadHighlight(page);
+
+    await test.expect(q.button("Highlight")).toBeFocused();
+    await test.expect(q.button("Highlight")).toBeInViewport();
+  });
+
+  // The third thing a pending move can do: be given up on. Picking another tool
+  // makes the toolbar abandon the request for the one that never arrived, and a
+  // request it gave up on is spent rather than still waiting, so it is not left
+  // behind for a later instance to carry out.
+  // https://github.com/ariakit/ariakit/issues/7360
+  test("keeps focus and page position when composite behavior comes back after an abandoned request", async ({
+    page,
+    q,
+  }) => {
+    await askForHighlight(page);
+    await q.button("Bold").click();
+    await test.expect(q.button("Bold")).toBeFocused();
+    await handOff(page);
+    const scroll = await recordScrollEvents(page);
+
+    await takeBackAndSettle(page);
+
+    await test.expect(handOffControl(page)).toBeFocused();
+    test.expect(await page.evaluate(() => window.scrollY)).toBe(0);
+    test.expect(await scroll.events()).not.toContain("document");
+  });
+
+  // The same pending move, across the handoff that replaces what would carry it
+  // out. Only the handoff is exercised here: collapsing also points the store
+  // at the toolbar container, which retires the request instead of leaving it
+  // pending.
+  test("focuses a tool that loads after composite behavior comes back", async ({
+    page,
+    q,
+  }) => {
+    await askForHighlight(page);
+    await handOff(page);
+    await takeBackAndSettle(page);
+
+    await loadHighlight(page);
+
+    await test.expect(q.button("Highlight")).toBeFocused();
+    await test.expect(q.button("Highlight")).toBeInViewport();
   });
 });

--- a/app/src/sandbox/composite-7360/test.ts
+++ b/app/src/sandbox/composite-7360/test.ts
@@ -41,6 +41,20 @@ async function takeBack() {
   expect(handOffControl()).not.toBeChecked();
 }
 
+/**
+ * Asks for a tool that has not loaded yet. The move counts as a request like
+ * any other, but nothing can carry it out until the item registers.
+ */
+async function askForHighlight() {
+  await click(q.button("Focus highlight tool"));
+  expect(q.button.maybe("Highlight")).not.toBeInTheDocument();
+}
+
+async function loadHighlight() {
+  await click(q.button("Load highlight tool"));
+  expect(q.button("Highlight")).toBeInTheDocument();
+}
+
 // Pins the harness: with no move behind it, nothing in the library asks for
 // focus here.
 test("keeps focus when an untouched toolbar comes back", async () => {
@@ -103,7 +117,7 @@ test("keeps focus when composite behavior comes back", async () => {
 // takes focus once the toolbar is a composite again. The move comes from the
 // arrow key, which still moves the active item meanwhile; only focus stops
 // following it.
-// https://github.com/ariakit/ariakit/issues/7363
+// Related: https://github.com/ariakit/ariakit/issues/7363
 test("focuses a newly moved item when composite behavior comes back", async () => {
   await moveToSecondItem();
   await handOff();
@@ -142,4 +156,45 @@ test("focuses the toolbar when a focus command runs while it is handed off", asy
   await takeBack();
 
   expect(q.toolbar("Formatting")).toHaveFocus();
+});
+
+// Pins the third kind of pending move, the one waiting on its item rather than
+// on the toolbar: with nothing replacing the toolbar meanwhile, the request is
+// carried out when the tool loads.
+test("focuses a tool that loads after being asked for", async () => {
+  await askForHighlight();
+
+  await loadHighlight();
+
+  expect(q.button("Highlight")).toHaveFocus();
+});
+
+// The third thing a pending move can do: be given up on. Picking another tool
+// makes the toolbar abandon the request for the one that never arrived, and a
+// request it gave up on is spent rather than still waiting, so it is not left
+// behind for a later instance to carry out.
+// https://github.com/ariakit/ariakit/issues/7360
+test("keeps focus when composite behavior comes back after an abandoned request", async () => {
+  await askForHighlight();
+  await click(q.button("Bold"));
+  expect(q.button("Bold")).toHaveFocus();
+
+  await handOff();
+  await takeBack();
+
+  expect(handOffControl()).toHaveFocus();
+});
+
+// The same pending move, across the handoff that replaces what would carry it
+// out. Only the handoff is exercised here: collapsing also points the store at
+// the toolbar container, which retires the request instead of leaving it
+// pending.
+test("focuses a tool that loads after composite behavior comes back", async () => {
+  await askForHighlight();
+  await handOff();
+  await takeBack();
+
+  await loadHighlight();
+
+  expect(q.button("Highlight")).toHaveFocus();
 });

--- a/app/src/sandbox/composite-7360/test.ts
+++ b/app/src/sandbox/composite-7360/test.ts
@@ -1,0 +1,145 @@
+import { click, press, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+// `test-browser.ts` is authoritative for the page movement that the replayed
+// focus request causes. happy-dom has no layout, so only the focus half is
+// observable here.
+
+/**
+ * Moves the active item with the keyboard. The move is what arms the replay: it
+ * leaves a move count behind that a fresh effect instance reads as a focus
+ * request to carry out when the toolbar comes back, whether it comes back by
+ * mounting again or by becoming a composite again.
+ */
+async function moveToSecondItem() {
+  await click(q.button("Bold"));
+  await press.ArrowRight();
+  expect(q.button("Italic")).toHaveFocus();
+}
+
+async function collapse() {
+  await click(q.button("Collapse toolbar"));
+  expect(q.toolbar.maybe("Formatting")).not.toBeInTheDocument();
+}
+
+async function expand() {
+  await click(q.button("Expand toolbar"));
+  expect(q.toolbar("Formatting")).toBeInTheDocument();
+}
+
+function handOffControl() {
+  return q.checkbox("Hand off composite behavior");
+}
+
+async function handOff() {
+  await click(handOffControl());
+  expect(handOffControl()).toBeChecked();
+}
+
+async function takeBack() {
+  await click(handOffControl());
+  expect(handOffControl()).not.toBeChecked();
+}
+
+// Pins the harness: with no move behind it, nothing in the library asks for
+// focus here.
+test("keeps focus when an untouched toolbar comes back", async () => {
+  await collapse();
+
+  await expand();
+
+  expect(q.button("Collapse toolbar")).toHaveFocus();
+});
+
+// https://github.com/ariakit/ariakit/issues/7360
+test("keeps focus when the toolbar comes back after a move", async () => {
+  await moveToSecondItem();
+  await collapse();
+
+  await expand();
+
+  expect(q.button("Collapse toolbar")).toHaveFocus();
+});
+
+// https://github.com/ariakit/ariakit/issues/7360
+test("keeps focus through repeated remounts", async () => {
+  await moveToSecondItem();
+  await collapse();
+
+  for (let cycle = 0; cycle < 3; cycle += 1) {
+    await expand();
+    expect(q.button("Collapse toolbar")).toHaveFocus();
+    await collapse();
+  }
+
+  expect(q.button("Expand toolbar")).toHaveFocus();
+});
+
+// The same pin as the control above, for the other way the toolbar comes back.
+test("keeps focus when untouched composite behavior comes back", async () => {
+  await handOff();
+
+  await takeBack();
+
+  expect(handOffControl()).toHaveFocus();
+});
+
+// The sibling request: with an item still active, what gets replayed presents
+// that item instead of the toolbar container. Handing composite behavior over
+// and taking it back remounts the effect without replacing the toolbar element,
+// so this also covers a remount the element itself survives.
+// https://github.com/ariakit/ariakit/issues/7360
+test("keeps focus when composite behavior comes back", async () => {
+  await moveToSecondItem();
+  await handOff();
+
+  await takeBack();
+
+  expect(handOffControl()).toHaveFocus();
+});
+
+// The other half of that branch: a move recorded while composite behavior is
+// handed off has nothing to carry it out, so it stays pending and its item
+// takes focus once the toolbar is a composite again. The move comes from the
+// arrow key, which still moves the active item meanwhile; only focus stops
+// following it.
+// https://github.com/ariakit/ariakit/issues/7363
+test("focuses a newly moved item when composite behavior comes back", async () => {
+  await moveToSecondItem();
+  await handOff();
+
+  await click(q.button("Italic"));
+  await press.ArrowRight();
+  await takeBack();
+
+  expect(q.button("Underline")).toHaveFocus();
+});
+
+test("focuses the toolbar when a focus command runs while it is expanded", async () => {
+  await click(q.button("Focus toolbar"));
+
+  expect(q.toolbar("Formatting")).toHaveFocus();
+});
+
+// A move that arrives with no composite element to carry it out stays pending,
+// so the toolbar takes focus once it is back.
+test("focuses the toolbar when a focus command runs while it is collapsed", async () => {
+  await moveToSecondItem();
+  await collapse();
+
+  await click(q.button("Focus toolbar"));
+  await expand();
+
+  expect(q.toolbar("Formatting")).toHaveFocus();
+});
+
+// The same pending move, but with the toolbar mounted the whole time and only
+// its `composite` prop switching off and back on.
+test("focuses the toolbar when a focus command runs while it is handed off", async () => {
+  await handOff();
+
+  await click(q.button("Focus toolbar"));
+  await takeBack();
+
+  expect(q.toolbar("Formatting")).toHaveFocus();
+});

--- a/app/src/sandbox/composite-superseded-move/index.react.tsx
+++ b/app/src/sandbox/composite-superseded-move/index.react.tsx
@@ -1,0 +1,64 @@
+import * as Ariakit from "@ariakit/react";
+import { useState } from "react";
+
+/**
+ * A tool palette that can take focus itself, with the store created by the page
+ * so it outlives every mount of the palette.
+ *
+ * Asking for a tool that has not loaded records a move nothing can carry out
+ * yet. Clicking the palette itself then focuses the palette rather than a tool,
+ * which replaces that pending request with the palette's own. The request is
+ * spent from there on, so nothing should carry it out later.
+ *
+ * Handing off composite behavior renders the same palette with
+ * `composite={false}`, the way a widget does when another composite takes over
+ * focus and keyboard navigation for it. Taking it back mounts a fresh effect,
+ * which is what a replayed request would come back through.
+ */
+export default function Example() {
+  const store = Ariakit.useCompositeStore();
+  const [handedOff, setHandedOff] = useState(false);
+  const [zoomLoaded, setZoomLoaded] = useState(false);
+
+  return (
+    <main style={{ display: "grid", gap: 16, justifyItems: "start" }}>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+        <button type="button" tabIndex={0} onClick={() => store.move("zoom")}>
+          Focus zoom tool
+        </button>
+        <button type="button" tabIndex={0} onClick={() => setZoomLoaded(true)}>
+          Load zoom tool
+        </button>
+        <label>
+          <input
+            type="checkbox"
+            tabIndex={0}
+            checked={handedOff}
+            onChange={(event) => setHandedOff(event.currentTarget.checked)}
+          />
+          Hand off composite behavior
+        </label>
+      </div>
+      {/* Padded, so there is palette to click that is not a tool. `tabIndex`
+      keeps the palette itself focusable while a tool is active, which is what
+      lets it take a pending request over. */}
+      <Ariakit.Composite
+        store={store}
+        composite={!handedOff}
+        role="listbox"
+        aria-label="Tools"
+        tabIndex={0}
+        style={{ display: "grid", gap: 8, padding: 16, minWidth: 160 }}
+      >
+        <Ariakit.CompositeItem id="pen" role="option">
+          Pen
+        </Ariakit.CompositeItem>
+        {zoomLoaded && (
+          <Ariakit.CompositeItem id="zoom" role="option">
+            Zoom
+          </Ariakit.CompositeItem>
+        )}
+      </Ariakit.Composite>
+    </main>
+  );
+}

--- a/app/src/sandbox/composite-superseded-move/test-browser.ts
+++ b/app/src/sandbox/composite-superseded-move/test-browser.ts
@@ -1,0 +1,95 @@
+import type { Page } from "@playwright/test";
+import { flushFrames, withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test, query }) => {
+  /**
+   * Asks for a tool that has not loaded yet. The move counts as a request like
+   * any other, but nothing can carry it out until the item registers.
+   */
+  const askForZoom = async (page: Page) => {
+    const q = query(page);
+    await q.button("Focus zoom tool").click();
+    await test.expect(q.option("Zoom")).toBeHidden();
+  };
+
+  const handOffControl = (page: Page) =>
+    query(page).checkbox("Hand off composite behavior");
+
+  const handOff = async (page: Page) => {
+    await handOffControl(page).click();
+    await test.expect(handOffControl(page)).toBeChecked();
+  };
+
+  /**
+   * Takes composite behavior back and settles the point where a focus request
+   * would land.
+   */
+  const takeBackAndSettle = async (page: Page) => {
+    await handOffControl(page).click();
+    await test.expect(handOffControl(page)).not.toBeChecked();
+    // Focus staying put has no positive state to wait on, and the effect that
+    // would disturb it runs a commit after the palette is a composite again.
+    await flushFrames(page);
+  };
+
+  // Pins the harness: with no move behind it, the `composite` prop switching
+  // off and on moves nothing on its own.
+  test("keeps focus when untouched composite behavior comes back", async ({
+    page,
+  }) => {
+    await handOff(page);
+
+    await takeBackAndSettle(page);
+
+    await test.expect(handOffControl(page)).toBeFocused();
+  });
+
+  // Pins the other half: with nothing taking the request over, it stays pending
+  // and the tool takes focus once it loads.
+  test("focuses a tool that loads after being asked for", async ({
+    page,
+    q,
+  }) => {
+    await askForZoom(page);
+
+    await q.button("Load zoom tool").click();
+
+    await test.expect(q.option("Zoom")).toBeFocused();
+  });
+
+  // Pins the handoff on its own, so the test below cannot pass merely because
+  // handing composite behavior over and back spends a pending request. It does
+  // not: the request is still waiting, so it survives.
+  test("focuses a tool that loads after composite behavior comes back", async ({
+    page,
+    q,
+  }) => {
+    await askForZoom(page);
+    await handOff(page);
+    await takeBackAndSettle(page);
+
+    await q.button("Load zoom tool").click();
+
+    await test.expect(q.option("Zoom")).toBeFocused();
+  });
+
+  // The palette taking focus replaces the pending request with its own, which
+  // spends it. A spent request is not left behind for the next effect instance,
+  // so taking composite behavior back moves nothing.
+  // https://github.com/ariakit/ariakit/issues/7360
+  test("keeps focus when composite behavior comes back after the palette took the request over", async ({
+    page,
+    q,
+  }) => {
+    await askForZoom(page);
+    // Into the palette's own padding. A centred click would land on the tool
+    // that sits there instead, and focus a tool rather than the palette.
+    await q.listbox("Tools").click({ position: { x: 4, y: 4 } });
+    await test.expect(q.listbox("Tools")).toBeFocused();
+
+    await handOff(page);
+    await takeBackAndSettle(page);
+
+    await test.expect(handOffControl(page)).toBeFocused();
+  });
+});

--- a/app/src/sandbox/composite-superseded-move/test.ts
+++ b/app/src/sandbox/composite-superseded-move/test.ts
@@ -1,0 +1,73 @@
+import { click, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+/**
+ * Asks for a tool that has not loaded yet. The move counts as a request like
+ * any other, but nothing can carry it out until the item registers.
+ */
+async function askForZoom() {
+  await click(q.button("Focus zoom tool"));
+  expect(q.option.maybe("Zoom")).not.toBeInTheDocument();
+}
+
+function handOffControl() {
+  return q.checkbox("Hand off composite behavior");
+}
+
+async function handOff() {
+  await click(handOffControl());
+  expect(handOffControl()).toBeChecked();
+}
+
+async function takeBack() {
+  await click(handOffControl());
+  expect(handOffControl()).not.toBeChecked();
+}
+
+// Pins the harness: with no move behind it, the `composite` prop switching off
+// and on moves nothing on its own.
+test("keeps focus when untouched composite behavior comes back", async () => {
+  await handOff();
+
+  await takeBack();
+
+  expect(handOffControl()).toHaveFocus();
+});
+
+// Pins the other half: with nothing taking the request over, it stays pending
+// and the tool takes focus once it loads.
+test("focuses a tool that loads after being asked for", async () => {
+  await askForZoom();
+
+  await click(q.button("Load zoom tool"));
+
+  expect(q.option("Zoom")).toHaveFocus();
+});
+
+// Pins the handoff on its own, so the test below cannot pass merely because
+// handing composite behavior over and back spends a pending request. It does
+// not: the request is still waiting, so it survives.
+test("focuses a tool that loads after composite behavior comes back", async () => {
+  await askForZoom();
+  await handOff();
+  await takeBack();
+
+  await click(q.button("Load zoom tool"));
+
+  expect(q.option("Zoom")).toHaveFocus();
+});
+
+// The palette taking focus replaces the pending request with its own, which
+// spends it. A spent request is not left behind for the next effect instance,
+// so taking composite behavior back moves nothing.
+// https://github.com/ariakit/ariakit/issues/7360
+test("keeps focus when composite behavior comes back after the palette took the request over", async () => {
+  await askForZoom();
+  await click(q.listbox("Tools"));
+  expect(q.listbox("Tools")).toHaveFocus();
+
+  await handOff();
+  await takeBack();
+
+  expect(handOffControl()).toHaveFocus();
+});

--- a/app/src/sandbox/menubar-navigation/menubar.react.tsx
+++ b/app/src/sandbox/menubar-navigation/menubar.react.tsx
@@ -17,20 +17,6 @@ const SetPlacementContext = React.createContext<
   Dispatch<SetStateAction<Ariakit.MenuProviderProps["placement"]>>
 >(() => {});
 
-// TODO: Remove once https://github.com/ariakit/ariakit/issues/7360 is fixed.
-// The recorded move count is what the menu carries out again when it comes
-// back, so clear it once the menu goes away. A move issued later, while it is
-// still away, is pending and has to survive.
-function ForgetRecordedMoves() {
-  const menu = Ariakit.useMenuContext();
-  const mounted = Ariakit.useStoreState(menu, "mounted");
-  React.useEffect(() => {
-    if (mounted) return;
-    menu?.setState("moves", 0);
-  }, [mounted, menu]);
-  return null;
-}
-
 export interface MenubarProps extends Ariakit.MenubarProps {}
 
 export const Menubar = React.forwardRef<HTMLDivElement, MenubarProps>(
@@ -54,7 +40,6 @@ export const Menubar = React.forwardRef<HTMLDivElement, MenubarProps>(
               showTimeout={100}
               hideTimeout={250}
             >
-              <ForgetRecordedMoves />
               {props.children}
               <Ariakit.Menu
                 // This menu component is shared across all menus in the

--- a/app/src/sandbox/menubar-navigation/menubar.react.tsx
+++ b/app/src/sandbox/menubar-navigation/menubar.react.tsx
@@ -17,6 +17,20 @@ const SetPlacementContext = React.createContext<
   Dispatch<SetStateAction<Ariakit.MenuProviderProps["placement"]>>
 >(() => {});
 
+// TODO: Remove once https://github.com/ariakit/ariakit/issues/7360 is fixed.
+// The recorded move count is what the menu carries out again when it comes
+// back, so clear it once the menu goes away. A move issued later, while it is
+// still away, is pending and has to survive.
+function ForgetRecordedMoves() {
+  const menu = Ariakit.useMenuContext();
+  const mounted = Ariakit.useStoreState(menu, "mounted");
+  React.useEffect(() => {
+    if (mounted) return;
+    menu?.setState("moves", 0);
+  }, [mounted, menu]);
+  return null;
+}
+
 export interface MenubarProps extends Ariakit.MenubarProps {}
 
 export const Menubar = React.forwardRef<HTMLDivElement, MenubarProps>(
@@ -40,6 +54,7 @@ export const Menubar = React.forwardRef<HTMLDivElement, MenubarProps>(
               showTimeout={100}
               hideTimeout={250}
             >
+              <ForgetRecordedMoves />
               {props.children}
               <Ariakit.Menu
                 // This menu component is shared across all menus in the

--- a/app/src/sandbox/menubar-navigation/test-browser.ts
+++ b/app/src/sandbox/menubar-navigation/test-browser.ts
@@ -190,4 +190,32 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await page.keyboard.press("ArrowDown");
     await expect(q.menuitem("Archives")).toBeFocused();
   });
+
+  // Arrowing into the menu records a move on the shared menu store. The menu
+  // itself unmounts on the way to Contact and comes back with a null active
+  // item, while that store lives on in the menubar's provider. That stale move
+  // and that active item are the container-focus request being replayed.
+  // Focusing a menubar item doesn't record a move, so opening one alone doesn't
+  // arm this.
+  // https://github.com/ariakit/ariakit/issues/7360
+  test("keeps focus on the menu item when the shared menu is mounted again", async ({
+    page,
+    browserName,
+  }) => {
+    const q = query(page);
+    await pressTab(page, browserName);
+    await expect(q.menuitem("Services")).toBeFocused();
+    await expect(q.menu("Services")).toBeVisible();
+
+    await page.keyboard.press("ArrowDown");
+    await expect(q.menuitem("Web Development")).toBeFocused();
+
+    await page.keyboard.press("ArrowLeft");
+    await expect(q.menuitem("Contact")).toBeFocused();
+    await expect(q.menu("Services")).not.toBeVisible();
+
+    await page.keyboard.press("ArrowRight");
+    await expect(q.menu("Services")).toBeVisible();
+    await expect(q.menuitem("Services")).toBeFocused();
+  });
 });

--- a/packages/ariakit-react-components/src/composite/composite.tsx
+++ b/packages/ariakit-react-components/src/composite/composite.tsx
@@ -119,46 +119,54 @@ type PresentItem = ReturnType<typeof usePresentItem>;
 
 interface MoveRequest {
   /**
-   * The `CompositeFocusOnMove` instance that has claimed the current move, or
-   * `null` while no instance has.
+   * The `CompositeFocusOnMove` instance that consumed the current move, or
+   * `null` while none has.
    */
-  claimedBy: object | null;
+  consumedBy: object | null;
 }
 
 /**
- * Tracks, per store, which instance has claimed the current move. This has to
+ * Tracks, per store, which instance has consumed the current move. This has to
  * outlive the component: `moves` only counts requests, so a fresh instance
- * reading a nonzero count can't tell a request still waiting for a composite
- * element from one an earlier instance already acted on.
+ * reading a nonzero count can't tell a request still waiting, for its item or
+ * for a composite element, from one an earlier instance already acted on.
  */
 const moveRequests = new WeakMap<CompositeStore, MoveRequest>();
 
 function getMoveRequest(store: CompositeStore) {
   const cached = moveRequests.get(store);
   if (cached) return cached;
-  const request: MoveRequest = { claimedBy: null };
+  const request: MoveRequest = { consumedBy: null };
   moveRequests.set(store, request);
   // Every change to the count starts a new request, including the resets that
-  // cancel a pending one, so it goes back to being unclaimed.
+  // cancel a pending one, so it goes back to being unconsumed.
   sync(store, ["moves"], () => {
-    request.claimedBy = null;
+    request.consumedBy = null;
   });
   return request;
 }
 
 /**
- * Whether `instance` may act on the store's current move, claiming it when it
- * may. The claim is per component instance rather than per composite element,
- * because switching the `composite` prop off and on again mounts a fresh
- * instance while the element itself survives. Both effects claim before the
- * guard that decides whether they act, so a request one of them read is never
- * left unclaimed for a later instance to act on.
+ * Whether `instance` may act on the store's current move. An unconsumed request
+ * is available to whichever instance is around; a consumed one stays with the
+ * instance that consumed it, so its own effects can still run again.
  */
-function claimMove(store: CompositeStore, instance: object) {
-  const request = getMoveRequest(store);
-  if (request.claimedBy && request.claimedBy !== instance) return false;
-  request.claimedBy = instance;
-  return true;
+function mayActOnMove(store: CompositeStore, instance: object) {
+  const { consumedBy } = getMoveRequest(store);
+  return !consumedBy || consumedBy === instance;
+}
+
+/**
+ * Records that `instance` consumed the store's move `moves`, so no later
+ * instance replays it. It is per component instance rather than per composite
+ * element, because switching the `composite` prop off and on again mounts a
+ * fresh instance while the element itself survives. A consumption that arrives
+ * after the count has moved on is dropped, resets included, because it settles
+ * the request the count held when it started.
+ */
+function consumeMove(store: CompositeStore, instance: object, moves: number) {
+  if (store.getState().moves !== moves) return;
+  getMoveRequest(store).consumedBy = instance;
 }
 
 interface CompositeFocusOnMoveProps {
@@ -204,7 +212,8 @@ const CompositeFocusOnMove = memo(function CompositeFocusOnMove({
   useEffect(() => {
     if (!moves) return;
     if (!focusOnMove) return;
-    if (!claimMove(store, instanceRef.current)) return;
+    const instance = instanceRef.current;
+    if (!mayActOnMove(store, instance)) return;
     const { activeId } = store.getState();
     if (activeId == null) return;
     // A programmatic move made while focus is already outside keeps its
@@ -215,6 +224,7 @@ const CompositeFocusOnMove = memo(function CompositeFocusOnMove({
       requireFocus: ownsFocus(store),
       focus: true,
       scrollIntoView,
+      onConsume: () => consumeMove(store, instance, moves),
     });
     // oxlint-disable-next-line react/exhaustive-effect-dependencies -- store invalidation signal
   }, [store, moves, focusOnMove, compositeElement, present, scrollIntoView]);
@@ -224,10 +234,14 @@ const CompositeFocusOnMove = memo(function CompositeFocusOnMove({
   useSafeLayoutEffect(() => {
     if (!moves) return;
     if (!compositeElement) return;
-    if (!claimMove(store, instanceRef.current)) return;
+    const instance = instanceRef.current;
+    if (!mayActOnMove(store, instance)) return;
     const { activeId } = store.getState();
     const isSelfActive = activeId === null;
     if (!isSelfActive) return;
+    // This branch has nothing left to wait for, so it consumes the request
+    // here rather than reporting back the way a presentation does.
+    consumeMove(store, instance, moves);
     const previousElement = previousElementRef.current;
     // We have to clean up the previous element ref so an additional blur
     // event is not fired on it, for example, when looping through items while

--- a/packages/ariakit-react-components/src/composite/composite.tsx
+++ b/packages/ariakit-react-components/src/composite/composite.tsx
@@ -12,6 +12,7 @@ import {
   memo,
 } from "@ariakit/react-utils";
 import type { Props } from "@ariakit/react-utils";
+import { sync } from "@ariakit/store";
 import {
   flatten2DArray,
   reverseArray,
@@ -116,6 +117,50 @@ function findFirstEnabledItemInTheLastRow(items: CompositeStoreItem[]) {
 
 type PresentItem = ReturnType<typeof usePresentItem>;
 
+interface MoveRequest {
+  /**
+   * The `CompositeFocusOnMove` instance that has claimed the current move, or
+   * `null` while no instance has.
+   */
+  claimedBy: object | null;
+}
+
+/**
+ * Tracks, per store, which instance has claimed the current move. This has to
+ * outlive the component: `moves` only counts requests, so a fresh instance
+ * reading a nonzero count can't tell a request still waiting for a composite
+ * element from one an earlier instance already acted on.
+ */
+const moveRequests = new WeakMap<CompositeStore, MoveRequest>();
+
+function getMoveRequest(store: CompositeStore) {
+  const cached = moveRequests.get(store);
+  if (cached) return cached;
+  const request: MoveRequest = { claimedBy: null };
+  moveRequests.set(store, request);
+  // Every change to the count starts a new request, including the resets that
+  // cancel a pending one, so it goes back to being unclaimed.
+  sync(store, ["moves"], () => {
+    request.claimedBy = null;
+  });
+  return request;
+}
+
+/**
+ * Whether `instance` may act on the store's current move, claiming it when it
+ * may. The claim is per component instance rather than per composite element,
+ * because switching the `composite` prop off and on again mounts a fresh
+ * instance while the element itself survives. Both effects claim before the
+ * guard that decides whether they act, so a request one of them read is never
+ * left unclaimed for a later instance to act on.
+ */
+function claimMove(store: CompositeStore, instance: object) {
+  const request = getMoveRequest(store);
+  if (request.claimedBy && request.claimedBy !== instance) return false;
+  request.claimedBy = instance;
+  return true;
+}
+
 interface CompositeFocusOnMoveProps {
   store: CompositeStore;
   focusOnMove?: boolean;
@@ -149,11 +194,17 @@ const CompositeFocusOnMove = memo(function CompositeFocusOnMove({
   // `false` to `true` after a `move(null)` call. The composite element rarely
   // changes, so this doesn't add renders while navigating.
   const compositeElement = useStoreState(store, "compositeElement");
+  // Identifies this instance to the store's move request. A ref survives the
+  // effect re-runs of the same instance, including StrictMode's double
+  // invocation, but not a remount, which is exactly the distinction the request
+  // needs.
+  const instanceRef = useRef({});
 
   // Present the active item.
   useEffect(() => {
     if (!moves) return;
     if (!focusOnMove) return;
+    if (!claimMove(store, instanceRef.current)) return;
     const { activeId } = store.getState();
     if (activeId == null) return;
     // A programmatic move made while focus is already outside keeps its
@@ -173,6 +224,7 @@ const CompositeFocusOnMove = memo(function CompositeFocusOnMove({
   useSafeLayoutEffect(() => {
     if (!moves) return;
     if (!compositeElement) return;
+    if (!claimMove(store, instanceRef.current)) return;
     const { activeId } = store.getState();
     const isSelfActive = activeId === null;
     if (!isSelfActive) return;

--- a/packages/ariakit-react-components/src/composite/utils.ts
+++ b/packages/ariakit-react-components/src/composite/utils.ts
@@ -103,6 +103,13 @@ export interface PresentItemParams {
    * @private
    */
   scrollIntoView?: (element: HTMLElement) => void;
+  /**
+   * Called at most once, when this presentation is finished with the request:
+   * by carrying it out, or by giving up on it. An uncalled `onConsume` means
+   * the request is still waiting, so a caller that cancels can hand it on.
+   * @private
+   */
+  onConsume?: () => void;
 }
 
 /**
@@ -117,6 +124,7 @@ function presentItem({
   markedOnly,
   requireFocus,
   scrollIntoView,
+  onConsume,
 }: PresentItemParams) {
   let element: HTMLElement | null = null;
   let resolvedId: string | undefined;
@@ -211,10 +219,24 @@ function presentItem({
     removeFocusListeners?.();
     unsubscribe?.();
   };
+  let consumed = false;
+  const consume = () => {
+    if (consumed) return;
+    consumed = true;
+    onConsume?.();
+  };
+  // `settle` consumes the request; `cancel` hands it on. A presentation the
+  // caller already cancelled has handed its request on, so settling it
+  // afterwards must not take it back.
+  const settle = () => {
+    if (done) return;
+    consume();
+    return cancel();
+  };
   const present = () => {
     if (done) return;
     const state = store.getState();
-    if (abandonedByState(state)) return cancel();
+    if (abandonedByState(state)) return settle();
     let restoreFocus = false;
     if (!element) {
       // The item may not have rendered yet, so keep waiting for it.
@@ -230,7 +252,7 @@ function presentItem({
       // wake may still beat passive item registration.
       // https://github.com/ariakit/ariakit/pull/7030#discussion_r3703432937
       element = resolveElement(state);
-      if (!element) return cancel();
+      if (!element) return settle();
     }
     // Removing the focused node parks focus on `body`; restore only when ref
     // cleanup identified removal. Explicit blur stays latched until this
@@ -239,7 +261,7 @@ function presentItem({
     if (restoreFocus) {
       focused = false;
     } else if (!stillOwnsFocus(element)) {
-      return cancel();
+      return settle();
     }
     // Only the focus half is withheld: a list that is already on screen still
     // scrolls to the item the user just made active.
@@ -251,10 +273,13 @@ function presentItem({
     // focus it still owes would land on the wrong one.
     if (focusWithheld) {
       const { activeId } = state;
-      if (activeId != null && activeId !== resolvedId) return cancel();
+      if (activeId != null && activeId !== resolvedId) return settle();
     }
     if (focus && !focused && !focusWithheld) {
       focused = true;
+      // Recorded before the focus call, so a handler that reaches back into the
+      // store and starts a new request doesn't get this one's consumption.
+      consume();
       focusLeftElement = false;
       const itemElement = element;
       removeFocusListeners?.();
@@ -283,7 +308,7 @@ function presentItem({
       // A withheld request still owes focus, so keep it pending. Only a
       // request with nothing left to give is finished here.
       if (focusWithheld) return;
-      return cancel();
+      return settle();
     }
     // The item can't be shown yet: a popup that is still hidden while closed,
     // or one that hasn't been positioned yet, would be scrolled to no visible
@@ -295,7 +320,7 @@ function presentItem({
     // repeats a nearest-edge scroll, since a closed popup never takes the
     // centering branch, so it settles unless something else moved the list.
     if (!focusWithheld) {
-      cancel();
+      settle();
     }
     if (scrollIntoView) {
       scrollIntoView(element);
@@ -316,7 +341,9 @@ function presentItem({
   ] as Array<keyof CompositeStoreState>;
   unsubscribe = subscribe(store, keys, present);
   present();
-  return cancel;
+  // `settle` rides along so a caller that is retiring this presentation, rather
+  // than handing its request on, can say so.
+  return Object.assign(cancel, { settle });
 }
 
 /**
@@ -330,7 +357,7 @@ function presentItem({
  * See https://github.com/ariakit/ariakit/pull/7029
  */
 export function usePresentItem(store?: CompositeStore) {
-  const cancelRef = useRef<(() => void) | null>(null);
+  const cancelRef = useRef<ReturnType<typeof presentItem> | null>(null);
   const ownerRef = useRef(store);
   const cancel = useCallback(() => {
     cancelRef.current?.();
@@ -340,12 +367,15 @@ export function usePresentItem(store?: CompositeStore) {
     (params: Omit<PresentItemParams, "store">) => {
       if (!store) return;
       if (ownerRef.current !== store) return;
-      cancel();
+      // A presentation this call replaces is retired rather than handed on:
+      // whatever asked for the new one is the current intent.
+      cancelRef.current?.settle();
+      cancelRef.current = null;
       const cancelCurrent = presentItem({ store, ...params });
       cancelRef.current = cancelCurrent;
       return cancelCurrent;
     },
-    [store, cancel],
+    [store],
   );
   useSafeLayoutEffect(() => {
     ownerRef.current = store;


### PR DESCRIPTION
## Motivation

Removing a [`Composite`](https://ariakit.com/reference/composite) from the tree and adding it back moves focus to its own container and scrolls the page to it, although nothing asked for a new focus move.

These two calls mean different things:

```tsx
store.move(null); // Request focus on the composite container.
store.setActiveId(null); // Point the active item at the container, asking for no focus.
```

`move()` increments a `moves` counter that `setActiveId()` leaves alone. `CompositeFocusOnMove` keys two effects off that counter, so a fresh instance of it reads a count left behind by a move that was already carried out and acts on that count again. A fresh instance appears in two ways: the whole `Composite` remounting, and the `composite` prop flipping from `false` to `true`, which remounts only that child while the DOM element survives.

Both effects replay, and which one does depends on the active item:

- with `activeId === null`, the container takes focus and the page scrolls to it;
- with an item still active, that item takes focus and the page scrolls to it instead.

The sequence reported against the `menubar-navigation` example is arrow into a menu, arrow out to a sibling item, then arrow back. The shared menu unmounts on the way and comes back with the earlier move still recorded and a null active item, so its container steals focus from the menubar item.

## Solution

The commits land in the order the components issue-fix workflow requires: the failing reproduction first, then a userland workaround, then the library fix.

### Reproduction

`app/src/sandbox/composite-7360/` is a formatting toolbar at the end of a long document, with the store owned by the page so it outlives every mount of the toolbar. Collapsing the toolbar points its active item back at the container, the way an app does for a widget that should come back with no item of its own selected. The toolbar is rendered last so that removing and adding it changes layout only below the controls, which keeps the browser's own scroll anchoring out of the measurements. A highlight tool that loads on demand lets the fixture ask for a tool before it exists.

Twelve browser tests run in Chromium, Firefox and WebKit, with a happy-dom duplicate of each for the focus half:

| Test | Pins |
| --- | --- |
| Untouched toolbar comes back | Harness control: mounting alone moves nothing |
| Untouched composite behavior comes back | Harness control: the `composite` flip alone moves nothing |
| Toolbar comes back after a move | The reported container replay |
| Repeated remounts | The replay does not accumulate |
| Composite behavior comes back | The sibling item replay, on a remount the element survives |
| Composite behavior comes back after an abandoned request | A request the toolbar gave up on is spent, not left behind |
| Newly moved item comes back | A move recorded while handed off must still be carried out |
| Focus command while expanded | `move(null)` still focuses and scrolls to the container |
| Focus command while collapsed | A move with no composite element stays pending |
| Focus command while handed off | The same, across `composite={false}` to `composite={true}` |
| Tool loads after being asked for | A move waiting on its item is carried out when the item arrives |
| Tool loads after composite behavior comes back | That pending move survives the instance being replaced |
| Menubar sequence | The reported `menubar-navigation` reproduction |

Four of them fail on `main` in all three engines, along with the menubar test. The rest pass and must keep passing: together they are what stops a fix from suppressing the effects wholesale.

`app/src/sandbox/composite-superseded-move/` covers the one state the toolbar cannot express. Taking a pending request over needs a composite element that can take focus while an item is active, and a roving-tabindex toolbar's container is focusable only when no item is, exactly when that branch does not run. The palette there carries `tabIndex`, so clicking its own padding focuses it and replaces the pending request with its own.

### The fix

`CompositeFocusOnMove` now records, per store, which of its instances consumed the current move, and refuses the request to any other instance. A `sync` on `moves` clears that record, so every new request and every reset of the counter starts unconsumed.

The record has to outlive the component, because the count alone cannot tell a request that is still waiting from one an earlier instance already acted on. It is keyed on the **component instance** rather than on the composite element: switching `composite` off and on again mounts a fresh instance while the element itself survives, so an element-keyed record would be a no-op on exactly that path. A ref token survives the same instance's effect re-runs, including StrictMode's double invocation, but not a remount, which is the distinction the request needs.

What the record tracks is **consumption**, not merely reading the request. A move has three outcomes, and only the last is handed on:

- **Carried out.** Focus reached the item, or the container branch focused the container. Spent, so a later instance must not repeat it.
- **Given up on.** The popup closed, the user moved to another item, focus left the composite, or a new presentation replaced this one. Also spent: the request is dead, not owed.
- **Still waiting.** The target item has not registered yet, or a closed popup has not opened. Nothing consumed it, so whichever instance is around when the wait ends carries it out.

Recording on read collapses the last two into the first and drops pending requests. Recording only on carry-out collapses the middle one into the last and replays abandoned requests. Both were caught by review on this branch, and each of the three states now has a test that fails against a version of the fix that collapses it into another.

`presentItem` reports consumption through a new `@private` `onConsume`, fired where it delivers focus and at every point where it gives up. Its returned `cancel` carries a `settle` alongside it, so `usePresentItem` can retire a live presentation it is replacing, while an owner cancelling one on unmount still hands the request on.

`consumeMove` also takes the `moves` value its effect ran with and drops a consumption that arrives after the count has moved on, so a focus handler that starts a new request does not inherit this one's consumption. That guard ships without a red check: the window needs a store write to re-enter a live presentation between a `moves` change and React flushing the effect whose cleanup would cancel it, and no reachable consumer path was found. It compares the count by value, so it does not cover a reset that returns to the same number.

## Preview

Recorded against `app/src/sandbox/composite-7360/` at 1280 × 800: click the first toolbar item, press ArrowRight, return to the controls at the top of the document, collapse the toolbar, then expand it again.

Before, the toolbar takes focus and the page jumps from 0px to 1580px to reach it.

[before.webm](https://github.com/user-attachments/assets/ce930309-66a5-4546-ace2-f12242e8ed04)

After, focus stays on the control that was clicked and the page stays at 0px.

[after.webm](https://github.com/user-attachments/assets/7ff41ba8-30c0-496e-a16b-0a51396aa9d0)

## Workaround

Until this ships, an app can clear the recorded move count itself once the composite goes away, so there is nothing left for a fresh instance to carry out.

```tsx
// TODO: Remove once https://github.com/ariakit/ariakit/issues/7360 is fixed.
const away = !expanded || handedOff;
useEffect(() => {
  if (!away) return;
  store.setState("moves", 0);
}, [away, store]);
```

For a popup that closes itself, such as the shared menu in `menubar-navigation`, put the same effect in a component inside the provider that owns the store, keyed on `mounted`:

```tsx
// TODO: Remove once https://github.com/ariakit/ariakit/issues/7360 is fixed.
function ForgetRecordedMoves() {
  const menu = Ariakit.useMenuContext();
  const mounted = Ariakit.useStoreState(menu, "mounted");
  useEffect(() => {
    if (mounted) return;
    menu?.setState("moves", 0);
  }, [mounted, menu]);
  return null;
}
```

This is narrower than the fix, and the limitations matter:

- **It clears once, on the way out, and is not a standing invariant.** A `move()` issued later, while the composite is still away, is genuinely pending and must still be carried out when it returns. That is why `away` is a single dependency: splitting it into the two flags that produce it re-runs the effect on a transition between two away states and silently drops that pending request.
- **A `move()` issued in the same commit that takes the composite away is lost**, because the effect runs after that commit. The fix preserves such a request; this does not.
- **The `away` condition must cover every way the composite goes away** — unmounting, and the [`composite`](https://ariakit.com/reference/composite#composite-1) prop becoming `false`. A missed path leaves the replay in place.
- **Do not clear on the way back in.** The container-focus effect is a layout effect, so it runs before a passive effect in the same commit.
- **`moves` is shared state, so this is not safe on every store.** It is safe on plain composite, menu and menubar stores. On a [`Tab`](https://ariakit.com/reference/tab) store it commits the active tab as selected, because that store reacts to any change of `moves` and `selectOnMove` defaults to `true`. On a [`Combobox`](https://ariakit.com/reference/combobox) store it disarms selection-follows-open and rewrites the active value. [`Select`](https://ariakit.com/reference/select) and [`Radio`](https://ariakit.com/reference/radio) ignore a reset and are unaffected.
- **`moves` stops matching its documented meaning**, the number of times [`move`](https://ariakit.com/reference/use-composite-store#move) has been called, for any consumer code that reads it.

## Review gate reassessment

<details>
<summary>Cycle 3: Continue the reproduction-fixture direction, with a comment verify-or-delete sweep</summary>

**Assessment**

Issue severity: a confirmed bug in stable `@ariakit/react`. A remounted `Composite` steals DOM focus and scrolls the page with no move requested, which is a focus-management and orientation defect rather than a cosmetic one.

Expected frequency: needs a prior move, a remount, and `activeId === null` together. That combination occurs in the shipped `menubar-navigation` example, so it is reachable through normal use rather than only through a contrived case.

Supported scope: every widget built on `Composite` that is conditionally rendered while its store outlives it, including `Toolbar`, `Menu`, `Select`, `Combobox`, and `Tab`.

Likely user impact: focus lands on a container the user never targeted, and the page jumps. Measured at 0px to 1580px in the reproduction fixture.

Implementation and maintenance complexity: this snapshot adds no library code, no public API, no new abstraction, and no shared helper. It adds one issue-number sandbox, its Playwright test, its happy-dom duplicate, and one test in an existing fixture, reusing `withFramework`, `flushFrames`, `recordScrollEvents`, and `query`. Three small local helpers, two `useState` booleans, no new state machinery.

Cause of the repeated cycles: of eleven findings across three cycles, only one (cycle 1, scroll anchoring making the page assertions unfalsifiable) required a design change, and it has not recurred. Eight were comment or naming accuracy, six of those in one specific class: a comment asserting library behavior the library does not have. Counts and severity both fall across cycles, 6 to 4 to 1. This is an authoring-accuracy pattern in prose about library internals, not a design converging on a problem.

**Decision**

Continue the current direction. There is no machinery to simplify or remove: the snapshot is the failing reproduction and contains no implementation. Every candidate narrowing would drop coverage the issue asks for by name, including the `composite={false}` to `composite={true}` case it warns must be preserved. The six browser tests are jointly satisfiable only by a fix that distinguishes a consumed move request from a pending one, so the preservation tests are load-bearing rather than padding.

The cycle-3 finding is addressed by widening the remedy to match the defect class: every falsifiable claim about library behavior in the four changed files was verified against source in one pass, or corrected. Thirteen of fourteen held. The one that did not described `composite={false}` as producing "a plain group" with "tab navigation"; the prop actually stops the component managing focus and keyboard navigation so another composite can take over, and the items keep roving tabindex. That wording, the control's label, and the matching test titles were corrected. The menubar comment was also tightened: the active item is null when the menu returns through two separate paths, so the comment now states the observable fact instead of attributing it to one.

Intentionally unsupported in this snapshot: consolidating the issue-number fixture into a semantic one. This is a declined non-goal rather than a registered follow-up. The fixture-lifecycle rules place a new isolated reproduction at step 2, and step 3 consolidation triggers only once issue-number fixtures develop stable overlap, which has not happened. No follow-up record is needed.

No registered follow-up issues arose from this track.

</details>

<details>
<summary>Cycle 6: Continue, and complete the reproduction with the sibling effect</summary>

**Assessment**

Issue severity, expected frequency, supported scope and likely user impact are unchanged from cycle 3, and cycle 6 raised the assessed impact: the defect has a second live path that the reproduction did not cover.

Implementation and maintenance complexity: still no library code, no public API, no new abstraction, and no shared helper. Cycle 6 adds one browser test and one happy-dom duplicate that reuse the fixture's existing controls, with no fixture change.

Cause of the repeated cycles: finding counts run 6, 4, 1, 2, 1, 1. Cycles 1 to 5 were one blocking harness defect plus eleven comment-accuracy and test-strength items, and they converged. Cycle 6 is a different kind of finding, the first substantive one since cycle 1: a coverage gap, found by running the reproduction against unmodified base code. So the cycles are not one problem recurring.

One process defect is worth recording: the cycle-3 remedy introduced the cycle-4 finding, because it sourced its replacement wording from the prop's public JSDoc instead of verifying against the implementation. Every remedy for a "comment asserts behavior the library does not have" finding must itself be verified against the implementation in the same cycle.

**Decision**

Continue the current direction, and include the cycle-6 coverage rather than deferring it.

`CompositeFocusOnMove` runs two effects on the same stale `moves` counter. The reproduction pinned only the container-focus one, guarded by `activeId === null`. Its sibling, "Present the active item", guarded by `activeId != null`, replays a completed move by the same mechanism. Measured on the base commit through the fixture's own controls: after moving to the second item, handing composite behavior over, and returning the page to its origin, taking that behavior back moves focus back to the item and the page from 0px to 1580px, with no new move requested.

This is the same defect through the other branch of the same effect pair, not separable work: the issue's expected behavior says adding the composite back must not create a new focus or scroll request, with no branch qualifier, and the workflow requires reproduction coverage to land before the library fix. Splitting it would either leave the fix's second half unasserted or close the issue with one branch still broken.

The scope is fenced to one browser test and one happy-dom duplicate on the existing controls. Needing new fixture state or a new sandbox would have been the signal to split instead.

This finding also falsified the planned library fix before any of it was written. The plan was to record which composite element had carried out the store's current move request. When only the `composite` prop flips, the effect remounts while the composite element is unchanged, so an element-keyed claim still matches and the replay is allowed. The discriminator has to be the component instance, which a per-instance token records. One guard then covers both effects, so this coverage adds no library machinery.

Registered follow-up: https://github.com/ariakit/ariakit/issues/7363, for the `composite` prop JSDoc, whose "stop managing focus and keyboard navigation for its items" wording is imprecise about item-level navigation. It is pre-existing on `main` and independent of this change, and its ambiguity produced the cycle-4 finding here.

Intentionally unsupported: consolidating this issue-number fixture into a semantic one, as recorded at cycle 3.

</details>

<details>
<summary>Cycle 9: Continue, with a narrowed comment policy</summary>

**Assessment**

Issue severity, supported scope, likely user impact and expected frequency are unchanged. The menubar reproduction is the frequency argument that matters: arrow into a menu, arrow out to a sibling, arrow back is plain keyboard use of a shipped composition.

Implementation and maintenance complexity: still no library code, no public contract, no new abstraction, no platform policy, no runtime cost. The helpers are ten extractions of two to four lines, each one a prior cycle asked for.

The nine-test suite is at minimum size rather than padded. Each test maps either to an explicit acceptance criterion in the issue or to a demonstrated wrong fix, and the cycle-9 reviewer stress-tested seven candidate wrong fixes without finding one that passes all nine. Removing a test would admit a wrong fix, so "simplify or remove machinery" and "narrow the supported contract" are both unavailable on the substance.

Cause of the repeated cycles: of twenty-five findings, six were test validity or coverage, fifteen comment or naming accuracy, and four readability or reuse. The comment findings cluster immediately after the cycles that added tests, because prose written for a smaller suite went stale when new callers arrived, and two of them were introduced by a previous cycle's own remedy. Cycle 9 is the first cycle where the suite did not grow, and it found no correctness, coverage or accuracy defect. The series is converging.

For the skill's low-complexity clause: this is a test-and-fixture-only snapshot whose maintenance cost is the standard, bounded cost of any sandbox in this repository. The repeated cycles do not create a meaningful complexity concern.

**Decision**

Continue, and adopt a narrowed comment policy as the direction refinement rather than a batch deletion of existing prose.

Comments here make one of three kinds of claim: why a setup exists, what the test would otherwise fail to catch, or a derived description of library internals that no assertion depends on. Every one of the fifteen accuracy findings lived in the third kind. Every comment of the first two kinds has produced no finding in nine cycles. The rule going forward: a sentence describing library behavior must be needed to understand why an assertion in that file is what it is; otherwise delete it, and when it is needed, verify it at the call site and attach a permalink where a durable record exists.

A batch cull of existing prose was considered and rejected. It would diverge from the register of the nearest sibling fixtures and of the component source itself, it would discard notes that earned themselves through blocking findings, and rewriting fifty lines of unreviewed prose at this stage is the exact mechanism that produced two of the findings being counted.

Two cycle-9 remedies were revised on this basis. The helper whose name and JSDoc promised an ordering its body lacks is fixed by shortening the JSDoc to its load-bearing clause and renaming it, not by reordering a passing test to satisfy prose. The reuse finding is scoped to the happy-dom file. The browser file's two apparent duplications are deliberate: those tests need no scroll to the top, so routing them through the shared helper would trade duplication for a which-helper-do-I-call problem.

Registered follow-up from earlier cycles, still open: https://github.com/ariakit/ariakit/issues/7363.

Intentionally unsupported: consolidating this issue-number fixture into a semantic one, as recorded at cycle 3.

</details>

<details>
<summary>Cycle 12: Continue, with the record tracking consumption rather than reading</summary>

**Assessment**

Issue severity, supported scope, likely user impact and expected frequency are unchanged from cycle 9. What changed is that the library fix now exists and has been reviewed on its own terms, over three rounds prompted by the pull request comments.

Implementation and maintenance complexity: the fix adds a per-store `WeakMap` record, two small helpers, one `sync` subscription, one `@private` `presentItem` callback, an idempotent `consume`, a `settle` wrapper over `cancel`, and a `settle` property on the value `presentItem` returns. That is more machinery than the first draft, which was a single read-time guard.

Cause of the repeated cycles: all three rounds found the same class of defect, a move request being misclassified at the moment a presentation stops. Round 1 found that claiming on read discards a request still waiting for its item, reproduced through the fixture. Round 1 also found that claiming on carry-out alone replays a request the presentation gave up on, reproduced the same way. Round 2 found that the give-up contract missed the one stop that comes from outside the presentation, a replacement through `usePresentItem`. Each round narrowed the same question rather than opening a new one, and the answer converged on a single invariant.

**Decision**

Continue, and keep the consumption contract.

Four simpler designs were evaluated and rejected on evidence rather than taste.

Claiming at read is what the first draft did. It drops any request whose item registers later, which is supported behavior with its own coverage in `app/src/sandbox/composite-late-item-focus/`.

Claiming only when the item is already connected, the smallest prototype proposed on the pull request, fixes that and nothing else. A request whose item never arrives is never claimed, so picking another item abandons it and leaves it to be replayed. This is what the abandoned-request test pins, and that test was written from a reproduction rather than from the code.

Claiming at read and releasing on cleanup when the presentation is still waiting appears to need no `presentItem` change, but it does not save anything and does not go far enough. Knowing whether a presentation is still waiting means tracking exactly the same thing at exactly the same points inside `presentItem`, since a cancelled presentation and a pending one are otherwise indistinguishable, and it adds a release path on top. It also leaves the superseded case untouched: a presentation replaced through `usePresentItem` would still be released on cleanup and replayed.

Recording a consumed `moves` count per store, which would remove the request record, the `sync` subscription and the instance token together, is unsafe. `CompositeContainer` sets `moves` back to `0`, so a reset followed by fresh moves can reach a count that was already recorded as consumed and silently retire a live request. Resetting on every change of the counter is what avoids that, and it needs the record.

The remaining machinery is the smallest that distinguishes states the store cannot distinguish on its own, because `moves` counts requests and records nothing about what became of them. The tests that pin those states are jointly satisfiable only by a design that keeps them apart: each one fails against a version of the fix that collapses its state into another, and each of those failures was measured rather than argued.

The third state has a third way in, and it needed its own fixture rather than a follow-up. A request can also be taken over, when a new presentation replaces one that is still waiting. `composite-7360` cannot reach it: the palette branch that takes a request over runs only while an item is active, and a roving-tabindex toolbar's container is focusable only while none is, so the two never meet there. That is a property of the fixture rather than of the defect, and `app/src/sandbox/composite-superseded-move/` supplies the missing shape with a listbox-style palette that carries `tabIndex`. Its reproduction test fails in all three engines when the replacement cancels instead of settling, while both of its controls pass, so the failure isolates the takeover.

Registered follow-up: https://github.com/ariakit/ariakit/issues/7378. Review found a second route to the same symptom, and this one is not a replay of a request that was carried out. A move for an item that never registers stays pending, and a later `setActiveId(null)` leaves it indistinguishable from a request for the container, so the container takes focus and the page scrolls on the next mount. It reproduces from this pull request's own fixture, and it reproduces the same way with the merge-base library files swapped in, so it is pre-existing rather than introduced here. Resolving it means recording what a move asked for, not only what became of it, which is a different question from the one this change answers.

Intentionally unsupported, as recorded at cycle 3: consolidating this issue-number fixture into a semantic one. The new fixture is semantic rather than issue-numbered, because it covers a state of the contract rather than a distinct report.

The follow-up registered at cycle 6, https://github.com/ariakit/ariakit/issues/7363, was closed on `main` by #7366.

</details>

Fixes #7360
