### PR TITLE
Add comment reflow linting

### DIFF
--- a/.changeset/changelog.ts
+++ b/.changeset/changelog.ts
@@ -9,8 +9,8 @@ import type {
  * `getDependencyReleaseLine` functions, this module exports a non-standard
  * `getChangelogEntry` hook. It only works because
  * patches/@changesets__apply-release-plan@8.1.0.patch makes upstream's
- * getChangelogEntry delegate to it instead of rendering the default
- * "### Major/Minor/Patch Changes" sections.
+ * getChangelogEntry delegate to it instead of rendering the default "###
+ * Major/Minor/Patch Changes" sections.
  *
  * When bumping `@changesets/apply-release-plan`, regenerate the patch with
  * `pnpm patch @changesets/apply-release-plan`, re-insert the hook before the
@@ -80,9 +80,7 @@ export async function getChangelogEntry(
   changelogLines: ChangelogLines,
 ) {
   // const date = new Date().toLocaleDateString("en-US", {
-  //   month: "long",
-  //   day: "numeric",
-  //   year: "numeric",
+  //   month: "long", day: "numeric", year: "numeric",
   // });
   const text = await getChangelogText(Object.values(changelogLines).flat());
   return `## ${release.newVersion}\n\n${text}`;

--- a/app/astro.config.ts
+++ b/app/astro.config.ts
@@ -81,8 +81,7 @@ export default defineConfig({
     ],
     // TODO: Remove this workaround once withastro/astro#17166 is fixed.
     // Pre-optimize bare SSR imports so the Cloudflare adapter cannot reload
-    // React mid-request.
-    // https://github.com/withastro/astro/issues/17166
+    // React mid-request. https://github.com/withastro/astro/issues/17166
     optimizeDeps: {
       include: [
         "astro/virtual-modules/transitions.js",

--- a/app/astro.config.ts
+++ b/app/astro.config.ts
@@ -81,7 +81,8 @@ export default defineConfig({
     ],
     // TODO: Remove this workaround once withastro/astro#17166 is fixed.
     // Pre-optimize bare SSR imports so the Cloudflare adapter cannot reload
-    // React mid-request. https://github.com/withastro/astro/issues/17166
+    // React mid-request.
+    // https://github.com/withastro/astro/issues/17166
     optimizeDeps: {
       include: [
         "astro/virtual-modules/transitions.js",

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -82,10 +82,10 @@ export default defineConfig({
             launchOptions: {
               args: ["--enable-precise-memory-info"],
             },
-            // Fail a wedged navigation fast instead of letting it consume
-            // the whole test budget; healthy CI page loads finish in a few
-            // seconds. Iteration contexts bound their navigations the same
-            // way in ariakit-scripts perf.ts.
+            // Fail a wedged navigation fast instead of letting it consume the
+            // whole test budget; healthy CI page loads finish in a few seconds.
+            // Iteration contexts bound their navigations the same way in
+            // ariakit-scripts perf.ts.
             navigationTimeout: 30_000,
             // Tracing a retried attempt would add overhead to the retried
             // measurement and distort its metrics.
@@ -96,8 +96,8 @@ export default defineConfig({
           retries: 1,
           // Script-profile tests do over 100s of real work on slow runners.
           // This is headroom over observed durations, not a hang allowance:
-          // navigations are bounded above. CI perf runs pass the same value
-          // via --timeout in perf.yml (PLAYWRIGHT_TEST_TIMEOUT), which takes
+          // navigations are bounded above. CI perf runs pass the same value via
+          // --timeout in perf.yml (PLAYWRIGHT_TEST_TIMEOUT), which takes
           // precedence, so keep the two in sync.
           timeout: 180_000,
         },
@@ -126,8 +126,8 @@ export default defineConfig({
             ...devices["Desktop Safari"],
             launchOptions: {
               slowMo,
-              // Healthy macOS CI launches complete initial page setup within
-              // 24 seconds; fail a wedged WebKit process without waiting for
+              // Healthy macOS CI launches complete initial page setup within 24
+              // seconds; fail a wedged WebKit process without waiting for
               // Playwright's three-minute default.
               timeout: CI ? 45_000 : undefined,
             },

--- a/app/src/examples/dialog-framer-motion/test.ts
+++ b/app/src/examples/dialog-framer-motion/test.ts
@@ -20,8 +20,8 @@ test("show/hide on click", async () => {
 });
 
 test("prevent body scroll", async () => {
-  // jsdom reports a space-consuming scrollbar and supports
-  // scrollbar-gutter, so the scroll lock lands on the html element.
+  // jsdom reports a space-consuming scrollbar and supports scrollbar-gutter, so
+  // the scroll lock lands on the html element.
   const { documentElement } = document;
   const lockStyle =
     "scrollbar-gutter: stable; overflow-x: hidden; overflow-y: hidden";

--- a/app/src/lib/array.ts
+++ b/app/src/lib/array.ts
@@ -10,8 +10,8 @@
 /**
  * Returns the first item whose property value matches a value in `values`.
  *
- * Values are tried in order, so the match for the earliest value wins.
- * `null` and `undefined` values are skipped.
+ * Values are tried in order, so the match for the earliest value wins. `null`
+ * and `undefined` values are skipped.
  */
 export function findInOrder<T, K extends keyof T>(
   array: T[],
@@ -21,8 +21,8 @@ export function findInOrder<T, K extends keyof T>(
 /**
  * Returns the first item whose selected value matches a value in `values`.
  *
- * Values are tried in order, so the match for the earliest value wins.
- * `null` and `undefined` values are skipped.
+ * Values are tried in order, so the match for the earliest value wins. `null`
+ * and `undefined` values are skipped.
  */
 export function findInOrder<T, Value>(
   array: T[],

--- a/app/src/lib/auth.ts
+++ b/app/src/lib/auth.ts
@@ -158,8 +158,8 @@ export interface CreateTeamParams {
 }
 
 // Clerk enforces unique organization slugs, so deriving one from the checkout
-// session gives retries and concurrent fulfillment an idempotency key.
-// Keep the slug compact while preserving 128 bits of the session hash.
+// session gives retries and concurrent fulfillment an idempotency key. Keep the
+// slug compact while preserving 128 bits of the session hash.
 async function getCheckoutTeamSlug(checkoutSession: string) {
   const data = new TextEncoder().encode(checkoutSession);
   const hash = await crypto.subtle.digest("SHA-256", data);

--- a/app/src/lib/build-styles.ts
+++ b/app/src/lib/build-styles.ts
@@ -338,13 +338,13 @@ function splitBody(content: string): SplitBodyResult {
 }
 
 /**
- * Parse a block body into ordered PropertyDecl[] preserving declaration and block order.
+ * Parse a block body into ordered PropertyDecl[] preserving declaration and
+ * block order.
  */
 export function parsePropertyDecls(body: string): PropertyDecl[] {
   const { items } = splitBody(body);
   const decls: PropertyDecl[] = [];
-  // Carry comments forward so they stay beside the next normalized
-  // declaration.
+  // Carry comments forward so they stay beside the next normalized declaration.
   let pendingApplyComments: string[] = [];
 
   const flushPendingComments = () => {
@@ -386,8 +386,7 @@ export function parsePropertyDecls(body: string): PropertyDecl[] {
         continue;
       }
       flushPendingComments();
-      // Preserve unknown valueless declarations instead of dropping DSL
-      // syntax.
+      // Preserve unknown valueless declarations instead of dropping DSL syntax.
       decls.push({ name: s, value: {} });
       continue;
     }
@@ -584,8 +583,8 @@ function extractAkTokensFromApplyLine(line: string) {
   const tokens = line.trim().split(/\s+/);
   const akTokens: string[] = [];
   for (const tok of tokens) {
-    // Resolve last segment after colons as the actual utility,
-    // keep any ak-* segments as potential variants or utilities
+    // Resolve last segment after colons as the actual utility, keep any ak-*
+    // segments as potential variants or utilities
     const segments = splitVariantSegments(tok);
     for (let i = 0; i < segments.length; i++) {
       const seg = segments[i];

--- a/app/src/lib/collection-cache.ts
+++ b/app/src/lib/collection-cache.ts
@@ -34,7 +34,7 @@ export function getCachedCollection<C extends CollectionKey>(
     promise = getCollection(collection);
     collectionCache.set(collection, promise);
   }
-  // The cache maps each collection name to entries of that same collection;
-  // the assertion only restores the per-key type the Map cannot express.
+  // The cache maps each collection name to entries of that same collection; the
+  // assertion only restores the per-key type the Map cannot express.
   return promise as Promise<CollectionEntry<C>[]>;
 }

--- a/app/src/lib/content.ts
+++ b/app/src/lib/content.ts
@@ -147,9 +147,9 @@ async function getMarkdownRenderer() {
 }
 
 // Rendering markdown is a pure text transform, and reference descriptions
-// repeat heavily (inherited props share docs across components and
-// frameworks), so memoizing by source string collapses thousands of renders
-// into a few hundred unique ones.
+// repeat heavily (inherited props share docs across components and frameworks),
+// so memoizing by source string collapses thousands of renders into a few
+// hundred unique ones.
 const markdownHtmlCache = new Map<string, Promise<string>>();
 
 export function markdownToHtml(markdownString: string) {

--- a/app/src/lib/jsdoc-loader.ts
+++ b/app/src/lib/jsdoc-loader.ts
@@ -165,8 +165,8 @@ function getReExportStatements(
 }
 
 /**
- * Resolves a path without an extension to the first existing `.tsx` or
- * `.ts` variant, returning `undefined` if neither exists.
+ * Resolves a path without an extension to the first existing `.tsx` or `.ts`
+ * variant, returning `undefined` if neither exists.
  */
 function resolveExtension(basePath: string): string | undefined {
   if (existsSync(`${basePath}.tsx`)) return `${basePath}.tsx`;
@@ -175,10 +175,9 @@ function resolveExtension(basePath: string): string | undefined {
 }
 
 /**
- * Parses a source file for relative imports and returns the resolved
- * absolute paths of those that fall within `boundaryDir`. This captures
- * local helper files (e.g., utils, context) that live inside the same
- * component directory.
+ * Parses a source file for relative imports and returns the resolved absolute
+ * paths of those that fall within `boundaryDir`. This captures local helper
+ * files (e.g., utils, context) that live inside the same component directory.
  */
 function getLocalImports(
   sourceFilePath: string,
@@ -206,11 +205,11 @@ function getLocalImports(
 }
 
 /**
- * Gets the full set of source file paths that a component module depends
- * on, without creating a ts-morph project. Starts from the public module
- * re-exports and recursively follows local imports within the component
- * directory so that internal helpers (utils, context files, backdrop
- * components, etc.) are included for mtime tracking.
+ * Gets the full set of source file paths that a component module depends on,
+ * without creating a ts-morph project. Starts from the public module re-exports
+ * and recursively follows local imports within the component directory so that
+ * internal helpers (utils, context files, backdrop components, etc.) are
+ * included for mtime tracking.
  */
 function getComponentSourceFilePaths(
   component: string,
@@ -236,8 +235,8 @@ function getComponentSourceFilePaths(
     }
   }
 
-  // Recursively follow local imports within the component directory so
-  // internal helpers, utils, and context files are included.
+  // Recursively follow local imports within the component directory so internal
+  // helpers, utils, and context files are included.
   while (queue.length > 0) {
     const filePath = queue.shift();
     if (!filePath) break;
@@ -255,9 +254,9 @@ function getComponentSourceFilePaths(
 
 /**
  * Collects all source files under `{corePath}/src/` that live in shared
- * (non-component) directories such as `utils/`. These files are imported
- * by virtually every component, so any change should trigger a full
- * framework rebuild.
+ * (non-component) directories such as `utils/`. These files are imported by
+ * virtually every component, so any change should trigger a full framework
+ * rebuild.
  */
 function getSharedSourceFiles(
   corePath: string,
@@ -306,9 +305,9 @@ function getFileMtimes(files: string[]): Record<string, number> {
 }
 
 /**
- * Safely parses a JSON string into a `FrameworkCache`. Returns `null` if
- * the string is falsy, malformed, or doesn't match the expected shape
- * (e.g., after a format change or interrupted write).
+ * Safely parses a JSON string into a `FrameworkCache`. Returns `null` if the
+ * string is falsy, malformed, or doesn't match the expected shape (e.g., after
+ * a format change or interrupted write).
  */
 function parseFrameworkCache(json: string | undefined): FrameworkCache | null {
   if (!json) return null;
@@ -341,8 +340,8 @@ function mtimesEqual(
 }
 
 /**
- * Stores references for a component in the data store and returns the
- * generated entry IDs.
+ * Stores references for a component in the data store and returns the generated
+ * entry IDs.
  */
 function storeComponentReferences(
   store: LoaderContext["store"],
@@ -359,9 +358,9 @@ function storeComponentReferences(
 }
 
 /**
- * Parses a core source file for relative imports to other component
- * directories (e.g., `from "../composite/composite.tsx"`). Returns the
- * resolved absolute paths of those imports.
+ * Parses a core source file for relative imports to other component directories
+ * (e.g., `from "../composite/composite.tsx"`). Returns the resolved absolute
+ * paths of those imports.
  */
 function getSourceFileImportedPaths(sourceFilePath: string): string[] {
   if (!existsSync(sourceFilePath)) return [];
@@ -400,9 +399,9 @@ function getComponentFromCorePath(
 }
 
 /**
- * Builds a component-level dependency graph by scanning cross-component
- * imports in all core source files. Returns a map from each component to
- * the list of other components it imports from.
+ * Builds a component-level dependency graph by scanning cross-component imports
+ * in all core source files. Returns a map from each component to the list of
+ * other components it imports from.
  */
 function buildComponentDependencyGraph(
   componentModules: string[],
@@ -437,9 +436,9 @@ function buildComponentDependencyGraph(
 }
 
 /**
- * Given a set of directly changed components and a dependency graph,
- * returns all components that need rebuilding — the directly changed ones
- * plus every component that transitively depends on them.
+ * Given a set of directly changed components and a dependency graph, returns
+ * all components that need rebuilding — the directly changed ones plus every
+ * component that transitively depends on them.
  */
 function propagateChanges(
   directlyChanged: Set<string>,
@@ -517,8 +516,8 @@ export function jsdoc(...frameworkOptions: JsDocFrameworkOptions[]) {
         }
 
         // Track shared (non-component) source files like utils/ that are
-        // imported by virtually every component. A change in any shared
-        // file forces a full framework rebuild.
+        // imported by virtually every component. A change in any shared file
+        // forces a full framework rebuild.
         const sharedFiles = getSharedSourceFiles(corePath, componentModules);
         const sharedMtimes = getFileMtimes(sharedFiles);
 
@@ -547,8 +546,8 @@ export function jsdoc(...frameworkOptions: JsDocFrameworkOptions[]) {
         }
 
         // When the cache is absent (first run, corrupted, or format change),
-        // clear all existing store entries for this framework so stale
-        // entries from a previous run don't persist.
+        // clear all existing store entries for this framework so stale entries
+        // from a previous run don't persist.
         if (!cachedState) {
           for (const key of context.store.keys()) {
             if (key.startsWith(`${framework}/`)) {
@@ -677,9 +676,9 @@ export function jsdoc(...frameworkOptions: JsDocFrameworkOptions[]) {
 
       if (!watchedPaths.size) return;
 
-      // In watch mode, reload all references for the affected framework.
-      // This keeps the watcher simple while still updating the cache for
-      // subsequent cold starts.
+      // In watch mode, reload all references for the affected framework. This
+      // keeps the watcher simple while still updating the cache for subsequent
+      // cold starts.
       context.watcher.on("all", (_, path) => {
         const options = frameworkOptions.find(({ corePath, packagePath }) =>
           [corePath, packagePath].some(
@@ -1015,8 +1014,8 @@ function getBaseInterfaces(iface: Node) {
 }
 
 /**
- * Finds property declarations for a given prop name across base interfaces
- * of the provided owner interface, in nearest-first order.
+ * Finds property declarations for a given prop name across base interfaces of
+ * the provided owner interface, in nearest-first order.
  */
 function findPropDeclsInBaseHierarchy(owner: Node, propName: string) {
   const cachedByName = basePropDeclsCache.get(owner);

--- a/app/src/lib/nextjs.ts
+++ b/app/src/lib/nextjs.ts
@@ -20,10 +20,9 @@ const NEXTJS_PRODUCTION_DOMAIN = "nextjs.ariakit.com";
 const NEXTJS_DEFAULT_PORT = "3000";
 
 /**
- * Regex pattern to match Next.js preview URLs.
- * Matches: /{framework}/previews/{example}/ where the first example segment
- * contains "nextjs".
- * Examples:
+ * Regex pattern to match Next.js preview URLs. Matches:
+ * /{framework}/previews/{example}/ where the first example segment contains
+ * "nextjs". Examples:
  * - /react/previews/tab-nextjs/
  * - /react/previews/menu-nextjs-app-router/
  * - /react/previews/menu-nextjs/nested/
@@ -61,7 +60,8 @@ interface GetNextjsUrlFromRequestParams {
  * - ariakit-preview.workers.dev → ariakit-nextjs.workers.dev
  * - next.ariakit.com → nextjs.ariakit.com
  * - ariakit.com and *.ariakit.com → nextjs.ariakit.com
- * - ariakit.org and *.ariakit.org → nextjs.ariakit.com (legacy, redirected during migration)
+ * - ariakit.org and *.ariakit.org → nextjs.ariakit.com (legacy, redirected
+ *   during migration)
  */
 export function getNextjsUrlFromRequest({
   requestUrl,

--- a/app/src/lib/reference-tokenizer.ts
+++ b/app/src/lib/reference-tokenizer.ts
@@ -37,7 +37,8 @@ interface NameToReference {
 interface ImportInfo {
   hasAriakitImport: boolean;
   namespaceAliases: Set<string>;
-  namedImports: Map<string, string>; // localName -> exportedName
+  // localName -> exportedName
+  namedImports: Map<string, string>;
 }
 
 interface TokenRange {
@@ -593,8 +594,8 @@ function findTopLevelObjectKeys(
 }
 
 /**
- * Finds state key ranges in useStoreState calls (both string and arrow
- * selector variants).
+ * Finds state key ranges in useStoreState calls (both string and arrow selector
+ * variants).
  */
 function findUseStoreStateStateRanges(
   code: string,
@@ -706,7 +707,8 @@ function findClassTokenRanges(code: string): TokenRange[] {
           if (partText.startsWith("ak-")) {
             ranges.push({ start: partStart, end: partEnd, name: partText });
           }
-          partStart = segmentStart + charIndex + 1; // skip colon
+          // skip colon
+          partStart = segmentStart + charIndex + 1;
         }
       }
 
@@ -759,7 +761,8 @@ function findClassTokenRanges(code: string): TokenRange[] {
       findAkTokensInRange(segmentStart, index);
     }
 
-    return index + 1; // position after closing backtick
+    // position after closing backtick
+    return index + 1;
   };
 
   /**
@@ -1039,8 +1042,8 @@ export function findCodeReferenceAnchors({
 }
 
 /**
- * Uncached implementation of `findCodeReferenceAnchors`. Callers must treat
- * the returned ranges as read-only since the result is memoized.
+ * Uncached implementation of `findCodeReferenceAnchors`. Callers must treat the
+ * returned ranges as read-only since the result is memoized.
  */
 function computeCodeReferenceAnchors({
   code,
@@ -1266,8 +1269,7 @@ function processNamedImports(
 }
 
 /**
- * Processes JSX component tags to create anchors for component names and
- * props.
+ * Processes JSX component tags to create anchors for component names and props.
  */
 function processComponentTags(
   code: string,
@@ -1345,7 +1347,8 @@ function processComponentTags(
     const shouldProcess = isFromAriakit || (!importedSource && !hasAnyImport);
 
     if (shouldProcess) {
-      const start = (compMatch.index || 0) + 1; // after '<'
+      // after '<'
+      const start = (compMatch.index || 0) + 1;
       const end = start + componentName.length;
       anchorComponent(start, end, componentName);
       anchorProps(compMatch.index || 0, componentName);
@@ -1394,7 +1397,8 @@ function processNamespacedCalls(
 
     const targetRef = ref ?? storeRef;
     const labelKind = getLabelKind(targetRef);
-    const start = (callMatch.index || 0) + namespace.length + 1; // after "ns."
+    // after "ns."
+    const start = (callMatch.index || 0) + namespace.length + 1;
     const end = start + funcName.length;
 
     if (targetRef) {
@@ -1635,7 +1639,8 @@ function buildPerLineAnchors(
     lineStarts[lineIndex] = accumulator;
     const line = lines[lineIndex];
     if (line != null) {
-      accumulator += line.length + 1; // include \n
+      // include \n
+      accumulator += line.length + 1;
     }
   }
 

--- a/app/src/lib/source-plugin.ts
+++ b/app/src/lib/source-plugin.ts
@@ -122,7 +122,8 @@ function isUtilsPath(filePath: string) {
 }
 
 /**
- * Normalize a filename to a basename without framework suffix and relative path.
+ * Normalize a filename to a basename without framework suffix and relative
+ * path.
  */
 function normalizeFilename(filename: string, baseDir: string) {
   const noFrameworkSuffix = removeFrameworkSuffix(filename);
@@ -463,8 +464,8 @@ function computeSourceStylesFromSources(sources: Record<string, SourceFile>) {
 }
 
 /**
- * Generate a flattened file (final files record entry) from a source file.
- * Uses a cache keyed by absolute id.
+ * Generate a flattened file (final files record entry) from a source file. Uses
+ * a cache keyed by absolute id.
  */
 async function generateFlattenedFileCached(baseDir: string, file: SourceFile) {
   const cacheKey = cacheKeyForFile(file.id, file.content);

--- a/app/src/lib/source.ts
+++ b/app/src/lib/source.ts
@@ -70,8 +70,8 @@ export interface SourceFile {
    */
   dependencies?: Record<string, string>;
   /**
-   * External dev-only dependencies (currently only @types/*) referenced by
-   * this file, keyed by package name with the resolved version as value.
+   * External dev-only dependencies (currently only @types/*) referenced by this
+   * file, keyed by package name with the resolved version as value.
    */
   devDependencies?: Record<string, string>;
 }
@@ -145,8 +145,8 @@ function getOrCreate<K, V>(map: Map<K, V>, key: K, factory: () => V): V {
 }
 
 /**
- * Removes lines that only contain a semicolon, which may be left after
- * deleting import declarations via regex replacements.
+ * Removes lines that only contain a semicolon, which may be left after deleting
+ * import declarations via regex replacements.
  */
 function cleanSemicolonOnlyLines(text: string): string {
   return text.replace(/^[\t ]*;[\t ]*(?:\r?\n|$)/gm, "");
@@ -165,7 +165,9 @@ function cleanupText(text: string): string {
   return collapseExcessBlankLines(cleanSemicolonOnlyLines(text));
 }
 
-/** Extracts the module path from regex match groups (single/double/template). */
+/**
+ * Extracts the module path from regex match groups (single/double/template).
+ */
 function getPathFromGroups(
   groups: RegExpExecArray["groups"],
 ): string | undefined {
@@ -173,8 +175,8 @@ function getPathFromGroups(
 }
 
 /**
- * Determines the quote character used in regex match groups.
- * Defaults to double quote if no match found.
+ * Determines the quote character used in regex match groups. Defaults to double
+ * quote if no match found.
  */
 function getQuoteFromGroups(groups: RegExpExecArray["groups"]): string {
   if (groups?.single != null) return "'";
@@ -191,15 +193,15 @@ function buildModuleSource(path: string, attributes = ""): string {
 }
 
 /**
- * Extracts the comma-separated specifier text inside braces from an
- * import-like declaration string.
+ * Extracts the comma-separated specifier text inside braces from an import-like
+ * declaration string.
  * @example
  * extractSpecifiersInsideBraces('import { A, type B } from "mod";')
  * // Returns "A, type B"
  */
 function extractSpecifiersInsideBraces(matchText: string): string | null {
-  // Match ` from ` followed by a quote to avoid matching "from" inside identifiers
-  // (e.g., `transformFrom`)
+  // Match ` from ` followed by a quote to avoid matching "from" inside
+  // identifiers (e.g., `transformFrom`)
   const fromIndex = matchText.search(/\sfrom\s+['"`]/);
   if (fromIndex < 0) return null;
   const beforeFrom = matchText.slice(0, fromIndex);
@@ -228,8 +230,8 @@ function normalizeSpecifier(specifier: string): string {
 }
 
 /**
- * Parses a named import specifier list, separating runtime and type-only
- * names. Handles inline `type` modifiers.
+ * Parses a named import specifier list, separating runtime and type-only names.
+ * Handles inline `type` modifiers.
  * @example
  * parseNamedSpecifiers("A, type B, C as D")
  * // Returns { runtime: ["A", "C as D"], typeOnly: ["B"] }
@@ -259,8 +261,8 @@ function parseNamedSpecifiers(inside: string): ParsedSpecifiers {
 }
 
 /**
- * Parses a type-only import specifier list (from `import type { ... }`).
- * All specifiers are assumed to be type-only.
+ * Parses a type-only import specifier list (from `import type { ... }`). All
+ * specifiers are assumed to be type-only.
  */
 function parseTypeOnlySpecifiers(inside: string): string[] {
   return inside
@@ -403,8 +405,8 @@ function buildHoistedImports(
  *
  * The specifier list is re-emitted on one line per kind, which deliberately
  * discards the author's original wrapping; any import-attributes clause is
- * carried through verbatim. Restoring the original text here is not the fix
- * for an over-width line.
+ * carried through verbatim. Restoring the original text here is not the fix for
+ * an over-width line.
  */
 function buildRemainingImport(
   remainingRuntime: string[],
@@ -517,8 +519,8 @@ export function mergeImports(
 
   const hoisted = buildHoistedImports(valueNamed, typeNamed);
 
-  // Rewrite originals, retaining only untransformed specifiers.
-  // Removed declarations leave a semicolon marker for the cleanup pass.
+  // Rewrite originals, retaining only untransformed specifiers. Removed
+  // declarations leave a semicolon marker for the cleanup pass.
   let body = content;
 
   const replaceImportDeclarations = (pattern: RegExp, isTypeOnly: boolean) => {
@@ -613,9 +615,9 @@ function insertSorted(array: string[], value: string): void {
 
 /**
  * Computes topological order of a group's members based on internal imports.
- * Files that import other files are placed after their dependencies.
- * Uses Kahn's algorithm with lexical tie-breaker for determinism.
- * Falls back to lexicographic order if a cycle is detected.
+ * Files that import other files are placed after their dependencies. Uses
+ * Kahn's algorithm with lexical tie-breaker for determinism. Falls back to
+ * lexicographic order if a cycle is detected.
  */
 function computeTopologicalOrder(
   files: Record<string, SourceFile>,
@@ -739,8 +741,8 @@ function getStyleKey(dep: StyleDependency): string {
 }
 
 /**
- * Merges multiple style dependency arrays, deduplicating by identity.
- * Returns undefined if no styles remain.
+ * Merges multiple style dependency arrays, deduplicating by identity. Returns
+ * undefined if no styles remain.
  */
 function mergeStyles(
   ...lists: Array<StyleDependency[] | undefined>
@@ -812,9 +814,8 @@ function parseNamespaceTypeImport(stmt: string): [string, string] | null {
 }
 
 /**
- * Hoists import declarations to the top of the content.
- * Deduplicates namespace imports where a value import makes a type import
- * redundant.
+ * Hoists import declarations to the top of the content. Deduplicates namespace
+ * imports where a value import makes a type import redundant.
  */
 export function hoistImports(content: string): string {
   const imports = new Set<string>();

--- a/app/src/lib/stripe.ts
+++ b/app/src/lib/stripe.ts
@@ -429,8 +429,8 @@ export async function processCheckout({
     return session;
   }
   if (type === "team") {
-    // Create or reuse the team before removing personal Plus credit so a
-    // failed upgrade retry doesn't take away the user's existing access.
+    // Create or reuse the team before removing personal Plus credit so a failed
+    // upgrade retry doesn't take away the user's existing access.
     await createTeam({ context, user: clerkId, checkoutSession: session.id });
     if (Number(creditUsed)) {
       await removePlusFromUser({ context, user: clerkId });

--- a/app/src/lib/styles-json-types.ts
+++ b/app/src/lib/styles-json-types.ts
@@ -8,7 +8,10 @@
  * SPDX-License-Identifier: UNLICENSED
  */
 
-/** JSON shape for `#app/styles/styles.json` (shared by `env.d.ts` and `styles.ts`). */
+/**
+ * JSON shape for `#app/styles/styles.json` (shared by `env.d.ts` and
+ * `styles.ts`).
+ */
 
 export type StyleType = "utility" | "variant" | "at-property";
 

--- a/app/src/lib/styles.test.ts
+++ b/app/src/lib/styles.test.ts
@@ -38,7 +38,8 @@ test("scanAkTokensInFiles scans from start for each file (lastIndex reset)", () 
   );
   expect(tokens.has("ak-one")).toBe(true);
   expect(tokens.has("ak-two")).toBe(true);
-  // These should be found in the second file even if the regex lastIndex carried over
+  // These should be found in the second file even if the regex lastIndex
+  // carried over
   expect(tokens.has("ak-three")).toBe(true);
   expect(tokens.has("ak-four")).toBe(true);
 });
@@ -350,7 +351,8 @@ test("utilities include variant dependencies via not-* ak prefix", () => {
   const variantDep = idle?.dependencies.find(
     (dep) => dep.type === "variant" && dep.name === "ak-command-disabled",
   );
-  // The nested `@variant not-ak-command-disabled` should resolve as a dependency
+  // The nested `@variant not-ak-command-disabled` should resolve as a
+  // dependency
   expect(variantDep).toEqual({
     type: "variant",
     name: "ak-command-disabled",

--- a/app/src/lib/use-controllable-state.react.ts
+++ b/app/src/lib/use-controllable-state.react.ts
@@ -18,10 +18,10 @@ function isUpdater<T>(value: T | ((prev: T) => T)): value is (prev: T) => T {
  * A hook that creates a state that can be either controlled or uncontrolled.
  * @param state The controlled state value
  * @param setState The controlled state setter function that accepts a direct
- * value
+ *   value
  * @param defaultState The default state value when uncontrolled
  * @returns A tuple containing the current state value and a setter function
- * that supports both direct values and updater functions
+ *   that supports both direct values and updater functions
  */
 export function useControllableState<T>(
   defaultState: T | (() => T),

--- a/app/src/pages/og-image/_generate-images.ts
+++ b/app/src/pages/og-image/_generate-images.ts
@@ -19,9 +19,9 @@ import type { OGImageItem } from "./api.ts";
 const BASE_URL = process.env.OG_IMAGE_BASE_URL ?? "http://localhost:4321";
 const PUBLIC_DIR = path.resolve(process.cwd(), "public");
 
-// Maximum fraction of pixels allowed to differ before the image is
-// considered changed. This avoids committing images that only differ
-// due to sub-pixel rendering or anti-aliasing across runs.
+// Maximum fraction of pixels allowed to differ before the image is considered
+// changed. This avoids committing images that only differ due to sub-pixel
+// rendering or anti-aliasing across runs.
 const MAX_DIFF_PIXEL_RATIO = 0.001;
 const MAX_BLANK_PIXEL_RATIO = 0.995;
 const MAX_SCREENSHOT_ATTEMPTS = 3;
@@ -253,8 +253,8 @@ function removeStaleImages(items: OGImageItem[]) {
 
 async function main() {
   console.log("🔥 Generating OG images");
-  // Use the full Chromium channel because headless-shell produces incorrect
-  // OG image captures for the repeated thumbnail strip on newer Playwright.
+  // Use the full Chromium channel because headless-shell produces incorrect OG
+  // image captures for the repeated thumbnail strip on newer Playwright.
   const browser = await chromium.launch({ channel: "chromium" });
   const context = await browser.newContext({
     viewport: { width: 600, height: 315 },

--- a/app/src/sandbox/aria-labelledby-aria-label/test-chrome.ts
+++ b/app/src/sandbox/aria-labelledby-aria-label/test-chrome.ts
@@ -70,7 +70,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
   test("tag list with aria-label has no aria-labelledby", async ({ q }) => {
     // Playwright filters an initially empty display: contents list from default
-    // role queries. https://github.com/ariakit/ariakit/issues/7164
+    // role queries.
+    // https://github.com/ariakit/ariakit/issues/7164
     const listbox = q.listbox("Custom tag list label", {
       includeHidden: true,
     });

--- a/app/src/sandbox/aria-labelledby-aria-label/test-chrome.ts
+++ b/app/src/sandbox/aria-labelledby-aria-label/test-chrome.ts
@@ -69,9 +69,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
   });
 
   test("tag list with aria-label has no aria-labelledby", async ({ q }) => {
-    // Playwright filters an initially empty display: contents list from
-    // default role queries.
-    // https://github.com/ariakit/ariakit/issues/7164
+    // Playwright filters an initially empty display: contents list from default
+    // role queries. https://github.com/ariakit/ariakit/issues/7164
     const listbox = q.listbox("Custom tag list label", {
       includeHidden: true,
     });

--- a/app/src/sandbox/ariakit-tailwind-layer-contrast-inheritance/test-chrome.ts
+++ b/app/src/sandbox/ariakit-tailwind-layer-contrast-inheritance/test-chrome.ts
@@ -109,9 +109,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
           const nested = q.region(longhand.nested);
           const direct = q.region(longhand.direct);
 
-          // Read this before the loop starts moving `--contrast`. The
-          // contrast pair converges at a high enough `--contrast`, where `50`
-          // and the `25` default resolve to the same color.
+          // Read this before the loop starts moving `--contrast`. The contrast
+          // pair converges at a high enough `--contrast`, where `50` and the
+          // `25` default resolve to the same color.
           const baselineColor = await getBackgroundColor(
             q.region(longhand.baseline),
           );

--- a/app/src/sandbox/ariakit-tailwind-layer-transparent/test-chrome.ts
+++ b/app/src/sandbox/ariakit-tailwind-layer-transparent/test-chrome.ts
@@ -6,8 +6,8 @@ import { withFramework } from "#app/test-utils/preview.ts";
 // the color, so Chrome keeps the OKLCH channels and serializes an unpainted
 // element as `oklch(<l> <c> <h> / 0)`.
 const UNPAINTED = /\/ 0\)$/;
-// A painted translucent layer keeps a fractional alpha. An opaque one drops
-// the alpha component entirely.
+// A painted translucent layer keeps a fractional alpha. An opaque one drops the
+// alpha component entirely.
 const TRANSLUCENT = /\/ 0\.\d+\)$/;
 
 // The controls have no `ak-layer-transparent`, so they paint either way. An
@@ -44,8 +44,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
       "background-color",
       painted,
     );
-    // Only the background is gated. Both buttons resolve the same layer, so
-    // the edge the utility leaves alone must still match.
+    // Only the background is gated. Both buttons resolve the same layer, so the
+    // edge the utility leaves alone must still match.
     const edge = await q
       .button("Plain layer")
       .evaluate((element) => window.getComputedStyle(element).borderTopColor);
@@ -86,8 +86,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
   }) => {
     const control = q.button("Translucent control");
     // Both buttons take their alpha from the same fixture color, so a collapse
-    // would move them together and the comparison below would still hold.
-    // This rejects a collapse in either direction.
+    // would move them together and the comparison below would still hold. This
+    // rejects a collapse in either direction.
     await expect(control).toHaveCSS("background-color", TRANSLUCENT);
     const painted = await getBackgroundColor(control);
     await expect(q.button("Translucent ghost")).toHaveCSS(

--- a/app/src/sandbox/collection-renderer-6337/test-browser.ts
+++ b/app/src/sandbox/collection-renderer-6337/test-browser.ts
@@ -6,8 +6,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     page,
     q,
   }) => {
-    // Expected values follow the fixed-size formula: paddingStart + itemSize *
-    // index + gap * index.
+    // Expected values follow the fixed-size formula:
+    // `paddingStart + itemSize * index + gap * index`.
     await test.expect(q.button("Measured 1")).toHaveCSS("top", "20px");
     await test.expect(q.button("Measured 2")).toHaveCSS("top", "62px");
     await test.expect(q.button("Fixed 1")).toHaveCSS("top", "20px");

--- a/app/src/sandbox/collection-renderer-6337/test-browser.ts
+++ b/app/src/sandbox/collection-renderer-6337/test-browser.ts
@@ -6,8 +6,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     page,
     q,
   }) => {
-    // Expected values follow the fixed-size formula:
-    // paddingStart + itemSize * index + gap * index.
+    // Expected values follow the fixed-size formula: paddingStart + itemSize *
+    // index + gap * index.
     await test.expect(q.button("Measured 1")).toHaveCSS("top", "20px");
     await test.expect(q.button("Measured 2")).toHaveCSS("top", "62px");
     await test.expect(q.button("Fixed 1")).toHaveCSS("top", "20px");

--- a/app/src/sandbox/combobox-5165/test-browser.ts
+++ b/app/src/sandbox/combobox-5165/test-browser.ts
@@ -33,8 +33,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     const combobox = q.combobox();
     await combobox.focus();
 
-    // Scroll programmatically without a wheel event to simulate scrollbar
-    // drag or other non-wheel scroll paths
+    // Scroll programmatically without a wheel event to simulate scrollbar drag
+    // or other non-wheel scroll paths
     await popover.evaluate((el) => {
       el.scrollTop = el.scrollHeight - el.clientHeight - 50;
     });

--- a/app/src/sandbox/combobox-ime-6663/test-chrome.ts
+++ b/app/src/sandbox/combobox-ime-6663/test-chrome.ts
@@ -57,9 +57,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await traceImeEvents(page);
 
     // This CDP sequence is derived from a real macOS Korean 2-set trace for
-    // typing t k r h k, which should produce 사과. CDP preserves the final
-    // value, but it still exposes the harmful focus move that makes the native
-    // macOS IME drop the composed 고 syllable and produce 사ㅏ.
+    // typing t k r h k, which should produce 사과. CDP preserves the final value,
+    // but it still exposes the harmful focus move that makes the native macOS
+    // IME drop the composed 고 syllable and produce 사ㅏ.
     await setComposition(cdp, "ㅅ");
     await setComposition(cdp, "사");
     await setComposition(cdp, "삭");

--- a/app/src/sandbox/combobox-ime-6663/test.ts
+++ b/app/src/sandbox/combobox-ime-6663/test.ts
@@ -9,9 +9,9 @@ test("keeps focus in the combobox between IME composition sessions", async () =>
   await type("사", combobox, { isComposing: true });
   expect(combobox).toHaveFocus();
 
-  // A Korean IME commits the previous syllable and immediately starts
-  // composing the next one within a single keystroke, so no animation frames
-  // pass between compositionend and the next compositionstart.
+  // A Korean IME commits the previous syllable and immediately starts composing
+  // the next one within a single keystroke, so no animation frames pass between
+  // compositionend and the next compositionstart.
   await dispatch.compositionEnd(combobox);
   await dispatch.compositionStart(combobox);
   await sleep();

--- a/app/src/sandbox/combobox-item-value/index.react.tsx
+++ b/app/src/sandbox/combobox-item-value/index.react.tsx
@@ -24,14 +24,12 @@ function normalize(value: string) {
     .toLowerCase();
 }
 
-// The first syllable is followed by a combining acute accent that
-// normalization removes, and the user value is that syllable's lone medial
-// jamo.
+// The first syllable is followed by a combining acute accent that normalization
+// removes, and the user value is that syllable's lone medial jamo.
 const markedApple = "사\u0301과.txt";
 const medialJamo = "\u1161";
 
-// Overlapping partial matches that together cover every part of the
-// syllable.
+// Overlapping partial matches that together cover every part of the syllable.
 const syllable = "각";
 const partialValues = ["가", "\u1161\u11a8"];
 

--- a/app/src/sandbox/combobox-item-value/test.ts
+++ b/app/src/sandbox/combobox-item-value/test.ts
@@ -59,8 +59,8 @@ test("keeps combining marks attached in decomposed item values", async () => {
 });
 
 test("renders a single autocomplete span for normalized-empty input", async () => {
-  // A lone combining mark normalizes to an empty string, which must not
-  // produce highlights but must keep the autocomplete span structure.
+  // A lone combining mark normalizes to an empty string, which must not produce
+  // highlights but must keep the autocomplete span structure.
   await type("\u0301", q.combobox("Search files"));
 
   const option = q.option("notes.txt");

--- a/app/src/sandbox/combobox-links/test-browser.ts
+++ b/app/src/sandbox/combobox-links/test-browser.ts
@@ -59,8 +59,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     context,
     browserName,
   }) => {
-    // Chrome and Firefox can take a while to materialize the modifier+Enter
-    // tab under CI load.
+    // Chrome and Firefox can take a while to materialize the modifier+Enter tab
+    // under CI load.
     test.slow();
     const combobox = q.combobox("Links");
     await combobox.click();
@@ -78,8 +78,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
         await expect(page).toHaveURL(/https:\/\/ariakit\.com/);
       }).toPass();
     } else {
-      // Keep the page-event deadline inside the 90-second slow-test budget so
-      // a missing tab names the event instead of timing out the whole test.
+      // Keep the page-event deadline inside the 90-second slow-test budget so a
+      // missing tab names the event instead of timing out the whole test.
       const newPagePromise = context.waitForEvent("page", {
         timeout: 60_000,
       });

--- a/app/src/sandbox/combobox-list-7302/index.react.tsx
+++ b/app/src/sandbox/combobox-list-7302/index.react.tsx
@@ -135,9 +135,9 @@ function SearchIssues() {
   );
 }
 
-// A list for the same store can be rendered outside the popup, for example
-// into a side panel. It is not inside the popup, so it does not take the popup
-// role and the popover keeps owning its own items.
+// A list for the same store can be rendered outside the popup, for example into
+// a side panel. It is not inside the popup, so it does not take the popup role
+// and the popover keeps owning its own items.
 function SearchDocs() {
   const [panel, setPanel] = useState<HTMLElement | null>(null);
 

--- a/app/src/sandbox/combobox-list-form-named-active-element/index.react.tsx
+++ b/app/src/sandbox/combobox-list-form-named-active-element/index.react.tsx
@@ -5,9 +5,9 @@ const fruits = ["Apple", "Banana", "Cherry", "Grape"];
 
 // A saved-searches form on the page carries a name that collides with the
 // member `ComboboxList` reads to confirm the list still holds focus, so the
-// document answers `activeElement` with the form. The redirect that hands
-// focus back to the combobox never runs, and the list keeps DOM focus that
-// belongs on the input.
+// document answers `activeElement` with the form. The redirect that hands focus
+// back to the combobox never runs, and the list keeps DOM focus that belongs on
+// the input.
 export default function Example() {
   const [focusHistory, setFocusHistory] = useState<string[]>([]);
   const recordFocus = (name: string) => {

--- a/app/src/sandbox/combobox-list-form-named-active-element/test-browser.ts
+++ b/app/src/sandbox/combobox-list-form-named-active-element/test-browser.ts
@@ -11,8 +11,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     const focusHistory = q.status("Focus history");
     await test.expect(focusHistory).toHaveText("none");
 
-    // Click the list's own padding band. A centered click would land on an
-    // item and exercise the composite item redirect instead of the list one.
+    // Click the list's own padding band. A centered click would land on an item
+    // and exercise the composite item redirect instead of the list one.
     await q.listbox("Fruit options").click({ position: { x: 8, y: 8 } });
 
     await test.expect(focusHistory).toHaveText("list → combobox");

--- a/app/src/sandbox/combobox-select-3837/test-browser.ts
+++ b/app/src/sandbox/combobox-select-3837/test-browser.ts
@@ -14,10 +14,11 @@ withFramework(import.meta.dirname, async ({ test }) => {
   // Floating UI computes for the popover (the `--popover-available-height`
   // variable), which drives the popover max-height and, in a virtualized list,
   // the set of rendered items. With `autoSelect`, every rendered-items change
-  // re-ran the auto-select logic and called `store.move()` on the already-active
-  // item. Because `move()` always bumps the internal `moves` counter, Composite
-  // re-focused the item via `focusIntoView`, bouncing DOM focus off the input
-  // and back. This focus churn dropped characters while typing.
+  // re-ran the auto-select logic and called `store.move()` on the
+  // already-active item. Because `move()` always bumps the internal `moves`
+  // counter, Composite re-focused the item via `focusIntoView`, bouncing DOM
+  // focus off the input and back. This focus churn dropped characters while
+  // typing.
   //
   // We simulate the viewport change deterministically by shrinking the popover
   // through the same `--popover-available-height` variable, then assert that
@@ -43,10 +44,10 @@ withFramework(import.meta.dirname, async ({ test }) => {
     test.expect(renderedBefore).toBeGreaterThan(2);
     test.expect(renderedBefore).toBeLessThan(50);
 
-    // The virtualizer's ResizeObserver ignores its very first callback, so flush
-    // a couple of frames to make sure that first callback has already fired.
-    // Otherwise a fast run could have our resize below swallowed as the ignored
-    // one, and the bug would not reproduce.
+    // The virtualizer's ResizeObserver ignores its very first callback, so
+    // flush a couple of frames to make sure that first callback has already
+    // fired. Otherwise a fast run could have our resize below swallowed as the
+    // ignored one, and the bug would not reproduce.
     await flushFrames(page, 2);
 
     // From now on, count any focus event that lands on an option element.

--- a/app/src/sandbox/combobox-select-4593/test-browser.ts
+++ b/app/src/sandbox/combobox-select-4593/test-browser.ts
@@ -10,9 +10,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
     page.on("pageerror", (error) => errors.push(error.message));
     await q.combobox("Favorite fruit").click();
     await test.expect(q.option("Apple")).toBeVisible();
-    // Clicking an item when id={undefined} is passed should not throw
-    // "Maximum call stack size exceeded" due to an infinite event loop between
-    // blur events and focus handling.
+    // Clicking an item when id={undefined} is passed should not throw "Maximum
+    // call stack size exceeded" due to an infinite event loop between blur
+    // events and focus handling.
     await q.option("Banana").click();
     await test.expect(q.combobox("Favorite fruit")).toHaveText("Banana");
     test.expect(errors).toEqual([]);

--- a/app/src/sandbox/combobox-select-4767/test-browser.ts
+++ b/app/src/sandbox/combobox-select-4767/test-browser.ts
@@ -107,8 +107,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     const banana = q.option("Banana");
     await test.expect(banana).toBeFocused();
 
-    // Backspace would navigate the page back in WebKit, so the editing-key
-    // half of this behavior is only exercised in the happy-dom duplicate.
+    // Backspace would navigate the page back in WebKit, so the editing-key half
+    // of this behavior is only exercised in the happy-dom duplicate.
     await page.keyboard.press("o");
     await test.expect(q.option("Orange")).toBeFocused();
     await test.expect(select).not.toBeFocused();

--- a/app/src/sandbox/combobox-select-6313/index.react.tsx
+++ b/app/src/sandbox/combobox-select-6313/index.react.tsx
@@ -4,8 +4,9 @@ import { useLayoutEffect, useMemo, useState } from "react";
 
 const list = ["Apple", "Banana", "Cherry", "Grape", "Lemon", "Orange"];
 
-// The descendant layout effect runs before ComboboxProvider initializes, so this
-// store-level listener exposes reentrant writes during the initial parent push.
+// The descendant layout effect runs before ComboboxProvider initializes, so
+// this store-level listener exposes reentrant writes during the initial parent
+// push.
 function ValueFollowsHighlight() {
   const combobox = Ariakit.useComboboxContext();
 

--- a/app/src/sandbox/combobox-select-6319/test-browser.ts
+++ b/app/src/sandbox/combobox-select-6319/test-browser.ts
@@ -49,8 +49,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.option("Triangle")).toBeHidden();
     await test.expect(combobox).toBeFocused();
     await test.expect(combobox).toContainText("Triangle");
-    // The item after Triangle has no value, so the wrap should skip it and
-    // land on the first valued item
+    // The item after Triangle has no value, so the wrap should skip it and land
+    // on the first valued item
     await page.keyboard.press("ArrowDown");
     await test.expect(combobox).toContainText("Square");
   });

--- a/app/src/sandbox/combobox-select-6319/test.ts
+++ b/app/src/sandbox/combobox-select-6319/test.ts
@@ -1,8 +1,8 @@
 import { click, press, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
-// The page-freeze variant (two trailing items without value) is covered only
-// by the browser test: on the buggy code, the keydown handler loops forever
+// The page-freeze variant (two trailing items without value) is covered only by
+// the browser test: on the buggy code, the keydown handler loops forever
 // synchronously, which would hang the happy-dom worker instead of failing.
 // https://github.com/ariakit/ariakit/issues/6319
 test("arrow keys on the closed select skip the trailing item without value", async () => {
@@ -29,8 +29,8 @@ test("arrow keys on the closed select with focusLoop wrap past the item without 
   await press.Escape();
   expect(combobox).toHaveFocus();
   expect(combobox).toHaveTextContent("Triangle");
-  // The item after Triangle has no value, so the wrap should skip it and
-  // land on the first valued item
+  // The item after Triangle has no value, so the wrap should skip it and land
+  // on the first valued item
   await press.ArrowDown();
   expect(combobox).toHaveTextContent("Square");
 });

--- a/app/src/sandbox/combobox-select-6623/index.react.tsx
+++ b/app/src/sandbox/combobox-select-6623/index.react.tsx
@@ -1,13 +1,12 @@
 import * as Ariakit from "@ariakit/react";
 import { useLayoutEffect, useRef, useState } from "react";
 
-// The app manages the initial focus itself (autoFocusOnShow is disabled on
-// the popover below): the recommended option focuses itself as soon as it
-// mounts, before the browser paints, so there's no focus flicker. With
-// virtualFocus, focusing an option is expected to redirect DOM focus to the
-// listbox and mark the option as active. The explicit tabIndex makes the
-// option focusable on its very first render, which is required for the
-// mount-time focus() call to work.
+// The app manages the initial focus itself (autoFocusOnShow is disabled on the
+// popover below): the recommended option focuses itself as soon as it mounts,
+// before the browser paints, so there's no focus flicker. With virtualFocus,
+// focusing an option is expected to redirect DOM focus to the listbox and mark
+// the option as active. The explicit tabIndex makes the option focusable on its
+// very first render, which is required for the mount-time focus() call to work.
 //
 // The combobox-select-open-page-scroll sandbox has the same self-focusing
 // option and does reproduce a page jump from it.

--- a/app/src/sandbox/combobox-select-6623/test-browser.ts
+++ b/app/src/sandbox/combobox-select-6623/test-browser.ts
@@ -21,8 +21,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await q.combobox("Favorite fruit").click();
     await test.expect(q.listbox()).toBeVisible();
     await test.expect(q.combobox("Search fruits")).toBeFocused();
-    // Give a stray redirect a chance to fire before asserting focus stayed
-    // put.
+    // Give a stray redirect a chance to fire before asserting focus stayed put.
     await page.waitForTimeout(200);
     await test.expect(q.combobox("Search fruits")).toBeFocused();
   });

--- a/app/src/sandbox/combobox-select-collapsed-focus/index.react.tsx
+++ b/app/src/sandbox/combobox-select-collapsed-focus/index.react.tsx
@@ -146,9 +146,9 @@ interface HoverSelectProps {
   focusOnHover: Ariakit.ComboboxItemProps["focusOnHover"];
 }
 
-// The pointer side of the same contract. An explicit boolean and a callback
-// are authored here so the collapsed gate is exercised on the authored path,
-// which the default predicate alone never reaches.
+// The pointer side of the same contract. An explicit boolean and a callback are
+// authored here so the collapsed gate is exercised on the authored path, which
+// the default predicate alone never reaches.
 // https://github.com/ariakit/ariakit/issues/7118
 function HoverSelect({ label, focusOnHover }: HoverSelectProps) {
   return (
@@ -177,10 +177,9 @@ function HoverSelect({ label, focusOnHover }: HoverSelectProps) {
 }
 
 // An authored callback with a side effect: the consumer moves the composite
-// from inside the predicate, like the select-grid example does. The closed
-// gate must keep the callback from running at all, or the move would still
-// activate the item and steal focus.
-// https://github.com/ariakit/ariakit/issues/7118
+// from inside the predicate, like the select-grid example does. The closed gate
+// must keep the callback from running at all, or the move would still activate
+// the item and steal focus. https://github.com/ariakit/ariakit/issues/7118
 function MoveHoverSelect() {
   const combobox = Ariakit.useComboboxStore({
     defaultSelectedValue: "Apple",
@@ -216,11 +215,10 @@ function MoveHoverSelect() {
   );
 }
 
-// An authored callback that closes the list from inside the predicate and
-// still returns true. The gate must re-read the live open state after the
-// callback, or the stale pre-check result would activate the item and steal
-// focus right as the list collapses.
-// https://github.com/ariakit/ariakit/issues/7118
+// An authored callback that closes the list from inside the predicate and still
+// returns true. The gate must re-read the live open state after the callback,
+// or the stale pre-check result would activate the item and steal focus right
+// as the list collapses. https://github.com/ariakit/ariakit/issues/7118
 function HideHoverSelect() {
   const combobox = Ariakit.useComboboxStore({
     defaultSelectedValue: "Apple",

--- a/app/src/sandbox/combobox-select-collapsed-focus/index.react.tsx
+++ b/app/src/sandbox/combobox-select-collapsed-focus/index.react.tsx
@@ -179,7 +179,8 @@ function HoverSelect({ label, focusOnHover }: HoverSelectProps) {
 // An authored callback with a side effect: the consumer moves the composite
 // from inside the predicate, like the select-grid example does. The closed gate
 // must keep the callback from running at all, or the move would still activate
-// the item and steal focus. https://github.com/ariakit/ariakit/issues/7118
+// the item and steal focus.
+// https://github.com/ariakit/ariakit/issues/7118
 function MoveHoverSelect() {
   const combobox = Ariakit.useComboboxStore({
     defaultSelectedValue: "Apple",
@@ -218,7 +219,8 @@ function MoveHoverSelect() {
 // An authored callback that closes the list from inside the predicate and still
 // returns true. The gate must re-read the live open state after the callback,
 // or the stale pre-check result would activate the item and steal focus right
-// as the list collapses. https://github.com/ariakit/ariakit/issues/7118
+// as the list collapses.
+// https://github.com/ariakit/ariakit/issues/7118
 function HideHoverSelect() {
   const combobox = Ariakit.useComboboxStore({
     defaultSelectedValue: "Apple",

--- a/app/src/sandbox/combobox-select-collapsed-focus/test-browser.ts
+++ b/app/src/sandbox/combobox-select-collapsed-focus/test-browser.ts
@@ -49,11 +49,11 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     });
   }
 
-  // https://github.com/ariakit/ariakit/issues/7093
-  // Only virtual focus asks for the active item when the select itself is
-  // focused, which happens while the list is still closed. That request is the
-  // one that has to survive until the list opens, so a pointer open with no
-  // move before it still presents the item.
+  // https://github.com/ariakit/ariakit/issues/7093 Only virtual focus asks for
+  // the active item when the select itself is focused, which happens while the
+  // list is still closed. That request is the one that has to survive until the
+  // list opens, so a pointer open with no move before it still presents the
+  // item.
   test("opening the collapsed select with a pointer presents its item", async ({
     q,
   }) => {
@@ -66,9 +66,9 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(focusedOptions).toHaveText("Apple");
   });
 
-  // https://github.com/ariakit/ariakit/issues/7093
-  // Withholding focus must not also withhold the rest of the presentation: a
-  // list that is already on screen still belongs at the active item.
+  // https://github.com/ariakit/ariakit/issues/7093 Withholding focus must not
+  // also withhold the rest of the presentation: a list that is already on
+  // screen still belongs at the active item.
   test("typeahead scrolls a collapsed list to the active item", async ({
     q,
   }) => {
@@ -88,10 +88,10 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(select).toBeFocused();
   });
 
-  // https://github.com/ariakit/ariakit/issues/7093
-  // Focusing the collapsed select leaves a presentation waiting for the list to
-  // open. Picking another option before that happens has to retire it, or
-  // opening the list would present the option that was active on focus.
+  // https://github.com/ariakit/ariakit/issues/7093 Focusing the collapsed
+  // select leaves a presentation waiting for the list to open. Picking another
+  // option before that happens has to retire it, or opening the list would
+  // present the option that was active on focus.
   test("picking an option before opening retires the pending presentation", async ({
     q,
   }) => {
@@ -107,10 +107,9 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
   });
 
   // https://github.com/ariakit/ariakit/pull/7098#discussion_r3742291859
-  // Withholding belongs to the widget that owns focus. A move made from
-  // outside keeps presenting immediately, so the focus it moves is
-  // attributable to that call instead of landing on whoever is focused when
-  // the list next opens.
+  // Withholding belongs to the widget that owns focus. A move made from outside
+  // keeps presenting immediately, so the focus it moves is attributable to that
+  // call instead of landing on whoever is focused when the list next opens.
   test("a move from outside the widget still presents immediately", async ({
     page,
     q,
@@ -136,10 +135,10 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(openList).toBeFocused();
   });
 
-  // https://github.com/ariakit/ariakit/pull/7098#discussion_r3742291859
-  // Once focus is on an option, moving between options is navigation inside
-  // the list, not focus leaving the control, so the focus ring has to keep up
-  // with the active item even though the list is collapsed.
+  // https://github.com/ariakit/ariakit/pull/7098#discussion_r3742291859 Once
+  // focus is on an option, moving between options is navigation inside the
+  // list, not focus leaving the control, so the focus ring has to keep up with
+  // the active item even though the list is collapsed.
   test("arrow keys keep moving focus between options in a collapsed list", async ({
     page,
     q,
@@ -175,17 +174,17 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
       await grape.hover();
 
       await test.expect(select).toHaveAttribute("aria-expanded", "false");
-      // Hover activation is committed inside the mousemove handler, so there
-      // is no positive state to wait for. Cross the frames a presentation
-      // would use to reach the item before asserting that none did.
+      // Hover activation is committed inside the mousemove handler, so there is
+      // no positive state to wait for. Cross the frames a presentation would
+      // use to reach the item before asserting that none did.
       await flushFrames(page);
       await test.expect(grape).not.toHaveAttribute("data-active-item");
       await test.expect(other).toBeFocused();
     });
 
-    // https://github.com/ariakit/ariakit/issues/7118
-    // The gate is about the closed list, not about the authored value, so the
-    // same item still takes hover once the select opens.
+    // https://github.com/ariakit/ariakit/issues/7118 The gate is about the
+    // closed list, not about the authored value, so the same item still takes
+    // hover once the select opens.
     test(`${label}: hovering an option activates it once the list opens`, async ({
       q,
     }) => {
@@ -202,10 +201,10 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     });
   }
 
-  // https://github.com/ariakit/ariakit/issues/7118
-  // The other hover direction: after the list closes by clicking an option,
-  // moving the pointer off that option must not clear the active item or move
-  // focus while the list is collapsed.
+  // https://github.com/ariakit/ariakit/issues/7118 The other hover direction:
+  // after the list closes by clicking an option, moving the pointer off that
+  // option must not clear the active item or move focus while the list is
+  // collapsed.
   test("hover end on a collapsed list keeps the active item", async ({
     page,
     q,
@@ -223,30 +222,29 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await grape.click();
     await test.expect(select).toHaveAttribute("aria-expanded", "false");
     await test.expect(grape).toHaveAttribute("data-active-item");
-    // Clicking an option in an always-visible list leaves DOM focus on it
-    // even as the list collapses, so the hover end below starts from the
-    // option.
+    // Clicking an option in an always-visible list leaves DOM focus on it even
+    // as the list collapses, so the hover end below starts from the option.
     await test.expect(grape).toBeFocused();
 
     // The click's mouseup resets the mouse-movement tracker, and a hover
-    // teleport fires the boundary events before any mousemove, which would
-    // skip the hover-end handler entirely. Move within the option first the
-    // way a real pointer would, so the tracker is armed when it leaves.
+    // teleport fires the boundary events before any mousemove, which would skip
+    // the hover-end handler entirely. Move within the option first the way a
+    // real pointer would, so the tracker is armed when it leaves.
     await grape.hover({ position: { x: 4, y: 4 } });
     await other.hover();
 
-    // Retaining the attribute and focus is an absence-of-change assertion,
-    // and the mouseleave clearing would land within a frame, so cross the
-    // frames before asserting that nothing changed.
+    // Retaining the attribute and focus is an absence-of-change assertion, and
+    // the mouseleave clearing would land within a frame, so cross the frames
+    // before asserting that nothing changed.
     await flushFrames(page);
     await test.expect(grape).toHaveAttribute("data-active-item");
     await test.expect(grape).toBeFocused();
   });
 
-  // https://github.com/ariakit/ariakit/issues/7118
-  // The closed gate must keep the authored callback from running at all: this
-  // one moves the composite from inside the predicate, so merely invoking it
-  // while collapsed would activate the item and steal focus.
+  // https://github.com/ariakit/ariakit/issues/7118 The closed gate must keep
+  // the authored callback from running at all: this one moves the composite
+  // from inside the predicate, so merely invoking it while collapsed would
+  // activate the item and steal focus.
   test("a side-effectful callback does nothing on a collapsed list", async ({
     page,
     q,
@@ -262,17 +260,16 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await grape.hover();
 
     await test.expect(select).toHaveAttribute("aria-expanded", "false");
-    // Hover activation is committed inside the mousemove handler, so there
-    // is no positive state to wait for. Cross the frames a presentation
-    // would use to reach the item before asserting that none did.
+    // Hover activation is committed inside the mousemove handler, so there is
+    // no positive state to wait for. Cross the frames a presentation would use
+    // to reach the item before asserting that none did.
     await flushFrames(page);
     await test.expect(grape).not.toHaveAttribute("data-active-item");
     await test.expect(other).toBeFocused();
   });
 
-  // https://github.com/ariakit/ariakit/issues/7118
-  // The gate is about the closed list: the same side-effectful callback keeps
-  // working once the select opens.
+  // https://github.com/ariakit/ariakit/issues/7118 The gate is about the closed
+  // list: the same side-effectful callback keeps working once the select opens.
   test("a side-effectful callback activates the option once the list opens", async ({
     q,
   }) => {
@@ -288,11 +285,10 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(grape).toHaveAttribute("data-active-item");
   });
 
-  // https://github.com/ariakit/ariakit/issues/7118
-  // The open state must be re-read after the authored callback runs: this one
-  // closes the list from inside the predicate and still returns true, so a
-  // stale pre-check result would activate the item and steal focus right as
-  // the list collapses.
+  // https://github.com/ariakit/ariakit/issues/7118 The open state must be
+  // re-read after the authored callback runs: this one closes the list from
+  // inside the predicate and still returns true, so a stale pre-check result
+  // would activate the item and steal focus right as the list collapses.
   test("a callback that closes the list on hover activates nothing", async ({
     q,
   }) => {
@@ -315,9 +311,9 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(other).toBeFocused();
   });
 
-  // https://github.com/ariakit/ariakit/issues/7118
-  // The default predicate is part of the same contract: with no authored
-  // focusOnHover, hovering an option in a collapsed list changes nothing.
+  // https://github.com/ariakit/ariakit/issues/7118 The default predicate is
+  // part of the same contract: with no authored focusOnHover, hovering an
+  // option in a collapsed list changes nothing.
   test("default hover on a collapsed list changes nothing", async ({
     page,
     q,
@@ -329,17 +325,17 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await grape.hover();
 
     await test.expect(select).toHaveAttribute("aria-expanded", "false");
-    // Hover activation is committed inside the mousemove handler, so there
-    // is no positive state to wait for. Cross the frames a presentation
-    // would use to reach the item before asserting that none did.
+    // Hover activation is committed inside the mousemove handler, so there is
+    // no positive state to wait for. Cross the frames a presentation would use
+    // to reach the item before asserting that none did.
     await flushFrames(page);
     await test.expect(grape).not.toHaveAttribute("data-active-item");
     await test.expect(q.status("Fruit focused options")).toHaveText("none");
   });
 
-  // https://github.com/ariakit/ariakit/issues/7118
-  // Without ComboboxSelect the default stays false even while the list is
-  // open, so hover only activates an item when the consumer opts in.
+  // https://github.com/ariakit/ariakit/issues/7118 Without ComboboxSelect the
+  // default stays false even while the list is open, so hover only activates an
+  // item when the consumer opts in.
   test("default hover in an open plain combobox activates nothing", async ({
     page,
     q,
@@ -353,9 +349,9 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
 
     await grape.hover();
 
-    // Hover activation is committed inside the mousemove handler, so there
-    // is no positive state to wait for. Cross the frames a presentation
-    // would use to reach the item before asserting that none did.
+    // Hover activation is committed inside the mousemove handler, so there is
+    // no positive state to wait for. Cross the frames a presentation would use
+    // to reach the item before asserting that none did.
     await flushFrames(page);
     await test.expect(grape).not.toHaveAttribute("data-active-item");
     await test.expect(combobox).toBeFocused();
@@ -371,9 +367,9 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await combobox.focus();
 
     await test.expect(combobox).toHaveAttribute("aria-expanded", "false");
-    // The composite can present its active item from a queued microtask or
-    // from a passive effect that runs after paint, so cross those frames
-    // before asserting that focus never reached the list.
+    // The composite can present its active item from a queued microtask or from
+    // a passive effect that runs after paint, so cross those frames before
+    // asserting that focus never reached the list.
     await flushFrames(page);
     await test.expect(combobox).toBeFocused();
     await test.expect(q.status("Filter focused options")).toHaveText("none");

--- a/app/src/sandbox/combobox-select-collapsed-focus/test-browser.ts
+++ b/app/src/sandbox/combobox-select-collapsed-focus/test-browser.ts
@@ -49,11 +49,11 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     });
   }
 
-  // https://github.com/ariakit/ariakit/issues/7093 Only virtual focus asks for
-  // the active item when the select itself is focused, which happens while the
-  // list is still closed. That request is the one that has to survive until the
-  // list opens, so a pointer open with no move before it still presents the
-  // item.
+  // https://github.com/ariakit/ariakit/issues/7093
+  // Only virtual focus asks for the active item when the select itself is
+  // focused, which happens while the list is still closed. That request is the
+  // one that has to survive until the list opens, so a pointer open with no
+  // move before it still presents the item.
   test("opening the collapsed select with a pointer presents its item", async ({
     q,
   }) => {
@@ -66,9 +66,9 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(focusedOptions).toHaveText("Apple");
   });
 
-  // https://github.com/ariakit/ariakit/issues/7093 Withholding focus must not
-  // also withhold the rest of the presentation: a list that is already on
-  // screen still belongs at the active item.
+  // https://github.com/ariakit/ariakit/issues/7093
+  // Withholding focus must not also withhold the rest of the presentation: a
+  // list that is already on screen still belongs at the active item.
   test("typeahead scrolls a collapsed list to the active item", async ({
     q,
   }) => {
@@ -88,10 +88,10 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(select).toBeFocused();
   });
 
-  // https://github.com/ariakit/ariakit/issues/7093 Focusing the collapsed
-  // select leaves a presentation waiting for the list to open. Picking another
-  // option before that happens has to retire it, or opening the list would
-  // present the option that was active on focus.
+  // https://github.com/ariakit/ariakit/issues/7093
+  // Focusing the collapsed select leaves a presentation waiting for the list to
+  // open. Picking another option before that happens has to retire it, or
+  // opening the list would present the option that was active on focus.
   test("picking an option before opening retires the pending presentation", async ({
     q,
   }) => {
@@ -135,8 +135,8 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(openList).toBeFocused();
   });
 
-  // https://github.com/ariakit/ariakit/pull/7098#discussion_r3742291859 Once
-  // focus is on an option, moving between options is navigation inside the
+  // https://github.com/ariakit/ariakit/pull/7098#discussion_r3742291859
+  // Once focus is on an option, moving between options is navigation inside the
   // list, not focus leaving the control, so the focus ring has to keep up with
   // the active item even though the list is collapsed.
   test("arrow keys keep moving focus between options in a collapsed list", async ({
@@ -182,9 +182,9 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
       await test.expect(other).toBeFocused();
     });
 
-    // https://github.com/ariakit/ariakit/issues/7118 The gate is about the
-    // closed list, not about the authored value, so the same item still takes
-    // hover once the select opens.
+    // https://github.com/ariakit/ariakit/issues/7118
+    // The gate is about the closed list, not about the authored value, so the
+    // same item still takes hover once the select opens.
     test(`${label}: hovering an option activates it once the list opens`, async ({
       q,
     }) => {
@@ -201,10 +201,10 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     });
   }
 
-  // https://github.com/ariakit/ariakit/issues/7118 The other hover direction:
-  // after the list closes by clicking an option, moving the pointer off that
-  // option must not clear the active item or move focus while the list is
-  // collapsed.
+  // https://github.com/ariakit/ariakit/issues/7118
+  // The other hover direction: after the list closes by clicking an option,
+  // moving the pointer off that option must not clear the active item or move
+  // focus while the list is collapsed.
   test("hover end on a collapsed list keeps the active item", async ({
     page,
     q,
@@ -241,10 +241,10 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(grape).toBeFocused();
   });
 
-  // https://github.com/ariakit/ariakit/issues/7118 The closed gate must keep
-  // the authored callback from running at all: this one moves the composite
-  // from inside the predicate, so merely invoking it while collapsed would
-  // activate the item and steal focus.
+  // https://github.com/ariakit/ariakit/issues/7118
+  // The closed gate must keep the authored callback from running at all: this
+  // one moves the composite from inside the predicate, so merely invoking it
+  // while collapsed would activate the item and steal focus.
   test("a side-effectful callback does nothing on a collapsed list", async ({
     page,
     q,
@@ -268,8 +268,9 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(other).toBeFocused();
   });
 
-  // https://github.com/ariakit/ariakit/issues/7118 The gate is about the closed
-  // list: the same side-effectful callback keeps working once the select opens.
+  // https://github.com/ariakit/ariakit/issues/7118
+  // The gate is about the closed list: the same side-effectful callback keeps
+  // working once the select opens.
   test("a side-effectful callback activates the option once the list opens", async ({
     q,
   }) => {
@@ -285,10 +286,11 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(grape).toHaveAttribute("data-active-item");
   });
 
-  // https://github.com/ariakit/ariakit/issues/7118 The open state must be
-  // re-read after the authored callback runs: this one closes the list from
-  // inside the predicate and still returns true, so a stale pre-check result
-  // would activate the item and steal focus right as the list collapses.
+  // https://github.com/ariakit/ariakit/issues/7118
+  // The open state must be re-read after the authored callback runs: this one
+  // closes the list from inside the predicate and still returns true, so a
+  // stale pre-check result would activate the item and steal focus right as the
+  // list collapses.
   test("a callback that closes the list on hover activates nothing", async ({
     q,
   }) => {
@@ -311,9 +313,9 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(other).toBeFocused();
   });
 
-  // https://github.com/ariakit/ariakit/issues/7118 The default predicate is
-  // part of the same contract: with no authored focusOnHover, hovering an
-  // option in a collapsed list changes nothing.
+  // https://github.com/ariakit/ariakit/issues/7118
+  // The default predicate is part of the same contract: with no authored
+  // focusOnHover, hovering an option in a collapsed list changes nothing.
   test("default hover on a collapsed list changes nothing", async ({
     page,
     q,
@@ -333,9 +335,9 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await test.expect(q.status("Fruit focused options")).toHaveText("none");
   });
 
-  // https://github.com/ariakit/ariakit/issues/7118 Without ComboboxSelect the
-  // default stays false even while the list is open, so hover only activates an
-  // item when the consumer opts in.
+  // https://github.com/ariakit/ariakit/issues/7118
+  // Without ComboboxSelect the default stays false even while the list is open,
+  // so hover only activates an item when the consumer opts in.
   test("default hover in an open plain combobox activates nothing", async ({
     page,
     q,

--- a/app/src/sandbox/combobox-select-collapsed-focus/test.ts
+++ b/app/src/sandbox/combobox-select-collapsed-focus/test.ts
@@ -40,10 +40,11 @@ for (const label of labels) {
   });
 }
 
-// https://github.com/ariakit/ariakit/issues/7093 Only virtual focus asks for
-// the active item when the select itself is focused, which happens while the
-// list is still closed. That request is the one that has to survive until the
-// list opens, so a pointer open with no move before it still presents the item.
+// https://github.com/ariakit/ariakit/issues/7093
+// Only virtual focus asks for the active item when the select itself is
+// focused, which happens while the list is still closed. That request is the
+// one that has to survive until the list opens, so a pointer open with no move
+// before it still presents the item.
 test("opening the collapsed select with a pointer presents its item", async () => {
   const select = q.combobox("Fruit");
 
@@ -53,10 +54,10 @@ test("opening the collapsed select with a pointer presents its item", async () =
   expect(q.status("Fruit focused options")).toHaveTextContent(/^Apple$/);
 });
 
-// https://github.com/ariakit/ariakit/issues/7093 Focusing the collapsed select
-// leaves a presentation waiting for the list to open. Picking another option
-// before that happens has to retire it, or opening the list would present the
-// option that was active on focus.
+// https://github.com/ariakit/ariakit/issues/7093
+// Focusing the collapsed select leaves a presentation waiting for the list to
+// open. Picking another option before that happens has to retire it, or opening
+// the list would present the option that was active on focus.
 test("picking an option before opening retires the pending presentation", async () => {
   const select = q.combobox("Code");
   await focus(select);
@@ -87,10 +88,10 @@ test("a move from outside the widget still presents immediately", async () => {
   expect(openList).toHaveFocus();
 });
 
-// https://github.com/ariakit/ariakit/pull/7098#discussion_r3742291859 Once
-// focus is on an option, moving between options is navigation inside the list,
-// not focus leaving the control, so the focus ring has to keep up with the
-// active item even though the list is collapsed.
+// https://github.com/ariakit/ariakit/pull/7098#discussion_r3742291859
+// Once focus is on an option, moving between options is navigation inside the
+// list, not focus leaving the control, so the focus ring has to keep up with
+// the active item even though the list is collapsed.
 test("arrow keys keep moving focus between options in a collapsed list", async () => {
   const list = q.listbox("Stage options");
   const draft = q.within(list).option("Draft");
@@ -125,9 +126,9 @@ for (const label of hoverLabels) {
     expect(other).toHaveFocus();
   });
 
-  // https://github.com/ariakit/ariakit/issues/7118 The gate is about the closed
-  // list, not about the authored value, so the same item still takes hover once
-  // the select opens.
+  // https://github.com/ariakit/ariakit/issues/7118
+  // The gate is about the closed list, not about the authored value, so the
+  // same item still takes hover once the select opens.
   test(`${label}: hovering an option activates it once the list opens`, async () => {
     const select = q.combobox(label);
     const list = q.listbox(`${label} options`);
@@ -142,10 +143,10 @@ for (const label of hoverLabels) {
   });
 }
 
-// https://github.com/ariakit/ariakit/issues/7118 The other hover direction:
-// after the list closes by clicking an option, moving the pointer off that
-// option must not clear the active item or move focus while the list is
-// collapsed.
+// https://github.com/ariakit/ariakit/issues/7118
+// The other hover direction: after the list closes by clicking an option,
+// moving the pointer off that option must not clear the active item or move
+// focus while the list is collapsed.
 test("hover end on a collapsed list keeps the active item", async () => {
   const select = q.combobox("Hover fruit");
   const list = q.listbox("Hover fruit options");
@@ -172,10 +173,10 @@ test("hover end on a collapsed list keeps the active item", async () => {
   expect(grape).toHaveFocus();
 });
 
-// https://github.com/ariakit/ariakit/issues/7118 The closed gate must keep the
-// authored callback from running at all: this one moves the composite from
-// inside the predicate, so merely invoking it while collapsed would activate
-// the item and steal focus.
+// https://github.com/ariakit/ariakit/issues/7118
+// The closed gate must keep the authored callback from running at all: this one
+// moves the composite from inside the predicate, so merely invoking it while
+// collapsed would activate the item and steal focus.
 test("a side-effectful callback does nothing on a collapsed list", async () => {
   const select = q.combobox("Move hover fruit");
   const list = q.listbox("Move hover fruit options");
@@ -194,8 +195,9 @@ test("a side-effectful callback does nothing on a collapsed list", async () => {
   expect(other).toHaveFocus();
 });
 
-// https://github.com/ariakit/ariakit/issues/7118 The gate is about the closed
-// list: the same side-effectful callback keeps working once the select opens.
+// https://github.com/ariakit/ariakit/issues/7118
+// The gate is about the closed list: the same side-effectful callback keeps
+// working once the select opens.
 test("a side-effectful callback activates the option once the list opens", async () => {
   const select = q.combobox("Move hover fruit");
   const list = q.listbox("Move hover fruit options");
@@ -209,10 +211,11 @@ test("a side-effectful callback activates the option once the list opens", async
   expect(grape).toHaveAttribute("data-active-item");
 });
 
-// https://github.com/ariakit/ariakit/issues/7118 The open state must be re-read
-// after the authored callback runs: this one closes the list from inside the
-// predicate and still returns true, so a stale pre-check result would activate
-// the item and steal focus right as the list collapses.
+// https://github.com/ariakit/ariakit/issues/7118
+// The open state must be re-read after the authored callback runs: this one
+// closes the list from inside the predicate and still returns true, so a stale
+// pre-check result would activate the item and steal focus right as the list
+// collapses.
 test("a callback that closes the list on hover activates nothing", async () => {
   const select = q.combobox("Hide hover fruit");
   const list = q.listbox("Hide hover fruit options");
@@ -232,9 +235,9 @@ test("a callback that closes the list on hover activates nothing", async () => {
   expect(other).toHaveFocus();
 });
 
-// https://github.com/ariakit/ariakit/issues/7118 The default predicate is part
-// of the same contract: with no authored focusOnHover, hovering an option in a
-// collapsed list changes nothing.
+// https://github.com/ariakit/ariakit/issues/7118
+// The default predicate is part of the same contract: with no authored
+// focusOnHover, hovering an option in a collapsed list changes nothing.
 test("default hover on a collapsed list changes nothing", async () => {
   const select = q.combobox("Fruit");
   const list = q.listbox("Fruit options");
@@ -249,9 +252,9 @@ test("default hover on a collapsed list changes nothing", async () => {
   expect(q.status("Fruit focused options")).toHaveTextContent(/^none$/);
 });
 
-// https://github.com/ariakit/ariakit/issues/7118 Without ComboboxSelect the
-// default stays false even while the list is open, so hover only activates an
-// item when the consumer opts in.
+// https://github.com/ariakit/ariakit/issues/7118
+// Without ComboboxSelect the default stays false even while the list is open,
+// so hover only activates an item when the consumer opts in.
 test("default hover in an open plain combobox activates nothing", async () => {
   const combobox = q.combobox("Filter");
   const list = q.listbox("Filter options");

--- a/app/src/sandbox/combobox-select-collapsed-focus/test.ts
+++ b/app/src/sandbox/combobox-select-collapsed-focus/test.ts
@@ -14,10 +14,10 @@ for (const label of labels) {
     await focus(select);
 
     expect(select).toHaveAttribute("aria-expanded", "false");
-    // The composite can present its active item from a queued microtask or
-    // from a passive effect, and `focus` only flushes microtasks. Cross a
-    // macrotask so a presentation has a chance to run before asserting that
-    // nothing focused an item.
+    // The composite can present its active item from a queued microtask or from
+    // a passive effect, and `focus` only flushes microtasks. Cross a macrotask
+    // so a presentation has a chance to run before asserting that nothing
+    // focused an item.
     await sleep();
     expect(select).toHaveFocus();
     expect(focusedOptions).toHaveTextContent(/^none$/);
@@ -30,8 +30,8 @@ for (const label of labels) {
     expect(select).toHaveAttribute("aria-expanded", "false");
     expect(focusedOptions).toHaveTextContent(/^none$/);
 
-    // Opening the list is what turns its items into focus targets, so this
-    // also shows that the recorder fires when an item really is focused.
+    // Opening the list is what turns its items into focus targets, so this also
+    // shows that the recorder fires when an item really is focused.
     await press("ArrowDown", select);
 
     expect(select).toHaveAttribute("aria-expanded", "true");
@@ -40,11 +40,10 @@ for (const label of labels) {
   });
 }
 
-// https://github.com/ariakit/ariakit/issues/7093
-// Only virtual focus asks for the active item when the select itself is
-// focused, which happens while the list is still closed. That request is the
-// one that has to survive until the list opens, so a pointer open with no move
-// before it still presents the item.
+// https://github.com/ariakit/ariakit/issues/7093 Only virtual focus asks for
+// the active item when the select itself is focused, which happens while the
+// list is still closed. That request is the one that has to survive until the
+// list opens, so a pointer open with no move before it still presents the item.
 test("opening the collapsed select with a pointer presents its item", async () => {
   const select = q.combobox("Fruit");
 
@@ -54,10 +53,10 @@ test("opening the collapsed select with a pointer presents its item", async () =
   expect(q.status("Fruit focused options")).toHaveTextContent(/^Apple$/);
 });
 
-// https://github.com/ariakit/ariakit/issues/7093
-// Focusing the collapsed select leaves a presentation waiting for the list to
-// open. Picking another option before that happens has to retire it, or
-// opening the list would present the option that was active on focus.
+// https://github.com/ariakit/ariakit/issues/7093 Focusing the collapsed select
+// leaves a presentation waiting for the list to open. Picking another option
+// before that happens has to retire it, or opening the list would present the
+// option that was active on focus.
 test("picking an option before opening retires the pending presentation", async () => {
   const select = q.combobox("Code");
   await focus(select);
@@ -88,10 +87,10 @@ test("a move from outside the widget still presents immediately", async () => {
   expect(openList).toHaveFocus();
 });
 
-// https://github.com/ariakit/ariakit/pull/7098#discussion_r3742291859
-// Once focus is on an option, moving between options is navigation inside the
-// list, not focus leaving the control, so the focus ring has to keep up with
-// the active item even though the list is collapsed.
+// https://github.com/ariakit/ariakit/pull/7098#discussion_r3742291859 Once
+// focus is on an option, moving between options is navigation inside the list,
+// not focus leaving the control, so the focus ring has to keep up with the
+// active item even though the list is collapsed.
 test("arrow keys keep moving focus between options in a collapsed list", async () => {
   const list = q.listbox("Stage options");
   const draft = q.within(list).option("Draft");
@@ -126,9 +125,9 @@ for (const label of hoverLabels) {
     expect(other).toHaveFocus();
   });
 
-  // https://github.com/ariakit/ariakit/issues/7118
-  // The gate is about the closed list, not about the authored value, so the
-  // same item still takes hover once the select opens.
+  // https://github.com/ariakit/ariakit/issues/7118 The gate is about the closed
+  // list, not about the authored value, so the same item still takes hover once
+  // the select opens.
   test(`${label}: hovering an option activates it once the list opens`, async () => {
     const select = q.combobox(label);
     const list = q.listbox(`${label} options`);
@@ -143,10 +142,10 @@ for (const label of hoverLabels) {
   });
 }
 
-// https://github.com/ariakit/ariakit/issues/7118
-// The other hover direction: after the list closes by clicking an option,
-// moving the pointer off that option must not clear the active item or move
-// focus while the list is collapsed.
+// https://github.com/ariakit/ariakit/issues/7118 The other hover direction:
+// after the list closes by clicking an option, moving the pointer off that
+// option must not clear the active item or move focus while the list is
+// collapsed.
 test("hover end on a collapsed list keeps the active item", async () => {
   const select = q.combobox("Hover fruit");
   const list = q.listbox("Hover fruit options");
@@ -161,22 +160,22 @@ test("hover end on a collapsed list keeps the active item", async () => {
   await click(grape);
   expect(select).toHaveAttribute("aria-expanded", "false");
   expect(grape).toHaveAttribute("data-active-item");
-  // Clicking an option in an always-visible list leaves DOM focus on it even
-  // as the list collapses, so the hover end below starts from the option.
+  // Clicking an option in an always-visible list leaves DOM focus on it even as
+  // the list collapses, so the hover end below starts from the option.
   expect(grape).toHaveFocus();
 
-  // `hover` settles the DOM before resolving, so the assertions below run
-  // after any clearing the mouseleave handler committed.
+  // `hover` settles the DOM before resolving, so the assertions below run after
+  // any clearing the mouseleave handler committed.
   await hover(other);
 
   expect(grape).toHaveAttribute("data-active-item");
   expect(grape).toHaveFocus();
 });
 
-// https://github.com/ariakit/ariakit/issues/7118
-// The closed gate must keep the authored callback from running at all: this
-// one moves the composite from inside the predicate, so merely invoking it
-// while collapsed would activate the item and steal focus.
+// https://github.com/ariakit/ariakit/issues/7118 The closed gate must keep the
+// authored callback from running at all: this one moves the composite from
+// inside the predicate, so merely invoking it while collapsed would activate
+// the item and steal focus.
 test("a side-effectful callback does nothing on a collapsed list", async () => {
   const select = q.combobox("Move hover fruit");
   const list = q.listbox("Move hover fruit options");
@@ -186,8 +185,8 @@ test("a side-effectful callback does nothing on a collapsed list", async () => {
   await click(other);
   expect(other).toHaveFocus();
 
-  // `hover` settles the DOM before resolving, so the assertions below run
-  // after any activation the mousemove handler committed.
+  // `hover` settles the DOM before resolving, so the assertions below run after
+  // any activation the mousemove handler committed.
   await hover(grape);
 
   expect(select).toHaveAttribute("aria-expanded", "false");
@@ -195,9 +194,8 @@ test("a side-effectful callback does nothing on a collapsed list", async () => {
   expect(other).toHaveFocus();
 });
 
-// https://github.com/ariakit/ariakit/issues/7118
-// The gate is about the closed list: the same side-effectful callback keeps
-// working once the select opens.
+// https://github.com/ariakit/ariakit/issues/7118 The gate is about the closed
+// list: the same side-effectful callback keeps working once the select opens.
 test("a side-effectful callback activates the option once the list opens", async () => {
   const select = q.combobox("Move hover fruit");
   const list = q.listbox("Move hover fruit options");
@@ -211,11 +209,10 @@ test("a side-effectful callback activates the option once the list opens", async
   expect(grape).toHaveAttribute("data-active-item");
 });
 
-// https://github.com/ariakit/ariakit/issues/7118
-// The open state must be re-read after the authored callback runs: this one
-// closes the list from inside the predicate and still returns true, so a
-// stale pre-check result would activate the item and steal focus right as
-// the list collapses.
+// https://github.com/ariakit/ariakit/issues/7118 The open state must be re-read
+// after the authored callback runs: this one closes the list from inside the
+// predicate and still returns true, so a stale pre-check result would activate
+// the item and steal focus right as the list collapses.
 test("a callback that closes the list on hover activates nothing", async () => {
   const select = q.combobox("Hide hover fruit");
   const list = q.listbox("Hide hover fruit options");
@@ -226,8 +223,8 @@ test("a callback that closes the list on hover activates nothing", async () => {
   expect(other).toHaveFocus();
   expect(select).toHaveAttribute("aria-expanded", "true");
 
-  // `hover` settles the DOM before resolving, so the assertions below run
-  // after any activation the mousemove handler committed.
+  // `hover` settles the DOM before resolving, so the assertions below run after
+  // any activation the mousemove handler committed.
   await hover(banana);
 
   expect(select).toHaveAttribute("aria-expanded", "false");
@@ -235,16 +232,16 @@ test("a callback that closes the list on hover activates nothing", async () => {
   expect(other).toHaveFocus();
 });
 
-// https://github.com/ariakit/ariakit/issues/7118
-// The default predicate is part of the same contract: with no authored
-// focusOnHover, hovering an option in a collapsed list changes nothing.
+// https://github.com/ariakit/ariakit/issues/7118 The default predicate is part
+// of the same contract: with no authored focusOnHover, hovering an option in a
+// collapsed list changes nothing.
 test("default hover on a collapsed list changes nothing", async () => {
   const select = q.combobox("Fruit");
   const list = q.listbox("Fruit options");
   const grape = q.within(list).option("Grape");
 
-  // `hover` settles the DOM before resolving, so the assertions below run
-  // after any activation the mousemove handler committed.
+  // `hover` settles the DOM before resolving, so the assertions below run after
+  // any activation the mousemove handler committed.
   await hover(grape);
 
   expect(select).toHaveAttribute("aria-expanded", "false");
@@ -252,9 +249,9 @@ test("default hover on a collapsed list changes nothing", async () => {
   expect(q.status("Fruit focused options")).toHaveTextContent(/^none$/);
 });
 
-// https://github.com/ariakit/ariakit/issues/7118
-// Without ComboboxSelect the default stays false even while the list is open,
-// so hover only activates an item when the consumer opts in.
+// https://github.com/ariakit/ariakit/issues/7118 Without ComboboxSelect the
+// default stays false even while the list is open, so hover only activates an
+// item when the consumer opts in.
 test("default hover in an open plain combobox activates nothing", async () => {
   const combobox = q.combobox("Filter");
   const list = q.listbox("Filter options");
@@ -263,8 +260,8 @@ test("default hover in an open plain combobox activates nothing", async () => {
   await click(combobox);
   expect(combobox).toHaveAttribute("aria-expanded", "true");
 
-  // `hover` settles the DOM before resolving, so the assertions below run
-  // after any activation the mousemove handler committed.
+  // `hover` settles the DOM before resolving, so the assertions below run after
+  // any activation the mousemove handler committed.
   await hover(grape);
 
   expect(grape).not.toHaveAttribute("data-active-item");

--- a/app/src/sandbox/combobox-select-open-page-scroll/index.react.tsx
+++ b/app/src/sandbox/combobox-select-open-page-scroll/index.react.tsx
@@ -37,10 +37,10 @@ const popoverStyle = {
  *   composite element, so nothing can scroll the page.
  * - The `Combobox` element rendered inside the popup instead of next to the
  *   select. It's the composite element focus is redirected to, and keeping it
- *   in the popup is what leaves the popup's initial focus unresolved so an
- *   item is focused first.
- * - `unmountOnHide`, so that element only mounts as the popup opens. Without
- *   it the popup is already positioned by then and the bug doesn't reproduce.
+ *   in the popup is what leaves the popup's initial focus unresolved so an item
+ *   is focused first.
+ * - `unmountOnHide`, so that element only mounts as the popup opens. Without it
+ *   the popup is already positioned by then and the bug doesn't reproduce.
  */
 function BranchSelect() {
   const [searchValue, setSearchValue] = useState("");
@@ -114,13 +114,14 @@ interface SelfFocusingBranchSelectProps {
 }
 
 /**
- * The {@link BranchSelect} shape, with an option that focuses itself, in the two
- * arrangements that decide what the composite element is when that focus lands.
+ * The {@link BranchSelect} shape, with an option that focuses itself, in the
+ * two arrangements that decide what the composite element is when that focus
+ * lands.
  *
- * With a select trigger, the trigger is the composite element while the popup is
- * unmounted and the search field takes over once it mounts. Without one, nothing
- * is the composite element until the search field registers, which is a commit
- * after the option's mount effect has already run.
+ * With a select trigger, the trigger is the composite element while the popup
+ * is unmounted and the search field takes over once it mounts. Without one,
+ * nothing is the composite element until the search field registers, which is a
+ * commit after the option's mount effect has already run.
  *
  * Either way the popup is still at its pre-placement origin when the composite
  * gets its focus back, and the page moves and stays moved.
@@ -129,8 +130,8 @@ interface SelfFocusingBranchSelectProps {
  * reproduce this. See https://github.com/ariakit/ariakit/issues/6623
  *
  * Two things keep this distinct from {@link BranchSelect} and must not be
- * "restored" to match it: `autoFocusOnShow={false}`, which lets the option's own
- * mount focus win over the dialog's initial focus, and the absence of
+ * "restored" to match it: `autoFocusOnShow={false}`, which lets the option's
+ * own mount focus win over the dialog's initial focus, and the absence of
  * `defaultSelectedValue`, which keeps the store from resolving a selected item
  * that would mask that focus.
  */

--- a/app/src/sandbox/combobox-select-programmatic-open/index.react.tsx
+++ b/app/src/sandbox/combobox-select-programmatic-open/index.react.tsx
@@ -18,10 +18,10 @@ export default function Example() {
   });
 
   // A global shortcut opens the picker programmatically, leaving focus wherever
-  // the user left it, so the open never passes through the select.
-  // A button that refuses focus would not do: Safari falls back to the last
-  // mousedown target for the disclosure element, so the open would carry an
-  // opener there and not in the other engines.
+  // the user left it, so the open never passes through the select. A button
+  // that refuses focus would not do: Safari falls back to the last mousedown
+  // target for the disclosure element, so the open would carry an opener there
+  // and not in the other engines.
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key !== "F2") return;

--- a/app/src/sandbox/combobox-select-programmatic-open/test-browser.ts
+++ b/app/src/sandbox/combobox-select-programmatic-open/test-browser.ts
@@ -14,7 +14,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
   // Focus is asserted only at the end, so the presentation assertion above it
   // still runs against the unfixed behavior instead of being skipped by an
-  // earlier failure. https://github.com/ariakit/ariakit/issues/7068
+  // earlier failure.
+  // https://github.com/ariakit/ariakit/issues/7068
   test("presents options that arrive after the open", async ({ page, q }) => {
     await page.keyboard.press("F2");
     await test.expect(q.listbox()).toBeVisible();

--- a/app/src/sandbox/combobox-select-programmatic-open/test-browser.ts
+++ b/app/src/sandbox/combobox-select-programmatic-open/test-browser.ts
@@ -14,8 +14,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
   // Focus is asserted only at the end, so the presentation assertion above it
   // still runs against the unfixed behavior instead of being skipped by an
-  // earlier failure.
-  // https://github.com/ariakit/ariakit/issues/7068
+  // earlier failure. https://github.com/ariakit/ariakit/issues/7068
   test("presents options that arrive after the open", async ({ page, q }) => {
     await page.keyboard.press("F2");
     await test.expect(q.listbox()).toBeVisible();
@@ -91,8 +90,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
   }) => {
     await page.keyboard.press("F2");
     await test.expect(q.combobox("Vegetable")).toBeFocused();
-    // The presentation is still waiting for its target, which is what makes
-    // the focus move below an abandonment rather than a no-op.
+    // The presentation is still waiting for its target, which is what makes the
+    // focus move below an abandonment rather than a no-op.
     await test.expect(q.option("Onion")).toHaveCount(0);
 
     await q.textbox("Note").click();

--- a/app/src/sandbox/combobox-select-programmatic-open/test.ts
+++ b/app/src/sandbox/combobox-select-programmatic-open/test.ts
@@ -2,8 +2,7 @@ import { click, press, q, sleep } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 // The scroll side of the presentation is browser-only and lives in
-// test-browser.ts.
-// https://github.com/ariakit/ariakit/issues/7068
+// test-browser.ts. https://github.com/ariakit/ariakit/issues/7068
 test("takes focus when opened without focus", async () => {
   expect(document.body).toHaveFocus();
 
@@ -15,8 +14,7 @@ test("takes focus when opened without focus", async () => {
 
 // Focus is asserted only at the end, so the registration assertion above it
 // still runs against the unfixed behavior instead of being skipped by an
-// earlier failure.
-// https://github.com/ariakit/ariakit/issues/7068
+// earlier failure. https://github.com/ariakit/ariakit/issues/7068
 test("keeps focus while options arrive after the open", async () => {
   await press("F2");
   expect(q.listbox()).toBeVisible();

--- a/app/src/sandbox/combobox-select-programmatic-open/test.ts
+++ b/app/src/sandbox/combobox-select-programmatic-open/test.ts
@@ -2,7 +2,8 @@ import { click, press, q, sleep } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 // The scroll side of the presentation is browser-only and lives in
-// test-browser.ts. https://github.com/ariakit/ariakit/issues/7068
+// test-browser.ts.
+// https://github.com/ariakit/ariakit/issues/7068
 test("takes focus when opened without focus", async () => {
   expect(document.body).toHaveFocus();
 
@@ -14,7 +15,8 @@ test("takes focus when opened without focus", async () => {
 
 // Focus is asserted only at the end, so the registration assertion above it
 // still runs against the unfixed behavior instead of being skipped by an
-// earlier failure. https://github.com/ariakit/ariakit/issues/7068
+// earlier failure.
+// https://github.com/ariakit/ariakit/issues/7068
 test("keeps focus while options arrive after the open", async () => {
   await press("F2");
   expect(q.listbox()).toBeVisible();

--- a/app/src/sandbox/combobox-select-renderer/test-browser.ts
+++ b/app/src/sandbox/combobox-select-renderer/test-browser.ts
@@ -34,11 +34,11 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
 
         // Horizontal orientation lays items out along the x-axis: the renderer
         // offsets each item by `left` and keeps a shared `top` of 0. The last
-        // option "Cherry" (index 2) lands at `itemSize * 2 = 192px`; asserting the
-        // last item keeps the check robust because it stays rendered as a
-        // persistent index even when virtualization trims middle items. Before the
-        // fix, the dropped `orientation` prop fell back to vertical, offsetting by
-        // `top` instead.
+        // option "Cherry" (index 2) lands at `itemSize * 2 = 192px`; asserting
+        // the last item keeps the check robust because it stays rendered as a
+        // persistent index even when virtualization trims middle items. Before
+        // the fix, the dropped `orientation` prop fell back to vertical,
+        // offsetting by `top` instead.
         const cherry = q.option("Cherry");
         await test.expect(cherry).toHaveCSS("left", "192px");
         await test.expect(cherry).toHaveCSS("top", "0px");

--- a/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
+++ b/app/src/sandbox/combobox-select-selected-value-presentation/test-browser.ts
@@ -189,8 +189,8 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
     await q.combobox("Render-counted fruit").click();
     await test.expect(q.listbox("Render-counted fruit")).toBeVisible();
     // The open still commits on the next frames, and the absence of an item
-    // render has no positive state to await, so give a stray render a chance
-    // to appear before asserting it never happened.
+    // render has no positive state to await, so give a stray render a chance to
+    // appear before asserting it never happened.
     await flushFrames(page);
 
     await test.expect(item).toHaveAttribute("data-render-count", "2");
@@ -387,7 +387,8 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
 
     await test.expect(q.option("Focus target")).toBeFocused();
     // Focus has moved before the pending presentation callback can run. There
-    // is no positive state for its cancellation, so wait through its checkpoint.
+    // is no positive state for its cancellation, so wait through its
+    // checkpoint.
     await flushFrames(page);
     await test.expect(q.option("Focus target")).toBeInViewport();
     await test.expect(q.option("Watermelon")).not.toBeInViewport();
@@ -622,7 +623,8 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
 
     await test.expect(q.option("Focus target")).toBeFocused();
     // Focus has moved before the pending presentation callback can run. There
-    // is no positive state for its cancellation, so wait through its checkpoint.
+    // is no positive state for its cancellation, so wait through its
+    // checkpoint.
     await flushFrames(page);
     await test.expect(q.option("Focus target")).toBeInViewport();
     await test.expect(q.option("Watermelon")).not.toBeInViewport();

--- a/app/src/sandbox/combobox-select-tag-tooltip-element-id/test-chrome.ts
+++ b/app/src/sandbox/combobox-select-tag-tooltip-element-id/test-chrome.ts
@@ -52,7 +52,8 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     const label = section.text("Tag label");
     const input = section.textbox("Tag label");
     // Playwright filters an initially empty display: contents list from default
-    // role queries. https://github.com/ariakit/ariakit/issues/7164
+    // role queries.
+    // https://github.com/ariakit/ariakit/issues/7164
     const list = section.listbox("Tag label", { includeHidden: true });
     // The label names the control too, which groups the tag list and the input.
     const control = section.group("Tag label");

--- a/app/src/sandbox/combobox-select-tag-tooltip-element-id/test-chrome.ts
+++ b/app/src/sandbox/combobox-select-tag-tooltip-element-id/test-chrome.ts
@@ -51,9 +51,8 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     const section = query(q.region("Tag"));
     const label = section.text("Tag label");
     const input = section.textbox("Tag label");
-    // Playwright filters an initially empty display: contents list from
-    // default role queries.
-    // https://github.com/ariakit/ariakit/issues/7164
+    // Playwright filters an initially empty display: contents list from default
+    // role queries. https://github.com/ariakit/ariakit/issues/7164
     const list = section.listbox("Tag label", { includeHidden: true });
     // The label names the control too, which groups the tag list and the input.
     const control = section.group("Tag label");

--- a/app/src/sandbox/command-press-state/test-browser.ts
+++ b/app/src/sandbox/command-press-state/test-browser.ts
@@ -45,8 +45,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
   // moves away while Space is still held, the keyup is delivered to the new
   // focus target, so that handler never runs. Native buttons cancel Space
   // activation when they lose focus before the keyup, and the non-native
-  // emulation must do the same. These tests cover the two legs of that bug:
-  // the element staying stuck looking pressed after focus leaves, and a keyup
+  // emulation must do the same. These tests cover the two legs of that bug: the
+  // element staying stuck looking pressed after focus leaves, and a keyup
   // bubbling from a focused child dispatching a synthetic click on the element
   // even though the press never finished on it.
 
@@ -76,17 +76,17 @@ withFramework(import.meta.dirname, async ({ test }) => {
     page,
     q,
   }) => {
-    // Playwright text queries match the element's full text content (which
-    // here includes the nested button's label), so exact matching must be
-    // turned off to find the card by its own text.
+    // Playwright text queries match the element's full text content (which here
+    // includes the nested button's label), so exact matching must be turned off
+    // to find the card by its own text.
     const card = q.text("Open article", { exact: false });
     await card.focus();
 
     await page.keyboard.down("Space");
     await test.expect(card).toHaveAttribute("data-active");
 
-    // Move focus into the nested button while Space is still held, so the
-    // keyup fires on the button and bubbles through the card. The press never
+    // Move focus into the nested button while Space is still held, so the keyup
+    // fires on the button and bubbles through the card. The press never
     // finished on the card, so it must not dispatch a synthetic click on
     // itself, and losing focus must clear the pressed state. The move is
     // scripted rather than pressing Tab because WebKit skips native buttons

--- a/app/src/sandbox/command-press-state/test.ts
+++ b/app/src/sandbox/command-press-state/test.ts
@@ -40,9 +40,9 @@ test("data-active is cleared when focus leaves while Space is held", async () =>
   expect(command).toHaveAttribute("data-active");
 
   // Clicking elsewhere while Space is still held moves focus to the body, so
-  // the keyup lands there and never reaches the command. Losing focus
-  // mid-press must cancel the press, like a native button, instead of leaving
-  // the element stuck looking pressed.
+  // the keyup lands there and never reaches the command. Losing focus mid-press
+  // must cancel the press, like a native button, instead of leaving the element
+  // stuck looking pressed.
   await click(q.text("Outside text"));
   expect(command).not.toHaveFocus();
   expect(command).not.toHaveAttribute("data-active");

--- a/app/src/sandbox/composite-6335/test-chrome-firefox.ts
+++ b/app/src/sandbox/composite-6335/test-chrome-firefox.ts
@@ -6,8 +6,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.option("Item 1")).toBeVisible();
     const input = q.spinbutton("Page");
     await input.click();
-    // Clearing the field makes the page number NaN, a transient state while
-    // the user types another page number
+    // Clearing the field makes the page number NaN, a transient state while the
+    // user types another page number
     await input.press("ControlOrMeta+a");
     await input.press("Delete");
     await test.expect(input).toHaveValue("");

--- a/app/src/sandbox/composite-6335/test.ts
+++ b/app/src/sandbox/composite-6335/test.ts
@@ -2,8 +2,8 @@ import { click, dispatch, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 // Number inputs don't expose the text selection API that the type() utility
-// relies on, so fire the input events the browser produces while the user
-// edits the field.
+// relies on, so fire the input events the browser produces while the user edits
+// the field.
 async function setValue(input: HTMLElement, value: string) {
   const inputType = value ? "insertText" : "deleteContentBackward";
   await dispatch.input(input, { target: { value }, inputType });

--- a/app/src/sandbox/composite-7360/test-browser.ts
+++ b/app/src/sandbox/composite-7360/test-browser.ts
@@ -180,8 +180,7 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
   // handed off has nothing to carry it out, so it stays pending and its item
   // takes focus once the toolbar is a composite again. The move comes from the
   // arrow key, which still moves the active item meanwhile; only focus stops
-  // following it.
-  // Related: https://github.com/ariakit/ariakit/issues/7363
+  // following it. Related: https://github.com/ariakit/ariakit/issues/7363
   test("focuses a newly moved item when composite behavior comes back", async ({
     page,
     q,

--- a/app/src/sandbox/composite-7360/test.ts
+++ b/app/src/sandbox/composite-7360/test.ts
@@ -116,8 +116,7 @@ test("keeps focus when composite behavior comes back", async () => {
 // handed off has nothing to carry it out, so it stays pending and its item
 // takes focus once the toolbar is a composite again. The move comes from the
 // arrow key, which still moves the active item meanwhile; only focus stops
-// following it.
-// Related: https://github.com/ariakit/ariakit/issues/7363
+// following it. Related: https://github.com/ariakit/ariakit/issues/7363
 test("focuses a newly moved item when composite behavior comes back", async () => {
   await moveToSecondItem();
   await handOff();

--- a/app/src/sandbox/composite-dialog-virtual-focus/index.react.tsx
+++ b/app/src/sandbox/composite-dialog-virtual-focus/index.react.tsx
@@ -6,9 +6,9 @@ const folders = ["Inbox", "Archive", "Trash"];
 // composite through the dialog keeps the dialog's own tabindex="-1", so the
 // dialog's initial focus falls through to whatever is tabbable inside it. The
 // options are only rendered while the dialog is open, so they mount after the
-// listbox element rather than with it. Nothing is selected up front, so
-// opening the dialog should leave the list without a highlighted option until
-// an arrow key is pressed.
+// listbox element rather than with it. Nothing is selected up front, so opening
+// the dialog should leave the list without a highlighted option until an arrow
+// key is pressed.
 export default function Example() {
   const dialog = Ariakit.useDialogStore();
   const open = Ariakit.useStoreState(dialog, "open");

--- a/app/src/sandbox/composite-iframe-6312/test-browser.ts
+++ b/app/src/sandbox/composite-iframe-6312/test-browser.ts
@@ -14,9 +14,9 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
 
     await page.keyboard.press("PageDown");
 
-    // With a 220px iframe viewport and 50px items, one page down lands on
-    // Item 7. Before the fix, paging used the outer page's much taller viewport
-    // and jumped far past it.
+    // With a 220px iframe viewport and 50px items, one page down lands on Item 7.
+    // Before the fix, paging used the outer page's much taller viewport and
+    // jumped far past it.
     await test.expect(frame.button("Item 7")).toBeFocused();
   });
 });

--- a/app/src/sandbox/composite-item-tabbable/test-browser.ts
+++ b/app/src/sandbox/composite-item-tabbable/test-browser.ts
@@ -9,8 +9,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await page.keyboard.press("Tab");
     await test.expect(q.option("Starred")).toBeFocused();
 
-    // The containerless store never gets a composite element, so its items
-    // must keep roving tabindex and skip straight to the next widget.
+    // The containerless store never gets a composite element, so its items must
+    // keep roving tabindex and skip straight to the next widget.
     await page.keyboard.press("Tab");
     await test.expect(q.listbox("Virtual focus")).toBeFocused();
 

--- a/app/src/sandbox/composite-item-tabbable/test.ts
+++ b/app/src/sandbox/composite-item-tabbable/test.ts
@@ -8,7 +8,8 @@ const virtualFocusWarning =
 
 // The composite element is published one commit after the items mount, so
 // gating only on it would drop roving tabindex for composite stores that never
-// get a composite element. https://github.com/ariakit/ariakit/pull/6832
+// get a composite element.
+// https://github.com/ariakit/ariakit/pull/6832
 test("keeps a single tab stop per composite once hydrated", async () => {
   await press.Tab();
   expect(q.option("Starred")).toHaveFocus();

--- a/app/src/sandbox/composite-item-tabbable/test.ts
+++ b/app/src/sandbox/composite-item-tabbable/test.ts
@@ -8,8 +8,7 @@ const virtualFocusWarning =
 
 // The composite element is published one commit after the items mount, so
 // gating only on it would drop roving tabindex for composite stores that never
-// get a composite element.
-// https://github.com/ariakit/ariakit/pull/6832
+// get a composite element. https://github.com/ariakit/ariakit/pull/6832
 test("keeps a single tab stop per composite once hydrated", async () => {
   await press.Tab();
   expect(q.option("Starred")).toHaveFocus();

--- a/app/src/sandbox/composite-late-item-focus/test-browser.ts
+++ b/app/src/sandbox/composite-late-item-focus/test-browser.ts
@@ -112,8 +112,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await q.button("Target bold action").click();
     await q.button("Show pending toolbar").click();
 
-    // The item registers in a passive effect, and no state exposes when a
-    // stale pending presentation would move focus afterward.
+    // The item registers in a passive effect, and no state exposes when a stale
+    // pending presentation would move focus afterward.
     await flushFrames(page);
     await test.expect(q.button("Hide pending toolbar")).toBeFocused();
     await test.expect(q.button("Bold action")).not.toBeFocused();
@@ -144,8 +144,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await q.button("Target bold action").click();
     await q.button("Show pending toolbar").click();
 
-    // The item registers in a passive effect, and no state exposes when a
-    // stale pending presentation would move focus afterward.
+    // The item registers in a passive effect, and no state exposes when a stale
+    // pending presentation would move focus afterward.
     await flushFrames(page);
     await test.expect(q.button("Hide pending toolbar")).toBeFocused();
     await test.expect(q.button("Bold action")).not.toBeFocused();
@@ -170,8 +170,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await q.button("Queue initial toolbar").click();
     await q.button("Show initially hidden toolbar").click();
 
-    // The item registers in a passive effect, and no state exposes when a
-    // stale pending presentation would move focus afterward.
+    // The item registers in a passive effect, and no state exposes when a stale
+    // pending presentation would move focus afterward.
     await flushFrames(page);
     await test.expect(q.button("Show initially hidden toolbar")).toBeFocused();
     await test.expect(q.button("Initial bold action")).not.toBeFocused();

--- a/app/src/sandbox/composite-menu-3768/test-browser.ts
+++ b/app/src/sandbox/composite-menu-3768/test-browser.ts
@@ -6,9 +6,10 @@ withFramework(import.meta.dirname, async ({ test }) => {
     q,
   }) => {
     // The menu button in the first row must be reachable with ArrowRight from
-    // its preceding sibling. It's a `CompositeItem` wrapped in a `MenuProvider`,
-    // so before the fix it was registered in the menu's own composite store
-    // instead of the outer composite store, and arrow navigation skipped it.
+    // its preceding sibling. It's a `CompositeItem` wrapped in a
+    // `MenuProvider`, so before the fix it was registered in the menu's own
+    // composite store instead of the outer composite store, and arrow
+    // navigation skipped it.
     await q.button("Button A1").focus();
     await test.expect(q.button("Button A1")).toBeFocused();
     await page.keyboard.press("ArrowRight");

--- a/app/src/sandbox/composite-navigation/test-browser.ts
+++ b/app/src/sandbox/composite-navigation/test-browser.ts
@@ -48,11 +48,11 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(grape).toHaveAttribute("data-focus-visible", "true");
   });
 
-  // https://github.com/ariakit/ariakit/issues/7099
-  // Orange is the last item of the non-looping composite, so the key moves
-  // nothing and no focus event fires. Only the item's own keydown handling can
-  // apply the attribute here. The test above moves focus instead, which
-  // discards that handling when the item blurs before its callback runs.
+  // https://github.com/ariakit/ariakit/issues/7099 Orange is the last item of
+  // the non-looping composite, so the key moves nothing and no focus event
+  // fires. Only the item's own keydown handling can apply the attribute here.
+  // The test above moves focus instead, which discards that handling when the
+  // item blurs before its callback runs.
   test("shows focus-visible on the item when an Alt-modified navigation key doesn't move focus", async ({
     page,
     q,
@@ -90,9 +90,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(firstCell).toHaveAttribute("data-focus-visible", "true");
   });
 
-  // https://github.com/ariakit/ariakit/issues/7099
-  // The counterpart of the tests above. A modified key that Ariakit doesn't use
-  // to move focus is typing or a shortcut, so it must keep pointer modality.
+  // https://github.com/ariakit/ariakit/issues/7099 The counterpart of the tests
+  // above. A modified key that Ariakit doesn't use to move focus is typing or a
+  // shortcut, so it must keep pointer modality.
   test("keeps pointer modality on a modified non-navigation key", async ({
     page,
     q,

--- a/app/src/sandbox/composite-navigation/test-browser.ts
+++ b/app/src/sandbox/composite-navigation/test-browser.ts
@@ -48,11 +48,11 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(grape).toHaveAttribute("data-focus-visible", "true");
   });
 
-  // https://github.com/ariakit/ariakit/issues/7099 Orange is the last item of
-  // the non-looping composite, so the key moves nothing and no focus event
-  // fires. Only the item's own keydown handling can apply the attribute here.
-  // The test above moves focus instead, which discards that handling when the
-  // item blurs before its callback runs.
+  // https://github.com/ariakit/ariakit/issues/7099
+  // Orange is the last item of the non-looping composite, so the key moves
+  // nothing and no focus event fires. Only the item's own keydown handling can
+  // apply the attribute here. The test above moves focus instead, which
+  // discards that handling when the item blurs before its callback runs.
   test("shows focus-visible on the item when an Alt-modified navigation key doesn't move focus", async ({
     page,
     q,
@@ -90,9 +90,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(firstCell).toHaveAttribute("data-focus-visible", "true");
   });
 
-  // https://github.com/ariakit/ariakit/issues/7099 The counterpart of the tests
-  // above. A modified key that Ariakit doesn't use to move focus is typing or a
-  // shortcut, so it must keep pointer modality.
+  // https://github.com/ariakit/ariakit/issues/7099
+  // The counterpart of the tests above. A modified key that Ariakit doesn't use
+  // to move focus is typing or a shortcut, so it must keep pointer modality.
   test("keeps pointer modality on a modified non-navigation key", async ({
     page,
     q,

--- a/app/src/sandbox/composite-navigation/test.ts
+++ b/app/src/sandbox/composite-navigation/test.ts
@@ -93,11 +93,11 @@ test("moves focus-visible with an Alt-modified navigation key", async () => {
   expect(grape).toHaveAttribute("data-focus-visible", "true");
 });
 
-// https://github.com/ariakit/ariakit/issues/7099
-// Orange is the last item of the non-looping composite, so the key moves
-// nothing and no focus event fires. Only the item's own keydown handling can
-// apply the attribute here. The test above moves focus instead, which discards
-// that handling when the item blurs before its callback runs.
+// https://github.com/ariakit/ariakit/issues/7099 Orange is the last item of the
+// non-looping composite, so the key moves nothing and no focus event fires.
+// Only the item's own keydown handling can apply the attribute here. The test
+// above moves focus instead, which discards that handling when the item blurs
+// before its callback runs.
 test("shows focus-visible on the item when an Alt-modified navigation key doesn't move focus", async () => {
   const orange = q.button("Orange");
 
@@ -124,9 +124,9 @@ test("moves focus-visible with Ctrl+Home on a grid", async () => {
   expect(firstCell).toHaveAttribute("data-focus-visible", "true");
 });
 
-// https://github.com/ariakit/ariakit/issues/7099
-// The counterpart of the tests above. A modified key that Ariakit doesn't use
-// to move focus is typing or a shortcut, so it must keep pointer modality.
+// https://github.com/ariakit/ariakit/issues/7099 The counterpart of the tests
+// above. A modified key that Ariakit doesn't use to move focus is typing or a
+// shortcut, so it must keep pointer modality.
 test("keeps pointer modality on a modified non-navigation key", async () => {
   const orange = q.button("Orange");
   const grape = q.button("Grape");

--- a/app/src/sandbox/composite-navigation/test.ts
+++ b/app/src/sandbox/composite-navigation/test.ts
@@ -93,11 +93,11 @@ test("moves focus-visible with an Alt-modified navigation key", async () => {
   expect(grape).toHaveAttribute("data-focus-visible", "true");
 });
 
-// https://github.com/ariakit/ariakit/issues/7099 Orange is the last item of the
-// non-looping composite, so the key moves nothing and no focus event fires.
-// Only the item's own keydown handling can apply the attribute here. The test
-// above moves focus instead, which discards that handling when the item blurs
-// before its callback runs.
+// https://github.com/ariakit/ariakit/issues/7099
+// Orange is the last item of the non-looping composite, so the key moves
+// nothing and no focus event fires. Only the item's own keydown handling can
+// apply the attribute here. The test above moves focus instead, which discards
+// that handling when the item blurs before its callback runs.
 test("shows focus-visible on the item when an Alt-modified navigation key doesn't move focus", async () => {
   const orange = q.button("Orange");
 
@@ -124,9 +124,9 @@ test("moves focus-visible with Ctrl+Home on a grid", async () => {
   expect(firstCell).toHaveAttribute("data-focus-visible", "true");
 });
 
-// https://github.com/ariakit/ariakit/issues/7099 The counterpart of the tests
-// above. A modified key that Ariakit doesn't use to move focus is typing or a
-// shortcut, so it must keep pointer modality.
+// https://github.com/ariakit/ariakit/issues/7099
+// The counterpart of the tests above. A modified key that Ariakit doesn't use
+// to move focus is typing or a shortcut, so it must keep pointer modality.
 test("keeps pointer modality on a modified non-navigation key", async () => {
   const orange = q.button("Orange");
   const grape = q.button("Grape");

--- a/app/src/sandbox/composite-presentation-cancel-on-unmount/test-browser.ts
+++ b/app/src/sandbox/composite-presentation-cancel-on-unmount/test-browser.ts
@@ -94,9 +94,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
   // Refusing to present after the panel goes away must not outlive the panel
   // itself, so the two presentations a reopened panel schedules are pinned
-  // here: the one its own focus handler queues, and the one a programmatic
-  // move requests. The scroll is what discriminates, because the entry is
-  // already the active item before either action.
+  // here: the one its own focus handler queues, and the one a programmatic move
+  // requests. The scroll is what discriminates, because the entry is already
+  // the active item before either action.
   test("presents the active item when the reopened panel is focused", async ({
     q,
   }) => {

--- a/app/src/sandbox/composite-presentation-cancel-on-unmount/test.ts
+++ b/app/src/sandbox/composite-presentation-cancel-on-unmount/test.ts
@@ -8,7 +8,8 @@ import { expect, test } from "vitest";
 // both before that microtask, so those two dismissals are not split the same
 // way. A dismissal in a later task behaves alike in both. The outcome asserted
 // in both files is the same either way: nothing may move focus on its own after
-// the panel is dismissed. https://github.com/ariakit/ariakit/issues/7024
+// the panel is dismissed.
+// https://github.com/ariakit/ariakit/issues/7024
 
 /**
  * Reopens the panel, puts DOM focus on a plain button inside it, then loads the

--- a/app/src/sandbox/composite-presentation-cancel-on-unmount/test.ts
+++ b/app/src/sandbox/composite-presentation-cancel-on-unmount/test.ts
@@ -7,9 +7,8 @@ import { expect, test } from "vitest";
 // and a `flushSync` unmount before it, while the simulated events here commit
 // both before that microtask, so those two dismissals are not split the same
 // way. A dismissal in a later task behaves alike in both. The outcome asserted
-// in both files is the same either way: nothing may move focus on its own
-// after the panel is dismissed.
-// https://github.com/ariakit/ariakit/issues/7024
+// in both files is the same either way: nothing may move focus on its own after
+// the panel is dismissed. https://github.com/ariakit/ariakit/issues/7024
 
 /**
  * Reopens the panel, puts DOM focus on a plain button inside it, then loads the
@@ -60,8 +59,8 @@ test("keeps focus after tabbing into a panel that hides itself", async () => {
 // Refusing to present after the panel goes away must not outlive the panel
 // itself. The scroll that discriminates in the browser is invisible here, so
 // the move is driven from outside the panel instead, and the handoff it
-// triggers is what proves the presentation ran: the entry takes focus and
-// hands it back to the panel.
+// triggers is what proves the presentation ran: the entry takes focus and hands
+// it back to the panel.
 test("presents the active item when a move targets the reopened panel", async () => {
   await click(q.button("Focus and hide shortcuts synchronously"));
   await click(q.button("Show shortcuts"));

--- a/app/src/sandbox/composite-presentation-cancel/test-browser.ts
+++ b/app/src/sandbox/composite-presentation-cancel/test-browser.ts
@@ -7,9 +7,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
   // presented into. The store notifies its listeners synchronously, so the
   // parked request is woken while the item is still rendered and still visible:
   // nothing else stops it from scrolling the page to a popup that never got
-  // placed.
-  // Browser-only: the symptom is the document scroll offset, which happy-dom
-  // cannot model because it stubs `scrollIntoView`.
+  // placed. Browser-only: the symptom is the document scroll offset, which
+  // happy-dom cannot model because it stubs `scrollIntoView`.
   // https://github.com/ariakit/ariakit/issues/6986
   test("abandons a parked presentation when the popup closes", async ({
     page,
@@ -80,8 +79,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
   // replaced, so an item that leaves for good has to end the request instead of
   // sending it back to waiting. Otherwise the same item returning later, long
   // after the move that asked for it, would revive the request and scroll the
-  // page to it.
-  // https://github.com/ariakit/ariakit/issues/7021
+  // page to it. https://github.com/ariakit/ariakit/issues/7021
   test("abandons a parked presentation when its item leaves for good", async ({
     page,
     q,

--- a/app/src/sandbox/composite-presentation-cancel/test-browser.ts
+++ b/app/src/sandbox/composite-presentation-cancel/test-browser.ts
@@ -79,7 +79,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
   // replaced, so an item that leaves for good has to end the request instead of
   // sending it back to waiting. Otherwise the same item returning later, long
   // after the move that asked for it, would revive the request and scroll the
-  // page to it. https://github.com/ariakit/ariakit/issues/7021
+  // page to it.
+  // https://github.com/ariakit/ariakit/issues/7021
   test("abandons a parked presentation when its item leaves for good", async ({
     page,
     q,

--- a/app/src/sandbox/composite-renderer-6215/index.react.tsx
+++ b/app/src/sandbox/composite-renderer-6215/index.react.tsx
@@ -11,10 +11,10 @@ import "./style.css";
 // and detach from the DOM; they must be unobserved, and the observer must be
 // disconnected when the list unmounts, so no detached node is retained.
 //
-// Like the issue's StackBlitz repro, we wrap the global ResizeObserver — calling
-// through to the real one so measurement still happens — to make the otherwise
-// invisible leak observable: the count below is the number of item nodes still
-// observed after they have detached from the document.
+// Like the issue's StackBlitz repro, we wrap the global ResizeObserver —
+// calling through to the real one so measurement still happens — to make the
+// otherwise invisible leak observable: the count below is the number of item
+// nodes still observed after they have detached from the document.
 
 const observedItems = new Set<Element>();
 
@@ -65,7 +65,8 @@ export default function Example() {
   const [detached, setDetached] = useState(0);
 
   // Surface the leak live as the user scrolls. React bails out of re-rendering
-  // when the count is unchanged, so this only re-renders when it actually moves.
+  // when the count is unchanged, so this only re-renders when it actually
+  // moves.
   useEffect(() => {
     let raf = requestAnimationFrame(function tick() {
       setDetached(countDetachedObservedItems());

--- a/app/src/sandbox/composite-renderer-6215/test-browser.ts
+++ b/app/src/sandbox/composite-renderer-6215/test-browser.ts
@@ -3,12 +3,12 @@ import { flushFrames, withFramework } from "#app/test-utils/preview.ts";
 withFramework(import.meta.dirname, async ({ test }) => {
   // https://github.com/ariakit/ariakit/issues/6215
   //
-  // Scrolling the virtualized list mounts and unmounts item nodes, and each item
-  // is measured by the renderer's internal ResizeObserver. Items that scroll out
-  // (or remount to a new node, or are removed when the list unmounts) must stop
-  // being observed so their detached nodes aren't retained. The sandbox wraps
-  // the real ResizeObserver and shows how many observed item nodes are detached
-  // from the document; that count must stay at 0.
+  // Scrolling the virtualized list mounts and unmounts item nodes, and each
+  // item is measured by the renderer's internal ResizeObserver. Items that
+  // scroll out (or remount to a new node, or are removed when the list
+  // unmounts) must stop being observed so their detached nodes aren't retained.
+  // The sandbox wraps the real ResizeObserver and shows how many observed item
+  // nodes are detached from the document; that count must stay at 0.
   test("does not retain detached item nodes that are no longer rendered", async ({
     page,
     q,
@@ -60,7 +60,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await flushFrames(page);
     await test.expect(detachedCount).toHaveText("0");
 
-    // Unmounting the list must disconnect the observer — still nothing retained.
+    // Unmounting the list must disconnect the observer — still nothing
+    // retained.
     await q.button("Unmount the list").click();
     await test.expect(q.button(/^item /)).toHaveCount(0);
     // The list removal is observable above, but the negative leak counter is

--- a/app/src/sandbox/composite-renderer-6216/index.react.tsx
+++ b/app/src/sandbox/composite-renderer-6216/index.react.tsx
@@ -21,10 +21,10 @@ const items = [
   { id: "row-3" },
 ] satisfies readonly CompositeRendererItem[];
 
-// A horizontal group nested one level deeper, inside a same-orientation wrapper.
-// The wrapper measures the group through metadata alone, so the group's height
-// comes from the largest column extent (max of 28 and 36) rather than the sum
-// of the columns' widths.
+// A horizontal group nested one level deeper, inside a same-orientation
+// wrapper. The wrapper measures the group through metadata alone, so the
+// group's height comes from the largest column extent (max of 28 and 36) rather
+// than the sum of the columns' widths.
 const nestedColumns = [
   { id: "nested-column-0", style: { width: COLUMN_WIDTH, height: 28 } },
   { id: "nested-column-1", style: { width: COLUMN_WIDTH, height: 36 } },

--- a/app/src/sandbox/composite-renderer-6216/test-browser.ts
+++ b/app/src/sandbox/composite-renderer-6216/test-browser.ts
@@ -5,11 +5,12 @@ withFramework(import.meta.dirname, async ({ test }) => {
   test("vertical renderer measures a horizontal group's height along the parent axis", async ({
     q,
   }) => {
-    // "group" is a horizontal group of five 140px columns rendered one row tall.
-    // Its height must be measured from the rendered element (40px), so the row
-    // after it sits at 40 * 3 = 120px. Before the fix, the renderer summed the
-    // columns' widths (700px) as the group's height, pushing "row-3" to 780px.
-    // The group itself stays at 40 * 2 = 80px, anchoring the rows before it.
+    // "group" is a horizontal group of five 140px columns rendered one row
+    // tall. Its height must be measured from the rendered element (40px), so
+    // the row after it sits at 40 * 3 = 120px. Before the fix, the renderer
+    // summed the columns' widths (700px) as the group's height, pushing "row-3"
+    // to 780px. The group itself stays at 40 * 2 = 80px, anchoring the rows
+    // before it.
     await test.expect(q.button("group")).toHaveCSS("top", "80px");
     await test.expect(q.button("row-3")).toHaveCSS("top", "120px");
   });
@@ -19,8 +20,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
   }) => {
     // "nested-group" wraps a horizontal group whose columns are 28px and 36px
     // tall. Measured through metadata alone, the group's height is the largest
-    // column extent (36px), so "nested-row-2" sits at 40 + 36 = 76px. Before the
-    // fix it summed the columns' widths (280px), pushing it to 320px.
+    // column extent (36px), so "nested-row-2" sits at 40 + 36 = 76px. Before
+    // the fix it summed the columns' widths (280px), pushing it to 320px.
     await test.expect(q.button("nested-row-2")).toHaveCSS("top", "76px");
   });
 });

--- a/app/src/sandbox/composite-row-6334/index.react.tsx
+++ b/app/src/sandbox/composite-row-6334/index.react.tsx
@@ -1,10 +1,10 @@
 import * as Ariakit from "@ariakit/react";
 
-// A partially rendered (windowed) two-column grid: only the rows showing
-// cells 21-24 out of a 100-cell collection are mounted. The row-level
-// aria-posinset prop gives each row's starting position and aria-setsize the
-// full set size so every cell can compute its own position.
-// See https://github.com/ariakit/ariakit/issues/6334
+// A partially rendered (windowed) two-column grid: only the rows showing cells
+// 21-24 out of a 100-cell collection are mounted. The row-level aria-posinset
+// prop gives each row's starting position and aria-setsize the full set size so
+// every cell can compute its own position. See
+// https://github.com/ariakit/ariakit/issues/6334
 export default function Example() {
   return (
     <Ariakit.CompositeProvider>

--- a/app/src/sandbox/composite-typeahead-buffer/test.ts
+++ b/app/src/sandbox/composite-typeahead-buffer/test.ts
@@ -16,8 +16,8 @@ function typeahead(key: string) {
 test("keeps typeahead characters scoped to each composite instance", async () => {
   await press.Tab();
 
-  // Keep the first composite's "ap" buffer alive so the old global buffer
-  // would leak into the second composite during the "b" keydown below.
+  // Keep the first composite's "ap" buffer alive so the old global buffer would
+  // leak into the second composite during the "b" keydown below.
   vi.useFakeTimers();
 
   try {

--- a/app/src/sandbox/dialog-4345/index.react.tsx
+++ b/app/src/sandbox/dialog-4345/index.react.tsx
@@ -1,12 +1,12 @@
 import * as Ariakit from "@ariakit/react";
 import { useEffect, useState } from "react";
 
-// Reproduces https://github.com/ariakit/ariakit/issues/4345: the page opts
-// into an always-visible scrollbar with an inline overflow-y: scroll on the
-// html element (a common anti-layout-shift technique). Opening a modal dialog
-// must not shift the layout, must still lock the page scroll (the page
-// scrolls through the html element, so hiding the body overflow alone has no
-// effect), and closing it must leave the html inline style exactly as it was.
+// Reproduces https://github.com/ariakit/ariakit/issues/4345: the page opts into
+// an always-visible scrollbar with an inline overflow-y: scroll on the html
+// element (a common anti-layout-shift technique). Opening a modal dialog must
+// not shift the layout, must still lock the page scroll (the page scrolls
+// through the html element, so hiding the body overflow alone has no effect),
+// and closing it must leave the html inline style exactly as it was.
 export default function Example() {
   const [open, setOpen] = useState(false);
 

--- a/app/src/sandbox/dialog-4345/test-browser.ts
+++ b/app/src/sandbox/dialog-4345/test-browser.ts
@@ -10,8 +10,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
       page.evaluate(() => document.documentElement.getAttribute("style") || "");
     const getScrollY = () => page.evaluate(() => window.scrollY);
     await test.expect.poll(getHtmlStyle).toContain("overflow-y: scroll");
-    // Scroll down first so the assertions below also cover the lock keeping
-    // the current scroll position. The button is sticky, so clicking it won't
+    // Scroll down first so the assertions below also cover the lock keeping the
+    // current scroll position. The button is sticky, so clicking it won't
     // scroll the page back into view.
     await page.mouse.move(10, 10);
     await page.mouse.wheel(0, 200);

--- a/app/src/sandbox/dialog-5057/test-browser.ts
+++ b/app/src/sandbox/dialog-5057/test-browser.ts
@@ -5,9 +5,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
     q,
   }) => {
     // When Dialog uses render={(props) => <div><div {...props} /></div>},
-    // data-enter should be removed when the dialog closes, even if the
-    // dialog element itself has no CSS transitions.
-    // See https://github.com/ariakit/ariakit/issues/5057
+    // data-enter should be removed when the dialog closes, even if the dialog
+    // element itself has no CSS transitions. See
+    // https://github.com/ariakit/ariakit/issues/5057
     await q.button("Show modal").click();
     await test.expect(q.dialog("Success")).toBeVisible();
 
@@ -22,9 +22,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
   test("data-enter is re-added when dialog with render wrapper reopens", async ({
     q,
   }) => {
-    // After closing and reopening, data-enter should be re-added so
-    // enter animations replay correctly.
-    // See https://github.com/ariakit/ariakit/issues/5057
+    // After closing and reopening, data-enter should be re-added so enter
+    // animations replay correctly. See
+    // https://github.com/ariakit/ariakit/issues/5057
     await q.button("Show modal").click();
     await test.expect(q.dialog("Success")).toBeVisible();
     await q.button("OK").click();

--- a/app/src/sandbox/dialog-5156/test-browser.ts
+++ b/app/src/sandbox/dialog-5156/test-browser.ts
@@ -19,8 +19,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     // EventTarget (such as window or an XMLHttpRequest). Those listeners used
     // to call `contains()` on the target, throwing a TypeError (in Chromium,
     // "Failed to execute 'contains' on 'Node': parameter 1 is not of type
-    // 'Node'"; the wording varies by engine).
-    // See https://github.com/ariakit/ariakit/issues/5156
+    // 'Node'"; the wording varies by engine). See
+    // https://github.com/ariakit/ariakit/issues/5156
     await page.evaluate(() => {
       // `event.target` is read-only and set during dispatch, so shadow it with
       // a bare EventTarget to stand in for the non-Node target.
@@ -37,8 +37,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
       // Escape would close the dialog; its listener handles the target too.
       dispatch(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
     });
-    // A foreign mousedown target can remain recorded until a standalone
-    // outside click occurs without replacing it.
+    // A foreign mousedown target can remain recorded until a standalone outside
+    // click occurs without replacing it.
     await page.evaluate(() => {
       const event = new MouseEvent("mousedown", { bubbles: true });
       Object.defineProperty(event, "target", {

--- a/app/src/sandbox/dialog-backdrop-6339/test.ts
+++ b/app/src/sandbox/dialog-backdrop-6339/test.ts
@@ -13,9 +13,9 @@ test("backdrop fades out on close when only the backdrop is animated", async () 
   // Focus returns to the disclosure as soon as the dialog closes, so a failure
   // below unambiguously points at the backdrop leave transition.
   expect(q.button("Show dialog")).toHaveFocus();
-  // On close, the backdrop must receive data-leave and remain visible while
-  // its 500ms exit transition runs. Before the fix, the dialog hides instantly
-  // and data-leave is never applied.
+  // On close, the backdrop must receive data-leave and remain visible while its
+  // 500ms exit transition runs. Before the fix, the dialog hides instantly and
+  // data-leave is never applied.
   await expect.poll(() => backdrop.getAttribute("data-leave")).toBe("true");
   expect(backdrop).not.toHaveStyle("display: none");
   await expect.poll(() => backdrop.style.display).toBe("none");

--- a/app/src/sandbox/dialog-backdrop-7335/test-chrome.ts
+++ b/app/src/sandbox/dialog-backdrop-7335/test-chrome.ts
@@ -40,8 +40,7 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
 
   // Keeps the backdrop truthy, so this passes before the fix too: it's the
   // control that separates the falsy/truthy boundary from an ordinary
-  // re-render.
-  // https://github.com/ariakit/ariakit/issues/7335
+  // re-render. https://github.com/ariakit/ariakit/issues/7335
   test("changing the backdrop's appearance keeps the contents", async ({
     q,
   }) => {

--- a/app/src/sandbox/dialog-backdrop-7335/test-chrome.ts
+++ b/app/src/sandbox/dialog-backdrop-7335/test-chrome.ts
@@ -40,7 +40,8 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
 
   // Keeps the backdrop truthy, so this passes before the fix too: it's the
   // control that separates the falsy/truthy boundary from an ordinary
-  // re-render. https://github.com/ariakit/ariakit/issues/7335
+  // re-render.
+  // https://github.com/ariakit/ariakit/issues/7335
   test("changing the backdrop's appearance keeps the contents", async ({
     q,
   }) => {

--- a/app/src/sandbox/dialog-backdrop-7344/index.react.tsx
+++ b/app/src/sandbox/dialog-backdrop-7344/index.react.tsx
@@ -1,9 +1,9 @@
 import * as Ariakit from "@ariakit/react";
 
 // Regression fixture for https://github.com/ariakit/ariakit/issues/7344. The
-// backdrop is fixed and covers the viewport, so the dialog has to be
-// positioned as well. Otherwise it stays in flow behind the backdrop and the
-// browser test cannot click the dismiss button.
+// backdrop is fixed and covers the viewport, so the dialog has to be positioned
+// as well. Otherwise it stays in flow behind the backdrop and the browser test
+// cannot click the dismiss button.
 const css = `
   .backdrop {
     background: rgb(0 0 0 / 0.4);

--- a/app/src/sandbox/dialog-disclosure-5224/test-chrome-firefox.ts
+++ b/app/src/sandbox/dialog-disclosure-5224/test-chrome-firefox.ts
@@ -6,8 +6,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
   }) => {
     // When DialogDisclosure uses render={<Button onClick={undefined}>},
     // mergeProps should preserve the internal onClick handler instead of
-    // overwriting it with undefined.
-    // See https://github.com/ariakit/ariakit/issues/5224
+    // overwriting it with undefined. See
+    // https://github.com/ariakit/ariakit/issues/5224
     await q.button("Open dialog").click();
     await test.expect(q.dialog()).toBeVisible();
   });
@@ -16,8 +16,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     q,
   }) => {
     // When Button has className="base" and render={<a className={undefined}>},
-    // mergeProps should produce "base" instead of "base undefined".
-    // See https://github.com/ariakit/ariakit/issues/5224
+    // mergeProps should produce "base" instead of "base undefined". See
+    // https://github.com/ariakit/ariakit/issues/5224
     const el = q.text("Check className");
     await test.expect(el).toHaveAttribute("class", "base");
   });

--- a/app/src/sandbox/dialog-form-7201/index.react.tsx
+++ b/app/src/sandbox/dialog-form-7201/index.react.tsx
@@ -8,8 +8,7 @@ interface CoverageDialogProps {
 
 // A benefits form names its controls after what they collect, and both `self`
 // and `document` below collide with a member the realm helpers read from the
-// form itself.
-// https://github.com/ariakit/ariakit/issues/7201
+// form itself. https://github.com/ariakit/ariakit/issues/7201
 function CoverageDialog({ label, withDocumentField }: CoverageDialogProps) {
   const [open, setOpen] = useState(false);
   return (

--- a/app/src/sandbox/dialog-form-7201/index.react.tsx
+++ b/app/src/sandbox/dialog-form-7201/index.react.tsx
@@ -8,7 +8,8 @@ interface CoverageDialogProps {
 
 // A benefits form names its controls after what they collect, and both `self`
 // and `document` below collide with a member the realm helpers read from the
-// form itself. https://github.com/ariakit/ariakit/issues/7201
+// form itself.
+// https://github.com/ariakit/ariakit/issues/7201
 function CoverageDialog({ label, withDocumentField }: CoverageDialogProps) {
   const [open, setOpen] = useState(false);
   return (

--- a/app/src/sandbox/dialog-hidden-dismiss/index.react.tsx
+++ b/app/src/sandbox/dialog-hidden-dismiss/index.react.tsx
@@ -140,13 +140,13 @@ export default function Example() {
   );
 }
 
-// The state lives below the dialog, the way content that loads on its own
-// does, so that mounting the dismiss control doesn't render the dialog again.
+// The state lives below the dialog, the way content that loads on its own does,
+// so that mounting the dismiss control doesn't render the dialog again.
 // https://github.com/ariakit/ariakit/issues/7321
 function ActivityBody() {
   const [loaded, setLoaded] = useState(false);
-  // The wrapper outlives the state change, so the dismiss control appears
-  // below the dialog's own children rather than among them.
+  // The wrapper outlives the state change, so the dismiss control appears below
+  // the dialog's own children rather than among them.
   return (
     <div>
       {loaded ? (

--- a/app/src/sandbox/dialog-hidden-dismiss/test-chrome.ts
+++ b/app/src/sandbox/dialog-hidden-dismiss/test-chrome.ts
@@ -5,7 +5,8 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
   // Modal dialogs keep the fallback dismiss button so that screen reader users
   // aren't trapped in them. It renders next to the dialog rather than inside
   // it, so a dialog element whose role doesn't allow a `button` among its owned
-  // elements doesn't get one. https://github.com/ariakit/ariakit/issues/4270
+  // elements doesn't get one.
+  // https://github.com/ariakit/ariakit/issues/4270
   // https://github.com/ariakit/ariakit/issues/7310
   test("modal dialog without a dismiss element gets a hidden one", async ({
     q,
@@ -20,7 +21,8 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
   // Rendering it next to the dialog puts it outside every "inside the dialog"
   // check, so the dialog has to keep treating it as its own. The modal backdrop
   // absorbs a pointer click on it, so dispatch the click the way assistive
-  // technology activation does. https://github.com/ariakit/ariakit/issues/7310
+  // technology activation does.
+  // https://github.com/ariakit/ariakit/issues/7310
   test("hidden dismiss closes the dialog and restores focus", async ({ q }) => {
     await q.button("Terms").click();
     await test.expect(q.dialog("Terms")).toBeVisible();

--- a/app/src/sandbox/dialog-hidden-dismiss/test-chrome.ts
+++ b/app/src/sandbox/dialog-hidden-dismiss/test-chrome.ts
@@ -4,9 +4,8 @@ import { withFramework } from "#app/test-utils/preview.ts";
 withFramework(import.meta.dirname, async ({ test, query }) => {
   // Modal dialogs keep the fallback dismiss button so that screen reader users
   // aren't trapped in them. It renders next to the dialog rather than inside
-  // it, so a dialog element whose role doesn't allow a `button` among its
-  // owned elements doesn't get one.
-  // https://github.com/ariakit/ariakit/issues/4270
+  // it, so a dialog element whose role doesn't allow a `button` among its owned
+  // elements doesn't get one. https://github.com/ariakit/ariakit/issues/4270
   // https://github.com/ariakit/ariakit/issues/7310
   test("modal dialog without a dismiss element gets a hidden one", async ({
     q,
@@ -19,10 +18,9 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
   });
 
   // Rendering it next to the dialog puts it outside every "inside the dialog"
-  // check, so the dialog has to keep treating it as its own. The modal
-  // backdrop absorbs a pointer click on it, so dispatch the click the way
-  // assistive technology activation does.
-  // https://github.com/ariakit/ariakit/issues/7310
+  // check, so the dialog has to keep treating it as its own. The modal backdrop
+  // absorbs a pointer click on it, so dispatch the click the way assistive
+  // technology activation does. https://github.com/ariakit/ariakit/issues/7310
   test("hidden dismiss closes the dialog and restores focus", async ({ q }) => {
     await q.button("Terms").click();
     await test.expect(q.dialog("Terms")).toBeVisible();

--- a/app/src/sandbox/dialog-hidden-dismiss/test.ts
+++ b/app/src/sandbox/dialog-hidden-dismiss/test.ts
@@ -4,8 +4,7 @@ import { expect, test } from "vitest";
 // Modal dialogs keep the fallback dismiss button so that screen reader users
 // aren't trapped in them. It renders next to the dialog rather than inside it,
 // so a dialog element whose role doesn't allow a `button` among its owned
-// elements doesn't get one.
-// https://github.com/ariakit/ariakit/issues/4270
+// elements doesn't get one. https://github.com/ariakit/ariakit/issues/4270
 // https://github.com/ariakit/ariakit/issues/7310
 test("modal dialog without a dismiss element gets a hidden one", async () => {
   await click(q.button("Terms"));

--- a/app/src/sandbox/dialog-hidden-dismiss/test.ts
+++ b/app/src/sandbox/dialog-hidden-dismiss/test.ts
@@ -4,7 +4,8 @@ import { expect, test } from "vitest";
 // Modal dialogs keep the fallback dismiss button so that screen reader users
 // aren't trapped in them. It renders next to the dialog rather than inside it,
 // so a dialog element whose role doesn't allow a `button` among its owned
-// elements doesn't get one. https://github.com/ariakit/ariakit/issues/4270
+// elements doesn't get one.
+// https://github.com/ariakit/ariakit/issues/4270
 // https://github.com/ariakit/ariakit/issues/7310
 test("modal dialog without a dismiss element gets a hidden one", async () => {
   await click(q.button("Terms"));

--- a/app/src/sandbox/dialog-nested-variants/test.ts
+++ b/app/src/sandbox/dialog-nested-variants/test.ts
@@ -13,8 +13,8 @@ function expectModalStyle(toHaveStyle: boolean) {
   expect(documentElement)[prop].toHaveStyle("scrollbar-gutter: stable");
   expect(documentElement)[prop].toHaveStyle("overflow-x: hidden");
   expect(documentElement)[prop].toHaveStyle("overflow-y: hidden");
-  // The scrollbar-gutter lock neither defines --scrollbar-width nor touches
-  // the body styles.
+  // The scrollbar-gutter lock neither defines --scrollbar-width nor touches the
+  // body styles.
   expect(
     getComputedStyle(documentElement).getPropertyValue("--scrollbar-width"),
   ).toBe("");

--- a/app/src/sandbox/dialog-persistent-elements/test-browser.ts
+++ b/app/src/sandbox/dialog-persistent-elements/test-browser.ts
@@ -89,7 +89,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.dialog("Dialog")).toBeVisible();
   });
 
-  // Regression for https://github.com/ariakit/ariakit/pull/6810#discussion_r3635586651
+  // Regression for
+  // https://github.com/ariakit/ariakit/pull/6810#discussion_r3635586651
   test("keeps persistent elements after replacing an open dialog node", async ({
     page,
     q,
@@ -183,7 +184,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.dialog("Dialog")).not.toBeVisible();
   });
 
-  // Regression for https://github.com/ariakit/ariakit/pull/6810#discussion_r3635034591
+  // Regression for
+  // https://github.com/ariakit/ariakit/pull/6810#discussion_r3635034591
   test("closes when interacting with a same-id dialog in another root", async ({
     q,
   }) => {
@@ -195,7 +197,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.dialog("Dialog")).not.toBeVisible();
   });
 
-  // Regression for https://github.com/ariakit/ariakit/pull/6810#discussion_r3635035742
+  // Regression for
+  // https://github.com/ariakit/ariakit/pull/6810#discussion_r3635035742
   test("closes on a no-focus outside shadow click", async ({ q }) => {
     await q.button("Open dialog").click();
     await test.expect(q.dialog("Dialog")).toBeVisible();
@@ -204,7 +207,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.dialog("Dialog")).not.toBeVisible();
   });
 
-  // Regression for https://github.com/ariakit/ariakit/pull/6810#discussion_r3635035742
+  // Regression for
+  // https://github.com/ariakit/ariakit/pull/6810#discussion_r3635035742
   test("stays open when dragging from persistent shadow content", async ({
     page,
     q,

--- a/app/src/sandbox/dialog-persistent-elements/test.ts
+++ b/app/src/sandbox/dialog-persistent-elements/test.ts
@@ -16,8 +16,8 @@ test("stays open when interacting with a persistent element before the dialog is
   await click(q.button("Open dialog"));
   expect(q.dialog("Dialog")).toBeVisible();
 
-  // The dialog hasn't been focused yet (autoFocusOnShow={false}). Clicking
-  // the persistent field must not close it.
+  // The dialog hasn't been focused yet (autoFocusOnShow={false}). Clicking the
+  // persistent field must not close it.
   await click(q.textbox("Notification field"));
   expect(q.textbox("Notification field")).toHaveFocus();
   expect(q.dialog("Dialog")).toBeVisible();
@@ -60,7 +60,8 @@ test("keeps the documented behavior after the dialog has been focused", async ()
   expect(q.dialog("Dialog")).toBeVisible();
 });
 
-// Regression for https://github.com/ariakit/ariakit/pull/6810#discussion_r3635586651
+// Regression for
+// https://github.com/ariakit/ariakit/pull/6810#discussion_r3635586651
 test("keeps persistent elements after replacing an open dialog node", async () => {
   await click(q.button("Open dialog"));
   await click(q.button("Replace dialog element"));
@@ -147,7 +148,8 @@ test("closes when interacting inside an unrelated shadow root", async () => {
   await expect.poll(q.dialog.maybe.hidden.lazy("Dialog")).not.toBeVisible();
 });
 
-// Regression for https://github.com/ariakit/ariakit/pull/6810#discussion_r3635034591
+// Regression for
+// https://github.com/ariakit/ariakit/pull/6810#discussion_r3635034591
 test("closes when interacting with a same-id dialog in another root", async () => {
   await click(q.button("Show shadow dialog"));
   await click(q.button("Open dialog"));
@@ -162,7 +164,8 @@ test("closes when interacting with a same-id dialog in another root", async () =
   await expect.poll(q.dialog.maybe.hidden.lazy("Dialog")).not.toBeVisible();
 });
 
-// Regression for https://github.com/ariakit/ariakit/pull/6810#discussion_r3635035742
+// Regression for
+// https://github.com/ariakit/ariakit/pull/6810#discussion_r3635035742
 test("closes on a no-focus outside shadow click", async () => {
   await click(q.button("Open dialog"));
   expect(q.dialog("Dialog")).toBeVisible();
@@ -176,7 +179,8 @@ test("closes on a no-focus outside shadow click", async () => {
   await expect.poll(q.dialog.maybe.hidden.lazy("Dialog")).not.toBeVisible();
 });
 
-// Regression for https://github.com/ariakit/ariakit/pull/6810#discussion_r3635035742
+// Regression for
+// https://github.com/ariakit/ariakit/pull/6810#discussion_r3635035742
 test("stays open when dragging from persistent shadow content", async () => {
   await click(q.button("Open dialog"));
   expect(q.dialog("Dialog")).toBeVisible();

--- a/app/src/sandbox/dialog-reopen-focus-state/index.react.tsx
+++ b/app/src/sandbox/dialog-reopen-focus-state/index.react.tsx
@@ -2,8 +2,8 @@ import * as Ariakit from "@ariakit/react";
 import { useEffect, useRef, useState } from "react";
 
 // Reproduces a dialog that fails to close when, after being reopened, focus
-// lands on freshly added outside content (an async-loaded panel, a toast, etc.).
-// To see the bug:
+// lands on freshly added outside content (an async-loaded panel, a toast,
+// etc.). To see the bug:
 //   1. Open the dialog and focus the field inside it (this marks the dialog as
 //      interacted-with).
 //   2. Close it, then open it again.
@@ -18,8 +18,8 @@ export default function Example() {
   const controlsRef = useRef<HTMLDivElement>(null);
   const fieldRef = useRef<HTMLInputElement>(null);
 
-  // Focus the field as soon as it appears, simulating outside content that grabs
-  // focus while the dialog is open.
+  // Focus the field as soon as it appears, simulating outside content that
+  // grabs focus while the dialog is open.
   useEffect(() => {
     if (!showField) return;
     fieldRef.current?.focus();

--- a/app/src/sandbox/dialog-reopen-focus-state/test-browser.ts
+++ b/app/src/sandbox/dialog-reopen-focus-state/test-browser.ts
@@ -19,8 +19,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.dialog("Dialog")).toBeVisible();
 
     // Revealing the outside field moves focus to a brand-new node outside the
-    // dialog. Because reopening reset the "was focused inside" flag, this counts
-    // as interacting outside and closes the dialog.
+    // dialog. Because reopening reset the "was focused inside" flag, this
+    // counts as interacting outside and closes the dialog.
     await q.button("Reveal outside field").click();
     await test.expect(q.textbox("Dynamic outside field")).toBeFocused();
     await test.expect(q.dialog("Dialog")).not.toBeVisible();

--- a/app/src/sandbox/disclosure-content-lifecycle/test-browser.ts
+++ b/app/src/sandbox/disclosure-content-lifecycle/test-browser.ts
@@ -93,15 +93,15 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
     await test.expect(content).toHaveAttribute("data-enter", "true");
     await test.expect(section).toHaveAttribute("data-animating-state", "false");
 
-    // Hide it and measure how long the content stays mounted. The content has
-    // a transition (delay 500ms + duration 10ms = ends at 510ms; see
-    // style.css) and a leave animation (delay 0ms + duration 300ms = ends at
-    // 300ms), so the longest per-property end time is 510ms. The buggy timeout
-    // was max(delays) + max(durations) = 500 + 300 = 800ms, keeping the
-    // content mounted ~290ms too long. We measure the unmount delay in the
-    // browser because it's the only precise, user-observable signal for "the
-    // content stays mounted too long"; Playwright command latency is too coarse
-    // to tell 510ms from 800ms.
+    // Hide it and measure how long the content stays mounted. The content has a
+    // transition (delay 500ms + duration 10ms = ends at 510ms; see style.css)
+    // and a leave animation (delay 0ms + duration 300ms = ends at 300ms), so
+    // the longest per-property end time is 510ms. The buggy timeout was
+    // max(delays) + max(durations) = 500 + 300 = 800ms, keeping the content
+    // mounted ~290ms too long. We measure the unmount delay in the browser
+    // because it's the only precise, user-observable signal for "the content
+    // stays mounted too long"; Playwright command latency is too coarse to tell
+    // 510ms from 800ms.
     const unmountDelay = await page.evaluate(async () => {
       const region = document.querySelector(
         '[aria-label="Mixed transition and animation"]',
@@ -128,8 +128,8 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
     });
 
     // The content should unmount close to 510ms, not 800ms. 700ms sits well
-    // between the two so the assertion fails on the buggy timeout and passes
-    // on the fix, with margin for setTimeout/requestAnimationFrame jitter.
+    // between the two so the assertion fails on the buggy timeout and passes on
+    // the fix, with margin for setTimeout/requestAnimationFrame jitter.
     test.expect(unmountDelay).toBeLessThan(700);
     // Sanity check: it still waited for the real animation rather than
     // unmounting immediately.

--- a/app/src/sandbox/focusable-click-focus/test-browser.ts
+++ b/app/src/sandbox/focusable-click-focus/test-browser.ts
@@ -7,9 +7,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(button).toBeFocused();
   });
 
-  // https://github.com/ariakit/ariakit/issues/7099 Nothing here is a composite,
-  // so this pins the modality rule on a plain Focusable rather than on
-  // composite navigation.
+  // https://github.com/ariakit/ariakit/issues/7099
+  // Nothing here is a composite, so this pins the modality rule on a plain
+  // Focusable rather than on composite navigation.
   test("shows focus-visible on a modified navigation key", async ({
     page,
     q,

--- a/app/src/sandbox/focusable-click-focus/test-browser.ts
+++ b/app/src/sandbox/focusable-click-focus/test-browser.ts
@@ -7,9 +7,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(button).toBeFocused();
   });
 
-  // https://github.com/ariakit/ariakit/issues/7099
-  // Nothing here is a composite, so this pins the modality rule on a plain
-  // Focusable rather than on composite navigation.
+  // https://github.com/ariakit/ariakit/issues/7099 Nothing here is a composite,
+  // so this pins the modality rule on a plain Focusable rather than on
+  // composite navigation.
   test("shows focus-visible on a modified navigation key", async ({
     page,
     q,

--- a/app/src/sandbox/focusable-click-focus/test.ts
+++ b/app/src/sandbox/focusable-click-focus/test.ts
@@ -1,9 +1,9 @@
 import { click, press, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
-// https://github.com/ariakit/ariakit/issues/7099
-// Nothing here is a composite, so this pins the modality rule on a plain
-// Focusable rather than on composite navigation.
+// https://github.com/ariakit/ariakit/issues/7099 Nothing here is a composite,
+// so this pins the modality rule on a plain Focusable rather than on composite
+// navigation.
 test("shows focus-visible on a modified navigation key", async () => {
   const button = q.button("Button");
 

--- a/app/src/sandbox/focusable-click-focus/test.ts
+++ b/app/src/sandbox/focusable-click-focus/test.ts
@@ -1,9 +1,9 @@
 import { click, press, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
-// https://github.com/ariakit/ariakit/issues/7099 Nothing here is a composite,
-// so this pins the modality rule on a plain Focusable rather than on composite
-// navigation.
+// https://github.com/ariakit/ariakit/issues/7099
+// Nothing here is a composite, so this pins the modality rule on a plain
+// Focusable rather than on composite navigation.
 test("shows focus-visible on a modified navigation key", async () => {
   const button = q.button("Button");
 

--- a/app/src/sandbox/focusable-tab-7153/test-browser.ts
+++ b/app/src/sandbox/focusable-tab-7153/test-browser.ts
@@ -36,9 +36,9 @@ async function expectNoNavigation(locator: Locator) {
   const url = page.url();
   // A blocked gesture leaves nothing behind to assert on, so wait out the
   // window in which the browser would have delivered the destination. The
-  // slowest delivery measured across the three engines was 1.4s, so this
-  // budget leaves room for a loaded runner without waiting on the clock for
-  // longer than the gesture can plausibly take.
+  // slowest delivery measured across the three engines was 1.4s, so this budget
+  // leaves room for a loaded runner without waiting on the clock for longer
+  // than the gesture can plausibly take.
   const newTab = page
     .context()
     .waitForEvent("page", { timeout: 5_000 })

--- a/app/src/sandbox/form-6307/index.react.tsx
+++ b/app/src/sandbox/form-6307/index.react.tsx
@@ -23,8 +23,8 @@ export default function Example() {
     }
   });
 
-  // Surface the number of successful submissions so the success is observable in
-  // the preview (and so tests can wait for the submit to fully settle).
+  // Surface the number of successful submissions so the success is observable
+  // in the preview (and so tests can wait for the submit to fully settle).
   const successCount = ak.useStoreState(form, "submitSucceed");
 
   const [showNickname, setShowNickname] = useState(false);

--- a/app/src/sandbox/form-6307/test-browser.ts
+++ b/app/src/sandbox/form-6307/test-browser.ts
@@ -9,15 +9,16 @@ withFramework(import.meta.dirname, async ({ test }) => {
     const email = q.textbox("Email");
     const addNickname = q.button("Add nickname");
 
-    // 1. Submit with the email empty: the submission fails and the invalid email
-    //    field is focused (correct autoFocusOnSubmit behavior).
+    // 1. Submit with the email empty: the submission fails and the invalid
+    //    email field is focused (correct autoFocusOnSubmit behavior).
     await q.button("Save").click();
     await test.expect(email).toBeFocused();
     await test.expect(email).toHaveAttribute("aria-invalid", "true");
 
-    // 2. Type a valid value, wait for it to be accepted, then submit again. Wait
-    //    for the successful submission to fully settle (with resetOnSubmit={false}
-    //    the form keeps its values) before touching the form again.
+    // 2. Type a valid value, wait for it to be accepted, then submit again.
+    //    Wait for the successful submission to fully settle (with
+    //    resetOnSubmit={false} the form keeps its values) before touching the
+    //    form again.
     await email.fill("jane");
     await test.expect(email).toHaveAttribute("aria-invalid", "false");
     await q.button("Save").click();
@@ -37,11 +38,13 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await page.keyboard.press("Enter");
     await test.expect(q.textbox("Nickname")).toBeVisible();
 
-    // The buggy focus steal runs in an effect after the items change, so wait for
-    // it to settle and assert the final focus rather than a pre-steal transient.
+    // The buggy focus steal runs in an effect after the items change, so wait
+    // for it to settle and assert the final focus rather than a pre-steal
+    // transient.
     await page.waitForTimeout(250);
 
-    // Focus must stay on the button and must not be stolen by the invalid email.
+    // Focus must stay on the button and must not be stolen by the invalid
+    // email.
     await test.expect(addNickname).toBeFocused();
     await test.expect(email).not.toBeFocused();
   });

--- a/app/src/sandbox/form-6307/test.ts
+++ b/app/src/sandbox/form-6307/test.ts
@@ -13,8 +13,9 @@ test("a successful submit does not steal focus on later items changes", async ()
   expect(email).toHaveAttribute("aria-invalid", "true");
 
   // 2. Type a valid value, wait for it to be accepted, then submit again. Wait
-  //    for the successful submission to fully settle (with resetOnSubmit={false}
-  //    the form keeps its values) before touching the form again.
+  //    for the successful submission to fully settle (with
+  //    resetOnSubmit={false} the form keeps its values) before touching the
+  //    form again.
   await type("jane", email);
   expect(email).toHaveAttribute("aria-invalid", "false");
   await click(q.button("Save"));

--- a/app/src/sandbox/form-6309/test-browser.ts
+++ b/app/src/sandbox/form-6309/test-browser.ts
@@ -8,9 +8,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
     // emulation forces hidden tabs to stay visible, which masks the bug — so
     // recreate the browser's own behavior: install (before the app loads, so
     // userland code and the form store see it) a `requestAnimationFrame` that
-    // stops firing while `document.hidden` is true. The store's `submit()` awaits
-    // a frame internally, so it must still complete through a timeout fallback
-    // instead of stalling on "Saving" forever.
+    // stops firing while `document.hidden` is true. The store's `submit()`
+    // awaits a frame internally, so it must still complete through a timeout
+    // fallback instead of stalling on "Saving" forever.
     await page.addInitScript(() => {
       const native = window.requestAnimationFrame.bind(window);
       window.requestAnimationFrame = (callback) =>

--- a/app/src/sandbox/form-array-focus/index.react.tsx
+++ b/app/src/sandbox/form-array-focus/index.react.tsx
@@ -3,9 +3,9 @@ import { useState } from "react";
 
 // Array-field names are user-controlled (they come from `defaultValues` /
 // `names`), so they can be prefixes of sibling arrays (`tags` vs `tags2`) or
-// contain regex metacharacters (`c++`). FormPush/FormRemove must still match the
-// exact array and focus the right field.
-// See https://github.com/ariakit/ariakit/issues/6219
+// contain regex metacharacters (`c++`). FormPush/FormRemove must still match
+// the exact array and focus the right field. See
+// https://github.com/ariakit/ariakit/issues/6219
 export default function Example() {
   const form = ak.useFormStore({
     defaultValues: {

--- a/app/src/sandbox/form-array-focus/test-browser.ts
+++ b/app/src/sandbox/form-array-focus/test-browser.ts
@@ -26,10 +26,12 @@ withFramework(import.meta.dirname, async ({ test }) => {
   test("FormPush keeps focus within the target array, not a sibling sharing the name prefix", async ({
     q,
   }) => {
-    // `tags` and `tags2` are separate arrays, and `tags` is a prefix of `tags2`.
+    // `tags` and `tags2` are separate arrays, and `tags` is a prefix of
+    // `tags2`.
     await q.button("Add tag").click();
-    // Auto-focus must stay on a `tags` field (mirrored by the status output) and
-    // never leak into the `tags2` sibling, whose name shares the `tags` prefix.
+    // Auto-focus must stay on a `tags` field (mirrored by the status output)
+    // and never leak into the `tags2` sibling, whose name shares the `tags`
+    // prefix.
     await test.expect(q.status()).toHaveText(/^Focused field: tags\.\d+$/);
   });
 
@@ -45,8 +47,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
   test("FormPush keeps focus within an array whose name has regex metacharacters", async ({
     q,
   }) => {
-    // The `c++` array name contains regex metacharacters. Building the auto-focus
-    // matcher must not throw, and focus must stay within the array.
+    // The `c++` array name contains regex metacharacters. Building the
+    // auto-focus matcher must not throw, and focus must stay within the array.
     await q.button("Add version").click();
     await test.expect(q.status()).toHaveText(/^Focused field: c\+\+\.\d+$/);
   });

--- a/app/src/sandbox/form-array-focus/test.ts
+++ b/app/src/sandbox/form-array-focus/test.ts
@@ -32,8 +32,8 @@ test("FormPush keeps focus within the target array, not a sibling sharing the na
 });
 
 test("FormRemove keeps focus within the target array, not a sibling sharing the name prefix", async () => {
-  // Removing from `tags` must move focus to another `tags` field and never
-  // leak into the `tags2` sibling, whose name shares the `tags` prefix.
+  // Removing from `tags` must move focus to another `tags` field and never leak
+  // into the `tags2` sibling, whose name shares the `tags` prefix.
   await click(q.button("Remove tags.0"));
   expect(activeFieldName()).toBe("tags.1");
 });

--- a/app/src/sandbox/form-checkbox-integer-like-name/index.react.tsx
+++ b/app/src/sandbox/form-checkbox-integer-like-name/index.react.tsx
@@ -3,8 +3,10 @@ import * as Ariakit from "@ariakit/react";
 export default function Example() {
   const form = Ariakit.useFormStore({
     defaultValues: {
-      "123": true, // integer-like property name
-      safe: true, // non integer-like property name
+      // integer-like property name
+      "123": true,
+      // non integer-like property name
+      safe: true,
     },
   });
 

--- a/app/src/sandbox/form-names-6308/index.react.tsx
+++ b/app/src/sandbox/form-names-6308/index.react.tsx
@@ -2,9 +2,9 @@ import * as ak from "@ariakit/react";
 import { Component, useState } from "react";
 import type { ReactNode } from "react";
 
-// Regression fixture for https://github.com/ariakit/ariakit/issues/6308.
-// React and Object.prototype.toString probe absent symbol keys; the names
-// proxy must return undefined instead of coercing a Symbol to a string.
+// Regression fixture for https://github.com/ariakit/ariakit/issues/6308. React
+// and Object.prototype.toString probe absent symbol keys; the names proxy must
+// return undefined instead of coercing a Symbol to a string.
 class NameBoundary extends Component<
   { children: ReactNode },
   { error: Error | null }

--- a/app/src/sandbox/form-names-6308/test-chrome.ts
+++ b/app/src/sandbox/form-names-6308/test-chrome.ts
@@ -2,11 +2,12 @@ import { withFramework } from "#app/test-utils/preview.ts";
 
 // Reproduces https://github.com/ariakit/ariakit/issues/6308
 //
-// The bug is a catastrophic Symbol coercion crash, so the regression these tests
-// lock in is its *absence*. Both the userland workaround (coercing the name) and
-// the library fix avoid that crash but reach it differently — the workaround
-// renders the path text, the fix surfaces React's own invalid-child error — so
-// the assertions accept either graceful outcome rather than one exact message.
+// The bug is a catastrophic Symbol coercion crash, so the regression these
+// tests lock in is its *absence*. Both the userland workaround (coercing the
+// name) and the library fix avoid that crash but reach it differently — the
+// workaround renders the path text, the fix surfaces React's own invalid-child
+// error — so the assertions accept either graceful outcome rather than one
+// exact message.
 withFramework(import.meta.dirname, async ({ test }) => {
   test("rendering a raw form.names.* value does not crash with a Symbol coercion error", async ({
     q,
@@ -14,9 +15,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
     // Rendering `{form.names.email}` makes react-dom probe the value for
     // `Symbol.iterator`; accessing that absent symbol must not throw "Cannot
     // convert a Symbol value to a string". The paragraph text survives in every
-    // case because the boundary only wraps the name, so wait for it first — that
-    // commit also carries the boundary fallback, making the negative assertion
-    // below non-racy.
+    // case because the boundary only wraps the name, so wait for it first —
+    // that commit also carries the boundary fallback, making the negative
+    // assertion below non-racy.
     await q.button("Show field name").click();
     const submittedAs = q.text(/This value is submitted as/);
     await test.expect(submittedAs).toBeVisible();
@@ -29,9 +30,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
     q,
   }) => {
     // `Object.prototype.toString.call(name)` probes `Symbol.toStringTag`, which
-    // must resolve gracefully so the call returns an `[object …]` tag instead of
-    // throwing inside the proxy (the fix yields "[object Object]", a coercing
-    // workaround "[object String]").
+    // must resolve gracefully so the call returns an `[object …]` tag instead
+    // of throwing inside the proxy (the fix yields "[object Object]", a
+    // coercing workaround "[object String]").
     await q.button("Inspect field name").click();
     await test.expect(q.status()).toHaveText(/^\[object \w+\]$/);
   });

--- a/app/src/sandbox/hovercard-5156/test-browser.ts
+++ b/app/src/sandbox/hovercard-5156/test-browser.ts
@@ -8,9 +8,10 @@ withFramework(import.meta.dirname, async ({ test }) => {
     const errors: string[] = [];
     page.on("pageerror", (error) => errors.push(error.message));
 
-    // Focusing the disclosure shows it and attaches its global focusout listener
-    // to the document; pressing Enter then opens the hovercard. Waiting for the
-    // hovercard content confirms that flow completed before we dispatch below.
+    // Focusing the disclosure shows it and attaches its global focusout
+    // listener to the document; pressing Enter then opens the hovercard.
+    // Waiting for the hovercard content confirms that flow completed before we
+    // dispatch below.
     await q.button("More details").focus();
     await page.keyboard.press("Enter");
     await test
@@ -19,8 +20,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
     // A focusout whose relatedTarget is a non-Node EventTarget (such as one
     // dispatched on window or an XMLHttpRequest) used to make the listener call
-    // `contains()` on it and throw a TypeError.
-    // See https://github.com/ariakit/ariakit/issues/5156
+    // `contains()` on it and throw a TypeError. See
+    // https://github.com/ariakit/ariakit/issues/5156
     await page.evaluate(() => {
       document.dispatchEvent(
         new FocusEvent("focusout", {

--- a/app/src/sandbox/hovercard-interactions/test.ts
+++ b/app/src/sandbox/hovercard-interactions/test.ts
@@ -13,8 +13,8 @@ const hoverOutside = async () => {
 test("shows after hovering and hides after hovering outside", async () => {
   expect(maybeHovercard()).not.toBeInTheDocument();
 
-  // Dispatch directly so the assertions run before the timeout can expire
-  // when the full suite delays the interaction helper.
+  // Dispatch directly so the assertions run before the timeout can expire when
+  // the full suite delays the interaction helper.
   await dispatch.mouseMove(q.link("@ariakit.com"));
   expect(maybeHovercard()).not.toBeInTheDocument();
   await expect.poll(hovercard).toBeVisible();

--- a/app/src/sandbox/menu-3214/test-chrome.ts
+++ b/app/src/sandbox/menu-3214/test-chrome.ts
@@ -1,8 +1,8 @@
 import { gotoAndSettle, withFramework } from "#app/test-utils/preview.ts";
 
 // React's "Maximum update depth exceeded" error. In production builds React
-// throws the minified variant that links to https://react.dev/errors/185.
-// See https://github.com/ariakit/ariakit/issues/3214.
+// throws the minified variant that links to https://react.dev/errors/185. See
+// https://github.com/ariakit/ariakit/issues/3214.
 const updateDepthError =
   /maximum update depth exceeded|react\.dev\/errors\/185/i;
 

--- a/app/src/sandbox/menu-4270/test-chrome.ts
+++ b/app/src/sandbox/menu-4270/test-chrome.ts
@@ -38,8 +38,8 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
       .poll(async () => (await readMenu())?.name)
       .toBe("Preview");
 
-    // Only the menu button joins the modal context. Everything else outside
-    // the menu keeps being disabled one element at a time.
+    // Only the menu button joins the modal context. Everything else outside the
+    // menu keeps being disabled one element at a time.
     await test.expect(q.button("Publish")).toHaveAttribute("inert", "");
 
     // The browser refuses focus on inert content, so focus stays in the menu

--- a/app/src/sandbox/menu-4270/test.ts
+++ b/app/src/sandbox/menu-4270/test.ts
@@ -8,8 +8,8 @@ test("modal menu exposes only its items to assistive technology", async () => {
   expect(menu).toBeVisible();
   expect(q.within(menu).menuitem.all()).toHaveLength(3);
   expect(q.within(menu).button.all()).toHaveLength(0);
-  // The fallback dismiss button is still rendered, next to the menu rather
-  // than inside it, so the menu owns only its own items.
+  // The fallback dismiss button is still rendered, next to the menu rather than
+  // inside it, so the menu owns only its own items.
   // https://github.com/ariakit/ariakit/issues/7310
   const dismiss = q.button("Dismiss popup");
   expect(menu).not.toContainElement(dismiss);

--- a/app/src/sandbox/menu-button-disabled/index.react.tsx
+++ b/app/src/sandbox/menu-button-disabled/index.react.tsx
@@ -2,8 +2,8 @@ import * as Ariakit from "@ariakit/react";
 import { useMenuButton } from "@ariakit/react-components/menu/menu-button";
 
 // The public hook, unlike the component, keeps an own undefined value in the
-// props it spreads, so it must still resolve the false default rather than
-// fall through to the trigger's true default.
+// props it spreads, so it must still resolve the false default rather than fall
+// through to the trigger's true default.
 function HookMenuButton() {
   const store = Ariakit.useMenuStore({ timeout: 0 });
   const props = useMenuButton<"button">({

--- a/app/src/sandbox/menu-context-interactions/test-chrome.ts
+++ b/app/src/sandbox/menu-context-interactions/test-chrome.ts
@@ -10,10 +10,9 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
   // modal context. The fallback dismiss button renders next to the menu, where
   // the ARIA menu pattern doesn't forbid it, so the menu still owns only its
   // own items. Safari reaches the capture through a different branch, since it
-  // leaves `BODY` as the active element for a native button without an
-  // explicit tab index, and giving the button one here would move this test
-  // off the branch it covers.
-  // https://github.com/ariakit/ariakit/issues/4270
+  // leaves `BODY` as the active element for a native button without an explicit
+  // tab index, and giving the button one here would move this test off the
+  // branch it covers. https://github.com/ariakit/ariakit/issues/4270
   // https://github.com/ariakit/ariakit/issues/7310
   test("context menu keeps a dismiss button outside the menu", async ({
     page,

--- a/app/src/sandbox/menu-context-interactions/test-chrome.ts
+++ b/app/src/sandbox/menu-context-interactions/test-chrome.ts
@@ -12,7 +12,8 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
   // own items. Safari reaches the capture through a different branch, since it
   // leaves `BODY` as the active element for a native button without an explicit
   // tab index, and giving the button one here would move this test off the
-  // branch it covers. https://github.com/ariakit/ariakit/issues/4270
+  // branch it covers.
+  // https://github.com/ariakit/ariakit/issues/4270
   // https://github.com/ariakit/ariakit/issues/7310
   test("context menu keeps a dismiss button outside the menu", async ({
     page,

--- a/app/src/sandbox/menu-context-interactions/test.ts
+++ b/app/src/sandbox/menu-context-interactions/test.ts
@@ -21,7 +21,8 @@ test("show context menu and hide it by clicking outside", async () => {
 
 // The dialog names the focused control as a fallback disclosure, but a captured
 // control can't be assumed to close the menu, so it doesn't join the modal
-// context. https://github.com/ariakit/ariakit/issues/4270
+// context.
+// https://github.com/ariakit/ariakit/issues/4270
 // https://github.com/ariakit/ariakit/issues/7310
 test("context menu keeps a dismiss button outside the menu", async () => {
   await click(q.button("Open menu"));

--- a/app/src/sandbox/menu-context-interactions/test.ts
+++ b/app/src/sandbox/menu-context-interactions/test.ts
@@ -19,10 +19,9 @@ test("show context menu and hide it by clicking outside", async () => {
   expect(q.menu.maybe()).not.toBeInTheDocument();
 });
 
-// The dialog names the focused control as a fallback disclosure, but a
-// captured control can't be assumed to close the menu, so it doesn't join the
-// modal context.
-// https://github.com/ariakit/ariakit/issues/4270
+// The dialog names the focused control as a fallback disclosure, but a captured
+// control can't be assumed to close the menu, so it doesn't join the modal
+// context. https://github.com/ariakit/ariakit/issues/4270
 // https://github.com/ariakit/ariakit/issues/7310
 test("context menu keeps a dismiss button outside the menu", async () => {
   await click(q.button("Open menu"));

--- a/app/src/sandbox/menu-dialog-close/test-browser.ts
+++ b/app/src/sandbox/menu-dialog-close/test-browser.ts
@@ -50,8 +50,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.dialog()).not.toBeVisible();
 
     // Focus returns to the original disclosure (openButton) from the first
-    // open. The non-interactive click did not hijack the disclosure because
-    // the isFocusable() guard filtered out the non-focusable mousedown target.
+    // open. The non-interactive click did not hijack the disclosure because the
+    // isFocusable() guard filtered out the non-focusable mousedown target.
     await test.expect(openButton).toBeFocused();
   });
 });

--- a/app/src/sandbox/menu-modal-composition/menu.react.tsx
+++ b/app/src/sandbox/menu-modal-composition/menu.react.tsx
@@ -44,7 +44,7 @@ export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
   // 1. They are nested in the React tree.
   // 2. They are appended to the body element after the parent dialog is opened.
   // 3. They are referenced in the getPersistentElements prop of the parent
-  //     dialog.
+  //    dialog.
   //
   // By dynamically mounting the menu popover using the mounted state, we're
   // relying on (2). This ensures parent menus won't close when we interact with
@@ -101,8 +101,8 @@ export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
                 disclosure &&
                 nativeEvent.composedPath().includes(disclosure)
               ) {
-                // The disclosure isn't in the menu's React subtree, so the
-                // menu can't stop the event at its own boundary.
+                // The disclosure isn't in the menu's React subtree, so the menu
+                // can't stop the event at its own boundary.
                 event.stopPropagation();
               }
               return true;

--- a/app/src/sandbox/menu-modal-persistent-elements/test-browser.ts
+++ b/app/src/sandbox/menu-modal-persistent-elements/test-browser.ts
@@ -17,8 +17,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(menuButton).toBeFocused();
   });
 
-  // The menu button joins the modal context on its own now, so the elements
-  // the `getPersistentElements` prop returns have to be kept alongside it.
+  // The menu button joins the modal context on its own now, so the elements the
+  // `getPersistentElements` prop returns have to be kept alongside it.
   // https://github.com/ariakit/ariakit/issues/4270
   test("keeps persistent elements the prop returns", async ({ page, q }) => {
     await q.button("Actions").click();
@@ -33,8 +33,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
 
   // The menu sets its own tree snapshot key for the disclosure. A caller that
   // returns different persistent elements over time sets one too, and the menu
-  // has to carry it along rather than replace it, or the dialog never reads
-  // the persistent elements again and the new one stays out of the tab order.
+  // has to carry it along rather than replace it, or the dialog never reads the
+  // persistent elements again and the new one stays out of the tab order.
   // https://github.com/ariakit/ariakit/pull/7303#discussion_r3887846878
   test("caller's tree snapshot key still refreshes persistent elements", async ({
     page,

--- a/app/src/sandbox/menu-modal-persistent-elements/test.ts
+++ b/app/src/sandbox/menu-modal-persistent-elements/test.ts
@@ -1,8 +1,8 @@
 import { click, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
-// The dialog collects persistent elements from an effect that doesn't depend
-// on the disclosure, so swapping one connected disclosure for another used to
+// The dialog collects persistent elements from an effect that doesn't depend on
+// the disclosure, so swapping one connected disclosure for another used to
 // leave the old one in the modal context and the new one inert, while
 // `aria-labelledby` already pointed at the new one.
 // https://github.com/ariakit/ariakit/pull/7303#discussion_r3884581660

--- a/app/src/sandbox/menu-motion-transitions/menu.react.tsx
+++ b/app/src/sandbox/menu-motion-transitions/menu.react.tsx
@@ -74,9 +74,8 @@ export interface MenuItemProps extends React.ComponentPropsWithoutRef<
   typeof MotionMenuItem
 > {}
 
-// Instead of using the Ariakit `render` prop, we give control to Motion
-// so it can process the props before we pass the remainder to
-// `Ariakit.MenuItem`.
+// Instead of using the Ariakit `render` prop, we give control to Motion so it
+// can process the props before we pass the remainder to `Ariakit.MenuItem`.
 const MotionMenuItem = motion.create(Ariakit.MenuItem);
 
 export const MenuItem = React.forwardRef<HTMLDivElement, MenuItemProps>(

--- a/app/src/sandbox/menu-perf/perf-chrome.ts
+++ b/app/src/sandbox/menu-perf/perf-chrome.ts
@@ -66,8 +66,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     });
   });
 
-  // Same interaction as "open menu", but with the script profiler enabled
-  // so the PR comment shows where the scripting time goes. Profiling adds
+  // Same interaction as "open menu", but with the script profiler enabled so
+  // the PR comment shows where the scripting time goes. Profiling adds
   // overhead, so the unprofiled test above is the one to read for timings.
   test("open menu (script profile)", async ({ perf }) => {
     await perf.measure(({ q }) => openMenu(q), {

--- a/app/src/sandbox/menu-placing-pass/index.react.tsx
+++ b/app/src/sandbox/menu-placing-pass/index.react.tsx
@@ -20,8 +20,8 @@ const lastAction = `Action ${actionCount}`;
 const measureError = "Could not measure the Actions menu";
 
 /**
- * Holds menu positioning open while replacing the focused item's DOM node.
- * The replacement keeps the same id, so it remains the same logical item.
+ * Holds menu positioning open while replacing the focused item's DOM node. The
+ * replacement keeps the same id, so it remains the same logical item.
  */
 function FocusedReplacementMenu() {
   const menu = Ariakit.useMenuStore();

--- a/app/src/sandbox/menu-placing-pass/test-browser.ts
+++ b/app/src/sandbox/menu-placing-pass/test-browser.ts
@@ -117,7 +117,8 @@ withFramework(import.meta.dirname, async ({ query, test }) => {
     await q.button("Actions").click();
     await test.expect(menu).toBeVisible();
     // The default pass has written a transform by now, which is what brings the
-    // menu under its button, so the callback is the only thing left to wait for.
+    // menu under its button, so the callback is the only thing left to wait
+    // for.
     await test.expect(firstItem).toBeInViewport();
     // A popup that isn't placed doesn't take its initial focus, so focus
     // staying on the button is the user-facing half of the state the attribute

--- a/app/src/sandbox/menu-placing-pass/test.ts
+++ b/app/src/sandbox/menu-placing-pass/test.ts
@@ -84,7 +84,8 @@ test("keeps the popup unplaced while a custom updatePosition is still working", 
 // pins is a scheduling property rather than anything the browser decides: a
 // popup that mounts once its store is already open, with no `Popover` mounted
 // to publish the show transition, must not take focus before its own pass
-// finishes. https://github.com/ariakit/ariakit/pull/7032#discussion_r3703769238
+// finishes.
+// https://github.com/ariakit/ariakit/pull/7032#discussion_r3703769238
 test("keeps focus out of a popup that mounts after its store is open", async () => {
   const trigger = q.button("Late actions");
   await click(trigger);

--- a/app/src/sandbox/menu-placing-pass/test.ts
+++ b/app/src/sandbox/menu-placing-pass/test.ts
@@ -84,8 +84,7 @@ test("keeps the popup unplaced while a custom updatePosition is still working", 
 // pins is a scheduling property rather than anything the browser decides: a
 // popup that mounts once its store is already open, with no `Popover` mounted
 // to publish the show transition, must not take focus before its own pass
-// finishes.
-// https://github.com/ariakit/ariakit/pull/7032#discussion_r3703769238
+// finishes. https://github.com/ariakit/ariakit/pull/7032#discussion_r3703769238
 test("keeps focus out of a popup that mounts after its store is open", async () => {
   const trigger = q.button("Late actions");
   await click(trigger);

--- a/app/src/sandbox/menu-slide-navigation/menu.react.tsx
+++ b/app/src/sandbox/menu-slide-navigation/menu.react.tsx
@@ -31,16 +31,16 @@ export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
   const open = Ariakit.useStoreState(menu, "open");
   const autoFocusOnShow = Ariakit.useStoreState(menu, "autoFocusOnShow");
 
-  // By default, submenus don't automatically receive focus when they open.
-  // But here we want them to always receive focus.
+  // By default, submenus don't automatically receive focus when they open. But
+  // here we want them to always receive focus.
   React.useLayoutEffect(() => {
     if (!autoFocusOnShow) {
       menu.setAutoFocusOnShow(true);
     }
   }, [autoFocusOnShow, menu]);
 
-  // We only want to delay hiding the menu, so we immediately stop the
-  // animation when it's opening.
+  // We only want to delay hiding the menu, so we immediately stop the animation
+  // when it's opening.
   React.useLayoutEffect(() => {
     if (open) {
       menu.stopAnimation();
@@ -71,10 +71,9 @@ export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
         const scrollLeft = Math.abs(parentWrapper.scrollLeft);
         const wrapperOffset = scrollLeft + parentWrapper.clientWidth;
         if (wrapperOffset <= parent.getOffsetRight()) {
-          // Since the submenu is not visible anymore at this point, we want
-          // to hide it completely right away. That's why we syncrhonously
-          // hide it and immediately stops the animation so it's completely
-          // unmounted.
+          // Since the submenu is not visible anymore at this point, we want to
+          // hide it completely right away. That's why we syncrhonously hide it
+          // and immediately stops the animation so it's completely unmounted.
           flushSync(menu.hide);
           menu.stopAnimation();
         }

--- a/app/src/sandbox/menubar-7410/index.react.tsx
+++ b/app/src/sandbox/menubar-7410/index.react.tsx
@@ -12,8 +12,8 @@ interface MenubarMenuProps extends Ariakit.MenuProviderProps {
   label: string;
 }
 
-// A menubar entry that opens a menu. Rendered inside another menu, it becomes
-// a submenu.
+// A menubar entry that opens a menu. Rendered inside another menu, it becomes a
+// submenu.
 function MenubarMenu({ label, children, ...props }: MenubarMenuProps) {
   return (
     <Ariakit.MenuProvider {...props}>

--- a/app/src/sandbox/menubar-navigation/test-browser.ts
+++ b/app/src/sandbox/menubar-navigation/test-browser.ts
@@ -196,8 +196,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
   // item, while that store lives on in the menubar's provider. That stale move
   // and that active item are the container-focus request being replayed.
   // Focusing a menubar item doesn't record a move, so opening one alone doesn't
-  // arm this.
-  // https://github.com/ariakit/ariakit/issues/7360
+  // arm this. https://github.com/ariakit/ariakit/issues/7360
   test("keeps focus on the menu item when the shared menu is mounted again", async ({
     page,
     q,

--- a/app/src/sandbox/menubar-navigation/test-browser.ts
+++ b/app/src/sandbox/menubar-navigation/test-browser.ts
@@ -196,7 +196,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
   // item, while that store lives on in the menubar's provider. That stale move
   // and that active item are the container-focus request being replayed.
   // Focusing a menubar item doesn't record a move, so opening one alone doesn't
-  // arm this. https://github.com/ariakit/ariakit/issues/7360
+  // arm this.
+  // https://github.com/ariakit/ariakit/issues/7360
   test("keeps focus on the menu item when the shared menu is mounted again", async ({
     page,
     q,

--- a/app/src/sandbox/popover-6310/index.react.tsx
+++ b/app/src/sandbox/popover-6310/index.react.tsx
@@ -5,8 +5,8 @@ import { useRef } from "react";
 //
 // Reproduces a portaled popover whose content starts with a non-focusable
 // element (the common custom file upload pattern: a `display: none`
-// `<input type="file">` followed by a visible "Choose file" button).
-// To see the bug:
+// `<input type="file">` followed by a visible "Choose file" button). To see the
+// bug:
 //   1. Click "Attachments": the popover opens and "Choose file" is focused
 //      (correct).
 //   2. Click "Attachments" again to close the popover. Closing moves focus to

--- a/app/src/sandbox/popover-6310/test-browser.ts
+++ b/app/src/sandbox/popover-6310/test-browser.ts
@@ -26,8 +26,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
       .toHaveAttribute("tabindex", "-1");
 
     // Reopening must move focus to the visible button again, exactly like the
-    // first open did. Before the fix, focus stayed on the disclosure because the
-    // focusable fallback resolved to the hidden file input.
+    // first open did. Before the fix, focus stayed on the disclosure because
+    // the focusable fallback resolved to the hidden file input.
     await q.button("Attachments").click();
     await test.expect(q.dialog("Attachments")).toBeVisible();
     await test.expect(q.button("Choose file")).toBeFocused();

--- a/app/src/sandbox/popover-6310/test.ts
+++ b/app/src/sandbox/popover-6310/test.ts
@@ -21,9 +21,9 @@ test("reopened portaled popover focuses the first focusable element when a hidde
   // when no element inside is tabbable, so confirm the disable actually ran.
   expect(q.button.hidden("Choose file")).toHaveAttribute("tabindex", "-1");
 
-  // Reopening must move focus to the visible button again. Before the fix, focus
-  // stayed on the disclosure because the focusable fallback resolved to the
-  // hidden file input and focusing it is a no-op.
+  // Reopening must move focus to the visible button again. Before the fix,
+  // focus stayed on the disclosure because the focusable fallback resolved to
+  // the hidden file input and focusing it is a no-op.
   await click(q.button("Attachments"));
   expect(q.dialog("Attachments")).toBeVisible();
   expect(q.button("Choose file")).toHaveFocus();

--- a/app/src/sandbox/popover-arrow/index.react.tsx
+++ b/app/src/sandbox/popover-arrow/index.react.tsx
@@ -4,11 +4,11 @@ import { useState } from "react";
 
 // See https://github.com/ariakit/ariakit/issues/6321
 //
-// PopoverArrow infers its stroke from the popover's computed styles, treating
-// a box-shadow with zero offsets/blur and a positive spread (a Tailwind-style
+// PopoverArrow infers its stroke from the popover's computed styles, treating a
+// box-shadow with zero offsets/blur and a positive spread (a Tailwind-style
 // "ring") as the border. Both halves of that inference are broken:
-// - The ring-width regex rejects any spread whose px text contains the digit
-//   0, so 10px and 0.5px rings are not detected and the arrow renders with no
+// - The ring-width regex rejects any spread whose px text contains the digit 0,
+//   so 10px and 0.5px rings are not detected and the arrow renders with no
 //   stroke at all.
 // - The ring color is never used, so even detected rings (1px) draw the arrow
 //   with the popover's inherited text color instead of the ring color.
@@ -41,15 +41,15 @@ function RingPopover({ label, boxShadow, style }: RingPopoverProps) {
 // `right: 100%` on its arrow element. Later position updates never clear that
 // declaration: they only write `left`, `top`, and the new side. With both
 // `left` and `right` set, RTL over-constrained absolute positioning ignores
-// `left`, so the stale `right: 100%` pins the arrow to the popover's left
-// edge, visually detached from the anchor.
+// `left`, so the stale `right: 100%` pins the arrow to the popover's left edge,
+// visually detached from the anchor.
 //
 // Two user-level triggers change the resolved placement while the popover is
 // open:
 // 1. Scrolling the container so the anchor nears its right edge, which makes
 //    the popover flip above the anchor (browser test).
-// 2. Clicking "Show above", which changes the `placement` prop (also covered
-//    by the happy-dom test, where layout-driven flips can't happen).
+// 2. Clicking "Show above", which changes the `placement` prop (also covered by
+//    the happy-dom test, where layout-driven flips can't happen).
 function RtlPlacementPopover() {
   const [placement, setPlacement] = useState<"right" | "top">("right");
   return (

--- a/app/src/sandbox/popover-arrow/test.ts
+++ b/app/src/sandbox/popover-arrow/test.ts
@@ -6,12 +6,12 @@ const ringColor = "rgb(59, 130, 246)";
 // happy-dom's getComputedStyle returns the declared box-shadow value (unitless
 // zero lengths, color last) rather than the browser's normalized serialization
 // (color first, all lengths in px), so this file exercises the declared-value
-// form of the ring inference while the browser test covers the normalized
-// form. With the reported bug present, the declared form missed ring
-// detection for every case here (stroke: none), so only the browser test
-// distinguishes the two reported defects (undetected ring width vs. wrong
-// stroke color). React sets stroke-width unitless and happy-dom does not
-// resolve it to px, so the expected widths are unitless here.
+// form of the ring inference while the browser test covers the normalized form.
+// With the reported bug present, the declared form missed ring detection for
+// every case here (stroke: none), so only the browser test distinguishes the
+// two reported defects (undetected ring width vs. wrong stroke color). React
+// sets stroke-width unitless and happy-dom does not resolve it to px, so the
+// expected widths are unitless here.
 const cases = [
   { label: "Thin ring", strokeWidth: "2" },
   { label: "Thick ring", strokeWidth: "20" },
@@ -62,9 +62,9 @@ for (const { label, strokeWidth, stroke } of cases) {
   test(`arrow stroke matches the ${label.toLowerCase()} box-shadow`, async () => {
     await click(q.button(label));
     const dialog = q.dialog(label);
-    // The arrow SVG paths inherit the stroke and stroke-width set on the
-    // arrow element, so the values on the arrow are what the user sees drawn
-    // around the arrow notch.
+    // The arrow SVG paths inherit the stroke and stroke-width set on the arrow
+    // element, so the values on the arrow are what the user sees drawn around
+    // the arrow notch.
     const arrow = dialog.querySelector(".arrow");
     expect(arrow).toBeInTheDocument();
     expect(arrow).toHaveStyle({ stroke: stroke ?? ringColor, strokeWidth });

--- a/app/src/sandbox/popover-closed-overflow-padding/index.react.tsx
+++ b/app/src/sandbox/popover-closed-overflow-padding/index.react.tsx
@@ -1,8 +1,8 @@
 import * as Ariakit from "@ariakit/react";
 
 // An initially closed popover that stays mounted while hidden and uses the
-// default positioning. The overflow padding CSS variable is public API and
-// must be exposed on the wrapper even before the popover first opens.
+// default positioning. The overflow padding CSS variable is public API and must
+// be exposed on the wrapper even before the popover first opens.
 export default function Example() {
   return (
     <Ariakit.PopoverProvider>

--- a/app/src/sandbox/popover-closed-overflow-padding/test-chrome-firefox.ts
+++ b/app/src/sandbox/popover-closed-overflow-padding/test-chrome-firefox.ts
@@ -2,8 +2,7 @@ import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
   // The overflow padding variable is public API and must be exposed on the
-  // wrapper even while the popover is closed and hidden, before it first
-  // opens.
+  // wrapper even while the popover is closed and hidden, before it first opens.
   test("exposes the overflow padding variable on a closed popover", async ({
     page,
   }) => {

--- a/app/src/sandbox/popover-disclosure-7087/test-browser.ts
+++ b/app/src/sandbox/popover-disclosure-7087/test-browser.ts
@@ -84,8 +84,7 @@ withFramework(import.meta.dirname, async ({ test }) => {
   // apart from the application assigning the same button. So a show() that
   // names nothing keeps the button rather than the element that happened to be
   // focused, which also anchors the popup to that button and returns focus
-  // there on close.
-  // https://github.com/ariakit/ariakit/issues/7087
+  // there on close. https://github.com/ariakit/ariakit/issues/7087
   test("keeps a mounted button as the opener when the open names none", async ({
     q,
   }) => {

--- a/app/src/sandbox/popover-disclosure-7087/test-browser.ts
+++ b/app/src/sandbox/popover-disclosure-7087/test-browser.ts
@@ -84,7 +84,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
   // apart from the application assigning the same button. So a show() that
   // names nothing keeps the button rather than the element that happened to be
   // focused, which also anchors the popup to that button and returns focus
-  // there on close. https://github.com/ariakit/ariakit/issues/7087
+  // there on close.
+  // https://github.com/ariakit/ariakit/issues/7087
   test("keeps a mounted button as the opener when the open names none", async ({
     q,
   }) => {

--- a/app/src/sandbox/popover-disclosure-7087/test.ts
+++ b/app/src/sandbox/popover-disclosure-7087/test.ts
@@ -111,7 +111,8 @@ test("replaces the fallback after an open that captured nothing", async () => {
 // The popup's own store is derived and gets replaced when its wrapper remounts,
 // while the editor's store carries the opener across. Whatever tracks that the
 // field was only a fallback has to survive that too, or the field stays the
-// opener forever. https://github.com/ariakit/ariakit/issues/7087
+// opener forever.
+// https://github.com/ariakit/ariakit/issues/7087
 test("replaces the fallback after the popup's own store is replaced", async () => {
   const note = q.textbox("Note");
   const title = q.textbox("Title");

--- a/app/src/sandbox/popover-disclosure-7087/test.ts
+++ b/app/src/sandbox/popover-disclosure-7087/test.ts
@@ -111,8 +111,7 @@ test("replaces the fallback after an open that captured nothing", async () => {
 // The popup's own store is derived and gets replaced when its wrapper remounts,
 // while the editor's store carries the opener across. Whatever tracks that the
 // field was only a fallback has to survive that too, or the field stays the
-// opener forever.
-// https://github.com/ariakit/ariakit/issues/7087
+// opener forever. https://github.com/ariakit/ariakit/issues/7087
 test("replaces the fallback after the popup's own store is replaced", async () => {
   const note = q.textbox("Note");
   const title = q.textbox("Title");

--- a/app/src/sandbox/popover-disclosure-render/test-chrome-firefox.ts
+++ b/app/src/sandbox/popover-disclosure-render/test-chrome-firefox.ts
@@ -65,9 +65,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(q.dialog()).toBeVisible();
 
     await q.button("Set Fallback disclosure element").click();
-    // The first click also moves focus into the button, which updates
-    // one-time focus state. Its final render has no separate observable
-    // completion state, so wait before sampling the count.
+    // The first click also moves focus into the button, which updates one-time
+    // focus state. Its final render has no separate observable completion
+    // state, so wait before sampling the count.
     await flushFrames(page);
 
     const popoverRenders = q.status("Fallback popover renders");

--- a/app/src/sandbox/popover-disclosure-render/test.ts
+++ b/app/src/sandbox/popover-disclosure-render/test.ts
@@ -1,10 +1,10 @@
 import { click, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
-// Each popover has an explicit anchor, so the disclosure element isn't used
-// for positioning. The preserveTabOrder feature, its remaining consumer,
-// takes effect only on non-modal portals, so disclosure element updates must
-// not re-render a modal popover, a plain non-portaled popover, or a portal with
+// Each popover has an explicit anchor, so the disclosure element isn't used for
+// positioning. The preserveTabOrder feature, its remaining consumer, takes
+// effect only on non-modal portals, so disclosure element updates must not
+// re-render a modal popover, a plain non-portaled popover, or a portal with
 // preserveTabOrder disabled. Browser duplicate in test-chrome-firefox.ts.
 test.each([
   {

--- a/app/src/sandbox/portal-combobox-7218/index.react.tsx
+++ b/app/src/sandbox/portal-combobox-7218/index.react.tsx
@@ -5,8 +5,8 @@ import { useRef } from "react";
 const items = Array.from({ length: 30 }, (_, index) => `Item ${index + 1}`);
 const formName = "preferences";
 
-// React 19 reads the same named property during commits. Scope the collision
-// to native browser work so its failure does not hide Ariakit's behavior.
+// React 19 reads the same named property during commits. Scope the collision to
+// native browser work so its failure does not hide Ariakit's behavior.
 function setFormName(formRef: RefObject<HTMLFormElement | null>, name: string) {
   const form = formRef.current;
   if (!form) return;

--- a/app/src/sandbox/portal-dialog-6322/test-browser.ts
+++ b/app/src/sandbox/portal-dialog-6322/test-browser.ts
@@ -12,9 +12,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await q.textbox("Name").click();
     await page.keyboard.type("hello");
 
-    // Before the fix, the first keystroke re-renders the parent, the new
-    // inline portalRef identity recreates the portal node, and the remounted
-    // dialog moves focus to the Close button, so only "h" lands in the field.
+    // Before the fix, the first keystroke re-renders the parent, the new inline
+    // portalRef identity recreates the portal node, and the remounted dialog
+    // moves focus to the Close button, so only "h" lands in the field.
     await test.expect(q.textbox("Name")).toHaveValue("hello");
     await test.expect(q.textbox("Name")).toBeFocused();
   });
@@ -26,8 +26,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await q.textbox("Notes").click();
     await page.keyboard.type("hello");
 
-    // Before the fix, the portal node is recreated on every keystroke and
-    // focus falls back to the body, so only "h" lands in the field.
+    // Before the fix, the portal node is recreated on every keystroke and focus
+    // falls back to the body, so only "h" lands in the field.
     await test.expect(q.textbox("Notes")).toHaveValue("hello");
     await test.expect(q.textbox("Notes")).toBeFocused();
   });

--- a/app/src/sandbox/portal-toggle-ref-cleanup/test-chrome.ts
+++ b/app/src/sandbox/portal-toggle-ref-cleanup/test-chrome.ts
@@ -22,8 +22,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
       .toBeVisible();
 
     await q.button("Disable inline portal").click();
-    // The content is rendered in place once the portal is disabled, and the
-    // new inline portalRef must not have fired against the removed node.
+    // The content is rendered in place once the portal is disabled, and the new
+    // inline portalRef must not have fired against the removed node.
     await test.expect(q.text("Inline portal content")).toBeVisible();
     await test
       .expect(q.text("Inline portal attach connected: yes"))

--- a/app/src/sandbox/portal-toggle-ref-cleanup/test.ts
+++ b/app/src/sandbox/portal-toggle-ref-cleanup/test.ts
@@ -16,8 +16,8 @@ test("does not attach an inline portalRef to the removed node when the portal pr
   expect(q.text("Inline portal attach connected: yes")).toBeVisible();
 
   await click(q.button("Disable inline portal"));
-  // The content is rendered in place once the portal is disabled, and the
-  // new inline portalRef must not have fired against the removed node.
+  // The content is rendered in place once the portal is disabled, and the new
+  // inline portalRef must not have fired against the removed node.
   expect(q.text("Inline portal content")).toBeVisible();
   expect(q.text("Inline portal attach connected: yes")).toBeVisible();
 });

--- a/app/src/sandbox/radio-6345/index.react.tsx
+++ b/app/src/sandbox/radio-6345/index.react.tsx
@@ -5,10 +5,10 @@ import { useState } from "react";
 export default function Example() {
   const [fruit, setFruit] = useState("none");
 
-  // Standard React radio idiom: commit the value only when the radio that
-  // fired the event is checked. Arrow-key selection used to silently defeat
-  // this gate because the forwarded focus event still had checked === false.
-  // See https://github.com/ariakit/ariakit/issues/6345
+  // Standard React radio idiom: commit the value only when the radio that fired
+  // the event is checked. Arrow-key selection used to silently defeat this gate
+  // because the forwarded focus event still had checked === false. See
+  // https://github.com/ariakit/ariakit/issues/6345
   function onChange(event: ChangeEvent<HTMLInputElement>) {
     if (event.target.checked) {
       setFruit(event.target.value);

--- a/app/src/sandbox/radio-group-3833/test-browser.ts
+++ b/app/src/sandbox/radio-group-3833/test-browser.ts
@@ -1,9 +1,10 @@
 import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
-  // https://github.com/ariakit/ariakit/issues/3833 Without name attributes, the
-  // browser treats all radio inputs as one group. This affects native browser
-  // behaviors like Tab navigation and form submission.
+  // https://github.com/ariakit/ariakit/issues/3833
+  // Without name attributes, the browser treats all radio inputs as one group.
+  // This affects native browser behaviors like Tab navigation and form
+  // submission.
   test("radios have unique name attributes per group", async ({ q }) => {
     const fruitsGroup = q.radiogroup("Fruits");
     const vegetablesGroup = q.radiogroup("Vegetables");

--- a/app/src/sandbox/radio-group-3833/test-browser.ts
+++ b/app/src/sandbox/radio-group-3833/test-browser.ts
@@ -1,9 +1,9 @@
 import { withFramework } from "#app/test-utils/preview.ts";
 
 withFramework(import.meta.dirname, async ({ test }) => {
-  // https://github.com/ariakit/ariakit/issues/3833
-  // Without name attributes, the browser treats all radio inputs as one group.
-  // This affects native browser behaviors like Tab navigation and form submission.
+  // https://github.com/ariakit/ariakit/issues/3833 Without name attributes, the
+  // browser treats all radio inputs as one group. This affects native browser
+  // behaviors like Tab navigation and form submission.
   test("radios have unique name attributes per group", async ({ q }) => {
     const fruitsGroup = q.radiogroup("Fruits");
     const vegetablesGroup = q.radiogroup("Vegetables");
@@ -27,8 +27,8 @@ withFramework(import.meta.dirname, async ({ test }) => {
   });
 
   test("Tab moves focus between groups", async ({ page, q }) => {
-    // Check a radio so the group has a selection — Tab behavior differs when
-    // a radio is checked vs. when none is checked.
+    // Check a radio so the group has a selection — Tab behavior differs when a
+    // radio is checked vs. when none is checked.
     await q.radio("Apple").click();
     await test.expect(q.radio("Apple")).toBeChecked();
 

--- a/app/src/sandbox/select-combobox-name-7346/test.ts
+++ b/app/src/sandbox/select-combobox-name-7346/test.ts
@@ -40,8 +40,8 @@ for (const label of [
 }
 
 for (const label of ["Select named", "Combobox named"]) {
-  // Keeps name nonempty, so this passes before the fix too. It distinguishes
-  // a rename from the empty/nonempty boundary that caused the remount.
+  // Keeps name nonempty, so this passes before the fix too. It distinguishes a
+  // rename from the empty/nonempty boundary that caused the remount.
   // https://github.com/ariakit/ariakit/issues/7346
   test(`${label} keeps popup state when name stays nonempty`, async () => {
     await click(q.combobox(label));

--- a/app/src/sandbox/select-legacy/public-cases/composite.react.tsx
+++ b/app/src/sandbox/select-legacy/public-cases/composite.react.tsx
@@ -195,10 +195,10 @@ export function LegacyPublicSelectItemCustomCase() {
   );
 }
 
-// An authored focusOnHover callback with a side effect: the consumer moves
-// the composite from inside the predicate, like the select-grid example does.
-// While the select is collapsed, the callback must not run at all, or the
-// move would still activate the item, commit its value, and steal focus.
+// An authored focusOnHover callback with a side effect: the consumer moves the
+// composite from inside the predicate, like the select-grid example does. While
+// the select is collapsed, the callback must not run at all, or the move would
+// still activate the item, commit its value, and steal focus.
 // https://github.com/ariakit/ariakit/issues/7120
 export function LegacyPublicSelectCollapsedHoverCase() {
   const select = Ariakit.useSelectStore({ defaultValue: "Apple" });

--- a/app/src/sandbox/select-legacy/public-tests/combobox.react.test-helper.ts
+++ b/app/src/sandbox/select-legacy/public-tests/combobox.react.test-helper.ts
@@ -17,8 +17,7 @@ describe.each([
     await click(q.button(`Show ${caseName}`));
   });
 
-  // examples/select-combobox/test.ts
-  // examples/select-combobox-store/test.ts
+  // examples/select-combobox/test.ts examples/select-combobox-store/test.ts
   test("filters and selects through the combined stores", async () => {
     const select = q.combobox(label);
     await click(select);

--- a/app/src/sandbox/select-legacy/public-tests/composite.react.test-helper.ts
+++ b/app/src/sandbox/select-legacy/public-tests/composite.react.test-helper.ts
@@ -31,8 +31,7 @@ describe.each([
     await click(q.button(`Show ${caseName}`));
   });
 
-  // examples/select-grid/test.ts
-  // examples/select-grid-store/test.ts
+  // examples/select-grid/test.ts examples/select-grid-store/test.ts
   test("moves through the two-dimensional Select composite", async () => {
     const select = q.combobox(label);
     expect(select).toHaveTextContent("Center");
@@ -85,11 +84,11 @@ describe("public-select-collapsed-hover", () => {
     await click(q.button("Show public-select-collapsed-hover"));
   });
 
-  // https://github.com/ariakit/ariakit/issues/7120
-  // The authored focusOnHover callback moves the composite from inside the
-  // predicate. While the select is collapsed, the callback must not run at
-  // all, or the move would still activate the item, commit its value, and
-  // steal focus from the unrelated control.
+  // https://github.com/ariakit/ariakit/issues/7120 The authored focusOnHover
+  // callback moves the composite from inside the predicate. While the select is
+  // collapsed, the callback must not run at all, or the move would still
+  // activate the item, commit its value, and steal focus from the unrelated
+  // control.
   test("a side-effectful focusOnHover callback does nothing on a collapsed list", async () => {
     const select = q.combobox("Collapsed hover fruit");
     const grape = q.option("Grape");
@@ -108,9 +107,8 @@ describe("public-select-collapsed-hover", () => {
     expect(other).toHaveFocus();
   });
 
-  // https://github.com/ariakit/ariakit/issues/7120
-  // The gate is about the closed list: the same side-effectful callback
-  // keeps working once the select opens.
+  // https://github.com/ariakit/ariakit/issues/7120 The gate is about the closed
+  // list: the same side-effectful callback keeps working once the select opens.
   test("the same callback activates the option once the select opens", async () => {
     const select = q.combobox("Collapsed hover fruit");
     const grape = q.option("Grape");
@@ -129,10 +127,10 @@ describe("public-select-hide-on-hover", () => {
     await click(q.button("Show public-select-hide-on-hover"));
   });
 
-  // https://github.com/ariakit/ariakit/pull/7121#discussion_r3780074062
-  // The authored callback closes the select and returns true. Built-in
-  // activation must still stop, or the hovered item would become active in
-  // the just-collapsed list.
+  // https://github.com/ariakit/ariakit/pull/7121#discussion_r3780074062 The
+  // authored callback closes the select and returns true. Built-in activation
+  // must still stop, or the hovered item would become active in the
+  // just-collapsed list.
   test("built-in activation stops when the callback closes the select", async () => {
     const select = q.combobox("Hide-on-hover fruit");
     const grape = q.option("Grape");

--- a/app/src/sandbox/select-legacy/public-tests/composite.react.test-helper.ts
+++ b/app/src/sandbox/select-legacy/public-tests/composite.react.test-helper.ts
@@ -84,11 +84,11 @@ describe("public-select-collapsed-hover", () => {
     await click(q.button("Show public-select-collapsed-hover"));
   });
 
-  // https://github.com/ariakit/ariakit/issues/7120 The authored focusOnHover
-  // callback moves the composite from inside the predicate. While the select is
-  // collapsed, the callback must not run at all, or the move would still
-  // activate the item, commit its value, and steal focus from the unrelated
-  // control.
+  // https://github.com/ariakit/ariakit/issues/7120
+  // The authored focusOnHover callback moves the composite from inside the
+  // predicate. While the select is collapsed, the callback must not run at all,
+  // or the move would still activate the item, commit its value, and steal
+  // focus from the unrelated control.
   test("a side-effectful focusOnHover callback does nothing on a collapsed list", async () => {
     const select = q.combobox("Collapsed hover fruit");
     const grape = q.option("Grape");
@@ -107,8 +107,9 @@ describe("public-select-collapsed-hover", () => {
     expect(other).toHaveFocus();
   });
 
-  // https://github.com/ariakit/ariakit/issues/7120 The gate is about the closed
-  // list: the same side-effectful callback keeps working once the select opens.
+  // https://github.com/ariakit/ariakit/issues/7120
+  // The gate is about the closed list: the same side-effectful callback keeps
+  // working once the select opens.
   test("the same callback activates the option once the select opens", async () => {
     const select = q.combobox("Collapsed hover fruit");
     const grape = q.option("Grape");
@@ -127,9 +128,9 @@ describe("public-select-hide-on-hover", () => {
     await click(q.button("Show public-select-hide-on-hover"));
   });
 
-  // https://github.com/ariakit/ariakit/pull/7121#discussion_r3780074062 The
-  // authored callback closes the select and returns true. Built-in activation
-  // must still stop, or the hovered item would become active in the
+  // https://github.com/ariakit/ariakit/pull/7121#discussion_r3780074062
+  // The authored callback closes the select and returns true. Built-in
+  // activation must still stop, or the hovered item would become active in the
   // just-collapsed list.
   test("built-in activation stops when the callback closes the select", async () => {
     const select = q.combobox("Hide-on-hover fruit");

--- a/app/src/sandbox/select-legacy/test-public-browser.ts
+++ b/app/src/sandbox/select-legacy/test-public-browser.ts
@@ -93,11 +93,11 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(select).toContainText("Square");
   });
 
-  // https://github.com/ariakit/ariakit/issues/7120 The authored focusOnHover
-  // callback moves the composite from inside the predicate. While the select is
-  // collapsed, the callback must not run at all, or the move would still
-  // activate the item, commit its value, and steal focus from the unrelated
-  // control.
+  // https://github.com/ariakit/ariakit/issues/7120
+  // The authored focusOnHover callback moves the composite from inside the
+  // predicate. While the select is collapsed, the callback must not run at all,
+  // or the move would still activate the item, commit its value, and steal
+  // focus from the unrelated control.
   test("a side-effectful focusOnHover callback does nothing on a collapsed list", async ({
     page,
     q,
@@ -122,8 +122,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(other).toBeFocused();
   });
 
-  // https://github.com/ariakit/ariakit/issues/7120 The gate is about the closed
-  // list: the same side-effectful callback keeps working once the select opens.
+  // https://github.com/ariakit/ariakit/issues/7120
+  // The gate is about the closed list: the same side-effectful callback keeps
+  // working once the select opens.
   test("the same callback activates the option once the select opens", async ({
     q,
   }) => {
@@ -139,9 +140,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(grape).toHaveAttribute("data-active-item");
   });
 
-  // https://github.com/ariakit/ariakit/pull/7121#discussion_r3780074062 The
-  // authored callback closes the select and returns true. Built-in activation
-  // must still stop, or the hovered item would become active in the
+  // https://github.com/ariakit/ariakit/pull/7121#discussion_r3780074062
+  // The authored callback closes the select and returns true. Built-in
+  // activation must still stop, or the hovered item would become active in the
   // just-collapsed list.
   test("built-in activation stops when the callback closes the select", async ({
     q,

--- a/app/src/sandbox/select-legacy/test-public-browser.ts
+++ b/app/src/sandbox/select-legacy/test-public-browser.ts
@@ -93,11 +93,11 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(select).toContainText("Square");
   });
 
-  // https://github.com/ariakit/ariakit/issues/7120
-  // The authored focusOnHover callback moves the composite from inside the
-  // predicate. While the select is collapsed, the callback must not run at
-  // all, or the move would still activate the item, commit its value, and
-  // steal focus from the unrelated control.
+  // https://github.com/ariakit/ariakit/issues/7120 The authored focusOnHover
+  // callback moves the composite from inside the predicate. While the select is
+  // collapsed, the callback must not run at all, or the move would still
+  // activate the item, commit its value, and steal focus from the unrelated
+  // control.
   test("a side-effectful focusOnHover callback does nothing on a collapsed list", async ({
     page,
     q,
@@ -113,18 +113,17 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await grape.hover();
 
     await test.expect(select).toHaveAttribute("aria-expanded", "false");
-    // Hover activation is committed inside the mousemove handler, so there
-    // is no positive state to wait for. Cross the frames a presentation
-    // would use to reach the item before asserting that none did.
+    // Hover activation is committed inside the mousemove handler, so there is
+    // no positive state to wait for. Cross the frames a presentation would use
+    // to reach the item before asserting that none did.
     await flushFrames(page);
     await test.expect(grape).not.toHaveAttribute("data-active-item");
     await test.expect(select).toContainText("Apple");
     await test.expect(other).toBeFocused();
   });
 
-  // https://github.com/ariakit/ariakit/issues/7120
-  // The gate is about the closed list: the same side-effectful callback
-  // keeps working once the select opens.
+  // https://github.com/ariakit/ariakit/issues/7120 The gate is about the closed
+  // list: the same side-effectful callback keeps working once the select opens.
   test("the same callback activates the option once the select opens", async ({
     q,
   }) => {
@@ -140,10 +139,10 @@ withFramework(import.meta.dirname, async ({ test }) => {
     await test.expect(grape).toHaveAttribute("data-active-item");
   });
 
-  // https://github.com/ariakit/ariakit/pull/7121#discussion_r3780074062
-  // The authored callback closes the select and returns true. Built-in
-  // activation must still stop, or the hovered item would become active in
-  // the just-collapsed list.
+  // https://github.com/ariakit/ariakit/pull/7121#discussion_r3780074062 The
+  // authored callback closes the select and returns true. Built-in activation
+  // must still stop, or the hovered item would become active in the
+  // just-collapsed list.
   test("built-in activation stops when the callback closes the select", async ({
     q,
   }) => {

--- a/app/src/sandbox/tab-form-named-active-element/index.react.tsx
+++ b/app/src/sandbox/tab-form-named-active-element/index.react.tsx
@@ -9,8 +9,8 @@ const sections = [
 
 // A saved-views form on the page carries a name that collides with the member
 // the tab store reads to learn whether a tab holds focus, so the document
-// answers `activeElement` with the form. Selecting a section through the
-// number shortcut then leaves keyboard focus behind on the previous tab.
+// answers `activeElement` with the form. Selecting a section through the number
+// shortcut then leaves keyboard focus behind on the previous tab.
 export default function Example() {
   const tab = Ariakit.useTabStore({ defaultSelectedId: "overview" });
   const [focusHistory, setFocusHistory] = useState<string[]>([]);

--- a/app/src/sandbox/tag/test-browser.ts
+++ b/app/src/sandbox/tag/test-browser.ts
@@ -33,8 +33,8 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     await expect(q.listbox("Tags")).not.toHaveAttribute("aria-owns");
     const tagList = query(q.listbox("Tags"));
     await expect(tagList.option()).toHaveCount(2);
-    // The listbox role accepts only options as children, so the input must be
-    // a sibling of the tag list rather than a descendant of it.
+    // The listbox role accepts only options as children, so the input must be a
+    // sibling of the tag list rather than a descendant of it.
     await expect(tagList.textbox()).toHaveCount(0);
     await expect(q.textbox("Tags")).toBeVisible();
   });

--- a/app/src/sandbox/tag/test.ts
+++ b/app/src/sandbox/tag/test.ts
@@ -42,8 +42,8 @@ test("renders the tags inside the listbox and the input outside it", async () =>
 });
 
 test("labels the control, the tag list and the input", async () => {
-  // The tags and the input are separate widgets, so the control groups them
-  // and the label names all three.
+  // The tags and the input are separate widgets, so the control groups them and
+  // the label names all three.
   const control = q.group("Tags");
   expect(control).toContainElement(q.listbox("Tags"));
   expect(control).toContainElement(q.textbox("Tags"));

--- a/app/src/sandbox/tooltip-4894/test.ts
+++ b/app/src/sandbox/tooltip-4894/test.ts
@@ -1,10 +1,10 @@
 import { click, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
-// See https://github.com/ariakit/ariakit/issues/4894
-// In happy-dom, this documents the stable forced-open state. The mixed test below
-// fails without the re-entrant loop guard, and test-chrome.ts covers the pure
-// forced-open flow in a real browser.
+// See https://github.com/ariakit/ariakit/issues/4894 In happy-dom, this
+// documents the stable forced-open state. The mixed test below fails without
+// the re-entrant loop guard, and test-chrome.ts covers the pure forced-open
+// flow in a real browser.
 test("keeps multiple forced tooltips visible", async () => {
   await click(q.button("Show forced tooltips"));
   expect(q.tooltip("FORCED ONE")).toBeVisible();

--- a/app/src/sandbox/tooltip-button-disabled/test-browser.ts
+++ b/app/src/sandbox/tooltip-button-disabled/test-browser.ts
@@ -137,9 +137,10 @@ withFramework(import.meta.dirname, async ({ test }) => {
   });
 
   test("keeps truly disabled anchors out of pointer reach", async ({ q }) => {
-    // Focusable applies `pointer-events: none` to truly disabled elements, so no
-    // mouse move can reach these anchors and the shield is the behavior here.
-    // The hover decision is covered by the two tests below, where it's lifted.
+    // Focusable applies `pointer-events: none` to truly disabled elements, so
+    // no mouse move can reach these anchors and the shield is the behavior
+    // here. The hover decision is covered by the two tests below, where it's
+    // lifted.
     await test
       .expect(q.button("Rename file"))
       .toHaveCSS("pointer-events", "none");
@@ -214,9 +215,9 @@ withFramework(import.meta.dirname, async ({ test }) => {
   test("shows the tooltip on hover when the rendered button is disabled with focusable false", async ({
     q,
   }) => {
-    // `focusable={false}` makes the button's disabled props inoperative, so
-    // the anchor keeps the element keyboard reachable and reveals on focus.
-    // Hover has to agree, or the tooltip becomes keyboard-only.
+    // `focusable={false}` makes the button's disabled props inoperative, so the
+    // anchor keeps the element keyboard reachable and reveals on focus. Hover
+    // has to agree, or the tooltip becomes keyboard-only.
     await q.button("Compress file").hover();
     await test
       .expect(q.tooltip("Compression runs in the background"))

--- a/app/src/sandbox/tooltip-button-disabled/test.ts
+++ b/app/src/sandbox/tooltip-button-disabled/test.ts
@@ -130,8 +130,8 @@ test("does not open a delayed tooltip when the anchor turns truly disabled while
 
 test("shows the tooltip on hover when the rendered button is disabled with focusable false", async () => {
   // `focusable={false}` makes the button's disabled props inoperative, so the
-  // anchor keeps the element keyboard reachable and reveals on focus. Hover
-  // has to agree, or the tooltip becomes keyboard-only.
+  // anchor keeps the element keyboard reachable and reveals on focus. Hover has
+  // to agree, or the tooltip becomes keyboard-only.
   await hover(q.button("Compress file"));
   expect(q.tooltip("Compression runs in the background")).toBeVisible();
 });
@@ -145,8 +145,8 @@ test("shows the tooltip on keyboard focus when the rendered button is disabled w
 });
 
 test("does not show the tooltip on hover when the anchor is disabled with focusable false", async () => {
-  // With `focusable={false}` the anchor has no tab stop and no focus reveal,
-  // so revealing on hover would reach pointer users alone. No pointer-events
+  // With `focusable={false}` the anchor has no tab stop and no focus reveal, so
+  // revealing on hover would reach pointer users alone. No pointer-events
   // shield applies here, so the hover decision itself is what this asserts.
   expect(q.text("Encrypt file")).not.toHaveAttribute("tabindex");
   await hover(q.text("Encrypt file"));
@@ -159,8 +159,8 @@ test("does not open a delayed tooltip when the anchor loses focusable while it i
   // `focusable={false}` and out of the tab order.
   expect(q.text("Upload file")).not.toHaveAttribute("tabindex");
   // Same 150ms show timeout as the "Preview file" control above, and still
-  // nothing observable to poll, so cross it before asserting the tooltip
-  // stayed closed.
+  // nothing observable to poll, so cross it before asserting the tooltip stayed
+  // closed.
   await sleep(250);
   expect(
     q.tooltip.maybe("Uploading needs a connection"),

--- a/app/src/sandbox/tooltip-fullscreen-portal/test-browser.ts
+++ b/app/src/sandbox/tooltip-fullscreen-portal/test-browser.ts
@@ -19,10 +19,9 @@ async function getPortalState(page: Page) {
 }
 
 withFramework(import.meta.dirname, async ({ test }) => {
-  // See https://github.com/ariakit/ariakit/issues/6585
-  // To reproduce the React 18 StrictMode failure in a browser, serve the app
-  // with `pnpm react18 -- pnpm dev-app`. CI's React 18 signal comes from
-  // test.ts.
+  // See https://github.com/ariakit/ariakit/issues/6585 To reproduce the React
+  // 18 StrictMode failure in a browser, serve the app with
+  // `pnpm react18 -- pnpm dev-app`. CI's React 18 signal comes from test.ts.
   test("does not leak duplicate tooltip portal containers", async ({
     page,
     q,

--- a/app/src/sandbox/tooltip-fullscreen-portal/test.ts
+++ b/app/src/sandbox/tooltip-fullscreen-portal/test.ts
@@ -1,8 +1,8 @@
 import { click, hover, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
-// See https://github.com/ariakit/ariakit/issues/6585
-// This regression reproduces in React 18 development StrictMode.
+// See https://github.com/ariakit/ariakit/issues/6585 This regression reproduces
+// in React 18 development StrictMode.
 test("does not leak duplicate tooltip portal containers in StrictMode", async () => {
   expect(q.status("Portal containers")).toHaveTextContent(
     "Portal containers: 0",

--- a/app/src/sandbox/tooltip-interactions/test.ts
+++ b/app/src/sandbox/tooltip-interactions/test.ts
@@ -60,8 +60,8 @@ test("waits again after keyboard focus is lost", async () => {
   expect(q.tooltip.maybe("Tooltip content")).not.toBeInTheDocument();
 
   await hoverOutside();
-  // Dispatch directly so the assertion runs before the timeout can expire
-  // when the full suite delays the interaction helper.
+  // Dispatch directly so the assertion runs before the timeout can expire when
+  // the full suite delays the interaction helper.
   await dispatch.mouseOver(anchor);
   await dispatch.mouseEnter(anchor);
   await dispatch.mouseMove(anchor);

--- a/app/src/test-utils/accessibility.ts
+++ b/app/src/test-utils/accessibility.ts
@@ -15,8 +15,8 @@ async function createTreeReader(page: Page) {
 }
 
 /**
- * Returns a function that reads the menu node from Chromium's own
- * accessibility tree, with its accessible name and the roles it owns.
+ * Returns a function that reads the menu node from Chromium's own accessibility
+ * tree, with its accessible name and the roles it owns.
  */
 export async function createMenuAccessibilityReader(page: Page) {
   const readNodes = await createTreeReader(page);
@@ -25,8 +25,8 @@ export async function createMenuAccessibilityReader(page: Page) {
     const menu = nodes.find(
       (node) => node.role?.value === "menu" && !node.ignored,
     );
-    // Returning null instead of throwing keeps `expect.poll` retrying, since
-    // it evaluates the value function outside of its own try/catch.
+    // Returning null instead of throwing keeps `expect.poll` retrying, since it
+    // evaluates the value function outside of its own try/catch.
     if (!menu) return null;
     const nodeById = new Map(nodes.map((node) => [node.nodeId, node]));
     const children =

--- a/app/src/test-utils/fixtures.ts
+++ b/app/src/test-utils/fixtures.ts
@@ -20,10 +20,9 @@ export interface PerfHelpers {
 }
 
 /**
- * Callback invoked with the iteration's page and a query bound to it. Each
- * perf iteration runs in a fresh browser context, so callbacks must use the
- * helpers they receive instead of closing over the test's fixture `page` or
- * `q`.
+ * Callback invoked with the iteration's page and a query bound to it. Each perf
+ * iteration runs in a fresh browser context, so callbacks must use the helpers
+ * they receive instead of closing over the test's fixture `page` or `q`.
  */
 export type PerfCallback = (helpers: PerfHelpers) => Promise<void> | void;
 
@@ -93,10 +92,10 @@ export const test = base.extend<{
           toPerfMeasureOptions(options),
         ),
     });
-    // Only record results for passing attempts. A failed attempt is retried
-    // in a fresh worker, so appending its partial results (measures that
-    // succeeded before the failure in a multi-measure test) would count them
-    // again when the retry passes and records the full set.
+    // Only record results for passing attempts. A failed attempt is retried in
+    // a fresh worker, so appending its partial results (measures that succeeded
+    // before the failure in a multi-measure test) would count them again when
+    // the retry passes and records the full set.
     const passed = testInfo.status === testInfo.expectedStatus;
     if (passed && results.length > 0) {
       appendResults(results, testInfo);

--- a/app/src/test-utils/preview.ts
+++ b/app/src/test-utils/preview.ts
@@ -36,9 +36,9 @@ export async function gotoAndSettle(page: Page, url: string) {
 /**
  * Waits for animation frames in the page so effects can settle.
  *
- * Use sparingly. Prefer a retrying assertion against existing observable
- * state. When no such state exists, add a comment explaining why waiting for
- * frames is necessary.
+ * Use sparingly. Prefer a retrying assertion against existing observable state.
+ * When no such state exists, add a comment explaining why waiting for frames is
+ * necessary.
  */
 export function flushFrames(page: Page, frames = 2) {
   return page.evaluate(

--- a/app/src/test-utils/visual.ts
+++ b/app/src/test-utils/visual.ts
@@ -398,9 +398,9 @@ export async function visual(
           await expect(page).toHaveScreenshot(fileSnapshotName, {
             ...screenshotOptions,
           });
-          // Touch the screenshot file so the CI stale-detection step
-          // (which deletes files older than a pre-run marker) knows
-          // this screenshot is still expected by a test.
+          // Touch the screenshot file so the CI stale-detection step (which
+          // deletes files older than a pre-run marker) knows this screenshot is
+          // still expected by a test.
           touchScreenshot(testInfo, fileSnapshotName);
         });
       }

--- a/app/src/tests/reference-hovercards-browser.ts
+++ b/app/src/tests/reference-hovercards-browser.ts
@@ -42,15 +42,15 @@ test("reference hovercard shows partial content on hover", async ({
   const anchor = q.link("DisclosureContent").first();
   // Hovercard anchors hydrate lazily (client:idle), and a pointer that is
   // already resting on the anchor when hydration completes never produces a
-  // pointerenter event. Move the pointer away and re-hover until the
-  // hovercard opens.
+  // pointerenter event. Move the pointer away and re-hover until the hovercard
+  // opens.
   await expect(async () => {
     await page.mouse.move(0, 0);
     await anchor.hover();
     await expect(q.dialog()).toBeVisible({ timeout: 2000 });
   }).toPass({ timeout: 20_000 });
-  // The hovercard fetches the DisclosureContent reference partial on demand
-  // and renders its content.
+  // The hovercard fetches the DisclosureContent reference partial on demand and
+  // renders its content.
   await expect(q.dialog()).toContainText("Optional Props", {
     timeout: 10_000,
   });

--- a/examples/menu-framer-motion/menu.tsx
+++ b/examples/menu-framer-motion/menu.tsx
@@ -76,9 +76,8 @@ export interface MenuItemProps extends React.ComponentPropsWithoutRef<
   typeof MotionMenuItem
 > {}
 
-// Instead of using the Ariakit `render` prop, we give control to Motion
-// so it can process the props before we pass the remainder to
-// `Ariakit.MenuItem`.
+// Instead of using the Ariakit `render` prop, we give control to Motion so it
+// can process the props before we pass the remainder to `Ariakit.MenuItem`.
 const MotionMenuItem = motion.create(Ariakit.MenuItem);
 
 export const MenuItem = React.forwardRef<HTMLDivElement, MenuItemProps>(

--- a/examples/menu-slide/menu.tsx
+++ b/examples/menu-slide/menu.tsx
@@ -31,16 +31,16 @@ export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
   const open = Ariakit.useStoreState(menu, "open");
   const autoFocusOnShow = Ariakit.useStoreState(menu, "autoFocusOnShow");
 
-  // By default, submenus don't automatically receive focus when they open.
-  // But here we want them to always receive focus.
+  // By default, submenus don't automatically receive focus when they open. But
+  // here we want them to always receive focus.
   React.useLayoutEffect(() => {
     if (!autoFocusOnShow) {
       menu.setAutoFocusOnShow(true);
     }
   }, [autoFocusOnShow, menu]);
 
-  // We only want to delay hiding the menu, so we immediately stop the
-  // animation when it's opening.
+  // We only want to delay hiding the menu, so we immediately stop the animation
+  // when it's opening.
   React.useLayoutEffect(() => {
     if (open) {
       menu.stopAnimation();
@@ -71,10 +71,9 @@ export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
         const scrollLeft = Math.abs(parentWrapper.scrollLeft);
         const wrapperOffset = scrollLeft + parentWrapper.clientWidth;
         if (wrapperOffset <= parent.getOffsetRight()) {
-          // Since the submenu is not visible anymore at this point, we want
-          // to hide it completely right away. That's why we syncrhonously
-          // hide it and immediately stops the animation so it's completely
-          // unmounted.
+          // Since the submenu is not visible anymore at this point, we want to
+          // hide it completely right away. That's why we syncrhonously hide it
+          // and immediately stops the animation so it's completely unmounted.
           flushSync(menu.hide);
           menu.stopAnimation();
         }

--- a/nextjs/next.config.ts
+++ b/nextjs/next.config.ts
@@ -12,8 +12,9 @@ const config: NextConfig = {
 
   // Pin the Turbopack root to the monorepo root (the parent of this workspace).
   // Otherwise Next.js walks up the tree collecting every workspace/lockfile and
-  // picks the outermost one as the root. In a git worktree nested under the main
-  // checkout, that outermost match is the main checkout, which is the wrong root.
+  // picks the outermost one as the root. In a git worktree nested under the
+  // main checkout, that outermost match is the main checkout, which is the
+  // wrong root.
   turbopack: {
     root: join(import.meta.dirname, ".."),
   },

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "oxfmt";
 
 export default defineConfig({
   printWidth: 80,
+  jsdoc: false,
   sortImports: { newlinesBetween: false },
   ignorePatterns: [
     "*.css",

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -26,10 +26,16 @@ const disabledReactRules = {
 } as const;
 
 export default defineConfig({
-  // Declaring `react` only in an override would enable just the rules that
-  // the override names, silently disabling every other React rule, including
+  // Declaring `react` only in an override would enable just the rules that the
+  // override names, silently disabling every other React rule, including
   // `react/jsx-key` and `react/no-children-prop`.
   plugins: ["typescript", "react", "import"],
+  jsPlugins: [
+    {
+      name: "comment-reflow",
+      specifier: "oxlint-plugin-comment-reflow",
+    },
+  ],
   options: {
     // Type-aware rules resolve `astro:content` through the gitignored
     // `app/.astro`, so the `lint` and `lint-fix` scripts and the pre-commit
@@ -51,6 +57,10 @@ export default defineConfig({
     pedantic: "off",
   },
   rules: {
+    "comment-reflow/reflow": [
+      "error",
+      { printWidth: 80, trailingComments: "always" },
+    ],
     // Type-only exports are incorrectly reported as missing.
     // https://github.com/oxc-project/oxc/issues/13258
     "import/namespace": "off",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "open-cli": "9.0.0",
     "oxfmt": "0.66.0",
     "oxlint": "1.81.0",
-    "oxlint-plugin-comment-reflow": "0.1.1",
+    "oxlint-plugin-comment-reflow": "0.1.2",
     "oxlint-tsgolint": "7.0.2001",
     "pkg-pr-new": "0.0.88",
     "react": "19.2.8",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "open-cli": "9.0.0",
     "oxfmt": "0.66.0",
     "oxlint": "1.81.0",
-    "oxlint-plugin-comment-reflow": "0.1.0",
+    "oxlint-plugin-comment-reflow": "0.1.1",
     "oxlint-tsgolint": "7.0.2001",
     "pkg-pr-new": "0.0.88",
     "react": "19.2.8",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "open-cli": "9.0.0",
     "oxfmt": "0.66.0",
     "oxlint": "1.81.0",
+    "oxlint-plugin-comment-reflow": "0.1.0",
     "oxlint-tsgolint": "7.0.2001",
     "pkg-pr-new": "0.0.88",
     "react": "19.2.8",

--- a/packages/ariakit-components/src/collection/collection-store.ts
+++ b/packages/ariakit-components/src/collection/collection-store.ts
@@ -216,8 +216,8 @@ export function createCollectionStore<
       // previous ones, such as the Combobox auto-selected item.
       // https://github.com/ariakit/ariakit/issues/3914
       //
-      // sortItems writes back into this store, which can re-enter this
-      // listener on the next microtask, so skip the array already published.
+      // sortItems writes back into this store, which can re-enter this listener
+      // on the next microtask, so skip the array already published.
       if (state.renderedItems !== collection.getState().renderedItems) {
         sortItems(state.renderedItems);
       }
@@ -385,8 +385,8 @@ export interface CollectionStoreState<
    */
   items: T[];
   /**
-   * Lists all items, along with their metadata, in the exact order they appear in
-   * the DOM. This state is automatically updated when an item is rendered or
+   * Lists all items, along with their metadata, in the exact order they appear
+   * in the DOM. This state is automatically updated when an item is rendered or
    * unmounted using the
    * [`renderItem`](https://ariakit.com/reference/use-collection-store#renderitem)
    * function.

--- a/packages/ariakit-components/src/combobox/combobox-store.ts
+++ b/packages/ariakit-components/src/combobox/combobox-store.ts
@@ -203,8 +203,8 @@ export function createComboboxStore({
       : null;
 
   // Use the select as the composite element until an input or explicit
-  // composite element takes ownership. The input may mount after the select,
-  // so this must stay in sync rather than being decided by the select ref alone.
+  // composite element takes ownership. The input may mount after the select, so
+  // this must stay in sync rather than being decided by the select ref alone.
   setup(combobox, () =>
     sync(combobox, ["compositeElement", "selectElement"], (state) => {
       if (!state.selectElement && !syncedSelectElement) return;
@@ -280,8 +280,8 @@ export function createComboboxStore({
   );
 
   // Prefer the select as the popover anchor, then the composite element, then
-  // the disclosure. Track only the fallback assigned here so an explicit
-  // anchor keeps ownership.
+  // the disclosure. Track only the fallback assigned here so an explicit anchor
+  // keeps ownership.
   setup(combobox, () =>
     sync(
       combobox,
@@ -389,8 +389,8 @@ export function createComboboxStore({
   );
 
   // When the activeId changes, but the moves count doesn't, we reset the
-  // activeValue state. This is useful when the activeId changes because of
-  // a mouse move interaction. Both changes also transfer active item ownership
+  // activeValue state. This is useful when the activeId changes because of a
+  // mouse move interaction. Both changes also transfer active item ownership
   // away from the selected-item resolver.
   setup(combobox, () =>
     sync(combobox, ["moves", "activeId"], (state, prevState) => {
@@ -513,8 +513,8 @@ export interface ComboboxStoreState<
   compositeElementInFocusOrder: CompositeStoreState<ComboboxStoreItem>["compositeElementInFocusOrder"];
   /**
    * @deprecated Use
-   * [`compositeElementInFocusOrder`](https://ariakit.com/reference/combobox-provider#compositeelementinfocusorder)
-   * instead.
+   *   [`compositeElementInFocusOrder`](https://ariakit.com/reference/combobox-provider#compositeelementinfocusorder)
+   *   instead.
    */
   includesBaseElement: CompositeStoreState<ComboboxStoreItem>["includesBaseElement"];
   /**
@@ -552,8 +552,8 @@ export interface ComboboxStoreState<
   /**
    * The combobox input value.
    * @deprecated Use
-   * [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue)
-   * instead.
+   *   [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue)
+   *   instead.
    */
   value: string;
   /**
@@ -629,9 +629,9 @@ export interface ComboboxStoreState<
    * [`defaultSelectedValue`](https://ariakit.com/reference/combobox-provider#defaultselectedvalue)
    * props are arrays.
    * @deprecated Use the
-   * [`resetValueOnSelect`](https://ariakit.com/reference/combobox-item#resetvalueonselect)
-   * prop on [`ComboboxItem`](https://ariakit.com/reference/combobox-item)
-   * instead.
+   *   [`resetValueOnSelect`](https://ariakit.com/reference/combobox-item#resetvalueonselect)
+   *   prop on [`ComboboxItem`](https://ariakit.com/reference/combobox-item)
+   *   instead.
    */
   resetValueOnSelect: boolean;
   /**
@@ -685,8 +685,9 @@ export interface ComboboxStoreFunctions<
    * Sets the
    * [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue)
    * state.
-   * @deprecated Use [`setInputValue`](https://ariakit.com/reference/combobox-provider#setinputvalue)
-   * instead.
+   * @deprecated Use
+   *   [`setInputValue`](https://ariakit.com/reference/combobox-provider#setinputvalue)
+   *   instead.
    */
   setValue: SetState<ComboboxStoreState<T>["value"]>;
   /**
@@ -694,8 +695,8 @@ export interface ComboboxStoreFunctions<
    * [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue)
    * state to its initial value.
    * @deprecated Use
-   * [`resetInputValue`](https://ariakit.com/reference/use-combobox-store#resetinputvalue)
-   * instead.
+   *   [`resetInputValue`](https://ariakit.com/reference/use-combobox-store#resetinputvalue)
+   *   instead.
    */
   resetValue: () => void;
   /**
@@ -752,8 +753,8 @@ export interface ComboboxStoreOptions<
   /**
    * The initial value of the combobox input.
    * @deprecated Use
-   * [`defaultInputValue`](https://ariakit.com/reference/combobox-provider#defaultinputvalue)
-   * instead.
+   *   [`defaultInputValue`](https://ariakit.com/reference/combobox-provider#defaultinputvalue)
+   *   instead.
    * @default ""
    */
   defaultValue?: ComboboxStoreState<T>["value"];

--- a/packages/ariakit-components/src/composite/composite-store.ts
+++ b/packages/ariakit-components/src/composite/composite-store.ts
@@ -251,11 +251,11 @@ function verticalizeItems(items: CompositeStoreItem[]) {
       if (item) {
         verticalized.push({
           ...item,
-          // If there's no rowId, it means that it's not a grid composite, but
-          // a single row instead. So, instead of verticalizing it, that is,
+          // If there's no rowId, it means that it's not a grid composite, but a
+          // single row instead. So, instead of verticalizing it, that is,
           // assigning a different rowId based on the column index, we keep it
-          // undefined so they will be part of the same row. This is useful
-          // when using up/down on one-dimensional composites.
+          // undefined so they will be part of the same row. This is useful when
+          // using up/down on one-dimensional composites.
           rowId: item.rowId ? `${i}` : undefined,
         });
       }
@@ -435,8 +435,8 @@ export function createCompositeStore<
               : focusLoop !== "vertical");
           if (!canLoop) return undefined;
           // Wrap around to the beginning (or end, when scanning backward) of
-          // the same row, matching the flipItems behavior in the generic
-          // logic below.
+          // the same row, matching the flipItems behavior in the generic logic
+          // below.
           return findEnabledItemId({
             items: renderedItems,
             fromIndex: step === 1 ? 0 : renderedItems.length - 1,
@@ -769,8 +769,8 @@ export interface CompositeStoreState<
    * Whether the composite element is in the arrow-key focus order.
    *
    * @deprecated Use
-   * [`compositeElementInFocusOrder`](https://ariakit.com/reference/composite-provider#compositeelementinfocusorder)
-   * instead.
+   *   [`compositeElementInFocusOrder`](https://ariakit.com/reference/composite-provider#compositeelementinfocusorder)
+   *   instead.
    */
   includesBaseElement: boolean;
   /**
@@ -804,8 +804,8 @@ export interface CompositeStoreFunctions<
    * Sets the composite element state.
    *
    * @deprecated Use
-   * [`setCompositeElement`](https://ariakit.com/reference/use-composite-store#setcompositeelement)
-   * instead.
+   *   [`setCompositeElement`](https://ariakit.com/reference/use-composite-store#setcompositeelement)
+   *   instead.
    */
   setBaseElement: SetState<CompositeStoreState<T>["baseElement"]>;
   /**

--- a/packages/ariakit-components/src/disclosure/disclosure-store.ts
+++ b/packages/ariakit-components/src/disclosure/disclosure-store.ts
@@ -213,7 +213,7 @@ export interface DisclosureStoreOptions extends StoreOptions<
 > {
   /**
    * @deprecated Manually setting the `animated` prop is no longer necessary.
-   * This will be removed in a future release.
+   *   This will be removed in a future release.
    */
   animated?: DisclosureStoreState["animated"];
   /**

--- a/packages/ariakit-components/src/form/form-store.ts
+++ b/packages/ariakit-components/src/form/form-store.ts
@@ -45,10 +45,10 @@ function isPrototypePathSegment(key: PathSegment) {
 function nextFrame() {
   return new Promise<void>((resolve) => {
     // Browsers pause `requestAnimationFrame` in hidden documents, which would
-    // stall `validate()`/`submit()` until the tab becomes visible again. Race it
-    // against a timeout so a hidden document still makes progress; in a visible
-    // document the frame wins first, preserving the "after the next render"
-    // timing.
+    // stall `validate()`/`submit()` until the tab becomes visible again. Race
+    // it against a timeout so a hidden document still makes progress; in a
+    // visible document the frame wins first, preserving the "after the next
+    // render" timing.
     const timeoutId = setTimeout(resolve, 100);
     requestAnimationFrame(() => {
       clearTimeout(timeoutId);
@@ -566,8 +566,8 @@ export interface FormStoreFunctions<
   /**
    * Removes a value from an array field.
    *
-   * The array length is preserved: the removed index is replaced with `null`
-   * so indices stay stable for field keys, touched state, errors, and
+   * The array length is preserved: the removed index is replaced with `null` so
+   * indices stay stable for field keys, touched state, errors, and
    * [`FormRemove`](https://ariakit.com/reference/form-remove) focus handling.
    * Filter out `null` values before submitting if your payload should omit
    * removed items.

--- a/packages/ariakit-components/src/menu/menu-store.test.ts
+++ b/packages/ariakit-components/src/menu/menu-store.test.ts
@@ -58,10 +58,9 @@ test("keeps an explicit placement in a vertical parent menu", () => {
 
 // A store passed with the `store` or `popover` option carries the placement it
 // already holds, which the derived default must not replace, the same way it
-// gives way to an explicit placement.
-// A popover store is merged below the menu, inside the hovercard store, so it
-// applies its placement while the menu store initializes rather than when the
-// menu store resolves its own.
+// gives way to an explicit placement. A popover store is merged below the menu,
+// inside the hovercard store, so it applies its placement while the menu store
+// initializes rather than when the menu store resolves its own.
 test("keeps the placement of a popover store passed to a submenu", () => {
   const parent = createMenuStore();
   const submenu = createMenuStore({ parent, popover: createPopoverStore() });

--- a/packages/ariakit-components/src/menu/menu-store.ts
+++ b/packages/ariakit-components/src/menu/menu-store.ts
@@ -71,9 +71,9 @@ export function createMenuStore({
   // A menu opens away from the items of the composite that owns its button, so
   // a vertical parent menu or menubar places it beside them. Any other
   // orientation, and no parent menu or menubar at all, keeps it below.
-  // https://github.com/ariakit/ariakit/issues/7410 The annotation is
-  // load-bearing: defaultValue infers through a rest parameter, which widens a
-  // bare literal union to string.
+  // https://github.com/ariakit/ariakit/issues/7410
+  // The annotation is load-bearing: defaultValue infers through a rest
+  // parameter, which widens a bare literal union to string.
   const orientedPlacement: HovercardStoreState["placement"] =
     parentOrientation === "vertical" ? "right-start" : "bottom-start";
 

--- a/packages/ariakit-components/src/menu/menu-store.ts
+++ b/packages/ariakit-components/src/menu/menu-store.ts
@@ -71,9 +71,9 @@ export function createMenuStore({
   // A menu opens away from the items of the composite that owns its button, so
   // a vertical parent menu or menubar places it beside them. Any other
   // orientation, and no parent menu or menubar at all, keeps it below.
-  // https://github.com/ariakit/ariakit/issues/7410
-  // The annotation is load-bearing: defaultValue infers through a rest
-  // parameter, which widens a bare literal union to string.
+  // https://github.com/ariakit/ariakit/issues/7410 The annotation is
+  // load-bearing: defaultValue infers through a rest parameter, which widens a
+  // bare literal union to string.
   const orientedPlacement: HovercardStoreState["placement"] =
     parentOrientation === "vertical" ? "right-start" : "bottom-start";
 

--- a/packages/ariakit-components/src/popover/popover-store.ts
+++ b/packages/ariakit-components/src/popover/popover-store.ts
@@ -154,9 +154,9 @@ export interface PopoverStoreState extends DialogStoreState {
    * asserting it again.
    *
    * Components that move focus or scroll into the popup wait for this to become
-   * `false`, otherwise they act on an element that's still at its
-   * pre-placement origin, or at a position it's about to leave, and drag the
-   * page along with it.
+   * `false`, otherwise they act on an element that's still at its pre-placement
+   * origin, or at a position it's about to leave, and drag the page along with
+   * it.
    * @deprecated
    * @private
    */

--- a/packages/ariakit-components/src/select/select-store.ts
+++ b/packages/ariakit-components/src/select/select-store.ts
@@ -155,10 +155,9 @@ export function createSelectStore({
   // Keep the selected item active while the popover is closed.
   setup(select, () =>
     sync(select, ["mounted", "items", "value"], (state) => {
-      // TODO: Revisit with the "open with keyboard, then try to open
-      // again" test when deprecating ComboboxProvider as a
-      // SelectProvider parent.
-      // A composed Combobox owns active-item synchronization.
+      // TODO: Revisit with the "open with keyboard, then try to open again"
+      // test when deprecating ComboboxProvider as a SelectProvider parent. A
+      // composed Combobox owns active-item synchronization.
       if (combobox) return;
       if (state.mounted) return;
       const values = toArray(state.value);

--- a/packages/ariakit-components/src/tab/tab-store.ts
+++ b/packages/ariakit-components/src/tab/tab-store.ts
@@ -231,12 +231,12 @@ export function createTabStore({
       selectedIdFromSelectedValue = tab.getState().selectedId;
     };
     const restoreSelectedId = () => {
-      // We suppress the activeId sync to prevent the activeId state from
-      // being set to the selectedId state since this is just a restoration of
-      // the selectedId state from a select or combobox selected value.
-      // setState early-returns on unchanged values and emits no batch event
-      // to consume the suppression, so only arm it when the restore will
-      // actually change the state.
+      // We suppress the activeId sync to prevent the activeId state from being
+      // set to the selectedId state since this is just a restoration of the
+      // selectedId state from a select or combobox selected value. setState
+      // early-returns on unchanged values and emits no batch event to consume
+      // the suppression, so only arm it when the restore will actually change
+      // the state.
       const { selectedId } = tab.getState();
       if (selectedId === selectedIdFromSelectedValue) return;
       pendingRestore = true;
@@ -326,9 +326,9 @@ export interface TabStoreState extends CompositeStoreState<TabStoreItem> {
 export interface TabStoreFunctions extends CompositeStoreFunctions<TabStoreItem> {
   /**
    * Sets the
-   * [`selectedId`](https://ariakit.com/reference/tab-provider#selectedid) state.
-   * If another tab has DOM focus and the selected tab is enabled, focus will
-   * move to the selected tab. If you want to always move focus, use the
+   * [`selectedId`](https://ariakit.com/reference/tab-provider#selectedid)
+   * state. If another tab has DOM focus and the selected tab is enabled, focus
+   * will move to the selected tab. If you want to always move focus, use the
    * [`select`](https://ariakit.com/reference/use-tab-store#select) function
    * instead.
    * @example

--- a/packages/ariakit-components/src/tag/tag-store.ts
+++ b/packages/ariakit-components/src/tag/tag-store.ts
@@ -132,7 +132,8 @@ export interface TagStoreFunctions extends CompositeStoreFunctions<TagStoreItem>
    */
   resetValue: () => void;
   /**
-   * Sets the [`values`](https://ariakit.com/reference/tag-provider#values) state.
+   * Sets the [`values`](https://ariakit.com/reference/tag-provider#values)
+   * state.
    */
   setValues: SetState<TagStoreState["values"]>;
   /**

--- a/packages/ariakit-components/src/tooltip/tooltip-store.ts
+++ b/packages/ariakit-components/src/tooltip/tooltip-store.ts
@@ -59,13 +59,13 @@ export interface TooltipStoreState extends HovercardStoreState {
    * Determines whether the tooltip is being used as a label or a description
    * for the anchor element.
    * @deprecated Render a visually hidden label or use the `aria-label` or
-   * `aria-labelledby` attributes on the anchor element instead.
+   *   `aria-labelledby` attributes on the anchor element instead.
    * @default "description"
    */
   type: "label" | "description";
   /**
-   * The amount of time after a tooltip is hidden while all tooltips on the
-   * page can be shown immediately, without waiting for the show timeout.
+   * The amount of time after a tooltip is hidden while all tooltips on the page
+   * can be shown immediately, without waiting for the show timeout.
    * @default 300
    */
   skipTimeout: number;

--- a/packages/ariakit-react-components/src/checkbox/checkbox-check.tsx
+++ b/packages/ariakit-react-components/src/checkbox/checkbox-check.tsx
@@ -91,9 +91,9 @@ export interface CheckboxCheckOptions<
   /**
    * Object returned by the
    * [`useCheckboxStore`](https://ariakit.com/reference/use-checkbox-store)
-   * hook. This prop doesn't affect the checkmark. It's accepted for
-   * consistency with other Ariakit components and is not passed to the
-   * underlying element. The checked state is derived solely from the
+   * hook. This prop doesn't affect the checkmark. It's accepted for consistency
+   * with other Ariakit components and is not passed to the underlying element.
+   * The checked state is derived solely from the
    * [`checked`](https://ariakit.com/reference/checkbox-check#checked) prop or,
    * when it's not provided, from the closest
    * [`Checkbox`](https://ariakit.com/reference/checkbox) component.

--- a/packages/ariakit-react-components/src/checkbox/checkbox-store.ts
+++ b/packages/ariakit-react-components/src/checkbox/checkbox-store.ts
@@ -15,8 +15,8 @@ export function useCheckboxStoreProps<T extends Core.CheckboxStore>(
 }
 
 /**
- * Creates a checkbox store to conveniently manage a checkbox value,
- * whether it's a string, number, boolean, or an array of strings or numbers.
+ * Creates a checkbox store to conveniently manage a checkbox value, whether
+ * it's a string, number, boolean, or an array of strings or numbers.
  * @see https://ariakit.com/components/checkbox
  * @example
  * ```jsx

--- a/packages/ariakit-react-components/src/collection/collection-renderer.tsx
+++ b/packages/ariakit-react-components/src/collection/collection-renderer.tsx
@@ -218,7 +218,8 @@ function getItemSize(
   // When the nested items run along the axis being measured, the item's size is
   // the sum of its children's sizes. When they run along the cross axis (e.g. a
   // horizontal group inside a vertical list), summing would measure the wrong
-  // axis, so we fall through to the element/max-child measurement below instead.
+  // axis, so we fall through to the element/max-child measurement below
+  // instead.
   if (items?.length && hasSameOrientation) {
     const paddingStart = itemObject.paddingStart ?? itemObject.padding ?? 0;
     const paddingEnd = itemObject.paddingEnd ?? itemObject.padding ?? 0;
@@ -723,8 +724,8 @@ export function useCollectionRenderer<T extends Item = any>({
   const processVisibleIndices = useCallback(() => {
     const offsets = offsetsRef.current;
 
-    // Ref and resolver targets can change during commit. Skip passive work
-    // from the previous scroller until the resolved value reaches context.
+    // Ref and resolver targets can change during commit. Skip passive work from
+    // the previous scroller until the resolved value reaches context.
     scrollerController?.revalidate();
     if (scrollerRef.current !== scroller) return;
     if (!scroller) return;
@@ -913,9 +914,9 @@ export function useCollectionRenderer<T extends Item = any>({
 
   // Disconnect the observer when the renderer unmounts so it doesn't retain the
   // measured item nodes or keep firing resize callbacks. Re-observe the tracked
-  // elements on setup so observation survives a simulated unmount/remount (e.g.,
-  // React StrictMode), which runs this cleanup but doesn't necessarily re-run
-  // the item ref callbacks.
+  // elements on setup so observation survives a simulated unmount/remount
+  // (e.g., React StrictMode), which runs this cleanup but doesn't necessarily
+  // re-run the item ref callbacks.
   useEffect(() => {
     for (const element of elements.values()) {
       elementObserver?.observe(element);
@@ -993,7 +994,8 @@ export function useCollectionRenderer<T extends Item = any>({
     // When `itemSize` is set the renderer doesn't measure items, so nothing
     // should stay observed; otherwise keep the items that are still rendered.
     // The empty set also cleans up if `itemSize` switches from unset to a fixed
-    // size at runtime, which would otherwise leave already-measured nodes behind.
+    // size at runtime, which would otherwise leave already-measured nodes
+    // behind.
     const renderedIds = itemSize
       ? new Set<string>()
       : new Set(itemsProps.map((itemProps) => itemProps.id));
@@ -1094,8 +1096,8 @@ export interface CollectionRendererOptions<
    * Object returned by the
    * [`useCollectionStore`](https://ariakit.com/reference/use-collection-store)
    * hook. If not provided, the closest
-   * [Collection](https://ariakit.com/components/collection) component's
-   * context will be used.
+   * [Collection](https://ariakit.com/components/collection) component's context
+   * will be used.
    *
    * The store
    * [`items`](https://ariakit.com/reference/use-collection-store#items) state
@@ -1137,8 +1139,8 @@ export interface CollectionRendererOptions<
    */
   items?: Items<T>;
   /**
-   * The element whose viewport determines which items are rendered. By
-   * default, the closest scrolling ancestor is used.
+   * The element whose viewport determines which items are rendered. By default,
+   * the closest scrolling ancestor is used.
    *
    * The element must be a scrolling ancestor in the same document. If a
    * function is provided, it will be called with the renderer element as an

--- a/packages/ariakit-react-components/src/combobox/__utils.ts
+++ b/packages/ariakit-react-components/src/combobox/__utils.ts
@@ -69,8 +69,8 @@ function centerItemInScrollport(element: HTMLElement, scrollport: HTMLElement) {
     (elementRightOutside &&
       !elementLeftOutside &&
       elementRect.width < scrollportWidth);
-  // Preserve native inline-nearest behavior without scrolling ancestors
-  // outside the popup.
+  // Preserve native inline-nearest behavior without scrolling ancestors outside
+  // the popup.
   let left = 0;
   if (alignLeft) {
     left = (elementRect.left - scrollportLeft) / scaleX;

--- a/packages/ariakit-react-components/src/combobox/combobox-dismiss.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-dismiss.tsx
@@ -25,8 +25,8 @@ export const useComboboxDismiss = createHook<TagName, ComboboxDismissOptions>(
 
 /**
  * Renders a button that hides a
- * [`ComboboxPopover`](https://ariakit.com/reference/combobox-popover)
- * component when clicked.
+ * [`ComboboxPopover`](https://ariakit.com/reference/combobox-popover) component
+ * when clicked.
  * @example
  * ```jsx {4}
  * <ComboboxProvider>

--- a/packages/ariakit-react-components/src/combobox/combobox-heading.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-heading.tsx
@@ -53,8 +53,8 @@ export interface ComboboxHeadingOptions<
    * hook.
    *
    * **Note**: This prop has no effect on this component. The heading is linked
-   * to the closest [`ComboboxList`](https://ariakit.com/reference/combobox-list)
-   * or
+   * to the closest
+   * [`ComboboxList`](https://ariakit.com/reference/combobox-list) or
    * [`ComboboxPopover`](https://ariakit.com/reference/combobox-popover)
    * component through React context.
    */

--- a/packages/ariakit-react-components/src/combobox/combobox-input.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-input.tsx
@@ -19,7 +19,8 @@ export const useComboboxInput = useCombobox;
  * When rendered inside a
  * [`ComboboxPopover`](https://ariakit.com/reference/combobox-popover) with
  * [`ComboboxSelect`](https://ariakit.com/reference/combobox-select), it turns
- * the select into a filterable select and receives focus when the popover opens.
+ * the select into a filterable select and receives focus when the popover
+ * opens.
  * @see https://ariakit.com/components/combobox
  * @example
  * ```jsx {4}

--- a/packages/ariakit-react-components/src/combobox/combobox-item-check.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item-check.tsx
@@ -72,11 +72,11 @@ export interface ComboboxItemCheckOptions<
   /**
    * Object returned by the
    * [`useComboboxStore`](https://ariakit.com/reference/use-combobox-store)
-   * hook. This prop doesn't affect the checkmark. It's accepted for
-   * consistency with other Ariakit components and is not passed to the
-   * underlying element. The checked state is derived solely from the
-   * [`checked`](https://ariakit.com/reference/combobox-item-check#checked)
-   * prop or, when it's not provided, from the closest
+   * hook. This prop doesn't affect the checkmark. It's accepted for consistency
+   * with other Ariakit components and is not passed to the underlying element.
+   * The checked state is derived solely from the
+   * [`checked`](https://ariakit.com/reference/combobox-item-check#checked) prop
+   * or, when it's not provided, from the closest
    * [`ComboboxItem`](https://ariakit.com/reference/combobox-item) component.
    */
   store?: ComboboxStore;

--- a/packages/ariakit-react-components/src/combobox/combobox-item-value.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item-value.tsx
@@ -126,8 +126,8 @@ function splitValue(itemValue?: string | null, userValue?: string | string[]) {
   // Offsets are computed in normalized space so matching stays
   // diacritic-insensitive, but the parts are sliced from the original string.
   // Translate the offsets to original character boundaries before slicing, as
-  // normalization may change the string length for values such as Hangul,
-  // kana, and decomposed (NFD) strings.
+  // normalization may change the string length for values such as Hangul, kana,
+  // and decomposed (NFD) strings.
   const offsets = toOriginalOffsets(
     itemValue,
     mergeOverlappingOffsets(

--- a/packages/ariakit-react-components/src/combobox/combobox-item.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-item.tsx
@@ -198,9 +198,9 @@ export const useComboboxItem = createHook<TagName, ComboboxItemOptions>(
       if (!compositeElement) return;
       if (hasFocus(compositeElement)) return;
       // When the combobox is not working with virtual focus, the items will
-      // receive DOM focus. Therefore, pressing printable keys will not fill
-      // the text field. So we need to programmatically focus on the text
-      // field when the user presses printable keys.
+      // receive DOM focus. Therefore, pressing printable keys will not fill the
+      // text field. So we need to programmatically focus on the text field when
+      // the user presses printable keys.
       const printable =
         event.key.length === 1 && !event.ctrlKey && !event.metaKey;
       const pc = !isApple();
@@ -298,10 +298,10 @@ export const useComboboxItem = createHook<TagName, ComboboxItemOptions>(
       store,
       ...props,
       // Disable focusOnHover when the popup is closed, even for authored
-      // values, so pointer hover can't activate an item or move focus while
-      // the combobox is collapsed. The open check comes first so authored
-      // callbacks with side effects don't run at all while closed, and it's
-      // re-read afterwards because the callback itself may close the list.
+      // values, so pointer hover can't activate an item or move focus while the
+      // combobox is collapsed. The open check comes first so authored callbacks
+      // with side effects don't run at all while closed, and it's re-read
+      // afterwards because the callback itself may close the list.
       // https://github.com/ariakit/ariakit/issues/7118
       focusOnHover(event) {
         if (!store.getState().open) return false;
@@ -445,10 +445,10 @@ export interface ComboboxItemOptions<T extends ElementType = TagName>
    * Defaults to `false`, or `true` when the item is used with a
    * [`ComboboxSelect`](https://ariakit.com/reference/combobox-select).
    *
-   * Regardless of the value, hover has no effect while the combobox is
-   * closed: hovering an item never activates it or moves focus, and moving
-   * the pointer off an item never clears the active item or moves focus back
-   * to the combobox.
+   * Regardless of the value, hover has no effect while the combobox is closed:
+   * hovering an item never activates it or moves focus, and moving the pointer
+   * off an item never clears the active item or moves focus back to the
+   * combobox.
    */
   focusOnHover?: CompositeHoverOptions["focusOnHover"];
 }

--- a/packages/ariakit-react-components/src/combobox/combobox-list.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-list.tsx
@@ -139,7 +139,8 @@ export const useComboboxList = createHook<TagName, ComboboxListOptions>(
     // Heading hooks publish their id through DialogHeadingContext. Redirecting
     // that setter here makes the heading label this list, whose props take
     // precedence when it shares an element with ComboboxPopover.
-    // ComboboxHeadingContext also exposes the id so nested lists can inherit it.
+    // ComboboxHeadingContext also exposes the id so nested lists can inherit
+    // it.
     props = useWrapElement(
       props,
       (element) => (

--- a/packages/ariakit-react-components/src/combobox/combobox-popover.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-popover.tsx
@@ -225,9 +225,9 @@ export const useComboboxPopover = createHook<TagName, ComboboxPopoverOptions>(
       // A select-shaped popup takes focus on every open, including a default or
       // programmatic one: showing it is a request to interact with it, and
       // leaving focus behind would strand the user outside an open listbox.
-      // https://github.com/ariakit/ariakit/issues/7068
-      // Keep this a boolean, since a callback would always be truthy and defeat
-      // the dialog's early-out for popups that take no focus at all.
+      // https://github.com/ariakit/ariakit/issues/7068 Keep this a boolean,
+      // since a callback would always be truthy and defeat the dialog's
+      // early-out for popups that take no focus at all.
       autoFocusOnShow: hasSelect,
       initialFocus: hasSelect ? inputElement : undefined,
       finalFocus: selectElement || compositeElement,
@@ -344,8 +344,8 @@ export interface ComboboxPopoverOptions<T extends ElementType = TagName>
    * combobox item that starts with the entered characters.
    *
    * Defaults to `false` when a
-   * [`ComboboxInput`](https://ariakit.com/reference/combobox-input) is rendered,
-   * and `true` otherwise.
+   * [`ComboboxInput`](https://ariakit.com/reference/combobox-input) is
+   * rendered, and `true` otherwise.
    */
   typeahead?: CompositeTypeaheadOptions<T>["typeahead"];
   /**
@@ -366,8 +366,8 @@ export interface ComboboxPopoverOptions<T extends ElementType = TagName>
   /**
    * Whether the combobox's
    * [`selectedValue`](https://ariakit.com/reference/combobox-provider#selectedvalue)
-   * should be restored to what it was before the first item movement when
-   * the popover accepts Escape and the cancelable close event isn't prevented.
+   * should be restored to what it was before the first item movement when the
+   * popover accepts Escape and the cancelable close event isn't prevented.
    * Selection changes made before any item movement become part of the selected
    * value Escape restores.
    *

--- a/packages/ariakit-react-components/src/combobox/combobox-popover.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-popover.tsx
@@ -225,9 +225,9 @@ export const useComboboxPopover = createHook<TagName, ComboboxPopoverOptions>(
       // A select-shaped popup takes focus on every open, including a default or
       // programmatic one: showing it is a request to interact with it, and
       // leaving focus behind would strand the user outside an open listbox.
-      // https://github.com/ariakit/ariakit/issues/7068 Keep this a boolean,
-      // since a callback would always be truthy and defeat the dialog's
-      // early-out for popups that take no focus at all.
+      // https://github.com/ariakit/ariakit/issues/7068
+      // Keep this a boolean, since a callback would always be truthy and defeat
+      // the dialog's early-out for popups that take no focus at all.
       autoFocusOnShow: hasSelect,
       initialFocus: hasSelect ? inputElement : undefined,
       finalFocus: selectElement || compositeElement,

--- a/packages/ariakit-react-components/src/combobox/combobox-renderer.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-renderer.tsx
@@ -160,8 +160,8 @@ export interface ComboboxRendererOptions<T extends Item = any> extends Omit<
   /**
    * The current selected value of the combobox. This will ensure the item with
    * the given value is rendered even if it's not in the viewport, so it can be
-   * automatically focused when the combobox popover is opened. If not
-   * provided, the selected value will be read from the store.
+   * automatically focused when the combobox popover is opened. If not provided,
+   * the selected value will be read from the store.
    */
   selectedValue?: ComboboxStoreSelectedValue;
 }

--- a/packages/ariakit-react-components/src/combobox/combobox-select-label.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-select-label.tsx
@@ -61,8 +61,8 @@ export const useComboboxSelectLabel = createHook<
 
 /**
  * Renders a label for the
- * [`ComboboxSelect`](https://ariakit.com/reference/combobox-select)
- * component. Clicking the label moves focus to the select element.
+ * [`ComboboxSelect`](https://ariakit.com/reference/combobox-select) component.
+ * Clicking the label moves focus to the select element.
  * @example
  * ```jsx {2}
  * <ComboboxProvider>

--- a/packages/ariakit-react-components/src/combobox/combobox-select.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-select.tsx
@@ -66,11 +66,11 @@ function nextWithValue(store: ComboboxStore, next: ComboboxStore["next"]) {
       if (nextItem.value != null) {
         return nextItem.id;
       }
-      // Walking from the last returned id, as if the key was pressed again
-      // from there, skips items without value even across focusLoop
-      // boundaries. A repeated id means the walk cycled through every
-      // reachable item without finding one with value, so we return undefined
-      // to keep move() from changing the active item.
+      // Walking from the last returned id, as if the key was pressed again from
+      // there, skips items without value even across focusLoop boundaries. A
+      // repeated id means the walk cycled through every reachable item without
+      // finding one with value, so we return undefined to keep move() from
+      // changing the active item.
       if (visitedIds.has(nextId)) return;
       visitedIds.add(nextId);
       nextId = next({ activeId: nextId });
@@ -328,8 +328,8 @@ export const useComboboxSelect = createHook<TagName, ComboboxSelectOptions>(
     props = {
       ...props,
       // The store points the active item at the current selection while the
-      // popup is closed, but a collapsed select must not reference an item
-      // that may not even be rendered.
+      // popup is closed, but a collapsed select must not reference an item that
+      // may not even be rendered.
       "aria-activedescendant": mounted
         ? props["aria-activedescendant"]
         : undefined,

--- a/packages/ariakit-react-components/src/combobox/combobox-separator.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-separator.tsx
@@ -47,8 +47,8 @@ export const useComboboxSeparator = createHook<
  * Renders a divider between
  * [`ComboboxItem`](https://ariakit.com/reference/combobox-item) elements.
  * @deprecated Use
- * [`ComboboxGroup`](https://ariakit.com/reference/combobox-group) with CSS
- * borders instead.
+ *   [`ComboboxGroup`](https://ariakit.com/reference/combobox-group) with CSS
+ *   borders instead.
  * @see https://ariakit.com/components/combobox
  * @example
  * ```jsx {5}

--- a/packages/ariakit-react-components/src/combobox/combobox-store.ts
+++ b/packages/ariakit-react-components/src/combobox/combobox-store.ts
@@ -145,8 +145,8 @@ export interface ComboboxStoreOptions<
    * [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue)
    * state changes.
    * @deprecated Use
-   * [`setInputValue`](https://ariakit.com/reference/combobox-provider#setinputvalue)
-   * instead.
+   *   [`setInputValue`](https://ariakit.com/reference/combobox-provider#setinputvalue)
+   *   instead.
    */
   setValue?: (value: ComboboxStoreState<T>["value"]) => void;
   /**

--- a/packages/ariakit-react-components/src/combobox/combobox-value.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox-value.tsx
@@ -14,8 +14,8 @@ import { ComboboxInputValue } from "./combobox-input-value.tsx";
  * that gets called with the current value as an argument. This can be used as
  * an uncontrolled API to render the combobox value in a custom way.
  * @deprecated Use
- * [`ComboboxInputValue`](https://ariakit.com/reference/combobox-input-value)
- * instead.
+ *   [`ComboboxInputValue`](https://ariakit.com/reference/combobox-input-value)
+ *   instead.
  * @see https://ariakit.com/components/combobox
  * @example
  * ```jsx {3-5}
@@ -33,7 +33,7 @@ export function ComboboxValue(props: ComboboxValueProps = {}) {
 
 /**
  * @deprecated Use
- * [`ComboboxInputValueProps`](https://ariakit.com/reference/combobox-input-value)
- * instead.
+ *   [`ComboboxInputValueProps`](https://ariakit.com/reference/combobox-input-value)
+ *   instead.
  */
 export interface ComboboxValueProps extends ComboboxInputValueProps {}

--- a/packages/ariakit-react-components/src/combobox/combobox.tsx
+++ b/packages/ariakit-react-components/src/combobox/combobox.tsx
@@ -233,10 +233,10 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
     );
 
     // The current input value may differ from state.inputValue when
-    // autoComplete is either "both" or "inline", in which case it will be
-    // the active item value or a combination of the input value and the active
-    // item value if it's the first item and it's been auto selected. This will
-    // only affect the element's value, not the combobox state.
+    // autoComplete is either "both" or "inline", in which case it will be the
+    // active item value or a combination of the input value and the active item
+    // value if it's the first item and it's been auto selected. This will only
+    // affect the element's value, not the combobox state.
     const inputValue = useMemo(() => {
       if (!inline) return storeInputValue;
       if (!canInline) return storeInputValue;
@@ -316,10 +316,11 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
     const autoSelectIdRef = useRef<string | null | undefined>(null);
     // Tracks the item (id and value) the autoSelect behavior last moved focus
     // to, so we can tell an already-focused item apart from one that only looks
-    // the same, such as a different value under the same id (e.g. an index-keyed
-    // list after filtering) or an item that became active without focus. This is
-    // distinct from autoSelectIdRef above, which tracks the current target for
-    // the scroll guard. Reset when the popover closes so reopening re-focuses.
+    // the same, such as a different value under the same id (e.g. an
+    // index-keyed list after filtering) or an item that became active without
+    // focus. This is distinct from autoSelectIdRef above, which tracks the
+    // current target for the scroll guard. Reset when the popover closes so
+    // reopening re-focuses.
     const autoSelectMovedRef = useRef<{
       id: string | null;
       value?: string;
@@ -342,10 +343,10 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
         userScrolledRef.current = true;
       };
       const onScroll = () => {
-        // Mark any non-programmatic scroll as user-initiated so we don't
-        // reset the scroll position when new items load (e.g., infinite
-        // scroll, scrollbar drag). Programmatic scrolls from scrollIntoView
-        // set isAutoScrollingRef to avoid false positives.
+        // Mark any non-programmatic scroll as user-initiated so we don't reset
+        // the scroll position when new items load (e.g., infinite scroll,
+        // scrollbar drag). Programmatic scrolls from scrollIntoView set
+        // isAutoScrollingRef to avoid false positives.
         if (!isAutoScrollingRef.current) {
           userScrolledRef.current = true;
         }
@@ -466,9 +467,9 @@ export const useCombobox = createHook<TagName, ComboboxOptions>(
         if (element && "scrollIntoView" in element) {
           isAutoScrollingRef.current = true;
           element.scrollIntoView({ block: "nearest", inline: "nearest" });
-          // Clear after the browser dispatches the scroll event. Scroll
-          // events fire during the "scroll steps" of the rendering update,
-          // which run before requestAnimationFrame callbacks.
+          // Clear after the browser dispatches the scroll event. Scroll events
+          // fire during the "scroll steps" of the rendering update, which run
+          // before requestAnimationFrame callbacks.
           requestAnimationFrame(() => {
             isAutoScrollingRef.current = false;
           });
@@ -872,8 +873,8 @@ export interface ComboboxOptions<
   /**
    * Whether the items will be filtered based on
    * [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue)
-   * and
-   * whether the input value will temporarily change based on the active item.
+   * and whether the input value will temporarily change based on the active
+   * item.
    *
    * This prop is based on the standard
    * [`aria-autocomplete`](https://w3c.github.io/aria/#aria-autocomplete)
@@ -889,8 +890,7 @@ export interface ComboboxOptions<
    *   behavior.
    * - `both`: indicates that the items will be dynamically rendered based on
    *   [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue)
-   *   and the
-   *   input value will temporarily change based on the active item. The
+   *   and the input value will temporarily change based on the active item. The
    *   filtering logic must be implemented by the consumer of this component,
    *   whereas Ariakit will automatically provide the inline autocompletion
    *   behavior.
@@ -950,8 +950,8 @@ export interface ComboboxOptions<
    * or [`ComboboxPopover`](https://ariakit.com/reference/combobox-popover)
    * components should be shown when the input is clicked.
    * @deprecated Use
-   * [`showOnClick`](https://ariakit.com/reference/combobox#showonclick)
-   * instead.
+   *   [`showOnClick`](https://ariakit.com/reference/combobox#showonclick)
+   *   instead.
    * @default true
    */
   showOnMouseDown?: BooleanOrCallback<MouseEvent<HTMLElement>>;
@@ -976,8 +976,8 @@ export interface ComboboxOptions<
    * components should be shown when the user presses the arrow up or down keys
    * while focusing on the combobox input element.
    * @deprecated Use
-   * [`showOnKeyPress`](https://ariakit.com/reference/combobox#showonkeypress)
-   * instead.
+   *   [`showOnKeyPress`](https://ariakit.com/reference/combobox#showonkeypress)
+   *   instead.
    * @default true
    */
   showOnKeyDown?: BooleanOrCallback<ReactKeyboardEvent<HTMLElement>>;
@@ -1000,12 +1000,10 @@ export interface ComboboxOptions<
   /**
    * Whether the combobox
    * [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue)
-   * state
-   * should be updated when the input value changes. This is useful if you want
-   * to customize how the store
+   * state should be updated when the input value changes. This is useful if you
+   * want to customize how the store
    * [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue)
-   * is updated
-   * based on the input element's value.
+   * is updated based on the input element's value.
    *
    * Live examples:
    * - [Textarea with inline
@@ -1016,8 +1014,7 @@ export interface ComboboxOptions<
   /**
    * Whether the combobox
    * [`inputValue`](https://ariakit.com/reference/combobox-provider#inputvalue)
-   * state
-   * should be updated when the combobox input element gets clicked. This
+   * state should be updated when the combobox input element gets clicked. This
    * usually only applies when
    * [`autoComplete`](https://ariakit.com/reference/combobox#autocomplete) is
    * `both` or `inline`, because the input value will temporarily change based

--- a/packages/ariakit-react-components/src/command/command.tsx
+++ b/packages/ariakit-react-components/src/command/command.tsx
@@ -218,8 +218,8 @@ export const useCommand = createHook<TagName, CommandOptions>(
  * extra attributes and event handlers to ensure accessibility. It can be
  * activated with the keyboard using the
  * [`clickOnEnter`](https://ariakit.com/reference/command#clickonenter) and
- * [`clickOnSpace`](https://ariakit.com/reference/command#clickonspace)
- * props. Both are set to `true` by default.
+ * [`clickOnSpace`](https://ariakit.com/reference/command#clickonspace) props.
+ * Both are set to `true` by default.
  * @see https://ariakit.com/components/command
  * @example
  * ```jsx

--- a/packages/ariakit-react-components/src/composite/__move-request.ts
+++ b/packages/ariakit-react-components/src/composite/__move-request.ts
@@ -13,9 +13,9 @@ interface MoveRequest {
 }
 
 /**
- * Tracks the current move per store. This has to outlive the component:
- * `moves` only counts requests, so a fresh instance can't tell whether a move
- * was consumed or what target a pending move asked for.
+ * Tracks the current move per store. This has to outlive the component: `moves`
+ * only counts requests, so a fresh instance can't tell whether a move was
+ * consumed or what target a pending move asked for.
  */
 const moveRequests = new WeakMap<Core.CompositeStore["item"], MoveRequest>();
 

--- a/packages/ariakit-react-components/src/composite/composite-container.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-container.tsx
@@ -114,9 +114,9 @@ export const useCompositeContainer = createHook<
     const isOpen = isOpenRef.current;
     if (isSelfTarget(event)) {
       // The container element itself has received focus. Here we make an
-      // additional step in case tabbable elements have been added lazily to
-      // the DOM. We get all containers in the current composite element and
-      // disable all tabbable elements inside them.
+      // additional step in case tabbable elements have been added lazily to the
+      // DOM. We get all containers in the current composite element and disable
+      // all tabbable elements inside them.
       isOpenRef.current = false;
       const { compositeElement } = store.getState();
       const selector = "[data-composite-container]";
@@ -128,14 +128,13 @@ export const useCompositeContainer = createHook<
         }
       }
     } else if (!isOpen) {
-      // Otherwise, if any element inside the container has received focus,
-      // for example, by a direct user click, we should act as the container
-      // has been opened.
+      // Otherwise, if any element inside the container has received focus, for
+      // example, by a direct user click, we should act as the container has
+      // been opened.
       isOpenRef.current = true;
       restoreFocusIn(event.currentTarget);
-      // Resets the moves in the store so the composite item will not be
-      // focused right after the focusable element inside the container gets
-      // focus.
+      // Resets the moves in the store so the composite item will not be focused
+      // right after the focusable element inside the container gets focus.
       store?.setState("moves", 0);
     }
   });

--- a/packages/ariakit-react-components/src/composite/composite-item.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-item.tsx
@@ -262,7 +262,8 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
           // If activeId refers to an item that's disabled or not connected to
           // the DOM, we make all items tabbable so users can tab into the
           // composite widget. Once the activeId is valid, we restore the roving
-          // tabindex. See https://github.com/ariakit/ariakit/issues/3232
+          // tabindex. See
+          // https://github.com/ariakit/ariakit/issues/3232
           // https://github.com/ariakit/ariakit/issues/4129
           const item = store?.item(state.activeId);
           if (item?.disabled) return true;

--- a/packages/ariakit-react-components/src/composite/composite-item.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-item.tsx
@@ -259,10 +259,10 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
           if (!state.renderedItems.length) return true;
           if (tabbable) return true;
           if (state.activeId === null) return false;
-          // If activeId refers to an item that's disabled or not connected to the
-          // DOM, we make all items tabbable so users can tab into the composite
-          // widget. Once the activeId is valid, we restore the roving tabindex. See
-          // https://github.com/ariakit/ariakit/issues/3232
+          // If activeId refers to an item that's disabled or not connected to
+          // the DOM, we make all items tabbable so users can tab into the
+          // composite widget. Once the activeId is valid, we restore the roving
+          // tabindex. See https://github.com/ariakit/ariakit/issues/3232
           // https://github.com/ariakit/ariakit/issues/4129
           const item = store?.item(state.activeId);
           if (item?.disabled) return true;
@@ -375,9 +375,9 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
         hasFocusedComposite.current = true;
         // If the previously focused element is a composite or composite item
         // component, we'll transfer focus silently to the composite element.
-        // That's because this is just a transition event, the composite
-        // element was likely already focused, so we're just immediately
-        // returning focus to it when navigating through the items.
+        // That's because this is just a transition event, the composite element
+        // was likely already focused, so we're just immediately returning focus
+        // to it when navigating through the items.
         if (fromComposite) {
           focusSilently(compositeElement);
         }
@@ -401,10 +401,10 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
       // disconnected. Wait for a connected element before redirecting focus.
       // https://github.com/ariakit/ariakit/issues/6623
 
-      // Items that opt out of registering themselves in the store never
-      // produce the unregister store update that the scheduled redirect below
-      // relies on to self-clean, so they keep the previous behavior of
-      // dropping the redirect.
+      // Items that opt out of registering themselves in the store never produce
+      // the unregister store update that the scheduled redirect below relies on
+      // to self-clean, so they keep the previous behavior of dropping the
+      // redirect.
       if (shouldRegisterItem === false) return;
       const { currentTarget, relatedTarget } = event;
       const cancelScheduledFocusRedirect = () => {
@@ -413,11 +413,11 @@ export const useCompositeItem = createHook<TagName, CompositeItemOptions>(
       };
       cancelScheduledFocusRedirect();
       // Subscribe to every store update, not just compositeElement changes, so
-      // the pending redirect is also discarded when the item unmounts without
-      // a composite element ever arriving.
+      // the pending redirect is also discarded when the item unmounts without a
+      // composite element ever arriving.
       cancelScheduledFocusRedirectRef.current = subscribe(store, null, () => {
-        // The redirect is no longer relevant if the item lost DOM focus in
-        // the meantime, including when it was unmounted.
+        // The redirect is no longer relevant if the item lost DOM focus in the
+        // meantime, including when it was unmounted.
         if (getActiveElement(currentTarget) !== currentTarget) {
           cancelScheduledFocusRedirect();
           return;
@@ -635,8 +635,8 @@ export interface CompositeItemOptions<T extends ElementType = TagName>
    * Whether the scroll behavior should be prevented when pressing arrow keys on
    * the first or the last items.
    * @deprecated Use CSS
-   * [`scroll-margin`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin)
-   * instead.
+   *   [`scroll-margin`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin)
+   *   instead.
    * @default false
    */
   preventScrollOnKeyDown?: BooleanOrCallback<KeyboardEvent<HTMLElement>>;

--- a/packages/ariakit-react-components/src/composite/composite-typeahead.tsx
+++ b/packages/ariakit-react-components/src/composite/composite-typeahead.tsx
@@ -106,9 +106,8 @@ function getSameInitialItems({
   if (!activeItem) return items;
   if (!itemTextStartsWith(activeItem, char)) return items;
   const { chars } = typeaheadState;
-  // Keep a matching multi-character query; otherwise repeated initials cycle
-  // by collapsing "oo" to "o" and rotating earlier matches after the active
-  // item.
+  // Keep a matching multi-character query; otherwise repeated initials cycle by
+  // collapsing "oo" to "o" and rotating earlier matches after the active item.
   if (chars !== char && itemTextStartsWith(activeItem, chars)) return items;
   typeaheadState.chars = char;
   return flipItems(
@@ -145,10 +144,10 @@ export const useCompositeTypeahead = createHook<
 
   const onKeyDownCaptureProp = props.onKeyDownCapture;
 
-  // We have to listen to the event in the capture phase because the event
-  // might be handled by a child component. For example, the space key may
-  // trigger a click event on a child component. We need to prevent this
-  // behavior if the character is a valid typeahead key.
+  // We have to listen to the event in the capture phase because the event might
+  // be handled by a child component. For example, the space key may trigger a
+  // click event on a child component. We need to prevent this behavior if the
+  // character is a valid typeahead key.
   const onKeyDownCapture = useEvent((event: KeyboardEvent<HTMLType>) => {
     onKeyDownCaptureProp?.(event);
     if (event.defaultPrevented) return;

--- a/packages/ariakit-react-components/src/composite/composite.tsx
+++ b/packages/ariakit-react-components/src/composite/composite.tsx
@@ -153,8 +153,8 @@ interface CompositeFocusOnMoveProps {
  * item. This lives in a separate memoized component so moving through items
  * doesn't re-render the whole composite component, and composite re-renders
  * don't re-render this component. It's only rendered when the `composite` prop
- * is enabled, so this render-driving subscription doesn't run for
- * non-composite widgets. The store hook tracks move requests separately.
+ * is enabled, so this render-driving subscription doesn't run for non-composite
+ * widgets. The store hook tracks move requests separately.
  */
 const CompositeFocusOnMove = memo(function CompositeFocusOnMove({
   store,
@@ -164,14 +164,14 @@ const CompositeFocusOnMove = memo(function CompositeFocusOnMove({
   scrollIntoView,
 }: CompositeFocusOnMoveProps) {
   const moves = useStoreState(store, "moves");
-  // The composite element is also tracked so the move-to-container effect
-  // below can run once it becomes available. It's published to the store
-  // through a ref callback and a transaction effect on the parent composite
-  // component, which run after this child component's effects. Without this
-  // dependency, the effect could read a not-yet-published composite element
-  // and never retry, for example when the `composite` prop switches from
-  // `false` to `true` after a `move(null)` call. The composite element rarely
-  // changes, so this doesn't add renders while navigating.
+  // The composite element is also tracked so the move-to-container effect below
+  // can run once it becomes available. It's published to the store through a
+  // ref callback and a transaction effect on the parent composite component,
+  // which run after this child component's effects. Without this dependency,
+  // the effect could read a not-yet-published composite element and never
+  // retry, for example when the `composite` prop switches from `false` to
+  // `true` after a `move(null)` call. The composite element rarely changes, so
+  // this doesn't add renders while navigating.
   const compositeElement = useStoreState(store, "compositeElement");
   // Identifies this instance to the store's move request. A ref survives the
   // effect re-runs of the same instance, including StrictMode's double
@@ -214,26 +214,26 @@ const CompositeFocusOnMove = memo(function CompositeFocusOnMove({
     const isSelfActive = activeId === null;
     if (!isSelfActive) return;
     if (activeId !== moveRequest.targetId) return;
-    // This branch has nothing left to wait for, so it consumes the request
-    // here rather than reporting back the way a presentation does.
+    // This branch has nothing left to wait for, so it consumes the request here
+    // rather than reporting back the way a presentation does.
     consumeMove(store, instance, moves);
     const previousElement = previousElementRef.current;
-    // We have to clean up the previous element ref so an additional blur
-    // event is not fired on it, for example, when looping through items while
+    // We have to clean up the previous element ref so an additional blur event
+    // is not fired on it, for example, when looping through items while
     // compositeElementInFocusOrder is true.
     previousElementRef.current = null;
     if (previousElement) {
-      // We fire a blur event on the previous active item before moving focus
-      // to the composite element so the events are dispatched in the right
-      // order (blur, then focus).
+      // We fire a blur event on the previous active item before moving focus to
+      // the composite element so the events are dispatched in the right order
+      // (blur, then focus).
       fireBlurEvent(previousElement, { relatedTarget: compositeElement });
     }
     if (!hasFocus(compositeElement)) {
-      // Scroll before focusing, so a focus handler that presents something
-      // else scrolls last and wins. Only for a target that can actually take
-      // focus: the focus call below is a no-op for an unfocusable composite,
-      // and moving the page to an element that never receives focus is the
-      // movement this is meant to replace, not emulate.
+      // Scroll before focusing, so a focus handler that presents something else
+      // scrolls last and wins. Only for a target that can actually take focus:
+      // the focus call below is a no-op for an unfocusable composite, and
+      // moving the page to an element that never receives focus is the movement
+      // this is meant to replace, not emulate.
       if (isFocusable(compositeElement)) {
         compositeElement.scrollIntoView({
           block: "nearest",
@@ -386,8 +386,8 @@ export const useComposite = createHook<TagName, CompositeOptions>(
           // A real-focus composite may initially focus the composite element
           // while the item marked as its presentation target is outside the
           // viewport. Bring that item into view without moving DOM focus away
-          // from the composite element.
-          // The id is pinned because the active item is cleared right below.
+          // from the composite element. The id is pinned because the active
+          // item is cleared right below.
           const { activeId } = store.getState();
           if (activeId != null) {
             present({
@@ -429,8 +429,8 @@ export const useComposite = createHook<TagName, CompositeOptions>(
       const nextActiveElementIsItem = isItem(store, nextActiveElement);
       const previousElement = previousElementRef.current;
       previousElementRef.current = null;
-      // This is an intermediate blur event: blurring the composite container
-      // to focus on an item (nextActiveElement).
+      // This is an intermediate blur event: blurring the composite container to
+      // focus on an item (nextActiveElement).
       if (isSelfTarget(event) && nextActiveElementIsItem) {
         // The next active element will be the same as the active item in the
         // store in these two scenarios:
@@ -658,8 +658,8 @@ export interface CompositeOptions<
    * behavior and stops applying composite ARIA attributes. Another composite
    * component should take over these responsibilities.
    *
-   * Keyboard navigation on items remains active and can still change the
-   * active item. To disable arrow-key navigation, set
+   * Keyboard navigation on items remains active and can still change the active
+   * item. To disable arrow-key navigation, set
    * [`moveOnKeyPress`](https://ariakit.com/reference/composite#moveonkeypress)
    * to `false` on this component and its items.
    *
@@ -684,8 +684,8 @@ export interface CompositeOptions<
    * arrow keys are pressed, given that the composite element is focused and
    * there's no active item.
    *
-   * **Note**: To control automatic focus movement when navigating through items,
-   * use the
+   * **Note**: To control automatic focus movement when navigating through
+   * items, use the
    * [`focusOnMove`](https://ariakit.com/reference/composite#focusonmove) prop
    * instead. If you want to control the behavior _only when arrow keys are
    * pressed_, where

--- a/packages/ariakit-react-components/src/composite/utils.ts
+++ b/packages/ariakit-react-components/src/composite/utils.ts
@@ -75,8 +75,8 @@ export function ownsFocus(store: CompositeStore) {
   if (compositeElement?.contains(activeElement)) return true;
   if (isItem(store, activeElement)) return true;
   // Items are only recognizable once they register, which is a commit after
-  // they mount, and the composite element can sit outside the popup, so
-  // neither check above covers an option that has just focused itself.
+  // they mount, and the composite element can sit outside the popup, so neither
+  // check above covers an option that has just focused itself.
   return !!getPopupElement(store)?.contains(activeElement);
 }
 
@@ -114,8 +114,8 @@ export interface PresentItemParams {
 
 /**
  * Focuses a composite item without scrolling, then brings it into view after
- * any containing popup has been positioned.
- * Returns a function that cancels a pending presentation.
+ * any containing popup has been positioned. Returns a function that cancels a
+ * pending presentation.
  */
 function presentItem({
   store,
@@ -305,8 +305,8 @@ function presentItem({
     // Focus may move immediately, but scrolling is reserved for an explicit
     // presentation target; hover and stale active ids must not move the page.
     if (markedOnly && !element.hasAttribute("data-autofocus")) {
-      // A withheld request still owes focus, so keep it pending. Only a
-      // request with nothing left to give is finished here.
+      // A withheld request still owes focus, so keep it pending. Only a request
+      // with nothing left to give is finished here.
       if (focusWithheld) return;
       return settle();
     }

--- a/packages/ariakit-react-components/src/composite/utils.ts
+++ b/packages/ariakit-react-components/src/composite/utils.ts
@@ -349,10 +349,10 @@ function presentItem({
 /**
  * Owns at most one pending presentation for the component's current store.
  * Layout-effect ownership prevents store swaps or unmounts from stranding a
- * request, while newer requests replace older ones.
- * Layout setup runs before child passive effects can request presentation;
- * cleanup clears ownership during unmount before later handlers or microtasks
- * can enqueue work. The initial ref covers the first render before setup.
+ * request, while newer requests replace older ones. Layout setup runs before
+ * child passive effects can request presentation; cleanup clears ownership
+ * during unmount before later handlers or microtasks can enqueue work. The
+ * initial ref covers the first render before setup.
  *
  * See https://github.com/ariakit/ariakit/pull/7029
  */

--- a/packages/ariakit-react-components/src/dialog/dialog-heading.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog-heading.tsx
@@ -77,10 +77,10 @@ export interface DialogHeadingOptions<
    * Object returned by the
    * [`useDialogStore`](https://ariakit.com/reference/use-dialog-store) hook.
    *
-   * **Note**: This prop has no effect on this component. The heading is
-   * linked to the closest [`Dialog`](https://ariakit.com/reference/dialog)
-   * component through React context, so it must be rendered inside the dialog
-   * for the `aria-labelledby` prop to be set on the dialog element.
+   * **Note**: This prop has no effect on this component. The heading is linked
+   * to the closest [`Dialog`](https://ariakit.com/reference/dialog) component
+   * through React context, so it must be rendered inside the dialog for the
+   * `aria-labelledby` prop to be set on the dialog element.
    */
   store?: DialogStore;
 }

--- a/packages/ariakit-react-components/src/dialog/dialog.tsx
+++ b/packages/ariakit-react-components/src/dialog/dialog.tsx
@@ -92,8 +92,8 @@ function isAlreadyFocusingAnotherElement(dialog?: HTMLElement | null) {
   if (!activeElement) return false;
   if (dialog && contains(dialog, activeElement)) return false;
   // The hidden dismiss button renders next to the dialog, so activating it
-  // would otherwise read as focus having moved somewhere else entirely, and
-  // the dialog would skip restoring focus to its disclosure.
+  // would otherwise read as focus having moved somewhere else entirely, and the
+  // dialog would skip restoring focus to its disclosure.
   if (isHiddenDismiss(activeElement, dialog?.id)) return false;
   if (isFocusable(activeElement)) return true;
   return false;
@@ -165,8 +165,8 @@ function getLaterOpenModalPortals(dialog: HTMLElement) {
     if (!portalId) continue;
     const portal = root.getElementById(portalId);
     if (!portal || !contains(portal, currentDialog)) continue;
-    // Active portals belong to an established stack. DOM order is only used
-    // to break ties between dialogs opening in the same layout pass.
+    // Active portals belong to an established stack. DOM order is only used to
+    // break ties between dialogs opening in the same layout pass.
     if (openModalPortals.has(portal)) continue;
     portals.push(portal);
   }
@@ -226,14 +226,13 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
   });
 
   // domReady can be also the portal node element so it's updated when the
-  // portal node changes (like in between re-renders), triggering effects
-  // again.
+  // portal node changes (like in between re-renders), triggering effects again.
   const { portalRef, portalNode, domReady } = usePortalRef(
     portal,
     props.portalRef,
   );
-  // Modal dialogs don't use tab-order sentinels to match native <dialog>.
-  // Tab may reach browser UI instead of cycling inside, which is intentional.
+  // Modal dialogs don't use tab-order sentinels to match native <dialog>. Tab
+  // may reach browser UI instead of cycling inside, which is intentional.
   // https://github.com/ariakit/ariakit/issues/7092#issuecomment-5227754640
   const preserveTabOrderProp = props.preserveTabOrder;
   const preserveTabOrder = useStoreState(
@@ -250,10 +249,10 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
   usePreventBodyScroll(contentElement, id, preventBodyScroll && !hidden);
 
   // Tracks whether focus restoration should be skipped after an outside
-  // interaction to match native HTML behavior.
-  // Reset when the dialog opens to avoid stale flags from prevented closes
-  // (e.g., onClose calling event.preventDefault), async closes with
-  // animations, or when autoFocusOnHide is disabled.
+  // interaction to match native HTML behavior. Reset when the dialog opens to
+  // avoid stale flags from prevented closes (e.g., onClose calling
+  // event.preventDefault), async closes with animations, or when
+  // autoFocusOnHide is disabled.
   const interactedOutsideRef = useRef(false);
   const focusedStoreRef = useRef<DialogStore | null>(null);
   useSafeLayoutEffect(() => {
@@ -314,8 +313,8 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     const dialog = ref.current;
     // A disclosure element no capture left behind names the opener
     // deliberately, whether it comes from a Disclosure component or from the
-    // application assigning it before showing the dialog. The capture is only
-    // a fallback for when nothing said otherwise, so it must not overwrite it.
+    // application assigning it before showing the dialog. The capture is only a
+    // fallback for when nothing said otherwise, so it must not overwrite it.
     // https://github.com/ariakit/ariakit/issues/7087
     const hasNamedDisclosure = () => {
       const { disclosureElement } = store.getState();
@@ -398,8 +397,8 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     return () => observer.disconnect();
   }, [modal, open, domReady, contentElement]);
 
-  // TODO: Move this behavior into DisclosureContent.
-  // Keep closing animated content inert until its mounted state ends.
+  // TODO: Move this behavior into DisclosureContent. Keep closing animated
+  // content inert until its mounted state ends.
   useSafeLayoutEffect(() => {
     if (!supportsInert()) return;
     if (open) return;
@@ -715,8 +714,8 @@ export const useDialog = createHook<TagName, DialogOptions>(function useDialog({
     const dialog = ref.current;
     if (!mounted) return false;
     if (!dialog) return false;
-    // Ignore the event if the current dialog is marked by another dialog.
-    // This guarantees that only the topmost dialog will close on Escape.
+    // Ignore the event if the current dialog is marked by another dialog. This
+    // guarantees that only the topmost dialog will close on Escape.
     if (isElementMarked(dialog)) return false;
     const accepted = hideOnEscapeProp(event);
     escapeEvents.set(event, {

--- a/packages/ariakit-react-components/src/dialog/utils/use-hide-on-interact-outside.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/use-hide-on-interact-outside.ts
@@ -129,9 +129,9 @@ function useEventOutside({
         callListener(event);
         return;
       }
-      // Clicked on dialog's bounding box
-      // Mouse coordinates are relative to the target's viewport, so compare
-      // them with this dialog only when both belong to the same document.
+      // Clicked on dialog's bounding box Mouse coordinates are relative to the
+      // target's viewport, so compare them with this dialog only when both
+      // belong to the same document.
       if (
         getDocument(composedTarget ?? target) === contentDocument &&
         isMouseEventOnDialog(event, contentElement)
@@ -190,9 +190,9 @@ export function useHideOnInteractOutside({
     contentElement,
   );
   const focusedRef = useRef(false);
-  // Tracks whether the content element has been focused at least once since
-  // the dialog opened. The event listeners below use this to decide whether
-  // the marked-tree check applies. Shared by all event types.
+  // Tracks whether the content element has been focused at least once since the
+  // dialog opened. The event listeners below use this to decide whether the
+  // marked-tree check applies. Shared by all event types.
   useSafeLayoutEffect(() => {
     if (!open) return;
     if (!domReady) return;

--- a/packages/ariakit-react-components/src/dialog/utils/use-prevent-body-scroll.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/use-prevent-body-scroll.ts
@@ -1,4 +1,5 @@
-// Based on https://github.com/floating-ui/floating-ui/blob/1201e72e67a80e479122293d46d96c9bbc8f156d/packages/react-dom-interactions/src/FloatingOverlay.tsx
+// Based on
+// https://github.com/floating-ui/floating-ui/blob/1201e72e67a80e479122293d46d96c9bbc8f156d/packages/react-dom-interactions/src/FloatingOverlay.tsx
 import { useSafeLayoutEffect } from "@ariakit/react-utils";
 import { getDocument, getWindow, chain, isApple, isMac } from "@ariakit/utils";
 import { useEffect } from "react";
@@ -8,14 +9,14 @@ import { useRootDialog } from "./use-root-dialog.ts";
 // Only iOS doesn't respect `overflow: hidden` on document.body.
 const isIOS = isApple() && !isMac();
 
-// Use layout timing to measure and lock before paint. Keep iOS passive
-// because its scroll capture/restore depends on dialog focus timing. isIOS
-// is session-stable, so the hook choice cannot change between renders.
+// Use layout timing to measure and lock before paint. Keep iOS passive because
+// its scroll capture/restore depends on dialog focus timing. isIOS is
+// session-stable, so the hook choice cannot change between renders.
 // https://github.com/ariakit/ariakit/pull/6288
 const useLockEffect = isIOS ? useEffect : useSafeLayoutEffect;
 
-// The CSS global isn't part of the Window type, even though browsers expose
-// it on every window object.
+// The CSS global isn't part of the Window type, even though browsers expose it
+// on every window object.
 interface WindowWithCSS extends Window {
   CSS?: Pick<typeof CSS, "supports">;
 }
@@ -69,10 +70,10 @@ export function usePreventBodyScroll(
       const scrollbarGutter =
         computedStyle.getPropertyValue("scrollbar-gutter");
       const hasGutter = scrollbarGutter.includes("stable");
-      // When the html overflow isn't visible, the page scrolls through the
-      // html element itself and the body overflow doesn't propagate to the
-      // viewport, so hiding the body overflow alone wouldn't lock the page
-      // scroll. See https://github.com/ariakit/ariakit/issues/4345
+      // When the html overflow isn't visible, the page scrolls through the html
+      // element itself and the body overflow doesn't propagate to the viewport,
+      // so hiding the body overflow alone wouldn't lock the page scroll. See
+      // https://github.com/ariakit/ariakit/issues/4345
       const isOverflowVisible = (value: string) =>
         // happy-dom and jsdom return an empty string for unset computed
         // values, whereas browsers return the visible keyword.
@@ -112,8 +113,8 @@ export function usePreventBodyScroll(
           hideHtmlOverflow(),
         );
       }
-      // Fallback for browsers without scrollbar-gutter support (Safari <
-      // 18.2): compensate the removed scrollbar with body padding and expose
+      // Fallback for browsers without scrollbar-gutter support (Safari < 18.2):
+      // compensate the removed scrollbar with body padding and expose
       // --scrollbar-width so userland position: fixed elements can compensate
       // too.
       return withHiddenHtmlOverflow(
@@ -162,11 +163,11 @@ export function usePreventBodyScroll(
     const restore = setStyle();
 
     return () => {
-      // Defer the restore to a microtask so it runs after this commit's
-      // layout effects, such as the dialog's focus-on-hide. This preserves
-      // the close ordering the passive phase provided before: focus first
-      // (while the scroll is still locked), then unlock. The orchestrate
-      // stacks keep this safe if the scroll gets locked again in between.
+      // Defer the restore to a microtask so it runs after this commit's layout
+      // effects, such as the dialog's focus-on-hide. This preserves the close
+      // ordering the passive phase provided before: focus first (while the
+      // scroll is still locked), then unlock. The orchestrate stacks keep this
+      // safe if the scroll gets locked again in between.
       queueMicrotask(restore);
     };
   }, [isRootDialog, contentElement]);

--- a/packages/ariakit-react-components/src/dialog/utils/use-previous-mouse-down-ref.ts
+++ b/packages/ariakit-react-components/src/dialog/utils/use-previous-mouse-down-ref.ts
@@ -27,8 +27,8 @@ export function getFrameChain(element: Element) {
 
 /**
  * Returns the full composed path and readable iframe host chain for positive
- * dialog membership, plus a target projected into the reference element's
- * root for outside-tree marks.
+ * dialog membership, plus a target projected into the reference element's root
+ * for outside-tree marks.
  */
 export function getEventTargets(
   event: Event,

--- a/packages/ariakit-react-components/src/disclosure/disclosure-content.tsx
+++ b/packages/ariakit-react-components/src/disclosure/disclosure-content.tsx
@@ -36,8 +36,8 @@ function parseCSSTime(time: string | undefined) {
   return Number.isNaN(parsed) ? 0 : parsed;
 }
 
-// CSS cycles shorter delay/duration lists to match the property/name list.
-// Pair each item's delay and duration; independent maxima can overestimate.
+// CSS cycles shorter delay/duration lists to match the property/name list. Pair
+// each item's delay and duration; independent maxima can overestimate.
 function getEndTime(names: string, delays: string, durations: string) {
   const nameList = names.split(",");
   const delayList = delays.split(",");
@@ -148,9 +148,9 @@ export const useDisclosureContent = createHook<
   useSafeLayoutEffect(() => {
     if (!animated) {
       // When animation detection has disabled animations (e.g., no CSS
-      // transition was detected on the content element), manage data-enter
-      // so wrapper elements using :has([data-enter]) work correctly even
-      // when the content element itself has no transitions.
+      // transition was detected on the content element), manage data-enter so
+      // wrapper elements using :has([data-enter]) work correctly even when the
+      // content element itself has no transitions.
       if (!open) {
         hasClosedRef.current = true;
         setTransition(null);
@@ -163,15 +163,15 @@ export const useDisclosureContent = createHook<
       return;
     }
     // When the disclosure content element is rendered in a portal, we need to
-    // wait for the portal to be mounted and connected to the DOM before we
-    // can start the animation.
+    // wait for the portal to be mounted and connected to the DOM before we can
+    // start the animation.
     if (!contentElement?.isConnected) {
       setTransition(null);
       return;
     }
     // Double requestAnimationFrame is necessary here to avoid potential bugs
-    // when the data attribute is added before the element is fully rendered
-    // in the DOM, which wouldn't trigger the animation.
+    // when the data attribute is added before the element is fully rendered in
+    // the DOM, which wouldn't trigger the animation.
     return afterPaint(() => {
       setTransition(open ? "enter" : mounted ? "leave" : null);
     });
@@ -207,8 +207,8 @@ export const useDisclosureContent = createHook<
       elements.push(otherElement);
     }
     // Conversely, if we're rendering a dialog, its backdrop may be animated
-    // while the dialog itself is not. The backdrop element isn't tracked in
-    // the store, so the dialog passes it in through otherElementRef.
+    // while the dialog itself is not. The backdrop element isn't tracked in the
+    // store, so the dialog passes it in through otherElementRef.
     const relatedElement = otherElementRef?.current;
     if (relatedElement) {
       elements.push(relatedElement);
@@ -219,10 +219,9 @@ export const useDisclosureContent = createHook<
     const timeout = Math.max(...elements.map(getElementEndTime));
     // If the timeout is zero, there's no animation or transition, either
     // because they weren't defined in the CSS or the duration was explicitly
-    // set to zero. In this scenario, we can halt the animation right away
-    // and, if we're entering, we can set the animated state to false so
-    // the element unmounts immediately on close without waiting for a
-    // leave animation.
+    // set to zero. In this scenario, we can halt the animation right away and,
+    // if we're entering, we can set the animated state to false so the element
+    // unmounts immediately on close without waiting for a leave animation.
     if (!timeout) {
       if (transition === "enter") {
         store.setState("animated", false);
@@ -329,8 +328,8 @@ export interface DisclosureContentOptions<
   /**
    * A ref to another element whose CSS transitions and animations should be
    * taken into account when computing the animation timeout, such as the
-   * dialog's backdrop element, which may be animated while the dialog itself
-   * is not.
+   * dialog's backdrop element, which may be animated while the dialog itself is
+   * not.
    * @deprecated
    * @private
    */
@@ -342,8 +341,8 @@ export interface DisclosureContentOptions<
    * none` style will not be applied, unless explicitly set otherwise.
    *
    * This prop is particularly useful when using third-party animation libraries
-   * such as Motion or React Spring, where the element needs to be
-   * visible for exit animations to work.
+   * such as Motion or React Spring, where the element needs to be visible for
+   * exit animations to work.
    *
    * Live examples:
    * - [Dialog with

--- a/packages/ariakit-react-components/src/focusable/focusable.tsx
+++ b/packages/ariakit-react-components/src/focusable/focusable.tsx
@@ -417,8 +417,7 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
     // anything else that's set up by React effects on the onFocus event. So we
     // don't pass the autoFocus prop to the element and instead manually focus
     // the element when it's mounted. The order in which this effect runs also
-    // matters. See
-    // https://x.com/diegohaz/status/1408180632933388289
+    // matters. See https://x.com/diegohaz/status/1408180632933388289
     const autoFocusRef = useEvent((element: HTMLElement | null) => {
       if (!focusable) return;
       if (!autoFocus) return;

--- a/packages/ariakit-react-components/src/focusable/focusable.tsx
+++ b/packages/ariakit-react-components/src/focusable/focusable.tsx
@@ -144,8 +144,8 @@ function getTabIndex({
   if (!focusable) return tabIndexProp;
   if (trulyDisabled) {
     if (nativeTabbable && !supportsDisabled) {
-      // Anchor, audio and video tags don't support the `disabled` attribute.
-      // We must pass tabIndex={-1} so they don't receive focus on tab.
+      // Anchor, audio and video tags don't support the `disabled` attribute. We
+      // must pass tabIndex={-1} so they don't receive focus on tab.
       return -1;
     }
     // Elements that support the `disabled` attribute don't need tabIndex.
@@ -159,8 +159,8 @@ function getTabIndex({
     }
     return tabIndexProp;
   }
-  // If the element is enabled and is not natively tabbable, we have to
-  // fallback tabIndex={0}.
+  // If the element is enabled and is not natively tabbable, we have to fallback
+  // tabIndex={0}.
   return tabIndexProp ?? 0;
 }
 
@@ -417,8 +417,7 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
     // anything else that's set up by React effects on the onFocus event. So we
     // don't pass the autoFocus prop to the element and instead manually focus
     // the element when it's mounted. The order in which this effect runs also
-    // matters. See
-    // https://x.com/diegohaz/status/1408180632933388289
+    // matters. See https://x.com/diegohaz/status/1408180632933388289
     const autoFocusRef = useEvent((element: HTMLElement | null) => {
       if (!focusable) return;
       if (!autoFocus) return;

--- a/packages/ariakit-react-components/src/focusable/focusable.tsx
+++ b/packages/ariakit-react-components/src/focusable/focusable.tsx
@@ -417,7 +417,8 @@ export const useFocusable = createHook<TagName, FocusableOptions>(
     // anything else that's set up by React effects on the onFocus event. So we
     // don't pass the autoFocus prop to the element and instead manually focus
     // the element when it's mounted. The order in which this effect runs also
-    // matters. See https://x.com/diegohaz/status/1408180632933388289
+    // matters. See
+    // https://x.com/diegohaz/status/1408180632933388289
     const autoFocusRef = useEvent((element: HTMLElement | null) => {
       if (!focusable) return;
       if (!autoFocus) return;

--- a/packages/ariakit-react-components/src/form/form-field.tsx
+++ b/packages/ariakit-react-components/src/form/form-field.tsx
@@ -49,10 +49,9 @@ export const useFormField = createHook<TagName, FormFieldOptions>(
  * underlying element. This is so we can use it not only for native form
  * elements but also for custom components whose value is not controlled by the
  * native `value` and `onChange` props.
- * @deprecated
- * This component has been renamed to
- * [`FormControl`](https://ariakit.com/reference/form-control). The API remains
- * the same.
+ * @deprecated This component has been renamed to
+ *   [`FormControl`](https://ariakit.com/reference/form-control). The API
+ *   remains the same.
  * @example
  * ```jsx {11-19}
  * const form = useFormStore({

--- a/packages/ariakit-react-components/src/form/form-input.tsx
+++ b/packages/ariakit-react-components/src/form/form-input.tsx
@@ -19,9 +19,9 @@ type TagName = typeof TagName;
 type HTMLType = HTMLElementTagNameMap[TagName];
 
 /**
- * Returns props to create a `FormInput` component. Unlike `useFormControl`, this
- * hook returns the `value` and `onChange` props that can be passed to a native
- * input, select or textarea elements.
+ * Returns props to create a `FormInput` component. Unlike `useFormControl`,
+ * this hook returns the `value` and `onChange` props that can be passed to a
+ * native input, select or textarea elements.
  * @see https://ariakit.com/components/form
  * @example
  * ```jsx

--- a/packages/ariakit-react-components/src/form/form-radio-group.tsx
+++ b/packages/ariakit-react-components/src/form/form-radio-group.tsx
@@ -32,10 +32,10 @@ type TagName = typeof TagName;
  */
 export const useFormRadioGroup = createHook<TagName, FormRadioGroupOptions>(
   function useFormRadioGroup({ store, ...props }) {
-    // Reset the composite context so FormRadio items inside this group
-    // don't register to an unrelated ancestor composite store (e.g.,
-    // TabStore). Form controls explicitly pass their store to
-    // useCollectionItem, so they're not affected by this reset.
+    // Reset the composite context so FormRadio items inside this group don't
+    // register to an unrelated ancestor composite store (e.g., TabStore). Form
+    // controls explicitly pass their store to useCollectionItem, so they're not
+    // affected by this reset.
     props = useWrapElement(
       props,
       (element) => (

--- a/packages/ariakit-react-components/src/form/form-store.ts
+++ b/packages/ariakit-react-components/src/form/form-store.ts
@@ -202,7 +202,7 @@ export interface FormStoreFunctions<T extends FormStoreValues = FormStoreValues>
    * // Can also use store.names for type safety.
    * const emailValue = useFormValue(store, store.names.email);
    * @deprecated Use
-   * [`useFormValue`](https://ariakit.com/reference/use-form-value) instead.
+   *   [`useFormValue`](https://ariakit.com/reference/use-form-value) instead.
    */
   // oxlint-disable-next-line no-unnecessary-type-parameters
   useValue: <T = any>(name: StringLike) => T;
@@ -222,8 +222,8 @@ export interface FormStoreFunctions<T extends FormStoreValues = FormStoreValues>
    *   }
    * });
    * @deprecated Use
-   * [`useFormValidate`](https://ariakit.com/reference/use-form-validate)
-   * instead.
+   *   [`useFormValidate`](https://ariakit.com/reference/use-form-validate)
+   *   instead.
    */
   useValidate: (callback: Core.FormStoreCallback<FormStoreState<T>>) => void;
   /**
@@ -243,7 +243,7 @@ export interface FormStoreFunctions<T extends FormStoreValues = FormStoreValues>
    *   }
    * });
    * @deprecated Use
-   * [`useFormSubmit`](https://ariakit.com/reference/use-form-submit) instead.
+   *   [`useFormSubmit`](https://ariakit.com/reference/use-form-submit) instead.
    */
   useSubmit: (callback: Core.FormStoreCallback<FormStoreState<T>>) => void;
 }

--- a/packages/ariakit-react-components/src/form/form.tsx
+++ b/packages/ariakit-react-components/src/form/form.tsx
@@ -217,8 +217,7 @@ export interface FormOptions<_T extends ElementType = TagName> extends Options {
   store?: FormStore;
   /**
    * Determines if the form should invoke the validation callbacks registered
-   * with
-   * [`useFormValidate`](https://ariakit.com/reference/use-form-validate)
+   * with [`useFormValidate`](https://ariakit.com/reference/use-form-validate)
    * when the [`values`](https://ariakit.com/reference/use-form-store#values)
    * change.
    * @default true
@@ -226,8 +225,7 @@ export interface FormOptions<_T extends ElementType = TagName> extends Options {
   validateOnChange?: boolean;
   /**
    * Determines if the form should invoke the validation callbacks registered
-   * with
-   * [`useFormValidate`](https://ariakit.com/reference/use-form-validate)
+   * with [`useFormValidate`](https://ariakit.com/reference/use-form-validate)
    * when a field loses focus.
    * @default true
    */

--- a/packages/ariakit-react-components/src/group/group-label.tsx
+++ b/packages/ariakit-react-components/src/group/group-label.tsx
@@ -47,8 +47,8 @@ export const useGroupLabel = createHook<TagName, GroupLabelOptions>(
 
 /**
  * Renders a label in a group. This component should be wrapped with a
- * [`Group`](https://ariakit.com/reference/group) so the `aria-labelledby`
- * prop is correctly set on the group element.
+ * [`Group`](https://ariakit.com/reference/group) so the `aria-labelledby` prop
+ * is correctly set on the group element.
  * @see https://ariakit.com/components/group
  * @example
  * ```jsx

--- a/packages/ariakit-react-components/src/hovercard/__hovercard-trigger.tsx
+++ b/packages/ariakit-react-components/src/hovercard/__hovercard-trigger.tsx
@@ -39,14 +39,14 @@ export const useHovercardTrigger = createHook<TagName, HovercardTriggerOptions>(
     const triggerRef = useRef<HTMLElement | null>(null);
     const showTimeoutRef = useRef(0);
 
-    // A truly disabled trigger must not reveal its content on hover, since
-    // that content would be reachable by pointer users alone. Read it from the
+    // A truly disabled trigger must not reveal its content on hover, since that
+    // content would be reachable by pointer users alone. Read it from the
     // element, because `render` composition can resolve the disabled state
     // below this hook. `focusable={false}` on this trigger's own props also
     // counts: it makes `accessibleWhenDisabled` inoperative and stops focus
-    // from revealing anything, and an inactive Focusable below never stamps,
-    // so only these props can say so. As an event function, this reads the
-    // latest render's values even from a pending show timeout.
+    // from revealing anything, and an inactive Focusable below never stamps, so
+    // only these props can say so. As an event function, this reads the latest
+    // render's values even from a pending show timeout.
     // https://github.com/ariakit/ariakit/issues/7115
     // https://github.com/ariakit/ariakit/issues/7116
     const isTrulyDisabled = useEvent((element: Element) => {
@@ -193,8 +193,8 @@ export interface HovercardTriggerOptions<
    * activating the trigger rather than explaining it. An element that declares
    * `aria-disabled` or `disabled` on its own, outside Ariakit props, counts as
    * disabled here too. A disabled trigger that isn't `accessibleWhenDisabled`
-   * never shows the content on hover, since the content would then be
-   * reachable by pointer users alone; this prop can't turn that back on.
+   * never shows the content on hover, since the content would then be reachable
+   * by pointer users alone; this prop can't turn that back on.
    * @default true
    * @deprecated
    * @private

--- a/packages/ariakit-react-components/src/hovercard/hovercard-disclosure.tsx
+++ b/packages/ariakit-react-components/src/hovercard/hovercard-disclosure.tsx
@@ -78,10 +78,10 @@ export const useHovercardDisclosure = createHook<
         if (anchor && contains(anchor, nextActiveElement)) return;
         if (popover && contains(popover, nextActiveElement)) return;
         if (disclosure && contains(disclosure, nextActiveElement)) return;
-        // When the portal prop is set to true on the Hovercard component,
-        // it's going to render focus trap elements outside of the portal.
-        // These elements may transfer focus to the disclosure button, so we
-        // also ignore them here.
+        // When the portal prop is set to true on the Hovercard component, it's
+        // going to render focus trap elements outside of the portal. These
+        // elements may transfer focus to the disclosure button, so we also
+        // ignore them here.
         if (
           isElement(nextActiveElement) &&
           nextActiveElement.hasAttribute("data-focus-trap")
@@ -111,8 +111,8 @@ export const useHovercardDisclosure = createHook<
   const onClickProp = props.onClick;
 
   // By default, hovercards don't receive focus when they are shown. When the
-  // disclosure element is clicked, though, we want it to behave like a
-  // popover, so we set the autoFocusOnShow prop to true.
+  // disclosure element is clicked, though, we want it to behave like a popover,
+  // so we set the autoFocusOnShow prop to true.
   const onClick = useEvent((event: MouseEvent<HTMLType>) => {
     onClickProp?.(event);
     if (event.defaultPrevented) return;

--- a/packages/ariakit-react-components/src/hovercard/hovercard-heading.tsx
+++ b/packages/ariakit-react-components/src/hovercard/hovercard-heading.tsx
@@ -56,11 +56,11 @@ export interface HovercardHeadingOptions<
    * [`useHovercardStore`](https://ariakit.com/reference/use-hovercard-store)
    * hook.
    *
-   * **Note**: This prop has no effect on this component. The heading is
-   * linked to the closest
-   * [`Hovercard`](https://ariakit.com/reference/hovercard) component through
-   * React context, so it must be rendered inside the hovercard for the
-   * `aria-labelledby` prop to be set on the hovercard element.
+   * **Note**: This prop has no effect on this component. The heading is linked
+   * to the closest [`Hovercard`](https://ariakit.com/reference/hovercard)
+   * component through React context, so it must be rendered inside the
+   * hovercard for the `aria-labelledby` prop to be set on the hovercard
+   * element.
    */
   store?: HovercardStore;
 }

--- a/packages/ariakit-react-components/src/menu/menu-bar-provider.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-bar-provider.tsx
@@ -4,9 +4,9 @@ import { MenubarProvider } from "../menubar/menubar-provider.tsx";
 
 /**
  * Provides a menubar store to MenuBar components.
- * @deprecated
- * Use [`MenubarProvider`](https://ariakit.com/reference/menubar-provider)
- * instead.
+ * @deprecated Use
+ *   [`MenubarProvider`](https://ariakit.com/reference/menubar-provider)
+ *   instead.
  * @example
  * ```jsx
  * <MenuBarProvider>

--- a/packages/ariakit-react-components/src/menu/menu-bar-store.ts
+++ b/packages/ariakit-react-components/src/menu/menu-bar-store.ts
@@ -22,9 +22,9 @@ export function useMenuBarStoreProps<T extends Core.MenuBarStore>(
 
 /**
  * Creates a menu bar store.
- * @deprecated
- * Use [`useMenubarStore`](https://ariakit.com/reference/use-menubar-store)
- * instead.
+ * @deprecated Use
+ *   [`useMenubarStore`](https://ariakit.com/reference/use-menubar-store)
+ *   instead.
  * @example
  * ```jsx
  * const menubar = useMenuBarStore();

--- a/packages/ariakit-react-components/src/menu/menu-bar.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-bar.tsx
@@ -45,8 +45,7 @@ export const useMenuBar = createHook<TagName, MenuBarOptions>(
 /**
  * Renders a menu bar that may contain a group of menu items that control other
  * submenus.
- * @deprecated
- * Use [`Menubar`](https://ariakit.com/reference/menubar) instead.
+ * @deprecated Use [`Menubar`](https://ariakit.com/reference/menubar) instead.
  * @example
  * ```jsx
  * <MenuBarProvider>

--- a/packages/ariakit-react-components/src/menu/menu-button.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-button.tsx
@@ -223,9 +223,9 @@ export const useMenuButton = createHook<TagName, MenuButtonOptions>(
 
     const contentElement = useStoreState(store, "contentElement");
 
-    // Use the combobox presence to pick the correct fallback so
-    // aria-haspopup stays stable before the content element mounts.
-    // See https://github.com/ariakit/ariakit/issues/4443
+    // Use the combobox presence to pick the correct fallback so aria-haspopup
+    // stays stable before the content element mounts. See
+    // https://github.com/ariakit/ariakit/issues/4443
     const hasCombobox = !!store.combobox;
     const popupRole = getPopupRole(
       contentElement,

--- a/packages/ariakit-react-components/src/menu/menu-context.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-context.tsx
@@ -47,9 +47,9 @@ export const MenuScopedContextProvider = menu.ScopedContextProvider;
 
 /**
  * Returns the menuBar store from the nearest menuBar container.
- * @deprecated
- * Use [`useMenubarContext`](https://ariakit.com/reference/use-menubar-context)
- * instead.
+ * @deprecated Use
+ *   [`useMenubarContext`](https://ariakit.com/reference/use-menubar-context)
+ *   instead.
  * @example
  * function MenuBar() {
  *   const store = useMenuBarContext();

--- a/packages/ariakit-react-components/src/menu/menu-item-check.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-item-check.tsx
@@ -69,14 +69,13 @@ export interface MenuItemCheckOptions<
   /**
    * Object returned by the
    * [`useMenuStore`](https://ariakit.com/reference/use-menu-store) hook. This
-   * prop doesn't affect the checkmark. It's accepted for consistency with
-   * other Ariakit components and is not passed to the underlying element. The
-   * checked state is derived solely from the
+   * prop doesn't affect the checkmark. It's accepted for consistency with other
+   * Ariakit components and is not passed to the underlying element. The checked
+   * state is derived solely from the
    * [`checked`](https://ariakit.com/reference/menu-item-check#checked) prop or,
    * when it's not provided, from the closest
    * [`MenuItemCheckbox`](https://ariakit.com/reference/menu-item-checkbox) or
-   * [`MenuItemRadio`](https://ariakit.com/reference/menu-item-radio)
-   * component.
+   * [`MenuItemRadio`](https://ariakit.com/reference/menu-item-radio) component.
    */
   store?: MenuStore;
 }

--- a/packages/ariakit-react-components/src/menu/menu-item.tsx
+++ b/packages/ariakit-react-components/src/menu/menu-item.tsx
@@ -103,8 +103,8 @@ export const useMenuItem = createHook<TagName, MenuItemOptions>(
       if (isDownloading(event)) return;
       if (isOpeningInNewTab(event)) return;
       if (!hideMenu) return;
-      // If this item is also a submenu button or any other disclosure, we
-      // don't want to hide the menu.
+      // If this item is also a submenu button or any other disclosure, we don't
+      // want to hide the menu.
       const popupType = event.currentTarget.getAttribute("aria-haspopup");
       if (popupType && popupType !== "false") return;
       if (!hideOnClickProp(event)) return;
@@ -152,10 +152,10 @@ export const useMenuItem = createHook<TagName, MenuItemOptions>(
         const { compositeElement, items } = store.getState();
         // Hovering is not a request to move the page or menu; the pointer is
         // already on what the user cares about. Keyboard navigation presents
-        // items through the composite's own scroll step.
-        // If the menu item is also a submenu button, we should move actual DOM
-        // focus to it so that the submenu will not close when the user moves
-        // the cursor back to the menu button.
+        // items through the composite's own scroll step. If the menu item is
+        // also a submenu button, we should move actual DOM focus to it so that
+        // the submenu will not close when the user moves the cursor back to the
+        // menu button.
         if (isWithinMenu) {
           if (event.currentTarget.hasAttribute("aria-expanded")) {
             event.currentTarget.focus({ preventScroll: true });
@@ -187,8 +187,7 @@ export const useMenuItem = createHook<TagName, MenuItemOptions>(
 /**
  * Renders a menu item inside
  * [`MenuList`](https://ariakit.com/reference/menu-list) or
- * [`Menu`](https://ariakit.com/reference/menu)
- * components.
+ * [`Menu`](https://ariakit.com/reference/menu) components.
  * @see https://ariakit.com/components/menu
  * @example
  * ```jsx {4-5}
@@ -213,9 +212,8 @@ export interface MenuItemOptions<T extends ElementType = TagName>
   /**
    * Object returned by the
    * [`useMenuStore`](https://ariakit.com/reference/use-menu-store) or
-   * [`useMenubarStore`](https://ariakit.com/reference/use-menubar-store)
-   * hooks. If not provided, the closest
-   * [`Menu`](https://ariakit.com/reference/menu),
+   * [`useMenubarStore`](https://ariakit.com/reference/use-menubar-store) hooks.
+   * If not provided, the closest [`Menu`](https://ariakit.com/reference/menu),
    * [`MenuList`](https://ariakit.com/reference/menu-list),
    * [`Menubar`](https://ariakit.com/reference/menubar), or
    * [`MenubarProvider`](https://ariakit.com/reference/menubar-provider)

--- a/packages/ariakit-react-components/src/menu/menu.tsx
+++ b/packages/ariakit-react-components/src/menu/menu.tsx
@@ -76,9 +76,9 @@ export const useMenu = createHook<TagName, MenuOptions>(function useMenu({
   };
 
   // The aria-labelledby prop on MenuList defaults to the MenuButton's id. On
-  // Dialog/Popover/Hovercard/Menu, we need to consider MenuHeading as well
-  // and it should take precedence. That's why we need to destructure this
-  // prop here and check if aria-labelledby is set later.
+  // Dialog/Popover/Hovercard/Menu, we need to consider MenuHeading as well and
+  // it should take precedence. That's why we need to destructure this prop here
+  // and check if aria-labelledby is set later.
   const { "aria-labelledby": ariaLabelledBy, ...menuListProps } = useMenuList({
     store,
     alwaysVisible,
@@ -92,8 +92,8 @@ export const useMenu = createHook<TagName, MenuOptions>(function useMenu({
 
   // Resolve the initial focus element inside a selector so the component
   // re-renders only when the resolved element changes, not whenever
-  // `renderedItems` gets a new array identity. Returning `undefined` means
-  // auto focus on show is disabled.
+  // `renderedItems` gets a new array identity. Returning `undefined` means auto
+  // focus on show is disabled.
   const initialFocusElement = useStoreState(
     store,
     ["autoFocusOnShow", "initialFocus", "renderedItems", "compositeElement"],
@@ -142,12 +142,12 @@ export const useMenu = createHook<TagName, MenuOptions>(function useMenu({
     };
   }, [modal, initialFocusElement]);
 
-  // When the `autoFocusOnShow` prop is set to `true` (default), we'll only
-  // move focus to the menu when there's an initialFocusRef set or the menu is
-  // modal. Otherwise, users would have to manually call
-  // store.setAutoFocusOnShow(true) every time they want to open the menu.
-  // This differs from the usual dialog behavior that would automatically
-  // focus on the dialog container when no initialFocusRef is set.
+  // When the `autoFocusOnShow` prop is set to `true` (default), we'll only move
+  // focus to the menu when there's an initialFocusRef set or the menu is modal.
+  // Otherwise, users would have to manually call store.setAutoFocusOnShow(true)
+  // every time they want to open the menu. This differs from the usual dialog
+  // behavior that would automatically focus on the dialog container when no
+  // initialFocusRef is set.
   const canAutoFocusOnShow = !!initialFocusRef || !!props.initialFocus || modal;
   const autoFocusOnShowProp =
     autoFocusOnShow === false ? false : canAutoFocusOnShow && autoFocusOnShow;
@@ -163,13 +163,13 @@ export const useMenu = createHook<TagName, MenuOptions>(function useMenu({
   // Modal menus keep their menu button in the modal context so that it stays
   // out of the `inert` subtree. Chromium refuses to read an `inert` element as
   // the menu's `aria-labelledby` target, and the button doubles as the way out
-  // of the menu. https://github.com/ariakit/ariakit/issues/4270
-  // The button has to be an element the application named, since a disclosure
-  // the dialog captured only happened to have focus and can't be assumed to
-  // close the menu. It also has to be connected, mirroring the dialog's own
-  // definition of a named disclosure, and live outside the menu, otherwise the
-  // menu would become an ancestor of one of its own persistent elements, which
-  // the dialog reads as a nested dialog.
+  // of the menu. https://github.com/ariakit/ariakit/issues/4270 The button has
+  // to be an element the application named, since a disclosure the dialog
+  // captured only happened to have focus and can't be assumed to close the
+  // menu. It also has to be connected, mirroring the dialog's own definition of
+  // a named disclosure, and live outside the menu, otherwise the menu would
+  // become an ancestor of one of its own persistent elements, which the dialog
+  // reads as a nested dialog.
   const persistentDisclosure = useStoreState(
     store,
     ["disclosureElement", "contentElement"],
@@ -248,8 +248,8 @@ export const useMenu = createHook<TagName, MenuOptions>(function useMenu({
         }
         if (hideOnHoverOutside != null) return hideOnHoverOutside;
         // Hide the menu when hovering outside if it's a submenu in a dropdown
-        // menu or if it's a menu in a menubar and the menu button doesn't
-        // have focus.
+        // menu or if it's a menu in a menubar and the menu button doesn't have
+        // focus.
         if (hasParentMenu) return true;
         if (!parentIsMenubar) return false;
         if (!disclosureElement) return true;
@@ -335,8 +335,8 @@ export interface MenuOptions<T extends ElementType = TagName>
    *   or any other element assigned with
    *   [`setDisclosureElement`](https://ariakit.com/reference/use-menu-store#setdisclosureelement),
    *   is part of the modal context, so it can still label the menu.
-   * - A visually hidden dismiss button will be rendered next to the menu if
-   *   the [`MenuDismiss`](https://ariakit.com/reference/menu-dismiss) component
+   * - A visually hidden dismiss button will be rendered next to the menu if the
+   *   [`MenuDismiss`](https://ariakit.com/reference/menu-dismiss) component
    *   hasn't been used. This allows screen reader users to close the menu.
    * - When the menu is open, the element tree outside of both the menu and its
    *   menu button will be inert.

--- a/packages/ariakit-react-components/src/popover/popover-arrow.tsx
+++ b/packages/ariakit-react-components/src/popover/popover-arrow.tsx
@@ -90,10 +90,10 @@ function getRingFromSegment(segment: string, maskedSegment: string) {
   if (!width) return;
   const lengthsStart = match.index ?? 0;
   const lengthsEnd = lengthsStart + match[0].length;
-  // Whatever remains of the segment once the length run and the optional
-  // inset keyword are removed is the ring color. This works regardless of the
-  // color syntax and of whether the browser serializes the color before or
-  // after the lengths.
+  // Whatever remains of the segment once the length run and the optional inset
+  // keyword are removed is the ring color. This works regardless of the color
+  // syntax and of whether the browser serializes the color before or after the
+  // lengths.
   const rest = `${segment.slice(0, lengthsStart)} ${segment.slice(lengthsEnd)}`;
   const color = rest.replace(/\binset\b/g, " ").trim();
   const ring: RingStyle = { width, color: color || undefined };
@@ -184,12 +184,11 @@ export const usePopoverArrow = createHook<TagName, PopoverArrowOptions>(
 
     // When the popover is outlined by a ring, the arrow stroke must match the
     // ring color so the arrow blends into the outline. A ring segment with an
-    // omitted color defaults to currentColor per CSS, so use the computed
-    // text color then. Computed styles always serialize a concrete shadow
-    // color, but declared values returned by some test environments may omit
-    // it. Without a ring, fall back to the border color, which always
-    // resolves to a concrete value on connected elements (currentColor at the
-    // very least).
+    // omitted color defaults to currentColor per CSS, so use the computed text
+    // color then. Computed styles always serialize a concrete shadow color, but
+    // declared values returned by some test environments may omit it. Without a
+    // ring, fall back to the border color, which always resolves to a concrete
+    // value on connected elements (currentColor at the very least).
     const fallbackColor = isRing
       ? style?.getPropertyValue("color")
       : style?.getPropertyValue(`border-${dir}-color`);

--- a/packages/ariakit-react-components/src/popover/popover-heading.tsx
+++ b/packages/ariakit-react-components/src/popover/popover-heading.tsx
@@ -55,10 +55,10 @@ export interface PopoverHeadingOptions<
    * Object returned by the
    * [`usePopoverStore`](https://ariakit.com/reference/use-popover-store) hook.
    *
-   * **Note**: This prop has no effect on this component. The heading is
-   * linked to the closest [`Popover`](https://ariakit.com/reference/popover)
-   * component through React context, so it must be rendered inside the popover
-   * for the `aria-labelledby` prop to be set on the popover element.
+   * **Note**: This prop has no effect on this component. The heading is linked
+   * to the closest [`Popover`](https://ariakit.com/reference/popover) component
+   * through React context, so it must be rendered inside the popover for the
+   * `aria-labelledby` prop to be set on the popover element.
    */
   store?: PopoverStore;
 }

--- a/packages/ariakit-react-components/src/popover/popover.tsx
+++ b/packages/ariakit-react-components/src/popover/popover.tsx
@@ -130,9 +130,8 @@ function getOffsetMiddleware(
       typeof props.gutter === "number"
         ? props.gutter + arrowOffset
         : (props.gutter ?? arrowOffset);
-    // If there's no placement alignment (*-start or *-end),
-    // we'll fallback to the crossAxis offset as it also works
-    // for center-aligned placements.
+    // If there's no placement alignment (*-start or *-end), we'll fallback to
+    // the crossAxis offset as it also works for center-aligned placements.
     const hasAlignment = !!placement.split("-")[1];
     return {
       crossAxis: !hasAlignment ? props.shift : undefined,
@@ -276,10 +275,9 @@ export const usePopover = createHook<TagName, PopoverOptions>(
 
     const arrowElement = useStoreState(store, "arrowElement");
     const anchorElement = useStoreState(store, "anchorElement");
-    // The disclosure element is only used as the preserveTabOrder anchor,
-    // which takes effect only on portals and is disabled by the dialog for
-    // modal dialogs, so don't subscribe to it unless the feature can take
-    // effect.
+    // The disclosure element is only used as the preserveTabOrder anchor, which
+    // takes effect only on portals and is disabled by the dialog for modal
+    // dialogs, so don't subscribe to it unless the feature can take effect.
     const shouldPreserveTabOrder = preserveTabOrder && portal && !modal;
     const disclosureElement = useStoreState(
       store,
@@ -324,9 +322,9 @@ export const usePopover = createHook<TagName, PopoverOptions>(
         : (overflowPadding.left ?? 0);
 
     // Whether the popover is unmounted (closed and not animating) while its
-    // element stays both connected to the DOM and hidden. The alwaysVisible
-    // and hidden props can keep the element visible while closed, in which
-    // case the positioning effect below must keep running.
+    // element stays both connected to the DOM and hidden. The alwaysVisible and
+    // hidden props can keep the element visible while closed, in which case the
+    // positioning effect below must keep running.
     const hiddenWhileUnmounted =
       !mounted && isHidden(mounted, props.hidden, props.alwaysVisible);
 
@@ -357,13 +355,13 @@ export const usePopover = createHook<TagName, PopoverOptions>(
         `${getOverflowPaddingValue(positioningPadding)}px`,
       );
 
-      // The popover element stays connected to the DOM when it's closed but
-      // not unmounted. The default updatePosition function bails out while
+      // The popover element stays connected to the DOM when it's closed but not
+      // unmounted. The default updatePosition function bails out while
       // unmounted, so autoUpdate would only keep ancestor scroll/resize
       // listeners and observers running for a hidden element. Skip all of it
       // and set everything up again once the popover is shown. Custom
-      // updatePosition callbacks still run while hidden since they may
-      // position the popover in ways that don't depend on the open state.
+      // updatePosition callbacks still run while hidden since they may position
+      // the popover in ways that don't depend on the open state.
       if (hiddenWhileUnmounted && !hasCustomUpdatePosition) return;
 
       const anchor = getAnchorElement(anchorElement, getAnchorRectProp);
@@ -560,10 +558,10 @@ export const usePopover = createHook<TagName, PopoverOptions>(
     // Subscribe to `mounted` so the show transition publishes `placing` before
     // descendant layout effects observe it; the positioning effect is too late
     // because layout effects run child-first. Only a mounted Popover asserts
-    // this, so popups with nothing to position never wait.
-    // Count writers per store and defer the final reset by a microtask so
-    // StrictMode replay, keyed replacement, and store swaps cannot briefly
-    // clear or strand ancestor-owned state.
+    // this, so popups with nothing to position never wait. Count writers per
+    // store and defer the final reset by a microtask so StrictMode replay,
+    // keyed replacement, and store swaps cannot briefly clear or strand
+    // ancestor-owned state.
     // https://github.com/ariakit/ariakit/pull/7009#discussion_r3699800772
     useSafeLayoutEffect(() => {
       if (!store) return;
@@ -590,9 +588,9 @@ export const usePopover = createHook<TagName, PopoverOptions>(
 
     const position = fixed ? "fixed" : "absolute";
 
-    // Wrap our element in a div that will be used to position the popover.
-    // This way the user doesn't need to override the popper's position to
-    // create animations.
+    // Wrap our element in a div that will be used to position the popover. This
+    // way the user doesn't need to override the popper's position to create
+    // animations.
     props = useWrapElement(
       props,
       (element) => (

--- a/packages/ariakit-react-components/src/portal/portal.tsx
+++ b/packages/ariakit-react-components/src/portal/portal.tsx
@@ -28,9 +28,9 @@ const TagName = "div" satisfies ElementType;
 type TagName = typeof TagName;
 type HTMLType = HTMLElementTagNameMap[TagName];
 
-// Returns the best root element for appending portal nodes. When an element
-// is in fullscreen mode, portals must be appended inside the fullscreen
-// element instead of document.body so they remain visible.
+// Returns the best root element for appending portal nodes. When an element is
+// in fullscreen mode, portals must be appended inside the fullscreen element
+// instead of document.body so they remain visible.
 function getRootElement(element?: Element | null) {
   const doc = getDocument(element);
   const { fullscreenElement } = doc;
@@ -80,8 +80,8 @@ function attachPortalRef(
 }
 
 function detachPortalRef(attached: AttachedPortalRef) {
-  // Preserve React 19 callback ref cleanup semantics. Otherwise, detach the
-  // ref with null like any other React ref.
+  // Preserve React 19 callback ref cleanup semantics. Otherwise, detach the ref
+  // with null like any other React ref.
   if (typeof attached.cleanup === "function") {
     attached.cleanup();
   } else {
@@ -120,8 +120,8 @@ export const usePortal = createHook<TagName, PortalOptions>(function usePortal({
   const outerAfterRef = useRef<HTMLSpanElement>(null);
 
   const portalRefProp = useLiveRef(portalRef);
-  // Tracks the currently attached portalRef so the two effects below can
-  // detach and re-attach it without sharing dependencies.
+  // Tracks the currently attached portalRef so the two effects below can detach
+  // and re-attach it without sharing dependencies.
   const attachedPortalRefRef = useRef<AttachedPortalRef | null>(null);
 
   // Create the portal node and attach it to the DOM.
@@ -144,14 +144,14 @@ export const usePortal = createHook<TagName, PortalOptions>(function usePortal({
     }
     // If the portal element doesn't have an id already, set one.
     if (!portalEl.id) {
-      // Use the element's id so rendering <Portal id="some-id" /> will
-      // produce predictable results.
+      // Use the element's id so rendering <Portal id="some-id" /> will produce
+      // predictable results.
       portalEl.id = element.id ? `portal/${element.id}` : getRandomId();
     }
-    // Set the internal portal node state and attach the portalRef prop. The
-    // ref is read through a live ref so its identity is not a dependency of
-    // this effect: a portalRef identity change must not recreate the portal
-    // node. The effect below re-fires the ref in that case.
+    // Set the internal portal node state and attach the portalRef prop. The ref
+    // is read through a live ref so its identity is not a dependency of this
+    // effect: a portalRef identity change must not recreate the portal node.
+    // The effect below re-fires the ref in that case.
     setPortalNode(portalEl);
     attachedPortalRefRef.current = attachPortalRef(
       portalRefProp.current,
@@ -195,11 +195,10 @@ export const usePortal = createHook<TagName, PortalOptions>(function usePortal({
         rootElement.appendChild(portalNode);
       }
     };
-    // Sync immediately in case fullscreen was entered before this effect
-    // ran, which can happen if the portal mounts while already in
-    // fullscreen mode. Skip when the captured node is already disconnected,
-    // which happens for a StrictMode cleanup node whose layout cleanup
-    // already removed it.
+    // Sync immediately in case fullscreen was entered before this effect ran,
+    // which can happen if the portal mounts while already in fullscreen mode.
+    // Skip when the captured node is already disconnected, which happens for a
+    // StrictMode cleanup node whose layout cleanup already removed it.
     if (portalNode.isConnected) {
       onFullscreenChange();
     }
@@ -225,9 +224,9 @@ export const usePortal = createHook<TagName, PortalOptions>(function usePortal({
     };
   }, [portal, preserveTabOrder, preserveTabOrderAnchor]);
 
-  // When preserveTabOrder is true, make sure elements inside the portal
-  // element are tabbable only when the portal has already been focused,
-  // either by tabbing into a focus trap element outside or using the mouse.
+  // When preserveTabOrder is true, make sure elements inside the portal element
+  // are tabbable only when the portal has already been focused, either by
+  // tabbing into a focus trap element outside or using the mouse.
   useEffect(() => {
     if (!portalNode) return;
     if (!preserveTabOrder) return;
@@ -332,9 +331,9 @@ export const usePortal = createHook<TagName, PortalOptions>(function usePortal({
               className="__focus-trap-outer-before"
               onFocus={(event) => {
                 // If the event is coming from the outer after focus trap, it
-                // means there's no tabbable element inside the portal. In
-                // this case, we don't focus the inner before focus trap, but
-                // the previous tabbable element outside the portal.
+                // means there's no tabbable element inside the portal. In this
+                // case, we don't focus the inner before focus trap, but the
+                // previous tabbable element outside the portal.
                 const fromOuter = event.relatedTarget === outerAfterRef.current;
                 if (!fromOuter && isFocusEventOutside(event, portalNode)) {
                   queueFocus(innerBeforeRef.current);

--- a/packages/ariakit-react-components/src/radio/radio.tsx
+++ b/packages/ariakit-react-components/src/radio/radio.tsx
@@ -75,14 +75,14 @@ export const useRadio = createHook<TagName, RadioOptions>(function useRadio({
     (state) => checked ?? getIsChecked(value, state?.value),
   );
 
-  // Use the store's id as the default name to ensure radios in different
-  // groups have unique names. This prevents the browser from treating all
-  // radios as a single group. See https://github.com/ariakit/ariakit/issues/3833
+  // Use the store's id as the default name to ensure radios in different groups
+  // have unique names. This prevents the browser from treating all radios as a
+  // single group. See https://github.com/ariakit/ariakit/issues/3833
   const storeId = useStoreState(store, "id");
   const name = nameProp ?? storeId;
 
-  // TODO: Consider moving this synchronization into the radio store.
-  // Keep the checked radio active; otherwise the first item becomes active.
+  // TODO: Consider moving this synchronization into the radio store. Keep the
+  // checked radio active; otherwise the first item becomes active.
   useEffect(() => {
     if (!id) return;
     if (!isChecked) return;
@@ -96,8 +96,8 @@ export const useRadio = createHook<TagName, RadioOptions>(function useRadio({
   const nativeRadio = isNativeRadio(tagName, props.type);
   const disabled = groupDisabled || disabledFromProps(props);
   // When the checked property is programmatically set on the change event, we
-  // need to schedule the element's property update, so the controlled
-  // isChecked state can be taken into account.
+  // need to schedule the element's property update, so the controlled isChecked
+  // state can be taken into account.
   const [propertyUpdated, schedulePropertyUpdate] = useForceUpdate();
 
   useEffect(() => {
@@ -155,13 +155,13 @@ export const useRadio = createHook<TagName, RadioOptions>(function useRadio({
     const { moves, activeId } = store.getState();
     if (!moves) return;
     if (id && activeId !== id) return;
-    // The composite keydown handler calls preventDefault() before moving
-    // focus, which suppresses the browser's native check-on-arrow-key
-    // behavior. Replay that activation with a real click so React delivers an
-    // actual change event with checked already set, going through its
-    // controlled input state restoration. The checked guard keeps no-op focus
-    // events, such as tabbing back to the checked radio, from dispatching
-    // spurious clicks. See https://github.com/ariakit/ariakit/issues/6345
+    // The composite keydown handler calls preventDefault() before moving focus,
+    // which suppresses the browser's native check-on-arrow-key behavior. Replay
+    // that activation with a real click so React delivers an actual change
+    // event with checked already set, going through its controlled input state
+    // restoration. The checked guard keeps no-op focus events, such as tabbing
+    // back to the checked radio, from dispatching spurious clicks. See
+    // https://github.com/ariakit/ariakit/issues/6345
     if (event.currentTarget.checked) return;
     event.currentTarget.click();
   });

--- a/packages/ariakit-react-components/src/select/select-anchor.tsx
+++ b/packages/ariakit-react-components/src/select/select-anchor.tsx
@@ -34,7 +34,7 @@ export const useSelectAnchor = createHook<TagName, SelectAnchorOptions>(
  * Renders an element that acts as the anchor for the
  * [`SelectPopover`](https://ariakit.com/reference/select-popover) component.
  * @deprecated Use
- * [`ComboboxAnchor`](https://ariakit.com/reference/combobox-anchor) instead.
+ *   [`ComboboxAnchor`](https://ariakit.com/reference/combobox-anchor) instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {3}

--- a/packages/ariakit-react-components/src/select/select-arrow.tsx
+++ b/packages/ariakit-react-components/src/select/select-arrow.tsx
@@ -41,8 +41,8 @@ export const useSelectArrow = createHook<TagName, SelectArrowOptions>(
  * rendered inside the [`Select`](https://ariakit.com/reference/select)
  * component.
  * @deprecated Use
- * [`ComboboxSelectArrow`](https://ariakit.com/reference/combobox-select-arrow)
- * instead.
+ *   [`ComboboxSelectArrow`](https://ariakit.com/reference/combobox-select-arrow)
+ *   instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {4}

--- a/packages/ariakit-react-components/src/select/select-context.tsx
+++ b/packages/ariakit-react-components/src/select/select-context.tsx
@@ -19,8 +19,8 @@ const ctx = createStoreContext<SelectStore>(
 /**
  * Returns the select store from the nearest select container.
  * @deprecated Use
- * [`useComboboxContext`](https://ariakit.com/reference/use-combobox-context)
- * instead.
+ *   [`useComboboxContext`](https://ariakit.com/reference/use-combobox-context)
+ *   instead.
  * @example
  * function Select() {
  *   const store = useSelectContext();

--- a/packages/ariakit-react-components/src/select/select-dismiss.tsx
+++ b/packages/ariakit-react-components/src/select/select-dismiss.tsx
@@ -40,7 +40,8 @@ export const useSelectDismiss = createHook<TagName, SelectDismissOptions>(
  * rendered within a [`SelectList`](https://ariakit.com/reference/select-list)
  * instead of directly within the popover.
  * @deprecated Use
- * [`ComboboxDismiss`](https://ariakit.com/reference/combobox-dismiss) instead.
+ *   [`ComboboxDismiss`](https://ariakit.com/reference/combobox-dismiss)
+ *   instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {4}
@@ -69,10 +70,9 @@ export interface SelectDismissOptions<
 > extends PopoverDismissOptions<T> {
   /**
    * Object returned by the
-   * [`useSelectStore`](https://ariakit.com/reference/use-select-store) hook.
-   * If not provided, the closest
-   * [`Select`](https://ariakit.com/reference/select) or
-   * [`SelectProvider`](https://ariakit.com/reference/select-provider)
+   * [`useSelectStore`](https://ariakit.com/reference/use-select-store) hook. If
+   * not provided, the closest [`Select`](https://ariakit.com/reference/select)
+   * or [`SelectProvider`](https://ariakit.com/reference/select-provider)
    * components' context will be used.
    */
   store?: SelectStore;

--- a/packages/ariakit-react-components/src/select/select-group-label.tsx
+++ b/packages/ariakit-react-components/src/select/select-group-label.tsx
@@ -33,8 +33,8 @@ export const useSelectGroupLabel = createHook<TagName, SelectGroupLabelOptions>(
  * [`SelectGroup`](https://ariakit.com/reference/select-group) so the
  * `aria-labelledby` prop is properly set on the select group element.
  * @deprecated Use
- * [`ComboboxGroupLabel`](https://ariakit.com/reference/combobox-group-label)
- * instead.
+ *   [`ComboboxGroupLabel`](https://ariakit.com/reference/combobox-group-label)
+ *   instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {5,10}

--- a/packages/ariakit-react-components/src/select/select-group.tsx
+++ b/packages/ariakit-react-components/src/select/select-group.tsx
@@ -39,7 +39,7 @@ export const useSelectGroup = createHook<TagName, SelectGroupOptions>(
  * [`SelectGroupLabel`](https://ariakit.com/reference/select-group-label) can be
  * rendered as a child to provide a label for the group.
  * @deprecated Use
- * [`ComboboxGroup`](https://ariakit.com/reference/combobox-group) instead.
+ *   [`ComboboxGroup`](https://ariakit.com/reference/combobox-group) instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {4-8}

--- a/packages/ariakit-react-components/src/select/select-heading.tsx
+++ b/packages/ariakit-react-components/src/select/select-heading.tsx
@@ -58,7 +58,8 @@ export const useSelectHeading = createHook<TagName, SelectHeadingOptions>(
  * rendered within a [`SelectList`](https://ariakit.com/reference/select-list)
  * instead of directly within the popover.
  * @deprecated Use
- * [`ComboboxHeading`](https://ariakit.com/reference/combobox-heading) instead.
+ *   [`ComboboxHeading`](https://ariakit.com/reference/combobox-heading)
+ *   instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {4}
@@ -90,10 +91,10 @@ export interface SelectHeadingOptions<
    * [`useSelectStore`](https://ariakit.com/reference/use-select-store) hook.
    *
    * **Note**: This prop has no effect on this component. The heading is linked
-   * to the closest [`SelectList`](https://ariakit.com/reference/select-list)
-   * or [`SelectPopover`](https://ariakit.com/reference/select-popover)
-   * component through React context, so it must be rendered inside the list or
-   * popover for the `aria-labelledby` prop to be set on that element.
+   * to the closest [`SelectList`](https://ariakit.com/reference/select-list) or
+   * [`SelectPopover`](https://ariakit.com/reference/select-popover) component
+   * through React context, so it must be rendered inside the list or popover
+   * for the `aria-labelledby` prop to be set on that element.
    */
   store?: SelectStore;
 }

--- a/packages/ariakit-react-components/src/select/select-item-check.tsx
+++ b/packages/ariakit-react-components/src/select/select-item-check.tsx
@@ -41,8 +41,8 @@ export const useSelectItemCheck = createHook<TagName, SelectItemCheckOptions>(
  * [`checked`](https://ariakit.com/reference/select-item-check#checked) prop is
  * automatically derived from the context.
  * @deprecated Use
- * [`ComboboxItemCheck`](https://ariakit.com/reference/combobox-item-check)
- * instead.
+ *   [`ComboboxItemCheck`](https://ariakit.com/reference/combobox-item-check)
+ *   instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {5,9}

--- a/packages/ariakit-react-components/src/select/select-item-selected.tsx
+++ b/packages/ariakit-react-components/src/select/select-item-selected.tsx
@@ -10,8 +10,8 @@ import { SelectItemCheckedContext } from "./select-context.tsx";
  * As a value component, it doesn't render any DOM elements and therefore
  * doesn't accept HTML props.
  * @deprecated Use
- * [`ComboboxItemSelected`](https://ariakit.com/reference/combobox-item-selected)
- * instead.
+ *   [`ComboboxItemSelected`](https://ariakit.com/reference/combobox-item-selected)
+ *   instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {5-7}

--- a/packages/ariakit-react-components/src/select/select-item.tsx
+++ b/packages/ariakit-react-components/src/select/select-item.tsx
@@ -185,10 +185,10 @@ export const useSelectItem = createHook<TagName, SelectItemOptions>(
       store,
       ...props,
       // Withhold focusOnHover while the popup is closed, even for authored
-      // values, so hover can't activate an item or move focus while the
-      // select is collapsed. Check open before the authored callback so its
-      // side effects never run while closed, and again after so built-in
-      // activation stops when the callback itself closes the select.
+      // values, so hover can't activate an item or move focus while the select
+      // is collapsed. Check open before the authored callback so its side
+      // effects never run while closed, and again after so built-in activation
+      // stops when the callback itself closes the select.
       // https://github.com/ariakit/ariakit/issues/7120
       focusOnHover(event) {
         if (!store.getState().open) return false;
@@ -215,8 +215,8 @@ export const useSelectItem = createHook<TagName, SelectItemOptions>(
  * By default, the [`value`](https://ariakit.com/reference/select-item#value)
  * prop will be rendered as the children, but this can be overriden if a custom
  * children is provided.
- * @deprecated Use
- * [`ComboboxItem`](https://ariakit.com/reference/combobox-item) instead.
+ * @deprecated Use [`ComboboxItem`](https://ariakit.com/reference/combobox-item)
+ *   instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {4-5}

--- a/packages/ariakit-react-components/src/select/select-label.tsx
+++ b/packages/ariakit-react-components/src/select/select-label.tsx
@@ -80,8 +80,8 @@ export const useSelectLabel = createHook<TagName, SelectLabelOptions>(
  * label element. This component will move focus to the
  * [`Select`](https://ariakit.com/reference/select) component when clicked.
  * @deprecated Use
- * [`ComboboxSelectLabel`](https://ariakit.com/reference/combobox-select-label)
- * instead.
+ *   [`ComboboxSelectLabel`](https://ariakit.com/reference/combobox-select-label)
+ *   instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {2}

--- a/packages/ariakit-react-components/src/select/select-list.tsx
+++ b/packages/ariakit-react-components/src/select/select-list.tsx
@@ -184,8 +184,8 @@ export const useSelectList = createHook<TagName, SelectListOptions>(
  *
  * The `aria-labelledby` prop is set to the
  * [`Select`](https://ariakit.com/reference/select) element's `id` by default.
- * @deprecated Use
- * [`ComboboxList`](https://ariakit.com/reference/combobox-list) instead.
+ * @deprecated Use [`ComboboxList`](https://ariakit.com/reference/combobox-list)
+ *   instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {5-8}

--- a/packages/ariakit-react-components/src/select/select-popover.tsx
+++ b/packages/ariakit-react-components/src/select/select-popover.tsx
@@ -40,7 +40,8 @@ export const useSelectPopover = createHook<TagName, SelectPopoverOptions>(
  * default, but can be overriden by any other valid select popup role
  * (`listbox`, `menu`, `tree`, `grid` or `dialog`).
  * @deprecated Use
- * [`ComboboxPopover`](https://ariakit.com/reference/combobox-popover) instead.
+ *   [`ComboboxPopover`](https://ariakit.com/reference/combobox-popover)
+ *   instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {3-6}

--- a/packages/ariakit-react-components/src/select/select-provider.tsx
+++ b/packages/ariakit-react-components/src/select/select-provider.tsx
@@ -10,8 +10,8 @@ type Value = SelectStoreValue;
  * Provides a select store to [Select](https://ariakit.com/components/select)
  * components.
  * @deprecated Use
- * [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)
- * instead.
+ *   [`ComboboxProvider`](https://ariakit.com/reference/combobox-provider)
+ *   instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx

--- a/packages/ariakit-react-components/src/select/select-row.tsx
+++ b/packages/ariakit-react-components/src/select/select-row.tsx
@@ -55,8 +55,8 @@ export const useSelectRow = createHook<TagName, SelectRowOptions>(
  * [`SelectItem`](https://ariakit.com/reference/select-item) elements wrapped
  * within this component will automatically receive a
  * [`rowId`](https://ariakit.com/reference/select-item#rowid) prop.
- * @deprecated Use
- * [`ComboboxRow`](https://ariakit.com/reference/combobox-row) instead.
+ * @deprecated Use [`ComboboxRow`](https://ariakit.com/reference/combobox-row)
+ *   instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {4-11}

--- a/packages/ariakit-react-components/src/select/select-separator.tsx
+++ b/packages/ariakit-react-components/src/select/select-separator.tsx
@@ -38,8 +38,8 @@ export const useSelectSeparator = createHook<TagName, SelectSeparatorOptions>(
  * Renders a divider between
  * [`SelectItem`](https://ariakit.com/reference/select-item) elements.
  * @deprecated Use
- * [`ComboboxGroup`](https://ariakit.com/reference/combobox-group) with CSS
- * borders instead.
+ *   [`ComboboxGroup`](https://ariakit.com/reference/combobox-group) with CSS
+ *   borders instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {5}

--- a/packages/ariakit-react-components/src/select/select-store.ts
+++ b/packages/ariakit-react-components/src/select/select-store.ts
@@ -56,8 +56,8 @@ export function useSelectStoreProps<T extends Core.SelectStore>(
  * Creates a select store to control the state of
  * [Select](https://ariakit.com/components/select) components.
  * @deprecated Use
- * [`useComboboxStore`](https://ariakit.com/reference/use-combobox-store)
- * instead.
+ *   [`useComboboxStore`](https://ariakit.com/reference/use-combobox-store)
+ *   instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx

--- a/packages/ariakit-react-components/src/select/select-value.tsx
+++ b/packages/ariakit-react-components/src/select/select-value.tsx
@@ -16,17 +16,16 @@ type Value = SelectStoreValue;
  * [`fallback`](https://ariakit.com/reference/select-value#fallback) prop to use
  * as a default value if the store's value is an empty string or empty array.
  *
- * The store's
- * [`value`](https://ariakit.com/reference/use-select-store#value) is
- * otherwise rendered as-is.
+ * The store's [`value`](https://ariakit.com/reference/use-select-store#value)
+ * is otherwise rendered as-is.
  *
  * Additionally, it takes a
  * [`children`](https://ariakit.com/reference/select-value#children) function
  * that gets called with the current value as an argument. This is handy for
  * rendering the value in a custom way.
  * @deprecated Use
- * [`ComboboxSelectedValue`](https://ariakit.com/reference/combobox-selected-value)
- * instead.
+ *   [`ComboboxSelectedValue`](https://ariakit.com/reference/combobox-selected-value)
+ *   instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {3}
@@ -104,9 +103,8 @@ export interface SelectValueProps<T extends Value = Value> {
    * The value to use as a default if the store's value is an empty string or
    * empty array.
    *
-   * The store's
-   * [`value`](https://ariakit.com/reference/use-select-store#value) is
-   * otherwise rendered as-is.
+   * The store's [`value`](https://ariakit.com/reference/use-select-store#value)
+   * is otherwise rendered as-is.
    * @default ""
    */
   fallback?: T;

--- a/packages/ariakit-react-components/src/select/select.tsx
+++ b/packages/ariakit-react-components/src/select/select.tsx
@@ -59,11 +59,11 @@ function nextWithValue(store: SelectStore, next: SelectStore["next"]) {
       if (nextItem.value != null) {
         return nextItem.id;
       }
-      // Walking from the last returned id, as if the key was pressed again
-      // from there, skips items without value even across focusLoop
-      // boundaries. A repeated id means the walk cycled through every
-      // reachable item without finding one with value, so we return undefined
-      // to keep move() from changing the active item.
+      // Walking from the last returned id, as if the key was pressed again from
+      // there, skips items without value even across focusLoop boundaries. A
+      // repeated id means the walk cycled through every reachable item without
+      // finding one with value, so we return undefined to keep move() from
+      // changing the active item.
       if (visitedIds.has(nextId)) return;
       visitedIds.add(nextId);
       nextId = next({ activeId: nextId });
@@ -168,8 +168,8 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
   const [autofill, setAutofill] = useState(false);
   const nativeSelectChangedRef = useRef(false);
 
-  // Resets the autofilled state when the select value changes, but only if
-  // the change wasn't triggered by the native select element (which is an
+  // Resets the autofilled state when the select value changes, but only if the
+  // change wasn't triggered by the native select element (which is an
   // autofill).
   useEffect(() => {
     const nativeSelectChanged = nativeSelectChangedRef.current;
@@ -305,7 +305,7 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
  * [`SelectArrow`](https://ariakit.com/reference/select-arrow) component. This
  * can be customized by passing different children to the component.
  * @deprecated Use
- * [`ComboboxSelect`](https://ariakit.com/reference/combobox-select) instead.
+ *   [`ComboboxSelect`](https://ariakit.com/reference/combobox-select) instead.
  * @see https://ariakit.com/components/select
  * @example
  * ```jsx {2}
@@ -341,11 +341,10 @@ export interface SelectOptions<T extends ElementType = TagName>
    */
   store?: SelectStore;
   /**
-   * Determines if the
-   * [`SelectList`](https://ariakit.com/reference/select-list) or
-   * [`SelectPopover`](https://ariakit.com/reference/select-popover) components
-   * will appear when the user uses arrow keys while the select element is
-   * in focus.
+   * Determines if the [`SelectList`](https://ariakit.com/reference/select-list)
+   * or [`SelectPopover`](https://ariakit.com/reference/select-popover)
+   * components will appear when the user uses arrow keys while the select
+   * element is in focus.
    * @default true
    */
   showOnKeyDown?: BooleanOrCallback<KeyboardEvent<HTMLElement>>;
@@ -364,8 +363,8 @@ export interface SelectOptions<T extends ElementType = TagName>
    * [`SelectPopover`](https://ariakit.com/reference/select-popover) components.
    * @default true
    * @deprecated Use
-   * [`toggleOnClick`](https://ariakit.com/reference/select#toggleonclick)
-   * instead.
+   *   [`toggleOnClick`](https://ariakit.com/reference/select#toggleonclick)
+   *   instead.
    */
   toggleOnPress?: BooleanOrCallback<
     MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>

--- a/packages/ariakit-react-components/src/tab/tab-panel.tsx
+++ b/packages/ariakit-react-components/src/tab/tab-panel.tsx
@@ -135,10 +135,10 @@ export const useTabPanel = createHook<TagName, TabPanelOptions>(
 
     const [hasTabbableChildren, setHasTabbableChildren] = useState(false);
 
-    // Re-check tabbable children each time the panel becomes visible so
-    // content rendered conditionally on tab selection is accounted for. The
-    // tabId dependency covers the single-panel pattern, where the panel stays
-    // mounted and only its tabId and children change on tab selection.
+    // Re-check tabbable children each time the panel becomes visible so content
+    // rendered conditionally on tab selection is accounted for. The tabId
+    // dependency covers the single-panel pattern, where the panel stays mounted
+    // and only its tabId and children change on tab selection.
     useSafeLayoutEffect(() => {
       if (!mounted) return;
       const element = ref.current;

--- a/packages/ariakit-react-components/src/tab/tab.tsx
+++ b/packages/ariakit-react-components/src/tab/tab.tsx
@@ -51,8 +51,8 @@ export const useTab = createHook<TagName, TabOptions>(function useTab({
       "Tab must be wrapped in a TabList component.",
   );
 
-  // Keep a reference to the default id so we can wait before all tabs have
-  // been assigned an id before registering them in the store. See
+  // Keep a reference to the default id so we can wait before all tabs have been
+  // assigned an id before registering them in the store. See
   // https://github.com/ariakit/ariakit/issues/1721
   const defaultId = useId();
   const id = props.id || defaultId;

--- a/packages/ariakit-react-components/src/tag/tag-input.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-input.tsx
@@ -130,10 +130,10 @@ export const useTagInput = createHook<TagName, TagInputOptions>(
         const eventWithValues = Object.assign(event, { values });
         if (values.length && addValueOnChangeProp(eventWithValues)) {
           // We need to prevent the default behavior here in case the tag input
-          // component is combined with another component that also listens to the
-          // change event and updates the store value, such as Combobox. In this
-          // case, the tag input logic should take precedence even if this event
-          // handler is called first.
+          // component is combined with another component that also listens to
+          // the change event and updates the store value, such as Combobox. In
+          // this case, the tag input logic should take precedence even if this
+          // event handler is called first.
           event.preventDefault();
           for (const tagValue of values) {
             store.addValue(tagValue);
@@ -270,10 +270,9 @@ export interface TagInputOptions<
     EventWithValues<ChangeEvent<HTMLElement>>
   >;
   /**
-   * Whether the tag
-   * [`value`](https://ariakit.com/reference/tag-provider#value) state
-   * should be updated when the input value changes. This is useful if you want
-   * to customize how the store
+   * Whether the tag [`value`](https://ariakit.com/reference/tag-provider#value)
+   * state should be updated when the input value changes. This is useful if you
+   * want to customize how the store
    * [`value`](https://ariakit.com/reference/tag-provider#value) is updated
    * based on the input element's value.
    * @default true

--- a/packages/ariakit-react-components/src/tag/tag-store.ts
+++ b/packages/ariakit-react-components/src/tag/tag-store.ts
@@ -57,8 +57,7 @@ export interface TagStoreOptions
   extends Core.TagStoreOptions, CompositeStoreOptions<TagStoreItem> {
   /**
    * A callback that gets called when the
-   * [`value`](https://ariakit.com/reference/tag-provider#value) state
-   * changes.
+   * [`value`](https://ariakit.com/reference/tag-provider#value) state changes.
    */
   setValue?: (value: TagStoreState["value"]) => void;
   /**

--- a/packages/ariakit-react-components/src/tag/tag-value.tsx
+++ b/packages/ariakit-react-components/src/tag/tag-value.tsx
@@ -6,16 +6,15 @@ import type { TagStore, TagStoreState } from "./tag-store.ts";
 
 /**
  * Renders the current
- * [`value`](https://ariakit.com/reference/use-tag-store#value) state in
- * the [tag store](https://ariakit.com/reference/use-tag-store).
+ * [`value`](https://ariakit.com/reference/use-tag-store#value) state in the
+ * [tag store](https://ariakit.com/reference/use-tag-store).
  *
  * As a value component, it doesn't render any DOM elements and therefore
  * doesn't accept HTML props.
  *
- * It takes a
- * [`children`](https://ariakit.com/reference/tag-value#children) function
- * that gets called with the current value as an argument. This can be used as
- * an uncontrolled API to render the tag value in a custom way.
+ * It takes a [`children`](https://ariakit.com/reference/tag-value#children)
+ * function that gets called with the current value as an argument. This can be
+ * used as an uncontrolled API to render the tag value in a custom way.
  * @see https://ariakit.com/components/tag
  * @example
  * ```jsx {3-5}
@@ -49,10 +48,10 @@ export function TagValue({ store, children }: TagValueProps = {}) {
 export interface TagValueProps {
   /**
    * Object returned by the
-   * [`useTagStore`](https://ariakit.com/reference/use-tag-store)
-   * hook. If not provided, the closest
-   * [`TagProvider`](https://ariakit.com/reference/tag-provider)
-   * component's context will be used.
+   * [`useTagStore`](https://ariakit.com/reference/use-tag-store) hook. If not
+   * provided, the closest
+   * [`TagProvider`](https://ariakit.com/reference/tag-provider) component's
+   * context will be used.
    */
   store?: TagStore;
   /**

--- a/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
+++ b/packages/ariakit-react-components/src/tooltip/tooltip-anchor.tsx
@@ -40,8 +40,8 @@ function hideStore(store: TooltipStore | null) {
   if (!store) return;
   hidingStores.add(store);
   store.hide();
-  // Cleanup runs after `hide()` so controlled `open` props still see this
-  // store in `hidingStores` when their batch microtask forces them open again.
+  // Cleanup runs after `hide()` so controlled `open` props still see this store
+  // in `hidingStores` when their batch microtask forces them open again.
   queueMicrotask(() => hidingStores.delete(store));
 }
 
@@ -106,9 +106,8 @@ export const useTooltipAnchor = createHook<TagName, TooltipAnchorOptions>(
           // Otherwise, if the current tooltip is closed, we should set a
           // timeout to hide the active tooltip in the global store. This is so
           // we can show other tooltips without a delay when there's already an
-          // active tooltip (see the showOnHover method below).
-          // Read skipTimeout lazily because this sync only subscribes to
-          // mounted.
+          // active tooltip (see the showOnHover method below). Read skipTimeout
+          // lazily because this sync only subscribes to mounted.
           const id = setTimeout(removeStore, store.getState().skipTimeout);
           return () => clearTimeout(id);
         }),

--- a/packages/ariakit-react-store/readme.md
+++ b/packages/ariakit-react-store/readme.md
@@ -44,7 +44,7 @@ interface UseState<S> {
   /**
    * Re-renders the component when state changes and returns the current state.
    * @deprecated Use
-   * [`useStoreState`](https://ariakit.com/reference/use-store-state) instead.
+   *   [`useStoreState`](https://ariakit.com/reference/use-store-state) instead.
    * @example
    * const state = store.useState();
    */
@@ -285,7 +285,7 @@ type Store<T extends CoreStore = CoreStore> = T & {
    * Re-renders the component when the state changes and returns the current
    * state.
    * @deprecated Use
-   * [`useStoreState`](https://ariakit.com/reference/use-store-state) instead.
+   *   [`useStoreState`](https://ariakit.com/reference/use-store-state) instead.
    */
   useState: UseState<StoreState<T>>;
 };

--- a/packages/ariakit-react-store/src/index.tsx
+++ b/packages/ariakit-react-store/src/index.tsx
@@ -14,7 +14,7 @@ export interface UseState<S> {
   /**
    * Re-renders the component when state changes and returns the current state.
    * @deprecated Use
-   * [`useStoreState`](https://ariakit.com/reference/use-store-state) instead.
+   *   [`useStoreState`](https://ariakit.com/reference/use-store-state) instead.
    * @example
    * const state = store.useState();
    */
@@ -25,7 +25,7 @@ export interface UseState<S> {
    * re-render.
    * @param key The state key.
    * @deprecated Use
-   * [`useStoreState`](https://ariakit.com/reference/use-store-state) instead.
+   *   [`useStoreState`](https://ariakit.com/reference/use-store-state) instead.
    * @example
    * const foo = store.useState("foo");
    */
@@ -37,7 +37,7 @@ export interface UseState<S> {
    * selector function.
    * @param selector The selector function.
    * @deprecated Use
-   * [`useStoreState`](https://ariakit.com/reference/use-store-state) instead.
+   *   [`useStoreState`](https://ariakit.com/reference/use-store-state) instead.
    * @example
    * const foo = store.useState((state) => state.foo);
    */
@@ -278,10 +278,10 @@ function getStoreStateObjectKeys(
  * Receives an Ariakit store object (which can be `null` or `undefined`) and
  * returns the current state. Unlike `useStoreState`, this hook receives an
  * object with keys that map to store keys or selector functions. Store keys in
- * the object are always subscribed to. When selector dependency keys are
- * passed as the second argument, they must include every store key read by
- * every selector, or the returned snapshot may stay stale. An empty list means
- * only direct store keys in the object will notify the selectors.
+ * the object are always subscribed to. When selector dependency keys are passed
+ * as the second argument, they must include every store key read by every
+ * selector, or the returned snapshot may stay stale. An empty list means only
+ * direct store keys in the object will notify the selectors.
  * @example
  * Reading direct and derived values with selector dependencies:
  * ```js
@@ -437,7 +437,7 @@ export function useStoreProps<
  * Creates a React store from a core store object and returns a tuple with the
  * store and a function to update the store.
  * @param createStore A function that receives the props and returns a core
- * store object.
+ *   store object.
  * @param props The props to pass to the createStore function.
  */
 export function useStore<T extends CoreStore, P>(
@@ -471,7 +471,7 @@ export type Store<T extends CoreStore = CoreStore> = T & {
    * Re-renders the component when the state changes and returns the current
    * state.
    * @deprecated Use
-   * [`useStoreState`](https://ariakit.com/reference/use-store-state) instead.
+   *   [`useStoreState`](https://ariakit.com/reference/use-store-state) instead.
    */
   useState: UseState<StoreState<T>>;
 };

--- a/packages/ariakit-react-utils/readme.md
+++ b/packages/ariakit-react-utils/readme.md
@@ -581,12 +581,12 @@ interface Options {
    * original component props and gives back a React element with the props
    * merged.
    *
-   * Some Ariakit components detect the type of the underlying element when
-   * they mount. If the render element's type may change while the component
-   * is mounted, pass a
+   * Some Ariakit components detect the type of the underlying element when they
+   * mount. If the render element's type may change while the component is
+   * mounted, pass a
    * [`key`](https://react.dev/learn/preserving-and-resetting-state) prop that
-   * changes with the element type so React remounts the component with the
-   * new element. Remounting resets uncontrolled state, so keep the relevant
+   * changes with the element type so React remounts the component with the new
+   * element. Remounting resets uncontrolled state, so keep the relevant state
    // ... 11 more lines
    * for more details.
    */

--- a/packages/ariakit-react-utils/src/hooks.ts
+++ b/packages/ariakit-react-utils/src/hooks.ts
@@ -162,9 +162,9 @@ export function useMergeRefs(...refs: Array<Ref<any> | undefined>) {
           if (cleanup) {
             cleanup();
           } else {
-            // React only sees the merged ref, so its cleanup replaces the
-            // usual null call for all refs. Child refs that didn't return a
-            // cleanup still need the null detach they would receive alone.
+            // React only sees the merged ref, so its cleanup replaces the usual
+            // null call for all refs. Child refs that didn't return a cleanup
+            // still need the null detach they would receive alone.
             setRef(ref, null);
           }
         }
@@ -431,8 +431,8 @@ export function useIsMouseMoving() {
   useEffect(() => {
     if (hasInstalledGlobalEventListeners) return;
     // We're not returning the event listener cleanup function here because we
-    // may lose some events if this component is unmounted, but others are
-    // still mounted.
+    // may lose some events if this component is unmounted, but others are still
+    // mounted.
     addGlobalEventListener("mousemove", setMouseMoving, true);
     // See https://github.com/ariakit/ariakit/issues/1137
     addGlobalEventListener("mousedown", resetMouseMoving, true);

--- a/packages/ariakit-react-utils/src/types.ts
+++ b/packages/ariakit-react-utils/src/types.ts
@@ -32,13 +32,13 @@ export interface Options {
    * original component props and gives back a React element with the props
    * merged.
    *
-   * Some Ariakit components detect the type of the underlying element when
-   * they mount. If the render element's type may change while the component
-   * is mounted, pass a
+   * Some Ariakit components detect the type of the underlying element when they
+   * mount. If the render element's type may change while the component is
+   * mounted, pass a
    * [`key`](https://react.dev/learn/preserving-and-resetting-state) prop that
-   * changes with the element type so React remounts the component with the
-   * new element. Remounting resets uncontrolled state, so keep the relevant
-   * state controlled:
+   * changes with the element type so React remounts the component with the new
+   * element. Remounting resets uncontrolled state, so keep the relevant state
+   * controlled:
    * ```jsx
    * <Checkbox
    *   key={custom ? "custom" : "native"}

--- a/packages/ariakit-scripts/src/docs.test.ts
+++ b/packages/ariakit-scripts/src/docs.test.ts
@@ -971,8 +971,8 @@ const docsPackages: Array<{ dir: string; targets: DocsTarget[] }> = [
 
 // Generated React signatures depend on the installed React types (e.g.
 // `RefObject` vs `MutableRefObject`), so the committed readmes are only
-// canonical under the repo's React version. Skip this check on the older
-// React 18 test run, where regeneration would infer different signatures.
+// canonical under the repo's React version. Skip this check on the older React
+// 18 test run, where regeneration would infer different signatures.
 const reactMajor = Number.parseInt(
   createRequire(import.meta.url)("react/package.json").version,
   10,

--- a/packages/ariakit-scripts/src/docs.ts
+++ b/packages/ariakit-scripts/src/docs.ts
@@ -199,8 +199,8 @@ function getExcludeSourceFile(
   exclude: string,
   rootPath: string,
 ) {
-  // Prefer the module the entry re-exports under this specifier so excluding
-  // an external package like `@playwright/test` resolves to its declarations.
+  // Prefer the module the entry re-exports under this specifier so excluding an
+  // external package like `@playwright/test` resolves to its declarations.
   for (const declaration of entrySourceFile.getExportDeclarations()) {
     if (declaration.getModuleSpecifierValue() !== exclude) continue;
     const sourceFile = declaration.getModuleSpecifierSourceFile();
@@ -590,8 +590,8 @@ function hasFencedCodeBlock(code: string) {
 function renderExample(example: string) {
   const trimmed = example.trim();
   // Examples that already contain a fenced code block (optionally with
-  // surrounding prose) are treated as Markdown and emitted as-is. Wrapping
-  // them in another code fence would nest fences and break rendering.
+  // surrounding prose) are treated as Markdown and emitted as-is. Wrapping them
+  // in another code fence would nest fences and break rendering.
   if (hasFencedCodeBlock(trimmed)) return trimmed;
   return renderCodeBlock(trimmed);
 }

--- a/packages/ariakit-scripts/src/perf-compare.test.ts
+++ b/packages/ariakit-scripts/src/perf-compare.test.ts
@@ -397,8 +397,8 @@ test("reads and writes an absolute results directory outside the current directo
   const workingDir = createTempDir();
   const outputDir = path.join(createTempDir(), "chrome-rounds");
   // Numbered, job-indexed names are what the perf workflow stages into the
-  // directory it passes, so this covers the round-file branch the relative
-  // test above does not reach.
+  // directory it passes, so this covers the round-file branch the relative test
+  // above does not reach.
   writeJsonInto(outputDir, "baseline-1-j1-worker0.json", [createResult(100)]);
   writeJsonInto(outputDir, "current-1-j1-worker0.json", [createResult(120)]);
 
@@ -406,8 +406,8 @@ test("reads and writes an absolute results directory outside the current directo
 
   const markdown = readFileSync(path.join(outputDir, "comparison.md"), "utf-8");
   expect(markdown).toContain("100ms → 120ms (+20%) :warning:");
-  // The workflow reads every generated file from the directory it passed in,
-  // so the whole output set must follow the rounds instead of the cwd.
+  // The workflow reads every generated file from the directory it passed in, so
+  // the whole output set must follow the rounds instead of the cwd.
   expect(existsSync(path.join(outputDir, "comparison.json"))).toBe(true);
   expect(existsSync(path.join(outputDir, "confirmation-files.txt"))).toBe(true);
   expect(existsSync(path.join(outputDir, "confirmation-targets.json"))).toBe(
@@ -858,8 +858,8 @@ test("does not flag noisy rounds that disagree on direction", () => {
   expect(markdown).not.toContain("Unconfirmed changes");
   expect(markdown).not.toMatch(/% :warning:/);
   expect(markdown).toContain("Aggregated across 5 interleaved rounds");
-  // Clean comparisons still write the workflow list so shell consumers can
-  // read it unconditionally.
+  // Clean comparisons still write the workflow list so shell consumers can read
+  // it unconditionally.
   expect(readConfirmationFilesList(dir)).toBe("");
 });
 
@@ -895,8 +895,8 @@ test("reports overlapping same-direction rounds as unconfirmed candidates", () =
   );
   expect(markdown).not.toContain("| open with mouse | Scripting |");
   expect(markdown).toContain("120ms | 140ms | +20ms (+17%)");
-  // Candidates are reported in the unconfirmed changes section, not repeated
-  // in the detailed breakdown diagnostics.
+  // Candidates are reported in the unconfirmed changes section, not repeated in
+  // the detailed breakdown diagnostics.
   expect(markdown).not.toContain("Unflagged threshold-sized changes");
   expect(markdown).not.toMatch(/% :warning:/);
   expect(markdown).not.toMatch(/% :rocket:/);
@@ -906,8 +906,8 @@ test("grades candidates by their displayed pairs percent", () => {
   const dir = createTempDir();
   const baseline = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
   // 70 of 100 pairwise deltas support round 1 and 69 of 100 support round 2,
-  // pooling to 139/200 = 69.5%, which displays as "pairs 70%". The medium
-  // grade must match the displayed percent, not the raw 69.5 value.
+  // pooling to 139/200 = 69.5%, which displays as "pairs 70%". The medium grade
+  // must match the displayed percent, not the raw 69.5 value.
   writeRawRound(dir, "baseline", 1, baseline);
   writeRawRound(dir, "current", 1, [35, 45, 75, 85, 85, 85, 85, 85, 85, 85]);
   writeRawRound(dir, "baseline", 2, baseline);
@@ -1093,8 +1093,8 @@ test("lists confirmation files for significant and candidate changes", () => {
     "sandbox/a/perf-chrome.ts",
     "sandbox/b/perf-chrome.ts",
   ]);
-  // The perf workflow consumes the flagged files as a plain-text list, one
-  // per line.
+  // The perf workflow consumes the flagged files as a plain-text list, one per
+  // line.
   expect(readConfirmationFilesList(dir)).toBe(
     "sandbox/a/perf-chrome.ts\nsandbox/b/perf-chrome.ts\n",
   );

--- a/packages/ariakit-scripts/src/perf-compare.ts
+++ b/packages/ariakit-scripts/src/perf-compare.ts
@@ -30,15 +30,15 @@ const THRESHOLD_PERCENT = 10;
 const MIN_SIGNIFICANT_DELTA_MS = 5;
 // Require at least 75% of each required round's pairwise raw-sample deltas to
 // support the paired median direction before a browser comparison becomes
-// significant. Threshold-sized changes whose rounds agree on direction but
-// fail this gate are reported as unconfirmed candidates instead.
+// significant. Threshold-sized changes whose rounds agree on direction but fail
+// this gate are reported as unconfirmed candidates instead.
 const RAW_SAMPLE_SUPPORT_QUANTILE = 0.25;
 // Cap the unconfirmed candidate table so a noisy run cannot flood the PR
 // comment; the detailed breakdown still lists every metric.
 const MAX_VISIBLE_CANDIDATE_ROWS = 10;
 // Pooled pairwise raw-sample agreement at or above this percent grades an
-// unconfirmed candidate as medium confidence: close to the 75% per-round
-// raw support gate without meeting it in every round.
+// unconfirmed candidate as medium confidence: close to the 75% per-round raw
+// support gate without meeting it in every round.
 const MEDIUM_CONFIDENCE_PAIRWISE_PERCENT = 70;
 
 type MetricKey = keyof PerfMetrics;
@@ -178,8 +178,8 @@ export interface PerfCompareRunResult {
   markdown: string;
 }
 
-// Metrics shown in the summary table and detailed breakdown. All of them can
-// be flagged as significant or reported as unconfirmed candidates.
+// Metrics shown in the summary table and detailed breakdown. All of them can be
+// flagged as significant or reported as unconfirmed candidates.
 const PRIMARY_METRICS: MetricKey[] = ["scripting", "rendering", "inp", "total"];
 
 const METRIC_LABELS: Record<MetricKey, string> = {
@@ -320,8 +320,8 @@ export function checkNodeBenchmarkResults(
 }
 
 // Discover round files like `baseline-1-worker0.json` and
-// `current-1-worker0.json`. If no numbered rounds are present, fall back to
-// the previous single-run files such as `baseline-worker0.json`.
+// `current-1-worker0.json`. If no numbered rounds are present, fall back to the
+// previous single-run files such as `baseline-worker0.json`.
 function discoverRoundFiles(
   prefix: string,
   options: PerfCompareOptions,
@@ -638,8 +638,8 @@ function computeSignificance({
   }
 
   // Share of all raw sample pairs (baseline x current, pooled across rounds)
-  // that move in the median's direction. 50% means the raw distributions
-  // fully overlap; the per-round raw support gate needs 75%.
+  // that move in the median's direction. 50% means the raw distributions fully
+  // overlap; the per-round raw support gate needs 75%.
   const pairwiseSupportPercent =
     pairwiseCount > 0 ? (pairwiseSupportCount / pairwiseCount) * 100 : 0;
 
@@ -854,8 +854,8 @@ function getSignificanceIcon(row: ComparisonRow, options: PerfCompareOptions) {
 }
 
 // Test files whose rows warrant extra confirmation rounds. Candidates are
-// included so a change that only fails raw sample support gets more data
-// before the final comparison is published.
+// included so a change that only fails raw sample support gets more data before
+// the final comparison is published.
 function getConfirmationFiles(rows: ComparisonRow[]): string[] {
   const files = new Set<string>();
   for (const row of rows) {
@@ -1190,10 +1190,10 @@ function formatSupport(row: ComparisonRow, options: PerfCompareOptions) {
   return `${rounds}, ${raw}, ${pairs}`;
 }
 
-// Candidate confidence comes from the pooled pairwise raw-sample agreement:
-// how many baseline x current sample pairs move in the median's direction.
-// Grade on the rounded value shown in the support diagnostics so a row can
-// never display a percent at the grade boundary with the lower grade.
+// Candidate confidence comes from the pooled pairwise raw-sample agreement: how
+// many baseline x current sample pairs move in the median's direction. Grade on
+// the rounded value shown in the support diagnostics so a row can never display
+// a percent at the grade boundary with the lower grade.
 function getCandidateConfidence(row: ComparisonRow) {
   const percent = Math.round(row.pairwiseSupportPercent);
   if (percent >= MEDIUM_CONFIDENCE_PAIRWISE_PERCENT) {

--- a/packages/ariakit-scripts/src/perf.test.ts
+++ b/packages/ariakit-scripts/src/perf.test.ts
@@ -120,13 +120,13 @@ test("detects navigation timeouts by class and message", () => {
   );
   expect(isNavigationTimeoutError(navigationTimeout)).toBe(true);
 
-  // Same message on a plain Error must not match: only Playwright timeouts
-  // are transient navigation stalls.
+  // Same message on a plain Error must not match: only Playwright timeouts are
+  // transient navigation stalls.
   const plainError = new Error("page.goto: Timeout 30000ms exceeded.");
   expect(isNavigationTimeoutError(plainError)).toBe(false);
 
-  // Non-navigation Playwright timeouts (interactions, verify steps) must not
-  // be retried; they can reflect real behavior of the measured code.
+  // Non-navigation Playwright timeouts (interactions, verify steps) must not be
+  // retried; they can reflect real behavior of the measured code.
   const clickTimeout = new errors.TimeoutError(
     'locator.click: Timeout 5000ms exceeded.\nCall log:\n  - waiting for locator("#nope")',
   );

--- a/packages/ariakit-scripts/src/perf.ts
+++ b/packages/ariakit-scripts/src/perf.ts
@@ -117,11 +117,11 @@ export interface PerfMeasureOptions {
   warmup?: number;
   /**
    * Unmeasured setup callback run before every iteration's measured
-   * interaction. For interaction measurements it runs after the iteration
-   * page loads; for page-load measurements it runs on the blank page before
-   * the measured navigation. Useful for getting the page into the state the
-   * measured interaction expects, such as opening a dialog before measuring
-   * how long it takes to close it.
+   * interaction. For interaction measurements it runs after the iteration page
+   * loads; for page-load measurements it runs on the blank page before the
+   * measured navigation. Useful for getting the page into the state the
+   * measured interaction expects, such as opening a dialog before measuring how
+   * long it takes to close it.
    */
   setup?: PerfMeasureCallback;
   /**
@@ -435,9 +435,9 @@ export function isPerfProfileLabel(label: string): boolean {
 
 /**
  * Resolves whether profiling runs in the measured iteration or in separate
- * diagnostic iterations. Env-driven profiling keeps the old quick measured
- * path with profiler overhead; explicit profiling options on regular labels
- * keep timing metrics unprofiled.
+ * diagnostic iterations. Env-driven profiling keeps the old quick measured path
+ * with profiler overhead; explicit profiling options on regular labels keep
+ * timing metrics unprofiled.
  */
 export function getPerfProfileMode({
   label,
@@ -1050,14 +1050,16 @@ async function gotoAndSettle(page: Page, url: string) {
 export interface SettleQuiescentOptions {
   /** Milliseconds between metric polls. */
   pollInterval?: number;
-  /** Minimum tracked-work increase in ms between polls that counts as activity. */
+  /**
+   * Minimum tracked-work increase in ms between polls that counts as activity.
+   */
   epsilon?: number;
   /** Consecutive quiet polls required before the page counts as settled. */
   quietPolls?: number;
   /**
    * Cap in ms on the polling phase, so busy pages cannot stall runs. Polling
-   * runs in whole `pollInterval` steps, so a non-divisible cap is rounded up
-   * to the next whole poll.
+   * runs in whole `pollInterval` steps, so a non-divisible cap is rounded up to
+   * the next whole poll.
    */
   maxWait?: number;
 }
@@ -1253,11 +1255,11 @@ async function measureOnce(
 
 /**
  * Context options mirrored from the test project configuration so iteration
- * contexts match the fixture page environment. `browser.newContext` starts
- * from Playwright's built-in defaults rather than the project's `use` block,
- * so the context-relevant options are forwarded explicitly. Only project-level
- * options are visible here: a per-file `test.use()` override would apply to
- * the fixture page but not to iteration contexts.
+ * contexts match the fixture page environment. `browser.newContext` starts from
+ * Playwright's built-in defaults rather than the project's `use` block, so the
+ * context-relevant options are forwarded explicitly. Only project-level options
+ * are visible here: a per-file `test.use()` override would apply to the fixture
+ * page but not to iteration contexts.
  */
 function getContextOptions(testInfo: TestInfo): BrowserContextOptions {
   const use = testInfo.project.use;
@@ -1291,15 +1293,15 @@ interface MeasureIterationParams {
 }
 
 /**
- * The runner's `screenshot: "only-on-failure"` captures the fixture page,
- * which never receives the interaction; attach the iteration page so failures
- * show the page that was actually measured. Best-effort: the original error
- * matters more than a failed screenshot.
+ * The runner's `screenshot: "only-on-failure"` captures the fixture page, which
+ * never receives the interaction; attach the iteration page so failures show
+ * the page that was actually measured. Best-effort: the original error matters
+ * more than a failed screenshot.
  */
 async function attachFailureScreenshot(testInfo: TestInfo, page: Page) {
   try {
-    // Bound the screenshot so a hung renderer cannot delay the rethrow of
-    // the original, more informative error.
+    // Bound the screenshot so a hung renderer cannot delay the rethrow of the
+    // original, more informative error.
     const body = await page.screenshot({ timeout: 5000 });
     await testInfo.attach("perf-iteration-failure", {
       body,
@@ -1335,10 +1337,10 @@ async function measureIteration(
       }
     };
 
-    // Track durations in thread CPU time instead of wall-clock time so time
-    // the renderer main thread spends preempted by other processes on a
-    // contended runner is not counted. The time domain must be set when the
-    // domain is enabled.
+    // Track durations in thread CPU time instead of wall-clock time so time the
+    // renderer main thread spends preempted by other processes on a contended
+    // runner is not counted. The time domain must be set when the domain is
+    // enabled.
     await cdp.send("Performance.enable", { timeDomain: "threadTicks" });
     if (params.scriptProfile) {
       cdp.on("Debugger.scriptParsed", onScriptParsed);
@@ -1438,8 +1440,8 @@ async function measureIterationWithRetry(
 
 /**
  * Runs the interaction multiple times, discards warm-up runs, and returns the
- * median metrics. Each iteration runs in a fresh browser context so the
- * samples are independent; see `measureIteration`.
+ * median metrics. Each iteration runs in a fresh browser context so the samples
+ * are independent; see `measureIteration`.
  */
 export async function createPerfMeasure(
   page: Page,

--- a/packages/ariakit-scripts/src/react18.test.ts
+++ b/packages/ariakit-scripts/src/react18.test.ts
@@ -44,12 +44,12 @@ async function writeJsonFile(path: string, value: unknown) {
 }
 
 /**
- * Copies the environment without the variables that redirect where git
- * resolves a repository.
+ * Copies the environment without the variables that redirect where git resolves
+ * a repository.
  *
- * Both the fixture and the react18 command locate their repository through
- * git. Left in place, these variables would point them at the caller's own
- * checkout, and at the persistent workspace that `removeFixture` deletes.
+ * Both the fixture and the react18 command locate their repository through git.
+ * Left in place, these variables would point them at the caller's own checkout,
+ * and at the persistent workspace that `removeFixture` deletes.
  */
 function getGitSafeEnv() {
   const env = { ...process.env };

--- a/packages/ariakit-solid-components/src/as/as.tsx
+++ b/packages/ariakit-solid-components/src/as/as.tsx
@@ -14,8 +14,8 @@ const cache = new Map<string, Component<any>>();
 
 /**
  * Allows a component to be rendered as a different HTML element or Solid
- * component. Must be passed to the `render` prop of a component that
- * supports it.
+ * component. Must be passed to the `render` prop of a component that supports
+ * it.
  *
  * To render as an HTML element, use `<As.element />` (e.g. `<As.button />`).
  *

--- a/packages/ariakit-solid-components/src/group/group.tsx
+++ b/packages/ariakit-solid-components/src/group/group.tsx
@@ -47,8 +47,8 @@ export const useGroup = createHook<TagName, GroupOptions>(
 
 /**
  * Renders a group element. Optionally, a
- * [`GroupLabel`](https://solid.ariakit.com/reference/group-label) can be rendered as
- * a child to provide a label for the group.
+ * [`GroupLabel`](https://solid.ariakit.com/reference/group-label) can be
+ * rendered as a child to provide a label for the group.
  * @see https://solid.ariakit.com/components/group
  * @example
  * ```jsx

--- a/packages/ariakit-solid-components/src/heading/heading-level.tsx
+++ b/packages/ariakit-solid-components/src/heading/heading-level.tsx
@@ -6,8 +6,8 @@ import type { HeadingLevels } from "./utils.ts";
 /**
  * A component that sets the heading level for its children. It doesn't render
  * any HTML element, just sets the
- * [`level`](https://solid.ariakit.com/reference/heading-level#level) prop on the
- * context.
+ * [`level`](https://solid.ariakit.com/reference/heading-level#level) prop on
+ * the context.
  * @see https://solid.ariakit.com/components/heading
  * @example
  * ```jsx

--- a/packages/ariakit-solid-utils/readme.md
+++ b/packages/ariakit-solid-utils/readme.md
@@ -200,8 +200,8 @@ const [extractedProps, restProps] = extractPropsWithDefaults(props, {
 ````ts
 type RefStore<T> = {
   /**
-   * The current value of the ref. It is a non-reactive getter, wrapped with
-   * the `untrack` function.
+   * The current value of the ref. It is a non-reactive getter, wrapped with the
+   * `untrack` function.
    *
    * **Important note**: since this is a getter, TypeScript might reflect the
    * wrong type in some cases. For example:
@@ -417,8 +417,8 @@ interface Options {
    * takes in the original component props and gives back a Solid component
    * instance with the props merged.
    *
-   * Check out the [Composition](https://solid.ariakit.com/guide/composition) guide
-   * for more details.
+   * Check out the [Composition](https://solid.ariakit.com/guide/composition)
+   * guide for more details.
    */
   render?: RenderValue<JSX.HTMLAttributes<any>>;
 }

--- a/packages/ariakit-solid-utils/src/reactivity.ts
+++ b/packages/ariakit-solid-utils/src/reactivity.ts
@@ -14,8 +14,8 @@ import {
 } from "solid-js";
 
 /**
- * Creates a stable accessor. Useful when creating derived accessors that
- * depend on a mutable variable that may change later.
+ * Creates a stable accessor. Useful when creating derived accessors that depend
+ * on a mutable variable that may change later.
  * @example
  * let value = 0;
  * const accessor = stableAccessor(value, (v) => v + 1);
@@ -89,8 +89,8 @@ export function extractPropsWithDefaults<
  */
 export type RefStore<T> = {
   /**
-   * The current value of the ref. It is a non-reactive getter, wrapped with
-   * the `untrack` function.
+   * The current value of the ref. It is a non-reactive getter, wrapped with the
+   * `untrack` function.
    *
    * **Important note**: since this is a getter, TypeScript might reflect the
    * wrong type in some cases. For example:
@@ -126,10 +126,10 @@ export type RefStore<T> = {
 
 /**
  * Creates a ref object that contains the value getter (`value`) and setter
- * (`set`) as properties for convenience. It also has a `reset` method that
- * can be used to set the value to the initial value that was passed,
- * which is `undefined` by default. The `current` getter can be used to obtain
- * the value without tracking it reactively.
+ * (`set`) as properties for convenience. It also has a `reset` method that can
+ * be used to set the value to the initial value that was passed, which is
+ * `undefined` by default. The `current` getter can be used to obtain the value
+ * without tracking it reactively.
  * @example
  * ```jsx
  * const ref = createRef();

--- a/packages/ariakit-solid-utils/src/system.tsx
+++ b/packages/ariakit-solid-utils/src/system.tsx
@@ -83,9 +83,9 @@ export function createHook<
  * Splits "option props" from the rest in a component hook. Must be called
  * inside `createHook`.
  *
- * The first argument is an object that defines the props that will be extracted,
- * with their default values. To extract a prop without a default, set it to
- * `undefined`.
+ * The first argument is an object that defines the props that will be
+ * extracted, with their default values. To extract a prop without a default,
+ * set it to `undefined`.
  *
  * The hook function must be passed as the second argument, and it will receive
  * the rest of the props and the extracted options.

--- a/packages/ariakit-solid-utils/src/types.ts
+++ b/packages/ariakit-solid-utils/src/types.ts
@@ -39,8 +39,8 @@ export interface Options {
    * takes in the original component props and gives back a Solid component
    * instance with the props merged.
    *
-   * Check out the [Composition](https://solid.ariakit.com/guide/composition) guide
-   * for more details.
+   * Check out the [Composition](https://solid.ariakit.com/guide/composition)
+   * guide for more details.
    */
   render?: RenderValue<JSX.HTMLAttributes<any>>;
 }

--- a/packages/ariakit-store/src/index.ts
+++ b/packages/ariakit-store/src/index.ts
@@ -22,8 +22,8 @@ type StoreInit = () => () => void;
 // These three are intentionally identical `Sync<S, K>` signatures; they differ
 // only in runtime timing semantics, not in types: subscribe fires after a
 // change; sync fires immediately on registration and synchronously on every
-// change; batch fires immediately on registration, then microtask-coalesced
-// on subsequent changes. See the storeSubscribe/storeSync/storeBatch
+// change; batch fires immediately on registration, then microtask-coalesced on
+// subsequent changes. See the storeSubscribe/storeSync/storeBatch
 // implementations in createStore. The keys also narrow the listener state.
 // Include a key only when its changes should trigger the listener. Read other
 // state with store.getState() inside the listener.
@@ -320,8 +320,8 @@ function notifyStoreListener<S extends State>(
 ) {
   if (group.suspendCounts?.has(listener)) return;
   const { disposables } = group;
-  // Skip the cleanup lookup when no listener has registered a cleanup.
-  // The `.size` gate keeps an empty disposables map off this hot path.
+  // Skip the cleanup lookup when no listener has registered a cleanup. The
+  // `.size` gate keeps an empty disposables map off this hot path.
   const cleanup = disposables.size ? disposables.get(listener) : undefined;
   if (cleanup) {
     disposables.delete(listener);
@@ -716,10 +716,9 @@ export function createStore<S extends State>(
 
     if (isSameValue(nextValue, currentValue)) return;
 
-    // Track the active dispatch so storeBatch can distinguish idle
-    // registration (refresh prevStateBatch) from registration during an
-    // in-flight setState (keep prevStateBatch so the upcoming microtask
-    // reports the correct diff).
+    // Track the active dispatch so storeBatch can distinguish idle registration
+    // (refresh prevStateBatch) from registration during an in-flight setState
+    // (keep prevStateBatch so the upcoming microtask reports the correct diff).
     const wasInDispatch = inDispatch;
     inDispatch = true;
     const prevState = state;
@@ -792,8 +791,8 @@ export function createStore<S extends State>(
 
     updatedKeys.add(key);
 
-    // Coalesce multiple setStates in the same microtask via a pending flag.
-    // Any setStates queued before the microtask runs share the same flush.
+    // Coalesce multiple setStates in the same microtask via a pending flag. Any
+    // setStates queued before the microtask runs share the same flush.
     if (batchPending) return;
     batchPending = true;
     queueMicrotask(() => {
@@ -895,8 +894,8 @@ export function batch<T extends Store, K extends keyof StoreState<T>>(
 ): T extends Store ? ReturnType<StoreBatch<StoreState<T>, K>> : void;
 
 /**
- * Registers a listener function that's called immediately and after a batch
- * of state changes in the store.
+ * Registers a listener function that's called immediately and after a batch of
+ * state changes in the store.
  */
 export function batch(store?: Store, ...args: Parameters<StoreBatch>) {
   if (!store) return;

--- a/packages/ariakit-store/src/test.ts
+++ b/packages/ariakit-store/src/test.ts
@@ -516,8 +516,8 @@ test("re-registers a listener without dragging a stale cleanup forward", () => {
   sync(store, null, listener);
   store.setState("count", 2);
 
-  // "cleanup 2" must fire before "run 3" so the previous registration
-  // doesn't leak its pending cleanup.
+  // "cleanup 2" must fire before "run 3" so the previous registration doesn't
+  // leak its pending cleanup.
   expect(events).toEqual([
     "run 1",
     "cleanup 1",
@@ -1740,9 +1740,9 @@ test("keeps the batch baseline current across idle setStates between subscriptio
   store.setState("count", 2);
   store.setState("count", 3);
 
-  // Register a new batch listener mid-dispatch. The listener registered
-  // here must see (4, 3) — not (4, 1) — as its initial diff, even though
-  // the idle setStates produced no batch microtask.
+  // Register a new batch listener mid-dispatch. The listener registered here
+  // must see (4, 3) — not (4, 1) — as its initial diff, even though the idle
+  // setStates produced no batch microtask.
   const laterCalls: Array<[number, number]> = [];
   let registered = false;
   sync(store, ["count"], (state) => {
@@ -1788,8 +1788,8 @@ test("keeps the batch baseline current when a batch listener unsubscribes itself
 
   store.setState("count", 3);
 
-  // The new batch listener registered mid-dispatch must see [3, 2] — the
-  // diff from the post-flush state, not the pre-flush snapshot ([3, 1]).
+  // The new batch listener registered mid-dispatch must see [3, 2] — the diff
+  // from the post-flush state, not the pre-flush snapshot ([3, 1]).
   expect(laterCalls).toEqual([[3, 2]]);
 });
 
@@ -1817,8 +1817,8 @@ test("keeps the batch baseline current when the only batch listener unsubscribes
 
   store.setState("count", 2);
 
-  // The new batch listener registered mid-dispatch must see [2, 1] — the
-  // diff from the post-flush state, not the pre-flush snapshot ([2, 0]).
+  // The new batch listener registered mid-dispatch must see [2, 1] — the diff
+  // from the post-flush state, not the pre-flush snapshot ([2, 0]).
   expect(laterCalls).toEqual([[2, 1]]);
 });
 
@@ -1842,9 +1842,9 @@ test("keeps the batch baseline current when a batch listener registers a success
   store.setState("count", 3);
   await flushBatch();
 
-  // The successor batch listener was registered when state was {count: 2},
-  // so the next flush must diff against that baseline, not the pre-flush
-  // snapshot from the original listener's flush ({count: 1}).
+  // The successor batch listener was registered when state was {count: 2}, so
+  // the next flush must diff against that baseline, not the pre-flush snapshot
+  // from the original listener's flush ({count: 1}).
   const lastCall = laterCalls.at(-1);
   expect(lastCall).toEqual([3, 2]);
 });

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -80,9 +80,9 @@ const TEXT_CONTRAST_CYAN_LIGHTNESS_START = 0.45;
 const CONTRAST_SCALE = 0.3334;
 const DISABLED_CONTRAST_SCALE = 0.25;
 const DISABLED_TEXT_CONTRAST_SCALE = 0.8;
-// Text gets a doubled contrast lift because the ancestor layer also shifts
-// with `--contrast`; the extra push compensates for the parent's movement so
-// the text actually changes lightness/alpha visibly rather than tracking the
+// Text gets a doubled contrast lift because the ancestor layer also shifts with
+// `--contrast`; the extra push compensates for the parent's movement so the
+// text actually changes lightness/alpha visibly rather than tracking the
 // background.
 const TEXT_CONTRAST_SCALE = CONTRAST_SCALE * 2;
 const TEXT_CONTRAST_L = fn.inflate(fn.sub(DARK_THRESHOLD_L, l));
@@ -142,9 +142,9 @@ const utilities = new Set<ReturnType<typeof ak.utility>>();
 // `layer-`/`state-` names that must not set the layer-modified flag.
 // `layer-transparent` reads the flag instead of setting it, so stamping it
 // would make it paint unconditionally. The longhands below are inert until a
-// second utility on the same element reads what they write: the mix values
-// only reach the `layer-mix` and `layer-mix-*` bodies, and the contrast amount
-// is multiplied out unless `layer-contrast` sets a direction.
+// second utility on the same element reads what they write: the mix values only
+// reach the `layer-mix` and `layer-mix-*` bodies, and the contrast amount is
+// multiplied out unless `layer-contrast` sets a direction.
 // https://github.com/ariakit/ariakit/issues/7392
 const UNMODIFIED_LAYER_UTILITIES = new Set([
   "layer-transparent",
@@ -362,8 +362,8 @@ function getSafeLightness(
 
 /**
  * Computes a lightness offset that avoids forbidden lightness. If the next
- * lightness enters the forbidden interval, we either flip direction or clamp
- * to the entry boundary, whichever yields more lightness distance from the
+ * lightness enters the forbidden interval, we either flip direction or clamp to
+ * the entry boundary, whichever yields more lightness distance from the
  * original layer color.
  */
 function getResolvedLightnessOffset(
@@ -382,22 +382,22 @@ function getResolvedLightnessOffset(
   // Clamp the flipped candidate before comparing its distance from the source.
   const flippedDelta = fn.neg(normalDelta);
   const flippedL = fn.clamp01(fn.add(l, flippedDelta));
-  // Directional distance: sign is only meaningful when inForbidden=1
-  // where travel direction is well-defined, so we can avoid abs() which
-  // would duplicate the sub-expression in max(x, -x).
+  // Directional distance: sign is only meaningful when inForbidden=1 where
+  // travel direction is well-defined, so we can avoid abs() which would
+  // duplicate the sub-expression in max(x, -x).
   const flippedDist = fn.mul(fn.sub(l, flippedL), direction);
   const boundaryDelta = fn.sub(entryBoundary, l);
   const boundaryDist = fn.mul(boundaryDelta, direction);
   // Only flip if it produces more distance from the original lightness.
   const shouldFlip = fn.binary(fn.sub(flippedDist, boundaryDist));
-  // When forbidden: blend between boundary and flipped deltas.
-  // Using a + x*(b-a) instead of a*(1-x) + b*x so shouldFlip appears once.
+  // When forbidden: blend between boundary and flipped deltas. Using a +
+  // x*(b-a) instead of a*(1-x) + b*x so shouldFlip appears once.
   const forbiddenDelta = fn.add(
     boundaryDelta,
     fn.mul(shouldFlip, fn.sub(flippedDelta, boundaryDelta)),
   );
-  // Blend between normal and forbidden deltas.
-  // Same rearrangement so inForbidden appears once instead of three times.
+  // Blend between normal and forbidden deltas. Same rearrangement so
+  // inForbidden appears once instead of three times.
   return fn.add(
     normalDelta,
     fn.mul(inForbidden, fn.sub(forbiddenDelta, normalDelta)),
@@ -879,7 +879,8 @@ function getPushValue(value: Value) {
  */
 function withUtilityTokenGate(value: Value, tokenValue: Value) {
   // Use raw calc here because fn.mul(0, ...) simplifies to 0, dropping the
-  // --value() dependency that gates this declaration to matching utility tokens.
+  // --value() dependency that gates this declaration to matching utility
+  // tokens.
   return fn.add(value, fn.calc`0 * ${tokenValue}`);
 }
 
@@ -1051,9 +1052,9 @@ interface TextLightnessStep {
 }
 
 /**
- * Precomputed text values per quantized parent lightness. Both ak-text
- * delivery paths (the if() chains and the container query fallback) read this
- * table, so they always produce identical values.
+ * Precomputed text values per quantized parent lightness. Both ak-text delivery
+ * paths (the if() chains and the container query fallback) read this table, so
+ * they always produce identical values.
  */
 function getTextLightnessSteps(): TextLightnessStep[] {
   return getQuantizedLchLightnessSteps().map((parentLightness) => {
@@ -1168,8 +1169,8 @@ function getContrastL(selfRelativeL: Value, contrastValue: Value) {
     fn.add(vars.layerContrastParentL, parentShift),
   );
   const parentDirectedL = getDirectionalLightness(l, parentTargetL, direction);
-  // When ak-layer-contrast is active, direction is ±1 so |direction|=1.
-  // When inactive, direction=0. Use this as a blend mask.
+  // When ak-layer-contrast is active, direction is ±1 so |direction|=1. When
+  // inactive, direction=0. Use this as a blend mask.
   const isActive = fn.mul(direction, direction);
   return fn.add(
     fn.mul(parentDirectedL, isActive),
@@ -1383,13 +1384,12 @@ utility(
   ]),
 );
 
-// Paints the layer color only while the modified flag is set, so a control
-// that opens a layer just to give its children a color context stays
-// see-through at rest. Nearly every other `layer-*` and `state-*` utility sets
-// that flag; UNMODIFIED_LAYER_UTILITIES lists the ones that must not, this
-// utility included.
-// Scaling the source alpha rather than replacing it keeps a translucent layer
-// translucent once it paints.
+// Paints the layer color only while the modified flag is set, so a control that
+// opens a layer just to give its children a color context stays see-through at
+// rest. Nearly every other `layer-*` and `state-*` utility sets that flag;
+// UNMODIFIED_LAYER_UTILITIES lists the ones that must not, this utility
+// included. Scaling the source alpha rather than replacing it keeps a
+// translucent layer translucent once it paints.
 utility(
   "layer-transparent",
   set.backgroundColor(
@@ -1865,9 +1865,9 @@ function getTextDirectional() {
 const textLightnessSteps = getTextLightnessSteps();
 
 /**
- * Resolves a per-step text value as a single if() chain over the parent
- * layer's quantized text lightness. The else value must match the variable's
- * registered initial so unmatched contexts keep today's behavior.
+ * Resolves a per-step text value as a single if() chain over the parent layer's
+ * quantized text lightness. The else value must match the variable's registered
+ * initial so unmatched contexts keep today's behavior.
  */
 function getTextStepIf(
   parentTextL: VarProperty,
@@ -2197,8 +2197,8 @@ function getLayerEdgeContextDeclarations() {
 const LAST_VISIBLE_SELECTOR = "&:not(:has(~ *:not([hidden],template)))";
 
 /**
- * Returns cover/overflow declarations that use calc-based conditionals for
- * axis and edge handling, avoiding container style queries on self properties.
+ * Returns cover/overflow declarations that use calc-based conditionals for axis
+ * and edge handling, avoiding container style queries on self properties.
  */
 function getFrameStretchDeclarations({
   stretchInset,
@@ -2220,12 +2220,12 @@ function getFrameStretchDeclarations({
   const isCol = fn.sub(1, parentRow);
   const isRow = parentRow;
   const negStretchInset = fn.neg(stretchInset);
-  // Incorporate user-specified margin (from ak-frame-m-*) additively so
-  // both stretch and manual margin adjustments are applied together.
+  // Incorporate user-specified margin (from ak-frame-m-*) additively so both
+  // stretch and manual margin adjustments are applied together.
   const totalNegMargin = fn.add(negStretchInset, inputs.frameMargin);
-  // Concentric border radius: reduce parent radius by the total visual
-  // distance from parent border-box edge to child border-box edge.
-  // frameMargin moves the child further inward, so it reduces the radius.
+  // Concentric border radius: reduce parent radius by the total visual distance
+  // from parent border-box edge to child border-box edge. frameMargin moves the
+  // child further inward, so it reduces the radius.
   const childRadius = fn.max(
     fn.sub(parentRadius, fn.add(radiusInset, inputs.frameMargin)),
     "0px",
@@ -2355,13 +2355,13 @@ utility(
     );
     const minimumRadius = fn.min("0.125rem", inputs.frameRadius);
     const autoRadius = fn.max(minimumRadius, fn.max(nestedRadius, "0px"));
-    // When parent padding + margin >= 1rem, the child is far enough from
-    // the parent edge that concentric radius is not meaningful — use the
-    // child's own declared radius instead.
+    // When parent padding + margin >= 1rem, the child is far enough from the
+    // parent edge that concentric radius is not meaningful — use the child's
+    // own declared radius instead.
     //
     // Formula: max(auto - inflated, min(declared, auto + inflated))
-    //   No cap  (excess=0): max(auto, min(declared, auto)) = auto
-    //   Cap     (excess>0): max(auto - huge, min(declared, auto + huge))
+    //   No cap (excess=0): max(auto, min(declared, auto)) = auto Cap
+    //   (excess>0): max(auto - huge, min(declared, auto + huge))
     //                      = max(negative, declared) = declared
     //
     // Subtract 0.5px so that exactly 1rem triggers the cap (>= not >).
@@ -2448,9 +2448,9 @@ utility(
     const parentBorder = inherit(vars.frameParentBorderContext, "0px");
     const parentRadius = inherit(vars.frameParentRadiusContext, "0px");
     const parentRow = inherit(vars.frameParentRowContext, "0");
-    // Stretch past parent content box by the child's own border width so
-    // the child's content box aligns with the parent's content box. This
-    // also collapses borders/rings when both parent and child have them.
+    // Stretch past parent content box by the child's own border width so the
+    // child's content box aligns with the parent's content box. This also
+    // collapses borders/rings when both parent and child have them.
     const stretchInset = fn.add(parentPadding, inputs.frameBorder);
     const radiusInset = fn.sub(parentBorder, inputs.frameBorder);
     return getFrameStretchDeclarations({

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -390,8 +390,8 @@ function getResolvedLightnessOffset(
   const boundaryDist = fn.mul(boundaryDelta, direction);
   // Only flip if it produces more distance from the original lightness.
   const shouldFlip = fn.binary(fn.sub(flippedDist, boundaryDist));
-  // When forbidden: blend between boundary and flipped deltas. Using a +
-  // x*(b-a) instead of a*(1-x) + b*x so shouldFlip appears once.
+  // When forbidden: blend between boundary and flipped deltas. Using
+  // `a + x*(b-a)` instead of `a*(1-x) + b*x` so shouldFlip appears once.
   const forbiddenDelta = fn.add(
     boundaryDelta,
     fn.mul(shouldFlip, fn.sub(flippedDelta, boundaryDelta)),

--- a/packages/ariakit-tailwind/src/lib.ts
+++ b/packages/ariakit-tailwind/src/lib.ts
@@ -691,8 +691,8 @@ export const fn = {
     `style${fn.query(property, value)}`,
 
   /**
-   * Builds an if() conditional expression. No space is allowed between `if`
-   * and the opening parenthesis.
+   * Builds an if() conditional expression. No space is allowed between `if` and
+   * the opening parenthesis.
    */
   if: (
     branches: [condition: string, value: Value][],

--- a/packages/ariakit-test/src/__init-event.ts
+++ b/packages/ariakit-test/src/__init-event.ts
@@ -1,10 +1,11 @@
-// Part of this code is based on https://github.com/testing-library/user-event/blob/d7483f049a1ec2ebf1ca1e2c1f4367849fca5997/src/event/createEvent.ts
+// Part of this code is based on
+// https://github.com/testing-library/user-event/blob/d7483f049a1ec2ebf1ca1e2c1f4367849fca5997/src/event/createEvent.ts
 import { getKeys } from "@ariakit/utils";
 import type { OwnerWindowSource } from "./__utils.ts";
 import { getOwnerWindow } from "./__utils.ts";
 
-// Pointer Events Level 4 includes this member in its initializer, but TypeScript
-// 6.0 declares it only on the resulting event.
+// Pointer Events Level 4 includes this member in its initializer, but
+// TypeScript 6.0 declares it only on the resulting event.
 export type PointerEventInitWithPersistentDeviceId = PointerEventInit & {
   persistentDeviceId?: PointerEvent["persistentDeviceId"];
 };
@@ -72,8 +73,8 @@ function sanitizeString(value: string | null | undefined) {
 }
 
 // `PointerEventInit` defaults the contact geometry to 1x1, and Pointer Events
-// requires 1 from a device that doesn't report geometry of its own, like a mouse.
-// https://w3c.github.io/pointerevents/#dom-pointerevent-width
+// requires 1 from a device that doesn't report geometry of its own, like a
+// mouse. https://w3c.github.io/pointerevents/#dom-pointerevent-width
 function sanitizeContactSize(size: number | undefined) {
   return size ?? 1;
 }
@@ -205,8 +206,7 @@ function initUIEvent(event: UIEvent, { view, detail }: UIEventInit) {
 // it. `data` is also the only member the interface adds to `UIEvent`. The
 // parameter accepts `InputEventInit` too, because `initEvent` hands every
 // initializer the same options object and that interface declares a nullable
-// `data` of its own.
-// https://w3c.github.io/uievents/#idl-compositionevent
+// `data` of its own. https://w3c.github.io/uievents/#idl-compositionevent
 function initCompositionEvent(
   event: CompositionEvent,
   { data }: CompositionEventInit | InputEventInit,
@@ -473,7 +473,7 @@ function isUIEvent(event: Event, realm: EventRealm): event is UIEvent {
  * event name may run this, because it overwrites whatever the constructor did
  * with the values in `options`.
  * @param target The node, document, or window the event was built for, whose
- * realm owns the constructors the interface tests run against.
+ *   realm owns the constructors the interface tests run against.
  */
 export function initEvent<T extends Event>(
   event: T,

--- a/packages/ariakit-test/src/__init-event.ts
+++ b/packages/ariakit-test/src/__init-event.ts
@@ -74,7 +74,8 @@ function sanitizeString(value: string | null | undefined) {
 
 // `PointerEventInit` defaults the contact geometry to 1x1, and Pointer Events
 // requires 1 from a device that doesn't report geometry of its own, like a
-// mouse. https://w3c.github.io/pointerevents/#dom-pointerevent-width
+// mouse.
+// https://w3c.github.io/pointerevents/#dom-pointerevent-width
 function sanitizeContactSize(size: number | undefined) {
   return size ?? 1;
 }
@@ -206,7 +207,8 @@ function initUIEvent(event: UIEvent, { view, detail }: UIEventInit) {
 // it. `data` is also the only member the interface adds to `UIEvent`. The
 // parameter accepts `InputEventInit` too, because `initEvent` hands every
 // initializer the same options object and that interface declares a nullable
-// `data` of its own. https://w3c.github.io/uievents/#idl-compositionevent
+// `data` of its own.
+// https://w3c.github.io/uievents/#idl-compositionevent
 function initCompositionEvent(
   event: CompositionEvent,
   { data }: CompositionEventInit | InputEventInit,

--- a/packages/ariakit-test/src/__mouse.test.ts
+++ b/packages/ariakit-test/src/__mouse.test.ts
@@ -1,7 +1,7 @@
 // Covers the pointer members a gesture reports: the contact size and transducer
-// angle `dispatch.ts` defaults, and the pressure and primary pointer `__mouse.ts`
-// derives per phase. Both are exercised through the public helpers that fire the
-// events.
+// angle `dispatch.ts` defaults, and the pressure and primary pointer
+// `__mouse.ts` derives per phase. Both are exercised through the public helpers
+// that fire the events.
 import { afterEach, expect, test } from "vitest";
 import { click, hover, mouseDown, mouseUp, q } from "./index.ts";
 
@@ -65,8 +65,8 @@ test("hover reports the same values on the events leaving an element", async () 
   ]);
 });
 
-// A caller passing `buttons` describes a pointer moving with a button held, like
-// a drag, which is in the active buttons state.
+// A caller passing `buttons` describes a pointer moving with a button held,
+// like a drag, which is in the active buttons state.
 test("hover reports pressure while a button stays held", async () => {
   document.body.innerHTML = `<button type="button">Resize</button>`;
 
@@ -118,7 +118,8 @@ test("a chorded release keeps the pressure of the button still held", async () =
   ]);
 });
 
-// This is the pointer sequence all three engines produce for one ordinary click.
+// This is the pointer sequence all three engines produce for one ordinary
+// click.
 test("click reports the values a browser reports through the gesture", async () => {
   document.body.innerHTML = `<button type="button">Submit</button>`;
 
@@ -141,8 +142,8 @@ test("click reports the values a browser reports through the gesture", async () 
 });
 
 // The transducer angle reaches a gesture from the dispatch layer, so one press
-// covers it for every helper. Every engine reports a perpendicular transducer for
-// a mouse.
+// covers it for every helper. Every engine reports a perpendicular transducer
+// for a mouse.
 test("a press reports the transducer angle of a perpendicular pointer", async () => {
   document.body.innerHTML = `<button type="button">Resize</button>`;
 
@@ -187,8 +188,8 @@ test("explicit pointer values win over the simulated ones", async () => {
   ]);
 });
 
-// Zero is a value a pressure-sensitive device reports, so it has to win over the
-// 0.5 the press would otherwise derive.
+// Zero is a value a pressure-sensitive device reports, so it has to win over
+// the 0.5 the press would otherwise derive.
 test("an explicit zero pressure wins over the pressure a press derives", async () => {
   document.body.innerHTML = `<button type="button">Draw</button>`;
 

--- a/packages/ariakit-test/src/__mouse.ts
+++ b/packages/ariakit-test/src/__mouse.ts
@@ -47,7 +47,8 @@ export function omitButtons(options?: PointerEventInit): PointerEventInit {
 
 // A pointing device with no pressure sensor, which is what these helpers
 // simulate, reports 0.5 while it is in the active buttons state and 0
-// otherwise. https://w3c.github.io/pointerevents/#dom-pointerevent-pressure
+// otherwise.
+// https://w3c.github.io/pointerevents/#dom-pointerevent-pressure
 function getPressure(buttons: number) {
   return buttons === 0 ? 0 : 0.5;
 }

--- a/packages/ariakit-test/src/__mouse.ts
+++ b/packages/ariakit-test/src/__mouse.ts
@@ -3,8 +3,8 @@ import type { PointerEventInitWithPersistentDeviceId } from "./__init-event.ts";
 
 // `MouseEvent.buttons` is a bitmask of the buttons currently held down, and its
 // bits are not ordered like `MouseEvent.button`: the secondary button is bit 1
-// while the auxiliary button is bit 2. Pointer Events defines the whole mapping,
-// including the pen eraser.
+// while the auxiliary button is bit 2. Pointer Events defines the whole
+// mapping, including the pen eraser.
 // https://w3c.github.io/pointerevents/#the-buttons-property
 const buttonsByButton: Record<number, number> = {
   0: 1,
@@ -31,8 +31,8 @@ function omit(
 }
 
 // Each phase derives `buttons` from the button it simulates. `mouseDown` and
-// `mouseUp` run a single phase, so an explicit value describes a chord there and
-// wins. A multi-step helper runs every phase from one init, where no single
+// `mouseUp` run a single phase, so an explicit value describes a chord there
+// and wins. A multi-step helper runs every phase from one init, where no single
 // value is right for all of them, so it drops `buttons` with `omitButtons`.
 
 /**
@@ -46,19 +46,19 @@ export function omitButtons(options?: PointerEventInit): PointerEventInit {
 }
 
 // A pointing device with no pressure sensor, which is what these helpers
-// simulate, reports 0.5 while it is in the active buttons state and 0 otherwise.
-// https://w3c.github.io/pointerevents/#dom-pointerevent-pressure
+// simulate, reports 0.5 while it is in the active buttons state and 0
+// otherwise. https://w3c.github.io/pointerevents/#dom-pointerevent-pressure
 function getPressure(buttons: number) {
   return buttons === 0 ? 0 : 0.5;
 }
 
 // Neither `dispatch` nor the phase builders below can own these, because
 // `click.ts` and `select.ts` build `click`, `auxclick`, and `contextmenu` from
-// the same gesture options, and Pointer Events resets every pointer attribute on
-// those three except `pointerId` and `pointerType`. Unlike the contact size and
-// transducer angle `dispatch` defaults, these two reset to something other than
-// what a gesture derives. Only the helpers that fire pointer events apply them,
-// so the click-family options below never pick them up.
+// the same gesture options, and Pointer Events resets every pointer attribute
+// on those three except `pointerId` and `pointerType`. Unlike the contact size
+// and transducer angle `dispatch` defaults, these two reset to something other
+// than what a gesture derives. Only the helpers that fire pointer events apply
+// them, so the click-family options below never pick them up.
 // https://www.w3.org/TR/pointerevents/#the-click-auxclick-and-contextmenu-events
 
 /**

--- a/packages/ariakit-test/src/__utils.test.ts
+++ b/packages/ariakit-test/src/__utils.test.ts
@@ -8,9 +8,9 @@ afterEach(() => {
 // Resolving the realm by reading one member is only safe while nothing shadows
 // it. A form exposes its controls as named properties, and browsers let those
 // override built-ins, so a control named `ownerDocument` answers the lookup
-// this
-// helper starts from. Measured on Chromium 151, Firefox 153, and WebKit 26.5;
-// happy-dom defines `ownerDocument` on the prototype chain, so it is emulated.
+// this helper starts from. Measured on Chromium 151, Firefox 153, and WebKit
+// 26.5; happy-dom defines `ownerDocument` on the prototype chain, so it is
+// emulated.
 // https://github.com/ariakit/ariakit/issues/7209
 test("getOwnerWindow resolves a form whose control answers the owner document", () => {
   const form = document.createElement("form");

--- a/packages/ariakit-test/src/__utils.test.ts
+++ b/packages/ariakit-test/src/__utils.test.ts
@@ -7,7 +7,8 @@ afterEach(() => {
 
 // Resolving the realm by reading one member is only safe while nothing shadows
 // it. A form exposes its controls as named properties, and browsers let those
-// override built-ins, so a control named `ownerDocument` answers the lookup this
+// override built-ins, so a control named `ownerDocument` answers the lookup
+// this
 // helper starts from. Measured on Chromium 151, Firefox 153, and WebKit 26.5;
 // happy-dom defines `ownerDocument` on the prototype chain, so it is emulated.
 // https://github.com/ariakit/ariakit/issues/7209

--- a/packages/ariakit-test/src/__utils.ts
+++ b/packages/ariakit-test/src/__utils.ts
@@ -8,9 +8,9 @@ const preventMouseEvents = new WeakMap<Document, boolean>();
 
 /**
  * The happy-dom marker is per-window. A same-origin iframe window created in
- * happy-dom does not expose it, so this returns `false` for that window. Callers
- * that must cover iframe realms must resolve the environment another way.
- * https://github.com/ariakit/ariakit/issues/7283
+ * happy-dom does not expose it, so this returns `false` for that window.
+ * Callers that must cover iframe realms must resolve the environment another
+ * way. https://github.com/ariakit/ariakit/issues/7283
  */
 export function isHappyDOM(
   win: Window | null | undefined = typeof window !== "undefined"
@@ -130,8 +130,8 @@ export async function flushScheduler(maxTurns = 10) {
       await flushMicrotasks();
       // A mutation may be observed a microtask after it lands, so require two
       // consecutive quiet turns before treating the tree as settled. This keeps
-      // a render slice that hasn't committed its DOM changes yet from ending the
-      // drain early.
+      // a render slice that hasn't committed its DOM changes yet from ending
+      // the drain early.
       stableTurns = mutated ? 0 : stableTurns + 1;
       if (stableTurns >= 2) break;
     }

--- a/packages/ariakit-test/src/__utils.ts
+++ b/packages/ariakit-test/src/__utils.ts
@@ -10,7 +10,8 @@ const preventMouseEvents = new WeakMap<Document, boolean>();
  * The happy-dom marker is per-window. A same-origin iframe window created in
  * happy-dom does not expose it, so this returns `false` for that window.
  * Callers that must cover iframe realms must resolve the environment another
- * way. https://github.com/ariakit/ariakit/issues/7283
+ * way.
+ * https://github.com/ariakit/ariakit/issues/7283
  */
 export function isHappyDOM(
   win: Window | null | undefined = typeof window !== "undefined"

--- a/packages/ariakit-test/src/click.test.ts
+++ b/packages/ariakit-test/src/click.test.ts
@@ -198,9 +198,9 @@ test("click with the secondary button matches rightClick", async () => {
   ]);
 });
 
-// Unlike `click`, browsers keep firing `auxclick` on a disabled control. Chromium
-// and WebKit fire it; Firefox is the exception and fires neither `auxclick` nor
-// the compatibility mouse events.
+// Unlike `click`, browsers keep firing `auxclick` on a disabled control.
+// Chromium and WebKit fire it; Firefox is the exception and fires neither
+// `auxclick` nor the compatibility mouse events.
 test("click with the auxiliary button dispatches auxclick on disabled controls", async () => {
   document.body.innerHTML = `<button type="button" disabled>Paste</button>`;
 
@@ -286,8 +286,7 @@ function recordPointerMembers(element: Element, types: string[]) {
 
 // Pointer Events carries only the causal pointer's ID and type onto the event
 // that ends the gesture. Chromium resets `isPrimary` as required; Firefox and
-// WebKit carry it over instead.
-// https://github.com/ariakit/ariakit/issues/7204
+// WebKit carry it over instead. https://github.com/ariakit/ariakit/issues/7204
 test("click carries only the pointer identity to the click event", async () => {
   document.body.innerHTML = `<button type="button">Submit</button>`;
 

--- a/packages/ariakit-test/src/click.test.ts
+++ b/packages/ariakit-test/src/click.test.ts
@@ -286,7 +286,8 @@ function recordPointerMembers(element: Element, types: string[]) {
 
 // Pointer Events carries only the causal pointer's ID and type onto the event
 // that ends the gesture. Chromium resets `isPrimary` as required; Firefox and
-// WebKit carry it over instead. https://github.com/ariakit/ariakit/issues/7204
+// WebKit carry it over instead.
+// https://github.com/ariakit/ariakit/issues/7204
 test("click carries only the pointer identity to the click event", async () => {
   document.body.innerHTML = `<button type="button">Submit</button>`;
 

--- a/packages/ariakit-test/src/click.ts
+++ b/packages/ariakit-test/src/click.ts
@@ -170,11 +170,11 @@ async function clickOption(
  * (e.g. `{ shiftKey: true }`).
  *
  * Pass `button` to click with another mouse button. Activation behavior runs on
- * `click`, so a non-primary button fires `auxclick` instead and doesn't activate
- * labels or `option` elements, and the secondary button also fires `contextmenu`
- * while it's held down. Each step derives `buttons` from that button, so an
- * explicit `buttons` is ignored here; `mouseDown` and `mouseUp` accept one to
- * describe a chorded gesture.
+ * `click`, so a non-primary button fires `auxclick` instead and doesn't
+ * activate labels or `option` elements, and the secondary button also fires
+ * `contextmenu` while it's held down. Each step derives `buttons` from that
+ * button, so an explicit `buttons` is ignored here; `mouseDown` and `mouseUp`
+ * accept one to describe a chorded gesture.
  * @example
  * ```ts
  * await click(q.button("Submit"));
@@ -199,8 +199,8 @@ export function click(
     await hover(element, getHoverOptions(stepOptions));
     await mouseDown(element, stepOptions);
 
-    // The element may be hidden after hover/mouseDown, so we need to check again
-    // and find the first visible parent.
+    // The element may be hidden after hover/mouseDown, so we need to check
+    // again and find the first visible parent.
     while (!isVisible(element)) {
       if (!element.parentElement) return;
       element = element.parentElement;
@@ -212,9 +212,10 @@ export function click(
     }
 
     if (!tap) {
-      // Press-and-release dwell between mouseDown and mouseUp: let work scheduled
-      // on pointer/mouse down flush (microtask/rAF) before releasing, without a
-      // wall-clock delay. The final settle below keeps the real timer.
+      // Press-and-release dwell between mouseDown and mouseUp: let work
+      // scheduled on pointer/mouse down flush (microtask/rAF) before releasing,
+      // without a wall-clock delay. The final settle below keeps the real
+      // timer.
       await settle();
     }
 

--- a/packages/ariakit-test/src/dispatch-without-pointer-event.test.ts
+++ b/packages/ariakit-test/src/dispatch-without-pointer-event.test.ts
@@ -52,8 +52,8 @@ test("keeps the click family on the closest interface available", async () => {
     expect(event?.button).toBe(0);
     expect(event?.getModifierState("Shift")).toBe(true);
     expect(event?.pointerType).toBe("mouse");
-    // The positive side of the boundary the `pointer*` test pins below, where
-    // a bare `Event` carries no `pageX` at all.
+    // The positive side of the boundary the `pointer*` test pins below, where a
+    // bare `Event` carries no `pageX` at all.
     expect(event?.pageX).toBeDefined();
   } finally {
     button.remove();

--- a/packages/ariakit-test/src/dispatch.jsdom.test.ts
+++ b/packages/ariakit-test/src/dispatch.jsdom.test.ts
@@ -25,9 +25,10 @@ function createIframeButton() {
 }
 
 // `createEvent` resolves the constructor from the target's own window, so an
-// event dispatched at a node inside an iframe is built in that realm and matches
-// none of the ambient `instanceof` tests `initEvent` picked its initializers
-// with. Every member only an initializer assigns was left undefined.
+// event dispatched at a node inside an iframe is built in that realm and
+// matches none of the ambient `instanceof` tests `initEvent` picked its
+// initializers with. Every member only an initializer assigns was left
+// undefined.
 //
 // These two types prove it because neither is reached by a name. The type
 // fallbacks cover the drag events and `wheel` (`mouseDerivedEventTypes`), the

--- a/packages/ariakit-test/src/dispatch.test.ts
+++ b/packages/ariakit-test/src/dispatch.test.ts
@@ -281,7 +281,8 @@ test("dispatch(element, event) reports the same standard modifiers and x/y as th
 // UI Events specifies one modifier name per `EventModifierInit` member, and an
 // unrecognized name reports false. `modifierHyper` and `modifierSuper` are left
 // out, since no engine reports either; the keyboard parity test below covers
-// them instead. https://w3c.github.io/uievents/#event-modifier-initializers
+// them instead.
+// https://w3c.github.io/uievents/#event-modifier-initializers
 // https://github.com/ariakit/ariakit/issues/7168
 const modifierNameByInitMember = {
   altKey: "Alt",
@@ -364,7 +365,8 @@ test("dispatch.click reports false for modifier names it doesn't recognize", asy
 // Every dispatcher the two interfaces cover is listed, because the set they are
 // selected by mirrors `@testing-library/dom`'s event map by hand. `dragExit` is
 // the exception: browsers never fire it, so it has no typed listener to assert
-// through. https://github.com/ariakit/ariakit/issues/7169
+// through.
+// https://github.com/ariakit/ariakit/issues/7169
 test.each([
   ["wheel", "wheel"],
   ["drag", "drag"],
@@ -618,7 +620,8 @@ function readTransducerAngles(event: PointerEvent) {
 // `initPointerEvent` used to leave these two alone, so they reached the event
 // only through the constructor and took happy-dom's default of 0. Chromium,
 // Firefox, and WebKit all report π/2 and 0 for a mouse, on every pointer event
-// including `click`. https://github.com/ariakit/ariakit/issues/7172
+// including `click`.
+// https://github.com/ariakit/ariakit/issues/7172
 test("dispatch.pointerDown reports the transducer angles of a perpendicular pointer", async () => {
   const button = document.createElement("button");
   document.body.append(button);
@@ -686,7 +689,8 @@ test("dispatch.pointerDown derives tilt from transducer angles", async () => {
 });
 
 // Web IDL converts signed zero to positive zero when it stores the rounded
-// result as a `long`. https://github.com/ariakit/ariakit/issues/7185
+// result as a `long`.
+// https://github.com/ariakit/ariakit/issues/7185
 test("dispatch.pointerDown normalizes rounded tilt to positive zero", async () => {
   const event = await getPointerDownEvent({
     altitudeAngle: 0.5,

--- a/packages/ariakit-test/src/dispatch.test.ts
+++ b/packages/ariakit-test/src/dispatch.test.ts
@@ -281,8 +281,7 @@ test("dispatch(element, event) reports the same standard modifiers and x/y as th
 // UI Events specifies one modifier name per `EventModifierInit` member, and an
 // unrecognized name reports false. `modifierHyper` and `modifierSuper` are left
 // out, since no engine reports either; the keyboard parity test below covers
-// them instead.
-// https://w3c.github.io/uievents/#event-modifier-initializers
+// them instead. https://w3c.github.io/uievents/#event-modifier-initializers
 // https://github.com/ariakit/ariakit/issues/7168
 const modifierNameByInitMember = {
   altKey: "Alt",
@@ -365,8 +364,7 @@ test("dispatch.click reports false for modifier names it doesn't recognize", asy
 // Every dispatcher the two interfaces cover is listed, because the set they are
 // selected by mirrors `@testing-library/dom`'s event map by hand. `dragExit` is
 // the exception: browsers never fire it, so it has no typed listener to assert
-// through.
-// https://github.com/ariakit/ariakit/issues/7169
+// through. https://github.com/ariakit/ariakit/issues/7169
 test.each([
   ["wheel", "wheel"],
   ["drag", "drag"],
@@ -558,8 +556,8 @@ function readPointerMembers(event: PointerEvent) {
 
 // Pointer Events defaults `width` and `height` to 1, and requires 1 from any
 // device with no contact geometry to report, like a mouse. The pressure and the
-// primary pointer stay at their dictionary defaults, because a lone event carries
-// no gesture to derive them from.
+// primary pointer stay at their dictionary defaults, because a lone event
+// carries no gesture to derive them from.
 // https://w3c.github.io/pointerevents/#dom-pointerevent-width
 test("dispatch.pointerDown reports the PointerEventInit defaults for the contact, pressure, and primary pointer", async () => {
   const button = document.createElement("button");
@@ -596,8 +594,8 @@ test("dispatch.pointerDown preserves provided pointer values", async () => {
   }
 });
 
-// Zero is a contact size a digitizer can report, so it has to survive instead of
-// falling back to the default.
+// Zero is a contact size a digitizer can report, so it has to survive instead
+// of falling back to the default.
 test("dispatch.pointerDown preserves a zero contact size", async () => {
   const button = document.createElement("button");
   document.body.append(button);
@@ -620,8 +618,7 @@ function readTransducerAngles(event: PointerEvent) {
 // `initPointerEvent` used to leave these two alone, so they reached the event
 // only through the constructor and took happy-dom's default of 0. Chromium,
 // Firefox, and WebKit all report π/2 and 0 for a mouse, on every pointer event
-// including `click`.
-// https://github.com/ariakit/ariakit/issues/7172
+// including `click`. https://github.com/ariakit/ariakit/issues/7172
 test("dispatch.pointerDown reports the transducer angles of a perpendicular pointer", async () => {
   const button = document.createElement("button");
   document.body.append(button);
@@ -689,8 +686,7 @@ test("dispatch.pointerDown derives tilt from transducer angles", async () => {
 });
 
 // Web IDL converts signed zero to positive zero when it stores the rounded
-// result as a `long`.
-// https://github.com/ariakit/ariakit/issues/7185
+// result as a `long`. https://github.com/ariakit/ariakit/issues/7185
 test("dispatch.pointerDown normalizes rounded tilt to positive zero", async () => {
   const event = await getPointerDownEvent({
     altitudeAngle: 0.5,
@@ -719,8 +715,8 @@ test.each([
   },
 );
 
-// Chromium and Firefox preserve both explicit pairs, so conversion only fills
-// a pair the caller omitted completely.
+// Chromium and Firefox preserve both explicit pairs, so conversion only fills a
+// pair the caller omitted completely.
 test("dispatch.pointerDown preserves both provided orientation pairs", async () => {
   const event = await getPointerDownEvent({
     tiltX: 10,

--- a/packages/ariakit-test/src/dispatch.ts
+++ b/packages/ariakit-test/src/dispatch.ts
@@ -15,8 +15,9 @@ type Target = Document | Window | Node | Element | null;
 type EventFunction = (element: Target, options?: object) => Promise<boolean>;
 
 // `@testing-library/dom` has no `auxclick` in its event map, so `dispatch` adds
-// it to the events it can build by name. Its `doubleClick` alias has no matching
-// `createEvent` method, so only the buildable `dblClick` name is exposed.
+// it to the events it can build by name. Its `doubleClick` alias has no
+// matching `createEvent` method, so only the buildable `dblClick` name is
+// exposed.
 type DispatchEventType = Exclude<EventType, "doubleClick"> | "auxClick";
 
 type EventsObject = {
@@ -129,8 +130,8 @@ function dispatchDisabledControlClick(
 
   // Real browsers fire `input`/`change` only when the value changed: a checkbox
   // always toggles; a radio only when it wasn't already selected. Dispatch each
-  // through `withWindowEvent` so happy-dom's missing `window.event` reflects the
-  // event being dispatched (as in jsdom/browsers), not the outer click.
+  // through `withWindowEvent` so happy-dom's missing `window.event` reflects
+  // the event being dispatched (as in jsdom/browsers), not the outer click.
   if (input.isConnected && (isCheckbox || !wasChecked)) {
     const fireActivationEvent = (type: "input" | "change") => {
       const activationEvent = createEvent[type](input);
@@ -168,11 +169,11 @@ function baseDispatch(element: Target, event: Event): Promise<boolean> {
 }
 
 // The `@testing-library/dom` event map builds `click` and `contextmenu` from
-// `MouseEvent` and has no `auxclick` entry, but Pointer Events defines all three
-// as `PointerEvent`, which is what Chromium, Firefox, and WebKit dispatch. Only
-// the interface and the pointer members change; `button` and `buttons` keep
-// their mouse-event semantics. Replacing the map's `click` entry also drops its
-// `button: 0`, which `initMouseEvent` assigns anyway.
+// `MouseEvent` and has no `auxclick` entry, but Pointer Events defines all
+// three as `PointerEvent`, which is what Chromium, Firefox, and WebKit
+// dispatch. Only the interface and the pointer members change; `button` and
+// `buttons` keep their mouse-event semantics. Replacing the map's `click` entry
+// also drops its `button: 0`, which `initMouseEvent` assigns anyway.
 // https://www.w3.org/TR/pointerevents/#the-click-auxclick-and-contextmenu-events
 const clickFamilyInit = { bubbles: true, cancelable: true, composed: true };
 
@@ -217,35 +218,36 @@ const events = eventNames.reduce((events, eventName) => {
 
 /**
  * Creates and fires a DOM event on an element, then waits for the resulting
- * microtasks to flush. Call `dispatch.<eventName>(element, options)` to build and
- * fire a specific event (e.g. `dispatch.keyDown`, `dispatch.click`,
- * `dispatch.input`), or call `dispatch(element, event)` directly with an `Event`
- * instance.
+ * microtasks to flush. Call `dispatch.<eventName>(element, options)` to build
+ * and fire a specific event (e.g. `dispatch.keyDown`, `dispatch.click`,
+ * `dispatch.input`), or call `dispatch(element, event)` directly with an
+ * `Event` instance.
  *
  * Unlike higher-level helpers such as `click` and `type`, this fires a single
  * event without simulating the surrounding interaction sequence. Pointer and
- * mouse events fired on an element with `pointer-events: none` are re-dispatched
- * on the nearest ancestor that has pointer events enabled, matching how browsers
- * route those events.
+ * mouse events fired on an element with `pointer-events: none` are
+ * re-dispatched on the nearest ancestor that has pointer events enabled,
+ * matching how browsers route those events.
  *
  * A pointer event built by name reports the contact size and transducer angle
- * browsers report for a device with neither, so `width` and `height` are `1` and
- * `altitudeAngle` is a right angle. Supplying only the tilt or spherical angle
- * pair derives the other pair. The members describing a gesture, such as
- * `pressure` and `isPrimary`, keep their defaults here; the higher-level helpers
- * fill those in. An event you construct yourself keeps whatever its constructor
- * gave it.
+ * browsers report for a device with neither, so `width` and `height` are `1`
+ * and `altitudeAngle` is a right angle. Supplying only the tilt or spherical
+ * angle pair derives the other pair. The members describing a gesture, such as
+ * `pressure` and `isPrimary`, keep their defaults here; the higher-level
+ * helpers fill those in. An event you construct yourself keeps whatever its
+ * constructor gave it.
  *
  * Mouse and pointer events built by name derive `pageX` and `pageY` from the
- * client coordinates and target window scroll, and derive `which` from `button`.
- * The layout-dependent `offsetX` and `offsetY` keep the environment's values.
+ * client coordinates and target window scroll, and derive `which` from
+ * `button`. The layout-dependent `offsetX` and `offsetY` keep the environment's
+ * values.
  *
  * `click`, `auxclick`, and `contextmenu` are built as `PointerEvent`, the way
  * browsers dispatch them, so they accept and report pointer properties such as
  * `pointerType`. An environment with no `PointerEvent` builds them as
  * `MouseEvent` instead, and they report the same properties there.
- * @returns A promise that resolves to `false` when the event's default action was
- * prevented with `event.preventDefault()`, and `true` otherwise.
+ * @returns A promise that resolves to `false` when the event's default action
+ *   was prevented with `event.preventDefault()`, and `true` otherwise.
  * @example
  * ```ts
  * await dispatch.keyDown(q.textbox(), { key: "Enter" });

--- a/packages/ariakit-test/src/hover.ts
+++ b/packages/ariakit-test/src/hover.ts
@@ -14,13 +14,13 @@ function isPointerEventsEnabled(element: Element) {
 
 /**
  * Moves the pointer over an element, simulating a real user hovering it. Fires
- * the relevant `pointer`/`mouse` enter, over, and move events, and dispatches the
- * matching leave events on the previously hovered element.
+ * the relevant `pointer`/`mouse` enter, over, and move events, and dispatches
+ * the matching leave events on the previously hovered element.
  *
- * Hidden elements and elements with `pointer-events: none` are handled the way a
- * browser would. Pass `options` to set event properties such as modifier keys.
- * The pointer events report `pressure: 0`, or `0.5` when you pass `buttons` to
- * describe a move with a button held down, as during a drag.
+ * Hidden elements and elements with `pointer-events: none` are handled the way
+ * a browser would. Pass `options` to set event properties such as modifier
+ * keys. The pointer events report `pressure: 0`, or `0.5` when you pass
+ * `buttons` to describe a move with a button held down, as during a drag.
  * @example
  * ```ts
  * await hover(q.button("More options"));
@@ -64,8 +64,8 @@ export function hover(element: Element | null, options?: PointerEventInit) {
       }
     }
 
-    // Settle between leaving the previously hovered element and entering the new
-    // one — a cheap settle covers the transition's microtask/rAF work.
+    // Settle between leaving the previously hovered element and entering the
+    // new one — a cheap settle covers the transition's microtask/rAF work.
     await settle();
 
     if (pointerEventsEnabled) {

--- a/packages/ariakit-test/src/mouse-up.ts
+++ b/packages/ariakit-test/src/mouse-up.ts
@@ -18,12 +18,12 @@ import { dispatch } from "./dispatch.ts";
  * This is the counterpart to `mouseDown` and one step of a full `click`. Pass
  * `options` to set event properties such as modifier keys, or `button` to
  * release another mouse button. The events report no button still held down in
- * `buttons`, like a browser does, unless you pass `buttons` yourself to describe
- * the buttons a chorded gesture keeps held. When that value shows another button
- * stays held down, the release fires `pointermove` instead of `pointerup`, the
- * way Pointer Events routes a chorded release, and the compatibility `mouseup`
- * still fires. The pointer event reports `pressure: 0`, or `0.5` while a chorded
- * gesture keeps a button held.
+ * `buttons`, like a browser does, unless you pass `buttons` yourself to
+ * describe the buttons a chorded gesture keeps held. When that value shows
+ * another button stays held down, the release fires `pointermove` instead of
+ * `pointerup`, the way Pointer Events routes a chorded release, and the
+ * compatibility `mouseup` still fires. The pointer event reports `pressure: 0`,
+ * or `0.5` while a chorded gesture keeps a button held.
  * @example
  * ```ts
  * await mouseDown(q.button("Resize"));

--- a/packages/ariakit-test/src/playwright.ts
+++ b/packages/ariakit-test/src/playwright.ts
@@ -17,13 +17,13 @@ type RoleQueries = Record<AriaRole, RoleQuery>;
 type Queries = RoleQueries & { text: TextQuery };
 
 /**
- * Creates role- and text-based query helpers for a Playwright `Page`, `Locator`,
- * or `FrameLocator`. Call a role method such as `query(page).button(name)` to get
- * a `Locator` from `getByRole`, or `query(page).text(name)` to match by text
- * content.
+ * Creates role- and text-based query helpers for a Playwright `Page`,
+ * `Locator`, or `FrameLocator`. Call a role method such as
+ * `query(page).button(name)` to get a `Locator` from `getByRole`, or
+ * `query(page).text(name)` to match by text content.
  *
- * Names are matched exactly by default. This mirrors the role-based `query` from
- * the package root for end-to-end Playwright tests.
+ * Names are matched exactly by default. This mirrors the role-based `query`
+ * from the package root for end-to-end Playwright tests.
  * @example
  * ```ts
  * const { button, dialog } = query(page);

--- a/packages/ariakit-test/src/press.test.ts
+++ b/packages/ariakit-test/src/press.test.ts
@@ -13,11 +13,12 @@ function getTextInput() {
   return input;
 }
 
-// A scripted click dispatched on a disabled control fires its listeners in jsdom
-// and real browsers; happy-dom drops it, but `dispatch` normalizes that (see
-// dispatch.ts), so these run in the default happy-dom. They guard the disabled
-// gate on the synthetic Space/Enter activation: without the gate, the activation
-// dispatches a click that — once normalized — would reach the listener here.
+// A scripted click dispatched on a disabled control fires its listeners in
+// jsdom and real browsers; happy-dom drops it, but `dispatch` normalizes that
+// (see dispatch.ts), so these run in the default happy-dom. They guard the
+// disabled gate on the synthetic Space/Enter activation: without the gate, the
+// activation dispatches a click that — once normalized — would reach the
+// listener here.
 test("press.up does not activate a disabled control on Space release", async () => {
   const button = document.createElement("button");
   button.disabled = true;
@@ -321,8 +322,7 @@ test("press.Enter on a textarea emits an Enter keypress charCode", async () => {
 
 // Keyboard activation still fires a `PointerEvent`, but Chromium, Firefox, and
 // WebKit all report an unset pointer on it, so the click must not claim a mouse
-// pressed the control.
-// https://github.com/ariakit/ariakit/issues/7162
+// pressed the control. https://github.com/ariakit/ariakit/issues/7162
 test("press activates a button with no pointer behind the click", async () => {
   const button = document.createElement("button");
   document.body.append(button);

--- a/packages/ariakit-test/src/press.test.ts
+++ b/packages/ariakit-test/src/press.test.ts
@@ -322,7 +322,8 @@ test("press.Enter on a textarea emits an Enter keypress charCode", async () => {
 
 // Keyboard activation still fires a `PointerEvent`, but Chromium, Firefox, and
 // WebKit all report an unset pointer on it, so the click must not claim a mouse
-// pressed the control. https://github.com/ariakit/ariakit/issues/7162
+// pressed the control.
+// https://github.com/ariakit/ariakit/issues/7162
 test("press activates a button with no pointer behind the click", async () => {
   const button = document.createElement("button");
   document.body.append(button);

--- a/packages/ariakit-test/src/press.ts
+++ b/packages/ariakit-test/src/press.ts
@@ -246,8 +246,8 @@ function isDisabledByFieldset(element: Element) {
 }
 
 // Browsers never activate a disabled control, so the synthetic Enter/Space
-// activations below skip one. An element that disables itself in its own keydown
-// handler is already disabled by the time the activation runs.
+// activations below skip one. An element that disables itself in its own
+// keydown handler is already disabled by the time the activation runs.
 function isDisabled(element: Element | HTMLButtonElement) {
   if (!("disabled" in element)) return false;
   if (element.disabled) return true;
@@ -406,10 +406,10 @@ const keyUpMap: KeyActionMap = {
       (element instanceof HTMLInputElement &&
         spaceableTypes.includes(element.type));
 
-    // Don't synthesize the click on a disabled control — e.g. a split `press.up`
-    // landing on a control that disabled itself on keydown but is still focused
-    // (the DOM test environments don't blur it the way a real browser does, and
-    // jsdom would otherwise fire the click).
+    // Don't synthesize the click on a disabled control — e.g. a split
+    // `press.up` landing on a control that disabled itself on keydown but is
+    // still focused (the DOM test environments don't blur it the way a real
+    // browser does, and jsdom would otherwise fire the click).
     if (isSpaceable && !isDisabled(element)) {
       await dispatch.click(element, { ...options, ...noPointerOptions });
     }
@@ -470,20 +470,21 @@ async function pressKeyUp({
 }
 
 /**
- * Presses a key on an element, simulating a real user keyboard interaction. Fires
- * `keydown` and `keyup` and applies the browser's default behavior for that key —
- * moving focus with `Tab`, activating buttons and submitting forms with `Enter`,
- * clicking buttons, checkboxes, and radios with `Space`, moving the caret with the
- * arrow and `Home`/`End` keys, and typing printable characters into text fields.
+ * Presses a key on an element, simulating a real user keyboard interaction.
+ * Fires `keydown` and `keyup` and applies the browser's default behavior for
+ * that key — moving focus with `Tab`, activating buttons and submitting forms
+ * with `Enter`, clicking buttons, checkboxes, and radios with `Space`, moving
+ * the caret with the arrow and `Home`/`End` keys, and typing printable
+ * characters into text fields.
  *
- * When no element is passed, the currently focused element is used. Shortcuts such
- * as `press.Enter()` and `press.Tab()` are provided for common keys, and
+ * When no element is passed, the currently focused element is used. Shortcuts
+ * such as `press.Enter()` and `press.Tab()` are provided for common keys, and
  * `press.ShiftTab()` moves focus backwards.
  *
- * Use `press.down` and `press.up` to fire only the keydown or keyup
- * half of a press. Each defaults to the currently focused element, so a key
- * released after focus moved away — for example, an element that disables itself
- * on keydown — lands where a real browser would deliver it.
+ * Use `press.down` and `press.up` to fire only the keydown or keyup half of a
+ * press. Each defaults to the currently focused element, so a key released
+ * after focus moved away — for example, an element that disables itself on
+ * keydown — lands where a real browser would deliver it.
  * @example
  * ```ts
  * await press.Tab();
@@ -551,15 +552,15 @@ export function press(
  * Fires only the `keydown` half of a key press on an element, simulating a real
  * user pressing a key down without releasing it yet. Focuses the element first
  * (since a key press always lands on the focused element) and applies the
- * browser's default keydown behavior for the key, such as moving focus with `Tab`
- * or the caret with the arrow keys. As a low-level half of a press, it fires a
- * raw `keydown` and does not type printable characters into text fields the way
- * the combined `press` does.
+ * browser's default keydown behavior for the key, such as moving focus with
+ * `Tab` or the caret with the arrow keys. As a low-level half of a press, it
+ * fires a raw `keydown` and does not type printable characters into text fields
+ * the way the combined `press` does.
  *
- * When no element is passed, the currently focused element is used. Pair it with
- * `press.up` to drive a press in two steps, which matters when the keydown
- * moves focus — for example, an element that disables itself on keydown blurs to
- * the body, so the later keyup must land there, not on the original element.
+ * When no element is passed, the currently focused element is used. Pair it
+ * with `press.up` to drive a press in two steps, which matters when the keydown
+ * moves focus — for example, an element that disables itself on keydown blurs
+ * to the body, so the later keyup must land there, not on the original element.
  * Shortcuts such as `press.down.Space()` are provided for common keys.
  * @example
  * ```ts
@@ -598,16 +599,16 @@ function pressDown(
 }
 
 /**
- * Fires only the `keyup` half of a key press, simulating a real user releasing a
- * key. Unlike `press.down`, it doesn't move focus: the keyup lands on the
- * passed element or, when none is given, on the currently focused element — which
- * is where a real browser delivers it after the matching `press.down`.
+ * Fires only the `keyup` half of a key press, simulating a real user releasing
+ * a key. Unlike `press.down`, it doesn't move focus: the keyup lands on the
+ * passed element or, when none is given, on the currently focused element —
+ * which is where a real browser delivers it after the matching `press.down`.
  * Applies the browser's default keyup behavior for the key, such as clicking
- * buttons, checkboxes, and radios with `Space`. Because it runs independently of
- * the matching `press.down`, it can't suppress that default based on the keydown's
- * default having been prevented the way the combined `press` does — though it
- * still respects the keyup event's own cancellation and the Meta key. Use the
- * combined `press` when that distinction matters.
+ * buttons, checkboxes, and radios with `Space`. Because it runs independently
+ * of the matching `press.down`, it can't suppress that default based on the
+ * keydown's default having been prevented the way the combined `press` does —
+ * though it still respects the keyup event's own cancellation and the Meta key.
+ * Use the combined `press` when that distinction matters.
  *
  * Shortcuts such as `press.up.Space()` are provided for common keys.
  * @example
@@ -628,10 +629,10 @@ function pressUp(
 
     if (!element) return;
 
-    // No `isPressable` guard here, unlike `press` and `press.down`. A keyup lands
-    // on whatever currently holds focus, which can be an element that just became
-    // unfocusable — e.g. one that disabled itself on the matching keydown but is
-    // still `document.activeElement` until the browser blurs it.
+    // No `isPressable` guard here, unlike `press` and `press.down`. A keyup
+    // lands on whatever currently holds focus, which can be an element that
+    // just became unfocusable — e.g. one that disabled itself on the matching
+    // keydown but is still `document.activeElement` until the browser blurs it.
     await pressKeyUp({ element, key, options });
 
     await sleep();

--- a/packages/ariakit-test/src/query.ts
+++ b/packages/ariakit-test/src/query.ts
@@ -276,12 +276,12 @@ function createQueryObject(queries = documentQueries): QueryObject {
 }
 
 /**
- * Queries the DOM by ARIA role, accessible name, text, or label, built on top of
- * Testing Library. Call a role method such as `query.button(name)` or
+ * Queries the DOM by ARIA role, accessible name, text, or label, built on top
+ * of Testing Library. Call a role method such as `query.button(name)` or
  * `query.dialog()` to get the matching element, passing a string or `RegExp` to
  * match its accessible name. Queries throw when no matching element is found.
- * Use `query.text()` and `query.labeled()` to query by text content or associated
- * label, and `query.within(element)` to scope queries to a subtree.
+ * Use `query.text()` and `query.labeled()` to query by text content or
+ * associated label, and `query.within(element)` to scope queries to a subtree.
  *
  * Every query also exposes `.lazy` (return a reusable function that runs the
  * query when called), `.all` (return all matches, including an empty array),
@@ -302,8 +302,8 @@ function createQueryObject(queries = documentQueries): QueryObject {
 export const query = createQueryObject();
 
 /**
- * Short alias for `query`. Queries the DOM by ARIA role, accessible name, text, or
- * label.
+ * Short alias for `query`. Queries the DOM by ARIA role, accessible name, text,
+ * or label.
  * @example
  * ```ts
  * const dialog = q.dialog.maybe.lazy("Settings");

--- a/packages/ariakit-test/src/react.test.tsx
+++ b/packages/ariakit-test/src/react.test.tsx
@@ -8,8 +8,8 @@ import { type } from "./type.ts";
 afterEach(cleanup);
 
 // These lock in the cheap per-step `settle()` used between an interaction's
-// sub-steps: a component's microtask/rAF-scheduled work must still flush between
-// steps even though there's no wall-clock delay there anymore.
+// sub-steps: a component's microtask/rAF-scheduled work must still flush
+// between steps even though there's no wall-clock delay there anymore.
 
 test("type fires a controlled onChange once per character, in order", async () => {
   const onChange = vi.fn<(value: string) => void>();

--- a/packages/ariakit-test/src/react.tsx
+++ b/packages/ariakit-test/src/react.tsx
@@ -6,9 +6,9 @@ import { flushMicrotasks, nextFrame, wrapAsync } from "./__utils.ts";
 export * from "./index.ts";
 
 /**
- * Options for the `render` function. Accepts every option from Testing Library's
- * `render` (except `queries`), plus `strictMode` to wrap the rendered UI in
- * React's `StrictMode`.
+ * Options for the `render` function. Accepts every option from Testing
+ * Library's `render` (except `queries`), plus `strictMode` to wrap the rendered
+ * UI in React's `StrictMode`.
  * @example
  * ```tsx
  * const options: RenderOptions = { strictMode: true };
@@ -35,12 +35,13 @@ function wrapRender<T extends (...args: any[]) => any>(
 }
 
 /**
- * Renders a React element into the document for testing, waiting for effects and
- * the next frame to flush before resolving.
+ * Renders a React element into the document for testing, waiting for effects
+ * and the next frame to flush before resolving.
  *
- * Built on Testing Library's `render`, it returns `unmount` to remove the tree and
- * an async `rerender` to update it with new UI. Pass `strictMode: true` to wrap
- * the element in React's `StrictMode`, or any other Testing Library render option.
+ * Built on Testing Library's `render`, it returns `unmount` to remove the tree
+ * and an async `rerender` to update it with new UI. Pass `strictMode: true` to
+ * wrap the element in React's `StrictMode`, or any other Testing Library render
+ * option.
  * @example
  * ```tsx
  * const { rerender, unmount } = await render(<Button>Submit</Button>);

--- a/packages/ariakit-test/src/right-click.ts
+++ b/packages/ariakit-test/src/right-click.ts
@@ -1,9 +1,10 @@
 import { click } from "./click.ts";
 
 /**
- * Right-clicks on an element, simulating the sequence of events a real secondary
- * mouse click produces — hovering the target, then right-button `pointerdown`,
- * `mousedown`, `focus`, `contextmenu`, `pointerup`, `mouseup`, and `auxclick`.
+ * Right-clicks on an element, simulating the sequence of events a real
+ * secondary mouse click produces — hovering the target, then right-button
+ * `pointerdown`, `mousedown`, `focus`, `contextmenu`, `pointerup`, `mouseup`,
+ * and `auxclick`.
  *
  * Hidden elements are handled the same way a browser would, and no synthetic
  * `click` event is fired. Pass `options` to set event properties such as

--- a/packages/ariakit-test/src/select.ts
+++ b/packages/ariakit-test/src/select.ts
@@ -10,11 +10,12 @@ import { sleep } from "./sleep.ts";
 /**
  * Selects a range of text within an element, simulating a real user dragging
  * across it. Hovers and presses on the element, finds the given `text` in its
- * descendant text nodes, sets the document selection to cover it, then releases.
+ * descendant text nodes, sets the document selection to cover it, then
+ * releases.
  *
- * When no element is passed, `document.body` is used. Pass `options` to set event
- * properties such as modifier keys. Each step derives `buttons` from the button
- * it presses, so an explicit `buttons` is ignored.
+ * When no element is passed, `document.body` is used. Pass `options` to set
+ * event properties such as modifier keys. Each step derives `buttons` from the
+ * button it presses, so an explicit `buttons` is ignored.
  * @example
  * ```ts
  * await select("hello world");

--- a/packages/ariakit-test/src/shims.test.ts
+++ b/packages/ariakit-test/src/shims.test.ts
@@ -80,8 +80,8 @@ test("runs animation frame callbacks as a spec-compliant batch", async () => {
 
 test("gives mouse and pointer events the browser's modifier state and x/y", () => {
   // These hold natively in browsers and jsdom (see shims.jsdom.test.ts), so the
-  // assertions are not guarded by `isBrowser`. Dispatching without going through
-  // `dispatch` reaches only the environment shim.
+  // assertions are not guarded by `isBrowser`. Dispatching without going
+  // through `dispatch` reaches only the environment shim.
   const button = document.createElement("button");
   document.body.append(button);
   const received: MouseEvent[] = [];
@@ -124,9 +124,10 @@ test("gives mouse and pointer events the browser's modifier state and x/y", () =
       [false, false, true, true, 0, 0],
       [true, false, true, false, 0, 0],
     ]);
-    // An unrecognized key reports false, the way browsers do. `Object.prototype`
-    // member names are the interesting case: looking them up on a plain object
-    // literal finds an inherited value and reports something other than false.
+    // An unrecognized key reports false, the way browsers do.
+    // `Object.prototype` member names are the interesting case: looking them up
+    // on a plain object literal finds an inherited value and reports something
+    // other than false.
     expect(received[0]?.getModifierState("constructor")).toBe(false);
     expect(received[0]?.getModifierState("Nope")).toBe(false);
   } finally {
@@ -136,8 +137,8 @@ test("gives mouse and pointer events the browser's modifier state and x/y", () =
 
 test("gives keyboard events the browser's exact modifier state", () => {
   // These hold natively in browsers and jsdom (see shims.jsdom.test.ts), so the
-  // assertions are not guarded by `isBrowser`. Dispatching without going through
-  // `press` or `dispatch.keyDown` reaches only the environment shim.
+  // assertions are not guarded by `isBrowser`. Dispatching without going
+  // through `press` or `dispatch.keyDown` reaches only the environment shim.
   const input = document.createElement("input");
   document.body.append(input);
   const received: KeyboardEvent[] = [];
@@ -172,11 +173,11 @@ test("gives keyboard events the browser's exact modifier state", () => {
     expect(received[0]?.getModifierState("alt")).toBe(false);
     expect(received[1]?.getModifierState("altgraph")).toBe(false);
     expect(received[2]?.getModifierState("shift")).toBe(false);
-    // An unrecognized name reports false, the way browsers do. `Object.prototype`
-    // member names are the interesting case: looking them up on a plain object
-    // literal finds an inherited value and reports something other than false.
-    // This event has recorded members, so the name reaches the recorded set
-    // rather than stopping at the standard-flag lookup.
+    // An unrecognized name reports false, the way browsers do.
+    // `Object.prototype` member names are the interesting case: looking them up
+    // on a plain object literal finds an inherited value and reports something
+    // other than false. This event has recorded members, so the name reaches
+    // the recorded set rather than stopping at the standard-flag lookup.
     expect(received[2]?.getModifierState("constructor")).toBe(false);
     expect(received[2]?.getModifierState("Nope")).toBe(false);
   } finally {
@@ -297,11 +298,11 @@ test("cancels a not-yet-run animation frame callback within the same frame", asy
 test("runs the listener for a click dispatched on a disabled button", async () => {
   if (isBrowser) return;
   // happy-dom drops a scripted click on a disabled <button>/<input> entirely.
-  // jsdom and real browsers (verified on Chromium, Firefox, and WebKit) still run
-  // the listeners — only clicks queued from a real user interaction are barred. A
-  // plain button has no activation behavior, so the click just reaches the
-  // listener (the case PR #6271 needed for a disabled `Command`). `dispatch`
-  // normalizes that (see dispatch.ts).
+  // jsdom and real browsers (verified on Chromium, Firefox, and WebKit) still
+  // run the listeners — only clicks queued from a real user interaction are
+  // barred. A plain button has no activation behavior, so the click just
+  // reaches the listener (the case PR #6271 needed for a disabled `Command`).
+  // `dispatch` normalizes that (see dispatch.ts).
   const button = document.createElement("button");
   button.disabled = true;
   let buttonClicks = 0;
@@ -372,10 +373,10 @@ test("toggles a disabled checkbox in either direction for a scripted click", asy
 
 test("reverts a disabled checkbox toggle in either direction when a click listener prevents it", async () => {
   if (isBrowser) return;
-  // The checkbox is toggled before the click listener runs, so the listener sees
-  // the flipped value; preventDefault() then cancels the activation, restoring
-  // the previous checked state and firing no input/change — matching jsdom and
-  // real browsers. Covers both toggle directions.
+  // The checkbox is toggled before the click listener runs, so the listener
+  // sees the flipped value; preventDefault() then cancels the activation,
+  // restoring the previous checked state and firing no input/change — matching
+  // jsdom and real browsers. Covers both toggle directions.
   for (const initiallyChecked of [false, true]) {
     const checkbox = document.createElement("input");
     checkbox.type = "checkbox";
@@ -406,9 +407,9 @@ test("reverts a disabled checkbox toggle in either direction when a click listen
 
 test("clears and restores a disabled checkbox's indeterminate state on a scripted click", async () => {
   if (isBrowser) return;
-  // A scripted click on a disabled indeterminate checkbox clears `indeterminate`
-  // (and toggles `checked`) before the click listener runs; preventDefault()
-  // restores both. Verified on Chromium, Firefox, and WebKit.
+  // A scripted click on a disabled indeterminate checkbox clears
+  // `indeterminate` (and toggles `checked`) before the click listener runs;
+  // preventDefault() restores both. Verified on Chromium, Firefox, and WebKit.
   for (const prevent of [false, true]) {
     const checkbox = document.createElement("input");
     checkbox.type = "checkbox";
@@ -534,10 +535,10 @@ test("restores a disabled radio group when a click listener prevents the selecti
 test("restores a disabled radio group linked by the form attribute when prevented", async () => {
   if (isBrowser) return;
   // Radios linked to a form by the `form` attribute (instead of nesting) are
-  // still grouped by happy-dom's `checked` setter at the root node — a scope that
-  // differs from the radio's resolved `form`. The snapshot must cover that scope
-  // so preventDefault restores the previously-selected peer rather than leaving
-  // the whole group unchecked.
+  // still grouped by happy-dom's `checked` setter at the root node — a scope
+  // that differs from the radio's resolved `form`. The snapshot must cover that
+  // scope so preventDefault restores the previously-selected peer rather than
+  // leaving the whole group unchecked.
   const form = document.createElement("form");
   form.id = "radio-group-form";
   const selected = document.createElement("input");
@@ -565,10 +566,10 @@ test("restores a disabled radio group linked by the form attribute when prevente
 
 test("reverts only the activation's changes, preserving listener changes to other radios", async () => {
   if (isBrowser) return;
-  // A prevented click reverts only what the activation changed (the clicked radio
-  // and the peer it unchecked), not state a listener changes during the click. A
-  // same-name radio in another scope (a separate group) is flipped by the
-  // listener here and must keep the listener's value after preventDefault.
+  // A prevented click reverts only what the activation changed (the clicked
+  // radio and the peer it unchecked), not state a listener changes during the
+  // click. A same-name radio in another scope (a separate group) is flipped by
+  // the listener here and must keep the listener's value after preventDefault.
   const form = document.createElement("form");
   const selected = document.createElement("input");
   const clicked = document.createElement("input");
@@ -580,8 +581,8 @@ test("reverts only the activation's changes, preserving listener changes to othe
   outside.name = "pick";
   form.append(selected, clicked);
   document.body.append(form, outside);
-  // Select the out-of-form radio first (its root-wide scope would otherwise clear
-  // the in-form one), then the in-form radio, leaving both selected.
+  // Select the out-of-form radio first (its root-wide scope would otherwise
+  // clear the in-form one), then the in-form radio, leaving both selected.
   outside.checked = true;
   selected.checked = true;
   clicked.addEventListener("click", (event) => {
@@ -603,7 +604,8 @@ test("doesn't submit or reset a form from a click on a disabled submit/reset con
   if (isBrowser) return;
   // Real browsers run the click listeners for a scripted click on a disabled
   // submit/reset control but skip its form-activation behavior — the form is
-  // neither submitted nor reset. happy-dom drops the click for both <button> and
+  // neither submitted nor reset. happy-dom drops the click for both <button>
+  // and
   // <input> through separate per-class dispatchEvent overrides, so cover both.
   // Verified on Chromium, Firefox, and WebKit.
   const form = document.createElement("form");

--- a/packages/ariakit-test/src/shims.test.ts
+++ b/packages/ariakit-test/src/shims.test.ts
@@ -605,9 +605,8 @@ test("doesn't submit or reset a form from a click on a disabled submit/reset con
   // Real browsers run the click listeners for a scripted click on a disabled
   // submit/reset control but skip its form-activation behavior — the form is
   // neither submitted nor reset. happy-dom drops the click for both <button>
-  // and
-  // <input> through separate per-class dispatchEvent overrides, so cover both.
-  // Verified on Chromium, Firefox, and WebKit.
+  // and <input> through separate per-class dispatchEvent overrides, so cover
+  // both. Verified on Chromium, Firefox, and WebKit.
   const form = document.createElement("form");
   const controls = (["submit", "reset"] as const).flatMap((type) =>
     ["button", "input"].map((tag) => {

--- a/packages/ariakit-test/src/shims.ts
+++ b/packages/ariakit-test/src/shims.ts
@@ -135,7 +135,8 @@ const initOnlyModifierMembers = new Map<string, keyof EventModifierInit>([
 // aliases of `clientX`/`clientY`, which browsers and jsdom provide. A named
 // dispatcher installs both while initializing the event, so only events the
 // caller built reached listeners without them. PointerEvent extends MouseEvent
-// and inherits this patch. https://github.com/ariakit/ariakit/issues/7156
+// and inherits this patch.
+// https://github.com/ariakit/ariakit/issues/7156
 // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/getModifierState
 // https://drafts.csswg.org/cssom-view/#dom-mouseevent-x
 function polyfillMouseEventMembers() {
@@ -145,9 +146,9 @@ function polyfillMouseEventMembers() {
   if (typeof prototype.getModifierState !== "function") {
     // happy-dom's constructor keeps only the standard flags and drops the
     // `modifier*` init members, so this fallback can never report the others.
-    // https://github.com/ariakit/ariakit/issues/7165 Plain assignment matches
-    // the writable, enumerable, configurable descriptor browsers and jsdom give
-    // this method.
+    // https://github.com/ariakit/ariakit/issues/7165
+    // Plain assignment matches the writable, enumerable, configurable
+    // descriptor browsers and jsdom give this method.
     prototype.getModifierState = function getModifierState(
       this: MouseEvent,
       key: string,

--- a/packages/ariakit-test/src/shims.ts
+++ b/packages/ariakit-test/src/shims.ts
@@ -84,10 +84,10 @@ function applyBrowserShims() {
     window.alert = () => {};
   }
 
-  // happy-dom diverges from real browsers in a few spec-conformance areas; these
-  // shims patch them for the whole test environment (jsdom already behaves
-  // correctly). Each helper returns a function that restores the original
-  // behavior.
+  // happy-dom diverges from real browsers in a few spec-conformance areas;
+  // these shims patch them for the whole test environment (jsdom already
+  // behaves correctly). Each helper returns a function that restores the
+  // original behavior.
   const restoreHappyDOMShims = isHappyDOM()
     ? [
         patchHappyDOMFormData(),
@@ -135,8 +135,7 @@ const initOnlyModifierMembers = new Map<string, keyof EventModifierInit>([
 // aliases of `clientX`/`clientY`, which browsers and jsdom provide. A named
 // dispatcher installs both while initializing the event, so only events the
 // caller built reached listeners without them. PointerEvent extends MouseEvent
-// and inherits this patch.
-// https://github.com/ariakit/ariakit/issues/7156
+// and inherits this patch. https://github.com/ariakit/ariakit/issues/7156
 // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/getModifierState
 // https://drafts.csswg.org/cssom-view/#dom-mouseevent-x
 function polyfillMouseEventMembers() {
@@ -146,9 +145,9 @@ function polyfillMouseEventMembers() {
   if (typeof prototype.getModifierState !== "function") {
     // happy-dom's constructor keeps only the standard flags and drops the
     // `modifier*` init members, so this fallback can never report the others.
-    // https://github.com/ariakit/ariakit/issues/7165
-    // Plain assignment matches the writable, enumerable, configurable
-    // descriptor browsers and jsdom give this method.
+    // https://github.com/ariakit/ariakit/issues/7165 Plain assignment matches
+    // the writable, enumerable, configurable descriptor browsers and jsdom give
+    // this method.
     prototype.getModifierState = function getModifierState(
       this: MouseEvent,
       key: string,
@@ -331,9 +330,9 @@ function patchHappyDOMAnimationFrame() {
     flushScheduled = false;
     // Snapshot only the handles registered before this frame; a callback added
     // during the flush keeps its entry in `pending` and runs on the next frame.
-    // Re-read each handle from the live map and remove it right before invoking,
-    // so a callback can still cancel another not-yet-run callback in the same
-    // frame (`cancelAnimationFrame` deletes from this same map).
+    // Re-read each handle from the live map and remove it right before
+    // invoking, so a callback can still cancel another not-yet-run callback in
+    // the same frame (`cancelAnimationFrame` deletes from this same map).
     const handles = Array.from(pending.keys());
     const timestamp = window.performance.now();
     for (const handle of handles) {

--- a/packages/ariakit-test/src/sleep.ts
+++ b/packages/ariakit-test/src/sleep.ts
@@ -1,10 +1,10 @@
 import { flushScheduler, isBrowser, nextFrame, wrapAsync } from "./__utils.ts";
 
-// The intermediate sub-steps of each interaction now settle without a wall-clock
-// delay (see `settle()`), so this delay only applies to the final settle after
-// an interaction. It's kept small in non-browser environments — but not zero, as
-// a few milliseconds remain load-bearing for some interactions, such as hiding a
-// dialog by clicking outside.
+// The intermediate sub-steps of each interaction now settle without a
+// wall-clock delay (see `settle()`), so this delay only applies to the final
+// settle after an interaction. It's kept small in non-browser environments —
+// but not zero, as a few milliseconds remain load-bearing for some
+// interactions, such as hiding a dialog by clicking outside.
 const defaultMs = isBrowser ? 150 : 4;
 
 /**
@@ -12,10 +12,11 @@ const defaultMs = isBrowser ? 150 : 4;
  * two animation frames and a short timeout.
  *
  * The other helpers in this package call it internally, but you can await it
- * directly to let pending updates, transitions, or effects flush before asserting.
- * The default delay is small and environment-dependent; pass `ms` to override it.
- * Outside a real browser it also drains the host scheduler so concurrent React
- * work that the delay raced past settles before the call resolves.
+ * directly to let pending updates, transitions, or effects flush before
+ * asserting. The default delay is small and environment-dependent; pass `ms` to
+ * override it. Outside a real browser it also drains the host scheduler so
+ * concurrent React work that the delay raced past settles before the call
+ * resolves.
  * @example
  * ```ts
  * await click(q.button("Open"));

--- a/packages/ariakit-test/src/type.ts
+++ b/packages/ariakit-test/src/type.ts
@@ -33,13 +33,13 @@ function workAroundEmailInput(element: Element) {
 /**
  * Types text into an element, simulating a real user pressing each key. Focuses
  * the element, then for each character fires `keydown`, updates the value and
- * caret position of text fields through an `input` event (preceded by `keypress`
- * when inserting a printable character), and fires `keyup`.
+ * caret position of text fields through an `input` event (preceded by
+ * `keypress` when inserting a printable character), and fires `keyup`.
  *
- * Special characters map to their keys: `"\b"` is Backspace, `"\x7f"` is Delete,
- * `"\n"` is Enter, and `"\t"` is Tab. When no element is passed, the currently
- * focused element is used. Pass `options` to set event properties such as modifier
- * keys or composition state.
+ * Special characters map to their keys: `"\b"` is Backspace, `"\x7f"` is
+ * Delete, `"\n"` is Enter, and `"\t"` is Tab. When no element is passed, the
+ * currently focused element is used. Pass `options` to set event properties
+ * such as modifier keys or composition state.
  * @example
  * ```ts
  * await type("Hello", q.textbox());
@@ -144,8 +144,8 @@ export function type(
       }
 
       // Between keystrokes the component only needs its microtask/rAF-scheduled
-      // work to flush (e.g. a controlled input re-render, combobox re-target), so
-      // a cheap settle keeps typing fast without a per-character wall delay.
+      // work to flush (e.g. a controlled input re-render, combobox re-target),
+      // so a cheap settle keeps typing fast without a per-character wall delay.
       await settle();
 
       await dispatch.keyUp(element, { key, ...options });

--- a/packages/ariakit-test/src/wait-for.ts
+++ b/packages/ariakit-test/src/wait-for.ts
@@ -4,8 +4,9 @@ import { wrapAsync } from "./__utils.ts";
 /**
  * Re-runs a callback until it stops throwing or the timeout is reached,
  * re-exporting Testing Library's `waitFor` with this package's async batching
- * applied. Use it to wait for an assertion to pass after an asynchronous update.
- * Pass `options` to configure the `timeout`, `interval`, and other behavior.
+ * applied. Use it to wait for an assertion to pass after an asynchronous
+ * update. Pass `options` to configure the `timeout`, `interval`, and other
+ * behavior.
  * @example
  * ```ts
  * await click(q.button("Close"));

--- a/packages/ariakit-utils/src/dom.test.ts
+++ b/packages/ariakit-utils/src/dom.test.ts
@@ -268,8 +268,8 @@ test("getWindow falls back when a document answers its default view with another
 
 // When that frame is cross-origin, its window still answers `window` with
 // itself and throws a `SecurityError` for `document`, so refusing to answer has
-// to count as owning another document.
-// The environment has no cross-origin frames, so the refusal is emulated.
+// to count as owning another document. The environment has no cross-origin
+// frames, so the refusal is emulated.
 test("getWindow falls back when the view it resolves refuses to report its document", () => {
   const refusingView = {
     window: null as unknown,

--- a/packages/ariakit-utils/src/dom.ts
+++ b/packages/ariakit-utils/src/dom.ts
@@ -156,8 +156,8 @@ export function getActiveElement(
     ? (activeElementGetter.call(ownerDocument) as Element | null)
     : ownerDocument.activeElement;
   if (!activeElement?.nodeName) {
-    // In IE11, activeElement might be an empty object if we're interacting
-    // with elements inside of an iframe.
+    // In IE11, activeElement might be an empty object if we're interacting with
+    // elements inside of an iframe.
     return null;
   }
   if (frame && isFrame(activeElement) && activeElement.contentDocument?.body) {

--- a/packages/ariakit-utils/src/focus.test.ts
+++ b/packages/ariakit-utils/src/focus.test.ts
@@ -134,8 +134,8 @@ test("getFirstTabbableIn falls back to the first focusable candidate", () => {
 
   setVisible(negative);
 
-  // No tabbable elements: without the fallback we get null; with the
-  // fallback we get the first focusable element.
+  // No tabbable elements: without the fallback we get null; with the fallback
+  // we get the first focusable element.
   expect(getFirstTabbableIn(container)).toBe(null);
   expect(getFirstTabbableIn(container, false, true)).toBe(negative);
 });
@@ -203,8 +203,8 @@ test("getLastTabbableIn fallback returns the last focusable candidate", () => {
   setNotVisible(hidden);
 
   // No tabbable elements (both are tabindex="-1"). The fallback must skip the
-  // trailing non-focusable hidden button and return the last focusable one,
-  // not just the last selector match.
+  // trailing non-focusable hidden button and return the last focusable one, not
+  // just the last selector match.
   expect(getLastTabbableIn(container, false, true)).toBe(visible);
 });
 

--- a/packages/ariakit-utils/src/misc.ts
+++ b/packages/ariakit-utils/src/misc.ts
@@ -307,8 +307,8 @@ export function disabledFromElement(element: Element) {
 /**
  * Removes undefined values from an object. Only own properties are copied, so
  * an inherited enumerable property never becomes an own property of the result.
- * A `__proto__` key is dropped because assigning it would replace the
- * prototype of the result instead of adding a property to it.
+ * A `__proto__` key is dropped because assigning it would replace the prototype
+ * of the result instead of adding a property to it.
  */
 export function removeUndefinedValues<T extends AnyObject>(obj: T) {
   const result = {} as T;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,9 @@ importers:
       oxlint:
         specifier: 1.81.0
         version: 1.81.0(oxlint-tsgolint@7.0.2001)
+      oxlint-plugin-comment-reflow:
+        specifier: 0.1.0
+        version: 0.1.0
       oxlint-tsgolint:
         specifier: 7.0.2001
         version: 7.0.2001
@@ -4188,6 +4191,10 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@oxlint/plugins@1.81.0':
+    resolution: {integrity: sha512-HhD8kd3r6XpelZkhxhRty/po8V6yK1VV63Eq4kSsOS2IoHUywG3DV2EX+z/ZHw46aLI74Y6aA604NRiAqLKW9w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@peculiar/asn1-schema@2.6.0':
     resolution: {integrity: sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==}
@@ -8852,6 +8859,10 @@ packages:
         optional: true
       vite-plus:
         optional: true
+
+  oxlint-plugin-comment-reflow@0.1.0:
+    resolution: {integrity: sha512-4LXXpJrhsHYAkpi9z9GPN7lZKw91G5mRLDfPYmYyYrGRrjNdbX4aqTpJ8wDmGkVnTqnBtp2TC8rnZSWk1I1PFA==}
+    engines: {node: ^24.18.0 || >=26.0.0}
 
   oxlint-tsgolint@7.0.2001:
     resolution: {integrity: sha512-KjK/XLcXr1DSyonKhsuFqJRiuKqcyG9j3LJ8nkOsrLzGvodBPqzHOKauy10asLMDI0sUpvb+1sxlzff3udZvfg==}
@@ -14206,6 +14217,8 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.81.0':
     optional: true
 
+  '@oxlint/plugins@1.81.0': {}
+
   '@peculiar/asn1-schema@2.6.0':
     dependencies:
       asn1js: 3.0.7
@@ -19373,6 +19386,10 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.66.0
       '@oxfmt/binding-win32-ia32-msvc': 0.66.0
       '@oxfmt/binding-win32-x64-msvc': 0.66.0
+
+  oxlint-plugin-comment-reflow@0.1.0:
+    dependencies:
+      '@oxlint/plugins': 1.81.0
 
   oxlint-tsgolint@7.0.2001:
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,8 +209,8 @@ importers:
         specifier: 1.81.0
         version: 1.81.0(oxlint-tsgolint@7.0.2001)
       oxlint-plugin-comment-reflow:
-        specifier: 0.1.0
-        version: 0.1.0
+        specifier: 0.1.1
+        version: 0.1.1
       oxlint-tsgolint:
         specifier: 7.0.2001
         version: 7.0.2001
@@ -8860,8 +8860,8 @@ packages:
       vite-plus:
         optional: true
 
-  oxlint-plugin-comment-reflow@0.1.0:
-    resolution: {integrity: sha512-4LXXpJrhsHYAkpi9z9GPN7lZKw91G5mRLDfPYmYyYrGRrjNdbX4aqTpJ8wDmGkVnTqnBtp2TC8rnZSWk1I1PFA==}
+  oxlint-plugin-comment-reflow@0.1.1:
+    resolution: {integrity: sha512-wertIO1oP1kZhcN7lsf79EfdLq3o9VmeN1TDDzolxuJE8/euMCCh+933Fd0HPX7d6q1xf50JN04RZMk/gxzKKQ==}
     engines: {node: ^24.18.0 || >=26.0.0}
 
   oxlint-tsgolint@7.0.2001:
@@ -19387,7 +19387,7 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.66.0
       '@oxfmt/binding-win32-x64-msvc': 0.66.0
 
-  oxlint-plugin-comment-reflow@0.1.0:
+  oxlint-plugin-comment-reflow@0.1.1:
     dependencies:
       '@oxlint/plugins': 1.81.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,8 +209,8 @@ importers:
         specifier: 1.81.0
         version: 1.81.0(oxlint-tsgolint@7.0.2001)
       oxlint-plugin-comment-reflow:
-        specifier: 0.1.1
-        version: 0.1.1
+        specifier: 0.1.2
+        version: 0.1.2
       oxlint-tsgolint:
         specifier: 7.0.2001
         version: 7.0.2001
@@ -8860,8 +8860,8 @@ packages:
       vite-plus:
         optional: true
 
-  oxlint-plugin-comment-reflow@0.1.1:
-    resolution: {integrity: sha512-wertIO1oP1kZhcN7lsf79EfdLq3o9VmeN1TDDzolxuJE8/euMCCh+933Fd0HPX7d6q1xf50JN04RZMk/gxzKKQ==}
+  oxlint-plugin-comment-reflow@0.1.2:
+    resolution: {integrity: sha512-UeQtfDSvgNomke/sArDXFYY7lDVOFhVu6emnTuQCAk5RBf7ikJQUN/d80usBCR6Tk93OdiBbtFCDnZhmIOMGRg==}
     engines: {node: ^24.18.0 || >=26.0.0}
 
   oxlint-tsgolint@7.0.2001:
@@ -19387,7 +19387,7 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.66.0
       '@oxfmt/binding-win32-x64-msvc': 0.66.0
 
-  oxlint-plugin-comment-reflow@0.1.1:
+  oxlint-plugin-comment-reflow@0.1.2:
     dependencies:
       '@oxlint/plugins': 1.81.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,9 @@ allowBuilds:
   sharp: true
   workerd: true
 
+minimumReleaseAgeExclude:
+  - oxlint-plugin-comment-reflow@0.1.0
+
 overrides:
   "@ariakit/components": "workspace:*"
   "@ariakit/react": "workspace:*"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,7 +18,7 @@ allowBuilds:
   workerd: true
 
 minimumReleaseAgeExclude:
-  - oxlint-plugin-comment-reflow@0.1.0
+  - oxlint-plugin-comment-reflow@0.1.1
 
 overrides:
   "@ariakit/components": "workspace:*"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,7 +18,7 @@ allowBuilds:
   workerd: true
 
 minimumReleaseAgeExclude:
-  - oxlint-plugin-comment-reflow@0.1.1
+  - oxlint-plugin-comment-reflow@0.1.2
 
 overrides:
   "@ariakit/components": "workspace:*"

--- a/scripts/build/utils.js
+++ b/scripts/build/utils.js
@@ -129,8 +129,7 @@ function normalizePath(filePath) {
 }
 
 /**
- * Filters out files starting with __
- * Includes directories and TS/JS files.
+ * Filters out files starting with __ Includes directories and TS/JS files.
  * @param {string} rootPath
  * @param {string} filename
  */

--- a/templates/react/vite.config.ts
+++ b/templates/react/vite.config.ts
@@ -4,8 +4,7 @@ import { defineConfig } from "vite";
 
 // The StackBlitz generators import this template's package.json and reuse its
 // shared version pins. Keep dependency renames/removals in sync with
-// app/src/lib/stackblitz.ts.
-// https://vite.dev/config/
+// app/src/lib/stackblitz.ts. https://vite.dev/config/
 export default defineConfig({
   plugins: [tailwindcss(), react()],
 });

--- a/templates/react/vite.config.ts
+++ b/templates/react/vite.config.ts
@@ -4,7 +4,8 @@ import { defineConfig } from "vite";
 
 // The StackBlitz generators import this template's package.json and reuse its
 // shared version pins. Keep dependency renames/removals in sync with
-// app/src/lib/stackblitz.ts. https://vite.dev/config/
+// app/src/lib/stackblitz.ts.
+// https://vite.dev/config/
 export default defineConfig({
   plugins: [tailwindcss(), react()],
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -27,9 +27,9 @@ function getFrameworkTestIncludes(framework: Framework) {
     const dir = dirname(file);
     return [`${dir}/test.{ts,tsx}`, `${dir}/${framework}.test.{ts,tsx}`];
   });
-  // The first glob covers framework packages except explicit DOM overrides.
-  // The second picks up framework-marked test files in any other package,
-  // like ariakit-test.
+  // The first glob covers framework packages except explicit DOM overrides. The
+  // second picks up framework-marked test files in any other package, like
+  // ariakit-test.
   return [
     `packages/ariakit-${framework}*/src/**/{test,!(*.dom).test}.{ts,tsx}`,
     `packages/*/src/**/*${framework}.test.{ts,tsx}`,

--- a/vitest.setup.framework.ts
+++ b/vitest.setup.framework.ts
@@ -2,8 +2,8 @@ import { beforeEach } from "vitest";
 
 type Framework = "react" | "solid";
 
-// Keep the path opaque so Vite's dynamic import vars transform does not
-// rewrite nested example paths into an unsupported one-level glob.
+// Keep the path opaque so Vite's dynamic import vars transform does not rewrite
+// nested example paths into an unsupported one-level glob.
 async function importDefault(path: string) {
   const { default: component } = await import(path);
   return component;

--- a/website/build-pages/reference-utils.test.ts
+++ b/website/build-pages/reference-utils.test.ts
@@ -47,6 +47,21 @@ function getReturnProp(reference: Reference, name: string) {
   return prop;
 }
 
+test.each([
+  ["form", "FormField", "FormControl"],
+  ["menu", "MenuBar", "Menubar"],
+  ["menu", "MenuBarProvider", "MenubarProvider"],
+  ["menu", "useMenuBarStore", "useMenubarStore"],
+  ["menu", "useMenuBarContext", "useMenubarContext"],
+])("preserves the deprecation for %s/%s", (module, name, replacement) => {
+  const filename = join(
+    process.cwd(),
+    `packages/ariakit-react/src/${module}.ts`,
+  );
+  const reference = getReference(filename, name);
+  expect(reference.deprecated).toEqual(expect.stringContaining(replacement));
+});
+
 test("does not use non-props function parameters as reference props", () => {
   expect(getReference(formFilename, "useFormValue").props).toEqual([]);
   expect(getReference(formFilename, "useFormValidate").props).toEqual([]);


### PR DESCRIPTION
## Motivation

Keep comment wrapping and placement consistent with Ariakit's code style through the existing lint workflow.

## Solution

Add `oxlint-plugin-comment-reflow@0.1.2` and enable its rule with `{ printWidth: 80, trailingComments: "always" }`. Disable Oxfmt's JSDoc formatting so the plugin owns comment reflow. Apply the initial cleanup across the files covered by Oxlint.

Use v0.1.2 to preserve standalone permalink lines and reflow prose that contains semicolons or HTML element names. Keep formulas in inline code so wrapping does not split their expressions. The release also includes the JSDoc tag separator fix; regression coverage checks the generated deprecation guidance of legacy APIs.

The cleanup preserves source syntax and comment wording, with inline-code delimiters added around two formulas. Eligible trailing comments move above their targets. Directives, code examples, and protected comment layouts remain under the plugin's preservation rules.

## Verification

- `pnpm lint-fix` followed by `pnpm lint`.
- `pnpm tsc`.
- `pnpm test run app/src/lib/jsdoc-loader.test.ts website/build-pages/reference-utils.test.ts`.
- `pnpm build-website-lite`.
- Compared source syntax and parsed JSDoc tag names against the original source, and verified standalone permalink preservation, with the autofocus reference deliberately kept inline after `See`.
- Reproduced merged permalinks and orphan lines with v0.1.1, then verified the same cases and repeated reflow with v0.1.2.
- Ran the upstream core regression suite against the published v0.1.2 build.
- Rebuilt Tailwind CSS and confirmed no generated CSS diff.
- Confirmed the deprecation tests fail with malformed tags and pass with valid metadata.
- Ran v0.1.2 on the original multiline deprecation comments and verified that it produces the current source without manual repairs.
- Inspected generated modern and legacy `ComboboxItemCheck` references, including prop descriptions, links, and legacy page anchors.


