### PR TITLE
Mark unstable APIs as deprecated

### DIFF
--- a/packages/ariakit-components/src/popover/popover-store.ts
+++ b/packages/ariakit-components/src/popover/popover-store.ts
@@ -157,6 +157,7 @@ export interface PopoverStoreState extends DialogStoreState {
    * `false`, otherwise they act on an element that's still at its
    * pre-placement origin, or at a position it's about to leave, and drag the
    * page along with it.
+   * @deprecated
    * @private
    */
   unstable_placing: boolean;

--- a/packages/ariakit-react-components/src/composite/composite-item.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-item.tsx
@@ -599,6 +599,7 @@ export interface CompositeItemOptions<T extends ElementType = TagName>
   store?: CompositeStore;
   /**
    * Determines how the item is scrolled into view when it's presented.
+   * @deprecated
    * @private
    */
   unstable_scrollIntoView?: (element: HTMLElement) => void;

--- a/packages/ariakit-react-components/src/composite/composite.tsx
+++ b/packages/ariakit-react-components/src/composite/composite.tsx
@@ -669,6 +669,7 @@ export interface CompositeOptions<
   store?: CompositeStore;
   /**
    * Determines how an item is scrolled into view when it's presented.
+   * @deprecated
    * @private
    */
   unstable_scrollIntoView?: (element: HTMLElement) => void;

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -1229,6 +1229,7 @@ export interface DialogOptions<T extends ElementType = TagName>
    * An opaque value that makes the dialog take a new snapshot of the element
    * tree and mark it again. It's only ever compared by identity, so composed
    * components can combine several sources into one value.
+   * @deprecated
    * @private
    */
   unstable_treeSnapshotKey?: unknown;

--- a/packages/ariakit-react-components/src/disclosure/disclosure-content.tsx
+++ b/packages/ariakit-react-components/src/disclosure/disclosure-content.tsx
@@ -331,6 +331,7 @@ export interface DisclosureContentOptions<
    * taken into account when computing the animation timeout, such as the
    * dialog's backdrop element, which may be animated while the dialog itself
    * is not.
+   * @deprecated
    * @private
    */
   unstable_otherElementRef?: RefObject<HTMLElement | null>;

--- a/packages/ariakit-react-components/src/hovercard/__hovercard-trigger.tsx
+++ b/packages/ariakit-react-components/src/hovercard/__hovercard-trigger.tsx
@@ -196,6 +196,7 @@ export interface HovercardTriggerOptions<
    * never shows the content on hover, since the content would then be
    * reachable by pointer users alone; this prop can't turn that back on.
    * @default true
+   * @deprecated
    * @private
    */
   unstable_showOnHoverWhenDisabled?: BooleanOrCallback<

--- a/packages/ariakit-react-components/src/menu/menu-button.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-button.tsx
@@ -339,6 +339,7 @@ export interface MenuButtonOptions<T extends ElementType = TagName>
    * when it is, opting in leaves the menu reachable by pointer users alone,
    * because a disabled menu button never opens its menu from the keyboard.
    * @default false
+   * @deprecated
    * @private
    */
   unstable_showOnHoverWhenDisabled?: HovercardAnchorOptions<T>["unstable_showOnHoverWhenDisabled"];


### PR DESCRIPTION
## Motivation

APIs prefixed with `unstable_` are renamed when they become stable. Their type declarations should expose this transitional contract to TypeScript consumers.

## Solution

Add a bare `@deprecated` JSDoc tag alongside the existing `@private` tag on every current `unstable_` API declaration:

```ts
/**
 * @deprecated
 * @private
 */
```

This keeps runtime behavior unchanged and preserves private filtering in generated references.

## Testing

- `pnpm build`
- `pnpm lint-fix`
- `pnpm tsc`
- `pnpm test app/src/lib/jsdoc-loader.test.ts website/build-pages/reference-utils.test.ts`
- `pnpm build-website-lite`
