### PR TITLE
Fix vertical RTL menubar arrow navigation

### DIFF
--- a/.changeset/300-menubar-vertical-rtl-arrows.md
+++ b/.changeset/300-menubar-vertical-rtl-arrows.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react-components": patch
+"@ariakit/react": patch
+---
+
+Fixed ArrowDown and ArrowUp moving in reverse order from an open menu in a vertical RTL [`Menubar`](https://ariakit.com/reference/menubar).

--- a/app/src/sandbox/menubar-interactions/index.react.tsx
+++ b/app/src/sandbox/menubar-interactions/index.react.tsx
@@ -35,6 +35,7 @@ function VerticalMenus() {
         aria-label="Vertical RTL menubar"
         className="menubar"
         orientation="vertical"
+        rtl
       >
         {["Document", "History", "Zoom"].map((label) => (
           <Ariakit.MenuProvider

--- a/app/src/sandbox/menubar-interactions/index.react.tsx
+++ b/app/src/sandbox/menubar-interactions/index.react.tsx
@@ -14,7 +14,50 @@ export default function Example() {
     <>
       <MenuInteractions />
       <MenuControls />
+      <VerticalMenus />
     </>
+  );
+}
+
+function VerticalMenus() {
+  const [horizontal, setHorizontal] = useState(false);
+  return (
+    <div className="menu-controls" dir="rtl">
+      <label>
+        <input
+          type="checkbox"
+          checked={horizontal}
+          onChange={(event) => setHorizontal(event.currentTarget.checked)}
+        />
+        Horizontal menus
+      </label>
+      <Ariakit.Menubar
+        aria-label="Vertical RTL menubar"
+        className="menubar"
+        orientation="vertical"
+        rtl
+      >
+        {["Document", "History", "Zoom"].map((label) => (
+          <Ariakit.MenuProvider
+            key={label}
+            placement="left-start"
+            orientation={horizontal ? "horizontal" : "vertical"}
+          >
+            <Ariakit.MenuItem render={<Ariakit.MenuButton />}>
+              {label}
+            </Ariakit.MenuItem>
+            <Ariakit.Menu className="menu" gutter={4}>
+              <Ariakit.MenuItem className="menu-item">
+                {label} settings
+              </Ariakit.MenuItem>
+              <Ariakit.MenuItem className="menu-item">
+                {label} options
+              </Ariakit.MenuItem>
+            </Ariakit.Menu>
+          </Ariakit.MenuProvider>
+        ))}
+      </Ariakit.Menubar>
+    </div>
   );
 }
 

--- a/app/src/sandbox/menubar-interactions/index.react.tsx
+++ b/app/src/sandbox/menubar-interactions/index.react.tsx
@@ -35,7 +35,6 @@ function VerticalMenus() {
         aria-label="Vertical RTL menubar"
         className="menubar"
         orientation="vertical"
-        rtl
       >
         {["Document", "History", "Zoom"].map((label) => (
           <Ariakit.MenuProvider

--- a/app/src/sandbox/menubar-interactions/style.css
+++ b/app/src/sandbox/menubar-interactions/style.css
@@ -31,6 +31,10 @@
   border-radius: 0.25rem;
 }
 
+.menu-controls .menu[aria-orientation="horizontal"] {
+  display: flex;
+}
+
 .menu-controls :focus-visible {
   outline: 2px solid royalblue;
   outline-offset: 2px;

--- a/app/src/sandbox/menubar-interactions/test-chrome.ts
+++ b/app/src/sandbox/menubar-interactions/test-chrome.ts
@@ -1,0 +1,31 @@
+import { withFramework } from "#app/test-utils/preview.ts";
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  for (const target of ["menu container", "horizontal menu item"]) {
+    for (const key of ["ArrowDown", "ArrowUp"]) {
+      // https://github.com/ariakit/ariakit/issues/7415
+      test(`${key} follows vertical RTL menubar order from the ${target}`, async ({
+        page,
+        q,
+      }) => {
+        if (target === "horizontal menu item") {
+          await q.checkbox("Horizontal menus").check();
+        }
+        await q.menuitem("Document").click();
+        await test.expect(q.menu("Document")).toBeFocused();
+        if (target === "horizontal menu item") {
+          await page.keyboard.press("ArrowRight");
+          await test.expect(q.menuitem("Document settings")).toBeFocused();
+        }
+        await page.keyboard.press(key);
+        const next = key === "ArrowDown" ? "History" : "Zoom";
+        await test.expect(q.menuitem(next)).toBeFocused();
+        await test.expect(q.menu(next)).toBeVisible();
+        await test
+          .expect(q.menuitem(next))
+          .toHaveAttribute("aria-expanded", "true");
+        await test.expect(q.menu("Document")).toBeHidden();
+      });
+    }
+  }
+});

--- a/app/src/sandbox/menubar-interactions/test.ts
+++ b/app/src/sandbox/menubar-interactions/test.ts
@@ -238,3 +238,26 @@ for (const key of ["ArrowDown", "ArrowUp"] as const) {
     });
   }
 }
+
+for (const target of ["menu container", "horizontal menu item"]) {
+  for (const key of ["ArrowDown", "ArrowUp"] as const) {
+    // https://github.com/ariakit/ariakit/issues/7415
+    test(`${key} follows vertical RTL menubar order from the ${target}`, async () => {
+      if (target === "horizontal menu item") {
+        await click(q.checkbox("Horizontal menus"));
+      }
+      await click(q.menuitem("Document"));
+      expect(q.menu("Document")).toHaveFocus();
+      if (target === "horizontal menu item") {
+        await press.ArrowRight();
+        expect(q.menuitem("Document settings")).toHaveFocus();
+      }
+      await press[key]();
+      const next = key === "ArrowDown" ? "History" : "Zoom";
+      expect(q.menuitem(next)).toHaveFocus();
+      expect(q.menu(next)).toBeVisible();
+      expect(q.menuitem(next)).toHaveAttribute("aria-expanded", "true");
+      expect(q.menu.maybe("Document")).not.toBeInTheDocument();
+    });
+  }
+}

--- a/packages/ariakit-react-components/src/menu/menu-list.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-list.tsx
@@ -141,11 +141,11 @@ export const useMenuList = createHook<TagName, MenuListOptions>(
           },
           ArrowDown: () => {
             if (isMenubarHorizontal) return;
-            return parentMenubar.next();
+            return parentMenubar.down();
           },
           ArrowUp: () => {
             if (isMenubarHorizontal) return;
-            return parentMenubar.previous();
+            return parentMenubar.up();
           },
         };
         const action = keyMap[event.key as keyof typeof keyMap];


### PR DESCRIPTION
## Motivation

In a vertical RTL `Menubar`, ArrowDown and ArrowUp move to the wrong entry when pressed in an open menu. For example, Down from the Document menu opens Zoom instead of History.

Fixes #7415

## Solution

`MenuList` now calls `down()` and `up()` for vertical menubar navigation. These methods keep their vertical direction under RTL. Horizontal navigation continues to use `next()` and `previous()`.

```ts
// Vertical menubar navigation
const keys = {
  ArrowDown: () => parentMenubar.down(),
  ArrowUp: () => parentMenubar.up(),
};
```

A separate RTL scenario in the existing `menubar-interactions` sandbox covers both keys from the menu container and from an item in a horizontal menu. The final sandbox has `rtl` enabled and contains no workaround. The changeset covers `@ariakit/react-components` and `@ariakit/react`.

## Validation

The regression cases fail with the reported reversal before the workaround and pass with both the workaround and the library fix. The final fix passes the focused integration tests on React 19 and React 18, plus the Chrome menubar tests. The package build, TypeScript, lint, and CSS checks pass.

## Preview

Before the fix, clicking Document and pressing Down opens Zoom; Up opens History:

https://github.com/user-attachments/assets/2989754f-8fc7-46c0-9c88-10a95308cb04

With the library fix, Down opens History and Up opens Zoom:

https://github.com/user-attachments/assets/d90abf2e-2180-464e-8a35-c5f15906f823
## Workaround

Omit `rtl` from the vertical `Menubar` and keep `dir="rtl"` on the surrounding element. Up and Down then follow vertical order from the open menu.

```tsx
<div dir="rtl">
  {/* TODO: Restore rtl after https://github.com/ariakit/ariakit/issues/7415 is fixed. */}
  <Ariakit.Menubar orientation="vertical">
    {/* Menu providers, buttons, and menus */}
  </Ariakit.Menubar>
</div>
```

This workaround applies to vertical menubars. Horizontal menubars still need `rtl` for their horizontal arrow navigation. Set each menu's own direction as needed.
