### PR TITLE
Tolerate invalid click event views

### DIFF
--- a/.changeset/300-command-jsdom-activation.md
+++ b/.changeset/300-command-jsdom-activation.md
@@ -3,8 +3,4 @@
 "@ariakit/react": patch
 ---
 
-Fixed `Command` keyboard activation in Vitest's default jsdom environment
-
-The click that [`Command`](https://ariakit.com/reference/command) synthesizes for `Enter` and `Space` on a non-native element no longer throws when Vitest replaces `document.defaultView` with its Node global context. This also restores keyboard activation for every component built on `Command`, including [`Button`](https://ariakit.com/reference/button) and [`MenuButton`](https://ariakit.com/reference/menu-button).
-
-Thanks to [@cloud-walker](https://github.com/cloud-walker) for reporting and reproducing the issue, diagnosing its cause, and exploring possible solutions.
+Fixed [`Command`](https://ariakit.com/reference/command) keyboard activation with `Enter` and `Space` in Vitest's default jsdom environment. This affects all components built on [`Command`](https://ariakit.com/reference/command), including [`Button`](https://ariakit.com/reference/button) and [`MenuButton`](https://ariakit.com/reference/menu-button). Thanks to [@cloud-walker](https://github.com/cloud-walker).

--- a/.changeset/300-command-jsdom-activation.md
+++ b/.changeset/300-command-jsdom-activation.md
@@ -1,0 +1,10 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed `Command` keyboard activation in Vitest's default jsdom environment
+
+The click that [`Command`](https://ariakit.com/reference/command) synthesizes for `Enter` and `Space` on a non-native element no longer throws when Vitest replaces `document.defaultView` with its Node global context. This also restores keyboard activation for every component built on `Command`, including [`Button`](https://ariakit.com/reference/button) and [`MenuButton`](https://ariakit.com/reference/menu-button).
+
+Thanks to [@cloud-walker](https://github.com/cloud-walker) for reporting and reproducing the issue, diagnosing its cause, and exploring possible solutions.

--- a/.changeset/300-fire-click-event-invalid-view.md
+++ b/.changeset/300-fire-click-event-invalid-view.md
@@ -1,0 +1,9 @@
+---
+"@ariakit/utils": patch
+---
+
+Fixed `fireClickEvent` in DOM environments with a non-`Window` document view
+
+`fireClickEvent` now passes `null` as the event view when `document.defaultView` exposes event constructors but is not a genuine `Window`. This prevents strict DOM implementations from rejecting the synthetic click while preserving the owner window for real browser documents and same-origin iframes.
+
+Thanks to [@cloud-walker](https://github.com/cloud-walker) for reporting and reproducing the issue, diagnosing its cause, and exploring possible solutions.

--- a/.changeset/300-fire-click-event-invalid-view.md
+++ b/.changeset/300-fire-click-event-invalid-view.md
@@ -2,8 +2,4 @@
 "@ariakit/utils": patch
 ---
 
-Fixed `fireClickEvent` in DOM environments with a non-`Window` document view
-
-`fireClickEvent` now passes `null` as the event view when `document.defaultView` exposes event constructors but is not a genuine `Window`. This prevents strict DOM implementations from rejecting the synthetic click while preserving the owner window for real browser documents and same-origin iframes.
-
-Thanks to [@cloud-walker](https://github.com/cloud-walker) for reporting and reproducing the issue, diagnosing its cause, and exploring possible solutions.
+Fixed `fireClickEvent` to pass a valid event view in DOM environments where `document.defaultView` is not a genuine `Window`. Thanks to [@cloud-walker](https://github.com/cloud-walker).

--- a/app/src/sandbox/command-keyboard-click/react.test.ts
+++ b/app/src/sandbox/command-keyboard-click/react.test.ts
@@ -1,8 +1,7 @@
 // @vitest-environment jsdom
-/// <reference types="vitest/jsdom" />
 
 import { focus, press, q } from "@ariakit/test";
-import { expect, onTestFinished, test } from "vitest";
+import { expect, test } from "vitest";
 
 const NO_POINTER_CLICK =
   'PointerEvent, own window, pointerId -1, pointerType ""';
@@ -14,29 +13,10 @@ function getClickEvents() {
     .map((item) => item.textContent);
 }
 
-function restoreJsdomWindow() {
-  const originalDescriptor = Object.getOwnPropertyDescriptor(
-    document,
-    "defaultView",
-  );
-  if (!originalDescriptor) {
-    throw new Error("document.defaultView descriptor is not available");
-  }
-  // TODO: Remove once https://github.com/ariakit/ariakit/issues/7395 is fixed.
-  Object.defineProperty(document, "defaultView", {
-    configurable: true,
-    value: jsdom.window,
-  });
-  onTestFinished(() => {
-    Object.defineProperty(document, "defaultView", originalDescriptor);
-  });
-}
-
 // https://github.com/ariakit/ariakit/issues/7395
 test("Enter activation works in Vitest's non-VM jsdom environment", async () => {
   expect(document.defaultView).toBe(window);
   expect(window).not.toBeInstanceOf(Window);
-  restoreJsdomWindow();
 
   await focus(q.button("Report click"));
   await press.Enter();
@@ -48,7 +28,6 @@ test("Enter activation works in Vitest's non-VM jsdom environment", async () => 
 test("Space activation works in Vitest's non-VM jsdom environment", async () => {
   expect(document.defaultView).toBe(window);
   expect(window).not.toBeInstanceOf(Window);
-  restoreJsdomWindow();
 
   await focus(q.button("Report click"));
   await press.Space();

--- a/app/src/sandbox/command-keyboard-click/react.test.ts
+++ b/app/src/sandbox/command-keyboard-click/react.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
+/// <reference types="vitest/jsdom" />
 
 import { focus, press, q } from "@ariakit/test";
-import { expect, test } from "vitest";
+import { expect, onTestFinished, test } from "vitest";
 
 const NO_POINTER_CLICK =
   'PointerEvent, own window, pointerId -1, pointerType ""';
@@ -13,10 +14,29 @@ function getClickEvents() {
     .map((item) => item.textContent);
 }
 
+function restoreJsdomWindow() {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(
+    document,
+    "defaultView",
+  );
+  if (!originalDescriptor) {
+    throw new Error("document.defaultView descriptor is not available");
+  }
+  // TODO: Remove once https://github.com/ariakit/ariakit/issues/7395 is fixed.
+  Object.defineProperty(document, "defaultView", {
+    configurable: true,
+    value: jsdom.window,
+  });
+  onTestFinished(() => {
+    Object.defineProperty(document, "defaultView", originalDescriptor);
+  });
+}
+
 // https://github.com/ariakit/ariakit/issues/7395
 test("Enter activation works in Vitest's non-VM jsdom environment", async () => {
   expect(document.defaultView).toBe(window);
   expect(window).not.toBeInstanceOf(Window);
+  restoreJsdomWindow();
 
   await focus(q.button("Report click"));
   await press.Enter();
@@ -28,6 +48,7 @@ test("Enter activation works in Vitest's non-VM jsdom environment", async () => 
 test("Space activation works in Vitest's non-VM jsdom environment", async () => {
   expect(document.defaultView).toBe(window);
   expect(window).not.toBeInstanceOf(Window);
+  restoreJsdomWindow();
 
   await focus(q.button("Report click"));
   await press.Space();

--- a/app/src/sandbox/command-keyboard-click/react.test.ts
+++ b/app/src/sandbox/command-keyboard-click/react.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+
+import { focus, press, q } from "@ariakit/test";
+import { expect, test } from "vitest";
+
+const NO_POINTER_CLICK =
+  'PointerEvent, own window, pointerId -1, pointerType ""';
+
+function getClickEvents() {
+  return q
+    .within(q.list("Document click events"))
+    .listitem.all()
+    .map((item) => item.textContent);
+}
+
+// https://github.com/ariakit/ariakit/issues/7395
+test("Enter activation works in Vitest's non-VM jsdom environment", async () => {
+  expect(document.defaultView).toBe(window);
+  expect(window).not.toBeInstanceOf(Window);
+
+  await focus(q.button("Report click"));
+  await press.Enter();
+
+  expect(getClickEvents()).toEqual([NO_POINTER_CLICK]);
+});
+
+// https://github.com/ariakit/ariakit/issues/7395
+test("Space activation works in Vitest's non-VM jsdom environment", async () => {
+  expect(document.defaultView).toBe(window);
+  expect(window).not.toBeInstanceOf(Window);
+
+  await focus(q.button("Report click"));
+  await press.Space();
+
+  expect(getClickEvents()).toEqual([NO_POINTER_CLICK]);
+});

--- a/packages/ariakit-utils/readme.md
+++ b/packages/ariakit-utils/readme.md
@@ -768,7 +768,7 @@ function fireClickEvent(
 
 Creates and dispatches a click event.
 
-The event is a `PointerEvent` built by the window that owns the element, the way browsers dispatch it, falling back to a `MouseEvent` where that window has no `PointerEvent`. Its `view` is that window and it is composed. It reports no pointer behind the click unless the caller passes one, and reports every other pointer attribute at its default value, the way a click always does.
+The event is a `PointerEvent` built by the window that owns the element, the way browsers dispatch it, falling back to a `MouseEvent` where that window has no `PointerEvent`. Its `view` is that window when it is a genuine `Window`, or `null` otherwise, and it is composed. It reports no pointer behind the click unless the caller passes one, and reports every other pointer attribute at its default value, the way a click always does.
 
 Example:
 

--- a/packages/ariakit-utils/src/events.test.ts
+++ b/packages/ariakit-utils/src/events.test.ts
@@ -307,6 +307,30 @@ test("fireClickEvent uses the element's window as the view and composes the clic
   expect(clicked?.composed).toBe(true);
 });
 
+// https://github.com/ariakit/ariakit/issues/7395
+test("fireClickEvent omits a view that is not a Window instance", () => {
+  const otherDocument = document.implementation.createHTMLDocument("Other");
+  const button = otherDocument.body.appendChild(
+    otherDocument.createElement("button"),
+  );
+  const view = {
+    document: otherDocument,
+    MouseEvent,
+    PointerEvent,
+    Window,
+  };
+  Object.defineProperty(view, "window", { value: view });
+  Object.defineProperty(otherDocument, "defaultView", {
+    configurable: true,
+    value: view,
+  });
+
+  const clicked = captureClick(button);
+
+  expect(clicked).toBeInstanceOf(PointerEvent);
+  expect(clicked?.view).toBe(null);
+});
+
 // jsdom implements `PointerEvent` only from v27, so `jest-environment-jsdom` 30
 // still has none. Activation has to keep working there rather than throwing,
 // dropping only the pointer members.

--- a/packages/ariakit-utils/src/events.test.ts
+++ b/packages/ariakit-utils/src/events.test.ts
@@ -331,6 +331,28 @@ test("fireClickEvent omits a view that is not a Window instance", () => {
   expect(clicked?.view).toBe(null);
 });
 
+test("fireClickEvent omits a view without a Window constructor", () => {
+  const otherDocument = document.implementation.createHTMLDocument("Other");
+  const button = otherDocument.body.appendChild(
+    otherDocument.createElement("button"),
+  );
+  const view = {
+    document: otherDocument,
+    MouseEvent,
+    PointerEvent,
+  };
+  Object.defineProperty(view, "window", { value: view });
+  Object.defineProperty(otherDocument, "defaultView", {
+    configurable: true,
+    value: view,
+  });
+
+  const clicked = captureClick(button);
+
+  expect(clicked).toBeInstanceOf(PointerEvent);
+  expect(clicked?.view).toBe(null);
+});
+
 // jsdom implements `PointerEvent` only from v27, so `jest-environment-jsdom` 30
 // still has none. Activation has to keep working there rather than throwing,
 // dropping only the pointer members.

--- a/packages/ariakit-utils/src/events.ts
+++ b/packages/ariakit-utils/src/events.ts
@@ -179,8 +179,12 @@ const resetAttributes: Record<ResetAttribute, true> = {
 // pass a live event. Copying it would flatten it to its own properties, which a
 // live event mostly doesn't have, and inheriting from it would break the native
 // getters' brand checks, so the members are layered on with a proxy instead.
-function getClickEventInit(view: Window, eventInit?: PointerEventInit | null) {
+function getClickEventInit(
+  view: Window & typeof globalThis,
+  eventInit?: PointerEventInit | null,
+) {
   const init = eventInit ?? {};
+  const eventView = view instanceof view.Window ? view : null;
   // Proxying a fresh object rather than the caller's, because a trap may not
   // report a value different from a frozen own property of its target, and
   // every member below is layered over whatever the caller froze. Only the
@@ -189,7 +193,7 @@ function getClickEventInit(view: Window, eventInit?: PointerEventInit | null) {
   const target: PointerEventInit = {};
   return new Proxy(target, {
     get(_target, key) {
-      if (key === "view") return view;
+      if (key === "view") return eventView;
       if (key === "composed") return true;
       if (key === "pointerId") return init.pointerId ?? -1;
       if (key === "pointerType") return init.pointerType ?? "";
@@ -208,10 +212,10 @@ function getClickEventInit(view: Window, eventInit?: PointerEventInit | null) {
  *
  * The event is a `PointerEvent` built by the window that owns the element, the
  * way browsers dispatch it, falling back to a `MouseEvent` where that window
- * has no `PointerEvent`. Its `view` is that window and it is composed. It
- * reports no pointer behind the click unless the caller passes one, and reports
- * every other pointer attribute at its default value, the way a click always
- * does.
+ * has no `PointerEvent`. Its `view` is that window when it is a genuine
+ * `Window`, or `null` otherwise, and it is composed. It reports no pointer
+ * behind the click unless the caller passes one, and reports every other
+ * pointer attribute at its default value, the way a click always does.
  * @example
  * fireClickEvent(document.getElementById("id"));
  */

--- a/packages/ariakit-utils/src/events.ts
+++ b/packages/ariakit-utils/src/events.ts
@@ -184,7 +184,11 @@ function getClickEventInit(
   eventInit?: PointerEventInit | null,
 ) {
   const init = eventInit ?? {};
-  const eventView = view instanceof view.Window ? view : null;
+  const WindowConstructor = view.Window;
+  const eventView =
+    typeof WindowConstructor === "function" && view instanceof WindowConstructor
+      ? view
+      : null;
   // Proxying a fresh object rather than the caller's, because a trap may not
   // report a value different from a frozen own property of its target, and
   // every member below is layered over whatever the caller froze. Only the


### PR DESCRIPTION
## Motivation

Vitest's default non-VM jsdom environment replaces `document.defaultView` with its Node global context. That context exposes the jsdom event constructors but is not itself a jsdom `Window`, so `fireClickEvent` passes a value that `PointerEvent` rejects as `UIEventInit.view`. Enter and Space activation then throw before a non-native [`Command`](https://ariakit.com/reference/command) can dispatch its click.

Fixes #7395.

## Solution

Validate the resolved event view against its own realm before supplying it to the event constructor:

```ts
const WindowConstructor = view.Window;
const eventView =
  typeof WindowConstructor === "function" && view instanceof WindowConstructor
    ? view
    : null;
```

This preserves the genuine owner window in browsers and same-origin iframes. It passes `null` only when a DOM environment exposes a view that its own event constructors do not recognize as a `Window`.

The regression coverage exercises both Enter and Space through the public `Command` behavior in Vitest's unchanged non-VM jsdom environment. A focused utility test also verifies the invalid-view fallback. Separate changesets cover `@ariakit/utils`, `@ariakit/react-components`, and `@ariakit/react`.

## Workaround

Until the fix is released, restore the underlying jsdom `Window` as `document.defaultView` in a Vitest setup file:

```ts
/// <reference types="vitest/jsdom" />

if (typeof jsdom !== "undefined") {
  // TODO: Remove once https://github.com/ariakit/ariakit/issues/7395 is fixed.
  Object.defineProperty(document, "defaultView", {
    configurable: true,
    value: jsdom.window,
  });
}
```

After this change, `document.defaultView` is the genuine jsdom `Window`, while Vitest's `window` global remains its Node global context. Therefore, `document.defaultView !== window`. Tests that depend on that identity must account for the difference.

## Acknowledgments

Thanks to [@cloud-walker](https://github.com/cloud-walker) for reporting and reproducing the issue, diagnosing its cause, and exploring possible solutions.
