### PR TITLE
Scope Playwright browser caches by workspace

### DIFF
--- a/.github/workflows/install-playwright/action.yml
+++ b/.github/workflows/install-playwright/action.yml
@@ -28,10 +28,11 @@ runs:
       with:
         path: |
           ${{ runner.os == 'macOS' && '~/Library/Caches/ms-playwright' || runner.os == 'Windows' && '~\\AppData\\Local\\ms-playwright' || '~/.cache/ms-playwright' }}
-        key: playwright-${{ runner.os }}-${{ steps.engines.outputs.cache-key }}-${{ hashFiles('pnpm-lock.yaml') }}
+        # Workspaces can require different Playwright browser revisions.
+        key: playwright-${{ runner.os }}-${{ inputs.workspace }}-${{ steps.engines.outputs.cache-key }}-${{ hashFiles('pnpm-lock.yaml') }}
         restore-keys: |
-          playwright-${{ runner.os }}-${{ steps.engines.outputs.cache-key }}-
-          playwright-${{ runner.os }}-
+          playwright-${{ runner.os }}-${{ inputs.workspace }}-${{ steps.engines.outputs.cache-key }}-
+          playwright-${{ runner.os }}-${{ inputs.workspace }}-
 
     - name: Install Playwright
       if: steps.cache-playwright.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Motivation

Plus can restore an exact browser cache hit from an app job and then fail to find `chromium-1234`. The shared action uses the operating system, engines, and lockfile hash as its cache key, but `website` requires Playwright 1.62 while `app` requires 1.63. Both workspaces can therefore write different browser revisions under the same key. This configuration is present on `main`; the [failed Plus job](https://github.com/ariakit/ariakit/actions/runs/34411633027/job/102667287423) confirms the exact-hit failure.

## Solution

Include the workspace in the primary key and both restore prefixes. For example, `playwright-Linux-website-chromium-<hash>` is separate from `playwright-Linux-app-chromium-<hash>`. Old shared keys cannot match the new prefixes. Partial restores within the same workspace still run the existing browser installation step.

Verified the old key collision and the new cache matching behavior locally across the supported operating systems and engine inputs. Playwright install dry runs confirm Chromium revisions 1234 for website and 1243 for app. `pnpm lint-fix` and `git diff --check` pass. The full Plus suite requires CI credentials and was not run locally.
