### PR TITLE
Fix menu placement in menubar interactions sandbox

### DIFF
--- a/app/src/sandbox/menubar-interactions/index.react.tsx
+++ b/app/src/sandbox/menubar-interactions/index.react.tsx
@@ -124,9 +124,9 @@ function MenuInteractions() {
   );
 }
 
-function ToolsMenu() {
+function ToolsMenu(props: Ariakit.MenuProviderProps) {
   return (
-    <Ariakit.MenuProvider>
+    <Ariakit.MenuProvider {...props}>
       <Ariakit.MenuItem render={<Ariakit.MenuButton />}>Tools</Ariakit.MenuItem>
       <Ariakit.Menu className="menu" gutter={4}>
         <Ariakit.MenuItem className="menu-item">New document</Ariakit.MenuItem>
@@ -165,6 +165,7 @@ function ToolsMenu() {
 
 function MenuControls() {
   const [vertical, setVertical] = useState(false);
+  const placement = vertical ? "right-start" : "bottom-start";
   return (
     <div className="menu-controls">
       <label>
@@ -179,8 +180,8 @@ function MenuControls() {
         className="menubar"
         orientation={vertical ? "vertical" : "horizontal"}
       >
-        <ToolsMenu />
-        <Ariakit.MenuProvider>
+        <ToolsMenu placement={placement} />
+        <Ariakit.MenuProvider placement={placement}>
           <Ariakit.MenuItem render={<Ariakit.MenuButton />}>
             Format
           </Ariakit.MenuItem>
@@ -191,7 +192,7 @@ function MenuControls() {
           </Ariakit.Menu>
         </Ariakit.MenuProvider>
         <Ariakit.ComboboxProvider defaultValue="abc">
-          <Ariakit.MenuProvider>
+          <Ariakit.MenuProvider placement={placement}>
             <Ariakit.MenuItem render={<Ariakit.MenuButton />}>
               Insert
             </Ariakit.MenuItem>


### PR DESCRIPTION
## Motivation

The `menubar-interactions` sandbox changes its menubar orientation with a checkbox, but its Tools, Format, and Insert menus receive no placement that follows the layout. The vertical layout needs the menus to open beside their entries.

Closes #7426

## Solution

Pass the same explicit placement to each menu provider, including through the `ToolsMenu` wrapper:

```tsx
const placement = vertical ? "right-start" : "bottom-start";
```

## Verification

- `pnpm lint-fix` and `pnpm tsc` pass.
- The existing `menubar-interactions/test.ts` suite passes with React 19 and React 18.
- `APP_PORT=4323 NEXTJS_PORT=3000 pnpm test-chrome menubar-interactions --workers=2` passes.
- A Chrome walkthrough confirms that ArrowRight opens all three menus beside their entries after checking the checkbox. After clearing it, ArrowDown opens Tools below its entry.

## Preview

![The Tools menu opens beside its entry with focus on New document](https://github.com/user-attachments/assets/3f337297-4ee7-4b27-affd-3d0f6f23071a)

The recording shows the explicit placement after switching to vertical, opening Tools, Format, and Insert with ArrowRight, then switching back to horizontal and opening Tools with ArrowDown.

https://github.com/user-attachments/assets/164b5f85-06ca-445b-9a39-dc4bffc54aca
