### PR TITLE
Update PopoverArrow colors when its popover opens

### DIFF
--- a/.changeset/300-popover-arrow-theme-colors.md
+++ b/.changeset/300-popover-arrow-theme-colors.md
@@ -1,0 +1,6 @@
+---
+"@ariakit/react": patch
+"@ariakit/react-components": patch
+---
+
+Fixed [`PopoverArrow`](https://ariakit.com/reference/popover-arrow) keeping the colors it read when the popover first rendered, so an arrow opened after a theme change no longer shows the previous theme's fill and stroke. This also applies to components built on it, such as [`TooltipArrow`](https://ariakit.com/reference/tooltip-arrow) and [`MenuArrow`](https://ariakit.com/reference/menu-arrow).

--- a/app/src/sandbox/popover-arrow/index.react.tsx
+++ b/app/src/sandbox/popover-arrow/index.react.tsx
@@ -94,10 +94,56 @@ function RtlPlacementPopover() {
   );
 }
 
+// A theme switch changes the popover colors through a stylesheet, like a dark
+// mode class on an ancestor, without re-rendering the popover. The light theme
+// outlines the popover with a ring and the dark theme with a border, so the
+// arrow must also switch between its ring and border strokes. PopoverArrow used
+// to keep the colors it read when the popover mounted, so an arrow opened after
+// the switch still showed the light theme.
+const themeStyles = `
+  .theme-switch .themed-popover {
+    background-color: rgb(255, 255, 255);
+    color: rgb(15, 23, 42);
+    box-shadow: 0 0 0 1px rgb(59, 130, 246);
+  }
+  .theme-switch[data-theme="dark"] .themed-popover {
+    background-color: rgb(15, 23, 42);
+    color: rgb(248, 250, 252);
+    border: 2px solid rgb(250, 204, 21);
+    box-shadow: none;
+  }
+`;
+
+function ThemeSwitchPopover() {
+  const [dark, setDark] = useState(false);
+  return (
+    <div className="theme-switch" data-theme={dark ? "dark" : "light"}>
+      <style>{themeStyles}</style>
+      <label>
+        <input
+          type="checkbox"
+          checked={dark}
+          onChange={(event) => setDark(event.target.checked)}
+        />
+        Dark theme
+      </label>
+      <Ariakit.PopoverProvider>
+        <Ariakit.PopoverDisclosure>Themed popover</Ariakit.PopoverDisclosure>
+        <Ariakit.Popover className="themed-popover" style={{ padding: 16 }}>
+          <Ariakit.PopoverArrow className="arrow" />
+          <Ariakit.PopoverHeading>Themed popover</Ariakit.PopoverHeading>
+          <p>The arrow follows the theme.</p>
+        </Ariakit.Popover>
+      </Ariakit.PopoverProvider>
+    </div>
+  );
+}
+
 export default function Example() {
   return (
     <>
       <RtlPlacementPopover />
+      <ThemeSwitchPopover />
       <div style={{ display: "flex", gap: 16, padding: 64 }}>
         <RingPopover label="Thin ring" boxShadow={`0 0 0 1px ${ringColor}`} />
         <RingPopover label="Thick ring" boxShadow={`0 0 0 10px ${ringColor}`} />

--- a/app/src/sandbox/popover-arrow/test-browser.ts
+++ b/app/src/sandbox/popover-arrow/test-browser.ts
@@ -99,6 +99,31 @@ withFramework(import.meta.dirname, async ({ test }) => {
       .toBeLessThanOrEqual(anchorBox.x + anchorBox.width);
   });
 
+  test("arrow takes the new theme colors when the popover opens after a theme switch", async ({
+    page,
+    q,
+  }) => {
+    const disclosure = q.button("Themed popover");
+    await disclosure.click();
+    const dialog = q.dialog("Themed popover");
+    const arrow = dialog.locator(".arrow");
+    await test.expect(arrow).toHaveCSS("fill", "rgb(255, 255, 255)");
+    await test.expect(arrow).toHaveCSS("stroke", ringColor);
+    await test.expect(arrow).toHaveCSS("stroke-width", "2px");
+
+    await page.keyboard.press("Escape");
+    await test.expect(dialog).toBeHidden();
+    await q.checkbox("Dark theme").check();
+
+    // The switch happened while the popover was closed and re-rendered nothing
+    // inside it, so only a fresh read on open can pick up the dark colors.
+    await disclosure.click();
+    await test.expect(dialog).toBeVisible();
+    await test.expect(arrow).toHaveCSS("fill", "rgb(15, 23, 42)");
+    await test.expect(arrow).toHaveCSS("stroke", "rgb(250, 204, 21)");
+    await test.expect(arrow).toHaveCSS("stroke-width", "4px");
+  });
+
   const cases = [
     // A 1px ring is detected by the current width regex, but the arrow stroke
     // must also match the ring color instead of the inherited text color.

--- a/app/src/sandbox/popover-arrow/test.ts
+++ b/app/src/sandbox/popover-arrow/test.ts
@@ -1,4 +1,4 @@
-import { click, q } from "@ariakit/test";
+import { click, press, q } from "@ariakit/test";
 import { expect, test } from "vitest";
 
 const ringColor = "rgb(59, 130, 246)";
@@ -55,6 +55,30 @@ test("clears the arrow's stale static-side inset after a placement change", asyn
   // clearing that happens right after the reposition, such as the userland
   // workaround for this bug, without racing it.
   await expect.poll(() => arrow.style.right).toBe("");
+});
+
+test("arrow takes the new theme colors when the popover opens after a theme switch", async () => {
+  await click(q.button("Themed popover"));
+  const arrow = q.dialog("Themed popover").querySelector(".arrow");
+  expect(arrow).toBeInTheDocument();
+  expect(arrow).toHaveStyle({
+    fill: "rgb(255, 255, 255)",
+    stroke: ringColor,
+    strokeWidth: "2",
+  });
+
+  await press.Escape();
+  expect(q.dialog.maybe("Themed popover")).not.toBeInTheDocument();
+  await click(q.checkbox("Dark theme"));
+
+  // The switch happened while the popover was closed and re-rendered nothing
+  // inside it, so only a fresh read on open can pick up the dark colors.
+  await click(q.button("Themed popover"));
+  expect(arrow).toHaveStyle({
+    fill: "rgb(15, 23, 42)",
+    stroke: "rgb(250, 204, 21)",
+    strokeWidth: "4",
+  });
 });
 
 // See https://github.com/ariakit/ariakit/issues/6321

--- a/packages/ariakit-react-components/src/popover/popover-arrow.tsx
+++ b/packages/ariakit-react-components/src/popover/popover-arrow.tsx
@@ -30,17 +30,7 @@ const rotateMap = {
   left: `rotate(90 ${halfDefaultSize} ${halfDefaultSize})`,
 };
 
-function useComputedStyle(store: PopoverStore) {
-  const [style, setStyle] = useState<CSSStyleDeclaration>();
-  const contentElement = useStoreState(store, "contentElement");
-  useSafeLayoutEffect(() => {
-    if (!contentElement) return;
-    const win = getWindow(contentElement);
-    const computedStyle = win.getComputedStyle(contentElement);
-    setStyle(computedStyle);
-  }, [contentElement]);
-  return style;
-}
+type BasePlacement = ReturnType<typeof getBasePlacement>;
 
 interface RingStyle {
   width: number;
@@ -105,8 +95,7 @@ function getRingFromSegment(segment: string, maskedSegment: string) {
  * with a positive spread, as produced by Tailwind ring utilities) and returns
  * its width and color.
  */
-function getRing(style?: CSSStyleDeclaration) {
-  if (!style) return;
+function getRing(style: CSSStyleDeclaration) {
   const boxShadow = style.getPropertyValue("box-shadow");
   if (!boxShadow) return;
   if (boxShadow === "none") return;
@@ -124,6 +113,81 @@ function getRing(style?: CSSStyleDeclaration) {
     segmentStart = index + 1;
   }
   return;
+}
+
+interface ArrowStyle {
+  fill: string;
+  stroke: string;
+  borderWidth: number;
+  isRing: boolean;
+}
+
+interface GetArrowStyleParams {
+  style: CSSStyleDeclaration;
+  dir: BasePlacement;
+  borderWidthProp?: number;
+}
+
+/**
+ * Derives the arrow's fill, stroke and stroke mode from the popover's computed
+ * style.
+ */
+function getArrowStyle({
+  style,
+  dir,
+  borderWidthProp,
+}: GetArrowStyleParams): ArrowStyle {
+  const fill = style.getPropertyValue("background-color") || "none";
+  // Without a ring, the stroke takes the border color, which always resolves to
+  // a concrete value on connected elements (currentColor at the very least).
+  const borderColor = style.getPropertyValue(`border-${dir}-color`) || "none";
+  if (borderWidthProp != null) {
+    return {
+      fill,
+      stroke: borderColor,
+      borderWidth: borderWidthProp,
+      isRing: false,
+    };
+  }
+  const ring = getRing(style);
+  if (ring) {
+    // When the popover is outlined by a ring, the arrow stroke must match the
+    // ring color so the arrow blends into the outline. A ring segment with an
+    // omitted color defaults to currentColor per CSS, so use the computed text
+    // color then. Computed styles always serialize a concrete shadow color, but
+    // declared values returned by some test environments may omit it.
+    const stroke = ring.color || style.getPropertyValue("color") || "none";
+    // Math.ceil matches the border width fallback below so fractional ring
+    // widths still render a visible stroke on high-DPI screens.
+    return { fill, stroke, borderWidth: Math.ceil(ring.width), isRing: true };
+  }
+  const parsed = Number.parseFloat(
+    style.getPropertyValue(`border-${dir}-width`),
+  );
+  const borderWidth = Number.isNaN(parsed) ? 0 : Math.ceil(parsed);
+  return { fill, stroke: borderColor, borderWidth, isRing: false };
+}
+
+interface UseArrowStyleParams {
+  store: PopoverStore;
+  dir: BasePlacement;
+  borderWidthProp?: number;
+}
+
+function useArrowStyle({ store, dir, borderWidthProp }: UseArrowStyleParams) {
+  const [arrowStyle, setArrowStyle] = useState<ArrowStyle>();
+  const contentElement = useStoreState(store, "contentElement");
+  const open = useStoreState(store, "open");
+  // The popover colors can change while it's closed, for example after a theme
+  // switch, without re-rendering the arrow. The open state is a dependency so
+  // the computed style is read again every time the popover opens.
+  useSafeLayoutEffect(() => {
+    if (!contentElement) return;
+    const win = getWindow(contentElement);
+    const style = win.getComputedStyle(contentElement);
+    setArrowStyle(getArrowStyle({ style, dir, borderWidthProp }));
+  }, [contentElement, open, dir, borderWidthProp]);
+  return arrowStyle;
 }
 
 /**
@@ -160,39 +224,11 @@ export const usePopoverArrow = createHook<TagName, PopoverArrowOptions>(
     );
 
     const maskId = useId();
-    const style = useComputedStyle(store);
-    const fill = style?.getPropertyValue("background-color") || "none";
-
-    const [borderWidth, isRing, ringColor] = useMemo(() => {
-      if (borderWidthProp != null) {
-        return [borderWidthProp, false, undefined] as const;
-      }
-      if (!style) return [0, false, undefined] as const;
-      const ring = getRing(style);
-      // Math.ceil matches the border width fallback below so fractional ring
-      // widths still render a visible stroke on high-DPI screens.
-      if (ring) return [Math.ceil(ring.width), true, ring.color] as const;
-      const borderWidth = style.getPropertyValue(`border-${dir}-width`);
-      if (borderWidth) {
-        const parsed = Number.parseFloat(borderWidth);
-        if (!Number.isNaN(parsed)) {
-          return [Math.ceil(parsed), false, undefined] as const;
-        }
-      }
-      return [0, false, undefined] as const;
-    }, [borderWidthProp, style, dir]);
-
-    // When the popover is outlined by a ring, the arrow stroke must match the
-    // ring color so the arrow blends into the outline. A ring segment with an
-    // omitted color defaults to currentColor per CSS, so use the computed text
-    // color then. Computed styles always serialize a concrete shadow color, but
-    // declared values returned by some test environments may omit it. Without a
-    // ring, fall back to the border color, which always resolves to a concrete
-    // value on connected elements (currentColor at the very least).
-    const fallbackColor = isRing
-      ? style?.getPropertyValue("color")
-      : style?.getPropertyValue(`border-${dir}-color`);
-    const stroke = ringColor || fallbackColor || "none";
+    const arrowStyle = useArrowStyle({ store, dir, borderWidthProp });
+    const fill = arrowStyle?.fill ?? "none";
+    const stroke = arrowStyle?.stroke ?? "none";
+    const isRing = arrowStyle?.isRing ?? false;
+    const borderWidth = arrowStyle?.borderWidth ?? borderWidthProp ?? 0;
 
     const strokeWidth = borderWidth * 2 * (defaultSize / size);
     const transform = rotateMap[dir];


### PR DESCRIPTION
## Motivation

`PopoverArrow` keeps the fill and stroke it read when the popover first rendered. If the theme changes while the popover is closed, the arrow can show the old colors when the popover opens again.

This extracts the PopoverArrow fix from #7465 so it can ship separately from the Ariakit UI gallery changes.

## Solution

Read the popover's computed style again when its open state changes, and store the derived fill, stroke, border width, and ring mode together. This also updates components built on `PopoverArrow`, such as `TooltipArrow` and `MenuArrow`.

The existing `popover-arrow` sandbox includes a theme switch. Its browser and integration tests check the change from a light popover with a blue ring to a dark popover with a yellow border. The changeset covers `@ariakit/react-components` and `@ariakit/react`.

## Verification

- The theme regression fails without the fix in Chrome, Firefox, Safari, and the integration suite.
- All 27 arrow browser tests pass in Chrome, Firefox, and Safari.
- All 8 arrow integration tests pass with both React 19 and React 18.
- `pnpm build`, `pnpm lint-fix`, and `pnpm tsc` pass.

## Preview

Before: the reopened dark popover has a white arrow with a blue stroke.

![Dark popover with the old white arrow and blue stroke](https://github.com/user-attachments/assets/8b13a9c8-4617-408d-8573-1982e56e47e4)

After: the arrow matches the dark fill and yellow border.

![Dark popover with a matching arrow and yellow stroke](https://github.com/user-attachments/assets/5f082831-a24f-4aec-b4da-9ca4c4af8836)

The recording shows opening the light popover, closing it, changing the theme, and opening it again:

https://github.com/user-attachments/assets/57988c80-d346-4e51-810b-025b01f74753
