### PR TITLE
Make control joining optional and preserve tab corners

### DIFF
--- a/app/src/pages/ariakit-ui/_ariakit-ui/button.react.tsx
+++ b/app/src/pages/ariakit-ui/_ariakit-ui/button.react.tsx
@@ -384,8 +384,8 @@ export function ButtonSection() {
 
       <Sample
         title="Groups"
-        code='ButtonGroup $layout="horizontal" | "stretch" | "vertical" | "wrap" · $gap · $p="none"'
-        description="A group sizes its buttons together. Without padding the inner corners square off so the buttons join."
+        code='ButtonGroup $layout="horizontal" | "stretch" | "vertical" | "wrap" · $gap · $p="none" · $joined={false}'
+        description="A group sizes its buttons together. Adjacent buttons in a horizontal row join their borders and, without padding, their inner corners. Set $joined={false} to keep their borders and corners independent."
       >
         <Stage direction="column">
           <ButtonGroup $border $layer className="w-max max-w-full">
@@ -395,6 +395,17 @@ export function ButtonSection() {
           </ButtonGroup>
           <ButtonGroup $border $layer $p="none" className="w-max max-w-full">
             <Button>Joined</Button>
+            <Button>Buttons</Button>
+            <Button>No padding</Button>
+          </ButtonGroup>
+          <ButtonGroup
+            $border
+            $layer
+            $p="none"
+            $joined={false}
+            className="w-max max-w-full"
+          >
+            <Button>Independent</Button>
             <Button>Buttons</Button>
             <Button>No padding</Button>
           </ButtonGroup>

--- a/app/src/sandbox/button-group-layout/index.react.tsx
+++ b/app/src/sandbox/button-group-layout/index.react.tsx
@@ -1,8 +1,18 @@
 import { Button } from "@ariakit/react";
+import { ButtonGroup } from "@ariakit/ui/components/button.ariakit.react";
+import {
+  Tab,
+  TabGlider,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+} from "@ariakit/ui/components/tabs.ariakit.react";
 import { button, buttonGroup } from "@ariakit/ui/styles/button";
 
 const groups = [
   { title: "Horizontal", $layout: "horizontal", $gap: "auto", $p: "none" },
+  { title: "Stretched auto", $layout: "stretch", $gap: "auto", $p: "none" },
   { title: "Stretched", $layout: "stretch", $gap: "none", $p: "none" },
   { title: "Padded", $layout: "horizontal", $gap: "none", $p: 2 },
   { title: "Spaced", $layout: "horizontal", $gap: "md", $p: "none" },
@@ -46,6 +56,79 @@ export default function Example() {
           </div>
         </section>
       ))}
+      {(
+        [
+          { title: "Independent", $p: "none" },
+          { title: "Padded independent", $p: 2, $gap: "none" },
+        ] as const
+      ).map(({ title, ...props }) => (
+        <section key={title}>
+          <h2>{title}</h2>
+          <ButtonGroup
+            aria-label={title}
+            $border={2}
+            $joined={false}
+            {...props}
+          >
+            {["Day", "Week", "Month"].map((label) => (
+              <Button
+                key={label}
+                {...button.jsx({ $border: 2, $borderType: "border" })}
+              >
+                {label}
+              </Button>
+            ))}
+          </ButtonGroup>
+        </section>
+      ))}
+      {(["folder", "flat", "bevel"] as const).map((kind) => (
+        <section key={kind} className="grid gap-2">
+          <h2>{kind} tabs</h2>
+          <Tabs $p="none" $rounded="xl">
+            <TabList aria-label={`${kind} tabs`}>
+              <Tab $kind={kind}>Preview</Tab>
+              <Tab $kind={kind}>Code</Tab>
+              <Tab $kind={kind}>Usage</Tab>
+            </TabList>
+            <TabPanels>
+              <TabPanel single>The strip has no padding.</TabPanel>
+            </TabPanels>
+          </Tabs>
+        </section>
+      ))}
+      <section className="grid gap-2">
+        <h2>Folder glider</h2>
+        <Tabs $p="none" $rounded="xl">
+          <TabList aria-label="Folder glider">
+            <Tab>Preview</Tab>
+            <Tab>Code</Tab>
+            <Tab>Usage</Tab>
+            <TabGlider />
+          </TabList>
+          <TabPanels>
+            <TabPanel single>The glider follows the selected tab.</TabPanel>
+          </TabPanels>
+        </Tabs>
+      </section>
+      <section className="grid gap-2">
+        <h2>Joined tabs</h2>
+        <Tabs $p="none" $rounded="xl">
+          <TabList aria-label="Joined tabs" $joined>
+            <Tab $kind="flat" $border={2} $borderType="border">
+              Day
+            </Tab>
+            <Tab $kind="flat" $border={2} $borderType="border">
+              Week
+            </Tab>
+            <Tab $kind="flat" $border={2} $borderType="border">
+              Month
+            </Tab>
+          </TabList>
+          <TabPanels>
+            <TabPanel single>The tab list opts into joining.</TabPanel>
+          </TabPanels>
+        </Tabs>
+      </section>
     </div>
   );
 }

--- a/app/src/sandbox/button-group-layout/test-browser.ts
+++ b/app/src/sandbox/button-group-layout/test-browser.ts
@@ -7,6 +7,7 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
     for (const title of [
       "Horizontal",
       "Stretched",
+      "Stretched auto",
       "Padded",
       "Numeric zero",
       "Pixel zero",
@@ -16,6 +17,7 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
       const group = query(q.group(title));
       const first = group.button("Day");
       const middle = group.button("Week");
+      const last = group.button("Month");
       await test.expect(first).toBeVisible();
       await test.expect(middle).toHaveCSS("border-left-width", "2px");
       await test.expect
@@ -26,10 +28,16 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
           return firstBox.x + firstBox.width - middleBox.x;
         })
         .toBeCloseTo(2, 1);
+      await test.expect(middle).toHaveCSS("margin-inline-end", "-1px");
+      await test.expect(last).toHaveCSS("margin-inline-start", "-1px");
+      await test.expect(first).not.toHaveCSS("border-top-left-radius", "0px");
+      await test.expect(last).not.toHaveCSS("border-top-right-radius", "0px");
       if (title === "Padded") {
         await test.expect(middle).not.toHaveCSS("border-radius", "0px");
       } else {
         await test.expect(middle).toHaveCSS("border-radius", "0px");
+        await test.expect(first).toHaveCSS("border-top-right-radius", "0px");
+        await test.expect(last).toHaveCSS("border-top-left-radius", "0px");
       }
     }
   });
@@ -53,5 +61,53 @@ withFramework(import.meta.dirname, async ({ test, query }) => {
       await test.expect(middle).toHaveCSS("margin-inline-start", "0px");
       await test.expect(middle).toHaveCSS("margin-inline-end", "0px");
     }
+  });
+
+  test("keeps independent borders and corners when joining is disabled", async ({
+    q,
+  }) => {
+    for (const name of ["Independent", "Padded independent"]) {
+      const group = query(q.group(name));
+      for (const label of ["Day", "Week", "Month"]) {
+        const button = group.button(label);
+        await test.expect(button).toHaveCSS("margin-inline-start", "0px");
+        await test.expect(button).toHaveCSS("margin-inline-end", "0px");
+        await test
+          .expect(button)
+          .not.toHaveCSS("border-top-left-radius", "0px");
+        await test
+          .expect(button)
+          .not.toHaveCSS("border-top-right-radius", "0px");
+      }
+    }
+  });
+
+  // https://github.com/ariakit/ariakit/pull/5240
+  test("keeps both top corners on unpadded tabs", async ({ q }) => {
+    for (const name of [
+      "folder tabs",
+      "flat tabs",
+      "bevel tabs",
+      "Folder glider",
+    ]) {
+      const list = query(q.tablist(name));
+      for (const label of ["Preview", "Code", "Usage"]) {
+        const tab = list.tab(label);
+        await tab.click();
+        await test.expect(tab).toHaveAttribute("aria-selected", "true");
+        await test.expect(tab).toHaveCSS("border-top-left-radius", "12px");
+        await test.expect(tab).toHaveCSS("border-top-right-radius", "12px");
+        await test.expect(tab).toHaveCSS("margin-inline-end", "0px");
+      }
+    }
+  });
+
+  test("allows a tab list to opt into joining", async ({ q }) => {
+    const list = query(q.tablist("Joined tabs"));
+    await test.expect(list.tab("Week")).toHaveCSS("border-radius", "0px");
+    await test
+      .expect(list.tab("Week"))
+      .toHaveCSS("margin-inline-start", "-1px");
+    await test.expect(list.tab("Week")).toHaveCSS("margin-inline-end", "-1px");
   });
 });

--- a/packages/ariakit-ui/src/styles/control.ts
+++ b/packages/ariakit-ui/src/styles/control.ts
@@ -406,6 +406,13 @@ export const controlGroup = cv({
       lg: "[--group-gap:--spacing(3)] gap-(--group-gap)",
       xl: "[--group-gap:--spacing(4)] gap-(--group-gap)",
     },
+    /**
+     * Joins adjacent controls in horizontal and stretched layouts by
+     * overlapping their borders when the gap is zero and squaring their inner
+     * corners when the padding is also zero. Set to `false` to keep each
+     * control's borders and corners independent.
+     */
+    $joined: "",
   },
   defaultVariants: {
     $size: "auto",
@@ -413,8 +420,10 @@ export const controlGroup = cv({
     $layout: "horizontal",
     $p: 1,
     $gap: "auto",
+    $joined: true,
   },
   refine({ variants, addClass }) {
+    if (!variants.$joined) return;
     if (variants.$layout !== "horizontal" && variants.$layout !== "stretch") {
       return;
     }

--- a/packages/ariakit-ui/src/styles/tabs.ts
+++ b/packages/ariakit-ui/src/styles/tabs.ts
@@ -509,6 +509,8 @@ export const tabList = cv({
     $layer: true,
     $darken: 0.5,
     $cover: true,
+    // Each tab keeps its own shape, including when the strip has no padding.
+    $joined: false,
     $p: "unset",
     $rounded: "unset",
     // The cover adds this margin to its stretch and takes it off the radius, so


### PR DESCRIPTION
## Motivation

Tabs without strip padding inherit the control group's border-joining and corner rules. This squares the selected tab's inner top corner, even though each tab should keep its own shape. This is a follow-up to #5240.

## Solution

Add a boolean `$joined` variant that controls both the border overlap and the inner-corner rules. It defaults to `true` for control groups and `false` for tab lists. Joining still depends on the existing layout, gap, and padding conditions. The tab list keeps its frame cover behavior.

```tsx
<ButtonGroup $p="none" />
<ButtonGroup $p="none" $joined={false} />
<TabList /> // Independent by default; pass $joined to opt in.
```

Add an independent button-group example to the gallery and browser coverage for the defaults, explicit overrides, zero padding, spacing, and layout conditions. The tab checks cover folder, flat, and bevel tabs, plus a folder glider.

## Preview

The same unpadded folder tabs before and after the change:

| Before | After |
| --- | --- |
| ![The selected Preview tab has a square top-right corner](https://github.com/user-attachments/assets/0228b558-ef55-48fe-bdd3-8414fda01a3b) | ![The selected Preview tab has both top corners rounded](https://github.com/user-attachments/assets/7d5114ec-ef06-4363-9259-fe453b51deee) |

## Verification

- `pnpm lint-fix`
- `pnpm tsc`
- Browser regression tests pass in Chrome, Firefox, and Safari.
- Both new regression checks fail when the fix is removed and pass after restoration.
- Recipe output comparisons preserve existing button-group defaults and explicit joined tab lists.
