### PR TITLE
Use query fixtures in browser tests

### DIFF
--- a/app/src/sandbox/combobox-input-email/test-browser.ts
+++ b/app/src/sandbox/combobox-input-email/test-browser.ts
@@ -1,10 +1,11 @@
-import { query } from "@ariakit/test/playwright";
 import { expect } from "@playwright/test";
 import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
-  test("combobox should not throw when input type=email", async ({ page }) => {
-    const q = query(page);
+  test("combobox should not throw when input type=email", async ({
+    page,
+    q,
+  }) => {
     const combobox = q.combobox("Email");
     await combobox.click();
 
@@ -24,8 +25,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
   // https://github.com/ariakit/ariakit/issues/3086
   test("moves focus back to the email input when typing on an item", async ({
     page,
+    q,
   }) => {
-    const q = query(page);
     const combobox = q.combobox("Real focus email");
     await combobox.click();
     await combobox.fill("e");

--- a/app/src/sandbox/combobox-links/test-browser.ts
+++ b/app/src/sandbox/combobox-links/test-browser.ts
@@ -1,5 +1,5 @@
 import type { Page } from "@ariakit/test/playwright";
-import { expect, query } from "@ariakit/test/playwright";
+import { expect } from "@ariakit/test/playwright";
 import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
@@ -10,8 +10,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
     return isMac ? "Meta" : "Control";
   };
 
-  test("click on link with mouse", async ({ page }) => {
-    const q = query(page);
+  test("click on link with mouse", async ({ page, q }) => {
     await q.combobox("Links").click();
     await expect(q.listbox()).toBeVisible();
     await q.option("Ariakit.com").click();
@@ -20,10 +19,10 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
   test("click on link with middle button", async ({
     page,
+    q,
     context,
     browserName,
   }) => {
-    const q = query(page);
     await q.combobox("Links").click();
     await expect(q.listbox()).toBeVisible();
     await expect(q.combobox("Links")).toHaveValue("");
@@ -41,8 +40,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
     }
   });
 
-  test("click on link with cmd/ctrl", async ({ page, context }) => {
-    const q = query(page);
+  test("click on link with cmd/ctrl", async ({ page, q, context }) => {
     await q.combobox("Links").click();
     await expect(q.listbox()).toBeVisible();
     const modifier = await getClickModifier(page);
@@ -57,13 +55,13 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
   test("click on link with cmd/ctrl + enter", async ({
     page,
+    q,
     context,
     browserName,
   }) => {
     // Chrome and Firefox can take a while to materialize the modifier+Enter
     // tab under CI load.
     test.slow();
-    const q = query(page);
     const combobox = q.combobox("Links");
     await combobox.click();
     await expect(q.listbox()).toBeVisible();
@@ -98,14 +96,13 @@ withFramework(import.meta.dirname, async ({ test }) => {
     }
   });
 
-  test("click on target blank link", async ({ page, context }) => {
+  test("click on target blank link", async ({ q, context }) => {
     // Keep popup creation independent of the external site's availability.
     await context.route(
       "https://bsky.app/profile/ariakit.com",
       (route) => route.fulfill({ body: "" }),
       { times: 1 },
     );
-    const q = query(page);
     await q.combobox("Links").click();
     await expect(q.listbox()).toBeVisible();
     await expect(q.combobox("Links")).toHaveValue("");
@@ -118,8 +115,10 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await expect(newPage).toHaveURL("https://bsky.app/profile/ariakit.com");
   });
 
-  test("https://github.com/ariakit/ariakit/issues/2056", async ({ page }) => {
-    const q = query(page);
+  test("https://github.com/ariakit/ariakit/issues/2056", async ({
+    page,
+    q,
+  }) => {
     await q.combobox("Links").click();
     await expect(q.listbox()).toBeVisible();
     // Hover here is important to reproduce the issue.

--- a/app/src/sandbox/combobox-radix-select/test-mobile.ts
+++ b/app/src/sandbox/combobox-radix-select/test-mobile.ts
@@ -1,11 +1,12 @@
-import { query } from "@ariakit/test/playwright";
 import { expect } from "@playwright/test";
 import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
   // https://github.com/ariakit/ariakit/issues/3274
-  test("keeps the select open when the viewport resizes", async ({ page }) => {
-    const q = query(page);
+  test("keeps the select open when the viewport resizes", async ({
+    page,
+    q,
+  }) => {
     const select = q.combobox("Language");
     const input = q.combobox("Search languages");
     const dialog = q.dialog("Languages");

--- a/app/src/sandbox/combobox-tabs/test-browser.ts
+++ b/app/src/sandbox/combobox-tabs/test-browser.ts
@@ -1,11 +1,11 @@
-import { query } from "@ariakit/test/playwright";
 import { expect } from "@playwright/test";
 import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
-  test("https://github.com/ariakit/ariakit/issues/3941", async ({ page }) => {
-    const q = query(page);
-
+  test("https://github.com/ariakit/ariakit/issues/3941", async ({
+    page,
+    q,
+  }) => {
     await q.combobox().click();
     await expect(q.dialog()).toBeVisible();
 

--- a/app/src/sandbox/combobox/test-mobile.ts
+++ b/app/src/sandbox/combobox/test-mobile.ts
@@ -1,10 +1,8 @@
-import { query } from "@ariakit/test/playwright";
 import { expect } from "@playwright/test";
 import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
-  test("show/hide on tap", async ({ page }) => {
-    const q = query(page);
+  test("show/hide on tap", async ({ q }) => {
     await q.combobox("Your favorite fruit").tap();
     await expect(q.listbox()).toBeVisible();
     await q.document().click({ position: { x: 10, y: 10 } });
@@ -12,16 +10,14 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await expect(q.combobox()).not.toBeFocused();
   });
 
-  test("hide when tapping on item", async ({ page }) => {
-    const q = query(page);
+  test("hide when tapping on item", async ({ q }) => {
     await q.combobox("Your favorite fruit").tap();
     await q.option("🍎 Apple").tap();
     await expect(q.listbox()).not.toBeVisible();
     await expect(q.combobox()).toBeFocused();
   });
 
-  test("hide when tapping on item after clicking outside", async ({ page }) => {
-    const q = query(page);
+  test("hide when tapping on item after clicking outside", async ({ q }) => {
     await q.combobox().tap();
     await q.document().click({ position: { x: 10, y: 10 } });
     await q.combobox().tap();

--- a/app/src/sandbox/dialog-menu-interactions/test-browser.ts
+++ b/app/src/sandbox/dialog-menu-interactions/test-browser.ts
@@ -9,8 +9,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
     return page.locator(`[data-backdrop="${id}"]`);
   };
 
-  test("open/close menu by clicking on menu button", async ({ page }) => {
-    const q = query(page);
+  test("open/close menu by clicking on menu button", async ({ q }) => {
     await q.button("View recipe").click();
     await q.button("Share").click();
     await expect(q.menu()).toBeVisible();
@@ -18,8 +17,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await expect(q.menu()).not.toBeVisible();
   });
 
-  test("dragging the cursor to outside the dialog", async ({ page }) => {
-    const q = query(page);
+  test("dragging the cursor to outside the dialog", async ({ page, q }) => {
     await q.button("View recipe").click();
     await expect(q.dialog()).toBeVisible();
     await q.dialog().dragTo(await backdrop(page), {
@@ -28,8 +26,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await expect(q.dialog()).toBeVisible();
   });
 
-  test("dragging the cursor to outside the menu", async ({ page }) => {
-    const q = query(page);
+  test("dragging the cursor to outside the menu", async ({ q }) => {
     await q.button("View recipe").click();
     await q.button("Share").click();
     await expect(q.dialog()).toBeVisible();
@@ -39,8 +36,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await expect(q.menu()).toBeVisible();
   });
 
-  test("dragging the cursor to outside both", async ({ page }) => {
-    const q = query(page);
+  test("dragging the cursor to outside both", async ({ page, q }) => {
     await q.button("View recipe").click();
     await q.button("Share").click();
     await expect(q.dialog()).toBeVisible();

--- a/app/src/sandbox/menu-combobox-interactions/test-browser.ts
+++ b/app/src/sandbox/menu-combobox-interactions/test-browser.ts
@@ -6,10 +6,9 @@ const cases = [
   ["Store", "Store Add block", "Search store blocks"],
 ] as const;
 
-withFramework(import.meta.dirname, async ({ query, test }) => {
+withFramework(import.meta.dirname, async ({ test }) => {
   for (const [name, buttonLabel, searchLabel] of cases) {
-    test(`auto select first option with ${name}`, async ({ page }) => {
-      const q = query(page);
+    test(`auto select first option with ${name}`, async ({ q }) => {
       await q.button(buttonLabel).click();
       await expect(q.dialog(buttonLabel)).toBeVisible();
       await q.combobox(searchLabel).fill("a");
@@ -17,8 +16,10 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
     });
   }
 
-  test("https://github.com/ariakit/ariakit/issues/4324", async ({ page }) => {
-    const q = query(page);
+  test("https://github.com/ariakit/ariakit/issues/4324", async ({
+    page,
+    q,
+  }) => {
     const button = q.button("Provider Add block");
     const dialog = q.dialog("Provider Add block");
     await button.click();

--- a/app/src/sandbox/menu-nested-interactions/test-chrome.ts
+++ b/app/src/sandbox/menu-nested-interactions/test-chrome.ts
@@ -1,9 +1,11 @@
-import { expect, query } from "@ariakit/test/playwright";
+import { expect } from "@ariakit/test/playwright";
 import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
-  test("https://github.com/ariakit/ariakit/issues/4247", async ({ page }) => {
-    const q = query(page);
+  test("https://github.com/ariakit/ariakit/issues/4247", async ({
+    page,
+    q,
+  }) => {
     await q.button("Edit").click();
     await expect(q.menu("Edit")).toBeVisible();
     await q.menuitem("Find").hover();

--- a/app/src/sandbox/menubar-interactions/test-browser.ts
+++ b/app/src/sandbox/menubar-interactions/test-browser.ts
@@ -1,12 +1,11 @@
-import { query } from "@ariakit/test/playwright";
 import { expect } from "@playwright/test";
 import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
   test("re-open submenu and shift-tab back to the parent menu", async ({
     page,
+    q,
   }) => {
-    const q = query(page);
     await q.menuitem("File").click();
     await q.menuitem("Share").hover();
     await q.menuitem("Notes").hover();

--- a/app/src/sandbox/menubar-navigation/test-browser.ts
+++ b/app/src/sandbox/menubar-navigation/test-browser.ts
@@ -1,5 +1,5 @@
 import type { Page } from "@ariakit/test/playwright";
-import { expect, query } from "@ariakit/test/playwright";
+import { expect } from "@ariakit/test/playwright";
 import { withFramework } from "#app/test-utils/preview.ts";
 
 function pressTab(page: Page, browserName: string, shift = false) {
@@ -15,8 +15,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
   test("show menus by hovering over items without moving focus", async ({
     page,
+    q,
   }) => {
-    const q = query(page);
     const body = page.locator("body");
 
     await q.menuitem("Services").hover();
@@ -46,8 +46,10 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await expect(body).toBeFocused();
   });
 
-  test("show menus by hovering over items and subitems", async ({ page }) => {
-    const q = query(page);
+  test("show menus by hovering over items and subitems", async ({
+    page,
+    q,
+  }) => {
     await q.menuitem("Services").hover();
     await q.menuitem("Web Development").hover();
     await expect(q.menu("Services")).not.toBeFocused();
@@ -64,8 +66,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await expect(q.menu("Company")).not.toBeVisible();
   });
 
-  test("show menus by focusing on items", async ({ page, browserName }) => {
-    const q = query(page);
+  test("show menus by focusing on items", async ({ page, q, browserName }) => {
     await pressTab(page, browserName);
     await expect(q.menuitem("Services")).toBeFocused();
     await expect(q.menu("Services")).toBeVisible();
@@ -81,8 +82,11 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await expect(q.menu("Company")).not.toBeVisible();
   });
 
-  test("show menus by tabbing through items", async ({ page, browserName }) => {
-    const q = query(page);
+  test("show menus by tabbing through items", async ({
+    page,
+    q,
+    browserName,
+  }) => {
     await pressTab(page, browserName);
     await expect(q.menuitem("Services")).toBeFocused();
     await pressTab(page, browserName);
@@ -131,8 +135,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
   test("moving between menus with arrow keys after hovering over subitems", async ({
     page,
+    q,
   }) => {
-    const q = query(page);
     await q.menuitem("Blog").hover();
     await q.menuitem("Tech").hover();
     await page.keyboard.press("ArrowRight");
@@ -141,9 +145,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await expect(q.menuitem("Company")).not.toBeFocused();
   });
 
-  test("click on menuitem links", async ({ page, browserName }) => {
-    const q = query(page);
-
+  test("click on menuitem links", async ({ page, q, browserName }) => {
     await q.menuitem("Services").hover();
     await expect(q.menu("Services")).toBeVisible();
     await q.menuitem("Services").click();
@@ -175,9 +177,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await expect(q.menuitem("Services")).toBeFocused();
   });
 
-  test("moving between menu items with arrow keys", async ({ page }) => {
-    const q = query(page);
-
+  test("moving between menu items with arrow keys", async ({ page, q }) => {
     await q.menuitem("Blog").click();
     await expect(q.menu("Blog")).toBeVisible();
 
@@ -200,9 +200,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
   // https://github.com/ariakit/ariakit/issues/7360
   test("keeps focus on the menu item when the shared menu is mounted again", async ({
     page,
+    q,
     browserName,
   }) => {
-    const q = query(page);
     await pressTab(page, browserName);
     await expect(q.menuitem("Services")).toBeFocused();
     await expect(q.menu("Services")).toBeVisible();

--- a/app/src/sandbox/tab-panel-animated/test-chrome.ts
+++ b/app/src/sandbox/tab-panel-animated/test-chrome.ts
@@ -1,4 +1,3 @@
-import { query } from "@ariakit/test/playwright";
 import { expect } from "@playwright/test";
 import { withFramework } from "#app/test-utils/preview.ts";
 
@@ -9,9 +8,7 @@ const tab3 = "Explore";
 withFramework(import.meta.dirname, async ({ test }) => {
   test.describe.configure({ retries: 2 });
 
-  test("switch tabs", async ({ page }) => {
-    const q = query(page);
-
+  test("switch tabs", async ({ page, q }) => {
     await expect(q.tab(tab1)).toHaveAttribute("aria-selected", "true");
     await expect(q.tabpanel(tab1)).toBeVisible();
 

--- a/app/src/sandbox/tab-panel-scroll-restoration/test-chrome-firefox.ts
+++ b/app/src/sandbox/tab-panel-scroll-restoration/test-chrome-firefox.ts
@@ -37,9 +37,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
       const tabs = [`${name} 1`, `${name} 2`];
 
       for (const tab of tabs) {
-        test(`Restore scroll on ${tab}`, async ({ page }) => {
-          const q = query(page);
-
+        test(`Restore scroll on ${tab}`, async ({ page, q }) => {
           await q.tab(tab).click();
           await expect(q.tabpanel(tab)).toBeVisible();
 
@@ -63,9 +61,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
       const tabs = [`${name} 1`, `${name} 2`];
 
       for (const tab of tabs) {
-        test(`Reset scroll on ${tab}`, async ({ page }) => {
-          const q = query(page);
-
+        test(`Reset scroll on ${tab}`, async ({ page, q }) => {
           await q.tab(tab).click();
           await expect(q.tabpanel(tab)).toBeVisible();
 


### PR DESCRIPTION
## Motivation

Several app sandbox Playwright tests reconstruct accessible query helpers with `query(page)` even though the shared `test` fixture already supplies the same helper as `q`. This duplicates setup and leaves unnecessary imports.

## Solution

Destructure `q` from each affected test callback and remove redundant `query(page)` calls and unused imports across 12 sandbox suites. Keep direct `query(...)` calls only where tests use custom query implementations or helpers for nested or reusable locators.

```ts
test("example", async ({ page, q }) => {
  await q.button("Open").click();
});
```
